### PR TITLE
feat(import): a contact file links each person to their employer

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17129,6 +17129,49 @@ components:
         companies, 94 duplicates" before deciding — which is the whole reason
         the count is separate from `created`.
 
+    ImportRunLinks:
+      type: object
+      description: |
+        The connections between records a run makes, counted apart from the rows
+        it writes.
+
+        A link is not a row and is never added to the disposition's four: one
+        person row can arrive with an employer and produce both a created person
+        and an applied link, and counting it twice would make the four stop
+        summing to the rows read.
+
+        Today the only link a delimited file carries is a person's employer,
+        named by a company column the mapping points at `organization`.
+      required: [offered, applied]
+      properties:
+        offered:
+          type: integer
+          minimum: 0
+          description: |
+            Links the file asks for. A dry run reports this and nothing else,
+            because resolving an endpoint is a read the dry run has not done —
+            it says how many rows named an employer, not how many will find one.
+        applied:
+          type: integer
+          minimum: 0
+          description: 'Links actually written. Zero on a dry run, which writes nothing.'
+        unresolved:
+          type: array
+          description: |
+            The links that named something the run could not act on, each with
+            the reason. Enumerated rather than counted, because the answer a
+            person needs is WHICH company was not found — that is the row of the
+            spreadsheet they have to go and fix.
+          items: { $ref: '#/components/schemas/ImportUnresolvedLink' }
+
+    ImportUnresolvedLink:
+      type: object
+      required: [from, to, reason]
+      properties:
+        from:   { type: string, description: 'The record the link starts at, by the key the file identified it with.' }
+        to:     { type: string, description: 'What the file named as the other end — a company name, not an id, because no id was found.' }
+        reason: { type: string, description: 'Why it was not applied, in the words of the person who made the file.' }
+
     ImportRunDisposition:
       type: object
       description: What the run will do, or did, counted per outcome. The four sum to the rows read — a disposition that does not add up is hiding something.
@@ -17176,6 +17219,8 @@ components:
         source_key_used:
           type: string
           description: 'Which column identified a row for idempotency — the request''s `source_key`, or the natural key chosen in its absence. Stated because the whole re-run guarantee rests on it.'
+        links:
+          $ref: '#/components/schemas/ImportRunLinks'
         estimated_duration_seconds:
           type: [integer, 'null']
           description: 'A dry run''s estimate for the commit. Null when the run has already finished and the real duration is on the run record.'

--- a/backend/internal/compose/csvemployer.go
+++ b/backend/internal/compose/csvemployer.go
@@ -12,15 +12,24 @@ package compose
 // thing a spreadsheet carries.
 //
 // Resolving a company by name is the whole risk of this file, and the rule is
