### PR TITLE
fix(today): the receipt lane reads past the reader's own approvals

### DIFF
--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -234,12 +234,37 @@ const approvalStatusApproved = "approved"
 type attentionReceipts struct{ svc *approvals.Service }
 
 func (r attentionReceipts) Recent(ctx context.Context, since time.Time, limit int) ([]attention.Receipt, error) {
-	status := approvalStatusApproved
-	rows, _, err := r.svc.ListWire(ctx, approvals.ListInput{Status: &status, Limit: limit})
+	return recentReceipts(since, limit, func(scan int) ([]crmcontracts.Approval, error) {
+		status := approvalStatusApproved
+		rows, _, err := r.svc.ListWire(ctx, approvals.ListInput{Status: &status, Limit: scan})
+		return rows, err
+	})
+}
+
+// recentReceipts pages the approved queue and keeps what ran without asking.
+//
+// The read is WIDER than the lane shows, and that is the whole of this
+// function's reason to exist: the engine can only page approvals by status,
+// while `decided_by IS NULL` — the test for "nobody was asked" — is applied
+// afterwards. A read the size of the lane is filled by the reader's OWN recent
+// approvals and filters to nothing, so the lane reports a quiet night while
+// dozens of things ran. The same shape as the task lane's scan factor, and for
+// the same reason.
+//
+// The page reader is a parameter so a test can answer exactly the width it was
+// asked for; nothing else varies it.
+func recentReceipts(
+	since time.Time, limit int, page func(scan int) ([]crmcontracts.Approval, error),
+) ([]attention.Receipt, error) {
+	rows, err := page(approvals.PendingScanCap)
 	if err != nil {
 		return nil, err
 	}
-	return receiptsWithin(rows, since), nil
+	receipts := receiptsWithin(rows, since)
+	if len(receipts) > limit {
+		receipts = receipts[:limit]
+	}
+	return receipts, nil
 }
 
 // receiptsWithin keeps the decided rows this lane may claim: inside the window,

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -50,3 +50,55 @@ func approvalRow(summary string, decidedAt time.Time, decidedBy *openapi_types.U
 		DecidedBy: decidedBy,
 	}
 }
+
+// The receipts read reaches past the reader's own approvals.
+//
+// The filter that decides a receipt — decided_by IS NULL — runs AFTER the page
+// is read, because the engine can only page by status. So the SIZE of that read
+// decides whether an autonomous act is visible at all: a read the size of the
+// lane is filled by the reader's own recent decisions, filters down to nothing,
+// and the lane reports a quiet night while dozens of things ran.
+//
+// The bug was invisible while nothing was auto-applied: there was never an
+// autonomous act to crowd out. The stub answers a page of the reader's own
+// decisions with ONE autonomous act behind them, so a read that stops at the
+// lane's width finds nothing.
+func TestTheReceiptsReadIsWiderThanTheLaneItFills(t *testing.T) {
+	decidedAt := time.Date(2026, 8, 25, 8, 0, 0, 0, time.UTC)
+	human := openapi_types.UUID(ids.NewV7())
+
+	page := make([]crmcontracts.Approval, 0, doneLaneWidth+2)
+	for i := 0; i < doneLaneWidth+1; i++ {
+		page = append(page, approvalRow("A decision the reader made", decidedAt, &human))
+	}
+	page = append(page, approvalRow("Filed a message under Riverty", decidedAt, nil))
+
+	engine := &stubApprovalPage{rows: page}
+	receipts, err := recentReceipts(decidedAt.Add(-time.Hour), doneLaneWidth, engine.list)
+	if err != nil {
+		t.Fatalf("reading the receipts: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("the lane carries %d receipts; the read stopped at %d rows and never reached the autonomous act",
+			len(receipts), engine.asked)
+	}
+}
+
+// doneLaneWidth is what the day's surface shows in its receipt lane.
+const doneLaneWidth = 8
+
+// stubApprovalPage answers exactly the number of rows it is asked for, which is
+// the whole subject: a seam that asks for the lane's width gets a page of human
+// decisions and filters it to nothing.
+type stubApprovalPage struct {
+	rows  []crmcontracts.Approval
+	asked int
+}
+
+func (s *stubApprovalPage) list(limit int) ([]crmcontracts.Approval, error) {
+	s.asked = limit
+	if limit > len(s.rows) {
+		limit = len(s.rows)
+	}
+	return s.rows[:limit], nil
+}


### PR DESCRIPTION
## What was wrong

"Done for you" reads a page of approved approvals and keeps the rows nobody decided — `decided_by IS NULL`. The read asked the engine for **exactly the number the lane shows (8)**, so a page filled with the reader's own recent approvals filtered down to nothing, and the lane reported a quiet night while things had run.

The engine can only page approvals by status; the "nobody was asked" test is applied afterwards. A read the size of the lane therefore cannot see past the reader's own work.

## Why nobody noticed

Nothing runs autonomously yet, so there has never been an act to crowd out. The lane is empty for a real reason today, and it would have gone on looking correct right up until the first auto-applied write — at which point it would have hidden it.

Found while mapping what auto-apply would need in order to be visible.

## The fix

Read at `approvals.PendingScanCap` and trim to the lane afterwards — the same shape the task lane's `taskScanFactor` already uses, for the same reason, stated in the comment beside it.

The pager is now a parameter of `recentReceipts` so a test can answer exactly the width it was asked for. Nothing else varies it.

## Test

`TestTheReceiptsReadIsWiderThanTheLaneItFills` builds a page of nine of the reader's own approvals with one autonomous act behind them. Mutation-checked: narrowing the read back to the lane width fails it with the original symptom —

> the lane carries 0 receipts; the read stopped at 8 rows and never reached the autonomous act

## Verification

`make check-backend` and `make craft-static` green.

Note `main` is currently red on the integration and uat lanes from #2629 — see #2711. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the receipt lane so it can see past the reader’s own approvals and show autonomous acts. Previously it paged exactly the lane width (8) and filtered after fetch, which could make the lane look empty; now it scans up to `approvals.PendingScanCap` and trims to the lane size.

**Bug Fixes**
- Reads the approved queue at `approvals.PendingScanCap` and filters down to the lane width.
- Extracts paging into `recentReceipts(pageFn)` so tests can assert the exact scan width.
- Adds a test that fails if the read narrows back to the lane width, reproducing the original miss.
- Slightly increases read volume to avoid hiding auto-applied receipts.

<sup>Written for commit f677ccc4221bdf87307e858d8c9dc30e59dd094d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved approval receipt retrieval so eligible autonomous approvals are not hidden behind other decisions.
  * Receipt results are now correctly filtered to the requested time window and result limit.

* **Tests**
  * Added regression coverage for retrieving approvals beyond the visible lane width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->