### PR TITLE
fix(approvals): a staged call says what it does, not which route it took

### DIFF
--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -194,7 +194,7 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 		DiffHash:       diffHash,
 		TargetType:     target.TargetType,
 		TargetID:       target.TargetID,
-		Summary:        restSummary(pol.Op, r.Method, r.URL.Path, body),
+		Summary:        restSummary(pol, r, body),
 	})
 	if sErr != nil {
 		httperr.Write(w, r, sErr)

--- a/backend/internal/compose/agentgatestaging.go
+++ b/backend/internal/compose/agentgatestaging.go
@@ -224,13 +224,13 @@ func stageRefusal(w http.ResponseWriter, r *http.Request, staging agents.Approva
 // about it.
 //
 // Only the target is taken from the resolver. The line the human reads stays
-// this door's own (restSummary), because a REST summary names the concrete
-// method, path and body fields that this door's diff_hash actually binds.
-// Adopting the resolver's line on this door as well is blocked on the six types
-// the record seam does not serve: it can label those by id alone, so the change
-// would put "Archive tag 0195c3…" in front of an approver where the operation
-// and path stand today (margince/margince#1021 is where those types get
-// a name).
+// this door's own (restSummary), which now names the ACT — the contract's tool
+// verb and record type — plus the body fields this door's diff_hash binds. The
+// method and path it used to print are gone: a uuid names a record the reader
+// cannot open from it, and an operationId is the contract's word rather than
+// theirs. Adopting the resolver's line here instead is still blocked on the six
+// types the record seam does not serve: it labels those by id alone, which is
+// the same defect one layer over.
 //
 // It writes the refusal itself and reports ok=false, so a caller that cannot
 // name a target stages nothing.

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -298,7 +298,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		// write them to: "overwrite human-edited amount_minor" told an
 		// approver which field was at stake and never with what.
 		Summary: "overwrite human-edited " + strings.Join(split.Conflicts, ", ") + " — " +
-			restSummary(pol.Op, r.Method, r.URL.Path, split.Staged),
+			restSummary(pol, r, split.Staged),
 	})
 	if sErr != nil {
 		httperr.Write(w, r, fmt.Errorf("the other fields were updated, but staging the human-edited fields (%s) failed: %w",

--- a/backend/internal/compose/agentsummary.go
+++ b/backend/internal/compose/agentsummary.go
@@ -59,7 +59,7 @@ func restSummary(pol agentPolicy, r *http.Request, body []byte) string {
 	// old head carried it by accident, inside the path; naming it is what keeps
 	// an approver able to tell which deal they are pricing.
 	if pol.Tool == toolCreateRecord {
-		if parent := chi.URLParam(r, "id"); parent != "" {
+		if parent := createdUnder(r); parent != "" {
 			fields = append([]string{"under=" + parent}, fields...)
 		}
 	}
@@ -67,6 +67,28 @@ func restSummary(pol agentPolicy, r *http.Request, body []byte) string {
 		return head
 	}
 	return head + ": " + strings.Join(fields, ", ")
+}
+
+// createdUnder is the record a nested create hangs off.
+//
+// The INNERMOST routed id, not `{id}`: a deal-room comment is posted to
+// /deal-rooms/{id}/threads/{threadId}/comments and belongs to the THREAD, so
+// naming the room would tell a reader which conversation it was in and not
+// which exchange. A flat create names no parent and returns empty.
+func createdUnder(r *http.Request) string {
+	rctx := chi.RouteContext(r.Context())
+	if rctx == nil {
+		return ""
+	}
+	// chi appends params in the order the pattern declares them, so the last
+	// one is the deepest.
+	keys := rctx.URLParams.Keys
+	for i := len(keys) - 1; i >= 0; i-- {
+		if value := rctx.URLParams.Values[i]; value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // actPhrase names the act in words: "Update a deal", "Send an email".
@@ -77,6 +99,14 @@ func restSummary(pol agentPolicy, r *http.Request, body []byte) string {
 func actPhrase(pol agentPolicy, method, path string) string {
 	if pol.Tool == "" {
 		return fmt.Sprintf("%s (%s %s)", pol.Op, method, path)
+	}
+	// Some verbs cover two acts a reader must tell apart. `enrich` is both a
+	// one-page read and a whole-site crawl; `update_record` on a custom field
+	// is both retiring the field and changing what it offers. The verb cannot
+	// distinguish them — only the operation can, so where one is named here it
+	// wins.
+	if phrase, named := opPhrases[pol.Op]; named {
+		return phrase
 	}
 	verb := strings.ReplaceAll(pol.Tool, "_", " ")
 	// Only the GENERIC verbs need the record type to mean anything: "update
@@ -94,6 +124,32 @@ func actPhrase(pol agentPolicy, method, path string) string {
 func recordNoun(record agentRecordType) string {
 	return strings.ReplaceAll(string(record), "_", " ")
 }
+
+// opPhrases names the acts whose VERB is not enough to tell them apart.
+//
+// Deliberately keyed by operation rather than by route: the operation is what
+// the contract declares and what the policy carries, and a route pattern would
+// be a second spelling of it. Held by TestNoTwoStageableActsShareAHeadline,
+// which fails when a new pair collides.
+var opPhrases = map[string]string{
+	opScrapeCompany:            "Read this company's website",
+	opDeepReadCompany:          "Read this company's whole site",
+	opRetireCustomField:        "Retire a custom field",
+	opUpdateCustomFieldOptions: "Change a custom field's options",
+}
+
+// The operations whose headline this file names.
+//
+// A typo here leaves an act sharing a headline with its sibling, which is the
+// exact defect opPhrases exists to prevent — so the names are checked against
+// the generated policy table rather than trusted.
+// Held by: TestNoTwoStageableActsShareAHeadline (this package).
+const (
+	opScrapeCompany            = "scrapeCompany"
+	opDeepReadCompany          = "deepReadCompany"
+	opRetireCustomField        = "retireCustomField"
+	opUpdateCustomFieldOptions = "updateCustomFieldOptions"
+)
 
 // genericVerbs are the tools whose name carries no record: they act on
 // whatever the route points at, so the record type is the other half of what

--- a/backend/internal/compose/agentsummary.go
+++ b/backend/internal/compose/agentsummary.go
@@ -23,8 +23,11 @@ package compose
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 )
 
 // summaryFieldLimit bounds how many body fields a summary enumerates. A
@@ -36,17 +39,78 @@ const summaryFieldLimit = 8
 // cannot crowd out the fields after it.
 const summaryValueLimit = 48
 
-// restSummary describes the staged call: the operation and its concrete
-// path, plus the request body's own top-level fields. A body-less action
-// route (send this offer, archive this record) names the operation alone —
-// which is the whole change, and says so.
-func restSummary(op, method, path string, body []byte) string {
-	head := fmt.Sprintf("%s (%s %s)", op, method, path)
+// restSummary describes the staged call: what it does to what, plus the
+// request body's own top-level fields. A body-less action route (send this
+// offer, archive this record) names the act alone — which is the whole change,
+// and says so.
+//
+// The head used to be the operationId and the concrete path —
+// "updateDeal (PATCH /v1/deals/018f2a10-0000-7000-8000-00000000000a)" — which
+// put a camelCase identifier and a uuid at the top of a card somebody had to
+// decide. Neither told them anything: the uuid names a record they cannot read
+// from it, and the operationId is the contract's word, not theirs. The tool
+// verb and the record type are already on the policy, and together they are the
+// sentence.
+func restSummary(pol agentPolicy, r *http.Request, body []byte) string {
+	head := actPhrase(pol, r.Method, r.URL.Path)
 	fields := summaryFields(body)
+	// A CREATE is routed by its parent — createOffer posts under the deal the
+	// offer would belong to — and the parent appears nowhere in the body. The
+	// old head carried it by accident, inside the path; naming it is what keeps
+	// an approver able to tell which deal they are pricing.
+	if pol.Tool == toolCreateRecord {
+		if parent := chi.URLParam(r, "id"); parent != "" {
+			fields = append([]string{"under=" + parent}, fields...)
+		}
+	}
 	if len(fields) == 0 {
 		return head
 	}
 	return head + ": " + strings.Join(fields, ", ")
+}
+
+// actPhrase names the act in words: "Update a deal", "Send an email".
+//
+// Falls back to the operation and its path when the policy declares no tool —
+// a route with no verb has nothing better to say, and the old shape is at least
+// unambiguous to whoever has to debug it.
+func actPhrase(pol agentPolicy, method, path string) string {
+	if pol.Tool == "" {
+		return fmt.Sprintf("%s (%s %s)", pol.Op, method, path)
+	}
+	verb := strings.ReplaceAll(pol.Tool, "_", " ")
+	// Only the GENERIC verbs need the record type to mean anything: "update
+	// record" says nothing until it says which. Every other verb already names
+	// its own object — "send email" told against `activity` would read as
+	// "Send email: activity", which is worse than the verb alone.
+	if pol.RecordType == "" || !genericVerbs[pol.Tool] {
+		return upperFirst(verb)
+	}
+	return fmt.Sprintf("%s %s", upperFirst(verb), recordNoun(pol.RecordType))
+}
+
+// recordNoun is the record type as a reader says it: the wire spells
+// `deal_room`, a person says "deal room".
+func recordNoun(record agentRecordType) string {
+	return strings.ReplaceAll(string(record), "_", " ")
+}
+
+// genericVerbs are the tools whose name carries no record: they act on
+// whatever the route points at, so the record type is the other half of what
+// they do rather than a repetition of it.
+var genericVerbs = map[string]bool{
+	toolUpdateRecord:  true,
+	toolCreateRecord:  true,
+	toolArchiveRecord: true,
+	toolMergeRecords:  true,
+}
+
+// upperFirst capitalises the phrase, which is a sentence rather than a label.
+func upperFirst(phrase string) string {
+	if phrase == "" {
+		return phrase
+	}
+	return strings.ToUpper(phrase[:1]) + phrase[1:]
 }
 
 // summaryFields renders the body's top-level entries as key=value, sorted so

--- a/backend/internal/compose/agentsummary_test.go
+++ b/backend/internal/compose/agentsummary_test.go
@@ -9,16 +9,24 @@ package compose
 // operation, and the values the call would actually write.
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
+// summaryRequest is the request shape restSummary reads: the method, the path,
+// and the routed {id} a nested create is posted under.
+func summaryRequest(method, path string) *http.Request {
+	return httptest.NewRequest(method, path, nil)
+}
+
 func TestRestSummaryNamesTheValuesTheCallWouldWrite(t *testing.T) {
-	got := restSummary("updateDeal", "PATCH", "/v1/deals/018f2a10-0000-7000-8000-00000000000a",
+	pol := agentPolicy{Op: "updateDeal", Tool: "update_record", RecordType: recordTypeDeal}
+	got := restSummary(pol, summaryRequest("PATCH", "/v1/deals/018f2a10-0000-7000-8000-00000000000a"),
 		[]byte(`{"amount_minor":100,"currency":"EUR","expected_close_date":"2027-06-30"}`))
 
 	for _, want := range []string{
-		"updateDeal", "PATCH", "/v1/deals/018f2a10-0000-7000-8000-00000000000a",
 		"amount_minor=100", "currency=EUR", "expected_close_date=2027-06-30",
 	} {
 		if !strings.Contains(got, want) {
@@ -27,12 +35,52 @@ func TestRestSummaryNamesTheValuesTheCallWouldWrite(t *testing.T) {
 	}
 }
 
+// The head is a sentence, not the contract's own vocabulary.
+//
+// It used to read "updateDeal (PATCH /v1/deals/018f2a10-…)": a camelCase
+// operationId and a uuid, at the top of a card somebody had to decide. Neither
+// tells a reader anything — the uuid names a record they cannot read from it,
+// and the operationId is the contract's word rather than theirs.
+func TestRestSummaryLeadsWithTheActRatherThanTheRoute(t *testing.T) {
+	pol := agentPolicy{Op: "updateDeal", Tool: "update_record", RecordType: recordTypeDeal}
+	got := restSummary(pol, summaryRequest("PATCH", "/v1/deals/018f2a10-0000-7000-8000-00000000000a"),
+		[]byte(`{"amount_minor":100}`))
+
+	if !strings.HasPrefix(got, "Update record deal") {
+		t.Errorf("summary %q does not open by naming the act", got)
+	}
+	for _, unwanted := range []string{"updateDeal", "PATCH", "018f2a10"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("summary %q still carries %q, which says nothing to the person deciding", got, unwanted)
+		}
+	}
+}
+
+// A verb that already names its own record does not say it twice.
+func TestRestSummaryDoesNotRepeatTheRecordTheVerbNames(t *testing.T) {
+	pol := agentPolicy{Op: "sendEmail", Tool: "send_email", RecordType: recordTypeActivity}
+	got := restSummary(pol, summaryRequest("POST", "/v1/activities/018f2a10-0000-7000-8000-00000000beef/send-email"), nil)
+	if got != "Send email" {
+		t.Errorf("summary is %q, want a sentence that names the act once", got)
+	}
+}
+
+// A route the contract gives no verb has nothing better to say than what it is.
+func TestRestSummaryFallsBackToTheRouteWhenNoVerbIsDeclared(t *testing.T) {
+	pol := agentPolicy{Op: "someInternalThing"}
+	got := restSummary(pol, summaryRequest("POST", "/v1/internal/thing"), nil)
+	if !strings.Contains(got, "someInternalThing") || !strings.Contains(got, "/v1/internal/thing") {
+		t.Errorf("summary %q drops the only identification an undeclared route has", got)
+	}
+}
+
 // A body-less action route (send this offer, archive this record) has no
 // fields to name, and the operation IS the whole change.
 func TestRestSummaryOfABodylessActionNamesTheOperation(t *testing.T) {
-	got := restSummary("sendOffer", "POST", "/v1/offers/018f2a10-0000-7000-8000-00000000beef/send", nil)
-	if !strings.Contains(got, "sendOffer") || !strings.Contains(got, "/send") {
-		t.Errorf("summary %q does not name the operation", got)
+	pol := agentPolicy{Op: "sendOffer", Tool: "send_offer", RecordType: recordTypeOffer}
+	got := restSummary(pol, summaryRequest("POST", "/v1/offers/018f2a10-0000-7000-8000-00000000beef/send"), nil)
+	if !strings.Contains(got, "Send offer") {
+		t.Errorf("summary %q does not name the act", got)
 	}
 	if strings.Contains(got, ":") && strings.HasSuffix(got, ":") {
 		t.Errorf("summary %q trails an empty field list", got)
@@ -55,7 +103,7 @@ func TestRestSummaryBoundsAWidePatch(t *testing.T) {
 	}
 	b.WriteString("}")
 
-	got := restSummary("updatePerson", "PATCH", "/v1/people/x", []byte(b.String()))
+	got := restSummary(agentPolicy{Op: "updatePerson", Tool: "update_record", RecordType: recordTypePerson}, summaryRequest("PATCH", "/v1/people/x"), []byte(b.String()))
 	if !strings.Contains(got, "more") {
 		t.Errorf("a 30-field patch was not bounded: %q", got)
 	}
@@ -66,7 +114,7 @@ func TestRestSummaryBoundsAWidePatch(t *testing.T) {
 
 // A single long value cannot crowd out the fields after it.
 func TestRestSummaryBoundsOneLongValue(t *testing.T) {
-	got := restSummary("updatePerson", "PATCH", "/v1/people/x",
+	got := restSummary(agentPolicy{Op: "updatePerson", Tool: "update_record", RecordType: recordTypePerson}, summaryRequest("PATCH", "/v1/people/x"),
 		[]byte(`{"notes":"`+strings.Repeat("a", 500)+`","title":"CEO"}`))
 	if !strings.Contains(got, "title=CEO") {
 		t.Errorf("a long value crowded out the field after it: %q", got)
@@ -79,7 +127,7 @@ func TestRestSummaryBoundsOneLongValue(t *testing.T) {
 // Nested structure is named and counted rather than expanded — the summary
 // answers "what shape", the envelope answers "what exactly".
 func TestRestSummaryCountsNestedStructure(t *testing.T) {
-	got := restSummary("createOffer", "POST", "/v1/deals/x/offers",
+	got := restSummary(agentPolicy{Op: "createOffer", Tool: "create_record", RecordType: recordTypeOffer}, summaryRequest("POST", "/v1/deals/x/offers"),
 		[]byte(`{"currency":"EUR","line_items":[{"description":"Pilot"},{"description":"Support"}]}`))
 	if !strings.Contains(got, "line_items=[2]") {
 		t.Errorf("summary %q does not count the nested line items", got)
@@ -92,11 +140,11 @@ func TestRestSummaryCountsNestedStructure(t *testing.T) {
 // renders `owner_id=` for both — which reads like nothing is happening on the
 // one that hands the record to nobody.
 func TestRestSummaryDistinguishesNullFromEmpty(t *testing.T) {
-	cleared := restSummary("updateDeal", "PATCH", "/v1/deals/x", []byte(`{"owner_id":null}`))
+	cleared := restSummary(agentPolicy{Op: "updateDeal", Tool: "update_record", RecordType: recordTypeDeal}, summaryRequest("PATCH", "/v1/deals/x"), []byte(`{"owner_id":null}`))
 	if !strings.Contains(cleared, "owner_id=null") {
 		t.Errorf("summary %q does not show that owner_id is being CLEARED", cleared)
 	}
-	emptied := restSummary("updateDeal", "PATCH", "/v1/deals/x", []byte(`{"owner_id":""}`))
+	emptied := restSummary(agentPolicy{Op: "updateDeal", Tool: "update_record", RecordType: recordTypeDeal}, summaryRequest("PATCH", "/v1/deals/x"), []byte(`{"owner_id":""}`))
 	if strings.Contains(emptied, "owner_id=null") {
 		t.Errorf("summary %q reports an empty string as a clear", emptied)
 	}

--- a/backend/internal/compose/agentsummary_test.go
+++ b/backend/internal/compose/agentsummary_test.go
@@ -9,16 +9,57 @@ package compose
 // operation, and the values the call would actually write.
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 )
 
-// summaryRequest is the request shape restSummary reads: the method, the path,
-// and the routed {id} a nested create is posted under.
-func summaryRequest(method, path string) *http.Request {
-	return httptest.NewRequest(method, path, nil)
+// summaryRequest is the request shape restSummary reads. `params` are the
+// routed values in the order the pattern declares them — chi keeps that order,
+// and a nested create reads the LAST of them.
+func summaryRequest(method, path string, params ...[2]string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	rctx := chi.NewRouteContext()
+	for _, p := range params {
+		rctx.URLParams.Add(p[0], p[1])
+	}
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// A nested create names the record it hangs off, and it is the INNERMOST one.
+//
+// A deal-room comment is posted to /deal-rooms/{id}/threads/{threadId}/comments
+// and belongs to the thread. Naming `{id}` would tell a reader which
+// conversation it was in and not which exchange — two comments with the same
+// body on different threads in one room would read identically. The first
+// version of this did exactly that, and no test caught it because none of them
+// installed a route context at all.
+func TestANestedCreateNamesTheRecordItHangsOff(t *testing.T) {
+	pol := agentPolicy{Op: "replyDealRoomThread", Tool: "create_record", RecordType: recordTypeDealRoomComment}
+	req := summaryRequest("POST", "/v1/deal-rooms/room-1/threads/thread-9/comments",
+		[2]string{"id", "room-1"}, [2]string{"threadId", "thread-9"})
+
+	got := restSummary(pol, req, []byte(`{"body":"Sounds good"}`))
+	if !strings.Contains(got, "under=thread-9") {
+		t.Errorf("summary %q does not name the thread the comment attaches to", got)
+	}
+	if strings.Contains(got, "under=room-1") {
+		t.Errorf("summary %q names the room, which does not identify the exchange", got)
+	}
+}
+
+// A flat create has no parent, and inventing one would be worse than silence.
+func TestAFlatCreateNamesNoParent(t *testing.T) {
+	pol := agentPolicy{Op: "createCustomField", Tool: "create_record", RecordType: recordTypeCustomField}
+	got := restSummary(pol, summaryRequest("POST", "/v1/custom-fields"), []byte(`{"key":"industry"}`))
+	if strings.Contains(got, "under=") {
+		t.Errorf("summary %q claims a parent a top-level create does not have", got)
+	}
 }
 
 func TestRestSummaryNamesTheValuesTheCallWouldWrite(t *testing.T) {
@@ -153,14 +194,61 @@ func TestRestSummaryDistinguishesNullFromEmpty(t *testing.T) {
 	}
 }
 
-// Every verb that can actually reach a decision card reads as a sentence.
+// No two acts a human can be asked to decide share a headline.
 //
-// The corpus is derived rather than listed: a tool is stageable only when the
-// contract gives it a tier other than auto_execute, and it is exactly those
-// nine pairs whose summary a human ever sees. A verb added to that set with a
-// name that does not carry its own record — and no entry in genericVerbs —
-// would put "Do thing" on a card and drop which record it was about.
-func TestEveryStageableVerbNamesWhatItActsOn(t *testing.T) {
+// This is the property the whole change exists for. A verb often covers more
+// than one operation — `enrich` is both a one-page read and a whole-site crawl,
+// `update_record` on a custom field is both retiring it and changing what it
+// offers — and where two of those are BOTH confirm-first, one headline for two
+// acts asks somebody to approve a thing they cannot identify.
+//
+// Derived from the policy table rather than listed, so a contract change that
+// creates a new collision fails here instead of reaching a card.
+func TestNoTwoStageableActsShareAHeadline(t *testing.T) {
+	byPhrase := map[string][]string{}
+	// A verb covering several stageable operations must name each of them, or
+	// the ones it does not name collapse together. Checking only for identical
+	// phrases is not enough: naming ONE of a colliding pair separates them
+	// while leaving the other reading "Enrich organization", which still does
+	// not say which enrichment a reader is approving.
+	byVerb := map[string]map[string]bool{}
+	for _, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tier == tierAutoExecute {
+			continue
+		}
+		phrase := actPhrase(pol, "POST", "/v1/x")
+		byPhrase[phrase] = append(byPhrase[phrase], pol.Op)
+		// Keyed by verb AND record, because the generic verbs already separate
+		// two acts that differ only by what they act on: "Create record custom
+		// field" and "Create record webhook subscription" are distinct without
+		// naming either operation. What needs naming is two acts the headline
+		// cannot separate at all.
+		act := pol.Tool + "/" + string(pol.RecordType)
+		if byVerb[act] == nil {
+			byVerb[act] = map[string]bool{}
+		}
+		byVerb[act][pol.Op] = true
+	}
+	for phrase, ops := range byPhrase {
+		if len(ops) > 1 {
+			sort.Strings(ops)
+			t.Errorf("%q is the headline for %v — a reader cannot tell which they are approving", phrase, ops)
+		}
+	}
+	for act, ops := range byVerb {
+		if len(ops) < 2 {
+			continue
+		}
+		for op := range ops {
+			if _, named := opPhrases[op]; !named {
+				t.Errorf("%s covers %d stageable acts and %q is not named in opPhrases — its headline cannot identify it", act, len(ops), op)
+			}
+		}
+	}
+}
+
+// Every headline a human can meet is words, never a wire identifier.
+func TestEveryStageableActReadsAsWords(t *testing.T) {
 	for key, pol := range agentPolicies {
 		if pol.Access != accessTool || pol.Tier == tierAutoExecute {
 			continue
@@ -169,13 +257,6 @@ func TestEveryStageableVerbNamesWhatItActsOn(t *testing.T) {
 		if phrase == "" {
 			t.Errorf("%s: staged calls render an empty headline", key)
 			continue
-		}
-		// Either the verb names its own object, or the record type is appended.
-		namesRecord := strings.Contains(phrase, recordNoun(pol.RecordType))
-		verbCarriesIt := pol.RecordType == "" ||
-			strings.Contains(strings.ReplaceAll(pol.Tool, "_", " "), string(pol.RecordType))
-		if !namesRecord && !verbCarriesIt && genericVerbs[pol.Tool] {
-			t.Errorf("%s: %q names neither the verb's object nor its record type", key, phrase)
 		}
 		if strings.Contains(phrase, "_") {
 			t.Errorf("%s: %q still carries a wire identifier", key, phrase)

--- a/backend/internal/compose/agentsummary_test.go
+++ b/backend/internal/compose/agentsummary_test.go
@@ -152,3 +152,33 @@ func TestRestSummaryDistinguishesNullFromEmpty(t *testing.T) {
 		t.Error("clearing a field and emptying it render identically")
 	}
 }
+
+// Every verb that can actually reach a decision card reads as a sentence.
+//
+// The corpus is derived rather than listed: a tool is stageable only when the
+// contract gives it a tier other than auto_execute, and it is exactly those
+// nine pairs whose summary a human ever sees. A verb added to that set with a
+// name that does not carry its own record — and no entry in genericVerbs —
+// would put "Do thing" on a card and drop which record it was about.
+func TestEveryStageableVerbNamesWhatItActsOn(t *testing.T) {
+	for key, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tier == tierAutoExecute {
+			continue
+		}
+		phrase := actPhrase(pol, "POST", "/v1/x")
+		if phrase == "" {
+			t.Errorf("%s: staged calls render an empty headline", key)
+			continue
+		}
+		// Either the verb names its own object, or the record type is appended.
+		namesRecord := strings.Contains(phrase, recordNoun(pol.RecordType))
+		verbCarriesIt := pol.RecordType == "" ||
+			strings.Contains(strings.ReplaceAll(pol.Tool, "_", " "), string(pol.RecordType))
+		if !namesRecord && !verbCarriesIt && genericVerbs[pol.Tool] {
+			t.Errorf("%s: %q names neither the verb's object nor its record type", key, phrase)
+		}
+		if strings.Contains(phrase, "_") {
+			t.Errorf("%s: %q still carries a wire identifier", key, phrase)
+		}
+	}
+}


### PR DESCRIPTION
Every proposal an agent staged over REST led with the contract's own vocabulary and a uuid:

```
updateDeal (PATCH /v1/deals/018f2a10-0000-7000-8000-00000000000a): stage_id=…
```

That string is the **headline of a card somebody has to decide**. Neither half helps them: the uuid names a record they cannot open from it, and the operationId is the word the contract uses, not the word they do.

The tool verb and the record type were already on the policy, and together they are the sentence:

```
Update record deal: amount_minor=4500000, currency=EUR, expected_close_date=2026-09-27
Send email: subject=Follow-up, to=anna@example.com
Archive record activity
```

The record type is appended only for the **generic** verbs — update, create, archive, merge — because those say nothing until they say which record. Every other verb already names its object, and "Send email: activity" is worse than "Send email".

## What the audit turned up

Of 38 REST-gated verbs, 29 are `auto_execute` and never stage anything, so only **9 verb/record pairs** can ever reach a human. Two of those collapsed two different acts into one headline:

- **`enrich`** — one route reads a single page, the other crawls the whole site. Both confirm-first, both rendered "Enrich".
- **`update_record` on a custom field** — retiring the field and changing its options are different decisions with one name.

Where the verb cannot separate two acts, the operation names them. `TestNoTwoStageableActsShareAHeadline` derives the corpus from the policy table and fails when a contract change creates a new collision.

## Bugs found while fixing it

- **A nested create named the wrong parent.** A deal-room comment belongs to the thread, not the room; the code took `{id}`. Two comments with the same body on different threads would have read identically. Latent (both routes are auto-execute) but wrong for the routes it covered.
- **`under=` had no test.** Every case built its request without a chi route context, so the branch never ran — including the nested-offer case that looked like it covered this.
- **A regression the existing suite caught:** a CREATE is routed by its parent, so the deal an offer belongs to appeared only inside the path. `TestCreateOfferStagesNoIDThroughStageRefusal` failed the moment I dropped it. The parent is now named on purpose.

Also corrected a comment at the staging door that described the summary as naming the concrete method and path — and argued for keeping it that way.

`make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Approval cards for staged REST calls now open with the act (tool verb + record) and the values to be written, instead of the operationId and route UUID. This makes summaries readable, avoids ambiguous headlines, and includes the parent record for creates.

- Generic verbs append the record type; other verbs don’t repeat it.
- Creates add under=<parent-id> from the innermost routed param.
- Routes without a declared tool fall back to the old “op (METHOD path)” form.
- Disambiguates stageable acts that shared a headline by naming the operation where needed (e.g., “Read this company’s website” vs “Read this company’s whole site”; “Retire a custom field” vs “Change a custom field’s options”).
- Adds tests that: prevent headline collisions, ensure headlines are words (not wire ids), verify nested parent detection, and bound field listings.

**Bug Fixes**
- Nested creates previously named the wrong parent (took {id} instead of the innermost id). Now fixed and covered by tests.
- The under= path-derived parent had no coverage; tests added.
- Restored explicit parent naming for creates routed by their parent to avoid losing context in summaries.

<sup>Written for commit bf94fa83f97b8793021a25b3e76d14a094333fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Approval summaries now use clearer, human-readable descriptions of requested actions.
  * Summaries distinguish between similar operations and identify the relevant record type.
  * Nested record creation summaries include the applicable parent record for additional context.
  * Duplicate record names are avoided, and complex or lengthy field values are presented more consistently.
  * Existing fallback details remain available when richer policy context is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->