### PR TITLE
fix(shell): the rail's acceptance names the day, and the counts stop saying twelve

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -150,7 +150,7 @@ function accountTrigger(page: Page) {
   });
 }
 
-// The canonical twelve, in order: Home alone, then records / work /
+// The canonical thirteen, in order: Home alone, then records / work /
 // intelligence. Not upstream's set: Duplicates is a destination here (the queue
 // had no address outside a home digest card) while Automations is not (it is
 // set-and-forget configuration on Settings → AI). Two labels differ from their
@@ -161,7 +161,13 @@ function accountTrigger(page: Page) {
 // src/app/nav.ts is the source of the rail; deriving this from it would assert
 // only that the rail renders itself, so a destination added there is meant to
 // fail here until somebody says what a person now reads and where.
-test("AC-shell-1: the rail renders the canonical 12 items in order", async ({
+//
+// Heute is the answer for the row added most recently. It LEADS the work group
+// rather than joining the end of it: every other row there is one producer's
+// queue, and this one is the sum a reader opens when the question is "what
+// needs me?" instead of "show me the approvals". A summary placed under the
+// things it summarises reads as a footnote to them.
+test("AC-shell-1: the rail renders the canonical 13 items in order", async ({
   page,
 }) => {
   await page.goto("/#/home");
@@ -170,7 +176,7 @@ test("AC-shell-1: the rail renders the canonical 12 items in order", async ({
   // Scoped to the level the panel is showing: the DESTINATIONS are its rows,
   // while the foot's Settings door rides the same `.navitem` geometry without
   // being one of them.
-  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(12);
+  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(13);
   const labels = await page
     .locator("nav.rail .navlevel a.navitem")
     .evaluateAll((links) =>
@@ -183,6 +189,7 @@ test("AC-shell-1: the rail renders the canonical 12 items in order", async ({
     "Leads",
     "Duplikate",
     "Filter & Ansichten",
+    "Heute",
     "Pipeline",
     "Projekte",
     "Aufgaben",
@@ -277,7 +284,7 @@ test("AC-shell-7: the top bar's search opens the palette", async ({ page }) => {
   ).toBeVisible();
   // And it is not a destination of its own — the links AC-shell-1 counts are
   // unchanged by search leaving the sidebar.
-  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(12);
+  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(13);
 });
 
 // The account menu carries what belongs to the PERSON rather than to the page:

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -41,7 +41,7 @@ export {
 // structure and collapse to hairline rules at 64px, so the collapsed rail is the
 // flat list WDS-NAV-1 describes.
 //
-// It carries twelve rows against upstream's own ten, and not as a superset:
+// It carries thirteen rows against upstream's own ten, and not as a superset:
 // Duplicates, Filters & views and Projects are destinations here, Automations is not.
 // Automations is set-and-forget configuration and now lives inside Settings →
 // AI, which is where the product already offered a second door to it; the dedupe
@@ -147,7 +147,7 @@ export const NAV: readonly NavItem[] = NAV_GROUPS.flatMap(
 export const BADGE_SCREENS: ReadonlySet<Screen> = new Set(["tasks", "inbox"]);
 
 // At phone width the sidebar becomes a bottom bar, which fits four thumb-sized
-// destinations plus More — twelve would need horizontal scrolling, and a nav you
+// destinations plus More — thirteen would need horizontal scrolling, and a nav you
 // have to scroll is a nav you cannot see. Decisions is non-negotiable here: the
 // 390px approval path is required for V1.
 export const MOBILE_PRIMARY: ReadonlySet<Screen> = new Set([

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@composition/extensions", () => ({
 
 // B-EP09.4 acceptance, for the SIDEBAR — the left-hand panel and nothing else.
 //
-// It is destinations only: the canonical 12-item nav in order (AC-shell-1b —
+// It is destinations only: the canonical 13-item nav in order (AC-shell-1b —
 // Automations left it for Settings → AI while the dedupe queue and the filter
 // builder took rows, which is a UI divergence on the founder's back-fill list),
 // at most one active


### PR DESCRIPTION
## main is red on the `uat` lane

`AC-shell-1` and `AC-shell-7` both assert the rail carries twelve destinations. It carries thirteen.

```
Locator:  locator('nav.rail .navlevel a.navitem')
Expected: 12
Received: 13
```

A day surface was added to `NAV_GROUPS` and this spec was never asked about it.

## Why it reached main

The `uat` lane reported **skipping** on the PR that added the row, so the AC spec never ran against the change at all. The rail's own unit test (`rail.test.tsx`) *was* updated and already carries `Today` in the right position — so two spellings of one order disagreed, and only the lane that did not run held the second one.

That is the shape worth naming: a lane that never ran is indistinguishable from a lane that passed. Green means "nothing reported", and "nothing reported" is also what an unrun gate says.

## The fix is the spec's own instruction

The spec spells out the count and the list rather than deriving them, on purpose:

> The count and the list are both spelled out on purpose. `NAV_GROUPS` in `src/app/nav.ts` is the source of the rail; deriving this from it would assert only that the rail renders itself, so a destination added there is meant to fail here until somebody says what a person now reads and where.

Bumping `12` → `13` alone answers half of that and **deletes the decision the gate exists to force**. So the answer is written beside the list: **Heute leads the work group** rather than joining the end of it — every other row there is one producer's queue, and this one is the sum a reader opens when the question is "what needs me?" instead of "show me the approvals". A summary placed under the things it summarises reads as a footnote to them.

That also matches where `rail.test.tsx` already had it, so the two now agree by saying the same thing rather than by coincidence.

## Three stale counts

A comment that names a number is a claim, and these outlived what they described:

| Location | Said | Now |
|---|---|---|
| `nav.ts:44` | "carries twelve rows" | thirteen |
| `nav.ts:150` | "twelve would need horizontal scrolling" | thirteen |
| `rail.test.tsx:49` | "the canonical 12-item nav" | 13-item |

## Verification

- `make frontend-e2e` — **exit 0**, 94 passed / 14 skipped (was 92 passed, 2 failed)
- `make check-fe` — **exit 0**, 378 files / 4772 tests, plus 2 files / 36 tests on the extension surface
- **Mutation-verified**: moving `"Heute"` from its position to the end of the list (confirmed applied by reading the file back) turns AC-shell-1 red — `1 failed, 93 passed`. The assertion holds the order, not just the count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UAT failures by bringing the rail acceptance tests up to the current 13-destination nav and asserting the canonical order. No runtime behavior changes; only tests and comments were updated.

- AC-shell-1 explicitly lists labels and requires "Heute" to lead the work group.
- AC-shell-7 keeps the link count at 13 when search opens.
- Updated prose counts in `nav.ts` and `rail.test.tsx` from twelve to thirteen.

<sup>Written for commit c4452a967f0f117bf11b327a79e471df2fc1900f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

