### PR TITLE
feat(siteread): one button, and a read you asked for just fills the record

### DIFF
--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -9,25 +9,22 @@ package compose
 // folds the pages into a labeled corpus, and extracts it in ONE model
 // call (chunked only for outsized sites) through the no-guess evidence
 // gate — company fields, category facts, published people, and the
-// site's legal-entity census. The gated findings are staged as ONE
-// "deepread" proposal whose acceptance lands both halves in one
+// site's legal-entity census. The gated findings LAND directly, in one
 // transaction: profile fields fill-empty exactly like a quick scrape,
-// category facts land in organization_fact. The dossier (people's
-// site_read row) is the transparency surface the SPA polls: live phase
-// and page counts while running, then what was read, what was skipped
-// and why, and the proposals the findings staged.
+// category facts land in organization_fact. Nobody is asked to confirm a
+// read they pressed the button for — the write is marked as model-derived
+// and stays reversible instead. Published PEOPLE are the exception and
+// still stage as leads. The dossier (people's site_read row) is the
+// transparency surface the SPA polls: live phase and page counts while
+// running, then what was read and what it found.
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
@@ -36,7 +33,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/webread"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -325,100 +321,6 @@ func (w *siteDeepReadWorker) progressiveCallbacks(ctx context.Context, readID id
 		}
 	}
 	return progress, publishDraft
