### PR TITLE
fix(design-system): the accent as text lifts in dark, and the axe sweep stops guessing which palette it is in

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1231,6 +1231,32 @@ const ADDRESSED_VIEWS = [
   "reports/forecast",
 ];
 
+// The SAME sweep under the dark palette, which the suite measured by accident
+// for as long as the scheme went unpinned: a run inherited whichever palette
+// the machine reported, so one afternoon read light locally and dark on CI and
+// the lane presented as flaky. It was two palettes.
+//
+// It is a second block rather than a second tag on the block above because the
+// palettes are not the same subject. tokens.css publishes dark as its own set
+// of values — the accent lightens to the ADR-0040 mandate and the surfaces
+// darken — so a screen can pass in one and fail in the other with no markup
+// between them different. Eight findings across six screens were live here
+// when this block was written, every one of them accent-coloured text on an
+// accent-tinted fill, and none of them visible to the light sweep.
+test.describe("B-EP09.21: WCAG 2.2 AA (axe), dark palette", () => {
+  test.use({ colorScheme: "dark" });
+
+  for (const screen of CORE_SCREENS) {
+    test(`no AA violations on #/${screen} in dark`, async ({ page }) => {
+      await page.goto(`/#/${screen}`);
+      await page.waitForLoadState("networkidle");
+      await expectShellRendered(page);
+      await settleAnimations(page);
+      await expectNoAaViolations(page, `${screen} (dark)`);
+    });
+  }
+});
+
 test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
   for (const screen of CORE_SCREENS) {
     test(`no AA violations on #/${screen}`, async ({ page }) => {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,6 +48,16 @@ export default defineConfig({
     // so the record-clock and viewer-clock surfaces agree here and a test that
     // means to tell them apart has to say so itself.
     timezoneId: "Europe/Berlin",
+    // Pin the PALETTE for the same reason as the locale and the zone above:
+    // tokens.css publishes a light and a dark set behind
+    // `prefers-color-scheme`, so an unpinned scheme measures whichever one the
+    // runner happens to report — and the two do not have the same contrast.
+    // The axe sweep read light here and dark on CI within one hour, which
+    // presented as a flaky lane and was two palettes being sampled at random.
+    // Light is the default the product is built to (§2: "Build light-first");
+    // dark is swept explicitly by its own block in ac.spec.ts, so pinning here
+    // narrows what a test measures rather than what the suite covers.
+    colorScheme: "light",
     // the SW would compete with the network-edge seed mocks
     serviceWorkers: "block",
   },

--- a/frontend/src/app/account.css
+++ b/frontend/src/app/account.css
@@ -269,7 +269,7 @@
   align-items: center;
   justify-content: center;
   width: 14px;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .acctthemelabel {

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -550,7 +550,7 @@
 /* The link a heading can carry, pushed to the far end of it. */
 .arplain {
   margin-left: auto;
-  color: var(--accent);
+  color: var(--accentText);
   font-size: 11px;
   font-weight: var(--fw-medium);
   letter-spacing: 0;
@@ -603,7 +603,7 @@
   font-weight: var(--fw-medium);
   letter-spacing: -0.03em;
   line-height: 1;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* No counts at all, which is a report and not an absence. Dashed, because a
@@ -686,7 +686,7 @@
 .armore {
   display: inline-block;
   margin-top: var(--space-1);
-  color: var(--accent);
+  color: var(--accentText);
   font-size: 11.5px;
   text-decoration: none;
 }
@@ -763,7 +763,7 @@
   border: 1px solid var(--arTone);
   border-radius: var(--r-full);
   background: color-mix(in srgb, var(--arTone) 10%, transparent);
-  color: var(--accent);
+  color: var(--accentText);
   font-family: var(--f-mono);
   font-size: 12px;
   cursor: pointer;

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -536,7 +536,7 @@
   font-weight: var(--fw-semibold);
 }
 .rail .navitem.active svg {
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* One icon size in both states. Animating the glyph's box relayouts the whole
    sidebar every frame, and a resizing icon is the jitter — 18px reads correctly
@@ -730,7 +730,7 @@
 .rail .navback:hover svg,
 .rail .navback:focus-visible svg {
   transform: translateX(-2px);
-  color: var(--accent);
+  color: var(--accentText);
 }
 @media (prefers-reduced-motion: reduce) {
   .rail .navback svg {
@@ -977,7 +977,7 @@
   font-weight: var(--fw-semibold);
 }
 .sectionpickgroup a[aria-current="page"] svg {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* ===== ⌘K palette ===== */
@@ -1277,7 +1277,7 @@
   /* A destination inside the More sheet is still the current one; without this
      the closed bar shows no active tab at all on those routes. */
   .rail .railmore.active {
-    color: var(--accent);
+    color: var(--accentText);
   }
   .rail .railmore.active {
     background: var(--accentLight);

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -46,7 +46,7 @@
 }
 .badge-accent {
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* The quiet spelling: one status per row down a column, where a stack of
  * filled pills reads as decoration. The tone survives as the dot's colour and
@@ -131,7 +131,7 @@
 .avatar {
   border-radius: var(--r-full);
   background: var(--accentMed);
-  color: var(--accent);
+  color: var(--accentText);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -451,7 +451,7 @@
   padding: 0;
   border: 0;
   background: none;
-  color: var(--accent);
+  color: var(--accentText);
   font: inherit;
   cursor: pointer;
   text-align: left;
@@ -528,7 +528,7 @@
   font-family: var(--f-body);
   font-size: 12px;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accentText);
   background: transparent;
   border: 0;
   padding: 2px 4px;
@@ -699,7 +699,7 @@
 }
 .recordpicker-option[aria-pressed="true"] {
   border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accentText);
   background: var(--accentLight);
 }
 .recordpicker-selected {
@@ -716,7 +716,7 @@
   font-size: 13.5px;
 }
 .recordpicker-selected-check {
-  color: var(--accent);
+  color: var(--accentText);
   width: 15px;
   height: 15px;
   flex: none;

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -153,11 +153,11 @@
 .btn-ghost[aria-pressed="true"] {
   border-color: var(--accentMed);
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
 }
 .btn-ghost[aria-pressed="true"]:hover {
   background: var(--accentMed);
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* federated: the door into another company's sign-in.
  *
@@ -395,7 +395,7 @@
  * a sentence, which is the one that had nobody to draw it. A blanket `a` rule
  * would repaint the chrome instead. */
 a:not([class]) {
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: underline;
   text-underline-offset: 2px;
 }

--- a/frontend/src/design-system/briefitem.css
+++ b/frontend/src/design-system/briefitem.css
@@ -87,7 +87,7 @@
 }
 
 .brief-item-name:hover {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .brief-item-name:focus-visible {
@@ -221,7 +221,7 @@
   width: 13px;
   height: 13px;
   flex: none;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .brief-item-actions {

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -558,7 +558,7 @@
   margin-top: var(--space-1);
   font: inherit;
   font-size: 12px;
-  color: var(--accent);
+  color: var(--accentText);
   cursor: pointer;
 }
 
@@ -590,7 +590,7 @@
 /* A link the sender wrote, not one we generated: it carries the address as its
    own label so the destination is visible before the click. */
 .tl-text-link {
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: underline;
   overflow-wrap: anywhere;
 }

--- a/frontend/src/design-system/filechip.css
+++ b/frontend/src/design-system/filechip.css
@@ -47,10 +47,10 @@
 }
 .file-chip:hover {
   border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accentText);
 }
 .file-chip:hover svg {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* The ring. A chip is a link to a document; it had a hover state and nothing for

--- a/frontend/src/design-system/listtable.css
+++ b/frontend/src/design-system/listtable.css
@@ -55,7 +55,7 @@
 }
 .lt-vtab.on {
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* Pushed to the right of the views, but stays left of the action. */
@@ -106,7 +106,7 @@
 }
 .lt-search:focus-within {
   border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .lt-search-input {
@@ -185,12 +185,12 @@
 .lt-btn.on {
   border-color: var(--accentMed);
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .lt-chip-value {
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* An applied filter's compound row: attribute, condition, value and the "⋮"
@@ -230,7 +230,7 @@
   align-items: center;
   padding: 0 var(--space-3);
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -687,7 +687,7 @@
   color: var(--textPrimary);
 }
 .lt-sort.on {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* The arrow occupies its slot at all times and only becomes visible on the
@@ -720,7 +720,7 @@
   background: transparent;
   padding: 0;
   font: inherit;
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: underline;
   cursor: pointer;
 }

--- a/frontend/src/design-system/margince-workbench.css
+++ b/frontend/src/design-system/margince-workbench.css
@@ -209,7 +209,7 @@
 }
 
 .mw-step.is-now b {
-  color: var(--accent);
+  color: var(--accentText);
   border-color: var(--accentMed);
 }
 

--- a/frontend/src/design-system/panel.css
+++ b/frontend/src/design-system/panel.css
@@ -250,7 +250,7 @@
   border-bottom: 1px solid var(--accentMed);
 }
 .panel-accent > .panel-head h2 {
-  color: var(--accent);
+  color: var(--accentText);
 }
 .panel-accent > .panel-foot {
   border-top-color: var(--accentMed);

--- a/frontend/src/design-system/readings.css
+++ b/frontend/src/design-system/readings.css
@@ -92,10 +92,10 @@
 }
 .chip-link:hover {
   border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accentText);
 }
 .chip-link:hover svg {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* The ring. Same shape as the file chip it sits beside — both are a bordered

--- a/frontend/src/design-system/richtext.css
+++ b/frontend/src/design-system/richtext.css
@@ -109,7 +109,7 @@
 }
 
 .richtext-input a {
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: underline;
 }
 

--- a/frontend/src/design-system/select.css
+++ b/frontend/src/design-system/select.css
@@ -92,7 +92,7 @@
 }
 .select-option-check {
   flex: none;
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* The ACTIVE option — where the keyboard is, and what a pointer is hovering.
    One treatment for both, because they are one state: the popup tracks a single
@@ -101,7 +101,7 @@
   background: var(--bgHover);
 }
 .select-option[aria-selected="true"] {
-  color: var(--accent);
+  color: var(--accentText);
   font-weight: 500;
 }
 .select-option[aria-selected="true"].is-active {

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -32,6 +32,13 @@
   --bgTopbar: rgba(255, 255, 255, 0.9);
 
   --accent: #0b7a53;
+  /* The accent as TEXT, split from the accent as a FILL. They are the same
+   * value here and diverge in dark mode, which is the whole reason the split
+   * exists: --accent lightens to the ADR-0040 mandate #16a34a, and that tone
+   * sitting as text on the --accentLight tint derived from it measures 4.03:1
+   * — under the 4.5:1 AA needs for text this size. The fill cannot move, so
+   * the text does. Same shape as --tealText and the --mono*Text pairs. */
+  --accentText: #0b7a53;
   --accentLight: rgba(11, 122, 83, 0.09);
   --accentMed: rgba(11, 122, 83, 0.17);
 
@@ -400,6 +407,10 @@
      the --online disc) — dark ink there is a control-boundary failure, not
      a contrast fix, on backgrounds this palette never touches. --success
      and --danger are NOT in that set: see --textOnStatusControl below. */
+  /* Lifted off --accent, which cannot move. #4ade80 is the tone --mono0Text
+     already uses for emerald text on an emerald tint here, so the accent
+     reads as the same colour those chips do rather than as a second green. */
+  --accentText: #4ade80;
   --accentLight: rgba(22, 163, 74, 0.14);
   --accentMed: rgba(22, 163, 74, 0.26);
   /* DARK ink on the accent, not white — the accent itself is untouched
@@ -509,6 +520,8 @@
     --bgTopbar: rgba(20, 36, 32, 0.9);
 
     --accent: #16a34a;
+
+    --accentText: #4ade80;
 
     --accentLight: rgba(22, 163, 74, 0.14);
     --accentMed: rgba(22, 163, 74, 0.26);

--- a/frontend/src/design-system/trust.css
+++ b/frontend/src/design-system/trust.css
@@ -141,7 +141,7 @@ button.evidence-chip:hover {
    stripe on their Deal Room comment). */
 .provenance-buyer {
   background: var(--bgCard);
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* An unrecorded source claims neither a person nor a machine, and reads as
    the absence it is rather than borrowing either one's colour. */

--- a/frontend/src/mcp-apps/view.css
+++ b/frontend/src/mcp-apps/view.css
@@ -90,7 +90,7 @@ h1 {
 
 .score {
   margin-left: auto;
-  color: var(--accent);
+  color: var(--accentText);
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -326,7 +326,7 @@
   cursor: pointer;
   font-size: 12.5px;
   font-weight: 500;
-  color: var(--accent);
+  color: var(--accentText);
   padding: 0;
   text-transform: none;
   letter-spacing: normal;
@@ -626,7 +626,7 @@
   font-weight: 600;
   letter-spacing: 0.11em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--accentText);
 }
 /* (b) the greeting, in the first person: the system saying its own name. Not a
    heading — the h1 belongs to the task (§6.4), and this is a paragraph however
@@ -791,7 +791,7 @@
   width: var(--promiseIcon);
   height: var(--promiseIcon);
   border-radius: var(--r-sm);
-  color: var(--accent);
+  color: var(--accentText);
   background: var(--accentSurface);
 }
 .auth-promise-icon svg {

--- a/frontend/src/screens/backfill.css
+++ b/frontend/src/screens/backfill.css
@@ -91,7 +91,7 @@
   grid-row: 1 / 3;
   width: 20px;
   height: 20px;
-  color: var(--accent);
+  color: var(--accentText);
 }
 .capture-stat-value {
   font-family: var(--f-body);

--- a/frontend/src/screens/company-context.css
+++ b/frontend/src/screens/company-context.css
@@ -24,7 +24,7 @@
   margin-right: auto;
 }
 .company-context-count strong {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* One proposed change, as a full-bleed row of the review panel: its name and
@@ -70,5 +70,5 @@
  * It is a caveat on everything above it, not a headline: it used to be set at
  * 24px, larger than the page's own h1, for a number nobody acts on. */
 .company-context-coverage strong {
-  color: var(--accent);
+  color: var(--accentText);
 }

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -89,7 +89,7 @@
   color: var(--textMeta);
 }
 .co-meta-link {
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: none;
 }
 .co-meta-link:hover {

--- a/frontend/src/screens/connectors.css
+++ b/frontend/src/screens/connectors.css
@@ -19,7 +19,7 @@
 .connector-id > svg {
   width: 18px;
   height: 18px;
-  color: var(--accent);
+  color: var(--accentText);
   flex: none;
 }
 .connector-id > span {

--- a/frontend/src/screens/extension-access.css
+++ b/frontend/src/screens/extension-access.css
@@ -36,7 +36,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  color: var(--accent);
+  color: var(--accentText);
   overflow-wrap: anywhere;
 }
 

--- a/frontend/src/screens/extension-units.css
+++ b/frontend/src/screens/extension-units.css
@@ -19,7 +19,7 @@
 .extunits-name > svg {
   width: 18px;
   height: 18px;
-  color: var(--accent);
+  color: var(--accentText);
   flex: none;
 }
 
@@ -30,7 +30,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  color: var(--accent);
+  color: var(--accentText);
   text-decoration: none;
   white-space: nowrap;
 }

--- a/frontend/src/screens/home.css
+++ b/frontend/src/screens/home.css
@@ -97,7 +97,7 @@
   border: 1px solid var(--borderSubtle);
   border-radius: var(--r-full);
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
   font-size: var(--fs-lead);
   font-weight: var(--fw-semibold);
   cursor: pointer;

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -597,7 +597,7 @@
 
 .ob-scene-eyebrow {
   margin: 0;
-  color: var(--accent);
+  color: var(--accentText);
   font-family: var(--f-body);
   font-size: var(--fs-eyebrow);
   font-weight: var(--fw-semibold);
@@ -1684,7 +1684,7 @@
 }
 
 .ob-connect-card-cta {
-  color: var(--accent);
+  color: var(--accentText);
   font-family: var(--f-body);
   font-size: var(--fs-meta);
   font-weight: var(--fw-semibold);
@@ -1929,7 +1929,7 @@
   padding: 0;
   border: 0;
   background: none;
-  color: var(--accent);
+  color: var(--accentText);
   cursor: pointer;
   font: var(--fw-medium) var(--fs-sm) / var(--lh-normal) var(--f-body);
   text-decoration: underline;
@@ -2091,7 +2091,7 @@
 
 .ob-company-card-facts dd button:hover,
 .ob-company-card-facts dd button:focus-visible {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .ob-company-card-facts dd button:focus-visible {
@@ -2356,7 +2356,7 @@
    pill). */
 .ob-triage-nav-link[aria-current="true"] {
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
   font-weight: var(--fw-semibold);
 }
 
@@ -2995,7 +2995,7 @@
 }
 
 .ob-triage-fact-toggle[aria-pressed="true"] {
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .ob-triage-fact-toggle:disabled {

--- a/frontend/src/screens/onboarding-gate.css
+++ b/frontend/src/screens/onboarding-gate.css
@@ -247,7 +247,7 @@
   font-family: var(--f-body);
   font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
-  color: var(--accent);
+  color: var(--accentText);
 }
 .ob-gate-link:hover,
 .ob-gate-link:focus-visible {
@@ -573,7 +573,7 @@
 /* One of these three numbers is the payoff and the other two are context, so the
    eye is told which one to follow. It is also the only one that climbs. */
 .ob-scan-counts .ob-scan-found {
-  color: var(--accent);
+  color: var(--accentText);
   font-weight: var(--fw-medium);
 }
 /* A drawn separator rather than a character: a middot in a string would be copy

--- a/frontend/src/screens/onboarding-live-panel.css
+++ b/frontend/src/screens/onboarding-live-panel.css
@@ -86,7 +86,7 @@
   font-weight: var(--fw-semibold);
   letter-spacing: var(--tracking-eyebrow);
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .ob-live-card-chev {

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -47,7 +47,7 @@
   font-weight: var(--fw-semibold);
   letter-spacing: var(--tracking-eyebrow);
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--accentText);
   margin-bottom: var(--space-3);
 }
 .ttl {
@@ -60,7 +60,7 @@
   margin-bottom: var(--space-3);
 }
 .ttl .em {
-  color: var(--accent);
+  color: var(--accentText);
 }
 .ob-sub {
   color: var(--textSecondary);
@@ -654,7 +654,7 @@
   line-height: var(--lh-normal);
 }
 .legal-preview-card small {
-  color: var(--accent);
+  color: var(--accentText);
   font-family: var(--f-mono);
   font-size: var(--fs-meta);
 }
@@ -1249,7 +1249,7 @@
 }
 .choice-check svg {
   width: 14px;
-  color: var(--accent);
+  color: var(--accentText);
 }
 .choice-card b,
 .choice-card span span,

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -59,7 +59,7 @@
   border: 0;
   background: none;
   font: inherit;
-  color: var(--accent);
+  color: var(--accentText);
   cursor: pointer;
 }
 
@@ -664,7 +664,7 @@
   gap: var(--space-2);
   margin-top: var(--space-3);
   font-size: 13px;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 /* ---------------------------------------------------------------------------
@@ -837,7 +837,7 @@
   background: var(--accentLight);
   font-size: 12px;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .pe-claim-body {

--- a/frontend/src/screens/record360/record360.css
+++ b/frontend/src/screens/record360/record360.css
@@ -38,7 +38,7 @@
 
 .r360-standing-accent {
   background: var(--accentLight);
-  color: var(--accent);
+  color: var(--accentText);
 }
 
 .r360-standing-warn {

--- a/frontend/src/screens/settings.css
+++ b/frontend/src/screens/settings.css
@@ -324,7 +324,7 @@ p.settings-panel-sub {
    spaces to break at, so it also has to be allowed to break inside itself
    rather than set the row's minimum width. */
 .tool-name {
-  color: var(--accent);
+  color: var(--accentText);
   overflow-wrap: anywhere;
 }
 /* Struck, not dimmed. Dimming the row to 0.4 took it under the AA contrast


### PR DESCRIPTION
## The lane was not flaky. It was two palettes.

The `uat` axe sweep read green locally and red on CI within one hour, on one tree. Three different answers were seen for one screen: 12 violations, 1 violation, 0.

`frontend/playwright.config.ts` pins `locale: "de-DE"` and `timezoneId: "Europe/Berlin"`, each with a comment saying that an unpinned environment input makes the suite depend on where the runner sits. **`colorScheme` is the same class of input and was not in that list.** Every run measured whichever palette the machine happened to report, and the two palettes do not have the same contrast.

Reproduced on main's tip, same spec, same tree, only the scheme emulated:

```
PROBE[light] violations(0)=[]
PROBE[dark]  violations(1)=["color-contrast: .lt-vtab.on"]
```

## Pinning alone would have deleted the defect rather than found it

Sweeping all 18 `CORE_SCREENS` under dark surfaced **8 live findings across 6 screens** — every one of them accent-coloured text on an accent-tinted fill:

| Screen | Finding |
|---|---|
| companies, contacts | `.lt-vtab.on` |
| home | `.glance-count-flat` |
| settings | `.badge` |
| settings/data-model | `.stage-row > .badge-accent.badge` ×3 |
| settings/people | `.panel-accent > .panel-head > .panel-head-text > h2` |

One cause. `--accent` lightens to `#16a34a` in dark, and that tone reading as **text** on the `--accentLight` tint derived from it measures **4.03:1** against a 4.5:1 requirement.

## The fix follows the pattern already in the file

The fill cannot move — `#16a34a` is the ADR-0040 mandate — so the text does. `--accentText` splits the accent-as-text from the accent-as-fill, which is exactly the shape `--tealText` and the `--mono*Text` pairs already have in `tokens.css`, for the same stated reason: *lift the text without shifting the fill*.

Its dark value is `--mono0Text`'s own `#4ade80`, so emerald text on an emerald tint reads as one colour across the product rather than as a second green. **Light keeps `--accent`'s value, so the light theme renders identically to before at all seventy sites.**

### Seventy sites, not six

All 70 `color: var(--accent)` declarations across 31 files move to the new token — not just the six that happened to fail on a swept screen. A screen outside `CORE_SCREENS` has the same defect and no test to report it, and leaving two spellings of "the accent as text" means the next author picks whichever one they grep first.

## Dark is now gated, not sampled

A second `describe` sweeps every `CORE_SCREENS` entry under `colorScheme: "dark"`. It is a second block rather than a tag on the first because the palettes are not the same subject: a screen can pass in one and fail in the other with no markup between them different.

## Verification

- `make frontend-e2e` — **exit 0**, 112 passed (was 94; +18 dark sweeps), 0 failed
- `make check-fe` — **exit 0**, 382 files / 4797 tests, plus 2 files / 36 tests on the extension surface
- Re-ran after rebasing onto current main, and re-checked that no new `color: var(--accent)` site arrived in the meantime — 0

**Mutation-verified.** Reverting the dark `--accentText` to `#16a34a` (confirmed applied by grep) turns red exactly the six screens measured beforehand, and nothing else:

```
✘ no AA violations on #/home in dark
✘ no AA violations on #/contacts in dark
✘ no AA violations on #/companies in dark
✘ no AA violations on #/settings in dark
✘ no AA violations on #/settings/data-model in dark
✘ no AA violations on #/settings/people in dark
6 failed | 106 passed
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark‑mode contrast failures and stabilizes the axe sweep. Accent-colored text now uses a dedicated `--accentText` token (lifted in dark), and Playwright pins `colorScheme: "light"` with an explicit dark sweep to stop sampling palettes at random.

- Bug Fixes
  - Introduces `--accentText` (light equals `--accent`; dark `#4ade80`) to meet AA contrast on `--accentLight`.
  - Migrates ~70 `color: var(--accent)` text sites to `var(--accentText)`; light visuals stay the same; `--accent` remains the fill token.

- Tests
  - Pins `colorScheme: "light"` in `frontend/playwright.config.ts` and adds a full dark sweep of all `CORE_SCREENS`.
  - Removes palette-induced flakiness in axe and expands coverage (+18 dark sweeps).

<sup>Written for commit 329e1257b3beeb665bd5f527e977df2279dee90d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved dark-mode accent text contrast across the application to support WCAG 2.2 AA requirements.
  - Updated links, labels, controls, icons, selections, and navigation states for clearer dark-theme readability.

- **Bug Fixes**
  - Added automated accessibility checks for every primary screen in dark mode.
  - Standardized test runs to use the light theme unless dark-mode coverage is explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->