### PR TITLE
fix(people): the name-lane table holds only pairs Go calls equal

### DIFF
--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -444,11 +444,14 @@ func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
 		{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
 		{"accents", "Renée Bär", "Renee Bar"},
 		{"sharp s", "Anna Straße", "Anna Strasse"},
-		{"apostrophe", "Sean O'Brien", "Sean OBrien"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// The table IS the claim that Go calls these equal, so a pair that
+			// stops being equal is the finding — not a row that quietly excuses
+			// itself and leaves the lane untested in the direction that matters.
 			if normalizeName(tc.incumbent) != normalizeName(tc.second) {
-				t.Skipf("normalizeName does not call these equal, so the lane owes nothing: %q vs %q",
+				t.Fatalf("normalizeName no longer calls %q and %q equal, so this row "+
+					"tests nothing: either the fold changed or the pair never belonged here",
 					tc.incumbent, tc.second)
 			}
 			e := setupDedupe(t)


### PR DESCRIPTION
`main` is red on the integration lane. Shard 1/6, from #2637:

```
FAIL: integration tests must not skip — provision the env/service, do not skip:
    --- SKIP: TestEveryNameGoCallsEqualReachesTheNameLane/apostrophe (0.00s)
```

Exactly one skip in the whole lane, and it is not an unprovisioned service —
the subtest excuses itself.

## What the row could never do

`TestEveryNameGoCallsEqualReachesTheNameLane` asserts the invariant its own
comment states: *any pair `normalizeName` calls equal must reach the name
lane.* Each row first checks that Go does call the pair equal, and skipped
when it did not.

`normalizeName` folds case, strips combining marks and trims. It does not
touch punctuation. So `"Sean O'Brien"` and `"Sean OBrien"` are never equal
under it, the row skipped on every run, and no change to the lane could have
made it assert anything. Confirmed by running the fold over all six rows —
the other five are equal, that one is not.

## The guard was hiding more than one row

A row that steps aside when the fold disagrees is the failure mode the file's
own comment warns about, pointed at the test instead of the lane: it goes
quiet in the direction of doing nothing. If the fold ever stopped calling
`"Renée Bär"` and `"Renee Bar"` equal, that row would skip too — silently,
green, with the lane unproven exactly where it matters.

So the guard becomes the assertion it should always have been. The table is
the claim that Go calls these five equal; a pair that stops being equal is a
finding about the fold, not a reason to test nothing.

## Not fixed here

Whether `normalizeName` *should* fold punctuation — so that `"Sean O'Brien"`
and `"Sean OBrien"` are caught as a duplicate — is a real question, but it
changes matching for the whole dedupe lane and for `NormalizeOrgName`, which
builds on it. That is a product decision, not a red-fix.

## Verified

- `go vet -tags integration ./internal/modules/people/` — clean
- The fold checked directly over all six pairs: five equal, the apostrophe pair
  not, which is the whole of the diagnosis

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert the name lane test from skip-on-mismatch to fail-on-mismatch and drop the apostrophe case to fix the red integration lane. Previously the test skipped when a pair was not equal under `normalizeName`; now it fails, and the table holds only pairs `normalizeName` actually calls equal.

- Remove the "apostrophe" pair ("Sean O'Brien"/"Sean OBrien"), since `normalizeName` does not fold punctuation.
- Replace the skip guard with a fatal assertion to enforce that listed pairs remain equal under `normalizeName`.
- Test-only change; no runtime behavior change. CI stops failing due to a forbidden skip.

<sup>Written for commit 417a8d21dd3aa4c7574f7469fa8a6ea6509a37bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated name-normalization coverage to fail when expected duplicate matches are no longer detected.
  * Removed an obsolete apostrophe-normalization test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->