### PR TITLE
feat(integrations): the import switch decides whether captured contacts are bought

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17471,7 +17471,10 @@ components:
         automatic_import:
           type: boolean
           default: false
-          description: Still requires import preview, maximum-credit estimate and explicit confirmation.
+          description: >-
+            Enrich every person a connector creates. Capture mints one person
+            per external counterparty, so a mailbox sync spends a credit each
+            time; off by default for that reason.
         categories: { $ref: '#/components/schemas/ProviderCategorySelection' }
         refresh_after_days: { type: [integer, 'null'], minimum: 1 }
         daily_run_limit: { type: [integer, 'null'], minimum: 1 }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17472,9 +17472,9 @@ components:
           type: boolean
           default: false
           description: >-
-            Enrich every person a connector creates. Capture mints one person
-            per external counterparty, so a mailbox sync spends a credit each
-            time; off by default for that reason.
+            Enrich every person a connector creates. A mailbox, channel or
+            other connection mints one person per counterparty it sees, and
+            each purchase spends credits; off by default for that reason.
         categories: { $ref: '#/components/schemas/ProviderCategorySelection' }
         refresh_after_days: { type: [integer, 'null'], minimum: 1 }
         daily_run_limit: { type: [integer, 'null'], minimum: 1 }

--- a/backend/internal/compose/integration/persondataenrich_integration_test.go
+++ b/backend/internal/compose/integration/persondataenrich_integration_test.go
@@ -96,6 +96,20 @@ func actorEnvelope(personID ids.UUID, actorType, actorID string) events.Envelope
 	}
 }
 
