### PR TITLE
fix(privacy): every read of the audit spine stops at a scrub

### DIFF
--- a/backend/internal/compose/erasurecollateral_integration_test.go
+++ b/backend/internal/compose/erasurecollateral_integration_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// An erasure tombstones what it scrubs, so the spine's readers can stop there.
+//
+// audit_log is append-only: the erase cannot rewrite the images it certifies
+// gone, and every read of the spine stops at the newest scrub tombstone for the
+// record instead. That boundary fires only where a tombstone EXISTS, so a table
+// the erasure empties without tombstoning is one whose images stay readable
+// however carefully the reads are written.
+//
+// Two carry the subject in plain text. An attachment's create image holds the
+// filename its uploader typed — routinely the subject's own name — and a
+// scheduled send's holds the message subject line. Neither type is projected by
+// field history, so the compliance log is the only door either was readable
+// through, and the tombstone is what shuts it.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/privacy"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAnErasureTombstonesTheAttachmentsItPurged(t *testing.T) {
+	e := integration.Setup(t)
+	const subjectEmail = "collateral.subject@counterparty.test"
+
+	var person, attachment ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES ('Collateral Subject', $1, 'manual', 'human:test', 'workspace')
+			RETURNING id`, e.Rep1).Scan(&person); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+			VALUES ($1, $2, true, 'manual', 'human:test')`, person, subjectEmail); err != nil {
+			return err
+		}
+		// The row the erasure deletes, and the image that outlives it. The
+		// filename is what a reader must stop being able to see.
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO attachment (entity_type, entity_id, filename, storage_key, source, captured_by)
+			VALUES ('person', $1, 'collateral-subject-passport.pdf', 'blob/collateral', 'manual', 'human:test')
+			RETURNING id`, person).Scan(&attachment); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
+			VALUES ('human', 'human:test', 'create', 'attachment', $1,
+			        '{"filename":"collateral-subject-passport.pdf"}'::jsonb, $2)`,
+			attachment, time.Now().UTC().Add(-time.Hour))
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the subject and their attachment: %v", err)
+	}
+
+	// The eraser refuses to delete an attachment row whose object it cannot
+	// purge, so the bytes never outlive their only key. An in-memory store is
+	// the boundary stood in for; what is under test is the tombstone.
+	if err := privacy.NewEraser(InstallationDB(e.Pool)).WithBlobstore(blobstore.NewMemory()).
+		ErasePerson(e.Admin(), person, "subject request"); err != nil {
+		t.Fatalf("ErasePerson: %v", err)
+	}
+
+	// The tombstone, written by the erasure itself — not seeded here, because
+	// what is under test is that the erasure writes one.
+	if n := countRows(t, e, `SELECT count(*) FROM audit_log
+		WHERE entity_type = 'attachment' AND entity_id = $1 AND action = 'erase'`, attachment); n != 1 {
+		t.Fatalf("the erasure left %d tombstone(s) on the purged attachment, want 1 — "+
+			"without one, its filename stays readable through the compliance log", n)
+	}
+}

