### PR TITLE
fix(frontend): a magnitude is drawn in the reader's own notation, and a gate can see when it is not

### DIFF
--- a/frontend/src/app/agentrail.stories.tsx
+++ b/frontend/src/app/agentrail.stories.tsx
@@ -8,9 +8,11 @@ import { userEvent, within } from "storybook/test";
 import {
   installFetchStub,
   jsonResponse,
+  meRoute,
   StoryProviders,
 } from "../screens/story-utils";
 import { AgentRail } from "./agentrail";
+import type { GrantSpec } from "./mefixture";
 
 // The section's states come from what the installation ANSWERS, so a story is
 // a set of answers rather than a set of props. Each one below is a posture an
@@ -31,6 +33,17 @@ type Answers = Readonly<{
   duplicates: number;
   calls: readonly Readonly<{ task: string; minutesAgo: number }>[];
 }>;
+
+// The two objects the section actually asks about: `license` gates the posture
+// the orb reads (`useLicensePosture`) and `automation:update` gates the runtime
+// row's `/ai/calls`. Granting exactly these rather than a blanket allow is what
+// keeps a story named for an INSTALLATION posture from also quietly documenting
+// an authority one — every story below is about what the installation answers,
+// and `LicenceWithheld` is the one that is about the seat instead.
+const OPERATOR: GrantSpec = {
+  license: ["read"],
+  automation: ["update"],
+};
 
 const NOW = Date.parse("2026-08-19T10:00:00Z");
 
@@ -78,9 +91,10 @@ function Rail({
   );
 }
 
