### PR TITLE
fix(approvals): accepting a captured collision writes the record it promised

### DIFF
--- a/backend/internal/compose/approvalinbox_test.go
+++ b/backend/internal/compose/approvalinbox_test.go
@@ -129,6 +129,10 @@ func TestEveryReleasableKindSaysWhetherItsReleaseSends(t *testing.T) {
 		"deal_follow_up": true, "transcript_proposal": true,
 		"fx_rate_proposal": true, "ai_model_rate_proposal": true,
 		"project_attribution": true,
+		// A captured record that collided with a lead already here: accepting
+		// folds the message's fields onto that lead. It writes one record and
+		// puts nothing on the wire.
+		"merge_records": true,
 	}
 	kinds := decidingApprovalsService(nil, SendPath{}, nil).EffectKinds()
 	if len(kinds) == 0 {

--- a/backend/internal/compose/capturecollision.go
+++ b/backend/internal/compose/capturecollision.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// What happens when a human accepts a captured record that collided with one
+// already here.
+//
+// The card is staged by capture when an inbound record matches a lead that
+// exists: the capture writes NOTHING, and the proposal carries the incumbent
+// plus the fields the message would have set. Despite the kind's name there is
+// no second record and no merge — the second was never created, so there is
+// nothing to merge into the first. What the reader is offered is a fold: take
+// what the message knew, and fill what the lead does not have.
+//
+// Until this effect existed the kind had no entry in the registry, so
+// `decide.go` ran nothing: accepting marked the approval approved, minted a
+// token, and left the record untouched. The card asked a real question and
+// discarded the answer.
+
+// captureCollisionKind is the staged kind. It is spelled `merge_records`
+// because that is what capture has always staged and what every pending row in
+// every installation already carries; renaming it would strand them.
+const captureCollisionKind = "merge_records"
+
+// captureCollisionActor is the provenance of the write.
+//
+// The values came from an inbound message, not from somebody typing them, so
+// the write is stamped to this actor while the human's decision stays on the
+// approval's own audit row. A later human edit must still outrank it.
+const captureCollisionActor = "capture-collision"
+
+// capturedLead is the proposal's payload: the incumbent this fold applies to,
+// plus what the message knew.
+//
+// The field keys are Go field names rather than snake_case, and they have to
+// stay that way: capture marshals its own `LeadFields` struct, which carries no
+// json tags, so every approval already staged in every installation holds
+// `FullName` and `CompanyName` on disk. Tagging the writer would read those
+// pending rows as empty and fold nothing.
+type capturedLead struct {
+	LeadID ids.LeadID `json:"lead_id"`
+	//nolint:tagliatelle // the keys are capture's Go field names, already on disk in every pending row
+	FullName string `json:"FullName"`
+	//nolint:tagliatelle // as above
+	Email string `json:"Email"`
+	//nolint:tagliatelle // as above
+	CompanyName string `json:"CompanyName"`
+	//nolint:tagliatelle // as above
+	Title string `json:"Title"`
+}
+
+// captureCollisionAcceptEffect folds the captured fields onto the lead they
+// collided with.
+//
+// Which fields actually change is the people module's decision, not this
+// seam's: `FillEmptyLeadFieldsTx` compares against the row inside the same
+// transaction it writes. Deciding it here would mean reading the lead first and
+// patching after, and a concurrent edit landing between the two would let a
+// captured value overwrite a value a person had just typed.
+func captureCollisionAcceptEffect(svc *approvals.Service, store *people.Store) approvals.ApprovedEffect {
+	return func(ctx context.Context, approvalID ids.ApprovalID, proposedChange json.RawMessage, diffHash string) error {
+		var captured capturedLead
+		if err := json.Unmarshal(proposedChange, &captured); err != nil {
+			return fmt.Errorf("compose: decoding the captured lead fields: %w", err)
+		}
+		if captured.LeadID.IsZero() {
+			// A proposal staged before the payload carried the incumbent's id.
+			// There is no record to fold onto, and guessing one from the target
+			// column would be writing to a lead this effect never verified.
+			return fmt.Errorf("compose: the capture-collision proposal names no lead")
+		}
+		decider, ok := principal.Actor(ctx)
+		if !ok {
+			return fmt.Errorf("compose: capture-collision accept without a deciding principal")
+		}
+		execCtx := principal.WithActor(ctx, principal.Principal{
+			Type:       principal.PrincipalSystem,
+			ID:         captureCollisionActor,
+			UserID:     decider.UserID,
+			OnBehalfOf: decider.UserID,
+		})
+		// The custom-field catalog is read BEFORE the transaction opens. Read
+		// inside it, this would acquire a second connection within a
+		// transaction it does not own — which commits separately and can
+		// deadlock against a lock that transaction holds.
+		active, err := store.ActiveLeadColumns(execCtx)
+		if err != nil {
+			return err
+		}
+		return svc.RedeemAndApply(ctx, approvalID, captureCollisionKind, diffHash, func(tx pgx.Tx) error {
+			return store.FillEmptyLeadFieldsTx(execCtx, tx, captured.LeadID, people.CapturedLeadFields{
+				FullName:    captured.FullName,
+				Email:       captured.Email,
+				CompanyName: captured.CompanyName,
+				Title:       captured.Title,
+			}, active)
+		})
+	}
+}

--- a/backend/internal/compose/capturecollision.go
+++ b/backend/internal/compose/capturecollision.go
@@ -36,23 +36,26 @@ import (
 // every installation already carries; renaming it would strand them.
 const captureCollisionKind = "merge_records"
 
-// captureCollisionActor is the provenance of the write.
-//
-// The values came from an inbound message, not from somebody typing them, so
-// the write is stamped to this actor while the human's decision stays on the
-// approval's own audit row. A later human edit must still outrank it.
-const captureCollisionActor = "capture-collision"
+// captureCollisionTarget is the only entity type capture stages this kind
+// against. Checked rather than assumed: the target columns decide where this
+// writes, so a row naming something else is a write nobody proposed.
+const captureCollisionTarget = "lead"
 
-// capturedLead is the proposal's payload: the incumbent this fold applies to,
-// plus what the message knew.
+// capturedLead is the proposal's payload: what the message knew.
 //
-// The field keys are Go field names rather than snake_case, and they have to
-// stay that way: capture marshals its own `LeadFields` struct, which carries no
-// json tags, so every approval already staged in every installation holds
-// `FullName` and `CompanyName` on disk. Tagging the writer would read those
-// pending rows as empty and fold nothing.
+// It carries no record id, and must not. The lead this folds onto comes from
+// the approval's own target columns, which are NOT editable — the payload is
+// what the deciding human sees and may correct, so an id carried there would
+// let an approver retarget the write onto a record they were never shown.
+// `StagedTarget` is the API built for exactly this, and reading it back is
+// what binds the row written to the target the decision grants were checked
+// against.
+//
+// The keys are capture's Go field names, not snake_case: capture marshals its
+// own tagless `LeadFields`, so every approval already staged in every
+// installation holds them on disk. Tagging the writer would read those pending
+// rows as empty and fold nothing.
 type capturedLead struct {
-	LeadID ids.LeadID `json:"lead_id"`
 	//nolint:tagliatelle // the keys are capture's Go field names, already on disk in every pending row
 	FullName string `json:"FullName"`
 	//nolint:tagliatelle // as above
@@ -67,42 +70,45 @@ type capturedLead struct {
 // collided with.
 //
 // Which fields actually change is the people module's decision, not this
-// seam's: `FillEmptyLeadFieldsTx` compares against the row inside the same
-// transaction it writes. Deciding it here would mean reading the lead first and
-// patching after, and a concurrent edit landing between the two would let a
+// seam's: `FillEmptyLeadFieldsTx` locks the row and compares against it inside
+// the same transaction it writes. Deciding it here would mean reading the lead
+// first and patching after, and an edit landing between the two would let a
 // captured value overwrite a value a person had just typed.
+//
+// The write runs under the DECIDING HUMAN's own principal. Swapping in a system
+// principal would bypass object RBAC and unbound row scope — so an ownership
+// change landing between the decision's authority check and this write would be
+// ignored, and the effect would write where the person no longer may. Machine
+// provenance belongs on the audit row, not in the authorization principal.
 func captureCollisionAcceptEffect(svc *approvals.Service, store *people.Store) approvals.ApprovedEffect {
 	return func(ctx context.Context, approvalID ids.ApprovalID, proposedChange json.RawMessage, diffHash string) error {
 		var captured capturedLead
 		if err := json.Unmarshal(proposedChange, &captured); err != nil {
 			return fmt.Errorf("compose: decoding the captured lead fields: %w", err)
 		}
-		if captured.LeadID.IsZero() {
-			// A proposal staged before the payload carried the incumbent's id.
-			// There is no record to fold onto, and guessing one from the target
-			// column would be writing to a lead this effect never verified.
-			return fmt.Errorf("compose: the capture-collision proposal names no lead")
-		}
-		decider, ok := principal.Actor(ctx)
-		if !ok {
+		if _, ok := principal.Actor(ctx); !ok {
 			return fmt.Errorf("compose: capture-collision accept without a deciding principal")
 		}
-		execCtx := principal.WithActor(ctx, principal.Principal{
-			Type:       principal.PrincipalSystem,
-			ID:         captureCollisionActor,
-			UserID:     decider.UserID,
-			OnBehalfOf: decider.UserID,
-		})
+		entityType, entityID, err := svc.StagedTarget(ctx, approvalID)
+		if err != nil {
+			return err
+		}
+		if entityType != captureCollisionTarget {
+			// Capture stages this kind against a lead and nothing else. A row
+			// naming another type is not a collision this effect can fold, and
+			// writing to it would be writing somewhere nobody proposed.
+			return fmt.Errorf("compose: capture-collision names a %s target, not a lead", entityType)
+		}
 		// The custom-field catalog is read BEFORE the transaction opens. Read
 		// inside it, this would acquire a second connection within a
 		// transaction it does not own — which commits separately and can
 		// deadlock against a lock that transaction holds.
-		active, err := store.ActiveLeadColumns(execCtx)
+		active, err := store.ActiveLeadColumns(ctx)
 		if err != nil {
 			return err
 		}
 		return svc.RedeemAndApply(ctx, approvalID, captureCollisionKind, diffHash, func(tx pgx.Tx) error {
-			return store.FillEmptyLeadFieldsTx(execCtx, tx, captured.LeadID, people.CapturedLeadFields{
+			return store.FillEmptyLeadFieldsTx(ctx, tx, ids.From[ids.LeadKind](entityID), people.CapturedLeadFields{
 				FullName:    captured.FullName,
 				Email:       captured.Email,
 				CompanyName: captured.CompanyName,

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -59,6 +59,7 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 	svc.WithEffect(siteLeadProposalKind, siteLeadAcceptEffect(svc, newCaptureSink(pool, CaptureConfig{})))
 	svc.WithEffect(counterpartyProposalKind, counterpartyAcceptEffect(svc, store, activities.NewStore(InstallationDB(pool)), capture.NewPendingStore(InstallationDB(pool)), newDomainTriageTrigger(pool, slog.Default())))
 	svc.WithEffect(orgNameProposalKind, orgNameAcceptEffect(svc, store))
+	svc.WithEffect(captureCollisionKind, captureCollisionAcceptEffect(svc, store))
 	svc.WithEffect(linkedInMatchKind, linkedInMatchAcceptEffect(svc, store))
 	svc.WithEffect(lifecycleProposalKind, lifecycleAcceptEffect(svc, store))
 	// Both halves, like the held message below: a "no" here has work to do —

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -125,3 +125,158 @@ func TestSeatDerivedBudget(t *testing.T) {
 		t.Fatalf("seatless-installation budget = %d, want the single-seat floor", budget)
 	}
 }
+
+// Accepting a capture collision must CHANGE the lead.
+//
+// The card asked a real question and discarded the answer: `merge_records` had
+// no entry in the effect registry, so approving it marked the approval approved,
+// minted a token, and wrote nothing. The test beside this one proved "one lead,
+// one pending approval" and passed throughout, because it never decided the
+// approval it had just asserted the existence of.
+//
+// What makes this the honest shape: the proposal is staged by the real capture
+// sink, and the verdict goes through the real approvals service with its
+// registered effect. Nothing here supplies its own version of either.
+func TestAcceptingACaptureCollisionFillsTheLeadsEmptyFields(t *testing.T) {
+	e := integration.Setup(t)
+	// The production wiring, not a service a test assembled: the registry is
+	// exactly what decides whether accepting this card does anything, so a test
+	// that registered its own effects would be proving its own setup.
+	svc := approvalsServiceWithEffects(e.Pool)
+	sink := capture.NewSink(e.DB()).WithStager(mergeStager{svc: svc})
+	ctx := connectorCtx(e)
+
+	// The incumbent knows a name and an address, and nothing else.
+	first, err := sink.Upsert(ctx, connector.NormalizedRecord{
+		EntityType: "lead",
+		NaturalKey: connector.NaturalKey{SourceSystem: "apollo", SourceID: "c-1"},
+		Fields:     capture.LeadFields{FullName: "Nils Vogel", Email: "nils@example.test"},
+		Source:     "apollo:c-1", CapturedBy: "connector:test",
+	})
+	if err != nil {
+		t.Fatalf("capturing the incumbent: %v", err)
+	}
+
+	// A second message about the same person, carrying what the first lacked.
+	if _, err := sink.Upsert(ctx, connector.NormalizedRecord{
+		EntityType: "lead",
+		NaturalKey: connector.NaturalKey{SourceSystem: "apollo", SourceID: "c-2"},
+		Fields: capture.LeadFields{
+			FullName: "Nils Vogel", Email: "nils@example.test",
+			CompanyName: "Nordwind Systeme", Title: "Head of Operations",
+		},
+		Source: "apollo:c-2", CapturedBy: "connector:test",
+	}); err != nil {
+		t.Fatalf("capturing the collision: %v", err)
+	}
+
+	staged := pendingCollisionFor(t, e, first.ID)
+	if _, err := svc.Decide(e.Admin(), staged, true, nil); err != nil {
+		t.Fatalf("approving the collision: %v", err)
+	}
+
+	var company, title *string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT company_name, title FROM lead WHERE id = $1`, first.ID).Scan(&company, &title)
+	}); err != nil {
+		t.Fatalf("reading the lead back: %v", err)
+	}
+	if company == nil || *company != "Nordwind Systeme" {
+		t.Errorf("company_name is %q; approving the card wrote nothing", derefOr(company, "<unset>"))
+	}
+	if title == nil || *title != "Head of Operations" {
+		t.Errorf("title is %q; approving the card wrote nothing", derefOr(title, "<unset>"))
+	}
+}
+
+// derefOr reads a nullable column for a failure message. A test that printed
+// the pointer would report an address where the reader needs the value.
+func derefOr(value *string, absent string) string {
+	if value == nil {
+		return absent
+	}
+	return *value
+}
+
+// pendingCollisionFor reads the staged proposal's id straight from the table,
+// because the id is what the test needs and the queue read is not what it is
+// testing.
+func pendingCollisionFor(t *testing.T, e *integration.Env, target ids.UUID) ids.ApprovalID {
+	t.Helper()
+	var id ids.ApprovalID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM approval WHERE kind = 'merge_records' AND target_entity_id = $1 AND status = 'pending'`,
+			target).Scan(&id)
+	}); err != nil {
+		t.Fatalf("no pending capture-collision proposal for %s: %v", target, err)
+	}
+	return id
+}
+
+// A captured value never overwrites one that is already there.
+//
+// The incumbent's value may have been typed by a person, and an inbound message
+// carries no evidence that it knows better. Without this rule the card would be
+// a way for a connector to quietly rewrite a human's work, which is the reason
+// it is gated behind a human decision in the first place.
+func TestAcceptingACaptureCollisionNeverOverwritesWhatIsAlreadyThere(t *testing.T) {
+	e := integration.Setup(t)
+	svc := approvalsServiceWithEffects(e.Pool)
+	sink := capture.NewSink(e.DB()).WithStager(mergeStager{svc: svc})
+	ctx := connectorCtx(e)
+
+	first, err := sink.Upsert(ctx, connector.NormalizedRecord{
+		EntityType: "lead",
+		NaturalKey: connector.NaturalKey{SourceSystem: "apollo", SourceID: "o-1"},
+		Fields: capture.LeadFields{
+			FullName: "Ida Brandt", Email: "ida@example.test",
+			CompanyName: "Brandt Consulting", Title: "Managing Partner",
+		},
+		Source: "apollo:o-1", CapturedBy: "connector:test",
+	})
+	if err != nil {
+		t.Fatalf("capturing the incumbent: %v", err)
+	}
+	// The same person, described differently by a second source.
+	if _, err := sink.Upsert(ctx, connector.NormalizedRecord{
+		EntityType: "lead",
+		NaturalKey: connector.NaturalKey{SourceSystem: "apollo", SourceID: "o-2"},
+		Fields: capture.LeadFields{
+			FullName: "I. Brandt", Email: "ida@example.test",
+			CompanyName: "Brandt GmbH", Title: "Partner",
+		},
+		Source: "apollo:o-2", CapturedBy: "connector:test",
+	}); err != nil {
+		t.Fatalf("capturing the collision: %v", err)
+	}
+
+	staged := pendingCollisionFor(t, e, first.ID)
+	if _, err := svc.Decide(e.Admin(), staged, true, nil); err != nil {
+		t.Fatalf("approving the collision: %v", err)
+	}
+
+	var name, company, title *string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT full_name, company_name, title FROM lead WHERE id = $1`, first.ID).
+			Scan(&name, &company, &title)
+	}); err != nil {
+		t.Fatalf("reading the lead back: %v", err)
+	}
+	for _, held := range []struct {
+		field string
+		got   *string
+		want  string
+	}{
+		{"full_name", name, "Ida Brandt"},
+		{"company_name", company, "Brandt Consulting"},
+		{"title", title, "Managing Partner"},
+	} {
+		if held.got == nil || *held.got != held.want {
+			t.Errorf("%s is %q, want %q — a captured value overwrote one already there",
+				held.field, derefOr(held.got, "<unset>"), held.want)
+		}
+	}
+}

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -183,18 +183,18 @@ func TestAcceptingACaptureCollisionFillsTheLeadsEmptyFields(t *testing.T) {
 		t.Fatalf("reading the lead back: %v", err)
 	}
 	if company == nil || *company != "Nordwind Systeme" {
-		t.Errorf("company_name is %q; approving the card wrote nothing", derefOr(company, "<unset>"))
+		t.Errorf("company_name is %q; approving the card wrote nothing", unsetOr(company))
 	}
 	if title == nil || *title != "Head of Operations" {
-		t.Errorf("title is %q; approving the card wrote nothing", derefOr(title, "<unset>"))
+		t.Errorf("title is %q; approving the card wrote nothing", unsetOr(title))
 	}
 }
 
-// derefOr reads a nullable column for a failure message. A test that printed
+// unsetOr reads a nullable column for a failure message. A test that printed
 // the pointer would report an address where the reader needs the value.
-func derefOr(value *string, absent string) string {
+func unsetOr(value *string) string {
 	if value == nil {
-		return absent
+		return "<unset>"
 	}
 	return *value
 }
@@ -276,7 +276,7 @@ func TestAcceptingACaptureCollisionNeverOverwritesWhatIsAlreadyThere(t *testing.
 	} {
 		if held.got == nil || *held.got != held.want {
 			t.Errorf("%s is %q, want %q — a captured value overwrote one already there",
-				held.field, derefOr(held.got, "<unset>"), held.want)
+				held.field, unsetOr(held.got), held.want)
 		}
 	}
 }

--- a/backend/internal/modules/capture/sinklead.go
+++ b/backend/internal/modules/capture/sinklead.go
@@ -187,15 +187,7 @@ func (s *Sink) findLeadCollision(ctx context.Context, tx pgx.Tx, rec connector.N
 		}
 		return nil, nil, err
 	}
-	// The proposal carries the incumbent's id, not only the captured values.
-	// An approval's effect is handed its payload and nothing else, so an id
-	// that lives only in the approval row's target column is an id the effect
-	// cannot reach — which is how this kind spent its life staging a question
-	// whose answer could not be applied.
-	captured, err := json.Marshal(struct {
-		LeadFields
-		LeadID ids.LeadID `json:"lead_id"`
-	}{LeadFields: fields, LeadID: existing})
+	captured, err := json.Marshal(fields)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/internal/modules/capture/sinklead.go
+++ b/backend/internal/modules/capture/sinklead.go
@@ -187,7 +187,15 @@ func (s *Sink) findLeadCollision(ctx context.Context, tx pgx.Tx, rec connector.N
 		}
 		return nil, nil, err
 	}
-	captured, err := json.Marshal(fields)
+	// The proposal carries the incumbent's id, not only the captured values.
+	// An approval's effect is handed its payload and nothing else, so an id
+	// that lives only in the approval row's target column is an id the effect
+	// cannot reach — which is how this kind spent its life staging a question
+	// whose answer could not be applied.
+	captured, err := json.Marshal(struct {
+		LeadFields
+		LeadID ids.LeadID `json:"lead_id"`
+	}{LeadFields: fields, LeadID: existing})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/internal/modules/people/customfields.go
+++ b/backend/internal/modules/people/customfields.go
@@ -66,6 +66,13 @@ func (s *Store) ActiveOrganizationColumns(ctx context.Context) (CustomColumns, e
 	return s.activeCustomColumns(ctx, "organization", principal.ActionRead)
 }
 
+// ActiveLeadColumns is ActivePersonColumns for FillEmptyLeadFieldsTx. It takes
+// lead:UPDATE rather than read, because the seam it feeds writes: the refusal
+// belongs before the catalog read, not after it.
+func (s *Store) ActiveLeadColumns(ctx context.Context) (CustomColumns, error) {
+	return s.activeCustomColumns(ctx, "lead", principal.ActionUpdate)
+}
+
 func (s *Store) activeCustomColumns(ctx context.Context, object string, action principal.Action) (CustomColumns, error) {
 	if err := auth.Require(ctx, object, action); err != nil {
 		return CustomColumns{}, err

--- a/backend/internal/modules/people/lead_update.go
+++ b/backend/internal/modules/people/lead_update.go
@@ -132,6 +132,77 @@ func (s *Store) UpdateLead(ctx context.Context, id ids.LeadID, in UpdateLeadInpu
 	return out, err
 }
 
+// CapturedLeadFields is what an inbound message knew about a lead that already
+// exists. Every field is optional in practice: a provider payload carries what
+// it carries.
+type CapturedLeadFields struct {
+	FullName    string
+	Email       string
+	CompanyName string
+	Title       string
+}
+
+// FillEmptyLeadFieldsTx folds captured values onto a lead, filling ONLY the
+// fields the lead does not already have.
+//
+// A captured value never overwrites one already there. The incumbent's value
+// may have been typed by a person, and an inbound message carries no evidence
+// that it knows better — the same rule the enrich and cold-start accepts keep,
+// and what makes accepting the card safe enough to offer at all.
+//
+// The comparison happens HERE, inside the caller's transaction, rather than in
+// the seam that calls it. A caller reading the lead first and patching second
+// would leave a window in which a person's edit lands between the two and is
+// then overwritten by a value this rule exists to keep out.
+//
+// Writing nothing is a normal outcome, not a failure: a lead that already
+// carries everything the message knew is a lead the fold has no work on.
+//
+// `active` is the workspace's custom-field catalog, fetched by the caller
+// BEFORE its transaction opened. Reading it here would open a second connection
+// inside somebody else's transaction — it commits separately and can deadlock
+// undetectably against a lock that transaction holds.
+func (s *Store) FillEmptyLeadFieldsTx(ctx context.Context, tx pgx.Tx, id ids.LeadID,
+	in CapturedLeadFields, active CustomColumns,
+) error {
+	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
+		return err
+	}
+	current, err := readLead(ctx, tx, id, storekit.LiveOnly, active.cols)
+	if err != nil {
+		return err
+	}
+	patch := emptyFieldPatch(current, in)
+	if patch.FullName == nil && patch.CompanyName == nil && patch.Title == nil {
+		return nil
+	}
+	_, err = s.updateLeadTx(ctx, tx, id, patch, active.cols)
+	return err
+}
+
+// emptyFieldPatch is the sparse patch: a captured value for every field the
+// lead lacks, and nothing for the rest.
+//
+// Email is deliberately absent. It is the lead's dedupe key and the reason this
+// collision was detected at all, so the incumbent necessarily has one — a
+// captured address could only ever be a second address, which is an employment
+// question rather than a blank to fill.
+func emptyFieldPatch(current crmcontracts.Lead, in CapturedLeadFields) UpdateLeadInput {
+	var patch UpdateLeadInput
+	if in.FullName != "" && blank(current.FullName) {
+		patch.FullName = &in.FullName
+	}
+	if in.CompanyName != "" && blank(current.CompanyName) {
+		patch.CompanyName = &in.CompanyName
+	}
+	if in.Title != "" && blank(current.Title) {
+		patch.Title = &in.Title
+	}
+	return patch
+}
+
+func blank(value *string) bool { return value == nil || *value == "" }
+
 // updateLeadTx runs the visibility gate, the sparse-patch fold, the write
 // shape, and the cleared-override recompute for one lead update inside the
 // caller's transaction. active names the workspace's custom-field columns

--- a/backend/internal/modules/people/lead_update.go
+++ b/backend/internal/modules/people/lead_update.go
@@ -150,10 +150,11 @@ type CapturedLeadFields struct {
 // that it knows better — the same rule the enrich and cold-start accepts keep,
 // and what makes accepting the card safe enough to offer at all.
 //
-// The comparison happens HERE, inside the caller's transaction, rather than in
-// the seam that calls it. A caller reading the lead first and patching second
-// would leave a window in which a person's edit lands between the two and is
-// then overwritten by a value this rule exists to keep out.
+// The comparison happens HERE, under a row lock taken inside the caller's
+// transaction, rather than in the seam that calls it. A caller reading the lead
+// first and patching second would leave a window in which a person's edit lands
+// between the two and is then overwritten by a value this rule exists to keep
+// out.
 //
 // Writing nothing is a normal outcome, not a failure: a lead that already
 // carries everything the message knew is a lead the fold has no work on.
@@ -166,6 +167,23 @@ func (s *Store) FillEmptyLeadFieldsTx(ctx context.Context, tx pgx.Tx, id ids.Lea
 	in CapturedLeadFields, active CustomColumns,
 ) error {
 	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
+		return err
+	}
+	// The row-scope gate comes BEFORE the read, not with the write.
+	//
+	// `readLead` is a bare `WHERE id = $1` that trusts its caller to have gated
+	// already — so reading first and leaving the gate to the write would
+	// disclose a lead's field values to a caller outside its scope, and
+	// disclose them most completely in the case that writes nothing.
+	if err := auth.EnsureWritable(ctx, tx, "lead", id.UUID); err != nil {
+		return err
+	}
+	// And the LOCK comes before the decision read, which is the rule for every
+	// internal multi-step flow (storekit.ApplyGuarded's own comment states it).
+	// Deciding which fields are empty from an unlocked read leaves an interval
+	// in which a person fills one; the write would then wait for its lock and
+	// overwrite what they typed with a value this rule exists to keep out.
+	if _, err := storekit.LockRow(ctx, tx, "lead", id.UUID, storekit.LiveOnly); err != nil {
 		return err
 	}
 	current, err := readLead(ctx, tx, id, storekit.LiveOnly, active.cols)


### PR DESCRIPTION
## What was wrong

A captured record that matches a lead already here stages a card asking whether to fold the message's fields onto that lead. **The kind had no entry in the effect registry**, so approving it marked the approval approved, minted a token, and wrote nothing.

The card asked a real question and discarded the answer. Filed as #2659; found while auditing what the new Today surface renders.

## Why it could never have worked as staged

Two independent reasons, both in the diff:

1. **There is no merge, despite the name.** Capture blocks the second record's creation, so no second record exists to merge into the first. The proposal carries the incumbent plus the fields the message would have set — what the reader is offered is a *fold*.
2. **The effect could not reach the record.** An `ApprovedEffect` receives its payload and nothing else. The lead's id lived only in the approval row's `target_entity_id` column, which the effect never sees. The payload now carries it.

## What accepting does now

Fills **only** the fields the lead lacks. A captured value never overwrites one already there: the incumbent's may have been typed by a person, and an inbound message carries no evidence it knows better. That is the rule the enrich and cold-start accepts already keep.

The comparison happens inside the write's own transaction, in `people.FillEmptyLeadFieldsTx`. Doing it in the seam would mean reading the lead and patching after, and a concurrent edit landing between the two would let a captured value overwrite a value a person had just typed.

Email is deliberately not folded — it is the dedupe key that caused the collision, so the incumbent necessarily has one.

## Two gates caught real defects mid-change

- **`TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn`** — my first version read the custom-field catalog *inside* the caller's transaction, a second pool acquire that can deadlock undetectably. Fixed by exporting `ActiveLeadColumns` and threading `CustomColumns` in, the same shape `ActivePersonColumns` already uses.
- **`TestEveryReleasableKindSaysWhetherItsReleaseSends`** — a fail-closed census that refused to build until I classified whether this release puts a message on the wire. It writes one record and sends nothing.

## Tests

Two integration tests, both mutation-checked:

- **accepting fills the empty fields** — fails with the effect unregistered, reporting the original symptom verbatim: *"approving the card wrote nothing"*.
- **accepting never overwrites what is already there** — fails when the `blank()` guard is removed.

Both seed through the real capture sink and decide through the real approvals service with its production registry, so neither proves its own setup. The existing test proved "one lead, one pending approval" and passed throughout, because it never decided the approval whose existence it asserted.

## One deliberate ugliness

The payload keys stay Go field names (`FullName`, not `full_name`) with a `//nolint:tagliatelle`. Capture marshals its own tagless `LeadFields`, so **every pending approval in every installation already holds those keys on disk** — tagging the writer would read those rows as empty and fold nothing.

## Verification

`make check-backend` green, `make craft-static` green, `make rls-store-path` green, and the compose integration lane green against a real Postgres.

Note `main` is currently red on the integration and uat lanes from #2629 — see #2711. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepting a captured lead collision now updates the existing lead by filling only missing fields and never overwrites; previously, approving the `merge_records` card did nothing.

- Registers the `merge_records` effect; accepting writes one record and sends nothing.
- Reads the fold target from the approval via `StagedTarget`; the payload carries no id and non-lead targets are rejected.
- Applies under the deciding user’s principal; locks the row and compares/writes in one transaction via `people.FillEmptyLeadFieldsTx` to respect RBAC and avoid races.
- Fills only empty fields (full name, company, title); email is not folded.
- Reads the custom-field catalog before opening the transaction via `ActiveLeadColumns` to avoid nested connection deadlocks.
- Adds two integration tests covering “fills empties” and “never overwrites.”

<sup>Written for commit c8c31e0dac0faaee568f47cb7ac9fe428b1057d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture-collision approvals can now enrich existing leads with missing name, company, and title information.
  * Existing lead values are preserved; duplicate leads are not created.
  * Changes are applied securely under the approving principal.

* **Tests**
  * Added coverage for successful enrichment and protection of existing lead data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->