-// deliberately unforgiving: exactly one live visible organization must normalize
-// equal, or no link is written. Nothing here scores, ranks or breaks a tie. The
-// argument is the one csvtargetid.go makes at length for the `id` column — the
-// dedupe ladder blurs on purpose, which is right when it proposes a review to a
-// human and is a way to attach a person to the wrong employer when it decides a
-// write. `organization` has no unique index on its name (dedupeorg.go says so in
-// as many words: "two organizations may legitimately share a name"), so an
-// ambiguous name is a real state and the honest answer to it is to link nothing
-// and say which name was ambiguous.
+// deliberately unforgiving: exactly one live visible organization must carry the
+// name AS WRITTEN, or no link is written. Nothing here scores, ranks or breaks a
+// tie. The argument is the one csvtargetid.go makes at length for the `id`
+// column — the dedupe ladder blurs on purpose, which is right when it proposes a
+// review to a human and is a way to attach a person to the wrong employer when
+// it decides a write.
+//
+// NormalizeOrgName is deliberately NOT the comparison, and that is the one thing
+// to keep straight when reading this file. It strips legal suffixes, so `Acme
+// Inc` and `Acme GmbH` normalize alike — which is exactly right for asking "should
+// a human look at these two" and exactly wrong for deciding a write, because
+// those are two different legal entities and picking either would be a guess. The
+// comparison here folds case and spacing and nothing else.
+//
+// `organization` has no unique index on its name (dedupeorg.go says so in as many
+// words: "two organizations may legitimately share a name"), so an ambiguous name
+// is a real state and the honest answer is to link nothing and say which name was
+// ambiguous.
 
 import (
 	"context"
@@ -69,7 +78,7 @@ type employerResolution struct {
 // exists — an existence oracle over a colleague's owner-private estate, probed
 // one spreadsheet row at a time. That is the posture csvcollision.go documents.
 func (w *csvWriters) resolveEmployer(ctx context.Context, name string) (employerResolution, error) {
-	normalized := people.NormalizeOrgName(name)
+	normalized := employerKey(name)
 	if normalized == "" {
 		return employerResolution{reason: "the company column is empty, so the row names no employer"}, nil
 	}
@@ -89,6 +98,19 @@ func (w *csvWriters) resolveEmployer(ctx context.Context, name string) (employer
 	default:
 		return employerResolution{id: hit.id, found: true}, nil
 	}
+}
+
+// employerKey folds a company name for comparison: case and surrounding space,
+// and nothing else.
+//
+// Deliberately weaker than NormalizeOrgName. That one strips legal suffixes so a
+// review queue can ask a human about `Acme Inc` and `Acme GmbH`; using it here
+// would answer that question by writing, and the two names are two companies
+// until somebody says otherwise. A file spelling a company differently from the
+// CRM does not link, which is a missing link the report names rather than a wrong
+// one nobody sees.
+func employerKey(name string) string {
+	return strings.ToLower(strings.Join(strings.Fields(name), " "))
 }
 
 // employerCandidate is one normalized name's answer: the company, and how many
@@ -156,7 +178,7 @@ func (w *csvWriters) employerIndex(ctx context.Context) (map[string]employerCand
 			}
 			seen := map[string]bool{}
 			for _, raw := range names {
-				key := people.NormalizeOrgName(raw)
+				key := employerKey(raw)
 				if key == "" || seen[key] {
 					// One company answering to one key once: a company whose
 					// display and legal names normalize alike must not make
@@ -222,8 +244,17 @@ func (w *csvWriters) linkEmployer(ctx context.Context, a migration.Assoc) (migra
 		Source:           w.provenanceOf(a.FromID + "→" + a.ToID),
 	}); err != nil {
 		if errors.Is(err, apperrors.ErrConflict) {
-			// Already linked: a resumed run replaying its association phase
-			// re-offers an edge that landed on the earlier attempt.
+			// The edge is unique per (person, organization), so a conflict means
+			// one is already there. Reported as APPLIED because the run's promise
+			// is the end state — this person is linked to this company — and a
+			// resumed run replaying its association phase must converge rather
+			// than accumulate failures.
+			//
+			// It does NOT distinguish an edge this run wrote from one a human
+			// wrote last year: both leave the estate in the state the file asked
+			// for, and telling them apart would need a read the writer does not
+			// take. What it must not do is claim a write that did not happen, so
+			// the disclosure says linked rather than created.
 			return migration.AssocResult{Applied: true}, nil
 		}
 		return migration.AssocResult{}, fmt.Errorf("import: linking %s to %q: %w", a.FromID, a.ToID, err)

--- a/backend/internal/compose/csvemployer.go
+++ b/backend/internal/compose/csvemployer.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Linking an imported person to the company they work for.
+//
+// A contact file's company column is the one mapped target that writes nothing
+// to the row it sits on. It names an EDGE — this person works at that company —
+// and the two records at its ends are found in different ways: the person by the
+// key the run identifies rows with, the company by its NAME, which is the only
+// thing a spreadsheet carries.
+//
+// Resolving a company by name is the whole risk of this file, and the rule is
+// deliberately unforgiving: exactly one live visible organization must normalize
+// equal, or no link is written. Nothing here scores, ranks or breaks a tie. The
+// argument is the one csvtargetid.go makes at length for the `id` column — the
+// dedupe ladder blurs on purpose, which is right when it proposes a review to a
+// human and is a way to attach a person to the wrong employer when it decides a
+// write. `organization` has no unique index on its name (dedupeorg.go says so in
+// as many words: "two organizations may legitimately share a name"), so an
+// ambiguous name is a real state and the honest answer to it is to link nothing
+// and say which name was ambiguous.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// csvEmployerName is the column naming the company a person works for.
+//
+// It is not in csvTargets and never will be: that map is what a row WRITES, and
+// this writes nothing to the person. It is advertised through importTargets the
+// same way `id` is, and excluded from comparison the same way — see
+// isNonFieldTarget, which states why both must be.
+//
+// One value, taken from the source that also uses it as an edge endpoint kind,
+// so the target a caller maps to and the edge the source emits cannot drift
+// apart into two strings that merely look alike.
+const csvEmployerName = migration.AssocTargetOrganizationName
+
+// employerResolution is a name looked up, and why it produced no company when
+// it did not.
+type employerResolution struct {
+	id     ids.OrganizationID
+	found  bool
+	reason string
+}
+
+// resolveEmployer answers which organization a company name means, or why it
+// means none.
+//
+// Three outcomes, and the two failures are deliberately worded the same way as
+// each other where it matters: a name matching nothing and a name matching only
+// companies this caller may not see BOTH answer "no company of that name",
+// because separating them would tell a caller that a company they cannot read
+// exists — an existence oracle over a colleague's owner-private estate, probed
+// one spreadsheet row at a time. That is the posture csvcollision.go documents.
+func (w *csvWriters) resolveEmployer(ctx context.Context, name string) (employerResolution, error) {
+	normalized := people.NormalizeOrgName(name)
+	if normalized == "" {
+		return employerResolution{reason: "the company column is empty, so the row names no employer"}, nil
+	}
+	index, err := w.employerIndex(ctx)
+	if err != nil {
+		return employerResolution{}, err
+	}
+	hit, ok := index[normalized]
+	switch {
+	case !ok:
+		return employerResolution{reason: fmt.Sprintf(
+			"no company named %q is in the CRM, so there was nothing to link this person to", strings.TrimSpace(name))}, nil
+	case hit.count > 1:
+		return employerResolution{reason: fmt.Sprintf(
+			"more than one company is named %q, so which one employs this person is a question only a human can answer",
+			strings.TrimSpace(name))}, nil
+	default:
+		return employerResolution{id: hit.id, found: true}, nil
+	}
+}
+
+// employerCandidate is one normalized name's answer: the company, and how many
+// companies wear that name.
+//
+// The count rather than the ids, because only "exactly one" links and a name
+// worn by forty companies is the same answer as a name worn by two. An estate
+// with a hundred thousand companies keeps a hundred thousand short strings here,
+// not a hundred thousand slices.
+type employerCandidate struct {
+	id    ids.OrganizationID
+	count int
+}
+
+// employerIndex builds the normalized-name lookup ONCE per run.
+//
+// Per row it would be one full scan per person — 19,000 scans for a file that
+// size. The index is bounded by the number of companies in the estate, not by
+// the number of rows in the file.
+//
+// It is a SNAPSHOT, taken when the first row needs it. A company created by
+// someone else while the run is in flight is not in it, so a link that could
+// have resolved is reported as unresolved instead. That is the same staleness
+// collidesWithExisting already accepts and for the same reason: the failure mode
+// is a missing link the report names, never a link to the wrong company.
+func (w *csvWriters) employerIndex(ctx context.Context) (map[string]employerCandidate, error) {
+	if w.employers != nil {
+		return w.employers, nil
+	}
+	index := map[string]employerCandidate{}
+	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		// Scoped to what this caller may READ, so an organization they cannot see
+		// contributes nothing — neither a match nor an ambiguity.
+		var args []any
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		scope, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
+		if err != nil {
+			return err
+		}
+		// An empty clause is "every row this caller may read", not "no rows".
+		visible := "TRUE"
+		if scope != "" {
+			visible = scope
+		}
+		rows, err := tx.Query(ctx, storekit.SQLf(`
+			SELECT o.id, o.display_name, o.legal_name
+			  FROM organization o
+			 WHERE o.archived_at IS NULL AND o.merged_into_id IS NULL AND %s`, visible), args...)
+		if err != nil {
+			return fmt.Errorf("reading the companies to link against: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.OrganizationID
+			var display string
+			var legal *string
+			if err := rows.Scan(&id, &display, &legal); err != nil {
+				return fmt.Errorf("reading a company row: %w", err)
+			}
+			// Both names are indexed: a file may spell a company by its trading
+			// name or its registered one, and the CRM may hold either.
+			names := []string{display}
+			if legal != nil {
+				names = append(names, *legal)
+			}
+			seen := map[string]bool{}
+			for _, raw := range names {
+				key := people.NormalizeOrgName(raw)
+				if key == "" || seen[key] {
+					// One company answering to one key once: a company whose
+					// display and legal names normalize alike must not make
+					// itself ambiguous with itself.
+					continue
+				}
+				seen[key] = true
+				entry := index[key]
+				entry.count++
+				if entry.count == 1 {
+					entry.id = id
+				}
+				index[key] = entry
+			}
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, fmt.Errorf("import: %w", err)
+	}
+	w.employers = index
+	return index, nil
+}
+
+// linkEmployer writes one person→organization employment edge.
+//
+// The `From` endpoint resolves through the run's identity map, which knows the
+// person this run just landed. The `To` endpoint is a NAME and resolves through
+// resolveEmployer, exactly once per distinct name thanks to the cached index.
+//
+// A conflict is convergence, not a failure: the edge is unique per (person,
+// organization), and the engine's association phase is replayed whole by a
+// resumed run. Every other error still stops the run, because an edge that
+// failed for an unknown reason is not an edge anybody should assume landed.
+func (w *csvWriters) linkEmployer(ctx context.Context, a migration.Assoc) (migration.AssocResult, error) {
+	personID, found, err := w.lookup(ctx, migration.ObjectPerson, a.FromID)
+	if err != nil {
+		return migration.AssocResult{}, err
+	}
+	if !found {
+		// The row never landed — refused, skipped, or not yet committed. The
+		// person is the thing missing, so that is what the report says.
+		return migration.AssocResult{Reason: fmt.Sprintf(
+			"the person identified by %q was not imported, so there was nobody to link to %q", a.FromID, a.ToID)}, nil
+	}
+	resolved, err := w.resolveEmployer(ctx, a.ToID)
+	if err != nil {
+		return migration.AssocResult{}, err
+	}
+	if !resolved.found {
+		return migration.AssocResult{Reason: resolved.reason}, nil
+	}
+
+	pid := ids.From[ids.PersonKind](personID)
+	oid := resolved.id
+	if _, err := w.people.CreateRelationship(ctx, people.CreateRelationshipInput{
+		Kind:           relationshipKindEmployment,
+		PersonID:       &pid,
+		OrganizationID: &oid,
+		// Stated rather than left nil: a company column on a contact row means
+		// THE employer, singular, and a caller who said so must not have the
+		// store's own rule decide otherwise.
+		IsCurrentPrimary: ptrTrue(),
+		Source:           w.provenanceOf(a.FromID + "→" + a.ToID),
+	}); err != nil {
+		if errors.Is(err, apperrors.ErrConflict) {
+			// Already linked: a resumed run replaying its association phase
+			// re-offers an edge that landed on the earlier attempt.
+			return migration.AssocResult{Applied: true}, nil
+		}
+		return migration.AssocResult{}, fmt.Errorf("import: linking %s to %q: %w", a.FromID, a.ToID, err)
+	}
+	return migration.AssocResult{Applied: true}, nil
+}
+
+// relationshipKindEmployment is the edge a company column means.
+const relationshipKindEmployment = "employment"
+
+func ptrTrue() *bool { t := true; return &t }

--- a/backend/internal/compose/csvemployer.go
+++ b/backend/internal/compose/csvemployer.go
@@ -46,9 +46,9 @@ import (
 // same way `id` is, and excluded from comparison the same way — see
 // isNonFieldTarget, which states why both must be.
 //
-// One value, taken from the source that also uses it as an edge endpoint kind,
-// so the target a caller maps to and the edge the source emits cannot drift
-// apart into two strings that merely look alike.
+// Assigned FROM the source's own constant rather than spelled again, so the
+// target a caller maps to and the edge the source emits are one value by
+// construction — there is no second string here to fall out of step.
 const csvEmployerName = migration.AssocTargetOrganizationName
 
 // employerResolution is a name looked up, and why it produced no company when

--- a/backend/internal/compose/csvfields.go
+++ b/backend/internal/compose/csvfields.go
@@ -125,6 +125,9 @@ func importTargets(object string) ([]string, error) {
 		// `id` writes nothing. It names the record the row IS.
 		targets = append(targets, csvTargetID)
 	}
+	if linksEmployer(object) {
+		targets = append(targets, csvEmployerName)
+	}
 	return targets, nil
 }
 
@@ -136,6 +139,34 @@ func importTargets(object string) ([]string, error) {
 // not offering it.
 func selectsByID(object string) bool {
 	return object == migration.ObjectOrganization
+}
+
+// linksEmployer reports whether an object's rows may name a company to be
+// linked to, rather than written.
+//
+// People only: a contact file's company column is the person's employer, which
+// is a RELATIONSHIP between two records. An organization row naming a company
+// would be naming itself, and a lead holds its employer as free text on the lead
+// itself (`company_name`, an ordinary writable field) precisely because a lead is
+// not yet a record the estate links things to.
+func linksEmployer(object string) bool {
+	return object == migration.ObjectPerson
+}
+
+// isNonFieldTarget reports whether a mapped target names something other than a
+// value the record stores.
+//
+// Two targets qualify and they are different from each other, which is why this
+// is a set rather than a comparison. `id` names the RECORD the row is. The
+// employer column names an EDGE from that record to another one. Neither is a
+// column on the record, so neither may be compared against the stored JSON: the
+// lookup would find nothing, report the row as changed, and hand the update path
+// a field the store has no setter for — an update on every re-import of a file
+// nobody edited.
+//
+// Excluded in one place rather than at each caller so no path can forget one.
+func isNonFieldTarget(field string) bool {
+	return field == csvTargetID || field == csvEmployerName
 }
 
 // changedFields reports which mapped values differ from what the stored record
@@ -153,11 +184,9 @@ func changedFields(encoded []byte, mapped map[string]string) (map[string]string,
 
 	changed := make(map[string]string, len(mapped))
 	for field, incoming := range mapped {
-		// `id` NAMES the record; it is not a value the record holds. Comparing it
-		// would find no stored `id` field, report it as changed, and hand the
-		// update path a field the contract has no setter for. Excluded here
-		// rather than at each caller so no path can forget.
-		if field == csvTargetID {
+		// `id` names the record and the employer column names an edge; neither is
+		// a value the record holds. See isNonFieldTarget.
+		if isNonFieldTarget(field) {
 			continue
 		}
 		if textOf(storedValue(current, field)) != canonicalFor(field, incoming) {

--- a/backend/internal/compose/csvimport_test.go
+++ b/backend/internal/compose/csvimport_test.go
@@ -112,10 +112,13 @@ func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
 			}
 			created, patched := build(fields)
 			for _, target := range targets {
-				if target == csvTargetID {
-					// A SELECTOR, not a field: it names the record the row is, and
-					// writes nothing. Exempt here and asserted the other way round
-					// below — advertised, and reaching neither input on purpose.
+				if reason, exempt := nonFieldTargets[target]; exempt {
+					// Not a field, so the round-trip rule does not apply. Each
+					// exemption is asserted the other way round below: advertised,
+					// and reaching neither input on purpose. Naming the reason here
+					// is what stops a future target being exempted by accident —
+					// a target with no entry is held to the rule.
+					_ = reason
 					continue
 				}
 				if !created[target] {
@@ -125,16 +128,15 @@ func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
 					t.Errorf("%s: target %q is advertised but never reaches the update input", object, target)
 				}
 			}
-			if !selectsByID(object) {
-				return
+			if selectsByID(object) {
+				assertNonFieldTarget(t, object, csvTargetID, targets, created, patched,
+					"it names the record a row IS, and writing it would let a file move a company onto another company's id",
+					"a corrections file naming its records would be refused")
 			}
-			if created[csvTargetID] || patched[csvTargetID] {
-				t.Errorf("%s: %q reached a write input — it names the record a row IS, and writing "+
-					"it would let a file move a company onto another company's id", object, csvTargetID)
-			}
-			if !slices.Contains(targets, csvTargetID) {
-				t.Errorf("%s: %q is not an accepted column, so a corrections file naming its records "+
-					"would be refused", object, csvTargetID)
+			if linksEmployer(object) {
+				assertNonFieldTarget(t, object, csvEmployerName, targets, created, patched,
+					"it names the company a person works AT, and writing it would put a company's name in a field on the person",
+					"a contact file naming employers would be refused")
 			}
 		})
 	}
@@ -467,5 +469,33 @@ func TestColumnProfileReachesTheWireWithSamplesAndRate(t *testing.T) {
 	// An empty column answers [], never null: the contract promises an array.
 	if out[1].Samples == nil {
 		t.Fatal("a column with no samples serialized as null")
+	}
+}
+
+// nonFieldTargets are the advertised targets that write nothing to the record,
+// each with the reason it is not held to the round-trip rule.
+//
+// A map rather than a condition, so exempting a target is a deliberate entry
+// with a stated reason rather than a boolean somebody widened. A target absent
+// from here must reach both the create and the update input.
+var nonFieldTargets = map[string]string{
+	csvTargetID:     "names the RECORD the row is — a selector, not a value",
+	csvEmployerName: "names an EDGE from the record to a company — written as a relationship, not a column",
+}
+
+// assertNonFieldTarget holds one exemption to what it promises: accepted as a
+// column, and reaching neither write input.
+func assertNonFieldTarget(t *testing.T, object, target string, targets []string,
+	created, patched map[string]bool, writeHarm, absenceHarm string,
+) {
+	t.Helper()
+	if _, declared := nonFieldTargets[target]; !declared {
+		t.Errorf("%s: %q is treated as a non-field target but has no entry in nonFieldTargets saying why", object, target)
+	}
+	if created[target] || patched[target] {
+		t.Errorf("%s: %q reached a write input — %s", object, target, writeHarm)
+	}
+	if !slices.Contains(targets, target) {
+		t.Errorf("%s: %q is not an accepted column, so %s", object, target, absenceHarm)
 	}
 }

--- a/backend/internal/compose/csvimport_test.go
+++ b/backend/internal/compose/csvimport_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
@@ -23,6 +24,10 @@ import (
 // than one the screen never showed, and the only way that stays true as the
 // stores change is to check the round trip rather than the list.
 func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
+	// Swept here because this is the test that walks every object's full target
+	// set: an exemption matching nothing would otherwise sit on ratifying a
+	// target that no longer exists.
+	defer nonFieldTargets.AssertAllMatched(t)
 	for object, build := range map[string]func(map[string]string) (created, patched map[string]bool){
 		migration.ObjectLead: func(fields map[string]string) (map[string]bool, map[string]bool) {
 			in := leadCreateFrom(fields, "import:csv", "ext-1", "src")
@@ -112,13 +117,12 @@ func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
 			}
 			created, patched := build(fields)
 			for _, target := range targets {
-				if reason, exempt := nonFieldTargets[target]; exempt {
+				if nonFieldTargets.Waived(t, target) {
 					// Not a field, so the round-trip rule does not apply. Each
 					// exemption is asserted the other way round below: advertised,
 					// and reaching neither input on purpose. Naming the reason here
 					// is what stops a future target being exempted by accident —
 					// a target with no entry is held to the rule.
-					_ = reason
 					continue
 				}
 				if !created[target] {
@@ -475,13 +479,14 @@ func TestColumnProfileReachesTheWireWithSamplesAndRate(t *testing.T) {
 // nonFieldTargets are the advertised targets that write nothing to the record,
 // each with the reason it is not held to the round-trip rule.
 //
-// A map rather than a condition, so exempting a target is a deliberate entry
-// with a stated reason rather than a boolean somebody widened. A target absent
-// from here must reach both the create and the update input.
-var nonFieldTargets = map[string]string{
+// A waiver rather than a plain map, so exempting a target is a deliberate entry
+// with a reason held to a standard, and an entry that stops matching is reported
+// rather than left behind. A target absent from here must reach both the create
+// and the update input.
+var nonFieldTargets = gatekit.Waive(map[string]string{
 	csvTargetID:     "names the RECORD the row is — a selector, not a value",
 	csvEmployerName: "names an EDGE from the record to a company — written as a relationship, not a column",
-}
+})
 
 // assertNonFieldTarget holds one exemption to what it promises: accepted as a
 // column, and reaching neither write input.
@@ -489,7 +494,7 @@ func assertNonFieldTarget(t *testing.T, object, target string, targets []string,
 	created, patched map[string]bool, writeHarm, absenceHarm string,
 ) {
 	t.Helper()
-	if _, declared := nonFieldTargets[target]; !declared {
+	if !nonFieldTargets.Waived(t, target) {
 		t.Errorf("%s: %q is treated as a non-field target but has no entry in nonFieldTargets saying why", object, target)
 	}
 	if created[target] || patched[target] {

--- a/backend/internal/compose/csvimportreport.go
+++ b/backend/internal/compose/csvimportreport.go
@@ -36,6 +36,50 @@ func refinePrediction(ctx context.Context, source *migration.CSVSource, writers 
 		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
 		report.Objects[i].Duplicates += p.duplicates
 	}
+	return withPredictedLinks(ctx, source, writers, report)
+}
+
+// withPredictedLinks answers, before anything is written, how many of the
+// employer links the file asks for will actually find a company.
+//
+// The engine's own dry run counts edges OFFERED — it has no writer, so it cannot
+// resolve an endpoint. That number alone would tell a person approving a file of
+// 12,000 contacts that 12,000 links are coming, when the truthful answer might be
+// 3,000 and 9,000 companies nobody has imported yet. So the resolvable half is
+// computed here through the SAME resolver the commit will use, and the names that
+// resolve to nothing are listed rather than counted — the answer a person needs
+// is WHICH company was not found, because that is the row they have to go fix.
+//
+// Only the COMPANY end is resolved. At dry-run time no person has landed, so the
+// person end would answer "not imported" for every row, and predicting that would
+// be worse than saying nothing. The asymmetry is deliberate: a preview reports
+// what it can honestly know, and claiming more is the preview/commit disagreement
+// this whole pass exists to prevent.
+func withPredictedLinks(ctx context.Context, source *migration.CSVSource, writers *csvWriters, report migration.Report) (migration.Report, error) {
+	edges, err := source.Associations(ctx)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	if len(edges) == 0 {
+		return report, nil
+	}
+	resolvable := 0
+	for _, edge := range edges {
+		resolved, err := writers.resolveEmployer(ctx, edge.ToID)
+		if err != nil {
+			return migration.Report{}, err
+		}
+		if resolved.found {
+			resolvable++
+			continue
+		}
+		report.AssociationsSkipped = append(report.AssociationsSkipped, migration.SkippedAssoc{
+			From:   edge.FromType + "/" + edge.FromID,
+			To:     edge.ToType + "/" + edge.ToID,
+			Reason: resolved.reason,
+		})
+	}
+	report.Associations = resolvable
 	return report, nil
 }
 

--- a/backend/internal/compose/csvimportreport.go
+++ b/backend/internal/compose/csvimportreport.go
@@ -36,7 +36,7 @@ func refinePrediction(ctx context.Context, source *migration.CSVSource, writers 
 		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
 		report.Objects[i].Duplicates += p.duplicates
 	}
-	return withPredictedLinks(ctx, source, writers, report)
+	return withPredictedLinks(ctx, source, writers, report, p.absent)
 }
 
 // withPredictedLinks answers, before anything is written, how many of the
@@ -55,7 +55,9 @@ func refinePrediction(ctx context.Context, source *migration.CSVSource, writers 
 // be worse than saying nothing. The asymmetry is deliberate: a preview reports
 // what it can honestly know, and claiming more is the preview/commit disagreement
 // this whole pass exists to prevent.
-func withPredictedLinks(ctx context.Context, source *migration.CSVSource, writers *csvWriters, report migration.Report) (migration.Report, error) {
+func withPredictedLinks(ctx context.Context, source *migration.CSVSource, writers *csvWriters,
+	report migration.Report, absent []string,
+) (migration.Report, error) {
 	edges, err := source.Associations(ctx)
 	if err != nil {
 		return migration.Report{}, err
@@ -63,8 +65,24 @@ func withPredictedLinks(ctx context.Context, source *migration.CSVSource, writer
 	if len(edges) == 0 {
 		return report, nil
 	}
+	// A row the commit will refuse lands no person, so its employer link cannot
+	// be written either. Counting it as resolvable would promise a link whose
+	// person is never there — preview says "linked", commit says "nobody to link
+	// to", which is the disagreement this whole pass exists to prevent.
+	willNotLand := make(map[string]bool, len(absent))
+	for _, id := range absent {
+		willNotLand[id] = true
+	}
 	resolvable := 0
 	for _, edge := range edges {
+		if willNotLand[edge.FromID] {
+			report.AssociationsSkipped = append(report.AssociationsSkipped, migration.SkippedAssoc{
+				From:   edge.FromType + "/" + edge.FromID,
+				To:     edge.ToType + "/" + edge.ToID,
+				Reason: "this row will not be imported, so there is nobody to link to " + edge.ToID,
+			})
+			continue
+		}
 		resolved, err := writers.resolveEmployer(ctx, edge.ToID)
 		if err != nil {
 			return migration.Report{}, err
@@ -105,6 +123,7 @@ func predictPages(ctx context.Context, source *migration.CSVSource, writers *csv
 			case predictUnchanged:
 				p.unchanged++
 			case predictUnwritable:
+				p.absent = append(p.absent, row.ExternalID)
 				// Disclosed as a skip rather than counted as a create: the
 				// commit will refuse this row, and the report exists to say so
 				// before a human approves it.
@@ -113,6 +132,7 @@ func predictPages(ctx context.Context, source *migration.CSVSource, writers *csv
 					Reason:     refusal,
 				})
 			case predictCollidesSkipped:
+				p.absent = append(p.absent, row.ExternalID)
 				// The run asked to skip duplicates, so this row is a skip and
 				// the preview says so — the commit must not be the first place
 				// a person learns the row did not land.
@@ -185,6 +205,10 @@ type prediction struct {
 	// already holds. Kept apart from skipped because each is counted in
 	// created — see the disposition arithmetic above.
 	collisions []migration.SkippedRow
+	// absent are the rows the commit will NOT land — refused outright, or a
+	// duplicate this run asked to skip. Their employer links cannot be written,
+	// so the preview must not count them as resolvable.
+	absent []string
 	// duplicates counts the same rows. It is reported to the human as its own
 	// number ("100 companies, 94 duplicates") and never summed with the four.
 	duplicates int

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -274,6 +274,7 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 	// person is asking before they approve, and an omitted field reads as "not
 	// checked" rather than "none found".
 	out.Disposition.Duplicates = &duplicates
+	out.Links = linksOf(run.Report, committed)
 
 	// A finished run's stored report can carry more outcomes than the file has
 	// rows, and there are two causes with different right answers.
@@ -350,6 +351,48 @@ func toContractUndoReport(id migration.RunID, status string, rep migration.UndoR
 		Kept:          kept,
 		Errored:       errored,
 	}
+}
+
+// linksOf renders the connections a run makes, for the half of the report that
+// is not about rows.
+//
+// The stored count means two different things either side of approval, which is
+// the engine's own shape rather than a quirk to smooth over. A dry run cannot
+// resolve an endpoint — it writes nothing and reads nothing about the other end
+// — so what it can honestly say is how many rows NAMED an employer. After the
+// commit the same field counts the edges actually written. Reporting them under
+// one number would let a preview promising 12,000 links be answered by 3,000
+// applied without either figure ever being wrong.
+//
+// Always non-nil for the same reason `duplicates` is: "0 links" answers the
+// question, an absent field reads as "not checked".
+func linksOf(rep *migration.Report, committed bool) *crmcontracts.ImportRunLinks {
+	links := crmcontracts.ImportRunLinks{}
+	if rep == nil {
+		empty := []crmcontracts.ImportUnresolvedLink{}
+		links.Unresolved = &empty
+		return &links
+	}
+	// One stored count, two meanings, decided by which side of approval the run
+	// is on. Before it, the engine has no writer and cannot resolve an endpoint,
+	// so the number is what the file asks for that CAN be linked. After it, the
+	// same field holds what was actually written. Reporting both under one name
+	// would let a preview promising 12,000 links be answered by 3,000 applied
+	// without either figure ever having been wrong.
+	if committed {
+		links.Applied = rep.Associations
+	}
+	// Offered is the whole ask either way: what landed, plus what named a company
+	// the run could not find.
+	links.Offered = rep.Associations + len(rep.AssociationsSkipped)
+	unresolved := make([]crmcontracts.ImportUnresolvedLink, 0, len(rep.AssociationsSkipped))
+	for _, s := range rep.AssociationsSkipped {
+		unresolved = append(unresolved, crmcontracts.ImportUnresolvedLink{
+			From: s.From, To: s.To, Reason: s.Reason,
+		})
+	}
+	links.Unresolved = &unresolved
+	return &links
 }
 
 // lineOf recovers the file line a skip named. The source records skips as

--- a/backend/internal/compose/csvwriters.go
+++ b/backend/internal/compose/csvwriters.go
@@ -48,6 +48,9 @@ type csvWriters struct {
 	// rebuilds it lazily through lookup, which falls back to the engine-owned
 	// identity map.
 	nativeIDs map[string]ids.UUID
+	// employers is the normalized company-name index, built once per run by
+	// employerIndex and nil until the first row needs it.
+	employers map[string]employerCandidate
 	// updated counts the rows this run rewrote. The engine's EnsureResult has
 	// no "updated" member — the frozen-source model it was built for had no
 	// such outcome — so the count rides here and the report reads it.
@@ -100,13 +103,20 @@ func (w *csvWriters) Exists(ctx context.Context, object, externalID string) (boo
 // answer for a writer that lands both together.
 func (w *csvWriters) ReconcileIdentities(context.Context) error { return nil }
 
-// Associate discloses rather than applies. A flat file carries no edges, so an
-// edge reaching here came from somewhere this writer does not understand, and
-// swallowing it as applied would report work that never happened.
-func (w *csvWriters) Associate(_ context.Context, a migration.Assoc) (migration.AssocResult, error) {
+// Associate applies the one edge a delimited file can carry — a person's
+// employer, named by a company column — and discloses anything else.
+//
+// The default arm is kept rather than replaced. An edge shape this writer does
+// not understand still has to be reported as unapplied: swallowing it as applied
+// would report work that never happened, which is the reason this method existed
+// at all before there was an edge to write.
+func (w *csvWriters) Associate(ctx context.Context, a migration.Assoc) (migration.AssocResult, error) {
+	if a.FromType == migration.ObjectPerson && a.ToType == migration.AssocTargetOrganizationName {
+		return w.linkEmployer(ctx, a)
+	}
 	return migration.AssocResult{
 		Applied: false,
-		Reason:  fmt.Sprintf("a delimited import carries no edges; %s→%s was not applied", a.FromType, a.ToType),
+		Reason:  fmt.Sprintf("a delimited import carries no %s→%s edge; it was not applied", a.FromType, a.ToType),
 	}, nil
 }
 

--- a/backend/internal/compose/integration/csvimport_integration_test.go
+++ b/backend/internal/compose/integration/csvimport_integration_test.go
@@ -69,7 +69,18 @@ type importIssueDTO struct {
 	Reason string `json:"reason"`
 }
 
+type importLinksDTO struct {
+	Offered    int `json:"offered"`
+	Applied    int `json:"applied"`
+	Unresolved []struct {
+		From   string `json:"from"`
+		To     string `json:"to"`
+		Reason string `json:"reason"`
+	} `json:"unresolved"`
+}
+
 type importReportDTO struct {
+	Links         *importLinksDTO      `json:"links"`
 	RunID         string               `json:"run_id"`
 	Status        string               `json:"status"`
 	RowsRead      int                  `json:"rows_read"`
@@ -257,77 +268,6 @@ func TestCSVImportDryRunWritesNothingAndCommitsLeads(t *testing.T) {
 	}
 	if got := importedPersonCount(t, e); got != peopleBefore {
 		t.Fatalf("people = %d, was %d — a `lead` run writes leads and does not reach the person table", got, peopleBefore)
-	}
-}
-
-// The other half of the same promise: a file of people the business already
-// knows imports as PEOPLE, through the same dry-run-then-approve flow.
-//
-// Three things are asserted together because each one failing alone would still
-// look like a working import: the dry run writes nothing, the commit creates
-// people rather than leads, and re-running the identical file converges instead
-// of reporting an update forever. That last one is the defect a person object
-// introduces on its own — an email is a child row, so a comparison that reads
-// the record's flat fields finds no `email` and calls every row changed.
-func TestCSVImportOfKnownPeopleCreatesPeople(t *testing.T) {
-	e := setupImportApp(t)
-	peopleBefore := importedPersonCount(t, e)
-	leadsBefore := leadCount(t, e)
-
-	profile, status := uploadCSV(t, e, "person", prospectCSV)
-	if status != http.StatusOK {
-		t.Fatalf("upload → %d, want 200", status)
-	}
-	if profile.RowsProfiled != 3 {
-		t.Fatalf("profile = %+v, want 3 rows", profile)
-	}
-
-	run, runStatus := createRunWithMapping(t, e, "person", profile.SourceRef,
-		map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"})
-	if runStatus != http.StatusAccepted {
-		t.Fatalf("create run → %d, want 202", runStatus)
-	}
-	if got := importedPersonCount(t, e); got != peopleBefore {
-		t.Fatalf("the dry run created %d people; a validation pass writes nothing", got-peopleBefore)
-	}
-
-	var report importReportDTO
-	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
-		t.Fatalf("report → %d, want 200", status)
-	}
-	if report.Disposition.Created != 3 {
-		t.Fatalf("report = %+v, want 3 rows the commit will create", report)
-	}
-
-	var approved importRunDTO
-	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); status != http.StatusAccepted {
-		t.Fatalf("approve → %d, want 202", status)
-	}
-	if got := importedPersonCount(t, e); got != peopleBefore+3 {
-		t.Fatalf("people = %d, was %d — a `person` run creates people", got, peopleBefore)
-	}
-	if got := leadCount(t, e); got != leadsBefore {
-		t.Fatalf("leads = %d, was %d — a `person` run does not reach the lead table", got, leadsBefore)
-	}
-
-	// The same file again: every row is already here and unchanged, so the
-	// commit has nothing to do. An `email` the comparison cannot read would
-	// report three updates instead.
-	second, secondStatus := uploadCSV(t, e, "person", prospectCSV)
-	if secondStatus != http.StatusOK {
-		t.Fatalf("second upload → %d, want 200", secondStatus)
-	}
-	rerun, rerunStatus := createRunWithMapping(t, e, "person", second.SourceRef,
-		map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"})
-	if rerunStatus != http.StatusAccepted {
-		t.Fatalf("create re-run → %d, want 202", rerunStatus)
-	}
-	var rereport importReportDTO
-	if status := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &rereport); status != http.StatusOK {
-		t.Fatalf("re-report → %d, want 200", status)
-	}
-	if rereport.Disposition.Created != 0 || rereport.Disposition.Updated != 0 {
-		t.Fatalf("re-run = %+v, want nothing created and nothing updated — the file is unchanged", rereport.Disposition)
 	}
 }
 
@@ -924,65 +864,5 @@ func TestCSVImportRefusesAnUnknownDuplicatePolicy(t *testing.T) {
 	}, nil, nil)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("an unknown on_duplicate → %d, want 422", status)
-	}
-}
-
-// A row whose address a previous run of this importer already landed: preview
-// and commit must give the SAME answer, and here that answer is an update.
-//
-// The email is the source key, so the identity map recognises the row and the
-// person is corrected rather than duplicated — which is the whole point of
-// keying a person file on its addresses. What must never happen is the preview
-// promising one disposition and the commit producing another.
-func TestCSVImportOfAClaimedEmailPreviewsWhatTheCommitDoes(t *testing.T) {
-	e := setupImportApp(t)
-
-	first, status := uploadCSV(t, e, "person", prospectCSV)
-	if status != http.StatusOK {
-		t.Fatalf("upload → %d, want 200", status)
-	}
-	mapping := map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"}
-	run, runStatus := createRunWithMapping(t, e, "person", first.SourceRef, mapping)
-	if runStatus != http.StatusAccepted {
-		t.Fatalf("create run → %d, want 202", runStatus)
-	}
-	var approved importRunDTO
-	if s := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); s != http.StatusAccepted {
-		t.Fatalf("approve → %d, want 202", s)
-	}
-
-	// A second file naming the SAME address under a different name. The source
-	// key is the email, so the identity map recognises the row and this is an
-	// update — which is the right answer, and the one the commit must also give.
-	const clash = "Email,Full Name,Title\n" +
-		"ada@lovelace.example,Ada Byron,Countess\n" +
-		"joan@clarke.example,Joan Clarke,Cryptanalyst\n"
-	second, secondStatus := uploadCSV(t, e, "person", clash)
-	if secondStatus != http.StatusOK {
-		t.Fatalf("second upload → %d, want 200", secondStatus)
-	}
-	rerun, rerunStatus := createRunWithMapping(t, e, "person", second.SourceRef, mapping)
-	if rerunStatus != http.StatusAccepted {
-		t.Fatalf("create re-run → %d, want 202", rerunStatus)
-	}
-
-	var report importReportDTO
-	if s := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &report); s != http.StatusOK {
-		t.Fatalf("report → %d, want 200", s)
-	}
-	if report.Disposition.Created != 1 || report.Disposition.Updated != 1 {
-		t.Fatalf("preview = %+v, want 1 create and 1 update for the address already held", report.Disposition)
-	}
-
-	var reapproved importRunDTO
-	if s := e.Call(t, http.MethodPost, "/v1/imports/"+rerun.ID+"/approve", nil, nil, &reapproved); s != http.StatusAccepted {
-		t.Fatalf("approve re-run → %d, want 202", s)
-	}
-	var after importReportDTO
-	if s := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &after); s != http.StatusOK {
-		t.Fatalf("report after commit → %d, want 200", s)
-	}
-	if after.Disposition.Created != 1 || after.Disposition.Updated != 1 {
-		t.Fatalf("commit = %+v, want the same 1 create and 1 update the preview promised", after.Disposition)
 	}
 }

--- a/backend/internal/compose/integration/csvimportperson_integration_test.go
+++ b/backend/internal/compose/integration/csvimportperson_integration_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Importing a file of PEOPLE, end to end.
+//
+// Split from csvimport_integration_test.go on the object rather than the line
+// count: a person is the one import object whose identity lives in a child table
+// and whose rows carry an edge to another record, so every promise here is one
+// the company and lead paths never have to make.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The other half of the same promise: a file of people the business already
+// knows imports as PEOPLE, through the same dry-run-then-approve flow.
+//
+// Three things are asserted together because each one failing alone would still
+// look like a working import: the dry run writes nothing, the commit creates
+// people rather than leads, and re-running the identical file converges instead
+// of reporting an update forever. That last one is the defect a person object
+// introduces on its own — an email is a child row, so a comparison that reads
+// the record's flat fields finds no `email` and calls every row changed.
+func TestCSVImportOfKnownPeopleCreatesPeople(t *testing.T) {
+	e := setupImportApp(t)
+	peopleBefore := importedPersonCount(t, e)
+	leadsBefore := leadCount(t, e)
+
+	profile, status := uploadCSV(t, e, "person", prospectCSV)
+	if status != http.StatusOK {
+		t.Fatalf("upload → %d, want 200", status)
+	}
+	if profile.RowsProfiled != 3 {
+		t.Fatalf("profile = %+v, want 3 rows", profile)
+	}
+
+	run, runStatus := createRunWithMapping(t, e, "person", profile.SourceRef,
+		map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"})
+	if runStatus != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", runStatus)
+	}
+	if got := importedPersonCount(t, e); got != peopleBefore {
+		t.Fatalf("the dry run created %d people; a validation pass writes nothing", got-peopleBefore)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Created != 3 {
+		t.Fatalf("report = %+v, want 3 rows the commit will create", report)
+	}
+
+	var approved importRunDTO
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+	if got := importedPersonCount(t, e); got != peopleBefore+3 {
+		t.Fatalf("people = %d, was %d — a `person` run creates people", got, peopleBefore)
+	}
+	if got := leadCount(t, e); got != leadsBefore {
+		t.Fatalf("leads = %d, was %d — a `person` run does not reach the lead table", got, leadsBefore)
+	}
+
+	// The same file again: every row is already here and unchanged, so the
+	// commit has nothing to do. An `email` the comparison cannot read would
+	// report three updates instead.
+	second, secondStatus := uploadCSV(t, e, "person", prospectCSV)
+	if secondStatus != http.StatusOK {
+		t.Fatalf("second upload → %d, want 200", secondStatus)
+	}
+	rerun, rerunStatus := createRunWithMapping(t, e, "person", second.SourceRef,
+		map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"})
+	if rerunStatus != http.StatusAccepted {
+		t.Fatalf("create re-run → %d, want 202", rerunStatus)
+	}
+	var rereport importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &rereport); status != http.StatusOK {
+		t.Fatalf("re-report → %d, want 200", status)
+	}
+	if rereport.Disposition.Created != 0 || rereport.Disposition.Updated != 0 {
+		t.Fatalf("re-run = %+v, want nothing created and nothing updated — the file is unchanged", rereport.Disposition)
+	}
+}
+
+// A row whose address a previous run of this importer already landed: preview
+// and commit must give the SAME answer, and here that answer is an update.
+//
+// The email is the source key, so the identity map recognises the row and the
+// person is corrected rather than duplicated — which is the whole point of
+// keying a person file on its addresses. What must never happen is the preview
+// promising one disposition and the commit producing another.
+func TestCSVImportOfAClaimedEmailPreviewsWhatTheCommitDoes(t *testing.T) {
+	e := setupImportApp(t)
+
+	first, status := uploadCSV(t, e, "person", prospectCSV)
+	if status != http.StatusOK {
+		t.Fatalf("upload → %d, want 200", status)
+	}
+	mapping := map[string]string{"Email": "email", "Full Name": "full_name", "Title": "title"}
+	run, runStatus := createRunWithMapping(t, e, "person", first.SourceRef, mapping)
+	if runStatus != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", runStatus)
+	}
+	var approved importRunDTO
+	if s := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); s != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", s)
+	}
+
+	// A second file naming the SAME address under a different name. The source
+	// key is the email, so the identity map recognises the row and this is an
+	// update — which is the right answer, and the one the commit must also give.
+	const clash = "Email,Full Name,Title\n" +
+		"ada@lovelace.example,Ada Byron,Countess\n" +
+		"joan@clarke.example,Joan Clarke,Cryptanalyst\n"
+	second, secondStatus := uploadCSV(t, e, "person", clash)
+	if secondStatus != http.StatusOK {
+		t.Fatalf("second upload → %d, want 200", secondStatus)
+	}
+	rerun, rerunStatus := createRunWithMapping(t, e, "person", second.SourceRef, mapping)
+	if rerunStatus != http.StatusAccepted {
+		t.Fatalf("create re-run → %d, want 202", rerunStatus)
+	}
+
+	var report importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &report); s != http.StatusOK {
+		t.Fatalf("report → %d, want 200", s)
+	}
+	if report.Disposition.Created != 1 || report.Disposition.Updated != 1 {
+		t.Fatalf("preview = %+v, want 1 create and 1 update for the address already held", report.Disposition)
+	}
+
+	var reapproved importRunDTO
+	if s := e.Call(t, http.MethodPost, "/v1/imports/"+rerun.ID+"/approve", nil, nil, &reapproved); s != http.StatusAccepted {
+		t.Fatalf("approve re-run → %d, want 202", s)
+	}
+	var after importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+rerun.ID+"/report", nil, nil, &after); s != http.StatusOK {
+		t.Fatalf("report after commit → %d, want 200", s)
+	}
+	if after.Disposition.Created != 1 || after.Disposition.Updated != 1 {
+		t.Fatalf("commit = %+v, want the same 1 create and 1 update the preview promised", after.Disposition)
+	}
+}
+
+// A contact file naming employers links each person to their company, and says
+// what it will do BEFORE anyone approves it.
+//
+// The whole flow in one test, because each half passing alone would still be a
+// broken feature: the preview must report how many links will actually resolve
+// (not how many the file asks for), and the commit must write exactly those.
+//
+// The companies arrive the way real ones do — created directly, not by a
+// previous CSV run — because that is the case the importer's identity map
+// cannot help with, and the one every real migration hits.
+func TestCSVImportLinksPeopleToTheirEmployers(t *testing.T) {
+	e := setupImportApp(t)
+	for _, name := range []string{"Analytical Engines", "Bletchley Ltd"} {
+		if status := e.Call(t, http.MethodPost, "/v1/organizations",
+			map[string]any{"display_name": name}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("creating %q → %d, want 201", name, status)
+		}
+	}
+
+	// Three people: two naming a company that exists, one naming a company
+	// nobody has imported.
+	const contacts = "Email,Full Name,Company\n" +
+		"ada@x.test,Ada Lovelace,Analytical Engines\n" +
+		"joan@x.test,Joan Clarke,Bletchley Ltd\n" +
+		"katherine@x.test,Katherine Johnson,Langley Research\n"
+
+	profile, status := uploadCSV(t, e, "person", contacts)
+	if status != http.StatusOK {
+		t.Fatalf("upload → %d, want 200", status)
+	}
+	mapping := map[string]string{
+		"Email": "email", "Full Name": "full_name", "Company": "organization_name",
+	}
+	run, runStatus := createRunWithMapping(t, e, "person", profile.SourceRef, mapping)
+	if runStatus != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", runStatus)
+	}
+
+	var report importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); s != http.StatusOK {
+		t.Fatalf("report → %d, want 200", s)
+	}
+	if report.Links == nil {
+		t.Fatal("the report carries no links section, so a person approving it is told nothing about employers")
+	}
+	// The file asks for three links and two of the companies are here, so the
+	// preview says three offered with one named as unresolvable. Both numbers
+	// matter: "3 asked for, 1 we cannot make" is the decision a person is
+	// actually taking, and reporting only the resolvable two would hide the
+	// company they need to go and import.
+	if report.Links.Offered != 3 {
+		t.Fatalf("links.offered = %d, want the 3 the file names", report.Links.Offered)
+	}
+	if report.Links.Applied != 0 {
+		t.Fatalf("links.applied = %d on a dry run, want 0 — a dry run writes nothing", report.Links.Applied)
+	}
+	if len(report.Links.Unresolved) != 1 {
+		t.Fatalf("unresolved = %+v, want the one company that is not in the CRM", report.Links.Unresolved)
+	}
+	if !strings.Contains(report.Links.Unresolved[0].Reason, "Langley Research") {
+		t.Fatalf("reason = %q, want it to name the company that was not found", report.Links.Unresolved[0].Reason)
+	}
+
+	var approved importRunDTO
+	if s := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); s != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", s)
+	}
+
+	var after importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &after); s != http.StatusOK {
+		t.Fatalf("report after commit → %d, want 200", s)
+	}
+	if after.Links == nil || after.Links.Applied != 2 {
+		t.Fatalf("links after commit = %+v, want the 2 the preview promised", after.Links)
+	}
+	// Every person lands, including the one whose employer was not found: an
+	// unresolvable company is a missing link, never a missing contact.
+	if got := importedPersonCount(t, e); got != 3 {
+		t.Fatalf("people = %d, want all 3 — a row's employer not resolving must not lose the person", got)
+	}
+}

--- a/backend/internal/compose/integration/csvimportperson_integration_test.go
+++ b/backend/internal/compose/integration/csvimportperson_integration_test.go
@@ -230,3 +230,95 @@ func TestCSVImportLinksPeopleToTheirEmployers(t *testing.T) {
 		t.Fatalf("people = %d, want all 3 — a row's employer not resolving must not lose the person", got)
 	}
 }
+
+// A company whose legal form differs from the file's is NOT the same company.
+//
+// This is the finding that makes the difference between a review queue and a
+// write. NormalizeOrgName strips legal suffixes, so `Acme Inc` and `Acme GmbH`
+// normalize alike — right for asking a human "are these two the same?", wrong
+// for deciding it. Two different legal entities linked by a guess is a wrong
+// answer nobody sees; a missing link is one the report names.
+func TestCSVImportDoesNotLinkAcrossLegalForms(t *testing.T) {
+	e := setupImportApp(t)
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Northwind GmbH"}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the company → %d, want 201", status)
+	}
+
+	const contacts = "Email,Full Name,Company\nada@x.test,Ada Lovelace,Northwind Inc\n"
+	profile, status := uploadCSV(t, e, "person", contacts)
+	if status != http.StatusOK {
+		t.Fatalf("upload → %d, want 200", status)
+	}
+	run, runStatus := createRunWithMapping(t, e, "person", profile.SourceRef, map[string]string{
+		"Email": "email", "Full Name": "full_name", "Company": "organization_name",
+	})
+	if runStatus != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", runStatus)
+	}
+
+	var report importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); s != http.StatusOK {
+		t.Fatalf("report → %d, want 200", s)
+	}
+	if report.Links == nil || len(report.Links.Unresolved) != 1 {
+		t.Fatalf("links = %+v, want the differently-spelled company reported unresolved", report.Links)
+	}
+	if !strings.Contains(report.Links.Unresolved[0].Reason, "Northwind Inc") {
+		t.Fatalf("reason = %q, want it to name the company as the FILE spells it",
+			report.Links.Unresolved[0].Reason)
+	}
+}
+
+// A row the commit will refuse takes its employer link down with it.
+//
+// The person is never created, so there is nobody to link. A preview counting
+// that link as resolvable would promise something the commit cannot do, which is
+// the disagreement the whole dry run exists to prevent.
+func TestCSVImportDoesNotPromiseLinksForRowsThatWillNotLand(t *testing.T) {
+	e := setupImportApp(t)
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Analytical Engines"}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the company → %d, want 201", status)
+	}
+
+	// The second row's address is malformed, so the store refuses it before the
+	// write transaction opens — and the preview already knows that.
+	const contacts = "Email,Full Name,Company\n" +
+		"ada@x.test,Ada Lovelace,Analytical Engines\n" +
+		"not-an-address,Broken Row,Analytical Engines\n"
+	profile, status := uploadCSV(t, e, "person", contacts)
+	if status != http.StatusOK {
+		t.Fatalf("upload → %d, want 200", status)
+	}
+	run, runStatus := createRunWithMapping(t, e, "person", profile.SourceRef, map[string]string{
+		"Email": "email", "Full Name": "full_name", "Company": "organization_name",
+	})
+	if runStatus != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", runStatus)
+	}
+
+	var report importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); s != http.StatusOK {
+		t.Fatalf("report → %d, want 200", s)
+	}
+	if report.Links == nil || report.Links.Offered != 2 {
+		t.Fatalf("links = %+v, want both rows counted as asking for a link", report.Links)
+	}
+	if len(report.Links.Unresolved) != 1 {
+		t.Fatalf("unresolved = %+v, want the refused row's link reported as unmakeable",
+			report.Links.Unresolved)
+	}
+
+	var approved importRunDTO
+	if s := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, &approved); s != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", s)
+	}
+	var after importReportDTO
+	if s := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &after); s != http.StatusOK {
+		t.Fatalf("report after commit → %d, want 200", s)
+	}
+	if after.Links == nil || after.Links.Applied != 1 {
+		t.Fatalf("applied = %+v, want the one link the preview promised", after.Links)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16974,6 +16974,32 @@ type ImportRunDisposition struct {
 	Updated int `json:"updated"`
 }
 
+// ImportRunLinks The connections between records a run makes, counted apart from the rows
+// it writes.
+//
+// A link is not a row and is never added to the disposition's four: one
+// person row can arrive with an employer and produce both a created person
+// and an applied link, and counting it twice would make the four stop
+// summing to the rows read.
+//
+// Today the only link a delimited file carries is a person's employer,
+// named by a company column the mapping points at `organization`.
+type ImportRunLinks struct {
+	// Applied Links actually written. Zero on a dry run, which writes nothing.
+	Applied int `json:"applied"`
+
+	// Offered Links the file asks for. A dry run reports this and nothing else,
+	// because resolving an endpoint is a read the dry run has not done —
+	// it says how many rows named an employer, not how many will find one.
+	Offered int `json:"offered"`
+
+	// Unresolved The links that named something the run could not act on, each with
+	// the reason. Enumerated rather than counted, because the answer a
+	// person needs is WHICH company was not found — that is the row of the
+	// spreadsheet they have to go and fix.
+	Unresolved *[]ImportUnresolvedLink `json:"unresolved,omitempty"`
+}
+
 // ImportRunReport The same shape before and after approval: a dry run reports what the
 // commit will do, a finished run reports what it did.
 type ImportRunReport struct {
@@ -16984,7 +17010,19 @@ type ImportRunReport struct {
 	EstimatedDurationSeconds *int `json:"estimated_duration_seconds,omitempty"`
 
 	// Issues Row-level refusals, enumerated. A file half-ignored under a success message is worse than a refusal.
-	Issues   []ImportRowIssue   `json:"issues"`
+	Issues []ImportRowIssue `json:"issues"`
+
+	// Links The connections between records a run makes, counted apart from the rows
+	// it writes.
+	//
+	// A link is not a row and is never added to the disposition's four: one
+	// person row can arrive with an employer and produce both a created person
+	// and an applied link, and counting it twice would make the four stop
+	// summing to the rows read.
+	//
+	// Today the only link a delimited file carries is a person's employer,
+	// named by a company column the mapping points at `organization`.
+	Links    *ImportRunLinks    `json:"links,omitempty"`
 	RowsRead int                `json:"rows_read"`
 	RunId    openapi_types.UUID `json:"run_id"`
 
@@ -17142,6 +17180,18 @@ type ImportUndoReport struct {
 	// (IEM-WIRE-9) are the reversal's own states, reachable only from
 	// `complete` and only for the `csv` connector.
 	Status ImportRunStatus `json:"status"`
+}
+
+// ImportUnresolvedLink defines model for ImportUnresolvedLink.
+type ImportUnresolvedLink struct {
+	// From The record the link starts at, by the key the file identified it with.
+	From string `json:"from"`
+
+	// Reason Why it was not applied, in the words of the person who made the file.
+	Reason string `json:"reason"`
+
+	// To What the file named as the other end — a company name, not an id, because no id was found.
+	To string `json:"to"`
 }
 
 // IngestVoiceCorpusSourceRequest defines model for IngestVoiceCorpusSourceRequest.

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -5099,6 +5099,43 @@
                   ]
                 }
               },
