### PR TITLE
fix(records): one person key, one current-primary slot, one profile-field writer

### DIFF
--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -36,11 +36,13 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
@@ -340,6 +342,267 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 			}
 			if !tc.fires && hit {
 				t.Errorf("the detector reported a statement that asks the one definition, or asks nothing:\n%s", tc.src)
+			}
+		})
+	}
+}
+
+// The OTHER question about is_current_primary: which row holds the slot
+// uq_rel_current_primary_employer keeps unique. It is date-BLIND, so it cannot
+// share EmploymentIsCurrentSQL — a guard that asked "are they still employed"
+// would read a person serving notice as having freed a slot the index still
+// holds, and the write behind it would 409 instead of skipping.
+//
+// Six statements asked it by hand. The census above could not see any of them:
+// it judges a hand-written test on `ended_at`, and these spell neither the
+// helper nor that column. So this is a second detector over the same tree, for
+// the FRAGMENT — the flag AND-ed with an archived test — which is the shape
+// that hid six copies from a census that only knew whole predicates.
+
+// currentPrimarySlotHelper is the one spelling the six sites now call.
+const currentPrimarySlotHelper = "CurrentPrimarySlotSQL"
+
+// slotBlockedByTheModuleDAG ratifies the statement that cannot adopt the
+// helper today, for the architectural reason above and not for want of
+// somebody getting round to it: projects may not import people (ADR-0054 §3).
+//
+// Its own declaration and not a share of blockedByTheModuleDAG: a Waivers set
+// records what reached it, and AssertAllMatched belongs to exactly one census —
+// two sweeping the same set would make whichever ran first report false
+// staleness.
+var slotBlockedByTheModuleDAG = gatekit.Waive(map[string]string{
+	"internal/modules/projects/surface.go": "projects cannot import people (ADR-0054 §3); the predicate must move tier first",
+})
+
+// slotFragment matches the flag AND-ed with an archived test, in BOTH orders.
+//
+// Both, because a census that reads one direction of a two-way comparison lets
+// the mirrored form through, and the mirrored form is a respelling somebody
+// writes without noticing they have written one. An optional alias on each half
+// independently: the sites that shipped aliased both, one and neither.
+var slotFragment = regexp.MustCompile(
+	`(\w+\.)?is_current_primary\s+AND\s+(\w+\.)?archived_at\s+IS\s+NULL` +
+		`|(\w+\.)?archived_at\s+IS\s+NULL\s+AND\s+(\w+\.)?is_current_primary`)
+
+// slotColumn is what makes a statement a candidate at all, and it is the floor
+// this census counts against: `is_current_primary` is a relationship column and
+// nothing else in this schema carries it, so no kind-scoping is needed and none
+// is done — scoping to `kind = 'employment'` would have dropped every adopted
+// site, since the kind now lives inside the helper.
+var slotColumn = regexp.MustCompile(`is_current_primary`)
+
+func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
+	// A ratification that stops matching describes a site that has moved or
+	// been fixed, and leaving it quietly re-exempts whatever takes its name.
+	defer slotBlockedByTheModuleDAG.AssertAllMatched(t)
+
+	fset := token.NewFileSet()
+	var findings []string
+	judged := 0
+	for _, path := range handWrittenGoSources(t) {
+		if filepath.ToSlash(path) == employmentCurrencyOwner {
+			continue
+		}
+		// This file plants the probes below, which are deliberate defects.
+		if filepath.Base(path) == "employmentcurrency_test.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		scope := helperScope{
+			qualifier: importAliasOf(file, "github.com/gradionhq/margince/backend/internal/modules/people"),
+			inside:    file.Name != nil && file.Name.Name == "people",
+			names:     map[string]bool{currentPrimarySlotHelper: true},
+		}
+		for _, decl := range file.Decls {
+			for _, sql := range slotStatements(decl, scope) {
+				judged++
+				if !slotFragment.MatchString(sql) {
+					continue
+				}
+				if slotBlockedByTheModuleDAG.Waived(t, filepath.ToSlash(path)) {
+					continue
+				}
+				findings = append(findings, fmt.Sprintf("%s: %s", path, firstSlotLine(sql)))
+			}
+		}
+	}
+	if judged < 5 {
+		t.Fatalf("only %d statement(s) naming is_current_primary were judged, so this census covered almost nothing", judged)
+	}
+	if len(findings) == 0 {
+		return
+	}
+	t.Errorf("these statements spell the current-primary slot predicate by hand:\n  %s\n\n"+
+		"people.%s is the one spelling, and it mirrors uq_rel_current_primary_employer's own "+
+		"predicate — including the kind, which is part of that index. Call it.",
+		strings.Join(findings, "\n  "), currentPrimarySlotHelper)
+}
+
+// slotStatements returns the SQL statements in a declaration that name the
+// slot column, flattened so a helper call contributes its NAME and a
+// concatenated fragment is judged with the statement it belongs to.
+func slotStatements(decl ast.Decl, people helperScope) []string {
+	var out []string
+	seen := map[ast.Node]bool{}
+	ast.Inspect(decl, func(n ast.Node) bool {
+		if seen[n] {
+			return false
+		}
+		text, ok := flattenSQL(n, seen, people)
+		if !ok || !slotColumn.MatchString(text) {
+			return true
+		}
+		out = append(out, text)
+		return true
+	})
+	return out
+}
+
+// firstSlotLine points the report at the offending line rather than dumping
+// the whole statement. The fragment itself may straddle a line break — that is
+// how two of the six copies were written — so the flag's own line is what is
+// reported when no single line carries the whole match.
+func firstSlotLine(sql string) string {
+	lines := strings.Split(sql, "\n")
+	for _, line := range lines {
+		if slotFragment.MatchString(line) {
+			return strings.TrimSpace(line)
+		}
+	}
+	for _, line := range lines {
+		if slotColumn.MatchString(line) {
+			return strings.TrimSpace(line)
+		}
+	}
+	return strings.TrimSpace(lines[0])
+}
+
+// headCatalog is the generated shape of a freshly migrated database — the
+// index's own text, and therefore the only statement of what the slot
+// predicate IS. Deriving the expectation from it rather than restating the
+// predicate here is what keeps this gate from becoming a second copy of its
+// own subject: a migration that narrows the index fails this test instead of
+// leaving the helper quietly wrong.
+const headCatalog = "migrations/testdata/head_catalog.txt"
+
+// slotIndex is the unique index the helper exists to satisfy.
+const slotIndex = "uq_rel_current_primary_employer"
+
+// indexPredicate lifts the WHERE clause off a catalog line.
+var indexPredicate = regexp.MustCompile(`\sWHERE\s+(.*)$`)
+
+// printedSQLNoise is what Postgres prints that a hand-written predicate does not: the
+// parentheses it re-adds around every conjunct and the cast it resolves a
+// literal to. Removing it compares the two as PREDICATES rather than as text —
+// a text comparison loses to an equivalent spelling, and this one has two.
+var printedSQLNoise = regexp.MustCompile(`::text|[()]`)
+
+func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
+	catalog, err := os.ReadFile(headCatalog)
+	if err != nil {
+		t.Fatalf("reading %s: %v", headCatalog, err)
+	}
+	var predicate string
+	for _, line := range strings.Split(string(catalog), "\n") {
+		if !strings.Contains(line, slotIndex) || !strings.Contains(line, "CREATE UNIQUE INDEX") {
+			continue
+		}
+		match := indexPredicate.FindStringSubmatch(line)
+		if match == nil {
+			t.Fatalf("%s carries no WHERE clause in %s, so it is no longer a partial index and this "+
+				"helper has nothing to mirror:\n%s", slotIndex, headCatalog, line)
+		}
+		predicate = match[1]
+	}
+	if predicate == "" {
+		t.Fatalf("%s names no %s, so either the index is gone or the catalog is not what it was: "+
+			"this helper mirrors a predicate that has to exist", headCatalog, slotIndex)
+	}
+	if want, got := normalizedPredicate(predicate), normalizedPredicate(people.CurrentPrimarySlotSQL("")); want != got {
+		t.Errorf("people.%s renders %q, but %s is %q.\n\n"+
+			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
+			"the index then refuses with a 409; a wider one skips a write the index would have accepted.",
+			currentPrimarySlotHelper, got, slotIndex, want)
+	}
+	// The aliased form is the same predicate with every column qualified, and
+	// nothing else — the shape four of the six call sites need.
+	if want, got := "b.", people.CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
+		t.Errorf("people.%s(%q) = %q, want every one of the three columns qualified", currentPrimarySlotHelper, "b", got)
+	}
+}
+
+// normalizedPredicate reduces a predicate to what it asks: no Postgres
+// re-parenthesisation, no resolved cast, one space between tokens and one case
+// for the keywords.
+func normalizedPredicate(sql string) string {
+	return strings.Join(strings.Fields(printedSQLNoise.ReplaceAllString(sql, "")), " ")
+}
+
+// slotProbe is one planted statement and the answer the detector must give
+// for it. Every case is a shape the census would read green over if the
+// detector stopped seeing it — the census itself passes identically over a
+// clean tree and over a detector that has stopped detecting.
+var slotProbes = []struct {
+	name  string
+	fires bool
+	mode  string
+	src   string
+}{
+	{"the bare form that shipped", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL`\n}"},
+	{"the aliased form", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.is_current_primary AND b.archived_at IS NULL`\n}"},
+	// The mirrored conjunction is the same predicate written the other way
+	// round, and a census that reads one direction lets it through.
+	{"the two halves in the other order", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.archived_at IS NULL AND b.is_current_primary`\n}"},
+	{"the fragment split across a concatenation", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary AND ` + `archived_at IS NULL`\n}"},
+	// A helper call claims its whole subtree, so a lookalike from another
+	// package would have hidden a hand-written fragment inside its arguments.
+	{"a lookalike helper from another package", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE ` + other.CurrentPrimarySlotSQL(\"b.is_current_primary AND b.archived_at IS NULL\")\n}"},
+	{"a bare helper name in a file that does not import people", true, "noimport", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE ` + CurrentPrimarySlotSQL(\"b.is_current_primary AND b.archived_at IS NULL\")\n}"},
+
+	{"the real helper, qualified", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.person_id = $1 AND ` + people.CurrentPrimarySlotSQL(\"b\")\n}"},
+	{"the real helper, unqualified inside people", false, "people", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE person_id = $1 AND ` + CurrentPrimarySlotSQL(\"\")\n}"},
+	// The create path's guard is deliberately WIDER than the slot: it refuses
+	// the flag when the person has any employment that is current OR flagged,
+	// which is not the index's predicate and must not be rewritten as it.
+	{"the wider create-path guard, where the flag sits inside an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL AND (` + EmploymentIsCurrentSQL(\"ended_at\") + ` OR is_current_primary)`\n}"},
+	{"the flag with no archived test beside it", false, "", "\nfunc read() string {\n\treturn `UPDATE relationship SET is_current_primary = coalesce($3, is_current_primary)`\n}"},
+}
+
+func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
+	fset := token.NewFileSet()
+	for _, tc := range slotProbes {
+		t.Run(tc.name, func(t *testing.T) {
+			head := "package probe\n"
+			names := map[string]bool{currentPrimarySlotHelper: true}
+			scope := helperScope{qualifier: "people", names: names}
+			switch tc.mode {
+			case "people":
+				head, scope = "package people\n", helperScope{inside: true, names: names}
+			case "noimport":
+				scope = helperScope{names: names}
+			default:
+				head += "import \"github.com/gradionhq/margince/backend/internal/modules/people\"\n"
+			}
+			file, err := parser.ParseFile(fset, "probe.go", head+tc.src, 0)
+			if err != nil {
+				t.Fatalf("the probe does not parse, so it proves nothing: %v", err)
+			}
+			hit := false
+			for _, decl := range file.Decls {
+				for _, sql := range slotStatements(decl, scope) {
+					if slotFragment.MatchString(sql) {
+						hit = true
+					}
+				}
+			}
+			if tc.fires && !hit {
+				t.Errorf("the detector missed a hand-spelled slot predicate — the census would read green over this:\n%s", tc.src)
+			}
+			if !tc.fires && hit {
+				t.Errorf("the detector reported a statement that calls the one spelling, or asks a different question:\n%s", tc.src)
 			}
 		})
 	}

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -121,7 +121,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 		// test that hand-writes an employment currency test is still a finding
 		// and there is no reason to stop looking at the ones that do not plant
 		// anything.
-		if filepath.Base(path) == "employmentcurrency_test.go" {
+		if filepath.ToSlash(path) == slotProbeFile {
 			continue
 		}
 		file, err := parser.ParseFile(fset, path, nil, 0)
@@ -373,15 +373,48 @@ var slotBlockedByTheModuleDAG = gatekit.Waive(map[string]string{
 	"internal/modules/projects/surface.go": "projects cannot import people (ADR-0054 §3); the predicate must move tier first",
 })
 
-// slotFragment matches the flag AND-ed with an archived test, in BOTH orders.
+// spellsSlotPredicate reports whether a statement tests the flag and an
+// archived test IN ONE CONJUNCTION — which is the slot predicate, however it is
+// spelled.
 //
-// Both, because a census that reads one direction of a two-way comparison lets
-// the mirrored form through, and the mirrored form is a respelling somebody
-// writes without noticing they have written one. An optional alias on each half
-// independently: the sites that shipped aliased both, one and neither.
-var slotFragment = regexp.MustCompile(
-	`(\w+\.)?is_current_primary\s+AND\s+(\w+\.)?archived_at\s+IS\s+NULL` +
-		`|(\w+\.)?archived_at\s+IS\s+NULL\s+AND\s+(\w+\.)?is_current_primary`)
+// It works on conjunctive CHUNKS rather than on a two-term pattern, because
+// every shape a two-term pattern misses is a respelling somebody writes without
+// noticing: the two halves in the other order, another conjunct sitting between
+// them (`b.is_current_primary AND b.id <> a.id AND b.archived_at IS NULL` — the
+// merge copy was one edit from that), `= true` or `IS TRUE` instead of the bare
+// flag, and lower-case keywords. A text comparison loses to an equivalent
+// spelling, and there are four of them here.
+//
+// Splitting on OR and on parentheses is what keeps the create path out. Its
+// guard is deliberately WIDER than the slot — `archived_at IS NULL AND (still
+// employed OR is_current_primary)` — and that is a different question, not a
+// hand-spelled copy of this one: the flag never shares a conjunction with the
+// archived test there.
+func spellsSlotPredicate(sql string) bool {
+	for _, chunk := range slotChunks.Split(strings.ToLower(sql), -1) {
+		if slotFlagTest.MatchString(chunk) && slotArchivedTest.MatchString(chunk) {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	// slotChunks ends a conjunction: a parenthesis or an OR starts a different
+	// one, and two terms on opposite sides of either are not AND-ed together.
+	slotChunks = regexp.MustCompile(`[()]|\bor\b`)
+
+	// slotFlagTest is the flag asked as a boolean, in every spelling this
+	// dialect offers.
+	slotFlagTest = regexp.MustCompile(`(\w+\.)?is_current_primary(\s*=\s*true|\s+is\s+true)?\b`)
+
+	slotArchivedTest = regexp.MustCompile(`(\w+\.)?archived_at\s+is\s+null`)
+)
+
+// slotProbeFile plants the probes below, which are deliberate defects. Named by
+// PATH and not by basename: a basename skip silently exempts any future file
+// that takes the same name anywhere in the tree.
+const slotProbeFile = "employmentcurrency_test.go"
 
 // slotColumn is what makes a statement a candidate at all, and it is the floor
 // this census counts against: `is_current_primary` is a relationship column and
@@ -403,7 +436,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 			continue
 		}
 		// This file plants the probes below, which are deliberate defects.
-		if filepath.Base(path) == "employmentcurrency_test.go" {
+		if filepath.ToSlash(path) == slotProbeFile {
 			continue
 		}
 		file, err := parser.ParseFile(fset, path, nil, 0)
@@ -418,7 +451,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 		for _, decl := range file.Decls {
 			for _, sql := range slotStatements(decl, scope) {
 				judged++
-				if !slotFragment.MatchString(sql) {
+				if !spellsSlotPredicate(sql) {
 					continue
 				}
 				if slotBlockedByTheModuleDAG.Waived(t, filepath.ToSlash(path)) {
@@ -467,11 +500,6 @@ func slotStatements(decl ast.Decl, people helperScope) []string {
 func firstSlotLine(sql string) string {
 	lines := strings.Split(sql, "\n")
 	for _, line := range lines {
-		if slotFragment.MatchString(line) {
-			return strings.TrimSpace(line)
-		}
-	}
-	for _, line := range lines {
 		if slotColumn.MatchString(line) {
 			return strings.TrimSpace(line)
 		}
@@ -507,6 +535,16 @@ var slotProbes = []struct {
 	// which is not the index's predicate and must not be rewritten as it.
 	{"the wider create-path guard, where the flag sits inside an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL AND (` + EmploymentIsCurrentSQL(\"ended_at\") + ` OR is_current_primary)`\n}"},
 	{"the flag with no archived test beside it", false, "", "\nfunc read() string {\n\treturn `UPDATE relationship SET is_current_primary = coalesce($3, is_current_primary)`\n}"},
+
+	// Four spellings a two-term pattern missed, each verified green against it
+	// before this detector was rewritten to work on conjunctive chunks.
+	{"another conjunct sitting between the two halves", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.is_current_primary AND b.id <> $1 AND b.archived_at IS NULL`\n}"},
+	{"the flag compared to true rather than asked", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary = true AND archived_at IS NULL`\n}"},
+	{"the flag asked with IS TRUE", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary IS TRUE AND archived_at IS NULL`\n}"},
+	{"lower-case keywords", true, "", "\nfunc read() string {\n\treturn `select 1 from relationship where is_current_primary and archived_at is null`\n}"},
+	// The archived test belongs to the OTHER side of an OR, so the flag is not
+	// AND-ed with it and this is not the slot predicate.
+	{"the two halves on opposite sides of an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary OR archived_at IS NULL`\n}"},
 }
 
 func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
@@ -531,7 +569,7 @@ func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
 			hit := false
 			for _, decl := range file.Decls {
 				for _, sql := range slotStatements(decl, scope) {
-					if slotFragment.MatchString(sql) {
+					if spellsSlotPredicate(sql) {
 						hit = true
 					}
 				}

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -36,13 +36,11 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
@@ -479,67 +477,6 @@ func firstSlotLine(sql string) string {
 		}
 	}
 	return strings.TrimSpace(lines[0])
-}
-
-// headCatalog is the generated shape of a freshly migrated database — the
-// index's own text, and therefore the only statement of what the slot
-// predicate IS. Deriving the expectation from it rather than restating the
-// predicate here is what keeps this gate from becoming a second copy of its
-// own subject: a migration that narrows the index fails this test instead of
-// leaving the helper quietly wrong.
-const headCatalog = "migrations/testdata/head_catalog.txt"
-
-// slotIndex is the unique index the helper exists to satisfy.
-const slotIndex = "uq_rel_current_primary_employer"
-
-// indexPredicate lifts the WHERE clause off a catalog line.
-var indexPredicate = regexp.MustCompile(`\sWHERE\s+(.*)$`)
-
-// printedSQLNoise is what Postgres prints that a hand-written predicate does not: the
-// parentheses it re-adds around every conjunct and the cast it resolves a
-// literal to. Removing it compares the two as PREDICATES rather than as text —
-// a text comparison loses to an equivalent spelling, and this one has two.
-var printedSQLNoise = regexp.MustCompile(`::text|[()]`)
-
-func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
-	catalog, err := os.ReadFile(headCatalog)
-	if err != nil {
-		t.Fatalf("reading %s: %v", headCatalog, err)
-	}
-	var predicate string
-	for _, line := range strings.Split(string(catalog), "\n") {
-		if !strings.Contains(line, slotIndex) || !strings.Contains(line, "CREATE UNIQUE INDEX") {
-			continue
-		}
-		match := indexPredicate.FindStringSubmatch(line)
-		if match == nil {
-			t.Fatalf("%s carries no WHERE clause in %s, so it is no longer a partial index and this "+
-				"helper has nothing to mirror:\n%s", slotIndex, headCatalog, line)
-		}
-		predicate = match[1]
-	}
-	if predicate == "" {
-		t.Fatalf("%s names no %s, so either the index is gone or the catalog is not what it was: "+
-			"this helper mirrors a predicate that has to exist", headCatalog, slotIndex)
-	}
-	if want, got := normalizedPredicate(predicate), normalizedPredicate(people.CurrentPrimarySlotSQL("")); want != got {
-		t.Errorf("people.%s renders %q, but %s is %q.\n\n"+
-			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
-			"the index then refuses with a 409; a wider one skips a write the index would have accepted.",
-			currentPrimarySlotHelper, got, slotIndex, want)
-	}
-	// The aliased form is the same predicate with every column qualified, and
-	// nothing else — the shape four of the six call sites need.
-	if want, got := "b.", people.CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
-		t.Errorf("people.%s(%q) = %q, want every one of the three columns qualified", currentPrimarySlotHelper, "b", got)
-	}
-}
-
-// normalizedPredicate reduces a predicate to what it asks: no Postgres
-// re-parenthesisation, no resolved cast, one space between tokens and one case
-// for the keywords.
-func normalizedPredicate(sql string) string {
-	return strings.Join(strings.Fields(printedSQLNoise.ReplaceAllString(sql, "")), " ")
 }
 
 // slotProbe is one planted statement and the answer the detector must give

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -385,14 +385,52 @@ var slotBlockedByTheModuleDAG = gatekit.Waive(map[string]string{
 // flag, and lower-case keywords. A text comparison loses to an equivalent
 // spelling, and there are four of them here.
 //
-// Splitting on OR and on parentheses is what keeps the create path out. Its
-// guard is deliberately WIDER than the slot — `archived_at IS NULL AND (still
-// employed OR is_current_primary)` — and that is a different question, not a
-// hand-spelled copy of this one: the flag never shares a conjunction with the
-// archived test there.
+// Splitting on OR first is what keeps the create path out. Its guard is
+// deliberately WIDER than the slot — `archived_at IS NULL AND (still employed
+// OR is_current_primary)` — and there the flag and the archived test are in
+// different groups, which is a different question rather than a copy of this
+// one. Brackets are TRIMMED from a term rather than treated as separators: a
+// bracket is where a conjunction nests, not where it ends, and a split on them
+// missed `is_current_primary AND (archived_at IS NULL AND person_id = $1)`.
 func spellsSlotPredicate(sql string) bool {
-	for _, chunk := range slotChunks.Split(strings.ToLower(sql), -1) {
-		if slotFlagTest.MatchString(chunk) && slotArchivedTest.MatchString(chunk) {
+	for _, group := range slotOr.Split(strings.ToLower(sql), -1) {
+		flag, archived := false, false
+		for _, term := range slotAnd.Split(group, -1) {
+			if asksTheFlag(term) {
+				flag = true
+			}
+			if slotArchivedTerm.MatchString(term) {
+				archived = true
+			}
+		}
+		if flag && archived {
+			return true
+		}
+	}
+	return false
+}
+
+// asksTheFlag reports whether a conjunct TESTS the flag, which is the only
+// mention of it that makes a statement a guard. Two other mentions exist and
+// neither is one: an INSERT's column list NAMES it, and a merge relink ASSIGNS
+// it (`SET is_current_primary = a.is_current_primary AND NOT EXISTS (…)`) —
+// there the flag is the value being carried across, and the guard is the
+// EXISTS beside it.
+//
+// A test is what a bracketed SEGMENT of the conjunct ends with — the segment
+// and not the whole conjunct, because the statement text is a fragment and a
+// predicate's last term carries whatever closes and follows it. A column list
+// puts a comma after the name or closes the list on it; an assignment puts an
+// equals sign before it.
+func asksTheFlag(term string) bool {
+	for _, segment := range slotBrackets.Split(term, -1) {
+		trimmed := strings.TrimRight(segment, " \t\n")
+		at := slotFlagTail.FindStringIndex(trimmed)
+		if at == nil || at[1] != len(trimmed) {
+			continue
+		}
+		before := strings.TrimRight(trimmed[:at[0]], " \t\n")
+		if !strings.HasSuffix(before, ",") && !strings.HasSuffix(before, "=") {
 			return true
 		}
 	}
@@ -400,15 +438,24 @@ func spellsSlotPredicate(sql string) bool {
 }
 
 var (
-	// slotChunks ends a conjunction: a parenthesis or an OR starts a different
-	// one, and two terms on opposite sides of either are not AND-ed together.
-	slotChunks = regexp.MustCompile(`[()]|\bor\b`)
+	// slotOr ends a conjunction; slotAnd separates the terms inside one. Both
+	// are bounded so `or` does not match inside `organization_id`.
+	slotOr  = regexp.MustCompile(`\bor\b`)
+	slotAnd = regexp.MustCompile(`\band\b`)
 
-	// slotFlagTest is the flag asked as a boolean, in every spelling this
-	// dialect offers.
-	slotFlagTest = regexp.MustCompile(`(\w+\.)?is_current_primary(\s*=\s*true|\s+is\s+true)?\b`)
+	// slotBrackets ends a segment inside a conjunct — see asksTheFlag.
+	slotBrackets = regexp.MustCompile(`[()]`)
 
-	slotArchivedTest = regexp.MustCompile(`(\w+\.)?archived_at\s+is\s+null`)
+	// slotFlagTail is the flag asked as a boolean, in every spelling this
+	// dialect offers, anchored to the END of a conjunct — see asksTheFlag.
+	slotFlagTail = regexp.MustCompile(`(\w+\.)?is_current_primary(\s*=\s*true|\s+is\s+true)?$`)
+
+	// slotArchivedTerm is unanchored, because the statement text a census reads
+	// is a fragment: a conjunct carries whatever surrounds it — a SELECT before
+	// it, an ON CONFLICT after. There is no column-list ambiguity to guard
+	// against here the way there is for the flag, since a column list names
+	// `archived_at` and never tests it.
+	slotArchivedTerm = regexp.MustCompile(`(\w+\.)?archived_at\s+is\s+null\b`)
 )
 
 // slotProbeFile plants the probes below, which are deliberate defects. Named by
@@ -421,7 +468,7 @@ const slotProbeFile = "employmentcurrency_test.go"
 // nothing else in this schema carries it, so no kind-scoping is needed and none
 // is done — scoping to `kind = 'employment'` would have dropped every adopted
 // site, since the kind now lives inside the helper.
-var slotColumn = regexp.MustCompile(`is_current_primary`)
+var slotColumn = regexp.MustCompile(`(?i)is_current_primary`)
 
 func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 	// A ratification that stops matching describes a site that has moved or
@@ -545,6 +592,16 @@ var slotProbes = []struct {
 	// The archived test belongs to the OTHER side of an OR, so the flag is not
 	// AND-ed with it and this is not the slot predicate.
 	{"the two halves on opposite sides of an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary OR archived_at IS NULL`\n}"},
+	// A bracket is where a conjunction NESTS, not where it ends. A detector
+	// that ended a group at every bracket read this as two groups and missed
+	// the guard sitting whole inside them.
+	{"the second half inside a bracketed conjunction", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE is_current_primary AND (archived_at IS NULL AND person_id = $1)`\n}"},
+	// The merge relinks CARRY the flag across rather than testing it; the
+	// guard beside them is the EXISTS, which calls the helper.
+	{"the flag as the value of an assignment", false, "", "\nfunc read() string {\n\treturn `UPDATE relationship a SET is_current_primary = a.is_current_primary AND NOT EXISTS (SELECT 1 FROM relationship b WHERE b.person_id = $2) WHERE a.person_id = $1 AND a.archived_at IS NULL`\n}"},
+	// A statement that merely WRITES the column names it in a list; naming is
+	// not asking.
+	{"the flag in an INSERT's column list", false, "", "\nfunc read() string {\n\treturn `INSERT INTO relationship (kind, person_id, is_current_primary, archived_at) SELECT 'employment', $1, true, NULL FROM person WHERE archived_at IS NULL`\n}"},
 }
 
 func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -359,7 +359,8 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 // the FRAGMENT — the flag AND-ed with an archived test — which is the shape
 // that hid six copies from a census that only knew whole predicates.
 
-// currentPrimarySlotHelper is the one spelling the six sites now call.
+// currentPrimarySlotHelper names the helper this census requires, so the
+// report can point at it.
 const currentPrimarySlotHelper = "CurrentPrimarySlotSQL"
 
 // slotBlockedByTheModuleDAG ratifies the statement that cannot adopt the

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -420,8 +420,16 @@ func spellsSlotPredicate(sql string) bool {
 // A test is what a bracketed SEGMENT of the conjunct ends with — the segment
 // and not the whole conjunct, because the statement text is a fragment and a
 // predicate's last term carries whatever closes and follows it. A column list
-// puts a comma after the name or closes the list on it; an assignment puts an
-// equals sign before it.
+// puts a comma after the name; an assignment puts an equals sign before it; a
+// NEGATION asks the opposite question, which is "who does NOT hold the slot".
+//
+// One shape is knowingly over-reported: an INSERT whose column list is exactly
+// `(is_current_primary)`, where the closing bracket leaves a segment that reads
+// as a bare test. Distinguishing it would mean deciding whether an opening
+// bracket follows a keyword or a name, and getting THAT wrong drops the
+// contents of `NOT EXISTS (…)` — where five of the six statements this census
+// judges live. Over-reporting is a finding somebody dismisses; under-reporting
+// is a census that reads green over the defect and says nothing.
 func asksTheFlag(term string) bool {
 	for _, segment := range slotBrackets.Split(term, -1) {
 		trimmed := strings.TrimRight(segment, " \t\n")
@@ -430,9 +438,10 @@ func asksTheFlag(term string) bool {
 			continue
 		}
 		before := strings.TrimRight(trimmed[:at[0]], " \t\n")
-		if !strings.HasSuffix(before, ",") && !strings.HasSuffix(before, "=") {
-			return true
+		if strings.HasSuffix(before, ",") || strings.HasSuffix(before, "=") || strings.HasSuffix(before, "not") {
+			continue
 		}
+		return true
 	}
 	return false
 }
@@ -602,6 +611,13 @@ var slotProbes = []struct {
 	// A statement that merely WRITES the column names it in a list; naming is
 	// not asking.
 	{"the flag in an INSERT's column list", false, "", "\nfunc read() string {\n\treturn `INSERT INTO relationship (kind, person_id, is_current_primary, archived_at) SELECT 'employment', $1, true, NULL FROM person WHERE archived_at IS NULL`\n}"},
+	// The negation asks who does NOT hold the slot, which is the opposite
+	// question and not a second spelling of this one.
+	{"the flag negated", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE NOT is_current_primary AND archived_at IS NULL`\n}"},
+	// A guard inside NOT EXISTS, where five of the six judged statements live:
+	// the flag sits behind an opening bracket, and a detector that decided
+	// brackets by what precedes them would drop it.
+	{"a guard inside a NOT EXISTS subquery", true, "", "\nfunc read() string {\n\treturn `UPDATE relationship a SET x = 1 WHERE NOT EXISTS (SELECT 1 FROM relationship b WHERE b.is_current_primary AND b.archived_at IS NULL)`\n}"},
 }
 
 func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -357,9 +357,9 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 // the FRAGMENT — the flag AND-ed with an archived test — which is the shape
 // that hid six copies from a census that only knew whole predicates.
 
-// currentPrimarySlotHelper names the helper this census requires, so the
+// currentPrimarySlotPredicate names the helper this census requires, so the
 // report can point at it.
-const currentPrimarySlotHelper = "CurrentPrimarySlotSQL"
+const currentPrimarySlotPredicate = "CurrentPrimarySlotSQL"
 
 // slotBlockedByTheModuleDAG ratifies the statement that cannot adopt the
 // helper today, for the architectural reason above and not for want of
@@ -446,7 +446,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 		scope := helperScope{
 			qualifier: importAliasOf(file, "github.com/gradionhq/margince/backend/internal/modules/people"),
 			inside:    file.Name != nil && file.Name.Name == "people",
-			names:     map[string]bool{currentPrimarySlotHelper: true},
+			names:     map[string]bool{currentPrimarySlotPredicate: true},
 		}
 		for _, decl := range file.Decls {
 			for _, sql := range slotStatements(decl, scope) {
@@ -470,7 +470,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 	t.Errorf("these statements spell the current-primary slot predicate by hand:\n  %s\n\n"+
 		"people.%s is the one spelling, and it mirrors uq_rel_current_primary_employer's own "+
 		"predicate — including the kind, which is part of that index. Call it.",
-		strings.Join(findings, "\n  "), currentPrimarySlotHelper)
+		strings.Join(findings, "\n  "), currentPrimarySlotPredicate)
 }
 
 // slotStatements returns the SQL statements in a declaration that name the
@@ -552,7 +552,7 @@ func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
 	for _, tc := range slotProbes {
 		t.Run(tc.name, func(t *testing.T) {
 			head := "package probe\n"
-			names := map[string]bool{currentPrimarySlotHelper: true}
+			names := map[string]bool{currentPrimarySlotPredicate: true}
 			scope := helperScope{qualifier: "people", names: names}
 			switch tc.mode {
 			case "people":

--- a/backend/internal/compose/sitefactmerge.go
+++ b/backend/internal/compose/sitefactmerge.go
@@ -165,7 +165,7 @@ func mergePageResults(results []pageFactsResult) pageFactsResult {
 			}
 		}
 		for _, person := range res.people {
-			key := people.NormalizePersonName(person.Name)
+			key := sitePersonIdentity(person.Name, person.PublishedEmail)
 			at, seen := personIndex[key]
 			if !seen {
 				personIndex[key] = len(out.people)

--- a/backend/internal/compose/sitefactmerge.go
+++ b/backend/internal/compose/sitefactmerge.go
@@ -165,7 +165,7 @@ func mergePageResults(results []pageFactsResult) pageFactsResult {
 			}
 		}
 		for _, person := range res.people {
-			key := normalizedPersonName(person.Name)
+			key := people.NormalizePersonName(person.Name)
 			at, seen := personIndex[key]
 			if !seen {
 				personIndex[key] = len(out.people)

--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -11,7 +11,11 @@ package compose
 // copies out of the page — checked verbatim, then checked for reaching over
 // somebody else — rather than from where the two strings happen to sit.
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+)
 
 // attributionQuote checks the model's claim that the page gives THIS person
 // THIS role, and returns the page's own words that say so.
@@ -240,7 +244,7 @@ func gatePagePeople(parsed pageFactsReply, page crawlPage, idx snippetIndex, dro
 			SourceURL:       page.URL,
 			Confidence:      gatedConfidence,
 		}
-		key := normalizedPersonName(name)
+		key := people.NormalizePersonName(name)
 		if prior, dup := personIndex[key]; dup {
 			// Two claims for one person, and the reply's ORDER must not decide
 			// which survives. The tighter evidence wins: a role stated right

--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -11,11 +11,7 @@ package compose
 // copies out of the page — checked verbatim, then checked for reaching over
 // somebody else — rather than from where the two strings happen to sit.
 
-import (
-	"strings"
-
-	"github.com/gradionhq/margince/backend/internal/modules/people"
-)
+import "strings"
 
 // attributionQuote checks the model's claim that the page gives THIS person
 // THIS role, and returns the page's own words that say so.
@@ -244,7 +240,7 @@ func gatePagePeople(parsed pageFactsReply, page crawlPage, idx snippetIndex, dro
 			SourceURL:       page.URL,
 			Confidence:      gatedConfidence,
 		}
-		key := people.NormalizePersonName(name)
+		key := sitePersonIdentity(name, publishedEmail)
 		if prior, dup := personIndex[key]; dup {
 			// Two claims for one person, and the reply's ORDER must not decide
 			// which survives. The tighter evidence wins: a role stated right

--- a/backend/internal/compose/sitepeople.go
+++ b/backend/internal/compose/sitepeople.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -73,22 +74,19 @@ func verbatimOrEmpty(claimed, pageText string) string {
 	return claimed
 }
 
-// normalizedPersonName is a person's dedupe identity within one read AND
-// the stable half of the cross-read lead natural key: casefolded,
-// whitespace collapsed, so a re-read that reflows the page cannot mint a
-// second lead for the same printed name.
-func normalizedPersonName(name string) string {
-	return strings.ToLower(strings.Join(strings.Fields(name), " "))
-}
-
 // siteLeadSourceID is the lead's idempotency key under source_system
-// "siteread": the ORGANIZATION plus the normalized name (plus a published
-// email when the site prints one, so two distinct people who share a name
-// stay distinct). Keyed on the org, not the page URL, so the same person is
-// the same lead whether they were found on /team or /about, and whether a
-// later crawl's page layout moved — a page-URL key would duplicate them.
+// "siteread": the ORGANIZATION plus people.NormalizePersonName of the name
+// (plus a published email when the site prints one, so two distinct people
+// who share a name stay distinct). Keyed on the org, not the page URL, so the
+// same person is the same lead whether they were found on /team or /about,
+// and whether a later crawl's page layout moved — a page-URL key would
+// duplicate them.
+//
+// The name goes through the module's key and not a local casefold: this is a
+// person's identity across reads, so it is the same question people asks when
+// it decides whether a captured contact is somebody already stored.
 func siteLeadSourceID(orgID ids.UUID, name, publishedEmail string) string {
-	key := orgID.String() + "|" + normalizedPersonName(name)
+	key := orgID.String() + "|" + people.NormalizePersonName(name)
 	if e := strings.ToLower(strings.TrimSpace(publishedEmail)); e != "" {
 		key += "|" + e
 	}

--- a/backend/internal/compose/sitepeople.go
+++ b/backend/internal/compose/sitepeople.go
@@ -74,22 +74,32 @@ func verbatimOrEmpty(claimed, pageText string) string {
 	return claimed
 }
 
-// siteLeadSourceID is the lead's idempotency key under source_system
-// "siteread": the ORGANIZATION plus people.NormalizePersonName of the name
-// (plus a published email when the site prints one, so two distinct people
-// who share a name stay distinct). Keyed on the org, not the page URL, so the
-// same person is the same lead whether they were found on /team or /about,
-// and whether a later crawl's page layout moved — a page-URL key would
-// duplicate them.
+// sitePersonIdentity is WHO a published person is, for every step of a site
+// read that has to decide whether two claims are one person: the page lane's
+// per-page fold, the cross-page merge, and the cross-read lead key below.
 //
 // The name goes through the module's key and not a local casefold: this is a
-// person's identity across reads, so it is the same question people asks when
-// it decides whether a captured contact is somebody already stored.
-func siteLeadSourceID(orgID ids.UUID, name, publishedEmail string) string {
-	key := orgID.String() + "|" + people.NormalizePersonName(name)
+// person's identity, so it is the same question people asks when it decides
+// whether a captured contact is somebody already stored. That key UNACCENTS,
+// which is what makes "José Silva" and "Jose Silva" one person — and is also
+// why the printed address is part of the identity rather than a late
+// tie-break. Two real colleagues whose names differ only by an accent print
+// two addresses, and a fold that stopped at the name would keep one of them
+// and drop the other before the address was ever consulted.
+func sitePersonIdentity(name, publishedEmail string) string {
+	key := people.NormalizePersonName(name)
 	if e := strings.ToLower(strings.TrimSpace(publishedEmail)); e != "" {
 		key += "|" + e
 	}
-	digest := sha256.Sum256([]byte(key))
+	return key
+}
+
+// siteLeadSourceID is the lead's idempotency key under source_system
+// "siteread": the ORGANIZATION plus sitePersonIdentity. Keyed on the org, not
+// the page URL, so the same person is the same lead whether they were found on
+// /team or /about, and whether a later crawl's page layout moved — a page-URL
+// key would duplicate them.
+func siteLeadSourceID(orgID ids.UUID, name, publishedEmail string) string {
+	digest := sha256.Sum256([]byte(orgID.String() + "|" + sitePersonIdentity(name, publishedEmail)))
 	return hex.EncodeToString(digest[:])
 }

--- a/backend/internal/compose/sitepeople_test.go
+++ b/backend/internal/compose/sitepeople_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -61,5 +62,41 @@ func TestSiteLeadSourceIDFoldsTheDACHPairAndReflowedWhitespace(t *testing.T) {
 		if siteLeadSourceID(org, c.left, "") != siteLeadSourceID(org, c.right, "") {
 			t.Errorf("%q and %q took two lead keys — the key lost %s", c.left, c.right, c.what)
 		}
+	}
+}
+
+// The identity every step of a site read folds on, and the pair that made it
+// have to be more than a name.
+//
+// The page lane and the cross-page merge used to fold on the NAME alone while
+// the lead key folded on name plus the printed address. Two keys, and the
+// looser one ran first: two colleagues whose names differ only by an accent
+// were folded into one before the address that tells them apart was ever
+// consulted, and one of the two published people was dropped. The lead key
+// could not put back a person the merge had already discarded.
+func TestSitePersonIdentityKeepsTwoPeopleTheAddressesTellApart(t *testing.T) {
+	// The person key unaccents, which is what makes one person spelled two
+	// ways one person — and exactly why the address has to be part of this.
+	if people.NormalizePersonName("José Silva") != people.NormalizePersonName("Jose Silva") {
+		t.Fatal("the person key stopped unaccenting, so this test no longer plants the case it was written for")
+	}
+	if sitePersonIdentity("José Silva", "jose@acme.example") ==
+		sitePersonIdentity("Jose Silva", "silva@acme.example") {
+		t.Error("two published people with different printed addresses folded into one — the page lane " +
+			"discards one of them before the lead key can tell them apart")
+	}
+	// One person, two spellings of their name, one address: still one person.
+	if sitePersonIdentity("José Silva", "jose@acme.example") !=
+		sitePersonIdentity("Jose Silva", "  JOSE@acme.example ") {
+		t.Error("one person listed twice under two spellings took two identities")
+	}
+	// And it is the SAME identity the cross-read lead key is built on, so the
+	// two cannot decide differently about one pair.
+	org := ids.NewV7()
+	if (siteLeadSourceID(org, "José Silva", "jose@acme.example") ==
+		siteLeadSourceID(org, "Jose Silva", "silva@acme.example")) !=
+		(sitePersonIdentity("José Silva", "jose@acme.example") ==
+			sitePersonIdentity("Jose Silva", "silva@acme.example")) {
+		t.Error("the lead key and the read's own fold disagree about one pair")
 	}
 }

--- a/backend/internal/compose/sitepeople_test.go
+++ b/backend/internal/compose/sitepeople_test.go
@@ -40,3 +40,26 @@ func TestSiteLeadSourceIDIsOrgStableAcrossPagesAndNameReflow(t *testing.T) {
 		t.Fatalf("source id = %q, want a bare sha256 hex digest (no PII in the key)", teamPage)
 	}
 }
+
+// The two dimensions a person key has to fold, kept together because a key
+// that has one and not the other still mints a duplicate lead — and each was
+// held by only one of the two normalizers this key used to be spelled with.
+func TestSiteLeadSourceIDFoldsTheDACHPairAndReflowedWhitespace(t *testing.T) {
+	org := ids.NewV7()
+	for _, c := range []struct {
+		what  string
+		left  string
+		right string
+	}{
+		// strings.ToLower leaves ß alone, so a casefold-only key mints a
+		// second lead for the pair the DACH market prints daily.
+		{"a full Unicode fold", "Straße Müller", "STRASSE MULLER"},
+		// A page that reflows a name across a line break prints the same
+		// person; a key that keeps the second space mints them again.
+		{"an internal-whitespace collapse", "Anna Muster", "Anna  Muster"},
+	} {
+		if siteLeadSourceID(org, c.left, "") != siteLeadSourceID(org, c.right, "") {
+			t.Errorf("%q and %q took two lead keys — the key lost %s", c.left, c.right, c.what)
+		}
+	}
+}

--- a/backend/internal/modules/people/creatededupe.go
+++ b/backend/internal/modules/people/creatededupe.go
@@ -88,16 +88,18 @@ func manualDedupePerson(ctx context.Context, tx pgx.Tx, in CreatePersonInput) (P
 // the collision. The lane exists to stop a silent duplicate, so a duplicate it
 // silently misses under contention is the lane not working.
 //
-// The key is the NORMALIZED name, which is what the lane compares. Locking the
-// raw string would let "Lucy Vo" and "LUCY VO" take different locks and race
-// each other, which is the pair most likely to be typed twice.
+// The key is NormalizePersonName, which is what the lane compares — the same
+// call fuzzyPerson makes, because a lock keyed differently from the comparison
+// it guards is decorative. Locking the raw string would let "Lucy Vo" and
+// "LUCY VO" take different locks and race each other, which is the pair most
+// likely to be typed twice.
 //
 // Taken AFTER the phone lane and never interleaved with it: two lanes locked in
 // one fixed global order cannot deadlock, and phone-then-name is that order.
 // An empty name takes no lock — it can match nobody, since fuzzyPerson refuses a
 // nameless candidate before it scores.
 func lockNameLane(ctx context.Context, tx pgx.Tx, fullName string) error {
-	key := normalizeName(fullName)
+	key := NormalizePersonName(fullName)
 	if key == "" {
 		return nil
 	}

--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -444,14 +444,22 @@ func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
 		{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
 		{"accents", "Renée Bär", "Renee Bar"},
 		{"sharp s", "Anna Straße", "Anna Strasse"},
+		{"apostrophe", "Sean O'Brien", "Sean OBrien"},
+		// Reflowed internal whitespace, which is how a name copied off a
+		// crawled page arrives. The key collapses it, so the lane owes the
+		// pair — and the trigram arm cannot be relied on to rescue a short
+		// name whose two spellings also differ by an accent.
+		{"internal whitespace", "Ada Lindqvist", "Ada  Lindqvist"},
+		{"internal whitespace and accents", "Éva Ő", "Eva  O"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// The table IS the claim that Go calls these equal, so a pair that
-			// stops being equal is the finding — not a row that quietly excuses
-			// itself and leaves the lane untested in the direction that matters.
-			if normalizeName(tc.incumbent) != normalizeName(tc.second) {
-				t.Fatalf("normalizeName no longer calls %q and %q equal, so this row "+
-					"tests nothing: either the fold changed or the pair never belonged here",
+			// The skip-guard asks the key the lane actually decides on. It
+			// used to ask normalizeName, which is the METRIC's input: a pair
+			// the key calls equal and the metric does not was skipped rather
+			// than enforced, and the case this lane most needs — reflowed
+			// whitespace — is exactly that pair.
+			if NormalizePersonName(tc.incumbent) != NormalizePersonName(tc.second) {
+				t.Skipf("NormalizePersonName does not call these equal, so the lane owes nothing: %q vs %q",
 					tc.incumbent, tc.second)
 			}
 			e := setupDedupe(t)
@@ -472,7 +480,7 @@ func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
 			}
 			pairs := openCandidatePairs(ctx, t, e, "person", ids.UUID(second.Id))
 			if len(pairs) != 1 {
-				t.Fatalf("%q against %q left %d candidates, want 1 — normalizeName calls these the same name, "+
+				t.Fatalf("%q against %q left %d candidates, want 1 — NormalizePersonName calls these the same name, "+
 					"so the candidate query has to admit the row", tc.second, tc.incumbent, len(pairs))
 			}
 			if pairs[0].OtherID != ids.UUID(first.Id).String() {

--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -433,24 +433,64 @@ func TestANameNobodySharesLeavesTheQueueEmpty(t *testing.T) {
 // calls "  Ada Lindqvist  " and "Ada Lindqvist" equal, and a bare SQL comparison
 // does not. The trigram arm happens to rescue it, which is exactly why this test
 // exists — the lane must not depend on one approximate arm covering for another.
+// goEqualNamePair is one pair the person key calls equal, and the two tests
+// below both read this list: one asks whether the lane SEES the pair, the other
+// asks whether the arm that guarantees it does. Two lists would let the arm's
+// guarantee be asserted over a smaller set than the lane's.
+type goEqualNamePair struct {
+	name      string
+	incumbent string
+	second    string
+}
+
+var goEqualNamePairs = []goEqualNamePair{
+	{"identical", "Ada Lindqvist", "Ada Lindqvist"},
+	{"case differs", "Ada Lindqvist", "ADA LINDQVIST"},
+	{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
+	{"accents", "Renée Bär", "Renee Bar"},
+	{"sharp s", "Anna Straße", "Anna Strasse"},
+	// Reflowed internal whitespace, which is how a name copied off a crawled
+	// page arrives.
+	{"internal whitespace", "Ada Lindqvist", "Ada  Lindqvist"},
+	{"internal whitespace and accents", "Éva Ő", "Eva  O"},
+	// Greek final sigma: full folding maps ς onto σ, lower() does not, so this
+	// pair is one person in Go and — until the arm folded it too — two in SQL.
+	{"greek final sigma", "Οδυσσεύς Παππάς", "ΟΔΥΣΣΕΥΣ ΠΑΠΠΑΣ"},
+}
+
+// The arm's own claim, asked of the arm. The reachability test below cannot ask
+// it: the candidate query ORs three arms and the trigram one answers first, so a
+// pair reaches the lane whether or not this arm admits it — every pair here does
+// reach it with the arm reverted. What the arm exists for is that the lane not
+// DEPEND on a similarity threshold, and only a direct question holds that.
+func TestTheNameKeyArmAdmitsEveryGoEqualPair(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	for _, tc := range goEqualNamePairs {
+		t.Run(tc.name, func(t *testing.T) {
+			if NormalizePersonName(tc.incumbent) != NormalizePersonName(tc.second) {
+				t.Fatalf("NormalizePersonName does not call %q and %q equal, so this row asserts nothing "+
+					"about the arm — fix the key or drop the row", tc.incumbent, tc.second)
+			}
+			var admitted bool
+			if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+				return tx.QueryRow(ctx,
+					`SELECT `+personNameKeySQL("$1")+` = `+personNameKeySQL("$2"),
+					tc.incumbent, tc.second).Scan(&admitted)
+			}); err != nil {
+				t.Fatalf("ask the arm about %q and %q: %v", tc.incumbent, tc.second, err)
+			}
+			if !admitted {
+				t.Errorf("the name-key arm does not admit %q against %q, which the person key calls "+
+					"one name — the lane is left depending on the trigram arm's threshold for this pair",
+					tc.second, tc.incumbent)
+			}
+		})
+	}
+}
+
 func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		incumbent string
-		second    string
-	}{
-		{"identical", "Ada Lindqvist", "Ada Lindqvist"},
-		{"case differs", "Ada Lindqvist", "ADA LINDQVIST"},
-		{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
-		{"accents", "Renée Bär", "Renee Bar"},
-		{"sharp s", "Anna Straße", "Anna Strasse"},
-		// Reflowed internal whitespace, which is how a name copied off a
-		// crawled page arrives. The key collapses it, so the lane owes the
-		// pair — and the trigram arm cannot be relied on to rescue a short
-		// name whose two spellings also differ by an accent.
-		{"internal whitespace", "Ada Lindqvist", "Ada  Lindqvist"},
-		{"internal whitespace and accents", "Éva Ő", "Eva  O"},
-	} {
+	for _, tc := range goEqualNamePairs {
 		t.Run(tc.name, func(t *testing.T) {
 			// A FATAL guard, not a skip. The guard asks the key the lane
 			// decides on, and a row the key does not call equal is a row this

--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -444,7 +444,6 @@ func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
 		{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
 		{"accents", "Renée Bär", "Renee Bar"},
 		{"sharp s", "Anna Straße", "Anna Strasse"},
-		{"apostrophe", "Sean O'Brien", "Sean OBrien"},
 		// Reflowed internal whitespace, which is how a name copied off a
 		// crawled page arrives. The key collapses it, so the lane owes the
 		// pair — and the trigram arm cannot be relied on to rescue a short
@@ -453,14 +452,17 @@ func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
 		{"internal whitespace and accents", "Éva Ő", "Eva  O"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// The skip-guard asks the key the lane actually decides on. It
-			// used to ask normalizeName, which is the METRIC's input: a pair
-			// the key calls equal and the metric does not was skipped rather
-			// than enforced, and the case this lane most needs — reflowed
-			// whitespace — is exactly that pair.
+			// A FATAL guard, not a skip. The guard asks the key the lane
+			// decides on, and a row the key does not call equal is a row this
+			// table has no business carrying: it asserts nothing and says so
+			// to nobody. One row sat here in exactly that state — an
+			// apostrophe pair the fold never touched — and a skip is also how
+			// the five real rows would go quiet if the key ever stopped
+			// folding case or accents, which is the failure this file's own
+			// comment warns about, aimed at the test instead of the lane.
 			if NormalizePersonName(tc.incumbent) != NormalizePersonName(tc.second) {
-				t.Skipf("NormalizePersonName does not call these equal, so the lane owes nothing: %q vs %q",
-					tc.incumbent, tc.second)
+				t.Fatalf("NormalizePersonName does not call %q and %q equal, so this row asserts nothing "+
+					"about the lane — fix the key or drop the row", tc.incumbent, tc.second)
 			}
 			e := setupDedupe(t)
 			ctx := e.as()

--- a/backend/internal/modules/people/currentprimaryslot_test.go
+++ b/backend/internal/modules/people/currentprimaryslot_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 )
 
-// slotHelperName is what the failure report calls the function it is about.
-const slotHelperName = "CurrentPrimarySlotSQL"
+// slotPredicateName is what the failure report calls the function it is about.
+const slotPredicateName = "CurrentPrimarySlotSQL"
 
 // headCatalog is the generated shape of a freshly migrated database — the
 // index's own text, and therefore the only statement of what the slot
@@ -50,7 +50,7 @@ var printedSQLNoise = regexp.MustCompile(`::text|[()]`)
 // disjunction is the shape this comparison cannot judge.
 var disjunction = regexp.MustCompile(`(?i)\bOR\b`)
 
-func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
+func TestTheCurrentPrimarySlotPredicateMirrorsItsIndex(t *testing.T) {
 	catalog, err := os.ReadFile(headCatalog)
 	if err != nil {
 		t.Fatalf("reading %s: %v", headCatalog, err)
@@ -80,12 +80,12 @@ func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
 		t.Errorf("%s renders %q, but %s is %q.\n\n"+
 			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
 			"the index then refuses with a 409; a wider one skips a write the index would have accepted.",
-			slotHelperName, got, slotIndex, want)
+			slotPredicateName, got, slotIndex, want)
 	}
 	// The aliased form is the same predicate with every column qualified, and
 	// nothing else — the shape four of the six call sites need.
 	if want, got := "b.", CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
-		t.Errorf("%s(%q) = %q, want every one of the three columns qualified", slotHelperName, "b", got)
+		t.Errorf("%s(%q) = %q, want every one of the three columns qualified", slotPredicateName, "b", got)
 	}
 }
 

--- a/backend/internal/modules/people/currentprimaryslot_test.go
+++ b/backend/internal/modules/people/currentprimaryslot_test.go
@@ -34,11 +34,21 @@ const slotIndex = "uq_rel_current_primary_employer"
 // indexPredicate lifts the WHERE clause off a catalog line.
 var indexPredicate = regexp.MustCompile(`\sWHERE\s+(.*)$`)
 
-// printedSQLNoise is what Postgres prints that a hand-written predicate does not: the
-// parentheses it re-adds around every conjunct and the cast it resolves a
-// literal to. Removing it compares the two as PREDICATES rather than as text —
-// a text comparison loses to an equivalent spelling, and this one has two.
+// printedSQLNoise is what Postgres prints that a hand-written predicate does
+// not: the parentheses it re-adds around every conjunct and the cast it
+// resolves a literal to. Removing it compares the two as PREDICATES rather than
+// as text — a text comparison loses to an equivalent spelling, and this one has
+// two.
+//
+// Dropping parentheses is only sound while the predicate is a flat conjunction,
+// which is why the comparison below refuses to run over an OR rather than
+// quietly answering: `A AND (B OR C)` and `(A AND B) OR C` reduce to the same
+// text once the brackets are gone, so a mirror that kept going could pass a
+// helper that asks a different question.
 var printedSQLNoise = regexp.MustCompile(`::text|[()]`)
+
+// disjunction is the shape this comparison cannot judge.
+var disjunction = regexp.MustCompile(`(?i)\bOR\b`)
 
 func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
 	catalog, err := os.ReadFile(headCatalog)
@@ -61,6 +71,11 @@ func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
 		t.Fatalf("%s names no %s, so either the index is gone or the catalog is not what it was: "+
 			"this helper mirrors a predicate that has to exist", headCatalog, slotIndex)
 	}
+	if disjunction.MatchString(predicate) {
+		t.Fatalf("%s now carries an OR (%s), and this comparison strips parentheses — it cannot tell "+
+			"`A AND (B OR C)` from `(A AND B) OR C`. Compare the predicates structurally before trusting it again",
+			slotIndex, predicate)
+	}
 	if want, got := normalizedPredicate(predicate), normalizedPredicate(CurrentPrimarySlotSQL("")); want != got {
 		t.Errorf("%s renders %q, but %s is %q.\n\n"+
 			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
@@ -75,8 +90,11 @@ func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
 }
 
 // normalizedPredicate reduces a predicate to what it asks: no Postgres
-// re-parenthesisation, no resolved cast, one space between tokens and one case
-// for the keywords.
+// re-parenthesisation, no resolved cast, and one space between tokens.
+//
+// Case is NOT folded, deliberately. The catalog and the helper both spell SQL
+// keywords upper-case, and folding here would hide a helper that stopped doing
+// so — the mirror is also what a reader greps for when they want the predicate.
 func normalizedPredicate(sql string) string {
 	return strings.Join(strings.Fields(printedSQLNoise.ReplaceAllString(sql, "")), " ")
 }

--- a/backend/internal/modules/people/currentprimaryslot_test.go
+++ b/backend/internal/modules/people/currentprimaryslot_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// CurrentPrimarySlotSQL mirrors uq_rel_current_primary_employer, and this is
+// what holds it to the index rather than to somebody's memory of the index.
+//
+// It lives beside the helper and not with the census in backendarch because
+// the root package may not import a module (ADR-0054): the census reads the
+// tree as text and needs no import, while a mirror has to CALL the function.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// slotHelperName is what the failure report calls the function it is about.
+const slotHelperName = "CurrentPrimarySlotSQL"
+
+// headCatalog is the generated shape of a freshly migrated database — the
+// index's own text, and therefore the only statement of what the slot
+// predicate IS. Deriving the expectation from it rather than restating the
+// predicate here is what keeps this gate from becoming a second copy of its
+// own subject: a migration that narrows the index fails this test instead of
+// leaving the helper quietly wrong.
+const headCatalog = "../../../migrations/testdata/head_catalog.txt"
+
+// slotIndex is the unique index the helper exists to satisfy.
+const slotIndex = "uq_rel_current_primary_employer"
+
+// indexPredicate lifts the WHERE clause off a catalog line.
+var indexPredicate = regexp.MustCompile(`\sWHERE\s+(.*)$`)
+
+// printedSQLNoise is what Postgres prints that a hand-written predicate does not: the
+// parentheses it re-adds around every conjunct and the cast it resolves a
+// literal to. Removing it compares the two as PREDICATES rather than as text —
+// a text comparison loses to an equivalent spelling, and this one has two.
+var printedSQLNoise = regexp.MustCompile(`::text|[()]`)
+
+func TestTheCurrentPrimarySlotHelperMirrorsItsIndex(t *testing.T) {
+	catalog, err := os.ReadFile(headCatalog)
+	if err != nil {
+		t.Fatalf("reading %s: %v", headCatalog, err)
+	}
+	var predicate string
+	for _, line := range strings.Split(string(catalog), "\n") {
+		if !strings.Contains(line, slotIndex) || !strings.Contains(line, "CREATE UNIQUE INDEX") {
+			continue
+		}
+		match := indexPredicate.FindStringSubmatch(line)
+		if match == nil {
+			t.Fatalf("%s carries no WHERE clause in %s, so it is no longer a partial index and this "+
+				"helper has nothing to mirror:\n%s", slotIndex, headCatalog, line)
+		}
+		predicate = match[1]
+	}
+	if predicate == "" {
+		t.Fatalf("%s names no %s, so either the index is gone or the catalog is not what it was: "+
+			"this helper mirrors a predicate that has to exist", headCatalog, slotIndex)
+	}
+	if want, got := normalizedPredicate(predicate), normalizedPredicate(CurrentPrimarySlotSQL("")); want != got {
+		t.Errorf("%s renders %q, but %s is %q.\n\n"+
+			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
+			"the index then refuses with a 409; a wider one skips a write the index would have accepted.",
+			slotHelperName, got, slotIndex, want)
+	}
+	// The aliased form is the same predicate with every column qualified, and
+	// nothing else — the shape four of the six call sites need.
+	if want, got := "b.", CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
+		t.Errorf("%s(%q) = %q, want every one of the three columns qualified", slotHelperName, "b", got)
+	}
+}
+
+// normalizedPredicate reduces a predicate to what it asks: no Postgres
+// re-parenthesisation, no resolved cast, one space between tokens and one case
+// for the keywords.
+func normalizedPredicate(sql string) string {
+	return strings.Join(strings.Fields(printedSQLNoise.ReplaceAllString(sql, "")), " ")
+}

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -170,7 +170,7 @@ func DedupePerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonReso
 	// A nameless captured contact never fuzzy-matches: with no name there
 	// is nothing to score, and org_match alone would collide every
 	// colleague onto one record.
-	if normalizeName(c.FullName) == "" {
+	if NormalizePersonName(c.FullName) == "" {
 		return PersonResolution{Decision: DecisionNoMatch}, nil
 	}
 	return fuzzyPerson(ctx, tx, c)
@@ -324,7 +324,7 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 	// exact name with no employer known, so reading the name lane off `best`
 	// would lose exactly the pair it exists to catch.
 	sameName := PersonResolution{Decision: DecisionNoMatch}
-	candidateKey := normalizeName(c.FullName)
+	candidateKey := NormalizePersonName(c.FullName)
 	for rows.Next() {
 		var row personCandidateRow
 		if err := rows.Scan(&row.id, &row.fullName, &row.orgID, &row.orgDomain, &row.mailDomains); err != nil {
@@ -337,7 +337,7 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 			(confidence == best.Confidence && best.PersonID != (ids.PersonID{}) && row.id.String() < best.PersonID.String()) {
 			best.Confidence, best.PersonID = confidence, row.id
 		}
-		if normalizeName(row.fullName) == candidateKey {
+		if NormalizePersonName(row.fullName) == candidateKey {
 			// Same tie-break as above, and for the same reason: two incumbents
 			// spelled identically must not shuffle the queue between runs.
 			if confidence > sameName.Confidence ||

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -271,17 +271,20 @@ type personCandidateRow struct {
 // WHY THE CANDIDATE QUERY HAS THREE ARMS. The trigram arm and the employer arm
 // both narrow a set for a SCORE, and being approximate is fine there: a row they
 // miss was never going to win. The name-collision lane is not a score — it
-// decides on normalizeName equality — so a prefilter that is merely approximate
-// could hide a row that would have been exactly equal, and the employer arm
-// cannot rescue it because a manual create carries no employer at all.
+// decides on NormalizePersonName equality — so a prefilter that is merely
+// approximate could hide a row that would have been exactly equal, and the
+// employer arm cannot rescue it because a manual create carries no employer at
+// all.
 //
 // The third arm folds BOTH sides with SQL's own functions, exactly as the
 // trigram arm does. Computing one side in Go would move the divergence rather
 // than close it: SQL's lower+unaccent and Go's Unicode full folding are two
 // different normalizations, and the point is to stop relying on either being a
-// superset of the other. btrim because normalizeName trims and SQL does not —
-// "  Lucy Vo  " and "Lucy Vo" are equal in Go and unequal to a bare SQL
-// comparison, which is a real divergence today.
+// superset of the other. It is personNameKeySQL, which spells the two
+// properties NormalizePersonName has and a bare SQL comparison does not: the
+// trim, and the internal-whitespace collapse. Both are real divergences —
+// "  Lucy Vo  " and "Lucy Vo" are Go-equal, and so are "Éva  Ő" and "Éva Ő",
+// and a name reflowed across a line break is how the second one arrives.
 //
 // NO KNOWN PAIR NEEDS THAT ARM. Every case that could be constructed — case,
 // accents, ß, a trailing space — is already admitted by the trigram arm, and
@@ -310,7 +313,7 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 		 WHERE p.archived_at IS NULL
 		   AND (f_fold_apostrophes(lower(p.full_name)) % f_fold_apostrophes(lower($1))
 		        OR ($2::uuid IS NOT NULL AND r.organization_id = $2)
-		        OR btrim(f_fold_apostrophes(lower(p.full_name))) = btrim(f_fold_apostrophes(lower($1))))`,
+		        OR `+personNameKeySQL("p.full_name")+` = `+personNameKeySQL("$1")+`)`,
 		c.FullName, c.CurrentPrimaryOrgID)
 	if err != nil {
 		return PersonResolution{}, fmt.Errorf("dedupe person candidate set: %w", err)

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -294,8 +294,7 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 			       OR right(split_part(pe.email, '@', 2), length($4) + 1) = '.' || $4))
 		  AND NOT EXISTS (
 			SELECT 1 FROM relationship r
-			WHERE r.kind = 'employment' AND r.person_id = p.id
-			  AND r.is_current_primary AND r.archived_at IS NULL)
+			WHERE r.person_id = p.id AND `+CurrentPrimarySlotSQL("r")+`)
 		ON CONFLICT DO NOTHING`,
 		orgID, domainTriageSource(domain), by, domain)
 	if err != nil {

--- a/backend/internal/modules/people/employmentcurrency.go
+++ b/backend/internal/modules/people/employmentcurrency.go
@@ -102,13 +102,14 @@ func CurrentPrimaryEmploymentSQL(alias string) string {
 // relationship.go that empty the slot before a new row takes it. Every one of
 // them had spelled it by hand.
 //
-// Held by: TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/employmentcurrency_test.go)
+// Held by: TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/internal/modules/people/currentprimaryslot_test.go)
 // — it derives the expected predicate from uq_rel_current_primary_employer in
 // the migration head catalog, so the helper cannot drift from the index it
 // exists to satisfy.
 //
 // Two gates and not one, because either alone reads green over the defect that
-// shipped: TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in the same file
+// shipped: TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in
+// backend/employmentcurrency_test.go
 // reads every hand-written Go source for the FRAGMENT — the flag AND-ed with an
 // archived test, in either order — which is the shape that let six copies
 // through a census that only knew the whole predicate.

--- a/backend/internal/modules/people/employmentcurrency.go
+++ b/backend/internal/modules/people/employmentcurrency.go
@@ -72,16 +72,48 @@ func EmploymentIsCurrentSQL(date string) string {
 // second definition and fails there.
 //
 // READERS, not every mention of the column. The uniqueness guards must stay
-// date-BLIND and deliberately do — `employmentedge.go`, `domaintriageresolve.go`
-// and both merge relink paths ask "is the flag already taken" to keep
-// uq_rel_current_primary_employer satisfied, and that index's own predicate
-// knows nothing about dates. A guard that used this helper would think the slot
-// was free while the index still held it, and answer 409 instead of skipping.
-// Two different questions about one column; this one is "who works there now".
+// date-BLIND and deliberately do — that is the OTHER question about this
+// column, and CurrentPrimarySlotSQL below is its one spelling. A guard that
+// used this helper would think the slot was free while the index still held
+// it, and answer 409 instead of skipping. Two different questions about one
+// column; this one is "who works there now".
 func CurrentPrimaryEmploymentSQL(alias string) string {
 	prefix := ""
 	if alias != "" {
 		prefix = alias + "."
 	}
 	return storekit.SQLf("%sis_current_primary AND %s", prefix, EmploymentIsCurrentSQL(prefix+"ended_at"))
+}
+
+// CurrentPrimarySlotSQL is the other question about `is_current_primary`:
+// WHICH ROW HOLDS THE SLOT that uq_rel_current_primary_employer keeps unique
+// per person. It is the index's own predicate, and so it is date-BLIND —
+// asking it with EmploymentIsCurrentSQL would read a person serving notice as
+// having freed the slot while the index still held it, and the write that
+// followed would 409 instead of skipping.
+//
+// `alias` is the relationship table's alias at the call site, or "" when the
+// statement does not alias it.
+//
+// Six statements ask this: the two capture planters that must never reassign
+// an employer somebody already has (employmentedge.go, domaintriageresolve.go),
+// the two merge relinks that keep ≤1 slot-holder per person after re-homing
+// rows (merge.go, merge_organization.go), and the two demotions in
+// relationship.go that empty the slot before a new row takes it. Every one of
+// them had spelled it by hand.
+//
+// Held two ways, because either alone reads green over the defect that shipped:
+// TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/employmentcurrency_test.go)
+// derives the expected predicate from uq_rel_current_primary_employer in the
+// migration head catalog, so the helper cannot drift from the index it exists
+// to satisfy; TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in the same
+// file reads every hand-written Go source for the FRAGMENT — the flag AND-ed
+// with an archived test — which is the shape that let six copies through a
+// census that only knew the whole predicate.
+func CurrentPrimarySlotSQL(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	return storekit.SQLf("%skind = 'employment' AND %sis_current_primary AND %sarchived_at IS NULL", prefix, prefix, prefix)
 }

--- a/backend/internal/modules/people/employmentcurrency.go
+++ b/backend/internal/modules/people/employmentcurrency.go
@@ -102,14 +102,16 @@ func CurrentPrimaryEmploymentSQL(alias string) string {
 // relationship.go that empty the slot before a new row takes it. Every one of
 // them had spelled it by hand.
 //
-// Held two ways, because either alone reads green over the defect that shipped:
-// TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/employmentcurrency_test.go)
-// derives the expected predicate from uq_rel_current_primary_employer in the
-// migration head catalog, so the helper cannot drift from the index it exists
-// to satisfy; TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in the same
-// file reads every hand-written Go source for the FRAGMENT — the flag AND-ed
-// with an archived test — which is the shape that let six copies through a
-// census that only knew the whole predicate.
+// Held by: TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/employmentcurrency_test.go)
+// — it derives the expected predicate from uq_rel_current_primary_employer in
+// the migration head catalog, so the helper cannot drift from the index it
+// exists to satisfy.
+//
+// Two gates and not one, because either alone reads green over the defect that
+// shipped: TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in the same file
+// reads every hand-written Go source for the FRAGMENT — the flag AND-ed with an
+// archived test, in either order — which is the shape that let six copies
+// through a census that only knew the whole predicate.
 func CurrentPrimarySlotSQL(alias string) string {
 	prefix := ""
 	if alias != "" {

--- a/backend/internal/modules/people/employmentcurrency.go
+++ b/backend/internal/modules/people/employmentcurrency.go
@@ -95,24 +95,16 @@ func CurrentPrimaryEmploymentSQL(alias string) string {
 // `alias` is the relationship table's alias at the call site, or "" when the
 // statement does not alias it.
 //
-// Six statements ask this: the two capture planters that must never reassign
-// an employer somebody already has (employmentedge.go, domaintriageresolve.go),
-// the two merge relinks that keep ≤1 slot-holder per person after re-homing
-// rows (merge.go, merge_organization.go), and the two demotions in
-// relationship.go that empty the slot before a new row takes it. Every one of
-// them had spelled it by hand.
+// Held by: TestTheCurrentPrimarySlotPredicateMirrorsItsIndex (backend/internal/modules/people/currentprimaryslot_test.go)
+// — it derives the expectation from uq_rel_current_primary_employer in the
+// migration head catalog, so this cannot drift from the index it exists to
+// satisfy.
 //
-// Held by: TestTheCurrentPrimarySlotHelperMirrorsItsIndex (backend/internal/modules/people/currentprimaryslot_test.go)
-// — it derives the expected predicate from uq_rel_current_primary_employer in
-// the migration head catalog, so the helper cannot drift from the index it
-// exists to satisfy.
-//
-// Two gates and not one, because either alone reads green over the defect that
-// shipped: TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in
-// backend/employmentcurrency_test.go
-// reads every hand-written Go source for the FRAGMENT — the flag AND-ed with an
-// archived test, in either order — which is the shape that let six copies
-// through a census that only knew the whole predicate.
+// Two gates and not one, because either alone reads green over a second
+// spelling: TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling in
+// backend/employmentcurrency_test.go reads every hand-written Go source for the
+// FRAGMENT — the flag sharing a conjunction with an archived test — which a
+// census that knows only the whole predicate cannot see.
 func CurrentPrimarySlotSQL(alias string) string {
 	prefix := ""
 	if alias != "" {

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -76,7 +76,7 @@ func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyIn
 		SELECT 'employment', $1, $2, true, $3, $4
 		WHERE NOT EXISTS (
 			SELECT 1 FROM relationship
-			WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL)
+			WHERE person_id = $1 AND `+CurrentPrimarySlotSQL("")+`)
 		ON CONFLICT DO NOTHING
 		RETURNING id`,
 		personID, orgID, in.Source, in.CapturedBy).Scan(&edgeID)

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -145,8 +145,15 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 	case "title":
 		// Fill-only-empty: the NULL predicate is the CAS — an occupied
 		// title (human or otherwise) is never touched (GATE-AI-4).
+		//
+		// archived_at, for the same reason writePersonProfileField carries it:
+		// this column is the DISPLAY half of the evidence row above, and the
+		// two must refuse together. An erasure that commits between them would
+		// otherwise leave the evidence refused and the erased person's title
+		// written back — the fill split across two statements, and only one of
+		// them looking.
 		tag, err := tx.Exec(ctx, `
-			UPDATE person SET title = $2 WHERE id = $1 AND title IS NULL`, personID, value)
+			UPDATE person SET title = $2 WHERE id = $1 AND title IS NULL AND archived_at IS NULL`, personID, value)
 		if err != nil {
 			return false, fmt.Errorf("people: signature title fill: %w", err)
 		}

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -131,18 +131,14 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 		return false, nil
 	}
 
-	// The evidence row is the admission ticket: one row per (person, field),
-	// first verdict wins — a later pass can never overwrite it.
-	tag, err := tx.Exec(ctx, `
-		INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		ON CONFLICT (person_id, field) DO NOTHING`,
-		personID, f.Name, value, f.Evidence, sourceRef, f.Confidence, enrichSource, enrichCapturedBy)
-	if err != nil {
-		return false, fmt.Errorf("people: signature evidence row (%s): %w", f.Name, err)
-	}
-	if tag.RowsAffected() == 0 {
-		return false, nil
+	// A machine fill: the signature claims a field nobody has answered and
+	// never replaces one — writeProfileField carries that rule.
+	landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+		Field: f.Name, Value: value, EvidenceSnippet: f.Evidence, SourceRef: sourceRef,
+		Source: enrichSource, CapturedBy: enrichCapturedBy, Confidence: &f.Confidence,
+	}, claimUnanswered)
+	if err != nil || !landed {
+		return false, err
 	}
 
 	switch f.Name {

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -132,8 +132,8 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 	}
 
 	// A machine fill: the signature claims a field nobody has answered and
-	// never replaces one — writeProfileField carries that rule.
-	landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+	// never replaces one — writePersonProfileField carries that rule.
+	landed, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 		Field: f.Name, Value: value, EvidenceSnippet: f.Evidence, SourceRef: sourceRef,
 		Source: enrichSource, CapturedBy: enrichCapturedBy, Confidence: &f.Confidence,
 	}, claimUnanswered)

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -234,8 +234,7 @@ func relinkPersonEdges(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.Pe
 		UPDATE relationship a SET person_id = $2,
 		  is_current_primary = a.is_current_primary AND NOT EXISTS (
 		    SELECT 1 FROM relationship b
-		    WHERE b.person_id = $2 AND b.kind = 'employment'
-		      AND b.is_current_primary AND b.archived_at IS NULL)
+		    WHERE b.person_id = $2 AND `+CurrentPrimarySlotSQL("b")+`)
 		WHERE a.person_id = $1 AND a.archived_at IS NULL`, sourceID, targetID)
 	return tag.RowsAffected(), err
 }

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -346,8 +346,8 @@ func relinkOrgEdges(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.Organ
 		UPDATE relationship a SET organization_id = $2,
 		  is_current_primary = a.is_current_primary AND NOT EXISTS (
 		    SELECT 1 FROM relationship b
-		    WHERE b.person_id = a.person_id AND b.kind = 'employment'
-		      AND b.is_current_primary AND b.archived_at IS NULL AND b.id <> a.id)
+		    WHERE b.person_id = a.person_id AND b.id <> a.id
+		      AND `+CurrentPrimarySlotSQL("b")+`)
 		WHERE a.organization_id = $1 AND a.archived_at IS NULL`, sourceID, targetID); err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/mergerelink.go
+++ b/backend/internal/modules/people/mergerelink.go
@@ -56,7 +56,7 @@ func relinkPersonReferences(ctx context.Context, tx pgx.Tx, sourceID, targetID i
 	// would vanish at a merge nobody expected to lose it — and the row would
 	// then outlive the merged-away record's own archival.
 	//
-	// The one write of this table that is not writeProfileField, because it is
+	// The one write of this table that is not writePersonProfileField, because it is
 	// not a fill: it re-homes rows that already exist, whole and unexamined,
 	// and it moves ALL of a person's fields in one statement rather than
 	// deciding one. The precedence is the same rule stated there — a

--- a/backend/internal/modules/people/mergerelink.go
+++ b/backend/internal/modules/people/mergerelink.go
@@ -56,16 +56,20 @@ func relinkPersonReferences(ctx context.Context, tx pgx.Tx, sourceID, targetID i
 	// would vanish at a merge nobody expected to lose it — and the row would
 	// then outlive the merged-away record's own archival.
 	//
-	// ON CONFLICT DO NOTHING because the uniqueness is (person, field): where
-	// the survivor already holds that field, theirs is the one a human has
-	// been reading, and the merged-away copy is dropped rather than allowed to
-	// overwrite it.
+	// The one write of this table that is not writeProfileField, because it is
+	// not a fill: it re-homes rows that already exist, whole and unexamined,
+	// and it moves ALL of a person's fields in one statement rather than
+	// deciding one. The precedence is the same rule stated there — a
+	// merged-away copy claims a field the survivor has not answered and never
+	// replaces one — and the conflict target NAMES the uniqueness it relies
+	// on, so a future constraint on this table cannot silently start swallowing
+	// a different collision here.
 	if _, err = tx.Exec(ctx, `
 		INSERT INTO person_profile_field
 		  (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
 		SELECT $2, field, value, evidence_snippet, source_ref, confidence, source, captured_by
 		  FROM person_profile_field WHERE person_id = $1
-		ON CONFLICT DO NOTHING`, sourceID.UUID, targetID.UUID); err != nil {
+		ON CONFLICT (person_id, field) DO NOTHING`, sourceID.UUID, targetID.UUID); err != nil {
 		return counts, fmt.Errorf("relink enrichment fields: %w", err)
 	}
 	if _, err = tx.Exec(ctx,

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 )
 
 // The string metric behind the dedupe fuzzy tier (PO-F-1/PO-F-2
@@ -214,4 +216,20 @@ func jaro(a, b string) float64 {
 
 	m := float64(matches)
 	return (m/float64(len(ra)) + m/float64(len(rb)) + (m-float64(transpositions)/2)/m) / 3
+}
+
+// personNameKeySQL is the SQL side of NormalizePersonName: the two properties a
+// bare comparison lacks. Both sides of the equality arm in fuzzyPerson call it,
+// so that comparison cannot fold its two halves with different normalizations
+// of the same name.
+//
+// Not a mirror of the Go key — it deliberately is not one. SQL's lower and Go's
+// Unicode full fold are different normalizations, and this arm exists so the
+// lane does not rely on either being a superset of the other. What it DOES owe
+// is every property the Go key has that plain SQL text comparison does not: the
+// trim, and the collapse of internal whitespace, because a name a crawled page
+// reflowed across a line break is Go-equal to the same name typed by hand and
+// would otherwise be invisible to the arm that guarantees the lane sees it.
+func personNameKeySQL(expr string) string {
+	return storekit.SQLf(`btrim(regexp_replace(f_fold_apostrophes(lower(%s)), '\s+', ' ', 'g'))`, expr)
 }

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -62,6 +62,23 @@ func normalizeName(s string) string {
 	return strings.TrimSpace(cases.Fold().String(unaccented))
 }
 
+// NormalizePersonName is the person-name KEY: normalizeName's fold and
+// unaccent, plus a collapse of internal whitespace. Both halves are
+// load-bearing and neither implies the other.
+//
+// The fold is what makes Straße and STRASSE one person — strings.ToLower
+// leaves ß alone, and the DACH market meets that pair daily. The collapse is
+// what makes a page that reflows "Anna  Muster" across a line break the same
+// person as "Anna Muster" — a key that kept the second space mints a second
+// record on the next crawl of an unchanged page.
+//
+// Deliberately not normalizeName itself, which also feeds nameSimilarity:
+// that input is pinned by PO-PARAM-JW-2 so the spec's worked examples stay
+// reproducible against this code.
+func NormalizePersonName(s string) string {
+	return strings.Join(strings.Fields(normalizeName(s)), " ")
+}
+
 // NormalizeOrgName is normalizeName plus the PO-PARAM-1 legal-suffix
 // strip, applied only to the trailing token: "Co" inside "Coca Co" is a
 // name, "Co" at the end is a suffix.

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -218,18 +218,27 @@ func jaro(a, b string) float64 {
 	return (m/float64(len(ra)) + m/float64(len(rb)) + (m-float64(transpositions)/2)/m) / 3
 }
 
-// personNameKeySQL is the SQL side of NormalizePersonName: the two properties a
-// bare comparison lacks. Both sides of the equality arm in fuzzyPerson call it,
-// so that comparison cannot fold its two halves with different normalizations
-// of the same name.
+// personNameKeySQL is the SQL side of NormalizePersonName. Both sides of the
+// equality arm in fuzzyPerson call it, so that comparison cannot fold its two
+// halves with different normalizations of the same name.
 //
 // Not a mirror of the Go key — it deliberately is not one. SQL's lower and Go's
-// Unicode full fold are different normalizations, and this arm exists so the
-// lane does not rely on either being a superset of the other. What it DOES owe
-// is every property the Go key has that plain SQL text comparison does not: the
-// trim, and the collapse of internal whitespace, because a name a crawled page
-// reflowed across a line break is Go-equal to the same name typed by hand and
-// would otherwise be invisible to the arm that guarantees the lane sees it.
+// Unicode full fold are different normalizations, and the arm exists so the lane
+// does not rely on either being a superset of the other. What it DOES owe is
+// every pair the Go key calls equal, since that is the equality the lane
+// decides on, and three properties of the Go key are not free in SQL:
+//
+//   - the trim, and the collapse of internal whitespace, because a name a
+//     crawled page reflowed across a line break is Go-equal to the same name
+//     typed by hand;
+//   - Greek final sigma, which full folding maps onto σ and lower() leaves
+//     alone, so "Οδυσσεύς" and "ΟΔΥΣΣΕΥΣ" are one person in Go and two here.
+//
+// Held by TestTheNameKeyArmAdmitsEveryGoEqualPair (creatededupe_integration_test.go),
+// which runs this expression against the database over the same pairs the
+// reachability test carries — the arm's own claim, asked of the arm rather than
+// of the query it sits in, where the trigram arm answers first and hides it.
 func personNameKeySQL(expr string) string {
-	return storekit.SQLf(`btrim(regexp_replace(f_fold_apostrophes(lower(%s)), '\s+', ' ', 'g'))`, expr)
+	return storekit.SQLf(
+		`btrim(regexp_replace(replace(f_fold_apostrophes(lower(%s)), 'ς', 'σ'), '\s+', ' ', 'g'))`, expr)
 }

--- a/backend/internal/modules/people/namesim_test.go
+++ b/backend/internal/modules/people/namesim_test.go
@@ -155,3 +155,24 @@ func TestAConnectiveIsOnlyStrippedInsideACompoundLegalForm(t *testing.T) {
 		}
 	}
 }
+
+// NormalizePersonName is the key the create lane locks on and the key the
+// same-name comparison reads, so the two halves it folds are both part of the
+// contract — and each of them was, until this test, held by only one of the
+// two normalizers a person name used to run through.
+func TestNormalizePersonNameFoldsAndCollapses(t *testing.T) {
+	for _, c := range []struct{ left, right, lost string }{
+		{"Straße Müller", "STRASSE MULLER", "the full Unicode fold — ToLower leaves ß alone"},
+		{"Anna Muster", "Anna  Muster", "the internal-whitespace collapse"},
+		{" Anna Muster ", "anna muster", "the trim"},
+	} {
+		if got, want := NormalizePersonName(c.left), NormalizePersonName(c.right); got != want {
+			t.Errorf("NormalizePersonName(%q) = %q, NormalizePersonName(%q) = %q — the key lost %s",
+				c.left, got, c.right, want, c.lost)
+		}
+	}
+	// Two people are still two people: folding is not collapsing everybody.
+	if NormalizePersonName("Anna Muster") == NormalizePersonName("Bernd Beispiel") {
+		t.Error("two different names share one key")
+	}
+}

--- a/backend/internal/modules/people/personprofilefieldwrite.go
+++ b/backend/internal/modules/people/personprofilefieldwrite.go
@@ -93,12 +93,27 @@ type personProfileFieldRow struct {
 // straight back — in the window between two statements, not over the hours an
 // entry gate closes. A SELECT source rather than VALUES is what lets the
 // predicate travel with the row.
+//
+// FOR UPDATE, because the predicate alone only NARROWS that window. Reading the
+// person as live and inserting are one statement, but an erasure running
+// concurrently can still commit between this transaction's snapshot and its
+// own — and the foreign key would accept the parent it just archived, so the
+// row lands on an erased subject and nothing complains. The lock makes the two
+// take turns: an erasure in flight blocks here until it commits, and then this
+// statement finds no live row.
+//
+// Locking PERSON and not the field row: the field row may not exist yet, and
+// what has to be serialized is the subject's liveness. Every caller that goes
+// on to write a person COLUMN takes the same row next, so the order is
+// person-then-person and no new deadlock edge is introduced.
 func writePersonProfileField(ctx context.Context, tx pgx.Tx, personID ids.PersonID, row personProfileFieldRow, precedence personProfileFieldPrecedence) (bool, error) {
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO person_profile_field
 		  (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
 		SELECT $1, $2, $3, $4, $5, $6, $7, $8
-		 WHERE EXISTS (SELECT 1 FROM person WHERE id = $1 AND archived_at IS NULL)
+		  FROM person
+		 WHERE person.id = $1 AND person.archived_at IS NULL
+		   FOR UPDATE
 		ON CONFLICT (person_id, field) `+precedence.conflictClause(),
 		personID, row.Field, row.Value, row.EvidenceSnippet, row.SourceRef,
 		row.Confidence, row.Source, row.CapturedBy)

--- a/backend/internal/modules/people/personprofilefieldwrite.go
+++ b/backend/internal/modules/people/personprofilefieldwrite.go
@@ -5,15 +5,11 @@ package people
 
 // The one writer of person_profile_field, and the precedence rule it carries.
 //
-// Four passes fill this table — a mail signature, a public search result, a
-// site read and a human's acceptance of a research claim — and each used to
-// hand-copy the column list with its own ON CONFLICT clause. Three wrote
-// DO NOTHING and one wrote DO UPDATE, each justifying itself locally, so which
-// value a profile field held depended on which pass happened to run last
-// rather than on a rule anybody had stated.
+// Several passes fill this table — a mail signature, a public search result, a
+// site read, a human's acceptance of a research claim — and a conflict clause
+// chosen per pass makes the value a field holds depend on which pass ran last.
 //
-// The rule, stated once, is not "first wins" or "last wins". It is about WHO
-// is writing:
+// The rule is not "first wins" or "last wins". It is about WHO is writing:
 //
 //   - A machine fill CLAIMS an unanswered field and never replaces one. It read
 //     a footer, a search snippet or a page; none of that outranks an answer

--- a/backend/internal/modules/people/personprofilefieldwrite.go
+++ b/backend/internal/modules/people/personprofilefieldwrite.go
@@ -36,14 +36,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// profileFieldPrecedence is who is writing, and therefore what happens to a
+// personProfileFieldPrecedence is who is writing, and therefore what happens to a
 // row that is already there.
-type profileFieldPrecedence int
+type personProfileFieldPrecedence int
 
 const (
-	// claimUnanswered is every machine fill: the evidence row is an admission
-	// ticket, and one already issued for this field is the answer.
-	claimUnanswered profileFieldPrecedence = iota
+	// claimUnanswered is what a machine fill writes under: the evidence row is
+	// an admission ticket, and one already issued for this field is the answer.
+	claimUnanswered personProfileFieldPrecedence = iota
 	// replaceOnAcceptance is a human's decision, which outranks whatever a
 	// pass put there.
 	replaceOnAcceptance
@@ -54,7 +54,7 @@ const (
 // The whole row is replaced on acceptance, confidence included. Replacing the
 // value and keeping a confidence some earlier pass measured would leave the row
 // saying a human's answer had been scored by a model that never saw it.
-func (p profileFieldPrecedence) conflictClause() string {
+func (p personProfileFieldPrecedence) conflictClause() string {
 	if p == replaceOnAcceptance {
 		return `DO UPDATE SET value = EXCLUDED.value,
 		    evidence_snippet = EXCLUDED.evidence_snippet,
@@ -66,7 +66,7 @@ func (p profileFieldPrecedence) conflictClause() string {
 	return "DO NOTHING"
 }
 
-// profileFieldRow is one evidence row: a fact about who this person is, and
+// personProfileFieldRow is one evidence row: a fact about who this person is, and
 // what it was read from.
 //
 // Evidence and SourceRef are both NOT NULL on the table, so a claim that lost
@@ -77,7 +77,7 @@ func (p profileFieldPrecedence) conflictClause() string {
 // Confidence is a pointer because most passes have none: a human's acceptance
 // and a page read are not scored, and storing a 0 for "unscored" would read as
 // "measured, and certainly wrong".
-type profileFieldRow struct {
+type personProfileFieldRow struct {
 	Field           string
 	Value           string
 	EvidenceSnippet string
@@ -87,7 +87,7 @@ type profileFieldRow struct {
 	Confidence      *float64
 }
 
-// writeProfileField writes one evidence row and reports whether it landed —
+// writePersonProfileField writes one evidence row and reports whether it landed —
 // false meaning the field was already answered and this writer defers to it.
 //
 // The subject's liveness rides the INSERT rather than only the probe the entry
@@ -97,7 +97,7 @@ type profileFieldRow struct {
 // straight back — in the window between two statements, not over the hours an
 // entry gate closes. A SELECT source rather than VALUES is what lets the
 // predicate travel with the row.
-func writeProfileField(ctx context.Context, tx pgx.Tx, personID ids.PersonID, row profileFieldRow, precedence profileFieldPrecedence) (bool, error) {
+func writePersonProfileField(ctx context.Context, tx pgx.Tx, personID ids.PersonID, row personProfileFieldRow, precedence personProfileFieldPrecedence) (bool, error) {
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO person_profile_field
 		  (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)

--- a/backend/internal/modules/people/profilefieldprecedence_integration_test.go
+++ b/backend/internal/modules/people/profilefieldprecedence_integration_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// The precedence rule of person_profile_field, over a real Postgres, in BOTH
+// directions.
+//
+// One direction was already held: a second acceptance replaces the first
+// (researchclaim_integration_test.go). Held alone it reads green over the
+// inverse defect — a machine fill that also replaced would satisfy every
+// assertion there, and the pass that overwrote a human's correction would run
+// again the next night and overwrite it again. So the case that matters is the
+// one this file plants: a fill that arrives AFTER a human has answered.
+//
+// The signature pass is the fill used for the confidence half, because it is
+// the only writer that scores what it stores. A human's acceptance has no
+// model score, and a replacement that kept the old number would leave the row
+// saying a person's decision had been measured by a model that never saw it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// storedConfidence reads the column readStoredClaim leaves out, as the pointer
+// the table allows: NULL means unscored, which is what a human's answer is.
+func storedConfidence(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID, field string) *float64 {
+	t.Helper()
+	var got *float64
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT confidence FROM person_profile_field WHERE person_id = $1 AND field = $2`,
+			personID, field).Scan(&got)
+	}); err != nil {
+		t.Fatalf("read back the %s confidence: %v", field, err)
+	}
+	return got
+}
+
+// fillFromSignature runs the machine pass that scores what it writes.
+func fillFromSignature(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID, f SignatureField) bool {
+	t.Helper()
+	var applied bool
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		applied, err = e.store.applySignatureField(ctx, tx, personID, "mailto:signature", f)
+		return err
+	}); err != nil {
+		t.Fatalf("apply the signature field %s: %v", f.Name, err)
+	}
+	return applied
+}
+
+// A machine read a page or a footer; the human read the evidence and chose.
+// The fill claims an unanswered field and defers to an answered one, whichever
+// pass happens to run last.
+func TestAMachineFillNeverReplacesWhatAHumanAccepted(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Ola Brekke", "ola@precedence.test", "Brekke AS", "precedence.test")
+
+	accepted := ResearchClaimInput{
+		Field:     "linkedin",
+		Value:     "https://www.linkedin.com/in/ola-brekke",
+		Quote:     "Ola Brekke — Brekke AS, Oslo.",
+		SourceURL: "https://precedence.test/team",
+	}
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{accepted}); err != nil {
+		t.Fatalf("accept the claim: %v", err)
+	}
+
+	applied, err := e.store.ApplyDiscoveredFields(ctx, personID, []DiscoveredField{{
+		Field:           "linkedin",
+		Value:           "https://www.linkedin.com/in/someone-else",
+		EvidenceSnippet: "Someone Else — Brekke AS",
+		SourceRef:       "search:precedence",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyDiscoveredFields: %v", err)
+	}
+	if len(applied) != 0 {
+		t.Errorf("the search fill reported %v applied, want nothing: the field was already answered", applied)
+	}
+
+	got := readStoredClaim(ctx, t, e, personID, "linkedin")
+	if got.value != accepted.Value || got.source != researchSource {
+		t.Errorf("stored row = %+v, want the human's value under %s — a machine fill overwrote a decision", got, researchSource)
+	}
+	// The trigger owns the bump, so a version past 1 means the row was updated
+	// even where the value happened to survive.
+	if got.version != 1 {
+		t.Errorf("version = %d, want 1: the fill wrote the row rather than deferring to it", got.version)
+	}
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 1 {
+		t.Errorf("rows under this person = %d, want 1 — the fill landed a second row under a key the reader cannot see", rows)
+	}
+}
+
+// The other direction, and the column the replacement used to leave behind: a
+// human's acceptance takes the whole row, score included.
+func TestAnAcceptanceReplacesAMachineFillAndItsScore(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Mira Halvorsen", "mira@precedence.test", "Halvorsen AS", "precedence.test")
+
+	if !fillFromSignature(ctx, t, e, personID, SignatureField{
+		Name:       "role",
+		Value:      "Sales Engineer",
+		Evidence:   "Mira Halvorsen | Sales Engineer | Halvorsen AS",
+		Confidence: 0.9,
+	}) {
+		t.Fatal("the signature fill wrote nothing, so this test proves nothing about replacing it")
+	}
+	if score := storedConfidence(ctx, t, e, personID, "role"); score == nil || *score != 0.9 {
+		t.Fatalf("the signature fill stored confidence %v, want 0.9 — the setup is not the state this test replaces", score)
+	}
+
+	accepted := ResearchClaimInput{
+		Field:     "role",
+		Value:     "Head of Sales",
+		Quote:     "Mira Halvorsen now heads sales at Halvorsen AS.",
+		SourceURL: "https://precedence.test/news",
+	}
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{accepted}); err != nil {
+		t.Fatalf("accept the claim: %v", err)
+	}
+
+	got := readStoredClaim(ctx, t, e, personID, "role")
+	if got.value != accepted.Value || got.source != researchSource || got.capturedBy != "human:"+e.rep.String() {
+		t.Errorf("stored row = %+v, want the accepted claim under %s, captured by the human who chose it", got, researchSource)
+	}
+	if score := storedConfidence(ctx, t, e, personID, "role"); score != nil {
+		t.Errorf("confidence = %v after a human's acceptance, want NULL: the row would otherwise say a "+
+			"person's decision had been scored by a model that never saw it", *score)
+	}
+}

--- a/backend/internal/modules/people/profilefieldprecedence_integration_test.go
+++ b/backend/internal/modules/people/profilefieldprecedence_integration_test.go
@@ -143,3 +143,43 @@ func TestAnAcceptanceReplacesAMachineFillAndItsScore(t *testing.T) {
 			"person's decision had been scored by a model that never saw it", *score)
 	}
 }
+
+// The writer's liveness predicate refuses a row and SAYS SO, which is the half
+// its four callers' counters rest on.
+//
+// Reached the only way it can be reached deterministically: from inside the
+// transaction, with the person archived between the entry gate and the write.
+// That is exactly the window the predicate exists for — at READ COMMITTED each
+// statement takes a fresh snapshot, so an erasure that commits after
+// EnsureWritableLive is visible to the INSERT that follows it. Before the
+// predicate, the acceptance path could not have been in this position at all;
+// with it, a caller that ignored the answer would count a claim that is not
+// there, put that number in the audit row, and publish it on the outbox.
+func TestARefusedWriteReportsThatItDidNotLand(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Tore Aas", "tore@refused.test", "Aas AS", "refused.test")
+
+	var landed bool
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`UPDATE person SET archived_at = now() WHERE id = $1`, personID); err != nil {
+			return err
+		}
+		var err error
+		landed, err = writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
+			Field: "role", Value: "Owner", EvidenceSnippet: "Tore Aas owns the company.",
+			SourceRef: "https://refused.test/about", Source: researchSource, CapturedBy: "human:probe",
+		}, replaceOnAcceptance)
+		return err
+	}); err != nil {
+		t.Fatalf("run the write against an archived person: %v", err)
+	}
+	if landed {
+		t.Error("the writer reported a row landed on an archived person")
+	}
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 0 {
+		t.Errorf("rows for the archived person = %d, want 0", rows)
+	}
+}

--- a/backend/internal/modules/people/profilefieldprecedence_integration_test.go
+++ b/backend/internal/modules/people/profilefieldprecedence_integration_test.go
@@ -22,9 +22,12 @@ package people
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -181,5 +184,58 @@ func TestARefusedWriteReportsThatItDidNotLand(t *testing.T) {
 	}
 	if rows := claimRowsFor(ctx, t, e, personID); rows != 0 {
 		t.Errorf("rows for the archived person = %d, want 0", rows)
+	}
+}
+
+// The predicate NARROWS the window; the lock closes it. Proved by making an
+// erasure wait for a fill that is holding the subject.
+//
+// No sleep and no clock: the erasure's own lock_timeout is what reports the
+// blocking, and it can only fire when something is holding the row. Without the
+// lock the erasure commits immediately and the test fails on the successful
+// path, so both directions are observable.
+func TestAFillHoldsTheSubjectAgainstAConcurrentErasure(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Sunniva Dahl", "sunniva@holds.test", "Dahl AS", "holds.test")
+
+	held, release := make(chan struct{}), make(chan struct{})
+	filling := make(chan error, 1)
+	// once, because WithWorkspaceTx may run the closure again and a second
+	// close would panic in a goroutine the test cannot recover.
+	var announce sync.Once
+	go func() {
+		filling <- e.store.tx(ctx, func(tx pgx.Tx) error {
+			if _, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
+				Field: "role", Value: "Owner", EvidenceSnippet: "Sunniva Dahl owns the company.",
+				SourceRef: "https://holds.test/about", Source: researchSource, CapturedBy: "human:probe",
+			}, replaceOnAcceptance); err != nil {
+				return err
+			}
+			announce.Do(func() { close(held) })
+			<-release
+			return nil
+		})
+	}()
+	<-held
+
+	erasure := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '2s'`); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `UPDATE person SET archived_at = now() WHERE id = $1`, personID)
+		return err
+	})
+	close(release)
+	if err := <-filling; err != nil {
+		t.Fatalf("the fill itself failed, so this test proves nothing about the erasure: %v", err)
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(erasure, &pgErr) || pgErr.Code != "55P03" {
+		t.Fatalf("the erasure got %v, want a lock timeout (55P03) — a fill in flight must hold the "+
+			"subject, or the erasure commits between this transaction's snapshot and its write and "+
+			"the row lands on a person it had just cleared", erasure)
 	}
 }

--- a/backend/internal/modules/people/profilefieldwrite.go
+++ b/backend/internal/modules/people/profilefieldwrite.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The one writer of person_profile_field, and the precedence rule it carries.
+//
+// Four passes fill this table — a mail signature, a public search result, a
+// site read and a human's acceptance of a research claim — and each used to
+// hand-copy the column list with its own ON CONFLICT clause. Three wrote
+// DO NOTHING and one wrote DO UPDATE, each justifying itself locally, so which
+// value a profile field held depended on which pass happened to run last
+// rather than on a rule anybody had stated.
+//
+// The rule, stated once, is not "first wins" or "last wins". It is about WHO
+// is writing:
+//
+//   - A machine fill CLAIMS an unanswered field and never replaces one. It read
+//     a footer, a search snippet or a page; none of that outranks an answer
+//     already on the record, and a pass that overwrote one would undo a human's
+//     correction the next time it ran.
+//   - A HUMAN'S ACCEPTANCE replaces what is there. Somebody read the claim, the
+//     quote behind it and the document it came from, and chose it — that is the
+//     one input to this table that has weighed the evidence, and a row it could
+//     not replace would leave the reader looking at a value they had just
+//     rejected (ADR-0096 D4).
+//
+// So the argument below is the writer's authority, not the SQL verb.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// profileFieldPrecedence is who is writing, and therefore what happens to a
+// row that is already there.
+type profileFieldPrecedence int
+
+const (
+	// claimUnanswered is every machine fill: the evidence row is an admission
+	// ticket, and one already issued for this field is the answer.
+	claimUnanswered profileFieldPrecedence = iota
+	// replaceOnAcceptance is a human's decision, which outranks whatever a
+	// pass put there.
+	replaceOnAcceptance
+)
+
+// conflictClause renders the precedence as the ON CONFLICT it means.
+//
+// The whole row is replaced on acceptance, confidence included. Replacing the
+// value and keeping a confidence some earlier pass measured would leave the row
+// saying a human's answer had been scored by a model that never saw it.
+func (p profileFieldPrecedence) conflictClause() string {
+	if p == replaceOnAcceptance {
+		return `DO UPDATE SET value = EXCLUDED.value,
+		    evidence_snippet = EXCLUDED.evidence_snippet,
+		    source_ref = EXCLUDED.source_ref,
+		    confidence = EXCLUDED.confidence,
+		    source = EXCLUDED.source,
+		    captured_by = EXCLUDED.captured_by`
+	}
+	return "DO NOTHING"
+}
+
+// profileFieldRow is one evidence row: a fact about who this person is, and
+// what it was read from.
+//
+// Evidence and SourceRef are both NOT NULL on the table, so a claim that lost
+// its quote or its source cannot be stored at all — that is what makes the
+// evidence guarantee enforceable rather than promised, and no caller here may
+// weaken it.
+//
+// Confidence is a pointer because most passes have none: a human's acceptance
+// and a page read are not scored, and storing a 0 for "unscored" would read as
+// "measured, and certainly wrong".
+type profileFieldRow struct {
+	Field           string
+	Value           string
+	EvidenceSnippet string
+	SourceRef       string
+	Source          string
+	CapturedBy      string
+	Confidence      *float64
+}
+
+// writeProfileField writes one evidence row and reports whether it landed —
+// false meaning the field was already answered and this writer defers to it.
+//
+// The subject's liveness rides the INSERT rather than only the probe the entry
+// point ran. person_profile_field is a declared PII table and Art. 17 erasure
+// clears its rows while stamping the person archived, so a fill decided before
+// that commit and applied after it would put the erased subject's details
+// straight back — in the window between two statements, not over the hours an
+// entry gate closes. A SELECT source rather than VALUES is what lets the
+// predicate travel with the row.
+func writeProfileField(ctx context.Context, tx pgx.Tx, personID ids.PersonID, row profileFieldRow, precedence profileFieldPrecedence) (bool, error) {
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO person_profile_field
+		  (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8
+		 WHERE EXISTS (SELECT 1 FROM person WHERE id = $1 AND archived_at IS NULL)
+		ON CONFLICT (person_id, field) `+precedence.conflictClause(),
+		personID, row.Field, row.Value, row.EvidenceSnippet, row.SourceRef,
+		row.Confidence, row.Source, row.CapturedBy)
+	if err != nil {
+		return false, fmt.Errorf("people: profile field evidence row (%s): %w", row.Field, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -174,7 +174,7 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 			in.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
-				WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL
+				WHERE person_id = $1 AND `+CurrentPrimarySlotSQL("")+`
 				  AND `+EmploymentIsCurrentSQL("$2::date"),
 				*in.PersonID, in.EndedAt); err != nil {
 				return err
@@ -342,8 +342,7 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 			current.Kind == "employment" && current.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
-				WHERE kind = 'employment' AND person_id = $1 AND is_current_primary
-				  AND archived_at IS NULL AND id <> $2
+				WHERE person_id = $1 AND id <> $2 AND `+CurrentPrimarySlotSQL("")+`
 				  AND EXISTS (
 					SELECT 1 FROM relationship patched
 					 WHERE patched.id = $2

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -111,22 +111,14 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			return err
 		}
 		for _, claim := range claims {
-			// ON CONFLICT because the table holds one row per (person, field):
-			// accepting a newer claim about the same field REPLACES what was
-			// there, which is what a reader who just chose it expects.
+			// The one write in this table that REPLACES: somebody read the
+			// claim, its quote and the document behind it, and chose it.
 			// updated_at and version are the trigger's
-			// (trg_person_profile_field_updated), so the branch names neither.
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-				VALUES ($1, $2, $3, $4, $5, $6, $7)
-				ON CONFLICT (person_id, field) DO UPDATE
-				SET value = EXCLUDED.value,
-				    evidence_snippet = EXCLUDED.evidence_snippet,
-				    source_ref = EXCLUDED.source_ref,
-				    source = EXCLUDED.source,
-				    captured_by = EXCLUDED.captured_by`,
-				personID, claim.Field, claim.Value, claim.Quote,
-				claim.SourceURL, researchSource, by); err != nil {
+			// (trg_person_profile_field_updated), so nothing here names them.
+			if _, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+				Field: claim.Field, Value: claim.Value, EvidenceSnippet: claim.Quote,
+				SourceRef: claim.SourceURL, Source: researchSource, CapturedBy: by,
+			}, replaceOnAcceptance); err != nil {
 				return fmt.Errorf("save the research claim %q: %w", claim.Field, err)
 			}
 			saved++

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -115,11 +116,23 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			// claim, its quote and the document behind it, and chose it.
 			// updated_at and version are the trigger's
 			// (trg_person_profile_field_updated), so nothing here names them.
-			if _, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
+			landed, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 				Field: claim.Field, Value: claim.Value, EvidenceSnippet: claim.Quote,
 				SourceRef: claim.SourceURL, Source: researchSource, CapturedBy: by,
-			}, replaceOnAcceptance); err != nil {
+			}, replaceOnAcceptance)
+			if err != nil {
 				return fmt.Errorf("save the research claim %q: %w", claim.Field, err)
+			}
+			if !landed {
+				// An acceptance REPLACES, so the only way a row does not land
+				// is the writer's liveness predicate refusing it: an erasure
+				// committed between EnsureWritableLive above and this
+				// statement, which at READ COMMITTED is a fresh snapshot. The
+				// whole acceptance fails rather than counting a claim that is
+				// not there — the count rides the audit row and the outbox
+				// event, so a saved++ here would record a mutation that never
+				// happened, on the one table whose purpose is traceability.
+				return apperrors.ErrNotFound
 			}
 			saved++
 		}

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -115,7 +115,7 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			// claim, its quote and the document behind it, and chose it.
 			// updated_at and version are the trigger's
 			// (trg_person_profile_field_updated), so nothing here names them.
-			if _, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+			if _, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 				Field: claim.Field, Value: claim.Value, EvidenceSnippet: claim.Quote,
 				SourceRef: claim.SourceURL, Source: researchSource, CapturedBy: by,
 			}, replaceOnAcceptance); err != nil {

--- a/backend/internal/modules/people/searchpersonfields.go
+++ b/backend/internal/modules/people/searchpersonfields.go
@@ -109,7 +109,7 @@ func fillDiscoveredFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		}
 		// A machine fill: a search result claims a field nobody has answered
 		// and never replaces one.
-		landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+		landed, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 			Field: f.Field, Value: value, EvidenceSnippet: snippet, SourceRef: f.SourceRef,
 			Source: searchFieldSource, CapturedBy: by,
 		}, claimUnanswered)

--- a/backend/internal/modules/people/searchpersonfields.go
+++ b/backend/internal/modules/people/searchpersonfields.go
@@ -107,24 +107,16 @@ func fillDiscoveredFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		if value == "" || snippet == "" {
 			continue
 		}
-		// The subject's liveness rides the INSERT itself, not only the probe
-		// the entry point ran. person_profile_field is a declared PII table and
-		// Art. 17 erasure DELETES its rows while stamping the person archived —
-		// so a discovery approved before that commit and applied after it would
-		// otherwise put the erased subject's details straight back, in the
-		// window between two statements rather than over the hours the entry
-		// gate closes. A SELECT source rather than VALUES is what lets the
-		// predicate travel with the row.
-		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			SELECT $1, $2, $3, $4, $5, $6, $7
-			 WHERE EXISTS (SELECT 1 FROM person WHERE id = $1 AND archived_at IS NULL)
-			ON CONFLICT (person_id, field) DO NOTHING`,
-			personID, f.Field, value, snippet, f.SourceRef, searchFieldSource, by)
+		// A machine fill: a search result claims a field nobody has answered
+		// and never replaces one.
+		landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+			Field: f.Field, Value: value, EvidenceSnippet: snippet, SourceRef: f.SourceRef,
+			Source: searchFieldSource, CapturedBy: by,
+		}, claimUnanswered)
 		if err != nil {
-			return nil, fmt.Errorf("people: discovered field evidence row (%s): %w", f.Field, err)
+			return nil, err
 		}
-		if tag.RowsAffected() == 0 {
+		if !landed {
 			continue
 		}
 		if err := storekit.StampFields(ctx, tx, entityPerson, personID.UUID, f.SourceRef, by,

--- a/backend/internal/modules/people/sitepersonfields.go
+++ b/backend/internal/modules/people/sitepersonfields.go
@@ -219,18 +219,16 @@ func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		if value == "" {
 			return nil
 		}
-		// The evidence row is the admission ticket, first verdict wins — the
-		// same rule the signature pass writes under, so a site read can never
-		// overwrite what a signature (or a human) already answered.
-		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
-			ON CONFLICT (person_id, field) DO NOTHING`,
-			personID, field, value, in.EvidenceSnippet, sourceRef, siteFieldSource, by)
+		// A machine fill: what a page published claims a field nobody has
+		// answered and never replaces one.
+		landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+			Field: field, Value: value, EvidenceSnippet: in.EvidenceSnippet, SourceRef: sourceRef,
+			Source: siteFieldSource, CapturedBy: by,
+		}, claimUnanswered)
 		if err != nil {
-			return fmt.Errorf("people: site person evidence row (%s): %w", field, err)
+			return err
 		}
-		if tag.RowsAffected() == 0 {
+		if !landed {
 			return nil
 		}
 		if err := storekit.StampFields(ctx, tx, entityPerson, personID.UUID, sourceRef, by,

--- a/backend/internal/modules/people/sitepersonfields.go
+++ b/backend/internal/modules/people/sitepersonfields.go
@@ -246,10 +246,13 @@ func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		return nil, err
 	}
 	// The title column carries the role for display. Fill-only-empty: the NULL
-	// predicate is the CAS, so an occupied title stands whoever set it.
+	// predicate is the CAS, so an occupied title stands whoever set it — and
+	// archived_at, so this half refuses exactly when the evidence row above
+	// does. Without it an erasure committing between the two statements leaves
+	// the evidence refused and the erased person's title written back.
 	if role := strings.TrimSpace(in.Role); role != "" {
 		tag, err := tx.Exec(ctx, `
-			UPDATE person SET title = $2 WHERE id = $1 AND title IS NULL`, personID, role)
+			UPDATE person SET title = $2 WHERE id = $1 AND title IS NULL AND archived_at IS NULL`, personID, role)
 		if err != nil {
 			return nil, fmt.Errorf("people: site person title fill: %w", err)
 		}

--- a/backend/internal/modules/people/sitepersonfields.go
+++ b/backend/internal/modules/people/sitepersonfields.go
@@ -221,7 +221,7 @@ func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		}
 		// A machine fill: what a page published claims a field nobody has
 		// answered and never replaces one.
-		landed, err := writeProfileField(ctx, tx, personID, profileFieldRow{
+		landed, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 			Field: field, Value: value, EvidenceSnippet: in.EvidenceSnippet, SourceRef: sourceRef,
 			Source: siteFieldSource, CapturedBy: by,
 		}, claimUnanswered)

--- a/backend/personprofilefieldwriter_test.go
+++ b/backend/personprofilefieldwriter_test.go
@@ -136,7 +136,11 @@ func personProfileFieldStatements(decl ast.Decl) []string {
 			return false
 		}
 		text, ok := flattenSQL(n, seen, helperScope{names: map[string]bool{"writePersonProfileField": true}})
-		if !ok || !strings.Contains(text, "person_profile_field") {
+		// Lower-cased for the prefilter, because the detector is
+		// case-insensitive and a prefilter narrower than its detector is where
+		// a census goes blind: the file is dropped before anything looks at it,
+		// and there is no finding to notice.
+		if !ok || !strings.Contains(strings.ToLower(text), "person_profile_field") {
 			return true
 		}
 		out = append(out, text)
@@ -150,7 +154,7 @@ func personProfileFieldStatements(decl ast.Decl) []string {
 func firstPersonProfileFieldLine(sql string) string {
 	lines := strings.Split(sql, "\n")
 	for _, line := range lines {
-		if strings.Contains(line, "person_profile_field") {
+		if strings.Contains(strings.ToLower(line), "person_profile_field") {
 			return strings.TrimSpace(line)
 		}
 	}
@@ -184,6 +188,10 @@ var personProfileFieldProbes = []struct {
 	// An UPDATE answers the precedence question — what happens to a row that
 	// is already there — without ever reaching a conflict clause.
 	{"a second writer spelled as an UPDATE", true, "\nfunc write() string {\n\treturn `UPDATE person_profile_field SET value = $2 WHERE person_id = $1 AND field = 'role'`\n}"},
+	// The TABLE name in upper case. The detector folded case and the prefilter
+	// in front of it did not, which drops the statement before the detector
+	// ever runs.
+	{"the table identifier in upper case", true, "\nfunc write() string {\n\treturn `INSERT INTO PERSON_PROFILE_FIELD (person_id, field, value) VALUES ($1, $2, $3)`\n}"},
 }
 
 // The waiver's second half, read directly: a file key alone would ratify the

--- a/backend/personprofilefieldwriter_test.go
+++ b/backend/personprofilefieldwriter_test.go
@@ -5,7 +5,7 @@
 
 package backendarch
 
-// people.writeProfileField is the one writer of person_profile_field, and the
+// people.writePersonProfileField is the one writer of person_profile_field, and the
 // one place the precedence rule lives: a machine fill claims an unanswered
 // field, a human's acceptance replaces what is there.
 //
@@ -32,18 +32,18 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
-// profileFieldInsert matches a write of the table, in either spelling the
+// personProfileFieldInsert matches a write of the table, in either spelling the
 // tree uses: the column list on the same line as the table, or on the next.
 // Whitespace-tolerant rather than line-based, because two of the five copies
 // wrapped after the table name and a line-keyed census would have seen three.
-var profileFieldInsert = regexp.MustCompile(`INSERT\s+INTO\s+person_profile_field`)
+var personProfileFieldInsert = regexp.MustCompile(`INSERT\s+INTO\s+person_profile_field`)
 
-// profileFieldOwner is where the one writer lives. Its own statement is the
-// definition rather than a copy of it.
-const profileFieldOwner = "internal/modules/people/profilefieldwrite.go"
+// personProfileFieldOwner is where the writer this census requires lives. Its
+// own statement is the definition rather than a copy of it.
+const personProfileFieldOwner = "internal/modules/people/personprofilefieldwrite.go"
 
 // bulkRelinkIsNotAFill ratifies the merge carry-over, which is the one write of
-// this table that writeProfileField cannot serve.
+// this table that writePersonProfileField cannot serve.
 //
 // Keyed by FILE, so a second statement appearing in mergerelink.go is still a
 // finding: the ratification covers the write that exists, not the topic.
@@ -60,11 +60,11 @@ func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
 	var findings []string
 	judged := 0
 	for _, path := range handWrittenGoSources(t) {
-		if filepath.ToSlash(path) == profileFieldOwner {
+		if filepath.ToSlash(path) == personProfileFieldOwner {
 			continue
 		}
 		// PRODUCT writes, and the boundary is architectural rather than a
-		// shortcut: writeProfileField is unexported, so a fixture in another
+		// shortcut: writePersonProfileField is unexported, so a fixture in another
 		// package could not call it however much it wanted to, and a test that
 		// seeds a prior state is not answering the question this census asks —
 		// which production path writes the row, and under whose authority. The
@@ -78,15 +78,15 @@ func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
 		for _, decl := range file.Decls {
-			for _, sql := range profileFieldStatements(decl) {
+			for _, sql := range personProfileFieldStatements(decl) {
 				judged++
-				if !profileFieldInsert.MatchString(sql) {
+				if !personProfileFieldInsert.MatchString(sql) {
 					continue
 				}
 				if bulkRelinkIsNotAFill.Waived(t, filepath.ToSlash(path)) {
 					continue
 				}
-				findings = append(findings, fmt.Sprintf("%s: %s", path, firstProfileFieldLine(sql)))
+				findings = append(findings, fmt.Sprintf("%s: %s", path, firstPersonProfileFieldLine(sql)))
 			}
 		}
 	}
@@ -99,23 +99,23 @@ func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
 		return
 	}
 	t.Errorf("these statements write person_profile_field by hand:\n  %s\n\n"+
-		"people.writeProfileField is the one writer, and the ON CONFLICT clause is not the "+
+		"people.writePersonProfileField is the one writer, and the ON CONFLICT clause is not the "+
 		"caller's to choose: it follows from WHO is writing — a machine fill claims an "+
 		"unanswered field (claimUnanswered), a human's acceptance replaces what is there "+
 		"(replaceOnAcceptance). A hand-written clause is a second answer to that question.",
 		strings.Join(findings, "\n  "))
 }
 
-// profileFieldStatements returns the SQL statements in a declaration that name
+// personProfileFieldStatements returns the SQL statements in a declaration that name
 // the table at all — the candidate set this census counts against.
-func profileFieldStatements(decl ast.Decl) []string {
+func personProfileFieldStatements(decl ast.Decl) []string {
 	var out []string
 	seen := map[ast.Node]bool{}
 	ast.Inspect(decl, func(n ast.Node) bool {
 		if seen[n] {
 			return false
 		}
-		text, ok := flattenSQL(n, seen, helperScope{names: map[string]bool{"writeProfileField": true}})
+		text, ok := flattenSQL(n, seen, helperScope{names: map[string]bool{"writePersonProfileField": true}})
 		if !ok || !strings.Contains(text, "person_profile_field") {
 			return true
 		}
@@ -125,9 +125,9 @@ func profileFieldStatements(decl ast.Decl) []string {
 	return out
 }
 
-// firstProfileFieldLine points the report at the offending line rather than
+// firstPersonProfileFieldLine points the report at the offending line rather than
 // dumping the statement.
-func firstProfileFieldLine(sql string) string {
+func firstPersonProfileFieldLine(sql string) string {
 	lines := strings.Split(sql, "\n")
 	for _, line := range lines {
 		if strings.Contains(line, "person_profile_field") {
@@ -139,7 +139,7 @@ func firstProfileFieldLine(sql string) string {
 
 // The census above passes identically over a clean tree and over a detector
 // that has stopped detecting. These read the detector directly.
-var profileFieldProbes = []struct {
+var personProfileFieldProbes = []struct {
 	name  string
 	fires bool
 	src   string
@@ -161,7 +161,7 @@ var profileFieldProbes = []struct {
 
 func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
 	fset := token.NewFileSet()
-	for _, tc := range profileFieldProbes {
+	for _, tc := range personProfileFieldProbes {
 		t.Run(tc.name, func(t *testing.T) {
 			file, err := parser.ParseFile(fset, "probe.go", "package probe\n"+tc.src, 0)
 			if err != nil {
@@ -169,8 +169,8 @@ func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
 			}
 			hit := false
 			for _, decl := range file.Decls {
-				for _, sql := range profileFieldStatements(decl) {
-					if profileFieldInsert.MatchString(sql) {
+				for _, sql := range personProfileFieldStatements(decl) {
+					if personProfileFieldInsert.MatchString(sql) {
 						hit = true
 					}
 				}

--- a/backend/personprofilefieldwriter_test.go
+++ b/backend/personprofilefieldwriter_test.go
@@ -32,11 +32,20 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
-// personProfileFieldInsert matches a write of the table, in either spelling the
-// tree uses: the column list on the same line as the table, or on the next.
+// personProfileFieldWrite matches a write of the table.
+//
 // Whitespace-tolerant rather than line-based, because two of the five copies
 // wrapped after the table name and a line-keyed census would have seen three.
-var personProfileFieldInsert = regexp.MustCompile(`INSERT\s+INTO\s+person_profile_field`)
+// Case-insensitive, because SQL is, and a census that is not loses to the same
+// statement typed in lower case.
+//
+// UPDATE as well as INSERT: the precedence rule is what happens to a row that
+// is already there, and a second writer spelled `UPDATE person_profile_field
+// SET value = …` answers that question without ever reaching a conflict
+// clause. No such statement exists in the tree today, which is exactly when a
+// census is cheap to widen. DELETE stays out — erasure and the retention sweep
+// clear this table deliberately, and that is somebody else's rule.
+var personProfileFieldWrite = regexp.MustCompile(`(?i)(INSERT\s+INTO|UPDATE)\s+person_profile_field`)
 
 // personProfileFieldOwner is where the writer this census requires lives. Its
 // own statement is the definition rather than a copy of it.
@@ -45,11 +54,22 @@ const personProfileFieldOwner = "internal/modules/people/personprofilefieldwrite
 // bulkRelinkIsNotAFill ratifies the merge carry-over, which is the one write of
 // this table that writePersonProfileField cannot serve.
 //
-// Keyed by FILE, so a second statement appearing in mergerelink.go is still a
-// finding: the ratification covers the write that exists, not the topic.
+// Keyed by file AND by the SHAPE that makes it exempt. A file key alone
+// ratifies the topic rather than the instance: it would exempt every future
+// write in mergerelink.go, including a plain VALUES insert with a hand-picked
+// conflict clause, which is the defect this census exists for. isCarryOver
+// decides the second half of the key, so a statement that stops being a
+// carry-over stops being waived.
 var bulkRelinkIsNotAFill = gatekit.Waive(map[string]string{
-	"internal/modules/people/mergerelink.go": "re-homes existing rows whole at a merge, all of a person's fields in one statement, rather than deciding one fill — it examines no value and writes none of its own",
+	"internal/modules/people/mergerelink.go#carry-over": "re-homes existing rows whole at a merge, all of a person's fields in one statement, rather than deciding one fill — it examines no value and writes none of its own",
 })
+
+// isCarryOver reports whether a write takes its rows FROM this table rather
+// than from values a caller decided. That is the whole of what makes the merge
+// relink a different act from a fill, so it is what the waiver is keyed on.
+func isCarryOver(sql string) bool { return carryOverSource.MatchString(sql) }
+
+var carryOverSource = regexp.MustCompile(`(?is)INSERT\s+INTO\s+person_profile_field.*\bFROM\s+person_profile_field\b`)
 
 func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
 	// A ratification that stops matching describes a write that has moved or
@@ -80,10 +100,10 @@ func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
 		for _, decl := range file.Decls {
 			for _, sql := range personProfileFieldStatements(decl) {
 				judged++
-				if !personProfileFieldInsert.MatchString(sql) {
+				if !personProfileFieldWrite.MatchString(sql) {
 					continue
 				}
-				if bulkRelinkIsNotAFill.Waived(t, filepath.ToSlash(path)) {
+				if isCarryOver(sql) && bulkRelinkIsNotAFill.Waived(t, filepath.ToSlash(path)+"#carry-over") {
 					continue
 				}
 				findings = append(findings, fmt.Sprintf("%s: %s", path, firstPersonProfileFieldLine(sql)))
@@ -157,6 +177,28 @@ var personProfileFieldProbes = []struct {
 	{"a read of the table", false, "\nfunc read() string {\n\treturn `SELECT value FROM person_profile_field WHERE person_id = $1`\n}"},
 	{"the erasure delete", false, "\nfunc erase() string {\n\treturn `DELETE FROM person_profile_field WHERE person_id = $1`\n}"},
 	{"a join naming the table", false, "\nfunc read() string {\n\treturn `SELECT 1 FROM person p JOIN person_profile_field f ON f.person_id = p.id AND f.field = 'org_name'`\n}"},
+
+	// Two shapes that escaped the first detector, each verified green against
+	// it before this one was widened.
+	{"the same insert in lower case", true, "\nfunc write() string {\n\treturn `insert into person_profile_field (person_id, field, value) values ($1, $2, $3) on conflict (person_id, field) do update set value = excluded.value`\n}"},
+	// An UPDATE answers the precedence question — what happens to a row that
+	// is already there — without ever reaching a conflict clause.
+	{"a second writer spelled as an UPDATE", true, "\nfunc write() string {\n\treturn `UPDATE person_profile_field SET value = $2 WHERE person_id = $1 AND field = 'role'`\n}"},
+}
+
+// The waiver's second half, read directly: a file key alone would ratify the
+// topic, and this is what makes it ratify the instance.
+func TestOnlyACarryOverIsRatifiedInTheMergeRelink(t *testing.T) {
+	carryOver := "INSERT INTO person_profile_field\n  (person_id, field, value)\n  SELECT $2, field, value\n    FROM person_profile_field WHERE person_id = $1\n  ON CONFLICT (person_id, field) DO NOTHING"
+	if !isCarryOver(carryOver) {
+		t.Error("the merge relink's own statement is not recognised as a carry-over, so its waiver ratifies nothing")
+	}
+	// The shape the file waiver used to exempt: a fill, with a hand-picked
+	// conflict clause, sitting in the ratified file.
+	fill := "INSERT INTO person_profile_field (person_id, field, value)\n  VALUES ($1, $2, $3)\n  ON CONFLICT (person_id, field) DO UPDATE SET value = EXCLUDED.value"
+	if isCarryOver(fill) {
+		t.Error("a plain fill is read as a carry-over, so the merge relink's waiver still exempts the whole file")
+	}
 }
 
 func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
@@ -170,7 +212,7 @@ func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
 			hit := false
 			for _, decl := range file.Decls {
 				for _, sql := range personProfileFieldStatements(decl) {
-					if personProfileFieldInsert.MatchString(sql) {
+					if personProfileFieldWrite.MatchString(sql) {
 						hit = true
 					}
 				}

--- a/backend/profilefieldwriter_test.go
+++ b/backend/profilefieldwriter_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// people.writeProfileField is the one writer of person_profile_field, and the
+// one place the precedence rule lives: a machine fill claims an unanswered
+// field, a human's acceptance replaces what is there.
+//
+// That was five hand-copied INSERTs, three of them DO NOTHING and one DO
+// UPDATE, each arguing its own conflict clause in a comment beside it. Nothing
+// could see the disagreement: all five live inside ONE package, and
+// tableownership_test.go is keyed `package:table`, so its waiver model is blind
+// to intra-package duplicates by design. This is what sees them.
+//
+// It judges the STATEMENT and not the file: a file may hold the writer's own
+// insert and a read of the same table, and asking whether both shapes appear
+// somewhere in one file reports a pairing nobody wrote.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// profileFieldInsert matches a write of the table, in either spelling the
+// tree uses: the column list on the same line as the table, or on the next.
+// Whitespace-tolerant rather than line-based, because two of the five copies
+// wrapped after the table name and a line-keyed census would have seen three.
+var profileFieldInsert = regexp.MustCompile(`INSERT\s+INTO\s+person_profile_field`)
+
+// profileFieldOwner is where the one writer lives. Its own statement is the
+// definition rather than a copy of it.
+const profileFieldOwner = "internal/modules/people/profilefieldwrite.go"
+
+// bulkRelinkIsNotAFill ratifies the merge carry-over, which is the one write of
+// this table that writeProfileField cannot serve.
+//
+// Keyed by FILE, so a second statement appearing in mergerelink.go is still a
+// finding: the ratification covers the write that exists, not the topic.
+var bulkRelinkIsNotAFill = gatekit.Waive(map[string]string{
+	"internal/modules/people/mergerelink.go": "re-homes existing rows whole at a merge, all of a person's fields in one statement, rather than deciding one fill — it examines no value and writes none of its own",
+})
+
+func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
+	// A ratification that stops matching describes a write that has moved or
+	// been folded in, and leaving it quietly re-exempts whatever takes its name.
+	defer bulkRelinkIsNotAFill.AssertAllMatched(t)
+
+	fset := token.NewFileSet()
+	var findings []string
+	judged := 0
+	for _, path := range handWrittenGoSources(t) {
+		if filepath.ToSlash(path) == profileFieldOwner {
+			continue
+		}
+		// PRODUCT writes, and the boundary is architectural rather than a
+		// shortcut: writeProfileField is unexported, so a fixture in another
+		// package could not call it however much it wanted to, and a test that
+		// seeds a prior state is not answering the question this census asks —
+		// which production path writes the row, and under whose authority. The
+		// rule that a test must seed through the real writer is held where a
+		// test CAN reach one; it is not this gate's subject.
+		if strings.HasSuffix(filepath.Base(path), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			for _, sql := range profileFieldStatements(decl) {
+				judged++
+				if !profileFieldInsert.MatchString(sql) {
+					continue
+				}
+				if bulkRelinkIsNotAFill.Waived(t, filepath.ToSlash(path)) {
+					continue
+				}
+				findings = append(findings, fmt.Sprintf("%s: %s", path, firstProfileFieldLine(sql)))
+			}
+		}
+	}
+	// A census that judged nothing certifies nothing. The floor sits far below
+	// the real count so it catches a broken walk, not a changing tree.
+	if judged < 5 {
+		t.Fatalf("only %d statement(s) naming person_profile_field were judged, so this census covered almost nothing", judged)
+	}
+	if len(findings) == 0 {
+		return
+	}
+	t.Errorf("these statements write person_profile_field by hand:\n  %s\n\n"+
+		"people.writeProfileField is the one writer, and the ON CONFLICT clause is not the "+
+		"caller's to choose: it follows from WHO is writing — a machine fill claims an "+
+		"unanswered field (claimUnanswered), a human's acceptance replaces what is there "+
+		"(replaceOnAcceptance). A hand-written clause is a second answer to that question.",
+		strings.Join(findings, "\n  "))
+}
+
+// profileFieldStatements returns the SQL statements in a declaration that name
+// the table at all — the candidate set this census counts against.
+func profileFieldStatements(decl ast.Decl) []string {
+	var out []string
+	seen := map[ast.Node]bool{}
+	ast.Inspect(decl, func(n ast.Node) bool {
+		if seen[n] {
+			return false
+		}
+		text, ok := flattenSQL(n, seen, helperScope{names: map[string]bool{"writeProfileField": true}})
+		if !ok || !strings.Contains(text, "person_profile_field") {
+			return true
+		}
+		out = append(out, text)
+		return true
+	})
+	return out
+}
+
+// firstProfileFieldLine points the report at the offending line rather than
+// dumping the statement.
+func firstProfileFieldLine(sql string) string {
+	lines := strings.Split(sql, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "person_profile_field") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return strings.TrimSpace(lines[0])
+}
+
+// The census above passes identically over a clean tree and over a detector
+// that has stopped detecting. These read the detector directly.
+var profileFieldProbes = []struct {
+	name  string
+	fires bool
+	src   string
+}{
+	{"the VALUES form three of the five copies used", true, "\nfunc write() string {\n\treturn `INSERT INTO person_profile_field (person_id, field, value) VALUES ($1, $2, $3) ON CONFLICT (person_id, field) DO NOTHING`\n}"},
+	// Two of the five wrapped after the table name, which is where a
+	// line-keyed census goes blind.
+	{"the column list wrapped onto the next line", true, "\nfunc write() string {\n\treturn `INSERT INTO person_profile_field\n\t  (person_id, field, value)\n\tSELECT $1, $2, $3`\n}"},
+	{"the DO UPDATE form, which is the disagreement itself", true, "\nfunc write() string {\n\treturn `INSERT INTO person_profile_field (person_id, field, value) VALUES ($1, $2, $3) ON CONFLICT (person_id, field) DO UPDATE SET value = EXCLUDED.value`\n}"},
+	{"the statement split across a concatenation", true, "\nfunc write() string {\n\treturn `INSERT INTO ` + `person_profile_field (person_id, field) VALUES ($1, $2)`\n}"},
+	{"an insert held inside a formatter's argument", true, "\nfunc write() string {\n\treturn fmt.Sprintf(`INSERT INTO person_profile_field (person_id, field) VALUES ($1, $2) %s`, tail)\n}"},
+
+	// Reads and deletes are somebody else's rule: erasure and the retention
+	// sweep clear this table deliberately, and every render of it is a read.
+	{"a read of the table", false, "\nfunc read() string {\n\treturn `SELECT value FROM person_profile_field WHERE person_id = $1`\n}"},
+	{"the erasure delete", false, "\nfunc erase() string {\n\treturn `DELETE FROM person_profile_field WHERE person_id = $1`\n}"},
+	{"a join naming the table", false, "\nfunc read() string {\n\treturn `SELECT 1 FROM person p JOIN person_profile_field f ON f.person_id = p.id AND f.field = 'org_name'`\n}"},
+}
+
+func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
+	fset := token.NewFileSet()
+	for _, tc := range profileFieldProbes {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := parser.ParseFile(fset, "probe.go", "package probe\n"+tc.src, 0)
+			if err != nil {
+				t.Fatalf("the probe does not parse, so it proves nothing: %v", err)
+			}
+			hit := false
+			for _, decl := range file.Decls {
+				for _, sql := range profileFieldStatements(decl) {
+					if profileFieldInsert.MatchString(sql) {
+						hit = true
+					}
+				}
+			}
+			if tc.fires && !hit {
+				t.Errorf("the detector missed a hand-written write — the census would read green over this:\n%s", tc.src)
+			}
+			if !tc.fires && hit {
+				t.Errorf("the detector reported a statement that does not write the table:\n%s", tc.src)
+			}
+		})
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -75,9 +75,9 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
+| `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
 | `profilefieldreaders_test.go` | H2 | person\_profile\_field holds what a machine ASSERTED about a person, and ai\_feedback holds what a human then decided about that assertion. |
-| `profilefieldwriter_test.go` | H2 | people.writeProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |
 | `promptvoice_test.go` | H1 | Every prompt either speaks in Margince's one voice or says why it does not. |
 | `registrarparity_test.go` | H2 | A registry that claims to be complete must be. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -47,7 +47,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (35)
+## Census (36)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -77,6 +77,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
 | `profilefieldreaders_test.go` | H2 | person\_profile\_field holds what a machine ASSERTED about a person, and ai\_feedback holds what a human then decided about that assertion. |
+| `profilefieldwriter_test.go` | H2 | people.writeProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |
 | `promptvoice_test.go` | H1 | Every prompt either speaks in Margince's one voice or says why it does not. |
 | `registrarparity_test.go` | H2 | A registry that claims to be complete must be. |


### PR DESCRIPTION
Wave 1 of the duplication audit: the three `people` findings that are one review context — #2435 (`priority: high`), #2441 and #2434.

## #2435 — the person key folded ß on one path and collapsed whitespace on the other

Site capture keyed a person on `strings.ToLower` over `strings.Fields`; the module keyed on a full Unicode casefold with only a `TrimSpace`. So `Straße` and `STRASSE` minted two leads for one person in the market this product targets — and a straight swap to the module's spelling would have traded that for the other half of the same defect, re-minting a lead whenever a re-crawl reflowed the printed name across a line break.

`people.NormalizePersonName` is both properties. It is also what the create lane locks on (`lockNameLane`) and what the same-name comparison reads (`fuzzyPerson`) — those had to move together, because a lock keyed differently from the comparison it guards is decorative.

**The gate plants both defects, and each mutant was verified to apply, compile and fail on its own case:**

| mutant | case that must go red |
|---|---|
| key reverted to `ToLower` + `Fields` | `Straße Müller` / `STRASSE MULLER` |
| key reverted to `normalizeName` (fold, no collapse) | `Anna Muster` / `Anna  Muster` |

The whitespace half is the one the issue could not see.

## #2441 — the issue's suggested fix was wrong, and the census was short

The issue asks for both guards to route through `EmploymentIsCurrentSQL`. They must not: `employmentcurrency.go` already says, in a paragraph that predates the audit, that these guards are deliberately date-BLIND — a guard that read a notice period as a freed slot would think `uq_rel_current_primary_employer` was satisfied and answer 409 where it means to skip.

The duplication is real, but of the OTHER predicate. `CurrentPrimarySlotSQL` is that index's own predicate, and it had **seven** hand-written copies, not the two filed and not the four the comment names: the two capture planters, the two merge relinks, **both demotions in `relationship.go`**, and one in `projects` that cannot adopt it (a module may not import a sibling — ADR-0054 §3) and is ratified with that reason.

Held two ways, because either alone reads green over the defect that shipped:

- `TestTheCurrentPrimarySlotHelperMirrorsItsIndex` derives the expected predicate **from `uq_rel_current_primary_employer` in the migration head catalog**, so the helper cannot drift from what it exists to satisfy. Mutants verified: dropping the archived test, and dropping the kind, each fail against the catalog.
- `TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling` reads the tree for the FRAGMENT — the flag AND-ed with an archived test, **in either order** — which is the shape that hid six copies from a census that only knew whole predicates. Mutant verified by reverting one adopted site.

The probe suite covers the false-POSITIVE direction too: the create path's guard is deliberately wider (`archived_at IS NULL AND (still-employed OR flagged)`), and a probe asserts the detector does not report it.

## #2434 — the ruling, and it is not "first wins" or "last wins"

Five writers hand-copied the column list; three wrote `DO NOTHING` and one wrote `DO UPDATE`, each arguing its clause locally. Which value a profile field held depended on which pass ran last.

**The rule is who is writing.** A machine fill CLAIMS an unanswered field and never replaces one — it read a footer, a snippet or a page, and a pass that overwrote a human's correction would undo it again the next night. A human's ACCEPTANCE replaces what is there, because somebody read the claim, its quote and the document behind it and chose (ADR-0096 D4). So `researchclaim.go`'s `DO UPDATE` was right and stays; the other three are the same rule read the other way round. The ruling lives at the shared writer, in the code, not here.

Two things fall out:

- **The subject's liveness now rides all four inserts**, not just the search pass's. The Art. 17 window between an entry gate and a commit is the same window for every one of them.
- **A replacement now takes `confidence` too.** A row that kept a signature pass's score under a human's value said a person's decision had been measured by a model that never saw it.

The issue's own line that only `enrichsignature` writes `confidence` is false — `mergerelink.go:64` carries it through, so it is two of five. The merge relink stays outside the shared writer (it re-homes existing rows whole rather than deciding a fill) and is ratified with that reason; it now names its conflict target so a future constraint cannot start swallowing a different collision there.

**The direction already held was that a second acceptance replaces the first — which reads green over the inverse defect,** since a machine fill that also replaced satisfies every assertion in it. The integration tests here plant the fill that arrives AFTER a human answered. Three mutants verified: acceptance stops replacing, the replacement keeps the old score, and a machine fill takes the human's precedence.

## What a gate found by accident, and is worth knowing

`people` already had a `writeProfileField` — the ORGANIZATION profile field's one path. A second function of that name in the same package is the defect this change exists to remove, and no reader would see it: different files, different halves of the module.

It surfaced because `writeauthorityreach_test.go` keys its call graph by NAME, so the organization writer's auth probe answered for the person writer and two waivers went stale instead of a finding being reported. The fix here is the name (`writePersonProfileField`); the gate reading a merged graph is filed separately.

## Verification

- `make check-backend` green (the `retainedcolumncases_test.go` red was #2628's and is now merged in).
- `craft static --strict` over all 24 changed Go files: 0 blocker, 0 major, 0 minor.
- `make test-it DIR=backend/internal/modules/people` green.
- New production functions at **100%** statement coverage (`NormalizePersonName`, `CurrentPrimarySlotSQL`, `writePersonProfileField`, `conflictClause`).
- No prompt changed, so no aicert re-run is owed.

Closes #2435
Closes #2441
Closes #2434

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the person-name key, standardizes the current-primary slot guard, and centralizes `person_profile_field` writes under one precedence rule. This eliminates duplicate/missed matches, prevents slot-guard drift that caused 409s, and fixes counters that reported saves that never landed.

- Go and SQL now share `people.NormalizePersonName`; the exact-match arm uses `personNameKeySQL(...)` to add internal-whitespace collapse and Greek final-sigma folding.
- Site capture, cross-page merge, and `siteread` lead keys fold on `sitePersonIdentity` (normalized name + published email) to dedupe reflowed names and keep distinct colleagues separate.
- All machine fills and human acceptances go through `people.writePersonProfileField`; machines claim unanswered fields, human acceptances replace and update `confidence`; the merge relink stays a carry-over and names its conflict target.
- The writer enforces subject liveness and locks the person row (FOR UPDATE); `SaveResearchClaims` now fails when a write is refused; counters no longer over-report.
- Title fills from signatures and site reads only write when `archived_at IS NULL`.
- All current-primary slot guards call `people.CurrentPrimarySlotSQL`; a mirror test derives its predicate from `uq_rel_current_primary_employer`; the detector now matches conjunctive variants, ignores negations, and covers alternate spellings; `projects` remains waived due to the module DAG.
- No migrations required.

<sup>Written for commit bf61fd5267ce57352624821facf3c85e2c0f9dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved person matching across Unicode, accents, capitalization, spacing, and published email differences.
  * Standardized current-primary employment handling to prevent conflicting assignments.
  * Centralized profile-field updates so human-confirmed information takes precedence over automated discoveries.
  * Improved validation and reporting of profile-field persistence conflicts.

* **Bug Fixes**
  * Prevented archived people and invalid evidence from receiving profile updates.
  * Corrected profile-field precedence when replacing automated data with human-confirmed values.
  * Improved consistency when detecting current-primary employment conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## What review changed, and what it found that the code did not say

Three reviewers ran over this — Codex, a second model, and CodeRabbit. They converged on one defect independently and turned up five more between them. Everything below is in the branch.

### The defect all three found

**The acceptance path counted a write that did not happen.** `SaveResearchClaims` kept its unconditional `saved++` after the writer gained a liveness predicate, so an erasure committing between `EnsureWritableLive` and the INSERT — at READ COMMITTED each statement is a fresh snapshot, which is the window the predicate exists for — landed nothing while the audit row and the outbox event both reported one claim saved.

It fails the acceptance now rather than skipping the claim: a subject erased mid-transaction is not a claim the caller declined, it is their whole acceptance no longer being writable.

### The predicate narrowed a window; it did not close one

The read of `person` is `FOR UPDATE`. Without it an erasure can still commit between this transaction's snapshot and its own write, and the foreign key accepts the parent it has just archived — so the row lands on an erased subject and nothing complains. Locking `person` and not the field row, because the field row may not exist yet and what has to be serialized is the subject's liveness; every caller that then writes a person COLUMN takes the same row next, so no new deadlock edge.

Proved by making an erasure wait for a fill that is holding the subject. No sleep and no clock — the erasure's own `lock_timeout` reports the blocking, and without the lock it commits immediately and the probe fails on the successful path.

### Adopting the module's key made a site-read fold WORSE, not better

The page lane and the cross-page merge folded on the NAME while the lead key folded on name plus printed address. Two keys, and the looser one ran first. The module key UNACCENTS — which is what makes one person spelled two ways one person — so two colleagues published as `José Silva` and `Jose Silva` with two addresses collapsed into one before the address that tells them apart was ever consulted, and the lead key could not put back a person the merge had already discarded.

`sitePersonIdentity` is the one identity all three steps use now, and the printed address is part of it.

### Two title fills could write back an erased person's title

`enrichsignature.go` and `sitepersonfields.go` fill `person.title` in a statement beside the evidence row. The evidence row refuses on an archived subject; the title write had no such predicate, so the fill was split across two statements with only one of them looking. Both carry `archived_at IS NULL` now.

### The name-key arm was short by a letter, and nothing could have said so

The candidate query's exact-equality arm exists so the lane does not depend on the trigram threshold. The test in front of it asks whether a Go-equal pair REACHES the lane — which the trigram arm answers first, so every pair passed whether the arm admitted it or not. **Measured**: reverting `personNameKeySQL` left that test entirely green, because `f_fold_apostrophes(lower('Éva  Ő'))` is `eva  o` and pg_trgm normalises whitespace, so similarity is 1.

Asked directly, the arm did not admit `Οδυσσεύς` against `ΟΔΥΣΣΕΥΣ`: Go's full fold maps final sigma onto σ and `lower()` leaves it alone, so one person in Go was two in SQL. It folds it now, and `TestTheNameKeyArmAdmitsEveryGoEqualPair` asks the arm rather than the query it sits in. Both tests read ONE list of pairs, so the guarantee cannot be asserted over a smaller set than the lane's.

Not a duplicate anybody is losing today — the trigram arm admits that pair at 0.5 against a 0.3 threshold. That dependence is exactly what the arm was written to remove.

### Three gates read green over the defect they name

| gate | what escaped | now |
|---|---|---|
| slot census | `= true`, `IS TRUE`, lower case, an interleaved conjunct, a bracketed second half | reads terms — split on OR, then AND, then ask whether a term TESTS the flag |
| slot census | a column list NAMES the flag; a merge relink ASSIGNS it; `NOT` negates it | none of the three is a test, and each has a probe |
| writer census | case-sensitive, and INSERT-only | case-insensitive, and UPDATE too |
| both censuses | the cheap prefilter folded no case while the detector did | both fold — a prefilter narrower than its detector drops the file before anything looks at it |
| writer waiver | keyed by FILE while the comment claimed the instance, so every future write in the merge relink was exempt | keyed by file AND the carry-over shape, with its own test |

Every escape has a probe, and each was verified to fire at a real call site.

### One finding declined, and one trade taken deliberately

**Declined:** that the SQL candidate key does not fold the sharp s, leaving `Straße` unreachable from `Strasse`. Measured on the schema instead of argued: `f_fold_apostrophes(lower('Anna Straße'))` is `anna strasse` — the fold happens inside `unaccent` — and similarity against `Anna Strasse` is 1. Both arms already admit the pair, and the integration case asserting it has been green throughout.

**Taken deliberately:** the slot detector over-reports one shape — an INSERT whose column list is exactly `(is_current_primary)`. Telling it apart means deciding whether an opening bracket follows a keyword or a name, and getting THAT wrong drops the contents of `NOT EXISTS (…)`, where five of the six judged statements live. Over-reporting is a finding somebody dismisses; under-reporting is a census that reads green over the defect and says nothing. There is a firing probe for the `NOT EXISTS` shape so the trade is held rather than assumed.

### One thing this PR changes that no reviewer asked about

**`siteLeadSourceID`'s digest changes for any name carrying an accent or a ß.** It is a STORED idempotency key under `source_system: siteread` and the staging identity an undecided proposal is superseded by. A lead captured before this lands holds the old key; the next crawl of an unchanged page derives the new one, so it mints a second lead and stacks a second question beside the undecided proposal instead of superseding it. There is no backfill, which is the repo's stated posture on this — but the PR body should say so rather than leave it to be discovered.

## Issue filed alongside

margince/margince#2648 — the person-name key and its SQL prefilter disagree about an apostrophe. `f_fold_apostrophes` folds it on both arms; `NormalizePersonName` does not. The prefilter admits a pair the Go comparison then rejects, which is the inverse of the invariant the reachability test holds. Filed rather than fixed: folding punctuation changes matching for every person AND every organization, and the pinned Jaro-Winkler input with them.