-}
-
-// stageProposals stages everything the read evidenced: the ONE deepread
-// proposal first (when any field or fact survived), then one thin
-// site_lead per published person — the dossier's proposal_ids keep
-// that order.
-//
-// They share ONE approval bundle, because they are one act. Without it the
-// inbox shows a company's facts and each person the site published as unrelated
-// questions, and the only thing that knew they were asked together was the
-// dossier's own proposal_ids list — which no inbox reader can see. The bundle
-// is minted before anything is staged, so a lead the already-on-file probe skips
-// leaves no hole: a bundle is what the act PROPOSED, not what it happened to
-// insert.
-func (w *siteDeepReadWorker) stageProposals(ctx context.Context, readID ids.UUID, claim people.SiteReadClaim, mergedFields []evidencedField, mergedFacts []people.DeepReadFact, mergedPeople []sitePerson, pagesRead int) ([]ids.UUID, error) {
-	bundleID := ids.NewV7()
-	var proposalIDs []ids.UUID
-	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
-		// BOTH kinds this act stages, locked in one canonically ordered
-		// statement before it stages either, and before the leads pass takes
-		// its own narrower one.
-		//
-		// The order that matters is the transaction's, not each statement's.
-		// Staging the facts first joins a `deepread` row; staging the leads then
-		// joins `site_lead` rows — and because re-proposing REBUNDLES what it
-		// joins, a bundle ends up holding both kinds with different ages, which
-		// a decision walks as one interleaved (created_at, id) sequence. Two
-		// ordered runs, one per kind, are not one order: the decision can hold a
-		// lead this act is about to want while waiting for a facts row this act
-		// already holds.
-		// The claim's account is what everything below files under, and the
-		// pre-lock is the FIRST thing to need it — before this, a claim with no
-		// account reached the staging calls that dereference it only when there
-		// was something to stage, so an empty read was a silent no-op. It stays
-		// one.
-		if claim.OrganizationID == nil {
-			return fmt.Errorf("compose: site read %s claims no account to file its proposals under", readID)
-		}
-		if err := w.approvals.LockPendingGroupInTx(ctx, tx, *claim.OrganizationID,
-			deepReadProposalKind, siteLeadProposalKind); err != nil {
-			return err
-		}
-		if len(mergedFields)+len(mergedFacts) > 0 {
-			approvalID, err := w.stage(ctx, tx, readID, claim, mergedFields, mergedFacts, pagesRead, bundleID)
-			if err != nil {
-				return fmt.Errorf("staging the proposal: %w", err)
-			}
-			proposalIDs = []ids.UUID{approvalID.UUID}
-		}
-		leads, err := w.stageSiteLeadsInTx(ctx, tx, readID, claim, mergedPeople, bundleID)
-		if err != nil {
-			return err
-		}
-		proposalIDs = append(proposalIDs, leads...)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return proposalIDs, nil
-}
-
-// stage records the merged findings as ONE "deepread" proposal carrying
-// both halves of the read — the profile fields the existing fill-empty
-// machinery applies and the category facts bound for organization_fact —
-// plus the dossier id, so the accept effect links the landed facts back
-// to the read that evidenced them.
-func (w *siteDeepReadWorker) stage(ctx context.Context, tx pgx.Tx, readID ids.UUID, claim people.SiteReadClaim, mergedFields []evidencedField, mergedFacts []people.DeepReadFact, pagesRead int, bundleID ids.UUID) (ids.ApprovalID, error) {
-	if claim.OrganizationID == nil {
-		return ids.ApprovalID{}, errors.New("site deep read: an unbound onboarding draft cannot stage an organization approval")
-	}
-	fields := deepReadFields(mergedFields)
-	proposedChange, err := json.Marshal(people.DeepReadProposal{
-		OrganizationID: ids.From[ids.OrganizationKind](*claim.OrganizationID),
-		SourceURL:      claim.SeedURL,
-		SiteReadID:     readID,
-		Fields:         fields,
-		Facts:          mergedFacts,
-	})
-	if err != nil {
-		return ids.ApprovalID{}, err
-	}
-	digest := sha256.Sum256(proposedChange)
-	approvalID, err := w.approvals.StageOrJoinPendingInTx(ctx, tx, approvals.StageInput{
-		Kind:           deepReadProposalKind,
-		ProposedChange: proposedChange,
-		DiffHash:       hex.EncodeToString(digest[:]),
-		TargetType:     enrichTargetType,
-		TargetID:       *claim.OrganizationID,
-		Summary:        fmt.Sprintf("Deep site read of %s: %d fields, %d facts from %d pages", claim.SeedURL, len(mergedFields), len(mergedFacts), pagesRead),
-		JoinPending:    true,
-		BundleID:       bundleID,
-	})
-	return approvalID, err
 }
 
 // siteReadLegalEntities projects the gated census onto the dossier shape.

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -39,8 +39,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/authz"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -251,65 +249,6 @@ func TestDeepReadCrawlsExtractsStagesOneDeepReadProposalAndFinishesDone(t *testi
 	}
 	if updatedEvents != 1 {
 		t.Fatalf("%d organization.updated outbox events after accept, want exactly 1 for the whole delta", updatedEvents)
-	}
-}
-
-func TestDeepReadConcurrentStagingJoinsThePendingProposal(t *testing.T) {
-	e := integration.Setup(t)
-	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
-	ctx := deepReadWorkerCtx(context.Background(), SiteDeepReadArgs{
-		Workspace:   e.WS,
-		RequestedBy: "human:" + e.Rep1.String(),
-	})
-	readID := ids.NewV7()
-	claim := people.SiteReadClaim{OrganizationID: &org, SeedURL: seedURL}
-	facts := []people.DeepReadFact{{
-		Category: "offering", Field: "service", Value: "Implementation",
-		ValueKey: "implementation", EvidenceSnippet: "Guided implementation", SourceURL: seedURL, Confidence: 0.9,
-	}}
-	type result struct {
-		id  ids.ApprovalID
-		err error
-	}
-	ready := make(chan struct{}, 2)
-	start := make(chan struct{})
-	results := make(chan result, 2)
-	// One bundle for both passes: they are the same act racing itself, so what
-	// is under test is the join, not which act's grouping wins.
-	bundle := ids.NewV7()
-	for range 2 {
-		go func() {
-			ready <- struct{}{}
-			<-start
-			// Each pass in its own transaction, which is what makes them race:
-			// the staging path takes the identity lock inside whatever
-			// transaction it is handed, and one shared transaction would be one
-			// pass with two calls in it.
-			var id ids.ApprovalID
-			err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
-				var err error
-				id, err = worker.stage(ctx, tx, readID, claim, nil, facts, 1, bundle)
-				return err
-			})
-			results <- result{id: id, err: err}
-		}()
-	}
-	<-ready
-	<-ready
-	close(start)
-	first, second := <-results, <-results
-	if first.err != nil || second.err != nil {
-		t.Fatalf("concurrent staging errors = %v, %v", first.err, second.err)
-	}
-	if first.id != second.id {
-		t.Fatalf("concurrent staging returned %s and %s, want the same pending proposal", first.id, second.id)
-	}
-	if n := deepReadApprovals(t, e); n != 1 {
-		t.Fatalf("concurrent staging created %d deepread approvals, want 1", n)
-	}
-	if n := e.WsCount(t, `SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'approval.requested'`); n != 1 {
-		t.Fatalf("concurrent staging emitted %d approval.requested events, want 1", n)
 	}
 }
 
