### PR TITLE
fix(frontend): the day screen's figures are written in the reader's notation

### DIFF
--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -3,7 +3,7 @@ import { navigate } from "../app/router";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -42,7 +42,11 @@ type LaneShape = Readonly<{
 // The lead line: the largest true thing about the day, written here rather than
 // on the server because the server has no language. A reader who reads only
 // this line should still know whether to worry.
-function leadLine(day: Attention, t: ReturnType<typeof useT>): string {
+function leadLine(
+  day: Attention,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
   // A day with a lane missing from it is not a day this line may summarise:
   // "your day is clear" and "part of it is hidden from you" cannot both be on
   // one page, and the reader would believe the reassuring one.
@@ -54,10 +58,12 @@ function leadLine(day: Attention, t: ReturnType<typeof useT>): string {
     return t("day.lead.oneDecision");
   }
   if (decisions > 1) {
-    return t("day.lead.decisions", { count: decisions });
+    return t("day.lead.decisions", { count: formatNumber(decisions, locale) });
   }
   if (day.counts.planned > 0) {
-    return t("day.lead.plannedOnly", { count: day.counts.planned });
+    return t("day.lead.plannedOnly", {
+      count: formatNumber(day.counts.planned, locale),
+    });
   }
   if (day.done_for_you && day.done_for_you.length > 0) {
     return t("day.lead.ranOvernight");
@@ -107,7 +113,9 @@ function itemDetail(
     return item.detail;
   }
   if (item.confidence != null) {
-    return t("day.match", { percent: Math.round(item.confidence * 100) });
+    return t("day.match", {
+      percent: formatNumber(Math.round(item.confidence * 100), locale),
+    });
   }
   if (item.occurred_at) {
     return formatDateTime(item.occurred_at, locale, zone);
@@ -330,6 +338,7 @@ function TodayLanes({
   complete: ReturnType<typeof useTaskUpdate>;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const needsYou = day.needs_you ?? [];
   const planned = day.planned ?? [];
   const done = day.done_for_you ?? [];
@@ -346,7 +355,7 @@ function TodayLanes({
   };
   return (
     <>
-      <p className="t-h2 today-lead">{leadLine(day, t)}</p>
+      <p className="t-h2 today-lead">{leadLine(day, t, locale)}</p>
       <Lane
         shape={{
           title: t("day.needsYou"),
@@ -393,7 +402,9 @@ function TodayLanes({
       {day.counts.duplicates_open != null && day.counts.duplicates_open > 0 && (
         <p className="t-caption today-foot">
           <GitMerge size={14} aria-hidden />
-          {t("day.duplicatesOpen", { count: day.counts.duplicates_open })}
+          {t("day.duplicatesOpen", {
+            count: formatNumber(day.counts.duplicates_open, locale),
+          })}
         </p>
       )}
     </>


### PR DESCRIPTION
`main`'s production build has been failing since [#2675](https://github.com/margince/margince/pull/2675). Four `TS2322`s in `today.tsx`:

```
src/screens/today.tsx(57,38): error TS2322: Type 'number' is not assignable to type 'string'.
src/screens/today.tsx(60,40): ...
src/screens/today.tsx(110,29): ...
src/screens/today.tsx(396,38): ...
```

`t(key, { count: <number> })` against a translator whose params are `Record<string, string>`.

## Not a cast

`String(n)` would type-check and be wrong: it prints `1234` to a reader whose locale writes `1.234`. The tree's convention is `formatNumber(value, locale)` — `company360.tsx`, `companyapprovals.tsx` and others already do this, and [#2665](https://github.com/margince/margince/pull/2665) landed one commit before #2675 saying exactly that: *a figure is written in the reader's own notation*.

So all four go through `formatNumber`. `leadLine` gains the locale as a parameter; `TodayLanes` reads it from `useLocale`; `itemDetail` already had one.

## Why only `live-boot` caught it

`tsc -p tsconfig.json` **passes** on this code — I checked, and it is why `frontend / fe-quality` is green on main. The production build uses the stricter config, and `live-boot` is the only job that runs a real `pnpm build`.

`live-boot` is also not among `ci`'s `needs:`, and `ci` is the only required status check. So #2675 merged green by every check that gates a merge, and the breakage is invisible until someone reads a non-required job. That is worth a separate look — this PR only fixes the four lines.

## Verification

- `pnpm build` — exit 0 (fails on `origin/main` with the 8 errors above, verified on a clean worktree)
- `make check-fe` — exit 0; 4770 tests pass
- Run on Node 24 / pnpm 11, which is what CI pins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Counts, percentages, and duplicate summaries on the Today screen now use locale-aware number formatting.
  * Displayed values are formatted according to the active language and regional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->