### PR TITLE
fix(siteread): the crawl boundary follows the seed's redirect, and no later page may move it

### DIFF
--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -230,6 +230,7 @@ func (c *siteCrawler) CrawlStream(ctx context.Context, seedURL string, onPage fu
 	defer cancel()
 	pacer := c.newPacer()
 
+	requestedSeed := seedURL
 	seedURL, seedPage, err := c.fetchSeed(ctx, pacer, seedURL)
 	if err != nil {
 		return siteCrawl{}, err
@@ -240,6 +241,9 @@ func (c *siteCrawler) CrawlStream(ctx context.Context, seedURL string, onPage fu
 	}
 
 	run := newCrawlRun(c, pacer, seedURL, seedPage)
+	// The seed may have answered from another URL than the one asked for; a
+	// nav link back to the requested spelling is still the page already read.
+	run.markVisited(requestedSeed)
 	run.onPage = onPage
 	if onPage != nil {
 		onPage(run.crawl.Pages[0]) // the seed page is committed already
@@ -346,12 +350,11 @@ func untakenCandidates(queue []crawlCandidate, taken []bool) []crawlCandidate {
 	return rest
 }
 
-// fetchPaced is one polite fetch: pacer slot in, fetch, slot out.
 func newCrawlRun(c *siteCrawler, pacer crawlPacer, seedURL string, seedPage webread.Page) *crawlRun {
+	// Nav links back to the landing page arrive normalized; both spellings
+	// of the seed are the page already read.
 	visited := map[string]bool{seedURL: true}
 	if normalizedSeed, ok := normalizeCandidate(seedURL); ok {
-		// Nav links back to the landing page arrive normalized; both
-		// spellings of the seed are the page already read.
 		visited[normalizedSeed] = true
 	}
 	return &crawlRun{
@@ -396,6 +399,15 @@ func (r *crawlRun) discover(ctx context.Context, origin string, seedPage webread
 		r.queue = append(r.queue, crawlCandidate{url: loc})
 	}
 	r.queue = append(r.queue, linkCandidates(seedPage.Links)...)
+}
+
+// markVisited records a URL as already read, under both its literal and its
+// normalized spelling — the two forms a later candidate can arrive in.
+func (r *crawlRun) markVisited(rawURL string) {
+	r.visited[rawURL] = true
+	if normalized, ok := normalizeCandidate(rawURL); ok {
+		r.visited[normalized] = true
+	}
 }
 
 func (r *crawlRun) skip(candURL string, reason crmcontracts.SiteReadSkipReason) {

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -54,6 +54,10 @@ type fakeSitePage struct {
 	text   string
 	links  []string
 	robots bool
+	// finalURL is where this page's body "came from" — set it to model a
+	// redirect; empty means the page answered where it was asked, which is
+	// what webread.FetchPage reports for an unredirected fetch.
+	finalURL string
 	// ogImage and icons are the visual identity this page declares, the
 	// input the logo resolve ranks over.
 	ogImage string
@@ -87,8 +91,12 @@ func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, er
 	if page.robots {
 		return webread.Page{}, webread.ErrRobotsDisallowed
 	}
+	finalURL := page.finalURL
+	if finalURL == "" {
+		finalURL = rawURL
+	}
 	return webread.Page{
-		URL: rawURL, Text: page.text, Links: page.links, Bytes: len(page.text),
+		URL: rawURL, FinalURL: finalURL, Text: page.text, Links: page.links, Bytes: len(page.text),
 		OGImage: page.ogImage, Icons: page.icons,
 	}, nil
 }

--- a/backend/internal/compose/sitecrawlfetch.go
+++ b/backend/internal/compose/sitecrawlfetch.go
@@ -37,6 +37,7 @@ func (c *siteCrawler) ReadSeed(ctx context.Context, seedURL string) (crawlPage, 
 	}, nil
 }
 
+// fetchPaced is one polite fetch: pacer slot in, fetch, slot out.
 func (c *siteCrawler) fetchPaced(ctx context.Context, pacer crawlPacer, rawURL string) (webread.Page, error) {
 	if err := pacer.Wait(ctx); err != nil {
 		return webread.Page{}, err

--- a/backend/internal/compose/sitecrawlredirect_test.go
+++ b/backend/internal/compose/sitecrawlredirect_test.go
@@ -196,3 +196,28 @@ func TestCrawlEvidenceNamesTheURLThatServedThePage(t *testing.T) {
 		t.Fatalf("the redirect target was fetched again %d times although its content was already read", site.pageCalls[newPath])
 	}
 }
+
+func TestCrawlClassifiesARedirectedPageByItsDestination(t *testing.T) {
+	// A guessed /impressum that forwards to a careers page is not a legal
+	// notice: the committed kind follows the URL that served the body, and
+	// the unsatisfied probe kind stays open, so the next legal-page guess is
+	// still tried and the entity census still gets its page.
+	site := &fakeSite{pages: seedOnly()}
+	site.pages[seedURL+"/impressum"] = fakeSitePage{finalURL: seedURL + "/jobs", text: readable("Open roles at Acme.")}
+	site.pages[seedURL+"/imprint"] = fakeSitePage{text: readable("Acme GmbH, HRB 12345.")}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := map[string]crmcontracts.SiteReadPageKind{}
+	for _, page := range crawl.Pages {
+		kinds[page.URL] = page.Kind
+	}
+	if kinds[seedURL+"/jobs"] != crmcontracts.SiteReadPageKindOther {
+		t.Fatalf("the careers destination was committed as %q, want other: %v", kinds[seedURL+"/jobs"], kinds)
+	}
+	if kinds[seedURL+"/imprint"] != crmcontracts.SiteReadPageKindImpressum {
+		t.Fatalf("the impressum kind was closed by a redirected probe; pages = %v", kinds)
+	}
+}

--- a/backend/internal/compose/sitecrawlredirect_test.go
+++ b/backend/internal/compose/sitecrawlredirect_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a redirect means to the crawl. The fetch follows redirects, so the
+// requested URL and the URL that served the body can be two different sites.
+// The SEED's redirect is the site's own answer about where it lives — the
+// crawl boundary, probe origin, pacing and evidence all move with it. A LATER
+// page's redirect never moves anything: off-site destinations are discarded
+// unread, exactly like off-site links.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestCrawlFollowsTheSeedRedirectOntoAnotherDomain(t *testing.T) {
+	// The imported domain answers 301 onto a different registrable domain —
+	// acme.co forwarding to www.acme.vn. Every useful link on the landing page
+	// names the destination; a crawl still bounded by the requested domain
+	// would reject them all and read one page.
+	const requested = "https://acme.co"
+	const answering = "https://www.acme.vn"
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		requested: {
+			finalURL: answering,
+			text:     readable("Welcome to Acme."),
+			links:    []string{answering + "/about"},
+		},
+		answering + "/about": {text: readable("About Acme.")},
+	}}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if crawl.SeedURL != answering {
+		t.Fatalf("SeedURL = %q, want the answering %q", crawl.SeedURL, answering)
+	}
+	if crawl.Pages[0].URL != answering {
+		t.Fatalf("seed evidence URL = %q, want the URL that served it, %q", crawl.Pages[0].URL, answering)
+	}
+	var aboutRead bool
+	for _, page := range crawl.Pages {
+		if page.URL == answering+"/about" {
+			aboutRead = true
+		}
+	}
+	if !aboutRead {
+		t.Fatalf("the destination's own link was not crawled: %v", crawl.Pages)
+	}
+	for _, skip := range crawl.Skipped {
+		if skip.URL == answering+"/about" {
+			t.Fatalf("a destination-site link was skipped as %s", skip.Reason)
+		}
+	}
+	// Discovery probes ask the site that answered, not the forwarder.
+	if !slicesContains(site.fetched, answering+"/impressum") {
+		t.Errorf("probes did not move to the answering origin: %v", site.fetched)
+	}
+	if slicesContains(site.fetched, requested+"/impressum") {
+		t.Errorf("a probe still asked the forwarding host: %v", site.fetched)
+	}
+}
+
+func TestCrawlSeedApexToWWWRedirectReadsThePageOnce(t *testing.T) {
+	// The ordinary case: the apex forwards to www on the same site. The crawl
+	// carries the www identity, and a nav link back to the apex spelling is
+	// the page already read, not a second fetch.
+	const requested = "https://acme.example"
+	const answering = "https://www.acme.example"
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		requested: {
+			finalURL: answering,
+			text:     readable("Welcome home."),
+			links:    []string{requested, answering + "/team"},
+		},
+		answering + "/team": {text: readable("Our team.")},
+	}}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if crawl.SeedURL != answering {
+		t.Fatalf("SeedURL = %q, want %q", crawl.SeedURL, answering)
+	}
+	if site.pageCalls[requested] != 1 {
+		t.Fatalf("the apex spelling was fetched %d times, want once", site.pageCalls[requested])
+	}
+	var teamRead bool
+	for _, page := range crawl.Pages {
+		if page.URL == answering+"/team" {
+			teamRead = true
+		}
+	}
+	if !teamRead {
+		t.Fatalf("a same-site link was not crawled after the seed redirect: %v", crawl.Pages)
+	}
+}
+
+func TestCrawlDiscardsALaterPageThatRedirectsOffSite(t *testing.T) {
+	// A page on the site answering from ANOTHER site is the boundary crossing
+	// the off-domain gate exists for, one fetch later: the body — and every
+	// link in it — must be discarded, and only the seed's redirect may ever
+	// move the boundary.
+	partner := seedURL + "/partner"
+	site := &fakeSite{pages: seedOnly("/partner")}
+	site.pages[partner] = fakeSitePage{
+		finalURL: "https://evil.example/landing",
+		text:     readable("Content served by a different site."),
+		links:    []string{"https://evil.example/deeper"},
+	}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, page := range crawl.Pages {
+		if page.URL == partner || page.URL == "https://evil.example/landing" {
+			t.Fatalf("an off-site-redirecting page was committed as %q", page.URL)
+		}
+	}
+	want := crawlSkip{URL: partner, Reason: crmcontracts.SiteReadSkipReasonOffDomain}
+	var recorded bool
+	for _, skip := range crawl.Skipped {
+		if skip == want {
+			recorded = true
+		}
+	}
+	if !recorded {
+		t.Fatalf("the off-site redirect was not recorded as an off_domain skip: %v", crawl.Skipped)
+	}
+	if slicesContains(site.fetched, "https://evil.example/deeper") {
+		t.Fatal("a link from the discarded off-site body was fetched")
+	}
+}
+
+func TestCrawlPacesToTheAnsweringHostsCrawlDelay(t *testing.T) {
+	// Politeness follows the site that serves, not the host that forwards:
+	// the destination's robots.txt is the one whose Crawl-delay binds.
+	const requested = "https://acme.co"
+	const answering = "https://www.acme.vn"
+	site := &fakeSite{
+		pages: map[string]fakeSitePage{
+			requested: {finalURL: answering, text: readable("Welcome.")},
+		},
+		crawlDelays: map[string]time.Duration{answering: 2 * time.Second},
+	}
+	var slowed time.Duration
+	crawler := testSiteCrawler(site)
+	crawler.newPacer = func() crawlPacer { return instantPacer{slowedTo: &slowed} }
+
+	if _, err := crawler.Crawl(context.Background(), requested); err != nil {
+		t.Fatal(err)
+	}
+	if slowed != 2*time.Second {
+		t.Fatalf("pacer slowed to %s, want the answering host's 2s", slowed)
+	}
+}
+
+func TestCrawlEvidenceNamesTheURLThatServedThePage(t *testing.T) {
+	// A same-site redirect (an old path forwarding to the page's real home):
+	// the committed evidence URL is the destination, and that destination is
+	// marked read so another route to it costs no second fetch. Both paths
+	// classify as "other", so nav insertion order — the old path first —
+	// decides which fetch happens.
+	oldPath := seedURL + "/legacy-page"
+	newPath := seedURL + "/current-page"
+	site := &fakeSite{pages: seedOnly("/legacy-page", "/current-page")}
+	pageText := readable("The page that moved.")
+	site.pages[oldPath] = fakeSitePage{finalURL: newPath, text: pageText}
+	site.pages[newPath] = fakeSitePage{text: pageText}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var served, requestedSpelling bool
+	for _, page := range crawl.Pages {
+		if page.URL == newPath {
+			served = true
+		}
+		if page.URL == oldPath {
+			requestedSpelling = true
+		}
+	}
+	if !served || requestedSpelling {
+		t.Fatalf("evidence should name only the serving URL %q: %v", newPath, crawl.Pages)
+	}
+	if site.pageCalls[newPath] != 0 {
+		t.Fatalf("the redirect target was fetched again %d times although its content was already read", site.pageCalls[newPath])
+	}
+}

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -174,24 +174,29 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		return
 	}
 