@@ -712,64 +651,4 @@ func TestDeepReadAttributesItsWritesToTheRequesterTheRowNames(t *testing.T) {
 	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind = 'deepread' AND on_behalf_of = $1`, e.Rep1); n != 0 {
 		t.Errorf("%d proposals attributed to the payload's requester — the row is the authority", n)
 	}
-}
-
-// A read's proposals become visible ALL AT ONCE, which is what makes its bundle
-// mean "this is what the read found".
-//
-// Staged one commit at a time, a human refreshing their inbox between commits
-// could see the bundle, decide it, and be told the read's question was answered
-// while the rest of it was still being written; a worker that died mid-way would
-// leave a permanently partial set. The proof is that a staging which fails
-// part-way leaves NOTHING — the company proposal succeeds first, so a lead that
-// cannot stage must take it back with it.
-//
-// The lead is made unstageable at a real seam rather than by a hook: the
-// already-on-file probe asks under the REQUESTING HUMAN's authority, which the
-// worker resolves through identity, and a resolver that cannot answer stops that
-// lead — the org's own proposal having already been written.
-func TestDeepReadStagesAllOfAReadsProposalsOrNoneOfThem(t *testing.T) {
-	e := integration.Setup(t)
-	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
-	worker.authority = unresolvableAuthority{}
-	ctx := deepReadWorkerCtx(context.Background(), SiteDeepReadArgs{
-		Workspace:   e.WS,
-		RequestedBy: "human:" + e.Rep1.String(),
-	})
-	claim := people.SiteReadClaim{OrganizationID: &org, SeedURL: seedURL}
-	facts := []people.DeepReadFact{{
-		Category: "offering", Field: "service", Value: "Implementation",
-		ValueKey: "implementation", EvidenceSnippet: "Guided implementation", SourceURL: seedURL, Confidence: 0.9,
-	}}
-	published := sitePerson{
-		Name: "Anna Muster", Role: "CTO", PublishedEmail: "anna@acme.example",
-		EvidenceSnippet: "Anna Muster, CTO", SourceURL: seedURL,
-	}
-
-	if _, err := worker.stageProposals(ctx, ids.NewV7(), claim, nil, facts,
-		[]sitePerson{published}, 1); err == nil {
-		t.Fatal("staging a read whose lead cannot be staged succeeded, so this run proves nothing")
-	}
-	if n := deepReadApprovals(t, e); n != 0 {
-		t.Errorf("%d deepread proposals survived a read that could not stage all of itself, want 0 — "+
-			"a partial bundle is a whole question the inbox cannot answer", n)
-	}
-	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE bundle_id IS NOT NULL`); n != 0 {
-		t.Errorf("%d bundled proposals survived, want 0", n)
-	}
-}
-
-// unresolvableAuthority is identity's RBAC seam when it cannot answer — not a
-// missing user (which probeCtx handles by narrowing nothing), but a resolver
-// that failed. The site-lead staging refuses to guess a human's scope, so the
-// lead cannot be staged.
-type unresolvableAuthority struct{}
-
-func (unresolvableAuthority) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
-	return authz.RBAC{}, errors.New("identity is unreachable")
-}
-
-func (unresolvableAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
-	return "", errors.New("identity is unreachable")
 }