+// admitCapturedContacts is the customer switching automatic_import on, through
+// the same column the settings card writes. Separate from the setup so every
+// other case here keeps the default the server ships, which is off.
+func (c *providerConsumerEnv) admitCapturedContacts(t *testing.T) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(c.env.Admin(), c.env.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE provider_connection SET automatic_import = true WHERE provider = 'surfe'`)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func (c *providerConsumerEnv) runsForPerson(t *testing.T) int {
 	t.Helper()
 	var runs int
@@ -168,10 +182,29 @@ func TestAnAgentCreatedPersonBuysNothing(t *testing.T) {
 	}
 }
 
+// The other half of the import toggle: switched ON, a captured counterparty
+// buys exactly like a typed one. Without this case the refusal below passes
+// against a gate that admits nobody — the toggle could be wired to a constant
+// false and every assertion in this file would still be green.
+func TestACapturedContactIsBoughtOnceTheImportToggleIsOn(t *testing.T) {
+	c := setupProviderConsumer(t, "automatic_on_create")
+	c.admitCapturedContacts(t)
+
+	if err := c.consumer.HandleEvent(context.Background(),
+		actorEnvelope(c.personID, "connector", "connector:gmail")); err != nil {
+		t.Fatal(err)
+	}
+	if runs := c.runsForPerson(t); runs != 1 {
+		t.Errorf("%d runs exist for a captured counterparty with automatic_import on, want 1 — the customer switched capture enrichment on and got nothing", runs)
+	}
+	if *c.enqueued != 1 {
+		t.Errorf("%d submit jobs were committed, want 1 — a queued run with no job blocks every later attempt at that subject", *c.enqueued)
+	}
+}
+
 // Capture creates a person per external counterparty, so a mailbox connect
 // with a year of history would buy thousands of records. That is what
-// automatic_import governs — off by default, with a preview and an estimate
-// behind it — and it is NOT the individual-create toggle.
+// automatic_import governs, and it is NOT the individual-create toggle.
 func TestAConnectorCreatedPersonIsGovernedByTheImportToggle(t *testing.T) {
 	c := setupProviderConsumer(t, "automatic_on_create")
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21317,7 +21317,7 @@ type ProviderCategorySelection map[string]bool
 
 // ProviderConfiguration defines model for ProviderConfiguration.
 type ProviderConfiguration struct {
-	// AutomaticImport Still requires import preview, maximum-credit estimate and explicit confirmation.
+	// AutomaticImport Enrich every person a connector creates. Capture mints one person per external counterparty, so a mailbox sync spends a credit each time; off by default for that reason.
 	AutomaticImport           bool `json:"automatic_import"`
 	AutomaticIndividualCreate bool `json:"automatic_individual_create"`
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21317,7 +21317,7 @@ type ProviderCategorySelection map[string]bool
 
 // ProviderConfiguration defines model for ProviderConfiguration.
 type ProviderConfiguration struct {
-	// AutomaticImport Enrich every person a connector creates. Capture mints one person per external counterparty, so a mailbox sync spends a credit each time; off by default for that reason.
+	// AutomaticImport Enrich every person a connector creates. A mailbox, channel or other connection mints one person per counterparty it sees, and each purchase spends credits; off by default for that reason.
 	AutomaticImport           bool `json:"automatic_import"`
 	AutomaticIndividualCreate bool `json:"automatic_individual_create"`
 

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -29,6 +29,13 @@ const (
 	auditKeyProvider = "provider"
 	auditKeyMode     = "mode"
 	auditKeyPreset   = "preset"
+	// The two toggles that decide whether an arrival is bought without anybody
+	// asking. They belong in the image for the same reason mode does: an
+	// investigation into why credits drained asks who switched automatic
+	// buying on, and an audit row that records neither answers that with two
+	// identical images.
+	auditKeyAutoCreate = "automatic_individual_create"
+	auditKeyAutoImport = "automatic_import"
 )
 
 // Store owns the four platform tables. Every exported method gates before it

--- a/backend/internal/modules/integrations/update.go
+++ b/backend/internal/modules/integrations/update.go
@@ -102,8 +102,14 @@ func (s *Store) UpdateConfig(ctx context.Context, name string, patch ConfigPatch
 			}
 		}
 		if _, err := storekit.Audit(ctx, tx, "update", "provider_connection", uuidOf(current.id),
-			map[string]any{auditKeyMode: current.Mode, auditKeyPreset: current.Preset},
-			map[string]any{auditKeyMode: merged.Mode, auditKeyPreset: merged.Preset}); err != nil {
+			map[string]any{
+				auditKeyMode: current.Mode, auditKeyPreset: current.Preset,
+				auditKeyAutoCreate: current.AutomaticCreate, auditKeyAutoImport: current.AutomaticImport,
+			},
+			map[string]any{
+				auditKeyMode: merged.Mode, auditKeyPreset: merged.Preset,
+				auditKeyAutoCreate: merged.AutomaticCreate, auditKeyAutoImport: merged.AutomaticImport,
+			}); err != nil {
 			return err
 		}
 		conns, err := s.loadConnections(ctx, tx)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11835,7 +11835,7 @@ export interface components {
             /** @default true */
             automatic_individual_create: boolean;
             /**
-             * @description Still requires import preview, maximum-credit estimate and explicit confirmation.
+             * @description Enrich every person a connector creates. Capture mints one person per external counterparty, so a mailbox sync spends a credit each time; off by default for that reason.
              * @default false
              */
             automatic_import: boolean;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11835,7 +11835,7 @@ export interface components {
             /** @default true */
             automatic_individual_create: boolean;
             /**
-             * @description Enrich every person a connector creates. Capture mints one person per external counterparty, so a mailbox sync spends a credit each time; off by default for that reason.
+             * @description Enrich every person a connector creates. A mailbox, channel or other connection mints one person per counterparty it sees, and each purchase spends credits; off by default for that reason.
              * @default false
              */
             automatic_import: boolean;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6045,9 +6045,9 @@ export const de = {
   "provider.autoEnrich": "Neue Kontakte automatisch anreichern",
   "provider.autoEnrichHint":
     "Wenn jemand einen Kontakt von Hand anlegt, dessen Daten gleich mitkaufen.",
-  "provider.autoImport": "Kontakte aus verbundenen Postfächern anreichern",
+  "provider.autoImport": "Kontakte aus Verbindungen anreichern",
   "provider.autoImportHint":
-    "Ein Postfachabgleich legt für jede Person an, mit der geschrieben wurde — und jede kostet ein Guthaben.",
+    "Jedes Postfach, jeder Kanal und jede weitere Verbindung legt für jede erkannte Person einen Kontakt an — und jeder Kauf kostet Guthaben.",
   "provider.credits": "Restguthaben beim Anbieter",
   "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6045,6 +6045,9 @@ export const de = {
   "provider.autoEnrich": "Neue Kontakte automatisch anreichern",
   "provider.autoEnrichHint":
     "Wenn jemand einen Kontakt von Hand anlegt, dessen Daten gleich mitkaufen.",
+  "provider.autoImport": "Kontakte aus verbundenen Postfächern anreichern",
+  "provider.autoImportHint":
+    "Ein Postfachabgleich legt für jede Person an, mit der geschrieben wurde — und jede kostet ein Guthaben.",
   "provider.credits": "Restguthaben beim Anbieter",
   "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6097,9 +6097,9 @@ export const en = {
   "provider.autoEnrich": "Enrich new contacts automatically",
   "provider.autoEnrichHint":
     "When somebody adds a contact by hand, buy their details straight away.",
-  "provider.autoImport": "Enrich contacts from connected mailboxes",
+  "provider.autoImport": "Enrich contacts that arrive from a connection",
   "provider.autoImportHint":
-    "A mailbox sync adds a contact for everyone written to, and each one costs a credit.",
+    "Every mailbox, channel and other connection adds a contact for each person it sees, and buying one spends credits.",
   "provider.credits": "Credits left with the provider",
   "provider.credits.none": "The provider has not told us a balance yet.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6097,6 +6097,9 @@ export const en = {
   "provider.autoEnrich": "Enrich new contacts automatically",
   "provider.autoEnrichHint":
     "When somebody adds a contact by hand, buy their details straight away.",
+  "provider.autoImport": "Enrich contacts from connected mailboxes",
+  "provider.autoImportHint":
+    "A mailbox sync adds a contact for everyone written to, and each one costs a credit.",
   "provider.credits": "Credits left with the provider",
   "provider.credits.none": "The provider has not told us a balance yet.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5988,9 +5988,9 @@ export const vi = {
   "provider.autoEnrich": "Tự động làm giàu liên hệ mới",
   "provider.autoEnrichHint":
     "Khi ai đó thêm một liên hệ thủ công, mua luôn thông tin của họ.",
-  "provider.autoImport": "Làm giàu liên hệ từ hộp thư đã kết nối",
+  "provider.autoImport": "Làm giàu liên hệ đến từ kết nối",
   "provider.autoImportHint":
-    "Đồng bộ hộp thư sẽ thêm một liên hệ cho mỗi người từng trao đổi, và mỗi người tốn một tín dụng.",
+    "Mỗi hộp thư, kênh và kết nối khác đều thêm một liên hệ cho từng người nó thấy, và mỗi lần mua đều tốn tín dụng.",
   "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
   "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5988,6 +5988,9 @@ export const vi = {
   "provider.autoEnrich": "Tự động làm giàu liên hệ mới",
   "provider.autoEnrichHint":
     "Khi ai đó thêm một liên hệ thủ công, mua luôn thông tin của họ.",
+  "provider.autoImport": "Làm giàu liên hệ từ hộp thư đã kết nối",
+  "provider.autoImportHint":
+    "Đồng bộ hộp thư sẽ thêm một liên hệ cho mỗi người từng trao đổi, và mỗi người tốn một tín dụng.",
   "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
   "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
   "provider.credits.notConnected":

--- a/frontend/src/screens/integrations-provider.stories.tsx
+++ b/frontend/src/screens/integrations-provider.stories.tsx
@@ -141,6 +141,19 @@ export const ConnectDialog: Story = {
   },
 };
 
+// Both switches on: the state where a mailbox sync is also buying data, which
+// no other story draws. The two rows carry the same control at the same x, so
+// the only thing separating them is their labels — the picture worth having,
+// since a reader who misreads which one is on has misread the bill.
+export const OperatorEnrichingCapturedContacts: Story = {
+  render: cardStory(OPERATOR, [
+    {
+      ...connected,
+      configuration: { ...connected.configuration, automatic_import: true },
+    },
+  ]),
+};
+
 // May bind a key, may not destroy what it bought — so the overflow that holds
 // disconnect and delete-data is not offered at all.
 export const ConnectOnly: Story = {

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -159,7 +159,7 @@ describe("ProviderCard write posture", () => {
   const DISCONNECT = "Disconnect";
   const DELETE_DATA = "Delete bought data";
   const KEY_FIELD = "Replace the API key";
-  const AUTO_IMPORT = "Enrich contacts from connected mailboxes";
+  const AUTO_IMPORT = "Enrich contacts that arrive from a connection";
   // Disconnect and delete-data live behind the overflow, because neither is the
   // same weight as Connect: one is recoverable and the other irreversibly
   // destroys purchased contact data. The trigger's presence is what the grant

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -83,8 +83,16 @@ const ME_CONNECT_ONLY = meResponse("full", {
 
 function backend(principal: Me) {
   return vi.fn(async (input: RequestInfo | URL) => {
-    const path = new URL(String(input instanceof Request ? input.url : input))
-      .pathname;
+    const request = input instanceof Request ? input : undefined;
+    const path = new URL(String(request ? request.url : input)).pathname;
+    // A PATCH answers with the row it just wrote, which is what the card folds
+    // back into its cache. Routed by METHOD as well as path: the same path
+    // serves the list this card reads on the way in.
+    if (request?.method === "PATCH") {
+      return new Response(JSON.stringify(CONNECTION), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     const body = routeBody(path, principal);
     return new Response(JSON.stringify(body), {
       headers: { "Content-Type": "application/json" },
@@ -135,6 +143,11 @@ const SETTLE_MS = 10_000;
 // was slow (issue 1144).
 const RENDER_TEST_MS = SETTLE_MS + SLOWEST_MEASURED_TEST_MS;
 
+// A case that also waits on a WRITE settles twice, so it carries both waiters'
+// budgets. Derived from the same two constants rather than stated as a number,
+// so raising either moves this with it.
+const WRITE_TEST_MS = SETTLE_MS + RENDER_TEST_MS;
+
 // The card sits on the Settings → Integrations entry, whose predicate opens for
 // all five roles, and the reads behind it are granted to all five. The writes
 // are not: connecting spends money and destroying the data is irreversible, and
@@ -146,6 +159,7 @@ describe("ProviderCard write posture", () => {
   const DISCONNECT = "Disconnect";
   const DELETE_DATA = "Delete bought data";
   const KEY_FIELD = "Replace the API key";
+  const AUTO_IMPORT = "Enrich contacts from connected mailboxes";
   // Disconnect and delete-data live behind the overflow, because neither is the
   // same weight as Connect: one is recoverable and the other irreversibly
   // destroys purchased contact data. The trigger's presence is what the grant
@@ -157,7 +171,8 @@ describe("ProviderCard write posture", () => {
   }
 
   async function renderAs(principal: Me) {
-    vi.stubGlobal("fetch", backend(principal));
+    const fetch = backend(principal);
+    vi.stubGlobal("fetch", fetch);
     render(
       <Providers>
         <ProviderCard />
@@ -171,6 +186,7 @@ describe("ProviderCard write posture", () => {
       { name: CONNECTION.provider },
       { timeout: SETTLE_MS },
     );
+    return fetch;
   }
 
   it(
@@ -223,6 +239,47 @@ describe("ProviderCard write posture", () => {
       expect(screen.queryByText(READ_ONLY)).toBeNull();
     },
     RENDER_TEST_MS,
+  );
+
+  it(
+    "buys captured contacts only once the import switch is flipped",
+    async () => {
+      const user = userEvent.setup();
+      const fetch = await renderAs(ME_OPERATOR);
+
+      const importSwitch = screen.getByRole("switch", { name: AUTO_IMPORT });
+      // The fixture has it off, which is the state the server defaults to: a
+      // mailbox sync mints a person per counterparty, so nobody is billed for
+      // capture until somebody says so here.
+      expect(importSwitch.getAttribute("aria-checked")).toBe("false");
+      await user.click(importSwitch);
+
+      // Waited on rather than read straight after the click: the write leaves
+      // on a promise, so the call is recorded a tick later than the event. The
+      // client hands fetch a Request, so the method, body and headers are on
+      // that rather than on an init argument.
+      const patched = () =>
+        fetch.mock.calls
+          .map(([input]) => (input instanceof Request ? input : undefined))
+          .find((request) => request?.method === "PATCH");
+      await waitFor(() => expect(patched()).toBeTruthy(), {
+        timeout: SETTLE_MS,
+      });
+      const request = patched() as Request;
+      expect(await request.clone().json()).toEqual({
+        // Only the switch that moved. Sending the whole configuration would
+        // carry a stale copy of the OTHER switch back to the server, so one
+        // reader's flip would silently revert a colleague's.
+        configuration: { automatic_import: true },
+      });
+      // The row it overwrites is pinned, so a colleague's concurrent edit is a
+      // 409 rather than a silent loss.
+      expect(request.headers.get("If-Match")).toBe(String(CONNECTION.version));
+    },
+    // Two waiters, not one: the card has to settle before the switch exists,
+    // and the write it sends is awaited after. The ceiling covers the sum, or
+    // the second can still be inside its own budget when the test is killed.
+    WRITE_TEST_MS,
   );
 
   it(

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -39,10 +39,10 @@ import { connectionLabel, connectionTone } from "./provider-status";
 // decide whether new contacts are enriched automatically, and read what the
 // provider says is left against what this installation has spent.
 //
-// Four settings ROWS, in the order a reader needs them: the key that makes any
-// of this possible, the one judgement that spends it, then the two readings
-// those two produce. The readings take the full width because a table IS the
-// subject rather than an answer to a question; the key and the switch are
+// Five settings ROWS, in the order a reader needs them: the key that makes any
+// of this possible, the two judgements that spend it, then the two readings
+// those produce. The readings take the full width because a table IS the
+// subject rather than an answer to a question; the key and the switches are
 // answers, so they sit in the right column at the same x as every other card on
 // the page.
 //
@@ -317,13 +317,21 @@ function CreditsReading({
   );
 }
 
+// The half of the saved policy this card decides. A patch carries only the
+// switch that moved, so the two toggles never overwrite each other's value on
+// the way past — the server merges the rest of the policy itself.
+type PolicyPatch = Pick<
+  components["schemas"]["ProviderConfigurationPatch"],
+  "automatic_individual_create" | "automatic_import"
+>;
+
 function usePatchConfiguration(
   provider: ProviderConnection["provider"],
   version: number,
 ) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (automaticIndividualCreate: boolean) => {
+    mutationFn: async (configuration: PolicyPatch) => {
       const { data, error } = await api.PATCH(
         "/provider-connections/{provider}",
         {
@@ -335,11 +343,7 @@ function usePatchConfiguration(
             // stored.
             header: { "If-Match": String(version) },
           },
-          body: {
-            configuration: {
-              automatic_individual_create: automaticIndividualCreate,
-            },
-          },
+          body: { configuration },
         },
       );
       if (error) {
@@ -369,13 +373,14 @@ function usePatchConfiguration(
   });
 }
 
-// Auto-enrich is the one control here that a reader who may not change it still
-// needs to READ: it is the only place the installation says whether new contacts
-// are being enriched at somebody's expense. So it is neither absent (that would
-// hide a granted read) nor withheld (there is a fact to show) — it is the shape
-// the design system keeps for exactly this: a Switch, because flipping it
-// writes, with `reason` carrying the denial to a screen reader through
-// aria-describedby rather than leaving it beside the control as decoration.
+// The two auto-enrich switches are the controls here that a reader who may not
+// change them still needs to READ: this is the only place the installation says
+// whether new contacts are being enriched at somebody's expense. So neither is
+// absent (that would hide a granted read) nor withheld (there is a fact to
+// show) — each is the shape the design system keeps for exactly this: a Switch,
+// because flipping it writes, with `reason` carrying the denial to a screen
+// reader through aria-describedby rather than leaving it beside the control as
+// decoration.
 function PolicyRow({
   connection,
   canEdit,
@@ -396,6 +401,9 @@ function PolicyRow({
             // the id the row minted for it.
             describedBy={control["aria-describedby"]}
             checked={configuration.automatic_individual_create ?? false}
+            onChange={(next) =>
+              patch.mutate({ automatic_individual_create: next })
+            }
             // Three causes, and only one of them is worth words. A permission
             // is permanent and has to be explained; a write in flight explains
             // itself by finishing, and a disconnected provider is already
@@ -408,12 +416,32 @@ function PolicyRow({
             reason={canEdit ? undefined : t("captureSettings.adminOnly")}
             disabled={!canEdit || disconnected}
             pending={patch.isPending}
-            onChange={(next) => patch.mutate(next)}
             // The row already draws this name on the left, so the switch keeps
             // its own copy hidden: it owns its accessible name by design (see
             // switch.tsx) and pointing it at the row's span as well would name
             // it twice.
             label={t("provider.autoEnrich")}
+            labelHidden
+          />
+        )}
+      />
+      {/* Capture's arrivals, decided separately from the ones a colleague
+          types. One mailbox sync mints a person per external counterparty, so
+          this switch spends a credit per sender where the one above spends one
+          per deliberate act — which is why the customer gets to answer them
+          apart, and why this one starts off. */}
+      <SettingRow
+        label={t("provider.autoImport")}
+        description={t("provider.autoImportHint")}
+        control={(control) => (
+          <Switch
+            describedBy={control["aria-describedby"]}
+            checked={configuration.automatic_import ?? false}
+            reason={canEdit ? undefined : t("captureSettings.adminOnly")}
+            disabled={!canEdit || disconnected}
+            pending={patch.isPending}
+            onChange={(next) => patch.mutate({ automatic_import: next })}
+            label={t("provider.autoImport")}
             labelHidden
           />
         )}

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -425,11 +425,11 @@ function PolicyRow({
           />
         )}
       />
-      {/* Capture's arrivals, decided separately from the ones a colleague
-          types. One mailbox sync mints a person per external counterparty, so
-          this switch spends a credit per sender where the one above spends one
-          per deliberate act — which is why the customer gets to answer them
-          apart, and why this one starts off. */}
+      {/* Arrivals from a connection, decided separately from the ones a
+          colleague types. Every connector — a mailbox, a channel, an extension
+          — mints a person per counterparty it sees, so this switch spends per
+          arrival where the one above spends per deliberate act. That is why
+          the customer answers them apart, and why this one starts off. */}
       <SettingRow
         label={t("provider.autoImport")}
         description={t("provider.autoImportHint")}


### PR DESCRIPTION
## What this changes

A person created by a connector (a mailbox sync) is governed by
`automatic_import` on the provider connection. The server has always read that
flag at queue time; no screen could set it. A customer who connected a mailbox
therefore got no enrichment from it and no way to ask for one.

The contact-data provider card now carries a second switch beside the one that
governs a contact somebody typed. They are answered apart because they spend
differently: one credit per deliberate act, against one per counterparty a
mailbox sync finds. The new switch starts off, which is the server's default.

## The contract said something that was not true

`ProviderConfiguration.automatic_import` was described as *"Still requires
import preview, maximum-credit estimate and explicit confirmation."* None of
those is built, and the switch ships without them. The description now states
what the field does — enrich every person a connector creates, one credit each
— rather than promising a flow that does not exist. Type, default and
required-ness are unchanged, so this is description-only.

## Tests

- `TestACapturedContactIsBoughtOnceTheImportToggleIsOn` — the admit case the
  refusal test never had. Without it the queue-time gate could have refused
  everyone and stayed green. Mutation-checked: flipping the fixture back to
  `false` fails it.
- `buys captured contacts only once the import switch is flipped` — the flip
  sends `{configuration: {automatic_import: true}}` and nothing else, pinned
  with `If-Match`. Sending the whole configuration would carry a stale copy of
  the other switch and silently revert a colleague's edit. Mutation-checked
  against the wrong field.
- One story for the both-switches-on state.

## Verified

`make check-backend`, `make check-fe`, `make fe-uat` (44 stories), `make
craft-static`, and the `compose/integration` lane under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a second switch on the provider card to control enrichment of contacts captured by any connection. Previously captured contacts were never enriched because `automatic_import` was off and had no UI; turning it on now enriches each captured contact and spends credits, default stays off.

- New Features
  - Sends a minimal PATCH containing only the changed field and pins with `If-Match` to avoid overwriting the other switch.
  - Updates the API schema and generated TS types to reflect the real `automatic_import` behavior.
  - Adds an admit integration test, frontend tests for PATCH shape/ETag, and a story showing both switches on.
  - Adds i18n strings and hints in `en`, `de`, and `vi`.

- Bug Fixes
  - Broadens copy to “connection” (not only mailboxes) and removes the single-credit promise to match provider billing.
  - Writes both `automatic_individual_create` and `automatic_import` into audit images so flips are traceable.

<sup>Written for commit 6f57cbbc4e892bbc0f4d042a97a3554135e8fc5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Automatically import contacts” setting for connected integrations, including mailboxes, channels, and other sources.
  * Automatic import enriches each recognized contact individually and uses one credit per contact.
  * Automatic contact import and automatic individual creation can now be configured independently.
  * Added localized labels and guidance in English, German, and Vietnamese.
* **Documentation**
  * Clarified that automatic import is disabled by default and operates separately from individual creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->