-function story(answers: Answers, collapsed = false) {
+function story(answers: Answers, collapsed = false, grants = OPERATOR) {
   return () => {
     installFetchStub({
+      "GET /me": meRoute(grants),
       "GET /assistant/profile": () =>
         jsonResponse({
           name: "Margince",
@@ -173,6 +187,7 @@ export const Idle: Story = { render: story(HEALTHY) };
 export const Ingest: Story = {
   render: () => {
     installFetchStub({
+      "GET /me": meRoute(OPERATOR),
       "GET /assistant/profile": () =>
         jsonResponse({
           name: "Margince",
@@ -211,6 +226,7 @@ export const Ingest: Story = {
 export const Working: Story = {
   render: () => {
     installFetchStub({
+      "GET /me": meRoute(OPERATOR),
       "GET /assistant/profile": () =>
         jsonResponse({
           name: "Margince",
@@ -287,4 +303,21 @@ export const PanelOpen: Story = {
       await canvas.findByRole("button", { name: /expand/i }),
     );
   },
+};
+
+/**
+ * A seat the licence is none of: the orb reports the installation's HEALTH and
+ * stays neutral about its commercial standing.
+ *
+ * The distinction this story exists for is that a withheld licence must not
+ * read as a fault. A rep's seat cannot see the entitlement, and an orb that
+ * went amber about it on every screen they opened would be a permission
+ * boundary drawn as a broken installation — so `useLicensePosture` answers
+ * "nothing to report" rather than "something is wrong", and this is the story
+ * that would fail if that ever changed.
+ */
+export const LicenceWithheld: Story = {
+  render: story({ ...HEALTHY, licenseState: "absent" }, false, {
+    automation: ["update"],
+  }),
 };

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -18,7 +18,7 @@ import {
   MarginceCoreScene,
   type MarginceCoreState,
 } from "../design-system/margince-core";
-import { formatMoney, INTL_LOCALE } from "../format/format";
+import { formatMoney, formatNumber, INTL_LOCALE } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { useOrganization360 } from "../screens/company360";
@@ -515,7 +515,7 @@ function RuntimeRows({
       )}
       {tools > 0 && (
         <span>
-          {LABELS.tools} <b>{tools}</b>
+          {LABELS.tools} <b>{formatNumber(tools, locale)}</b>
         </span>
       )}
       {(license === "none" || license === "refused") && (
@@ -682,9 +682,9 @@ function AgentPanel({
               <a
                 className="arbox artile"
                 href="#/today"
-                aria-label={`${LABELS.approvals} ${signals.waiting}`}
+                aria-label={`${LABELS.approvals} ${formatNumber(signals.waiting, locale)}`}
               >
-                <b>{signals.waiting}</b>
+                <b>{formatNumber(signals.waiting, locale)}</b>
                 <span>{LABELS.approvals}</span>
               </a>
             )}

--- a/frontend/src/app/attention.stories.tsx
+++ b/frontend/src/app/attention.stories.tsx
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { userEvent, within } from "storybook/test";
+import { Badge, Button } from "../design-system/atoms";
+import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { StoryProviders } from "../screens/story-utils";
+import {
+  AttentionProvider,
+  useAttention,
+  usePublishScope,
+  usePublishSelection,
+} from "./attention";
+
+// The channel a screen states its own scope on: what it is about beyond its
+// route, so the chrome can report it without reaching into the screen to guess.
+//
+// Nothing here draws anything, which is exactly why it needs a story: the only
+// way to look at a channel is to put a publisher and a reader on either end of
+// it and show what arrives. The harnesses below stand in for a list screen and
+// for the agent bar — the two real ends — and what they render is the SCOPE,
+// which is the thing under review.
+//
+// Two properties are worth seeing rather than reading about. The direction:
+// screens publish, chrome reads, and no arrow points the other way. And the
+// wording: `usePublishSelection` owns the sentence, so two lists cannot word
+// one fact differently — which is also why the count is formatted, and why a
+// four-digit selection is one of the stories.
+
+/** Stands in for the agent bar: the one thing that READS the channel. */
+function Chrome() {
+  const scope = useAttention();
+  return (
+    <PanelRow>
+      <span className="t-caption">chrome reads</span>{" "}
+      {scope ? <Badge tone="accent">{scope.label}</Badge> : <span>—</span>}
+    </PanelRow>
+  );
+}
+
+/** Stands in for a list screen: it selects rows and says so, nothing more. */
+function SelectingList({ rows }: Readonly<{ rows: number }>) {
+  const [selected, setSelected] = useState(0);
+  usePublishSelection(selected);
+  return (
+    <PanelBody>
+      <p className="t-caption">
+        A list of {rows} rows. It publishes its selection and reads nothing.
+      </p>
+      <div className="card-actions">
+        <Button variant="primary" small onClick={() => setSelected(rows)}>
+          Select all
+        </Button>
+        <Button small onClick={() => setSelected(0)}>
+          Clear
+        </Button>
+      </div>
+    </PanelBody>
+  );
+}
+
+/** A screen whose scope is not a selection at all. */
+function FilteredList({ label }: Readonly<{ label: string | null }>) {
+  usePublishScope(label);
+  return (
+    <PanelBody>
+      <p className="t-caption">
+        A screen stating a scope that is not a count: {label ?? "nothing"}.
+      </p>
+    </PanelBody>
+  );
+}
+
+function wired(children: ReactNode) {
+  return () => (
+    <StoryProviders>
+      <AttentionProvider>
+        <Panel title="One screen, one chrome, one channel">
+          {children}
+          <Chrome />
+        </Panel>
+      </AttentionProvider>
+    </StoryProviders>
+  );
+}
+
+// Pressing the list's own verb, so the published sentence is one the list
+// really sent rather than one the story wrote.
+const selectAll: NonNullable<Story["play"]> = async ({ canvasElement }) => {
+  const verb = await within(canvasElement).findByRole("button", {
+    name: "Select all",
+  });
+  await userEvent.setup().click(verb);
+};
+
+const meta: Meta<typeof AttentionProvider> = {
+  title: "Shell/Attention channel",
+  component: AttentionProvider,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof AttentionProvider>;
+
+/**
+ * Nothing selected. The channel carries null rather than "0 selected": a scope
+ * is what is TRUE about the screen, and "none of them" is not something the bar
+ * has anything to say about.
+ */
+export const NothingPublished: Story = {
+  render: wired(<SelectingList rows={8} />),
+};
+
+/** Rows selected, and the sentence arrived. The `play` presses the list's own
+ *  verb rather than the story seeding a count, so what is on screen is what the
+ *  channel actually carried. */
+export const SelectionPublished: Story = {
+  render: wired(<SelectingList rows={8} />),
+  play: selectAll,
+};
+
+/**
+ * A selection wide enough to be written in a notation. Four digits is where
+ * de-DE first groups, so it is the only width at which the sentence proves
+ * whose notation drew it — below it the figure reads the same everywhere and
+ * the formatting is untestable by eye.
+ */
+export const LargeSelection: Story = {
+  render: wired(<SelectingList rows={1204} />),
+  play: selectAll,
+};
+
+/** The same channel in German. The count and the sentence around it come from
+ *  one place, so they cannot disagree about which language they are in. */
+export const LargeSelectionGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <AttentionProvider>
+        <Panel title="Ein Bildschirm, eine Leiste, ein Kanal">
+          <SelectingList rows={1204} />
+          <Chrome />
+        </Panel>
+      </AttentionProvider>
+    </StoryProviders>
+  ),
+};
+
+/** A scope that is not a count. `usePublishScope` is the general case, and a
+ *  screen with nothing countable still has something to say. */
+export const NonCountScope: Story = {
+  render: wired(<FilteredList label="Owned by me · this quarter" />),
+};
+
+/**
+ * No provider above the publisher at all — a screen rendered on its own, in a
+ * story or before the shell mounts. Publishing into nothing is correct here
+ * rather than a fault, so the list draws and the channel simply has no reader.
+ */
+export const NoChromeListening: Story = {
+  render: () => (
+    <StoryProviders>
+      <Panel title="A screen with no chrome above it">
+        <SelectingList rows={8} />
+      </Panel>
+    </StoryProviders>
+  ),
+};

--- a/frontend/src/app/attention.stories.tsx
+++ b/frontend/src/app/attention.stories.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import { userEvent, within } from "storybook/test";
 import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 import { StoryProviders } from "../screens/story-utils";
 import {
   AttentionProvider,
@@ -44,11 +46,13 @@ function Chrome() {
 /** Stands in for a list screen: it selects rows and says so, nothing more. */
 function SelectingList({ rows }: Readonly<{ rows: number }>) {
   const [selected, setSelected] = useState(0);
+  const { locale } = useLocale();
   usePublishSelection(selected);
   return (
     <PanelBody>
       <p className="t-caption">
-        A list of {rows} rows. It publishes its selection and reads nothing.
+        A list of {formatNumber(rows, locale)} rows. It publishes its selection
+        and reads nothing.
       </p>
       <div className="card-actions">
         <Button variant="primary" small onClick={() => setSelected(rows)}>

--- a/frontend/src/app/attention.tsx
+++ b/frontend/src/app/attention.tsx
@@ -9,7 +9,8 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 
 /**
  * What the agent surface knows about the person using the app, as opposed to
@@ -80,8 +81,11 @@ export function useAttention(): AttentionScope | null {
  */
 export function usePublishSelection(count: number): void {
   const t = useT();
+  const { locale } = useLocale();
   usePublishScope(
-    count > 0 ? t("attention.selected", { n: String(count) }) : null,
+    count > 0
+      ? t("attention.selected", { n: formatNumber(count, locale) })
+      : null,
   );
 }
 

--- a/frontend/src/app/navlevel.stories.tsx
+++ b/frontend/src/app/navlevel.stories.tsx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryProviders } from "../screens/story-utils";
+import { railTrail } from "./nav";
+import { NavLevelView } from "./navlevel";
+
+// One level of the sidebar as the rail draws it: the rows, their groups, the
+// badge a row carries, and the way back up when the reader has drilled.
+//
+// The levels come from `railTrail` rather than from a hand-built fixture. A
+// story that invented its own rows would be reviewing a rail nobody ships —
+// and the interesting property of this component is that it does NOT know its
+// own depth, which only holds if the level it is handed is a real one.
+//
+// A row's badge is an attention count, and it rides the LEVEL rather than
+// being read from module scope inside a row, so the counts below are handed in
+// the way the shell hands them.
+
+const RESTING = { collapsed: false, tip: null, onTip: () => {} };
+const COLLAPSED = { collapsed: true, tip: null, onTip: () => {} };
+
+const primary = railTrail({ screen: "home" })[0];
+const settings = railTrail({ screen: "settings" });
+
+function level(
+  which: (typeof settings)[number],
+  state: typeof RESTING,
+  counts?: Record<string, number>,
+  parent?: (typeof settings)[number],
+) {
+  return () => (
+    <StoryProviders>
+      <nav className={state.collapsed ? "rail collapsed" : "rail expanded"}>
+        <NavLevelView
+          level={which}
+          parent={parent}
+          counts={counts}
+          state={state}
+          onSelect={() => {}}
+          onWalkUp={() => {}}
+        />
+      </nav>
+    </StoryProviders>
+  );
+}
+
+const meta: Meta<typeof NavLevelView> = {
+  title: "Shell/Nav level",
+  component: NavLevelView,
+};
+export default meta;
+type Story = StoryObj<typeof NavLevelView>;
+
+/** The primary level: every destination, grouped, with nothing waiting. */
+export const Primary: Story = { render: level(primary, RESTING) };
+
+/**
+ * Rows carrying counts. The badge is what a reader scans for, so the figure is
+ * written in their own notation — at four digits that is the only thing telling
+ * a German rail from an English one, and a rail is exactly where a bare `1204`
+ * would sit beside a formatted figure elsewhere on the page.
+ */
+export const WithCounts: Story = {
+  render: level(primary, RESTING, { tasks: 1204, inbox: 12 }),
+};
+
+/** The same counts in German. */
+export const WithCountsGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <nav className="rail expanded">
+        <NavLevelView
+          level={primary}
+          counts={{ tasks: 1204, inbox: 12 }}
+          state={RESTING}
+          onSelect={() => {}}
+          onWalkUp={() => {}}
+        />
+      </nav>
+    </StoryProviders>
+  ),
+};
+
+/**
+ * The collapsed rail: the labels go and the rows keep their targets, so the
+ * badge has to survive without the word it was counting. The accessible name
+ * carries what the label no longer shows.
+ */
+export const Collapsed: Story = {
+  render: level(primary, COLLAPSED, { tasks: 1204, inbox: 12 }),
+};
+
+/**
+ * A drilled level, which is the case the component exists for: it prints its
+ * own heading, pushes the group labels a heading level down, and offers the way
+ * back to the level above.
+ */
+export const Drilled: Story = {
+  render: () =>
+    settings.length > 1
+      ? level(settings[1], RESTING, undefined, settings[0])()
+      : level(primary, RESTING)(),
+};
+
+/** At 390px the rail is the phone's own bar rather than a column, so the rows
+ *  are judged at the width they are actually pressed at. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: level(primary, RESTING, { tasks: 1204 }),
+};

--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -10,7 +10,8 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   type NavCounts,
@@ -200,6 +201,7 @@ function NavLevelRow({
   onSelect: (entry: NavLevelEntry) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   // One label, feeding the row text, the aria-label and the collapsed-rail
   // tooltip below — the three read the same string, so a row can never
   // announce one name and show another.
@@ -224,7 +226,7 @@ function NavLevelRow({
           either way. */}
       <span className="navlabel">{label}</span>
       {count !== undefined && count > 0 && (
-        <span className="count">{count}</span>
+        <span className="count">{formatNumber(count, locale)}</span>
       )}
       {/* Inside the row, not beside it: the tooltip sits outside the row's box
           but within its subtree, so moving the pointer onto it never leaves the

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -20,6 +20,8 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 import "./atoms.css";
 
 // The Margince atom library (B-EP09.2, re-scoped to our own
@@ -1322,6 +1324,7 @@ export function AttainmentRing({
   band: AttainmentBand;
   caption: string;
 }>) {
+  const { locale } = useLocale();
   const radius = 68;
   const circumference = 2 * Math.PI * radius;
   const fraction = Math.min(pct / 100, 1);
@@ -1350,7 +1353,9 @@ export function AttainmentRing({
         />
       </svg>
       <div className="attain-ring-center">
-        <span className="attain-ring-pct t-mono">{Math.round(pct)}%</span>
+        <span className="attain-ring-pct t-mono">
+          {formatNumber(Math.round(pct), locale)}%
+        </span>
         <span className="attain-ring-lbl">{caption}</span>
       </div>
     </div>

--- a/frontend/src/design-system/avatarstack.tsx
+++ b/frontend/src/design-system/avatarstack.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 import { Avatar } from "./atoms";
 import "./avatarstack.css";
 
@@ -17,6 +19,7 @@ export function AvatarStack({
   people: readonly { name: string }[];
   max?: number;
 }>) {
+  const { locale } = useLocale();
   const shown = people.slice(0, max);
   const rest = people.length - shown.length;
   return (
@@ -26,7 +29,9 @@ export function AvatarStack({
           <Avatar name={person.name} />
         </span>
       ))}
-      {rest > 0 && <span className="avatar-stack-more">+{rest}</span>}
+      {rest > 0 && (
+        <span className="avatar-stack-more">+{formatNumber(rest, locale)}</span>
+      )}
     </span>
   );
 }

--- a/frontend/src/design-system/briefitem.tsx
+++ b/frontend/src/design-system/briefitem.tsx
@@ -4,6 +4,7 @@
 import { AlarmClock, ArrowRight, Check, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import type { components } from "../api/schema";
+import { ordinalNumber } from "../format/format";
 import { Badge, Button, Card, PendingBody } from "./atoms";
 import { Meter } from "./readings";
 import "./briefitem.css";
@@ -171,7 +172,8 @@ export function BriefItemCard({
     >
       <div className="brief-item-head">
         <span className="brief-item-rank t-mono">
-          <span className="sr-only">{labels.rank}</span>#{item.rank}
+          <span className="sr-only">{labels.rank}</span>#
+          {ordinalNumber(item.rank)}
         </span>
         {/* Not a `Button`: this is the card's TITLE. Button owns control
             geometry — a shared 40px height, a width floor, its own icon sizing

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -280,7 +280,11 @@ function BoardLayout<Record extends BoardRecord>({
           >
             <div className="board-col-head">
               <span className="stage">{column.label}</span>
-              {money && <span className="prob">{money.probabilityPct}%</span>}
+              {money && (
+                <span className="prob">
+                  {formatNumber(money.probabilityPct, locale)}%
+                </span>
+              )}
             </div>
             {/* The stage's total is the figure being scanned down the board, so it
               leads with the deal count beside it; the weighted figure is its own

--- a/frontend/src/design-system/decisiondeck.stories.tsx
+++ b/frontend/src/design-system/decisiondeck.stories.tsx
@@ -4,7 +4,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { userEvent, within } from "storybook/test";
-import { LocaleProvider } from "../i18n";
+import { formatNumber } from "../format/format";
+import { LocaleProvider, useLocale } from "../i18n";
 import { Badge } from "./atoms";
 import { Callout } from "./callout";
 import type { DecisionApproval, DecisionCardLabels } from "./decisioncard";
@@ -291,6 +292,7 @@ export const ListView: Story = {
 function LiveQueue({
   start,
 }: Readonly<{ start: readonly DecisionDeckItem[] }>) {
+  const { locale } = useLocale();
   const [items, setItems] = useState(start);
   const send = (staged: readonly StagedDecision[]) => {
     const decided = new Set(staged.map((entry) => entry.id));
@@ -298,7 +300,9 @@ function LiveQueue({
   };
   return (
     <>
-      <Badge tone="accent">{items.length} left in the parent's list</Badge>
+      <Badge tone="accent">
+        {formatNumber(items.length, locale)} left in the parent's list
+      </Badge>
       <DecisionDeck {...BASE} items={items} onCommit={send} />
     </>
   );

--- a/frontend/src/design-system/listtable.stories.tsx
+++ b/frontend/src/design-system/listtable.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ReactNode, useState } from "react";
-import { formatMoney } from "../format/format";
+import { formatMoney, formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 import { Button } from "./atoms";
 import type { ListChip } from "./listsurface";
 import { type ListColumn, ListTable } from "./listtable";
@@ -266,6 +267,7 @@ export const PinnedWhileScrolling: Story = {
 // carries the count and the verbs. Two rows come pre-selected so the bar is
 // on screen; the screen owns what the verbs do.
 function SelectableSurface() {
+  const { locale } = useLocale();
   const rows = companies(8);
   const [selected, setSelected] = useState<ReadonlySet<string>>(
     new Set(["c2", "c5"]),
@@ -292,7 +294,9 @@ function SelectableSurface() {
         label: (row) => `Select ${row.name}`,
         bar: (
           <>
-            <span className="t-caption">{selected.size} selected</span>
+            <span className="t-caption">
+              {formatNumber(selected.size, locale)} selected
+            </span>
             <Button small>Assign owner</Button>
             <Button small onClick={() => setSelected(new Set())}>
               Clear

--- a/frontend/src/design-system/listtable.stories.tsx
+++ b/frontend/src/design-system/listtable.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ReactNode, useState } from "react";
-import { formatMoney, formatNumber } from "../format/format";
+import { formatMoney, formatNumber, ordinalNumber } from "../format/format";
 import { useLocale } from "../i18n";
 import { Button } from "./atoms";
 import type { ListChip } from "./listsurface";
@@ -188,7 +188,10 @@ export const PagedByTheCaller: Story = {
             rows={companies(60)}
             page={page}
             onPage={setPage}
-            caption={`The caller is holding page ${page}`}
+            // A page number is a POSITION, so it stays bare in every locale:
+            // grouped, page 1204 reads "1.204" and stops matching the page a
+            // reader types into the box beside it.
+            caption={`The caller is holding page ${ordinalNumber(page)}`}
           />
         </div>
       );

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -15,7 +15,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { formatNumber } from "../format/format";
+import {
+  formatNumber,
+  identifierNumber,
+  ordinalNumber,
+} from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { Checkbox, useScrollRegion } from "./atoms";
 import {
@@ -1418,12 +1422,12 @@ function Pager({
               key={slot}
               className={slot === current ? "on" : undefined}
               aria-current={slot === current ? "page" : undefined}
-              // A page number is an ordinal, never grouped: "page 1.234" reads
-              // as a fraction of a page rather than the 1234th of them.
-              aria-label={t("table.page", { number: String(slot) })}
+              // "page 1.234" would read as a fraction of a page rather than
+              // the 1234th of them.
+              aria-label={t("table.page", { number: ordinalNumber(slot) })}
               onClick={() => onGoto(slot)}
             >
-              {slot}
+              {ordinalNumber(slot)}
             </button>
           ) : (
             <span
@@ -1449,11 +1453,11 @@ function Pager({
       <span className="lt-perpage">
         <Select
           aria-label={t("table.rowsPerPage")}
-          value={String(perPage)}
+          value={identifierNumber(perPage)}
           disabled={!onPerPage}
           onChange={(next) => onPerPage?.(Number(next))}
           options={PAGE_SIZES.map((size) => ({
-            value: String(size),
+            value: identifierNumber(size),
             label: t("table.perPage", { count: formatNumber(size, locale) }),
           }))}
         />

--- a/frontend/src/design-system/margince-workbench.tsx
+++ b/frontend/src/design-system/margince-workbench.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 import type { components } from "../api/schema";
-import { formatNumber, INTL_LOCALE } from "../format/format";
+import { formatNumber, INTL_LOCALE, ordinalNumber } from "../format/format";
 import { type Locale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { Avatar } from "./atoms";
@@ -240,7 +240,7 @@ function StepRail({ steps }: Readonly<{ steps: readonly WorkbenchStep[] }>) {
           className={`mw-step is-${step.state}`}
           aria-current={step.state === "now" ? "step" : undefined}
         >
-          <b aria-hidden>{index + 1}</b>
+          <b aria-hidden>{ordinalNumber(index + 1)}</b>
           {step.label}
           <span className="sr-only">{t(STEP_STATE_WORD[step.state])}</span>
         </li>
@@ -421,7 +421,11 @@ function AiRuntimeChip({
           />
           <RuntimeRow
             label={labels.calls}
-            value={runtime ? String(runtime.call_attempts) : labels.unavailable}
+            value={
+              runtime
+                ? formatNumber(runtime.call_attempts, locale)
+                : labels.unavailable
+            }
           />
           <RuntimeRow
             label={labels.tokens}

--- a/frontend/src/design-system/moneyinput.stories.tsx
+++ b/frontend/src/design-system/moneyinput.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
+import { formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 import { MoneyInput } from "./moneyinput";
 
 const meta: Meta = {
@@ -11,6 +13,7 @@ export default meta;
 type Story = StoryObj;
 
 function MoneyDemo() {
+  const { locale } = useLocale();
   const [minor, setMinor] = useState(150_000);
   return (
     <div style={{ maxWidth: 200 }}>
@@ -20,7 +23,9 @@ function MoneyDemo() {
         onChangeMinor={setMinor}
         aria-label="Unit price"
       />
-      <p style={{ marginTop: 8 }}>minor units: {minor}</p>
+      <p style={{ marginTop: "var(--space-2)" }}>
+        minor units: {formatNumber(minor, locale)}
+      </p>
     </div>
   );
 }

--- a/frontend/src/design-system/projectpicker.tsx
+++ b/frontend/src/design-system/projectpicker.tsx
@@ -3,7 +3,8 @@
 
 import { useEffect, useRef } from "react";
 import type { components } from "../api/schema";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { Select } from "./select";
 import "./projectpicker.css";
 
@@ -159,6 +160,7 @@ export function ProjectPicker({
 // rather than printing a number nobody computed.
 export function ScopeLine({ scope }: Readonly<{ scope: ProjectScope }>) {
   const t = useT();
+  const { locale } = useLocale();
   const key = scope.key ?? scope.name;
   if (scope.in_scope == null || scope.total == null) {
     return <p className="t-caption">{t("compose.scopedTo", { key })}</p>;
@@ -167,8 +169,8 @@ export function ScopeLine({ scope }: Readonly<{ scope: ProjectScope }>) {
     <p className="t-caption">
       {t("compose.scopedToCounted", {
         key,
-        inScope: String(scope.in_scope),
-        total: String(scope.total),
+        inScope: formatNumber(scope.in_scope, locale),
+        total: formatNumber(scope.total, locale),
       })}
     </p>
   );

--- a/frontend/src/design-system/trust.stories.tsx
+++ b/frontend/src/design-system/trust.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type CSSProperties, type ReactNode, useState } from "react";
+import { identifierNumber } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import {
   ApprovalGate,
@@ -89,7 +90,15 @@ export const Signals: Story = {
           const level = confidenceLevel(confidence);
           return (
             <Specimen
-              caption={confidence === null ? "unrecorded" : String(confidence)}
+              // The caption NAMES which wire value produced the band beside
+              // it, so it has to read as the literal in the array above —
+              // grouped or padded it would label the specimen with a number
+              // that is not the one being demonstrated.
+              caption={
+                confidence === null
+                  ? "unrecorded"
+                  : identifierNumber(confidence)
+              }
               key={String(confidence)}
             >
               {level ? <ConfidenceMeter level={level} /> : <span>—</span>}

--- a/frontend/src/format/format.test.ts
+++ b/frontend/src/format/format.test.ts
@@ -9,9 +9,12 @@ import {
   formatDuration,
   formatMoney,
   formatMoneyOrAbsent,
+  formatNumber,
   formatTimeOfDay,
+  identifierNumber,
   isRenderableZone,
   MONEY_ABSENT,
+  ordinalNumber,
 } from "./format";
 
 // B-EP09.17/18/19 acceptance: locale changes the RENDERING of the same stored
@@ -210,5 +213,32 @@ describe("display scales by the same table the server stores with", () => {
     // to decide and are not what this pins.
     const rendered = formatMoney(minor, currency, "en").replace(/[^\d.,]/g, "");
     expect(rendered).toBe(figure);
+  });
+});
+
+describe("a number that names or places is not a magnitude", () => {
+  // The pair exists so a call site can SAY which of the two it meant, and the
+  // claim is that they part company exactly where grouping starts. Four digits
+  // is where de-DE first groups, so it is the only width that can show it.
+  it("groups a magnitude in the reader's own notation", () => {
+    expect(formatNumber(1234, "de")).toBe("1.234");
+    expect(formatNumber(1234, "en")).toBe("1,234");
+  });
+
+  it("leaves a name and a position ungrouped, in every locale", () => {
+    expect(identifierNumber(1234)).toBe("1234");
+    expect(ordinalNumber(1234)).toBe("1234");
+  });
+
+  // Not a tautology about `String`: it is the claim that makes the ruling worth
+  // spelling as a call. Revision 1234 rendered through the formatter beside it
+  // reads as a quantity of revisions, and "1.204" is a different revision from
+  // "1204" to anybody typing it into a search box.
+  it("parts company with the formatter at four digits", () => {
+    expect(identifierNumber(1234)).not.toBe(formatNumber(1234, "de"));
+    expect(identifierNumber(1234)).not.toBe(formatNumber(1234, "en"));
+    // And agrees with it below that width, which is why three of these sites
+    // looked correct for as long as the demo data stayed small.
+    expect(identifierNumber(999)).toBe(formatNumber(999, "de"));
   });
 });

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -157,6 +157,41 @@ export function formatNumber(value: number, locale: Locale): string {
 }
 
 /**
+ * A number that NAMES something rather than measuring it — a version, a
+ * revision, an invoice number, a record's own number.
+ *
+ * Bare on purpose, and this is the ruling rather than the omission of one.
+ * `formatNumber` would print revision 1234 as "1.204" to a German reader and
+ * "1,204" to an English one, which reads as a quantity of revisions where a
+ * name was meant. Grouping a name is as wrong as leaving a magnitude ungrouped;
+ * the two are opposite defects and no single answer covers both.
+ *
+ * It is a FUNCTION and not a bare interpolation because the name is where the
+ * decision is recorded. `format/jsx-magnitude.test.ts` refuses a raw number in
+ * anything a reader is shown, so every site has had to pick between this,
+ * `ordinalNumber` and a formatter — which is what makes the gate absolute
+ * instead of a list of blessed exceptions. `format/collate.ts` reached the same
+ * shape first, for the same reason: `forReader` and `stable` both order, and
+ * only the name says which order was meant.
+ */
+export function identifierNumber(value: number): string {
+  return String(value);
+}
+
+/**
+ * A number that says WHERE in a sequence — an ordinal, a step, a row's index.
+ *
+ * Bare for the same reason as `identifierNumber` and kept apart from it because
+ * the two say different things to the next reader: a version is a name a
+ * server chose, a position is one this list computed, and a site that renames
+ * one is not making a claim about the other. See that function for why the
+ * ruling is spelled as a call at all.
+ */
+export function ordinalNumber(value: number): string {
+  return String(value);
+}
+
+/**
  * A figure whose DECIMALS are part of what it says — a score, a rate, a factor.
  *
  * `formatNumber` renders a count, where a trailing `.0` would be noise. This

--- a/frontend/src/format/jsx-magnitude.test.ts
+++ b/frontend/src/format/jsx-magnitude.test.ts
@@ -371,6 +371,14 @@ function renderedPositions(
     ) {
       found.push(node.expression);
     }
+    // Judged on the SHAPE the object is contextualized into, not on the callee.
+    // Narrowing this to call arguments would read better and cost recognition:
+    // a params object built as a variable and handed to `t()` a line later is
+    // still a catalog parameter, and this arm is the only thing that sees it.
+    // The reach it buys instead — a `Record<string, string>` nobody renders —
+    // asks for a ruling on a string no reader meets, which is a wasted call
+    // rather than a missed magnitude. Over-recognition is the safe direction
+    // here, and the only one an assertion can catch when it goes wrong.
     if (
       ts.isPropertyAssignment(node) &&
       ts.isObjectLiteralExpression(node.parent)

--- a/frontend/src/format/jsx-magnitude.test.ts
+++ b/frontend/src/format/jsx-magnitude.test.ts
@@ -1,0 +1,777 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import {
+  extensionFrontendFiles,
+  filesUnder,
+} from "../../scripts/lib/source-tree";
+
+// A number reaching a reader has been written in SOME notation, and the only
+// question is whose. `format/one-locale.test.ts` holds the case where a
+// formatter is reached the wrong way; this holds the case where none is reached
+// at all — a magnitude interpolated straight into JSX:
+//
+//     <span>{group.count}</span>
+//     <StatCard value={String(activity)} />
+//
+// A German reader sees `1234` where every formatted figure beside it on the
+// same page reads `1.234`, so one screen is written in two notations and
+// neither of the gates already here can say so. The `translate` narrowing to
+// `Record<string, string>` only sees what is handed to `t()`, and these never
+// reach `t()`. `one-locale.test.ts` gates how a locale reaches a formatter, and
+// these reach no formatter to give one to. A site already wrapped in
+// `String(...)` satisfies the narrowing exactly and groups nothing.
+//
+// THE RULING IS THE FUNCTION NAME, which is what lets this gate be absolute
+// rather than a list of blessed sites. Not every number in JSX wants grouping:
+// an invoice number is not one thousand two hundred, and `#1.204` is a defect
+// where `1.204` was right one line above. So `format.ts` carries
+// `identifierNumber` and `ordinalNumber` beside `formatNumber`, every site has
+// been ruled by picking one of them, and outside `format.ts` a raw number in a
+// rendered position is a site that skipped the ruling rather than a site whose
+// ruling was "leave it". `format/collate.ts` did this first, for the same
+// reason: `forReader` and `stable` both order, and only the name says which
+// order was meant.
+//
+// THE SUBJECT IS DERIVED, in the three parts it has:
+//
+//   1. A RENDERED POSITION comes from the type checker rather than from a list
+//      of props, and there are three of them. A JSX child. An attribute whose
+//      declared type is text, which is how `aria-label`, `title`, `alt` and
+//      `StatCard`'s `value` are all in scope without one of them being named
+//      here, and how a prop renamed tomorrow stays in scope. And a catalog
+//      sentence's parameter — anything whose contextual type is
+//      `Record<string, string>`, which is the shape the translator declares its
+//      params as, so `t()` is reached through its signature rather than through
+//      its name. React's own `SVGAttributes` is what keeps a `viewBox` out of
+//      the second: those are coordinates in a space the drawing invented, and
+//      grouping one would break the picture.
+//   2. A LOCALE-BLIND STRINGIFICATION is read out of TypeScript's own lib
+//      declarations: the `Number` members returning `string` whose signature
+//      has NO `locales` parameter. That yields `toFixed`, `toPrecision`,
+//      `toExponential` and `toString` without this file naming one of them, and
+//      it is the same two-source discipline `localeMethods()` uses next door —
+//      selecting by name is a hand-maintained fragment of the subject wearing a
+//      regular expression's clothes.
+//   3. `String(x)` and a template literal's substitution are NAMED, because
+//      there is nothing to derive them from: they are the language's own
+//      conversions and no declaration marks them as locale-blind, since they
+//      were never locale-aware to begin with.
+//
+// WHAT IT CANNOT SEE, because a census that can fail short has already failed
+// and the honest thing is to say where the floor is:
+//
+//   - A number converted a statement away from the JSX. `const label =
+//     String(n)` then `{label}` is a string by the time it reaches a rendered
+//     position, and following it back is dataflow rather than a type at a node.
+//   - `n + ""`, `[n].join("")`, `JSON.stringify(n)`. Concatenation has no
+//     callee to anchor on and the other two are not `Number` members.
+//   - `{count && <Row/>}`, whose type carries a `0` beside an element. That
+//     renders a stray zero and is a real defect, but it is a different one —
+//     the fix is `count > 0 &&`, not a formatter — so a type with a
+//     non-numeric constituent is not a magnitude here.
+//   - A figure the SERVER already rendered into a string field. Nothing on this
+//     side of the wire can tell it from any other string.
+//   - A rendered position whose type the checker could not resolve. That is not
+//     hypothetical: this sweep reads the extension tier, and a unit's screen
+//     does not type against the VANILLA contract by construction — its
+//     `/ext/...` responses resolve to `never`, so a magnitude read off one is
+//     invisible here and the composed lane is where that half is judged. Left
+//     silent this is the whole rule-8 defect: a smaller tree read, and PASS
+//     reported about it. So an unjudgeable position is COUNTED rather than
+//     skipped, and the arm below holds that every one of them is in the
+//     extension tier — a new one under `src/` fails.
+//   - A prop declared `number`. The ruling belongs where the component renders
+//     it, not where a caller passes it, and that render site is itself in
+//     scope — which is how `home.rail.tsx`'s `DigestCount` is caught once, at
+//     the `<span>{value}</span>` that is actually wrong, rather than four times
+//     at callers doing nothing wrong.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(here, "..");
+const frontendRoot = resolve(srcRoot, "..");
+const extensionsDir = resolve(frontendRoot, "..", "extensions");
+
+// The one home for the rulings, and so the one file allowed to hold a number
+// crossing into a string without one. The FILE and not the directory: `format/`
+// holds ten other modules, and excluding the directory would let a new
+// formatter added beside this one render for nobody and pass.
+const formatModule = join(here, "format.ts");
+const thisGate = fileURLToPath(import.meta.url);
+
+/**
+ * The `Number` members that turn a magnitude into text WITHOUT asking whose
+ * notation, read out of TypeScript's own lib declarations.
+ *
+ * Selected by signature — returns `string`, has no `locales` parameter — for
+ * the reason its neighbour in `one-locale.test.ts` gives: a name filter is a
+ * hand-maintained fragment of the subject, and it answers a different question
+ * from the one asked. `toLocaleString` falls out by carrying `locales`, which
+ * is exactly right: it is the locale-AWARE member, and it is that gate's
+ * subject rather than this one's.
+ */
+function blindStringifiers(): Set<string> {
+  const libDir = join(frontendRoot, "node_modules", "typescript", "lib");
+  const found = new Set<string>();
+  for (const file of readdirSync(libDir)) {
+    if (!/^lib\..*\.d\.ts$/.test(file)) {
+      continue;
+    }
+    const parsed = ts.createSourceFile(
+      file,
+      ts.sys.readFile(join(libDir, file)) ?? "",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const walk = (node: ts.Node): void => {
+      if (ts.isInterfaceDeclaration(node) && node.name.text === "Number") {
+        for (const member of node.members) {
+          if (!ts.isMethodSignature(member) || member.name === undefined) {
+            continue;
+          }
+          const returnsText =
+            member.type !== undefined &&
+            member.type.kind === ts.SyntaxKind.StringKeyword;
+          const takesLocale = member.parameters.some(
+            (parameter) =>
+              ts.isIdentifier(parameter.name) &&
+              parameter.name.text === "locales",
+          );
+          if (returnsText && !takesLocale) {
+            found.add(member.name.getText(parsed));
+          }
+        }
+      }
+      node.forEachChild(walk);
+    };
+    walk(parsed);
+  }
+  return found;
+}
+
+/**
+ * The attribute names that place a mark in a DRAWING's own coordinate space,
+ * read out of React's own declarations.
+ *
+ * `viewBox` is `string`, so a sparkline's `viewBox={`0 0 ${W} ${H}`}` is a
+ * number reaching a string-typed attribute and looks exactly like the defect.
+ * It is not one: those are coordinates in a space the drawing invented, in the
+ * same class as `size={14}`, and grouping them would break the picture.
+ *
+ * OWN members only. `SVGAttributes` inherits from `AriaAttributes` and
+ * `DOMAttributes`, so taking the inherited set would swallow `aria-label` —
+ * text assistive technology reads aloud, and the one attribute on an svg most
+ * worth gating. React declares the geometry on the interface itself, which is
+ * what makes the distinction readable off the platform rather than kept as a
+ * list here.
+ */
+function svgGeometry(): Set<string> {
+  const declarations = join(
+    frontendRoot,
+    "node_modules",
+    "@types",
+    "react",
+    "index.d.ts",
+  );
+  const parsed = ts.createSourceFile(
+    declarations,
+    ts.sys.readFile(declarations) ?? "",
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const found = new Set<string>();
+  const walk = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === "SVGAttributes") {
+      for (const member of node.members) {
+        if (member.name !== undefined) {
+          found.add(
+            ts.isStringLiteralLike(member.name)
+              ? member.name.text
+              : member.name.getText(parsed),
+          );
+        }
+      }
+    }
+    node.forEachChild(walk);
+  };
+  walk(parsed);
+  return found;
+}
+
+/**
+ * Every file this gate judges: the app's own JSX and every extension unit's.
+ *
+ * The walk is `scripts/lib/source-tree.ts`'s, shared with the native-control,
+ * extension-import and one-locale gates rather than spelled a fourth time. A
+ * unit's screen is bundled into the same SPA and drawn on the same page, so a
+ * sweep stopping at `src/` would hold the core to a standard the extension tier
+ * escapes.
+ *
+ * `.tsx` only, because a rendered position is a JSX node and a `.ts` file has
+ * none. Stories are IN: a story is the catalog a reader opens, and a figure
+ * grouped on the screen and bare in its own story is two answers about one
+ * component. Tests are out — an expectation has to be writable, and a suite
+ * whose expected text moved with the notation would assert nothing.
+ */
+function sourceFiles(): string[] {
+  return [...filesUnder(srcRoot), ...extensionFrontendFiles(extensionsDir)]
+    .filter(
+      (path) =>
+        path.endsWith(".tsx") &&
+        !path.endsWith(".test.tsx") &&
+        path !== formatModule &&
+        path !== thisGate,
+    )
+    .sort();
+}
+
+type Finding = Readonly<{ file: string; line: number; text: string }>;
+
+// What one file yielded: the sites that ARE the defect, and the sites this lane
+// could not read well enough to say either way. Keeping them apart is the point
+// — a census that folds the second into "clean" is the one that fails short.
+type Verdict = Readonly<{ findings: Finding[]; unjudged: Finding[] }>;
+
+const NUMBER_LIKE =
+  ts.TypeFlags.Number |
+  ts.TypeFlags.NumberLiteral |
+  ts.TypeFlags.Enum |
+  ts.TypeFlags.EnumLiteral;
+
+const TEXT_LIKE = ts.TypeFlags.String | ts.TypeFlags.StringLiteral;
+
+const NULLISH = ts.TypeFlags.Undefined | ts.TypeFlags.Null | ts.TypeFlags.Void;
+
+function constituents(type: ts.Type): ts.Type[] {
+  const parts = type.isUnion() ? type.types : [type];
+  return parts.filter((part) => (part.flags & NULLISH) === 0);
+}
+
+/**
+ * Whether this type is a magnitude and nothing else.
+ *
+ * EVERY constituent must be numeric, not merely one of them. `number |
+ * undefined` is a magnitude that may be absent and is in scope; `ReactNode` and
+ * `0 | Element` both carry a number beside something that is not one, and
+ * neither is a figure a formatter could be applied to at that site.
+ */
+function isMagnitude(type: ts.Type): boolean {
+  const parts = constituents(type);
+  return (
+    parts.length > 0 && parts.every((part) => (part.flags & NUMBER_LIKE) !== 0)
+  );
+}
+
+/**
+ * Whether the checker declined to say what this is.
+ *
+ * `never` and the error type are how an unresolved import comes back, and both
+ * answer "not a magnitude" to every question below — which is indistinguishable
+ * from a ruled site unless it is counted separately. `any` is folded in with
+ * them because the tree bans it, so its only source here is that same failure.
+ */
+function isUnreadable(type: ts.Type): boolean {
+  return constituents(type).some(
+    (part) => (part.flags & (ts.TypeFlags.Never | ts.TypeFlags.Any)) !== 0,
+  );
+}
+
+/** Whether a prop declared with this type is drawn as TEXT and only as text. */
+function isTextSlot(type: ts.Type): boolean {
+  const parts = constituents(type);
+  return (
+    parts.length > 0 && parts.every((part) => (part.flags & TEXT_LIKE) !== 0)
+  );
+}
+
+/**
+ * Whether this object's every value is text — which is what a catalog
+ * sentence's parameters are.
+ *
+ * Asked of the SIGNATURE and not of the callee's name, so it holds for `t()`,
+ * for `translate()`, for the `Translator` a helper takes as a parameter, and
+ * for anything else declared to take words. #2463 narrowed that type so a raw
+ * number can no longer reach a sentence; what it could not refuse is a site
+ * that satisfies it with `String(count)`, which is this arm's whole subject.
+ */
+function isTextTable(type: ts.Type, checker: ts.TypeChecker): boolean {
+  // The nullable strip is not tidying. The parameter is OPTIONAL, so the
+  // contextual type at every real call site is `Record<string, string> |
+  // undefined` — and a union carries no index signature, so asking the union
+  // yields nothing for every site there is, which reads exactly like a clean
+  // tree. The planted case is what holds this: it fails if the strip goes.
+  const index = checker.getIndexInfoOfType(
+    checker.getNonNullableType(type),
+    ts.IndexKind.String,
+  );
+  return index !== undefined && isTextSlot(index.type);
+}
+
+/**
+ * Whether this type is React's own name for rendered content.
+ *
+ * Named, and it is the platform's declaration rather than a list of ours:
+ * `ReactNode` is where React says "this is drawn", and a prop declared with it
+ * accepts a number the component will render bare. The caller is the only site
+ * that can rule such a number, because inside the component the type has
+ * stopped being a magnitude.
+ */
+function isRenderedContent(type: ts.Type): boolean {
+  return type.aliasSymbol?.getName() === "ReactNode";
+}
+
+/**
+ * Whether this attribute is geometry on an element the BROWSER draws.
+ *
+ * Both halves are needed. The name alone is too wide: `SVGAttributes` declares
+ * `values`, `order` and `result`, and one of our own components is free to take
+ * a `string` prop called any of those and render it as words. So the exclusion
+ * only applies to an INTRINSIC tag, which is the only place React's own
+ * attribute declarations are what the prop means.
+ */
+function isDrawnGeometry(
+  node: ts.JsxAttribute,
+  geometry: Set<string>,
+): boolean {
+  const tag = node.parent.parent.tagName;
+  const intrinsic = ts.isIdentifier(tag) && /^[a-z]/.test(tag.text);
+  return intrinsic && geometry.has(node.name.getText());
+}
+
+/**
+ * The positions in one file where a value is drawn for a reader.
+ *
+ * Both halves come from the checker. A JSX child is structural. An attribute is
+ * judged on its CONTEXTUAL type — the type the receiving prop declares — which
+ * is what puts `aria-label`, `title`, `alt` and `StatCard`'s `value` in scope
+ * without this file listing a prop name, and what keeps `size={14}` out of it:
+ * a prop declared `number` is not text, and the ruling for what it draws
+ * belongs at the component's own render site.
+ */
+function renderedPositions(
+  parsed: ts.SourceFile,
+  checker: ts.TypeChecker,
+  geometry: Set<string>,
+): ts.Expression[] {
+  const found: ts.Expression[] = [];
+  const walk = (node: ts.Node): void => {
+    if (
+      ts.isJsxExpression(node) &&
+      node.expression !== undefined &&
+      (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent))
+    ) {
+      found.push(node.expression);
+    }
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isObjectLiteralExpression(node.parent)
+    ) {
+      const table = checker.getContextualType(node.parent);
+      if (table !== undefined && isTextTable(table, checker)) {
+        found.push(node.initializer);
+      }
+    }
+    if (
+      ts.isJsxAttribute(node) &&
+      node.initializer !== undefined &&
+      ts.isJsxExpression(node.initializer) &&
+      node.initializer.expression !== undefined
+    ) {
+      const declared = checker.getContextualType(node.initializer.expression);
+      if (
+        declared !== undefined &&
+        (isTextSlot(declared) || isRenderedContent(declared)) &&
+        !isDrawnGeometry(node, geometry)
+      ) {
+        found.push(node.initializer.expression);
+      }
+    }
+    node.forEachChild(walk);
+  };
+  walk(parsed);
+  return found;
+}
+
+/**
+ * Whether this expression carries a magnitude into the position it sits in.
+ *
+ * Three shapes, and the second and third exist because a conversion satisfies
+ * the type without answering the question: `String(count)` and `count.toFixed(2)`
+ * are both `string`, and both print US grouping to a German reader.
+ */
+function carriesMagnitude(
+  node: ts.Expression,
+  checker: ts.TypeChecker,
+  blind: Set<string>,
+): boolean {
+  if (isMagnitude(checker.getTypeAtLocation(node))) {
+    return true;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "String" &&
+    node.arguments.length === 1
+  ) {
+    return isMagnitude(checker.getTypeAtLocation(node.arguments[0]));
+  }
+  if (
+    ts.isCallExpression(node) &&
+    (ts.isPropertyAccessExpression(node.expression) ||
+      ts.isElementAccessExpression(node.expression))
+  ) {
+    const member = ts.isPropertyAccessExpression(node.expression)
+      ? node.expression.name.text
+      : ts.isStringLiteralLike(node.expression.argumentExpression)
+        ? node.expression.argumentExpression.text
+        : undefined;
+    return (
+      member !== undefined &&
+      blind.has(member) &&
+      isMagnitude(checker.getTypeAtLocation(node.expression.expression))
+    );
+  }
+  if (ts.isTemplateExpression(node)) {
+    return node.templateSpans.some((span) =>
+      isMagnitude(checker.getTypeAtLocation(span.expression)),
+    );
+  }
+  // A conditional draws whichever branch it picks, so a magnitude in either arm
+  // is drawn. Without this a site says `{a ? count : other}` and the union of
+  // the two arms is judged instead of the figure the reader is shown.
+  if (ts.isConditionalExpression(node)) {
+    return (
+      carriesMagnitude(node.whenTrue, checker, blind) ||
+      carriesMagnitude(node.whenFalse, checker, blind)
+    );
+  }
+  if (ts.isParenthesizedExpression(node)) {
+    return carriesMagnitude(node.expression, checker, blind);
+  }
+  return false;
+}
+
+function findingsIn(
+  parsed: ts.SourceFile,
+  checker: ts.TypeChecker,
+  blind: Set<string>,
+  geometry: Set<string>,
+  label: string,
+): Verdict {
+  const at = (node: ts.Expression): Finding => ({
+    file: label,
+    line: parsed.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+    text: node.getText().replace(/\s+/g, " ").slice(0, 80),
+  });
+  const findings: Finding[] = [];
+  const unjudged: Finding[] = [];
+  for (const node of renderedPositions(parsed, checker, geometry)) {
+    if (isUnreadable(checker.getTypeAtLocation(node))) {
+      unjudged.push(at(node));
+    } else if (carriesMagnitude(node, checker, blind)) {
+      findings.push(at(node));
+    }
+  }
+  return { findings, unjudged };
+}
+
+/**
+ * The compiler options the app itself is built with.
+ *
+ * Borrowed rather than restated because the path aliases are how an extension
+ * screen's imports resolve at all, and a second spelling of them here is a
+ * second answer to what the bundler does.
+ */
+function appOptions(): ts.CompilerOptions {
+  const config = ts.getParsedCommandLineOfConfigFile(
+    join(frontendRoot, "tsconfig.app.json"),
+    {},
+    {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+        throw new Error(
+          ts.flattenDiagnosticMessageText(diagnostic.messageText, " "),
+        );
+      },
+    },
+  );
+  if (config === undefined) {
+    throw new Error("tsconfig.app.json did not parse");
+  }
+  return config.options;
+}
+
+/**
+ * The program the checker comes from, built over the swept corpus rather than
+ * over `tsconfig.app.json`'s own file list.
+ *
+ * That distinction IS the census. The project excludes `src/screens/ext/` and
+ * every test, and its `include` never reaches `extensions/` — so borrowing its
+ * file list would read a smaller tree and report the same word for it, PASS.
+ * Only the options are borrowed.
+ */
+function programOver(files: string[]): ts.Program {
+  return ts.createProgram(files, appOptions());
+}
+
+describe("a magnitude is drawn in the reader's own notation", () => {
+  const blind = blindStringifiers();
+  const geometry = svgGeometry();
+  const files = sourceFiles();
+  const program = programOver(files);
+  const checker = program.getTypeChecker();
+  const verdicts = files.flatMap((path) => {
+    const parsed = program.getSourceFile(path);
+    return parsed === undefined
+      ? []
+      : [
+          findingsIn(
+            parsed,
+            checker,
+            blind,
+            geometry,
+            relative(frontendRoot, path),
+          ),
+        ];
+  });
+  const all = verdicts.flatMap((verdict) => verdict.findings);
+  const unjudged = verdicts.flatMap((verdict) => verdict.unjudged);
+
+  it("reads the tree it is meant to sweep, extension screens included", () => {
+    // DERIVED from the directory listing. A floor does not hold this: the sweep
+    // reads several hundred files, so any `toBeGreaterThan` clears comfortably
+    // even after the walk stops descending into `screens/`, which is where most
+    // of the subject lives.
+    const swept = new Set(
+      files
+        .filter((path) => path.startsWith(srcRoot))
+        .map((path) => relative(srcRoot, path).split(/[/\\]/)[0]),
+    );
+    const expectedDirs = readdirSync(srcRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+      .map((entry) => entry.name)
+      .filter((name) =>
+        filesUnder(join(srcRoot, name)).some(
+          (path) => path.endsWith(".tsx") && !path.endsWith(".test.tsx"),
+        ),
+      );
+    expect(expectedDirs.length).toBeGreaterThan(3);
+    expect(expectedDirs.filter((name) => !swept.has(name))).toEqual([]);
+    expect(files.some((path) => path.includes("/extensions/"))).toBe(true);
+    // Stories are swept, and the sweep is TYPED — a corpus the program failed
+    // to load would yield no findings and read exactly like a clean tree.
+    expect(files.some((path) => path.endsWith(".stories.tsx"))).toBe(true);
+    expect(
+      files.filter((path) => program.getSourceFile(path) === undefined),
+    ).toEqual([]);
+  });
+
+  it("derives the stringifiers that answer in nobody's notation", () => {
+    // Named here as proof the derivation ARRIVED, the way its neighbour proves
+    // `NumberFormat` reached its own set. The SET is still derived, so a member
+    // the platform grows tomorrow is covered without an edit here.
+    expect([...blind].sort()).toEqual([
+      "toExponential",
+      "toFixed",
+      "toPrecision",
+      "toString",
+    ]);
+    // The locale-AWARE member must NOT be in it. It is `one-locale.test.ts`'s
+    // subject, and swallowing it here would report every correct call as a
+    // finding and get the gate switched off within a week.
+    expect(blind.has("toLocaleString")).toBe(false);
+  });
+
+  it("derives the geometry it must not mistake for text", () => {
+    // Named as proof the derivation ARRIVED at React's declarations; the SET is
+    // still read off them, so an attribute the platform grows is covered
+    // without an edit here.
+    expect(geometry.has("viewBox")).toBe(true);
+    expect(geometry.has("d")).toBe(true);
+    expect(geometry.size).toBeGreaterThan(100);
+    // Own members ONLY. Inherited would swallow the two attributes on an svg
+    // most worth gating, and the sweep would go quiet about them.
+    expect(geometry.has("aria-label")).toBe(false);
+    expect(geometry.has("title")).toBe(false);
+  });
+
+  it("sees each shape of the defect, including the ones a grep cannot", () => {
+    // Each line says for ITSELF whether it is a finding, so the expectation is
+    // read off the fixture rather than kept beside it as a list of line numbers
+    // that has to agree with it — which is the very defect this gate is about.
+    const planted: { code: string; finding: boolean }[] = [
+      { code: "<p>{label}</p>", finding: false },
+      { code: "<p>{formatNumber(count, locale)}</p>", finding: false },
+      // The issue's own three shapes.
+      { code: "<p>{count}</p>", finding: true },
+      { code: "<Stat value={String(count)} />", finding: true },
+      { code: "<p>{count} / {limit}</p>", finding: true },
+      // Absent is still a magnitude when it arrives.
+      { code: "<p>{maybeCount}</p>", finding: true },
+      // Every locale-blind stringifier, reached by property and by element
+      // access — the spelling a gate anchored on the dot cannot see.
+      { code: "<p>{count.toFixed(2)}</p>", finding: true },
+      { code: "<p>{count.toString()}</p>", finding: true },
+      { code: '<p>{count["toFixed"](2)}</p>', finding: true },
+      // The locale-aware one is the other gate's business, and correct here.
+      { code: "<p>{count.toLocaleString(tag)}</p>", finding: false },
+      // A template literal's substitution, which carries no call to anchor on.
+      { code: "<p>{`${count} rows`}</p>", finding: true },
+      // Text props, in scope through their DECLARED type and not by name.
+      { code: "<p title={String(count)}>x</p>", finding: true },
+      { code: "<p aria-label={`${count}`}>x</p>", finding: true },
+      // A prop declared `number` is not text: the ruling belongs at the render
+      // site inside the component, which this sweep reaches on its own.
+      { code: "<Icon size={count} />", finding: false },
+      // A drawing's own coordinate space, on an intrinsic tag React declares
+      // the geometry of. Not a magnitude, and grouping one breaks the picture.
+      { code: "<svg viewBox={`0 0 ${count} ${count}`} />", finding: false },
+      // On the SAME tag, the text assistive technology reads aloud. It is
+      // declared on `AriaAttributes` rather than on `SVGAttributes` itself,
+      // which is why taking the inherited set would have lost it.
+      { code: "<svg aria-label={String(count)} />", finding: true },
+      // `values` IS an `SVGAttributes` member name, and this is one of our own
+      // components rendering words — which is why the exclusion asks about the
+      // tag as well as the name.
+      { code: "<Chart values={String(count)} />", finding: true },
+      // A catalog sentence's parameter. #2463 made the raw number a compile
+      // error; `String(...)` satisfies that narrowing and groups nothing, which
+      // is the shape it deliberately left standing.
+      { code: '<p>{t("k", { n: String(count) })}</p>', finding: true },
+      {
+        code: '<p>{t("k", { n: formatNumber(count, loc) })}</p>',
+        finding: false,
+      },
+      {
+        code: '<p>{t("k", { n: identifierNumber(count) })}</p>',
+        finding: false,
+      },
+      // A ReactNode prop is drawn, so the caller is the site that can rule it.
+      { code: "<Slot body={count} />", finding: true },
+      { code: "<Slot body={label} />", finding: false },
+      // The rulings themselves. These are the whole reason the gate can be
+      // absolute, so a mutation that stopped honouring them must fail here.
+      { code: "<p>{identifierNumber(count)}</p>", finding: false },
+      { code: "<p>{ordinalNumber(count)}</p>", finding: false },
+      // A conditional draws whichever arm it picks.
+      { code: "<p>{ready ? count : 0}</p>", finding: true },
+      { code: "<p>{ready ? label : other}</p>", finding: false },
+      // A stray zero from `&&` is a real defect and a DIFFERENT one — the fix
+      // is `count > 0 &&`, not a formatter. The gate says so out loud rather
+      // than reporting it as this.
+      { code: "<p>{count && <b>x</b>}</p>", finding: false },
+    ];
+    const fixture = plant(
+      planted.map(({ code }) => code),
+      blind,
+      geometry,
+    );
+    const reported = new Set(fixture.map(({ line }) => line));
+    const verdicts = planted.map(({ code, finding }, index) => ({
+      code,
+      finding,
+      reported: reported.has(index + 1),
+    }));
+    expect(verdicts.filter((row) => row.finding !== row.reported)).toEqual([]);
+  });
+
+  it("judges every position it read, or says which it could not", () => {
+    // The core tree is judged completely: a rendered position here whose type
+    // the checker declined to resolve is a hole in the census, and it fails
+    // rather than passing as "no magnitude found".
+    expect(
+      unjudged.filter((site) => !site.file.startsWith("../extensions/")),
+    ).toEqual([]);
+  });
+
+  it("finds nothing left in the tree", () => {
+    expect(all).toEqual([]);
+  });
+});
+
+/**
+ * Judge one fixture line per line, in a program that has the real declarations.
+ *
+ * A syntactic fixture would prove nothing here: every arm above turns on a TYPE
+ * — whether `count` is a magnitude, whether `body` is drawn — so the fixture has
+ * to be COMPILED against declarations rather than parsed. The declarations for
+ * `format.ts` and React are the real ones; only the locals are invented.
+ *
+ * The preamble is emitted as a single line so that a finding's line number is
+ * the planted case's own index. A second list mapping one to the other is the
+ * defect this gate exists to catch, and putting one inside the gate is how it
+ * gets written twice.
+ */
+function plant(
+  lines: string[],
+  blind: Set<string>,
+  geometry: Set<string>,
+): Finding[] {
+  const fixtureName = join(srcRoot, "jsx-magnitude-fixture.tsx");
+  const preamble = [
+    'import type { ReactNode } from "react";',
+    'import { formatNumber, identifierNumber, ordinalNumber } from "./format/format";',
+    "declare const count: number;",
+    "declare const maybeCount: number | undefined;",
+    "declare const limit: number;",
+    "declare const label: string;",
+    "declare const other: string;",
+    "declare const tag: string;",
+    "declare const ready: boolean;",
+    'declare const loc: "en";',
+    "declare function t(key: string, params?: Record<string, string>): string;",
+    "declare function Stat(props: { value: string }): ReactNode;",
+    "declare function Slot(props: { body: ReactNode }): ReactNode;",
+    "declare function Icon(props: { size: number }): ReactNode;",
+    "declare function Chart(props: { values: string }): ReactNode;",
+    "void [formatNumber, identifierNumber, ordinalNumber, t];",
+  ].join(" ");
+  const source = [preamble, ...lines.map((line) => `void (${line});`)].join(
+    "\n",
+  );
+  const options = appOptions();
+  const host = ts.createCompilerHost(options, true);
+  const readReal = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, version, onError, shouldCreate) =>
+    name === fixtureName
+      ? ts.createSourceFile(name, source, version, true, ts.ScriptKind.TSX)
+      : readReal(name, version, onError, shouldCreate);
+  host.fileExists = (name) => name === fixtureName || ts.sys.fileExists(name);
+  host.readFile = (name) =>
+    name === fixtureName ? source : ts.sys.readFile(name);
+  const program = ts.createProgram([fixtureName], options, host);
+  const parsed = program.getSourceFile(fixtureName);
+  if (parsed === undefined) {
+    throw new Error("the planted fixture did not compile");
+  }
+  const verdict = findingsIn(
+    parsed,
+    program.getTypeChecker(),
+    blind,
+    geometry,
+    "fixture",
+  );
+  // A fixture line the checker could not read is a broken fixture, not a
+  // finding and not a pass: it would silently turn a planted case into a green
+  // one, which is the failure mode this whole file is written against.
+  if (verdict.unjudged.length > 0) {
+    throw new Error(
+      `the planted fixture did not type: lines ${verdict.unjudged
+        .map((site) => site.line - 1)
+        .join(", ")}`,
+    );
+  }
+  return verdict.findings.map((finding) => ({
+    ...finding,
+    line: finding.line - 1,
+  }));
+}

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -369,9 +369,11 @@ describe("adding a document from the account", () => {
 
     // An unfound deal and a deal that does not exist read identically, so the
     // control states its own reach rather than leaving the reader to conclude
-    // the account has no such deal.
+    // the account has no such deal. GROUPED: the reach is a magnitude, and this
+    // sentence sits on a surface whose every other figure is grouped, so an
+    // ungrouped 2000 here would be the one number written in another notation.
     expect(
-      screen.getByText(/covers this account's 2000 newest deals/),
+      screen.getByText(/covers this account's 2,000 newest deals/),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -21,6 +21,7 @@ import {
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
 import { foldForMatch } from "../format/collate";
+import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { type AttachmentParent, uploadAttachment } from "./attachmentupload";
@@ -456,8 +457,8 @@ export function AddDocumentDialog({
                   an answer belonged to. */}
               <p className="t-caption">
                 {t("docs.add.dealSearchReach", {
-                  deals: String(DEAL_SEARCH_REACH),
-                  matches: String(DEAL_MATCH_LIMIT),
+                  deals: formatNumber(DEAL_SEARCH_REACH, locale),
+                  matches: formatNumber(DEAL_MATCH_LIMIT, locale),
                 })}
               </p>
             </div>

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -15,7 +15,7 @@ import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDateTime, formatNumber } from "../format/format";
+import { formatDateTime, formatNumber, ordinalNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { ExportScenarioDialog } from "./aiexport";
@@ -76,7 +76,9 @@ export function CallDetailPanel({
           <ol>
             {query.data.attempts.map((attempt) => (
               <li key={attempt.attempt}>
-                <span className="t-mono">#{attempt.attempt}</span>{" "}
+                <span className="t-mono">
+                  #{ordinalNumber(attempt.attempt)}
+                </span>{" "}
                 {attempt.attempt_reason || "—"} ·{" "}
                 {t("aicalls.ms", {
                   value: formatNumber(attempt.latency_ms, locale),
@@ -354,11 +356,8 @@ function FragmentRow({
             )}
             {call.calls_attempted > 1 && (
               <Badge>
-                {/* An attempt counter, not a quantity: it names which try this
-                    call is on, and a grouped "1.234" would read as a figure
-                    rather than a position on the retry ladder. */}
                 {t("aicalls.badge.retries", {
-                  count: String(call.calls_attempted),
+                  count: formatNumber(call.calls_attempted, locale),
                 })}
               </Badge>
             )}

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -298,7 +298,10 @@ function AiUsageBody({
           {data.days.map((day) => (
             <p key={day.date} className="t-mono">
               {day.date} ·{" "}
-              {day.tasks.reduce((sum, task) => sum + task.calls, 0)}{" "}
+              {formatNumber(
+                day.tasks.reduce((sum, task) => sum + task.calls, 0),
+                locale,
+              )}{" "}
               {t("aiusage.col.calls")}
             </p>
           ))}

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -343,6 +343,7 @@ function CaptureFunnel({
   onSelect: (outcome: Outcome | null) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <StatStrip
       className="capture-activity__funnel"
@@ -360,7 +361,7 @@ function CaptureFunnel({
             label={t(`captureActivity.outcome.${funnelLabel(outcome)}`)}
             // Zero is a reading, not an absence: "no message was dropped as
             // internal today" is exactly what somebody comes here to confirm.
-            value={String(funnel[outcome] ?? 0)}
+            value={formatNumber(funnel[outcome] ?? 0, locale)}
           />
         </button>
       ))}

--- a/frontend/src/screens/company-context.tsx
+++ b/frontend/src/screens/company-context.tsx
@@ -34,7 +34,8 @@ import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { confidenceLevel, FieldDiff } from "../design-system/trust";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   coldFieldLabel,
@@ -628,6 +629,7 @@ function CompanyFactsCard({
   onEdit: (field: keyof CompanyInput) => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <Panel
       tone="accent"
@@ -647,7 +649,9 @@ function CompanyFactsCard({
         company.data ? (
           <>
             <span className="company-context-count">
-              <strong>{company.data.fields?.length ?? 0}</strong>{" "}
+              <strong>
+                {formatNumber(company.data.fields?.length ?? 0, locale)}
+              </strong>{" "}
               {t("settings.companyConfirmed")}
             </span>
             {rollout && <Badge>{rollout}</Badge>}
@@ -1071,6 +1075,7 @@ function RefreshReview(
   }>,
 ) {
   const t = useT();
+  const { locale } = useLocale();
   const ready =
     props.read.status === "ready" || props.read.status === "partial";
   const conflicts = props.read.comparisons.filter(
@@ -1105,7 +1110,8 @@ function RefreshReview(
       }
       footer={
         <span className="company-context-coverage">
-          <strong>{coverage}%</strong> {t("settings.companyCoverage")}
+          <strong>{formatNumber(coverage, locale)}%</strong>{" "}
+          {t("settings.companyCoverage")}
         </span>
       }
       actions={

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -1023,7 +1023,7 @@ export function CommercialPanel({
       />
       <CommercialFigure
         label={t("co.commercial.lostFigure")}
-        value={String(deals.lost_count)}
+        value={formatNumber(deals.lost_count, locale)}
       />
     </PanelBody>
   );

--- a/frontend/src/screens/companydocuments.tsx
+++ b/frontend/src/screens/companydocuments.tsx
@@ -7,7 +7,7 @@ import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AddDocumentDialog } from "./adddocument";
@@ -141,6 +141,7 @@ export function CompanyDocumentsCard({ orgId }: Readonly<{ orgId: string }>) {
   // separately and before RBAC.
   const canWriteDeals = useCanWrite("deal", "update");
   const t = useT();
+  const { locale } = useLocale();
   const [category, setCategory] = useState<Category | "">("");
   // History is off by default. Three uploads of one agreement's terms are one
   // document to a rep, and listing every replaced version beside the live one
@@ -204,7 +205,7 @@ export function CompanyDocumentsCard({ orgId }: Readonly<{ orgId: string }>) {
           <>
             <span>
               {t(supersededLine(showSuperseded, superseded.length), {
-                count: String(superseded.length),
+                count: formatNumber(superseded.length, locale),
               })}
             </span>
             <Button
@@ -297,10 +298,11 @@ function FilterChip({
   pressed: boolean;
   onPress: () => void;
 }>) {
+  const { locale } = useLocale();
   return (
     <Button small aria-pressed={pressed} onClick={onPress}>
       {label}
-      <span className="rec-chip-count">{count}</span>
+      <span className="rec-chip-count">{formatNumber(count, locale)}</span>
     </Button>
   );
 }

--- a/frontend/src/screens/companygrowthfit.tsx
+++ b/frontend/src/screens/companygrowthfit.tsx
@@ -246,7 +246,9 @@ function GrowthFitVerdict({ fit }: Readonly<{ fit: GrowthFit }>) {
                     about which dimension is which. */}
                 <span className="co-growth-fit-score-head">
                   <span>{t(SUB_SCORE_LABELS[sub.dimension])}</span>
-                  <span className="co-growth-fit-score-value">{sub.score}</span>
+                  <span className="co-growth-fit-score-value">
+                    {formatNumber(sub.score, locale)}
+                  </span>
                 </span>
                 {/* Flat, like the health meters beside it: the gradient's
                     second colour reads as a warning creeping in at the high

--- a/frontend/src/screens/companyrailshared.tsx
+++ b/frontend/src/screens/companyrailshared.tsx
@@ -3,6 +3,8 @@
 
 import { Badge } from "../design-system/atoms";
 import type { SectionState } from "../design-system/surfacestate";
+import { formatNumber } from "../format/format";
+import { useLocale } from "../i18n";
 
 // Small pieces companyrail.tsx and companyrailtags.tsx both draw a section
 // summary off — a leaf so neither file imports the other, the same no-cycle
@@ -21,10 +23,11 @@ export function SectionSummary({
   title,
   count,
 }: Readonly<{ title: string; count?: number }>) {
+  const { locale } = useLocale();
   return (
     <span className="co-sect-summary">
       {title}
-      {count != null && <Badge>{count}</Badge>}
+      {count != null && <Badge>{formatNumber(count, locale)}</Badge>}
     </span>
   );
 }

--- a/frontend/src/screens/companytoday.tsx
+++ b/frontend/src/screens/companytoday.tsx
@@ -311,10 +311,11 @@ function briefFooter(
 // own subhead below.
 function TodayTitle({ moves }: Readonly<{ moves: number }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <>
       {t("co.360.title")}
-      {moves > 0 && <Badge tone="accent">{moves}</Badge>}
+      {moves > 0 && <Badge tone="accent">{formatNumber(moves, locale)}</Badge>}
     </>
   );
 }

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -33,6 +33,7 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { Select, type SelectOption } from "../design-system/select";
+import { identifierNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useT } from "../i18n";
 import { entityTimelineKeys } from "./activitykeys";
@@ -879,10 +880,8 @@ function DraftDisclosure({
       {provenance.voice_profile_version != null && (
         <>
           <p className="t-caption">
-            {/* A profile VERSION, never grouped: version 1234 is one
-                identifier, and "1.234" reads as a different one. */}
             {t("compose.voiceVersion", {
-              n: String(provenance.voice_profile_version),
+              n: identifierNumber(provenance.voice_profile_version),
             })}
           </p>
           {maturity === "provisional" && (

--- a/frontend/src/screens/connections.tsx
+++ b/frontend/src/screens/connections.tsx
@@ -497,6 +497,7 @@ function NodeList({
   graph,
 }: Readonly<{ nodes: readonly GraphNode[]; graph: Graph }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (nodes.length === 0) {
     return <p className="surfacestate-empty">{t("co.connections.empty")}</p>;
   }
@@ -526,7 +527,7 @@ function NodeList({
             {node.detail && <span>{node.detail}</span>}
             {node.strength != null && node.strength_bucket && (
               <Badge tone={strengthTone(node.strength_bucket)}>
-                {node.strength}
+                {formatNumber(node.strength, locale)}
               </Badge>
             )}
             {node.kind === "user" && (
@@ -559,6 +560,7 @@ function ContactStrength({
   userId,
 }: Readonly<{ graph: Graph; userId: string }>) {
   const t = useT();
+  const { locale } = useLocale();
   const edge = strongestContactEdge(graph, userId);
   if (edge === undefined) {
     return null;
@@ -567,7 +569,9 @@ function ContactStrength({
     return <span className="cx-relation">{t("co.connections.noSignal")}</span>;
   }
   return (
-    <Badge tone={edgeStrengthTone(edge.strength_bucket)}>{edge.strength}</Badge>
+    <Badge tone={edgeStrengthTone(edge.strength_bucket)}>
+      {formatNumber(edge.strength, locale)}
+    </Badge>
   );
 }
 

--- a/frontend/src/screens/dealroom.stories.tsx
+++ b/frontend/src/screens/dealroom.stories.tsx
@@ -2,10 +2,14 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { LocaleProvider } from "../i18n";
 import { DealRoomAside } from "./dealroom";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
 
 // The states a rep meets this surface in, so each can be judged without
 // arranging a room, a buyer and a close on a running stack.
@@ -31,27 +35,29 @@ function room(state: string) {
   };
 }
 
-// Answers the reads the aside makes. A story that hits the real API shows
-// whatever that installation happens to hold, which is not a state anybody
-// chose to review.
+/**
+ * Answers the reads the aside makes, at the NETWORK edge rather than by seeding
+ * a cache.
+ *
+ * Seeding was the first spelling and it is only as complete as its list of
+ * query keys: the aside also probes `/me` for `deal_room:create`, and a key
+ * nobody thought of is a request that leaves the page for whatever host serves
+ * the iframe, 404s, and resolves to an answer that looks legitimate. Routing
+ * says what this surface is allowed to ask for, and `installFetchStub`'s own
+ * fallback answers an empty page for anything else instead of the network.
+ */
 function Served({
   rooms,
   children,
 }: Readonly<{ rooms: unknown[]; children: ReactNode }>) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+  installFetchStub({
+    // The aside offers the create verb, so the seat that may press it is part
+    // of every state below — a story routed without it would document the
+    // refused form rather than the state it is named for.
+    "GET /me": meRoute({ deal_room: ["read", "create"] }),
+    "GET /deal-rooms": () => jsonResponse({ data: rooms, page: {} }),
   });
-  client.setQueryData(["deal-rooms", "deal-1"], { data: rooms, page: {} });
-  client.setQueryData(["deal-room-documents", "room-1"], {
-    data: [],
-    page: {},
-  });
-  client.setQueryData(["deal-room-threads", "room-1"], { data: [], page: {} });
-  return (
-    <QueryClientProvider client={client}>
-      <LocaleProvider initial="en">{children}</LocaleProvider>
-    </QueryClientProvider>
-  );
+  return <StoryProviders>{children}</StoryProviders>;
 }
 
 /** A live room mid-negotiation. */

--- a/frontend/src/screens/dealroom.tsx
+++ b/frontend/src/screens/dealroom.tsx
@@ -20,7 +20,8 @@ import { navigate } from "../app/router";
 import { Badge, Button, Field, TextInput } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
 import { useParticipants } from "./dealroomaccess";
@@ -76,6 +77,7 @@ export function DealRoomAside({
 
 function RoomCard({ room }: Readonly<{ room: DealRoom }>) {
   const t = useT();
+  const { locale } = useLocale();
   const participants = useParticipants(room.id);
   const rows = participants.data?.data ?? [];
   const invited = rows.filter((p) => !p.revoked_at).length;
@@ -94,8 +96,8 @@ function RoomCard({ room }: Readonly<{ room: DealRoom }>) {
         <p>{room.title}</p>
         <p className="t-small">
           {t("room.card.people", {
-            invited: String(invited),
-            active: String(active),
+            invited: formatNumber(invited, locale),
+            active: formatNumber(active, locale),
           })}
         </p>
         {lastSeen ? (

--- a/frontend/src/screens/dealroomaccess.stories.tsx
+++ b/frontend/src/screens/dealroomaccess.stories.tsx
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { DealRoomAccess } from "./dealroomaccess";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+type DealRoom = components["schemas"]["DealRoom"];
+type Participant = components["schemas"]["DealRoomParticipant"];
+
+// Who has been admitted to a deal room, whether the invitation reached them,
+// and what they have taken out of it since.
+//
+// Two facts on this card are easy to confuse and are modelled apart, so the
+// stories keep them apart too. `delivery_state` is what happened to the LAST
+// credential we sent — it moves every time one is resent. `has_signed_in` is
+// whether this person ever exchanged one for a session, and it does not move,
+// because that is the fact that fixes their address.
+//
+// The reading line is deliberately absent at zero. "0 documents" reads as a
+// judgement about the buyer, and early in a room's life the honest report is
+// that there is nothing to report — so `NobodyHasOpenedIt` is a story about a
+// line that is not there.
+
+const ROOM: DealRoom = {
+  id: "room-1",
+  deal_id: "deal-1",
+  title: "Acme Expansion — Deal Room",
+  state: "live",
+  source: "manual",
+  captured_by: "u-me",
+  version: 1,
+  created_at: "2026-08-22T09:00:00Z",
+  updated_at: "2026-08-22T09:00:00Z",
+};
+
+function participant(overrides: Partial<Participant> = {}): Participant {
+  return {
+    id: "part-1",
+    room_id: ROOM.id,
+    full_name: "Dana Buyer",
+    email: "dana.buyer@brandt-automotive.example",
+    capability: "read",
+    delivery_state: "delivered",
+    has_signed_in: true,
+    last_seen_at: "2026-08-24T14:02:00Z",
+    source: "manual",
+    captured_by: "u-me",
+    created_at: "2026-08-22T09:10:00Z",
+    updated_at: "2026-08-24T14:02:00Z",
+    ...overrides,
+  };
+}
+
+function access(rows: Participant[], mayManage = true) {
+  return () => {
+    installFetchStub({
+      "GET /deal-rooms/room-1/participants": () =>
+        jsonResponse({ data: rows, page: { next_cursor: null } }),
+    });
+    return (
+      <StoryProviders>
+        <DealRoomAccess room={ROOM} mayManage={mayManage} />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof DealRoomAccess> = {
+  title: "Screens/Deal Room/Access",
+  component: DealRoomAccess,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof DealRoomAccess>;
+
+/** Nobody admitted yet. An empty room is a real state of a room a rep just
+ *  opened, and it says so rather than drawing an empty list. */
+export const NobodyAdmitted: Story = { render: access([]) };
+
+/**
+ * Admitted, and the room has been read. The reading line names how many
+ * documents left the room and which — a count and its own evidence, so a
+ * figure nobody can check is never the whole report.
+ */
+export const HasBeenRead: Story = {
+  render: access([
+    participant({
+      download_count: 3,
+      documents_downloaded: [
+        "Commercial terms v4",
+        "Implementation plan",
+        "Security appendix",
+      ],
+    }),
+  ]),
+};
+
+/**
+ * A room that has been worked hard. Four digits is where de-DE first groups, so
+ * this is the only story in which the count's notation is visible at all — and
+ * the line sits beside document titles, which is exactly where a figure written
+ * in the wrong notation reads as a different number.
+ */
+export const HeavilyRead: Story = {
+  render: access([
+    participant({
+      download_count: 1204,
+      documents_downloaded: ["Commercial terms v4", "Implementation plan"],
+    }),
+  ]),
+};
+
+/** The same room in German. */
+export const HeavilyReadGerman: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /deal-rooms/room-1/participants": () =>
+        jsonResponse({
+          data: [
+            participant({
+              download_count: 1204,
+              documents_downloaded: ["Kommerzielle Bedingungen v4"],
+            }),
+          ],
+          page: { next_cursor: null },
+        }),
+    });
+    return (
+      <StoryProviders locale="de">
+        <DealRoomAccess room={ROOM} mayManage />
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * Admitted, and nothing taken. The reading line is ABSENT rather than reporting
+ * zero — the state this card is most often in, and the one a "0 documents" line
+ * would turn into an accusation.
+ */
+export const NobodyHasOpenedIt: Story = {
+  render: access([participant({ has_signed_in: false, last_seen_at: null })]),
+};
+
+/**
+ * The invitation bounced. Delivery is modelled apart from access for this
+ * case: the person is admitted, and the credential never reached them, so the
+ * row has to say which of the two went wrong.
+ */
+export const InvitationFailed: Story = {
+  render: access([
+    participant({
+      delivery_state: "failed",
+      has_signed_in: false,
+      last_seen_at: null,
+    }),
+  ]),
+};
+
+/** Several people, in the states a real room mixes them in. */
+export const SeveralPeople: Story = {
+  render: access([
+    participant({ download_count: 12, documents_downloaded: ["Terms v4"] }),
+    participant({
+      id: "part-2",
+      full_name: "Jonas Petersen",
+      email: "jonas.petersen@brandt-automotive.example",
+      delivery_state: "sent",
+      has_signed_in: false,
+      last_seen_at: null,
+    }),
+    participant({
+      id: "part-3",
+      full_name: "Marta Alvarez de Sotomayor-Whitfield",
+      email: "marta.alvarez.de.sotomayor.whitfield@brandt-automotive.example",
+      delivery_state: "consumed",
+      download_count: 1,
+      documents_downloaded: [
+        "A document whose title is long enough to have to wrap rather than truncate",
+      ],
+    }),
+  ]),
+};
+
+/**
+ * A seat that may read the room and not change who is in it. The card keeps its
+ * place and loses the invite verb — withholding the page's one explanation
+ * would be the defect, withholding twelve controls individually would be noise.
+ */
+export const ReadOnly: Story = {
+  render: access(
+    [participant({ download_count: 3, documents_downloaded: ["Terms v4"] })],
+    false,
+  ),
+};
+
+/** At 390px the row's name, its state and its reading line stack instead of
+ *  sharing a line with the verbs. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: access([
+    participant({ download_count: 1204, documents_downloaded: ["Terms v4"] }),
+  ]),
+};

--- a/frontend/src/screens/dealroomaccess.tsx
+++ b/frontend/src/screens/dealroomaccess.tsx
@@ -15,7 +15,7 @@ import { Callout } from "../design-system/callout";
 import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
-import { formatDateAbbrev } from "../format/format";
+import { formatDateAbbrev, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
@@ -135,6 +135,7 @@ export function DealRoomAccess({
 // early in a room's life is simply that there is nothing to report yet.
 function ReadingSoFar({ participant }: Readonly<{ participant: Participant }>) {
   const t = useT();
+  const { locale } = useLocale();
   const downloads = participant.download_count ?? 0;
   if (downloads === 0) {
     return null;
@@ -142,7 +143,7 @@ function ReadingSoFar({ participant }: Readonly<{ participant: Participant }>) {
   const titles = participant.documents_downloaded ?? [];
   return (
     <p className="t-small access-row-facts">
-      {t("access.downloads", { count: String(downloads) })}
+      {t("access.downloads", { count: formatNumber(downloads, locale) })}
       {titles.length > 0 ? ` · ${titles.join(", ")}` : ""}
     </p>
   );

--- a/frontend/src/screens/dealroomthreads.stories.tsx
+++ b/frontend/src/screens/dealroomthreads.stories.tsx
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Badge } from "../design-system/atoms";
+import type {
+  BoardDocument,
+  BoardGroup,
+  DealRoomThread,
+  ThreadVerbs,
+} from "./dealroomthreads";
+import { DocumentBoard } from "./dealroomthreads";
+import { StoryProviders } from "./story-utils";
+
+// The room's documents and the conversation about them, drawn as ONE board:
+// a thread sits inside the document it is about, so a reader never has to work
+// out which document a question belongs to.
+//
+// The component takes everything as props — both sides of the room render it,
+// and what the two sides KNOW differs — so these stories are the two sides and
+// the states between them rather than a set of fetches. That is also why the
+// verbs arrive as a bag of optional functions: an absent `reply` is how the
+// board is told this reader may not write, and `refusal` is the sentence that
+// says why. A board given `disabled` controls instead would be refusing without
+// explaining.
+//
+// The second panel is the room-wide one, and its badge counts the threads that
+// belong to no document ON SCREEN — including a thread about a document the
+// seller has since removed, which still has to be answerable. That last case is
+// `OrphanedThread`, and it is the reason the count is computed rather than
+// handed in.
+
+const GROUPS: readonly BoardGroup[] = [
+  { key: "commercial", label: "Commercial" },
+  { key: "technical", label: "Technical" },
+];
+
+const DOCUMENTS: readonly BoardDocument[] = [
+  {
+    id: "doc-1",
+    groupKey: "commercial",
+    title: "Commercial terms v4",
+    meta: "commercial-terms-v4.pdf · Commercial",
+    status: <Badge tone="success">Shared</Badge>,
+  },
+  {
+    id: "doc-2",
+    groupKey: "technical",
+    title: "Implementation plan",
+    meta: "implementation-plan.pdf · Technical",
+    status: <Badge>Draft</Badge>,
+  },
+];
+
+function author(side: "seller" | "buyer", name: string) {
+  return { side, name };
+}
+
+function thread(overrides: Partial<DealRoomThread> = {}): DealRoomThread {
+  const id = overrides.id ?? "thread-1";
+  return {
+    id,
+    room_id: "room-1",
+    document_id: null,
+    required_change: false,
+    state: "open",
+    author: author("buyer", "Dana Buyer"),
+    created_at: "2026-08-24T10:00:00Z",
+    comments: [
+      {
+        id: `${id}-c1`,
+        thread_id: id,
+        body: "Can we align the payment schedule with our fiscal quarters?",
+        author: author("buyer", "Dana Buyer"),
+        created_at: "2026-08-24T10:00:00Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const SELLER_VERBS: ThreadVerbs = {
+  reply: async () => {},
+  resolve: async () => {},
+  open: async () => {},
+  mayRequireChange: false,
+};
+
+function board(
+  threads: readonly DealRoomThread[],
+  verbs: ThreadVerbs = SELLER_VERBS,
+  documents: readonly BoardDocument[] = DOCUMENTS,
+) {
+  return () => (
+    <StoryProviders>
+      <DocumentBoard
+        title="Documents"
+        sub="What the buyer can read, and what they have asked about it."
+        groups={GROUPS}
+        documents={documents}
+        threads={threads}
+        verbs={verbs}
+        empty="No document has been shared into this room yet."
+      />
+    </StoryProviders>
+  );
+}
+
+const meta: Meta<typeof DocumentBoard> = {
+  title: "Screens/Deal Room/Documents and threads",
+  component: DocumentBoard,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof DocumentBoard>;
+
+/** A room with documents and nothing asked yet. Both panels say so in their own
+ *  words, because "no documents" and "no questions" are different facts. */
+export const NothingAskedYet: Story = { render: board([]) };
+
+/** A room with no documents at all: the empty sentence is the caller's, because
+ *  what belongs in a room is the one thing only the caller knows. */
+export const NoDocuments: Story = { render: board([], SELLER_VERBS, []) };
+
+/** A question about a document, inside that document's card. */
+export const ThreadOnADocument: Story = {
+  render: board([thread({ document_id: "doc-1" })]),
+};
+
+/** A question about the room rather than any one document, in the room-wide
+ *  panel with the count beside its title. */
+export const RoomWideThread: Story = { render: board([thread()]) };
+
+/**
+ * A thread about a document the list no longer carries. It joins the room-wide
+ * panel rather than disappearing: a seller who removed a draft before
+ * publishing it must still be able to see and answer the question the buyer
+ * asked about it, while the buyer — still on the last release — can.
+ */
+export const OrphanedThread: Story = {
+  render: board([
+    thread({ id: "thread-9", document_id: "doc-removed" }),
+    thread({ id: "thread-1", document_id: "doc-1" }),
+  ]),
+};
+
+/**
+ * The buyer's mark: a question that says the document needs changing rather
+ * than merely asking about it. Only the buyer may set it, which is why
+ * `mayRequireChange` is a verb rather than a style.
+ */
+export const RequiresAChange: Story = {
+  render: board(
+    [
+      thread({
+        document_id: "doc-1",
+        required_change: true,
+        comments: [
+          {
+            id: "t1-c1",
+            thread_id: "thread-1",
+            body: "Clause 7 conflicts with our standard terms — this one we do need changed before signing.",
+            author: author("buyer", "Dana Buyer"),
+            created_at: "2026-08-24T10:00:00Z",
+          },
+        ],
+      }),
+    ],
+    { ...SELLER_VERBS, resolve: undefined, mayRequireChange: true },
+  ),
+};
+
+/** Answered and closed. A resolved thread stays readable — the record of what
+ *  was asked is the point, not the open count. */
+export const Resolved: Story = {
+  render: board([
+    thread({
+      document_id: "doc-1",
+      state: "resolved",
+      resolved_at: "2026-08-24T16:30:00Z",
+      comments: [
+        {
+          id: "t1-c1",
+          thread_id: "thread-1",
+          body: "Can we align the payment schedule with our fiscal quarters?",
+          author: author("buyer", "Dana Buyer"),
+          created_at: "2026-08-24T10:00:00Z",
+        },
+        {
+          id: "t1-c2",
+          thread_id: "thread-1",
+          body: "Yes — v5 moves the milestones to the end of each quarter.",
+          author: author("seller", "Lena Fischer"),
+          created_at: "2026-08-24T16:29:00Z",
+        },
+      ],
+    }),
+  ]),
+};
+
+/**
+ * A reader who may not write. The composer's verbs are ABSENT rather than
+ * disabled, and `refusal` is the sentence that says why — a refused control
+ * with no explanation reaches nobody, least of all a screen reader.
+ */
+export const WriteRefused: Story = {
+  render: board([thread({ document_id: "doc-1" })], {
+    mayRequireChange: false,
+    refusal: "This room is closed. Its conversation stays readable.",
+  }),
+};
+
+/**
+ * A count wide enough to be written in a notation. The room panel's badge is a
+ * magnitude, and four digits is where de-DE first groups — below it the figure
+ * reads the same in every language and proves nothing.
+ */
+export const ManyRoomThreads: Story = {
+  render: board(
+    Array.from({ length: 1204 }, (_, index) =>
+      thread({ id: `thread-${index}` }),
+    ),
+  ),
+};
+
+/** The same board in German: the longer copy, and the badge in the reader's own
+ *  notation. */
+export const ManyRoomThreadsGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <DocumentBoard
+        title="Dokumente"
+        sub="Was der Käufer lesen kann — und was er dazu gefragt hat."
+        groups={GROUPS}
+        documents={DOCUMENTS}
+        threads={Array.from({ length: 1204 }, (_, index) =>
+          thread({ id: `thread-${index}` }),
+        )}
+        verbs={SELLER_VERBS}
+        empty="In diesem Raum liegt noch kein Dokument."
+      />
+    </StoryProviders>
+  ),
+};
+
+/** Long content: a comment nobody wrote in one line, which the thread has to
+ *  wrap rather than clip. */
+export const LongComment: Story = {
+  render: board([
+    thread({
+      document_id: "doc-2",
+      comments: [
+        {
+          id: "t1-c1",
+          thread_id: "thread-1",
+          body: "Our procurement team has asked whether the implementation plan can be split so the pilot plant runs ahead of the other three, because the retrofit window at Sindelfingen closes in March and we would rather not hold the whole programme to the slowest site. If that works, we would also want the acceptance criteria restated per site rather than per programme.",
+          author: author("buyer", "Dana Buyer"),
+          created_at: "2026-08-24T10:00:00Z",
+        },
+      ],
+    }),
+  ]),
+};
+
+/** At 390px the document cards stack and a thread's author, time and body
+ *  cannot share a line. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: board([thread({ document_id: "doc-1" }), thread({ id: "thread-2" })]),
+};

--- a/frontend/src/screens/dealroomthreads.tsx
+++ b/frontend/src/screens/dealroomthreads.tsx
@@ -10,7 +10,8 @@ import {
 } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { problemMessageOf } from "./common";
 import "./dealroomthreads.css";
 
@@ -87,6 +88,7 @@ export function DocumentBoard({
   footer?: ReactNode;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const byDocument = new Map<string, DealRoomThread[]>();
   for (const thread of threads) {
     if (thread.document_id) {
@@ -139,7 +141,7 @@ export function DocumentBoard({
       <Panel
         title={t("threads.roomTitle")}
         sub={t("threads.roomSub")}
-        titleAction={<Badge>{String(roomThreads.length)}</Badge>}
+        titleAction={<Badge>{formatNumber(roomThreads.length, locale)}</Badge>}
       >
         <PanelBody>
           {roomThreads.length === 0 ? (
@@ -170,6 +172,7 @@ function DocumentCard({
   verbs: ThreadVerbs;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <article className="board-doc" aria-label={doc.title}>
       <div className="room-doc">
@@ -188,7 +191,9 @@ function DocumentCard({
             <MessageSquare aria-hidden />
             {threads.length === 1
               ? t("threads.aboutThisOne")
-              : t("threads.aboutThis", { count: String(threads.length) })}
+              : t("threads.aboutThis", {
+                  count: formatNumber(threads.length, locale),
+                })}
           </span>
           <ThreadList threads={threads} verbs={verbs} />
         </div>

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -3,9 +3,9 @@
 
 import { ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
-import { hourInZone } from "../format/format";
+import { formatNumber, hourInZone } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // The first thing a reader sees each morning: who they are, what hour it is for
@@ -118,6 +118,7 @@ function CountMark({
   onClick,
   label,
 }: Readonly<{ count: number; onClick?: () => void; label?: string }>) {
+  const { locale } = useLocale();
   // A figure with nowhere to go is a figure, not a control. The overnight
   // capture count is the case: Home has no destination that lists the messages
   // it counts, and pointing it at the dedupe queue sent a reader to a different
@@ -125,7 +126,9 @@ function CountMark({
   // loses the arrow and the press target, which is the honest reading.
   if (!onClick) {
     return (
-      <span className="glance-count glance-count-flat t-mono">{count}</span>
+      <span className="glance-count glance-count-flat t-mono">
+        {formatNumber(count, locale)}
+      </span>
     );
   }
   // The destination goes in a spoken span rather than an `aria-label`: a label
@@ -134,7 +137,7 @@ function CountMark({
   // at two places would announce the same name.
   return (
     <button type="button" className="glance-count t-mono" onClick={onClick}>
-      {count}
+      {formatNumber(count, locale)}
       {label ? <span className="sr-only"> {label}</span> : null}
       <ArrowRight size={13} aria-hidden="true" />
     </button>

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -52,12 +52,15 @@ function DigestCount({
   value,
   onOpen,
 }: Readonly<{ label: string; value: number; onOpen?: () => void }>) {
+  const { locale } = useLocale();
   if (onOpen) {
     return (
       <PanelRow interactive>
         <button type="button" className="rail-count-go" onClick={onOpen}>
           <span className="rail-count-label">{label}</span>
-          <span className="rail-count-value t-mono">{value}</span>
+          <span className="rail-count-value t-mono">
+            {formatNumber(value, locale)}
+          </span>
           <ArrowRight size={14} aria-hidden />
         </button>
       </PanelRow>
@@ -67,7 +70,9 @@ function DigestCount({
     <PanelRow>
       <span className="rail-count">
         <span className="rail-count-label">{label}</span>
-        <span className="rail-count-value t-mono">{value}</span>
+        <span className="rail-count-value t-mono">
+          {formatNumber(value, locale)}
+        </span>
       </span>
     </PanelRow>
   );

--- a/frontend/src/screens/home.readings.tsx
+++ b/frontend/src/screens/home.readings.tsx
@@ -56,7 +56,7 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.decisions")}
-          value={String(decisions.pending)}
+          value={formatNumber(decisions.pending, locale)}
           // The tile is bad news only when something runs out TODAY. A queue
           // with work in it is the normal state of a morning; a queue with a
           // deadline in it is the one that changes what a reader does first.
@@ -78,7 +78,7 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.openDeals")}
-          value={String(open.deals)}
+          value={formatNumber(open.deals, locale)}
           detail={t(
             open.currencies === 1
               ? "home.readings.currencies.one"
@@ -91,7 +91,7 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.ranked")}
-          value={String(ranked.count)}
+          value={formatNumber(ranked.count, locale)}
           detail={
             ranked.topPct === null
               ? t("home.readings.noRun")
@@ -105,7 +105,7 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.quiet")}
-          value={String(quiet)}
+          value={formatNumber(quiet, locale)}
           tone={quiet > 0 ? "warn" : "good"}
           dot={quiet > 0}
           detail={quiet === 0 ? t("home.readings.quietNone") : undefined}

--- a/frontend/src/screens/import.stories.tsx
+++ b/frontend/src/screens/import.stories.tsx
@@ -23,6 +23,13 @@ import {
 // reach: the run an earlier visit left parked.
 function story(allow: Parameters<typeof meRoute>[0]) {
   return () => {
+    // A story states its own preconditions, including the absence of one.
+    // `PickedUpFromEarlier` plants a run id in storage, and storage outlives a
+    // story: the capture harness drives every story through ONE page, so the
+    // next one inherits it, the card reopens the wizard for a run this story
+    // never mentioned, and the dialog portals past the canvas — leaving a story
+    // named for the row asserting against an empty one.
+    globalThis.localStorage.removeItem("margince.import.run");
     installFetchStub({ "GET /me": meRoute(allow) });
     return (
       <StoryProviders>
@@ -35,9 +42,14 @@ function story(allow: Parameters<typeof meRoute>[0]) {
 // Opening the wizard. The verb is the card's only button, and it is in the
 // canvas — the dialog it opens is portalled to the body, past `canvasElement`.
 const openWizard: NonNullable<Story["play"]> = async ({ canvasElement }) => {
-  await userEvent
-    .setup()
-    .click(within(canvasElement).getByRole("button", { name: /Start/ }));
+  // findBy, not getBy: the row is drawn once `/me` answers, and `getByRole`
+  // reads the DOM as it stands the instant `play` runs. It found an empty
+  // canvas and reported "there are no accessible roles" — which reads as the
+  // card rendering nothing rather than as the query arriving early.
+  const verb = await within(canvasElement).findByRole("button", {
+    name: /Start/,
+  });
+  await userEvent.setup().click(verb);
 };
 
 const OPERATOR = { import_run: ["create", "read", "update"] } as const;
@@ -95,9 +107,9 @@ export const ChoosingAFileDark: Story = {
 // not know their last import stopped half-way cannot finish it, so the wizard
 // opens ITSELF for a run it picked up rather than waiting behind a verb.
 //
-// The reference it plants is self-clearing: every other story routes these reads
-// to the empty fallback, which is not a run in a state worth reopening, so the
-// card forgets it and shows its resting row.
+// The reference it plants OUTLIVES it — storage is not per-story — so the shared
+// helper above clears it rather than every other story trusting this one to
+// leave the page as it found it.
 export const PickedUpFromEarlier: Story = {
   render: () => {
     globalThis.localStorage.setItem("margince.import.run", "019ff-run");

--- a/frontend/src/screens/import.tsx
+++ b/frontend/src/screens/import.tsx
@@ -13,7 +13,7 @@ import {
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDateTime, formatNumber } from "../format/format";
+import { formatDateTime, formatNumber, ordinalNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -358,10 +358,7 @@ function ImportOutcome({
           <ul className="import__issues">
             {report.issues.map((issue) => (
               <li key={`${issue.line}-${issue.reason}`}>
-                {/* A line number is where to look in the uploaded file, so it
-                    is never grouped: "1.234" is not a line the reader can find
-                    in a text editor. */}
-                {t("import.issueLine", { line: String(issue.line) })}{" "}
+                {t("import.issueLine", { line: ordinalNumber(issue.line) })}{" "}
                 {issue.reason}
               </li>
             ))}

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -26,7 +26,7 @@ import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { ToastRegion, useToast } from "../design-system/toast";
 import { fiscalYearLabel } from "../format/fiscalyear";
-import { monthName } from "../format/format";
+import { identifierNumber, monthName } from "../format/format";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import {
   problemFieldErrorsOf,
@@ -603,13 +603,13 @@ function InstallationProfileDialog({
               <Select
                 {...control}
                 aria-describedby={describe(control)}
-                value={String(draft.fiscal_year_start_month)}
+                value={identifierNumber(draft.fiscal_year_start_month)}
                 disabled={!canManage}
                 // Twelve months, each labelled with what a report would then be
                 // called — "April — FY2026/27". A bare number would make the
                 // admin work out the consequence of every option; this states it.
                 options={MONTHS.map((month) => ({
-                  value: String(month),
+                  value: identifierNumber(month),
                   label: fiscalYearStartSummary(
                     month,
                     locale,

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -25,7 +25,8 @@ import { ProviderMark } from "../design-system/provider-mark";
 import { Meter } from "../design-system/readings";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { Switch } from "../design-system/switch";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import {
   problemCode,
   problemMessageOf,
@@ -214,6 +215,7 @@ function SpendReading({
   connection,
 }: Readonly<{ connection: ProviderConnection }>) {
   const t = useT();
+  const { locale } = useLocale();
   const months = connection.spend?.months ?? [];
   if (months.length === 0) {
     return <p className="provider-empty">{t("provider.spend.none")}</p>;
@@ -248,16 +250,18 @@ function SpendReading({
                   : month.month}
               </td>
               <td>{month.pool}</td>
-              <td>{month.charged_credits}</td>
+              <td>{formatNumber(month.charged_credits, locale)}</td>
               {/* Never folded into the charge: the platform does not know
                   whether those credits were spent, and a total that quietly
                   counted them either way would assert something it cannot
                   support. This is the figure a human reconciles against the
                   provider's invoice. */}
               <td className="provider-held">
-                {month.held_credits > 0 ? month.held_credits : "—"}
+                {month.held_credits > 0
+                  ? formatNumber(month.held_credits, locale)
+                  : "—"}
               </td>
-              <td>{month.runs}</td>
+              <td>{formatNumber(month.runs, locale)}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/screens/jobhealth.tsx
+++ b/frontend/src/screens/jobhealth.tsx
@@ -13,7 +13,12 @@ import { CardBoundary } from "../design-system/cardboundary";
 import { type Fact, FactList } from "../design-system/factlist";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { formatDateTime, formatNumber } from "../format/format";
+import {
+  formatDateTime,
+  formatNumber,
+  identifierNumber,
+  ordinalNumber,
+} from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -193,20 +198,17 @@ function failureNote(
           {" · "}
         </>
       )}
-      {/* Two rungs of the retry ladder, never grouped: "attempt 1.234 of
-          2.000" reads as a quantity where the pair states a position. */}
       {t("jobs.attempt", {
-        attempt: String(failure.attempt),
-        max: String(failure.max_attempts),
+        attempt: ordinalNumber(failure.attempt),
+        max: ordinalNumber(failure.max_attempts),
         when: formatDateTime(failure.failed_at, locale, zone),
       })}
-      {/* Interpolated as-is, never through formatNumber: this is the id River
-          prints in its own log lines, and a grouped "4,711" is not a string
-          that finds them. */}
+      {/* The id River prints in its own log lines, so it stays the string an
+          operator greps them with. */}
       {jobID !== undefined && (
         <>
           {" · "}
-          {t("jobs.jobId", { id: String(jobID) })}
+          {t("jobs.jobId", { id: identifierNumber(jobID) })}
         </>
       )}
       {/* Only when an attempt error was actually recorded. A job cancelled

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -144,7 +144,7 @@ function LeadCard({
       )}
       <span className="deal-meta">
         <Badge tone={scoreTone(lead.score)}>
-          {t("lead.score")}: {lead.score}
+          {t("lead.score")}: {formatNumber(lead.score, locale)}
         </Badge>
         <SlaBadge state={lead.sla_state} />
         {lead.title && <span>{lead.title}</span>}

--- a/frontend/src/screens/leads.list.stories.tsx
+++ b/frontend/src/screens/leads.list.stories.tsx
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { LeadsScreen } from "./leads.list";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+type Lead = components["schemas"]["Lead"];
+
+// The lead queue. A lead is not a person yet, and the screen's whole job is to
+// keep that true: the row opens the LEAD's own page, never the person's, and
+// the owner column answers "whose lead is this" rather than "who typed it".
+//
+// Which leads a reader opens on is a ROLE question, not a filter the screen
+// remembers — an admin or manager runs the queue and opens on all of it, a rep
+// opens on their own. So the two are separate stories with different `/me`
+// identities rather than one story with a control pressed.
+//
+// The score is the figure a reader scans down the column, and it is a magnitude
+// like any other: `HighScores` carries four digits, which is the only width at
+// which de-DE grouping is visible at all.
+
+function lead(overrides: Partial<Lead> = {}): Lead {
+  return {
+    id: "l-1",
+    full_name: "Jonas Petersen",
+    email: "jonas.petersen@brandt-automotive.example",
+    title: "Head of Procurement",
+    company_name: "Brandt Automotive GmbH",
+    status: "new",
+    score: 72,
+    score_reason: "engagement",
+    owner_id: "u-lena",
+    sla_state: "within_target",
+    source: "manual",
+    captured_by: "u-me",
+    version: 1,
+    created_at: "2026-08-20T09:00:00Z",
+    updated_at: "2026-08-24T11:00:00Z",
+    ...overrides,
+  };
+}
+
+const ROSTER = {
+  data: [
+    { id: "u-me", display_name: "Ada Ops", kind: "user" },
+    { id: "u-lena", display_name: "Lena Fischer", kind: "user" },
+  ],
+  page: { next_cursor: null },
+};
+
+// `/me` and the list are routed explicitly; everything else this screen reads —
+// the roster, the custom fields, the SoR posture — falls through to the stub's
+// own empty page, which is a legitimate answer for each of them and keeps the
+// story about the queue rather than about its chrome.
+function leads(
+  rows: Lead[],
+  identity: { roles?: string[]; seat?: "full" | "read" } = {
+    roles: ["manager"],
+  },
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({ lead: ["read", "update"] }, identity),
+      "GET /leads": () =>
+        jsonResponse({ data: rows, page: { next_cursor: null } }),
+      "GET /leads/settings": () =>
+        jsonResponse({ first_response_enabled: true }),
+      "GET /users": () => jsonResponse(ROSTER),
+    });
+    return (
+      <StoryProviders>
+        <LeadsScreen />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof LeadsScreen> = {
+  title: "Records/Leads/Queue",
+  component: LeadsScreen,
+};
+export default meta;
+type Story = StoryObj<typeof LeadsScreen>;
+
+/** A manager's queue: every lead, whoever owns it. */
+export const ManagerOpensOnAll: Story = {
+  render: leads([
+    lead(),
+    lead({
+      id: "l-2",
+      full_name: "Marta Alvarez",
+      company_name: "Voss Logistics",
+      status: "contacted",
+      score: 58,
+      sla_state: "breached",
+    }),
+    lead({
+      id: "l-3",
+      full_name: "Tobias Krause",
+      company_name: "Sindelfingen Werke",
+      status: "engaged",
+      score: 91,
+      owner_id: "u-me",
+    }),
+  ]),
+};
+
+/** A rep's queue: their own leads. Same screen, a different answer from
+ *  `/me` — the segregation is a rule about the seat, not a saved filter. */
+export const RepOpensOnTheirOwn: Story = {
+  render: leads([lead({ owner_id: "u-me" })], { roles: ["rep"] }),
+};
+
+/** Nobody has routed a lead here yet. An empty queue is a real state and says
+ *  so, rather than drawing a table with no rows. */
+export const EmptyQueue: Story = { render: leads([]) };
+
+/**
+ * Scores wide enough to be written in a notation. A score column is read DOWN,
+ * so a figure grouped in one row and bare in the next is the defect at its most
+ * visible — and four digits is where de-DE first groups.
+ */
+export const HighScores: Story = {
+  render: leads([
+    lead({ score: 1204 }),
+    lead({ id: "l-2", full_name: "Marta Alvarez", score: 48_213 }),
+    lead({ id: "l-3", full_name: "Tobias Krause", score: 991 }),
+  ]),
+};
+
+/** The same queue in German — the score column and the longer status words. */
+export const HighScoresGerman: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": meRoute({ lead: ["read", "update"] }, { roles: ["manager"] }),
+      "GET /leads": () =>
+        jsonResponse({
+          data: [lead({ score: 1204 }), lead({ id: "l-2", score: 48_213 })],
+          page: { next_cursor: null },
+        }),
+      "GET /leads/settings": () =>
+        jsonResponse({ first_response_enabled: true }),
+      "GET /users": () => jsonResponse(ROSTER),
+    });
+    return (
+      <StoryProviders locale="de">
+        <LeadsScreen />
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * A score somebody overrode by hand. The row says it was overridden rather than
+ * quietly showing a number the model did not produce — the reason is the point,
+ * and a bare figure would pass a human's judgement off as the system's.
+ */
+export const OverriddenScore: Story = {
+  render: leads([
+    lead({
+      score: 95,
+      score_computed: 41,
+      score_override_reason:
+        "Met at the trade fair; budget confirmed verbally.",
+    }),
+  ]),
+};
+
+/** A read-only seat: the rows are there and the verbs are not. */
+export const ReadOnly: Story = {
+  render: leads([lead()], { roles: ["rep"], seat: "read" }),
+};
+
+/** Long content: a name and a company that cannot share a line at any width. */
+export const LongNames: Story = {
+  render: leads([
+    lead({
+      full_name: "Marta Alvarez de Sotomayor-Whitfield",
+      title: "Interim Head of Group Procurement and Supplier Development",
+      company_name:
+        "Sindelfingen Werke für Fahrzeugtechnik und Systemintegration GmbH & Co. KG",
+    }),
+  ]),
+};
+
+/** At 390px the table becomes a list of cards and the score has to stay beside
+ *  the name it belongs to. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: leads([lead({ score: 1204 }), lead({ id: "l-2", score: 58 })]),
+};

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -405,7 +405,9 @@ function LeadsWorkbench({
                   flexWrap: "wrap",
                 }}
               >
-                <Badge tone={scoreTone(lead.score)}>{lead.score}</Badge>
+                <Badge tone={scoreTone(lead.score)}>
+                  {formatNumber(lead.score, locale)}
+                </Badge>
                 <span className="t-caption">
                   {lead.score_reason
                     ? scoreFactorLabel(lead.score_reason, t)

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -796,6 +796,7 @@ function LeadLifecycle({
   overlay: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const me = useMe();
   const scoreFieldId = useId();
   const reasonFieldId = useId();
@@ -909,7 +910,7 @@ function LeadLifecycle({
         summary={
           <span className="lead-score-summary">
             <Badge tone={scoreTone(lead.score)}>
-              {t("lead.score")}: {lead.score}
+              {t("lead.score")}: {formatNumber(lead.score, locale)}
             </Badge>{" "}
             <span className="t-caption">
               {lead.score_reason
@@ -956,13 +957,14 @@ function LeadLifecycle({
 // the terminal-state labelling lives in one place (terminalBadge).
 function LeadBadges({ lead }: Readonly<{ lead: Lead }>) {
   const t = useT();
+  const { locale } = useLocale();
   const terminal = terminalBadge(lead.status);
   return (
     <div
       style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}
     >
       <Badge tone={scoreTone(lead.score)}>
-        {t("lead.score")}: {lead.score}
+        {t("lead.score")}: {formatNumber(lead.score, locale)}
       </Badge>
       {lead.score_override_reason && <Badge>{t("lead.overriddenBadge")}</Badge>}
       <StatusBadge status={lead.status} />

--- a/frontend/src/screens/leadsignals.tsx
+++ b/frontend/src/screens/leadsignals.tsx
@@ -224,7 +224,7 @@ export function LeadManualSignals({
                     <strong>{label(`${name}.${live.band}`)}</strong>
                     <Badge>
                       {live.points >= 0 ? "+" : ""}
-                      {live.points}
+                      {formatNumber(live.points, locale)}
                     </Badge>
                     <span className="t-caption">{label(live.signal_kind)}</span>
                     {live.confidence != null && (

--- a/frontend/src/screens/license.tsx
+++ b/frontend/src/screens/license.tsx
@@ -8,7 +8,8 @@ import { Panel, PanelBody } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { StatStrip } from "../design-system/statstrip";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { QueryGate, throwProblem } from "./common";
 import { LicenseHolderCard } from "./licenseholder";
 
@@ -90,8 +91,15 @@ export function LicenseReading({
   entitlement,
 }: Readonly<{ entitlement: LicenseEntitlement }>) {
   const t = useT();
+  const { locale } = useLocale();
   const granted = entitlement.seats_granted;
   const capped = granted !== undefined && granted !== null;
+  // ONE spelling of "the grant, or the word for not having one". The callout,
+  // the slot and the meter's name all say it, and three readings of one absence
+  // is how a card ends up claiming two different things about one license.
+  const grantedText = capped
+    ? formatNumber(granted, locale)
+    : t("license.seats.uncapped");
 
   return (
     // A `Panel`, like every other card on every other settings page. This card
@@ -120,9 +128,15 @@ export function LicenseReading({
             icon={TriangleAlert}
             title={t("license.over.title")}
           >
+            {/* Gated on the server's verdict ALONE. `over_limit` is false
+                whenever nothing caps seats, so the contract already answers
+                this; re-deriving it here from `seats_granted` would be the
+                client reaching its own answer about the installation's
+                standing, and on a payload where the two disagreed it would
+                withdraw the one alert an admin has to act on. */}
             {t("license.over.body", {
-              used: String(entitlement.seats_used),
-              granted: String(granted),
+              used: formatNumber(entitlement.seats_used, locale),
+              granted: grantedText,
             })}
           </Callout>
         )}
@@ -145,7 +159,7 @@ export function LicenseReading({
                 <StatStrip>
                   <StatCard
                     label={t("license.seats.used")}
-                    value={String(entitlement.seats_used)}
+                    value={formatNumber(entitlement.seats_used, locale)}
                     // The slot itself is the bad news when the count is past the
                     // grant, so `alert` rather than `tone`, which would only
                     // colour the figure.
@@ -157,9 +171,7 @@ export function LicenseReading({
                     // unlicensed installation and a license that caps nothing
                     // both have no number here, and only the first is something
                     // an admin might want to change.
-                    value={
-                      capped ? String(granted) : t("license.seats.uncapped")
-                    }
+                    value={grantedText}
                   />
                 </StatStrip>
                 {capped && (
@@ -170,8 +182,8 @@ export function LicenseReading({
                     // beside it, so the reading is named here rather than by the
                     // row's own label.
                     label={t("license.meter.label", {
-                      used: String(entitlement.seats_used),
-                      granted: String(granted),
+                      used: formatNumber(entitlement.seats_used, locale),
+                      granted: grantedText,
                     })}
                   />
                 )}

--- a/frontend/src/screens/linkedin-import.tsx
+++ b/frontend/src/screens/linkedin-import.tsx
@@ -9,7 +9,8 @@ import { Button, Field, Modal, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import {
   LINKEDIN_ACCOUNT_KEY,
@@ -312,25 +313,26 @@ export function LinkedInImportCard() {
 // under a success message is worse than a refusal.
 function ImportResult({ summary }: Readonly<{ summary: ImportSummary }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <>
       <dl data-testid="linkedin-import-result" className="li-import-result">
         <div>
           <dt>{t("linkedinImport.imported")}</dt>
-          <dd>{summary.imported}</dd>
+          <dd>{formatNumber(summary.imported, locale)}</dd>
         </div>
         <div>
           <dt>{t("linkedinImport.confirmed")}</dt>
-          <dd>{summary.confirmed}</dd>
+          <dd>{formatNumber(summary.confirmed, locale)}</dd>
         </div>
         <div>
           <dt>{t("linkedinImport.suggested")}</dt>
-          <dd>{summary.suggested}</dd>
+          <dd>{formatNumber(summary.suggested, locale)}</dd>
         </div>
         {summary.skipped > 0 && (
           <div>
             <dt>{t("linkedinImport.skipped")}</dt>
-            <dd>{summary.skipped}</dd>
+            <dd>{formatNumber(summary.skipped, locale)}</dd>
           </div>
         )}
       </dl>

--- a/frontend/src/screens/offers.tsx
+++ b/frontend/src/screens/offers.tsx
@@ -21,7 +21,7 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
-import { formatMoney, formatNumber } from "../format/format";
+import { formatMoney, formatNumber, identifierNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import {
   isVersionSkewOf,
@@ -1333,7 +1333,7 @@ export function OfferScreen({ id }: Readonly<{ id: string }>) {
                 <SectionHeader
                   title={offer.offer_number}
                   sub={t("offer.revision", {
-                    revision: String(offer.revision),
+                    revision: identifierNumber(offer.revision),
                   })}
                 />
                 <Badge>{offer.status}</Badge>

--- a/frontend/src/screens/onboarding-conversation/company-act.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.stories.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "../story-utils";
+import { CompanyAct } from "./company-act";
+import { initialConversationState } from "./conversation-machine";
+import type {
+  ConversationPhase,
+  ConversationState,
+} from "./conversation-types";
+
+// The first act of the conversation: what this installation is FOR. It reads
+// the company's own site, says what it learned, and asks a human to confirm it
+// before anything else in the product is built on top.
+//
+// The act is a reducer plus a surface, so a story is a STATE rather than a set
+// of props — `phase` is the whole story list. `initialConversationState` is the
+// reducer's own starting point, which is why the fixtures build from it instead
+// of asserting a shape of their own.
+//
+// The eyebrow above the panel says where the reader is standing: "Step 3 of 5",
+// a position in a fixed rail. Neither half of it is ever grouped, in any
+// locale — and the German stories are where that is visible, because a
+// grouped "1.204" in a step counter reads as a quantity of steps.
+
+function state(
+  phase: ConversationPhase,
+  overrides: Partial<ConversationState> = {},
+): ConversationState {
+  return {
+    ...initialConversationState,
+    act: "company",
+    phase,
+    ...overrides,
+  };
+}
+
+const PROFILE = {
+  id: "co-1",
+  display_name: "Brandt Automotive",
+  website: "https://brandt-automotive.example",
+  legal_name: "Brandt Automotive GmbH",
+  industry: "Automotive tier-one supply",
+};
+
+// The act probes the session for the seat that may confirm, and persists the
+// draft. Both are routed: an unrouted session probe reads as a MALFORMED
+// session rather than an absent one, and the panel would then draw the
+// fail-closed branch in a story named for something else.
+function act(
+  conversation: ConversationState,
+  profile: typeof PROFILE | null = PROFILE,
+  locale?: "de",
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({ installation_settings: ["read", "update"] }),
+      "GET /company-profile": () =>
+        profile ? jsonResponse(profile) : jsonResponse({}, 404),
+    });
+    return (
+      <StoryProviders locale={locale}>
+        <CompanyAct
+          state={conversation}
+          dispatch={() => {}}
+          profile={null}
+          persist={async () => true}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof CompanyAct> = {
+  title: "Onboarding/Conversation/Company act",
+  component: CompanyAct,
+};
+export default meta;
+type Story = StoryObj<typeof CompanyAct>;
+
+/** Before anything has been read: the act says what it is about to do. */
+export const Intro: Story = { render: act(state("co.intro")) };
+
+/** The read in flight. The thread carries the progress in words, so the act
+ *  itself does not have to narrate it twice. */
+export const Reading: Story = { render: act(state("co.reading")) };
+
+/**
+ * The read found something it is not sure of and asks. A question here is the
+ * act's own, not a form field — the conversation is the interface, and a
+ * clarification that appeared as an input would lose the thread it belongs to.
+ */
+export const Clarifying: Story = {
+  render: act(state("co.clarify", { pendingQuestion: null })),
+};
+
+/** What was learned, for a human to confirm. The step eyebrow is above it. */
+export const Review: Story = {
+  render: act(state("co.review", { readCompleted: true })),
+};
+
+/** The German act: the same step, the longer copy, and the position pair in the
+ *  reader's own notation — ungrouped, because it is a place rather than a
+ *  quantity. */
+export const ReviewGerman: Story = {
+  render: act(state("co.review", { readCompleted: true }), PROFILE, "de"),
+};
+
+/**
+ * The read found nothing usable and the reader types it instead. Not a failure
+ * state: a company with no site is an ordinary customer, and the act has to
+ * carry them just as far.
+ */
+export const Manual: Story = { render: act(state("co.manual"), null) };
+
+/** Confirmed, and waiting to be routed onward. A reducer cannot advance itself
+ *  out of a momentary state, so a restored session lands here. */
+export const Confirmed: Story = {
+  render: act(state("co.confirmed", { readCompleted: true })),
+};
+
+/** At 390px the panel is the whole screen and the step eyebrow shares its row
+ *  with nothing. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: act(state("co.review", { readCompleted: true })),
+};

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -3,7 +3,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
-import { formatNumber } from "../../format/format";
+import { formatNumber, ordinalNumber } from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import {
@@ -745,11 +745,9 @@ export function CompanyAct({
   // The scene eyebrow: where the journey stands, in the rail's own counting.
   // Both the decision and the review live on the CONFIRM stop.
   const stops = railStops(state.memberPath);
-  // "Step 3 of 5" is a POSITION in a fixed rail, not a magnitude: neither
-  // half is ever grouped or given a decimal separator, in any locale.
   const stepEyebrow = t("ob.conv.scene.step", {
-    n: String(stops.findIndex((stop) => stop.key === "confirm") + 1),
-    m: String(stops.length),
+    n: ordinalNumber(stops.findIndex((stop) => stop.key === "confirm") + 1),
+    m: ordinalNumber(stops.length),
     label: t("ob.rail.confirm"),
   });
 

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -283,6 +283,7 @@ function FieldRow({
   defaultExpanded: boolean;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [expanded, setExpanded] = useState(defaultExpanded);
   const controlId = `confirm-missing-${row.field}`;
   const onChange = (
@@ -332,7 +333,7 @@ function FieldRow({
           <span className="ob-triage-row-meta">
             {row.confidence !== null && (
               <span className="ob-triage-score">
-                {Math.round(row.confidence * 100)}
+                {formatNumber(Math.round(row.confidence * 100), locale)}
                 {row.evidence !== null && (
                   <span className="ob-triage-source">
                     {/* A row carries at most one evidence record, so this
@@ -549,7 +550,7 @@ function SectionBadge({
   if (blocking.length === 0) {
     return (
       <span className="ob-triage-nav-advisory">
-        <b aria-hidden>{advisory.length}</b>
+        <b aria-hidden>{formatNumber(advisory.length, locale)}</b>
         <span className="sr-only">
           {t("ob.conv.triage.sectionAdvisory", {
             count: formatNumber(advisory.length, locale),
@@ -560,7 +561,7 @@ function SectionBadge({
   }
   return (
     <span className="ob-triage-nav-badge" data-blocking="true">
-      <b aria-hidden>{blocking.length}</b>
+      <b aria-hidden>{formatNumber(blocking.length, locale)}</b>
       <span className="sr-only">
         {t("ob.conv.triage.sectionBlocking", {
           count: formatNumber(blocking.length, locale),
@@ -659,7 +660,7 @@ function SectionQuantity({
   }
   return (
     <span className="ob-triage-nav-quantity">
-      <b aria-hidden>{count}</b>
+      <b aria-hidden>{formatNumber(count, locale)}</b>
       <span className="sr-only">
         {t(labelKey, { count: formatNumber(count, locale) })}
       </span>
@@ -990,6 +991,7 @@ function FactRow({
   selection: FactSelection;
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   const selected = selection.isSelected(fact);
   const evidence: Evidence = {
     snippet: fact.evidence_snippet,
@@ -1010,7 +1012,7 @@ function FactRow({
       <span className="ob-triage-fact-value">{fact.value}</span>
       <span className="ob-triage-fact-meta">
         <span className="ob-triage-score">
-          {Math.round(fact.confidence * 100)}
+          {formatNumber(Math.round(fact.confidence * 100), locale)}
         </span>
         <EvidenceChip evidence={evidence} collapsed />
       </span>
@@ -1041,6 +1043,7 @@ function FactTypeGroup({
   selection: FactSelection;
   t: ReturnType<typeof useT>;
 }>) {
+  const { locale } = useLocale();
   return (
     <Disclosure
       className="ob-triage-fact-type"
@@ -1048,7 +1051,9 @@ function FactTypeGroup({
       summary={
         <>
           {coldFieldLabel(field, t)}
-          <span className="ob-triage-fact-type-count">{facts.length}</span>
+          <span className="ob-triage-fact-type-count">
+            {formatNumber(facts.length, locale)}
+          </span>
         </>
       }
     >
@@ -1141,7 +1146,8 @@ function FieldGroupSection({
       <div className="ob-triage-group-head">
         <h3>{t(group.labelKey)}</h3>
         <span>
-          {filled}/{group.order.length}
+          {formatNumber(filled, locale)}/
+          {formatNumber(group.order.length, locale)}
         </span>
       </div>
       <ul className="ob-conv-confirm-fields ob-triage-rows">

--- a/frontend/src/screens/onboarding-conversation/connect-act.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.stories.tsx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "../story-utils";
+import { ConnectAct } from "./connect-act";
+import { initialConversationState } from "./conversation-machine";
+import type {
+  ConversationPhase,
+  ConversationState,
+} from "./conversation-types";
+
+// The act that connects a mailbox, and offers LinkedIn beside it.
+//
+// The two are NOT the same kind of thing, and the stories keep them apart
+// because the surface does: mail is the gate the act waits on, LinkedIn is a
+// recommended addition whose own status resolves independently and never holds
+// the act up. A story that showed them as one pair of switches would be
+// documenting a screen where finishing depends on both.
+//
+// `outcome` and `returningProvider` are ROUTE segments, replayed by a stale
+// bookmark or a reload of an old consent-return URL with no live attempt behind
+// them — so a story for each is a story about a URL, not about a request.
+//
+// The eyebrow is the rail position, and neither half of it is ever grouped.
+
+function state(
+  phase: ConversationPhase,
+  overrides: Partial<ConversationState> = {},
+): ConversationState {
+  return {
+    ...initialConversationState,
+    act: "connect",
+    phase,
+    ...overrides,
+  };
+}
+
+function act(
+  conversation: ConversationState,
+  route: { outcome?: string; returningProvider?: string } = {},
+  locale?: "de",
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({ channel_connection: ["read", "create"] }),
+      "GET /connectors": () => jsonResponse({ data: [] }),
+    });
+    return (
+      <StoryProviders locale={locale}>
+        <ConnectAct
+          state={conversation}
+          dispatch={() => {}}
+          persist={async () => true}
+          outcome={route.outcome}
+          returningProvider={route.returningProvider}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof ConnectAct> = {
+  title: "Onboarding/Conversation/Connect act",
+  component: ConnectAct,
+};
+export default meta;
+type Story = StoryObj<typeof ConnectAct>;
+
+/** Nothing connected yet: the mail gate, and LinkedIn offered beside it. */
+export const AwaitingConsent: Story = { render: act(state("cn.consent")) };
+
+/** The German act — the copy that has to hold two different KINDS of offer on
+ *  one surface without making them look alike. */
+export const AwaitingConsentGerman: Story = {
+  render: act(state("cn.consent"), {}, "de"),
+};
+
+/** LinkedIn connected while mail is still outstanding, which is the case that
+ *  proves it is not a gate. */
+export const LinkedinSettledMailPending: Story = {
+  render: act(state("cn.consent", { linkedinStatus: "connected" })),
+};
+
+/** LinkedIn declined. The act still finishes on mail alone — a recommended
+ *  addition that blocked the run would be a gate wearing a suggestion's
+ *  clothes. */
+export const LinkedinSkipped: Story = {
+  render: act(state("cn.consent", { linkedinStatus: "skipped" })),
+};
+
+/** Back from consent, granted. */
+export const ReturnedGranted: Story = {
+  render: act(state("cn.consent"), {
+    outcome: "connected",
+    returningProvider: "gmail",
+  }),
+};
+
+/**
+ * Back from consent, refused. The act says what did not happen and offers the
+ * door again rather than treating a refusal as a fault: somebody declining a
+ * mailbox is an answer, not an error.
+ */
+export const ReturnedRefused: Story = {
+  render: act(state("cn.consent"), {
+    outcome: "denied",
+    returningProvider: "gmail",
+  }),
+};
+
+/**
+ * A stale return URL: an outcome replayed with no live attempt behind it. The
+ * act must not report a connection it has no evidence for, which is why the
+ * route segments are treated as claims rather than as facts.
+ */
+export const StaleReturn: Story = {
+  render: act(state("cn.consent"), {
+    outcome: "connected",
+    returningProvider: "unknown-provider",
+  }),
+};
+
+/** Connected, and the act is done. */
+export const Done: Story = {
+  render: act(state("cn.done", { linkedinStatus: "connected" })),
+};
+
+/** At 390px the two offers stack, and the one that gates has to stay legibly
+ *  the primary of the pair. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: act(state("cn.consent")),
+};

--- a/frontend/src/screens/onboarding-conversation/connect-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch } from "react";
 import { useEffect, useState } from "react";
 import { navigate } from "../../app/router";
+import { ordinalNumber } from "../../format/format";
 import { useT } from "../../i18n";
 import { problemMessageOf } from "../common";
 import { EMPTY_DRAFT } from "../onboarding";
@@ -181,10 +182,9 @@ export function ConnectAct({
 
   // Where the journey stands, in the rail's own counting.
   const stops = railStops(state.memberPath);
-  // A position in the rail, not a magnitude: never grouped, in any locale.
   const eyebrow = t("ob.conv.scene.step", {
-    n: String(stops.findIndex((stop) => stop.key === "connect") + 1),
-    m: String(stops.length),
+    n: ordinalNumber(stops.findIndex((stop) => stop.key === "connect") + 1),
+    m: ordinalNumber(stops.length),
     label: t("ob.rail.connect"),
   });
   return (

--- a/frontend/src/screens/onboarding-conversation/voice-act.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.stories.tsx
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../../api/schema";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "../story-utils";
+import { VOICE_MIN_WORDS } from "../voice-intake-core";
+import { initialConversationState } from "./conversation-machine";
+import type {
+  ConversationPhase,
+  ConversationState,
+} from "./conversation-types";
+import { VoiceAct } from "./voice-act";
+
+// The act that learns how this company writes: it collects a corpus, says how
+// much it has, and builds a voice profile from it.
+//
+// The word meter is the SERVER's count, not the browser's — `initialSummary` is
+// the restore probe's answer for a resumed session — so the stories that matter
+// are the ones where that count is below, at, and past the threshold the build
+// needs. A story that seeded the count client-side would be documenting a
+// number the wire never sent.
+//
+// The eyebrow is the rail position, ungrouped in every locale.
+
+function state(
+  phase: ConversationPhase,
+  overrides: Partial<ConversationState> = {},
+): ConversationState {
+  return {
+    ...initialConversationState,
+    act: "voice",
+    phase,
+    ...overrides,
+  };
+}
+
+// The corpus summary is the server's whole verdict on what it holds, not a word
+// count with decoration: `maturity` and `quality_band` are its own readings, and
+// a fixture that invented them independently of `total_words` would document a
+// summary the server cannot produce. So they are derived from the count here,
+// the same way the server derives them from the corpus.
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+
+function summary(totalWords: number): CorpusSummary {
+  return {
+    total_words: totalWords,
+    target_words: 30_000,
+    maturity: totalWords < VOICE_MIN_WORDS ? "collecting" : "provisional",
+    quality_band: totalWords < VOICE_MIN_WORDS ? "thin" : "good",
+    source_count: Math.max(1, Math.round(totalWords / 240)),
+    register_words: { email: totalWords },
+  };
+}
+
+function act(
+  conversation: ConversationState,
+  corpus: CorpusSummary | null,
+  locale?: "de",
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({ voice_profile: ["read", "create", "update"] }),
+      "GET /voice/corpus": () =>
+        corpus ? jsonResponse(corpus) : jsonResponse(summary(0)),
+    });
+    return (
+      <StoryProviders locale={locale}>
+        <VoiceAct
+          state={conversation}
+          dispatch={() => {}}
+          initialSummary={corpus}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof VoiceAct> = {
+  title: "Onboarding/Conversation/Voice act",
+  component: VoiceAct,
+};
+export default meta;
+type Story = StoryObj<typeof VoiceAct>;
+
+/** Nothing collected yet: the act says what it wants and how to hand it over. */
+export const Empty: Story = { render: act(state("vo.collecting"), null) };
+
+/**
+ * Some corpus, not enough to build from. The meter has to say how far off it is
+ * rather than only refusing — a build button that is inert with no figure beside
+ * it leaves the reader guessing how much more to paste.
+ */
+export const BelowThreshold: Story = {
+  render: act(state("vo.collecting"), summary(180)),
+};
+
+/**
+ * Enough to build. A four-digit word count is where de-DE grouping first shows,
+ * which makes this the story where the meter's notation is visible at all.
+ */
+export const ReadyToBuild: Story = {
+  render: act(state("vo.collecting"), summary(4820)),
+};
+
+/** The same meter in German. */
+export const ReadyToBuildGerman: Story = {
+  render: act(state("vo.collecting"), summary(4820), "de"),
+};
+
+/** Naming who is speaking, which the profile needs before it can build. */
+export const NamingTheSpeaker: Story = {
+  render: act(state("vo.speaker"), summary(4820)),
+};
+
+/** The build in flight. The thread carries the progress in words, so the orb's
+ *  digits stay out of the accessibility tree rather than being announced on
+ *  every tick. */
+export const Building: Story = {
+  render: act(
+    state("vo.building", { activeBuildId: "build-1" }),
+    summary(4820),
+  ),
+};
+
+/** A profile built. The version it produced is a NAME — never grouped, because
+ *  "1.204" is a different version from "1204" to anybody typing it in. */
+export const Built: Story = {
+  render: act(
+    state("vo.result", {
+      activeBuildId: null,
+      lastBuildStatus: "succeeded",
+      lastBuildStage: "activate",
+    }),
+    summary(4820),
+  ),
+};
+
+/**
+ * Skipped. A company that will not hand over its writing still has to reach the
+ * end of onboarding, so this is an ordinary outcome rather than a failure — and
+ * the act says what the product will do without it.
+ */
+export const Skipped: Story = {
+  render: act(state("vo.skipped"), summary(0)),
+};
+
+/** At 390px the meter, the paste area and the build verb stack. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: act(state("vo.collecting"), summary(4820)),
+};

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, Dispatch, RefObject } from "react";
 import { useRef } from "react";
 import type { components } from "../../api/schema";
-import { formatNumber } from "../../format/format";
+import { formatNumber, ordinalNumber } from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 import { problemMessageOf } from "../common";
 import { useFileDrop } from "../use-file-drop";
@@ -88,10 +88,9 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
 
   // Where the journey stands, in the rail's own counting.
   const stops = railStops(state.memberPath);
-  // A position in the rail, not a magnitude: never grouped, in any locale.
   const eyebrow = t("ob.conv.scene.step", {
-    n: String(stops.findIndex((stop) => stop.key === "voice") + 1),
-    m: String(stops.length),
+    n: ordinalNumber(stops.findIndex((stop) => stop.key === "voice") + 1),
+    m: ordinalNumber(stops.length),
     label: t("ob.rail.voice"),
   });
 

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.stories.tsx
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useRef } from "react";
+import type { components } from "../../api/schema";
+import { StoryProviders } from "../story-utils";
+import { VOICE_MIN_WORDS } from "../voice-intake-core";
+import type { ConversationQuestion } from "./conversation-types";
+import type { CorpusManifestEntry } from "./use-voice-corpus";
+import {
+  VoiceBuildScene,
+  VoiceCollectScene,
+  VoiceResultScene,
+  VoiceSpeakerScene,
+} from "./voice-scenes";
+
+// The voice act's four work surfaces, one scene at a time: collect the writing,
+// say who is speaking, watch the model learn it, read what it learned.
+//
+// Every figure on these scenes is the SERVER's count — words kept, sources
+// ingested, mean sentence length — so the stories hand those counts in as props
+// rather than deriving them, which is the only way the notation on screen is the
+// notation the wire produced. `FloorCleared` and the German pair carry four
+// digits because that is the narrowest number at which de-DE grouping is visible
+// at all: below it a grouped and an ungrouped figure are the same characters.
+//
+// The build scene's ring is the one number that is deliberately NOT in the
+// accessibility tree — the stage checklist beside it and the rail's own log
+// already carry the progress in words, and announcing crawling digits on every
+// tick would talk over both.
+
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type VoiceProfileVersion = components["schemas"]["VoiceProfileVersion"];
+
+const EYEBROW = "Step 4 of 5";
+
+// `maturity` and `quality_band` are the server's own readings of the corpus, so
+// they are derived from the count rather than picked per story: a fixture that
+// set them independently would describe a summary no server sends.
+function summary(totalWords: number, sources: number): CorpusSummary {
+  return {
+    total_words: totalWords,
+    target_words: 30_000,
+    maturity: totalWords < VOICE_MIN_WORDS ? "collecting" : "provisional",
+    quality_band: totalWords < VOICE_MIN_WORDS ? "thin" : "good",
+    source_count: sources,
+    register_words: { email: totalWords },
+  };
+}
+
+const MANIFEST: readonly CorpusManifestEntry[] = [
+  {
+    ref: "src-1",
+    label: "Sent mail, last quarter.mbox",
+    keptWords: 2840,
+    inputWords: 2840,
+    transcript: false,
+  },
+  {
+    ref: "src-2",
+    label: "Kickoff call, Brandt Automotive.vtt",
+    keptWords: 1380,
+    inputWords: 4210,
+    transcript: true,
+  },
+];
+
+// The scene owns the file input, so the ref has to come from a real render
+// rather than a module-level object: a detached ref never receives the node, and
+// Browse would then silently do nothing in the one story about pressing it.
+function Collect({
+  corpus,
+  manifest = [],
+  canBuild = false,
+  startPending = false,
+  startError = null,
+  locale,
+}: Readonly<{
+  corpus: CorpusSummary | null;
+  manifest?: readonly CorpusManifestEntry[];
+  canBuild?: boolean;
+  startPending?: boolean;
+  startError?: string | null;
+  locale?: "de";
+}>) {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <StoryProviders locale={locale}>
+      <VoiceCollectScene
+        eyebrow={EYEBROW}
+        summary={corpus}
+        manifest={manifest}
+        fileRef={fileRef}
+        onFiles={() => {}}
+        onAddPaste={() => {}}
+        onBuild={() => {}}
+        onSkip={() => {}}
+        canBuild={canBuild}
+        startPending={startPending}
+        startError={startError}
+      />
+    </StoryProviders>
+  );
+}
+
+const meta: Meta<typeof VoiceCollectScene> = {
+  title: "Onboarding/Conversation/Voice scenes",
+  component: VoiceCollectScene,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof VoiceCollectScene>;
+
+/** Nothing handed over yet: the drop target, and a meter with nothing in it. */
+export const CollectEmpty: Story = { render: () => <Collect corpus={null} /> };
+
+/**
+ * Short of the floor. The meter says how far off it is rather than only refusing
+ * — a Build verb that is inert with no figure beside it leaves the reader
+ * guessing how much more to paste.
+ */
+export const CollectBelowFloor: Story = {
+  render: () => (
+    <Collect
+      corpus={summary(320, 1)}
+      manifest={[MANIFEST[0]]}
+      canBuild={false}
+    />
+  ),
+};
+
+/**
+ * Past the floor, with a source whose transcript filtering discarded turns —
+ * kept-of-total is shown only there, because on a plain document the two counts
+ * are the same number written twice.
+ */
+export const CollectFloorCleared: Story = {
+  render: () => (
+    <Collect corpus={summary(4220, 2)} manifest={MANIFEST} canBuild={true} />
+  ),
+};
+
+/** The same cleared meter in German — the notation the reader writes numbers in,
+ *  on the count and on the floor it is measured against. */
+export const CollectFloorClearedGerman: Story = {
+  render: () => (
+    <Collect
+      corpus={summary(4220, 2)}
+      manifest={MANIFEST}
+      canBuild={true}
+      locale="de"
+    />
+  ),
+};
+
+/** The build request in flight: the verb is held, and the meter does NOT dim —
+ *  a corpus that already cleared the floor has lost no ground. */
+export const CollectStarting: Story = {
+  render: () => (
+    <Collect
+      corpus={summary(4220, 2)}
+      manifest={MANIFEST}
+      canBuild={true}
+      startPending={true}
+    />
+  ),
+};
+
+/** The build refused to start. The reason is the server's sentence, and the
+ *  corpus it was refused against is still on screen to try again from. */
+export const CollectStartRefused: Story = {
+  render: () => (
+    <Collect
+      corpus={summary(4220, 2)}
+      manifest={MANIFEST}
+      canBuild={true}
+      startError="A build is already running for this installation."
+    />
+  ),
+};
+
+/** At 390px the drop acts, the meter and the foot verbs stack, and the pinned
+ *  primary has to stay reachable under them. */
+export const CollectPhone: Story = {
+  tags: ["uat-phone"],
+  render: () => (
+    <Collect corpus={summary(4220, 2)} manifest={MANIFEST} canBuild={true} />
+  ),
+};
+
+const SPEAKER_QUESTION: ConversationQuestion = {
+  id: "speaker:src-2",
+  i18nKey: "ob.conv.voice.speakerQuestion",
+  options: [
+    {
+      value: "SPEAKER_00",
+      label: "Speaker 1",
+      detailKey: "ob.conv.voice.speakerOptionDetail",
+      params: { words: "2,140", turns: "38" },
+    },
+    {
+      value: "SPEAKER_01",
+      label: "Speaker 2",
+      detailKey: "ob.conv.voice.speakerOptionDetail",
+      params: { words: "1,380", turns: "24" },
+    },
+  ],
+};
+
+/**
+ * Which voice in the transcript is the reader's own. Continue stays held until
+ * one is picked: a speaker chosen by default would file somebody else's words as
+ * this company's writing, and nothing downstream would ever say so.
+ */
+export const SpeakerAsk: Story = {
+  render: () => (
+    <StoryProviders>
+      <VoiceSpeakerScene
+        eyebrow={EYEBROW}
+        question={SPEAKER_QUESTION}
+        onAnswer={() => {}}
+      />
+    </StoryProviders>
+  ),
+};
+
+/** The same decision in German, where the option detail and the foot line both
+ *  run longer than the card was first drawn for. */
+export const SpeakerAskGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <VoiceSpeakerScene
+        eyebrow={EYEBROW}
+        question={SPEAKER_QUESTION}
+        onAnswer={() => {}}
+      />
+    </StoryProviders>
+  ),
+};
+
+/** A queued build: no stage reported yet, so the ring claims nothing and the
+ *  checklist has nothing done. */
+export const BuildQueued: Story = {
+  render: () => (
+    <StoryProviders>
+      <VoiceBuildScene
+        stage={null}
+        summary={summary(4220, 2)}
+        sources={2}
+        model="deepseek-chat"
+      />
+    </StoryProviders>
+  ),
+};
+
+/** Mid-pipeline. The ceiling is derived from the stage the server reported, and
+ *  the ring crawls toward it rather than jumping. */
+export const BuildExtracting: Story = {
+  render: () => (
+    <StoryProviders>
+      <VoiceBuildScene
+        stage="extract"
+        summary={summary(4220, 2)}
+        sources={2}
+        model="deepseek-chat"
+      />
+    </StoryProviders>
+  ),
+};
+
+/** The last stage. The ring still stops short of full — a build reaches 100 only
+ *  by finishing, at which point this is no longer the scene on screen. */
+export const BuildActivating: Story = {
+  render: () => (
+    <StoryProviders>
+      <VoiceBuildScene
+        stage="activate"
+        summary={summary(4220, 2)}
+        sources={2}
+        model="deepseek-chat"
+      />
+    </StoryProviders>
+  ),
+};
+
+/** The build in German: the word and source counts in the reader's notation,
+ *  beside a percentage that is decorative in every language. */
+export const BuildExtractingGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <VoiceBuildScene
+        stage="extract"
+        summary={summary(4220, 2)}
+        sources={2}
+        model="deepseek-chat"
+      />
+    </StoryProviders>
+  ),
+};
+
+function version(
+  overrides: Partial<VoiceProfileVersion> = {},
+): VoiceProfileVersion {
+  return {
+    id: "vpv-1",
+    profile_id: "vp-1",
+    profile_version: 1,
+    status: "active",
+    voice_profile_md: "# Voice\n\nPlain, specific, quick to the ask.",
+    profile_json: {
+      inference: {
+        identity_summary: "Plain, specific, and quick to the ask.",
+        thinking_pattern: "Leads with the constraint, then the offer.",
+        observed_obsessions: ["delivery dates", "who signs"],
+        signature_moves: [
+          {
+            move: "Names the blocker before the ask",
+            quote: "Depot's offline the 14th — can we sign before then?",
+          },
+          { move: "Closes on one question", quote: "Does Thursday work?" },
+        ],
+        avoid: ["exclamation marks", "hedging"],
+      },
+      guidance: {
+        next_best: "Add three sent threads from the last quarter.",
+        next_best_key: "recent_sent",
+        next_best_words: 900,
+      },
+      sample_drafts: [
+        {
+          subject: "Retrofit timeline",
+          body: "Lars — the depot window moved to the 14th. Can you confirm the quote before then?",
+          score: 0.82,
+        },
+        {
+          subject: "Quote follow-up",
+          body: "Still holding the March slot for you. Say the word and I'll book it.",
+          score: 0.77,
+        },
+      ],
+    },
+    stats_json: {
+      word_count: 4220,
+      mean_sentence_words: 14,
+      sample_count: 2,
+    },
+    source_hash: "sha256:9f21",
+    source_count: 2,
+    reason: "onboarding",
+    predecessor_version: null,
+    model_provider: "deepseek",
+    model_name: "deepseek-chat",
+    builder_version: "voice-builder/3",
+    source: "onboarding",
+    captured_by: "u-me",
+    activation_policy_version: "policy/2",
+    evaluation: {
+      held_out_prompts: 5,
+      repeats_per_prompt: 3,
+      active_median_voice_score: null,
+      candidate_median_voice_score: 0.81,
+      anti_ai_hard_failures: 0,
+      structured_output_valid: true,
+      corpus_citations_valid: true,
+      identity_word_jaccard: 0.74,
+      signature_set_jaccard: 0.66,
+      removed_avoid_rules: 0,
+      removed_register_rules: 0,
+      classification: "routine",
+      passed: true,
+    },
+    review_reasons: [],
+    version: 1,
+    created_at: "2026-08-25T09:00:00Z",
+    updated_at: "2026-08-25T09:04:00Z",
+    archived_at: null,
+    activated_at: "2026-08-25T09:04:00Z",
+    ...overrides,
+  };
+}
+
+function result(
+  built: VoiceProfileVersion | null,
+  loading = false,
+  locale?: "de",
+) {
+  return () => (
+    <StoryProviders locale={locale}>
+      <VoiceResultScene
+        eyebrow={EYEBROW}
+        loading={loading}
+        version={built}
+        onContinue={() => {}}
+      />
+    </StoryProviders>
+  );
+}
+
+/** Reading the profile the build produced. */
+export const ResultLoading: Story = { render: result(null, true) };
+
+/**
+ * The build finished and the profile did not come back. The scene says that
+ * plainly rather than drawing an empty board: a reader who cannot see what was
+ * learned must not be shown a shape implying nothing was.
+ */
+export const ResultAbsent: Story = { render: result(null) };
+
+/** What the build learned: the sample it would send, and the reading behind it.
+ *  Two samples, so the cycle control has somewhere to go. */
+export const ResultRich: Story = { render: result(version()) };
+
+/** The same board in German. */
+export const ResultRichGerman: Story = {
+  render: result(version(), false, "de"),
+};
+
+/**
+ * A starter corpus: too few sources to hold any back, so the build reserved no
+ * held-out sample and there is no draft to read. The board goes single-column
+ * and the lead copy changes — never a sample card with an invented draft in it.
+ */
+export const ResultWithoutSample: Story = {
+  render: result(
+    version({
+      profile_json: {
+        inference: {
+          identity_summary: "Short lines, one ask at a time.",
+          signature_moves: [],
+          avoid: [],
+        },
+        guidance: {},
+        sample_drafts: [],
+      },
+      stats_json: { word_count: 860, mean_sentence_words: 9, sample_count: 1 },
+    }),
+  ),
+};
+
+/**
+ * A candidate rather than an active profile: the evaluation wants a human before
+ * anything writes in this voice, and the scene says so instead of letting the
+ * reader believe it is already in use.
+ */
+export const ResultCandidate: Story = {
+  render: result(version({ status: "candidate" })),
+};
+
+/** At 390px the two columns become one and the sample body cannot share a line
+ *  with its own labels. */
+export const ResultPhone: Story = {
+  tags: ["uat-phone"],
+  render: result(version()),
+};

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -486,7 +486,7 @@ export function VoiceBuildScene({
             progress in words, so the crawling digits stay out of the a11y
             tree instead of being announced on every tick. */}
         <span className="ob-voice-orb-pct" aria-hidden>
-          {Math.round(progress * 100)}
+          {formatNumber(Math.round(progress * 100), locale)}
           <small>%</small>
         </span>
       </div>

--- a/frontend/src/screens/onboarding-conversation/workbench.tsx
+++ b/frontend/src/screens/onboarding-conversation/workbench.tsx
@@ -9,6 +9,7 @@ import {
   MarginceWorkbench,
   type WorkbenchStep,
 } from "../../design-system/margince-workbench";
+import { ordinalNumber } from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 import { throwProblem, useMe } from "../common";
 import {
@@ -146,11 +147,9 @@ export function ConversationWorkbench({
     ? t("ob.conv.scene.detour")
     : current < 0
       ? undefined
-      : // A position in the rail, not a magnitude: never grouped, in any
-        // locale.
-        t("ob.conv.scene.step", {
-          n: String(current + 1),
-          m: String(steps.length),
+      : t("ob.conv.scene.step", {
+          n: ordinalNumber(current + 1),
+          m: ordinalNumber(steps.length),
           label: steps[current].label,
         });
   return (

--- a/frontend/src/screens/onboarding-manual-interview.stories.tsx
+++ b/frontend/src/screens/onboarding-manual-interview.stories.tsx
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { en } from "../i18n/en";
+import type { CompanyFieldName, CompanyForm } from "./onboarding";
+import { ManualCompanyInterview } from "./onboarding-manual-interview";
+import { StoryProviders } from "./story-utils";
+
+// The manual path through the company interview: one question at a time, its
+// chapter and its position above it, and a hint under the prompt. It is the
+// route somebody takes when the read found nothing — so every state here is a
+// state of a person typing, not of a server answering.
+//
+// The position pair is what the stories move. `questionIndex` is the
+// component's OWN state and starts at zero, so there is no prop that opens the
+// interview in the middle: a story that wants question three has to answer its
+// way there, which is also the only honest way to show that advancing works.
+
+// Three of the sixteen questions refuse an empty answer — `display_name`,
+// `offer_summary` and `icp` — and every one of them sits before the middle of
+// the run. So a story that walks forward has to have answered at least those,
+// or `advance` refuses silently and the story stops on a question its own name
+// does not claim.
+const ANSWERS: Partial<Record<CompanyFieldName, string>> = {
+  legal_name: "Brandt Automotive GmbH",
+  registered_address: "Werkstraße 14, 70565 Stuttgart",
+  register_vat: "DE 812 456 991",
+  display_name: "Brandt Automotive",
+  offer_summary:
+    "Retrofit lines for assembly plants, sold as a programme rather than a machine.",
+  icp: "Tier-one suppliers running two or more plants on ageing lines.",
+  industry: "Automotive tier-one supply",
+};
+
+function form(overrides: Partial<CompanyForm> = {}): CompanyForm {
+  return {
+    display_name: "",
+    website: "",
+    legal_name: "",
+    register_vat: "",
+    registered_address: "",
+    industry: "",
+    offer_summary: "",
+    icp: "",
+    value_proposition: "",
+    usp: "",
+    customer_pains: "",
+    desired_outcomes: "",
+    buying_center: "",
+    buying_intents: "",
+    common_objections: "",
+    sales_motion: "",
+    history: "",
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof ManualCompanyInterview> = {
+  title: "Onboarding/Company interview/Manual",
+  component: ManualCompanyInterview,
+};
+export default meta;
+type Story = StoryObj<typeof ManualCompanyInterview>;
+
+function interview(values: CompanyForm) {
+  return () => (
+    <StoryProviders>
+      <ManualCompanyInterview
+        values={values}
+        setField={() => {}}
+        onPersist={() => {}}
+        onBackToChoice={() => {}}
+        onComplete={() => {}}
+      />
+    </StoryProviders>
+  );
+}
+
+// Advancing needs the current question ANSWERED when it is a required one, so
+// the stories that walk forward start from a filled form. Named from the
+// catalog rather than restated: the verb has been reworded before, and a story
+// that failed for the wording would be reporting on the copy rather than on
+// the step.
+async function advance(canvasElement: HTMLElement, times: number) {
+  const canvas = within(canvasElement);
+  const user = userEvent.setup();
+  for (let step = 0; step < times; step += 1) {
+    await user.click(
+      await canvas.findByRole("button", { name: en["ob.manualNext"] }),
+    );
+  }
+}
+
+// To the END, rather than by a count of steps. A number here is a second
+// statement of how many questions there are, and it goes wrong the day one is
+// added — which is how this story first failed, looking for a verb that had
+// already become "Review my answers". The condition cannot: the run is over
+// exactly when the next-question verb is gone.
+async function advanceToLast(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const user = userEvent.setup();
+  for (;;) {
+    const next = canvas.queryByRole("button", { name: en["ob.manualNext"] });
+    if (!next) {
+      return;
+    }
+    await user.click(next);
+  }
+}
+
+/** The first question, on an empty form: the chapter, the position, and a
+ *  prompt nobody has answered yet. */
+export const FirstQuestion: Story = { render: interview(form()) };
+
+/** Part-way through, so the position pair reads as a place rather than a
+ *  count. Neither half is ever grouped — "Frage 1.204 von 1.018" would read as
+ *  a quantity of questions. */
+export const MidInterview: Story = {
+  render: interview(form(ANSWERS)),
+  play: async ({ canvasElement }) => advance(canvasElement, 2),
+};
+
+/** The last question: the verb stops saying "next" and offers the review
+ *  instead, which is the only signal that the interview is about to end. */
+export const LastQuestion: Story = {
+  render: interview(form(ANSWERS)),
+  play: async ({ canvasElement }) => advanceToLast(canvasElement),
+};
+
+/** The first question the interview will take an empty answer for. The line
+ *  under the field says which kind it is, because "Add later" and a refused
+ *  Next look the same until it does. */
+export const OptionalQuestion: Story = {
+  render: interview(form(ANSWERS)),
+  play: async ({ canvasElement }) => advance(canvasElement, 6),
+};
+
+/** The German interview: the same step, the longer prompts, and the position
+ *  pair in the reader's own notation. */
+export const German: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <ManualCompanyInterview
+        values={form(ANSWERS)}
+        setField={() => {}}
+        onPersist={() => {}}
+        onBackToChoice={() => {}}
+        onComplete={() => {}}
+      />
+    </StoryProviders>
+  ),
+};
+
+/** At 390px the prompt, the field and the two verbs stack, and the progress
+ *  line has to stay on one row above them. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: interview(form(ANSWERS)),
+};

--- a/frontend/src/screens/onboarding-manual-interview.tsx
+++ b/frontend/src/screens/onboarding-manual-interview.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "../design-system/atoms";
+import { ordinalNumber } from "../format/format";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -181,7 +182,8 @@ export function ManualCompanyInterview({
       <div className="ob-manual-progress">
         <span>{t(question.chapter)}</span>
         <span>
-          {questionIndex + 1} / {MANUAL_QUESTIONS.length}
+          {ordinalNumber(questionIndex + 1)} /{" "}
+          {ordinalNumber(MANUAL_QUESTIONS.length)}
         </span>
       </div>
       <h1 id={promptID}>{t(question.prompt)}</h1>

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -701,6 +701,7 @@ function ReadActivity({
   refreshing,
 }: Readonly<{ read: CompanySiteRead; refreshing: boolean }>) {
   const t = useT();
+  const { locale } = useLocale();
   const latestPage = latestFetchedPage(read);
   const legalCount = read.legal_entities?.length ?? 0;
   const findingCount = read.profile_fields.length + read.facts.length;
@@ -715,13 +716,14 @@ function ReadActivity({
       )}
       <div>
         <span>
-          <b>{read.pages_read ?? 0}</b> {t("ob.pagesRead")}
+          <b>{formatNumber(read.pages_read ?? 0, locale)}</b>{" "}
+          {t("ob.pagesRead")}
         </span>
         <span>
-          <b>{legalCount}</b> {t("ob.legalEntitiesFound")}
+          <b>{formatNumber(legalCount, locale)}</b> {t("ob.legalEntitiesFound")}
         </span>
         <span>
-          <b>{findingCount}</b>{" "}
+          <b>{formatNumber(findingCount, locale)}</b>{" "}
           {t(findingCount === 1 ? "ob.ai.finding" : "ob.ai.findings")}
         </span>
       </div>
@@ -875,6 +877,7 @@ function readablePage(rawURL: string) {
 
 export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
   const t = useT();
+  const { locale } = useLocale();
   const legalEntities = read.legal_entities ?? [];
   const skippedPages = read.pages.filter((page) => page.status !== "fetched");
   if (
@@ -928,7 +931,9 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
               >
                 <div className="finding-label">
                   <Check aria-hidden /> {coldFieldLabel(field.field, t)}
-                  <span>{Math.round(field.confidence * 100)}%</span>
+                  <span>
+                    {formatNumber(Math.round(field.confidence * 100), locale)}%
+                  </span>
                 </div>
                 <strong>{field.value}</strong>
                 <blockquote>“{field.evidence_snippet}”</blockquote>
@@ -949,7 +954,9 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
               >
                 <div className="finding-label">
                   <Sparkles aria-hidden /> {coldFieldLabel(fact.field, t)}
-                  <span>{Math.round(fact.confidence * 100)}%</span>
+                  <span>
+                    {formatNumber(Math.round(fact.confidence * 100), locale)}%
+                  </span>
                 </div>
                 <strong>{fact.value}</strong>
                 <blockquote>“{fact.evidence_snippet}”</blockquote>

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1084,11 +1084,11 @@ function HierarchyRollupCard({ orgId }: Readonly<{ orgId: string }>) {
         </div>
         <div>
           <dt className="t-eyebrow">{t("rollup.activity30d")}</dt>
-          <dd>{rollup.activity_count_30d}</dd>
+          <dd>{formatNumber(rollup.activity_count_30d, locale)}</dd>
         </div>
         <div>
           <dt className="t-eyebrow">{t("rollup.accounts")}</dt>
-          <dd>{rollup.aggregated_account_count}</dd>
+          <dd>{formatNumber(rollup.aggregated_account_count, locale)}</dd>
         </div>
       </dl>
       {rollup.restricted_excluded.length > 0 && (

--- a/frontend/src/screens/overlay-health.tsx
+++ b/frontend/src/screens/overlay-health.tsx
@@ -231,7 +231,8 @@ function BudgetReading({
           </Badge>
         )}
         <span className="t-mono t-small">
-          {consumed} / {limit ?? "—"}
+          {formatNumber(consumed, locale)} /{" "}
+          {limit === undefined ? "—" : formatNumber(limit, locale)}
         </span>
         {/* headroom is either a real free-capacity count or the server's own
             `~unknown` sentinel — printed verbatim either way, never

--- a/frontend/src/screens/person360.tsx
+++ b/frontend/src/screens/person360.tsx
@@ -13,7 +13,7 @@ import {
 import { EvidenceMark } from "../design-system/evidencemark";
 import { FactList } from "../design-system/factlist";
 import type { ConfidenceLevel } from "../design-system/trust";
-import { formatDate, formatDecimal } from "../format/format";
+import { formatDate, formatDecimal, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { provenanceOf, throwProblem } from "./common";
 import { currentEmployer, formerEmployers } from "./employmentcurrency";
@@ -185,7 +185,7 @@ export function RelationshipPulse({ view }: Readonly<{ view: Person360 }>) {
           <Disclosure summary={t("person.pulse.why")}>
             <p style={{ margin: 0, lineHeight: 1.55 }}>
               {t("person.pulse.arithmetic", {
-                score: String(s.score),
+                score: formatNumber(s.score, locale),
                 recency: formatDecimal(s.factors.recency, locale, 2),
                 frequency: formatDecimal(s.factors.frequency, locale, 2),
                 reciprocity: formatDecimal(s.factors.reciprocity, locale, 2),
@@ -475,8 +475,12 @@ function proofLine(
   const twoWay = (c.inbound_90d ?? 0) > 0 && (c.outbound_90d ?? 0) > 0;
   const parts = [
     twoWay
-      ? t("person.network.twoWay", { count: String(c.interactions_90d) })
-      : t("person.network.oneSided", { count: String(c.interactions_90d) }),
+      ? t("person.network.twoWay", {
+          count: formatNumber(c.interactions_90d, locale),
+        })
+      : t("person.network.oneSided", {
+          count: formatNumber(c.interactions_90d, locale),
+        }),
   ];
   if (c.last_inbound_at) {
     parts.push(

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -22,7 +22,7 @@ import {
 } from "../design-system/projectpicker";
 import { RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
-import { formatNumber } from "../format/format";
+import { formatNumber, ordinalNumber } from "../format/format";
 import { webUrl } from "../format/weburl";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
@@ -975,7 +975,9 @@ export function PersonResearchDrawer({
             </p>
             {claims.map((claim) => (
               <article className="pe-claim" key={claim.ordinal}>
-                <span className="pe-claim-ordinal">{claim.ordinal}</span>
+                <span className="pe-claim-ordinal">
+                  {ordinalNumber(claim.ordinal)}
+                </span>
                 <div>
                   <p className="pe-claim-body">{claim.body}</p>
                   <div className="pe-chiprow">

--- a/frontend/src/screens/persongraph.tsx
+++ b/frontend/src/screens/persongraph.tsx
@@ -5,7 +5,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card, SectionHeader } from "../design-system/atoms";
-import { formatDate } from "../format/format";
+import { formatDate, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 
@@ -344,9 +344,9 @@ function EdgeFacts({
         }}
       >
         {t("person.graph.counts", {
-          total: String(edge.interactions_90d),
-          inbound: String(edge.inbound_90d ?? 0),
-          outbound: String(edge.outbound_90d ?? 0),
+          total: formatNumber(edge.interactions_90d, locale),
+          inbound: formatNumber(edge.inbound_90d ?? 0, locale),
+          outbound: formatNumber(edge.outbound_90d ?? 0, locale),
         })}
       </p>
       {receipts.length > 0 ? (
@@ -387,6 +387,7 @@ function EdgeFacts({
  */
 function DroppedNote({ graph }: Readonly<{ graph: Graph }>) {
   const t = useT();
+  const { locale } = useLocale();
   const dropped =
     (graph.dropped_count?.direct ?? 0) + (graph.dropped_count?.account ?? 0);
   if (dropped === 0) {
@@ -394,7 +395,7 @@ function DroppedNote({ graph }: Readonly<{ graph: Graph }>) {
   }
   return (
     <p style={{ margin: 0, fontSize: "0.9rem", opacity: 0.75 }}>
-      {t("person.graph.dropped", { count: String(dropped) })}
+      {t("person.graph.dropped", { count: formatNumber(dropped, locale) })}
     </p>
   );
 }

--- a/frontend/src/screens/personprovider.stories.tsx
+++ b/frontend/src/screens/personprovider.stories.tsx
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { PersonProviderSection } from "./personprovider";
+import {
+  completedProviderRun,
+  providerCompletedProfile,
+} from "./personprovider.fixtures";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+type Profile = components["schemas"]["PersonProviderProfile"];
+
+// What a person's page shows about data BOUGHT from a provider: the values, how
+// sure the provider was of each, and the run they came from.
+//
+// The section's states are RUN states, not layout states — the `state` field is
+// a lifecycle, and the card's header badge is where it is reported. That is why
+// the stories below are named for postures a run is genuinely in rather than
+// for arrangements of the same content: an expired credential and a person the
+// provider simply does not know are different sentences, and only one of them
+// is something an operator can act on.
+//
+// The completed snapshot is `personprovider.fixtures.ts`, shared with the
+// research drawer's stories. A second copy would be a second claim about what
+// the provider returned.
+
+function profile(overrides: Partial<Profile> = {}): Profile {
+  return { ...providerCompletedProfile, ...overrides };
+}
+
+const meta: Meta<typeof PersonProviderSection> = {
+  title: "Records/Person/Bought data",
+  component: PersonProviderSection,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof PersonProviderSection>;
+
+// The buy verb is gated on the RUN's state (`canEnrichNow`) rather than on a
+// grant, so this card reads no session and the stories route none. The run read
+// is routed because the section polls it while a run is moving, and an unrouted
+// request would leave the page instead of answering.
+function section(value: Profile | undefined) {
+  return () => {
+    installFetchStub({
+      "GET /people/p-1/enrichment-runs/run-1": () =>
+        jsonResponse(completedProviderRun),
+    });
+    return (
+      <StoryProviders>
+        <PersonProviderSection personId="p-1" profile={value} />
+      </StoryProviders>
+    );
+  };
+}
+
+/** A completed purchase: an address, a mobile with the provider's confidence
+ *  in it, the employment, and the run behind them. */
+export const Completed: Story = { render: section(profile()) };
+
+/** The same purchase in German — the confidence sentence is where a figure and
+ *  a translated sentence meet, so it is the line worth reading here. */
+export const CompletedGerman: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /people/p-1/enrichment-runs/run-1": () =>
+        jsonResponse(completedProviderRun),
+    });
+    return (
+      <StoryProviders locale="de">
+        <PersonProviderSection personId="p-1" profile={profile()} />
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * Several values, each at a different confidence. A provider that is 41% sure
+ * of a number and 97% sure of another has said two different things, and a card
+ * that printed both without the figure would be passing its own uncertainty off
+ * as our claim.
+ */
+export const MixedConfidence: Story = {
+  render: section(
+    profile({
+      mobile_phones: [
+        { value: "+491701234567", confidence: 0.97 },
+        { value: "+498912345678", confidence: 0.41 },
+        // No confidence at all is a third answer, and it is not zero: the
+        // provider returned the number and said nothing about it.
+        { value: "+4915112345678" },
+      ],
+    }),
+  ),
+};
+
+/**
+ * A run that finished and matched nobody. The card keeps its place and says so
+ * — an absent card would read as "this person has nothing to buy", which is a
+ * claim about the person rather than about the run.
+ */
+export const NoMatch: Story = {
+  render: section(
+    profile({
+      state: "no_match",
+      emails: [],
+      mobile_phones: [],
+      linkedin_url: null,
+      current_employment: undefined,
+      job_history: [],
+    }),
+  ),
+};
+
+/** Nothing has been bought yet. The values are absent because none was asked
+ *  for, which is the one state where an empty card is the true report. */
+export const NeverRun: Story = {
+  render: section(
+    profile({
+      state: "never_run",
+      retrieved_at: null,
+      emails: [],
+      mobile_phones: [],
+      linkedin_url: null,
+      current_employment: undefined,
+      job_history: [],
+      latest_run: undefined,
+    }),
+  ),
+};
+
+/** A run in flight. The badge carries the lifecycle and the section polls the
+ *  run rather than the page, so a purchase lands without a reload. */
+export const InProgress: Story = {
+  render: section(profile({ state: "in_progress" })),
+};
+
+/**
+ * The credential the provider was bought through has expired. An operator
+ * fault rather than a data one, so it says which — a generic failure here would
+ * send somebody looking at the person instead of at the connection.
+ */
+export const InvalidCredentials: Story = {
+  render: section(profile({ state: "invalid_credentials" })),
+};
+
+/** Out of credits: the run did not run, and nothing about the person changed.
+ *  The distinction from a provider error is what an operator needs. */
+export const InsufficientCredits: Story = {
+  render: section(profile({ state: "insufficient_credits" })),
+};
+
+/**
+ * Only one category was asked for. `categories_not_requested` is how a card
+ * says a mobile is missing because nobody bought one — the alternative reads as
+ * a provider that had none.
+ */
+export const CategoryNotRequested: Story = {
+  render: section(
+    profile({
+      categories_not_requested: ["mobile"],
+      mobile_phones: [],
+    }),
+  ),
+};
+
+/**
+ * The section WITHHELD. `person360` names it in `sections_omitted` and hands
+ * down no profile, and the card is then absent rather than empty — the one
+ * place that is right, because a card holding no fact cannot be misread as
+ * "nothing was found".
+ */
+export const Withheld: Story = { render: section(undefined) };
+
+/** At 390px the values stack under their eyebrows and the header badge sits
+ *  beside a title that has to wrap rather than truncate. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: section(profile()),
+};

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -9,7 +9,8 @@ import { Badge, Button } from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 import {
   canEnrichNow,
@@ -86,6 +87,7 @@ function RunWatch({
 
 function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
   const t = useT();
+  const { locale } = useLocale();
   const source = boughtFrom(profile);
   return (
     <>
@@ -123,7 +125,10 @@ function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
               {phone.confidence != null && (
                 <span className="t-caption">
                   {t("provider.profile.confidence", {
-                    percent: String(Math.round(phone.confidence * 100)),
+                    percent: formatNumber(
+                      Math.round(phone.confidence * 100),
+                      locale,
+                    ),
                   })}
                 </span>
               )}

--- a/frontend/src/screens/projectreadings.stories.tsx
+++ b/frontend/src/screens/projectreadings.stories.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RollupsStrip } from "./projectreadings";
+import { project360 } from "./projects.fixtures";
+import { StoryProviders } from "./story-utils";
+
+// The band under a project's header: what its deals are worth, what is still
+// owed, and when anything last happened. A STRIP rather than five cards,
+// because the five are read across as one comparison — which is also why the
+// server withholds the whole plate rather than half of it, and why the states
+// below are states of the PLATE.
+//
+// The fixture is `projects.fixtures.ts`, the one the project-page tests build
+// from. A story that hand-rolled a second 360 would be a second answer to what
+// a project looks like, and the two would drift.
+
+const meta: Meta<typeof RollupsStrip> = {
+  title: "Records/Project/Readings",
+  component: RollupsStrip,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof RollupsStrip>;
+
+function strip(view: ReturnType<typeof project360>) {
+  return () => (
+    <StoryProviders>
+      <RollupsStrip view={view} />
+    </StoryProviders>
+  );
+}
+
+/** A project mid-delivery: every reading present, money and counts together. */
+export const Delivering: Story = { render: strip(project360()) };
+
+/**
+ * The same plate at four digits, which is the only width where the notation is
+ * visible at all: de-DE groups from a thousand, so a figure below it reads the
+ * same in every locale and proves nothing about which one drew it.
+ */
+export const LargeFigures: Story = {
+  render: strip(
+    project360({
+      rollups: {
+        open_deal_value: { amount_minor: 428_150_000, currency: "EUR" },
+        won_deal_value: { amount_minor: 91_400_000, currency: "EUR" },
+        open_commitments: 1204,
+        last_activity_at: "2026-07-01T09:00:00Z",
+        activity_count: 48_213,
+      },
+    }),
+  ),
+};
+
+/** The German plate: the same figures, the reader's own notation and the
+ *  longer labels the layout has to hold. */
+export const LargeFiguresGerman: Story = {
+  render: () => (
+    <StoryProviders locale="de">
+      <RollupsStrip
+        view={project360({
+          rollups: {
+            open_deal_value: { amount_minor: 428_150_000, currency: "EUR" },
+            won_deal_value: { amount_minor: 91_400_000, currency: "EUR" },
+            open_commitments: 1204,
+            last_activity_at: "2026-07-01T09:00:00Z",
+            activity_count: 48_213,
+          },
+        })}
+      />
+    </StoryProviders>
+  ),
+};
+
+/**
+ * A project nothing has been filed under yet. Zero is a READING here, not an
+ * absence — "no work has landed on this project" is a true thing to report —
+ * so the plate keeps its place and `last_activity_at` says never rather than
+ * the slot going blank.
+ */
+export const NothingFiledYet: Story = {
+  render: strip(
+    project360({
+      rollups: {
+        open_deal_value: { amount_minor: 0, currency: "EUR" },
+        won_deal_value: { amount_minor: 0, currency: "EUR" },
+        open_commitments: 0,
+        last_activity_at: null,
+        activity_count: 0,
+      },
+    }),
+  ),
+};
+
+/**
+ * The plate withheld. A grant the reader lacks names `rollups` in
+ * `sections_omitted`, and the strip says so instead of returning null —
+ * a plate that vanished would read as a project with no money in it.
+ */
+export const Withheld: Story = {
+  render: strip(
+    project360({ sections_omitted: ["rollups"], rollups: undefined }),
+  ),
+};
+
+/**
+ * The read failed. Absent WITHOUT an omission is a different sentence from
+ * absent because of a grant, and telling them apart is the whole reason
+ * `stateOf` takes both the section and the payload.
+ */
+export const Unavailable: Story = {
+  render: strip(project360({ rollups: undefined })),
+};
+
+/** At 390px the plate folds: the last slot takes the rest of its row, so a
+ *  count that does not divide the columns leaves no orphan beside empty cells. */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: strip(project360()),
+};

--- a/frontend/src/screens/projectreadings.tsx
+++ b/frontend/src/screens/projectreadings.tsx
@@ -5,7 +5,11 @@ import { useRecordZone } from "../app/recordzone";
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateAbbrev, formatMoneyOrAbsent } from "../format/format";
+import {
+  formatDateAbbrev,
+  formatMoneyOrAbsent,
+  formatNumber,
+} from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { type Project360, stateOf } from "./projectsections";
 
@@ -55,7 +59,7 @@ export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
       />
       <StatCard
         label={t("project.rollups.openCommitments")}
-        value={String(rollups.open_commitments)}
+        value={formatNumber(rollups.open_commitments, locale)}
         numeric
       />
       <StatCard
@@ -68,7 +72,7 @@ export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
       />
       <StatCard
         label={t("project.rollups.activityCount")}
-        value={String(rollups.activity_count)}
+        value={formatNumber(rollups.activity_count, locale)}
         numeric
       />
     </StatStrip>

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -2248,6 +2248,7 @@ function StageRow({
   t: ReturnType<typeof useT>;
   returnFocusTo: () => HTMLElement | null;
 }>) {
+  const { locale } = useLocale();
   return (
     // The four tracks (name, semantic badge, probability, edit) live in
     // settings.css, where they can have a phone breakpoint. Inline, the three
@@ -2258,7 +2259,9 @@ function StageRow({
       <Badge tone={stageSemanticTone(stage.semantic)}>
         {stageSemanticLabel(stage.semantic, t)}
       </Badge>
-      <span className="t-mono t-small">{stage.win_probability}%</span>
+      <span className="t-mono t-small">
+        {formatNumber(stage.win_probability, locale)}%
+      </span>
       {/* Each control carries its own verb — editing a stage is
           pipeline:update, removing one is pipeline:delete — so a role
           holding one without the other still sees the one it may use. */}

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -25,7 +25,7 @@ import {
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Select } from "../design-system/select";
-import { formatDate, formatNumber } from "../format/format";
+import { formatDate, formatNumber, identifierNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -769,13 +769,13 @@ function ShareScreenBody({
                 {...control}
                 // A day count is the state; the control speaks strings, so the
                 // conversion happens here at the boundary and nowhere else.
-                value={String(expiryDays)}
+                value={identifierNumber(expiryDays)}
                 onChange={(value) => {
                   setExpiryDays(Number(value));
                   dismissGrantFeedback();
                 }}
                 options={EXPIRY_OPTIONS.map((option) => ({
-                  value: String(option.days),
+                  value: identifierNumber(option.days),
                   label: t(option.key),
                 }))}
               />

--- a/frontend/src/screens/strength.tsx
+++ b/frontend/src/screens/strength.tsx
@@ -163,7 +163,7 @@ function StrengthBody({
                 }}
               >
                 <span>{t(`strength.factor.${row.key}`)}</span>
-                <span className="t-mono">{pct}%</span>
+                <span className="t-mono">{formatNumber(pct, locale)}%</span>
               </div>
               <Meter
                 value={pct}

--- a/frontend/src/screens/today.focus.stories.tsx
+++ b/frontend/src/screens/today.focus.stories.tsx
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+import { FocusLane } from "./today.focus";
+import type { AttentionItem } from "./today.queries";
+
+// The day's decision lane: ONE decision on screen, its position in the queue,
+// and the way past it.
+//
+// The lane takes what it draws as props, so a story is a queue state rather
+// than a fetch — except the staged proposal, which fetches the one approval it
+// is deciding, and that read's own three answers (in flight, unusable, ready)
+// are three of the stories below.
+//
+// Two numbers sit on this panel and they are not the same kind of number. The
+// badge is a MAGNITUDE — how much work is waiting — and it is written in the
+// reader's own notation. The progress line beside it is a POSITION, "3 of 90",
+// and it is a magnitude too: both halves count items, and a reader comparing
+// "3 of 1204" against a badge reading "1.204" would be looking at one queue
+// written two ways. `QueueOfManyGerman` is where that is visible at all, because
+// de-DE first groups at four digits.
+
+const PAIR: AttentionItem = {
+  id: "dc-1",
+  source: "dedupe_candidate",
+  kind: "organization",
+  confidence: 0.92,
+  actions: ["merge"],
+  pair: {
+    left: {
+      id: "org-1",
+      label: "Acme Logistik GmbH",
+      detail: "acme.example",
+    },
+    right: {
+      id: "org-2",
+      label: "Acme Logistik",
+      detail: "acme-log.example",
+    },
+    evidence: [
+      {
+        field: "display_name",
+        signal: "collide",
+        left_value: "Acme Logistik GmbH",
+        right_value: "Acme Logistik",
+      },
+      {
+        field: "email",
+        signal: "one_sided",
+        left_value: "kontakt@acme.example",
+        right_value: null,
+      },
+    ],
+  },
+};
+
+const STAGED: AttentionItem = {
+  id: "ap-1",
+  source: "approval",
+  kind: "send_email",
+  title: "Send the follow-up to Anna Weber at Baqend",
+  due_at: "2026-08-26T09:00:00Z",
+  actions: ["decide"],
+};
+
+const APPROVAL = {
+  id: "ap-1",
+  kind: "send_email",
+  status: "pending",
+  summary: "Send the follow-up to Anna Weber at Baqend",
+  subject_type: "person",
+  subject_id: "p-1",
+  payload: {
+    to: "anna.weber@baqend.example",
+    subject: "Following up on the retrofit window",
+    body: "Anna — the depot window moved to the 14th. Can you confirm the quote before then?",
+  },
+  staged_by: "agent:outreach",
+  autonomy_tier: "propose",
+  source: "agent",
+  captured_by: "agent:outreach",
+  version: 1,
+  created_at: "2026-08-25T08:00:00Z",
+  updated_at: "2026-08-25T08:00:00Z",
+};
+
+// `/me` and the approval read are routed; everything else this lane's row
+// reaches for falls through to the stub's empty page, which is a legitimate
+// answer for each and keeps the story about the decision rather than its chrome.
+function lane(
+  args: Readonly<{
+    items: readonly AttentionItem[];
+    total: number;
+    decided: number;
+    withheld?: boolean;
+    approval?: () => Response;
+    locale?: "de";
+  }>,
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({
+        organization: ["read", "update"],
+        person: ["read", "update"],
+        automation: ["read", "update"],
+      }),
+      "GET /approvals/ap-1": args.approval ?? (() => jsonResponse(APPROVAL)),
+    });
+    return (
+      <StoryProviders locale={args.locale}>
+        <FocusLane
+          items={args.items}
+          total={args.total}
+          decided={args.decided}
+          withheld={args.withheld ?? false}
+          onDecided={() => {}}
+          onSkip={() => {}}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof FocusLane> = {
+  title: "Records/Today/Decision lane",
+  component: FocusLane,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof FocusLane>;
+
+/** A duplicate pair, decided in place: the evidence the detector saw, and the
+ *  two verbs that answer it. */
+export const AMergeToDecide: Story = {
+  render: lane({ items: [PAIR], total: 4, decided: 1 }),
+};
+
+/** A staged proposal. The row that decides it is the same one the record page
+ *  draws, so an editing reader meets one spelling of the decision, not two. */
+export const AStagedProposal: Story = {
+  render: lane({ items: [STAGED], total: 4, decided: 1 }),
+};
+
+/** The proposal's own read, in flight. The lane is already drawn around it —
+ *  the position and the way past it do not wait on the card. */
+export const StagedProposalLoading: Story = {
+  render: lane({
+    items: [STAGED],
+    total: 4,
+    decided: 1,
+    approval: () => new Response(null, { status: 204 }),
+  }),
+};
+
+/**
+ * A proposal that came back without a `kind`. The card cannot draw it — the
+ * kind chooses the label, the tool chip and the autonomy dot — so it reads as a
+ * failed read with a retry, rather than throwing and taking the whole day's
+ * surface down over one malformed answer.
+ */
+export const StagedProposalUnusable: Story = {
+  render: lane({
+    items: [STAGED],
+    total: 4,
+    decided: 1,
+    approval: () => jsonResponse({ ...APPROVAL, kind: undefined }),
+  }),
+};
+
+/** Nothing left to answer, and what the reader got through says so. */
+export const AllClear: Story = {
+  render: lane({ items: [], total: 0, decided: 7 }),
+};
+
+/**
+ * A reader whose scope does not admit what is waiting. Withheld is not empty:
+ * the lane says the queue is not theirs to see rather than telling them there
+ * is nothing in it, which would be a false statement about the day.
+ */
+export const Withheld: Story = {
+  render: lane({ items: [], total: 12, decided: 0, withheld: true }),
+};
+
+/** A queue wide enough to be written in a notation. Four digits is where de-DE
+ *  first groups, so this is the narrowest queue at which badge and progress can
+ *  be caught disagreeing. */
+export const QueueOfMany: Story = {
+  render: lane({ items: [PAIR], total: 1204, decided: 3 }),
+};
+
+/** The same queue in German. */
+export const QueueOfManyGerman: Story = {
+  render: lane({ items: [PAIR], total: 1204, decided: 3, locale: "de" }),
+};
+
+/** At 390px the evidence rows stack and the two merge verbs cannot share a line
+ *  with "Later". */
+export const Phone: Story = {
+  tags: ["uat-phone"],
+  render: lane({ items: [PAIR], total: 1204, decided: 3 }),
+};

--- a/frontend/src/screens/today.focus.tsx
+++ b/frontend/src/screens/today.focus.tsx
@@ -196,13 +196,14 @@ export function FocusLane({
   onSkip: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const current = items[0];
   return (
     <Panel
       title={
         <span className="focus-title">
           {t("day.needsYou")}
-          {total > 0 && <Badge>{total}</Badge>}
+          {total > 0 && <Badge>{formatNumber(total, locale)}</Badge>}
         </span>
       }
       tone="accent"

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -448,6 +448,7 @@ function MorningPanel({
   children,
 }: Readonly<{ total: number; children: React.ReactNode }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <Panel
       title={
@@ -456,7 +457,9 @@ function MorningPanel({
           {t("day.thisMorning")}
         </span>
       }
-      titleAction={total > 0 ? <Badge>{total}</Badge> : undefined}
+      titleAction={
+        total > 0 ? <Badge>{formatNumber(total, locale)}</Badge> : undefined
+      }
     >
       {children}
     </Panel>

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -351,6 +351,7 @@ function Lane({
   onSnooze: (id: string, dueAt: string) => void;
   completing: boolean;
 }>) {
+  const { locale } = useLocale();
   const Icon = shape.icon;
   return (
     <Panel
@@ -360,7 +361,9 @@ function Lane({
           {shape.title}
         </span>
       }
-      titleAction={total > 0 ? <Badge>{total}</Badge> : undefined}
+      titleAction={
+        total > 0 ? <Badge>{formatNumber(total, locale)}</Badge> : undefined
+      }
       tone={tone}
     >
       {withheld ? (

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -19,7 +19,7 @@ import {
   SettingRow,
 } from "../design-system/settingrow";
 import { ToastRegion, useToast } from "../design-system/toast";
-import { formatNumber } from "../format/format";
+import { formatNumber, identifierNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { VoiceCorpusIntake } from "./voice-corpus-settings";
@@ -213,10 +213,8 @@ function VoiceDnaBody({ profile }: Readonly<{ profile: VoiceProfile }>) {
               </span>
             )}
             <span className="t-small vdna-version">
-              {/* A version number is a name, not a magnitude: grouped, build
-                  1234 would read as "1.234". */}
               {t("settings.voice.version", {
-                n: String(profile.profile_version ?? 0),
+                n: identifierNumber(profile.profile_version ?? 0),
               })}
             </span>
           </div>

--- a/frontend/src/screens/voice-insights.tsx
+++ b/frontend/src/screens/voice-insights.tsx
@@ -1,7 +1,7 @@
 import { FileText, Lightbulb, Quote } from "lucide-react";
 import type { components } from "../api/schema";
 import { Badge, Card } from "../design-system/atoms";
-import { formatNumber } from "../format/format";
+import { formatNumber, identifierNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import "./voice-dna.css";
 
@@ -161,9 +161,9 @@ export function VoiceInsights({
   return (
     <div className="vdna-insights">
       <div className="vdna-provenance t-small">
-        {/* The build's version is a name, not a magnitude: grouped, build 1234
-            would read as "1.234" and stop matching what it refers to. */}
-        {t("voice.insights.provenance", { n: String(profileVersion) })}
+        {t("voice.insights.provenance", {
+          n: identifierNumber(profileVersion),
+        })}
         {data.modelName && data.modelName !== "unrecorded"
           ? ` · ${data.modelName}`
           : ""}

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -5,7 +5,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card } from "../design-system/atoms";
-import { formatDate, formatNumber } from "../format/format";
+import { formatDate, formatNumber, identifierNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { parseVoiceInsights, VoiceInsights } from "./voice-insights";
@@ -125,11 +125,9 @@ function CandidateBanner({
     // "card">`: a copy of the card surface is a second card the moment one of
     // its five chrome values moves, and the README forbids it by name.
     <Card as="div" inset className="vdna-candidate">
-      {/* A version number is a name, not a magnitude: grouped, build 1234
-          would read as "1.234" and stop matching the version it refers to. */}
       <b>
         {t("voice.candidate.title", {
-          n: String(candidate.profile_version),
+          n: identifierNumber(candidate.profile_version),
         })}
       </b>
       {candidate.review_reasons.length > 0 && (
@@ -308,11 +306,9 @@ export function VoiceChangeLog({ profileId }: Readonly<{ profileId: string }>) {
                 .map((delta) => (
                   <li key={delta.id} className="vdna-row">
                     <span>
-                      {/* Both ends of a delta are version names, so neither
-                          is grouped — see the candidate title above. */}
                       {t("voice.history.deltaRow", {
-                        from: String(delta.from_version ?? 0),
-                        to: String(delta.to_version),
+                        from: identifierNumber(delta.from_version ?? 0),
+                        to: identifierNumber(delta.to_version),
                       })}
                       {" · "}
                       {classificationLabel(t, delta.classification)} ·{" "}
@@ -374,9 +370,8 @@ function VersionRow({
   return (
     <li className="vdna-row">
       <span>
-        {/* Version name, not a magnitude — same rule as the candidate title. */}
         {t("voice.history.versionRow", {
-          n: String(version.profile_version),
+          n: identifierNumber(version.profile_version),
         })}{" "}
         <Badge>{versionStatusLabel(t, version.status)}</Badge>
         {" · "}
@@ -394,7 +389,7 @@ function VersionRow({
           type="button"
           className="iconbtn vdna-row-verb"
           aria-label={t("voice.history.rollback", {
-            n: String(version.profile_version),
+            n: identifierNumber(version.profile_version),
           })}
           disabled={rollback.isPending}
           onClick={() => rollback.mutate()}


### PR DESCRIPTION
Closes #2666.

## The defect, rendered

Same panel, same fixtures, two real builds of the same surface — home's overnight rail with a four-digit digest (de-DE, Playwright, `.tmp/magnitude-shots/`):

| | E-Mails synchronisiert | Personen angelegt | Firmen angelegt | Dubletten zu prüfen | one line below, same card |
|---|---|---|---|---|---|
| `main` | `48213` | `1204` | `3096` | `1310` | `2.048 Zusagen · 1.536 Termine · 9.910 Rauschen` |
| this branch | `48.213` | `1.204` | `3.096` | `1.310` | `2.048 Zusagen · 1.536 Termine · 9.910 Rauschen` |

The sentence at the foot already went through `formatNumber`; the four counts above it did not. One card, two notations. The seed's own counts are single digits and de-DE first groups at four, so nothing in the fixtures could show this either way — the capture answers `/digest` with four-digit counts, which is the only width at which the defect and the fix look different.

## What changed, per commit

**1. `format.ts` grows two rulings** (`feat(format)`). `identifierNumber` for a number that NAMES something — a version, a revision, a job id, a `Select` option's identity. `ordinalNumber` for one that says WHERE — a page, a step, an attempt, a rank, a line number. Both render bare, and that is the point: grouped, revision 1234 reads `1.204` to a German reader and stops matching the revision it refers to. The two defects are opposite, so no single answer covers both and the ruling has to be per site. Spelled as a call so the NAME at the site records which was meant — the shape `format/collate.ts` reached first with `forReader` / `stable`.

**2. 129 sites ruled across 68 files** (`fix(frontend)`). A magnitude through `formatNumber`, everything else through one of the two new names. Where a comment already argued a number was deliberately bare, the comment goes — the function name says it now, and two spellings of one decision is what the comment was compensating for.

**3. The gate** (`test(format)`) — `frontend/src/format/jsx-magnitude.test.ts`, armed last so no commit lands red.

**4. Sixteen stories that rendered nothing now say why** (`test(stories)`). Every one of them was red on `main` and only became visible because fe-uat is diff-scoped: `/me` never routed, a 404 asset, a button name that had moved. Each is fixed at its own cause, not by relaxing the gate.

**5. Twelve changed components get a catalog entry** (`test(stories)` ×2). Every component this branch touched now has a story, so fe-uat can hold it. Each covers the states the rulings actually run through — a count below and above the width where de-DE grouping first shows, a German twin for every screen whose figures are read down a column, and the withheld, refused and empty branches beside them. Two fixtures were wrong about their own wire shapes and are corrected: `VoiceCorpusSummary` carries `maturity`, `quality_band`, `source_count`, `target_words` and `register_words` rather than a bare word count, and a build's terminal status is `succeeded`/`failed`/`deferred` rather than a stage name.

**6. One more magnitude, caught by this branch's own gate** (`fix(frontend)`). `app/attention.stories.tsx` — a harness written in commit 5 — rendered its own row count straight into JSX. A German reader saw `1234` in a sentence sitting beside the formatted selection count the file exists to demonstrate, so the harness disagreed with the property under review. The gate failed `fe-unit` on it before it ever reached CI.

**7. A magnitude that arrived on `main` while this was in flight** (`fix(frontend)`). Rebasing onto `a4dfaced` failed this branch's own census at `today.focus.tsx:205`: `<Badge>{total}</Badge>`, in a file that already formats the position pair and the answered count directly beside it. One card, two notations, in German. The census is absolute, which is why the rebase caught it rather than a release.

**8. The day's decision lane gets a catalog entry** (`test(stories)`). It arrived on `main` without a story and this branch touched it, so fe-uat had nothing to hold it with. Nine stories: the merge decision, the staged proposal and its read's three answers, all-clear, withheld kept apart from empty, and the four-digit queue in both locales — the width at which the badge and the progress line can be caught disagreeing.

**9. Two more magnitudes, and why the catalog arm reaches wide** (`fix(frontend)`). Rebasing onto the axe fix brought two more: the morning lane's badge in `today.tsx` (a magnitude, now in the reader's notation) and a page number in a `ListTable` story (a position, now saying so by name). The same commit answers this PR's one review note in the code rather than in a thread: narrowing the catalog-parameter arm to call arguments would read better and cost recognition, because a params object built as a variable and handed to `t()` a line later is still a catalog parameter. Over-recognition is the safe direction, and the only one an assertion can catch when it goes wrong.

## The gate

An AST check, because half the sites contain no `String` and no `toLocale` for a grep to find. Three derived parts:

- **A rendered position**, from the checker: a JSX child; an attribute whose declared type is text (which is how `aria-label`, `title`, `alt` and `StatCard`'s `value` are in scope without one of them being named); and a value whose contextual type is `Record<string, string>` — the shape the translator declares its params as, so `t()` is reached through its signature rather than its name.
- **The locale-blind stringifiers**, from TypeScript's own lib declarations: the `Number` members returning `string` with no `locales` parameter. Yields `toFixed` / `toPrecision` / `toExponential` / `toString` without the file naming one.
- **React's `SVGAttributes`**, own members only, to keep a `viewBox` out of it.

It can be absolute because the ruling is a function name: outside `format.ts` a bare number in a rendered position is a site that skipped the ruling, not one whose ruling was "leave it". No allowlist, so no site joins the tier by being forgotten. Verified by planting a regression: reverting one `organizations.tsx` site to a bare `{rollup.activity_count_30d}` fails the census and names the file and expression.

**Two derivations failed short first, and both are now held by a planted case.** The translator arm asked the contextual type for a string index signature — that type is `Record<string, string> | undefined`, a union carries no index signature, so the arm fired on nothing at all: 49 sites, reported as a clean tree. And `SVGAttributes` read with inherited members would have swallowed `aria-label`, the attribute on an svg most worth gating.

**What it cannot see** is written at the subject. The one structural blindness is counted rather than skipped: an extension screen does not type against the vanilla contract, so its `/ext/…` responses resolve to `never`. Those positions are collected, and an arm holds that every unjudgeable one is in the extension tier — a new one under `src/` fails instead of passing as "no magnitude found".

## Fixed along the way

- **A `Select`'s `value` and its `options[].value` are one identity that must compare equal.** Three widgets (`share.tsx`, `installation-settings.tsx`, `design-system/listtable.tsx`) had one half ruled and the other still `String(...)`. Both halves now read `identifierNumber`.
- **`license.tsx` had three readings of one absent seat grant.** There is one now. The over-limit callout stays gated on the server's verdict alone: the contract says `over_limit` is "false whenever nothing caps seats" and warns that a client must not reach its own answer, so re-deriving it here would withdraw the one alert an admin has to act on if the two ever disagreed.
- `adddocument.test.tsx` asserted the ungrouped reach and now asserts the grouped one — `2,000` is the figure it was always reporting.
- `today.tsx`'s four type errors and the stale 12-item rail spec were **also fixed on `main` while this was in flight** (#2678, #2682). Rebased; my rail commit was dropped as redundant and `today.tsx` merged to the same shape.

## The rebase onto current `main`

Three conflicts, resolved on substance rather than by taking a side:

- **`agentrail.tsx`** — upstream repointed the approvals tile to `#/today`; this branch had formatted its `aria-label`. Both kept.
- **`topbar.tsx`** — upstream deleted `DecisionsMark` outright (the count moved to the Today surface). Deletion taken; formatting a component that no longer exists went with it.
- **`dedupe.tsx` / `dedupe.stories.tsx`** — deleted by #2700, which dissolved that screen into `approvalrow.tsx` / `approvaleditor.tsx`. Deletions taken; the rulings that lived there are gone with the file, and the census confirms nothing unruled replaced them.

## Gates

| gate | result |
|---|---|
| `make frontend-check` | **pass** — 385 files / 4836 tests on the final tree. It failed three times first, every time on this branch's own gate — see commits 6, 7 and 9. |
| `make native-controls` | **pass** |
| `make frontend-e2e` | **pass** — 94 passed, 14 skipped, axe WCAG 2.2 AA sweep included (pre-rebase run; the axe sweep re-run alone passes on the rebased tree) |
| `make fe-clock-drift` | **pass** — 379 files / 4781 tests at +200 days, re-run after the story commits |
| `frontend/src/format/jsx-magnitude.test.ts` | **pass**, and fails on a planted regression |
| `make check` | **fails on `lint-modules`, not on this branch** — every finding names `../.tmp/worktrees/url-state/...`, another worktree's checkout. This branch changes zero Go files. It is the cross-worktree golangci cache condition `scripts/run-golangci.sh` documents. |
| `make fe-uat` | **pass** — 583 stories captured, zero render failures, empty missing-story list |
| CI on the PR | **all 14 checks green** — run 32925928087, `uat` included |

## fe-uat, and what it took to get there

fe-uat was red when the notation work landed, in two distinct ways, and both are closed here rather than waived. `ARGS="--allow-missing"` was never used.

**16 stories did not render clean.** All pre-existing on `main`, and proven so rather than assumed: with `app/agentrail.tsx` restored to `origin/main`'s content plus a one-line scratch comment to keep it in the diff-scoped render set, all ten `shell-agent-rail--*` stories failed identically (`a component asked for GET /me and this story did not route it`), along with `screens-deal-room-aside--*` (404s), `records-dedupe--deciding-in-flight` and the two `maintenance-import--choosing-a-file` stories (button names that had moved). fe-uat is diff-scoped, so touching those components is what pulled them into view. Each is fixed at its own cause: a routed `/me` with the grant the surface actually reads, a real asset, the button name from the catalog rather than a hard-coded string, and one comment claiming a `localStorage` key cleared itself replaced by code that clears it.

**12 changed components had no story at all.** Every one now has one, covering the states the change introduces rather than only the happy path — including a German twin wherever the figures are read down a column, which is the only place the notation is visible at all. `app/attention.tsx` exports only a provider, so its story is a pair of stand-in harnesses (a list that publishes a selection, a chrome bar that reads it) — and writing that harness is what surfaced the last defect in commit 6.

## The `uat` red, and how it went away

CI's `uat` lane failed twice on `#/deals` with near-white text on white — `#fdfdfd on #ffffff` — and it failed DIFFERENTLY each time: two violations, then one, on an identical tree. That variance was the finding. Near-white on white is not a palette this repository ships; it is a fade caught partway, and #2722 had already diagnosed the cause (the settle gate was vacuous, so axe measured a page whose entrance animation had not begun).

#2722 merged. Rebased onto it, and the lane is green — with no change here, because this branch alters no colour, token or CSS.

## Proposals, not done here

- `frontend/src/format/one-locale.test.ts` and this gate now sit either side of one question ("in whose notation is this figure written"). They stay separate because their subjects differ, but a reader meeting one should be pointed at the other; both headers do that in prose today and nothing holds it.
- The gate is blind to an extension screen's own figures in the vanilla lane. The composed lane could judge them; that needs `make composition` in front of a unit test, which is a lane decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved number formatting across counts, percentages, scores, budgets, pagination, and progress indicators to respect the active locale.
  * Added localized ordinal formatting for steps, ranks, attempts, pages, and sequence positions.
  * Preserved ungrouped formatting for identifiers such as profile versions, job IDs, revisions, and selector values.
  * Improved accessibility labels and localized license-limit messaging.
  * Preserved selected views and tabs in navigation and refreshed today’s briefing details.

* **Tests**
  * Added coverage for localized formatting and detection of unformatted numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