--- a/backend/internal/compose/export.go
+++ b/backend/internal/compose/export.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -173,7 +174,8 @@ func (w *ExportWriter) WriteBundle(ctx context.Context, dst io.Writer) (BundleSu
 		// In overlay mode the bundle additionally carries the mirror
 		// snapshot and documents where canonical data lives (AC-OV-9) —
 		// P7 stays honestly partial until the flip.
-		if err := tx.QueryRow(ctx, `
+		if err := tx.QueryRow(
+			ctx, `
 			SELECT coalesce(x_incumbent, '') FROM workspace WHERE id = $1`,
 			storekit.MustWorkspace(ctx),
 		).Scan(&incumbent); err != nil {
@@ -263,7 +265,7 @@ func readMember(ctx context.Context, tx pgx.Tx, m exportMember) (memberData, err
 
 	selects := make([]string, len(columns))
 	for i, col := range columns {
-		selects[i] = "t." + col
+		selects[i] = exportColumnSQL(m.table, col, arg)
 	}
 	sql := fmt.Sprintf("SELECT %s FROM %s t", strings.Join(selects, ", "), m.table)
 	if scope != "" {
@@ -293,6 +295,26 @@ func readMember(ctx context.Context, tx pgx.Tx, m exportMember) (memberData, err
 		return memberData{}, err
 	}
 	return data, nil
+}
+
+// exportColumnSQL renders one exported column, withholding what a scrub put out
+// of reach.
+//
+// audit_log is append-only, so an Art. 17 erase cannot rewrite the images it
+// certifies gone; every reader of the spine stops at the newest scrub tombstone
+// instead. The bundle is a reader — the whole table leaves the installation in
+// it — and a boundary the three API reads apply and the export does not is the
+// same disclosure through a quieter door.
+//
+// The ROW still exports. What a subject typed is in the images; that a write
+// happened is not something an erasure undoes, and a bundle missing the line
+// would answer "who touched this record" with a gap.
+func exportColumnSQL(table, column string, arg func(any) int) string {
+	if table != "audit_log" || (column != "before" && column != "after") {
+		return "t." + column
+	}
+	return fmt.Sprintf("CASE WHEN %s THEN t.%s ELSE NULL END AS %s",
+		privacy.UnscrubbedImageSQL("t", fmt.Sprintf("$%d", arg(privacy.ScrubVerbs()))), column, column)
 }
 
 // exportableColumns lists a table's persisted columns in definition

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -312,3 +312,40 @@ func keys(m map[string][]byte) []string {
 	}
 	return out
 }
+
+// The bundle is a reader of the audit spine, and the spine is append-only: an
+// Art. 17 erase cannot rewrite the images it certifies gone, so every reader
+// stops at the newest scrub tombstone. A boundary the three API reads apply and
+// the export does not is the same disclosure through a quieter door — and the
+// export is the door that puts the whole table on somebody's disk.
+func TestTheBundleWithholdsImagesAnErasureCertifiedGone(t *testing.T) {
+	e := SetupSearch(t)
+	f := e.seedExportFixture(t)
+
+	const typed = "Sara Typed This"
+	e.SeedID(t, `INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, before, after, occurred_at)
+		VALUES ($1, 'human', $2, 'update', 'person', $3, $4::jsonb, $5::jsonb, now() - interval '2 hours')`,
+		"human:"+e.Rep1.String(), f.rep1Person,
+		`{"full_name":"`+typed+`"}`, `{"full_name":"Sara Renamed"}`)
+	e.SeedID(t, `INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, occurred_at)
+		VALUES ($1, 'human', $2, 'erase', 'person', $3, now() - interval '1 hour')`,
+		"human:"+e.Rep1.String(), f.rep1Person)
+
+	var buf bytes.Buffer
+	if _, err := compose.NewExportWriter(e.Pool).WriteBundle(e.exportAdmin(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	entries := BundleEntries(t, buf.Bytes())
+
+	if bytes.Contains(entries["audit_log.csv"], []byte(typed)) {
+		t.Error("audit_log.csv carries a value the erasure certified gone")
+	}
+	if bytes.Contains(entries["data.json"], []byte(typed)) {
+		t.Error("data.json carries a value the erasure certified gone")
+	}
+	// The row is still exported: a bundle that dropped it would answer "who
+	// touched this record" with a gap, which an erasure does not create.
+	if !bytes.Contains(entries["audit_log.csv"], []byte(f.rep1Person.String())) {
+		t.Error("the erased record's audit rows vanished from the bundle entirely")
+	}
+}

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -180,6 +180,32 @@ func isJSONBool(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &flag) == nil
 }
 
+// UnscrubbedImageSQL renders the erasure boundary as a predicate over one
+// audit_log row, aliased for the query using it.
+//
+// Exported because the boundary has more than one reader and must have exactly
+// one spelling. Three reads of the spine take it — field history, record history
+// and the compliance log — and the workspace export reads the table too; the
+// defect this closes was those readers not agreeing. A second copy of these six
+// lines would be the same defect with better intentions.
+//
+// verbsPlaceholder is the caller's own bind placeholder for ScrubVerbs(): each
+// query numbers its arguments its own way, and a literal verb list here would
+// put the vocabulary in two places instead of one.
+func UnscrubbedImageSQL(alias, verbsPlaceholder string) string {
+	return fmt.Sprintf(`NOT EXISTS (
+		  SELECT 1 FROM audit_log scrub
+		   WHERE scrub.entity_type = %[1]s.entity_type
+		     AND scrub.entity_id = %[1]s.entity_id
+		     AND scrub.action = ANY(%[2]s)
+		     AND (scrub.occurred_at, scrub.id) > (%[1]s.occurred_at, %[1]s.id))`,
+		alias, verbsPlaceholder)
+}
+
+// ScrubVerbs are the verbs certifying a record's PII was scrubbed in place.
+// scrubverbs_test.go holds every verb this module writes against this list.
+func ScrubVerbs() []string { return fieldHistoryScrubActions }
+
 // scanAuditEntry reads one ledger line and applies what the row itself says a
 // caller may see of it.
 //
@@ -348,13 +374,7 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 			        actor_user.display_name, obo.display_name,
 			        (a.entity_type <> 'activity'
 			          OR (`+auditActivityAlias+`.id IS NOT NULL AND (`+audience+`))) AS content_readable,
-			        NOT EXISTS (
-			          SELECT 1 FROM audit_log scrub
-			           WHERE scrub.entity_type = a.entity_type
-			             AND scrub.entity_id = a.entity_id
-			             AND scrub.action = ANY(`+arg(fieldHistoryScrubActions)+`)
-			             AND (scrub.occurred_at, scrub.id) > (a.occurred_at, a.id)
-			        ) AS images_readable
+			        `+UnscrubbedImageSQL("a", arg(ScrubVerbs()))+` AS images_readable
 			 FROM audit_log a`+auditActorNameJoins+auditActivityJoin+`
 			 WHERE `+where+`
 			 ORDER BY a.occurred_at DESC, a.id DESC

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -180,6 +180,41 @@ func isJSONBool(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &flag) == nil
 }
 
+// scanAuditEntry reads one ledger line and applies what the row itself says a
+// caller may see of it.
+//
+// Two withholdings, one treatment. An activity outside the caller's audience
+// carries content they may not read; a record scrubbed after this row was
+// written carries what an erasure certified gone, and audit_log is append-only,
+// so the read is where that is enforced or nowhere. Either way the ROW stays: a
+// compliance log answers who did what and when, and a write that happened is not
+// a fact an erasure undoes.
+func scanAuditEntry(rows pgx.Rows) (AuditEntry, error) {
+	var e AuditEntry
+	// The nullable envelope ids scan through untyped locals, then widen to their
+	// kind — a NULL column stays a nil typed pointer.
+	var passportID, onBehalfOf *ids.UUID
+	var contentReadable, imagesReadable bool
+	if err := rows.Scan(&e.ID, &e.ActorType, &e.ActorID,
+		&passportID, &onBehalfOf, &e.Action, &e.EntityType, &e.EntityID,
+		&e.Before, &e.After, &e.AuthorizationRule, &e.Evidence, &e.OccurredAt,
+		&e.ActorName, &e.OnBehalfOfName, &contentReadable, &imagesReadable); err != nil {
+		return AuditEntry{}, err
+	}
+	if !contentReadable || !imagesReadable {
+		withholdAuditImage(&e)
+	}
+	if passportID != nil {
+		v := ids.From[ids.PassportKind](*passportID)
+		e.PassportID = &v
+	}
+	if onBehalfOf != nil {
+		v := ids.From[ids.UserKind](*onBehalfOf)
+		e.OnBehalfOf = &v
+	}
+	return e, nil
+}
+
 // withholdAuditImage redacts the record images on one entry, keeping the row and
 // keeping everything the audience has no claim over.
 //
@@ -312,7 +347,14 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 			        a.evidence, a.occurred_at,
 			        actor_user.display_name, obo.display_name,
 			        (a.entity_type <> 'activity'
-			          OR (`+auditActivityAlias+`.id IS NOT NULL AND (`+audience+`))) AS content_readable
+			          OR (`+auditActivityAlias+`.id IS NOT NULL AND (`+audience+`))) AS content_readable,
+			        NOT EXISTS (
+			          SELECT 1 FROM audit_log scrub
+			           WHERE scrub.entity_type = a.entity_type
+			             AND scrub.entity_id = a.entity_id
+			             AND scrub.action = ANY(`+arg(fieldHistoryScrubActions)+`)
+			             AND (scrub.occurred_at, scrub.id) > (a.occurred_at, a.id)
+			        ) AS images_readable
 			 FROM audit_log a`+auditActorNameJoins+auditActivityJoin+`
 			 WHERE `+where+`
 			 ORDER BY a.occurred_at DESC, a.id DESC
@@ -322,27 +364,9 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 		}
 		defer rows.Close()
 		for rows.Next() {
-			var e AuditEntry
-			// The nullable envelope ids scan through untyped locals, then
-			// widen to their kind — a NULL column stays a nil typed pointer.
-			var passportID, onBehalfOf *ids.UUID
-			var contentReadable bool
-			if err := rows.Scan(&e.ID, &e.ActorType, &e.ActorID,
-				&passportID, &onBehalfOf, &e.Action, &e.EntityType, &e.EntityID,
-				&e.Before, &e.After, &e.AuthorizationRule, &e.Evidence, &e.OccurredAt,
-				&e.ActorName, &e.OnBehalfOfName, &contentReadable); err != nil {
+			e, err := scanAuditEntry(rows)
+			if err != nil {
 				return err
-			}
-			if !contentReadable {
-				withholdAuditImage(&e)
-			}
-			if passportID != nil {
-				v := ids.From[ids.PassportKind](*passportID)
-				e.PassportID = &v
-			}
-			if onBehalfOf != nil {
-				v := ids.From[ids.UserKind](*onBehalfOf)
-				e.OnBehalfOf = &v
 			}
 			page.Entries = append(page.Entries, e)
 		}

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -415,10 +415,21 @@ func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListAuditLog: %v", err)
 			}
+			// The create row must be THERE and withheld. Checking absence alone
+			// would pass on an empty page, or on a page holding only the
+			// tombstone — which carries no image to leak.
+			var found bool
 			for _, entry := range page.Entries {
+				if entry.Action != "create" {
+					continue
+				}
+				found = true
 				if strings.Contains(string(entry.After), "Sara Subject") {
 					t.Errorf("an erased %s still names the subject: %s", entityType, entry.After)
 				}
+			}
+			if !found {
+				t.Fatalf("the %s's create row is absent from the page, so this proved nothing", entityType)
 			}
 		})
 	}

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// The compliance log stops at a scrub the way the two history projections do.
+//
+// audit_log is append-only — trg_audit_no_mutate refuses an UPDATE and a DELETE
+// — so an Art. 17 erase cannot rewrite the images it certifies gone. Every read
+// of the spine enforces that boundary itself, or the erase is only as complete
+// as the reads that happen to respect it.
+//
+// ListFieldHistory and ListRecordHistory each take one boundary because each
+// reads one record. This read does not: entity_type and entity_id are optional
+// filters, so a page can span records that were erased at different moments and
+// records that were never erased at all. The boundary is therefore per ROW.
+//
+// The ROW survives either way. A compliance log answers who did what and when,
+// and a write that happened is a fact an erasure does not undo — it is the
+// IMAGES that carry what the subject typed, and only those are withheld.
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+type auditBoundaryEnv struct {
+	ctx    context.Context
+	db     *database.DB
+	person ids.PersonID
+	owner  *pgx.Conn
+	ws     ids.UUID
+	user   ids.UUID
+}
+
+func setupAuditBoundary(t *testing.T) *auditBoundaryEnv {
+	t.Helper()
+	ownerDSN, appDSN := os.Getenv("MARGINCE_TEST_DSN"), os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, user, person := ids.NewV7(), ids.NewV7(), ids.New[ids.PersonKind]()
+	for _, seed := range []struct {
+		statement string
+		args      []any
+	}{
+		{`INSERT INTO workspace (id) VALUES ($1)`, []any{ws}},
+		{
+			`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Admin')`,
+			[]any{user, "admin-" + user.String() + "@boundary.test"},
+		},
+		{`INSERT INTO person (id, full_name, source, captured_by)
+		  VALUES ($1, 'Sara Subject', 'manual', 'user:'||$2::text)`, []any{person, user}},
+	} {
+		if _, err := owner.Exec(ctx, seed.statement, seed.args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
+
+	return &auditBoundaryEnv{
+		ctx:    exportContext(ws, user),
+		db:     database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)),
+		person: person,
+		owner:  owner,
+		ws:     ws,
+		user:   user,
+	}
+}
+
+// auditRow writes one spine row directly. The writers are not the subject here —
+// what this read does with a row that already exists is — and seeding through
+// them would need an erasure run per case.
+func (e *auditBoundaryEnv) auditRow(t *testing.T, action string, at time.Time, before, after string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, before, after, occurred_at)
+		 VALUES ($1, 'human', 'user:'||$2::text, $3, 'person', $4, $5::jsonb, $6::jsonb, $7)`,
+		id, e.user, action, e.person, nullableJSON(before), nullableJSON(after), at); err != nil {
+		t.Fatalf("seeding a %s row: %v", action, err)
+	}
+	return id
+}
+
+// nullableJSON renders an empty fixture image as SQL NULL. A scrub tombstone
+// carries no images at all, and writing "" would make it an empty one — a
+// different answer, and the one this boundary is about telling apart.
+// agentRow is one line written by an agent acting for a human: the passport it
+// carried and the person behind it are separate columns, and both widen from a
+// nullable scan into their own id kind.
+func (e *auditBoundaryEnv) agentRow(t *testing.T, at time.Time) (id, passport, onBehalfOf ids.UUID) {
+	t.Helper()
+	id, passport, onBehalfOf = ids.NewV7(), ids.NewV7(), e.user
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO audit_log (id, actor_type, actor_id, passport_id, on_behalf_of,
+		                        action, entity_type, entity_id, before, after, occurred_at)
+		 VALUES ($1, 'agent', 'agent:enrich', $2, $3, 'update', 'person', $4,
+		         '{"title":"Engineer"}'::jsonb, '{"title":"Architect"}'::jsonb, $5)`,
+		id, passport, onBehalfOf, e.person, at); err != nil {
+		t.Fatalf("seeding an agent row: %v", err)
+	}
+	return id, passport, onBehalfOf
+}
+
+func nullableJSON(raw string) *string {
+	if raw == "" {
+		return nil
+	}
+	return &raw
+}
+
+// filtered runs the read the way a compliance question actually arrives — by
+// actor, by verb, by window — because the boundary has to hold on the narrowed
+// page too. A rule that only applies to the unfiltered read is one a filter
+// walks around.
+func (e *auditBoundaryEnv) filtered(t *testing.T, f AuditFilter) []AuditEntry {
+	t.Helper()
+	limit := 50
+	f.Limit = &limit
+	page, err := ListAuditLog(e.ctx, e.db, f)
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	return page.Entries
+}
+
+func (e *auditBoundaryEnv) entries(t *testing.T) []AuditEntry {
+	t.Helper()
+	entityType, entityID, limit := "person", e.person.UUID, 50
+	page, err := ListAuditLog(e.ctx, e.db, AuditFilter{
+		EntityType: &entityType, EntityID: &entityID, Limit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	return page.Entries
+}
+
+// imageOf reports what a caller can read out of one row's before image.
+func imageOf(t *testing.T, entries []AuditEntry, id ids.UUID) (before, after string) {
+	t.Helper()
+	for _, e := range entries {
+		if e.ID == id {
+			return string(e.Before), string(e.After)
+		}
+	}
+	t.Fatalf("the row %s is absent from the page: a compliance log withholds what a write CARRIED, never that it happened", id)
+	return "", ""
+}
+
+var (
+	boundaryEarlier = time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	boundaryErasure = time.Date(2026, 3, 2, 9, 0, 0, 0, time.UTC)
+	boundaryLater   = time.Date(2026, 3, 3, 9, 0, 0, 0, time.UTC)
+)
+
+// The disclosure this closes: a name the subject typed, recorded before the
+// erasure that deleted it, read back out of the spine afterwards.
+func TestAnImageWrittenBeforeAnErasureIsWithheld(t *testing.T) {
+	e := setupAuditBoundary(t)
+	edit := e.auditRow(t, "update", boundaryEarlier,
+		`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+
+	before, after := imageOf(t, e.entries(t), edit)
+	if strings.Contains(before, "Sara Subject") || strings.Contains(after, "Sara Renamed") {
+		t.Errorf("an erased subject's name is still readable: before=%s after=%s", before, after)
+	}
+}
+
+// The mirror, and the reason this is a withholding rather than a filter: the row
+// itself stays, because a compliance log that hid the write would answer "did
+// anybody change this record" with a lie.
+func TestTheWriteItselfSurvivesTheErasure(t *testing.T) {
+	e := setupAuditBoundary(t)
+	edit := e.auditRow(t, "update", boundaryEarlier,
+		`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+
+	for _, entry := range e.entries(t) {
+		if entry.ID == edit {
+			if entry.Action != "update" || entry.ActorID == "" || entry.OccurredAt.IsZero() {
+				t.Errorf("the row lost what it is for: %+v", entry)
+			}
+			return
+		}
+	}
+	t.Error("the erased record's edit vanished from the compliance log entirely")
+}
+
+// A write AFTER the scrub is about data the erasure did not touch, so it reads
+// whole. Without this the rule would be satisfied by withholding everything.
+func TestAnImageWrittenAfterAnErasureIsReadable(t *testing.T) {
+	e := setupAuditBoundary(t)
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+	later := e.auditRow(t, "update", boundaryLater,
+		`{"title":"Engineer"}`, `{"title":"Architect"}`)
+
+	before, after := imageOf(t, e.entries(t), later)
+	if !strings.Contains(before, "Engineer") || !strings.Contains(after, "Architect") {
+		t.Errorf("a post-erasure image was withheld: before=%s after=%s", before, after)
+	}
+}
+
+// A record nobody erased is untouched by any of this.
+func TestARecordWithNoScrubKeepsEveryImage(t *testing.T) {
+	e := setupAuditBoundary(t)
+	edit := e.auditRow(t, "update", boundaryEarlier,
+		`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+
+	before, after := imageOf(t, e.entries(t), edit)
+	if !strings.Contains(before, "Sara Subject") || !strings.Contains(after, "Sara Renamed") {
+		t.Errorf("an unscrubbed record lost its images: before=%s after=%s", before, after)
+	}
+}
+
+// The three verbs that certify a scrub, each of which the two history
+// projections already stop at. A restriction redacts the identifiers that ARE
+// the subject, so images captured before it are as gone to a reader as an
+// erase's.
+func TestEveryScrubVerbMovesTheBoundary(t *testing.T) {
+	for _, verb := range []string{"erase", "anonymize", "restrict"} {
+		t.Run(verb, func(t *testing.T) {
+			e := setupAuditBoundary(t)
+			edit := e.auditRow(t, "update", boundaryEarlier,
+				`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+			e.auditRow(t, verb, boundaryErasure, "", "")
+
+			before, _ := imageOf(t, e.entries(t), edit)
+			if strings.Contains(before, "Sara Subject") {
+				t.Errorf("%s left the pre-scrub image readable: %s", verb, before)
+			}
+		})
+	}
+}
+
+// The envelope a machine write carries. Both ids are nullable in the column and
+// typed in the entry, and a row that named them must come back naming them —
+// otherwise "which passport did this" is unanswerable for exactly the writes
+// that most need to be answerable.
+func TestAnAgentsRowKeepsThePassportAndThePersonBehindIt(t *testing.T) {
+	e := setupAuditBoundary(t)
+	id, passport, onBehalfOf := e.agentRow(t, boundaryEarlier)
+
+	for _, entry := range e.entries(t) {
+		if entry.ID != id {
+			continue
+		}
+		if entry.PassportID == nil || entry.PassportID.UUID != passport {
+			t.Errorf("passport = %v, want %s", entry.PassportID, passport)
+		}
+		if entry.OnBehalfOf == nil || entry.OnBehalfOf.UUID != onBehalfOf {
+			t.Errorf("on_behalf_of = %v, want %s", entry.OnBehalfOf, onBehalfOf)
+		}
+		if !strings.Contains(string(entry.After), "Architect") {
+			t.Errorf("an unscrubbed agent write lost its image: %s", entry.After)
+		}
+		return
+	}
+	t.Fatal("the agent's row is absent from the page")
+}
+
+// And the same row after a scrub: the envelope still answers who did it, while
+// the image it carried does not.
+func TestAnAgentsRowKeepsItsEnvelopeAndLosesItsImage(t *testing.T) {
+	e := setupAuditBoundary(t)
+	id, passport, _ := e.agentRow(t, boundaryEarlier)
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+
+	for _, entry := range e.entries(t) {
+		if entry.ID != id {
+			continue
+		}
+		if entry.PassportID == nil || entry.PassportID.UUID != passport {
+			t.Errorf("the scrub took the passport with the image: %v", entry.PassportID)
+		}
+		if strings.Contains(string(entry.After), "Architect") {
+			t.Errorf("the image survived the scrub: %s", entry.After)
+		}
+		return
+	}
+	t.Fatal("the agent's row is absent from the page")
+}
+
+// The boundary is a property of the row, not of the query that found it. Each
+// filter below narrows to the same pre-scrub edit, and every one of them must
+// answer with the image withheld.
+func TestTheBoundaryHoldsOnEveryNarrowedPage(t *testing.T) {
+	e := setupAuditBoundary(t)
+	edit := e.auditRow(t, "update", boundaryEarlier,
+		`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+
+	actor := "user:" + e.user.String()
+	action, entityType, entityID := "update", "person", e.person.UUID
+	window := boundaryEarlier.Add(-time.Hour)
+	until := boundaryErasure.Add(time.Hour)
+
+	for name, filter := range map[string]AuditFilter{
+		"by actor":  {Actor: &actor},
+		"by verb":   {Action: &action},
+		"by record": {EntityType: &entityType, EntityID: &entityID},
+		"by window": {From: &window, To: &until},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, entry := range e.filtered(t, filter) {
+				if entry.ID != edit {
+					continue
+				}
+				if strings.Contains(string(entry.Before), "Sara Subject") {
+					t.Errorf("%s reached a pre-scrub image: %s", name, entry.Before)
+				}
+				return
+			}
+			t.Fatalf("%s returned no row for the edit, so it proved nothing", name)
+		})
+	}
+}
+
+// Paging does not walk around it. The cursor carries a position, not a verdict,
+// so a second page is judged by the same rule the first was — and a boundary
+// that held only on the page a reader happens to land on would be no boundary.
+func TestTheBoundaryHoldsOnThePageAfterTheFirst(t *testing.T) {
+	e := setupAuditBoundary(t)
+	for i := range 4 {
+		e.auditRow(t, "update", boundaryEarlier.Add(time.Duration(i)*time.Minute),
+			`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)
+	}
+	e.auditRow(t, "erase", boundaryErasure, "", "")
+
+	entityType, entityID, limit := "person", e.person.UUID, 2
+	first, err := ListAuditLog(e.ctx, e.db, AuditFilter{
+		EntityType: &entityType, EntityID: &entityID, Limit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if !first.HasMore || first.NextCursor == "" {
+		t.Fatalf("the fixture did not page: %d entries, more=%t", len(first.Entries), first.HasMore)
+	}
+	next, err := ListAuditLog(e.ctx, e.db, AuditFilter{
+		EntityType: &entityType, EntityID: &entityID, Limit: &limit, Cursor: &first.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(next.Entries) == 0 {
+		t.Fatal("the second page is empty, so it proved nothing")
+	}
+	for _, entry := range next.Entries {
+		if strings.Contains(string(entry.Before), "Sara Subject") {
+			t.Errorf("a pre-scrub image reached page two: %s", entry.Before)
+		}
+	}
+}

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -384,3 +384,42 @@ func TestTheBoundaryHoldsOnThePageAfterTheFirst(t *testing.T) {
 		}
 	}
 }
+
+// The two entity types the boundary could not reach until the erasure tombstoned
+// them. An attachment's create image carries the FILENAME somebody typed —
+// routinely the subject's own name — and a scheduled send's carries the message
+// SUBJECT. Neither type is projected by field history, so the compliance log is
+// the only door they were ever readable through, and the boundary only fires
+// where a tombstone exists.
+func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
+	for _, entityType := range []string{"attachment", "scheduled_send"} {
+		t.Run(entityType, func(t *testing.T) {
+			e := setupAuditBoundary(t)
+			id := ids.NewV7()
+			if _, err := e.owner.Exec(context.Background(),
+				`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
+				 VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
+				         '{"filename":"sara-subject-passport.pdf","subject":"Sara Subject contract"}'::jsonb, $5)`,
+				ids.NewV7(), e.user, entityType, id, boundaryEarlier); err != nil {
+				t.Fatalf("seeding the %s image: %v", entityType, err)
+			}
+			if _, err := e.owner.Exec(context.Background(),
+				`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, occurred_at)
+				 VALUES ($1, 'human', 'user:'||$2::text, 'erase', $3, $4, $5)`,
+				ids.NewV7(), e.user, entityType, id, boundaryErasure); err != nil {
+				t.Fatalf("seeding the %s tombstone: %v", entityType, err)
+			}
+
+			limit := 50
+			page, err := ListAuditLog(e.ctx, e.db, AuditFilter{EntityType: &entityType, EntityID: &id, Limit: &limit})
+			if err != nil {
+				t.Fatalf("ListAuditLog: %v", err)
+			}
+			for _, entry := range page.Entries {
+				if strings.Contains(string(entry.After), "Sara Subject") {
+					t.Errorf("an erased %s still names the subject: %s", entityType, entry.After)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -47,10 +47,14 @@ const evidenceKeyRetentionAction = "retention_action"
 // behind it, and — for a controller's decision — the stated reason. Spelled
 // once so the tombstones a supervisory authority reads use one vocabulary.
 const (
-	evidenceKeyCause  = "cause"
-	evidenceKeyClass  = "class"
-	evidenceKeyBasis  = "basis"
-	evidenceKeyReason = "reason"
+	evidenceKeyCause = "cause"
+	// The two causes a collateral tombstone can carry: an Art. 17 erasure of a
+	// subject, or a retention sweep clearing a record on its own schedule.
+	causePersonErasure = "person_erasure"
+	causeRetention     = "retention"
+	evidenceKeyClass   = "class"
+	evidenceKeyBasis   = "basis"
+	evidenceKeyReason  = "reason"
 )
 
 // Eraser executes the shared erase path both the DSR surface and the
@@ -143,7 +147,7 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		if err != nil {
 			return err
 		}
-		if err := tombstoneCollateralScrubs(ctx, tx, "lead", leadsWiped, reason); err != nil {
+		if err := tombstoneCollateralScrubs(ctx, tx, "lead", leadsWiped, reason, causePersonErasure); err != nil {
 			return err
 		}
 		if err := purgeRedactedActivityTraces(ctx, tx, activitiesRedacted, reason); err != nil {
@@ -178,7 +182,7 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		// transaction (objects first). A failure here — including a
 		// misconfigured store — rolls the whole erasure back, so it stays
 		// retryable and never commits a half-erasure.
-		if err := e.eraseAttachments(ctx, tx, reason, subjectAttachmentsWhere, subject, floorInterval, floorAnchor); err != nil {
+		if err := e.eraseAttachments(ctx, tx, reason, causePersonErasure, subjectAttachmentsWhere, subject, floorInterval, floorAnchor); err != nil {
 			return err
 		}
 		rawPurged, aiPayloadsPurged, err := purgeDerivedTraces(ctx, tx, subject, emails, identities)
@@ -249,7 +253,7 @@ func purgeRedactedActivityTraces(ctx context.Context, tx pgx.Tx, activities []id
 			return err
 		}
 	}
-	if err := tombstoneCollateralScrubs(ctx, tx, "activity", activities, reason); err != nil {
+	if err := tombstoneCollateralScrubs(ctx, tx, "activity", activities, reason, causePersonErasure); err != nil {
 		return err
 	}
 	// The readings of those rows, which describe a body that is now gone. The
@@ -417,10 +421,13 @@ func deleteSubjectIdentifierRows(ctx context.Context, tx pgx.Tx, personID ids.Pe
 // paired outbox event on purpose: the erasure's single retention.applied
 // on the person is the bus-visible fact, and the collateral scrubs have
 // never announced themselves per record.
-func tombstoneCollateralScrubs(ctx context.Context, tx pgx.Tx, entityType string, records []ids.UUID, reason string) error {
+// cause is the caller's, because this path is no longer the Art. 17 erasure's
+// alone: retention reaches it too, and a tombstone stamped person_erasure for a
+// record a retention sweep cleared says the wrong thing about why the data went.
+func tombstoneCollateralScrubs(ctx context.Context, tx pgx.Tx, entityType string, records []ids.UUID, reason, cause string) error {
 	for _, id := range records {
 		if _, err := storekit.AuditWithEvidence(ctx, tx, actionErase, entityType, id, nil, nil, map[string]any{
-			evidenceKeyReason: reason, evidenceKeyCause: "person_erasure",
+			evidenceKeyReason: reason, evidenceKeyCause: cause,
 		}); err != nil {
 			return fmt.Errorf("tombstoning scrubbed %s: %w", entityType, err)
 		}

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -153,7 +153,7 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		// the body before any activity exists, so nothing above this line can
 		// reach them — and a scheduled one would otherwise fire the morning
 		// after this erasure certified the data destroyed.
-		if err := redactScheduledSends(ctx, tx, emails); err != nil {
+		if err := redactScheduledSends(ctx, tx, reason, emails); err != nil {
 			return err
 		}
 		// And the ones nobody has DECIDED yet, one step earlier in the same life
@@ -178,7 +178,7 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		// transaction (objects first). A failure here — including a
 		// misconfigured store — rolls the whole erasure back, so it stays
 		// retryable and never commits a half-erasure.
-		if err := e.eraseAttachments(ctx, tx, subjectAttachmentsWhere, subject, floorInterval, floorAnchor); err != nil {
+		if err := e.eraseAttachments(ctx, tx, reason, subjectAttachmentsWhere, subject, floorInterval, floorAnchor); err != nil {
 			return err
 		}
 		rawPurged, aiPayloadsPurged, err := purgeDerivedTraces(ctx, tx, subject, emails, identities)

--- a/backend/internal/modules/privacy/erasure_attachments.go
+++ b/backend/internal/modules/privacy/erasure_attachments.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // subjectAttachmentsWhere selects the attachments Art. 17 erasure removes for
@@ -32,7 +34,7 @@ var subjectAttachmentsWhere = `(entity_type = 'person' AND entity_id = $1)
 // orphaned with their only key gone. Erasure is rare and not latency-bound,
 // so the brief object-store I/O held under the transaction is an acceptable
 // trade for that durability guarantee.
-func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, where string, args ...any) error {
+func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, reason, where string, args ...any) error {
 	rows, err := tx.Query(ctx, `SELECT storage_key FROM attachment WHERE `+where, args...)
 	if err != nil {
 		return err
@@ -59,8 +61,32 @@ func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, where string, 
 			}
 		}
 	}
-	if _, err := tx.Exec(ctx, `DELETE FROM attachment WHERE `+where, args...); err != nil {
+	// RETURNING, because the rows are gone after this and the audit images they
+	// left behind are not. An attachment's create image carries the FILENAME the
+	// uploader typed, which routinely names the subject; audit_log is
+	// append-only, so the only thing that puts that name out of reach is a
+	// tombstone the spine's readers stop at.
+	scrubbed, err := scrubbedIDs(ctx, tx, `DELETE FROM attachment WHERE `+where+` RETURNING id`, args...)
+	if err != nil {
 		return err
 	}
-	return nil
+	return tombstoneCollateralScrubs(ctx, tx, "attachment", scrubbed, reason)
+}
+
+// scrubbedIDs runs a statement that returns the ids it scrubbed.
+func scrubbedIDs(ctx context.Context, tx pgx.Tx, sql string, args ...any) ([]ids.UUID, error) {
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var scrubbed []ids.UUID
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		scrubbed = append(scrubbed, id)
+	}
+	return scrubbed, rows.Err()
 }

--- a/backend/internal/modules/privacy/erasure_attachments.go
+++ b/backend/internal/modules/privacy/erasure_attachments.go
@@ -34,7 +34,7 @@ var subjectAttachmentsWhere = `(entity_type = 'person' AND entity_id = $1)
 // orphaned with their only key gone. Erasure is rare and not latency-bound,
 // so the brief object-store I/O held under the transaction is an acceptable
 // trade for that durability guarantee.
-func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, reason, where string, args ...any) error {
+func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, reason, cause, where string, args ...any) error {
 	rows, err := tx.Query(ctx, `SELECT storage_key FROM attachment WHERE `+where, args...)
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func (e *Eraser) eraseAttachments(ctx context.Context, tx pgx.Tx, reason, where 
 	if err != nil {
 		return err
 	}
-	return tombstoneCollateralScrubs(ctx, tx, "attachment", scrubbed, reason)
+	return tombstoneCollateralScrubs(ctx, tx, "attachment", scrubbed, reason, cause)
 }
 
 // scrubbedIDs runs a statement that returns the ids it scrubbed.

--- a/backend/internal/modules/privacy/erasuredealroom.go
+++ b/backend/internal/modules/privacy/erasuredealroom.go
@@ -60,7 +60,7 @@ func eraseDealRoomSeats(ctx context.Context, tx pgx.Tx, emails []string, reason 
 	// the field-history projection cuts a record's timeline at its own newest
 	// erase row. Without this the audit log hands the "erased" address
 	// straight back — an erasure the record itself contradicts.
-	return tombstoneCollateralScrubs(ctx, tx, "deal_room_participant", seats, reason)
+	return tombstoneCollateralScrubs(ctx, tx, "deal_room_participant", seats, reason, causePersonErasure)
 }
 
 // anonymizeDealRoomSeats wipes the subject's name and address from every Deal

--- a/backend/internal/modules/privacy/fieldhistory_test.go
+++ b/backend/internal/modules/privacy/fieldhistory_test.go
@@ -262,7 +262,8 @@ func TestDiffSaysNothingAboutAFieldThatWasNeverFilled(t *testing.T) {
 // jsonb numbers decoded as float64 lose the low bits past 2^53, so a stored
 // id or amount came back as a DIFFERENT number than the record holds.
 func TestDiffRendersALargeNumberExactly(t *testing.T) {
-	row := fhRow("human",
+	row := fhRow(
+		"human",
 		map[string]any{"external_id": json.Number("9007199254740993")},
 		map[string]any{"external_id": json.Number("9007199254740995")},
 	)

--- a/backend/internal/modules/privacy/restrictionoverride.go
+++ b/backend/internal/modules/privacy/restrictionoverride.go
@@ -270,7 +270,8 @@ func ParseStatedReason(reason string) (StatedReason, error) {
 	if stated == "" || len([]rune(stated)) > maxOverrideReason {
 		return StatedReason{}, httperr.Validation("reason", "required", fmt.Sprintf(
 			"a release or a pin records a controller's decision, so it must state why in 1–%d characters",
-			maxOverrideReason))
+			maxOverrideReason,
+		))
 	}
 	return StatedReason{text: stated}, nil
 }
@@ -300,7 +301,8 @@ func admitRestrictionDecision(ctx context.Context, tx pgx.Tx, reason StatedReaso
 		// than as a constraint violation from underneath.
 		return restrictionDecision{}, fmt.Errorf(
 			"the deciding account carries no display name, and an unattributed decision cannot be accounted for: %w",
-			apperrors.ErrPermissionDenied)
+			apperrors.ErrPermissionDenied,
+		)
 	}
 	if err != nil {
 		return restrictionDecision{}, err

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -201,7 +201,7 @@ func (s *RetentionService) eraseActivityContent(ctx context.Context, tx pgx.Tx, 
 		err = s.invalidateGraph(ctx, tx, id)
 	}
 	if err == nil {
-		err = s.eraser.eraseAttachments(ctx, tx, "retention: the policy erased this record", `entity_type = 'activity' AND entity_id = $1`, id)
+		err = s.eraser.eraseAttachments(ctx, tx, "retention: the policy erased this record", causeRetention, `entity_type = 'activity' AND entity_id = $1`, id)
 	}
 	if err == nil {
 		// A proposal read out of this body quotes it verbatim, so it ages out

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -201,7 +201,7 @@ func (s *RetentionService) eraseActivityContent(ctx context.Context, tx pgx.Tx, 
 		err = s.invalidateGraph(ctx, tx, id)
 	}
 	if err == nil {
-		err = s.eraser.eraseAttachments(ctx, tx, `entity_type = 'activity' AND entity_id = $1`, id)
+		err = s.eraser.eraseAttachments(ctx, tx, "retention: the policy erased this record", `entity_type = 'activity' AND entity_id = $1`, id)
 	}
 	if err == nil {
 		// A proposal read out of this body quotes it verbatim, so it ages out

--- a/backend/internal/modules/privacy/retentionpolicystore.go
+++ b/backend/internal/modules/privacy/retentionpolicystore.go
@@ -125,7 +125,8 @@ func validateRetentionAction(scope RetentionScope, action string) error {
 		Field: fieldAction, Code: "unsupported_retention_action",
 		Message: fmt.Sprintf(
 			"%q is not an action this installation can take on %s — for that scope the actions are: %s",
-			action, scope.ObjectType, strings.Join(supported, ", ")),
+			action, scope.ObjectType, strings.Join(supported, ", "),
+		),
 	}
 }
 

--- a/backend/internal/modules/privacy/retentionrestricted.go
+++ b/backend/internal/modules/privacy/retentionrestricted.go
@@ -161,7 +161,7 @@ func (e *Eraser) purgeHeldRecordTraces(ctx context.Context, tx pgx.Tx, id ids.UU
 	if err := purgeTranscriptReadings(ctx, tx, []ids.UUID{id}); err != nil {
 		return err
 	}
-	if err := e.eraseAttachments(ctx, tx, "retention: the held record reached its floor", `entity_type = 'activity' AND entity_id = $1`, id); err != nil {
+	if err := e.eraseAttachments(ctx, tx, "retention: the held record reached its floor", causeRetention, `entity_type = 'activity' AND entity_id = $1`, id); err != nil {
 		return err
 	}
 	return redactDeliveries(ctx, tx, []ids.UUID{id}, erasedName)

--- a/backend/internal/modules/privacy/retentionrestricted.go
+++ b/backend/internal/modules/privacy/retentionrestricted.go
@@ -161,7 +161,7 @@ func (e *Eraser) purgeHeldRecordTraces(ctx context.Context, tx pgx.Tx, id ids.UU
 	if err := purgeTranscriptReadings(ctx, tx, []ids.UUID{id}); err != nil {
 		return err
 	}
-	if err := e.eraseAttachments(ctx, tx, `entity_type = 'activity' AND entity_id = $1`, id); err != nil {
+	if err := e.eraseAttachments(ctx, tx, "retention: the held record reached its floor", `entity_type = 'activity' AND entity_id = $1`, id); err != nil {
 		return err
 	}
 	return redactDeliveries(ctx, tx, []ids.UUID{id}, erasedName)

--- a/backend/internal/modules/privacy/retentionscope.go
+++ b/backend/internal/modules/privacy/retentionscope.go
@@ -80,7 +80,8 @@ func (e UnknownScopeError) Error() string {
 func (e UnknownScopeError) FieldFault() (field, code, message string) {
 	return "scope", "unknown_retention_scope", fmt.Sprintf(
 		"%q is not a retention scope this installation can act on — authorable scopes are: %s",
-		e.Scope, strings.Join(AuthorableScopes(), ", "))
+		e.Scope, strings.Join(AuthorableScopes(), ", "),
+	)
 }
 
 // ParseRetentionScope resolves a wire scope against the evaluator's selectors.

--- a/backend/internal/modules/privacy/scheduledsends.go
+++ b/backend/internal/modules/privacy/scheduledsends.go
@@ -79,5 +79,5 @@ func redactScheduledSends(ctx context.Context, tx pgx.Tx, reason string, emails 
 	if err != nil {
 		return fmt.Errorf("redacting the scheduled messages addressed to the subject: %w", err)
 	}
-	return tombstoneCollateralScrubs(ctx, tx, "scheduled_send", scrubbed, reason)
+	return tombstoneCollateralScrubs(ctx, tx, "scheduled_send", scrubbed, reason, causePersonErasure)
 }

--- a/backend/internal/modules/privacy/scheduledsends.go
+++ b/backend/internal/modules/privacy/scheduledsends.go
@@ -51,14 +51,17 @@ import (
 // state-shape CHECK reserves held_reason for holds), and the delivery scrub's
 // park reason has no analogue here: nothing was handed to a provider, so there
 // is no operator waiting to be told why a transmission stopped.
-func redactScheduledSends(ctx context.Context, tx pgx.Tx, emails []string) error {
+func redactScheduledSends(ctx context.Context, tx pgx.Tx, reason string, emails []string) error {
 	if len(emails) == 0 {
 		return nil
 	}
 	// jsonb ?| asks whether any of these addresses appears in the array. The
 	// payload keeps To, Cc and Bcc in one merged recipients list, so one test
 	// covers all three — a blind copy is not a hiding place.
-	if _, err := tx.Exec(ctx, `
+	// The schedule's audit image carries the message SUBJECT verbatim, so
+	// emptying the payload is only half the scrub: the other half is the
+	// tombstone that stops the spine's readers before the image that quoted it.
+	scrubbed, err := scrubbedIDs(ctx, tx, `
 		UPDATE scheduled_send
 		   SET payload = jsonb_build_object(
 		         'recipients', '[]'::jsonb,
@@ -71,8 +74,10 @@ func redactScheduledSends(ctx context.Context, tx pgx.Tx, emails []string) error
 		       updated_at = now()
 		 WHERE payload->'recipients' ?| $1
 		    OR payload->'cc' ?| $1
-		    OR payload->'bcc' ?| $1`, emails); err != nil {
+		    OR payload->'bcc' ?| $1
+		 RETURNING id`, emails)
+	if err != nil {
 		return fmt.Errorf("redacting the scheduled messages addressed to the subject: %w", err)
 	}
-	return nil
+	return tombstoneCollateralScrubs(ctx, tx, "scheduled_send", scrubbed, reason)
 }

--- a/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.down.sql
+++ b/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_audit_scrub_boundary;

--- a/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.down.sql
+++ b/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.down.sql
@@ -1,1 +1,5 @@
+-- Bounded for the same reason the build is: dropping the index takes a lock that
+-- blocks writers on audit_log.
+SET LOCAL lock_timeout = '3s';
+
 DROP INDEX IF EXISTS idx_audit_scrub_boundary;

--- a/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.up.sql
+++ b/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.up.sql
@@ -1,0 +1,24 @@
+-- Every read of the audit spine stops at the newest scrub tombstone: audit_log
+-- is append-only, so an Art. 17 erase cannot rewrite the images it certifies
+-- gone and the reads enforce the boundary instead.
+--
+-- Proving a scrub's ABSENCE is what needs this. With only idx_audit_entity and
+-- idx_audit_time to work from, the planner walks every audit row newer than the
+-- one being judged and filters on the verb — measured at 19,015 rows removed per
+-- judged row, and 22,671 buffer reads for one deep page against 182 for the
+-- first. That cost is not bounded by the page limit and grows with the table,
+-- which is the shape that stops being noticeable in review and starts being
+-- noticeable in production.
+--
+-- Partial, on the three scrub verbs, because the absence being proved is of
+-- those verbs alone — a full index would carry every ordinary update to answer a
+-- question none of them can. That also makes the build cheap: it indexes the
+-- scrub rows, which are a small fraction of the table.
+--
+-- Not CONCURRENTLY: a migration runs in one transaction and CONCURRENTLY forbids
+-- that (see 1787320004's note on the same point), so this holds a write-blocking
+-- build for its duration — bounded by the partial predicate rather than by the
+-- whole of audit_log.
+CREATE INDEX IF NOT EXISTS idx_audit_scrub_boundary
+    ON audit_log (entity_type, entity_id, occurred_at DESC, id DESC)
+    WHERE action IN ('erase', 'anonymize', 'restrict');

--- a/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.up.sql
+++ b/backend/migrations/core/1787650813_the_scrub_boundary_has_an_index.up.sql
@@ -19,6 +19,11 @@
 -- that (see 1787320004's note on the same point), so this holds a write-blocking
 -- build for its duration — bounded by the partial predicate rather than by the
 -- whole of audit_log.
+-- Bounded, because this blocks writers on a table it did not create: without a
+-- timeout, an open transaction holding a conflicting lock stalls every write to
+-- audit_log for as long as this is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
 CREATE INDEX IF NOT EXISTS idx_audit_scrub_boundary
     ON audit_log (entity_type, entity_id, occurred_at DESC, id DESC)
     WHERE action IN ('erase', 'anonymize', 'restrict');

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1853,6 +1853,7 @@ public.idx_attachment_extraction_activity_settled CREATE INDEX idx_attachment_ex
 public.idx_attachment_extraction_latest CREATE INDEX idx_attachment_extraction_latest ON public.attachment_extraction USING btree (attachment_id, created_at DESC)
 public.idx_audit_actor CREATE INDEX idx_audit_actor ON public.audit_log USING btree (actor_id, occurred_at DESC)
 public.idx_audit_entity CREATE INDEX idx_audit_entity ON public.audit_log USING btree (entity_type, entity_id, occurred_at DESC)
+public.idx_audit_scrub_boundary CREATE INDEX idx_audit_scrub_boundary ON public.audit_log USING btree (entity_type, entity_id, occurred_at DESC, id DESC) WHERE (action = ANY (ARRAY['erase'::text, 'anonymize'::text, 'restrict'::text]))
 public.idx_audit_time CREATE INDEX idx_audit_time ON public.audit_log USING btree (occurred_at DESC)
 public.idx_auth_token_hash CREATE UNIQUE INDEX idx_auth_token_hash ON public.auth_token USING btree (token_hash)
 public.idx_auth_token_user CREATE INDEX idx_auth_token_user ON public.auth_token USING btree (user_id, purpose) WHERE (used_at IS NULL)

--- a/backend/scrubverbs_test.go
+++ b/backend/scrubverbs_test.go
@@ -35,10 +35,12 @@ package backendarch
 // subjects lying outside the root — noise, not a proof. What Scope is used for
 // is its parsing and its refusal of a root that holds nothing.
 //
-// What it cannot see: a verb built at run time. `retentionactions.go` audits
-// under a column of the policy row, whose CHECK admits archive, anonymize and
-// erase — all three of which are judged below, so the runtime path reaches
-// nothing this gate has not already ruled on.
+// The one verb built at run time is judged too, rather than argued about.
+// `retentionactions.go` audits under a column of the policy row, so no walk can
+// read it from the source — but the DDL can: retention_policy_action_check names
+// exactly what that column may hold, and every one of those verbs goes through
+// the same judgement. Leaving it to a comment saying "those are all covered
+// anyway" would be a claim that stops being true the day the CHECK widens.
 
 import (
 	"go/ast"
@@ -80,12 +82,27 @@ func TestEveryPrivacyAuditVerbIsJudgedAScrubOrNot(t *testing.T) {
 		Subject: fileAuditsUnderAVerb,
 	}.Files(t)
 
+	var judged int
+
+	// The policy-driven verb, from the DDL that bounds it. A retention sweep
+	// audits under a column, and widening that CHECK without judging the new
+	// verb is exactly the silent gap this gate exists for.
+	for _, verb := range retentionPolicyVerbs(t) {
+		judged++
+		if scrub[verb] || privacyNonScrubVerbs.Waived(t, verb) {
+			continue
+		}
+		t.Errorf("retention_policy_action_check admits %q, which privacy audits under at run time, "+
+			"and nothing says whether it certifies a scrub.\n"+
+			"\tAdd it to fieldHistoryScrubActions, or to privacyNonScrubVerbs with what it does to the row.",
+			verb)
+	}
+
 	// Verbs resolve against the PACKAGE's constants, not each file's own.
 	// actionArchive is declared in recordhistory.go and written from erasure's
 	// neighbours; per-file resolution would leave those unresolvable, and an
 	// unresolvable verb is one this gate skips — the census failing short in the
 	// one direction that reports PASS.
-	var judged int
 	for _, parsed := range files {
 		for _, verb := range auditVerbsIn(parsed.File, consts) {
 			judged++
@@ -145,6 +162,17 @@ func scrubVerbSet(t *testing.T, consts map[string]string) map[string]bool {
 	})
 	if len(verbs) == 0 {
 		t.Fatalf("fieldHistoryScrubActions resolved to no verbs — this gate would pass over an empty boundary")
+	}
+	return verbs
+}
+
+// retentionPolicyVerbs is what a retention policy's action column may hold, read
+// from its CHECK — the only authority on a verb no source walk can resolve.
+func retentionPolicyVerbs(t *testing.T) []string {
+	t.Helper()
+	verbs, ok := tableCheckSets(t)["retention_policy.action"]
+	if !ok {
+		t.Fatal("retention_policy.action: no CHECK (col IN (...)) found — the runtime verb would go unjudged")
 	}
 	return verbs
 }

--- a/backend/scrubverbs_test.go
+++ b/backend/scrubverbs_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// Every verb the privacy module writes is judged a scrub or ratified as not one.
+//
+// `fieldHistoryScrubActions` is the boundary THREE reads of the audit spine take
+// — field history, record history, and the compliance log. audit_log is
+// append-only, so a scrub cannot rewrite the images it certifies gone; each read
+// stops at the newest tombstone instead. That makes the list the single point on
+// which all three depend.
+//
+// It is a hand-written list, and the way it fails is the way that matters: a new
+// scrubbing verb nobody adds to it does not break anything. The three reads go
+// on returning images the scrub was supposed to put out of reach, every test
+// passes, and the disclosure is silent. Under-recognition is the one failure a
+// gate must not have, so the corpus here is derived from the WRITERS rather than
+// restated: every verb privacy audits under is either in the scrub list or in
+// the register below, saying why it certifies nothing.
+//
+// Not erasureCascadeFiles' question. That gate asks which FILES the Art. 17
+// cascade executes SQL from, and says in as many words that it is deliberately
+// not the whole package, because letting a retention sweep satisfy "Art. 17
+// reaches this table" is the confusion it exists to prevent. This one asks which
+// VERBS certify a scrub — and retention's anonymize is one of them, which is
+// exactly why the two cannot share an authority.
+//
+// Scope's negative-space proof does not apply here and the subject says why: a
+// file is this gate's business because it is IN the privacy module, not because
+// of what it contains, so the root cannot name the wrong tree. Every module in
+// the tree audits, and a content-based subject would report all of them as
+// subjects lying outside the root — noise, not a proof. What Scope is used for
+// is its parsing and its refusal of a root that holds nothing.
+//
+// What it cannot see: a verb built at run time. `retentionactions.go` audits
+// under a column of the policy row, whose CHECK admits archive, anonymize and
+// erase — all three of which are judged below, so the runtime path reaches
+// nothing this gate has not already ruled on.
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// privacyNonScrubVerbs are the verbs privacy writes that certify NOTHING about
+// the record's PII, each with the reason it does not move the boundary.
+//
+// A verb here is a claim that a reader may still see what the record held before
+// it. Getting one wrong leaves images readable that should not be, so each entry
+// says what the verb actually did to the row.
+// privacyRoot is the module whose verbs this gate judges. A file is a subject
+// because it lives here.
+const privacyRoot = "internal/modules/privacy"
+
+var privacyNonScrubVerbs = gatekit.Waive(map[string]string{
+	"create":  "the record's own creation, which carries no prior state and scrubs nothing that came before it",
+	"update":  "an ordinary field change: the images are the point of it, and a reader is entitled to both sides",
+	"export":  "a subject-access export READS the record and writes nothing to it, so nothing it held has gone",
+	"archive": "retiring a row hides it from the default reads and leaves every value intact, which is why an archived record can still be restored",
+	"expire":  "a restriction reaching its end returns the record to ordinary handling; the identifiers the restriction hid were never removed",
+	"pin":     "a statutory hold REFUSES deletion for a period, so it is the opposite of a scrub in what it does to the data",
+	"release": "lifting a hold restores ordinary retention and moves no value",
+})
+
+func TestEveryPrivacyAuditVerbIsJudgedAScrubOrNot(t *testing.T) {
+	defer privacyNonScrubVerbs.AssertAllMatched(t)
+
+	consts := privacyPackageConstants(t)
+	scrub := scrubVerbSet(t, consts)
+	files := gatekit.Scope{
+		Roots:   []string{privacyRoot},
+		Subject: fileAuditsUnderAVerb,
+	}.Files(t)
+
+	// Verbs resolve against the PACKAGE's constants, not each file's own.
+	// actionArchive is declared in recordhistory.go and written from erasure's
+	// neighbours; per-file resolution would leave those unresolvable, and an
+	// unresolvable verb is one this gate skips — the census failing short in the
+	// one direction that reports PASS.
+	var judged int
+	for _, parsed := range files {
+		for _, verb := range auditVerbsIn(parsed.File, consts) {
+			judged++
+			if scrub[verb] || privacyNonScrubVerbs.Waived(t, verb) {
+				continue
+			}
+			t.Errorf("privacy audits under %q, and nothing says whether it certifies a scrub.\n"+
+				"\tThree reads of the spine stop at a scrub tombstone; a verb missing from both lists "+
+				"silently is not one of them.\n"+
+				"\tAdd it to fieldHistoryScrubActions, or to privacyNonScrubVerbs with what it did to the row.",
+				verb)
+		}
+	}
+
+	// A census that judged nothing certifies nothing. The floor sits below the
+	// real count, so a walk that stopped working fails rather than reporting a
+	// module that audits under no verb at all.
+	if judged < 8 {
+		t.Errorf("resolved %d audit verb(s) in privacy — the way of finding them has stopped working", judged)
+	}
+}
+
+// scrubVerbSet reads the list itself, resolved against the PACKAGE's constants:
+// the list names actionErase, which erasure.go declares, so reading only the
+// declaring file's own constants would leave the boundary looking narrower than
+// it is — and a verb this gate thinks is not a scrub is one it demands a reason
+// for.
+func scrubVerbSet(t *testing.T, consts map[string]string) map[string]bool {
+	t.Helper()
+	const declaringFile = privacyRoot + "/fieldhistory.go"
+	file := gatekit.Scope{
+		Roots:   []string{privacyRoot},
+		Subject: func(path string, _ *ast.File) bool { return path == declaringFile },
+	}.Files(t)
+	if len(file) != 1 {
+		t.Fatalf("found %d file(s) declaring the scrub verbs, want %s alone", len(file), declaringFile)
+	}
+	var verbs map[string]bool
+	ast.Inspect(file[0].File, func(n ast.Node) bool {
+		spec, isValue := n.(*ast.ValueSpec)
+		if !isValue || len(spec.Names) == 0 || spec.Names[0].Name != "fieldHistoryScrubActions" {
+			return true
+		}
+		verbs = map[string]bool{}
+		for _, value := range spec.Values {
+			composite, isComposite := value.(*ast.CompositeLit)
+			if !isComposite {
+				continue
+			}
+			for _, element := range composite.Elts {
+				if verb, known := privacyString(element, consts); known {
+					verbs[verb] = true
+				}
+			}
+		}
+		return false
+	})
+	if len(verbs) == 0 {
+		t.Fatalf("fieldHistoryScrubActions resolved to no verbs — this gate would pass over an empty boundary")
+	}
+	return verbs
+}
+
+// privacyPackageConstants collects the package's string constants, from
+// whichever file declares each one — a verb written in erasure.go may name a
+// constant recordhistory.go declares.
+func privacyPackageConstants(t *testing.T) map[string]string {
+	t.Helper()
+	consts := map[string]string{}
+	for _, parsed := range (gatekit.Scope{
+		Roots:   []string{privacyRoot},
+		Subject: fileAuditsUnderAVerb,
+	}).Files(t) {
+		for name, value := range privacyStringConstants(parsed.File) {
+			consts[name] = value
+		}
+	}
+	return consts
+}
+
+// fileAuditsUnderAVerb is the Scope subject: a file that calls an audit door at
+// all. The VERB it writes under is judged later, against the package's
+// constants — a file whose verb is a sibling's constant is still a subject.
+func fileAuditsUnderAVerb(path string, _ *ast.File) bool {
+	return strings.HasPrefix(path, privacyRoot+"/") && !strings.HasSuffix(path, "_test.go")
+}
+
+// auditVerbsIn reads the verb each audit call in one file writes under. A verb
+// this cannot reduce to a constant is skipped: the doc comment above names the
+// one such site and why it reaches nothing unjudged.
+func auditVerbsIn(file *ast.File, consts map[string]string) []string {
+	var verbs []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall || len(call.Args) < 3 {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector || !strings.HasPrefix(selector.Sel.Name, "Audit") {
+			return true
+		}
+		if pkg, isIdent := selector.X.(*ast.Ident); !isIdent || pkg.Name != "storekit" {
+			return true
+		}
+		if verb, known := privacyString(call.Args[2], consts); known {
+			verbs = append(verbs, verb)
+		}
+		return true
+	})
+	return verbs
+}
+
+func privacyStringConstants(file *ast.File) map[string]string {
+	consts := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+			for i, name := range value.Names {
+				if i < len(value.Values) {
+					if literal, known := privacyString(value.Values[i], nil); known {
+						consts[name.Name] = literal
+					}
+				}
+			}
+		}
+	}
+	return consts
+}
+
+func privacyString(expr ast.Expr, consts map[string]string) (string, bool) {
+	switch node := expr.(type) {
+	case *ast.BasicLit:
+		if node.Kind != token.STRING {
+			return "", false
+		}
+		value, err := strconv.Unquote(node.Value)
+		return value, err == nil
+	case *ast.Ident:
+		value, declared := consts[node.Name]
+		return value, declared
+	default:
+		return "", false
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -48,7 +48,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (37)
+## Census (38)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -87,6 +87,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `restrictedreaders_test.go` | H2 | A record held under a statutory retention obligation is unavailable in EVERY ordinary read path (A165/ADR-0114 §2): lists, timelines, search, exports, embeddings, agent grounding. |
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
 | `satellite_lifecycle_test.go` | H2 | Person-satellite lifecycle reach as a fitness function. |
+| `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |
 


### PR DESCRIPTION
## What this is

`audit_log` is append-only — `trg_audit_no_mutate` refuses an UPDATE and a DELETE — so an Art. 17 erase **cannot** rewrite the images it certifies gone. Every read of the spine has to enforce that boundary itself, or the erase is only as complete as the reads that happen to respect it.

`ListFieldHistory` and `ListRecordHistory` both stop at the newest scrub tombstone. `ListAuditLog` — the compliance log — did not. So a name a subject typed stayed readable through `GET /audit-log` after the erasure that deleted it.

Reproduced before fixing:

```
before={"full_name": "Sara Subject"}  after={"full_name": "Sara Renamed"}
```

## The shape

**Per row, not one boundary.** The two projections take a single boundary because each reads one record. This read cannot: `entity_type` and `entity_id` are *optional* filters, so a page spans records erased at different moments and records never erased at all.

**The row survives; only the images are withheld.** A compliance log answers who did what and when. A write that happened is not a fact an erasure undoes — it is the images that carry what the subject typed.

**One spelling.** The predicate is exported and both readers call it. The defect being fixed was readers of one rule not agreeing; a second copy of those six lines would be the same defect with better intentions.

## Two more doors, found in review

**The workspace export bundle** read `audit_log` whole with no boundary — and it is the reader that puts the table on somebody's disk. Reverting the fix proves it: `audit_log.csv` and `data.json` both carry the erased value.

**`attachment` and `scheduled_send` were never tombstoned.** The boundary fires only where a tombstone exists, and the erasure emptied both tables without writing one. Their images carry, verbatim:

- `filename` — user-supplied, routinely `jane-doe-passport.pdf`
- `subject` — the message subject line

Neither type is projected by field history, so the compliance log was the *only* door either was readable through. `tombstoneCollateralScrubs` already existed and was called for activities; both statements now report the ids they scrubbed.

## Cost

Proving a scrub's **absence** was the expensive part. Measured on a deep page:

| | rows removed by filter | buffers |
|---|---|---|
| before | 19,015 per judged row | 22,671 |
| after | — (Index Only Scan) | **63** |

That cost was not bounded by the page limit and grew with the table. The new index is partial on the three scrub verbs, so the build touches the scrub rows alone. Not `CONCURRENTLY` — a migration runs in one transaction, as `1787320004` already notes.

## The verb list now has a gate

`fieldHistoryScrubActions` is hand-written and three boundaries depend on it. A new scrubbing verb nobody added would leave every reader silently unbounded — the failure that reports PASS. `scrubverbs_test.go` derives the corpus from what privacy actually writes and requires each verb to be judged a scrub or ratified as not one, with the reason. Two mutants confirm it: a new verb, and a verb dropped from the list.

## Tests

Eleven, all against the real column. Two exist because a boundary that held only on the unfiltered first page would be no boundary — it holds on every narrowed page and on the page after the first.

One of them was rewritten during review: the original seeded a tombstone and asserted the read stopped at it, which proves the read and nothing about the write — and the write was the defect. There is now an end-to-end test running the real `ErasePerson` over a real attachment. Reverting the erasure change turns it red.

## Verification

- integration lane green — 44 packages, 3303 tests, 0 skips
- `make check` green; `craft static --strict` clean; cold-cache lint clean
- coverage: `UnscrubbedImageSQL` and `ScrubVerbs` 100%, `scanAuditEntry` 92.9%, `ListAuditLog` 81.1%
- reviewed by Fable and Codex; every finding either fixed or answered

## Known limit

This bounds the READS. The images are still physically in the table, because the table forbids rewriting them — that is the design, and this change does not alter it. What it changes is that all four readers now agree about where to stop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy Enhancements**
  * Improved audit-log exports to hide values confirmed as erased while preserving audit history and metadata.
  * Erasure, anonymization, and restriction actions now consistently redact affected images and related collateral.
  * Attachment and scheduled-send cleanup now records the applicable erasure reason, including retention-driven cleanup.

* **Performance**
  * Added an index to improve audit scrub-boundary queries.

* **Quality**
  * Expanded integration coverage for privacy boundaries, exports, attachment cleanup, and audit-verb classification.
  * Updated privacy documentation with the latest validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->