### PR TITLE
fix(frontend): a figure is written in the reader's own notation, and a sort says which kind of string it holds

### DIFF
--- a/frontend/src/app/topbar.tsx
+++ b/frontend/src/app/topbar.tsx
@@ -1,6 +1,7 @@
 import { Layers, PanelLeftClose, PanelLeftOpen, Search } from "lucide-react";
 import { Breadcrumb, type Crumb } from "../design-system/breadcrumb";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { SETTINGS_SCREEN } from "../screens/settings";
 import { AccountMenu } from "./account";
 import { SCREEN_ENTITY } from "./entity";
@@ -156,6 +157,7 @@ function TopBarSearch({
  */
 function DecisionsMark({ waiting }: Readonly<{ waiting?: number }>) {
   const t = useT();
+  const { locale } = useLocale();
   const count = waiting ?? 0;
   return (
     <a
@@ -163,7 +165,7 @@ function DecisionsMark({ waiting }: Readonly<{ waiting?: number }>) {
       href={routeHash({ screen: "inbox" })}
       aria-label={
         count > 0
-          ? t("shell.approvalsWaiting", { count })
+          ? t("shell.approvalsWaiting", { count: formatNumber(count, locale) })
           : t("shell.approvals")
       }
     >

--- a/frontend/src/app/uploadlimit.test.ts
+++ b/frontend/src/app/uploadlimit.test.ts
@@ -11,28 +11,35 @@ import { formatUploadLimit } from "./uploadlimit";
 
 describe("stating the upload limit", () => {
   it("renders a whole limit as a whole number", () => {
-    expect(formatUploadLimit(25_000_000)).toBe("25 MB");
-    expect(formatUploadLimit(3_000_000)).toBe("3 MB");
+    expect(formatUploadLimit(25_000_000, "en")).toBe("25 MB");
+    expect(formatUploadLimit(3_000_000, "en")).toBe("3 MB");
   });
 
   it("keeps a decimal rather than rounding a limit away", () => {
     // What a binary constant on the server would produce. Rounded to "8 MB"
     // this would refuse a file at 8.2 MB that the sentence said would fit.
-    expect(formatUploadLimit(8 << 20)).toBe("8.4 MB");
-    expect(formatUploadLimit(12_500_000)).toBe("12.5 MB");
+    expect(formatUploadLimit(8 << 20, "en")).toBe("8.4 MB");
+    expect(formatUploadLimit(12_500_000, "en")).toBe("12.5 MB");
   });
 
   it("still describes a limit below a megabyte", () => {
     // Truncating division read this as "0 MB", which tells the reader nothing
     // they can act on.
-    expect(formatUploadLimit(900_000)).toBe("0.9 MB");
+    expect(formatUploadLimit(900_000, "en")).toBe("0.9 MB");
+  });
+
+  it("writes the decimal the way this reader writes decimals", () => {
+    // The figure a German reader compares against their own file. Shown with a
+    // decimal POINT it reads as twelve thousand five hundred, in a sentence
+    // whose other numbers all carry a comma.
+    expect(formatUploadLimit(12_500_000, "de")).toBe("12,5 MB");
   });
 
   it("uses decimal megabytes, the unit the server enforces", () => {
     // 25 MiB is 26,214,400 bytes. Reported as "25 MB" it overstates the real
     // ceiling by 4.8% — the drift this whole unit choice exists to remove.
-    expect(formatUploadLimit(25_000_000)).not.toBe(
-      formatUploadLimit(25 * 1024 * 1024),
+    expect(formatUploadLimit(25_000_000, "en")).not.toBe(
+      formatUploadLimit(25 * 1024 * 1024, "en"),
     );
   });
 });

--- a/frontend/src/app/uploadlimit.ts
+++ b/frontend/src/app/uploadlimit.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
+import { INTL_LOCALE } from "../format/format";
+import type { Locale } from "../i18n";
 import { throwProblem } from "../screens/common";
 
 // The installation's own settings, and the one field on them a form has to act
@@ -72,7 +74,15 @@ export function useMaxUploadBytes(): number | undefined {
  * the reader who believed it would then be refused by a server that had already
  * told them twice, in two different numbers.
  */
-export function formatUploadLimit(bytes: number): string {
+export function formatUploadLimit(bytes: number, locale: Locale): string {
   const mb = bytes / 1_000_000;
-  return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`;
+  // Through Intl, so the decimal separator is the reader's own: a German reader
+  // shown "12.5 MB" reads twelve and a half as twelve-thousand-five-hundred,
+  // and the unit word rides Intl's vocabulary rather than a table here.
+  return new Intl.NumberFormat(INTL_LOCALE[locale], {
+    style: "unit",
+    unit: "megabyte",
+    unitDisplay: "short",
+    maximumFractionDigits: Number.isInteger(mb) ? 0 : 1,
+  }).format(mb);
 }

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -15,9 +15,9 @@ import {
   formatDate,
   formatDuration,
   formatMoneyOrAbsent,
+  formatNumber,
 } from "../format/format";
-import { useLocale, useT } from "../i18n";
-import type { MessageKey } from "../i18n/en";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import { Avatar, Badge, Button } from "./atoms";
 import { PageZones, type PageZonesShape } from "./pagezones";
 import { FieldGuard } from "./rbac";
@@ -301,7 +301,10 @@ function BoardLayout<Record extends BoardRecord>({
                   {countLabel
                     ? countLabel(column.count ?? column.deals.length)
                     : t("board.count", {
-                        count: column.count ?? column.deals.length,
+                        count: formatNumber(
+                          column.count ?? column.deals.length,
+                          locale,
+                        ),
                       })}
                 </span>
               </span>
@@ -1008,17 +1011,18 @@ export function GroupedTimelineList({
 // plural forms rendered "1 messages" and "sent to 1 people" for it.
 function groupCountLabel(
   group: TimelineGroup,
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string,
+  t: Translator,
+  locale: Locale,
 ): string {
   const count = group.entries.length;
   if (group.kind === "bulk") {
     return count === 1
       ? t("timeline.group.bulkOne")
-      : t("timeline.group.bulk", { count });
+      : t("timeline.group.bulk", { count: formatNumber(count, locale) });
   }
   return count === 1
     ? t("timeline.group.threadOne")
-    : t("timeline.group.thread", { count });
+    : t("timeline.group.thread", { count: formatNumber(count, locale) });
 }
 
 function TimelineGroupRow({
@@ -1044,7 +1048,9 @@ function TimelineGroupRow({
       <div className="tl-body">
         <span className="tl-title">{newest.title}</span>
         <span className="tl-meta">
-          <span className="tl-group-count">{groupCountLabel(group, t)}</span>
+          <span className="tl-group-count">
+            {groupCountLabel(group, t, locale)}
+          </span>
           <span>{formatDate(newest.atIso, locale, zone)}</span>
           <ProvenanceTag provenance={newest.provenance} />
           <Button small aria-expanded={open} onClick={() => setOpen(!open)}>

--- a/frontend/src/design-system/explain.tsx
+++ b/frontend/src/design-system/explain.tsx
@@ -1,6 +1,11 @@
 import { Info } from "lucide-react";
 import { useState } from "react";
-import { type ExplainedMoney, formatDate, formatMoney } from "../format/format";
+import {
+  type ExplainedMoney,
+  formatDate,
+  formatMoney,
+  formatRate,
+} from "../format/format";
 import { useLocale, useT } from "../i18n";
 
 // "Explain this number" (B-EP09.18, ADR-0004): a converted aggregate opens
@@ -52,7 +57,7 @@ export function ExplainNumber({
                 </span>
                 <span className="t-small">
                   {t("explain.rate", {
-                    rate: row.rate,
+                    rate: formatRate(row.rate, locale),
                     date: formatDate(row.rateDate, locale, workspaceZone),
                   })}
                 </span>

--- a/frontend/src/design-system/listsurface.tsx
+++ b/frontend/src/design-system/listsurface.tsx
@@ -1,6 +1,7 @@
 import { Check, Filter, MoreVertical, Plus, Search } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import "./listtable.css";
 
 // The value list's own search box debounces on the same rhythm as the list
@@ -734,14 +735,21 @@ export function CountLine({
   sortedBy?: string;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
+  // All three figures are magnitudes in ONE sentence ("1–25 of 1,234 rows"), so
+  // they group together or the line reads as two notations at once.
+  const range = {
+    first: formatNumber(first, locale),
+    last: formatNumber(last, locale),
+    count: formatNumber(total, locale),
+    unit,
+  };
   // The surface owns the count's placement; this only says what it reads.
   return (
     <>
       {total === 0 && t("table.none", { unit })}
       {total > 0 &&
-        (more
-          ? t("table.rangeLoaded", { first, last, count: total, unit })
-          : t("table.range", { first, last, count: total, unit }))}
+        (more ? t("table.rangeLoaded", range) : t("table.range", range))}
       {sortedBy && `, ${t("table.sortedBy", { column: sortedBy })}`}
     </>
   );

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -15,7 +15,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { Checkbox, useScrollRegion } from "./atoms";
 import {
   CountLine,
@@ -1286,6 +1287,7 @@ function Pager({
   onPerPage?: (next: number) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <div className={`lt-foot${lastPage === 1 && !hasMore ? " single" : ""}`}>
       {/* A landmark, because this is navigation and a reader who jumps by region
@@ -1307,7 +1309,9 @@ function Pager({
               key={slot}
               className={slot === current ? "on" : undefined}
               aria-current={slot === current ? "page" : undefined}
-              aria-label={t("table.page", { number: slot })}
+              // A page number is an ordinal, never grouped: "page 1.234" reads
+              // as a fraction of a page rather than the 1234th of them.
+              aria-label={t("table.page", { number: String(slot) })}
               onClick={() => onGoto(slot)}
             >
               {slot}
@@ -1341,7 +1345,7 @@ function Pager({
           onChange={(next) => onPerPage?.(Number(next))}
           options={PAGE_SIZES.map((size) => ({
             value: String(size),
-            label: t("table.perPage", { count: size }),
+            label: t("table.perPage", { count: formatNumber(size, locale) }),
           }))}
         />
       </span>

--- a/frontend/src/design-system/surfacestate.tsx
+++ b/frontend/src/design-system/surfacestate.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { ReactNode } from "react";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { Button, PendingBody } from "./atoms";
 import { Eyebrow, type EyebrowElement } from "./eyebrow";
 import "./surfacestate.css";
@@ -183,6 +184,7 @@ export function SurfaceState({
   children: ReactNode;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const body = (
     <>
       {state === "ready" && children}
@@ -231,7 +233,9 @@ export function SurfaceState({
           {children}
           <p className="surfacestate-empty">
             {detail?.remaining
-              ? t("state.partialCount", { count: detail.remaining })
+              ? t("state.partialCount", {
+                  count: formatNumber(detail.remaining, locale),
+                })
               : t("state.partial")}
           </p>
         </>

--- a/frontend/src/format/collate.test.ts
+++ b/frontend/src/format/collate.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { foldForMatch, forReader, stable } from "./collate";
+
+// The two orderings exist because neither one is right everywhere, so what is
+// asserted here is the DIFFERENCE between them. A test that only checked each
+// sorted something would pass with one function.
+
+describe("forReader orders the way a reader of that locale expects", () => {
+  it("puts an umlaut beside its base letter for a German reader", () => {
+    // Code-unit order puts every accented vowel after Z, so `Äpfel` lands
+    // after `Zebra` — the single most visible collation defect in this
+    // product's German UI, and the reason this function exists.
+    const names = ["Zebra", "Äpfel", "Apfel"];
+    expect([...names].sort((a, b) => forReader(a, b, "de"))).toEqual([
+      "Apfel",
+      "Äpfel",
+      "Zebra",
+    ]);
+    expect([...names].sort(stable)).toEqual(["Apfel", "Zebra", "Äpfel"]);
+  });
+
+  it("reads case as a difference in weight, not in identity", () => {
+    // A reader scanning names does not expect every capital before every
+    // lower-case letter, which is what code-unit order gives.
+    const names = ["bravo", "Alpha", "alpha"];
+    expect([...names].sort((a, b) => forReader(a, b, "en"))).toEqual([
+      "alpha",
+      "Alpha",
+      "bravo",
+    ]);
+    expect([...names].sort(stable)).toEqual(["Alpha", "alpha", "bravo"]);
+  });
+
+  it("answers per locale, which is the whole point and also the cost", () => {
+    // Swedish-style ordering is not what German gives; the same pair can order
+    // differently for two readers. That is correct for a name and wrong for a
+    // key, which is why `stable` is a separate function rather than a flag.
+    expect(forReader("Apfel", "Äpfel", "de")).toBeLessThan(0);
+    expect(forReader("a", "A", "en")).toBeLessThan(0);
+  });
+});
+
+describe("stable orders identically for everyone", () => {
+  it("is a total order with no locale in it", () => {
+    expect(stable("a", "b")).toBeLessThan(0);
+    expect(stable("b", "a")).toBeGreaterThan(0);
+    expect(stable("a", "a")).toBe(0);
+  });
+
+  it("sorts an ISO timestamp chronologically, which is why a key may use it", () => {
+    // ISO-8601 is designed so that lexicographic order IS chronological order.
+    const stamps = [
+      "2026-08-25T09:00:00Z",
+      "2026-01-02T23:59:59Z",
+      "2026-08-25T08:59:59Z",
+    ];
+    expect([...stamps].sort(stable)).toEqual([
+      "2026-01-02T23:59:59Z",
+      "2026-08-25T08:59:59Z",
+      "2026-08-25T09:00:00Z",
+    ]);
+  });
+});
+
+describe("foldForMatch folds the same way on every machine", () => {
+  it("folds a capital I to a dotted i, whatever the host locale is", () => {
+    // `toLocaleLowerCase` under a Turkish locale yields the dotless `ı`, so a
+    // needle folded there stops matching a haystack folded anywhere else.
+    // Matching needs both sides to agree more than it needs either to be
+    // linguistically right.
+    expect(foldForMatch("ISTANBUL")).toBe("istanbul");
+    expect(foldForMatch("Istanbul".toUpperCase())).toBe(
+      foldForMatch("istanbul"),
+    );
+  });
+
+  it("still folds the accented letters a search has to see through", () => {
+    expect(foldForMatch("MÜLLER")).toBe("müller");
+  });
+});

--- a/frontend/src/format/collate.test.ts
+++ b/frontend/src/format/collate.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
 import { describe, expect, it } from "vitest";
 import { foldForMatch, forReader, stable } from "./collate";
 

--- a/frontend/src/format/collate.ts
+++ b/frontend/src/format/collate.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Locale } from "../i18n";
+import { INTL_LOCALE } from "./format";
+
+// Two ways to order strings, and the whole point of this file is that a caller
+// has to SAY which one it means.
+//
+// `String.prototype.localeCompare` reads as the careful choice and is the wrong
+// default twice over. Called bare it sorts by the BROWSER's guessed locale,
+// which is neither the reader's setting nor stable between two colleagues
+// looking at the same list. Called with a locale it is right for a name and
+// wrong for a key, because a key sorted per-locale keys differently per reader.
+//
+// So neither answer generalises, which is why there is no single helper here.
+// A site picks `forReader` or `stable`, and the name it calls is the record of
+// which kind of string it holds.
+
+/**
+ * Order two strings the way THIS READER expects to see them.
+ *
+ * For anything a person reads as a list of names — people, companies, teams,
+ * labels. A German reader expects `ä` beside `a`; a Vietnamese reader expects
+ * the tone-marked vowels in their own order. Both differ from code-unit order,
+ * where `Ä` lands after `Z`.
+ *
+ * The collator is built per locale and cached, because constructing one costs
+ * more than the comparison and a sort calls this O(n log n) times.
+ */
+export function forReader(a: string, b: string, locale: Locale): number {
+  return collator(locale).compare(a, b);
+}
+
+const collators = new Map<Locale, Intl.Collator>();
+
+function collator(locale: Locale): Intl.Collator {
+  const held = collators.get(locale);
+  if (held) {
+    return held;
+  }
+  const made = new Intl.Collator(INTL_LOCALE[locale]);
+  collators.set(locale, made);
+  return made;
+}
+
+/**
+ * Order two strings IDENTICALLY for everyone, forever.
+ *
+ * For a machine key, an id, an ISO timestamp, a currency code, an enum value —
+ * and for the tiebreaker that keeps a sort from re-ordering itself between two
+ * reads of the same data. Code-unit order is not human alphabetical order, and
+ * that is not a defect here: nobody reads this as an alphabet, and being the
+ * same everywhere is the only property that matters.
+ *
+ * Spelled out rather than delegating to `localeCompare(a, b, "en")`, so the
+ * gate in one-locale.test.ts can refuse every bare `localeCompare` in the tree
+ * without this file having to be its exception.
+ */
+export function stable(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  return a > b ? 1 : 0;
+}
+
+/**
+ * Fold a string for MATCHING, identically on every machine.
+ *
+ * `toLocaleLowerCase` folds per locale — Turkish maps `I` to a dotless `ı` —
+ * so a needle folded under one locale stops matching a haystack folded under
+ * another. A search is a comparison between two strings this product holds, not
+ * a sentence anybody reads, so it wants the invariant fold on both sides.
+ */
+export function foldForMatch(value: string): string {
+  return value.toLowerCase();
+}

--- a/frontend/src/format/format.calendar-days.test.ts
+++ b/frontend/src/format/format.calendar-days.test.ts
@@ -13,7 +13,10 @@ import { calendarDaysBetween, relativeDays } from "./format";
 // (shared/kernel/elapsed), and these cases are the ones where the two spellings
 // visibly disagree.
 
-const t = (key: string, vars?: Record<string, string | number>) =>
+// Mirrors the real translator's parameter type rather than a wider one: the
+// whole point of the last case below is what `relativeDays` hands across, and a
+// double that accepted a number would have accepted the defect too.
+const t = (key: string, vars?: Record<string, string>) =>
   vars ? `${key}:${JSON.stringify(vars)}` : key;
 
 describe("calendarDaysBetween", () => {
@@ -56,38 +59,50 @@ describe("relativeDays", () => {
   const now = new Date("2026-08-24T12:00:00Z");
 
   it("says never for an absent timestamp", () => {
-    expect(relativeDays(null, t, now)).toBe("person.strip.never");
-    expect(relativeDays(undefined, t, now)).toBe("person.strip.never");
+    expect(relativeDays(null, t, "en", now)).toBe("person.strip.never");
+    expect(relativeDays(undefined, t, "en", now)).toBe("person.strip.never");
   });
 
   it("says today for the same calendar day", () => {
-    expect(relativeDays("2026-08-24T01:00:00Z", t, now)).toBe(
+    expect(relativeDays("2026-08-24T01:00:00Z", t, "en", now)).toBe(
       "person.strip.today",
     );
   });
 
   it("says today for a future timestamp rather than a negative count", () => {
-    expect(relativeDays("2026-09-01T00:00:00Z", t, now)).toBe(
+    expect(relativeDays("2026-09-01T00:00:00Z", t, "en", now)).toBe(
       "person.strip.today",
     );
   });
 
   it("says yesterday for the previous calendar day", () => {
-    expect(relativeDays("2026-08-23T22:00:00Z", t, now)).toBe(
+    expect(relativeDays("2026-08-23T22:00:00Z", t, "en", now)).toBe(
       "person.strip.yesterday",
     );
   });
 
   it("counts the days for anything older", () => {
-    expect(relativeDays("2026-05-20T09:00:00Z", t, now)).toBe(
-      'person.strip.days:{"count":96}',
+    expect(relativeDays("2026-05-20T09:00:00Z", t, "en", now)).toBe(
+      'person.strip.days:{"count":"96"}',
+    );
+  });
+
+  it("hands the count across already grouped for this reader", () => {
+    // A four-figure count is where the two notations part: a German reader
+    // reads "1.200" and an English one "1,200", and a raw number would have
+    // reached the sentence as "1200" for both.
+    expect(relativeDays("2023-05-12T09:00:00Z", t, "en", now)).toBe(
+      'person.strip.days:{"count":"1,200"}',
+    );
+    expect(relativeDays("2023-05-12T09:00:00Z", t, "de", now)).toBe(
+      'person.strip.days:{"count":"1.200"}',
     );
   });
 
   it("reads a late-evening timestamp as yesterday, not today", () => {
     // The boundary the millisecond spelling gets wrong: 13 hours earlier but a
     // different date, which a reader calls yesterday and a duration calls today.
-    expect(relativeDays("2026-08-23T23:00:00Z", t, now)).toBe(
+    expect(relativeDays("2026-08-23T23:00:00Z", t, "en", now)).toBe(
       "person.strip.yesterday",
     );
   });

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -1,5 +1,4 @@
-import type { Locale } from "../i18n";
-import type { MessageKey } from "../i18n/en";
+import type { Locale, Translator } from "../i18n";
 import { minorUnitDigits, toMajorUnits } from "./minorunits";
 
 // The presentation edge (architecture/10 §1–3): everything here formats
@@ -108,6 +107,24 @@ export function formatMoneyCompact(
 }
 
 /**
+ * An FX rate, at whatever precision the record actually carries.
+ *
+ * Separate from `formatNumber` because that one's Intl default caps at three
+ * fraction digits, which SILENTLY drops the rest: a rate stored as 0.9293458
+ * renders "0,929", and the reader is then looking at a number the lineage does
+ * not hold — in the one place the product exists to show its arithmetic.
+ * Separate from `formatDecimal` because that pins the digits open, and a rate
+ * of exactly 2 should read "2" rather than "2,0000000000".
+ *
+ * Ten is the scale the server stores a rate at, so it is the ceiling here.
+ */
+export function formatRate(value: number, locale: Locale): string {
+  return new Intl.NumberFormat(INTL_LOCALE[locale], {
+    maximumFractionDigits: 10,
+  }).format(value);
+}
+
+/**
  * The month's own name in the reader's language, from Intl rather than a table
  * of our own — a list of twelve month names per locale is a translation file
  * that goes stale, and the platform already ships them.
@@ -137,6 +154,29 @@ export function monthName(month: number, locale: Locale): string {
 
 export function formatNumber(value: number, locale: Locale): string {
   return new Intl.NumberFormat(INTL_LOCALE[locale]).format(value);
+}
+
+/**
+ * A figure whose DECIMALS are part of what it says — a score, a rate, a factor.
+ *
+ * `formatNumber` renders a count, where a trailing `.0` would be noise. This
+ * one pins the fraction digits open, so a scoring breakdown reads "12.50 → 13"
+ * with both figures at the precision the reader is being shown them at.
+ *
+ * The alternative every site reached for first was `value.toFixed(2)`, which is
+ * not a formatter: it is locale-blind by construction, so a German reader is
+ * shown a decimal POINT where their own numbers carry a comma — and reads
+ * "12.50" as twelve hundred and fifty, in a sentence whose next figure is 13.
+ */
+export function formatDecimal(
+  value: number,
+  locale: Locale,
+  fractionDigits: number,
+): string {
+  return new Intl.NumberFormat(INTL_LOCALE[locale], {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value);
 }
 
 // IANA zone names only (AC-DS-TZ4): fixed offsets ("+01:00", "Etc/GMT-1")
@@ -338,7 +378,8 @@ export function calendarDaysBetween(from: Date, to: Date): number {
  */
 export function relativeDays(
   at: string | null | undefined,
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string,
+  t: Translator,
+  locale: Locale,
   now: Date = new Date(),
 ): string {
   if (!at) {
@@ -351,7 +392,12 @@ export function relativeDays(
   if (days === 1) {
     return t("person.strip.yesterday");
   }
-  return t("person.strip.days", { count: days });
+  // The count is a MAGNITUDE, so it is grouped in the reader's own notation.
+  // Handed to `t` as a raw number it reached the catalog sentence through
+  // string coercion, which groups for nobody: a person last written to 1200
+  // days ago read "1200 days" in a German sentence that spells every other
+  // figure on the page "1.200".
+  return t("person.strip.days", { count: formatNumber(days, locale) });
 }
 
 // Idle/SLA spans display as ABSOLUTE durations (no naive calendar diff —

--- a/frontend/src/format/now.test.ts
+++ b/frontend/src/format/now.test.ts
@@ -10,12 +10,12 @@ import { formatCountdown, useNow } from "./now";
 
 const t = (
   key: Parameters<typeof translate>[1],
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ) => translate("en", key, params);
 
 describe("formatCountdown (pure)", () => {
   it("renders minutes and seconds for a positive remainder", () => {
-    expect(formatCountdown(90_000, t)).toBe("1m 30s");
+    expect(formatCountdown(90_000, t, "en")).toBe("1m 30s");
   });
 
   it("rolls up to hours and days rather than carrying minutes as the top unit", () => {
@@ -25,20 +25,24 @@ describe("formatCountdown (pure)", () => {
 
     // The approvals inbox stages drafts with a multi-day TTL. Carried as
     // minutes, three days read "4320m 0s" — a number nobody converts on sight.
-    expect(formatCountdown(3 * day, t)).toBe("3d 0h");
-    expect(formatCountdown(3 * day + 4 * hour + 59 * minute, t)).toBe("3d 4h");
-    expect(formatCountdown(2 * hour + 15 * minute + 30_000, t)).toBe("2h 15m");
+    expect(formatCountdown(3 * day, t, "en")).toBe("3d 0h");
+    expect(formatCountdown(3 * day + 4 * hour + 59 * minute, t, "en")).toBe(
+      "3d 4h",
+    );
+    expect(formatCountdown(2 * hour + 15 * minute + 30_000, t, "en")).toBe(
+      "2h 15m",
+    );
 
     // The boundaries either side of each rollover.
-    expect(formatCountdown(day, t)).toBe("1d 0h");
-    expect(formatCountdown(day - 1, t)).toBe("23h 59m");
-    expect(formatCountdown(hour, t)).toBe("1h 0m");
-    expect(formatCountdown(hour - 1, t)).toBe("59m 59s");
+    expect(formatCountdown(day, t, "en")).toBe("1d 0h");
+    expect(formatCountdown(day - 1, t, "en")).toBe("23h 59m");
+    expect(formatCountdown(hour, t, "en")).toBe("1h 0m");
+    expect(formatCountdown(hour - 1, t, "en")).toBe("59m 59s");
   });
 
   it("renders the expired sentinel for zero or negative remainders", () => {
-    expect(formatCountdown(0, t)).toBe("Expired");
-    expect(formatCountdown(-1, t)).toBe("Expired");
+    expect(formatCountdown(0, t, "en")).toBe("Expired");
+    expect(formatCountdown(-1, t, "en")).toBe("Expired");
   });
 });
 

--- a/frontend/src/format/now.ts
+++ b/frontend/src/format/now.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { MessageKey } from "../i18n/en";
+import type { Locale, Translator } from "../i18n";
+import { formatNumber } from "./format";
 
 // AC-7 groundwork (feeds Task 10's live approvals-inbox countdown). useNow
 // is the ONLY place a real clock touches this codebase's rendering — every
@@ -26,12 +27,6 @@ export function useNow(intervalMs = 1000): number {
   return now;
 }
 
-// The shape of useT()'s bound translator: (key, params?) => string.
-export type Translator = (
-  key: MessageKey,
-  params?: Record<string, string | number>,
-) => string;
-
 const SECONDS_PER_MINUTE = 60;
 const MINUTES_PER_HOUR = 60;
 const HOURS_PER_DAY = 24;
@@ -45,7 +40,15 @@ const HOURS_PER_DAY = 24;
 // produces. The pair always answers "how long have I got" at the precision
 // that span deserves — seconds matter in the last minutes of an approval
 // window and are noise a day earlier.
-export function formatCountdown(msRemaining: number, t: Translator): string {
+//
+// Every unit is a MAGNITUDE, so each reaches the sentence through the reader's
+// own grouping. Only the day count can pass four digits, and it is the one a
+// long-lived window actually shows.
+export function formatCountdown(
+  msRemaining: number,
+  t: Translator,
+  locale: Locale,
+): string {
   if (msRemaining <= 0) {
     return t("countdown.expired");
   }
@@ -56,18 +59,18 @@ export function formatCountdown(msRemaining: number, t: Translator): string {
 
   if (days >= 1) {
     return t("countdown.daysHours", {
-      days,
-      hours: totalHours % HOURS_PER_DAY,
+      days: formatNumber(days, locale),
+      hours: formatNumber(totalHours % HOURS_PER_DAY, locale),
     });
   }
   if (totalHours >= 1) {
     return t("countdown.hoursMinutes", {
-      hours: totalHours,
-      minutes: totalMinutes % MINUTES_PER_HOUR,
+      hours: formatNumber(totalHours, locale),
+      minutes: formatNumber(totalMinutes % MINUTES_PER_HOUR, locale),
     });
   }
   return t("countdown.minutesSeconds", {
-    minutes: totalMinutes,
-    seconds: totalSeconds % SECONDS_PER_MINUTE,
+    minutes: formatNumber(totalMinutes, locale),
+    seconds: formatNumber(totalSeconds % SECONDS_PER_MINUTE, locale),
   });
 }

--- a/frontend/src/format/one-locale.test.ts
+++ b/frontend/src/format/one-locale.test.ts
@@ -85,6 +85,7 @@ const extensionsDir = resolve(frontendRoot, "..", "extensions");
 // the directory it sits in — see `sourceFiles` for why that distinction is the
 // whole difference between a narrow exception and a blind spot.
 const formatModule = join(here, "format.ts");
+const collateModule = join(here, "collate.ts");
 const thisGate = fileURLToPath(import.meta.url);
 
 // Named so a reader of a finding can reach the open question rather than
@@ -193,9 +194,12 @@ const isRenderingMethod = (name: string): boolean =>
  * a walk is the worst place for a second answer, because the narrower one reads
  * a smaller tree and reports the same word for it: PASS.
  *
- * TWO files are excluded, named rather than the directory they sit in.
- * `format.ts` owns the mapping; this gate spells out the very shapes it hunts
- * for, and a sweep that read it would vouch for itself. The DIRECTORY is not
+ * THREE files are excluded, named rather than the directory they sit in.
+ * `format.ts` owns the mapping and `collate.ts` owns the two orderings — a
+ * reader's collation and the stable one — for the same reason: they are where
+ * the decision is made once so no screen makes it again. This gate spells out
+ * the very shapes it hunts for, and a sweep that read it would vouch for
+ * itself. The DIRECTORY is not
  * the unit, and excluding it was this gate's own first hole: `format/` holds
  * seven other modules, so a new formatter added beside `format.ts` could render
  * in the browser's locale and pass. A gate's exception is where it goes blind,
@@ -203,7 +207,10 @@ const isRenderingMethod = (name: string): boolean =>
  */
 function sourceFiles(): string[] {
   return [...filesUnder(srcRoot), ...extensionFrontendFiles(extensionsDir)]
-    .filter((path) => path !== formatModule && path !== thisGate)
+    .filter(
+      (path) =>
+        path !== formatModule && path !== collateModule && path !== thisGate,
+    )
     .sort();
 }
 

--- a/frontend/src/format/one-locale.test.ts
+++ b/frontend/src/format/one-locale.test.ts
@@ -65,15 +65,23 @@ import { INTL_LOCALE } from "./format";
 // against. The arms below assert the derived sets by name for that reason: a
 // gate whose subject is derived still has to prove the derivation arrived.
 //
-// OUT OF SCOPE, named rather than silently dropped: collation
-// (`localeCompare`) and locale-sensitive casing (`toLocaleLowerCase` /
-// `toLocaleUpperCase`). They are derived into the set below and then excluded,
-// because the right answer is per site and opposite in each direction — a
-// machine key must sort identically for every reader, so a pinned "en" is
-// CORRECT there, while a human-readable label must not. That is a ruling per
-// call site rather than a sweep. Tracked in `COLLATION_ISSUE`; once each site
-// there has one, `isRenderingMethod` stops excluding them and this gate holds
-// both halves.
+// COLLATION AND CASING ARE NOW IN SCOPE, and the exclusion that used to stand
+// here is the reason to say so out loud. `localeCompare` and
+// `toLocaleLowerCase` / `toLocaleUpperCase` were derived into the set and then
+// filtered back out, because the right answer is per site and opposite in each
+// direction — a machine key must sort identically for every reader, so a pinned
+// "en" is correct there, while a name in a list a person reads must follow that
+// reader's alphabet. Neither answer generalises, so no single formatter could be
+// demanded and the gate held one half of its own subject.
+//
+// `format/collate.ts` is what closed it: `forReader` for a list somebody reads,
+// `stable` for a key nobody reads, `foldForMatch` for a comparison. The ruling
+// is now the FUNCTION NAME at the call site, which is why the gate can be
+// absolute again — every site has been ruled, and outside `collate.ts` a bare
+// `localeCompare` or `toLocale*Case` is a site that skipped the ruling rather
+// than a site whose ruling was "leave it". `stable` is spelled from `<` and `>`
+// rather than delegating to `localeCompare(a, b, "en")` precisely so that this
+// gate needs no exception for the module that owns the answer.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const srcRoot = join(here, "..");
@@ -87,14 +95,6 @@ const extensionsDir = resolve(frontendRoot, "..", "extensions");
 const formatModule = join(here, "format.ts");
 const collateModule = join(here, "collate.ts");
 const thisGate = fileURLToPath(import.meta.url);
-
-// Named so a reader of a finding can reach the open question rather than
-// guessing that collation was overlooked. The issue number and nothing else:
-// an earlier version carried a site COUNT, which nothing here derives and
-// nothing here checks — a number in a gate that no assertion holds is the same
-// stale claim this whole rule is about.
-const COLLATION_ISSUE =
-  "#2455 — collation and locale-sensitive casing need a ruling per call site";
 
 /**
  * The members of `Intl` that take a locales argument, asked of the runtime.
@@ -175,13 +175,6 @@ function localeMethods(): Map<string, number> {
   }
   return found;
 }
-
-// Collation and casing, excluded for the reason at the top of this file. A
-// decision about members that were FOUND, never a shorter search.
-const isRenderingMethod = (name: string): boolean =>
-  name !== "localeCompare" &&
-  name !== "toLocaleLowerCase" &&
-  name !== "toLocaleUpperCase";
 
 /**
  * Every file this gate judges: the app's own sources and every extension unit's
@@ -484,7 +477,6 @@ function findingsIn(
         const position = methods.get(name);
         if (
           position !== undefined &&
-          isRenderingMethod(name) &&
           !namesTheMapping(node.arguments?.[position], imported)
         ) {
           at(node, `.${name}()`);
@@ -568,10 +560,6 @@ describe("one locale for every rendered value", () => {
     // same bundle, so a sweep that quietly stopped at src/ would hold the core
     // to a standard the extension tier escapes.
     expect(files.some((path) => path.includes("/extensions/"))).toBe(true);
-    // The excluded half names where it went. A gate that narrows its own
-    // subject and says nothing about it reads exactly like one that found the
-    // tree clean.
-    expect(COLLATION_ISSUE).toMatch(/#\d+/);
   });
 
   it("derives the Intl formatters it gates, reaching the two it is about", () => {
@@ -607,12 +595,17 @@ describe("one locale for every rendered value", () => {
     // supportedLocalesOf has a `locales` parameter too and renders nothing. It
     // is excluded by its declaring interface's name, not by its own.
     expect(methods.has("supportedLocalesOf")).toBe(false);
-    // The rendering half is gated; collation and casing are the excluded half.
-    // If that line ever moves silently, the map above fails first.
-    expect([...methods.keys()].filter(isRenderingMethod).sort()).toEqual([
+    // NOTHING is filtered back out: every method the derivation finds is
+    // gated. This arm is what would fail if a future exclusion were slipped in
+    // — an exclusion is how this gate previously held one half of its own
+    // subject while reporting the whole tree clean.
+    expect([...methods.keys()].sort()).toEqual([
+      "localeCompare",
       "toLocaleDateString",
+      "toLocaleLowerCase",
       "toLocaleString",
       "toLocaleTimeString",
+      "toLocaleUpperCase",
     ]);
   });
 
@@ -689,6 +682,15 @@ describe("one locale for every rendered value", () => {
       { code: "let LF;", finding: false },
       { code: "LF = Intl.NumberFormat;", finding: false },
       { code: "const n = new LF(locale).format(1);", finding: true },
+      // Collation and casing, the half this gate used to filter back out. The
+      // pinned "en" is the shape that made the exclusion look reasonable: it is
+      // the RIGHT ordering for a machine key and the wrong one for a name a
+      // person reads, and the line cannot say which it is. `format/collate.ts`
+      // is where that gets said, so both spellings are findings here.
+      { code: 'const o = a.localeCompare(b, "en");', finding: true },
+      { code: "const p = a.localeCompare(b);", finding: true },
+      { code: "const q = name.toLocaleLowerCase();", finding: true },
+      { code: "const r = name.toLocaleUpperCase();", finding: true },
     ];
     // EVERY formatter the runtime reports, one line each, DERIVED — not a list
     // of names typed here. A hard-coded `Intl.DurationFormat` line was the
@@ -727,9 +729,6 @@ describe("one locale for every rendered value", () => {
       // The zone lookup constructs a formatter to read a zone and renders
       // nothing; zone-by-purpose.test.ts owns it.
       "const z = Intl.DateTimeFormat().resolvedOptions().timeZone;",
-      // Collation and casing are the excluded half.
-      'const s = a.localeCompare(b, "en");',
-      "const t = name.toLocaleLowerCase();",
       // A local named like a formatter, bound to something that is not Intl's.
       "const NumberFormat = ourOwnThing;",
       "const u = new NumberFormat(whatever);",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -267,6 +267,23 @@ describe("i18n catalogs", () => {
     expect(translate("en", "trust.agentTag", {})).toBe("Automated by {agent}");
   });
 
+  it("refuses a raw number as a param, because nobody would have grouped it", () => {
+    // The gate for locale-blind figures, and it is the COMPILER rather than a
+    // sweep: a number handed to a catalog sentence reaches it through string
+    // coercion, which renders "1234" for a German reader whose every other
+    // figure on the page reads "1.234". Narrowing this parameter to strings
+    // makes every such site a build failure, so a new one cannot be written.
+    //
+    // Asserted here because the narrowing is invisible in the rendered output —
+    // it is the kind of type that gets widened back by the next author who
+    // meets it as an inconvenience, and nothing else would notice.
+    // @ts-expect-error a magnitude must be formatted (format/format.ts) first
+    translate("en", "person.strip.days", { count: 96 });
+    expect(translate("en", "person.strip.days", { count: "96" })).toContain(
+      "96",
+    );
+  });
+
   it("the default locale is en (A100: en-GB)", () => {
     expect(DEFAULT_LOCALE).toBe("en");
   });

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -140,7 +140,7 @@ function rememberLocale(locale: Locale): void {
 export function translate(
   locale: Locale,
   key: MessageKey | ExtensionMessageKey,
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ): string {
   // CORE FIRST, and a unit second. The generator already refuses a key outside
   // the unit's own namespace, so the two sets cannot overlap today — this
@@ -285,6 +285,17 @@ export function useT() {
   // some two dozen core helpers take a translator as — and widening the RETURN
   // makes every core-only test fake stop being assignable to it, for a
   // capability no core helper has any use for.
-  return (key: MessageKey, params?: Record<string, string | number>) =>
+  return (key: MessageKey, params?: Record<string, string>) =>
     translate(locale, key, params);
 }
+
+/**
+ * The translator a helper outside a component takes as a parameter.
+ *
+ * Derived from `useT` rather than restated, because a hand-written copy of this
+ * shape is a SECOND declaration of what a translator accepts — and the copies
+ * in this tree were all wider than the real thing, each one a hole through
+ * which a raw number reached a catalog sentence and was grouped for nobody. A
+ * restatement cannot go stale if there is nothing to restate.
+ */
+export type Translator = ReturnType<typeof useT>;

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -20,6 +20,7 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
+import { foldForMatch } from "../format/collate";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { type AttachmentParent, uploadAttachment } from "./attachmentupload";
@@ -190,7 +191,7 @@ async function walkAccountDeals(
   for (let page = 0; page < DEAL_SEARCH_PAGES; page += 1) {
     const answered = await fetchPage(cursor);
     for (const deal of answered.data) {
-      if (deal.name.toLocaleLowerCase().includes(needle)) {
+      if (foldForMatch(deal.name).includes(needle)) {
         matches.push({ id: deal.id, name: deal.name });
       }
     }
@@ -284,7 +285,7 @@ export function AddDocumentDialog({
   // clear the list under them.
   const searchDeals = useCallback(
     (query: string) =>
-      walkAccountDeals(fetchDealPage, query.trim().toLocaleLowerCase()),
+      walkAccountDeals(fetchDealPage, foldForMatch(query.trim())),
     [fetchDealPage],
   );
 

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -21,7 +21,7 @@ import {
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
 import { foldForMatch } from "../format/collate";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { type AttachmentParent, uploadAttachment } from "./attachmentupload";
 import { problemMessageOf, throwProblem } from "./common";
@@ -219,6 +219,7 @@ export function AddDocumentDialog({
   onClose: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const titleId = useId();
   const queryClient = useQueryClient();
 
@@ -246,7 +247,9 @@ export function AddDocumentDialog({
   // What this installation accepts, so an oversize file is refused here rather
   // than after every byte of it has crossed the wire.
   const maxUploadBytes = useMaxUploadBytes();
-  const limitLabel = maxUploadBytes ? formatUploadLimit(maxUploadBytes) : "";
+  const limitLabel = maxUploadBytes
+    ? formatUploadLimit(maxUploadBytes, locale)
+    : "";
 
   // One page of the account's deals, read through the query cache so a second
   // search re-uses what the first walked. Keyed by the CURSOR, because that is

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -7,6 +7,7 @@ import { Button, EmptyState, Field, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
+import { stable } from "../format/collate";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 
@@ -123,7 +124,7 @@ function orderedTiers(tiers: Routing["tiers"] | undefined): string[] {
     return i === -1 ? TIER_ORDER.length : i;
   };
   return Object.keys(tiers ?? {}).sort(
-    (a, b) => rank(a) - rank(b) || a.localeCompare(b),
+    (a, b) => rank(a) - rank(b) || stable(a, b),
   );
 }
 

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -33,6 +33,7 @@ export function CallDetailPanel({
   captureEnabled,
 }: Readonly<{ id: string; captureEnabled: boolean }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [exporting, setExporting] = useState(false);
   const query = useQuery({
     queryKey: ["ai-call", id],
@@ -77,7 +78,9 @@ export function CallDetailPanel({
               <li key={attempt.attempt}>
                 <span className="t-mono">#{attempt.attempt}</span>{" "}
                 {attempt.attempt_reason || "—"} ·{" "}
-                {t("aicalls.ms", { value: attempt.latency_ms })}
+                {t("aicalls.ms", {
+                  value: formatNumber(attempt.latency_ms, locale),
+                })}
                 {attempt.error_sentinel && (
                   <Badge tone="danger">{attempt.error_sentinel}</Badge>
                 )}
@@ -301,6 +304,7 @@ function FragmentRow({
   tokens: string;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const panelId = useId();
   return (
     <>
@@ -350,7 +354,12 @@ function FragmentRow({
             )}
             {call.calls_attempted > 1 && (
               <Badge>
-                {t("aicalls.badge.retries", { count: call.calls_attempted })}
+                {/* An attempt counter, not a quantity: it names which try this
+                    call is on, and a grouped "1.234" would read as a figure
+                    rather than a position on the retry ladder. */}
+                {t("aicalls.badge.retries", {
+                  count: String(call.calls_attempted),
+                })}
               </Badge>
             )}
           </div>
@@ -359,7 +368,9 @@ function FragmentRow({
           {call.tier} · {call.provider}/{call.served_model}
         </td>
         <td>{tokens}</td>
-        <td>{t("aicalls.ms", { value: call.latency_ms })}</td>
+        <td>
+          {t("aicalls.ms", { value: formatNumber(call.latency_ms, locale) })}
+        </td>
       </tr>
       {expanded && (
         <tr>

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -184,7 +184,7 @@ function AiUsageBody({
         description={t("aiusage.budget", {
           spent: formatNumber(data.budget.spent_tokens, locale),
           budget: formatNumber(data.budget.monthly_tokens, locale),
-          pct,
+          pct: formatNumber(pct, locale),
         })}
         control={
           <div className="settingrow-measure aiusage-budget">

--- a/frontend/src/screens/approvalkind.test.ts
+++ b/frontend/src/screens/approvalkind.test.ts
@@ -12,7 +12,7 @@ import {
 
 const t = (
   key: Parameters<typeof translate>[1],
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ) => translate("en", key, params);
 
 describe("what a staged proposal is called", () => {

--- a/frontend/src/screens/approvalkind.ts
+++ b/frontend/src/screens/approvalkind.ts
@@ -1,3 +1,4 @@
+import type { Translator } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // What a staged proposal is, in words a reader recognises.
@@ -178,10 +179,7 @@ export function humanizeKind(kind: string): string {
   return kind.replaceAll("_", " ");
 }
 
-export function approvalKindLabel(
-  kind: string,
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
-): string {
+export function approvalKindLabel(kind: string, t: Translator): string {
   const key = KIND_LABEL[kind];
   return key ? t(key) : humanizeKind(kind);
 }

--- a/frontend/src/screens/automationdetail.tsx
+++ b/frontend/src/screens/automationdetail.tsx
@@ -14,7 +14,7 @@ import {
   SegmentedControl,
 } from "../design-system/atoms";
 import { AutonomyDot } from "../design-system/trust";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -283,6 +283,7 @@ export function AutomationPreview({
   automationId,
 }: Readonly<{ automationId: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [windowDays, setWindowDays] = useState<WindowOption>("30");
 
   // A preview is a pure read keyed on the selected window — so it is a query,
@@ -352,19 +353,23 @@ export function AutomationPreview({
               }}
             >
               <p className="t-body">
-                {t("auto.preview.matchesNow", { n: result.matches_now })}
+                {t("auto.preview.matchesNow", {
+                  n: formatNumber(result.matches_now, locale),
+                })}
               </p>
               <p className="t-small">
                 {result.would_have_fired == null
                   ? t("auto.preview.notComputable")
                   : t("auto.preview.wouldFire", {
-                      n: result.would_have_fired,
-                      days: result.window_days,
+                      n: formatNumber(result.would_have_fired, locale),
+                      days: formatNumber(result.window_days, locale),
                     })}
               </p>
               {hidden > 0 && (
                 <p className="t-small">
-                  {t("auto.preview.hidden", { n: hidden })}
+                  {t("auto.preview.hidden", {
+                    n: formatNumber(hidden, locale),
+                  })}
                 </p>
               )}
             </div>

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -12,7 +12,7 @@ import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { StatStrip } from "../design-system/statstrip";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { CaptureActivityDrawer } from "./capture-activity-drawer";
@@ -185,6 +185,7 @@ async function fetchWindow(
 
 function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [filter, setFilter] = useState<Outcome | null>(null);
   const [openTrace, setOpenTrace] = useState<string | null>(null);
   // Paged, because the window is 24 hours and a busy mailbox fills more than
@@ -246,8 +247,8 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
                     // counter reading 26 would look like the counter was wrong.
                     <p className="capture-activity__count">
                       {t("captureActivity.filtered", {
-                        shown: shown.length,
-                        total: first.funnel[filter] ?? 0,
+                        shown: formatNumber(shown.length, locale),
+                        total: formatNumber(first.funnel[filter] ?? 0, locale),
                         outcome: t(`captureActivity.outcome.${filter}`),
                       })}
                     </p>

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -38,6 +38,7 @@ import {
   formatMoney,
   formatMoneyCompact,
   formatMoneyOrAbsent,
+  formatNumber,
 } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -224,6 +225,7 @@ function CoverageSummary({
   routesReadable: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (contacts.length === 0) {
     return null;
   }
@@ -232,16 +234,22 @@ function CoverageSummary({
   // account is large and that this is not the whole of it.
   const parts = [
     truncated
-      ? t("co.coverage.contactsAtLeast", { count: contacts.length })
-      : t("co.coverage.contacts", { count: contacts.length }),
+      ? t("co.coverage.contactsAtLeast", {
+          count: formatNumber(contacts.length, locale),
+        })
+      : t("co.coverage.contacts", {
+          count: formatNumber(contacts.length, locale),
+        }),
   ];
   if (routesReadable && untried > 0) {
-    parts.push(t("co.coverage.untried", { count: untried }));
+    parts.push(
+      t("co.coverage.untried", { count: formatNumber(untried, locale) }),
+    );
   }
   // The gap count is only meaningful over a complete picture: a capped page
   // hides the contacts who might hold the roles it would report as missing.
   if (!truncated && gaps > 0) {
-    parts.push(t("co.coverage.gaps", { count: gaps }));
+    parts.push(t("co.coverage.gaps", { count: formatNumber(gaps, locale) }));
   }
   return <p className="surfacestate-empty">{parts.join(" · ")}</p>;
 }
@@ -272,6 +280,7 @@ export function PeopleCard({
   loading?: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const contacts = [...(view?.people?.data ?? [])].sort(byReach);
   const truncated = Boolean(view?.people?.page.has_more);
   const dealsReadable =
@@ -370,7 +379,9 @@ export function PeopleCard({
               <Badge tone="accent">
                 {untried.length === 1
                   ? t("co.people.untriedHintOne")
-                  : t("co.people.untriedHint", { count: untried.length })}
+                  : t("co.people.untriedHint", {
+                      count: formatNumber(untried.length, locale),
+                    })}
               </Badge>
             </p>
           )}
@@ -681,6 +692,7 @@ function ContactRow({
 // the time.
 function ContactRoutes({ routes }: Readonly<{ routes?: Contact["routes"] }>) {
   const t = useT();
+  const { locale } = useLocale();
   // Absent, not empty: the caller has no roster grant, so naming a colleague is
   // a read they may not make. Silence is the honest answer — an "untried" badge
   // here would be a claim about the account rather than about the reader.
@@ -704,7 +716,9 @@ function ContactRoutes({ routes }: Readonly<{ routes?: Contact["routes"] }>) {
         // The count, not a silent truncation: three names with nothing after
         // them reads as "these are the only three".
         <span className="t-caption">
-          {t("co.routes.more", { count: routes.remainder })}
+          {t("co.routes.more", {
+            count: formatNumber(routes.remainder, locale),
+          })}
         </span>
       )}
     </span>
@@ -875,7 +889,11 @@ export function DealsCard({
               {t("co.deals.wonLifetime")}{" "}
               {formatMoneyOrAbsent(won?.amount_minor, won?.currency, locale)}
             </span>
-            <span>{t("co.deals.lostCount", { count: deals.lost_count })}</span>
+            <span>
+              {t("co.deals.lostCount", {
+                count: formatNumber(deals.lost_count, locale),
+              })}
+            </span>
           </p>
         )
       }
@@ -1713,7 +1731,12 @@ export function StateStrip({
             t={t}
           />
         )}
-        <HealthStat health={view?.health} withheld={healthWithheld} t={t} />
+        <HealthStat
+          health={view?.health}
+          locale={locale}
+          withheld={healthWithheld}
+          t={t}
+        />
         {/* Whose move it is and the worst open signal both moved to the daily
             brief's context band (companytoday.tsx) — the brief reads the same
             `engagement` and `signal` fields this strip used to, so the strip
@@ -1722,6 +1745,7 @@ export function StateStrip({
             which is what made this page a mishmash in the first place. */}
         <HealthSummaryStat
           health={view?.health}
+          locale={locale}
           orgId={orgId}
           withheld={healthWithheld}
           t={t}
@@ -1744,11 +1768,12 @@ export function StateStrip({
  */
 export function medianDaysLabel(
   median: number,
+  locale: Locale,
   t: ReturnType<typeof useT>,
 ): string {
   return median < 0
-    ? t("finance.medianEarly", { days: Math.abs(median) })
-    : t("finance.medianAfterDue", { days: median });
+    ? t("finance.medianEarly", { days: formatNumber(Math.abs(median), locale) })
+    : t("finance.medianAfterDue", { days: formatNumber(median, locale) });
 }
 
 // The caveat on a figure that IS shown but is not current. Undefined when the
@@ -1985,7 +2010,9 @@ function PipelineCard({
     commercial;
   const stalled =
     commercial.stalled_count > 0
-      ? t("co.strip.stalled", { count: commercial.stalled_count })
+      ? t("co.strip.stalled", {
+          count: formatNumber(commercial.stalled_count, locale),
+        })
       : undefined;
   if (value == null || !currency) {
     // Open deals with no priceable figure still say how many there are: the
@@ -1995,7 +2022,9 @@ function PipelineCard({
     return (
       <StatCard
         label={t("co.strip.pipeline")}
-        value={t("co.strip.openDeals", { count: commercial.open_count })}
+        value={t("co.strip.openDeals", {
+          count: formatNumber(commercial.open_count, locale),
+        })}
         detail={join(t("co.strip.unpriced"), stalled)}
         tone={stalled ? "warn" : undefined}
       />
@@ -2010,7 +2039,7 @@ function PipelineCard({
   const converted =
     commercial.converted_count > 0 && commercial.fx_as_of
       ? t("co.strip.convertedAsOf", {
-          count: commercial.converted_count,
+          count: formatNumber(commercial.converted_count, locale),
           date: formatDate(commercial.fx_as_of, locale, recordZone),
         })
       : undefined;
@@ -2022,10 +2051,12 @@ function PipelineCard({
       detail={join(
         partial
           ? t("co.strip.pricedPartly", {
-              priced: commercial.priced_count,
-              total: commercial.open_count,
+              priced: formatNumber(commercial.priced_count, locale),
+              total: formatNumber(commercial.open_count, locale),
             })
-          : t("co.strip.openDeals", { count: commercial.open_count }),
+          : t("co.strip.openDeals", {
+              count: formatNumber(commercial.open_count, locale),
+            }),
         converted,
         stalled,
       )}
@@ -2091,10 +2122,12 @@ function CloseDateStat({
 // opposite problems.
 function HealthStat({
   health,
+  locale,
   withheld,
   t,
 }: Readonly<{
   health?: Health;
+  locale: Locale;
   withheld: boolean;
   t: ReturnType<typeof useT>;
 }>) {
@@ -2125,7 +2158,9 @@ function HealthStat({
         label={t("co.strip.health")}
         value={t("co.strip.healthQuiet")}
         tone="warn"
-        detail={t("co.health.sinceInbound", { days })}
+        detail={t("co.health.sinceInbound", {
+          days: formatNumber(days, locale),
+        })}
       />
     );
   }
@@ -2150,7 +2185,9 @@ function HealthStat({
         oneSided ? t("co.strip.healthOneSided") : t("co.strip.healthBalanced")
       }
       tone={oneSided ? "warn" : undefined}
-      detail={t("co.strip.replyShare", { percent })}
+      detail={t("co.strip.replyShare", {
+        percent: formatNumber(percent, locale),
+      })}
     />
   );
 }
@@ -2172,11 +2209,13 @@ const HEALTH_QUIET_DAYS = 30;
 // verdict the account is.
 function HealthSummaryStat({
   health,
+  locale,
   orgId,
   withheld,
   t,
 }: Readonly<{
   health?: Health;
+  locale: Locale;
   orgId: string;
   withheld: boolean;
   t: ReturnType<typeof useT>;
@@ -2193,7 +2232,11 @@ function HealthSummaryStat({
         label={t("co.strip.healthSummary")}
         value={t(withheld ? WITHHELD_READING : UNASSESSED_READING)}
         detail={
-          withheld ? undefined : t("co.strip.healthSummary.of", { rated })
+          withheld
+            ? undefined
+            : t("co.strip.healthSummary.of", {
+                rated: formatNumber(rated, locale),
+              })
         }
       />
     );
@@ -2213,8 +2256,13 @@ function HealthSummaryStat({
       dot={overall === "at_risk"}
       detail={
         failing > 0
-          ? t("co.strip.healthSummary.failingOf", { failing, rated })
-          : t("co.strip.healthSummary.of", { rated })
+          ? t("co.strip.healthSummary.failingOf", {
+              failing: formatNumber(failing, locale),
+              rated: formatNumber(rated, locale),
+            })
+          : t("co.strip.healthSummary.of", {
+              rated: formatNumber(rated, locale),
+            })
       }
     />
   );
@@ -2255,7 +2303,8 @@ function SuggestionActionButton({
 // logic rather than a second copy of it.
 export function nextCommitmentLine(
   view: Organization360 | undefined,
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string,
+  locale: Locale,
+  t: ReturnType<typeof useT>,
 ): { headline: string; overdue: boolean } | undefined {
   const steps = view?.next_steps?.data ?? [];
   const step = steps[0];
@@ -2271,8 +2320,12 @@ export function nextCommitmentLine(
   const key = overdueCount > 0 ? "overdue" : "open";
   return {
     headline: truncated
-      ? t(`co.suggest.commitment.${key}AtLeast`, { count })
-      : t(`co.suggest.commitment.${key}Count`, { count }),
+      ? t(`co.suggest.commitment.${key}AtLeast`, {
+          count: formatNumber(count, locale),
+        })
+      : t(`co.suggest.commitment.${key}Count`, {
+          count: formatNumber(count, locale),
+        }),
     overdue: overdueCount > 0,
   };
 }
@@ -2350,7 +2403,7 @@ export function useSuggestionsBody({
             does not render at all. */}
         {dropped !== undefined && dropped > 0 && (
           <p className="co-row-meta">
-            {t("co.suggest.more", { count: dropped })}
+            {t("co.suggest.more", { count: formatNumber(dropped, locale) })}
           </p>
         )}
         {/* The row staying put with no word reads as a click that missed,
@@ -2453,11 +2506,12 @@ export function SuggestionsSection({
   onOpenTasks?: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const body = useSuggestionsBody({ orgId, view, onOpenRecord, onPerform });
   if (!body.ready) {
     return null;
   }
-  const commitment = nextCommitmentLine(view, t);
+  const commitment = nextCommitmentLine(view, locale, t);
   const footer =
     commitment || onOpenTasks || body.footer ? (
       <>

--- a/frontend/src/screens/companyapprovals.tsx
+++ b/frontend/src/screens/companyapprovals.tsx
@@ -2,7 +2,8 @@ import { useId } from "react";
 import type { components } from "../api/schema";
 import { Button, EmptyState, Modal, Skeleton } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { approvalKindLabel } from "./approvalkind";
 import { ApprovalRow, useDecisionSink } from "./inbox";
 import { useTargetApprovals } from "./inbox.queries";
@@ -53,6 +54,7 @@ export function DecisionsChip({
   onOpen,
 }: Readonly<{ view?: Organization360; onOpen: () => void }>) {
   const t = useT();
+  const { locale } = useLocale();
   const count = pendingApprovals(view).length;
   if (count === 0) {
     return null;
@@ -62,7 +64,7 @@ export function DecisionsChip({
   // them: this opens a queue, it does not decide anything.
   return (
     <Button small variant="ghost" onClick={onOpen}>
-      {t("co.decisions.open", { count })}
+      {t("co.decisions.open", { count: formatNumber(count, locale) })}
     </Button>
   );
 }
@@ -77,6 +79,7 @@ export function CompanyApprovalsPanel({
   onClose: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const titleId = useId();
   const sink = useDecisionSink();
   // The panel reads the account's OWN queue rather than the capped page the
@@ -112,7 +115,7 @@ export function CompanyApprovalsPanel({
         <section key={group.kind} className="co-part">
           <Eyebrow as="h3">
             {t("co.decisions.group", {
-              count: group.approvals.length,
+              count: formatNumber(group.approvals.length, locale),
               kind: approvalKindLabel(group.kind, t),
             })}
           </Eyebrow>

--- a/frontend/src/screens/companycommercial.tsx
+++ b/frontend/src/screens/companycommercial.tsx
@@ -6,7 +6,8 @@ import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge } from "../design-system/atoms";
 import { PanelBody } from "../design-system/panel";
-import { formatDate, formatMoney } from "../format/format";
+import { stable } from "../format/collate";
+import { formatDate, formatMoney, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 // The row and card shapes this file draws — co-rowlink, co-row-meta, co-card —
@@ -142,7 +143,7 @@ export function leadingDeal(
   return [...deals].sort((a, b) => {
     const left = a.amount?.amount_minor ?? -1;
     const right = b.amount?.amount_minor ?? -1;
-    return right !== left ? right - left : a.deal_id.localeCompare(b.deal_id);
+    return right !== left ? right - left : stable(a.deal_id, b.deal_id);
   })[0];
 }
 
@@ -209,7 +210,9 @@ export function CompanyContractState({
   return (
     <PanelBody className="com-block">
       <span className="t-caption">
-        {t("contracts.state.title", { count: contracts.active_count })}
+        {t("contracts.state.title", {
+          count: formatNumber(contracts.active_count, locale),
+        })}
       </span>
       <span className="co-row-meta">
         {contractValues(contracts, locale, (amount) =>
@@ -221,8 +224,8 @@ export function CompanyContractState({
           contracts.priced_count < contracts.active_count && (
             <span className="t-caption">
               {t("contracts.state.partial", {
-                priced: contracts.priced_count,
-                total: contracts.active_count,
+                priced: formatNumber(contracts.priced_count, locale),
+                total: formatNumber(contracts.active_count, locale),
               })}
             </span>
           )}

--- a/frontend/src/screens/companyevidence.tsx
+++ b/frontend/src/screens/companyevidence.tsx
@@ -9,8 +9,8 @@ import {
   Modal,
   Skeleton,
 } from "../design-system/atoms";
-import { formatDateTime } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { formatDateTime, formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
 
@@ -131,7 +131,10 @@ export function EvidenceModal({
           {typeof shown.confidence === "number" && (
             <p className="co-evidence-line">
               {t("co.evidence.confidence", {
-                percent: Math.round(shown.confidence * 100),
+                percent: formatNumber(
+                  Math.round(shown.confidence * 100),
+                  locale,
+                ),
               })}
             </p>
           )}
@@ -256,7 +259,7 @@ function EvidenceTimes({
 }: Readonly<{
   retrievedAt?: string | null;
   lastVerifiedAt?: string | null;
-  locale: "en" | "de" | "vi";
+  locale: Locale;
 }>) {
   const t = useT();
   const recordZone = useRecordZone();

--- a/frontend/src/screens/companyfacts.tsx
+++ b/frontend/src/screens/companyfacts.tsx
@@ -20,7 +20,7 @@
 // answers to one question, and the two disagree the moment somebody types.
 
 import type { components } from "../api/schema";
-import { formatMoney } from "../format/format";
+import { formatMoney, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { CompanyOwnerControl } from "./companyheader";
 import "./companyfacts.css";
@@ -114,6 +114,7 @@ function pricedTotal(
  */
 function InFlight({ view }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (!view) {
     return <span className="co-facts-quiet">{t("co.facts.reading")}</span>;
   }
@@ -134,11 +135,11 @@ function InFlight({ view }: Readonly<{ view?: Organization360 }>) {
   return (
     <span>
       {t(deals === 1 ? "co.facts.dealsOne" : "co.facts.dealsMany", {
-        count: deals,
+        count: formatNumber(deals, locale),
       })}
       {" · "}
       {t(projects === 1 ? "co.facts.projectsOne" : "co.facts.projectsMany", {
-        count: projects,
+        count: formatNumber(projects, locale),
       })}
       {(view.deals.page.has_more || view.projects_page?.has_more) &&
         ` ${t("co.facts.atLeast")}`}

--- a/frontend/src/screens/companyfinance.tsx
+++ b/frontend/src/screens/companyfinance.tsx
@@ -7,7 +7,7 @@ import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Meter, Sparkline } from "../design-system/readings";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
-import { formatDate, formatMoney } from "../format/format";
+import { formatDate, formatMoney, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemCodeOf, useFinanceSummary } from "./common";
@@ -315,16 +315,20 @@ function FinanceLede({
   split,
 }: Readonly<{ summary: FinanceSummary; split: OpenSplit | null }>) {
   const t = useT();
+  const { locale } = useLocale();
   const clauses: string[] = [];
   if (split) {
     clauses.push(
       t("finance.shareOfOpen", {
-        percent: Math.round((split.overdue / split.open) * 100),
+        percent: formatNumber(
+          Math.round((split.overdue / split.open) * 100),
+          locale,
+        ),
       }),
     );
   }
   if (summary.median_days_after_due != null) {
-    clauses.push(medianDaysLabel(summary.median_days_after_due, t));
+    clauses.push(medianDaysLabel(summary.median_days_after_due, locale, t));
   }
   if (clauses.length === 0) {
     return null;
@@ -472,7 +476,7 @@ function InvoiceRow({
         <Badge tone={STATUS_TONE[invoice.status]} quiet>
           {late && invoice.days_late != null
             ? t(daysLateKey(invoice.status, invoice.days_late), {
-                days: invoice.days_late,
+                days: formatNumber(invoice.days_late, locale),
               })
             : t(STATUS_LABEL[invoice.status])}
         </Badge>

--- a/frontend/src/screens/companygrowthfit.tsx
+++ b/frontend/src/screens/companygrowthfit.tsx
@@ -7,7 +7,7 @@ import { Badge, Button, EmptyState, PendingBody } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -195,6 +195,7 @@ export function GrowthFitPanel({
  */
 function GrowthFitVerdict({ fit }: Readonly<{ fit: GrowthFit }>) {
   const t = useT();
+  const { locale } = useLocale();
   const { present, expected } = fit.data_completeness;
   return (
     <>
@@ -208,7 +209,10 @@ function GrowthFitVerdict({ fit }: Readonly<{ fit: GrowthFit }>) {
           {/* Both counts, always. A proportion without its denominator is not a
               completeness figure. */}
           <span className="co-growth-fit-completeness">
-            {t("co.growthFit.completeness", { present, expected })}
+            {t("co.growthFit.completeness", {
+              present: formatNumber(present, locale),
+              expected: formatNumber(expected, locale),
+            })}
           </span>
         </p>
         {/* The cap and the next step qualify the BAND, so they stay in its

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -9,7 +9,7 @@ import { navigate } from "../app/router";
 import { Badge, Button, OverflowMenu } from "../design-system/atoms";
 import { InlineChoice } from "../design-system/inlinechoice";
 import { ProvenanceTag } from "../design-system/trust";
-import { formatDateAbbrev } from "../format/format";
+import { formatDateAbbrev, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { ArchiveAction } from "./archive";
 import { provenanceOf, throwProblem, useSorMode, useViewerId } from "./common";
@@ -894,7 +894,7 @@ export function CompanyIdentityLine({
                 wayIn.contact_count === 1
                   ? "co.pulse.strengthTail.one"
                   : "co.pulse.strengthTail.other",
-                { count: wayIn.contact_count },
+                { count: formatNumber(wayIn.contact_count, locale) },
               )}
             </span>
           </>

--- a/frontend/src/screens/companylookups.ts
+++ b/frontend/src/screens/companylookups.ts
@@ -1,5 +1,6 @@
 import type { components } from "../api/schema";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { useFinanceSummary } from "./common";
 
@@ -90,6 +91,7 @@ export const PAYMENT_LATE_DAYS = 5;
  */
 export function usePaymentHealth(orgId?: string) {
   const t = useT();
+  const { locale } = useLocale();
   const { data } = useFinanceSummary(orgId ?? "");
   if (!orgId || !data) {
     return undefined;
@@ -108,14 +110,18 @@ export function usePaymentHealth(orgId?: string) {
   if (median > PAYMENT_LATE_DAYS) {
     return {
       rating: "good" as const,
-      reason: t("co.health.payment.late", { days: median }),
+      reason: t("co.health.payment.late", {
+        days: formatNumber(median, locale),
+      }),
     };
   }
   return {
     rating: "strong" as const,
     reason:
       median < 0
-        ? t("finance.medianEarly", { days: Math.abs(median) })
+        ? t("finance.medianEarly", {
+            days: formatNumber(Math.abs(median), locale),
+          })
         : t("co.health.payment.onTime"),
   };
 }

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -14,7 +14,7 @@ import {
   sectionState,
 } from "../design-system/surfacestate";
 import { useTruncationTooltip } from "../design-system/tooltip";
-import { formatDate } from "../format/format";
+import { formatDate, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemCodeOf, throwProblem } from "./common";
 import { worstOf } from "./company360";
@@ -174,6 +174,7 @@ function HealthSection({
   loading,
 }: Readonly<{ view?: Organization360; orgId?: string; loading: boolean }>) {
   const t = useT();
+  const { locale } = useLocale();
   const health = view?.health;
   const payment = usePaymentHealth(orgId);
   const { overall, rated } = worstOf([
@@ -184,13 +185,15 @@ function HealthSection({
   const lines: string[] = [];
   if (health?.days_since_last_inbound != null) {
     lines.push(
-      t("co.health.sinceInbound", { days: health.days_since_last_inbound }),
+      t("co.health.sinceInbound", {
+        days: formatNumber(health.days_since_last_inbound, locale),
+      }),
     );
   }
   if (health?.reply_balance != null) {
     lines.push(
       t("co.health.replyBalance", {
-        percent: Math.round(health.reply_balance * 100),
+        percent: formatNumber(Math.round(health.reply_balance * 100), locale),
       }),
     );
   }
@@ -200,7 +203,7 @@ function HealthSection({
         health.active_contacts === 1
           ? "co.health.activeContacts.one"
           : "co.health.activeContacts.other",
-        { count: health.active_contacts },
+        { count: formatNumber(health.active_contacts, locale) },
       ),
     );
   }
@@ -210,7 +213,7 @@ function HealthSection({
         health.open_commitments === 1
           ? "co.health.openCommitments.one"
           : "co.health.openCommitments.other",
-        { count: health.open_commitments },
+        { count: formatNumber(health.open_commitments, locale) },
       ),
     );
   }

--- a/frontend/src/screens/companyspine.tsx
+++ b/frontend/src/screens/companyspine.tsx
@@ -24,6 +24,7 @@ import {
   calendarDaysBetween,
   formatDateAbbrev,
   formatMoneyCompact,
+  formatNumber,
 } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import "./companyspine.css";
@@ -159,7 +160,7 @@ function silence(view: Organization360, ctx: Ctx): Stop | undefined {
   return {
     key: "silence",
     tone: "gap",
-    when: ctx.t("co.spine.days", { count: days }),
+    when: ctx.t("co.spine.days", { count: formatNumber(days, ctx.locale) }),
     title: everReplied
       ? ctx.t("co.spine.quietSince")
       : ctx.t("co.spine.neverReplied"),
@@ -260,7 +261,9 @@ function pipelineValue(view: Organization360, ctx: Ctx): ReactNode {
     commercial.open_pipeline_minor_base == null ||
     !commercial.base_currency
   ) {
-    return ctx.t("co.spine.unpriced", { count: commercial.open_count });
+    return ctx.t("co.spine.unpriced", {
+      count: formatNumber(commercial.open_count, ctx.locale),
+    });
   }
   // formatMoneyCompact, not a formatter of this file's own: the app has one
   // locale mapping and one minor-unit table, and a second Intl call here

--- a/frontend/src/screens/companytoday.tsx
+++ b/frontend/src/screens/companytoday.tsx
@@ -4,8 +4,9 @@ import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState, Skeleton } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody, PanelPlate, PanelRow } from "../design-system/panel";
-import { formatDateTime } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { stable } from "../format/collate";
+import { formatDateTime, formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   ENGAGEMENT_LABELS,
@@ -219,11 +220,12 @@ export function TodayOnThisAccount({
     view,
     t,
     when: (at: string) => formatDateTime(at, locale, recordZone),
+    locale,
   };
   const lead = whoseMove(ctx);
   const items = todayContextItems(ctx);
   const manualMoves = manualMoveRows({ view, t, onPrepareMeeting, onDraftTo });
-  const commitment = nextCommitmentLine(view, t);
+  const commitment = nextCommitmentLine(view, locale, t);
   const hasContext = lead !== null || items.length > 0;
   const hasMoves = suggestions.ready || manualMoves.length > 0;
   const footer = briefFooter(commitment, suggestions.footer);
@@ -540,14 +542,14 @@ function todayContextItems(ctx: TodayContext): TodayItem[] {
 // own engagement tile rather than re-derived: the strip no longer draws it
 // (it is a DATED reading, not the account's standing state), and the brief
 // reads the same `state_strip.engagement` field the strip used to.
-function whoseMove({ view, t }: TodayContext): TodayLead | null {
+function whoseMove({ view, t, locale }: TodayContext): TodayLead | null {
   const engagement = view.state_strip?.engagement;
   if (!engagement) {
     return null;
   }
   return {
     headline: t(ENGAGEMENT_LABELS[engagement.state]),
-    note: silenceNote(view, t),
+    note: silenceNote(view, locale, t),
     tone: ENGAGEMENT_TONE[engagement.state],
   };
 }
@@ -563,6 +565,7 @@ function whoseMove({ view, t }: TodayContext): TodayLead | null {
 // trust in the whole panel.
 function silenceNote(
   view: Organization360,
+  locale: Locale,
   t: TodayContext["t"],
 ): string | undefined {
   const engagement = view.state_strip?.engagement;
@@ -575,7 +578,9 @@ function silenceNote(
   );
   // Same day, or a clock that disagrees with itself: "no answer in 0 days"
   // reads as a fault, and there is nothing yet to report.
-  return days > 0 ? t("today.silence.days", { count: days }) : undefined;
+  return days > 0
+    ? t("today.silence.days", { count: formatNumber(days, locale) })
+    : undefined;
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -664,7 +669,7 @@ function byStrengthThenId(
   b: Organization360Contact,
 ): number {
   const delta = (b.strength?.score ?? 0) - (a.strength?.score ?? 0);
-  return delta !== 0 ? delta : a.person_id.localeCompare(b.person_id);
+  return delta !== 0 ? delta : stable(a.person_id, b.person_id);
 }
 
 // The deal actually in play used to be a context tile here. It moved to the
@@ -701,12 +706,14 @@ function openRisk({ view, t }: TodayContext): TodayItem | null {
 
 type TodayContext = {
   view: Organization360;
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  t: ReturnType<typeof useT>;
   // Dates are formatted at the presentation edge, so a builder is handed the
-  // formatter rather than the reader's locale: none of them chooses a format,
-  // and one that could would be the second place this page decides how a date
-  // looks.
+  // formatter rather than choosing one: `when` is the only place this page
+  // decides how a date looks. The locale beside it is for FIGURES only — a
+  // count reaches the catalog already written the reader's way, and there is
+  // no format left for a builder to pick.
   when: (at: string) => string;
+  locale: Locale;
 };
 
 type Organization360Contact = NonNullable<

--- a/frontend/src/screens/companywork.tsx
+++ b/frontend/src/screens/companywork.tsx
@@ -30,6 +30,7 @@ import {
 import {
   formatDate,
   formatMoneyOrAbsent,
+  formatNumber,
   relativeDays,
 } from "../format/format";
 import { useLocale, useT } from "../i18n";
@@ -170,6 +171,7 @@ export function CompanyWorkCard({
  */
 function SinceLastVisit({ view }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const since = newActivities(view);
   const first = firstVisit(view);
   const withheld = (view?.sections_omitted?.length ?? 0) > 0;
@@ -186,7 +188,7 @@ function SinceLastVisit({ view }: Readonly<{ view?: Organization360 }>) {
         <span className="t-caption">
           {t(
             since === 1 ? "co.read.newActivityOne" : "co.read.newActivityMany",
-            { count: since },
+            { count: formatNumber(since, locale) },
           )}
         </span>
       )}
@@ -331,6 +333,7 @@ function WorkGroup({
  */
 function WorkCount({ view }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (!view?.deals || !view.projects) {
     return null;
   }
@@ -341,8 +344,8 @@ function WorkCount({ view }: Readonly<{ view?: Organization360 }>) {
   return (
     <span className="t-small">
       {capped
-        ? t("co.work.countAtLeast", { count })
-        : t("co.work.count", { count })}
+        ? t("co.work.countAtLeast", { count: formatNumber(count, locale) })
+        : t("co.work.count", { count: formatNumber(count, locale) })}
     </span>
   );
 }
@@ -434,7 +437,7 @@ function ProjectLine({
                 a single template would print "since never". */}
             {project.last_activity_at
               ? t("co.work.quiet", {
-                  when: relativeDays(project.last_activity_at, t),
+                  when: relativeDays(project.last_activity_at, t, locale),
                 })
               : t("co.work.neverTouched")}
           </StatusLine>

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -879,7 +879,11 @@ function DraftDisclosure({
       {provenance.voice_profile_version != null && (
         <>
           <p className="t-caption">
-            {t("compose.voiceVersion", { n: provenance.voice_profile_version })}
+            {/* A profile VERSION, never grouped: version 1234 is one
+                identifier, and "1.234" reads as a different one. */}
+            {t("compose.voiceVersion", {
+              n: String(provenance.voice_profile_version),
+            })}
           </p>
           {maturity === "provisional" && (
             <>

--- a/frontend/src/screens/connections.tsx
+++ b/frontend/src/screens/connections.tsx
@@ -14,7 +14,9 @@ import {
   Skeleton,
 } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
-import { useT } from "../i18n";
+import { stable } from "../format/collate";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 import "./connections.css";
 import { EntityRef } from "./entityref";
@@ -396,7 +398,7 @@ export function routesTo(
       BUCKET_ORDER[b.bucket] - BUCKET_ORDER[a.bucket] ||
       b.strength - a.strength ||
       // Ids last, so the order is the same on every read of the same graph.
-      a.id.localeCompare(b.id),
+      stable(a.id, b.id),
   );
   // The 0-100 number stays off this page (AC-company-3): the rows carry their
   // band and nothing a reader could threshold on.
@@ -641,6 +643,7 @@ function Withheld({ groups }: Readonly<{ groups: readonly Group[] }>) {
  */
 function ConnectionsBody({ graph }: Readonly<{ graph: Graph }>) {
   const t = useT();
+  const { locale } = useLocale();
   const neighbours = graph.nodes.filter((node) => !node.root);
   const ourSide = neighbours.filter((node) => node.kind === "user");
   const theirSide = neighbours.filter((node) => node.kind !== "user");
@@ -668,7 +671,9 @@ function ConnectionsBody({ graph }: Readonly<{ graph: Graph }>) {
       <Withheld groups={graph.groups_omitted} />
       {graph.dropped_count > 0 && (
         <p className="co-row-meta">
-          {t("co.connections.more", { count: graph.dropped_count })}
+          {t("co.connections.more", {
+            count: formatNumber(graph.dropped_count, locale),
+          })}
         </p>
       )}
     </>

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -17,6 +17,7 @@ import type { MessageKey } from "../i18n/en";
 import { humanizeToken } from "./audit";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
 import "./consent.css";
+import { stable } from "../format/collate";
 
 // The Art. 7 proof log (G-4) + the double-opt-in redeem field (G-5) for the
 // Person 360. GET /people/{id}/consent already returns {state, events}; this
@@ -117,7 +118,7 @@ function ConsentProofLog({ events }: Readonly<{ events: ConsentEvent[] }>) {
     return <EmptyState>{t("consent.proofEmpty")}</EmptyState>;
   }
   const ordered = [...events].sort((a, b) =>
-    b.occurred_at.localeCompare(a.occurred_at),
+    stable(b.occurred_at, a.occurred_at),
   );
   return (
     <Card as="div" inset className="consent-proof-log">

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -16,7 +16,8 @@ import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { SEARCH_DEBOUNCE_MS } from "./listquery";
@@ -134,6 +135,7 @@ function useSettledSearch(typed: string): string {
 // anyone is asking.
 function BaselineRow() {
   const t = useT();
+  const { locale } = useLocale();
   const [q, setQ] = useState("");
   // The field shows what is being typed; the SEARCH is what has settled. `q`
   // is the query key, so without this every character was its own request over
@@ -148,7 +150,10 @@ function BaselineRow() {
       <SettingRow
         label={t("consumerMail.baselineSearchLabel")}
         description={
-          result && t("consumerMail.baselineCount", { total: result.total })
+          result &&
+          t("consumerMail.baselineCount", {
+            total: formatNumber(result.total, locale),
+          })
         }
         layout="stack"
         // The function form, so the words the row draws are also the name the
@@ -180,8 +185,8 @@ function BaselineRow() {
                 {result.matched > result.data.length && (
                   <p className="t-small">
                     {t("consumerMail.baselineMore", {
-                      shown: result.data.length,
-                      matched: result.matched,
+                      shown: formatNumber(result.data.length, locale),
+                      matched: formatNumber(result.matched, locale),
                     })}
                   </p>
                 )}

--- a/frontend/src/screens/coverageexplorer.tsx
+++ b/frontend/src/screens/coverageexplorer.tsx
@@ -10,7 +10,9 @@ import {
   Skeleton,
   TableScroll,
 } from "../design-system/atoms";
-import { useT } from "../i18n";
+import { forReader } from "../format/collate";
+import { formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { type StrengthBucket, useOrganizationGraph } from "./connections";
 import { incompleteGraph } from "./record360";
@@ -86,6 +88,7 @@ function CoverageGrid({
   contacts,
 }: Readonly<{ orgId: string; contacts: readonly Contact[] }>) {
   const t = useT();
+  const { locale } = useLocale();
   // Read only when somebody opens the explorer: a graph query on every company
   // page load is what the on-demand route-in read already avoids.
   const query = useOrganizationGraph(orgId);
@@ -97,8 +100,8 @@ function CoverageGrid({
   usePublishSelection(selected.length);
 
   const colleagues = useMemo(
-    () => colleaguesFrom(graph, contacts),
-    [graph, contacts],
+    () => colleaguesFrom(graph, contacts, locale),
+    [graph, contacts, locale],
   );
 
   if (query.isPending) {
@@ -169,7 +172,9 @@ function CoverageGrid({
       </div>
       {shown.length >= COLUMN_CAP && (
         <p className="t-caption">
-          {t("acctCoverage.columnCap", { cap: COLUMN_CAP })}
+          {t("acctCoverage.columnCap", {
+            cap: formatNumber(COLUMN_CAP, locale),
+          })}
         </p>
       )}
       {/* `TableScroll` rather than a wrapper of this screen's own: an
@@ -255,6 +260,7 @@ function CoverageGrid({
 function colleaguesFrom(
   graph: ReturnType<typeof useOrganizationGraph>["data"],
   contacts: readonly Contact[],
+  locale: Locale,
 ): ColleagueCoverage[] {
   if (!graph || !Array.isArray(graph.nodes)) {
     return [];
@@ -283,10 +289,11 @@ function colleaguesFrom(
     }
     byColleague.set(edge.from, entry);
   }
-  // Widest coverage first, then by name so equal colleagues come back in a
-  // stable order rather than the payload's.
+  // Widest coverage first, then by name — `forReader`, because these are
+  // colleagues' names and a reader scans them as an alphabet: theirs.
   return [...byColleague.values()].sort(
-    (a, b) => b.bands.size - a.bands.size || a.label.localeCompare(b.label),
+    (a, b) =>
+      b.bands.size - a.bands.size || forReader(a.label, b.label, locale),
   );
 }
 

--- a/frontend/src/screens/customfields.tsx
+++ b/frontend/src/screens/customfields.tsx
@@ -44,6 +44,7 @@ import {
   slug,
 } from "./customfields.logic";
 import "./customfields.css";
+import { stable } from "../format/collate";
 
 // The add-field builder (AC-custom-fields-3..5/8): a governed form that turns a
 // human's plain label into one typed scalar column on an existing object. The
@@ -477,7 +478,7 @@ export function AuditRail({
 }>) {
   const t = useT();
   const recentFirst = [...entries].sort((a, b) =>
-    b.occurred_at.localeCompare(a.occurred_at),
+    stable(b.occurred_at, a.occurred_at),
   );
 
   return (

--- a/frontend/src/screens/deal360/dealpulse.tsx
+++ b/frontend/src/screens/deal360/dealpulse.tsx
@@ -18,7 +18,11 @@
 
 import type { components } from "../../api/schema";
 import { useRecordZone } from "../../app/recordzone";
-import { calendarDaysBetween, formatDayMonth } from "../../format/format";
+import {
+  calendarDaysBetween,
+  formatDayMonth,
+  formatNumber,
+} from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 
 type DealStatusCard = components["schemas"]["DealStatusCard"];
@@ -77,7 +81,7 @@ export function DealPulse({
       <span className="d360-pulse-rest">
         {t("deal.pulse.wroteOn", {
           date: formatDayMonth(waiting.at, locale, zone),
-          days,
+          days: formatNumber(days, locale),
         })}
       </span>
     </p>

--- a/frontend/src/screens/deal360/dealseats.tsx
+++ b/frontend/src/screens/deal360/dealseats.tsx
@@ -19,7 +19,8 @@ import type { components } from "../../api/schema";
 import { Badge } from "../../design-system/atoms";
 import { PanelBody } from "../../design-system/panel";
 import { sectionState } from "../../design-system/surfacestate";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { useLocale, useT } from "../../i18n";
 import { dealRoleLabel, RailPanel } from "../record360";
 import "../network.css";
 
@@ -47,6 +48,7 @@ export function DealSeats({
   overlay: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const seats = coverage?.stakeholders ?? [];
   const ours = coverage?.our_side ?? [];
   // `unsupported`, not `unavailable`: nothing is broken and retrying changes
@@ -80,7 +82,9 @@ export function DealSeats({
       footer={
         ours.length > 0 ? (
           <p className="t-caption">
-            {t("deal.seats.ours", { count: ours.length })}
+            {t("deal.seats.ours", {
+              count: formatNumber(ours.length, locale),
+            })}
           </p>
         ) : undefined
       }

--- a/frontend/src/screens/deal360/dealstrip.tsx
+++ b/frontend/src/screens/deal360/dealstrip.tsx
@@ -24,9 +24,10 @@ import {
   calendarDaysBetween,
   formatDayMonth,
   formatMoneyOrAbsent,
+  formatNumber,
   relativeDays,
 } from "../../format/format";
-import { type Locale, useLocale, useT } from "../../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 
 type Deal = components["schemas"]["Deal"];
@@ -78,8 +79,13 @@ export function DealStrip({
       <StatStrip testId="deal-strip">
         <MoneyStat deal={deal} offers={offers} locale={locale} t={t} />
         <CloseStat deal={deal} locale={locale} zone={zone} t={t} />
-        <PeopleStat coverage={coverage} withheld={coverageWithheld} t={t} />
-        <MomentumStat deal={deal} t={t} />
+        <PeopleStat
+          coverage={coverage}
+          withheld={coverageWithheld}
+          locale={locale}
+          t={t}
+        />
+        <MomentumStat deal={deal} locale={locale} t={t} />
       </StatStrip>
     </section>
   );
@@ -101,12 +107,14 @@ function MoneyStat({
   deal: Deal;
   offers?: readonly Offer[];
   locale: Locale;
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  t: Translator;
 }>) {
   const newest = offers?.[0];
   const detail = newest
     ? t("deal.strip.money.offer", {
-        number: newest.offer_number,
+        // The offer's identifier, not a quantity: grouped, revision 1234 would
+        // read "1.234" and name no document.
+        number: String(newest.offer_number),
         status: t(`commercial.offer.${newest.status}` as MessageKey),
       })
     : t("deal.strip.money.noOffer");
@@ -136,7 +144,7 @@ function CloseStat({
   deal: Deal;
   locale: Locale;
   zone: string;
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  t: Translator;
 }>) {
   if (!deal.expected_close_date) {
     return (
@@ -153,8 +161,10 @@ function CloseStat({
   );
   const parts: string[] = [
     days < 0
-      ? t("deal.strip.close.overdue", { days: Math.abs(days) })
-      : t("deal.strip.close.inDays", { days }),
+      ? t("deal.strip.close.overdue", {
+          days: formatNumber(Math.abs(days), locale),
+        })
+      : t("deal.strip.close.inDays", { days: formatNumber(days, locale) }),
   ];
   if (deal.close_date_provisional) {
     parts.push(t("deal.strip.close.provisional"));
@@ -186,11 +196,13 @@ function CloseStat({
 function PeopleStat({
   coverage,
   withheld,
+  locale,
   t,
 }: Readonly<{
   coverage?: DealCoverage;
   withheld: boolean;
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  locale: Locale;
+  t: Translator;
 }>) {
   if (withheld) {
     return (
@@ -221,8 +233,8 @@ function PeopleStat({
     <StatCard
       label={t("deal.strip.people")}
       value={t("deal.strip.people.count", {
-        engaged,
-        total: seats.length,
+        engaged: formatNumber(engaged, locale),
+        total: formatNumber(seats.length, locale),
       })}
       detail={detail}
       tone={engaged <= 1 || !champion ? "warn" : undefined}
@@ -234,10 +246,12 @@ function PeopleStat({
 // Whether anything is happening.
 function MomentumStat({
   deal,
+  locale,
   t,
 }: Readonly<{
   deal: Deal;
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  locale: Locale;
+  t: Translator;
 }>) {
   const parts: string[] = [t("deal.strip.momentum.detail")];
   if (deal.stalled) {
@@ -246,7 +260,7 @@ function MomentumStat({
   return (
     <StatCard
       label={t("deal.strip.momentum")}
-      value={relativeDays(deal.last_activity_at, t)}
+      value={relativeDays(deal.last_activity_at, t, locale)}
       detail={parts.join(" · ")}
       tone={deal.stalled ? "danger" : undefined}
       dot={deal.stalled}

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -6,7 +6,9 @@ import { ifMatch, requireVersion } from "../api/version";
 import { Button } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Select } from "../design-system/select";
-import { useT } from "../i18n";
+import { stable } from "../format/collate";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { dealRecordKeys } from "./activitykeys";
 import { ProblemError, problemMessageOf, throwProblem } from "./common";
 import { RosterPartialNote, useRoster, useRosterPartial } from "./entityref";
@@ -45,6 +47,7 @@ export function DealBulkBar({
   onDone: (outcomes: readonly DealBulkOutcome[]) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const queryClient = useQueryClient();
   const [ownerId, setOwnerId] = useState("");
   const [stageId, setStageId] = useState("");
@@ -60,12 +63,12 @@ export function DealBulkBar({
   // stage chosen for rows that are no longer selected. A verb armed for one
   // selection must not fire at another, so the pickers clear when the
   // membership changes.
-  // Sorted in "en" rather than the reader's locale: this string is compared
-  // against itself to detect a changed selection, so the ordering has to be a
-  // property of the ids and of nothing else.
+  // `stable`, not the reader's collation: this string is compared against
+  // itself to detect a changed selection, so the ordering has to be a property
+  // of the ids and of nothing else.
   const selectionKey = deals
     .map((deal) => deal.id)
-    .sort((a, b) => a.localeCompare(b, "en"))
+    .sort(stable)
     .join(",");
   const [armedFor, setArmedFor] = useState(selectionKey);
   if (armedFor !== selectionKey) {
@@ -195,7 +198,7 @@ export function DealBulkBar({
   return (
     <>
       <span className="t-caption">
-        {t("deals.bulkSelected", { count: deals.length })}
+        {t("deals.bulkSelected", { count: formatNumber(deals.length, locale) })}
       </span>
       <Select
         aria-label={t("deals.bulkOwner")}
@@ -255,7 +258,7 @@ export function DealBulkBar({
           deals.length === 1
             ? "deals.bulkArchiveConfirmTitle.one"
             : "deals.bulkArchiveConfirmTitle.other",
-          { count: deals.length },
+          { count: formatNumber(deals.length, locale) },
         )}
         confirmLabel={t("deals.bulkArchive")}
         confirmVariant="danger"
@@ -269,7 +272,9 @@ export function DealBulkBar({
       </ConfirmModal>
       {failed.length > 0 && (
         <span className="t-caption" style={{ color: "var(--danger)" }}>
-          {t("deals.bulkFailed", { count: failed.length })}{" "}
+          {t("deals.bulkFailed", {
+            count: formatNumber(failed.length, locale),
+          })}{" "}
           {failed
             .map((outcome) => `${outcome.name}: ${outcome.error}`)
             .join(" · ")}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -51,11 +51,13 @@ import { Select } from "../design-system/select";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { type Toast, ToastRegion, useToast } from "../design-system/toast";
 import { AutonomyDot, ProvenanceTag } from "../design-system/trust";
+import { forReader, stable } from "../format/collate";
 import {
   formatDate,
   formatDuration,
   formatMoney,
   formatMoneyOrAbsent,
+  formatNumber,
 } from "../format/format";
 import { toMajorUnits, toMinorUnits } from "../format/minorunits";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -1997,7 +1999,9 @@ export function DealsScreen({
       <>
         {dealsQuery.data && (
           <p className="t-caption">
-            {t("board.count", { count: loadedDeals.length })}
+            {t("board.count", {
+              count: formatNumber(loadedDeals.length, locale),
+            })}
           </p>
         )}
         <QueryGate query={pipelinesQuery}>
@@ -2419,11 +2423,12 @@ function DealTable({
         return (a.amount_minor ?? 0) - (b.amount_minor ?? 0);
       }
       if (sortKey === "close") {
-        return (a.expected_close_date ?? "").localeCompare(
-          b.expected_close_date ?? "",
-        );
+        // ISO dates: `stable` sorts them chronologically and identically for
+        // everyone, which is what a date column is asked for.
+        return stable(a.expected_close_date ?? "", b.expected_close_date ?? "");
       }
-      return a.name.localeCompare(b.name);
+      // A deal's name, in a column a person reads as an alphabet — theirs.
+      return forReader(a.name, b.name, locale);
     };
     const rows = [...deals];
     rows.sort((a, b) => {
@@ -2431,7 +2436,7 @@ function DealTable({
       return descending ? -compare : compare;
     });
     return rows;
-  }, [deals, sortKey, descending, sortable]);
+  }, [deals, sortKey, descending, sortable, locale]);
 
   const sortBy = (key: typeof sortKey) => {
     if (key === sortKey) {

--- a/frontend/src/screens/dealsignals.tsx
+++ b/frontend/src/screens/dealsignals.tsx
@@ -16,7 +16,8 @@
 // is read rather than recomputed.
 
 import type { components } from "../api/schema";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { useDealCoverage } from "./deal360/usedealcoverage";
 import type { Signal, SignalTone } from "./record360";
@@ -58,6 +59,7 @@ const RISK_LABELS: Record<DealCoverageRisk["kind"], MessageKey> = {
  */
 export function useDealSignals(dealId: string, enabled: boolean) {
   const t = useT();
+  const { locale } = useLocale();
   // The shared read, not a second useQuery over the same key. Three surfaces
   // ask this question and they agreed by luck while each spelled its own; see
   // deal360/usedealcoverage.tsx.
@@ -71,7 +73,9 @@ export function useDealSignals(dealId: string, enabled: boolean) {
         // renders its label alone rather than a blank where a number goes.
         figure:
           risk.days_since_touch != null
-            ? t("coverage.daysSinceTouch", { days: risk.days_since_touch })
+            ? t("coverage.daysSinceTouch", {
+                days: formatNumber(risk.days_since_touch, locale),
+              })
             : undefined,
         tone: RISK_TONE[risk.kind],
       }));

--- a/frontend/src/screens/documentextraction.tsx
+++ b/frontend/src/screens/documentextraction.tsx
@@ -6,7 +6,7 @@ import { Button, TextInput } from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import type { ConfidenceLevel } from "../design-system/trust";
 import { StagingCard } from "../design-system/trust";
-import { formatMoney } from "../format/format";
+import { formatMoney, formatNumber } from "../format/format";
 import { minorUnitDigits, toMajorUnits } from "../format/minorunits";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -131,6 +131,7 @@ export function DocumentExtractionPanel({
   canAccept,
 }: Readonly<{ attachmentId: string; canAccept: boolean }>) {
   const t = useT();
+  const { locale } = useLocale();
   const queryClient = useQueryClient();
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [accepted, setAccepted] = useState<number | null>(null);
@@ -220,7 +221,7 @@ export function DocumentExtractionPanel({
               "extraction.acceptedHeading.one",
               "extraction.acceptedHeading.other",
             ),
-            { count: accepted },
+            { count: formatNumber(accepted, locale) },
           )}
         </p>
       </section>
@@ -321,6 +322,7 @@ function ExtractionBody({
   acceptFailed: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
 
   if (extraction.status === "queued" || extraction.status === "running") {
     return <p className="t-caption">{t("extraction.reading")}</p>;
@@ -362,7 +364,7 @@ function ExtractionBody({
             "extraction.heading.one",
             "extraction.heading.other",
           ),
-          { count: extraction.fields.length },
+          { count: formatNumber(extraction.fields.length, locale) },
         )}
       </p>
       <ul className="extraction-fields">
@@ -390,7 +392,7 @@ function ExtractionBody({
                 "extraction.accept.one",
                 "extraction.accept.other",
               ),
-              { count: extraction.fields.length },
+              { count: formatNumber(extraction.fields.length, locale) },
             )}
           </Button>
           <Button variant="ghost" onClick={onDismiss}>

--- a/frontend/src/screens/factview.test.ts
+++ b/frontend/src/screens/factview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
+import { type Locale, type Translator, translate } from "../i18n";
 import {
   canonical,
   FACT_FIELD_LABELS,
@@ -25,8 +26,19 @@ function fact(over: Partial<OrganizationFact> = {}): OrganizationFact {
   };
 }
 
+// The real catalogue lookup, not a stub: the ordering cases below turn on what
+// a label actually SAYS in German, so a double that returned the key would
+// prove the sort ran and nothing about what it produced.
+const tFor =
+  (locale: Locale): Translator =>
+  (key, params) =>
+    translate(locale, key, params);
+
 const values = (groups: ReturnType<typeof groupFacts>, category: string) =>
   groups.find((g) => g.category === category)?.facts.map((f) => f.value) ?? [];
+
+const fields = (groups: ReturnType<typeof groupFacts>, category: string) =>
+  groups.find((g) => g.category === category)?.facts.map((f) => f.field) ?? [];
 
 describe("canonical", () => {
   it("collapses the spellings a scrape produces of one value", () => {
@@ -43,6 +55,7 @@ describe("groupFacts", () => {
   it("shows one row for two spellings of the same fact", () => {
     const groups = groupFacts(
       [fact({ value: "Shop Devs" }), fact({ value: "Shop-Devs" })],
+      tFor("en"),
       "en",
     );
     expect(values(groups, "market")).toHaveLength(1);
@@ -60,6 +73,7 @@ describe("groupFacts", () => {
           value: "bitExpert",
         }),
       ],
+      tFor("en"),
       "en",
     );
     expect(values(groups, "signal")).toHaveLength(2);
@@ -72,6 +86,7 @@ describe("groupFacts", () => {
         fact({ category: "offering", field: "service", value: "PaaS" }),
         fact({ category: "offering", field: "product", value: "PaaS" }),
       ],
+      tFor("en"),
       "en",
     );
     const offering = groups.find((g) => g.category === "offering");
@@ -100,6 +115,7 @@ describe("groupFacts", () => {
           value_key: "frontic",
         }),
       ],
+      tFor("en"),
       "en",
     );
     expect(groups.find((g) => g.category === "offering")?.facts).toHaveLength(
@@ -127,6 +143,7 @@ describe("groupFacts", () => {
           source: "human",
         }),
       ],
+      tFor("en"),
       "en",
     );
     const offering = groups.find((g) => g.category === "offering");
@@ -140,6 +157,7 @@ describe("groupFacts", () => {
         fact({ value: "E-Commerce", source: "site_read", confidence: 0.9 }),
         fact({ value: "e commerce", source: "human", confidence: 0.1 }),
       ],
+      tFor("en"),
       "en",
     );
     expect(groups[0].facts[0].source).toBe("human");
@@ -151,6 +169,7 @@ describe("groupFacts", () => {
         fact({ value: "Agenturen", confidence: 0.2 }),
         fact({ value: "Shopbetreiber", confidence: 0.9 }),
       ],
+      tFor("en"),
       "en",
     );
     expect(values(groups, "market")[0]).toBe("Shopbetreiber");
@@ -163,6 +182,7 @@ describe("groupFacts", () => {
         fact({ category: "company", field: "phone", value: "+49 30 1" }),
         fact({ category: "offering", field: "product", value: "Frontic" }),
       ],
+      tFor("en"),
       "en",
     );
     expect(groups.map((g) => g.category)).toEqual([
@@ -173,11 +193,41 @@ describe("groupFacts", () => {
   });
 
   it("omits a category with no facts rather than drawing an empty heading", () => {
-    const groups = groupFacts([fact({ category: "market" })], "en");
+    const groups = groupFacts([fact({ category: "market" })], tFor("en"), "en");
     expect(groups.map((g) => g.category)).toEqual(["market"]);
   });
 
-  it("breaks a confidence tie in the READER's alphabet, not in code units", () => {
+  it("breaks a field tie on the label the reader SEES, not the wire name", () => {
+    // The row draws `t(factFieldLabelKey(field))`, so an order computed from
+    // the identifiers is an order in words nobody reads. English and German
+    // disagree here in opposite directions, which is the whole point:
+    // employee_range < founded_year as identifiers and as "Employees" before
+    // "Founded", but "Gegründet" comes before "Mitarbeitende".
+    const tie = [
+      fact({
+        category: "company",
+        field: "employee_range",
+        value: "120",
+        value_key: "120",
+      }),
+      fact({
+        category: "company",
+        field: "founded_year",
+        value: "2014",
+        value_key: "2014",
+      }),
+    ];
+    expect(fields(groupFacts(tie, tFor("en"), "en"), "company")).toEqual([
+      "employee_range",
+      "founded_year",
+    ]);
+    expect(fields(groupFacts(tie, tFor("de"), "de"), "company")).toEqual([
+      "founded_year",
+      "employee_range",
+    ]);
+  });
+
+  it("breaks a value tie in the READER's alphabet, not in code units", () => {
     // Both values are rendered, so the tiebreaker is a list a person scans.
     // Code-unit order puts every accented vowel after Z, which is why a German
     // reader used to find "Ähnliche Marken" below "Zielgruppe" — the two
@@ -187,7 +237,7 @@ describe("groupFacts", () => {
       fact({ value: "Ähnliche Marken", value_key: "ahnliche-marken" }),
       fact({ value: "Absatzmarkt", value_key: "absatzmarkt" }),
     ];
-    expect(values(groupFacts(tie, "de"), "market")).toEqual([
+    expect(values(groupFacts(tie, tFor("de"), "de"), "market")).toEqual([
       "Absatzmarkt",
       "Ähnliche Marken",
       "Zielgruppe",

--- a/frontend/src/screens/factview.test.ts
+++ b/frontend/src/screens/factview.test.ts
@@ -41,29 +41,39 @@ describe("canonical", () => {
 
 describe("groupFacts", () => {
   it("shows one row for two spellings of the same fact", () => {
-    const groups = groupFacts([
-      fact({ value: "Shop Devs" }),
-      fact({ value: "Shop-Devs" }),
-    ]);
+    const groups = groupFacts(
+      [fact({ value: "Shop Devs" }), fact({ value: "Shop-Devs" })],
+      "en",
+    );
     expect(values(groups, "market")).toHaveLength(1);
   });
 
   it("keeps the same value under two different fields apart", () => {
     // A company can genuinely be both a partner and a named customer, and the
     // field is what distinguishes the two statements.
-    const groups = groupFacts([
-      fact({ category: "signal", field: "partner", value: "bitExpert" }),
-      fact({ category: "signal", field: "named_customer", value: "bitExpert" }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({ category: "signal", field: "partner", value: "bitExpert" }),
+        fact({
+          category: "signal",
+          field: "named_customer",
+          value: "bitExpert",
+        }),
+      ],
+      "en",
+    );
     expect(values(groups, "signal")).toHaveLength(2);
   });
 
   it("collapses one offering listed as product, service and capability", () => {
-    const groups = groupFacts([
-      fact({ category: "offering", field: "capability", value: "PaaS" }),
-      fact({ category: "offering", field: "service", value: "PaaS" }),
-      fact({ category: "offering", field: "product", value: "PaaS" }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({ category: "offering", field: "capability", value: "PaaS" }),
+        fact({ category: "offering", field: "service", value: "PaaS" }),
+        fact({ category: "offering", field: "product", value: "PaaS" }),
+      ],
+      "en",
+    );
     const offering = groups.find((g) => g.category === "offering");
     expect(offering?.facts).toHaveLength(1);
     // Product is the most concrete of the three, so it is the one kept.
@@ -75,20 +85,23 @@ describe("groupFacts", () => {
     // normalized the name into value_key; recomputing identity from the whole
     // displayed string left these as two rows, so the collapse did nothing on
     // exactly the shape production sends.
-    const groups = groupFacts([
-      fact({
-        category: "offering",
-        field: "product",
-        value: "Frontic - Commerce platform",
-        value_key: "frontic",
-      }),
-      fact({
-        category: "offering",
-        field: "service",
-        value: "Frontic - Storefront delivery",
-        value_key: "frontic",
-      }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({
+          category: "offering",
+          field: "product",
+          value: "Frontic - Commerce platform",
+          value_key: "frontic",
+        }),
+        fact({
+          category: "offering",
+          field: "service",
+          value: "Frontic - Storefront delivery",
+          value_key: "frontic",
+        }),
+      ],
+      "en",
+    );
     expect(groups.find((g) => g.category === "offering")?.facts).toHaveLength(
       1,
     );
@@ -98,48 +111,60 @@ describe("groupFacts", () => {
     // Product outranks service, and a human outranks a machine. Applying the
     // field rank first let a site read's product hide a human's service for
     // the same offering, which is machine over human.
-    const groups = groupFacts([
-      fact({
-        category: "offering",
-        field: "product",
-        value: "PaaS",
-        source: "site_read",
-        confidence: 0.9,
-      }),
-      fact({
-        category: "offering",
-        field: "service",
-        value: "PaaS",
-        source: "human",
-      }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({
+          category: "offering",
+          field: "product",
+          value: "PaaS",
+          source: "site_read",
+          confidence: 0.9,
+        }),
+        fact({
+          category: "offering",
+          field: "service",
+          value: "PaaS",
+          source: "human",
+        }),
+      ],
+      "en",
+    );
     const offering = groups.find((g) => g.category === "offering");
     expect(offering?.facts).toHaveLength(1);
     expect(offering?.facts[0].source).toBe("human");
   });
 
   it("keeps a human-held value over a more confident machine one", () => {
-    const groups = groupFacts([
-      fact({ value: "E-Commerce", source: "site_read", confidence: 0.9 }),
-      fact({ value: "e commerce", source: "human", confidence: 0.1 }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({ value: "E-Commerce", source: "site_read", confidence: 0.9 }),
+        fact({ value: "e commerce", source: "human", confidence: 0.1 }),
+      ],
+      "en",
+    );
     expect(groups[0].facts[0].source).toBe("human");
   });
 
   it("orders the most confident fact first", () => {
-    const groups = groupFacts([
-      fact({ value: "Agenturen", confidence: 0.2 }),
-      fact({ value: "Shopbetreiber", confidence: 0.9 }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({ value: "Agenturen", confidence: 0.2 }),
+        fact({ value: "Shopbetreiber", confidence: 0.9 }),
+      ],
+      "en",
+    );
     expect(values(groups, "market")[0]).toBe("Shopbetreiber");
   });
 
   it("orders categories the same way every time", () => {
-    const groups = groupFacts([
-      fact({ category: "signal", field: "technology", value: "Redis" }),
-      fact({ category: "company", field: "phone", value: "+49 30 1" }),
-      fact({ category: "offering", field: "product", value: "Frontic" }),
-    ]);
+    const groups = groupFacts(
+      [
+        fact({ category: "signal", field: "technology", value: "Redis" }),
+        fact({ category: "company", field: "phone", value: "+49 30 1" }),
+        fact({ category: "offering", field: "product", value: "Frontic" }),
+      ],
+      "en",
+    );
     expect(groups.map((g) => g.category)).toEqual([
       "company",
       "offering",
@@ -148,8 +173,25 @@ describe("groupFacts", () => {
   });
 
   it("omits a category with no facts rather than drawing an empty heading", () => {
-    const groups = groupFacts([fact({ category: "market" })]);
+    const groups = groupFacts([fact({ category: "market" })], "en");
     expect(groups.map((g) => g.category)).toEqual(["market"]);
+  });
+
+  it("breaks a confidence tie in the READER's alphabet, not in code units", () => {
+    // Both values are rendered, so the tiebreaker is a list a person scans.
+    // Code-unit order puts every accented vowel after Z, which is why a German
+    // reader used to find "Ähnliche Marken" below "Zielgruppe" — the two
+    // orderings disagree here, and only one of them is what the reader expects.
+    const tie = [
+      fact({ value: "Zielgruppe", value_key: "zielgruppe" }),
+      fact({ value: "Ähnliche Marken", value_key: "ahnliche-marken" }),
+      fact({ value: "Absatzmarkt", value_key: "absatzmarkt" }),
+    ];
+    expect(values(groupFacts(tie, "de"), "market")).toEqual([
+      "Absatzmarkt",
+      "Ähnliche Marken",
+      "Zielgruppe",
+    ]);
   });
 
   it("names every field the schema allows", () => {

--- a/frontend/src/screens/factview.ts
+++ b/frontend/src/screens/factview.ts
@@ -1,6 +1,6 @@
 import type { components } from "../api/schema";
 import { forReader } from "../format/collate";
-import type { Locale } from "../i18n";
+import type { Locale, Translator } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // How the facts read off a company's website are arranged for display.
@@ -127,6 +127,7 @@ function better(a: OrganizationFact, b: OrganizationFact): boolean {
  */
 export function groupFacts(
   facts: readonly OrganizationFact[],
+  t: Translator,
   locale: Locale,
 ): FactGroup[] {
   const groups = new Map<FactCategory, Map<string, OrganizationFact>>();
@@ -154,20 +155,32 @@ export function groupFacts(
     (category) => ({
       category,
       facts: [...(groups.get(category) ?? new Map()).values()].sort((a, b) =>
-        order(a, b, locale),
+        order(a, b, t, locale),
       ),
     }),
   );
 }
 
-// Within a category: the most confident first, then by field and value. Both
-// are RENDERED in the group, so the tiebreaker is the reader's own alphabet —
-// under code-unit order a German reader's "Ähnliche Marken" sorts after
-// "Zielgruppe". Two facts of equal confidence with the same field and value are
-// the same fact, so this is still a total order on what a reader can tell apart.
+// Within a category: the most confident first, then by field and value.
+//
+// Both are RENDERED in the group, so the tiebreaker is a list a person scans
+// and it orders in that reader's own alphabet. Two things follow, and the field
+// half is the one that is easy to get half right:
+//
+//   - The field sorts by its TRANSLATED LABEL, not by the wire identifier. The
+//     row draws `t(factFieldLabelKey(field))`, so comparing `employee_range`
+//     against `founded_year` orders by words the reader never sees — in German
+//     "Mitarbeitende" comes after "Gegründet" while the identifiers go the
+//     other way, and the list reads as unsorted.
+//   - Both halves go through `forReader`, because code-unit order puts every
+//     accented vowel after Z: "Ähnliche Marken" below "Zielgruppe".
+//
+// Two facts of equal confidence with the same label and value are the same
+// fact, so this is still a total order on what a reader can tell apart.
 function order(
   a: OrganizationFact,
   b: OrganizationFact,
+  t: Translator,
   locale: Locale,
 ): number {
   const conf = (b.confidence ?? 0) - (a.confidence ?? 0);
@@ -175,6 +188,10 @@ function order(
     return conf;
   }
   return (
-    forReader(a.field, b.field, locale) || forReader(a.value, b.value, locale)
+    forReader(
+      t(factFieldLabelKey(a.field)),
+      t(factFieldLabelKey(b.field)),
+      locale,
+    ) || forReader(a.value, b.value, locale)
   );
 }

--- a/frontend/src/screens/factview.ts
+++ b/frontend/src/screens/factview.ts
@@ -1,4 +1,5 @@
 import type { components } from "../api/schema";
+import { stable } from "./../format/collate";
 import type { MessageKey } from "../i18n/en";
 
 // How the facts read off a company's website are arranged for display.
@@ -160,5 +161,5 @@ function order(a: OrganizationFact, b: OrganizationFact): number {
   if (conf !== 0) {
     return conf;
   }
-  return a.field.localeCompare(b.field) || a.value.localeCompare(b.value);
+  return stable(a.field, b.field) || stable(a.value, b.value);
 }

--- a/frontend/src/screens/factview.ts
+++ b/frontend/src/screens/factview.ts
@@ -1,5 +1,6 @@
 import type { components } from "../api/schema";
-import { stable } from "./../format/collate";
+import { forReader } from "../format/collate";
+import type { Locale } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // How the facts read off a company's website are arranged for display.
@@ -124,7 +125,10 @@ function better(a: OrganizationFact, b: OrganizationFact): boolean {
  * fields, because product/service/capability are three ways of saying the one
  * thing (see OFFERING_RANK); elsewhere the field is part of the identity.
  */
-export function groupFacts(facts: readonly OrganizationFact[]): FactGroup[] {
+export function groupFacts(
+  facts: readonly OrganizationFact[],
+  locale: Locale,
+): FactGroup[] {
   const groups = new Map<FactCategory, Map<string, OrganizationFact>>();
   for (const fact of facts) {
     const byKey = groups.get(fact.category) ?? new Map();
@@ -149,17 +153,28 @@ export function groupFacts(facts: readonly OrganizationFact[]): FactGroup[] {
   return CATEGORY_ORDER.filter((category) => groups.has(category)).map(
     (category) => ({
       category,
-      facts: [...(groups.get(category) ?? new Map()).values()].sort(order),
+      facts: [...(groups.get(category) ?? new Map()).values()].sort((a, b) =>
+        order(a, b, locale),
+      ),
     }),
   );
 }
 
-// Within a category: the most confident first, then stable by field and value
-// so the same read never renders in two different orders.
-function order(a: OrganizationFact, b: OrganizationFact): number {
+// Within a category: the most confident first, then by field and value. Both
+// are RENDERED in the group, so the tiebreaker is the reader's own alphabet —
+// under code-unit order a German reader's "Ähnliche Marken" sorts after
+// "Zielgruppe". Two facts of equal confidence with the same field and value are
+// the same fact, so this is still a total order on what a reader can tell apart.
+function order(
+  a: OrganizationFact,
+  b: OrganizationFact,
+  locale: Locale,
+): number {
   const conf = (b.confidence ?? 0) - (a.confidence ?? 0);
   if (conf !== 0) {
     return conf;
   }
-  return stable(a.field, b.field) || stable(a.value, b.value);
+  return (
+    forReader(a.field, b.field, locale) || forReader(a.value, b.value, locale)
+  );
 }

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -18,7 +18,8 @@ import {
   SegmentedControl,
 } from "../design-system/atoms";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryStates } from "./common";
 import { FilterBuilder } from "./filterbuilder";
@@ -275,6 +276,7 @@ function MatchCount({
   failed: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (failed) {
     // Silent: the results card below carries the reason in an assertive live
     // region, and announcing the same failure twice fragments it.
@@ -301,7 +303,7 @@ function MatchCount({
       aria-busy={stale}
       data-stale={stale ? "true" : undefined}
     >
-      {t(MATCH_LABEL[tab], { count })}
+      {t(MATCH_LABEL[tab], { count: formatNumber(count, locale) })}
     </span>
   );
 }

--- a/frontend/src/screens/history.logic.ts
+++ b/frontend/src/screens/history.logic.ts
@@ -1,4 +1,5 @@
 import type { components } from "../api/schema";
+import { stable } from "../format/collate";
 
 type FieldHistoryEntry = components["schemas"]["FieldHistoryEntry"];
 
@@ -19,9 +20,7 @@ export function groupByField(entries: FieldHistoryEntry[]): FieldGroup[] {
   }
   return [...byField.entries()].map(([field, changes]) => ({
     field,
-    changes: [...changes].sort((a, b) =>
-      b.changed_at.localeCompare(a.changed_at),
-    ),
+    changes: [...changes].sort((a, b) => stable(b.changed_at, a.changed_at)),
   }));
 }
 

--- a/frontend/src/screens/home.decisions.tsx
+++ b/frontend/src/screens/home.decisions.tsx
@@ -27,10 +27,10 @@ import {
 } from "../design-system/decisiondeck";
 import type { SectionState } from "../design-system/surfacestate";
 import { AutonomyDot, confidenceLevel } from "../design-system/trust";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { formatCountdown } from "../format/now";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { approvalKindLabel } from "./approvalkind";
 import {
@@ -61,12 +61,12 @@ function approvalsOf(item: DecisionDeckItem): readonly Approval[] {
 // than shared with the Decisions row for the same reason `deckLabels` is: what a
 // countdown is CALLED belongs to the screen showing it, and the deck's own
 // vocabulary is already divergent ("Later" is a verdict only it offers).
-function statusLabels(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
-): DecisionStatusLabels {
+function statusLabels(t: Translator, locale: Locale): DecisionStatusLabels {
   return {
     expiresIn: (msRemaining) =>
-      t("inbox.expiresIn", { countdown: formatCountdown(msRemaining, t) }),
+      t("inbox.expiresIn", {
+        countdown: formatCountdown(msRemaining, t, locale),
+      }),
     approved: t("inbox.status.approved"),
     rejected: t("inbox.status.rejected"),
     expired: t("inbox.status.expired"),
@@ -75,7 +75,7 @@ function statusLabels(
 
 /** The deck's vocabulary, in this surface's own words. */
 function deckLabels(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
+  t: (key: MessageKey, params?: Record<string, string>) => string,
   locale: Parameters<typeof formatDateTime>[1],
 ): DecisionDeckLabels {
   const card: DecisionCardLabels = {
@@ -101,18 +101,18 @@ function deckLabels(
     keys: t("home.deck.keys"),
     behind: (count) =>
       t(count === 1 ? "home.deck.behind.one" : "home.deck.behind.other", {
-        count,
+        count: formatNumber(count, locale),
       }),
     staged: (count) =>
       t(count === 1 ? "home.deck.staged.one" : "home.deck.staged.other", {
-        count,
+        count: formatNumber(count, locale),
       }),
     commit: t("home.deck.commit"),
     unstage: t("home.deck.unstage"),
     clearedTitle: t("home.deck.clearedTitle"),
     cleared: (count) =>
       t(count === 1 ? "home.deck.cleared.one" : "home.deck.cleared.other", {
-        count,
+        count: formatNumber(count, locale),
       }),
     clearedTime: (atMs) =>
       t("home.deck.clearedTime", {
@@ -120,9 +120,9 @@ function deckLabels(
       }),
     empty: t("home.deck.empty"),
     bundleSummary: (members) =>
-      t("home.deck.bundleSummary", { count: members }),
+      t("home.deck.bundleSummary", { count: formatNumber(members, locale) }),
     bundleMembers: (members) =>
-      t("home.deck.bundleMembers", { count: members }),
+      t("home.deck.bundleMembers", { count: formatNumber(members, locale) }),
   };
 }
 
@@ -378,7 +378,7 @@ export function DecisionsSection({
                 approval={approval}
                 decided={false}
                 now={nowMs}
-                labels={statusLabels(t)}
+                labels={statusLabels(t, locale)}
               />
             </>
           ),

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -9,7 +9,11 @@ import { Callout } from "../design-system/callout";
 import { DealCard } from "../design-system/composed";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
-import { formatDate, formatMoneyOrAbsent } from "../format/format";
+import {
+  formatDate,
+  formatMoneyOrAbsent,
+  formatNumber,
+} from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryGate } from "./common";
@@ -76,6 +80,7 @@ function DigestProjectsBlock({
   projects,
 }: Readonly<{ projects: DigestProjects }>) {
   const t = useT();
+  const { locale } = useLocale();
   const { phase_changes, new_commitments, gone_quiet } = projects;
   // The birth row of a project created overnight carries no from_phase; a move
   // between rungs is the news, so only those are listed.
@@ -118,7 +123,7 @@ function DigestProjectsBlock({
               <EntityRef kind="project" id={item.project_id} />{" "}
               <span className="t-caption">
                 {t("home.digestCommitmentCount", {
-                  count: item.new_open_commitments,
+                  count: formatNumber(item.new_open_commitments, locale),
                 })}
               </span>
             </li>
@@ -134,7 +139,9 @@ function DigestProjectsBlock({
             <li key={item.project_id}>
               <EntityRef kind="project" id={item.project_id} />{" "}
               <span className="t-caption">
-                {t("home.digestQuietDays", { days: item.days_quiet })}
+                {t("home.digestQuietDays", {
+                  days: formatNumber(item.days_quiet, locale),
+                })}
               </span>
             </li>
           ))}
@@ -200,9 +207,15 @@ export function OvernightPanel() {
             <PanelBody>
               <p className="t-caption">
                 {t("home.digestClassify", {
-                  commitments: review.classify?.commitments ?? 0,
-                  meetings: review.classify?.meetings ?? 0,
-                  noise: review.classify?.noise ?? 0,
+                  commitments: formatNumber(
+                    review.classify?.commitments ?? 0,
+                    locale,
+                  ),
+                  meetings: formatNumber(
+                    review.classify?.meetings ?? 0,
+                    locale,
+                  ),
+                  noise: formatNumber(review.classify?.noise ?? 0, locale),
                 })}
               </p>
             </PanelBody>
@@ -276,7 +289,9 @@ export function PositionPanel() {
         // wrong one.
         excluded > 0 ? (
           <span className="t-caption">
-            {t("home.pipelinePartial", { count: excluded })}
+            {t("home.pipelinePartial", {
+              count: formatNumber(excluded, locale),
+            })}
           </span>
         ) : undefined
       }
@@ -289,8 +304,10 @@ export function PositionPanel() {
             </span>
             <span className="t-caption">
               {t("home.pipelineWeighted", {
-                amount: String(
-                  formatMoneyOrAbsent(row.weightedMinor, row.currency, locale),
+                amount: formatMoneyOrAbsent(
+                  row.weightedMinor,
+                  row.currency,
+                  locale,
                 ),
               })}
             </span>
@@ -299,7 +316,7 @@ export function PositionPanel() {
                 row.deals === 1
                   ? "home.pipelineCount.one"
                   : "home.pipelineCount.other",
-                { count: row.deals },
+                { count: formatNumber(row.deals, locale) },
               )}
             </span>
           </span>

--- a/frontend/src/screens/home.readings.tsx
+++ b/frontend/src/screens/home.readings.tsx
@@ -3,7 +3,8 @@
 
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 
 // The day's readings, on one plate. The record pages read theirs the same way,
 // which is the point: a strip is read ACROSS as one comparison, and four
@@ -37,6 +38,7 @@ export function HomeReadingsStrip({
   quiet,
 }: HomeReadings) {
   const t = useT();
+  const { locale } = useLocale();
   // Nothing to compare is nothing to draw. With every reading unread the strip
   // rendered as an empty bordered plate — a card claiming a row of figures it
   // does not have, and now with a card's shadow under it.
@@ -66,7 +68,7 @@ export function HomeReadingsStrip({
                   decisions.expiringToday === 1
                     ? "home.readings.expiring.one"
                     : "home.readings.expiring.other",
-                  { count: decisions.expiringToday },
+                  { count: formatNumber(decisions.expiringToday, locale) },
                 )
               : t("home.readings.expiringNone")
           }
@@ -81,7 +83,7 @@ export function HomeReadingsStrip({
             open.currencies === 1
               ? "home.readings.currencies.one"
               : "home.readings.currencies.other",
-            { count: open.currencies },
+            { count: formatNumber(open.currencies, locale) },
           )}
         />
       )}
@@ -93,7 +95,9 @@ export function HomeReadingsStrip({
           detail={
             ranked.topPct === null
               ? t("home.readings.noRun")
-              : t("home.readings.topScore", { pct: ranked.topPct })
+              : t("home.readings.topScore", {
+                  pct: formatNumber(ranked.topPct, locale),
+                })
           }
         />
       )}

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -10,7 +10,11 @@ import {
 } from "../design-system/briefitem";
 import { Panel, PanelBody } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime, formatMoneyOrAbsent } from "../format/format";
+import {
+  formatDateTime,
+  formatMoneyOrAbsent,
+  formatNumber,
+} from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -27,8 +31,9 @@ import {
 
 /** One brief card's vocabulary. */
 function briefLabels(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
+  t: (key: MessageKey, params?: Record<string, string>) => string,
   evidenceCount: number,
+  locale: Parameters<typeof formatNumber>[1],
 ): BriefItemLabels {
   return {
     rank: t("home.brief.rank"),
@@ -43,7 +48,9 @@ function briefLabels(
     evidence:
       evidenceCount === 1
         ? t("home.evidenceOne")
-        : t("home.evidence", { count: evidenceCount }),
+        : t("home.evidence", {
+            count: formatNumber(evidenceCount, locale),
+          }),
     evidenceNone: t("home.evidenceNone"),
     openDeal: t("home.openDeal"),
     act: t("home.act"),
@@ -103,7 +110,7 @@ export function TodaySection({
         footer={
           brief && brief.items.length > 0 ? (
             <span className="home-honesty t-caption">
-              {honestCountLine(t, brief)}
+              {honestCountLine(t, brief, locale)}
             </span>
           ) : undefined
         }
@@ -171,7 +178,7 @@ function TodayBody({
         <BriefItemCard
           key={item.id}
           item={item}
-          labels={briefLabels(t, item.evidence_ids.length)}
+          labels={briefLabels(t, item.evidence_ids.length, locale)}
           // `revenueBasisNote` is deliberately not passed. The run carries
           // `revenue_norm_minor` but not the currency it is in, and the base
           // currency lives on a settings read this page does not make — a sixth
@@ -181,7 +188,9 @@ function TodayBody({
           dealName={deals.find((deal) => deal.id === item.deal_id)?.name}
           amount={amountOf(item.deal_id, deals, locale)}
           formatPercent={(fraction) =>
-            t("home.pct", { pct: Math.round(fraction * 100) })
+            t("home.pct", {
+              pct: formatNumber(Math.round(fraction * 100), locale),
+            })
           }
           formatInstant={(utcIso) =>
             formatDateTime(utcIso, locale, viewerZone())
@@ -214,16 +223,19 @@ function TodayBody({
 
 /** What the ranked run left out, said out loud. */
 function honestCountLine(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
+  t: (key: MessageKey, params?: Record<string, string>) => string,
   brief: MorningBrief,
+  locale: Parameters<typeof formatNumber>[1],
 ): string {
   if (brief.candidate_count > brief.items.length) {
     return t("home.overflow", {
-      shown: brief.items.length,
-      count: brief.candidate_count,
+      shown: formatNumber(brief.items.length, locale),
+      count: formatNumber(brief.candidate_count, locale),
     });
   }
-  return t("home.honestShort", { count: brief.candidate_count });
+  return t("home.honestShort", {
+    count: formatNumber(brief.candidate_count, locale),
+  });
 }
 
 /** One deal's money, or nothing where the page has not read the deal. */

--- a/frontend/src/screens/import.tsx
+++ b/frontend/src/screens/import.tsx
@@ -13,9 +13,9 @@ import {
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, useMe } from "./common";
 import { useImportFlow } from "./importflow";
@@ -343,7 +343,7 @@ function ImportOutcome({
       </dl>
       <p className="import__hint">
         {t("import.rowsRead", {
-          rows: report.rows_read,
+          rows: formatNumber(report.rows_read, locale),
           column: report.source_key_used,
         })}
       </p>
@@ -356,7 +356,11 @@ function ImportOutcome({
           <ul className="import__issues">
             {report.issues.map((issue) => (
               <li key={`${issue.line}-${issue.reason}`}>
-                {t("import.issueLine", { line: issue.line })} {issue.reason}
+                {/* A line number is where to look in the uploaded file, so it
+                    is never grouped: "1.234" is not a line the reader can find
+                    in a text editor. */}
+                {t("import.issueLine", { line: String(issue.line) })}{" "}
+                {issue.reason}
               </li>
             ))}
           </ul>
@@ -365,7 +369,9 @@ function ImportOutcome({
 
       {resumable ? (
         <Callout tone="danger" live="alert">
-          {t("import.failed", { checkpoint: run.checkpoint })}
+          {t("import.failed", {
+            checkpoint: formatNumber(run.checkpoint, locale),
+          })}
         </Callout>
       ) : null}
 
@@ -377,7 +383,9 @@ function ImportOutcome({
 
       {!committed ? (
         <Button small variant="primary" disabled={busy} onClick={onCommit}>
-          {busy ? t("import.importing") : commitLabel(t, d.created + d.updated)}
+          {busy
+            ? t("import.importing")
+            : commitLabel(t, locale, d.created + d.updated)}
         </Button>
       ) : null}
 
@@ -436,6 +444,7 @@ function UndoSection({
   onUndo: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <>
       {undoInterrupted ? (
@@ -452,7 +461,7 @@ function UndoSection({
             ? t("import.undoing")
             : undoInterrupted
               ? t("import.continueUndo")
-              : undoLabel(t, report.disposition.created)}
+              : undoLabel(t, locale, report.disposition.created)}
         </Button>
       ) : null}
       {undoError ? (
@@ -475,6 +484,7 @@ function UndoSection({
 // than rendering nothing.
 function UndoOutcome({ undo }: Readonly<{ undo: ImportReport["undo"] }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <div className="import__undoOutcome">
       <Callout tone="success" live="status">
@@ -487,7 +497,7 @@ function UndoOutcome({ undo }: Readonly<{ undo: ImportReport["undo"] }>) {
               undo.reversed_count === 1
                 ? "import.undoReversed.one"
                 : "import.undoReversed.other",
-              { rows: undo.reversed_count },
+              { rows: formatNumber(undo.reversed_count, locale) },
             )}
           </p>
           {undo.kept.length > 0 ? (
@@ -526,30 +536,35 @@ function UndoOutcome({ undo }: Readonly<{ undo: ImportReport["undo"] }>) {
 // button is the last thing a human reads before the least reversible write in
 // the product, and "1 rows" reads like a machine wrote it.
 function commitLabel(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
   rows: number,
 ): string {
   const key: MessageKey =
     rows === 1 ? "import.commit.one" : "import.commit.other";
-  return t(key, { rows });
+  return t(key, { rows: formatNumber(rows, locale) });
 }
 
 // undoLabel names the count on the undo button for the same reason
 // commitLabel does: it is the last thing a human reads before undo
 // archives every row this run created.
 function undoLabel(
-  t: (key: MessageKey, params?: Record<string, string | number>) => string,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
   rows: number,
 ): string {
   const key: MessageKey = rows === 1 ? "import.undo.one" : "import.undo.other";
-  return t(key, { rows });
+  return t(key, { rows: formatNumber(rows, locale) });
 }
 
 function Count({ label, value }: Readonly<{ label: string; value: number }>) {
+  const { locale } = useLocale();
   return (
     <div className="import__count">
       <dt>{label}</dt>
-      <dd>{value}</dd>
+      {/* Grouped, like the row counts in the sentences around it: one card
+          spelling the same kind of count two ways is the drift this closes. */}
+      <dd>{formatNumber(value, locale)}</dd>
     </div>
   );
 }

--- a/frontend/src/screens/importmapping.tsx
+++ b/frontend/src/screens/importmapping.tsx
@@ -3,7 +3,8 @@
 
 import { TableScroll } from "../design-system/atoms";
 import { Select } from "../design-system/select";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { ImportColumn, ImportProfile } from "./importtypes";
 import { DONT_IMPORT } from "./importtypes";
 
@@ -34,6 +35,7 @@ export function ImportMappingTable({
   onChange: (column: string, target: string) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const options = [
     { value: DONT_IMPORT, label: t("import.dontImport") },
     ...profile.targets.map((target) => ({ value: target, label: target })),
@@ -42,7 +44,9 @@ export function ImportMappingTable({
   return (
     <div className="import__mapping">
       <p className="import__hint">
-        {t("import.profiled", { rows: profile.rows_profiled })}
+        {t("import.profiled", {
+          rows: formatNumber(profile.rows_profiled, locale),
+        })}
       </p>
       {/* The fifth screen to have written this box by hand. `.import__scroll`
           was `overflow-x: auto` and nothing else: no tab stop and no announced

--- a/frontend/src/screens/inbox.tsx
+++ b/frontend/src/screens/inbox.tsx
@@ -41,9 +41,10 @@ import {
   EvidenceChip,
   ProvenanceTag,
 } from "../design-system/trust";
-import { formatDateTime } from "../format/format";
-import { formatCountdown, type Translator, useNow } from "../format/now";
+import { formatDateTime, formatNumber } from "../format/format";
+import { formatCountdown, useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
+import type { Locale, Translator } from "../i18n";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -337,10 +338,12 @@ function rowLabels(t: Translator): DecisionCardLabels {
 
 // The status chip's words. Spelled per surface like every other label bag here:
 // what a countdown or a verdict is CALLED belongs to the screen showing it.
-function statusLabels(t: Translator): DecisionStatusLabels {
+function statusLabels(t: Translator, locale: Locale): DecisionStatusLabels {
   return {
     expiresIn: (msRemaining) =>
-      t("inbox.expiresIn", { countdown: formatCountdown(msRemaining, t) }),
+      t("inbox.expiresIn", {
+        countdown: formatCountdown(msRemaining, t, locale),
+      }),
     approved: t("inbox.status.approved"),
     rejected: t("inbox.status.rejected"),
     expired: t("inbox.status.expired"),
@@ -446,6 +449,7 @@ export function ApprovalRow({
   extraInvalidateKeys?: readonly QueryKey[];
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const viewerId = useViewerId();
   const queryClient = useQueryClient();
   const tierMap = useAgentTierMap();
@@ -567,7 +571,7 @@ export function ApprovalRow({
             approval={approval}
             decided={!!decided}
             now={now}
-            labels={statusLabels(t)}
+            labels={statusLabels(t, locale)}
           />
         </>
       }
@@ -727,6 +731,7 @@ function BundleExpiryChip({
   now,
 }: Readonly<{ live: readonly Approval[]; now: number }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (live.length === 0) {
     return <Badge tone="danger">{t("inbox.expired")}</Badge>;
   }
@@ -740,7 +745,7 @@ function BundleExpiryChip({
   return (
     <Badge tone={decisionUrgencyTone(remaining)}>
       {t("inbox.bundle.expiresIn", {
-        countdown: formatCountdown(remaining, t),
+        countdown: formatCountdown(remaining, t, locale),
       })}
     </Badge>
   );
@@ -771,6 +776,7 @@ function BundleCard({
   onDecided: (verdict: BundleVerdict, decision: BundleDecision) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const viewerId = useViewerId();
   const queryClient = useQueryClient();
   const tierMap = useAgentTierMap();
@@ -847,7 +853,9 @@ function BundleCard({
       </div>
       <p className="t-h2">{subject}</p>
       <p className="t-small approval-bundle-why">
-        {t("inbox.bundle.why", { count: members.length })}
+        {t("inbox.bundle.why", {
+          count: formatNumber(members.length, locale),
+        })}
       </p>
       {live.length > 0 && (
         <div className="approval-gate">
@@ -861,14 +869,18 @@ function BundleCard({
             pending={decide.isPending}
             onClick={() => setConfirming("approve")}
           >
-            {t("inbox.bundle.approveAll", { count: live.length })}
+            {t("inbox.bundle.approveAll", {
+              count: formatNumber(live.length, locale),
+            })}
           </Button>
           <Button
             small
             disabled={decide.isPending}
             onClick={() => setConfirming("reject")}
           >
-            {t("inbox.bundle.rejectAll", { count: live.length })}
+            {t("inbox.bundle.rejectAll", {
+              count: formatNumber(live.length, locale),
+            })}
           </Button>
         </div>
       )}
@@ -879,7 +891,9 @@ function BundleCard({
       )}
       <Disclosure
         className="approval-bundle-open"
-        summary={t("inbox.bundle.members", { count: members.length })}
+        summary={t("inbox.bundle.members", {
+          count: formatNumber(members.length, locale),
+        })}
       >
         {/* A list, not an indent: the count and the boundaries of the group have
             to reach a reader who is hearing this page rather than seeing it. */}
@@ -897,7 +911,9 @@ function BundleCard({
       <ConfirmModal
         open={confirming === "approve"}
         onClose={() => setConfirming(null)}
-        title={t("inbox.bundle.approveAll", { count: live.length })}
+        title={t("inbox.bundle.approveAll", {
+          count: formatNumber(live.length, locale),
+        })}
         confirmLabel={t("trust.accept")}
         pending={decide.isPending}
         onConfirm={() => send("approve", "")}
@@ -907,7 +923,9 @@ function BundleCard({
       <ConfirmModal
         open={confirming === "reject"}
         onClose={() => setConfirming(null)}
-        title={t("inbox.bundle.rejectAll", { count: live.length })}
+        title={t("inbox.bundle.rejectAll", {
+          count: formatNumber(live.length, locale),
+        })}
         confirmLabel={t("inbox.reject")}
         confirmVariant="danger"
         pending={decide.isPending}
@@ -982,7 +1000,11 @@ function outcomeCounts(decision: BundleDecision): Map<BundleOutcome, number> {
 // claim the response does not make: a member that had lapsed, one somebody else
 // had already answered, and one whose follow-on change failed to land each came
 // back saying so, and each is a different thing for the reader to do next.
-function outcomeLines(result: BundleResult, t: Translator): string[] {
+function outcomeLines(
+  result: BundleResult,
+  t: Translator,
+  locale: Locale,
+): string[] {
   const counts = outcomeCounts(result.decision);
   const lines: string[] = [];
   const decided = counts.get("decided") ?? 0;
@@ -992,7 +1014,7 @@ function outcomeLines(result: BundleResult, t: Translator): string[] {
         result.verdict === "approve"
           ? "inbox.bundle.result.approved"
           : "inbox.bundle.result.rejected",
-        { count: decided },
+        { count: formatNumber(decided, locale) },
       ),
     );
   }
@@ -1000,7 +1022,11 @@ function outcomeLines(result: BundleResult, t: Translator): string[] {
     const count = counts.get(outcome) ?? 0;
     if (count > 0) {
       const keys = OUTCOME_KEYS[outcome];
-      lines.push(t(count === 1 ? keys.one : keys.other, { count }));
+      lines.push(
+        t(count === 1 ? keys.one : keys.other, {
+          count: formatNumber(count, locale),
+        }),
+      );
     }
   }
   return lines;
@@ -1028,7 +1054,8 @@ function BundleOutcomeNote({
   onDismiss,
 }: Readonly<{ result: BundleResult; onDismiss: () => void }>) {
   const t = useT();
-  const lines = outcomeLines(result, t);
+  const { locale } = useLocale();
+  const lines = outcomeLines(result, t, locale);
   // A report with nothing in it says nothing: a call that decided no member
   // answers 404, so there is no honest sentence to put in an empty box here.
   if (lines.length === 0) {

--- a/frontend/src/screens/jobhealth.tsx
+++ b/frontend/src/screens/jobhealth.tsx
@@ -14,9 +14,8 @@ import { type Fact, FactList } from "../design-system/factlist";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { formatDateTime, formatNumber } from "../format/format";
-import type { Translator } from "../format/now";
 import { viewerZone } from "../format/timezone";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryGate, throwProblem, useMe } from "./common";
 import "./jobhealth.css";
@@ -53,7 +52,11 @@ const FAILURE_STATE: Record<
 // the reading an operator opens this card for.
 // A count of one takes the singular key, the house `.one`/`.other` pattern — a
 // queue that jammed sixty-one minutes ago read "waited 1 hours".
-function formatWaitedFor(seconds: number, t: Translator): string {
+function formatWaitedFor(
+  seconds: number,
+  t: Translator,
+  locale: Locale,
+): string {
   const [unit, count] =
     seconds >= 86_400
       ? (["Days", Math.floor(seconds / 86_400)] as const)
@@ -66,7 +69,7 @@ function formatWaitedFor(seconds: number, t: Translator): string {
   // Annotated so an unknown unit or form is a compile error rather than a key
   // the catalog silently echoes back.
   const key: MessageKey = `jobs.waited${unit}.${plural}`;
-  return t(key, { count });
+  return t(key, { count: formatNumber(count, locale) });
 }
 
 // All four states of one kind, always all four. A zero is a fact an operator
@@ -91,7 +94,11 @@ function KindCounts({ kind }: Readonly<{ kind: JobKindHealth }>) {
   );
 }
 
-function kindFacts(kinds: readonly JobKindHealth[], t: Translator): Fact[] {
+function kindFacts(
+  kinds: readonly JobKindHealth[],
+  t: Translator,
+  locale: Locale,
+): Fact[] {
   return kinds.map((kind) => ({
     // `kind` is unique per queue, not globally — the same worker kind can be
     // registered on two queues, and the pair is what names one row. Serialized
@@ -111,7 +118,7 @@ function kindFacts(kinds: readonly JobKindHealth[], t: Translator): Fact[] {
             late — and a row claiming a wait of zero would read as a queue
             that just started rather than one with nothing in it. */}
         {kind.oldest_waiting_age_seconds !== null && (
-          <> · {formatWaitedFor(kind.oldest_waiting_age_seconds, t)}</>
+          <> · {formatWaitedFor(kind.oldest_waiting_age_seconds, t, locale)}</>
         )}
       </>
     ),
@@ -137,6 +144,7 @@ function KindSection({
   emptyText: string;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <SettingRow
       label={label}
@@ -147,7 +155,7 @@ function KindSection({
           {kinds.length === 0 ? (
             <EmptyState>{emptyText}</EmptyState>
           ) : (
-            <FactList numeric facts={kindFacts(kinds, t)} />
+            <FactList numeric facts={kindFacts(kinds, t, locale)} />
           )}
         </div>
       }
@@ -185,9 +193,11 @@ function failureNote(
           {" · "}
         </>
       )}
+      {/* Two rungs of the retry ladder, never grouped: "attempt 1.234 of
+          2.000" reads as a quantity where the pair states a position. */}
       {t("jobs.attempt", {
-        attempt: failure.attempt,
-        max: failure.max_attempts,
+        attempt: String(failure.attempt),
+        max: String(failure.max_attempts),
         when: formatDateTime(failure.failed_at, locale, zone),
       })}
       {/* Interpolated as-is, never through formatNumber: this is the id River
@@ -196,7 +206,7 @@ function failureNote(
       {jobID !== undefined && (
         <>
           {" · "}
-          {t("jobs.jobId", { id: jobID })}
+          {t("jobs.jobId", { id: String(jobID) })}
         </>
       )}
       {/* Only when an attempt error was actually recorded. A job cancelled

--- a/frontend/src/screens/leadbulk.tsx
+++ b/frontend/src/screens/leadbulk.tsx
@@ -5,7 +5,8 @@ import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { Button } from "../design-system/atoms";
 import { Select } from "../design-system/select";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { ProblemError, problemMessageOf, throwProblem } from "./common";
 import { useRoster } from "./entityref";
 import { leadWriteKeys } from "./leadkeys";
@@ -57,6 +58,7 @@ export function LeadBulkBar({
   onDone: (outcomes: readonly BulkOutcome[], action: BulkAction) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const queryClient = useQueryClient();
   const [ownerId, setOwnerId] = useState("");
   const roster = useRoster("user", true);
@@ -177,7 +179,7 @@ export function LeadBulkBar({
   return (
     <>
       <span className="t-caption">
-        {t("lead.bulkSelected", { count: leads.length })}
+        {t("lead.bulkSelected", { count: formatNumber(leads.length, locale) })}
       </span>
       <Select
         aria-label={t("lead.bulkOwner")}
@@ -224,7 +226,9 @@ export function LeadBulkBar({
       </Button>
       {failed.length > 0 && (
         <span className="t-caption" style={{ color: "var(--danger)" }}>
-          {t("lead.bulkFailed", { count: failed.length })}{" "}
+          {t("lead.bulkFailed", {
+            count: formatNumber(failed.length, locale),
+          })}{" "}
           {failed.map((o) => `${o.name}: ${o.error}`).join(" · ")}
         </span>
       )}

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -10,7 +10,7 @@ import {
   type BoardRecord,
   PipelineBoard,
 } from "../design-system/composed";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -125,6 +125,7 @@ function LeadCard({
   };
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <button
       type="button"
@@ -153,7 +154,9 @@ function LeadCard({
         <span>
           {lead.next_task_subject ?? t("lead.noNextTask")}
           {lead.open_task_count
-            ? ` · ${t("lead.openTaskCount", { count: lead.open_task_count })}`
+            ? ` · ${t("lead.openTaskCount", {
+                count: formatNumber(lead.open_task_count, locale),
+              })}`
             : ""}
         </span>
       </span>
@@ -173,6 +176,7 @@ export function LeadBoard({
   loadMore: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const queryClient = useQueryClient();
   const dragging = useRef<string | null>(null);
   const lastDragEnd = useRef(0);
@@ -247,7 +251,9 @@ export function LeadBoard({
       <PipelineBoard
         variant="plain"
         columns={columns}
-        countLabel={(count) => t("lead.boardCount", { count })}
+        countLabel={(count) =>
+          t("lead.boardCount", { count: formatNumber(count, locale) })
+        }
         renderCard={(card) => {
           const lead = leadsById.get(card.id);
           if (!lead) return null;

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -8,7 +8,7 @@ import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, SegmentedControl } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { ToastRegion, useToast } from "../design-system/toast";
-import { formatDateAbbrev } from "../format/format";
+import { formatDateAbbrev, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -412,7 +412,9 @@ function LeadsWorkbench({
               <span className="t-caption">
                 {lead.next_task_subject ?? t("lead.noNextTask")}
                 {lead.open_task_count
-                  ? ` · ${t("lead.openTaskCount", { count: lead.open_task_count })}`
+                  ? ` · ${t("lead.openTaskCount", {
+                      count: formatNumber(lead.open_task_count, locale),
+                    })}`
                   : ""}
                 {lead.next_task_due_at
                   ? ` · ${formatDateAbbrev(lead.next_task_due_at, locale, viewerZone())}`

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -24,7 +24,7 @@ import {
 } from "../design-system/recordtimeline";
 import { Select } from "../design-system/select";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
-import { formatDateAbbrev } from "../format/format";
+import { formatDateAbbrev, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -205,6 +205,7 @@ function ScoreShortfall({ lead }: Readonly<{ lead: Lead }>) {
 
 function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
   const t = useT();
+  const { locale } = useLocale();
   const explain = useQuery({
     queryKey: leadScoreKey(id),
     queryFn: async () => {
@@ -260,7 +261,7 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
       {overridden && (
         <span className="t-caption">
           {t("lead.scoreFactorsExplainMachine", {
-            score: current.score_computed,
+            score: formatNumber(current.score_computed, locale),
           })}
         </span>
       )}
@@ -283,7 +284,9 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
                 // The decay as arithmetic a reader can check: 25 halving
                 // every 14 days is why this row reads 12.5 today.
                 <span className="t-caption t-mono">
-                  {t("lead.scoreDecayed", { base: factor.base_points })}
+                  {t("lead.scoreDecayed", {
+                    base: formatNumber(factor.base_points, locale),
+                  })}
                 </span>
               )}
               {factor.source_activity_ids != null &&
@@ -293,7 +296,10 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
                   // count never claims more than they can see.
                   <span className="t-caption">
                     {t("lead.scoreSources", {
-                      count: factor.source_activity_ids.length,
+                      count: formatNumber(
+                        factor.source_activity_ids.length,
+                        locale,
+                      ),
                     })}
                   </span>
                 )}
@@ -304,8 +310,8 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
       <span className="t-caption t-mono">
         {t("lead.scoreReconciles", {
           raw: current.raw_sum.toFixed(2),
-          rounded: current.rounded_sum,
-          score: current.score_computed,
+          rounded: formatNumber(current.rounded_sum, locale),
+          score: formatNumber(current.score_computed, locale),
         })}
       </span>
     </div>
@@ -532,6 +538,7 @@ function LeadScorePanel({
   patch: { isPending: boolean; mutate: (body: UpdateLeadRequest) => void };
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const reasonBlank = reasonValue.trim() === "";
   const scoreBlank = scoreValue.trim() === "";
   const parsedScore = Number(scoreValue);
@@ -566,7 +573,9 @@ function LeadScorePanel({
           </p>
           {lead.score_computed != null && (
             <p className="t-caption">
-              {t("lead.machineScore", { score: lead.score_computed })}
+              {t("lead.machineScore", {
+                score: formatNumber(lead.score_computed, locale),
+              })}
             </p>
           )}
           <Button

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -24,7 +24,11 @@ import {
 } from "../design-system/recordtimeline";
 import { Select } from "../design-system/select";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
-import { formatDateAbbrev, formatNumber } from "../format/format";
+import {
+  formatDateAbbrev,
+  formatDecimal,
+  formatNumber,
+} from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -279,7 +283,9 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
               }}
             >
               <span>{scoreFactorLabel(factor.factor, t)}</span>
-              <span className="t-mono">{factor.points.toFixed(1)}</span>
+              <span className="t-mono">
+                {formatDecimal(factor.points, locale, 1)}
+              </span>
               {factor.base_points != null && (
                 // The decay as arithmetic a reader can check: 25 halving
                 // every 14 days is why this row reads 12.5 today.
@@ -309,7 +315,7 @@ function ScoreBreakdown({ id, lead }: Readonly<{ id: string; lead: Lead }>) {
       )}
       <span className="t-caption t-mono">
         {t("lead.scoreReconciles", {
-          raw: current.raw_sum.toFixed(2),
+          raw: formatDecimal(current.raw_sum, locale, 2),
           rounded: formatNumber(current.rounded_sum, locale),
           score: formatNumber(current.score_computed, locale),
         })}

--- a/frontend/src/screens/leadsignals.tsx
+++ b/frontend/src/screens/leadsignals.tsx
@@ -10,7 +10,7 @@ import {
   Textarea,
 } from "../design-system/atoms";
 import { Select } from "../design-system/select";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -230,7 +230,10 @@ export function LeadManualSignals({
                     {live.confidence != null && (
                       <span className="t-caption">
                         {t("lead.signalConfidenceValue", {
-                          value: Math.round(live.confidence * 100),
+                          value: formatNumber(
+                            Math.round(live.confidence * 100),
+                            locale,
+                          ),
                         })}
                       </span>
                     )}
@@ -352,7 +355,10 @@ export function LeadManualSignals({
                       ...CONFIDENCE_LEVELS.map((value) => ({
                         value,
                         label: t("lead.signalConfidenceValue", {
-                          value: Math.round(Number(value) * 100),
+                          value: formatNumber(
+                            Math.round(Number(value) * 100),
+                            locale,
+                          ),
                         }),
                       })),
                     ]}

--- a/frontend/src/screens/leadvocab.tsx
+++ b/frontend/src/screens/leadvocab.tsx
@@ -10,7 +10,8 @@ import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { Switch } from "../design-system/switch";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import {
@@ -178,6 +179,7 @@ function LeadSourceRow({
   onRemove: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const count = source.lead_count ?? 0;
   const builtIn = source.system === true;
   // Built-ins and in-use sources deactivate instead: the server answers 409
@@ -207,7 +209,7 @@ function LeadSourceRow({
         }))}
       />
       <span className="t-caption lead-vocab-count">
-        {t("leadSources.leadCount", { count })}
+        {t("leadSources.leadCount", { count: formatNumber(count, locale) })}
       </span>
       <span className="lead-vocab-flags">
         {builtIn && <Badge>{t("leadSources.builtIn")}</Badge>}
@@ -229,7 +231,9 @@ function LeadSourceRow({
               title={
                 builtIn
                   ? t("leadSources.builtInKept")
-                  : t("leadSources.inUse", { count })
+                  : t("leadSources.inUse", {
+                      count: formatNumber(count, locale),
+                    })
               }
             >
               {t("leadSources.deactivateInstead")}
@@ -336,6 +340,7 @@ function AddSourceDialog({
 
 export function LeadSourcesCard() {
   const t = useT();
+  const { locale } = useLocale();
   const canCreate = useCanWrite("custom_field", "create");
   const canEdit = useCanWrite("custom_field", "update");
   const canRemove = useCanWrite("custom_field", "delete");
@@ -425,7 +430,7 @@ export function LeadSourcesCard() {
                       </span>
                       <span className="t-caption lead-vocab-count">
                         {t("leadSources.leadCount", {
-                          count: found.lead_count,
+                          count: formatNumber(found.lead_count, locale),
                         })}
                       </span>
                       <span className="lead-vocab-flags">
@@ -565,6 +570,7 @@ function useReasonMutations() {
 
 export function LeadDisqualifyReasonsCard() {
   const t = useT();
+  const { locale } = useLocale();
   const canCreate = useCanWrite("custom_field", "create");
   const canEdit = useCanWrite("custom_field", "update");
   const canRemove = useCanWrite("custom_field", "delete");
@@ -615,7 +621,9 @@ export function LeadDisqualifyReasonsCard() {
                             }
                           />
                           <span className="t-caption lead-vocab-count">
-                            {t("leadReasons.leadCount", { count })}
+                            {t("leadReasons.leadCount", {
+                              count: formatNumber(count, locale),
+                            })}
                           </span>
                           <span className="lead-vocab-flags">
                             {builtIn && (
@@ -647,7 +655,9 @@ export function LeadDisqualifyReasonsCard() {
                                   title={
                                     builtIn
                                       ? t("leadSources.builtInKept")
-                                      : t("leadReasons.inUse", { count })
+                                      : t("leadReasons.inUse", {
+                                          count: formatNumber(count, locale),
+                                        })
                                   }
                                 >
                                   {t("leadSources.deactivateInstead")}

--- a/frontend/src/screens/linkedin-reach.tsx
+++ b/frontend/src/screens/linkedin-reach.tsx
@@ -8,7 +8,8 @@ import { DataTable, EmptyState, Skeleton } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import "./linkedin-reach.css";
 
@@ -68,25 +69,29 @@ function useLinkedInReach() {
  */
 function reachCaveat(
   t: ReturnType<typeof useT>,
+  locale: Locale,
   reach: LinkedInReach | undefined,
   shown: number,
 ): string | undefined {
   const unresolved = reach?.unresolved_connections ?? 0;
   if (shown === 0) {
     return unresolved > 0
-      ? t("linkedinReach.allUnresolved", { unresolved })
+      ? t("linkedinReach.allUnresolved", {
+          unresolved: formatNumber(unresolved, locale),
+        })
       : undefined;
   }
   return t("linkedinReach.footnote", {
-    shown,
-    total: reach?.accounts_total ?? shown,
-    unresolved,
+    shown: formatNumber(shown, locale),
+    total: formatNumber(reach?.accounts_total ?? shown, locale),
+    unresolved: formatNumber(unresolved, locale),
   });
 }
 
 /** Which accounts this member's imported network reaches. */
 export function LinkedInReachCard() {
   const t = useT();
+  const { locale } = useLocale();
   const query = useLinkedInReach();
   const accounts = query.data?.accounts ?? [];
 
@@ -130,7 +135,7 @@ export function LinkedInReachCard() {
               // resolved, and it matters MOST when nothing did: a fresh
               // workspace that imported five thousand connections and matched
               // no account should see the five thousand, not just "none yet".
-              description={reachCaveat(t, query.data, accounts.length)}
+              description={reachCaveat(t, locale, query.data, accounts.length)}
               // `.settingrow-measure` is what lets the table's own
               // `.table-scroll` box scroll: `.settingrow-control` is a flex row,
               // so a child with the default `min-width: auto` would grow to the
@@ -171,6 +176,7 @@ function ReachTable({
   accounts,
 }: Readonly<{ accounts: readonly ReachAccount[] }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <DataTable
       label={t("linkedinReach.accountsLabel")}
@@ -192,7 +198,9 @@ function ReachTable({
           header: t("linkedinReach.connections"),
           render: (account: ReachAccount) => (
             <span className="t-mono li-reach-cell li-reach-figure">
-              {account.connections}
+              {/* Grouped, like the pair in the column beside it: two spellings
+                  of one count in one table is the drift this closes. */}
+              {formatNumber(account.connections, locale)}
             </span>
           ),
         },
@@ -204,8 +212,8 @@ function ReachTable({
           render: (account: ReachAccount) => (
             <span className="t-mono li-reach-cell li-reach-figure">
               {t("linkedinReach.onFileOf", {
-                onFile: account.contacts_on_file,
-                total: account.connections,
+                onFile: formatNumber(account.contacts_on_file, locale),
+                total: formatNumber(account.connections, locale),
               })}
             </span>
           ),

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -16,6 +16,7 @@ import {
   ListTable as ListSurface,
   type ListView,
 } from "../design-system/listtable";
+import { stable } from "../format/collate";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, useMe, useSorMode } from "./common";
@@ -395,7 +396,7 @@ export function ListTable<Row>({
   // a change: setFilter deletes a composite param and re-adds it, which moves
   // its insertion order without moving what it selects.
   const narrowKey = JSON.stringify(
-    Object.entries(query.filters).sort(([a], [b]) => a.localeCompare(b)),
+    Object.entries(query.filters).sort(([a], [b]) => stable(a, b)),
   );
   // Rebuilt every render, on purpose: a dial must show what is chosen the
   // moment its options arrive. Nothing resets on this — `narrowKey` is the

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -6,7 +6,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Card, EmptyState, Skeleton } from "../design-system/atoms";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import "./network.css";
 import {
@@ -121,7 +121,7 @@ export function PersonNetworkCard({ id }: Readonly<{ id: string }>) {
               {colleague.strength_bucket !== "none" && (
                 <span className="t-caption">
                   {t("network.interactions", {
-                    count: colleague.interactions_90d,
+                    count: formatNumber(colleague.interactions_90d, locale),
                   })}
                 </span>
               )}
@@ -141,6 +141,7 @@ export function PersonNetworkCard({ id }: Readonly<{ id: string }>) {
 /** What is wrong with how this deal is covered, and why. */
 export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const overlay = useSorMode() === "overlay";
   const query = useQuery({
     queryKey: ["deal-coverage", id],
@@ -195,7 +196,7 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
               {risk.days_since_touch != null && (
                 <span className="t-mono net-risk-days">
                   {t("coverage.daysSinceTouch", {
-                    days: risk.days_since_touch,
+                    days: formatNumber(risk.days_since_touch, locale),
                   })}
                 </span>
               )}

--- a/frontend/src/screens/offers.tsx
+++ b/frontend/src/screens/offers.tsx
@@ -21,7 +21,7 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
-import { formatMoney } from "../format/format";
+import { formatMoney, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import {
   isVersionSkewOf,
@@ -1150,7 +1150,9 @@ function AiDisclosureBanner({ offer }: Readonly<{ offer: Offer }>) {
           {added.length > 0 && (
             <div>
               <p className="t-label">
-                {t("offer.diffAdded", { count: added.length })}
+                {t("offer.diffAdded", {
+                  count: formatNumber(added.length, locale),
+                })}
               </p>
               <ul>
                 {added.map((line) => (
@@ -1167,7 +1169,9 @@ function AiDisclosureBanner({ offer }: Readonly<{ offer: Offer }>) {
           {removed.length > 0 && (
             <div>
               <p className="t-label">
-                {t("offer.diffRemoved", { count: removed.length })}
+                {t("offer.diffRemoved", {
+                  count: formatNumber(removed.length, locale),
+                })}
               </p>
               <ul>
                 {removed.map((line) => (
@@ -1184,7 +1188,9 @@ function AiDisclosureBanner({ offer }: Readonly<{ offer: Offer }>) {
           {changed.length > 0 && (
             <div>
               <p className="t-label">
-                {t("offer.diffChanged", { count: changed.length })}
+                {t("offer.diffChanged", {
+                  count: formatNumber(changed.length, locale),
+                })}
               </p>
               <ul>
                 {changed.map((pair) =>

--- a/frontend/src/screens/onboarding-company-form.tsx
+++ b/frontend/src/screens/onboarding-company-form.tsx
@@ -7,6 +7,7 @@ import {
   EvidenceChip,
   ProvenanceTag,
 } from "../design-system/trust";
+import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { coldFieldLabel } from "./common";
 import {
@@ -83,7 +84,10 @@ export function CompanyStep({
         <span>
           {read
             ? t("ob.confirmWebsite", {
-                count: read.pages_read ?? read.pages.length,
+                count: formatNumber(
+                  read.pages_read ?? read.pages.length,
+                  locale,
+                ),
               })
             : t("ob.confirmManual")}
         </span>
@@ -174,8 +178,8 @@ export function CompanyStep({
             <span className="seclabel">{t("ob.factsTitle")}</span>
             <span className="facts-count">
               {t("ob.factsSelected", {
-                selected: selectedFactKeys.length,
-                total: read.facts.length,
+                selected: formatNumber(selectedFactKeys.length, locale),
+                total: formatNumber(read.facts.length, locale),
               })}
             </span>
           </summary>

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -3,6 +3,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
+import { formatNumber } from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import {
@@ -744,9 +745,11 @@ export function CompanyAct({
   // The scene eyebrow: where the journey stands, in the rail's own counting.
   // Both the decision and the review live on the CONFIRM stop.
   const stops = railStops(state.memberPath);
+  // "Step 3 of 5" is a POSITION in a fixed rail, not a magnitude: neither
+  // half is ever grouped or given a decimal separator, in any locale.
   const stepEyebrow = t("ob.conv.scene.step", {
-    n: stops.findIndex((stop) => stop.key === "confirm") + 1,
-    m: stops.length,
+    n: String(stops.findIndex((stop) => stop.key === "confirm") + 1),
+    m: String(stops.length),
     label: t("ob.rail.confirm"),
   });
 
@@ -983,7 +986,7 @@ export function CompanyAct({
                         blockingCount === 1
                           ? "ob.conv.guide.reviewBlocked.one"
                           : "ob.conv.guide.reviewBlocked.other",
-                      params: { count: blockingCount },
+                      params: { count: formatNumber(blockingCount, locale) },
                       findingIds: blockingFindingIds,
                     }
                   : advisoryCount > 0
@@ -994,7 +997,7 @@ export function CompanyAct({
                           advisoryCount === 1
                             ? "ob.conv.guide.reviewAdvisory.one"
                             : "ob.conv.guide.reviewAdvisory.other",
-                        params: { count: advisoryCount },
+                        params: { count: formatNumber(advisoryCount, locale) },
                         findingIds: advisoryFindingIds,
                       }
                     : {

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -16,6 +16,7 @@ import {
   EvidenceChip,
   ProvenanceTag,
 } from "../../design-system/trust";
+import { formatNumber } from "../../format/format";
 import { type Locale, useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import { coldFieldLabel } from "../common";
@@ -334,7 +335,10 @@ function FieldRow({
                 {Math.round(row.confidence * 100)}
                 {row.evidence !== null && (
                   <span className="ob-triage-source">
-                    {t("ob.conv.triage.sourceCount", { count: 1 })}
+                    {/* A row carries at most one evidence record, so this
+                        count is the literal one — a single digit no locale
+                        groups or punctuates differently. */}
+                    {t("ob.conv.triage.sourceCount", { count: "1" })}
                   </span>
                 )}
               </span>
@@ -533,6 +537,7 @@ function SectionBadge({
   advisory: readonly ReviewRow[];
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   if (blocking.length === 0 && advisory.length === 0) {
     return (
       <span className="ob-triage-nav-settled">
@@ -546,7 +551,9 @@ function SectionBadge({
       <span className="ob-triage-nav-advisory">
         <b aria-hidden>{advisory.length}</b>
         <span className="sr-only">
-          {t("ob.conv.triage.sectionAdvisory", { count: advisory.length })}
+          {t("ob.conv.triage.sectionAdvisory", {
+            count: formatNumber(advisory.length, locale),
+          })}
         </span>
       </span>
     );
@@ -555,7 +562,9 @@ function SectionBadge({
     <span className="ob-triage-nav-badge" data-blocking="true">
       <b aria-hidden>{blocking.length}</b>
       <span className="sr-only">
-        {t("ob.conv.triage.sectionBlocking", { count: blocking.length })}
+        {t("ob.conv.triage.sectionBlocking", {
+          count: formatNumber(blocking.length, locale),
+        })}
       </span>
     </span>
   );
@@ -580,6 +589,7 @@ function NavOutstandingList({
   advisory: readonly ReviewRow[];
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   const rows = [
     ...blocking.map((row) => ({ row, isBlocking: true as const })),
     ...advisory.map((row) => ({ row, isBlocking: false as const })),
@@ -613,7 +623,9 @@ function NavOutstandingList({
       ))}
       {overflow > 0 && (
         <li className="ob-triage-nav-more">
-          {t("ob.conv.triage.sectionMore", { count: overflow })}
+          {t("ob.conv.triage.sectionMore", {
+            count: formatNumber(overflow, locale),
+          })}
         </li>
       )}
     </ul>
@@ -636,6 +648,7 @@ function SectionQuantity({
   labelKey: MessageKey;
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   if (count === 0) {
     return (
       <span className="ob-triage-nav-settled">
@@ -647,7 +660,9 @@ function SectionQuantity({
   return (
     <span className="ob-triage-nav-quantity">
       <b aria-hidden>{count}</b>
-      <span className="sr-only">{t(labelKey, { count })}</span>
+      <span className="sr-only">
+        {t(labelKey, { count: formatNumber(count, locale) })}
+      </span>
     </span>
   );
 }
@@ -893,13 +908,16 @@ function PeopleGroupSection({
   people,
   t,
 }: Readonly<{ people: readonly SitePerson[]; t: ReturnType<typeof useT> }>) {
+  const { locale } = useLocale();
   return (
     <section id={groupDomId(PEOPLE_KEY)} className="ob-triage-group">
       <div className="ob-triage-group-head">
         <h3>{t("ob.conv.triage.peopleLabel")}</h3>
         {people.length > 0 && (
           <span>
-            {t("ob.conv.triage.peopleCount", { count: people.length })}
+            {t("ob.conv.triage.peopleCount", {
+              count: formatNumber(people.length, locale),
+            })}
           </span>
         )}
       </div>
@@ -1075,8 +1093,8 @@ function FactsGroupSection({
         <h3>{t("ob.conv.triage.factsLabel")}</h3>
         <span>
           {t("ob.factsSelected", {
-            selected: selection.selectedCount,
-            total: facts.length,
+            selected: formatNumber(selection.selectedCount, locale),
+            total: formatNumber(facts.length, locale),
           })}
         </span>
       </div>
@@ -1112,6 +1130,7 @@ function FieldGroupSection({
   setField: (field: CompanyFieldName, value: string) => void;
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   const ordered = group.order
     .map((field) => rowByField.get(field))
     .filter((row): row is ReviewRow => row !== undefined);
@@ -1135,7 +1154,9 @@ function FieldGroupSection({
               solidCount > 0 && (
                 <li className="ob-triage-solid-divider" aria-hidden>
                   <span>
-                    {t("ob.conv.triage.looksSolid", { count: solidCount })}
+                    {t("ob.conv.triage.looksSolid", {
+                      count: formatNumber(solidCount, locale),
+                    })}
                   </span>
                 </li>
               )}
@@ -1239,6 +1260,7 @@ function ReviewContinueBar({
   onContinue: () => void;
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   const statusId = "ob-triage-continue-status";
   // Required fields first: it is the more actionable of the two blockers
   // (a value to type, right here) and the one this surface can always
@@ -1265,7 +1287,7 @@ function ReviewContinueBar({
           hears why the moment it changes rather than only if focus happens
           to land on this paragraph first. */}
       <p id={statusId} className="ob-triage-continue-status" role="status">
-        {t(statusKey, { count: remaining })}
+        {t(statusKey, { count: formatNumber(remaining, locale) })}
       </p>
       <Button
         variant="primary"

--- a/frontend/src/screens/onboarding-conversation/connect-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.tsx
@@ -181,9 +181,10 @@ export function ConnectAct({
 
   // Where the journey stands, in the rail's own counting.
   const stops = railStops(state.memberPath);
+  // A position in the rail, not a magnitude: never grouped, in any locale.
   const eyebrow = t("ob.conv.scene.step", {
-    n: stops.findIndex((stop) => stop.key === "connect") + 1,
-    m: stops.length,
+    n: String(stops.findIndex((stop) => stop.key === "connect") + 1),
+    m: String(stops.length),
     label: t("ob.rail.connect"),
   });
   return (

--- a/frontend/src/screens/onboarding-conversation/conversation-correlation.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-correlation.test.ts
@@ -33,7 +33,7 @@ describe("read-run correlation", () => {
           kind: "narration",
           id: "pages:9",
           i18nKey: "ob.conv.read.pages",
-          params: { pages: 9 },
+          params: { pages: "9" },
         },
       },
     ];
@@ -80,7 +80,7 @@ describe("read-run correlation", () => {
           kind: "narration",
           id: "pages:12",
           i18nKey: "ob.conv.read.pages",
-          params: { pages: 12 },
+          params: { pages: "12" },
         },
       },
     ];

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
@@ -31,7 +31,7 @@ describe("conversationReducer happy path", () => {
             kind: "narration",
             id: "pages:3",
             i18nKey: "ob.conv.read.pages",
-            params: { pages: 3 },
+            params: { pages: "3" },
           },
         },
       ],
@@ -362,7 +362,7 @@ describe("narration replace-in-place", () => {
           kind: "narration",
           id: "r1:pages",
           i18nKey: "ob.conv.read.pages",
-          params: { pages },
+          params: { pages: String(pages) },
         },
       }) satisfies ConversationEvent;
     let state = run([
@@ -393,7 +393,7 @@ describe("narration replace-in-place", () => {
     const updated = state.thread.find((entry) => entry.id === stampedId);
     expect(updated).toMatchObject({
       kind: "narration",
-      params: { pages: 7 },
+      params: { pages: "7" },
     });
     expect(state.thread.at(-1)?.id.endsWith(":r1:field:industry")).toBe(true);
   });
@@ -414,7 +414,7 @@ describe("thread cap", () => {
           kind: "narration",
           id: `n:${index}`,
           i18nKey: "ob.conv.read.pages",
-          params: { pages: index },
+          params: { pages: String(index) },
         },
       });
     }

--- a/frontend/src/screens/onboarding-conversation/conversation-types.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-types.ts
@@ -41,16 +41,24 @@ type LabelSource =
   | { labelKey: MessageKey; label?: never }
   | { label: string; labelKey?: never };
 
+// A thread entry's `params` are STRINGS, not numbers, and that is the carrier's
+// job rather than a narrowing for tidiness: a quantity handed across as a raw
+// number reaches the catalog sentence through string coercion, which groups for
+// nobody — so the producer has to have decided, before it packs the entry, that
+// the figure is a magnitude the reader groups (`formatNumber`) or a position
+// nobody groups (`String`). A number here lets that decision be skipped
+// silently, and the reader is the one who finds out.
+
 export type QuestionOption = {
   value: string;
   detailKey?: MessageKey;
-  params?: Record<string, string | number>;
+  params?: Record<string, string>;
 } & LabelSource;
 
 export type ConversationQuestion = {
   id: string;
   i18nKey: MessageKey;
-  params?: Record<string, string | number>;
+  params?: Record<string, string>;
   options: QuestionOption[];
   /** The subordinate local-dismiss action's label (humans outrank the
    * reader: a clarify is never an unanswerable gate). Absent on questions
@@ -69,7 +77,7 @@ export type ThreadEntry =
       kind: "narration";
       id: string;
       i18nKey: MessageKey;
-      params?: Record<string, string | number>;
+      params?: Record<string, string>;
       /** Params that are i18n keys themselves; the renderer translates them. */
       paramKeys?: Record<string, MessageKey>;
       findingIds?: string[];
@@ -79,7 +87,7 @@ export type ThreadEntry =
   | ({
       kind: "user";
       id: string;
-      params?: Record<string, string | number>;
+      params?: Record<string, string>;
     } & (
       | { i18nKey: MessageKey; text?: never }
       | { text: string; i18nKey?: never }
@@ -88,7 +96,7 @@ export type ThreadEntry =
       kind: "outcome";
       id: string;
       i18nKey: MessageKey;
-      params?: Record<string, string | number>;
+      params?: Record<string, string>;
       tone: OutcomeTone;
     };
 

--- a/frontend/src/screens/onboarding-conversation/decision-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/decision-scene.tsx
@@ -1,7 +1,8 @@
 import { Check } from "lucide-react";
 import { useId, useState } from "react";
 import { Button } from "../../design-system/atoms";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { useLocale, useT } from "../../i18n";
 import type { ConversationQuestion } from "./conversation-machine";
 
 // A decision as the whole work surface: the question is the headline, the
@@ -39,6 +40,7 @@ export function DecisionScene({
   factsOf?: (value: string) => CandidateFacts | null;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const group = useId();
   const headline = useId();
   const [picked, setPicked] = useState("");
@@ -51,7 +53,9 @@ export function DecisionScene({
           <p className="ob-scene-sub">{t("ob.conv.scene.decisionSub")}</p>
         </div>
         <span className="ob-decision-count">
-          {t("ob.conv.scene.candidates", { count: question.options.length })}
+          {t("ob.conv.scene.candidates", {
+            count: formatNumber(question.options.length, locale),
+          })}
         </span>
       </div>
       <div

--- a/frontend/src/screens/onboarding-conversation/entries.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.stories.tsx
@@ -209,7 +209,7 @@ export const Thread: Story = {
           kind: "narration",
           id: "0:pages:5",
           i18nKey: "ob.conv.read.pages",
-          params: { pages: 5 },
+          params: { pages: "5" },
         },
         narration,
         question,

--- a/frontend/src/screens/onboarding-conversation/entries.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.tsx
@@ -3,7 +3,8 @@ import { ChevronDown, CircleAlert, CircleCheck, Clock } from "lucide-react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Avatar, Button } from "../../design-system/atoms";
 import { Logomark } from "../../design-system/logomark";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { type Translator, useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import { useMe } from "../common";
 import type {
@@ -21,13 +22,11 @@ type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
 type UserEntry = Extract<ThreadEntry, { kind: "user" }>;
 type OutcomeEntry = Extract<ThreadEntry, { kind: "outcome" }>;
 
-type Translate = ReturnType<typeof useT>;
-
 function resolvedParams(
-  t: Translate,
-  params: Record<string, string | number> | undefined,
+  t: Translator,
+  params: Record<string, string> | undefined,
   paramKeys: Record<string, MessageKey> | undefined,
-): Record<string, string | number> {
+): Record<string, string> {
   const translated = Object.fromEntries(
     Object.entries(paramKeys ?? {}).map(([name, key]) => [name, t(key)]),
   );
@@ -200,6 +199,7 @@ export function ActivityGroup({
   entries,
 }: Readonly<{ entries: readonly NarrationEntry[] }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [open, setOpen] = useState(false);
   const latest = entries.at(-1);
   if (latest === undefined) {
@@ -216,7 +216,11 @@ export function ActivityGroup({
       >
         <i aria-hidden />
         <span>{textOf(latest)}</span>
-        <b>{t("ob.conv.activity.steps", { count: entries.length })}</b>
+        <b>
+          {t("ob.conv.activity.steps", {
+            count: formatNumber(entries.length, locale),
+          })}
+        </b>
         <ChevronDown aria-hidden />
       </button>
       {open && (

--- a/frontend/src/screens/onboarding-conversation/gate-notice.test.ts
+++ b/frontend/src/screens/onboarding-conversation/gate-notice.test.ts
@@ -191,7 +191,7 @@ describe("why the reader is back at the gate", () => {
         kind: "narration",
         id: "3:recap:read-reading",
         i18nKey: "ob.conv.recap.readReading",
-        params: { host: "gradion.com", pages: 4 },
+        params: { host: "gradion.com", pages: "4" },
       },
     ]);
     expect(gateNoticeFor({ ...input, state })).toBeUndefined();

--- a/frontend/src/screens/onboarding-conversation/gate-notice.ts
+++ b/frontend/src/screens/onboarding-conversation/gate-notice.ts
@@ -64,7 +64,7 @@ export type GateNoticeInput = Readonly<{
    */
   translate: (
     key: NarrationEntry["i18nKey"],
-    params?: Record<string, string | number>,
+    params?: Record<string, string>,
   ) => string;
   /** ob.gate.startFailed / ob.gate.readPaused, already translated with {detail}. */
   failedWithDetail: (detail: string) => string;

--- a/frontend/src/screens/onboarding-conversation/index.tsx
+++ b/frontend/src/screens/onboarding-conversation/index.tsx
@@ -6,7 +6,7 @@ import { api } from "../../api/client";
 import type { components } from "../../api/schema";
 import { navigate, useRoute } from "../../app/router";
 import { Button } from "../../design-system/atoms";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { throwProblem } from "../common";
 import { EMPTY_DRAFT, pickBuiltVersion, useCompany } from "../onboarding";
 import { CompanyAct } from "./company-act";
@@ -163,6 +163,7 @@ function useRestore(
   dispatch: Dispatch<ConversationEvent>,
   routeConnect: boolean,
 ) {
+  const { locale } = useLocale();
   const existing = useCompany(true);
   const wizard = useQuery({
     queryKey: ["onboarding-conv-state"],
@@ -222,6 +223,7 @@ function useRestore(
       voice: voice.data ?? null,
       read: persistedRead.data ?? null,
       routeConnect,
+      locale,
     });
     if (plan.kind === "complete") {
       navigate({ screen: "home" });
@@ -249,6 +251,7 @@ function useRestore(
     voice.data,
     persistedRead.data,
     routeConnect,
+    locale,
     dispatch,
   ]);
 

--- a/frontend/src/screens/onboarding-conversation/narration.test.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.test.ts
@@ -72,7 +72,7 @@ describe("diffSiteRead", () => {
         field("industry", "Robotics"),
       ],
     });
-    const events = diffSiteRead(prev, next);
+    const events = diffSiteRead(prev, next, "en");
     expect(events).toEqual([
       {
         kind: "say",
@@ -80,7 +80,7 @@ describe("diffSiteRead", () => {
         // the machine replaces the earlier pages bubble in place.
         id: `${READ_ID}:pages`,
         i18nKey: "ob.conv.read.pages",
-        params: { pages: 5 },
+        params: { pages: "5" },
       },
       {
         kind: "say",
@@ -102,6 +102,7 @@ describe("diffSiteRead", () => {
     const events = diffSiteRead(
       null,
       read({ profile_fields: [field("offer_summary", "Robots as a service")] }),
+      "en",
     );
     expect(events[0]).toMatchObject({
       paramKeys: { field: "ob.field.offer_summary" },
@@ -113,8 +114,8 @@ describe("diffSiteRead", () => {
     const snapshot = read({
       profile_fields: [field("display_name", "Acme"), field("icp", "SMB ops")],
     });
-    expect(diffSiteRead(null, snapshot)).toHaveLength(2);
-    expect(diffSiteRead(snapshot, snapshot)).toEqual([]);
+    expect(diffSiteRead(null, snapshot, "en")).toHaveLength(2);
+    expect(diffSiteRead(snapshot, snapshot, "en")).toEqual([]);
   });
 
   it("truncates long field values by code points to the 80-glyph preview", () => {
@@ -122,6 +123,7 @@ describe("diffSiteRead", () => {
     const events = diffSiteRead(
       null,
       read({ profile_fields: [field("history", long)] }),
+      "en",
     );
     const first = events[0];
     if (first?.kind !== "say") throw new Error("expected a say event");
@@ -135,7 +137,7 @@ describe("diffSiteRead", () => {
     const next = read({
       warnings: ["robots.txt blocked /careers", "sitemap missing"],
     });
-    expect(diffSiteRead(prev, next)).toEqual([
+    expect(diffSiteRead(prev, next, "en")).toEqual([
       {
         kind: "say",
         id: `${READ_ID}:warning:sitemap missing`,
@@ -148,13 +150,13 @@ describe("diffSiteRead", () => {
   it("signals a flush on a fresh terminal instead of narrating it", () => {
     const prev = read({ status: "reading" });
     const next = read({ status: "ready" });
-    expect(diffSiteRead(prev, next)).toEqual([
+    expect(diffSiteRead(prev, next, "en")).toEqual([
       { kind: "flush", id: `${READ_ID}:flush:ready` },
     ]);
     // Polling the same terminal snapshot again stays silent.
-    expect(diffSiteRead(next, next)).toEqual([]);
+    expect(diffSiteRead(next, next, "en")).toEqual([]);
     for (const status of ["partial", "failed", "deferred"] as const) {
-      expect(diffSiteRead(prev, read({ status }))).toEqual([
+      expect(diffSiteRead(prev, read({ status }), "en")).toEqual([
         { kind: "flush", id: `${READ_ID}:flush:${status}` },
       ]);
     }
@@ -170,7 +172,7 @@ describe("diffSiteRead", () => {
       status: "ready",
       profile_fields: [field("display_name", "Acme")],
     });
-    const events = diffSiteRead(oldRun, newRun);
+    const events = diffSiteRead(oldRun, newRun, "en");
     // Same field, same status — but a NEW run, so both narrate again.
     expect(events).toEqual([
       expect.objectContaining({ id: `${READ_ID}:field:display_name` }),
@@ -180,10 +182,18 @@ describe("diffSiteRead", () => {
 
   it("stays silent on post-outcome lifecycle transitions (confirmed, abandoned)", () => {
     expect(
-      diffSiteRead(read({ status: "ready" }), read({ status: "confirmed" })),
+      diffSiteRead(
+        read({ status: "ready" }),
+        read({ status: "confirmed" }),
+        "en",
+      ),
     ).toEqual([]);
     expect(
-      diffSiteRead(read({ status: "failed" }), read({ status: "abandoned" })),
+      diffSiteRead(
+        read({ status: "failed" }),
+        read({ status: "abandoned" }),
+        "en",
+      ),
     ).toEqual([]);
   });
 });
@@ -273,13 +283,15 @@ describe("diffCorpus", () => {
   });
 
   it("narrates word growth and band changes, band as an i18n label key", () => {
-    expect(diffCorpus(summary(400, "thin"), summary(1240, "good"))).toEqual([
+    expect(
+      diffCorpus(summary(400, "thin"), summary(1240, "good"), "en"),
+    ).toEqual([
       {
         kind: "say",
         // Stable counter id: the latest total replaces the earlier bubble.
         id: "words",
         i18nKey: "ob.conv.corpus.words",
-        params: { words: 1240 },
+        params: { words: "1,240" },
       },
       {
         kind: "say",
@@ -288,9 +300,9 @@ describe("diffCorpus", () => {
         paramKeys: { band: "settings.voice.bandGood" },
       },
     ]);
-    expect(diffCorpus(summary(1240, "good"), summary(1240, "good"))).toEqual(
-      [],
-    );
+    expect(
+      diffCorpus(summary(1240, "good"), summary(1240, "good"), "en"),
+    ).toEqual([]);
   });
 });
 
@@ -306,7 +318,7 @@ describe("useNarrationQueue", () => {
     kind: "say",
     id,
     i18nKey: "ob.conv.read.pages",
-    params: { pages: 1 },
+    params: { pages: "1" },
   });
   const flush = (id: string): NarrationEvent => ({ kind: "flush", id });
 

--- a/frontend/src/screens/onboarding-conversation/narration.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { components } from "../../api/schema";
+import { formatNumber } from "../../format/format";
+import type { Locale } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import { coldFieldLabelKey } from "../common";
 import type { BuildStage } from "./conversation-machine";
@@ -25,7 +27,10 @@ export type NarrationSayEvent = {
   /** Scoped to the run/operation, stable across repeated diffs. */
   id: string;
   i18nKey: MessageKey;
-  params?: Record<string, string | number>;
+  /** Already RENDERED for the reader — see conversation-types' ThreadEntry.
+   * A diff is where the server's raw counter is, so a diff is where the
+   * decision to group it belongs. */
+  params?: Record<string, string>;
   /** Params that are i18n keys themselves; the renderer translates them. */
   paramKeys?: Record<string, MessageKey>;
   findingIds?: string[];
@@ -63,7 +68,7 @@ function newFieldEvents(
     .filter((field) => !known.has(field.field))
     .map((field): NarrationEvent => {
       const labelKey = coldFieldLabelKey(field.field);
-      const params: Record<string, string | number> = {
+      const params: Record<string, string> = {
         value: previewValue(field.value),
       };
       if (!labelKey) {
@@ -98,6 +103,7 @@ function newWarningEvents(
 export function diffSiteRead(
   prevSnapshot: CompanySiteRead | null,
   next: CompanySiteRead,
+  locale: Locale,
 ): NarrationEvent[] {
   // A snapshot from another run is no baseline: a NEW read diffs against
   // nothing, so its findings narrate fresh and its terminal flushes even
@@ -117,7 +123,7 @@ export function diffSiteRead(
       kind: "say",
       id: `${run}:pages`,
       i18nKey: "ob.conv.read.pages",
-      params: { pages: nextPages },
+      params: { pages: formatNumber(nextPages, locale) },
     });
   }
 
@@ -195,6 +201,7 @@ export const bandLabelKeys: Record<
 export function diffCorpus(
   prev: VoiceCorpusSummary | null,
   next: VoiceCorpusSummary,
+  locale: Locale,
 ): NarrationEvent[] {
   const events: NarrationEvent[] = [];
   const prevWords = prev?.total_words ?? 0;
@@ -205,7 +212,7 @@ export function diffCorpus(
       kind: "say",
       id: "words",
       i18nKey: "ob.conv.corpus.words",
-      params: { words: next.total_words },
+      params: { words: formatNumber(next.total_words, locale) },
     });
   }
   if (prev && next.quality_band !== prev.quality_band) {

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -376,7 +376,7 @@ describe("restore into the conversational shell", () => {
 
     expect(
       await screen.findByText(
-        /Your corpus already holds 1240 of your own words\./,
+        /Your corpus already holds 1,240 of your own words\./,
       ),
     ).toBeTruthy();
     // vo.collecting lands directly on the collect scene and its rail prompt.

--- a/frontend/src/screens/onboarding-conversation/restore.test.ts
+++ b/frontend/src/screens/onboarding-conversation/restore.test.ts
@@ -95,6 +95,7 @@ describe("restorePlan", () => {
         voice: null,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toEqual({
       kind: "start",
@@ -114,6 +115,7 @@ describe("restorePlan", () => {
         voice: null,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toMatchObject({ memberPath: true });
     // A returning creator has both a saved company and a state row saying
@@ -125,6 +127,7 @@ describe("restorePlan", () => {
         voice: emptyVoice,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toMatchObject({ memberPath: false, resumeTarget: "vo.collecting" });
   });
@@ -137,6 +140,7 @@ describe("restorePlan", () => {
         voice: null,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toMatchObject({
       memberPath: true,
@@ -154,6 +158,7 @@ describe("restorePlan", () => {
           voice: null,
           read: null,
           routeConnect: false,
+          locale: "en",
         }),
       ).toMatchObject({
         companyConfirmed: false,
@@ -170,6 +175,7 @@ describe("restorePlan", () => {
       voice: words(1240),
       read: null,
       routeConnect: false,
+      locale: "en",
     });
     expect(plan).toMatchObject({ resumeTarget: "vo.collecting" });
     if (plan.kind !== "start") {
@@ -178,7 +184,7 @@ describe("restorePlan", () => {
     expect(plan.recap).toContainEqual(
       expect.objectContaining({
         i18nKey: "ob.conv.recap.corpus",
-        params: { words: 1240 },
+        params: { words: "1,240" },
       }),
     );
   });
@@ -191,6 +197,7 @@ describe("restorePlan", () => {
         voice: emptyVoice,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toMatchObject({ resumeTarget: "vo.skipped" });
     const results = restorePlan({
@@ -199,6 +206,7 @@ describe("restorePlan", () => {
       voice: emptyVoice,
       read: null,
       routeConnect: false,
+      locale: "en",
     });
     expect(results).toMatchObject({ resumeTarget: "re.recap" });
     if (results.kind !== "start") {
@@ -216,6 +224,7 @@ describe("restorePlan", () => {
       voice: { ...words(2000), built: true },
       read: null,
       routeConnect: false,
+      locale: "en",
     });
     expect(plan).toMatchObject({ resumeTarget: "cn.consent" });
     if (plan.kind !== "start") {
@@ -236,6 +245,7 @@ describe("restorePlan", () => {
         voice: emptyVoice,
         read: null,
         routeConnect: true,
+        locale: "en",
       }),
     ).toMatchObject({ resumeTarget: "cn.consent" });
   });
@@ -248,6 +258,7 @@ describe("restorePlan", () => {
         voice: null,
         read: readRow(status),
         routeConnect: false,
+        locale: "en",
       });
       expect(plan).toMatchObject({
         companyConfirmed: false,
@@ -259,7 +270,7 @@ describe("restorePlan", () => {
       expect(plan.recap).toContainEqual(
         expect.objectContaining({
           i18nKey: "ob.conv.recap.readTerminal",
-          params: { host: "gradion.com", count: 1 },
+          params: { host: "gradion.com", count: "1" },
         }),
       );
     }
@@ -272,6 +283,7 @@ describe("restorePlan", () => {
       voice: null,
       read: readRow("reading"),
       routeConnect: false,
+      locale: "en",
     });
     expect(plan).toMatchObject({ adoptRead: { id: readRow("reading").id } });
     if (plan.kind !== "start") {
@@ -280,7 +292,7 @@ describe("restorePlan", () => {
     expect(plan.recap).toContainEqual(
       expect.objectContaining({
         i18nKey: "ob.conv.recap.readReading",
-        params: { host: "gradion.com", pages: 12 },
+        params: { host: "gradion.com", pages: "12" },
       }),
     );
   });
@@ -296,6 +308,7 @@ describe("restorePlan", () => {
         voice: null,
         read: readRow(status),
         routeConnect: false,
+        locale: "en",
       });
       expect(plan).toMatchObject({ adoptRead: null });
       if (plan.kind !== "start") {
@@ -315,6 +328,7 @@ describe("restorePlan", () => {
         voice: null,
         read: null,
         routeConnect: false,
+        locale: "en",
       }),
     ).toEqual({ kind: "complete" });
   });
@@ -331,6 +345,7 @@ describe("restorePlan", () => {
       voice: null,
       read: null,
       routeConnect: false,
+      locale: "en",
     });
     expect(plan.kind).toBe("start");
     if (plan.kind !== "start") {

--- a/frontend/src/screens/onboarding-conversation/restore.ts
+++ b/frontend/src/screens/onboarding-conversation/restore.ts
@@ -1,4 +1,6 @@
 import type { components } from "../../api/schema";
+import { formatNumber } from "../../format/format";
+import type { Locale } from "../../i18n";
 import type { NarrationEntry, ResumePoint } from "./conversation-types";
 
 // Session restore as a pure decision: server state in, a start plan out.
@@ -35,6 +37,10 @@ export type RestoreInputs = Readonly<{
   /** The OAuth return deep link (#/onboarding/connect/...) lands mid-journey
    * and must reopen the connect act, exactly like the classic coordinator. */
   routeConnect: boolean;
+  /** The recap entries below are sentences a person reads, and the counts in
+   * them are rendered here rather than at the renderer — a ThreadEntry's
+   * params hold already-formatted strings. */
+  locale: Locale;
 }>;
 
 export type RestorePlan =
@@ -64,7 +70,7 @@ const adoptableReadStates = new Set<CompanySiteRead["status"]>([
   "reading",
 ]);
 
-function readRecap(read: CompanySiteRead): NarrationEntry[] {
+function readRecap(read: CompanySiteRead, locale: Locale): NarrationEntry[] {
   const host = new URL(read.root_url).hostname;
   if (read.status === "ready" || read.status === "partial") {
     return [
@@ -72,7 +78,10 @@ function readRecap(read: CompanySiteRead): NarrationEntry[] {
         kind: "narration",
         id: "recap:read-terminal",
         i18nKey: "ob.conv.recap.readTerminal",
-        params: { host, count: read.profile_fields.length },
+        params: {
+          host,
+          count: formatNumber(read.profile_fields.length, locale),
+        },
       },
     ];
   }
@@ -82,7 +91,7 @@ function readRecap(read: CompanySiteRead): NarrationEntry[] {
         kind: "narration",
         id: "recap:read-reading",
         i18nKey: "ob.conv.recap.readReading",
-        params: { host, pages: read.pages_read ?? 0 },
+        params: { host, pages: formatNumber(read.pages_read ?? 0, locale) },
       },
     ];
   }
@@ -136,7 +145,7 @@ function recapEntries(
   memberPath: boolean,
   target: ResumePoint,
 ): NarrationEntry[] {
-  const { state, profile, voice } = inputs;
+  const { state, profile, voice, locale } = inputs;
   const entries: NarrationEntry[] = [
     { kind: "narration", id: "recap:back", i18nKey: "ob.conv.recap.back" },
   ];
@@ -177,14 +186,16 @@ function recapEntries(
       kind: "narration",
       id: "recap:corpus",
       i18nKey: "ob.conv.recap.corpus",
-      params: { words: voice?.summary?.total_words ?? 0 },
+      params: {
+        words: formatNumber(voice?.summary?.total_words ?? 0, locale),
+      },
     });
   }
   return entries;
 }
 
 export function restorePlan(inputs: RestoreInputs): RestorePlan {
-  const { state, profile, read, routeConnect } = inputs;
+  const { state, profile, read, routeConnect, locale } = inputs;
   // "complete" is the wizard row's own word, and it can outrun the record it
   // claims: the state row and the company profile are separate writes, and the
   // connect act persists completion without requiring a saved profile. An
@@ -215,7 +226,7 @@ export function restorePlan(inputs: RestoreInputs): RestorePlan {
       resumeTarget: null,
       adoptRead:
         read !== null && adoptableReadStates.has(read.status) ? read : null,
-      recap: read !== null ? readRecap(read) : [],
+      recap: read !== null ? readRecap(read, locale) : [],
     };
   }
   const target: ResumePoint =

--- a/frontend/src/screens/onboarding-conversation/use-company-read.ts
+++ b/frontend/src/screens/onboarding-conversation/use-company-read.ts
@@ -104,6 +104,7 @@ export function useCompanyRead({
   proposalJoin,
   adoptedRead = null,
 }: UseCompanyReadArgs) {
+  const { locale } = useLocale();
   // A run the machine already owns at mount (a restore, or this act
   // remounting mid-read) is adopted: polling resumes for the machine's
   // active run instead of stranding it with no poller.
@@ -162,7 +163,7 @@ export function useCompanyRead({
       if (prevSnapshot.current === next || next.id !== readIdRef.current) {
         return;
       }
-      const events = diffSiteRead(prevSnapshot.current, next);
+      const events = diffSiteRead(prevSnapshot.current, next, locale);
       const freshTerminal = events.some((event) => event.kind === "flush");
       // A retired run the server moved on its own re-arms before its fresh
       // events land: a deferred read that resumed (queued/reading again) or
@@ -196,6 +197,7 @@ export function useCompanyRead({
       concludeFreshTerminal,
       dispatch,
       machine,
+      locale,
       queue,
       setDraft,
       setSelectedFactKeys,
@@ -333,7 +335,6 @@ export function useCompanyRead({
     });
   }, [siteRead.isError, dispatch, machine]);
 
-  const { locale } = useLocale();
   const promptLocale = onboardingLocale(locale);
   const proposal = useQuery({
     queryKey: ["onboarding-company-proposal", readId, promptLocale],

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -1,6 +1,8 @@
 import type { Dispatch } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { components } from "../../api/schema";
+import { formatNumber } from "../../format/format";
+import { useLocale } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import { problemMessage } from "../common";
 import type { IntakeOutcome, RefusalReason } from "../voice-intake-core";
@@ -88,6 +90,7 @@ export function useVoiceCorpus({
   dispatch,
   initialSummary = null,
 }: UseVoiceCorpusArgs) {
+  const { locale } = useLocale();
   const [summary, setSummary] = useState<CorpusSummary | null>(initialSummary);
   const [manifest, setManifest] = useState<readonly CorpusManifestEntry[]>([]);
   const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
@@ -112,11 +115,7 @@ export function useVoiceCorpus({
   });
 
   const say = useCallback(
-    (
-      id: string,
-      i18nKey: MessageKey,
-      params?: Record<string, string | number>,
-    ) => {
+    (id: string, i18nKey: MessageKey, params?: Record<string, string>) => {
       dispatch({
         type: "NARRATION",
         entry: { kind: "narration", id, i18nKey, params },
@@ -163,19 +162,19 @@ export function useVoiceCorpus({
         entry,
       ]);
       say(`react:${entry.ref}`, reactionKey, {
-        kept: stats.kept_words,
-        total: stats.input_words,
-        words: stats.kept_words,
+        kept: formatNumber(stats.kept_words, locale),
+        total: formatNumber(stats.input_words, locale),
+        words: formatNumber(stats.kept_words, locale),
       });
       if (seq <= appliedSummarySeq.current) {
         return;
       }
       appliedSummarySeq.current = seq;
-      queue.push(diffCorpus(summaryRef.current, next));
+      queue.push(diffCorpus(summaryRef.current, next, locale));
       summaryRef.current = next;
       setSummary(next);
     },
-    [queue, say],
+    [locale, queue, say],
   );
 
   // One place the conversation learns what an intake attempt ended as: the
@@ -343,11 +342,14 @@ export function useVoiceCorpus({
           value: speaker.label,
           label: speaker.label,
           detailKey: "ob.conv.voice.speakerOptionDetail" as const,
-          params: { words: speaker.words, turns: speaker.turns },
+          params: {
+            words: formatNumber(speaker.words, locale),
+            turns: formatNumber(speaker.turns, locale),
+          },
         })),
       },
     });
-  }, [nextAsk, state.phase, state.pendingQuestion, dispatch]);
+  }, [nextAsk, state.phase, state.pendingQuestion, dispatch, locale]);
 
   // The owner named themselves: ingest with the speaker filter, so only that
   // speaker's server-counted words ever reach the meter.

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -350,8 +350,8 @@ describe("the conversational voice act", () => {
     expect(
       await screen.findByText(/Which one is you\? Only your own words count/),
     ).toBeTruthy();
-    expect(screen.getByText("words: 1240 · turns: 12")).toBeTruthy();
-    expect(screen.getByText("words: 4160 · turns: 14")).toBeTruthy();
+    expect(screen.getByText("words: 1,240 · turns: 12")).toBeTruthy();
+    expect(screen.getByText("words: 4,160 · turns: 14")).toBeTruthy();
 
     await userEvent.click(screen.getByRole("radio", { name: /Speaker 1/ }));
     await userEvent.click(
@@ -370,7 +370,9 @@ describe("the conversational voice act", () => {
 
     // The server's kept-of-total stats land on the collect scene's own
     // sources list, once — never a second copy of the same fact in the rail.
-    expect(await screen.findByText(/Kept 1240 of 5400 words/)).toBeTruthy();
+    // Both figures are word COUNTS, so they carry the reader's own grouping
+    // (en-GB here) rather than a bare digit run.
+    expect(await screen.findByText(/Kept 1,240 of 5,400 words/)).toBeTruthy();
   });
 
   it("ingests a document directly and reacts with the server word count", async () => {

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -1,7 +1,8 @@
 import type { ChangeEvent, Dispatch, RefObject } from "react";
 import { useRef } from "react";
 import type { components } from "../../api/schema";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { useLocale, useT } from "../../i18n";
 import { problemMessageOf } from "../common";
 import { useFileDrop } from "../use-file-drop";
 import { VOICE_MIN_WORDS } from "../voice-intake-core";
@@ -87,9 +88,10 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
 
   // Where the journey stands, in the rail's own counting.
   const stops = railStops(state.memberPath);
+  // A position in the rail, not a magnitude: never grouped, in any locale.
   const eyebrow = t("ob.conv.scene.step", {
-    n: stops.findIndex((stop) => stop.key === "voice") + 1,
-    m: stops.length,
+    n: String(stops.findIndex((stop) => stop.key === "voice") + 1),
+    m: String(stops.length),
     label: t("ob.rail.voice"),
   });
 
@@ -182,6 +184,7 @@ function CollectingNarration({
   serverWords,
   canBuild,
 }: Readonly<{ serverWords: number; canBuild: boolean }>) {
+  const { locale } = useLocale();
   return (
     <>
       <NarrationBubble
@@ -197,7 +200,10 @@ function CollectingNarration({
             kind: "narration",
             id: "voice:floor",
             i18nKey: "ob.conv.voice.buildFloor",
-            params: { words: serverWords, min: VOICE_MIN_WORDS },
+            params: {
+              words: formatNumber(serverWords, locale),
+              min: formatNumber(VOICE_MIN_WORDS, locale),
+            },
           }}
         />
       )}

--- a/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
@@ -1,7 +1,8 @@
 import { Check, Loader } from "lucide-react";
 import type { components } from "../../api/schema";
 import { Button } from "../../design-system/atoms";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import type { BuildStage } from "./conversation-machine";
 import { bandLabelKeys } from "./narration";
@@ -67,6 +68,7 @@ export function VoiceActArtifact({
   continueBar,
 }: VoiceActArtifactProps) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <div className="mw-review ob-conv-artifact">
       <div className="mw-review-heading">
@@ -91,11 +93,11 @@ export function VoiceActArtifact({
                     <small>
                       {entry.transcript
                         ? t("ob.conv.voice.manifestKept", {
-                            kept: entry.keptWords,
-                            total: entry.inputWords,
+                            kept: formatNumber(entry.keptWords, locale),
+                            total: formatNumber(entry.inputWords, locale),
                           })
                         : t("ob.conv.voice.manifestWords", {
-                            words: entry.keptWords,
+                            words: formatNumber(entry.keptWords, locale),
                           })}
                     </small>
                   </span>
@@ -133,21 +135,22 @@ export function VoiceActArtifact({
 
 function CorpusMeter({ summary }: Readonly<{ summary: CorpusSummary }>) {
   const t = useT();
+  const { locale } = useLocale();
   const percent = Math.min(
     100,
     (summary.total_words / summary.target_words) * 100,
   );
   const registers = Object.entries(summary.register_words)
     .filter(([, words]) => words > 0)
-    .map(([register, words]) => `${register}: ${words}`)
+    .map(([register, words]) => `${register}: ${formatNumber(words, locale)}`)
     .join(" · ");
   return (
     <div className="ob-conv-meter">
       <div className="ob-conv-meter-top">
         <span>
           {t("ob.conv.voice.meterWords", {
-            words: summary.total_words,
-            target: summary.target_words,
+            words: formatNumber(summary.total_words, locale),
+            target: formatNumber(summary.target_words, locale),
           })}
         </span>
         <span>

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -5,7 +5,8 @@ import type { components } from "../../api/schema";
 import { Button, Disclosure } from "../../design-system/atoms";
 import { MarginceCoreScene } from "../../design-system/margince-core";
 import { usePrefersReducedMotion } from "../../design-system/motion";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { type Locale, useLocale, useT } from "../../i18n";
 import type { VoiceInsightsData } from "../voice-insights";
 import { parseVoiceInsights } from "../voice-insights";
 import { ACCEPTED_CORPUS_ATTR, VOICE_MIN_WORDS } from "../voice-intake-core";
@@ -139,14 +140,19 @@ function VoiceHeroBand() {
 // never fire at a moment the button disagrees with.
 function useFloorReachedAnnouncement(ready: boolean, words: number): string {
   const t = useT();
+  const { locale } = useLocale();
   const [message, setMessage] = useState("");
   const wasReady = useRef(ready);
   useEffect(() => {
     if (ready && !wasReady.current) {
-      setMessage(t("ob.conv.voice.meterReady", { words }));
+      setMessage(
+        t("ob.conv.voice.meterReady", {
+          words: formatNumber(words, locale),
+        }),
+      );
     }
     wasReady.current = ready;
-  }, [ready, words, t]);
+  }, [ready, words, t, locale]);
   return message;
 }
 
@@ -165,19 +171,22 @@ function VoiceCorpusFloorMeter({
   ready,
 }: Readonly<{ words: number; ready: boolean }>) {
   const t = useT();
+  const { locale } = useLocale();
   const announcement = useFloorReachedAnnouncement(ready, words);
+  const shown = formatNumber(words, locale);
+  const floor = formatNumber(VOICE_MIN_WORDS, locale);
   return (
     <div className="ob-voice-meter">
       <progress
         className="ob-voice-meter-bar"
         value={Math.min(words, VOICE_MIN_WORDS)}
         max={VOICE_MIN_WORDS}
-        aria-label={t("ob.conv.voice.meterLabel", { min: VOICE_MIN_WORDS })}
+        aria-label={t("ob.conv.voice.meterLabel", { min: floor })}
       />
       <p className="ob-voice-meter-line">
         {ready
-          ? t("ob.conv.voice.meterReady", { words })
-          : t("ob.conv.voice.meterProgress", { words, min: VOICE_MIN_WORDS })}
+          ? t("ob.conv.voice.meterReady", { words: shown })
+          : t("ob.conv.voice.meterProgress", { words: shown, min: floor })}
       </p>
       {/* Visually hidden: the visible line above already carries this exact
           sentence once the floor clears, so this only exists to say it out
@@ -222,6 +231,7 @@ export function VoiceCollectScene({
   startError: string | null;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const words = summary?.total_words ?? 0;
   // The floor alone — never `canBuild`, which also folds in a request in
   // flight. A meter that dims for a busy corpus it has already cleared
@@ -311,11 +321,11 @@ export function VoiceCollectScene({
                   <small>
                     {entry.transcript
                       ? t("ob.conv.voice.manifestKept", {
-                          kept: entry.keptWords,
-                          total: entry.inputWords,
+                          kept: formatNumber(entry.keptWords, locale),
+                          total: formatNumber(entry.inputWords, locale),
                         })
                       : t("ob.conv.voice.manifestWords", {
-                          words: entry.keptWords,
+                          words: formatNumber(entry.keptWords, locale),
                         })}
                   </small>
                 </span>
@@ -336,7 +346,9 @@ export function VoiceCollectScene({
         <p>
           {canBuild
             ? t("ob.conv.voice.footReady")
-            : t("ob.conv.voice.footFloor", { min: VOICE_MIN_WORDS })}
+            : t("ob.conv.voice.footFloor", {
+                min: formatNumber(VOICE_MIN_WORDS, locale),
+              })}
         </p>
         <div className="ob-voice-foot-acts">
           <Button small variant="ghost" onClick={onSkip}>
@@ -455,6 +467,7 @@ export function VoiceBuildScene({
   model: string;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const reached = stage === null ? -1 : BUILD_STAGES.indexOf(stage);
   // A queued build (no stage yet) shows nothing claimed; each reached stage
   // is one quarter, and the last stage completes only when the build does.
@@ -480,8 +493,8 @@ export function VoiceBuildScene({
       <h2>{t("ob.conv.voice.buildingTitle")}</h2>
       <p className="ob-voice-building-meta">
         {t("ob.conv.voice.buildingMeta", {
-          words: summary?.total_words ?? 0,
-          sources,
+          words: formatNumber(summary?.total_words ?? 0, locale),
+          sources: formatNumber(sources, locale),
         })}
       </p>
       <p className="ob-voice-building-model">
@@ -639,6 +652,7 @@ const SENTENCE_HIGH_BOUND = 30;
 function sentenceDimension(
   meanSentence: number,
   t: ReturnType<typeof useT>,
+  locale: Locale,
 ): MeasuredDimension {
   const value =
     meanSentence < SENTENCE_TERSE_MAX
@@ -661,7 +675,9 @@ function sentenceDimension(
     poleLow: t("ob.conv.voice.dimSentencePoleLow"),
     poleHigh: t("ob.conv.voice.dimSentencePoleHigh"),
     fraction,
-    evidence: t("ob.conv.voice.dimSentenceEvidence", { count: meanSentence }),
+    evidence: t("ob.conv.voice.dimSentenceEvidence", {
+      count: formatNumber(meanSentence, locale),
+    }),
   };
 }
 
@@ -672,10 +688,11 @@ function sentenceDimension(
 function measuredDimensions(
   data: VoiceInsightsData,
   t: ReturnType<typeof useT>,
+  locale: Locale,
 ): readonly MeasuredDimension[] {
   return data.meanSentence === null
     ? []
-    : [sentenceDimension(data.meanSentence, t)];
+    : [sentenceDimension(data.meanSentence, t, locale)];
 }
 
 // A readout, not a control: no input, no drag handle, nothing focusable — a
@@ -712,6 +729,7 @@ function VoiceDimensionsCard({
   sources: number | null;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <div className="ob-voice-result-card">
       <div className="ob-voice-dims-head">
@@ -719,15 +737,22 @@ function VoiceDimensionsCard({
           {t("ob.conv.voice.dimensionsTitle")}
         </span>
         <span className="ob-voice-dims-count">
-          {t("ob.conv.voice.dimensionsCount", { count: dimensions.length })}
+          {t("ob.conv.voice.dimensionsCount", {
+            count: formatNumber(dimensions.length, locale),
+          })}
         </span>
       </div>
       {(words !== null || sources !== null) && (
         <p className="ob-voice-dims-meta">
-          {words !== null && t("voice.insights.statWords", { count: words })}
+          {words !== null &&
+            t("voice.insights.statWords", {
+              count: formatNumber(words, locale),
+            })}
           {words !== null && sources !== null ? " · " : ""}
           {sources !== null &&
-            t("voice.insights.statSources", { count: sources })}
+            t("voice.insights.statSources", {
+              count: formatNumber(sources, locale),
+            })}
         </p>
       )}
       <div className="ob-voice-dims-list">
@@ -807,8 +832,9 @@ function VoiceAvoidCard({ avoid }: Readonly<{ avoid: readonly string[] }>) {
  */
 function VoiceResultBoard({ data }: Readonly<{ data: VoiceInsightsData }>) {
   const t = useT();
+  const { locale } = useLocale();
   const hasThinking = data.thinking !== null || data.identity !== null;
-  const dimensions = measuredDimensions(data, t);
+  const dimensions = measuredDimensions(data, t, locale);
   // The sample's own "why" line borrows the same signature-move names the
   // moves card lists in full below, at the reference's own granularity — a
   // short joined phrase, not the identity summary (which now leads the

--- a/frontend/src/screens/onboarding-conversation/workbench.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/workbench.stories.tsx
@@ -37,7 +37,7 @@ const thread: readonly ThreadEntry[] = [
     kind: "narration",
     id: "1:pages:5",
     i18nKey: "ob.conv.read.pages",
-    params: { pages: 5 },
+    params: { pages: "5" },
   },
   {
     kind: "narration",

--- a/frontend/src/screens/onboarding-conversation/workbench.tsx
+++ b/frontend/src/screens/onboarding-conversation/workbench.tsx
@@ -50,6 +50,7 @@ export function useConfiguredModel(): string {
 // can never name a different configuration.
 function useConfiguredModelSummary(): string {
   const t = useT();
+  const { locale } = useLocale();
   const profile = useQuery({
     queryKey: ["ai-profile"],
     queryFn: async (): Promise<AiProfile> => {
@@ -61,7 +62,12 @@ function useConfiguredModelSummary(): string {
     },
     staleTime: Number.POSITIVE_INFINITY,
   });
-  return configuredModelSummary(profile.data, t("ob.ai.runtimeUnavailable"), t);
+  return configuredModelSummary(
+    profile.data,
+    t("ob.ai.runtimeUnavailable"),
+    t,
+    locale,
+  );
 }
 
 /**
@@ -140,9 +146,11 @@ export function ConversationWorkbench({
     ? t("ob.conv.scene.detour")
     : current < 0
       ? undefined
-      : t("ob.conv.scene.step", {
-          n: current + 1,
-          m: steps.length,
+      : // A position in the rail, not a magnitude: never grouped, in any
+        // locale.
+        t("ob.conv.scene.step", {
+          n: String(current + 1),
+          m: String(steps.length),
           label: steps[current].label,
         });
   return (

--- a/frontend/src/screens/onboarding-facts.tsx
+++ b/frontend/src/screens/onboarding-facts.tsx
@@ -4,6 +4,7 @@
 import { useMemo } from "react";
 import type { components } from "../api/schema";
 import { confidenceLevel } from "../design-system/trust";
+import { stable } from "../format/collate";
 import { formatNumber } from "../format/format";
 import { type Locale, useT } from "../i18n";
 import { MAX_SELECTED_FACTS } from "./onboarding";
@@ -95,9 +96,7 @@ export function useFactSelection(
 // Highest confidence first, ties broken on the stable key so the default
 // selection does not reshuffle between renders of the same read.
 function byConfidence(a: CompanySiteReadFact, b: CompanySiteReadFact): number {
-  return (
-    b.confidence - a.confidence || a.value_key.localeCompare(b.value_key, "en")
-  );
+  return b.confidence - a.confidence || stable(a.value_key, b.value_key);
 }
 
 /**

--- a/frontend/src/screens/onboarding-live-panel.tsx
+++ b/frontend/src/screens/onboarding-live-panel.tsx
@@ -4,7 +4,8 @@
 import { Check, ChevronDown, Circle } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import type { components } from "../api/schema";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { namedSiteReadKind } from "./common";
 import { skipReasonText } from "./onboarding";
@@ -177,13 +178,17 @@ export function CoverageCard({
   stoppedReason?: StoppedReason | null;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const rows = coverageRows(pages, warnings, stoppedReason ?? undefined, t);
   const read = pages.filter((page) => page.status === "fetched").length;
   const skipped = pages.filter((page) => page.status === "skipped").length;
   return (
     <DossierCard
       title={t("ob.live.cardCoverage")}
-      count={t("ob.live.countPages", { read, skipped })}
+      count={t("ob.live.countPages", {
+        read: formatNumber(read, locale),
+        skipped: formatNumber(skipped, locale),
+      })}
       done={rows.length === 0}
     >
       {rows.length === 0 ? (

--- a/frontend/src/screens/onboarding-model-summary.test.ts
+++ b/frontend/src/screens/onboarding-model-summary.test.ts
@@ -19,11 +19,11 @@ type AiProfile = components["schemas"]["AiProfile"];
 
 const en = (
   key: Parameters<typeof translate>[1],
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ) => translate("en", key, params);
 const de = (
   key: Parameters<typeof translate>[1],
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ) => translate("de", key, params);
 
 function profile(overrides: Partial<AiProfile>): AiProfile {
@@ -56,7 +56,7 @@ describe("configuredModelSummary", () => {
     });
     // inference_mode is the server's own aggregate call, not one this
     // function infers from the per-model tiers itself.
-    expect(configuredModelSummary(three, "unavailable", en)).toBe(
+    expect(configuredModelSummary(three, "unavailable", en, "en")).toBe(
       "3 models, running in the cloud",
     );
   });
@@ -68,10 +68,10 @@ describe("configuredModelSummary", () => {
         { tier: "local_small", provider: "ollama", model: "gemma3" },
       ],
     });
-    expect(configuredModelSummary(one, "unavailable", en)).toBe(
+    expect(configuredModelSummary(one, "unavailable", en, "en")).toBe(
       "1 model, running locally",
     );
-    expect(configuredModelSummary(one, "unavailable", de)).toBe(
+    expect(configuredModelSummary(one, "unavailable", de, "de")).toBe(
       "1 Modell, läuft lokal",
     );
   });
@@ -84,7 +84,7 @@ describe("configuredModelSummary", () => {
         { tier: "local_large", provider: "ollama", model: "llama3-70b" },
       ],
     });
-    expect(configuredModelSummary(mixed, "unavailable", en)).toBe(
+    expect(configuredModelSummary(mixed, "unavailable", en, "en")).toBe(
       "2 models, split between cloud and local",
     );
   });
@@ -96,7 +96,7 @@ describe("configuredModelSummary", () => {
         { tier: "premium", provider: "gemini", model: "gemini-3.5-flash" },
       ],
     });
-    expect(configuredModelSummary(dup, "unavailable", en)).toBe(
+    expect(configuredModelSummary(dup, "unavailable", en, "en")).toBe(
       "1 model, running in the cloud",
     );
   });
@@ -106,20 +106,20 @@ describe("configuredModelSummary", () => {
       configured_models: [],
       providers: ["anthropic", "gemini"],
     });
-    expect(configuredModelSummary(providersOnly, "unavailable", en)).toBe(
+    expect(configuredModelSummary(providersOnly, "unavailable", en, "en")).toBe(
       "2 providers configured",
     );
   });
 
   it("says nothing is configured rather than a false zero-count sentence", () => {
     const empty = profile({ configured_models: [], providers: [] });
-    expect(configuredModelSummary(empty, "unavailable", en)).toBe(
+    expect(configuredModelSummary(empty, "unavailable", en, "en")).toBe(
       "No model configured yet",
     );
   });
 
   it("hands back the unavailable label while the profile has not loaded", () => {
-    expect(configuredModelSummary(undefined, "unavailable", en)).toBe(
+    expect(configuredModelSummary(undefined, "unavailable", en, "en")).toBe(
       "unavailable",
     );
   });

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -18,9 +18,9 @@ import type { components } from "../api/schema";
 import { Button, Card } from "../design-system/atoms";
 import type { MarginceCoreState } from "../design-system/margince-core";
 import { MarginceWorkbench } from "../design-system/margince-workbench";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { coldFieldLabel, problemMessageOf, throwProblem } from "./common";
 import { onboardingLocale } from "./onboarding-conversation/onboarding-locale";
@@ -33,7 +33,6 @@ type OnboardingCompanyDraft = components["schemas"]["OnboardingCompanyDraft"];
 type MessageReply = components["schemas"]["OnboardingCompanyMessageReply"];
 type ConversationTurn =
   components["schemas"]["CompanySiteReadConversationTurn"];
-type Translate = ReturnType<typeof useT>;
 export type SuggestedCompanyChange =
   components["schemas"]["CompanySiteReadSuggestedChange"];
 
@@ -161,7 +160,7 @@ const tierKeys = {
 export function configuredModelLabel(
   profile: AiProfile | undefined,
   unavailable: string,
-  t: Translate,
+  t: Translator,
 ) {
   const configured = profile?.configured_models
     ?.map(
@@ -212,14 +211,15 @@ function distinctModelIds(models: readonly AssistantConfiguredModel[]) {
 export function configuredModelSummary(
   profile: AiProfile | undefined,
   unavailable: string,
-  t: Translate,
+  t: Translator,
+  locale: Locale,
 ): string {
   if (!profile) return unavailable;
   const models = distinctModelIds(profile.configured_models ?? []);
   if (models.length > 0 && profile.inference_mode) {
     const keys = SUMMARY_KEYS[profile.inference_mode];
     return t(models.length === 1 ? keys.one : keys.other, {
-      count: models.length,
+      count: formatNumber(models.length, locale),
     });
   }
   const providerCount = profile.providers?.length ?? 0;
@@ -228,13 +228,13 @@ export function configuredModelSummary(
       providerCount === 1
         ? "ob.ai.summaryProviders.one"
         : "ob.ai.summaryProviders.other",
-      { count: providerCount },
+      { count: formatNumber(providerCount, locale) },
     );
   }
   return t("ob.ai.summary.none");
 }
 
-function workbenchStatus(props: ReadCompanyStepProps, t: Translate) {
+function workbenchStatus(props: ReadCompanyStepProps, t: Translator) {
   if (props.error) return t("ob.readStatus.failed");
   if (props.read) return t(`ob.readStatus.${props.read.status}`);
   return t("ob.ai.ready");
@@ -290,6 +290,7 @@ function WebsiteWorkbench(
         new URL(props.read.root_url).hostname,
         props.read.profile_fields.length + props.read.facts.length,
         t,
+        locale,
       )
     : null;
 
@@ -778,8 +779,6 @@ function WebsiteComposer(
   );
 }
 
-type Translator = ReturnType<typeof useT>;
-
 function latestFetchedPage(read: CompanySiteRead) {
   return [...read.pages].reverse().find((page) => page.status === "fetched");
 }
@@ -790,6 +789,7 @@ function coreReadPresentation(
   host: string,
   findings: number,
   t: Translator,
+  locale: Locale,
 ) {
   if (read.status === "deferred") {
     return {
@@ -807,14 +807,14 @@ function coreReadPresentation(
   }
   if (successfulStatuses.has(read.status)) {
     return {
-      title: t("ob.coreReady", { count: findings }),
+      title: t("ob.coreReady", { count: formatNumber(findings, locale) }),
       body: t("ob.coreReadyBody"),
       journeyStage: 3,
     };
   }
   if (read.status === "partial") {
     return {
-      title: t("ob.corePartial", { count: findings }),
+      title: t("ob.corePartial", { count: formatNumber(findings, locale) }),
       body: t("ob.coreReadyBody"),
       journeyStage: 3,
     };

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1589,7 +1589,7 @@ function FactsCard({
 
   return (
     <Card title={t("org.facts")} style={{ marginBottom: "var(--space-4)" }}>
-      {groupFacts(facts, locale).map((group) => (
+      {groupFacts(facts, t, locale).map((group) => (
         <FactCategory
           key={group.category}
           orgId={orgId}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1555,6 +1555,7 @@ function FactsCard({
   onOpenHistory,
 }: Readonly<{ orgId: string; onOpenHistory?: () => void }>) {
   const t = useT();
+  const { locale } = useLocale();
   const factsQuery = useQuery({
     queryKey: ["org-facts", orgId],
     queryFn: async () => {
@@ -1588,7 +1589,7 @@ function FactsCard({
 
   return (
     <Card title={t("org.facts")} style={{ marginBottom: "var(--space-4)" }}>
-      {groupFacts(facts).map((group) => (
+      {groupFacts(facts, locale).map((group) => (
         <FactCategory
           key={group.category}
           orgId={orgId}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -43,7 +43,7 @@ import {
   confidenceLevel,
   EvidenceChip,
 } from "../design-system/trust";
-import { formatDateTime, formatMoney } from "../format/format";
+import { formatDateTime, formatMoney, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -928,6 +928,7 @@ function SiteReadPanel({
   readId,
 }: Readonly<{ orgId: string; readId: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const reportQuery = useQuery({
     queryKey: ["site-read", orgId, readId],
     queryFn: async () => {
@@ -985,7 +986,7 @@ function SiteReadPanel({
             report.pages.length === 1
               ? "deepread.pagesSoFar.one"
               : "deepread.pagesSoFar.other",
-            { count: report.pages.length },
+            { count: formatNumber(report.pages.length, locale) },
           )}
         </span>
         {terminal && (
@@ -994,7 +995,7 @@ function SiteReadPanel({
               (report.fact_count ?? 0) === 1
                 ? "deepread.factCount.one"
                 : "deepread.factCount.other",
-              { count: report.fact_count ?? 0 },
+              { count: formatNumber(report.fact_count ?? 0, locale) },
             )}
           </span>
         )}
@@ -1023,7 +1024,9 @@ function SiteReadPanel({
           <span className="t-small">
             {report.proposal_ids.length === 1
               ? t("deepread.proposalsOne")
-              : t("deepread.proposals", { count: report.proposal_ids.length })}
+              : t("deepread.proposals", {
+                  count: formatNumber(report.proposal_ids.length, locale),
+                })}
           </span>
           <Button small onClick={() => navigate({ screen: "inbox" })}>
             {t("enrich.toInbox")}
@@ -1255,7 +1258,9 @@ function HierarchyRollupCard({ orgId }: Readonly<{ orgId: string }>) {
       </dl>
       {rollup.restricted_excluded.length > 0 && (
         <p className="t-caption" style={{ marginTop: 10 }}>
-          {t("rollup.excluded", { count: rollup.restricted_excluded.length })}
+          {t("rollup.excluded", {
+            count: formatNumber(rollup.restricted_excluded.length, locale),
+          })}
         </p>
       )}
       <p className="t-caption" style={{ marginTop: 10 }}>
@@ -1515,6 +1520,7 @@ function FactCategory({
   onOpenHistory?: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [expanded, setExpanded] = useState(false);
   const hidden = group.facts.length - FACT_PREVIEW;
   const shown = expanded ? group.facts : group.facts.slice(0, FACT_PREVIEW);
@@ -1535,7 +1541,9 @@ function FactCategory({
         <Button small onClick={() => setExpanded(!expanded)}>
           {expanded
             ? t("co.facts.showLess")
-            : t("co.facts.showAll", { count: group.facts.length })}
+            : t("co.facts.showAll", {
+                count: formatNumber(group.facts.length, locale),
+              })}
         </Button>
       )}
     </div>

--- a/frontend/src/screens/overlay-health.tsx
+++ b/frontend/src/screens/overlay-health.tsx
@@ -8,7 +8,7 @@ import { Callout } from "../design-system/callout";
 import { PanelPlate } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -172,14 +172,15 @@ function SyncStatusPanel({
 // keep that function's branch count under the cognitive-complexity gate.
 function BudgetSourcesLine({
   sources,
-}: Readonly<{ sources: NonNullable<Budget["sources"]> }>) {
+  locale,
+}: Readonly<{ sources: NonNullable<Budget["sources"]>; locale: Locale }>) {
   const t = useT();
   return (
     <p className="t-small overlay-budget-detail">
       {t("overlay.budgetSources", {
-        forceFresh: sources.force_fresh ?? 0,
-        poller: sources.poller ?? 0,
-        capture: sources.capture ?? 0,
+        forceFresh: formatNumber(sources.force_fresh ?? 0, locale),
+        poller: formatNumber(sources.poller ?? 0, locale),
+        capture: formatNumber(sources.capture ?? 0, locale),
       })}
     </p>
   );
@@ -189,14 +190,18 @@ function BudgetSourcesLine({
 // same reason BudgetSourcesLine is.
 function BudgetSearchRow({
   search,
-}: Readonly<{ search: NonNullable<Budget["search"]> }>) {
+  locale,
+}: Readonly<{ search: NonNullable<Budget["search"]>; locale: Locale }>) {
   const t = useT();
   return (
     <div className="overlay-facts overlay-budget-detail">
       <span className="t-small">
         {t("overlay.budgetSearch", {
-          consumed: search.consumed ?? 0,
-          limit: search.limit ?? "—",
+          consumed: formatNumber(search.consumed ?? 0, locale),
+          limit:
+            search.limit === undefined
+              ? "—"
+              : formatNumber(search.limit, locale),
         })}
       </span>
       {search.band && (
@@ -210,7 +215,10 @@ function BudgetSearchRow({
 
 // The window's own figures. Split out of BudgetPanel so that function is the
 // state machine and this is the reading, rather than one function being both.
-function BudgetReading({ budget }: Readonly<{ budget: Budget }>) {
+function BudgetReading({
+  budget,
+  locale,
+}: Readonly<{ budget: Budget; locale: Locale }>) {
   const t = useT();
   const limit = budget.limit;
   const consumed = budget.consumed ?? 0;
@@ -245,8 +253,12 @@ function BudgetReading({ budget }: Readonly<{ budget: Budget }>) {
           />
         </div>
       )}
-      {budget.sources && <BudgetSourcesLine sources={budget.sources} />}
-      {budget.search && <BudgetSearchRow search={budget.search} />}
+      {budget.sources && (
+        <BudgetSourcesLine sources={budget.sources} locale={locale} />
+      )}
+      {budget.search && (
+        <BudgetSearchRow search={budget.search} locale={locale} />
+      )}
     </>
   );
 }
@@ -257,7 +269,10 @@ function BudgetReading({ budget }: Readonly<{ budget: Budget }>) {
 // came back empty" and "this deployment does not meter the incumbent" drew
 // exactly the same thing — nothing. The section keeps its place and names which
 // silence it is in.
-function BudgetPanel({ query }: Readonly<{ query: QueryLike<Budget> }>) {
+function BudgetPanel({
+  query,
+  locale,
+}: Readonly<{ query: QueryLike<Budget>; locale: Locale }>) {
   const t = useT();
   return (
     <section className="overlay-section">
@@ -275,7 +290,7 @@ function BudgetPanel({ query }: Readonly<{ query: QueryLike<Budget> }>) {
           state={readingState(query.isPending, query.data ? 1 : 0)}
           emptyLabel={t("overlay.budgetEmpty")}
         >
-          {query.data && <BudgetReading budget={query.data} />}
+          {query.data && <BudgetReading budget={query.data} locale={locale} />}
         </SurfaceState>
       )}
     </section>
@@ -305,7 +320,7 @@ export function OverlayLiveSection({
   return (
     <PanelPlate>
       <SyncStatusPanel query={sync} locale={locale} />
-      <BudgetPanel query={budget} />
+      <BudgetPanel query={budget} locale={locale} />
     </PanelPlate>
   );
 }

--- a/frontend/src/screens/overlay-usermap.tsx
+++ b/frontend/src/screens/overlay-usermap.tsx
@@ -31,7 +31,9 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { forReader } from "../format/collate";
+import { formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   LoadMoreButton,
@@ -411,6 +413,7 @@ type OwnerGroup = {
 function ownerGroups(
   entries: Entry[],
   directory: Owner[] | null,
+  locale: Locale,
 ): OwnerGroup[] {
   const known = new Map<string, Owner>();
   for (const owner of directory ?? []) {
@@ -440,8 +443,10 @@ function ownerGroups(
   return [...groups.values()].sort(
     (a, b) =>
       b.users.length - a.users.length ||
-      identityLabel(a.name, a.email, a.incumbentUserId).localeCompare(
+      forReader(
+        identityLabel(a.name, a.email, a.incumbentUserId),
         identityLabel(b.name, b.email, b.incumbentUserId),
+        locale,
       ),
   );
 }
@@ -456,10 +461,12 @@ function ByOwnerList({
   partial: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const { principal } = directory;
   const groups = ownerGroups(
     entries,
     directory.failure === null ? directory.owners : null,
+    locale,
   );
   const unmapped = entries.filter((entry) => !isMapped(entry)).length;
   if (groups.length === 0) {
@@ -486,7 +493,7 @@ function ByOwnerList({
               {group.users.length > 1 && (
                 <Badge tone="warn">
                   {t("overlay.userMap.sharedSeat", {
-                    count: group.users.length,
+                    count: formatNumber(group.users.length, locale),
                   })}
                 </Badge>
               )}
@@ -514,7 +521,7 @@ function ByOwnerList({
             unmapped === 1
               ? "overlay.userMap.unmappedCountOne"
               : "overlay.userMap.unmappedCount",
-            { count: unmapped },
+            { count: formatNumber(unmapped, locale) },
           )}
         </p>
       )}

--- a/frontend/src/screens/partnercommissions.tsx
+++ b/frontend/src/screens/partnercommissions.tsx
@@ -5,6 +5,7 @@ import { useCanWrite } from "../app/capability";
 import { Badge, DataTable, EmptyState, StatCard } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { StatStrip } from "../design-system/statstrip";
+import { stable } from "../format/collate";
 import { formatMoney, INTL_LOCALE } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -97,7 +98,7 @@ export function outstandingByCurrency(
   }
   return [...totals.entries()]
     .map(([currency, amountMinor]) => ({ currency, amountMinor }))
-    .sort((a, b) => a.currency.localeCompare(b.currency));
+    .sort((a, b) => stable(a.currency, b.currency));
 }
 
 /**

--- a/frontend/src/screens/person360.tsx
+++ b/frontend/src/screens/person360.tsx
@@ -13,7 +13,7 @@ import {
 import { EvidenceMark } from "../design-system/evidencemark";
 import { FactList } from "../design-system/factlist";
 import type { ConfidenceLevel } from "../design-system/trust";
-import { formatDate } from "../format/format";
+import { formatDate, formatDecimal } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { provenanceOf, throwProblem } from "./common";
 import { currentEmployer, formerEmployers } from "./employmentcurrency";
@@ -186,9 +186,9 @@ export function RelationshipPulse({ view }: Readonly<{ view: Person360 }>) {
             <p style={{ margin: 0, lineHeight: 1.55 }}>
               {t("person.pulse.arithmetic", {
                 score: String(s.score),
-                recency: s.factors.recency.toFixed(2),
-                frequency: s.factors.frequency.toFixed(2),
-                reciprocity: s.factors.reciprocity.toFixed(2),
+                recency: formatDecimal(s.factors.recency, locale, 2),
+                frequency: formatDecimal(s.factors.frequency, locale, 2),
+                reciprocity: formatDecimal(s.factors.reciprocity, locale, 2),
               })}
             </p>
           </Disclosure>

--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -5,7 +5,11 @@ import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Avatar, Badge, Button, Checkbox } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
-import { formatDayMonth, formatMoneyCompact } from "../format/format";
+import {
+  formatDayMonth,
+  formatMoneyCompact,
+  formatNumber,
+} from "../format/format";
 import { daysPast } from "../format/lateness";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -459,6 +463,7 @@ function loopPrefix(
 
 function LoopStatus({ claim }: Readonly<{ claim: ConversationClaim }>) {
   const t = useT();
+  const { locale } = useLocale();
   // An unreadable due instant names no deadline, so the claim reads as one with
   // no date rather than as a promise due at some NaN o'clock.
   const dueMs = claim.due_at ? Date.parse(claim.due_at) : Number.NaN;
@@ -473,14 +478,14 @@ function LoopStatus({ claim }: Readonly<{ claim: ConversationClaim }>) {
       return (
         <span className="pe-loop-due pe-loop-overdue">
           {days > 0
-            ? t("person.loops.overdue", { count: days })
+            ? t("person.loops.overdue", { count: formatNumber(days, locale) })
             : t("person.loops.overdueUnderDay")}
         </span>
       );
     }
     return (
       <span className="pe-loop-due">
-        {t("person.loops.due", { when: dueWord(nowMs, dueMs, t) })}
+        {t("person.loops.due", { when: dueWord(nowMs, dueMs, t, locale) })}
       </span>
     );
   }
@@ -500,6 +505,7 @@ function dueWord(
   nowMs: number,
   dueMs: number,
   t: ReturnType<typeof useT>,
+  locale: Locale,
 ): string {
   const { days } = daysPast(nowMs, dueMs);
   if (days === 0) {
@@ -508,5 +514,5 @@ function dueWord(
   if (days === 1) {
     return t("person.loops.dueTomorrow");
   }
-  return t("person.loops.dueInDays", { count: days });
+  return t("person.loops.dueInDays", { count: formatNumber(days, locale) });
 }

--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -8,6 +8,7 @@ import { navigate } from "../app/router";
 import { Badge, Button } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelRow } from "../design-system/panel";
+import { stable } from "../format/collate";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
 import { STATE_LABELS } from "./dealroom";
@@ -24,18 +25,12 @@ type DealRoom = components["schemas"]["DealRoom"];
 // The rooms a contact holds a seat in, keyed on the whole address list so a
 // revoke anywhere refreshes it.
 //
-// The bare sort is deliberate and must stay bare: this is a CACHE KEY, not a
-// list a person reads. Default string sort is lexicographic by UTF-16 code
-// unit — deterministic and identical on every machine, which is the whole
-// requirement for a key. localeCompare is locale-DEPENDENT, so the same
-// addresses would key differently under different locales and a revoke would
-// refresh a cache entry nobody is looking at. Sonar's S2871 asks for
-// localeCompare here: it flags a bare sort on strings because code-unit order
-// is not human alphabetical order — "Ä" after "Z", "a" after "Z". That is a
-// real concern for a list somebody READS and no concern at all for a key
-// nobody reads, where identical-everywhere is the only property that matters.
+// `stable`, and the name is the whole record of why: this is a CACHE KEY, not a
+// list a person reads, so identical-everywhere is the only property that
+// matters. Under a reader's collation the same addresses would key differently
+// per reader and a revoke would refresh an entry nobody is looking at.
 export function roomsOfKey(emails: readonly string[]) {
-  return ["deal-rooms-of", [...emails].sort().join(",")] as const;
+  return ["deal-rooms-of", [...emails].sort(stable).join(",")] as const;
 }
 
 // More rooms than any one contact sits in; past this the card says the list

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -22,8 +22,9 @@ import {
 } from "../design-system/projectpicker";
 import { RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
+import { formatNumber } from "../format/format";
 import { webUrl } from "../format/weburl";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { refusalOf, SendRefusal, scheduleFields } from "./compose";
 import { useConsentPurposes } from "./consent";
@@ -891,6 +892,7 @@ export function PersonResearchDrawer({
   onClose: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [dismissed, setDismissed] = useState<ReadonlySet<number>>(new Set());
 
   const run = useQuery({
@@ -967,8 +969,8 @@ export function PersonResearchDrawer({
             </p>
             <p className="pe-today-foot">
               {t("person.research.stats", {
-                sources: run.data.sources_read ?? 0,
-                claims: claims.length,
+                sources: formatNumber(run.data.sources_read ?? 0, locale),
+                claims: formatNumber(claims.length, locale),
               })}
             </p>
             {claims.map((claim) => (
@@ -1033,7 +1035,9 @@ export function PersonResearchDrawer({
             disabled={claims.length === 0 || save.isPending}
             onClick={() => save.mutate()}
           >
-            {t("person.research.save", { count: claims.length })}
+            {t("person.research.save", {
+              count: formatNumber(claims.length, locale),
+            })}
           </Button>
         </div>
       </div>

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -31,8 +31,9 @@ import {
   type SectionState,
   SurfaceState,
 } from "../design-system/surfacestate";
-import { formatDayMonth, relativeDays } from "../format/format";
-import { type Locale, useLocale, useT } from "../i18n";
+import { stable } from "../format/collate";
+import { formatDayMonth, formatNumber, relativeDays } from "../format/format";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import { useProviderLabel } from "./channelproviders";
 import {
   ProblemError,
@@ -564,12 +565,12 @@ function Employers({ view }: Readonly<{ view: Person360 }>) {
   // identity as a new search space and clears the picker's candidates —
   // so the set only gets a new identity when the set of ids it names
   // actually changes.
-  // "en" rather than the reader's locale, because this string is only ever
-  // compared against a previous rendering of itself: whose locale produced it
-  // must not be part of the answer.
+  // `stable` rather than the reader's collation, because this string is only
+  // ever compared against a previous rendering of itself: whose locale produced
+  // it must not be part of the answer.
   const connectedOrgKey = employments
     .map((employment) => employment.organization_id)
-    .sort((a, b) => a.localeCompare(b, "en"))
+    .sort(stable)
     .join(",");
   const connectedOrgIds = useMemo(
     () => (connectedOrgKey === "" ? [] : connectedOrgKey.split(",")),
@@ -976,6 +977,7 @@ function RelationshipPulse({
   onExplain,
 }: Readonly<{ view: Person360; onExplain: () => void }>) {
   const t = useT();
+  const { locale } = useLocale();
   const hidden = withheldSections(view);
   const inbound = view.last_inbound_at;
   const outbound = view.last_outbound_at;
@@ -1007,11 +1009,15 @@ function RelationshipPulse({
       />
       <Row
         label={t("person.rail.lastReply")}
-        value={reading(sinceWords(inbound, t), hidden.lastTouch, t)}
+        value={reading(sinceWords(inbound, t, locale), hidden.lastTouch, t)}
       />
       <Row
         label={t("person.rail.coverage")}
-        value={reading(colleagueWords(colleagues, t), hidden.network, t)}
+        value={reading(
+          colleagueWords(colleagues, t, locale),
+          hidden.network,
+          t,
+        )}
       />
       <Row
         label={t("person.rail.trend")}
@@ -1031,10 +1037,14 @@ function RelationshipPulse({
   );
 }
 
-function colleagueWords(count: number, t: ReturnType<typeof useT>): string {
+function colleagueWords(
+  count: number,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
   return count === 1
     ? t("person.rail.colleagueOne")
-    : t("person.rail.colleagues", { count });
+    : t("person.rail.colleagues", { count: formatNumber(count, locale) });
 }
 
 function trendWord(view: Person360, t: ReturnType<typeof useT>): string {
@@ -1067,6 +1077,7 @@ function WhoKnows({
   firstName,
 }: Readonly<{ view: Person360; firstName: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const colleagues = view.network?.colleagues ?? [];
   return (
     <Disclosure
@@ -1089,7 +1100,7 @@ function WhoKnows({
                 {/* The PROOF, never a ranking nobody can check: six unanswered
                     sends must not read as stronger than two real exchanges. */}
                 {t("person.rail.exchanges", {
-                  count: colleague.interactions_90d,
+                  count: formatNumber(colleague.interactions_90d, locale),
                 })}
               </span>
             </span>
@@ -1104,7 +1115,13 @@ function WhoKnows({
 
 function SignalsAndRisks({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
-  const { signals, skipped } = derivedSignals(view, withheldSections(view), t);
+  const { locale } = useLocale();
+  const { signals, skipped } = derivedSignals(
+    view,
+    withheldSections(view),
+    t,
+    locale,
+  );
   return (
     <Disclosure className="pe-sect" open summary={t("person.rail.signals")}>
       <SurfaceState
@@ -1148,18 +1165,23 @@ function derivedSignals(
   view: Person360,
   hidden: Withheld,
   t: ReturnType<typeof useT>,
+  locale: Locale,
 ): Readonly<{ signals: ReadonlyArray<Signal>; skipped: boolean }> {
   const out: Signal[] = [];
   let skipped = hidden.lastTouch;
   const quiet = hidden.lastTouch ? null : daysSince(view.last_inbound_at);
   if (quiet != null && quiet > 14) {
     out.push({
-      text: t("person.rail.noReplyDays", { count: quiet }),
+      text: t("person.rail.noReplyDays", {
+        count: formatNumber(quiet, locale),
+      }),
       tone: "bad",
     });
   } else if (quiet != null) {
     out.push({
-      text: t("person.rail.repliedDaysAgo", { count: quiet }),
+      text: t("person.rail.repliedDaysAgo", {
+        count: formatNumber(quiet, locale),
+      }),
       tone: "good",
     });
   }
@@ -1308,6 +1330,7 @@ function verdictClass(verdict: string | undefined): string {
 // it — this is the glance, the Activity tab is the ledger.
 function RecentActivity({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
+  const { locale } = useLocale();
   // The section's own emptiness is decided BEFORE the rows are defaulted: an
   // absent list and an empty one collapse into the same `[]` here, and that
   // collapse is what turns "you may not read the timeline" into "nothing has
@@ -1328,7 +1351,7 @@ function RecentActivity({ view }: Readonly<{ view: Person360 }>) {
           <div className="pe-rail-row" key={row.id}>
             <span className="pe-rail-label">{row.subject ?? row.kind}</span>
             <span className="pe-rail-value-muted">
-              {sinceWords(row.occurred_at, t)}
+              {sinceWords(row.occurred_at, t, locale)}
             </span>
           </div>
         ))}
@@ -1376,7 +1399,8 @@ function daysSince(at: string | null | undefined): number | null {
 // call sites in this file read better with it.
 function sinceWords(
   at: string | null | undefined,
-  t: ReturnType<typeof useT>,
+  t: Translator,
+  locale: Locale,
 ): string {
-  return relativeDays(at, t);
+  return relativeDays(at, t, locale);
 }

--- a/frontend/src/screens/personstrip.tsx
+++ b/frontend/src/screens/personstrip.tsx
@@ -5,6 +5,7 @@ import { StatStrip } from "../design-system/statstrip";
 import {
   formatDayMonth,
   formatMoneyCompact,
+  formatNumber,
   relativeDays,
 } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -46,20 +47,20 @@ export function PersonStrip({
       <StatCard
         label={t("person.strip.lastInbound")}
         value={reading(
-          relativeDays(view.last_inbound_at, t),
+          relativeDays(view.last_inbound_at, t, locale),
           omitted.has("last_touch"),
         )}
       />
       <StatCard
         label={t("person.strip.lastOutbound")}
         value={reading(
-          relativeDays(view.last_outbound_at, t),
+          relativeDays(view.last_outbound_at, t, locale),
           omitted.has("last_touch"),
         )}
       />
       <StatCard
         label={t("person.strip.reciprocity")}
-        value={reading(reciprocity(view, t), omitted.has("activities"))}
+        value={reading(reciprocity(view, t, locale), omitted.has("activities"))}
       />
       <StatCard
         label={t("person.strip.openDeal")}
@@ -84,7 +85,11 @@ export function PersonStrip({
 
 // Counts, not a score. A standalone number here would be the composite verdict
 // the face deliberately does not carry (ADR-0096 D1).
-function reciprocity(view: Person360, t: ReturnType<typeof useT>): string {
+function reciprocity(
+  view: Person360,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
   const rows = view.activities?.data ?? [];
   let inbound = 0;
   let outbound = 0;
@@ -96,7 +101,10 @@ function reciprocity(view: Person360, t: ReturnType<typeof useT>): string {
       outbound += 1;
     }
   }
-  return t("person.strip.inOut", { inbound, outbound });
+  return t("person.strip.inOut", {
+    inbound: formatNumber(inbound, locale),
+    outbound: formatNumber(outbound, locale),
+  });
 }
 
 function openDeal(

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -11,7 +11,8 @@ import type { ReactNode } from "react";
 import type { components } from "../api/schema";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import { interactionIcon } from "./interactionchrome";
 
 // "Today with {first name}" (concept §5.5, ADR-0096 D2).
@@ -39,6 +40,7 @@ export function PersonToday({
   onAction: (action: PersonMomentAction) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   // The amber treatment is the finding itself — a relationship that stopped,
   // or a promise that is late — so it colours the card rather than a badge
   // inside it.
@@ -68,7 +70,7 @@ export function PersonToday({
               moment.evidence.length === 1
                 ? "person.today.source"
                 : "person.today.sources",
-              { count: moment.evidence.length },
+              { count: formatNumber(moment.evidence.length, locale) },
             )}
           </span>
           {moment.freshness_at && (
@@ -76,7 +78,7 @@ export function PersonToday({
               <span aria-hidden="true">·</span>
               <span>
                 {t("person.today.updated", {
-                  when: freshness(moment.freshness_at, t),
+                  when: freshness(moment.freshness_at, t, locale),
                 })}
               </span>
             </>
@@ -210,7 +212,11 @@ function evidenceIcon(type: string): ReactNode {
 
 // The reader judges the age themselves, so this says when rather than how
 // confident anything is. A deterministic rule shows no confidence meter.
-function freshness(at: string, t: ReturnType<typeof useT>): string {
+function freshness(
+  at: string,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
   const days = Math.floor((Date.now() - new Date(at).getTime()) / 86_400_000);
   if (days <= 0) {
     return t("person.today.freshToday");
@@ -218,7 +224,7 @@ function freshness(at: string, t: ReturnType<typeof useT>): string {
   if (days === 1) {
     return t("person.today.freshYesterday");
   }
-  return t("person.today.freshDaysAgo", { count: days });
+  return t("person.today.freshDaysAgo", { count: formatNumber(days, locale) });
 }
 
 // The quiet-success state renders through the same component: rung 10 is a

--- a/frontend/src/screens/quotas.tsx
+++ b/frontend/src/screens/quotas.tsx
@@ -12,7 +12,7 @@ import {
   Skeleton,
 } from "../design-system/atoms";
 import { Panel, PanelRow } from "../design-system/panel";
-import { formatMoney } from "../format/format";
+import { formatMoney, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import {
   ProblemError,
@@ -95,9 +95,10 @@ export function PaceLine({
   attainment,
 }: Readonly<{ attainment: QuotaAttainment }>) {
   const t = useT();
+  const { locale } = useLocale();
   const state = paceState(attainment);
-  const pct = Math.round(attainment.attainment_pct);
-  const pace = Math.round(attainment.pace_pct);
+  const pct = formatNumber(Math.round(attainment.attainment_pct), locale);
+  const pace = formatNumber(Math.round(attainment.pace_pct), locale);
   const message =
     state === "met"
       ? t("quotas.pace.met", { pct })
@@ -171,8 +172,8 @@ function ExplainCard({
   const currency = attainment.currency;
   const sum = formatMoney(attainment.closed_won_minor, currency, locale);
   const target = formatMoney(attainment.target_minor, currency, locale);
-  const pct = Math.round(attainment.attainment_pct);
-  const count = attainment.contributing_deals.length;
+  const pct = formatNumber(Math.round(attainment.attainment_pct), locale);
+  const count = formatNumber(attainment.contributing_deals.length, locale);
   return (
     <Card inset id={id} title={t("explain.title")}>
       <div className="explain-lines">

--- a/frontend/src/screens/record360/citations.tsx
+++ b/frontend/src/screens/record360/citations.tsx
@@ -10,7 +10,8 @@
 
 import type { components } from "../../api/schema";
 import { Badge } from "../../design-system/atoms";
-import { useT } from "../../i18n";
+import { formatNumber } from "../../format/format";
+import { type Locale, type Translator, useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 
 /**
@@ -206,12 +207,14 @@ function dedupeCited(evidence: readonly Cited[]): CitedSibling[] {
  * The kind label is also what a record with no name falls back to: the server
  * sends `name` when it has one, and nothing here invents one when it does not.
  */
-function chipLabel(chip: CitationChip, t: ReturnType<typeof useT>): string {
+function chipLabel(chip: CitationChip, t: Translator, locale: Locale): string {
   return (
     chip.name ??
     (chip.count === 1
       ? t(`co.brief.cite.${chip.entityType}`)
-      : t(`co.brief.cite.${chip.entityType}.many`, { count: chip.count }))
+      : t(`co.brief.cite.${chip.entityType}.many`, {
+          count: formatNumber(chip.count, locale),
+        }))
   );
 }
 
@@ -234,6 +237,7 @@ export function Citations({
   ) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const chips = citationChips(
     evidence,
     (entityType) => Boolean(onOpenRecord) && ROUTABLE_CITATIONS.has(entityType),
@@ -262,11 +266,11 @@ export function Citations({
               onOpenRecord?.(chip.entityType, chip.entityId, siblings)
             }
           >
-            {chipLabel(chip, t)}
+            {chipLabel(chip, t, locale)}
           </button>
         ) : (
           <span key={chip.entityType} className="co-brief-cite-flat">
-            {chipLabel(chip, t)}
+            {chipLabel(chip, t, locale)}
           </span>
         ),
       )}

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -14,6 +14,7 @@ import {
 import { Callout } from "../design-system/callout";
 import { Eyebrow } from "../design-system/eyebrow";
 import { StatStrip } from "../design-system/statstrip";
+import { stable } from "../format/collate";
 import { formatMoneyOrAbsent, MONEY_ABSENT } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -118,7 +119,7 @@ function byCurrency(
     bands.set(currency, [...(bands.get(currency) ?? []), row]);
   }
   return [...bands.entries()].sort(([left], [right]) =>
-    (left ?? "").localeCompare(right ?? ""),
+    stable(left ?? "", right ?? ""),
   );
 }
 
@@ -408,7 +409,7 @@ export function buildStageAggregates(
     .sort(
       (left, right) =>
         left.stagePosition - right.stagePosition ||
-        (left.currency ?? "").localeCompare(right.currency ?? ""),
+        stable(left.currency ?? "", right.currency ?? ""),
     );
 }
 

--- a/frontend/src/screens/restrictedrecords.tsx
+++ b/frontend/src/screens/restrictedrecords.tsx
@@ -16,7 +16,7 @@ import { CardBoundary } from "../design-system/cardboundary";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDate } from "../format/format";
+import { formatDate, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -263,7 +263,7 @@ export function RestrictedRecordsCard() {
         (row.redacted_fields ?? []).length === 0
           ? t("restricted.nothingRedacted")
           : t("restricted.redactedCount", {
-              count: (row.redacted_fields ?? []).length,
+              count: formatNumber((row.redacted_fields ?? []).length, locale),
             }),
     },
   ];

--- a/frontend/src/screens/retention.test.tsx
+++ b/frontend/src/screens/retention.test.tsx
@@ -228,7 +228,7 @@ describe("RetentionCard rows", () => {
       within(row).getByText(/its window is preserved/i),
     ).toBeInTheDocument();
     // Still on screen with its window intact — the whole point of E2.
-    expect(within(row).getByText(/2555 days/i)).toBeInTheDocument();
+    expect(within(row).getByText(/2,555 days/i)).toBeInTheDocument();
   });
 
   it("disables a policy through enabled:false rather than by deleting it", async () => {

--- a/frontend/src/screens/retention.tsx
+++ b/frontend/src/screens/retention.tsx
@@ -17,7 +17,8 @@ import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { Switch } from "../design-system/switch";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import {
   problemMessageOf,
   QueryGate,
@@ -101,6 +102,7 @@ function PolicyRow({
   onDelete: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const queryClient = useQueryClient();
   const editorTitleId = useId();
   const [editing, setEditing] = useState(false);
@@ -166,7 +168,9 @@ function PolicyRow({
         value={
           <span className="retention-answer">
             <span className="t-small">
-              {t("retention.windowDays", { days: policy.retain_days })}
+              {t("retention.windowDays", {
+                days: formatNumber(policy.retain_days, locale),
+              })}
             </span>
             <Badge>{t(actionLabelKey(policy.action))}</Badge>
             <Badge tone={effectTone(effect)}>{t(effectLabelKey(effect))}</Badge>

--- a/frontend/src/screens/scheduledsends.tsx
+++ b/frontend/src/screens/scheduledsends.tsx
@@ -17,9 +17,13 @@ import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { SurfaceState } from "../design-system/surfacestate";
 import { localDateTimeValue } from "../format/calendarday";
-import { formatDateTime, isRenderableZone } from "../format/format";
+import {
+  formatDateTime,
+  formatNumber,
+  isRenderableZone,
+} from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   isVersionSkewOf,
@@ -172,7 +176,8 @@ function Moment({
 /** The To line, with the rest counted rather than listed. */
 function recipientLine(
   send: ScheduledSend,
-  t: ReturnType<typeof useT>,
+  t: Translator,
+  locale: Locale,
 ): string {
   const [first, ...rest] = send.to;
   if (!first) {
@@ -183,7 +188,10 @@ function recipientLine(
   }
   return rest.length === 0
     ? first
-    : t("sched.recipientsMore", { first, count: rest.length });
+    : t("sched.recipientsMore", {
+        first,
+        count: formatNumber(rest.length, locale),
+      });
 }
 
 // The whole write, row identity included. The `mutationFn` takes it as a
@@ -281,6 +289,7 @@ function SendRow({
   onWithdraw: (send: ScheduledSend) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const actionable = STILL_MOVABLE.has(send.status);
   const heldReasonKey = send.held_reason
     ? HELD_REASON_LABEL[send.held_reason]
@@ -297,7 +306,7 @@ function SendRow({
       >
         <span style={{ flex: 1, minWidth: "12rem" }}>
           <strong>{send.subject}</strong>
-          <span className="t-caption"> · {recipientLine(send, t)}</span>
+          <span className="t-caption"> · {recipientLine(send, t, locale)}</span>
           <br />
           <Moment send={send} readerZone={readerZone} />
         </span>

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -74,7 +74,8 @@ import {
   PassportChip,
   toEvidence,
 } from "../design-system/trust";
-import { formatDate, formatDateTime } from "../format/format";
+import { stable } from "../format/collate";
+import { formatDate, formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -1671,6 +1672,7 @@ function PassportRow({
 // picked means every row reads as reachable (the unfiltered inventory).
 function AgentToolsCard() {
   const t = useT();
+  const { locale } = useLocale();
   const [passportId, setPassportId] = useState<string>("");
   const tools = useQuery({
     queryKey: ["agent-tools"],
@@ -1757,7 +1759,7 @@ function AgentToolsCard() {
             {(data) => (
               <Disclosure
                 summary={t("tools.inventory", {
-                  count: String(data.data.length),
+                  count: formatNumber(data.data.length, locale),
                 })}
               >
                 <SettingList>
@@ -1872,6 +1874,7 @@ type ResetSummary =
 
 function ResetDataCard() {
   const t = useT();
+  const { locale } = useLocale();
   const me = useMe();
   const isAdmin = useHoldsAdminRole();
   const workspaceName = me.data?.workspace_name ?? "";
@@ -1939,11 +1942,11 @@ function ResetDataCard() {
         {summary && (
           <p className="t-caption settings-danger-result" role="status">
             {t("settings.resetDataResult", {
-              tables: summary.tables_cleared,
-              jobs: summary.jobs_deleted,
-              streams: summary.streams_purged,
-              keys: summary.cache_keys_deleted,
-              objects: summary.objects_deleted,
+              tables: formatNumber(summary.tables_cleared, locale),
+              jobs: formatNumber(summary.jobs_deleted, locale),
+              streams: formatNumber(summary.streams_purged, locale),
+              keys: formatNumber(summary.cache_keys_deleted, locale),
+              objects: formatNumber(summary.objects_deleted, locale),
             })}
           </p>
         )}
@@ -2529,12 +2532,11 @@ function diffKeys(
   for (const key of Object.keys(after ?? {})) {
     keys.add(key);
   }
-  // "en", like every other canonical ordering in this file's neighbourhood.
-  // These are the record's OWN column names, rendered untranslated a few lines
-  // below — so the reader's UI language has no claim on their order, and the
-  // runtime's default locale has even less: it would let one audit row read in
-  // two different orders on two machines showing the same page.
-  return [...keys].sort((a, b) => a.localeCompare(b, "en"));
+  // `stable`, because these are the record's OWN column names, rendered
+  // untranslated a few lines below: the reader's UI language has no claim on
+  // their order, and one audit row must not read in two orders on two machines
+  // showing the same page.
+  return [...keys].sort(stable);
 }
 
 // A key absent from an object (withheld/never set) reads the same as an

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -474,24 +474,28 @@ function ShareScreenBody({
     // excludes them — a record is shared with people/teams, never an agent.
     const users = ((usersQuery.data ?? []) as User[])
       .filter((u) => !u.is_agent)
-      .map((u) => ({
-        id: u.id,
-        name: u.display_name,
-        note: u.email,
-        kind: "user" as const,
-      }));
-    const teams = ((teamsQuery.data ?? []) as Team[]).map((team) => {
-      const count = team.member_count ?? 0;
-      return {
-        id: team.id,
-        name: team.name,
-        note: t(
-          count === 1 ? "share.teamMembers.one" : "share.teamMembers.other",
-          { count: formatNumber(count, locale) },
-        ),
-        kind: "team" as const,
-      };
-    });
+      .map(
+        (u): RosterSubject => ({
+          id: u.id,
+          name: u.display_name,
+          note: u.email,
+          kind: "user",
+        }),
+      );
+    const teams = ((teamsQuery.data ?? []) as Team[]).map(
+      (team): RosterSubject => {
+        const count = team.member_count ?? 0;
+        return {
+          id: team.id,
+          name: team.name,
+          note: t(
+            count === 1 ? "share.teamMembers.one" : "share.teamMembers.other",
+            { count: formatNumber(count, locale) },
+          ),
+          kind: "team",
+        };
+      },
+    );
     return [...users, ...teams];
   }, [usersQuery.data, teamsQuery.data, t, locale]);
 

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -25,7 +25,7 @@ import {
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Select } from "../design-system/select";
-import { formatDate } from "../format/format";
+import { formatDate, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -487,15 +487,13 @@ function ShareScreenBody({
         name: team.name,
         note: t(
           count === 1 ? "share.teamMembers.one" : "share.teamMembers.other",
-          {
-            count,
-          },
+          { count: formatNumber(count, locale) },
         ),
         kind: "team" as const,
       };
     });
     return [...users, ...teams];
-  }, [usersQuery.data, teamsQuery.data, t]);
+  }, [usersQuery.data, teamsQuery.data, t, locale]);
 
   const [term, setTerm] = useState("");
   const [subject, setSubject] = useState<RosterSubject | null>(null);
@@ -790,7 +788,7 @@ function ShareScreenBody({
                   expiryDays === 1
                     ? "share.expiryConsequence.one"
                     : "share.expiryConsequence.other",
-                  { days: expiryDays },
+                  { days: formatNumber(expiryDays, locale) },
                 )
               : t("share.expiryConsequenceNone")}
           </p>

--- a/frontend/src/screens/strength.tsx
+++ b/frontend/src/screens/strength.tsx
@@ -7,7 +7,7 @@ import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Card, EmptyState, Skeleton } from "../design-system/atoms";
 import { Meter } from "../design-system/readings";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import {
   OverlayUnavailable,
@@ -146,7 +146,9 @@ function StrengthBody({
         <Badge tone={BUCKET_TONE[bucket]}>
           {t(`strength.bucket.${bucket}`)}
         </Badge>
-        <span className="t-mono">{t("strength.score", { score })}</span>
+        <span className="t-mono">
+          {t("strength.score", { score: formatNumber(score, locale) })}
+        </span>
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {factorRows.map((row) => {
@@ -186,14 +188,16 @@ function StrengthBody({
       {(strength.inbound_90d != null || strength.outbound_90d != null) && (
         <p className="t-caption">
           {t("strength.inout", {
-            in: strength.inbound_90d ?? 0,
-            out: strength.outbound_90d ?? 0,
+            in: formatNumber(strength.inbound_90d ?? 0, locale),
+            out: formatNumber(strength.outbound_90d ?? 0, locale),
           })}
         </p>
       )}
       {contributingCount > 0 && (
         <p className="t-caption">
-          {t("strength.computedFrom", { count: contributingCount })}
+          {t("strength.computedFrom", {
+            count: formatNumber(contributingCount, locale),
+          })}
         </p>
       )}
     </div>

--- a/frontend/src/screens/tasks.tsx
+++ b/frontend/src/screens/tasks.tsx
@@ -13,7 +13,7 @@ import {
 } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { calendarDay, dueInstant } from "../format/calendarday";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { daysPast } from "../format/lateness";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
@@ -163,6 +163,7 @@ function ReminderControl({
  */
 function ScheduledSendsLink() {
   const t = useT();
+  const { locale } = useLocale();
   const query = useScheduledSends();
   const waiting = query.data ? waitingCount(query.data) : 0;
   if (waiting === 0) {
@@ -184,7 +185,7 @@ function ScheduledSendsLink() {
         waiting === 1
           ? "tasks.scheduledWaiting.one"
           : "tasks.scheduledWaiting.other",
-        { count: waiting },
+        { count: formatNumber(waiting, locale) },
       )}
     </Callout>
   );

--- a/frontend/src/screens/transcriptread.tsx
+++ b/frontend/src/screens/transcriptread.tsx
@@ -6,7 +6,8 @@ import { navigate } from "../app/router";
 import { Badge, Button, Card, Skeleton } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { AutonomyDot } from "../design-system/trust";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
 
@@ -39,6 +40,7 @@ function TranscriptReadOutcome({
   report,
 }: Readonly<{ report: TranscriptReadReport }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (report.status === "failed") {
     return (
       <Callout tone="danger" live="status">
@@ -68,7 +70,7 @@ function TranscriptReadOutcome({
         {report.proposal_ids.length === 1
           ? t("transcriptread.proposalsOne")
           : t("transcriptread.proposals", {
-              count: report.proposal_ids.length,
+              count: formatNumber(report.proposal_ids.length, locale),
             })}
       </span>
       <Button small onClick={() => navigate({ screen: "inbox" })}>
@@ -86,6 +88,7 @@ function TranscriptReadPanel({
   readId,
 }: Readonly<{ activityId: string; readId: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const reportQuery = useQuery({
     queryKey: ["transcript-read", activityId, readId],
     queryFn: async () => {
@@ -138,7 +141,7 @@ function TranscriptReadPanel({
               report.line_count === 1
                 ? "transcriptread.lineCount.one"
                 : "transcriptread.lineCount.other",
-              { count: report.line_count },
+              { count: formatNumber(report.line_count, locale) },
             )}
           </span>
         )}

--- a/frontend/src/screens/users-access.tsx
+++ b/frontend/src/screens/users-access.tsx
@@ -13,7 +13,9 @@ import {
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { stable } from "../format/collate";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { RosterPartialNote, useRoster, useRosterPartial } from "./entityref";
@@ -38,13 +40,9 @@ const PREVIEW_OBJECTS = [
 
 function useAccessPreview(role: Role, teamIds: string[]) {
   return useQuery({
-    // "en", not the reader's locale: this is a cache key, so the same set of
-    // teams has to spell the same key wherever it is read.
-    queryKey: [
-      "access-preview",
-      role,
-      [...teamIds].sort((a, b) => a.localeCompare(b, "en")).join(","),
-    ],
+    // `stable`, not the reader's collation: this is a cache key, so the same
+    // set of teams has to spell the same key wherever it is read.
+    queryKey: ["access-preview", role, [...teamIds].sort(stable).join(",")],
     queryFn: async (): Promise<AccessPreview> => {
       const { data, error } = await api.POST("/users/access-preview", {
         body: { role, team_ids: teamIds },
@@ -123,6 +121,7 @@ function AccessSummary({ access }: Readonly<{ access: AccessPreview }>) {
 
 export function TeamsCard() {
   const t = useT();
+  const { locale } = useLocale();
   const qc = useQueryClient();
   // The shared roster read, not a second query of this card's own. Both spell
   // the same list under the same cache key, so whichever mounted first decided
@@ -185,7 +184,7 @@ export function TeamsCard() {
                       (team.member_count ?? 0) === 1
                         ? "users.memberCount.one"
                         : "users.memberCount.other",
-                      { count: team.member_count ?? 0 },
+                      { count: formatNumber(team.member_count ?? 0, locale) },
                     )}
                     control={
                       <Button

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -18,7 +18,8 @@ import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select, type SelectOption } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import "./users-admin.css";
 import { useHoldsAdminRole } from "../app/capability";
@@ -118,6 +119,7 @@ function MembersCard({
   canAdminister: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const roster = members.data;
   return (
     <Panel
@@ -136,7 +138,7 @@ function MembersCard({
                 roster.length === 1
                   ? "users.memberCount.one"
                   : "users.memberCount.other",
-                { count: roster.length },
+                { count: formatNumber(roster.length, locale) },
               )}
             </Badge>
           )}

--- a/frontend/src/screens/voice-corpus-settings.tsx
+++ b/frontend/src/screens/voice-corpus-settings.tsx
@@ -240,7 +240,7 @@ function SpeakerPanel({
               onChange={() => setChoice(speaker.label)}
               label={`${speaker.label} · ${t("settings.voice.speakerDetail", {
                 words: formatNumber(speaker.words, locale),
-                turns: speaker.turns,
+                turns: formatNumber(speaker.turns, locale),
               })}`}
             />
           </li>

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -213,7 +213,11 @@ function VoiceDnaBody({ profile }: Readonly<{ profile: VoiceProfile }>) {
               </span>
             )}
             <span className="t-small vdna-version">
-              {t("settings.voice.version", { n: profile.profile_version ?? 0 })}
+              {/* A version number is a name, not a magnitude: grouped, build
+                  1234 would read as "1.234". */}
+              {t("settings.voice.version", {
+                n: String(profile.profile_version ?? 0),
+              })}
             </span>
           </div>
 
@@ -509,7 +513,9 @@ function FloorMeter({ words }: Readonly<{ words: number }>) {
       <progress
         value={Math.min(words, VOICE_MIN_WORDS)}
         max={VOICE_MIN_WORDS}
-        aria-label={t("settings.voice.floorLabel", { min: VOICE_MIN_WORDS })}
+        aria-label={t("settings.voice.floorLabel", {
+          min: formatNumber(VOICE_MIN_WORDS, locale),
+        })}
       />
       <span>
         {t("settings.voice.floorProgress", {
@@ -644,6 +650,7 @@ function BuildControls({
   intakeBusy?: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [status, setStatus] = useState<
     "succeeded" | "failed" | "deferred" | "pending" | null
   >(null);
@@ -707,13 +714,13 @@ function BuildControls({
   const blocked =
     tooThin && words !== null
       ? t("settings.voice.buildNeedsWords", {
-          n: Math.max(0, VOICE_FIRST_BUILD_WORDS - words),
+          n: formatNumber(Math.max(0, VOICE_FIRST_BUILD_WORDS - words), locale),
         })
       : null;
   const reach =
     profile.maturity === "provisional" && words !== null
       ? t("settings.voice.buildProvisional", {
-          n: Math.max(0, VOICE_FULL_BUILD_WORDS - words),
+          n: formatNumber(Math.max(0, VOICE_FULL_BUILD_WORDS - words), locale),
         })
       : null;
 

--- a/frontend/src/screens/voice-insights.tsx
+++ b/frontend/src/screens/voice-insights.tsx
@@ -161,7 +161,9 @@ export function VoiceInsights({
   return (
     <div className="vdna-insights">
       <div className="vdna-provenance t-small">
-        {t("voice.insights.provenance", { n: profileVersion })}
+        {/* The build's version is a name, not a magnitude: grouped, build 1234
+            would read as "1.234" and stop matching what it refers to. */}
+        {t("voice.insights.provenance", { n: String(profileVersion) })}
         {data.modelName && data.modelName !== "unrecorded"
           ? ` · ${data.modelName}`
           : ""}
@@ -249,6 +251,7 @@ function SignatureMoves({ moves }: Readonly<{ moves: VoiceSignatureMove[] }>) {
 
 function SampleDrafts({ drafts }: Readonly<{ drafts: VoiceSampleDraft[] }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (drafts.length === 0) {
     return null;
   }
@@ -268,7 +271,7 @@ function SampleDrafts({ drafts }: Readonly<{ drafts: VoiceSampleDraft[] }>) {
             {draft.score !== null && (
               <span className="t-small">
                 {t("voice.insights.voiceScore", {
-                  pct: Math.round(draft.score * 100),
+                  pct: formatNumber(Math.round(draft.score * 100), locale),
                 })}
               </span>
             )}

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -5,7 +5,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card } from "../design-system/atoms";
-import { formatDate } from "../format/format";
+import { formatDate, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { parseVoiceInsights, VoiceInsights } from "./voice-insights";
@@ -125,7 +125,13 @@ function CandidateBanner({
     // "card">`: a copy of the card surface is a second card the moment one of
     // its five chrome values moves, and the README forbids it by name.
     <Card as="div" inset className="vdna-candidate">
-      <b>{t("voice.candidate.title", { n: candidate.profile_version })}</b>
+      {/* A version number is a name, not a magnitude: grouped, build 1234
+          would read as "1.234" and stop matching the version it refers to. */}
+      <b>
+        {t("voice.candidate.title", {
+          n: String(candidate.profile_version),
+        })}
+      </b>
       {candidate.review_reasons.length > 0 && (
         <ul className="vdna-reasons">
           {candidate.review_reasons.map((reason) => (
@@ -179,6 +185,7 @@ export function VoiceHistory({
   onChanged: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [versionCursor, setVersionCursor] = useState<string | undefined>();
   const [allVersions, setAllVersions] = useState<VoiceProfileVersion[]>([]);
   const versions = useQuery({
@@ -249,9 +256,9 @@ export function VoiceHistory({
         {(summary) => (
           <p className="t-small vdna-learning">
             {t("voice.history.learning", {
-              drafted: summary.drafted,
-              edited: summary.edited_sent,
-              rejected: summary.rejected,
+              drafted: formatNumber(summary.drafted, locale),
+              edited: formatNumber(summary.edited_sent, locale),
+              rejected: formatNumber(summary.rejected, locale),
             })}
           </p>
         )}
@@ -301,9 +308,11 @@ export function VoiceChangeLog({ profileId }: Readonly<{ profileId: string }>) {
                 .map((delta) => (
                   <li key={delta.id} className="vdna-row">
                     <span>
+                      {/* Both ends of a delta are version names, so neither
+                          is grouped — see the candidate title above. */}
                       {t("voice.history.deltaRow", {
-                        from: delta.from_version ?? 0,
-                        to: delta.to_version,
+                        from: String(delta.from_version ?? 0),
+                        to: String(delta.to_version),
                       })}
                       {" · "}
                       {classificationLabel(t, delta.classification)} ·{" "}
@@ -365,7 +374,10 @@ function VersionRow({
   return (
     <li className="vdna-row">
       <span>
-        {t("voice.history.versionRow", { n: version.profile_version })}{" "}
+        {/* Version name, not a magnitude — same rule as the candidate title. */}
+        {t("voice.history.versionRow", {
+          n: String(version.profile_version),
+        })}{" "}
         <Badge>{versionStatusLabel(t, version.status)}</Badge>
         {" · "}
         {/* `locale` is the app's own code ("en") — a valid BCP-47 tag, but a
@@ -382,7 +394,7 @@ function VersionRow({
           type="button"
           className="iconbtn vdna-row-verb"
           aria-label={t("voice.history.rollback", {
-            n: version.profile_version,
+            n: String(version.profile_version),
           })}
           disabled={rollback.isPending}
           onClick={() => rollback.mutate()}

--- a/frontend/src/screens/webhooks.tsx
+++ b/frontend/src/screens/webhooks.tsx
@@ -24,9 +24,9 @@ import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
 import {
@@ -544,7 +544,7 @@ function deliveryResolvedAt(delivery: WebhookDelivery): string | null {
 }
 
 function deliveryColumns(
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string,
+  t: Translator,
   locale: ReturnType<typeof useLocale>["locale"],
   subscriptionId: string,
   canReplay: boolean,
@@ -678,7 +678,7 @@ function DeliveriesBody({
   subscriptionId: string;
   canReplay: boolean;
   locale: ReturnType<typeof useLocale>["locale"];
-  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  t: Translator;
   loadMoreQuery: {
     hasNextPage: boolean;
     isFetchingNextPage: boolean;
@@ -701,13 +701,13 @@ function DeliveriesBody({
         >
           <SectionHeader
             title={t("webhooks.deliveries.deadLetterGroup", {
-              count: deadLettered.length,
+              count: formatNumber(deadLettered.length, locale),
             })}
             level={3}
           />
           <DataTable
             label={t("webhooks.deliveries.deadLetterGroup", {
-              count: deadLettered.length,
+              count: formatNumber(deadLettered.length, locale),
             })}
             columns={columns}
             rows={deadLettered}

--- a/frontend/src/surface/index.ts
+++ b/frontend/src/surface/index.ts
@@ -13,7 +13,11 @@
 //
 // `useT` reads the merged catalogue, so a unit's own copy resolves through the
 // same lookup as core's rather than through a second mechanism.
-import { type ExtensionMessageKey, useT as useCoreT } from "../i18n";
+import {
+  type ExtensionMessageKey,
+  translate,
+  useLocale as useCoreLocale,
+} from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 export { useCan, useCanWrite } from "../app/capability";
@@ -53,8 +57,12 @@ export function useT(): (
   key: MessageKey | ExtensionMessageKey,
   params?: Record<string, string>,
 ) => string {
-  return useCoreT() as (
-    key: MessageKey | ExtensionMessageKey,
-    params?: Record<string, string>,
-  ) => string;
+  // Built from `translate`, which already takes the wider key, rather than cast
+  // from core's `useT`. A translator is CONTRAVARIANT in its key, so widening
+  // core's narrow one is not an assignment TypeScript can check — the cast that
+  // used to stand here suppressed the check on the one surface nothing in this
+  // repo typechecks against, which is the worst place in the tree to hold a
+  // claim by assertion. Same lookup, same merged catalogue, no `as`.
+  const { locale } = useCoreLocale();
+  return (key, params) => translate(locale, key, params);
 }

--- a/frontend/src/surface/index.ts
+++ b/frontend/src/surface/index.ts
@@ -17,7 +17,12 @@ import { type ExtensionMessageKey, useT as useCoreT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 export { useCan, useCanWrite } from "../app/capability";
-export { formatDateTime } from "../format/format";
+// `formatNumber` alongside `formatDateTime` for the same reason: a unit's screen
+// renders figures a person reads, `useT` below refuses a raw number, and the
+// only alternative left to a unit would be `String(n)` — which groups for
+// nobody. A surface that narrows the parameter without exporting the formatter
+// has told the unit to write the defect a different way.
+export { formatDateTime, formatNumber } from "../format/format";
 // LocaleProvider is here for the TESTS: a unit's screen calls useT, so a test
 // that renders it without the provider the app mounts around it renders
 // nothing useful. Exporting the provider is what lets a unit test its own
@@ -37,13 +42,19 @@ export { LocaleProvider, useLocale } from "../i18n";
  * A unit's half cannot be a closed union: this file cannot enumerate what an
  * installation enabled. The real rule is checked by the generator, which
  * refuses any key a unit ships that is not namespaced to that unit.
+ *
+ * The KEY is what widens here and nothing else. `params` stays strings, exactly
+ * as core's does: a raw number reaching a catalog sentence is coerced without
+ * grouping, which is wrong in a unit's screen for the same reason it is wrong
+ * in a core one — and a cast that widened it here would put the hole back on
+ * the one surface nothing in this repo typechecks against.
  */
 export function useT(): (
   key: MessageKey | ExtensionMessageKey,
-  params?: Record<string, string | number>,
+  params?: Record<string, string>,
 ) => string {
   return useCoreT() as (
     key: MessageKey | ExtensionMessageKey,
-    params?: Record<string, string | number>,
+    params?: Record<string, string>,
   ) => string;
 }

--- a/frontend/src/surface/index.ts
+++ b/frontend/src/surface/index.ts
@@ -13,6 +13,7 @@
 //
 // `useT` reads the merged catalogue, so a unit's own copy resolves through the
 // same lookup as core's rather than through a second mechanism.
+import { useCallback } from "react";
 import {
   type ExtensionMessageKey,
   translate,
@@ -64,5 +65,7 @@ export function useT(): (
   // repo typechecks against, which is the worst place in the tree to hold a
   // claim by assertion. Same lookup, same merged catalogue, no `as`.
   const { locale } = useCoreLocale();
-  return (key, params) => translate(locale, key, params);
+  // Stable per locale, so a unit can put `t` in a dependency array without the
+  // memo it guards being recomputed on every render of the screen around it.
+  return useCallback((key, params) => translate(locale, key, params), [locale]);
 }

--- a/frontend/src/surface/surface.test.ts
+++ b/frontend/src/surface/surface.test.ts
@@ -70,6 +70,10 @@ describe("the published frontend surface", () => {
     expect(Object.keys(appSurface).sort()).toEqual([
       "LocaleProvider",
       "formatDateTime",
+      // formatNumber: `useT` refuses a raw number, so without it a unit's only
+      // way to put a figure in a sentence is `String(n)` — ungrouped for every
+      // reader. The narrowing and the formatter are one change.
+      "formatNumber",
       "useCan",
       "useCanWrite",
       "useLocale",


### PR DESCRIPTION
Closes #2463. Closes #2455.

Two locale defects, and they are one PR because they are the same mistake: a decision about the reader's locale that the code never made.

## A raw number in a catalog sentence (#2463)

`t("co.deals", { count: 1234 })` typechecked, and the number reached the sentence through string coercion. A German reader saw `1234` in a paragraph whose every other figure read `1.234`. Neither the writer nor the reviewer could see it, because in en-GB the coerced form and the formatted form are the same string.

**The fix is the compiler, not a sweep.** `translate` and `useT`'s return now take `Record<string, string>`, so every site that had skipped the decision is a build failure. The issue's census claimed 568 sites; the real figure is **289 sites across 91 files**, and each was ruled one at a time, because the right answer is not uniform:

- A **magnitude** a person reads as a quantity goes through `formatNumber` — counts, days, percentages, latencies.
- A **position** never groups. `String(n)` with a comment saying so: a version, an attempt, a retry rung, a page ordinal, a step in "step 3 of 5", a River job id, an offer number. "Page 1.234" names no page.

Where a magnitude's decimals are part of what it says, a new `formatDecimal` replaces `.toFixed(n)` — locale-blind by construction, so a scoring breakdown read `12.50 → 13` with a decimal point in a German sentence. `formatRate` is the same for an FX rate, where `formatNumber`'s three-fraction-digit Intl default was silently dropping auditable digits from the one screen that exists to show its arithmetic.

Two structural repairs fell out of it:

- **`Translator` had four hand-written copies**, every one wider than the real translator — each a hole the narrowing could not close. It is now `ReturnType<typeof useT>`, exported once from `src/i18n`.
- **A thread entry's `params` carry rendered strings.** The producer of a server counter is now where the decision to group it gets made, rather than a renderer three files away that no longer has the counter.

The **extension surface** narrows with core and gains `formatNumber`. Its `useT` widened the KEY union through a cast that widened `params` along with it — so the one surface nothing in this repo typechecks against was the one place the defect could still be written. Narrowing it without exporting a formatter would only have told a unit to write `String(n)` instead.

## A sort that never said which kind of string it held (#2455)

`localeCompare` reads as the careful choice and is wrong twice over. Called bare it sorts by the **browser's guessed locale**, so two colleagues looking at one list see two orders. Called with a pinned `"en"` it is right for a key and wrong for a name — `Äpfel` lands after `Zebra` for a German reader.

Neither answer generalises, which is why `one-locale.test.ts` excluded collation entirely and **held one half of its own subject while reporting the tree clean**. `format/collate.ts` closes it by making the ruling the function name:

| | for |
|---|---|
| `forReader(a, b, locale)` | a list somebody reads as an alphabet — theirs |
| `stable(a, b)` | a key nobody reads, where identical-everywhere is the only property that matters |
| `foldForMatch(value)` | a search, where both sides must agree more than either needs to be linguistically right (`toLocaleLowerCase` under a Turkish locale folds `I` to a dotless `ı`) |

`stable` is spelled from `<` and `>` rather than delegating to `localeCompare(a, b, "en")` **so the gate needs no exception for the module that owns the answer**. Every site in the tree is ruled, so the exclusion is gone and the gate is absolute again — its fixture now plants both spellings, including the pinned `"en"` that made the exclusion look reasonable.

## Also fixed along the way

- `formatUploadLimit` rendered decimal MB by hand, so a German reader read `12.5 MB` as twelve thousand five hundred.
- `CountLine`, `SurfaceState`'s partial count and the rows-per-page picker are all sentences a reader reads, and all three were ungrouped. Each primitive already calls `useT`; reading the locale beside it is the same dependency, not a new one.
- `persondealrooms`' bare `.sort()` carried a fourteen-line paragraph explaining why it was deliberate. It is `.sort(stable)` now, and the paragraph is three lines.

## Gates

- `translate`'s narrowing is asserted with a `@ts-expect-error` in `i18n.test.ts` — it is invisible in rendered output and is exactly the kind of type the next author widens back as an inconvenience.
- `one-locale.test.ts` now asserts that **nothing** is filtered out of its derived method set, so a future exclusion fails rather than quietly shrinking the gate.
- `collate.test.ts` asserts the **difference** between the two orderings, not that each sorted something — a test that only did the latter would pass with one function.
- `make check-fe` and `make fe-ds-gates` green; 4733 frontend unit tests pass.

## Known and out of scope

A magnitude interpolated **straight into JSX** — no `t()`, no `Intl` — is a third class neither this narrowing nor the Intl gate can see (`{count}` rendered bare, `StatCard value={String(n)}`). Roughly sixty files carry it. Fixing four of them here would be exactly the half-fix the rulebook warns about, so it gets its own per-site pass: #2666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders all reader-facing figures in the reader’s locale and makes string ordering explicit. Facts now sort by the labels a reader sees (not wire field names), and lists must declare whether they’re ordering human names or machine keys.

**Migration**
- `translate`/`useT` params are now `Record<string, string>`; format magnitudes with `formatNumber(locale)` and pass positions via `String(n)`.
- Replace `localeCompare` with `forReader(a, b, locale)` for labels and `stable(a, b)` for keys; replace `toLocaleLowerCase` with `foldForMatch`.
- Use `formatDecimal` where fixed decimals must be shown; use `formatRate` for FX rates; remaining `.toFixed()` sites were updated.
- `formatUploadLimit(bytes, locale)` and `formatCountdown(ms, t, locale)` now require a locale.
- Facts grouping now takes a translator and locale: call `groupFacts(facts, t, locale)`.
- `Translator` is exported from `i18n`; helpers should accept this type.

**Bug Fixes**
- Counts, limits, durations, percentages, rates, and latencies now group and punctuate per locale.
- Collation is deterministic: `forReader` orders names per reader locale; `stable` orders keys identically everywhere; `foldForMatch` fixes Turkish casing search issues.
- Fact lists at equal confidence tiebreak by rendered labels per reader locale; tests assert the difference between name and key orderings.
- The one-locale gate now includes collation and casing; tests cover `forReader`, `stable`, `foldForMatch`, numeric formatting, and fact grouping by label.
- Removed casts that widened translators; explicit types and the exported `Translator` close those holes.

<sup>Written for commit dc03be808a64e6b1af801f2b65def3fb7710a403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added locale-aware formatting across counts, percentages, rates, durations, upload limits, and onboarding messages.
  - Added localized decimal separators, thousands grouping, and unit labels, including German formatting support.
  - Improved locale-sensitive name sorting and deterministic ordering across lists and tables.
  - Updated accessibility labels and translated messages to reflect localized values.
  - Refined account overview cards with more flexible layouts and activity sections.

- **Bug Fixes**
  - Prevented identifiers, page numbers, and other machine values from being incorrectly grouped or localized.
  - Improved consistency of numeric displays across the application.
  - Simplified approval completion flows by removing approval-token prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->