### PR TITLE
fix(deepread): the tests follow the read that applies what it evidenced

### DIFF
--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -131,10 +131,10 @@ func deepReadApprovals(t *testing.T, e *integration.Env) int {
 	return e.WsCount(t, `SELECT count(*) FROM approval WHERE kind = 'deepread'`)
 }
 
-func TestDeepReadCrawlsExtractsStagesOneDeepReadProposalAndFinishesDone(t *testing.T) {
+func TestDeepReadCrawlsExtractsAppliesWhatItEvidencedAndFinishesDone(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	worker, svc := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
+	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
 	read, args := startDeepRead(t, e, org)
 
 	if err := worker.run(context.Background(), args); err != nil {
@@ -156,41 +156,25 @@ func TestDeepReadCrawlsExtractsStagesOneDeepReadProposalAndFinishesDone(t *testi
 	if len(done.Pages) != 2 || done.Pages[0].Kind != "home" || done.Pages[1].Kind != "impressum" {
 		t.Fatalf("pages = %+v, want [home, impressum] in crawl order", done.Pages)
 	}
-	if len(done.ProposalIDs) != 1 {
-		t.Fatalf("proposal_ids = %v, want exactly the one staged bundle", done.ProposalIDs)
+	// Nobody is asked to confirm a read they pressed the button for, so the
+	// dossier stages nothing. The authority the apply needs was checked when
+	// the read was commissioned.
+	if len(done.ProposalIDs) != 0 || deepReadApprovals(t, e) != 0 {
+		t.Fatalf("proposal_ids = %v and %d deepread approvals, want the read to have applied its own findings",
+			done.ProposalIDs, deepReadApprovals(t, e))
+	}
+	// The human's authority rides the audit spine instead: the agent did the
+	// writing, on behalf of the person who asked.
+	if n := e.WsCount(t, `SELECT count(*) FROM audit_log WHERE actor_id = 'agent:deepread' AND on_behalf_of = $1`,
+		e.Rep1); n == 0 {
+		t.Fatal("no audit row on behalf of the requesting human")
 	}
 
-	// The staged row is ONE "deepread" proposal carrying the human's
-	// authority: bound to the org, on behalf of the requester.
-	var kind, status string
-	var onBehalf ids.UUID
-	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(context.Background(),
-			`SELECT kind, status, on_behalf_of FROM approval WHERE id = $1`,
-			done.ProposalIDs[0]).Scan(&kind, &status, &onBehalf)
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if kind != "deepread" || status != "pending" || onBehalf != e.Rep1 {
-		t.Fatalf("approval = %s/%s on behalf of %s, want deepread/pending on behalf of the requesting human", kind, status, onBehalf)
-	}
-
-	// A River retry after the terminal outcome no-ops on the Begin CAS:
-	// no second crawl, no second proposal.
+	// A River retry after the terminal outcome no-ops on the Begin CAS: no
+	// second crawl, and — now that the findings land rather than stage —
+	// nothing written twice.
 	if err := worker.run(context.Background(), args); err != nil {
 		t.Fatalf("retry after done: %v", err)
-	}
-	if n := deepReadApprovals(t, e); n != 1 {
-		t.Fatalf("retry staged again: %d deepread approvals, want 1", n)
-	}
-
-	// Acceptance lands BOTH halves in one transaction: the profile fields
-	// as agent:deepread evidence rows, the category facts in
-	// organization_fact linked back to the dossier, and ONE
-	// organization.updated event on the outbox carrying the whole delta.
-	if _, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](done.ProposalIDs[0]), true, nil); err != nil {
-		t.Fatalf("accept: %v", err)
 	}
 	var profileRows, factRows, updatedEvents int
 	var capturedBy, legalName, factCapturedBy string
@@ -252,29 +236,27 @@ func TestDeepReadCrawlsExtractsStagesOneDeepReadProposalAndFinishesDone(t *testi
 	}
 }
 
+// An effect that fails must leave its approval APPROVED and unconsumed, so the
+// decision can be retried rather than silently lost. The subject is a proposal
+// staged before reads began applying directly; the read is not run, because it
+// would apply its findings and stage nothing for this to be about.
 func TestDeepReadApplyFailureLeavesTheApprovedProposalUnconsumed(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	worker, svc := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
-	read, args := startDeepRead(t, e, org)
-	if err := worker.run(context.Background(), args); err != nil {
-		t.Fatal(err)
-	}
-	done, err := e.People.GetSiteRead(e.As(e.Rep1, nil, integration.AdminPerms), orgIDOf(org), read.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, svc := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
+	read, _ := startDeepRead(t, e, org)
+	proposal := stageLegacyDeepReadProposal(t, e, svc, org, read.ID, nil, servicesOfferings())
 	broken := []byte(`{"organization_id":"` + org.String() + `","source_url":"` + seedURL + `","site_read_id":"` + read.ID.String() + `","fields":[],"facts":[{"category":"unknown","field":"service","value":"X","value_key":"x","evidence_snippet":"X","source_url":"` + seedURL + `","confidence":0.9}]}`)
 	digest := sha256.Sum256(broken)
 	hash := hex.EncodeToString(digest[:])
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `UPDATE approval
-			SET proposed_change = $2, diff_hash = $3 WHERE id = $1`, done.ProposalIDs[0], broken, hash)
+			SET proposed_change = $2, diff_hash = $3 WHERE id = $1`, proposal, broken, hash)
 		return err
 	}); err != nil {
 		t.Fatal(err)
 	}
-	_, err = svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](done.ProposalIDs[0]), true, nil)
+	_, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](proposal), true, nil)
 	if err == nil {
 		t.Fatal("invalid deep-read effect unexpectedly applied")
 	}
@@ -282,7 +264,7 @@ func TestDeepReadApplyFailureLeavesTheApprovedProposalUnconsumed(t *testing.T) {
 	var consumed bool
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `SELECT status, consumed_at IS NOT NULL
-			FROM approval WHERE id = $1`, done.ProposalIDs[0]).Scan(&status, &consumed)
+			FROM approval WHERE id = $1`, proposal).Scan(&status, &consumed)
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -428,8 +410,15 @@ func TestDeepReadModelFailureMidwayKeepsWhatWasReadAsPartial(t *testing.T) {
 	// signal fact. The legal_name is WITHHELD — the failed imprint call
 	// left the entity census incomplete, and an unread legal page must
 	// never default to "one entity, the trio stands".
-	if partial.FactCount != 2 || len(partial.ProposalIDs) != 1 {
-		t.Fatalf("fact_count = %d proposals = %v, want the surviving lanes staged and the legal trio withheld", partial.FactCount, partial.ProposalIDs)
+	//
+	// A partial read APPLIES what it evidenced, exactly as a complete one
+	// does. The status is the honest report that a lane died; it is not a
+	// reason to discard the lanes that did not.
+	if partial.FactCount != 2 || len(partial.ProposalIDs) != 0 {
+		t.Fatalf("fact_count = %d proposals = %v, want the surviving lanes landed and the legal trio withheld", partial.FactCount, partial.ProposalIDs)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM organization_fact WHERE organization_id = $1`, org); n != 1 {
+		t.Errorf("%d organization_fact rows, want the home page's surviving signal landed", n)
 	}
 }
 
@@ -470,8 +459,8 @@ func runServicesDeepRead(t *testing.T, e *integration.Env, org ids.UUID) (people
 	if err != nil {
 		t.Fatal(err)
 	}
-	if done.FactCount != 2 || len(done.ProposalIDs) != 1 {
-		t.Fatalf("dossier = %+v, want the 2 deduped offerings staged as one proposal", done)
+	if done.FactCount != 2 || len(done.ProposalIDs) != 0 {
+		t.Fatalf("dossier = %+v, want the 2 deduped offerings landed and nothing staged", done)
 	}
 	return done, svc
 }
@@ -639,16 +628,24 @@ func TestDeepReadAttributesItsWritesToTheRequesterTheRowNames(t *testing.T) {
 	read, args := startDeepRead(t, e, org)
 
 	// The row says Rep2 asked; the payload still says Rep1. If the worker
-	// believes the payload, the staged proposal carries the wrong human.
+	// believes the payload, the rows it writes carry the wrong human.
 	e.WsExec(t, `UPDATE site_read SET requested_by = $1 WHERE id = $2`, "human:"+e.Rep2.String(), read.ID)
 
 	if err := worker.run(context.Background(), args); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind = 'deepread' AND on_behalf_of = $1`, e.Rep2); n != 1 {
-		t.Errorf("%d proposals on behalf of the requester the row names, want 1", n)
+	// The read applies its findings itself now, so the question is asked of the
+	// audit spine the writes left behind rather than of a proposal nobody
+	// stages any more. The spine is where a human's name lands: the actor is
+	// the agent that did the writing, and `on_behalf_of` is the person it did
+	// it for — which is the pair `withClaimedRequester` builds, and the whole
+	// reason the dossier row outranks the payload.
+	if n := e.WsCount(t, `SELECT count(*) FROM audit_log WHERE actor_id = 'agent:deepread' AND on_behalf_of = $1`,
+		e.Rep2); n == 0 {
+		t.Errorf("no audit row on behalf of the requester the site_read row names")
 	}
-	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind = 'deepread' AND on_behalf_of = $1`, e.Rep1); n != 0 {
-		t.Errorf("%d proposals attributed to the payload's requester — the row is the authority", n)
+	if n := e.WsCount(t, `SELECT count(*) FROM audit_log WHERE actor_id = 'agent:deepread' AND on_behalf_of = $1`,
+		e.Rep1); n != 0 {
+		t.Errorf("%d audit rows on behalf of the payload's requester — the row is the authority", n)
 	}
 }

--- a/backend/internal/compose/deepreadaccept_integration_test.go
+++ b/backend/internal/compose/deepreadaccept_integration_test.go
@@ -34,55 +34,45 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-func TestDeepReadOfferingsDedupeOnValueKeyAndAcceptRespectsHumanPrecedence(t *testing.T) {
+// Two rules, and the read now holds both itself: a value_key duplicate is
+// deduped before anything is written, and a fact a human already claimed is
+// never overwritten. The second used to be the ACCEPT's job; the read applies
+// directly now, so the guard has to live where the write does — and the human's
+// row is seeded BEFORE the read for the same reason.
+func TestDeepReadOfferingsDedupeOnValueKeyAndTheApplyRespectsHumanPrecedence(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	done, svc := runServicesDeepRead(t, e, org)
 
-	// The staged payload carries ONE service row — the higher-confidence
-	// spelling of the shared value_key — plus the product.
-	var proposedChange []byte
-	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(context.Background(),
-			`SELECT proposed_change FROM approval WHERE id = $1`, done.ProposalIDs[0]).Scan(&proposedChange)
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	proposal, err := people.UnmarshalDeepRead(proposedChange)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(proposal.Facts) != 2 {
-		t.Fatalf("staged facts = %+v, want the deduped service + the product", proposal.Facts)
-	}
-	service := proposal.Facts[0]
-	// The citation gate is binary (no model confidence), so a value_key
-	// duplicate keeps its FIRST spelling — deterministic, page-ordered.
-	if service.Field != "service" || service.ValueKey != "crm rollout" || service.Value != "CRM Rollout — implementation projects" {
-		t.Fatalf("staged service = %+v, want the first-seen spelling under value_key 'crm rollout'", service)
-	}
-
-	// A human has since claimed the service fact; the accept must land the
-	// product beside it and leave the human's row untouched.
-	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+	// A human has claimed the service fact. The read must land the product
+	// beside it and leave this row exactly as it is.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
 			VALUES ($1, 'offering', 'service', 'CRM Rollout (human curated)', 'crm rollout',
 			        'set by hand', '', 1, 'human', $2)`,
 			org, "human:"+e.Rep1.String())
 		return err
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](done.ProposalIDs[0]), true, nil); err != nil {
-		t.Fatalf("accept: %v", err)
+
+	done, _ := runServicesDeepRead(t, e, org)
+
+	// The citation gate is binary (no model confidence), so a value_key
+	// duplicate keeps its FIRST spelling — deterministic, page-ordered. The
+	// dossier reports what the read evidenced, which is where the dedupe is
+	// observable now that nothing is staged.
+	if len(done.Facts) != 2 {
+		t.Fatalf("read facts = %+v, want the deduped service + the product", done.Facts)
+	}
+	service := done.Facts[0]
+	if service.Field != "service" || service.ValueKey != "crm rollout" || service.Value != "CRM Rollout — implementation projects" {
+		t.Fatalf("read service = %+v, want the first-seen spelling under value_key 'crm rollout'", service)
 	}
 
 	var factRows int
 	var serviceValue, serviceCapturedBy, productValue string
-	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT count(*) FROM organization_fact WHERE organization_id = $1`, org).Scan(&factRows); err != nil {
@@ -97,18 +87,17 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndAcceptRespectsHumanPrecedence(t *te
 		return tx.QueryRow(ctx,
 			`SELECT coalesce(max(value), '') FROM organization_fact
 			 WHERE organization_id = $1 AND field = 'product'`, org).Scan(&productValue)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 	if factRows != 2 {
-		t.Fatalf("%d organization_fact rows after accept, want 2 (the human's service + the landed product)", factRows)
+		t.Fatalf("%d organization_fact rows after the read, want 2 (the human's service + the landed product)", factRows)
 	}
 	if serviceValue != "CRM Rollout (human curated)" || serviceCapturedBy != "human:"+e.Rep1.String() {
-		t.Fatalf("service row = %q by %q — the accept overwrote a human-claimed fact", serviceValue, serviceCapturedBy)
+		t.Fatalf("service row = %q by %q — the read overwrote a human-claimed fact", serviceValue, serviceCapturedBy)
 	}
 	if productValue != "Margince — our CRM product" {
-		t.Fatalf("product row = %q, want the staged product landed beside the human's row", productValue)
+		t.Fatalf("product row = %q, want the read's product landed beside the human's row", productValue)
 	}
 }
 
@@ -209,12 +198,17 @@ func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
 	}
 }
 
+// A rejection of a proposal staged BEFORE reads began applying directly. The
+// read is not run here: it would land its own findings and there would be
+// nothing left for a rejection to be observed against.
 func TestDeepReadRejectionLandsNothing(t *testing.T) {
 	e := integration.Setup(t)
 	org := insertOrg(t, e, e.Rep1, "acme.example", "")
-	done, svc := runServicesDeepRead(t, e, org)
+	_, svc := newDeepReadTestWorker(e, acmeServicesSite(), servicesDeepBrain())
+	read, _ := startDeepRead(t, e, org)
+	proposal := stageLegacyDeepReadProposal(t, e, svc, org, read.ID, nil, servicesOfferings())
 
-	if _, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](done.ProposalIDs[0]), false, nil); err != nil {
+	if _, err := svc.Decide(e.As(e.Rep2, nil, integration.AdminPerms), ids.From[ids.ApprovalKind](proposal), false, nil); err != nil {
 		t.Fatalf("reject: %v", err)
 	}
 	if n := e.WsCount(t, `SELECT count(*) FROM organization_fact`); n != 0 {
@@ -262,4 +256,23 @@ func postDeepRead(t *testing.T, e *integration.Env, engine *deepReadEngine, call
 		}
 	}
 	return rec, started
+}
+
+// servicesOfferings is what the services fixture evidences: one service and
+// one product, already deduped on their value keys.
+func servicesOfferings() []people.DeepReadFact {
+	return []people.DeepReadFact{
+		{
+			Category: "offering", Field: "service",
+			Value: "CRM Rollout — implementation projects", ValueKey: "crm rollout",
+			EvidenceSnippet: "We deliver CRM Rollout projects end to end.",
+			SourceURL:       seedURL + "/services", Confidence: 1,
+		},
+		{
+			Category: "offering", Field: "product",
+			Value: "Margince — our CRM product", ValueKey: "margince",
+			EvidenceSnippet: "Margince is our CRM product.",
+			SourceURL:       seedURL + "/services", Confidence: 1,
+		},
+	}
 }

--- a/backend/internal/compose/deepreadlegacyproposal_integration_test.go
+++ b/backend/internal/compose/deepreadlegacyproposal_integration_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The "deepread" approval the confirm-first path used to write, staged by hand
+// so the accept effect still has a subject.
+//
+// A fixture here would have been wrong a day ago and is right now, and the
+// difference is worth stating rather than assuming. The read no longer stages
+// what it finds — it applies directly — so nothing in production writes this
+// kind any more. What the accept tests hold is the narrower promise that rows
+// staged BEFORE that change are still sitting in inboxes and must still decide
+// correctly. Their subject is therefore a row production cannot produce today,
+// and seeding it is the only way to have one. When the last of those rows ages
+// out and the effect goes, this goes with it.
+//
+// It stages through the approvals writer that owns the table rather than an
+// INSERT of this file's own: a decision walks the row the writer produces —
+// canonical identity, diff hash, bundle — and a hand-rolled row that merely
+// looked like one would prove nothing about the path under test.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func stageLegacyDeepReadProposal(
+	t *testing.T,
+	e *integration.Env,
+	svc *approvals.Service,
+	org ids.UUID,
+	readID ids.UUID,
+	fields []people.DeepReadField,
+	facts []people.DeepReadFact,
+) ids.UUID {
+	t.Helper()
+	proposedChange, err := json.Marshal(people.DeepReadProposal{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		SourceURL:      seedURL,
+		SiteReadID:     readID,
+		Fields:         fields,
+		Facts:          facts,
+	})
+	if err != nil {
+		t.Fatalf("marshalling the legacy proposal: %v", err)
+	}
+	digest := sha256.Sum256(proposedChange)
+	var approvalID ids.ApprovalID
+	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		approvalID, err = svc.StageOrJoinPendingInTx(ctx, tx, approvals.StageInput{
+			Kind:           deepReadProposalKind,
+			ProposedChange: proposedChange,
+			DiffHash:       hex.EncodeToString(digest[:]),
+			TargetType:     enrichTargetType,
+			TargetID:       org,
+			Summary:        "Deep site read of " + seedURL,
+			JoinPending:    true,
+			BundleID:       ids.NewV7(),
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the legacy proposal: %v", err)
+	}
+	return approvalID.UUID
+}


### PR DESCRIPTION
## main is red on the integration lane

Six deep-read tests still assert the confirm-first contract that #2695 deliberately removed. Same signature in all of them — a read that found its facts and staged nothing:

```
FactCount:2 ProposalIDs:[] RequestedBy:human:…
want the 2 deduped offerings staged as one proposal
```

#2695 merged with **5 of 6 integration shards, the aggregator, and the `ci` verdict itself already failing**, so this was red before it landed rather than an interaction after.

It edited `deepread_integration_test.go` and left three failing **in that file**, and never touched `deepreadaccept_integration_test.go` at all. A sixth — `TestDeepReadCrawlsExtractsStagesOneDeepReadProposalAndFinishesDone` — encodes the old contract in its own name.

## The change itself is right and is not touched here

A read a human presses applies directly, because starting one already requires `organization:update` on that row — the accept step asked a second time and guarded nothing. This PR only brings the suite to that contract.

## Three tests were about the READ

| Test | Was | Now |
|---|---|---|
| `…CrawlsExtracts**Applies What It Evidenced**AndFinishesDone` | stages one proposal, then accepts it | applies both halves itself; nothing staged |
| `…ModelFailureMidwayKeepsWhatWasReadAsPartial` | surviving lanes **staged** | surviving lanes **landed** — the status reports a dead lane, it is not a reason to discard the others |
| `…AttributesItsWritesToTheRequesterTheRowNames` | `approval.on_behalf_of` | `audit_log.on_behalf_of` |

The provenance one is the interesting move. `captured_by` on the fact rows is `agent:deepread`; the human rides `on_behalf_of` on the audit spine, which is the pair `withClaimedRequester` actually builds. The proposal was one hop before that, so the old assertion was asking the wrong record and happened to work.

## Two were about ACCEPTANCE, which still has to work

#2695's own promise: *"proposals staged before this change are still in inboxes and must remain acceptable."* Those tests no longer run a read to get one — a read would apply its findings and leave nothing to decide. They stage the row directly, **through `approvals.StageOrJoinPendingInTx`**, the writer that owns the table, rather than an INSERT of the test's own: a decision walks the row that writer produces — canonical identity, diff hash, bundle — and a hand-rolled lookalike would prove nothing about the path under test.

`TestDeepReadOfferingsDedupeOnValueKeyAndTheApplyRespectsHumanPrecedence` splits differently: human precedence is the **apply's** job now, not the accept's, so the human's row is seeded *before* the read rather than between the stage and the decision. That tests the guard where the write actually happens.

## The fixture says why it is a fixture

A test that supplies its own version of production usually proves nothing about production. The exception is a subject production can no longer produce, which is exactly what a pre-change proposal is — and the new file says so, including that it and its two tests go when the accept effect does.

## Verification

- `go test -tags integration ./internal/compose/` — **ok**, whole package, 72.7s
- Each of the six verified individually against a local Postgres before and after

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red integration tests by aligning deep-read suites to the direct-apply contract. Old behavior staged a `deepread` approval for acceptance; new behavior applies evidenced facts immediately and records provenance on `audit_log`, leaving nothing staged.

- Bug Fixes
  - Moves provenance checks from `approval.on_behalf_of` to `audit_log.on_behalf_of` with actor `agent:deepread`.
  - Updates partial-read assertions to keep surviving lanes landed in `organization_fact` with `ProposalIDs` empty.
  - Shifts human-precedence enforcement to the apply step; tests seed the human row before the read and verify no overwrite.
  - Adjusts services dedupe test to validate deduped facts in the dossier rather than a staged proposal.
  - Adds `deepreadlegacyproposal_integration_test.go` to stage legacy proposals via `approvals.StageOrJoinPendingInTx` for accept/reject coverage without running a read.
  - Keeps acceptance semantics: rejections land nothing; failed applies leave approvals approved and unconsumed.
  - No production code changes or migrations.

<sup>Written for commit f0e15218a21fb9d5a4224d073fe2a682f8206ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deep-read integration coverage to verify that evidenced findings are applied directly.
  * Confirmed human-owned facts are preserved and duplicate offerings are consolidated.
  * Added coverage for retry idempotency, audit attribution, partial reads, and rejection behavior.
  * Added legacy proposal scenarios to validate failed applications and approval handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->