### PR TITLE
test(uat): the axe sweep reports the colours it measured

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1103,13 +1103,57 @@ async function expectNoAaViolations(page: Page, screen: string) {
       `axe could not decide ${undecided.length} finding(s) on #/${screen}; a human has to:\n  ${undecided.join("\n  ")}`,
     );
   }
-  expect(
-    results.violations.flatMap((violation) =>
-      violation.nodes.map(
-        (node) => `${violation.id}: ${node.target.join(" ")}`,
-      ),
-    ),
-  ).toEqual([]);
+  // A violation names the SELECTOR and nothing else, which is unactionable for
+  // the one class of failure this sweep actually produces: a contrast finding
+  // that appears on CI and on no developer's machine. Four runs named four
+  // different screens and every finding was small meta text, and none of them
+  // said what colours were measured — so there was nothing to compare against
+  // the tokens, and the investigation ran on hypotheses instead of readings.
+  //
+  // Axe already computed the pair. Reporting it costs nothing on a green run
+  // and turns a red one into evidence: the resolved theme, the two colours and
+  // the ratio, beside the threshold that rejected them.
+  const failures = results.violations.flatMap((violation) =>
+    violation.nodes.map((node) => {
+      const detail = node.any
+        .map((check) => {
+          const data = check.data as
+            | {
+                fgColor?: string;
+                bgColor?: string;
+                contrastRatio?: number;
+                expectedContrastRatio?: string;
+              }
+            | undefined;
+          if (!data?.fgColor) {
+            return check.message;
+          }
+          return `${data.fgColor} on ${data.bgColor} = ${data.contrastRatio}:1, needs ${data.expectedContrastRatio}`;
+        })
+        .join("; ");
+      return `${violation.id}: ${node.target.join(" ")} — ${detail}`;
+    }),
+  );
+  if (failures.length > 0) {
+    // The document's own theme, not the emulated scheme: a stamped
+    // `data-theme` outranks `prefers-color-scheme`, so the scheme a test asked
+    // for is not proof of the palette it got.
+    const painted = await page.evaluate(() => ({
+      dataTheme: document.documentElement.getAttribute("data-theme"),
+      prefersDark: window.matchMedia("(prefers-color-scheme: dark)").matches,
+      textMeta: getComputedStyle(document.documentElement)
+        .getPropertyValue("--textMeta")
+        .trim(),
+      bgPage: getComputedStyle(document.documentElement)
+        .getPropertyValue("--bgPage")
+        .trim(),
+    }));
+    throw new Error(
+      `axe found ${failures.length} AA violation(s) on #/${screen}\n` +
+        `  painted as: ${JSON.stringify(painted)}\n  ` +
+        failures.join("\n  "),
+    );
+  }
 }
 
 test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1086,6 +1086,40 @@ test.describe("§3.8: 390px mobile", () => {
  * only thing standing behind those today is the token law in tokens.css — meta
  * text takes `--textMeta`, and `--textTertiary` is for marks.
  */
+// What a colour-contrast check carries when it could MEASURE the pair. Axe
+// types `data` as unknown and fills it per check, so a rule that is not
+// colour-contrast carries something else entirely and colour-contrast itself
+// omits these when it could not resolve a background — the "partially overlaps
+// other elements" findings are exactly that shape.
+//
+// All four are required together rather than each defaulting, because a
+// half-filled reading is what this reporting exists to prevent: "#5e6c65 on
+// undefined = undefined:1" reads like a measurement and is not one, and it
+// would be believed. A check that cannot fill them falls back to axe's own
+// sentence, which at least says why.
+type ContrastReading = Readonly<{
+  fgColor: string;
+  bgColor: string;
+  contrastRatio: number;
+  expectedContrastRatio: string;
+}>;
+
+function isContrastReading(data: unknown): data is ContrastReading {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  return (
+    "fgColor" in data &&
+    typeof data.fgColor === "string" &&
+    "bgColor" in data &&
+    typeof data.bgColor === "string" &&
+    "contrastRatio" in data &&
+    typeof data.contrastRatio === "number" &&
+    "expectedContrastRatio" in data &&
+    typeof data.expectedContrastRatio === "string"
+  );
+}
+
 async function expectNoAaViolations(page: Page, screen: string) {
   const results = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
@@ -1116,20 +1150,11 @@ async function expectNoAaViolations(page: Page, screen: string) {
   const failures = results.violations.flatMap((violation) =>
     violation.nodes.map((node) => {
       const detail = node.any
-        .map((check) => {
-          const data = check.data as
-            | {
-                fgColor?: string;
-                bgColor?: string;
-                contrastRatio?: number;
-                expectedContrastRatio?: string;
-              }
-            | undefined;
-          if (!data?.fgColor) {
-            return check.message;
-          }
-          return `${data.fgColor} on ${data.bgColor} = ${data.contrastRatio}:1, needs ${data.expectedContrastRatio}`;
-        })
+        .map((check) =>
+          isContrastReading(check.data)
+            ? `${check.data.fgColor} on ${check.data.bgColor} = ${check.data.contrastRatio}:1, needs ${check.data.expectedContrastRatio}`
+            : check.message,
+        )
         .join("; ");
       return `${violation.id}: ${node.target.join(" ")} — ${detail}`;
     }),


### PR DESCRIPTION
## main is red on `uat`, and the failure has never said enough to act on

#2629 added `uat (main)` to main-health, so the lane that had been failing on and off all day is now visible on main. main-health 32853813449 on `d5830def4`: every other job green, `uat (main)` red.

The dominant failure is a contrast finding on **a different screen every run**:

| Run | Screen | Findings |
|---|---|---|
| 97820982534 | `#/contacts`, `#/companies` | 21 |
| 97815452003 | `#/deals` | — |
| 97819779899 | `#/home` | 11 |

Every one of them small meta text — `.t-caption`, `.t-small`, `.lt-count`, `.rail-count-label`, `.evidence-chip`. **None reproduces locally.** (A separate one-off PERF-1 wall-clock miss, 1312ms against a 1000ms budget, passes 3/3 locally and is runner load, not this.)

## The assertion was throwing away the evidence

```ts
node => `${violation.id}: ${node.target.join(" ")}`
```

A selector and nothing else. Four runs produced four selector lists and not one reading — no foreground, no background, no ratio, no threshold, no palette. So the investigation ran on hypotheses instead, and two of mine were wrong: a transient opacity on the list container (disproven — `getAnimations()` is empty and every ancestor is `opacity: 1`), and a palette mismatch (the token arithmetic clears 4.5 comfortably in both themes: `--textMeta` is 5.51:1 on white and 5.35:1 on the dark card).

Axe had already computed the pair. It was discarded one line before the assertion.

## What a red run says now

It also reports how the document was **painted**, not which scheme the test asked for — a stamped `data-theme` outranks `prefers-color-scheme`, so a pinned scheme is not proof of the palette that rendered. That is exactly the question a CI-only contrast finding raises, and exactly the one no previous failure could answer.

Verified by planting a failing `--textMeta`:

```
Error: axe found 15 AA violation(s) on #/contacts
  painted as: {"dataTheme":"light","prefersDark":false,"textMeta":"#b9c4bf","bgPage":"#fff"}
  color-contrast: .ws-org — #b9c4bf on #fbfcfb = 1.74:1, needs 4.5:1
  color-contrast: .topbar-searchlabel — #b9c4bf on #ffffff = 1.79:1, needs 4.5:1
  color-contrast: .lt-count — #b9c4bf on #ffffff = 1.79:1, needs 4.5:1
```

## What this PR does not do

**It does not turn main green.** The underlying contrast defect is still there and this makes no attempt to hide it — the sweep is unchanged in what it rejects, and nothing is loosened. It converts an unactionable red into a diagnosable one, so the next failure is evidence rather than another bit.

Green runs are byte-identical: the new code runs only when `violations.length > 0`.

## Verification

- `make frontend-e2e` — **exit 0**, 94 passed
- `biome check` clean, composed-tests `tsc` clean
- Reporting proven by a planted `--textMeta` failure, output above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CI contrast failures in UAT actionable by including the measured colors and ratios; previously errors listed only selectors. Passing runs are unchanged and no thresholds are relaxed.

- For each color-contrast violation, include foreground/background colors, the computed ratio, and the AA threshold only when axe provides a complete reading; otherwise show axe’s own message to avoid misleading partial data.
- Also print how the page was painted (data-theme, prefers-color-scheme match, `--textMeta`, `--bgPage`) to confirm the palette actually used.

<sup>Written for commit 0343970a95c8e29388d56f2f6a38f8582ed73b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility violation reports with detailed selectors, color values, contrast ratios, and required thresholds.
  * Added page theme and color-scheme context to accessibility error messages.
  * Improved handling of incomplete contrast findings by preserving clear diagnostic messages instead of displaying partial measurements.
  * Continued treating incomplete accessibility findings as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->