### PR TITLE
fix(today): the day's figures are written in the reader's own notation

### DIFF
--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
+import { type Locale, LocaleProvider } from "../i18n";
 import { TodayScreen } from "./today";
 
 // The day's surface, and the ways it can mislead the person reading it.
@@ -29,13 +30,15 @@ function stub(day: Attention) {
   );
 }
 
-function renderToday() {
+function renderToday(locale: Locale = "en") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <TodayScreen />
+      <LocaleProvider initial={locale}>
+        <TodayScreen />
+      </LocaleProvider>
     </QueryClientProvider>,
   );
 }
@@ -158,6 +161,50 @@ describe("what the day's surface offers", () => {
     // is empty instead of asserting that it is.
     expect(screen.queryByText("Your day is clear.")).toBeNull();
     expect(screen.getByText("Hidden from your account.")).toBeTruthy();
+  });
+
+  // Every figure on this page is a MAGNITUDE — a count of decisions, a count
+  // of duplicate pairs, a match percentage — so each one is written in the
+  // reader's own notation rather than coerced. A German reader reads "1.234";
+  // the coerced form says "1234", which they read as a different number.
+  //
+  // The compiler holds that these are strings. It cannot hold that they are
+  // FORMATTED ones: `String(n)` typechecks and is the right answer for a
+  // position — a page ordinal, a step, a version. It is the wrong answer here,
+  // and en-GB renders both spellings identically, so only a reader whose
+  // notation differs can tell the two apart. Hence German.
+  it("writes the day's figures in the reader's own notation", async () => {
+    stub({
+      ...emptyDay,
+      counts: { needs_you: 1234, planned: 0, duplicates_open: 5678 },
+      needs_you: [
+        {
+          id: "dc-1",
+          source: "dedupe_candidate",
+          kind: "organization",
+          confidence: 0.92,
+          actions: ["merge"],
+        },
+      ],
+    });
+    renderToday("de");
+    await screen.findByText("1.234 Entscheidungen warten auf dich.");
+    expect(
+      screen.getByText("5.678 Dubletten-Paare insgesamt offen"),
+    ).toBeTruthy();
+    // A percentage is a magnitude too, and below the grouping threshold it
+    // reads the same in both notations — asserted so the site is covered by
+    // name rather than by being too small to disagree.
+    expect(screen.getByText("92% Übereinstimmung")).toBeTruthy();
+  });
+
+  // The planned lead is a separate arm of the same function, reachable only
+  // when nothing needs deciding — so the test above cannot enter it, and a
+  // fourth site would otherwise be ruled by the compiler and by nobody else.
+  it("writes the planned figure in the reader's notation too", async () => {
+    stub({ ...emptyDay, counts: { needs_you: 0, planned: 4321 } });
+    renderToday("de");
+    await screen.findByText("Nichts zu entscheiden — 4.321 für heute geplant.");
   });
 
   it("leads with the count of what actually needs deciding", async () => {

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -3,7 +3,7 @@ import { navigate } from "../app/router";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -42,7 +42,11 @@ type LaneShape = Readonly<{
 // The lead line: the largest true thing about the day, written here rather than
 // on the server because the server has no language. A reader who reads only
 // this line should still know whether to worry.
-function leadLine(day: Attention, t: ReturnType<typeof useT>): string {
+function leadLine(
+  day: Attention,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
   // A day with a lane missing from it is not a day this line may summarise:
   // "your day is clear" and "part of it is hidden from you" cannot both be on
   // one page, and the reader would believe the reassuring one.
@@ -54,10 +58,12 @@ function leadLine(day: Attention, t: ReturnType<typeof useT>): string {
     return t("day.lead.oneDecision");
   }
   if (decisions > 1) {
-    return t("day.lead.decisions", { count: decisions });
+    return t("day.lead.decisions", { count: formatNumber(decisions, locale) });
   }
   if (day.counts.planned > 0) {
-    return t("day.lead.plannedOnly", { count: day.counts.planned });
+    return t("day.lead.plannedOnly", {
+      count: formatNumber(day.counts.planned, locale),
+    });
   }
   if (day.done_for_you && day.done_for_you.length > 0) {
     return t("day.lead.ranOvernight");
@@ -107,7 +113,9 @@ function itemDetail(
     return item.detail;
   }
   if (item.confidence != null) {
-    return t("day.match", { percent: Math.round(item.confidence * 100) });
+    return t("day.match", {
+      percent: formatNumber(Math.round(item.confidence * 100), locale),
+    });
   }
   if (item.occurred_at) {
     return formatDateTime(item.occurred_at, locale, zone);
@@ -330,6 +338,7 @@ function TodayLanes({
   complete: ReturnType<typeof useTaskUpdate>;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const needsYou = day.needs_you ?? [];
   const planned = day.planned ?? [];
   const done = day.done_for_you ?? [];
@@ -346,7 +355,7 @@ function TodayLanes({
   };
   return (
     <>
-      <p className="t-h2 today-lead">{leadLine(day, t)}</p>
+      <p className="t-h2 today-lead">{leadLine(day, t, locale)}</p>
       <Lane
         shape={{
           title: t("day.needsYou"),
@@ -393,7 +402,9 @@ function TodayLanes({
       {day.counts.duplicates_open != null && day.counts.duplicates_open > 0 && (
         <p className="t-caption today-foot">
           <GitMerge size={14} aria-hidden />
-          {t("day.duplicatesOpen", { count: day.counts.duplicates_open })}
+          {t("day.duplicatesOpen", {
+            count: formatNumber(day.counts.duplicates_open, locale),
+          })}
         </p>
       )}
     </>


### PR DESCRIPTION
## main does not compile

`frontend/src/screens/today.tsx` calls `t()` with a raw number at four sites, and `translate`/`useT` take `Record<string, string>`:

```
src/screens/today.tsx(57,38):  error TS2322: Type 'number' is not assignable to type 'string'.
src/screens/today.tsx(60,40):  error TS2322: ...
src/screens/today.tsx(110,29): error TS2322: ...
src/screens/today.tsx(396,38): error TS2322: ...
```

`make fe-typecheck-composed` exits 2, which fails **fe-quality, fe-bundle, the frontend aggregate and live-boot** on every pull request carrying a frontend diff.

## Why two green runs produced a red tree

Neither change was wrong and neither lane could have caught it.

The narrowing of `translate`/`useT` landed first, on the deliberate ruling that a site which skipped the locale decision must fail to compile rather than coerce. The Today screen was branched and gated **before** it, so its own lane type-checked against the previous signature. Both merged green. Nothing ever compiled the pair.

That is the complementary-skip shape: the hole is made entirely of green.

## The fix

All four figures are magnitudes a reader reads as quantities — decisions waiting, items planned, open duplicate pairs, a match percentage — so each goes through `formatNumber` with the reader's locale, matching the house form at the other call sites.

`String(n)` also compiles, and is the correct answer for a **position** (a page ordinal, a step, a version). None of these is a position. Choosing it here would print `1234` in a German sentence whose every other figure reads `1.234` — the precise defect the narrowing exists to stop.

`leadLine` takes the locale it now needs; `TodayLanes` reads it beside the translator it already holds.

## Holding the ruling

The compiler cannot tell a formatted string from a coerced one. A test does instead: a German reader is shown the grouped form at each site. en-GB renders both spellings identically, which is why the test picks a notation that can disagree.

Mutation-verified — reverting each site to `String(n)` was confirmed applied by grep, then observed to turn the test red:

| Site | Reverted to `String(n)` | Test |
|---|---|---|
| `day.lead.decisions` | `count: String(decisions)` | ❌ red |
| `day.lead.plannedOnly` | `count: String(day.counts.planned)` | ❌ red |
| `day.duplicatesOpen` | `count: String(day.counts.duplicates_open)` | ❌ red |
| `day.match` | — | asserted by name only |

The percentage is asserted but sits below the grouping threshold, where both spellings agree — stated in the test rather than left to look covered.

## Census

The composed typecheck **is** the census for this defect class, and it is better than a grep: it covers every call site of the narrowed signature across the tree, not the ones a pattern happens to match. It now reports zero.

## Verification

- `make fe-typecheck-composed` — clean
- `make check-fe` — **exit 0**, 378 test files / 4772 tests passed, plus 2 files / 36 tests on the extension surface

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes all figures on the Today screen and restores a green build. Previously we passed raw numbers to `t()`, which both broke typechecking and showed unformatted numbers; now magnitudes are formatted with the reader’s locale and passed as strings.

**Bug Fixes**
- Pass `locale` to `leadLine`; `TodayLanes` reads it via `useLocale`.
- Localize the decisions lead, planned-only lead, duplicates-open footnote, and match percentage using `formatNumber`.
- Add tests that assert German grouping to catch `String(n)` regressions.
- `make fe-typecheck-composed` and frontend jobs are green again; no migration required.

<sup>Written for commit 0675c8354155b8a9aa65a7116563ea00b98ee0d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Today screen counts and confidence percentages now use locale-aware number formatting.
  * German locale displays localized formatting for decisions, duplicates, match percentages, and planned items.
* **Tests**
  * Added coverage to verify localized Today screen number formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->