### PR TITLE
refactor(capture,platform): one reading of Retry-After, and it reads the whole header

### DIFF
--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture/googleconn"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/oauthflow"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -361,9 +362,9 @@ func (a *httpAPI) Watch(ctx context.Context, accessToken, topic string) (string,
 func classifyStatus(resp *http.Response, op string, body []byte) error {
 	switch {
 	case resp.StatusCode == http.StatusTooManyRequests:
-		return &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	case resp.StatusCode == http.StatusForbidden && googleconn.RateLimitBody(body):
-		return &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
 		return &connector.ProviderError{
 			Op: op, Status: resp.StatusCode, Reason: googleconn.Reason(body), Class: ErrAuthRejected,
@@ -374,18 +375,6 @@ func classifyStatus(resp *http.Response, op string, body []byte) error {
 		}
 	}
 	return nil
-}
-
-// retryAfter parses the provider's Retry-After (delta-seconds form; Google
-// does not send HTTP-dates here). Zero when absent — the caller's own backoff
-// takes over.
-func retryAfter(resp *http.Response) time.Duration {
-	if s := resp.Header.Get("Retry-After"); s != "" {
-		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return 0
 }
 
 // Read caps for the Gmail JSON responses. The metadata calls (profile, id

--- a/backend/internal/modules/capture/googleconn/googleconn.go
+++ b/backend/internal/modules/capture/googleconn/googleconn.go
@@ -20,12 +20,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture/oauthflow"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
@@ -83,10 +83,10 @@ func Get(ctx context.Context, client *http.Client, base, accessToken, path strin
 	// and let the registry back off rather than parking the connection. Google
 	// signals quota/rate limits as 429, or as 403 with a rate/quota reason.
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	}
 	if resp.StatusCode == http.StatusForbidden && RateLimitBody(body) {
-		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return resp.StatusCode, &connector.ProviderError{
@@ -274,18 +274,6 @@ func RateLimitBody(body []byte) bool {
 		}
 	}
 	return limit
-}
-
-// retryAfter parses the provider's Retry-After (delta-seconds form; Google does
-// not send HTTP-dates here). Zero when absent — the registry's own backoff then
-// takes over.
-func retryAfter(resp *http.Response) time.Duration {
-	if s := resp.Header.Get("Retry-After"); s != "" {
-		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return 0
 }
 
 // Descriptor is the shared static metadata for a read-only Google capture

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -25,24 +25,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
-
-// retryAfter parses the provider's Retry-After (delta-seconds form; Graph's
-// throttling responses use it). Zero when absent — the caller's own backoff
-// takes over.
-func retryAfter(resp *http.Response) time.Duration {
-	if s := resp.Header.Get("Retry-After"); s != "" {
-		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return 0
-}
 
 // messageOp names the raw-MIME fetch in a ProviderError. Its sibling calls carry
 // their URL path as the op; this one is a hand-built request whose URL embeds the
@@ -94,7 +81,7 @@ func graphReason(body []byte) string {
 func classifyStatus(resp *http.Response, op string, body []byte) error {
 	switch {
 	case resp.StatusCode == http.StatusTooManyRequests:
-		return &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
 		return &connector.ProviderError{
 			Op: op, Status: resp.StatusCode, Reason: graphReason(body), Class: ErrAuthRejected,

--- a/backend/internal/modules/capture/oauthflow/oauthflow.go
+++ b/backend/internal/modules/capture/oauthflow/oauthflow.go
@@ -18,10 +18,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -243,7 +243,7 @@ func (c *Client) token(ctx context.Context, form url.Values) (tokenResponse, err
 	// Retry-After and let the registry back off, rather than parking the
 	// connection as rejected. Classified on status before the body matters.
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return tokenResponse{}, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+		return tokenResponse{}, &connector.RateLimitedError{RetryAfter: retryafter.Of(resp)}
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 		return tokenResponse{}, &connector.ProviderError{
@@ -265,15 +265,4 @@ func (c *Client) token(ctx context.Context, form url.Values) (tokenResponse, err
 		return tokenResponse{}, fmt.Errorf("%s: decoding token response: %w", c.cfg.Provider, c.cfg.Unreachable)
 	}
 	return tok, nil
-}
-
-// retryAfter parses the token endpoint's Retry-After (delta-seconds); zero
-// when absent, leaving the registry's own backoff to take over.
-func retryAfter(resp *http.Response) time.Duration {
-	if s := resp.Header.Get("Retry-After"); s != "" {
-		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return 0
 }

--- a/backend/internal/modules/capture/telegram/api.go
+++ b/backend/internal/modules/capture/telegram/api.go
@@ -17,10 +17,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -414,18 +414,10 @@ const maxRetryAfter = 5 * time.Minute
 // backoff — which is the one case where guessing is better than waiting
 // forever.
 func retryAfterOf(resp *http.Response, env envelope) time.Duration {
-	seconds := env.Parameters.RetryAfter
-	if seconds <= 0 {
-		header, err := strconv.Atoi(strings.TrimSpace(resp.Header.Get("Retry-After")))
-		if err != nil {
-			return 0
-		}
-		seconds = header
+	if seconds := env.Parameters.RetryAfter; seconds > 0 {
+		return min(time.Duration(seconds)*time.Second, maxRetryAfter)
 	}
-	if seconds <= 0 {
-		return 0
-	}
-	return min(time.Duration(seconds)*time.Second, maxRetryAfter)
+	return min(retryafter.Of(resp), maxRetryAfter)
 }
 
 // classify is the ONE status verdict for every Bot API call, so the connect

--- a/backend/internal/platform/geocode/geocode.go
+++ b/backend/internal/platform/geocode/geocode.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/platform/outbound"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
 )
 
 // Point is a resolved location.
@@ -145,7 +146,7 @@ func (n *Nominatim) Resolve(ctx context.Context, query string) (Point, bool, err
 		// carries its own instruction about when to come back.
 		return Point{}, false, &ProviderRefusedError{
 			Status:     resp.StatusCode,
-			RetryAfter: retryAfter(resp.Header.Get("Retry-After")),
+			RetryAfter: retryafter.Of(resp),
 		}
 	}
 
@@ -199,25 +200,4 @@ func (e *ProviderRefusedError) Error() string {
 			e.Status, e.RetryAfter)
 	}
 	return fmt.Sprintf("geocode: the provider answered %d", e.Status)
-}
-
-// retryAfter reads the header, in either form the RFC allows.
-//
-// A malformed or absent value is zero rather than a guess: the caller's own
-// backoff is the fallback, and inventing a number the provider did not give
-// would be a worse answer than admitting it said nothing.
-func retryAfter(header string) time.Duration {
-	header = strings.TrimSpace(header)
-	if header == "" {
-		return 0
-	}
-	if seconds, err := strconv.Atoi(header); err == nil && seconds > 0 {
-		return time.Duration(seconds) * time.Second
-	}
-	if at, err := http.ParseTime(header); err == nil {
-		if wait := time.Until(at); wait > 0 {
-			return wait
-		}
-	}
-	return 0
 }

--- a/backend/internal/shared/kernel/retryafter/retryafter.go
+++ b/backend/internal/shared/kernel/retryafter/retryafter.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package retryafter is the one reading of the Retry-After header.
+//
+// Held by: TestTheRetryAfterReadingIsSpelledOnce (backend/oneretryafter_test.go)
+//
+// It was spelled six times: four byte-identical copies under capture (Gmail,
+// the Google connector base, Graph, the OAuth flow), the geocoder's own, and
+// Telegram's, which reads its envelope first and the header only as a fallback.
+// Only the geocoder's handled the whole header.
+//
+// RFC 9110 §10.2.3 gives Retry-After TWO forms — delta-seconds, and an
+// HTTP-date. The four capture copies parsed only the first, so a provider
+// answering `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT` was read as having
+// said nothing at all, and the connector fell back to its own backoff. That is
+// not a formatting detail: the whole point of honouring the header is to come
+// back when the provider said to rather than when we guessed, and coming back
+// early on a rate limit is how a throttle becomes a ban.
+//
+// Stdlib-only and in kernel because the callers are four capture connectors, a
+// platform package and a module — and a module never imports a sibling
+// (ADR-0054).
+package retryafter
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Of reads how long a response says to wait. Zero means it did not say — the
+// header was absent, unparseable, or named an instant already past — and the
+// caller falls back to its own backoff.
+func Of(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	return Header(resp.Header.Get("Retry-After"))
+}
+
+// Header is Of, for a caller that already holds the value.
+func Header(value string) time.Duration {
+	return HeaderAt(value, time.Now())
+}
+
+// HeaderAt is Header measured from a given instant — the whole rule, with the
+// one reading of the clock lifted out so a test can state the answer exactly
+// rather than assert a range around a real one.
+//
+// Both RFC 9110 §10.2.3 forms, in the order the spec lists them: delta-seconds
+// first, because a bare integer parses cheaply and the common case stays exact.
+func HeaderAt(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			// "0" means retry now, and a negative is malformed. Both are
+			// "nothing to wait for" rather than "wait none" — a caller that
+			// treated zero as an instruction would hammer a provider that
+			// just told it to slow down.
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	at, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	// Measured against OUR clock, not the response's Date header. A clock
+	// skewed against the provider's would make the wait wrong in whichever
+	// direction the skew runs, and this is the clock the sleep is actually
+	// measured against — so a wait computed from it lands where it was meant
+	// to, skew or no skew.
+	if wait := at.Sub(now); wait > 0 {
+		return wait
+	}
+	return 0
+}

--- a/backend/internal/shared/kernel/retryafter/retryafter_test.go
+++ b/backend/internal/shared/kernel/retryafter/retryafter_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package retryafter_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/retryafter"
+)
+
+// The instant every date case is measured against, so no case reads a clock.
+var now = time.Date(2026, 10, 21, 7, 0, 0, 0, time.UTC)
+
+func TestTheDeltaSecondsForm(t *testing.T) {
+	if got := retryafter.HeaderAt("120", now); got != 2*time.Minute {
+		t.Errorf("HeaderAt(%q) = %v, want 2m", "120", got)
+	}
+}
+
+// The half four connectors were missing. A provider answering in the date form
+// was read as having said nothing, and the caller came back on its own backoff
+// — early, on a rate limit, which is how a throttle becomes a ban.
+func TestTheHTTPDateForm(t *testing.T) {
+	if got := retryafter.HeaderAt("Wed, 21 Oct 2026 07:28:00 GMT", now); got != 28*time.Minute {
+		t.Errorf("HeaderAt(<a date 28 minutes out>) = %v, want 28m", got)
+	}
+}
+
+// A date already past is not a negative wait. It is the provider saying the
+// window has closed, which is the same instruction as saying nothing.
+func TestADateAlreadyPastAsksForNoWait(t *testing.T) {
+	if got := retryafter.HeaderAt("Wed, 21 Oct 2026 06:30:00 GMT", now); got != 0 {
+		t.Errorf("HeaderAt(<a date in the past>) = %v, want 0", got)
+	}
+}
+
+// Zero means retry now, and a negative is malformed. Neither is an interval to
+// wait, and a caller that treated zero as one would hammer a provider that has
+// just asked it to slow down.
+func TestNonPositiveSecondsAskForNoWait(t *testing.T) {
+	for _, value := range []string{"0", "-5"} {
+		if got := retryafter.HeaderAt(value, now); got != 0 {
+			t.Errorf("HeaderAt(%q) = %v, want 0", value, got)
+		}
+	}
+}
+
+func TestAnUnreadableHeaderAsksForNoWait(t *testing.T) {
+	for _, value := range []string{"", "   ", "soon", "12 seconds", "1.5"} {
+		if got := retryafter.HeaderAt(value, now); got != 0 {
+			t.Errorf("HeaderAt(%q) = %v, want 0 — an unreadable header is not an interval", value, got)
+		}
+	}
+}
+
+// Surrounding space is the provider's, not the value's.
+func TestSurroundingSpaceIsIgnored(t *testing.T) {
+	if got := retryafter.HeaderAt("  30  ", now); got != 30*time.Second {
+		t.Errorf("HeaderAt(%q) = %v, want 30s", "  30  ", got)
+	}
+}
+
+func TestOfReadsTheHeaderOffAResponse(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", "45")
+	if got := retryafter.Of(resp); got != 45*time.Second {
+		t.Errorf("Of(<a response asking for 45s>) = %v, want 45s", got)
+	}
+}
+
+// A nil response is what a transport hands back beside an error, and every
+// caller reaches for the wait before it knows which it got.
+func TestOfSurvivesANilResponse(t *testing.T) {
+	if got := retryafter.Of(nil); got != 0 {
+		t.Errorf("Of(nil) = %v, want 0", got)
+	}
+}
+
+func TestOfIsZeroWhenTheProviderSaidNothing(t *testing.T) {
+	if got := retryafter.Of(&http.Response{Header: http.Header{}}); got != 0 {
+		t.Errorf("Of(<a response with no Retry-After>) = %v, want 0", got)
+	}
+}

--- a/backend/oneretryafter_test.go
+++ b/backend/oneretryafter_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// The Retry-After header is read in one place, shared/kernel/retryafter.
+//
+// It was read in six: four byte-identical copies under capture (Gmail, the
+// Google connector base, Graph, the OAuth flow), the geocoder's own, and
+// Telegram's. Only the geocoder's handled the whole header — RFC 9110 §10.2.3
+// gives Retry-After two forms, delta-seconds and an HTTP-date, and the four
+// capture copies parsed only the first.
+//
+// That difference is the reason this is worth a gate rather than a tidy-up. A
+// provider answering with a date was read as having said nothing at all, so the
+// connector fell back to its own backoff and came back when IT guessed rather
+// than when the provider asked — and coming back early on a rate limit is how a
+// throttle becomes a ban. Fixing it meant editing four files, which is exactly
+// the arithmetic that leaves one of them unedited.
+//
+// WHAT THIS GATE CAN AND CANNOT SEE. The subject is a read of the header name:
+// `Header.Get("Retry-After")`, in any casing, off the syntax rather than the
+// text so the name inside a comment is not a finding. It cannot see a read
+// through a variable holding the name, nor a provider-specific interval carried
+// somewhere else entirely — Telegram's own `parameters.retry_after` is such a
+// value, and it stays in Telegram because it IS Telegram's, with the header
+// underneath it as the fallback. That envelope is not this subject.
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// retryAfterScope claims the header is read in kernel and nowhere else.
+// Nothing is exempt: kernel sits below every tier that talks to a provider, so
+// every caller can reach retryafter.Of.
+var retryAfterScope = gatekit.Scope{
+	Roots:   []string{"internal/shared/kernel/retryafter"},
+	Subject: readsTheRetryAfterHeader,
+	Exempt:  gatekit.Waive(map[string]string{}),
+}
+
+func TestTheRetryAfterReadingIsSpelledOnce(t *testing.T) {
+	inside := retryAfterScope.Files(t)
+	if len(inside) > 1 {
+		var where []string
+		for _, f := range inside {
+			where = append(where, f.Path)
+		}
+		t.Errorf("the Retry-After header is read in %d files inside the package that owns it:\n\t%s\n\n"+
+			"One reading, so a connector cannot be given the HTTP-date form while another is not. Call "+
+			"retryafter.Of", len(inside), strings.Join(where, "\n\t"))
+	}
+}
+
+// readsTheRetryAfterHeader reports whether a file reads the header off a
+// header map — `<expr>.Get("Retry-After")`, the casing being the wire's own
+// business rather than the caller's.
+func readsTheRetryAfterHeader(_ string, file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+		get, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || get.Sel.Name != "Get" {
+			return true
+		}
+		literal, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		name, err := strconv.Unquote(literal.Value)
+		if err == nil && strings.EqualFold(name, "Retry-After") {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// TestTheRetryAfterCensusStillSeesItsSubject is the vacuity check: a census
+// that has stopped matching passes by finding nothing, which is the same word
+// it prints over a clean tree.
+func TestTheRetryAfterCensusStillSeesItsSubject(t *testing.T) {
+	subjects := map[string]string{
+		"a read off a response's headers": "" +
+			"package p\nfunc f(resp *http.Response) string { return resp.Header.Get(\"Retry-After\") }",
+		"the same name in the casing the wire uses": "" +
+			"package p\nfunc f(h http.Header) string { return h.Get(\"retry-after\") }",
+		"a read off something that is not called resp": "" +
+			"package p\nfunc f(r *http.Response) string { return r.Header.Get(\"Retry-After\") }",
+	}
+	for name, body := range subjects {
+		if !readsTheRetryAfterHeader("x.go", parseGateFixture(t, body)) {
+			t.Errorf("the census no longer recognises %s, so it is guarding nothing", name)
+		}
+	}
+
+	nearMisses := map[string]string{
+		"the header NAME in a comment, which is prose and not a read": "" +
+			"package p\n// Retry-After is honoured by the registry.\nfunc f() {}",
+		"a different header, which half the transports read": "" +
+			"package p\nfunc f(resp *http.Response) string { return resp.Header.Get(\"Content-Type\") }",
+		"a provider's own interval carried in its envelope": "" +
+			"package p\nfunc f(env envelope) int { return env.Parameters.RetryAfter }",
+		"a Get with the wrong arity, which is a different method": "" +
+			"package p\nfunc f(m url.Values) string { return m.Get(\"Retry-After\", \"fallback\") }",
+	}
+	for name, body := range nearMisses {
+		if readsTheRetryAfterHeader("x.go", parseGateFixture(t, body)) {
+			t.Errorf("the census claims %s is a second reading of the header", name)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -48,7 +48,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (37)
+## Census (38)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -77,6 +77,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
+| `oneretryafter_test.go` | H2 | The Retry-After header is read in one place, shared/kernel/retryafter. |
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
 | `profilefieldreaders_test.go` | H2 | person\_profile\_field holds what a machine ASSERTED about a person, and ai\_feedback holds what a human then decided about that assertion. |


### PR DESCRIPTION
Wave 6 of the duplication audit, first of three. Item 2 of #2442 — and the census was short by two, in the direction that matters.

## The census

The issue names four byte-identical copies of `retryAfter(resp)` under `capture/`. There are **six** readings of the header, and the two the census could not see are the two that are different:

| site | shape |
|---|---|
| `capture/gmail/client.go` | `retryAfter(resp)` — delta-seconds only |
| `capture/googleconn/googleconn.go` | byte-identical |
| `capture/graph/transport.go` | byte-identical |
| `capture/oauthflow/oauthflow.go` | byte-identical |
| `platform/geocode/geocode.go` | `retryAfter(header string)` — **both RFC forms**, takes the value not the response |
| `capture/telegram/api.go` | `retryAfterOf(resp, env)` — envelope first, header as fallback, capped |

The census grepped for the four-argument shape, so the two that took a different argument were invisible to it. Same blind spot as #2443's month cut: a census keyed on the spelling it was written for cannot see the respelling.

## This is a defect, not a tidy-up

RFC 9110 §10.2.3 gives `Retry-After` **two** forms — `delta-seconds` and an HTTP-date. The four capture copies parsed only the first, so a provider answering

```
Retry-After: Wed, 21 Oct 2026 07:28:00 GMT
```

was read as having said **nothing at all**. The connector fell back to its own backoff and came back when *it* guessed rather than when the provider asked. The whole point of honouring the header is not to guess, and coming back early on a rate limit is how a throttle becomes a ban.

The geocoder's copy was the only complete one. Fixing the other four meant editing four files — which is precisely the arithmetic that leaves one of them unedited, and why the issue filed it as a duplication finding rather than a bug.

## Where it lives

`internal/shared/kernel/retryafter`, stdlib-only, below every tier that talks to a provider. The callers are four capture connectors, a platform package and a module — and a module never imports a sibling (ADR-0054), so kernel is the only home that serves all six.

`HeaderAt(value, now)` is the whole rule with the **one reading of the clock lifted out**, so the date form is stated exactly in a test rather than asserted as a range around a real one. `Header` and `Of` are that, at `time.Now()`.

Two decisions worth naming, both in the code:

- **Zero and negative delta-seconds are "nothing to wait for", not "wait none."** A caller that treated `Retry-After: 0` as an instruction would hammer a provider that has just asked it to slow down.
- **The date is measured against OUR clock, not the response's `Date` header.** A clock skewed against the provider's makes the wait wrong in whichever direction the skew runs, and ours is the clock the sleep is actually measured against — so a wait computed from it lands where it was meant to, skew or no skew.

## What did NOT move

Telegram's `parameters.retry_after`. That is Telegram's value in Telegram's envelope, not this subject; it stays where it is, with the header underneath it as the fallback it always was, and its five-minute cap is its own decision about its own retry ladder. The gate's header says so, because a reader who greps `retry_after` should find out why it is exempt without having to ask.

## The gate

`TestTheRetryAfterReadingIsSpelledOnce` sweeps the negative space: any file outside `kernel/retryafter` that reads the header fails. The subject is `<expr>.Get("Retry-After")` read **off the syntax**, so the header name inside a comment is not a finding — this tree names it in nine prose comments, and a gate that reported those would be waived away in a week. Casing is the wire's business, so `retry-after` matches too.

Mutation-verified: a probe reading the header in `graph/transport.go` fails the gate, naming the file. Near-miss fixtures pin the four ways it must stay silent — the name in a comment, a different header, a provider's own envelope field, and a `Get` with the wrong arity.

Stated honestly in the header: it cannot see a read through a variable holding the name, and it is not asked to see a provider-specific interval carried somewhere else entirely.

## Verification

`make check-backend` green. 92 lines deleted, 18 added.

Part of #2442 — two more to follow (`platform/backoff` for the identical jittered pair, and the `storekit` cursor envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Retry-After handling across capture and platform and fixes ignored HTTP-date values that led to early retries. Previously we parsed only delta-seconds; now we parse both forms and centralize the logic to schedule correct waits under rate limits.

**Bug Fixes**
- Parses HTTP-date and delta-seconds per RFC 9110 so providers’ dates are honored.
- Treats zero or negative values as “no wait,” not “retry immediately.”
- Measures date waits against our clock instead of the response Date header.

**Refactors**
- Centralizes parsing in `internal/shared/kernel/retryafter` via `retryafter.Of`.
- Replaces inline reads in Gmail, Google connector base, Graph, OAuth flow, and Geocode; Telegram keeps its envelope value with the header as a capped fallback.
- Adds gate `backend/oneretryafter_test.go` to block header reads outside `kernel/retryafter` and updates the gate inventory.

<sup>Written for commit 3989b207e978ff7f190e6cfc479d601aa0be8bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent handling of `Retry-After` responses across supported integrations.
  * Improved support for both delay values and HTTP date formats.
  * Preserved provider-specific retry delays and capped Telegram delays at five minutes.

* **Bug Fixes**
  * Improved behavior for invalid, missing, expired, or non-positive retry instructions.

* **Tests**
  * Added comprehensive coverage for retry-delay parsing and response handling.

* **Documentation**
  * Updated the gate inventory to reflect the new retry handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->