### PR TITLE
fix(company360): a payload with no omission list no longer breaks the record

### DIFF
--- a/frontend/src/screens/companywork.test.tsx
+++ b/frontend/src/screens/companywork.test.tsx
@@ -437,6 +437,23 @@ describe("what moved since the reader was last here", () => {
     ).toBeDefined();
   });
 
+  // A composite that answered WITHOUT the omission list at all. The field is
+  // required on the wire, so every fixture in this file supplies one and none
+  // of them covered this — meanwhile the real page read `.length` off the
+  // absent list, threw, and the whole company record rendered as "this view no
+  // longer works". An older server, a trimmed mock and a partial cache entry
+  // all produce this payload.
+  it("says nothing is withheld when the payload carries no omission list", () => {
+    const noList = view();
+    // Deleted rather than set to undefined: absent and explicitly-undefined are
+    // the same bytes over the wire, and `delete` is the one that reproduces a
+    // response that never named the field.
+    delete (noList as { sections_omitted?: unknown }).sections_omitted;
+
+    expect(() => sinceLastVisitFooter(noList)).not.toThrow();
+    expect(sinceLastVisitFooter(noList)).toBeUndefined();
+  });
+
   // The standalone card is the mount that stayed broken while the other was
   // fixed. Both go through the same helper now, and this is what says so.
   it("draws no footer band on the standalone card when nothing moved", () => {

--- a/frontend/src/screens/companywork.tsx
+++ b/frontend/src/screens/companywork.tsx
@@ -212,7 +212,11 @@ function speaksSinceLastVisit(view?: Organization360): boolean {
   return (
     firstVisit(view) ||
     newActivities(view) > 0 ||
-    (view?.sections_omitted.length ?? 0) > 0
+    // Optional on BOTH hops: a composite that answered without the omission
+    // list names nothing withheld, and reading `.length` off the absent list
+    // throws where the whole record page then renders as "this view no longer
+    // works".
+    (view?.sections_omitted?.length ?? 0) > 0
   );
 }
 


### PR DESCRIPTION
The company record page rendered as "this view no longer works" — an error
boundary over a `TypeError: Cannot read properties of undefined (reading
'length')`.

## The defect

`speaksSinceLastVisit` in `companywork.tsx` guarded the view but not the list
on it:

```ts
(view?.sections_omitted.length ?? 0) > 0
```

The optional chain stops at `view`. A composite that answered WITHOUT the
omission list threw, where it should read as "nothing was withheld". The
sibling spelling ten lines above already carried the second `?.` — the two
diverged, and the one without it is the one both mounts route through.

## Why the unit suite did not see it

`sections_omitted` is required on the wire, so all 22 fixtures in
`companywork.test.tsx` supply one. They passed against a page that could not
render.

`make frontend-e2e` caught it, and reported it as an axe failure — "no h1 on
#/companies/<id>". There was no h1 because there was no page. Worth
remembering: `check-fe` does not run Playwright, so a crash of this shape
passes every required check.

## The test

It `delete`s the field rather than assigning undefined — absent and
explicitly-undefined are the same bytes over the wire, and only `delete`
reproduces a response that never named it. Mutation-checked: it fails against
the old spelling.

## Checks

`make check-fe` (4739 tests) and `make frontend-e2e` (94 tests) both green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on the Company 360 page when `sections_omitted` is missing from the payload. Previously we read `.length` from `undefined` and the page showed “this view no longer works”; now a missing omission list is treated as “nothing withheld” and the page renders.

- Guard `sections_omitted` with optional chaining in `speaksSinceLastVisit` to avoid the TypeError.
- Add a test that deletes the field to simulate an absent wire value and prevent regressions.

<sup>Written for commit 9fee099c9d51c0f69815ca7ddf543d026f9a7558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause an error when visit data lacks omitted-section details.
  * The “Since last visit” footer now loads safely and remains unavailable when the required information is missing.

* **Tests**
  * Added coverage for visit payloads without omitted-section data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->