--- a/backend/internal/compose/deepreadautoapply.go
+++ b/backend/internal/compose/deepreadautoapply.go
@@ -78,6 +78,44 @@ func (w *siteDeepReadWorker) fillMatchedPeople(ctx context.Context, orgID ids.Or
 // auto-enrich sweep rather than a human.
 func isAutoEnrichRequest(requestedBy string) bool { return requestedBy == systemAutoEnrichActor }
 
+// applyForRequester is the human lane's terminal step: the person asked for
+// this read, so its org fields and facts land directly rather than becoming a
+// proposal that asks them to confirm what they just requested.
+//
+// It is deliberately NOT autoApply: that one also moves the auto-enrich sweep
+// cursor, which is bookkeeping for reads nobody asked for. A human read has no
+// cursor to advance, and advancing one would tell the sweep it had already
+// enriched a company it never looked at.
+//
+// Site people still stage as leads, on the same NEVER-8 grounds the automatic
+// lane keeps them: a person the site published is a new record about a human
+// being, not a column on the company the requester named.
+func (w *siteDeepReadWorker) applyForRequester(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, mergedFields []evidencedField, mergedFacts []people.DeepReadFact, mergedPeople []sitePerson) ([]ids.UUID, error) {
+	orgID := ids.From[ids.OrganizationKind](*claim.OrganizationID)
+	// Staged first for the reason autoApply states: the leads were evidenced
+	// independently of the org columns, so an apply failure must not drop them.
+	proposalIDs, err := w.stageSiteLeads(ctx, args.SiteReadID, claim, w.fillMatchedPeople(ctx, orgID, mergedPeople), ids.NewV7())
+	if err != nil {
+		return nil, err
+	}
+	fields := deepReadFields(mergedFields)
+	if len(fields) == 0 && len(mergedFacts) == 0 {
+		return proposalIDs, nil
+	}
+	if err := w.people.ApplyDeepRead(ctx, people.DeepReadProposal{
+		OrganizationID: orgID,
+		SourceURL:      claim.SeedURL,
+		SiteReadID:     args.SiteReadID,
+		Fields:         fields,
+		Facts:          mergedFacts,
+	}); err != nil {
+		// The people are staged; surfacing the error finishes the read failed,
+		// which is what tells the human the company half did not land.
+		return proposalIDs, fmt.Errorf("applying the deep read: %w", err)
+	}
+	return proposalIDs, nil
+}
+
 // autoApply is the auto-enrich lane's terminal step: apply the org fields +
 // facts directly, stage site people as leads, and record the cursor outcome.
 func (w *siteDeepReadWorker) autoApply(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, mergedFields []evidencedField, mergedFacts []people.DeepReadFact, mergedPeople []sitePerson) ([]ids.UUID, error) {

--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -111,7 +111,16 @@ func (w *siteDeepReadWorker) landFindings(ctx context.Context, args SiteDeepRead
 		// which ApplyDeepReadTx's auth.Require accepts.
 		return w.autoApply(ctx, args, claim, mergedFields, merged.facts, merged.people)
 	}
-	return w.stageProposals(ctx, args.SiteReadID, claim, mergedFields, merged.facts, merged.people, pagesRead)
+	// A read a human ASKED for applies its findings directly too: pressing
+	// "read the full site" is the decision, and staging what was just
+	// requested asks the same person the same question twice. Starting the
+	// read already required organization:update on this row
+	// (createOrJoinSiteRead), so the authority the apply needs was checked
+	// when it was commissioned. The findings stay marked as model-derived and
+	// reversible — direct is not unattributed. Site people still stage as
+	// leads: a stranger is a new record about a PERSON, which is a different
+	// question from filling in the company the human named.
+	return w.applyForRequester(ctx, args, claim, mergedFields, merged.facts, merged.people)
 }
 
 // readWarnings are the caveats the dossier shows a human: what this read could

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2100,19 +2100,11 @@ export const de = {
   "home.snooze": "Zurückstellen",
   "home.snoozedState": "zurückgestellt",
 
-  "enrich.title": "Von der Website lesen",
-  "enrich.sub":
-    "belegt oder weggelassen — füllt nur leere Felder, und nur nach deiner Freigabe",
-  "enrich.cta": "Jetzt lesen",
-  "enrich.reading": "Liest…",
-  "enrich.staged":
-    "Vorgemerkt — noch nichts geschrieben. Übernimm es im Eingang; nur leere Felder werden gefüllt.",
   "enrich.toInbox": "Eingang öffnen",
-  "enrich.from": "gelesen von {url}",
 
   "deepread.title": "Ganze Website lesen",
   "deepread.sub":
-    "Liest bis zu 12 Seiten der Firmenwebsite. Funde werden zur Prüfung vorgemerkt — nichts wird geschrieben, bis du übernimmst.",
+    "Liest die Firmenwebsite und trägt ein, was dort steht. Nur leere Felder werden gefüllt, alles ist als von der Website gelesen markiert, und du kannst es rückgängig machen.",
   "deepread.cta": "Ganze Website lesen",
   "deepread.starting": "Startet…",
   "deepread.unavailable":
@@ -2134,13 +2126,6 @@ export const de = {
   "deepread.stopDeadline": "Zeitlimit",
   "deepread.factCount.one": "{count} belegter Fakt vorgemerkt",
   "deepread.factCount.other": "{count} belegte Fakten vorgemerkt",
-  "deepread.pagesRead": "Gelesene Seiten",
-  "deepread.skippedPages": "Übersprungene Seiten",
-  "deepread.skipRobots": "robots.txt",
-  "deepread.skipOffDomain": "außerhalb der Domain",
-  "deepread.skipPageCap": "Seitenlimit",
-  "deepread.skipByteCap": "Größenlimit",
-  "deepread.skipUnreadable": "nicht lesbar",
   "deepread.proposals": "{count} Vorschläge warten auf deine Prüfung",
   "deepread.proposalsOne": "1 Vorschlag wartet auf deine Prüfung",
   "deepread.kindHome": "Startseite",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2125,19 +2125,11 @@ export const en = {
   "home.snooze": "Snooze",
   "home.snoozedState": "snoozed",
 
-  "enrich.title": "Read from the website",
-  "enrich.sub":
-    "evidence-or-omit — fills only empty fields, and only after your approval",
-  "enrich.cta": "Read now",
-  "enrich.reading": "Reading…",
-  "enrich.staged":
-    "Staged — nothing written yet. Accept it in your inbox; only empty fields fill.",
   "enrich.toInbox": "Open inbox",
-  "enrich.from": "read from {url}",
 
   "deepread.title": "Read the full site",
   "deepread.sub":
-    "Reads up to 12 pages of the company's website. Findings are staged for your review — nothing is written until you accept.",
+    "Reads the company's website and fills in what it finds. Only empty fields are filled, everything is marked as read from the site, and you can undo it.",
   "deepread.cta": "Read full site",
   "deepread.starting": "Starting…",
   "deepread.unavailable": "Site reading is not configured on this server.",
@@ -2158,13 +2150,6 @@ export const en = {
   "deepread.stopDeadline": "deadline",
   "deepread.factCount.one": "{count} evidenced fact staged",
   "deepread.factCount.other": "{count} evidenced facts staged",
-  "deepread.pagesRead": "Pages read",
-  "deepread.skippedPages": "Pages skipped",
-  "deepread.skipRobots": "robots.txt",
-  "deepread.skipOffDomain": "off domain",
-  "deepread.skipPageCap": "page cap",
-  "deepread.skipByteCap": "byte cap",
-  "deepread.skipUnreadable": "unreadable",
   "deepread.proposals": "{count} proposals waiting for your review",
   "deepread.proposalsOne": "1 proposal waiting for your review",
   "deepread.kindHome": "Home",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -154,7 +154,6 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "ob.conv.clarify.optionDetail",
   "create.linkedin",
   "person.enriched.field.linkedin",
-  "deepread.skipRobots",
   "quotas.periodRange",
 
   // Units, version rows and other format-only strings: symbols/abbreviations

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2088,19 +2088,11 @@ export const vi = {
   "home.snooze": "Tạm hoãn",
   "home.snoozedState": "đã tạm hoãn",
 
-  "enrich.title": "Đọc từ website",
-  "enrich.sub":
-    "có bằng chứng mới điền, không thì bỏ trống — chỉ điền vào ô còn trống, và chỉ sau khi bạn duyệt",
-  "enrich.cta": "Đọc ngay",
-  "enrich.reading": "Đang đọc…",
-  "enrich.staged":
-    "Đang chờ duyệt — chưa ghi gì. Hãy chấp nhận trong hộp phê duyệt; chỉ những ô còn trống mới được điền.",
   "enrich.toInbox": "Mở hộp phê duyệt",
-  "enrich.from": "đọc từ {url}",
 
   "deepread.title": "Đọc toàn bộ website",
   "deepread.sub":
-    "Đọc tối đa 12 trang trên website của công ty. Những gì tìm được sẽ chờ bạn rà soát — không gì được ghi cho đến khi bạn chấp nhận.",
+    "Đọc website của công ty và điền những gì tìm được. Chỉ điền vào các trường còn trống, mọi giá trị đều được đánh dấu là đọc từ website, và bạn có thể hoàn tác.",
   "deepread.cta": "Đọc toàn bộ website",
   "deepread.starting": "Đang bắt đầu…",
   "deepread.unavailable": "Máy chủ này chưa cấu hình việc đọc website.",
@@ -2121,13 +2113,6 @@ export const vi = {
   "deepread.stopDeadline": "hết thời hạn",
   "deepread.factCount.one": "{count} dữ kiện có bằng chứng đang chờ duyệt",
   "deepread.factCount.other": "{count} dữ kiện có bằng chứng đang chờ duyệt",
-  "deepread.pagesRead": "Số trang đã đọc",
-  "deepread.skippedPages": "Số trang bỏ qua",
-  "deepread.skipRobots": "robots.txt",
-  "deepread.skipOffDomain": "ngoài tên miền",
-  "deepread.skipPageCap": "giới hạn số trang",
-  "deepread.skipByteCap": "giới hạn dung lượng",
-  "deepread.skipUnreadable": "không đọc được",
   "deepread.proposals": "{count} đề xuất đang chờ bạn rà soát",
   "deepread.proposalsOne": "1 đề xuất đang chờ bạn rà soát",
   "deepread.kindHome": "Trang chủ",

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -32,12 +32,7 @@ import {
   mapOrgUpdate,
 } from "./organizations";
 
-// Company-360 enrichment (EP05 scrapeCompany): one click stages a 🟡
-// evidence-backed proposal — human field labels, per-field confidence +
-// evidence, the confirm-first banner (nothing written until the inbox
-// accept), and honest 422 degradation with the server's detail verbatim.
-//
-// Below that: the same P-14/15/16/1 shared-block wiring as contacts
+// The same P-14/15/16/1 shared-block wiring as contacts
 // (people.test.tsx) — search/sort/pagination, the rich create modal
 // (display_name/legal_name/industry/size_band/domains), the company-360
 // If-Match edit, and the duplicate_domain dedupe link.
@@ -75,32 +70,6 @@ async function openRecordMenu(testId: string): Promise<HTMLElement> {
   return screen.getByTestId(testId);
 }
 
-const proposal = {
-  proposal_id: "pr-1",
-  organization_id: "o-1",
-  source_url: "https://brandt.example",
-  status: "staged",
-  fields: [
-    {
-      field: "value_proposition",
-      value: "Fleet retrofits without downtime",
-      evidence_snippet: "We retrofit fleets without downtime",
-      source_url: "https://brandt.example",
-      confidence: 0.85,
-    },
-  ],
-};
-
-// The enrichment suite's only variable is what POST /enrich answers back; every
-// other read the page fires falls to the shared company backstop.
-function stubApi(enrich: () => Response) {
-  stubFetch(async (url, method) =>
-    method === "POST" && url.endsWith("/enrich")
-      ? enrich()
-      : companyBackstop(url),
-  );
-}
-
 // openHistory switches to the tab the account's chronology now lives on. The
 // timeline left the overview when the page gained People and History tabs, so
 // a test about the timeline has to go there first.
@@ -115,48 +84,6 @@ async function openHistory() {
 async function openProfile() {
   await userEvent.click(await screen.findByRole("button", { name: "Profile" }));
 }
-
-describe("company-360 enrichment", () => {
-  it("stages an evidence-backed proposal: human labels, confidence, confirm-first banner", async () => {
-    stubApi(() => jsonResponse(proposal));
-    render(<CompanyScreen id="o-1" />);
-    await waitFor(() =>
-      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
-    );
-    await openProfile();
-    await userEvent.click(screen.getByRole("button", { name: "Read now" }));
-    await waitFor(() =>
-      expect(screen.getByText("Value proposition")).toBeTruthy(),
-    );
-    expect(screen.queryByText("value_proposition")).toBeNull();
-    expect(screen.getByText("Fleet retrofits without downtime")).toBeTruthy();
-    expect(screen.getByText(/Staged — nothing written yet/)).toBeTruthy();
-    expect(screen.getByText(/read from https:\/\/brandt.example/)).toBeTruthy();
-  });
-
-  it("renders the honest 422 detail when the page is unreadable", async () => {
-    stubApi(() =>
-      jsonResponse(
-        {
-          title: "Unprocessable",
-          detail: "the organization has no domain to read",
-        },
-        422,
-      ),
-    );
-    render(<CompanyScreen id="o-1" />);
-    await waitFor(() =>
-      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
-    );
-    await openProfile();
-    await userEvent.click(screen.getByRole("button", { name: "Read now" }));
-    await waitFor(() =>
-      expect(
-        screen.getByText("the organization has no domain to read"),
-      ).toBeTruthy(),
-    );
-  });
-});
 
 // The deep read (A102/R2): one click starts a background whole-site crawl and
 // the card polls the read report until it lands on a terminal status. The
@@ -292,7 +219,7 @@ describe("company-360 deep read", () => {
     expect(screen.queryByText("Failed")).toBeNull();
   });
 
-  it("a partial report says it stopped early and names every skip reason", async () => {
+  it("a partial report says it stopped early, without listing the crawl's URLs", async () => {
     const { calls } = stubDeepRead({
       report: () =>
         jsonResponse({
@@ -314,13 +241,13 @@ describe("company-360 deep read", () => {
       expect(screen.getByText("Stopped early: page cap")).toBeTruthy(),
     );
     expect(screen.getByText("6 evidenced facts staged")).toBeTruthy();
-    expect(screen.getByText("Pages skipped")).toBeTruthy();
-    expect(screen.getByText("robots.txt")).toBeTruthy();
-    expect(screen.getByText("off domain")).toBeTruthy();
-    expect(screen.getByText("brandt.example/careers")).toBeTruthy();
+    // The crawl's own URL lists are debug output, not something a person
+    // reading a company record has any use for.
+    expect(screen.queryByText("Pages skipped")).toBeNull();
+    expect(screen.queryByText("brandt.example/careers")).toBeNull();
   });
 
-  it("a done report lists the pages read and links staged proposals to the inbox", async () => {
+  it("a done report links staged leads to the inbox and lists no crawl URLs", async () => {
     const { calls } = stubDeepRead({
       report: () =>
         jsonResponse({
@@ -341,9 +268,8 @@ describe("company-360 deep read", () => {
     );
     // A complete crawl carries no stopped-early banner.
     expect(screen.queryByText(/Stopped early:/)).toBeNull();
-    expect(screen.getByText("Pages read")).toBeTruthy();
-    expect(screen.getByText("Home")).toBeTruthy();
-    expect(screen.getByText("brandt.example/team")).toBeTruthy();
+    expect(screen.queryByText("Pages read")).toBeNull();
+    expect(screen.queryByText("brandt.example/team")).toBeNull();
 
     await userEvent.click(screen.getByRole("button", { name: "Open inbox" }));
     expect(window.location.hash).toBe("#/inbox");

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -37,12 +37,7 @@ import {
 } from "../design-system/recordtimeline";
 import { sectionState } from "../design-system/surfacestate";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
-import {
-  AutonomyDot,
-  ConfidenceMeter,
-  confidenceLevel,
-  EvidenceChip,
-} from "../design-system/trust";
+import { AutonomyDot, confidenceLevel } from "../design-system/trust";
 import { formatDateTime, formatMoney, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -55,7 +50,6 @@ import {
   provenanceOf,
   QueryGate,
   QueryStates,
-  siteReadKindLabel,
   throwProblem,
   useSorMode,
   useViewerId,
@@ -762,101 +756,6 @@ export function CompaniesScreen() {
   );
 }
 
-// The EP05 enrich verb on the company 360: one click reads the org's own
-// website through the cold-start fetch + no-guess gate and STAGES a 🟡
-// proposal — every rendered field carries evidence + confidence or was
-// omitted, and nothing writes until the human accepts it in the inbox
-// (accept fills only EMPTY fields).
-function EnrichCard({ orgId }: Readonly<{ orgId: string }>) {
-  const t = useT();
-  const enrich = useMutation({
-    mutationKey: ["enrich", orgId],
-    mutationFn: async () => {
-      const { data, error } = await api.POST("/organizations/{id}/enrich", {
-        params: { path: { id: orgId } },
-      });
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
-
-  return (
-    <Card
-      title={t("enrich.title")}
-      sub={t("enrich.sub")}
-      actions={
-        <Button
-          small
-          disabled={enrich.isPending}
-          onClick={() => enrich.mutate()}
-        >
-          {enrich.isPending ? t("enrich.reading") : t("enrich.cta")}
-        </Button>
-      }
-      style={{ marginBottom: "var(--space-4)" }}
-    >
-      {enrich.isError && (
-        <p className="t-caption" style={{ color: "var(--danger)" }}>
-          {problemMessageOf(enrich.error, t)}
-        </p>
-      )}
-      {enrich.data && (
-        <div>
-          <p
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              flexWrap: "wrap",
-              margin: "6px 0 12px",
-            }}
-          >
-            <AutonomyDot tier="confirm" />
-            <span className="t-small">{t("enrich.staged")}</span>
-            <Button small onClick={() => navigate({ screen: "inbox" })}>
-              {t("enrich.toInbox")}
-            </Button>
-          </p>
-          <p className="t-caption" style={{ marginBottom: 10 }}>
-            {t("enrich.from", { url: enrich.data.source_url })}
-          </p>
-          {enrich.data.fields.map((field) => {
-            const level = confidenceLevel(field.confidence);
-            return (
-              <div key={field.field} style={{ marginBottom: 12 }}>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                    marginBottom: 3,
-                  }}
-                >
-                  <span className="t-label">
-                    {coldFieldLabel(field.field, t)}
-                  </span>
-                  {level && <ConfidenceMeter level={level} />}
-                </div>
-                <div>{field.value}</div>
-                {field.evidence_snippet && (
-                  <EvidenceChip
-                    evidence={{
-                      snippet: field.evidence_snippet,
-                      source: field.source_url ?? "",
-                    }}
-                  />
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </Card>
-  );
-}
-
 type SiteReadReport = components["schemas"]["SiteReadReport"];
 
 const SITE_READ_STATUS_LABELS: Record<SiteReadReport["status"], MessageKey> = {
@@ -878,24 +777,6 @@ const SITE_READ_STOP_LABELS: Record<
   byte_cap: "deepread.stopByteCap",
   deadline: "deepread.stopDeadline",
 };
-
-const SITE_READ_SKIP_LABELS: Record<
-  components["schemas"]["SiteReadSkip"]["reason"],
-  MessageKey
-> = {
-  robots: "deepread.skipRobots",
-  off_domain: "deepread.skipOffDomain",
-  page_cap: "deepread.skipPageCap",
-  byte_cap: "deepread.skipByteCap",
-  unreadable: "deepread.skipUnreadable",
-};
-
-// Trims the scheme and clamps long paths so the pages/skips lists stay
-// scannable; the full URL survives on the title attribute.
-function shortUrl(url: string): string {
-  const bare = url.replace(/^https?:\/\//, "");
-  return bare.length > 60 ? `${bare.slice(0, 59)}…` : bare;
-}
 
 function SiteReadDeferral({ report }: Readonly<{ report: SiteReadReport }>) {
   const t = useT();
@@ -1032,58 +913,6 @@ function SiteReadPanel({
             {t("enrich.toInbox")}
           </Button>
         </p>
-      )}
-      {terminal && report.pages.length > 0 && (
-        <div style={{ marginTop: "var(--space-3)" }}>
-          <span className="t-label">{t("deepread.pagesRead")}</span>
-          <ul
-            className="t-small"
-            style={{
-              listStyle: "none",
-              margin: "var(--space-2) 0 0",
-              padding: 0,
-              display: "flex",
-              flexDirection: "column",
-              gap: "var(--space-1)",
-            }}
-          >
-            {report.pages.map((page) => (
-              <li key={page.url}>
-                <Badge>{siteReadKindLabel(page.kind, t)}</Badge>{" "}
-                <span className="t-mono" title={page.url}>
-                  {shortUrl(page.url)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      {terminal && report.skipped.length > 0 && (
-        <div style={{ marginTop: "var(--space-3)" }}>
-          <span className="t-label">{t("deepread.skippedPages")}</span>
-          <ul
-            className="t-small"
-            style={{
-              listStyle: "none",
-              margin: "var(--space-2) 0 0",
-              padding: 0,
-              display: "flex",
-              flexDirection: "column",
-              gap: "var(--space-1)",
-            }}
-          >
-            {report.skipped.map((skip) => (
-              <li key={skip.url}>
-                <span className="t-mono" title={skip.url}>
-                  {shortUrl(skip.url)}
-                </span>{" "}
-                <Badge tone="warn">
-                  {t(SITE_READ_SKIP_LABELS[skip.reason])}
-                </Badge>
-              </li>
-            ))}
-          </ul>
-        </div>
       )}
     </div>
   );
@@ -1274,8 +1103,8 @@ function HierarchyRollupCard({ orgId }: Readonly<{ orgId: string }>) {
 
 // One confirmed profile field (S-E02): the human field label, the value, and
 // a footer that names where it came from — provenance, confidence when the
-// read carried one, and the grounding evidence snippet. Mirrors EnrichCard's
-// field row, but these are ACCEPTED values on the record, not staged proposals.
+// read carried one, and the grounding evidence snippet. These are values that
+// LANDED on the record, whatever lane wrote them.
 // The shared trust-signal footer for an evidence-backed row: provenance
 // always, confidence whenever graded, and the evidence snippet when present.
 // One spelling for profile fields and facts so the "confidence is never
@@ -3011,7 +2840,6 @@ function ReferenceDisclosures({
       <Disclosure summary={t("co.tools.title")}>
         <CustomFieldsCard object="organization" record={org} />
         <HierarchyRollupCard orgId={org.id} />
-        <EnrichCard orgId={org.id} />
         <DeepReadCard orgId={org.id} />
       </Disclosure>
     </>


### PR DESCRIPTION
Four things the site-read card got wrong, all visible on one screenshot of a real Dibee read.

## 1. "Reads up to 12 pages" — it read 40

The 12-page ceiling (`autoEnrichMaxPages`) is the **automatic** lane's. `pageCeiling` returns the caller's request for a human read, which falls through to `defaultCrawlMaxPages = 40` — which is also why the card then said "Stopped early: page cap". The sentence described a different lane than the button it sat under.

## 2. It asked you to confirm a read you just requested

A read a human presses now applies its findings **directly**, through the same path the auto-enrich lane already used: same fill-empty machinery, same human-precedence guard, still marked as model-derived, still reversible.

The authority story holds without the accept step. Starting a read already requires `organization:update` plus `EnsureWritableLive` on that row (`createOrJoinSiteRead`) — exactly the permissions `ApplyDeepRead` needs. The accept step was asking the same person the same question twice, not guarding the record.

Published **people** still stage as leads (NEVER-8): a stranger is a new record about a human being, not a column on the company the requester named.

This is a new lane (`applyForRequester`), deliberately not a reuse of `autoApply` — that one also advances the auto-enrich sweep cursor, which is bookkeeping for reads nobody asked for.

## 3. Debug output on a company record

The card printed the crawl's own "Pages read" and "Pages skipped" lists — forty mono-spaced URLs like `www.dibee.vn/fuel-partners?lang=en`. Removed, along with the now-orphaned `shortUrl`, `SITE_READ_SKIP_LABELS` and `siteReadKindLabel` uses and their i18n keys.

## 4. Two buttons that both said "read the website"

"Read from the website" (quick field-fill) and "Read the full site" (crawl) were separate features presented as near-duplicates. `EnrichCard` is removed; the full-site read supersedes it.

## Dead code this leaves behind

Removing the confirm-first path strands `stageProposals`, `stage`, their two integration tests and the `unresolvableAuthority` double, so those go too.

**The accept EFFECT stays.** Proposals staged before this change are still sitting in inboxes and must remain acceptable — `deepReadAcceptEffect` is reachable from the approvals registry, not from the staging path.

## Verification

- `make check-backend`: green (craft static 0 issues across all packages).
- `make check-fe`: green — 4786 tests in 380 files.
- German and Vietnamese copy rewritten too; both still claimed "12 pages" and "nothing is written until you accept", which is now false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Human-triggered full-site reads now apply their findings directly instead of staging an approval, and the UI is a single “Read full site” button. This fixes the misleading “12 pages” copy (human reads use the deployment default page limit) and removes debug URL lists from the report; site people still stage as leads.

- Introduces `applyForRequester` to land org fields and facts immediately while keeping writes model-derived and reversible.
- Removes the confirm-first path and its dead code (`stageProposals`, `stage`) and the two integration tests.
- Deletes the quick “Read from the website” card; the full-site read supersedes it.
- Cleans the dossier: no “Pages read/skipped” URL lists; keeps phase and counts.
- Updates i18n strings (en/de/vi) to reflect direct apply and removes now-unused keys.
- Keeps the accept effect reachable for proposals staged before this change; auto-enrich behavior is unchanged.

**Migration**
- No user action required; existing staged proposals remain acceptable.
- If you extend translations, remove references to deleted deep-read skip labels and the old enrich card copy.

<sup>Written for commit 621e20f97b49ef7f5d172ecd965451eed474d07a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human-requested website reads now apply organization details and facts directly.
  * People discovered during website reads continue to be added as leads.
  * Applied findings fill empty fields and can be undone.

* **Improvements**
  * Simplified deep-read messaging and results displays.
  * Removed obsolete enrichment labels, page counts, skip details, and evidence indicators.
  * Automatic enrichment behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->