-	servedURL := adm.url
-	if page.FinalURL != "" {
+	servedURL, kind := adm.url, adm.kind
+	if page.FinalURL != "" && page.FinalURL != adm.url {
 		// The page's evidence names the URL that actually served it, and that
 		// URL counts as read: a second candidate redirecting to the same
-		// place must not buy another fetch.
+		// place must not buy another fetch. The kind was read off the URL we
+		// asked for, so it is reclassified too — a guessed /impressum
+		// forwarding to a careers page is not a legal notice.
 		servedURL = page.FinalURL
 		r.markVisited(servedURL)
+		kind = classifyKind(servedURL)
 	}
 	r.seenText[page.Text] = true
 	r.canonicalDone[localeCanonical(adm.url)] = true
-	if adm.kind == crmcontracts.SiteReadPageKindImpressum {
+	if kind == crmcontracts.SiteReadPageKindImpressum {
 		r.impressumRead++
 	}
 	r.totalBytes += page.Bytes
-	if adm.cand.probe {
+	if adm.cand.probe && kind == adm.cand.kind {
+		// A probe whose redirect landed on another kind of page did not find
+		// what it guessed at; its kind stays open for the next guess.
 		r.probeKindDone[adm.cand.kind] = true
 	}
-	committed := crawlPage{URL: servedURL, Kind: adm.kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur}
+	committed := crawlPage{URL: servedURL, Kind: kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur}
 	r.crawl.Pages = append(r.crawl.Pages, committed)
 	if r.onPage != nil {
 		r.onPage(committed)

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -144,6 +144,15 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		return
 	}
 	page := res.page
+	if page.FinalURL != "" && !webread.SameRegistrableDomain(r.seedURL, page.FinalURL) {
+		// The candidate was on-site but its server answered from another
+		// site. An off-site redirect is the same boundary crossing as an
+		// off-site link, discovered one fetch later — the body is discarded
+		// unread, links and all. Only the SEED's redirect may move the
+		// boundary (siteseed.go); a later page's never widens it.
+		r.skip(adm.url, crmcontracts.SiteReadSkipReasonOffDomain)
+		return
+	}
 	if utf8.RuneCountInString(page.Text) < crawlMinRunes {
 		r.skip(adm.url, crmcontracts.SiteReadSkipReasonUnreadable)
 		return
@@ -165,6 +174,14 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		return
 	}
 
+	servedURL := adm.url
+	if page.FinalURL != "" {
+		// The page's evidence names the URL that actually served it, and that
+		// URL counts as read: a second candidate redirecting to the same
+		// place must not buy another fetch.
+		servedURL = page.FinalURL
+		r.markVisited(servedURL)
+	}
 	r.seenText[page.Text] = true
 	r.canonicalDone[localeCanonical(adm.url)] = true
 	if adm.kind == crmcontracts.SiteReadPageKindImpressum {
@@ -174,7 +191,7 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 	if adm.cand.probe {
 		r.probeKindDone[adm.cand.kind] = true
 	}
-	committed := crawlPage{URL: adm.url, Kind: adm.kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur}
+	committed := crawlPage{URL: servedURL, Kind: adm.kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur}
 	r.crawl.Pages = append(r.crawl.Pages, committed)
 	if r.onPage != nil {
 		r.onPage(committed)

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -96,7 +96,6 @@ func (r *crawlRun) fetchWave(ctx context.Context, admitted []admission) []fetchR
 	return results
 }
 
-// commit files one fetched result — a page, a recorded skip, a silent
 // legalCensusOpen reports whether an Impressum candidate may still bypass
 // the one-language-per-document rule. The bypass exists because a group's
 // per-locale legal pages can name DIFFERENT legal entities, and the entity

--- a/backend/internal/compose/siteseed.go
+++ b/backend/internal/compose/siteseed.go
@@ -38,8 +38,9 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		page, err = c.fetchPaced(ctx, pacer, seedURL)
 	}
 	if err == nil || errors.Is(err, webread.ErrRobotsDisallowed) {
-		c.applyCrawlDelay(pacer, seedURL)
-		return seedURL, page, err
+		answered := answeredSeedURL(seedURL, page)
+		c.applyCrawlDelay(pacer, answered)
+		return answered, page, err
 	}
 	for _, candidate := range seedFallbacks(seedURL) {
 		if ctx.Err() != nil {
@@ -53,8 +54,9 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 			retryPage, retryErr = c.fetchPaced(ctx, pacer, candidate)
 		}
 		if retryErr == nil {
-			c.applyCrawlDelay(pacer, candidate)
-			return candidate, retryPage, nil
+			answered := answeredSeedURL(candidate, retryPage)
+			c.applyCrawlDelay(pacer, answered)
+			return answered, retryPage, nil
 		}
 		// A refusal is the site's answer, not a spelling that failed to
 		// resolve. Every remaining candidate is the SAME site under another
@@ -65,6 +67,19 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		}
 	}
 	return seedURL, webread.Page{}, err
+}
+
+// answeredSeedURL is the URL the seed's body actually came from. The fetch
+// follows redirects the ladder never sees — a domain answering 301 onto
+// another host "answers" in the ladder's eyes while serving nothing itself —
+// so the crawl boundary, the probe origin and the favicon derivation must all
+// name the destination, not the forwarder. A page without a final URL — the
+// robots-refused seed carries none — answers where it was asked.
+func answeredSeedURL(requested string, page webread.Page) string {
+	if page.FinalURL != "" {
+		return page.FinalURL
+	}
+	return requested
 }
 
 // seedFallbacks returns the other spellings of a seed worth trying, in order,

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -22,10 +22,15 @@ import (
 // declared, and the raw byte count (for the crawl's total byte budget — the
 // stripped text under-counts what was transferred).
 type Page struct {
-	URL   string
-	Text  string
-	Links []string
-	Bytes int
+	URL string
+	// FinalURL is where the body actually came from: the requested URL unless
+	// the server redirected, in which case it names the last hop. A crawler
+	// deciding what counts as on-site must judge by this one — the requested
+	// host may only forward.
+	FinalURL string
+	Text     string
+	Links    []string
+	Bytes    int
 	// OGImage is the og:image the page declared (absolute), or "" when it
 	// declared none.
 	OGImage string
@@ -74,12 +79,13 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 	}
 	ogImage, icons := extractHeadAssets(body, base)
 	return Page{
-		URL:     rawURL,
-		Text:    StripTags(body),
-		Links:   extractLinks(body, base),
-		Bytes:   len(body),
-		OGImage: ogImage,
-		Icons:   icons,
+		URL:      rawURL,
+		FinalURL: base.String(),
+		Text:     StripTags(body),
+		Links:    extractLinks(body, base),
+		Bytes:    len(body),
+		OGImage:  ogImage,
+		Icons:    icons,
 	}, nil
 }
 

--- a/backend/internal/platform/webread/page_test.go
+++ b/backend/internal/platform/webread/page_test.go
@@ -101,6 +101,46 @@ func TestFetchPageKeepsTheTextContractAndHarvestsLinks(t *testing.T) {
 	if page.Bytes != len(pageHTML) {
 		t.Fatalf("Page.Bytes = %d, want the raw size %d", page.Bytes, len(pageHTML))
 	}
+	// An unredirected page came from where it was asked.
+	if page.FinalURL != srv.URL+"/" {
+		t.Fatalf("Page.FinalURL = %q, want the requested %q", page.FinalURL, srv.URL+"/")
+	}
+}
+
+func TestFetchPageReportsWhereARedirectedBodyCameFrom(t *testing.T) {
+	// A crawler that only knows the requested URL treats every link on a
+	// redirected page as off-site; the final URL is what the boundary and the
+	// evidence must be judged by, so FetchPage has to carry it out.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			http.NotFound(w, r)
+		case "/old-home":
+			http.Redirect(w, r, "/new-home", http.StatusMovedPermanently)
+		case "/new-home":
+			//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertions below
+			_, _ = w.Write([]byte(`<html><body><a href="team">Team</a>The company.</body></html>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	page, err := testFetcher().FetchPage(context.Background(), srv.URL+"/old-home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.URL != srv.URL+"/old-home" {
+		t.Fatalf("Page.URL = %q, want the requested spelling kept", page.URL)
+	}
+	if page.FinalURL != srv.URL+"/new-home" {
+		t.Fatalf("Page.FinalURL = %q, want the redirect destination %q", page.FinalURL, srv.URL+"/new-home")
+	}
+	// Relative links resolve against where the body came from, not where it
+	// was asked for.
+	if want := []string{srv.URL + "/team"}; !reflect.DeepEqual(page.Links, want) {
+		t.Fatalf("Page.Links = %v, want %v", page.Links, want)
+	}
 }
 
 func TestSitemapLocParsing(t *testing.T) {


### PR DESCRIPTION
## What broke

A domain answering 301 onto another host — dibee.co forwarding to www.dibee.vn — was read as a one-page site. The fetch followed the redirect, but the crawl kept judging every discovered link against the requested domain and rejected them all as off-domain. The well-known probes, the sitemap lookup, the robots pacing and the favicon derivation all kept asking the host that served nothing.

## The fix

- `webread.Page` now carries `FinalURL`, the URL the body actually came from (`resp.Request.URL` after every hop). `Page.URL` stays the requested spelling.
- `fetchSeed` returns the final URL as the answering URL, so the crawl boundary, probe origin, sitemap origin, robots pacing, evidence URLs and logo derivation all name the destination — the same replacement the www/scheme fallback ladder already did, extended to redirects the HTTP client follows silently. The requested spelling stays marked visited.
- The reverse hole is closed too: a later on-site candidate whose server answers from another site was previously committed under its on-site URL. Its body is now discarded unread — links and all — and recorded as an `off_domain` skip. Only the seed's redirect may move the boundary.
- Committed pages carry the URL that served them, and that URL is marked visited so a second route to the same destination costs no second fetch.

Destination robots rules were already honored per hop by `CheckRedirect` re-passing the robots gate; no change needed there.

## Tests

- `webread`: `FetchPage` reports the redirect destination as `FinalURL` and keeps the requested `URL`; links resolve against where the body came from.
- `compose`: seed redirect across registrable domains crawls the destination's links and probes its origin; apex→www redirect reads the page once; a later page redirecting off-site is skipped `off_domain` with its links never fetched; the pacer slows to the answering host's Crawl-delay; evidence names the serving URL and the destination dedupes.

No migration, no API-contract change. `site_read.seed_url` keeps the requested URL as provenance.

## Fixed along the way

The stray `// fetchPaced is one polite fetch` comment sat above `newCrawlRun` in sitecrawl.go; it now sits on `fetchPaced` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follows the seed’s redirect so the crawl boundary, pacing, evidence URL, and page kind are set by the URL that actually served the content. Previously we judged by the requested host; now only the seed’s redirect can move the boundary, and any later off‑site redirect is discarded unread and recorded as off_domain.

**Bug Fixes**
- Adds `webread.Page.FinalURL`; links and evidence use the serving URL.
- Seed fetch paces and bounds to the serving URL; both requested and serving URLs are marked visited.
- Later pages that redirect off‑site are skipped as off_domain without reading their bodies.
- Commits pages under the serving URL and marks it visited to prevent duplicate fetches.
- Classifies redirected pages by their destination; probes that land on another kind keep their target kind open.
- Tests cover cross‑domain seed redirects, apex→www dedupe, off‑site redirect skips, pacing to the destination host, `FinalURL` reporting, and kind reclassification.
- No migration required.

**Refactors**
- Removes an orphaned comment above `legalCensusOpen` and puts the `fetchPaced` comment on `fetchPaced`.

<sup>Written for commit 7d5e714c27526f95895d1f91fc08d647c73c8e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crawling for redirected pages, including redirects between domain variants.
  * Prevented crawling content that redirects outside the permitted site boundary.
  * Reduced duplicate fetching when URLs resolve to the same destination.
  * Applied crawl delays to the host that actually serves redirected content.
  * Evidence now identifies the URL that served the page.
  * Relative links are resolved correctly after redirects.
  * Page classification now reflects the URL that served the content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->