### PR TITLE
refactor(frontend): the eyebrow is declared once, and a gate says so

### DIFF
--- a/frontend/src/design-system/cssrules.ts
+++ b/frontend/src/design-system/cssrules.ts
@@ -1,0 +1,97 @@
+// Reading CSS as rules and declarations, for the gates that judge one.
+//
+// It is here rather than inside a *.test.* file because two gates ask the same
+// question of the same tree — `onecard.test.ts` about the card surface,
+// `oneeyebrow.test.ts` about uppercase micro-type — and a second parser is a
+// second answer to "what is a rule", which drifts the way every other pair in
+// this tree drifted. It is also not a test file for the reason
+// `src/testing/steppedclock.tsx` is not: the design-system and lint gates skip
+// test files, and a helper this many gates lean on should answer to the same
+// rules the app does.
+//
+// It is a reader, not a CSS engine. It does not resolve the cascade, compute
+// specificity or expand shorthands — a gate that needed those would be asking a
+// different question, and each caller expands the equivalences its own subject
+// can be written in.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** One `selector { … }` rule, as written. */
+export type Rule = Readonly<{ selector: string; body: string }>;
+
+/** Every stylesheet under a directory, node_modules and dist excepted. */
+export function stylesheets(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" || entry.name === "dist"
+        ? []
+        : stylesheets(path);
+    }
+    return entry.name.endsWith(".css") ? [path] : [];
+  });
+}
+
+/**
+ * CSS comments are not rules, and one sitting above a rule was being read as
+ * its selector.
+ */
+export function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+export function rules(css: string): Rule[] {
+  const found: Rule[] = [];
+  // Non-greedy to the first `}`, which is why a nested block (a media query,
+  // `:is()` with braces) is not matched as one rule — the rules INSIDE it are,
+  // which is what these gates ask about anyway.
+  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    found.push({ selector: match[1].trim(), body: match[2] });
+  }
+  return found;
+}
+
+/**
+ * The `property: value` pairs in a rule body, in one spelling.
+ *
+ * Every whitespace difference is erased, because each of them computes
+ * identically and compares unequal: `background:var(--bgElevated)` without the
+ * space, and `var(--bgElevated )` with one inside the parentheses, each let an
+ * identical rule escape a gate comparing declaration text. These exist for the
+ * hand that does not run the formatter.
+ */
+export function declarations(body: string): readonly string[] {
+  return body
+    .split(";")
+    .map((part) =>
+      part
+        .trim()
+        .replace(/\s+/g, " ")
+        .replace(/\s*:\s*/g, ": ")
+        .replace(/\(\s+/g, "(")
+        .replace(/\s+\)/g, ")"),
+    )
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * The declarations of the ONE rule with this selector in a stylesheet.
+ *
+ * Exactly one, not the first. `.find()` silently adopts whichever comes first,
+ * so a second rule with the same selector anywhere in the file — a media-query
+ * override, a leftover — becomes the subject and the gate goes looking for the
+ * wrong declarations. With a rare declaration in the first rule that degrades
+ * to green while blind, which is the direction a gate must not fail in.
+ */
+export function soleRule(path: string, selector: string): Rule {
+  const declared = rules(withoutComments(readFileSync(path, "utf8"))).filter(
+    (rule) => rule.selector === selector,
+  );
+  if (declared.length !== 1) {
+    throw new Error(
+      `${path} declares ${selector} ${declared.length} times; a gate needs exactly one to read its subject from`,
+    );
+  }
+  return declared[0];
+}

--- a/frontend/src/design-system/margince-workbench.css
+++ b/frontend/src/design-system/margince-workbench.css
@@ -163,10 +163,6 @@
      everything under 13px, and every label in this chrome is 9-11px. */
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* The hairline that makes five stops one rail. Drawn, not marked up: a
@@ -260,10 +256,6 @@
   display: block;
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .mw-identity h1 {
@@ -391,10 +383,6 @@
   margin: 0;
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* The popover's subject is the machine, so its header reads the AI family
@@ -557,12 +545,8 @@
 .mw-progress-label {
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
   overflow: hidden;
   text-overflow: ellipsis;
-  text-transform: uppercase;
   white-space: nowrap;
 }
 
@@ -648,10 +632,6 @@
 .mw-shell.is-rail .mw-aifooter-label {
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .mw-shell.is-rail .mw-aistat,

--- a/frontend/src/design-system/margince-workbench.test.tsx
+++ b/frontend/src/design-system/margince-workbench.test.tsx
@@ -138,9 +138,9 @@ describe("the step rail", () => {
     expect(rail.querySelector("button")).toBeNull();
     expect(rail.querySelector("a")).toBeNull();
     expect(stops.map((stop) => stop.className)).toEqual([
-      "mw-step is-done",
-      "mw-step is-now",
-      "mw-step is-todo",
+      "t-eyebrow mw-step is-done",
+      "t-eyebrow mw-step is-now",
+      "t-eyebrow mw-step is-todo",
     ]);
   });
 

--- a/frontend/src/design-system/margince-workbench.tsx
+++ b/frontend/src/design-system/margince-workbench.tsx
@@ -116,7 +116,7 @@ export function MarginceWorkbench({
         className="mw-core"
       />
       <div className="mw-identity">
-        <span>{eyebrow}</span>
+        <span className="t-eyebrow">{eyebrow}</span>
         <h1>{title}</h1>
         <p>
           <i data-state={state} aria-hidden /> {status}
@@ -155,7 +155,7 @@ export function MarginceWorkbench({
                   spending — cost is part of who is talking, not a footnote. */}
               <div className="mw-aifooter">
                 {footerLabel !== undefined && (
-                  <span className="mw-aifooter-label">{footerLabel}</span>
+                  <span className="t-eyebrow mw-aifooter-label">{footerLabel}</span>
                 )}
                 <AiRuntimeChip
                   runtime={runtime}
@@ -237,7 +237,7 @@ function StepRail({ steps }: Readonly<{ steps: readonly WorkbenchStep[] }>) {
       {steps.map((step, index) => (
         <li
           key={step.label}
-          className={`mw-step is-${step.state}`}
+          className={`t-eyebrow mw-step is-${step.state}`}
           aria-current={step.state === "now" ? "step" : undefined}
         >
           <b aria-hidden>{index + 1}</b>
@@ -262,7 +262,7 @@ function StepProgress({
   return (
     <div className="mw-progress">
       {label !== undefined && (
-        <span className="mw-progress-label">{label}</span>
+        <span className="t-eyebrow mw-progress-label">{label}</span>
       )}
       <span className="mw-progress-track" aria-hidden>
         {steps.map((step) => (
@@ -445,7 +445,7 @@ function AiRuntimeChip({
             note={runtime?.unpriced_calls ? labels.partial : undefined}
           />
         </dl>
-        <p className="mw-aistat-f">{labels.scope}</p>
+        <p className="t-eyebrow mw-aistat-f">{labels.scope}</p>
       </div>
     </div>
   );

--- a/frontend/src/design-system/margince-workbench.tsx
+++ b/frontend/src/design-system/margince-workbench.tsx
@@ -155,7 +155,9 @@ export function MarginceWorkbench({
                   spending — cost is part of who is talking, not a footnote. */}
               <div className="mw-aifooter">
                 {footerLabel !== undefined && (
-                  <span className="t-eyebrow mw-aifooter-label">{footerLabel}</span>
+                  <span className="t-eyebrow mw-aifooter-label">
+                    {footerLabel}
+                  </span>
                 )}
                 <AiRuntimeChip
                   runtime={runtime}

--- a/frontend/src/design-system/margince-workbench.tsx
+++ b/frontend/src/design-system/margince-workbench.tsx
@@ -410,7 +410,7 @@ function AiRuntimeChip({
         <ChevronDown className="mw-aistat-caret" aria-hidden size={12} />
       </button>
       <div className="mw-aistat-pop" id={popoverId} hidden={!open}>
-        <p className="mw-aistat-h">{labels.answering}</p>
+        <p className="t-eyebrow mw-aistat-h">{labels.answering}</p>
         <dl className="mw-aistat-rows">
           <RuntimeRow label={labels.configured} value={configured} />
           <RuntimeRow

--- a/frontend/src/design-system/onecard.test.ts
+++ b/frontend/src/design-system/onecard.test.ts
@@ -1,7 +1,14 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+  declarations as declarationsIn,
+  rules,
+  soleRule,
+  stylesheets,
+  withoutComments,
+} from "./cssrules";
 
 // `Card` is the one card surface, and a hand-rolled one is a second card the
 // moment any of its chrome moves — which is not a warning, it is a description
@@ -34,83 +41,22 @@ const designSystem = join(frontendRoot, "src", "design-system");
 // see, because it sits beside the real one.
 const cardSource = join(designSystem, "atoms.css");
 
-function stylesheets(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      return entry.name === "node_modules" || entry.name === "dist"
-        ? []
-        : stylesheets(path);
-    }
-    return entry.name.endsWith(".css") ? [path] : [];
-  });
-}
-
-/** One `selector { … }` rule, as written. */
-type Rule = Readonly<{ selector: string; body: string }>;
-
-/** CSS comments are not rules, and one sitting above a rule was being read as
- * its selector. */
-function withoutComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
-
-function rules(css: string): Rule[] {
-  const found: Rule[] = [];
-  // Non-greedy to the first `}`, which is why a nested block (a media query,
-  // `:is()` with braces) is not matched as one rule — the rules INSIDE it are,
-  // which is what this asks about anyway.
-  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-    found.push({ selector: match[1].trim(), body: match[2] });
-  }
-  return found;
-}
-
 /**
  * `.card`'s own declarations, read from the design system rather than repeated
  * here — a hardcoded copy of the chrome would be the very thing this forbids,
  * and would stop matching the day somebody restyles the real card.
  */
 function cardChrome(): readonly string[] {
-  const atoms = readFileSync(cardSource, "utf8");
-  const declared = rules(withoutComments(atoms)).filter(
-    (r) => r.selector === ".card",
-  );
-  // EXACTLY one, not the first. `.find()` silently adopts whichever comes
-  // first, so a second `.card { … }` anywhere in the file — a media query
-  // override, a leftover — becomes the subject and the gate goes looking for
-  // the wrong declarations. It failed loudly when I planted one; that was luck,
-  // and with a rarer declaration in the first rule it degrades to green while
-  // blind.
-  if (declared.length !== 1) {
-    throw new Error(
-      `atoms.css declares .card ${declared.length} times; this gate needs exactly one to read its subject from`,
-    );
-  }
-  return declarations(declared[0].body);
+  return declarations(soleRule(cardSource, ".card").body);
 }
 
-/** The `property: value` pairs in a rule body, in one spelling. */
+/**
+ * The rule's declarations, each also expanded into the longhand a retyping
+ * hand would write. The whitespace spellings are erased by the shared reader;
+ * the shorthands below are this gate's own subject and stay here.
+ */
 function declarations(body: string): readonly string[] {
-  return body
-    .split(";")
-    .map((part) =>
-      part
-        .trim()
-        .replace(/\s+/g, " ")
-        // Around the colon too. Collapsing only runs of whitespace left
-        // `background:var(--bgElevated)` unequal to `background: var(...)`, so
-        // the same card written without a space escaped entirely — not a
-        // variant, the identical card, defeated by a spelling a formatter would
-        // erase. This gate exists for the hand that does not run the formatter.
-        .replace(/\s*:\s*/g, ": ")
-        // And inside the parentheses, for the same reason: `var(--bgElevated )`
-        // computes identically and compares unequal.
-        .replace(/\(\s+/g, "(")
-        .replace(/\s+\)/g, ")"),
-    )
-    .filter((part) => part.length > 0)
-    .flatMap(longhand);
+  return declarationsIn(body).flatMap(longhand);
 }
 
 /**

--- a/frontend/src/design-system/oneeyebrow.test.ts
+++ b/frontend/src/design-system/oneeyebrow.test.ts
@@ -141,6 +141,18 @@ function tokenValues(): Map<string, string> {
   return values;
 }
 
+/**
+ * Whether a rule body declares the eyebrow's type.
+ *
+ * PRESENT, not exclusive: a copy carries its own spacing, layout and colour —
+ * every one of the twenty-eight in this tree did — so asking whether the rule
+ * declares ONLY the four would have found none of them.
+ */
+function redeclaresTheEyebrow(body: string): boolean {
+  const declared = new Set(typeOf(body));
+  return eyebrowType().every((property) => declared.has(property));
+}
+
 describe("one eyebrow", () => {
   const sheets = stylesheets(join(frontendRoot, "src"));
 
@@ -171,16 +183,42 @@ describe("one eyebrow", () => {
     expect(eyebrowType()).toHaveLength(4);
   });
 
+  it("sees a copy that carries its own spacing and colour too", () => {
+    // Asked of the census's OWN predicate, not of a second spelling of it: a
+    // test that rewrote the comparison would keep passing while the comparison
+    // it describes was tightened into blindness. Every one of the twenty-eight
+    // copies in the tree carried extras — a set-equality here would have found
+    // none of them.
+    expect(
+      redeclaresTheEyebrow(`
+        margin: 0 0 var(--space-2);
+        display: flex;
+        gap: var(--space-1);
+        color: var(--accent);
+        font-size: var(--fs-eyebrow);
+        font-weight: var(--fw-semibold);
+        letter-spacing: var(--tracking-eyebrow);
+        text-transform: uppercase;
+      `),
+    ).toBe(true);
+    // And a rule taking three of the four is a variant somebody decided on.
+    expect(
+      redeclaresTheEyebrow(`
+        font-size: var(--fs-eyebrow);
+        font-weight: var(--fw-semibold);
+        text-transform: uppercase;
+      `),
+    ).toBe(false);
+  });
+
   it("is declared only by the design system", () => {
-    const type = eyebrowType();
     const copies: string[] = [];
     for (const path of sheets) {
       for (const rule of rules(withoutComments(readFileSync(path, "utf8")))) {
         if (path === eyebrowSource && rule.selector === ".t-eyebrow") {
           continue;
         }
-        const declared = new Set(typeOf(rule.body));
-        if (type.every((property) => declared.has(property))) {
+        if (redeclaresTheEyebrow(rule.body)) {
           copies.push(`${relative(frontendRoot, path)}: ${rule.selector}`);
         }
       }

--- a/frontend/src/design-system/oneeyebrow.test.ts
+++ b/frontend/src/design-system/oneeyebrow.test.ts
@@ -27,6 +27,11 @@ import {
 // a copy that took three of the four had already made the type worse without
 // anybody choosing it.
 //
+// The `font:` shorthand is expanded before comparing, because it sets the
+// weight and the size in one declaration and a rule written that way carries
+// two of the four under a property name a longhand comparison never sees. A
+// complete copy stood in the conversation sheet exactly like that.
+//
 // WHAT IT DELIBERATELY DOES NOT CATCH. A rule that takes SOME of the quadruple
 // is a variant somebody decided on, not a duplicate a test can name — an
 // uppercase label at a different size is a design decision, and reporting it
@@ -50,9 +55,52 @@ const tokens = join(designSystem, "tokens.css");
  * roles — so requiring it would make the gate see almost nothing.
  */
 function eyebrowType(): readonly string[] {
-  return declarations(soleRule(eyebrowSource, ".t-eyebrow").body)
+  return typeOf(soleRule(eyebrowSource, ".t-eyebrow").body);
+}
+
+/**
+ * A rule's type declarations, with the `font:` shorthand expanded and every
+ * token resolved.
+ *
+ * The shorthand is not a nicety. `font: var(--fw-semibold) var(--fs-eyebrow) /
+ * var(--lh-normal) var(--f-body)` sets the weight and the size in one
+ * declaration, so a rule written that way carries two of the four under a
+ * property name the longhand comparison never sees — it reads as 2 of 4 and
+ * passes. A complete copy stood in the conversation sheet exactly like that,
+ * and the census that found the other twenty-seven could not see it.
+ * `onecard.test.ts` learned this for its own shorthands; the lesson belongs to
+ * whichever gate compares declaration text, which is both of them.
+ */
+function typeOf(body: string): readonly string[] {
+  return declarations(body)
+    .flatMap(fontLonghand)
     .filter((declaration) => !declaration.startsWith("color:"))
     .map(resolved);
+}
+
+/**
+ * `font: <weight> <size>/<line-height> <family>` as its parts.
+ *
+ * Only the one ordering this tree writes, expanded into the two properties this
+ * gate compares. A general shorthand parser is a different program, and one
+ * that guessed wrong would make the gate fire on rules that are not eyebrows —
+ * which costs more than what the narrow version misses, because a gate that
+ * fires on correct code teaches readers to skip it.
+ */
+function fontLonghand(declaration: string): readonly string[] {
+  if (!declaration.startsWith("font: ")) {
+    return [declaration];
+  }
+  const parts = declaration.slice("font: ".length).split(" ");
+  const [weight, sizeAndLeading] = parts;
+  if (weight === undefined || sizeAndLeading === undefined) {
+    return [declaration];
+  }
+  const size = sizeAndLeading.split("/")[0];
+  if (size === undefined || size === "") {
+    return [declaration];
+  }
+  return [`font-weight: ${weight}`, `font-size: ${size}`];
 }
 
 /**
@@ -131,7 +179,7 @@ describe("one eyebrow", () => {
         if (path === eyebrowSource && rule.selector === ".t-eyebrow") {
           continue;
         }
-        const declared = new Set(declarations(rule.body).map(resolved));
+        const declared = new Set(typeOf(rule.body));
         if (type.every((property) => declared.has(property))) {
           copies.push(`${relative(frontendRoot, path)}: ${rule.selector}`);
         }

--- a/frontend/src/design-system/oneeyebrow.test.ts
+++ b/frontend/src/design-system/oneeyebrow.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  declarations,
+  rules,
+  soleRule,
+  stylesheets,
+  withoutComments,
+} from "./cssrules";
+
+// `.t-eyebrow` is the one spelling of uppercase micro-type, and this is what
+// makes that a fact rather than a retelling.
+//
+// Its own docblock in base.css has said "THE one spelling" since it was
+// written, and said it over TWENTY-SEVEN rules outside the design system that
+// re-declared the identical quadruple — the eyebrow font size, the semibold
+// weight, the eyebrow tracking and the uppercase transform — across the
+// onboarding screens, the conversation sheet and the workbench chrome itself.
+// Every copy looked right on its own. That is the shape this repository's
+// rulebook forbids: a uniqueness claim no test holds is either deleted or
+// gated.
+//
+// The four are ONE decision, not four properties. Uppercase at 11px sets
+// cramped at default spacing, which is what --tracking-eyebrow exists for, and
+// a copy that took three of the four had already made the type worse without
+// anybody choosing it.
+//
+// WHAT IT DELIBERATELY DOES NOT CATCH. A rule that takes SOME of the quadruple
+// is a variant somebody decided on, not a duplicate a test can name — an
+// uppercase label at a different size is a design decision, and reporting it
+// would be this gate asserting an answer nobody gave. It asks the narrow
+// question it can answer: is this the eyebrow, copied.
+
+const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const designSystem = join(frontendRoot, "src", "design-system");
+// The one rule this gate reads its subject FROM, and so the one rule it must
+// not report as a copy of itself.
+const eyebrowSource = join(designSystem, "base.css");
+const tokens = join(designSystem, "tokens.css");
+
+/**
+ * `.t-eyebrow`'s own type declarations, read from the design system rather
+ * than repeated here. A hardcoded copy of the quadruple would be the very thing
+ * this forbids, and would stop matching the day somebody restyles the eyebrow.
+ *
+ * `color` is dropped on purpose: it is the one property a caller is expected to
+ * override — the tree has eyebrows in accent, in AI text and in three meta
+ * roles — so requiring it would make the gate see almost nothing.
+ */
+function eyebrowType(): readonly string[] {
+  return declarations(soleRule(eyebrowSource, ".t-eyebrow").body)
+    .filter((declaration) => !declaration.startsWith("color:"))
+    .map(resolved);
+}
+
+/**
+ * A declaration with its `var(--token)` replaced by the token's value.
+ *
+ * Both sides of the comparison run through this, because `font-weight: 600` and
+ * `font-weight: var(--fw-semibold)` are the same weight and compare unequal —
+ * and the longhand is exactly what the hand that retypes a rule writes. A text
+ * comparison loses to an equivalent spelling, every time.
+ */
+function resolved(declaration: string): string {
+  return declaration.replace(/var\((--[\w-]+)\)/g, (whole, name: string) => {
+    const value = tokenValues().get(name);
+    return value ?? whole;
+  });
+}
+
+let cachedTokens: Map<string, string> | null = null;
+function tokenValues(): Map<string, string> {
+  if (cachedTokens !== null) {
+    return cachedTokens;
+  }
+  const values = new Map<string, string>();
+  for (const rule of rules(withoutComments(readFileSync(tokens, "utf8")))) {
+    for (const declaration of declarations(rule.body)) {
+      const colon = declaration.indexOf(": ");
+      const property = declaration.slice(0, colon);
+      if (property.startsWith("--")) {
+        values.set(property, declaration.slice(colon + 2));
+      }
+    }
+  }
+  cachedTokens = values;
+  return values;
+}
+
+describe("one eyebrow", () => {
+  const sheets = stylesheets(join(frontendRoot, "src"));
+
+  it("finds stylesheets to judge", () => {
+    // A census that read nothing certifies nothing, and this one is a census of
+    // zero once the tree is clean — it reads the same over a clean tree and a
+    // broken walk. So it also names the two places the copies actually lived.
+    expect(sheets.length).toBeGreaterThan(40);
+    expect(
+      sheets.some((path) =>
+        path.endsWith("onboarding-conversation/conversation.css"),
+      ),
+      "the walk did not reach the conversation sheet, which carried twelve of the twenty-seven copies",
+    ).toBe(true);
+    expect(
+      sheets.some((path) =>
+        path.endsWith("design-system/margince-workbench.css"),
+      ),
+      "the walk did not reach the workbench chrome, where five copies sat inside the design system itself",
+    ).toBe(true);
+  });
+
+  it("reads a subject worth comparing", () => {
+    // If the source rule ever stops declaring the quadruple, every rule in the
+    // tree trivially "contains" an empty subject and the gate would report the
+    // whole stylesheet — or, with one declaration left, almost nothing. Naming
+    // the count is what tells a restyle from a deletion.
+    expect(eyebrowType()).toHaveLength(4);
+  });
+
+  it("is declared only by the design system", () => {
+    const type = eyebrowType();
+    const copies: string[] = [];
+    for (const path of sheets) {
+      for (const rule of rules(withoutComments(readFileSync(path, "utf8")))) {
+        if (path === eyebrowSource && rule.selector === ".t-eyebrow") {
+          continue;
+        }
+        const declared = new Set(declarations(rule.body).map(resolved));
+        if (type.every((property) => declared.has(property))) {
+          copies.push(`${relative(frontendRoot, path)}: ${rule.selector}`);
+        }
+      }
+    }
+    expect(
+      copies,
+      "these rules re-declare the eyebrow. Carry `t-eyebrow` in the markup and " +
+        "keep only what is this element's own — its colour, its spacing, its " +
+        "layout. The four are one decision: uppercase at 11px sets cramped " +
+        "without --tracking-eyebrow, and a copy that took three of the four " +
+        "made the type worse without anybody choosing it.",
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/design-system/oneeyebrow.test.ts
+++ b/frontend/src/design-system/oneeyebrow.test.ts
@@ -56,7 +56,11 @@ function eyebrowType(): readonly string[] {
 }
 
 /**
- * A declaration with its `var(--token)` replaced by the token's value.
+ * A declaration with each token reference replaced by the token's value.
+ *
+ * The reference is not spelled out in this sentence on purpose: the
+ * custom-property gate reads every `var(…)` in the tree, prose included, and a
+ * made-up token name in an explanation is reported as one nothing defines.
  *
  * Both sides of the comparison run through this, because `font-weight: 600` and
  * `font-weight: var(--fw-semibold)` are the same weight and compare unequal —

--- a/frontend/src/screens/onboarding-backread.css
+++ b/frontend/src/screens/onboarding-backread.css
@@ -176,10 +176,6 @@
 
 .ob-backread-tally-label {
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   color: var(--textTertiary);
 }
 

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -502,7 +502,7 @@ function BackreadTallies({
     <dl className="ob-backread-tallies">
       {present.map((tally) => (
         <div className="ob-backread-tally" key={tally.key}>
-          <dt className="ob-backread-tally-label">{t(tally.label)}</dt>
+          <dt className="t-eyebrow ob-backread-tally-label">{t(tally.label)}</dt>
           <dd className="ob-backread-tally-value">
             {formatNumber(tally.count, locale)}
           </dd>

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -502,7 +502,9 @@ function BackreadTallies({
     <dl className="ob-backread-tallies">
       {present.map((tally) => (
         <div className="ob-backread-tally" key={tally.key}>
-          <dt className="t-eyebrow ob-backread-tally-label">{t(tally.label)}</dt>
+          <dt className="t-eyebrow ob-backread-tally-label">
+            {t(tally.label)}
+          </dt>
           <dd className="ob-backread-tally-value">
             {formatNumber(tally.count, locale)}
           </dd>

--- a/frontend/src/screens/onboarding-build-scene.css
+++ b/frontend/src/screens/onboarding-build-scene.css
@@ -216,10 +216,6 @@
   position: relative;
   z-index: 1;
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   text-align: center;
   color: var(--textMeta);
   animation: ob-build-sub-in calc(var(--obBuildMs) * 0.24)

--- a/frontend/src/screens/onboarding-build-scene.tsx
+++ b/frontend/src/screens/onboarding-build-scene.tsx
@@ -183,7 +183,7 @@ export function BuildScene({
             rather than a second one appearing next to it. */}
         <Wordmark alt={word} className="ob-build-wordmark" />
       </div>
-      <p className="ob-build-sub">{label}</p>
+      <p className="t-eyebrow ob-build-sub">{label}</p>
     </div>
   );
 }

--- a/frontend/src/screens/onboarding-company-form.tsx
+++ b/frontend/src/screens/onboarding-company-form.tsx
@@ -175,7 +175,7 @@ export function CompanyStep({
               summary states what is selected, which is the only thing a
               human needs unless they want to change it. */}
           <summary>
-            <span className="seclabel">{t("ob.factsTitle")}</span>
+            <span className="t-eyebrow seclabel">{t("ob.factsTitle")}</span>
             <span className="facts-count">
               {t("ob.factsSelected", {
                 selected: formatNumber(selectedFactKeys.length, locale),

--- a/frontend/src/screens/onboarding-conversation/artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/artifact.tsx
@@ -154,7 +154,7 @@ export function CompanyActArtifact(props: CompanyActArtifactProps) {
           the generic dossier heading would be a second voice above it. */}
       {(props.review == null || props.mode !== "dossier") && (
         <div className="mw-review-heading">
-          <span>{t("ob.ai.liveArtifact")}</span>
+          <span className="t-eyebrow">{t("ob.ai.liveArtifact")}</span>
           <h2>{t("ob.ai.companyKnowledge")}</h2>
           <p>
             {t(

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -1198,7 +1198,7 @@ function AttentionGroup({
   const labelId = `ob-conv-attention-${groupKey}`;
   return (
     <div className="ob-conv-attention-group">
-      <p className="ob-conv-attention-group-label" id={labelId}>
+      <p className="t-eyebrow ob-conv-attention-group-label" id={labelId}>
         {label}
       </p>
       <ul className="ob-conv-attention-list" aria-labelledby={labelId}>

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -844,7 +844,7 @@ export function CompanyAct({
   const reviewScene =
     state.phase === "co.review" && reviewProposal ? (
       <div className="ob-scene">
-        <p className="ob-scene-eyebrow">{stepEyebrow}</p>
+        <p className="t-eyebrow ob-scene-eyebrow">{stepEyebrow}</p>
         <CompanyConfirmCard
           proposal={reviewProposal}
           draft={draft}

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -247,7 +247,7 @@ function OmissionNotice({
     <div className="ob-triage-omitted">
       <FileQuestion aria-hidden />
       <div className="ob-triage-omitted-body">
-        <p className="ob-triage-omitted-label">
+        <p className="t-eyebrow ob-triage-omitted-label">
           {t("ob.conv.triage.omittedLabel")}
         </p>
         <p>
@@ -839,7 +839,7 @@ function CompanyIdentityCard({
               const { field } = fact;
               return (
                 <div key={fact.label}>
-                  <dt>{fact.label}</dt>
+                  <dt className="t-eyebrow">{fact.label}</dt>
                   <dd>
                     {field === null ? (
                       fact.value
@@ -1153,7 +1153,7 @@ function FieldGroupSection({
               group.workCount > 0 &&
               solidCount > 0 && (
                 <li className="ob-triage-solid-divider" aria-hidden>
-                  <span>
+                  <span className="t-eyebrow">
                     {t("ob.conv.triage.looksSolid", {
                       count: formatNumber(solidCount, locale),
                     })}
@@ -1470,7 +1470,7 @@ export function CompanyConfirmCard(props: CompanyConfirmCardProps) {
           under a tail head of its own. */}
       {props.read != null && (
         <div className="ob-triage-readmore">
-          <p className="ob-triage-rest-head">{t("ob.conv.triage.restTitle")}</p>
+          <p className="t-eyebrow ob-triage-rest-head">{t("ob.conv.triage.restTitle")}</p>
           <CoverageCard
             pages={props.read.pages}
             warnings={props.read.warnings}

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -1470,7 +1470,9 @@ export function CompanyConfirmCard(props: CompanyConfirmCardProps) {
           under a tail head of its own. */}
       {props.read != null && (
         <div className="ob-triage-readmore">
-          <p className="t-eyebrow ob-triage-rest-head">{t("ob.conv.triage.restTitle")}</p>
+          <p className="t-eyebrow ob-triage-rest-head">
+            {t("ob.conv.triage.restTitle")}
+          </p>
           <CoverageCard
             pages={props.read.pages}
             warnings={props.read.warnings}

--- a/frontend/src/screens/onboarding-conversation/connect-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-scene.tsx
@@ -201,7 +201,7 @@ export function ConnectScene({
   return (
     <div className="ob-scene ob-connect">
       <div>
-        <p className="ob-scene-eyebrow">{eyebrow}</p>
+        <p className="t-eyebrow ob-scene-eyebrow">{eyebrow}</p>
         <h2>{t("ob.conv.connect.sceneTitle")}</h2>
         <p className="ob-scene-sub">{t("ob.conv.connect.sceneSub")}</p>
       </div>
@@ -211,7 +211,7 @@ export function ConnectScene({
       <div className="ob-connect-section-head">
         <h3>
           {t("ob.conv.connect.mailboxTitle")}
-          <span className="ob-connect-pill ob-connect-pill-required">
+          <span className="t-eyebrow ob-connect-pill ob-connect-pill-required">
             {t("ob.conv.connect.required")}
           </span>
         </h3>
@@ -261,7 +261,7 @@ export function ConnectScene({
       <div className="ob-connect-section-head">
         <h3>
           {t("ob.conv.connect.networkTitle")}
-          <span className="ob-connect-pill ob-connect-pill-recommended">
+          <span className="t-eyebrow ob-connect-pill ob-connect-pill-recommended">
             {t("ob.conv.connect.recommended")}
           </span>
         </h3>

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -287,9 +287,7 @@
 .ob-conv-attention-group-label {
   margin: 0;
   color: var(--textSecondary);
-  font: var(--fw-semibold) var(--fs-eyebrow) / var(--lh-normal) var(--f-body);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-eyebrow);
+  line-height: var(--lh-normal);
 }
 
 .ob-conv-attention-list {

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -599,10 +599,6 @@
   margin: 0;
   color: var(--accent);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* The header block below owns the distance to the headline above; a margin
@@ -803,10 +799,6 @@
   margin: 0;
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-decision-proof blockquote {
@@ -987,10 +979,6 @@
   margin: var(--space-4) 0 var(--space-2);
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-voice-sources ul {
@@ -1209,10 +1197,6 @@
   margin: 0 0 var(--space-3);
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-voice-result-label svg {
@@ -1249,10 +1233,6 @@
 .ob-voice-sample-field {
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-voice-sample-body {
@@ -1277,10 +1257,6 @@
   flex: none;
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* The measured dimensions: a readout per axis the build actually scored —
@@ -1297,10 +1273,6 @@
 .ob-voice-dims-count {
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-voice-dims-meta {
@@ -1552,10 +1524,6 @@
   padding: 2px 6px;
   border-radius: var(--r-sm);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-connect-pill-required {
@@ -1946,10 +1914,6 @@
   border-top: 1px solid var(--borderSubtle);
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-triage-readmore {
@@ -2061,10 +2025,6 @@
 .ob-company-card-facts dt {
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-eyebrow);
 }
 
 .ob-company-card-facts dd {
@@ -2739,10 +2699,6 @@
 .ob-triage-omitted .ob-triage-omitted-label {
   color: var(--textSecondary);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* Danger red is reserved for the ONE tier that actually stops confirm — the
@@ -2781,10 +2737,6 @@
   flex: none;
   color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .ob-triage-solid-divider::after {

--- a/frontend/src/screens/onboarding-conversation/decision-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/decision-scene.tsx
@@ -48,7 +48,9 @@ export function DecisionScene({
     <div className="ob-scene ob-decision">
       <div className="ob-decision-head">
         <div>
-          <p className="t-eyebrow ob-scene-eyebrow">{t("ob.conv.scene.detour")}</p>
+          <p className="t-eyebrow ob-scene-eyebrow">
+            {t("ob.conv.scene.detour")}
+          </p>
           <h2 id={headline}>{t(question.i18nKey, question.params)}</h2>
           <p className="ob-scene-sub">{t("ob.conv.scene.decisionSub")}</p>
         </div>
@@ -172,7 +174,9 @@ function CandidateCard({
       </div>
       {hasEvidence && open && (
         <div className="ob-decision-proof" id={panel}>
-          <p className="t-eyebrow ob-decision-proof-head">{t("ob.conv.scene.whyThis")}</p>
+          <p className="t-eyebrow ob-decision-proof-head">
+            {t("ob.conv.scene.whyThis")}
+          </p>
           <blockquote>{facts?.snippet}</blockquote>
           {facts?.source !== undefined && facts.source !== "" && (
             <>

--- a/frontend/src/screens/onboarding-conversation/decision-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/decision-scene.tsx
@@ -48,7 +48,7 @@ export function DecisionScene({
     <div className="ob-scene ob-decision">
       <div className="ob-decision-head">
         <div>
-          <p className="ob-scene-eyebrow">{t("ob.conv.scene.detour")}</p>
+          <p className="t-eyebrow ob-scene-eyebrow">{t("ob.conv.scene.detour")}</p>
           <h2 id={headline}>{t(question.i18nKey, question.params)}</h2>
           <p className="ob-scene-sub">{t("ob.conv.scene.decisionSub")}</p>
         </div>
@@ -172,11 +172,11 @@ function CandidateCard({
       </div>
       {hasEvidence && open && (
         <div className="ob-decision-proof" id={panel}>
-          <p className="ob-decision-proof-head">{t("ob.conv.scene.whyThis")}</p>
+          <p className="t-eyebrow ob-decision-proof-head">{t("ob.conv.scene.whyThis")}</p>
           <blockquote>{facts?.snippet}</blockquote>
           {facts?.source !== undefined && facts.source !== "" && (
             <>
-              <p className="ob-decision-proof-head">
+              <p className="t-eyebrow ob-decision-proof-head">
                 {t("ob.conv.scene.foundOn")}
               </p>
               <span className="ob-decision-path">{pathOf(facts.source)}</span>

--- a/frontend/src/screens/onboarding-conversation/results-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/results-act.tsx
@@ -135,7 +135,7 @@ export function ResultsAct({
       artifact={
         <div className="mw-review ob-conv-artifact">
           <div className="mw-review-heading">
-            <span>{t("ob.ai.liveArtifact")}</span>
+            <span className="t-eyebrow">{t("ob.ai.liveArtifact")}</span>
             <h2>{t("ob.conv.results.artifactTitle")}</h2>
             <p>{t("ob.conv.results.artifactBody")}</p>
           </div>

--- a/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
@@ -72,7 +72,7 @@ export function VoiceActArtifact({
   return (
     <div className="mw-review ob-conv-artifact">
       <div className="mw-review-heading">
-        <span>{t("ob.ai.liveArtifact")}</span>
+        <span className="t-eyebrow">{t("ob.ai.liveArtifact")}</span>
         <h2>{t("ob.conv.voice.artifactTitle")}</h2>
         <p>{t("ob.conv.voice.artifactBody")}</p>
       </div>

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -794,7 +794,9 @@ function VoiceMovesCard({
   const t = useT();
   return (
     <div className="ob-voice-result-card">
-      <p className="t-eyebrow ob-voice-result-label">{t("voice.insights.movesLabel")}</p>
+      <p className="t-eyebrow ob-voice-result-label">
+        {t("voice.insights.movesLabel")}
+      </p>
       <ul className="ob-voice-moves">
         {moves.map((move) => (
           <li key={move.move}>
@@ -811,7 +813,9 @@ function VoiceAvoidCard({ avoid }: Readonly<{ avoid: readonly string[] }>) {
   const t = useT();
   return (
     <div className="ob-voice-result-card">
-      <p className="t-eyebrow ob-voice-result-label">{t("voice.insights.avoidLabel")}</p>
+      <p className="t-eyebrow ob-voice-result-label">
+        {t("voice.insights.avoidLabel")}
+      </p>
       <ul className="ob-voice-avoid">
         {avoid.map((item) => (
           <li key={item}>{item}</li>

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -100,7 +100,7 @@ export function VoiceScene({
     <div className="ob-scene ob-voice-scene">
       <div className="ob-decision-head">
         <div>
-          <p className="ob-scene-eyebrow">{eyebrow}</p>
+          <p className="t-eyebrow ob-scene-eyebrow">{eyebrow}</p>
           <h2>{title}</h2>
           {sub !== undefined && <p className="ob-scene-sub">{sub}</p>}
         </div>
@@ -310,7 +310,7 @@ export function VoiceCollectScene({
 
       {manifest.length > 0 && (
         <section className="ob-voice-sources">
-          <p className="ob-voice-sources-head">
+          <p className="t-eyebrow ob-voice-sources-head">
             <span>{t("ob.conv.voice.sourcesTitle")}</span>
           </p>
           <ul>
@@ -598,7 +598,7 @@ function VoiceSampleCard({
   return (
     <div className="ob-voice-result-card ob-voice-sample">
       <div className="ob-voice-sample-head">
-        <p className="ob-voice-result-label">
+        <p className="t-eyebrow ob-voice-result-label">
           {t("ob.conv.voice.sampleEyebrow")}
         </p>
         {drafts.length > 1 && (
@@ -612,14 +612,14 @@ function VoiceSampleCard({
         )}
       </div>
       <p className="ob-voice-sample-subject">
-        <span className="ob-voice-sample-field">
+        <span className="t-eyebrow ob-voice-sample-field">
           {t("ob.conv.voice.sampleSubjectLabel")}
         </span>
         <b>{sample.subject}</b>
       </p>
       <p className="ob-voice-sample-body">{sample.body}</p>
       <p className="ob-voice-sample-why">
-        <span className="ob-voice-sample-why-tag">
+        <span className="t-eyebrow ob-voice-sample-why-tag">
           {t("ob.conv.voice.sampleWhyTag")}
         </span>
         {why}
@@ -733,10 +733,10 @@ function VoiceDimensionsCard({
   return (
     <div className="ob-voice-result-card">
       <div className="ob-voice-dims-head">
-        <span className="ob-voice-result-label">
+        <span className="t-eyebrow ob-voice-result-label">
           {t("ob.conv.voice.dimensionsTitle")}
         </span>
-        <span className="ob-voice-dims-count">
+        <span className="t-eyebrow ob-voice-dims-count">
           {t("ob.conv.voice.dimensionsCount", {
             count: formatNumber(dimensions.length, locale),
           })}
@@ -778,7 +778,7 @@ function VoiceThinkingCard({
       )}
       {thinking !== null && (
         <>
-          <p className="ob-voice-result-label">
+          <p className="t-eyebrow ob-voice-result-label">
             <Lightbulb aria-hidden /> {t("voice.insights.thinkingLabel")}
           </p>
           <p>{thinking}</p>
@@ -794,7 +794,7 @@ function VoiceMovesCard({
   const t = useT();
   return (
     <div className="ob-voice-result-card">
-      <p className="ob-voice-result-label">{t("voice.insights.movesLabel")}</p>
+      <p className="t-eyebrow ob-voice-result-label">{t("voice.insights.movesLabel")}</p>
       <ul className="ob-voice-moves">
         {moves.map((move) => (
           <li key={move.move}>
@@ -811,7 +811,7 @@ function VoiceAvoidCard({ avoid }: Readonly<{ avoid: readonly string[] }>) {
   const t = useT();
   return (
     <div className="ob-voice-result-card">
-      <p className="ob-voice-result-label">{t("voice.insights.avoidLabel")}</p>
+      <p className="t-eyebrow ob-voice-result-label">{t("voice.insights.avoidLabel")}</p>
       <ul className="ob-voice-avoid">
         {avoid.map((item) => (
           <li key={item}>{item}</li>

--- a/frontend/src/screens/onboarding-conversation/workbench.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/workbench.stories.tsx
@@ -73,7 +73,7 @@ function Shell({ session }: Readonly<{ session: RouteMap[string] }>) {
           artifact={
             <div className="mw-review ob-conv-artifact">
               <div className="mw-review-heading">
-                <span>Live artifact</span>
+                <span className="t-eyebrow">Live artifact</span>
                 <h2>Company profile</h2>
                 <p>
                   The work surface each act fills; here it stands in for one.

--- a/frontend/src/screens/onboarding-gate.css
+++ b/frontend/src/screens/onboarding-gate.css
@@ -304,10 +304,6 @@
 .ob-gate-ai span {
   color: var(--aiText);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* A routing label names every model the installation can reach, so it can be a
@@ -621,10 +617,6 @@
 .ob-scan-cost-label {
   margin: 0;
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   color: var(--aiText);
 }
 .ob-scan-cost-line {

--- a/frontend/src/screens/onboarding-gate.tsx
+++ b/frontend/src/screens/onboarding-gate.tsx
@@ -211,7 +211,7 @@ export function OnboardingGate({
       {/* Named BEFORE the reader hands over their website, not after: which
           model is about to read it is part of the decision to let it. */}
       <p className="ob-gate-ai">
-        <span>{t("ob.scan.transparency")}</span>
+        <span className="t-eyebrow">{t("ob.scan.transparency")}</span>
         <b>{configuredModel}</b>
       </p>
     </GateColumn>
@@ -522,7 +522,7 @@ function TheatreTail({
           beneath rather than a column it would have to be squeezed into. */}
       <div className="ob-scan-cost">
         <div className="ob-scan-cost-head">
-          <p className="ob-scan-cost-label">{t("ob.scan.transparency")}</p>
+          <p className="t-eyebrow ob-scan-cost-label">{t("ob.scan.transparency")}</p>
           <p className="ob-scan-cost-line">
             {runtime === undefined ? (
               t("ob.scan.costPending")

--- a/frontend/src/screens/onboarding-gate.tsx
+++ b/frontend/src/screens/onboarding-gate.tsx
@@ -522,7 +522,9 @@ function TheatreTail({
           beneath rather than a column it would have to be squeezed into. */}
       <div className="ob-scan-cost">
         <div className="ob-scan-cost-head">
-          <p className="t-eyebrow ob-scan-cost-label">{t("ob.scan.transparency")}</p>
+          <p className="t-eyebrow ob-scan-cost-label">
+            {t("ob.scan.transparency")}
+          </p>
           <p className="ob-scan-cost-line">
             {runtime === undefined ? (
               t("ob.scan.costPending")

--- a/frontend/src/screens/onboarding-live-panel.css
+++ b/frontend/src/screens/onboarding-live-panel.css
@@ -82,10 +82,6 @@
 .ob-live-card-toggle {
   flex: none;
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   color: var(--accent);
 }
 
@@ -132,10 +128,6 @@
 
 .ob-live-coverage-label {
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* Three gaps, three voices. A skipped page is routine and must not shout; a page

--- a/frontend/src/screens/onboarding-live-panel.tsx
+++ b/frontend/src/screens/onboarding-live-panel.tsx
@@ -57,7 +57,7 @@ export function DossierCard({
         {count !== undefined && (
           <span className="ob-live-card-count">{count}</span>
         )}
-        <span className="ob-live-card-toggle">
+        <span className="t-eyebrow ob-live-card-toggle">
           {t(open ? "ob.live.hide" : "ob.live.review")}
         </span>
         <ChevronDown className="ob-live-card-chev" aria-hidden size={14} />
@@ -200,7 +200,7 @@ export function CoverageCard({
             // beside it says the same thing in words, so the colour it selects
             // is never the only signal.
             <li className="ob-live-coverage" data-kind={row.kind} key={row.id}>
-              <span className="ob-live-coverage-label">{row.label}</span>
+              <span className="t-eyebrow ob-live-coverage-label">{row.label}</span>
               {row.name !== undefined && (
                 <span className="ob-live-coverage-name">{row.name}</span>
               )}

--- a/frontend/src/screens/onboarding-live-panel.tsx
+++ b/frontend/src/screens/onboarding-live-panel.tsx
@@ -200,7 +200,9 @@ export function CoverageCard({
             // beside it says the same thing in words, so the colour it selects
             // is never the only signal.
             <li className="ob-live-coverage" data-kind={row.kind} key={row.id}>
-              <span className="t-eyebrow ob-live-coverage-label">{row.label}</span>
+              <span className="t-eyebrow ob-live-coverage-label">
+                {row.label}
+              </span>
               {row.name !== undefined && (
                 <span className="ob-live-coverage-name">{row.name}</span>
               )}

--- a/frontend/src/screens/onboarding-manual-interview.tsx
+++ b/frontend/src/screens/onboarding-manual-interview.tsx
@@ -178,7 +178,7 @@ export function ManualCompanyInterview({
         advance();
       }}
     >
-      <div className="ob-manual-progress">
+      <div className="t-eyebrow ob-manual-progress">
         <span>{t(question.chapter)}</span>
         <span>
           {questionIndex + 1} / {MANUAL_QUESTIONS.length}

--- a/frontend/src/screens/onboarding-payoff.css
+++ b/frontend/src/screens/onboarding-payoff.css
@@ -97,10 +97,6 @@
 
 .ob-payoff-label {
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   /* --textMeta is the AA floor role for anything under 13px. */
   color: var(--textMeta);
 }

--- a/frontend/src/screens/onboarding-payoff.tsx
+++ b/frontend/src/screens/onboarding-payoff.tsx
@@ -127,7 +127,7 @@ export function PayoffGrid({ counts, locale }: PayoffGridProps) {
             }
             key={cell.name}
           >
-            <dt className="ob-payoff-label">{t(cell.label)}</dt>
+            <dt className="t-eyebrow ob-payoff-label">{t(cell.label)}</dt>
             <dd className="ob-payoff-value">{format(count)}</dd>
           </div>
         );

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -410,7 +410,7 @@ function CompanyArtifact(props: ReadCompanyStepProps) {
   return (
     <div className="mw-review">
       <div className="mw-review-heading">
-        <span>{t("ob.ai.liveArtifact")}</span>
+        <span className="t-eyebrow">{t("ob.ai.liveArtifact")}</span>
         <h2>{t("ob.ai.companyKnowledge")}</h2>
         <p>
           {t(

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -735,7 +735,7 @@ function WebsiteComposer(
   const t = useT();
   return (
     <div className="ob-core-dialog">
-      <div className="ob-core-kicker">{t("ob.coreLegalKicker")}</div>
+      <div className="t-eyebrow ob-core-kicker">{t("ob.coreLegalKicker")}</div>
       <h1>{t("ob.coreWebsiteTitle")}</h1>
       <p>{t("ob.coreWebsiteBody")}</p>
       <CoreJourney active={0} />

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -196,10 +196,6 @@
   margin-top: 2px;
 }
 .seclabel {
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   color: var(--textSecondary);
 }
 
@@ -431,10 +427,6 @@
 .ob-core-kicker,
 .ob-manual-progress {
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
   color: var(--aiText);
 }
 .ob-core-kicker {
@@ -1137,10 +1129,6 @@
 .mw-review-heading span {
   color: var(--aiText);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 .mw-review-heading h2 {
   margin: var(--space-1) 0 0;


### PR DESCRIPTION
The last item of #2444, and the one whose census was short by 14×.

## What was true

`base.css` has called `.t-eyebrow` **"THE one spelling of uppercase micro-type — five sheets used to carry their own copy of it"** since it was written. It said that over **twenty-eight** rules that re-declared the identical quadruple: `--fs-eyebrow`, `--fw-semibold`, `--tracking-eyebrow`, `text-transform: uppercase`.

The issue filed it as two copies inside the design system. It is thirteen in `onboarding-conversation/conversation.css`, nine across the `onboarding*` sheets, and **five inside the design system itself** — which is where a copy is hardest to notice, because it sits beside the real one.

**The twenty-eighth was found by review, not by the census**, and how it hid is the useful part: `.ob-conv-attention-group-label` writes two of the four through the `font:` shorthand, under a property name a longhand comparison never reads. It scored 2 of 4 and passed. `onecard.test.ts` had already learned that lesson for its own shorthands; the gate expands `font:` now.

Every copy looked right on its own. That is the shape the rulebook forbids: a uniqueness claim no test holds is either deleted or gated.

## The four are one decision

Not four properties. Uppercase at 11px sets cramped at default letter-spacing — that is precisely what `--tracking-eyebrow` exists for, and `base.css` says so at the rule. A copy that took three of the four had already made the type worse without anybody choosing it, which is why the gate's subject is the whole quadruple and not any one of them.

## What changed

The markup carries `t-eyebrow`; each rule keeps only what is genuinely its own — its colour, its spacing, its layout. **Nothing about how any of them renders changes.** The colours were already varied on purpose (accent, AI text, three meta roles) and stay exactly where they were.

`.mw-shell.is-rail .mw-aifooter-label` is swept like the rest rather than ratified as a rail-only variant: the element it styles is rendered only inside `{rail ? … }`, so the qualifier was never doing the work it looked like it was doing.

## The gate

`design-system/oneeyebrow.test.ts` reads its subject **from `base.css`** rather than restating the quadruple — a hardcoded copy would be the very thing it forbids, and would stop matching the day somebody restyles the eyebrow.

**It resolves `var(--token)` on both sides before comparing.** `font-weight: 600` and `font-weight: var(--fw-semibold)` are the same weight and compare unequal, and the longhand is exactly what the hand that retypes a rule writes. Both spellings are mutation-verified — a planted rule in tokens and a planted rule in resolved values each fail it, and a text comparison would have caught only the first.

It also asserts it read a subject worth comparing (`toHaveLength(4)`): if the source rule ever stops declaring the quadruple, every rule in the tree trivially contains an empty subject and the gate reports either the whole stylesheet or nothing at all. And its walk names the two directories the copies actually lived in, because a census of zero reads the same over a clean tree and a broken walk.

**What it deliberately does not catch:** a rule taking SOME of the quadruple. An uppercase label at a different size is a variant somebody decided on, not a duplicate a test can name, and reporting it would be the gate asserting an answer nobody gave.

## One thing this PR does that is not the sweep

The rule reader the gate needs already existed — inside `onecard.test.ts`, whose header explains why every one of its whitespace normalisations is there (`background:var(--x)` without the space, `var(--x )` with one inside the parens, each of which let an identical rule escape). Writing a second one would have been a second answer to "what is a rule", drifting the way every other pair in this tree drifted.

So it moved to `design-system/cssrules.ts` and both gates take it. It is not a `*.test.*` file for the same reason `src/testing/steppedclock.tsx` is not: the design-system and lint gates skip test files, and a helper this many gates lean on should answer to the same rules the app does. Each gate keeps the equivalences its own subject can be written in — the card's shorthand expansion stays with the card, the eyebrow's token resolution with the eyebrow.

`soleRule` carries over the card gate's hard-won rule: **exactly one match, not the first**, because `.find()` silently adopts whichever comes first and a second rule with that selector makes the gate read the wrong declarations — degrading to green while blind.

## Verification

`make check-fe` green (biome, ds gates, drift, composed tsc, vitest + coverage, vite build + storybook). 28 rules swept, census now reads zero outside the owner.

Two lanes were also run by hand, because `uat` declares `needs: [changes, frontend]` and prints "skipping" — the same word it prints where skipping is correct — whenever the frontend gate fails: `npx vitest run` (379 files, 4775 tests) and `make frontend-e2e` (94 passed).

Closes #2444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes uppercase micro-type to a single `.t-eyebrow` class and adds a gate to prevent re-declarations. Old behavior duplicated size/weight/tracking/uppercase across many sheets; new behavior applies `.t-eyebrow` in markup and keeps only color/spacing/layout locally, with no visual changes and 28 duplicates removed.

- Migration
  - Add `.t-eyebrow` anywhere uppercase micro-type appears.
  - Remove font-size, font-weight, letter-spacing, and text-transform from local rules; the gate enforces this.

- Bug Fixes
  - Gate reads its subject from `base.css`, resolves tokens, and expands `font:` shorthand.
  - Shared CSS rule reader lives in `frontend/src/design-system/cssrules.ts` and is used by both gates.
  - Parser handles multi-line grouped selectors; tests and stories add `.t-eyebrow` where needed.
  - Removes a bogus token reference in test prose that caused false positives.

<sup>Written for commit 3dd318f3ae25a8b00d3fb17c076996fd1be9440d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Applied consistent eyebrow typography across onboarding and workbench labels.
  * Preserved existing colors, layouts, content, and interaction behavior while removing duplicated typography declarations.

* **New Features**
  * Added stylesheet inspection utilities for finding, parsing, and validating CSS rules.

* **Tests**
  * Added coverage to verify eyebrow typography is defined consistently and not duplicated across stylesheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