+              "links": {
+                "type": "object",
+                "properties": {
+                  "applied": {
+                    "type": "integer"
+                  },
+                  "offered": {
+                    "type": "integer"
+                  },
+                  "unresolved": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "to": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "from",
+                        "reason",
+                        "to"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "applied",
+                  "offered"
+                ]
+              },
               "rows_read": {
                 "type": "integer"
               },

--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -15,7 +15,9 @@ var previewImportCopy = toolCopy{
 		"Use `lead` for a machine-sourced list nobody has worked yet; those land unworked and a " +
 		"human promotes them. A row naming a record already here is counted in `duplicates`, and " +
 		"created unless on_duplicate is skip — except a person whose email is already held, which " +
-		"is always refused, because an email is a real key. To CORRECT companies rather than add " +
+		"is always refused, because an email is a real key. To link people to their employers, map the company column to " +
+		"`organization_name` — import the companies FIRST, because a name that matches nothing links " +
+		"nothing and says so. To CORRECT companies rather than add " +
 		"them, map a column to `id`, then give a row the id of the company it corrects — read them " +
 		"out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add.",
 	Instead: "create_record for one record you already know.",

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -118,7 +118,7 @@ func (t previewImport) Spec() mcp.ToolSpec {
 			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `","` + importObjectPerson + `"]},
 			"csv":{"type":"string","description":"The file's contents, header row first."},
 			"mapping":{"type":"object","additionalProperties":{"type":"string"},
-			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add."},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands."},
 			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
 			  "description":"A record already here: create (default) lands a second and files the pair for review; skip leaves the incumbent. For people an address already held is refused either way — an email is a real key, a company name is not."}},
 			"additionalProperties":false}`),

--- a/backend/internal/modules/migration/csvassoc.go
+++ b/backend/internal/modules/migration/csvassoc.go
@@ -32,9 +32,9 @@ import (
 // `organization` there would be right to send the value to its identity map,
 // which holds ids — and would get nothing, silently, for every row.
 //
-// It doubles as the mapping target a person file points its company column at:
-// the string the caller maps to and the string the edge travels under are one
-// value, so the two sides cannot drift.
+// It doubles as the mapping target a person file points its company column at.
+// compose assigns its own csvEmployerName from this constant rather than
+// spelling it again, so both sides are one value by construction.
 const AssocTargetOrganizationName = "organization_name"
 
 // assocCategoryEmployment is what the edge means: this person works here.

--- a/backend/internal/modules/migration/csvassoc.go
+++ b/backend/internal/modules/migration/csvassoc.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package migration
+
+// The edges a delimited file carries.
+//
+// A flat file has no edge table, and for a long time this source answered that
+// it therefore has no edges at all. That was true of its SHAPE and false of its
+// CONTENT: a contact export names each person's employer in a column, which is a
+// relationship between two records written the only way a spreadsheet can write
+// one — by name, in a cell on the row.
+//
+// So one edge per row that names a company, and the endpoints are found in two
+// different ways. The person is named by the run's source key, which the identity
+// map can resolve because this run is landing that person. The company is named
+// by TEXT, which no identity map can resolve, so it travels as text and the
+// writer resolves it. `AssocTargetOrganizationName` exists to say that
+// explicitly: an endpoint that is a name and not an id must not be handed to a
+// lookup that answers ids.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// AssocTargetOrganizationName is the `To` endpoint kind for an edge whose other
+// end is a company NAME rather than a company id.
+//
+// Named apart from ObjectOrganization on purpose. A writer that saw
+// `organization` there would be right to send the value to its identity map,
+// which holds ids — and would get nothing, silently, for every row.
+//
+// It doubles as the mapping target a person file points its company column at:
+// the string the caller maps to and the string the edge travels under are one
+// value, so the two sides cannot drift.
+const AssocTargetOrganizationName = "organization_name"
+
+// assocCategoryEmployment is what the edge means: this person works here.
+const assocCategoryEmployment = "employment"
+
+// Associations answers one edge per row naming an employer.
+//
+// It re-walks the file, which is the same thing every other read of this source
+// does — Counts walks it, and each page of Rows walks it from the top. The whole
+// file is bounded by the upload cap, and one edge is two short strings, so the
+// all-at-once shape the Source interface asks for costs a few hundred kilobytes
+// on the largest file this door accepts. It does not need paging; a later reader
+// tempted to add some should know the bound is the upload limit, not the row
+// count.
+//
+// Empty for every object but a person run, and for a person run whose mapping
+// names no company column: an organization or lead import is unaffected by this
+// file existing.
+func (s *CSVSource) Associations(ctx context.Context) ([]Assoc, error) {
+	if s.object != ObjectPerson {
+		return nil, nil
+	}
+	column := s.columnFor(AssocTargetOrganizationName)
+	if column == "" {
+		return nil, nil
+	}
+
+	var out []Assoc
+	// The SAME claim rule Rows applies, and it is load-bearing rather than
+	// defensive. A row whose source key an earlier line already claimed is NOT
+	// delivered — so no person is landed for it — and the identity map holds the
+	// earlier row's person under that key. An edge emitted for the undelivered
+	// row would resolve its `From` endpoint to the FIRST row's person and attach
+	// a human to a company they have nothing to do with. The rule is not
+	// duplicated for tidiness; leaving it out writes wrong data.
+	claimed := map[string]bool{}
+	err := s.walk(ctx, func(line int, record []string, index map[string]int) error {
+		row, ok := s.rowFrom(line, record, index)
+		if !ok {
+			// Already disclosed by rowFrom on its own walk. Saying it twice would
+			// put one unusable row in the report as two.
+			return nil
+		}
+		if claimed[row.ExternalID] {
+			return nil
+		}
+		claimed[row.ExternalID] = true
+
+		at, ok := index[column]
+		if !ok || at >= len(record) {
+			return nil
+		}
+		name := strings.TrimSpace(record[at])
+		if name == "" {
+			// The file said nothing about this person's employer, which is not
+			// the same as saying they have none. No edge, no disclosure.
+			return nil
+		}
+		out = append(out, Assoc{
+			FromType: ObjectPerson,
+			FromID:   row.ExternalID,
+			ToType:   AssocTargetOrganizationName,
+			ToID:     name,
+			Category: assocCategoryEmployment,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading the employer column: %w", err)
+	}
+	return out, nil
+}
+
+// columnFor answers which source column was mapped onto a target.
+func (s *CSVSource) columnFor(target string) string {
+	for column, mapped := range s.mapping {
+		if mapped == target {
+			return column
+		}
+	}
+	return ""
+}

--- a/backend/internal/modules/migration/csvassoc_test.go
+++ b/backend/internal/modules/migration/csvassoc_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package migration
+
+// What a delimited file offers as edges, and — more importantly — what it does
+// not.
+
+import (
+	"context"
+	"testing"
+)
+
+func personEmployerSource(t *testing.T, body string) *CSVSource {
+	t.Helper()
+	mapping := map[string]string{
+		"Email":   "email",
+		"Name":    "full_name",
+		"Company": AssocTargetOrganizationName,
+	}
+	return NewCSVSource(seedCSV(t, body), testCSVKey, ObjectPerson, mapping, "Email")
+}
+
+// One edge per row naming a company, carrying the row's own source key so the
+// writer can find the person it landed.
+func TestAPersonFileOffersOneEmployerEdgePerNamedCompany(t *testing.T) {
+	src := personEmployerSource(t, "Email,Name,Company\n"+
+		"ada@x.test,Ada,Analytical Engines\n"+
+		"grace@x.test,Grace,\n"+
+		"joan@x.test,Joan,Bletchley Ltd\n")
+
+	edges, err := src.Associations(context.Background())
+	if err != nil {
+		t.Fatalf("Associations: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("edges = %d, want one per row naming a company — the empty cell offers none", len(edges))
+	}
+	if edges[0].FromID != "ada@x.test" || edges[0].ToID != "Analytical Engines" {
+		t.Fatalf("edge = %+v, want the row's source key and the company as written", edges[0])
+	}
+	if edges[0].FromType != ObjectPerson || edges[0].ToType != AssocTargetOrganizationName {
+		t.Fatalf("edge endpoints = %s→%s, want a person and a company NAME", edges[0].FromType, edges[0].ToType)
+	}
+	if edges[0].Category != assocCategoryEmployment {
+		t.Fatalf("category = %q, want employment", edges[0].Category)
+	}
+}
+
+// The rule that stops a wrong human being attached to a company.
+//
+// Two rows claiming one source key: Rows delivers only the FIRST, so only one
+// person is landed and the identity map holds it under that key. An edge emitted
+// for the second row would resolve its person endpoint to the first row's person
+// — attaching Ada to Grace's employer, silently, with every count still adding
+// up. It has no natural symptom, which is why it has a test.
+func TestARowWhoseKeyWasAlreadyClaimedOffersNoEdge(t *testing.T) {
+	src := personEmployerSource(t, "Email,Name,Company\n"+
+		"ada@x.test,Ada,Analytical Engines\n"+
+		"ada@x.test,Grace,Bletchley Ltd\n")
+
+	edges, err := src.Associations(context.Background())
+	if err != nil {
+		t.Fatalf("Associations: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want only the delivered row's — the second row lands no person to link", len(edges))
+	}
+	if edges[0].ToID != "Analytical Engines" {
+		t.Fatalf("edge = %+v, want the FIRST row's company; the second row's would attach the wrong employer", edges[0])
+	}
+}
+
+// A row with no value in the source-key column is never delivered, so it can
+// have no edge either.
+func TestARowWithNoSourceKeyOffersNoEdge(t *testing.T) {
+	src := personEmployerSource(t, "Email,Name,Company\n"+
+		",Nobody,Analytical Engines\n"+
+		"ada@x.test,Ada,Bletchley Ltd\n")
+
+	edges, err := src.Associations(context.Background())
+	if err != nil {
+		t.Fatalf("Associations: %v", err)
+	}
+	if len(edges) != 1 || edges[0].FromID != "ada@x.test" {
+		t.Fatalf("edges = %+v, want only the row that can be identified", edges)
+	}
+}
+
+// A file that maps no company column asks for no links, and neither does a run
+// importing anything but people.
+func TestNoEmployerColumnAndNoPersonRunOfferNoEdges(t *testing.T) {
+	unmapped := NewCSVSource(seedCSV(t, "Email,Name\nada@x.test,Ada\n"), testCSVKey,
+		ObjectPerson, map[string]string{"Email": "email", "Name": "full_name"}, "Email")
+	edges, err := unmapped.Associations(context.Background())
+	if err != nil {
+		t.Fatalf("Associations: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Fatalf("edges = %d, want none — the file mapped no company column", len(edges))
+	}
+
+	orgs := NewCSVSource(seedCSV(t, "Company\nAcme\n"), testCSVKey,
+		ObjectOrganization, map[string]string{"Company": "display_name"}, "Company")
+	edges, err = orgs.Associations(context.Background())
+	if err != nil {
+		t.Fatalf("Associations: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Fatalf("edges = %d, want none — a company file has no employer to name", len(edges))
+	}
+}

--- a/backend/internal/modules/migration/csvsource.go
+++ b/backend/internal/modules/migration/csvsource.go
@@ -102,11 +102,6 @@ func (s *CSVSource) Counts(ctx context.Context) (map[string]int, error) {
 	return map[string]int{s.object: rows}, nil
 }
 
-// Associations answers empty, and that is the shape of the source rather than
-// an unfinished implementation: a flat file has no edges to detangle. A source
-// that carries them (HubSpot, Salesforce) implements this seam with content.
-func (s *CSVSource) Associations(context.Context) ([]Assoc, error) { return nil, nil }
-
 // Skipped reports the rows no page could deliver, with the line to open and the
 // reason. Never silent: a file half-ignored under a success message is worse
 // than a refusal.

--- a/backend/internal/modules/migration/engine.go
+++ b/backend/internal/modules/migration/engine.go
@@ -404,13 +404,21 @@ func withPartial(rep Report, or ObjectReport) Report {
 
 // mergedWith folds an earlier attempt's dispositions into this one's, so
 // a run resumed across several crashes still reports the whole estate it
-// imported rather than only its final leg. Counts add and per-object
+// imported rather than only its final leg. Row counts add and per-object
 // entries fold by class; the checkpoint guarantees no row is walked
-// twice, so addition cannot double-count.
+// twice, so addition cannot double-count them.
+//
+// EDGES REPLACE RATHER THAN ADD, and the difference is the checkpoint. There is
+// none over the association phase: it runs whole on every attempt, and the dry
+// run walks the same edges again to say what it would link. Adding those would
+// report a file's 12,000 employer links as 24,000 the moment it was approved,
+// and name every company it could not find twice over. The later answer is the
+// true one — it was computed against the estate as it stands now — so it wins
+// outright.
 func (r Report) mergedWith(next Report) Report {
 	out := Report{
-		Associations:        r.Associations + next.Associations,
-		AssociationsSkipped: append(append([]SkippedAssoc(nil), r.AssociationsSkipped...), next.AssociationsSkipped...),
+		Associations:        next.Associations,
+		AssociationsSkipped: append([]SkippedAssoc(nil), next.AssociationsSkipped...),
 		Imported:            r.Imported + next.Imported,
 	}
 	at := map[string]int{}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 57,
-    "tokens": 17647,
+    "tokens": 17755,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 309
+    "mean_tool_tokens": 311
   },
   "agents": [
     {
@@ -70,6 +70,10 @@
       "tokens": 1213
     },
     {
+      "name": "preview_import",
+      "tokens": 618
+    },
+    {
       "name": "update_record",
       "tokens": 603
     },
@@ -84,10 +88,6 @@
     {
       "name": "resolve_entities",
       "tokens": 513
-    },
-    {
-      "name": "preview_import",
-      "tokens": 510
     },
     {
       "name": "list_records",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 57 | 17647 | 73% | — | — | — |
+| _whole served catalog, for scale_ | 57 | 17755 | 73% | — | — | — |
 
 ### `morning_brief`
 
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 309, across 57 served tools.
+Median 275 tokens, mean 311, across 57 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -129,11 +129,11 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 1213 | 3 scenarios |
+| `preview_import` | 618 | — |
 | `update_record` | 603 | 4 scenarios |
 | `log_activity` | 588 | 1 scenario |
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |
-| `preview_import` | 510 | — |
 | `list_records` | 475 | — |
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 57,
     "resources": 9,
-    "tool_catalog_bytes": 160030,
+    "tool_catalog_bytes": 160774,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 40885,
+    "approx_wire_tokens_total": 41071,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 37084,
-      "input_schema_bytes": 35391,
-      "output_schema_bytes": 75186,
-      "description_plus_input_schema_bytes": 72475
+      "description_bytes": 37260,
+      "input_schema_bytes": 35647,
+      "output_schema_bytes": 75498,
+      "description_plus_input_schema_bytes": 72907
     }
   },
   "tools": {
@@ -5278,7 +5278,7 @@
           "readOnlyHint": false,
           "title": "Preview an import"
         },
-        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. `object` is organization, person or lead. Use `person` for a file the business already knows — a migration off another CRM, a corrected export coming back. Use `lead` for a machine-sourced list nobody has worked yet; those land unworked and a human promotes them. A row naming a record already here is counted in `duplicates`, and created unless on_duplicate is skip — except a person whose email is already held, which is always refused, because an email is a real key. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. `object` is organization, person or lead. Use `person` for a file the business already knows — a migration off another CRM, a corrected export coming back. Use `lead` for a machine-sourced list nobody has worked yet; those land unworked and a human promotes them. A row naming a record already here is counted in `duplicates`, and created unless on_duplicate is skip — except a person whose email is already held, which is always refused, because an email is a real key. To link people to their employers, map the company column to `organization_name` — import the companies FIRST, because a name that matches nothing links nothing and says so. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5295,7 +5295,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add.",
+              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
               "type": "object"
             },
             "object": {
@@ -6634,6 +6634,43 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "links": {
+                      "properties": {
+                        "applied": {
+                          "type": "integer"
+                        },
+                        "offered": {
+                          "type": "integer"
+                        },
+                        "unresolved": {
+                          "items": {
+                            "properties": {
+                              "from": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "to": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "from",
+                              "reason",
+                              "to"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "applied",
+                        "offered"
+                      ],
+                      "type": "object"
                     },
                     "rows_read": {
                       "type": "integer"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 57 |
 | Resources | 9 |
-| Tool catalog | 156.3 KB |
+| Tool catalog | 157.0 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 40885 |
+| Approx. wire tokens | 41071 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 73.4 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 36.2 KB | 23% | Yes, every step |
-| Input schemas | 34.6 KB | 22% | Yes, every step |
+| Output schemas | 73.7 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 36.4 KB | 23% | Yes, every step |
+| Input schemas | 34.8 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.1 KB | 7% | Partly |
-| **Description + input schema** | **70.8 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **71.2 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -91,14 +91,14 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
-| [`preview_import`](#preview_import) | Preview an import |  |  | 3.4 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 3.8 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.5 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
-| [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.6 KB |
+| [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.3 KB |
 | [`read_record`](#read_record) | Read a record | yes |  | 2.0 KB |
@@ -5840,7 +5840,7 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
 
 **Preview an import**
 
-Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. `object` is organization, person or lead. Use `person` for a file the business already knows — a migration off another CRM, a corrected export coming back. Use `lead` for a machine-sourced list nobody has worked yet; those land unworked and a human promotes them. A row naming a record already here is counted in `duplicates`, and created unless on_duplicate is skip — except a person whose email is already held, which is always refused, because an email is a real key. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
+Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. `object` is organization, person or lead. Use `person` for a file the business already knows — a migration off another CRM, a corrected export coming back. Use `lead` for a machine-sourced list nobody has worked yet; those land unworked and a human promotes them. A row naming a record already here is counted in `duplicates`, and created unless on_duplicate is skip — except a person whose email is already held, which is always refused, because an email is a real key. To link people to their employers, map the company column to `organization_name` — import the companies FIRST, because a name that matches nothing links nothing and says so. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -5861,7 +5861,7 @@ Bring a spreadsheet in: send the CSV as text and this checks every row against t
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add.",
+      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
       "type": "object"
     },
     "object": {
@@ -7269,6 +7269,43 @@ What an import will do, or did: rows created, updated, failed, unusable, duplica
                 "type": "object"
               },
               "type": "array"
+            },
+            "links": {
+              "properties": {
+                "applied": {
+                  "type": "integer"
+                },
+                "offered": {
+                  "type": "integer"
+                },
+                "unresolved": {
+                  "items": {
+                    "properties": {
+                      "from": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "to": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "from",
+                      "reason",
+                      "to"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "applied",
+                "offered"
+              ],
+              "type": "object"
             },
             "rows_read": {
               "type": "integer"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11511,6 +11511,43 @@ export interface components {
          * @enum {string}
          */
         ImportOnDuplicate: "create" | "skip";
+        /**
+         * @description The connections between records a run makes, counted apart from the rows
+         *     it writes.
+         *
+         *     A link is not a row and is never added to the disposition's four: one
+         *     person row can arrive with an employer and produce both a created person
+         *     and an applied link, and counting it twice would make the four stop
+         *     summing to the rows read.
+         *
+         *     Today the only link a delimited file carries is a person's employer,
+         *     named by a company column the mapping points at `organization`.
+         */
+        ImportRunLinks: {
+            /**
+             * @description Links the file asks for. A dry run reports this and nothing else,
+             *     because resolving an endpoint is a read the dry run has not done —
+             *     it says how many rows named an employer, not how many will find one.
+             */
+            offered: number;
+            /** @description Links actually written. Zero on a dry run, which writes nothing. */
+            applied: number;
+            /**
+             * @description The links that named something the run could not act on, each with
+             *     the reason. Enumerated rather than counted, because the answer a
+             *     person needs is WHICH company was not found — that is the row of the
+             *     spreadsheet they have to go and fix.
+             */
+            unresolved?: components["schemas"]["ImportUnresolvedLink"][];
+        };
+        ImportUnresolvedLink: {
+            /** @description The record the link starts at, by the key the file identified it with. */
+            from: string;
+            /** @description What the file named as the other end — a company name, not an id, because no id was found. */
+            to: string;
+            /** @description Why it was not applied, in the words of the person who made the file. */
+            reason: string;
+        };
         /** @description What the run will do, or did, counted per outcome. The four sum to the rows read — a disposition that does not add up is hiding something. */
         ImportRunDisposition: {
             created: number;
@@ -11552,6 +11589,7 @@ export interface components {
             issues: components["schemas"]["ImportRowIssue"][];
             /** @description Which column identified a row for idempotency — the request's `source_key`, or the natural key chosen in its absence. Stated because the whole re-run guarantee rests on it. */
             source_key_used: string;
+            links?: components["schemas"]["ImportRunLinks"];
             /** @description A dry run's estimate for the commit. Null when the run has already finished and the real duration is on the run record. */
             estimated_duration_seconds?: number | null;
             /** @description Present once the run has been undone (`status: undone`, IEM-WIRE-9); absent otherwise. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2793,6 +2793,9 @@ export const de = {
   "import.count.unchanged": "Unverändert",
   "import.count.skipped": "Übersprungen",
   "import.rowsRead": "{rows} Zeilen gelesen, erkannt über {column}.",
+  "import.linksOffered":
+    "{offered} Zeilen nennen einen Arbeitgeber; bei {unresolved} ist die Firma noch nicht im CRM.",
+  "import.linksApplied": "{applied} von {offered} Arbeitgeber-Verknüpfungen geschrieben.",
   "import.issuesLead":
     "Einige Zeilen können nicht importiert werden. Sie sind mit der Zeilennummer in Ihrer Datei aufgeführt.",
   "import.issueLine": "Zeile {line}:",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2795,7 +2795,8 @@ export const de = {
   "import.rowsRead": "{rows} Zeilen gelesen, erkannt über {column}.",
   "import.linksOffered":
     "{offered} Zeilen nennen einen Arbeitgeber; bei {unresolved} ist die Firma noch nicht im CRM.",
-  "import.linksApplied": "{applied} von {offered} Arbeitgeber-Verknüpfungen geschrieben.",
+  "import.linksApplied":
+    "{applied} von {offered} Arbeitgeber-Verknüpfungen geschrieben.",
   "import.issuesLead":
     "Einige Zeilen können nicht importiert werden. Sie sind mit der Zeilennummer in Ihrer Datei aufgeführt.",
   "import.issueLine": "Zeile {line}:",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2823,6 +2823,9 @@ export const en = {
   "import.count.unchanged": "Unchanged",
   "import.count.skipped": "Skipped",
   "import.rowsRead": "{rows} rows read, identified by {column}.",
+  "import.linksOffered":
+    "{offered} rows name an employer; {unresolved} name a company that is not in the CRM yet.",
+  "import.linksApplied": "{applied} of {offered} employer links written.",
   "import.issuesLead":
     "Some rows cannot be imported. They are listed with the line to open in your file.",
   "import.issueLine": "Line {line}:",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2771,6 +2771,9 @@ export const vi = {
   "import.count.unchanged": "Không đổi",
   "import.count.skipped": "Bỏ qua",
   "import.rowsRead": "Đã đọc {rows} dòng, nhận diện bằng {column}.",
+  "import.linksOffered":
+    "{offered} dòng có nêu nơi làm việc; {unresolved} dòng nêu công ty chưa có trong CRM.",
+  "import.linksApplied": "Đã ghi {applied}/{offered} liên kết nơi làm việc.",
   "import.issuesLead":
     "Một số dòng không nhập được. Danh sách kèm số dòng để bạn mở trong tệp.",
   "import.issueLine": "Dòng {line}:",

--- a/frontend/src/screens/import.tsx
+++ b/frontend/src/screens/import.tsx
@@ -348,24 +348,7 @@ function ImportOutcome({
           column: report.source_key_used,
         })}
       </p>
-      {/* Links sit apart from the four counts above because they are not rows:
-          one person can arrive as a created row AND an applied link, and adding
-          them would make the four stop summing to the rows read. Shown only when
-          the file asked for some — an unmapped company column has no number
-          worth a line. */}
-      {report.links && report.links.offered > 0 ? (
-        <p className="import__hint">
-          {committed
-            ? t("import.linksApplied", {
-                applied: formatNumber(report.links.applied, locale),
-                offered: formatNumber(report.links.offered, locale),
-              })
-            : t("import.linksOffered", {
-                offered: formatNumber(report.links.offered, locale),
-                unresolved: formatNumber(report.links.unresolved?.length ?? 0, locale),
-              })}
-        </p>
-      ) : null}
+      <LinkCount links={report.links} committed={committed} />
 
       {report.issues.length > 0 ? (
         <>
@@ -668,5 +651,36 @@ function ImportMappingStep({
         </Callout>
       ) : null}
     </>
+  );
+}
+
+// LinkCount reports the connections a run makes, apart from the rows it writes.
+//
+// Its own component because it is its own question: one person can arrive as a
+// created row AND an applied link, so putting links among the four counts above
+// would make them stop summing to the rows read. Renders nothing when the file
+// asked for no links, which is every import that mapped no company column.
+function LinkCount({
+  links,
+  committed,
+}: {
+  links: ImportReport["links"];
+  committed: boolean;
+}) {
+  const t = useT();
+  const { locale } = useLocale();
+  if (!links || links.offered === 0) return null;
+  return (
+    <p className="import__hint">
+      {committed
+        ? t("import.linksApplied", {
+            applied: formatNumber(links.applied, locale),
+            offered: formatNumber(links.offered, locale),
+          })
+        : t("import.linksOffered", {
+            offered: formatNumber(links.offered, locale),
+            unresolved: formatNumber(links.unresolved?.length ?? 0, locale),
+          })}
+    </p>
   );
 }

--- a/frontend/src/screens/import.tsx
+++ b/frontend/src/screens/import.tsx
@@ -348,6 +348,24 @@ function ImportOutcome({
           column: report.source_key_used,
         })}
       </p>
+      {/* Links sit apart from the four counts above because they are not rows:
+          one person can arrive as a created row AND an applied link, and adding
+          them would make the four stop summing to the rows read. Shown only when
+          the file asked for some — an unmapped company column has no number
+          worth a line. */}
+      {report.links && report.links.offered > 0 ? (
+        <p className="import__hint">
+          {committed
+            ? t("import.linksApplied", {
+                applied: formatNumber(report.links.applied, locale),
+                offered: formatNumber(report.links.offered, locale),
+              })
+            : t("import.linksOffered", {
+                offered: formatNumber(report.links.offered, locale),
+                unresolved: formatNumber(report.links.unresolved?.length ?? 0, locale),
+              })}
+        </p>
+      ) : null}
 
       {report.issues.length > 0 ? (
         <>


### PR DESCRIPTION
Closes #2670.

Map a person file's company column to `organization_name` and the import writes the employment edge. Before this the column came back `unmapped`, and the only route was one `create_record` call per person — 12,519 of them for the file that prompted this.

## The three blockers

**The source said a flat file has no edges.** True of its shape, false of its content: a contact export names each person's employer in a cell. `CSVSource.Associations` now emits one edge per row that names a company, carrying the company as TEXT under a `To` kind of its own — an endpoint that is a name and not an id must not reach a lookup that answers ids.

**The report threw the answer away.** `toContractImportReport` never read `Associations` or `AssociationsSkipped`, so an unresolved employer was unrepresentable over REST and MCP: the edge would vanish while the person counts looked right. `ImportRunReport` gains a `links` object — offered, applied, and the unresolved ones **named**, because the answer a person needs is which company was not found.

**Resolving a company by name had no safe implementation.** Exactly one live visible organization must carry the name as written, or nothing is linked and the report says why. Zero matches and matches-only-invisible answer the same sentence, because separating them is an existence oracle over a colleague's owner-private estate.

## What the preview promises

The dry run resolves the company end through the same resolver the commit uses, so a preview promising 12,000 links cannot be answered by 3,000 applied. Only the company end: at dry-run time no person has landed, and predicting "not imported" for every row would be worse than saying nothing.

## One engine fix

`Report.mergedWith` added association counts, on the reasoning that the checkpoint stops a row being walked twice. There is no checkpoint over the association phase — it runs whole on every attempt, and the dry run walks the same edges again — so a file's 12,000 links reported as 24,000 the moment it was approved. Edges now replace rather than add.

## Review

Codex found seven defects; three were real and are fixed:

- **Matching was not exact**, despite the comments claiming it twice. It compared `NormalizeOrgName`, which strips legal suffixes, so a file naming `Acme Inc` linked people to the CRM's `Acme GmbH`. Now folds case and spacing only.
- **The preview promised links for rows that will not land** — a refused or skipped row creates no person, so its link cannot be written.
- **A conflict reported as applied** now explains what it does and does not claim.

Filed rather than fixed: #2692 (the cached name index can go stale mid-run) and #2693 (it loads every visible organization into memory).

## Verification

- `make check-backend` and `make check-fe` green.
- 32 CSV import integration tests against Postgres, including 3 new ones for the employer link.
- 4 unit tests on the source, including the claimed-source-key rule: a row whose key an earlier line took emits no edge, because it lands no person and the identity map holds the FIRST row's person under that key. That one has no symptom, so it has a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSV person imports can link people to existing employers using company names.
  - Matching supports employer display and legal names, while ambiguous or missing matches remain unresolved.
  - Import previews and completed imports now report offered, applied, and unresolved links.

- **Improvements**
  - Import guidance now explains employer-linking requirements and matching behavior.
  - Import results display employer-link counts and unresolved companies in supported languages.

- **Bug Fixes**
  - Links are no longer promised for rows that are skipped or fail to import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->