### PR TITLE
fix(dedupe): a company name matches on a shared word, not shared letters

### DIFF
--- a/backend/internal/modules/people/dedupeorg.go
+++ b/backend/internal/modules/people/dedupeorg.go
@@ -237,6 +237,12 @@ func orgTrigramArms(args *[]any, axes ...string) []string {
 // An empty axis scores nothing rather than matching every other empty one: two
 // companies that both lack a registered name have said nothing about being the
 // same company.
+//
+// A pairing is only SCORED once the two names share a distinctive word
+// (orgnamegate.go). Jaro-Winkler cannot see a word boundary, and on company
+// names — where every name in a market ends in the same nouns — that made it
+// read shared vocabulary as shared identity: measured at 179 false pairs
+// against 1 true one across one real workspace.
 func bestOrgNamePairing(candidateDisplay, candidateLegal, rowDisplay, rowLegal string) OrganizationCandidateScore {
 	sides := []struct {
 		value string
@@ -248,6 +254,12 @@ func bestOrgNamePairing(candidateDisplay, candidateLegal, rowDisplay, rowLegal s
 		for _, right := range sides {
 			normalizedLeft, normalizedRight := NormalizeOrgName(left), NormalizeOrgName(right.value)
 			if normalizedLeft == "" || normalizedRight == "" {
+				continue
+			}
+			// BEFORE the score, not a filter applied after it: a pair with no
+			// word in common has said nothing about being one company, whatever
+			// their letters do.
+			if !sharesADistinctiveWord(left, right.value) {
 				continue
 			}
 			score := nameSimilarity(normalizedLeft, normalizedRight)

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The precondition on the PO-F-2 fuzzy tier: two company names may only be
+// SCORED against each other when they share a distinctive word.
+//
+// WHY THIS EXISTS. `nameSimilarity` is Jaro-Winkler, a character metric with no
+// concept of a word. On person names that is right — people have no legal forms
+// and no industry vocabulary, so shared letters really are evidence. On company
+// names it is not: every company in a market ends in the same handful of nouns,
+// and a metric that cannot see a word boundary reads that shared vocabulary as
+// shared identity.
+//
+// MEASURED, on the 296 company names in one real workspace. Of 43,660 pairs,
+// 180 scored at or above the 0.72 review threshold. Exactly ONE was a genuine
+// duplicate ("Arvato" / "Arvato Systems"). The other 179 were pairs like
+// Stripe/Strix (0.89), ACY Capital/Soda Capital (0.82), Fenwick
+// Software/Centric Software (0.82), HPS/KPS (0.72). A 99.4% false-positive
+// rate, firing on every organization create.
+//
+// It was not theoretical. A CSV import of 107 contacts refused to create nine
+// companies, reporting "a company of this name is already in the CRM" when no
+// such company existed — the operator went looking through the UI for records
+// that were never there.
+//
+// THE RULE. A genuine duplicate shares a whole distinctive word; the noise
+// shares only letters. "Arvato Systems" contains "arvato"; "Strix" contains no
+// word of "Stripe". So the score is only consulted once a shared distinctive
+// word is found. The same 180 pairs reduce to 3.
+//
+// WHAT THIS DOES NOT CHANGE. Not `nameSimilarity`, which stays exactly the
+// pinned Jaro-Winkler (PO-PARAM-JW-1) and stays shared with person dedupe
+// (dedupe.go), lead dedupe (leaddedupe.go) and site-person matching
+// (sitepersonfields.go), where the character metric is the right one. Not tier
+// 1 (`exactOrgByDomain`), which returns before this tier is reached — a domain
+// is an exact key and needs no name evidence at all.
+
+import "strings"
+
+// orgNameStopwords are the words a company name shares with its whole market:
+// present in many names, evidence of identity in none.
+//
+// A HAND-WRITTEN, VERSIONED LIST, and deliberately not one derived from the
+// workspace's own names at run time. A derived list would make the same two
+// names match in one workspace and not in another, drift as each workspace
+// grew, and put a second query inside `DedupeOrganizationForCreate`, which
+// holds the organization-name write lock while the ladder runs. Every other
+// dedupe parameter in this package is an auditable constant (dedupe.go), and
+// this one is read the same way.
+//
+// English, German and Vietnamese, because those are the markets the estate
+// currently holds. A NEW market needs its own generics added here — the list is
+// a precision policy, not a language model, and a market whose generics are
+// missing simply keeps today's false positives rather than gaining new ones.
+//
+// "phat" earns its place the same way "group" does: it is Vietnamese for
+// "prosper" and ends company names the way "Group" ends English ones. Measured
+// in the corpus, it appeared in three unrelated names.
+var orgNameStopwords = map[string]bool{
+	// Structural.
+	"the": true, "and": true, "of": true, "for": true,
+	// Corporate form that survives NormalizeOrgName's legal-suffix strip.
+	"group": true, "holding": true, "holdings": true, "company": true,
+	"international": true, "global": true, "worldwide": true, "national": true,
+	// Sector vocabulary.
+	"digital": true, "technology": true, "technologies": true, "tech": true,
+	"solutions": true, "systems": true, "services": true, "software": true,
+	"consulting": true, "consultants": true, "partners": true, "associates": true,
+	"capital": true, "ventures": true, "investments": true, "financial": true,
+	"health": true, "healthcare": true, "care": true, "medical": true,
+	"hospital": true, "clinic": true,
+	"engineering": true, "industries": true, "manufacturing": true,
+	"media": true, "marketing": true, "communications": true, "logistics": true,
+	// Vietnamese generics.
+	"cong": true, "ty": true, "co": true, "phat": true,
+}
+
+// orgFuzzyTokenFloor is the shortest token a NEAR-identical (rather than equal)
+// match is trusted on.
+//
+// A 0.90 Jaro-Winkler score means something different at each length. On two
+// seven-letter tokens it is a spelling variant; on two four-letter tokens it is
+// one letter, which is how "SORA" met "Suraksha" in the corpus. Equality is
+// still honoured at every length — this floor bounds only the fuzzy comparison,
+// so "3M" and "HP" match themselves exactly while never matching a neighbour.
+const orgFuzzyTokenFloor = 5
+
+// orgFuzzyTokenSimilarity is the bar a token PAIR must clear to count as the
+// same word.
+//
+// Set above the pair scores this is meant to reject and below the
+// transliterations it must keep: "Müller"/"Mueller" scores 0.93 and
+// "Straße"/"Strasse" 1.00 after the fold, both of which the DACH market
+// produces daily.
+const orgFuzzyTokenSimilarity = 0.90
+
+// orgTokenSeparators split a name into words for THIS gate's purposes.
+//
+// A hyphen or a slash joins two words in one company name — "ACME-Group",
+// "Rich-Media/Solutions" — and `strings.Fields` alone leaves them fused. That
+// fusion loses real duplicates: "Acme Ltd" and "ACME-Group Ltd" share the word
+// "acme", but as one token "acme-group" it matches nothing.
+//
+// Deliberately NOT done inside NormalizeOrgName, which also produces exact
+// grouping keys (orgMatchKeys in linkedinimport.go, the promotion sweep's
+// buckets). Splitting there would make two DIFFERENT names equal as keys.
+// Splitting here changes only which words this gate compares.
+func orgTokenSeparators(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '-' || r == '/' || r == '_'
+}
+
+// distinctiveOrgTokens are a name's words with the market's shared vocabulary
+// removed.
+//
+// LENGTH IS NOT A FILTER HERE, and an earlier version that dropped tokens under
+// three runes was wrong: it threw away "3M", whose two characters ARE the
+// company. A word is dropped for being generic, never for being short.
+func distinctiveOrgTokens(name string) []string {
+	fields := strings.FieldsFunc(NormalizeOrgName(name), orgTokenSeparators)
+	out := make([]string, 0, len(fields))
+	for _, token := range fields {
+		if !orgNameStopwords[token] {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+// sameOrgToken answers whether two words are the same word.
+//
+// Equal at any length, or near-identical when both are long enough for
+// near-identity to mean a spelling variant rather than a different word.
+func sameOrgToken(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if len([]rune(a)) < orgFuzzyTokenFloor || len([]rune(b)) < orgFuzzyTokenFloor {
+		return false
+	}
+	return jaroWinkler(a, b) >= orgFuzzyTokenSimilarity
+}
+
+// squashedOrgName is the name with its word separators removed, for the one
+// case that has no distinctive word to compare.
+//
+// "Health Care" and "Healthcare" are the same company written two ways, and
+// every word in both is generic. Requiring exact equality there would lose the
+// pair over a space. Removing the separators merges exactly that difference and
+// nothing else: "Health Care" and "Medical Care" stay apart, because squashing
+// does not make different words equal.
+//
+// The same separators the token split uses, so "E-Commerce" and "E Commerce"
+// take one path rather than two.
+func squashedOrgName(name string) string {
+	return strings.Join(strings.FieldsFunc(NormalizeOrgName(name), orgTokenSeparators), "")
+}
+
+// sharesADistinctiveWord is the gate itself: may these two names be scored?
+//
+// The ALL-GENERIC fallback is the interesting branch. A name made entirely of
+// market vocabulary ("Health Care", "The Group") has nothing distinctive to
+// match on, so the character metric would be back to comparing letters with
+// nothing to anchor them. Comparing the squashed names instead answers the only
+// question left — is this the same generic name written differently — without
+// readmitting the noise.
+func sharesADistinctiveWord(a, b string) bool {
+	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
+	if len(left) == 0 || len(right) == 0 {
+		return squashedOrgName(a) == squashedOrgName(b)
+	}
+	for _, x := range left {
+		for _, y := range right {
+			if sameOrgToken(x, y) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -37,7 +37,10 @@ package people
 // 1 (`exactOrgByDomain`), which returns before this tier is reached — a domain
 // is an exact key and needs no name evidence at all.
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // orgNameStopwords are the words a company name shares with its whole market:
 // present in many names, evidence of identity in none.
@@ -59,8 +62,6 @@ import "strings"
 // "prosper" and ends company names the way "Group" ends English ones. Measured
 // in the corpus, it appeared in three unrelated names.
 var orgNameStopwords = map[string]bool{
-	// Structural.
-	"the": true, "and": true, "of": true, "for": true,
 	// Corporate form that survives NormalizeOrgName's legal-suffix strip.
 	"group": true, "holding": true, "holdings": true, "company": true,
 	"international": true, "global": true, "worldwide": true, "national": true,
@@ -75,17 +76,87 @@ var orgNameStopwords = map[string]bool{
 	"media": true, "marketing": true, "communications": true, "logistics": true,
 	// Vietnamese generics.
 	"cong": true, "ty": true, "co": true, "phat": true,
+	// A brand written as its domain — "Capital.com", "Digital.ai" — splits into
+	// the name and the top-level domain. The TLD is the most generic token
+	// there is: every company that writes its name this way shares one. Without
+	// these, "Capital.com" reduces to the single token "com" and matches every
+	// other .com in the estate.
+	//
+	// "co" is already above, as a Vietnamese generic and an English legal form.
+	"com": true, "net": true, "org": true, "io": true, "ai": true,
+	"app": true, "dev": true, "inc": true, "gmbh": true,
+	// Country codes and the second level beneath them. "giba.or.kr" and
+	// "utp.or.kr" are two Korean companies, and without "or" and "kr" here they
+	// met on the shared domain suffix — the same failure as two ".com"s.
+	"kr": true, "jp": true, "cn": true, "vn": true, "uk": true, "de": true,
+	"au": true, "nz": true, "sg": true, "in": true, "br": true, "eu": true,
+	"or": true, "ne": true, "ac": true, "gov": true, "edu": true,
+}
+
+// orgNameArticles are the words that can never be the whole of a name.
+//
+// Every other stopword can: "Capital", "Health" and "Digital" are all real
+// businesses, so when a strip would empty a name the first word is restored and
+// the comparison proceeds. An article is different — "The Group" and "The
+// Holding" would both restore to "the" and meet on it, which is two companies
+// matching on an English article.
+//
+// They are stopwords too, folded into orgNameStopwords by init below rather
+// than written out twice. One list, one place to add a language.
+var orgNameArticles = map[string]bool{
+	"the": true, "a": true, "an": true, "and": true, "of": true, "for": true,
+	"le": true, "la": true, "les": true, "der": true, "die": true, "das": true,
+}
+
+func init() {
+	for article := range orgNameArticles {
+		orgNameStopwords[article] = true
+	}
 }
 
 // orgFuzzyTokenFloor is the shortest token a NEAR-identical (rather than equal)
 // match is trusted on.
 //
 // A 0.90 Jaro-Winkler score means something different at each length. On two
-// seven-letter tokens it is a spelling variant; on two four-letter tokens it is
-// one letter, which is how "SORA" met "Suraksha" in the corpus. Equality is
-// still honoured at every length — this floor bounds only the fuzzy comparison,
-// so "3M" and "HP" match themselves exactly while never matching a neighbour.
-const orgFuzzyTokenFloor = 5
+// seven-letter tokens it is a spelling variant; on two three-letter tokens it is
+// one letter in three, which is how "SORA" met "Suraksha" in the corpus.
+// Equality is still honoured at every length — this floor bounds only the fuzzy
+// comparison, so "3M" and "HP" match themselves exactly while never matching a
+// neighbour.
+//
+// THREE, and the length was measured rather than guessed. German transliterates
+// an umlaut into a second vowel, which makes a short surname pair one rune
+// apart: "Bär" folds to "bar" (3) and "Baer" to "baer" (4); "Röhm" to "rohm"
+// and "Roehm" to "roehm"; likewise Götz/Goetz and Köhlm/Koehlm. A floor of five
+// refused every one of them, and those names are on companies.
+//
+// Three is safe because the SIMILARITY bar is what separates these, not the
+// length. Measured on every three-letter pair that must stay apart —
+// hps/kps 0.78, acy/ace 0.82, ibm/ibn 0.82, sora/sura 0.85 — against the
+// transliterations that must meet: bar/baer 0.93, rohm/roehm 0.95. The gap is
+// clean, and 0.90 sits inside it.
+//
+// Two is where it stops: a two-letter pair one letter apart has nothing left to
+// distinguish it, and equality already covers "3M" and "HP" matching themselves.
+const orgFuzzyTokenFloor = 3
+
+// orgGateTokenBudget bounds how many words this gate will compare on one side.
+//
+// The comparison is a nested loop, so the work is the PRODUCT of the two token
+// counts — and `display_name` is `text` with no maxLength in the contract, so
+// one create can hand it a megabyte. That would be a slow function anywhere
+// else; here it runs inside `DedupeOrganizationForCreate`, which holds the
+// workspace-wide organization-name write lock, so an unbounded name would pin
+// every organization-name writer in the workspace behind it.
+//
+// The same reasoning as nameScoringMaxRunes (namesim.go), which bounds the
+// length of one comparison. That bound does not help here: it caps each call
+// and this is about the NUMBER of calls.
+//
+// 32 words is far past any real company name — the longest in the measured
+// corpus was 6. Past the bound the gate compares the first 32 words of each
+// side, which for names this long is the same answer any comparison would give.
+const orgGateTokenBudget = 32
 
 // orgFuzzyTokenSimilarity is the bar a token PAIR must clear to count as the
 // same word.
@@ -96,19 +167,38 @@ const orgFuzzyTokenFloor = 5
 // produces daily.
 const orgFuzzyTokenSimilarity = 0.90
 
+// orgFuzzyTokenLengthSlack is how much longer one word may be than the other
+// and still be called the same word.
+//
+// ONE RUNE, which is what a transliteration costs: "bar" becomes "baer", "rohm"
+// becomes "roehm", "gotz" becomes "goetz". Every one adds a single vowel.
+//
+// Without it, Jaro-Winkler's prefix boost makes a short word match any longer
+// word that starts with it — "base" against "baseplan" scores exactly 0.90, and
+// Base.com and Baseplan are two companies in one real workspace. A shared
+// prefix is not a spelling variant, and the similarity bar alone cannot tell
+// them apart.
+const orgFuzzyTokenLengthSlack = 1
+
 // orgTokenSeparators split a name into words for THIS gate's purposes.
 //
-// A hyphen or a slash joins two words in one company name — "ACME-Group",
-// "Rich-Media/Solutions" — and `strings.Fields` alone leaves them fused. That
-// fusion loses real duplicates: "Acme Ltd" and "ACME-Group Ltd" share the word
-// "acme", but as one token "acme-group" it matches nothing.
+// Anything that is not a letter or a digit separates two words. Company names
+// arrive punctuated every way a writer can punctuate them — "ACME-Group",
+// "Rich-Media/Solutions", "Hewlett.Packard", "Capital.com", an en dash where a
+// hyphen was meant — and a fused token loses a real duplicate: "Acme Ltd" and
+// "ACME-Group Ltd" share the word "acme", but as one token "acme-group" it
+// matches nothing.
+//
+// A CLASS rather than a list, deliberately. An earlier version named six ASCII
+// characters and missed the period and the en dash, which is the shape of bug
+// that keeps being rediscovered one punctuation mark at a time.
 //
 // Deliberately NOT done inside NormalizeOrgName, which also produces exact
 // grouping keys (orgMatchKeys in linkedinimport.go, the promotion sweep's
 // buckets). Splitting there would make two DIFFERENT names equal as keys.
 // Splitting here changes only which words this gate compares.
 func orgTokenSeparators(r rune) bool {
-	return r == ' ' || r == '\t' || r == '\n' || r == '-' || r == '/' || r == '_'
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 }
 
 // distinctiveOrgTokens are a name's words with the market's shared vocabulary
@@ -119,10 +209,35 @@ func orgTokenSeparators(r rune) bool {
 // company. A word is dropped for being generic, never for being short.
 func distinctiveOrgTokens(name string) []string {
 	fields := strings.FieldsFunc(NormalizeOrgName(name), orgTokenSeparators)
-	out := make([]string, 0, len(fields))
+	out := make([]string, 0, min(len(fields), orgGateTokenBudget))
 	for _, token := range fields {
-		if !orgNameStopwords[token] {
-			out = append(out, token)
+		if orgNameStopwords[token] {
+			continue
+		}
+		if len(out) == orgGateTokenBudget {
+			break
+		}
+		out = append(out, token)
+	}
+	// THE STRIP MUST NEVER REMOVE THE WHOLE NAME, the same rule
+	// NormalizeOrgName follows when a legal suffix IS the company. A name of
+	// nothing but generic words still has to be comparable to itself:
+	// "Capital" is a real business, "Capital.com" is how it writes itself, and
+	// a gate that empties both has nothing left to match them on.
+	//
+	// The FIRST non-article word, not all of them. Keeping every word would
+	// readmit what this gate exists to remove — "Health Care" and "Medical
+	// Care" would meet on the shared "care", which is the market's vocabulary
+	// and not an identity. Keeping the head of the name is where a brand sits:
+	// "Capital" in "Capital.com", "Health" in "Health Care".
+	//
+	// An article is skipped rather than restored, because it can never be a
+	// name: restoring it made "The Group" and "The Holding" meet on "the".
+	if len(out) == 0 {
+		for _, token := range fields {
+			if !orgNameArticles[token] {
+				return []string{token}
+			}
 		}
 	}
 	return out
@@ -132,24 +247,38 @@ func distinctiveOrgTokens(name string) []string {
 //
 // Equal at any length, or near-identical when both are long enough for
 // near-identity to mean a spelling variant rather than a different word.
+//
+// A WORD IS NOT A PREFIX OF ANOTHER WORD. Jaro-Winkler boosts a shared start,
+// so a short word scores high against any longer word beginning with it —
+// "base" and "baseplan" reach exactly 0.90, and they are two companies. A
+// spelling variant changes the letters inside a word, not its length: "rohm"
+// and "roehm" differ by one rune, "bar" and "baer" by one. So the two words
+// must be within one rune of each other in length before their similarity is
+// consulted at all.
 func sameOrgToken(a, b string) bool {
 	if a == b {
 		return true
 	}
-	if len([]rune(a)) < orgFuzzyTokenFloor || len([]rune(b)) < orgFuzzyTokenFloor {
+	lenA, lenB := len([]rune(a)), len([]rune(b))
+	if lenA < orgFuzzyTokenFloor || lenB < orgFuzzyTokenFloor {
+		return false
+	}
+	if max(lenA, lenB)-min(lenA, lenB) > orgFuzzyTokenLengthSlack {
 		return false
 	}
 	return jaroWinkler(a, b) >= orgFuzzyTokenSimilarity
 }
 
-// squashedOrgName is the name with its word separators removed, for the one
-// case that has no distinctive word to compare.
+// squashedOrgName is the name with its word separators removed.
 //
-// "Health Care" and "Healthcare" are the same company written two ways, and
-// every word in both is generic. Requiring exact equality there would lose the
-// pair over a space. Removing the separators merges exactly that difference and
-// nothing else: "Health Care" and "Medical Care" stay apart, because squashing
-// does not make different words equal.
+// Two things need this, and both are the same difference: where the writer put
+// the space. "Health Care" and "Healthcare" are one company; so are "Digital
+// Ocean" and "DigitalOcean", "Media Markt" and "MediaMarkt". Compounding is how
+// brands are written half the time and it must not decide identity.
+//
+// It merges exactly that difference and nothing else. "Health Care" and
+// "Medical Care" stay apart, because removing spaces does not make different
+// words equal.
 //
 // The same separators the token split uses, so "E-Commerce" and "E Commerce"
 // take one path rather than two.
@@ -159,17 +288,27 @@ func squashedOrgName(name string) string {
 
 // sharesADistinctiveWord is the gate itself: may these two names be scored?
 //
-// The ALL-GENERIC fallback is the interesting branch. A name made entirely of
-// market vocabulary ("Health Care", "The Group") has nothing distinctive to
-// match on, so the character metric would be back to comparing letters with
-// nothing to anchor them. Comparing the squashed names instead answers the only
-// question left — is this the same generic name written differently — without
-// readmitting the noise.
+// Two ways to answer yes, and the second is not a fallback for the first.
+//
+// THE SQUASHED NAME is asked first, because compounding hides a shared word
+// rather than removing it: "DigitalOcean" is one token, so it shares no word
+// with "Digital Ocean" even though they are plainly one company. The same
+// comparison is also the whole answer for a name of nothing but market
+// vocabulary ("Health Care", "The Group"), which has no distinctive word for
+// the token pass to find.
+//
+// THE TOKEN PASS then asks whether the two names share a word that means
+// something — one that is not the vocabulary every company in the market uses.
 func sharesADistinctiveWord(a, b string) bool {
-	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
-	if len(left) == 0 || len(right) == 0 {
-		return squashedOrgName(a) == squashedOrgName(b)
+	// Where the writer put the space is not evidence of a different company.
+	//
+	// An EMPTY squashed name is not a match with another empty one: two names
+	// made entirely of punctuation have said nothing about being one company,
+	// the same way two blank legal names do in bestOrgNamePairing.
+	if squashed := squashedOrgName(a); squashed != "" && squashed == squashedOrgName(b) {
+		return true
 	}
+	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
 	for _, x := range left {
 		for _, y := range right {
 			if sameOrgToken(x, y) {

--- a/backend/internal/modules/people/orgnamegate_integration_test.go
+++ b/backend/internal/modules/people/orgnamegate_integration_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+import "testing"
+
+// The nine companies a CSV import refused to create, against a live database.
+//
+// The unit test asks the scorer directly. This asks the LADDER — the trigram
+// candidate query, the visibility rules and the decision — exactly as an import
+// does. Each incumbent below is the real company the matcher named when it told
+// an operator that a company of that name was already in the CRM.
+func TestTheNineRefusedCompaniesNoLongerCollide(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	incumbents := []string{
+		"Salesforce", "Soda Capital", "Centric Software", "HealthCare Logic",
+		"The Performance Network Group (TPNG)", "Thinksmart Group",
+		"MTA TECH", "Elephant Digital", "JTL-Software",
+	}
+	for _, name := range incumbents {
+		if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: name, Source: "manual",
+		}); err != nil {
+			t.Fatalf("seeding %q: %v", name, err)
+		}
+	}
+
+	refused := []string{
+		"Bytesforce", "ACY Capital", "Fenwick Software", "TLC Healthcare",
+		"The NMG Group", "The Alta Group", "Multimedia Technology",
+		"Digital Matter", "Pronto Software",
+	}
+	for _, name := range refused {
+		m := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{DisplayName: name})
+		if m.Decision != DecisionNoMatch {
+			t.Errorf("%q collided (decision %s, confidence %.4f) — no company of "+
+				"that name is in the estate, and the operator was sent looking for one",
+				name, m.Decision, m.Confidence)
+		}
+	}
+
+	// And the control: a real duplicate of a seeded name still meets, so the
+	// gate has not simply turned the fuzzy tier off.
+	dup := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
+		DisplayName: "Centric Software Pty Ltd",
+	})
+	if dup.Decision != DecisionFuzzyReview {
+		t.Fatalf("a genuine duplicate scored %s (confidence %.4f), want fuzzy_review",
+			dup.Decision, dup.Confidence)
+	}
+}

--- a/backend/internal/modules/people/orgnamegate_test.go
+++ b/backend/internal/modules/people/orgnamegate_test.go
@@ -3,7 +3,10 @@
 
 package people
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The pairs that sent an operator looking for records that did not exist.
 //
@@ -33,6 +36,20 @@ func TestUnrelatedCompaniesAreNotScoredAgainstEachOther(t *testing.T) {
 		// Generic words shared, nothing else.
 		{"The Group", "The Holding"},
 		{"Health Care", "Medical Care"},
+		// The control on the squashed-name comparison: two companies that
+		// share a generic FIRST word are not one company, however the
+		// separators fall.
+		{"Capital One", "Capital Group"},
+		{"Digital Ocean", "Digital Matter"},
+		{"Media Markt", "Media Monks"},
+		{"Health Engine", "Health Direct"},
+		// A word is not a prefix of another word. Jaro-Winkler boosts a shared
+		// start, so "base" reaches exactly 0.90 against "baseplan" — and these
+		// are two companies in one real workspace.
+		{"Base.com", "Baseplan"},
+		// Two domains share their suffix, not their identity. Without the
+		// country code and the level beneath it, both of these reduce to "or".
+		{"giba.or.kr", "utp.or.kr"},
 	}
 	for _, pair := range unrelated {
 		got := bestOrgNamePairing(pair[0], "", pair[1], "").Confidence
@@ -81,6 +98,30 @@ func TestRealDuplicatesStillMeetAtTheFuzzyTier(t *testing.T) {
 		{"Health Care", "Healthcare"},
 		{"The Group", "The Group Ltd"},
 		{"Digital Solutions", "Digital Solutions GmbH"},
+		// A generic word compounded onto the distinctive one. Half of all
+		// brands are written both ways, and the compound form leaves the token
+		// pass nothing to match: "digitalocean" shares no word with "digital
+		// ocean". These are the pairs the squashed-name comparison exists for.
+		{"Digital Ocean", "DigitalOcean"},
+		{"Media Markt", "MediaMarkt"},
+		{"Tech Data", "TechData Corp"},
+		{"Health Engine", "HealthEngine"},
+		// A company whose whole name is a word this gate calls generic.
+		{"Capital", "Capital Ltd"},
+		{"Capital One", "Capital One Financial"},
+		// A brand written as its own domain. The strip must not empty the name
+		// and leave the top-level domain as its identity.
+		{"Capital", "Capital.com"},
+		{"Digital", "Digital.ai"},
+		{"Media", "Media.net"},
+		// Punctuation is a word separator, whatever punctuation it is. An
+		// earlier version listed six ASCII characters and missed the period.
+		{"Hewlett Packard", "Hewlett.Packard"},
+		// Short transliterations. German turns an umlaut into a second vowel,
+		// which lands these at three and four runes.
+		{"Bär", "Baer"},
+		{"Röhm", "Roehm"},
+		{"Götz", "Goetz"},
 	}
 	for _, pair := range duplicates {
 		got := bestOrgNamePairing(pair[0], "", pair[1], "").Confidence
@@ -122,15 +163,76 @@ func TestNearIdentityIsOnlyTrustedOnLongEnoughWords(t *testing.T) {
 	}
 }
 
-// A name of nothing but market vocabulary has no distinctive word, and the
-// fallback answers the only question left: is this the same generic name
-// written differently?
-func TestAnAllGenericNameFallsBackToTheSquashedName(t *testing.T) {
-	if !sharesADistinctiveWord("Health Care", "Healthcare") {
-		t.Error("one company written with and without a space no longer meets")
+// Where the writer put the space is not evidence of a different company.
+//
+// This is asked BEFORE the token pass, not as a fallback after it: compounding
+// hides a shared word rather than removing one. "DigitalOcean" is a single
+// token, so it shares no word with "Digital Ocean" — but they are one company,
+// and the token pass alone would never say so.
+func TestCompoundingDoesNotDecideIdentity(t *testing.T) {
+	same := [][2]string{
+		{"Health Care", "Healthcare"},
+		{"Digital Ocean", "DigitalOcean"},
+		{"Media Markt", "MediaMarkt"},
+		{"E-Commerce", "E Commerce"},
 	}
-	if sharesADistinctiveWord("Health Care", "Medical Care") {
-		t.Error("two different generic names met — squashing must not make different words equal")
+	for _, pair := range same {
+		if !sharesADistinctiveWord(pair[0], pair[1]) {
+			t.Errorf("%q and %q no longer meet — they differ only in spacing",
+				pair[0], pair[1])
+		}
+	}
+	// Squashing merges the separators and nothing else: it must not make two
+	// different words equal.
+	different := [][2]string{
+		{"Health Care", "Medical Care"},
+		{"Digital Ocean", "Digital Matter"},
+	}
+	for _, pair := range different {
+		if sharesADistinctiveWord(pair[0], pair[1]) {
+			t.Errorf("%q and %q met — squashing must not make different words equal",
+				pair[0], pair[1])
+		}
+	}
+}
+
+// The comparison is a nested loop, so its cost is the PRODUCT of the two token
+// counts — and it runs inside DedupeOrganizationForCreate, which holds the
+// workspace-wide organization-name write lock. `display_name` is `text` with no
+// maxLength in the contract, so one create can hand it a megabyte; unbounded,
+// that would pin every organization-name writer in the workspace behind it.
+//
+// The 256-rune cap in jaroWinkler does not help: it bounds each call, and this
+// is about the number of calls.
+func TestTheTokenLoopIsBounded(t *testing.T) {
+	huge := strings.Repeat("acme ", 20000)
+	if got := len(distinctiveOrgTokens(huge)); got > orgGateTokenBudget {
+		t.Errorf("a 20,000-word name yields %d tokens, past the %d budget — the "+
+			"comparison is quadratic and runs under the name write lock",
+			got, orgGateTokenBudget)
+	}
+	// And the bound must not cost a real name: the longest in the measured
+	// corpus was six words.
+	if got := len(distinctiveOrgTokens("Dynamic Air Quality Solutions Pty Ltd")); got == 0 {
+		t.Error("an ordinary six-word name lost all its tokens")
+	}
+}
+
+// A word is not a prefix of another word.
+//
+// Jaro-Winkler boosts a shared start, so a short word scores high against any
+// longer word beginning with it. A spelling variant changes the letters inside
+// a word, not its length.
+func TestAPrefixIsNotASpellingVariant(t *testing.T) {
+	if sameOrgToken("base", "baseplan") {
+		t.Error("a word matched a longer word that merely starts with it")
+	}
+	if sameOrgToken("rate", "ratepay") {
+		t.Error("a word matched a longer word that merely starts with it")
+	}
+	// One rune apart is what a transliteration costs, and must still meet.
+	if !sameOrgToken("rohm", "roehm") {
+		t.Error("a one-rune transliteration no longer meets")
 	}
 }
 

--- a/backend/internal/modules/people/orgnamegate_test.go
+++ b/backend/internal/modules/people/orgnamegate_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// The pairs that sent an operator looking for records that did not exist.
+//
+// Each is a real name from one workspace, and each scored at or above the 0.72
+// review threshold on Jaro-Winkler alone. None is a duplicate of the other.
+// This is the regression: the character metric said yes and the estate said no.
+func TestUnrelatedCompaniesAreNotScoredAgainstEachOther(t *testing.T) {
+	unrelated := [][2]string{
+		// The nine that broke a CSV import of 107 contacts.
+		{"Bytesforce", "Salesforce"},
+		{"ACY Capital", "Soda Capital"},
+		{"Fenwick Software", "Centric Software"},
+		{"Pronto Software", "Centric Software"},
+		{"TLC Healthcare", "HealthCare Logic"},
+		{"The NMG Group", "The Performance Network Group (TPNG)"},
+		{"The Alta Group", "Thinksmart Group"},
+		{"Multimedia Technology", "MTA TECH"},
+		{"Digital Matter", "Elephant Digital"},
+		// The highest-scoring noise in the same corpus.
+		{"Stripe", "Strix"},
+		{"HPS", "KPS"},
+		{"FIS", "igus"},
+		{"EMS", "OPMS"},
+		{"netcare", "Newtrend"},
+		{"adesso", "ADSSI"},
+		{"SORA", "Suraksha"},
+		// Generic words shared, nothing else.
+		{"The Group", "The Holding"},
+		{"Health Care", "Medical Care"},
+	}
+	for _, pair := range unrelated {
+		got := bestOrgNamePairing(pair[0], "", pair[1], "").Confidence
+		if got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, at or above the %.2f review threshold — "+
+				"these are different companies",
+				pair[0], pair[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// The gate must not cost recall. Every pair here is one company written two
+// ways, and every one has to survive.
+func TestRealDuplicatesStillMeetAtTheFuzzyTier(t *testing.T) {
+	duplicates := [][2]string{
+		// The legal-suffix case the fuzzy tier exists for (PO-PARAM-1).
+		{"Acme Inc", "Acme GmbH"},
+		{"Siemens AG", "Siemens"},
+		{"basecom GmbH & Co. KG", "basecom"},
+		{"Shopware AG", "shopware"},
+		// A qualifier added or dropped.
+		{"Arvato", "Arvato Systems"},
+		{"Sun", "Sun Microsystems"},
+		{"The NMG Group", "NMG Group"},
+		{"Fenwick Software", "Fenwick Software Pty Ltd"},
+		{"ACY Capital", "ACY Capital Pty Ltd"},
+		{"Digital Matter", "Digital Matter Pty Ltd"},
+		// Transliteration, which the DACH market produces daily.
+		{"Müller Software", "Mueller Software"},
+		{"Straße Handel", "Strasse Handel"},
+		// Spacing and compounding.
+		{"TLC Healthcare", "TLC Health Care"},
+		{"Pricewaterhouse Coopers", "PricewaterhouseCoopers"},
+		{"Dynamic-QS", "Dynamic QS"},
+		{"E-Commerce Ltd", "Ecommerce Ltd"},
+		// A hyphen joins two words, and treating the pair as one token lost
+		// this: "acme-group" matches nothing, while "acme" matches "acme".
+		{"Acme Ltd", "ACME-Group Ltd"},
+		{"Rich Media", "Rich-Media Solutions"},
+		// A short name IS the company: length is not a filter.
+		{"3M", "3M Company"},
+		{"Box", "Box Inc"},
+		{"IBM", "IBM"},
+		{"HPS", "HPS"},
+		// Every word generic, so there is no distinctive token to gate on.
+		{"Health Care", "Healthcare"},
+		{"The Group", "The Group Ltd"},
+		{"Digital Solutions", "Digital Solutions GmbH"},
+	}
+	for _, pair := range duplicates {
+		got := bestOrgNamePairing(pair[0], "", pair[1], "").Confidence
+		if got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold — "+
+				"this is one company and the queue will never see it",
+				pair[0], pair[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// Length is not evidence that a word means nothing.
+//
+// An earlier version of the gate dropped tokens under three runes as
+// insignificant, which threw away "3M" — whose two characters are the entire
+// company — and would have turned a working match into a miss.
+func TestAShortNameIsStillAName(t *testing.T) {
+	for _, name := range []string{"3M", "HP", "GE", "Box", "Sun", "IBM"} {
+		if got := distinctiveOrgTokens(name); len(got) == 0 {
+			t.Errorf("%q has no distinctive token, so it can never match itself", name)
+		}
+	}
+}
+
+// Near-identity is only trusted where it means a spelling variant.
+//
+// On two long words a 0.90 score is an umlaut or a doubled letter. On two short
+// ones it is a different word: "sora" and "sura" differ by one character out of
+// four. Equality is honoured at every length, which is what keeps "3M" working.
+func TestNearIdentityIsOnlyTrustedOnLongEnoughWords(t *testing.T) {
+	if sameOrgToken("sora", "sura") {
+		t.Error("two four-letter words one character apart counted as the same word")
+	}
+	if !sameOrgToken("3m", "3m") {
+		t.Error("a short word no longer matches itself exactly")
+	}
+	if !sameOrgToken("mueller", "muller") {
+		t.Error("the ue/ü transliteration no longer meets, and the DACH market produces it daily")
+	}
+}
+
+// A name of nothing but market vocabulary has no distinctive word, and the
+// fallback answers the only question left: is this the same generic name
+// written differently?
+func TestAnAllGenericNameFallsBackToTheSquashedName(t *testing.T) {
+	if !sharesADistinctiveWord("Health Care", "Healthcare") {
+		t.Error("one company written with and without a space no longer meets")
+	}
+	if sharesADistinctiveWord("Health Care", "Medical Care") {
+		t.Error("two different generic names met — squashing must not make different words equal")
+	}
+}
+
+// The gate is organization-only. `nameSimilarity` stays the pinned Jaro-Winkler
+// (PO-PARAM-JW-1) that person dedupe, lead dedupe and site-person matching all
+// read, where a character metric is the right one: people carry no legal forms
+// and no industry vocabulary.
+func TestTheGateDoesNotReachPersonNameSimilarity(t *testing.T) {
+	// Two unrelated people whose names merely look alike still score high,
+	// because that is the person ladder's job to weigh against other evidence.
+	if got := nameSimilarity("Jon Smith", "Jan Smith"); got < 0.8 {
+		t.Errorf("person name similarity = %.4f, want the unchanged metric", got)
+	}
+}
+
+// Classes no name metric reaches, before this change or after.
+//
+// Written down so a reader does not mistake the gate for their cause. Each pair
+// is one company, and each scores below the review threshold on the ORIGINAL
+// metric — the gate takes nothing away here. They are answered by tier 1, the
+// exact domain match, which needs no name evidence at all.
+func TestClassesThatOnlyDomainEvidenceCanAnswer(t *testing.T) {
+	unreachable := [][2]string{
+		{"IBM", "International Business Machines"},
+		{"BMW", "Bayerische Motoren Werke"},
+		{"Facebook", "Meta"},
+		{"Сбербанк", "Sberbank"},
+		{"삼성전자", "Samsung Electronics"},
+	}
+	for _, pair := range unreachable {
+		if got := nameSimilarity(NormalizeOrgName(pair[0]), NormalizeOrgName(pair[1])); got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f on the raw metric — this test's premise "+
+				"is that name similarity cannot reach it, and that has changed",
+				pair[0], pair[1], got)
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

The organization fuzzy tier scored company names with Jaro-Winkler, a character metric with no concept of a word. On person names that is right. On company names it is not: every company in a market ends in the same handful of nouns, and a metric that cannot see a word boundary reads shared vocabulary as shared identity.

**Measured on 296 real company names from one workspace.** Of 43,660 pairs, 180 scored at or above the 0.72 review threshold. Exactly one was a genuine duplicate.

| | | score |
|---|---|---|
| Stripe | Strix | 0.89 |
| ACY Capital | Soda Capital | 0.82 |
| Fenwick Software | Centric Software | 0.82 |
| Bytesforce | Salesforce | 0.75 |
| HPS | KPS | 0.72 |

A 99.4% false-positive rate, firing on every organization create.

**It was not theoretical.** A CSV import of 107 contacts refused to create nine companies, reporting "a company of this name is already in the CRM" when no such company existed. The operator went looking through the UI for records that were never there.

## The fix

A pairing is scored only once the two names share a **distinctive word** — one that is not the market's shared vocabulary. The same 180 pairs reduce to **3**.

## What the measurements forced

Each of these broke a real pair before it was fixed:

- **Length is not a filter.** An earlier cut dropped tokens under three runes and threw away `3M`, whose two characters are the company.
- **A word is not a prefix of another word.** Jaro-Winkler boosts a shared start, so `base` scores exactly 0.90 against `baseplan` — and Base.com and Baseplan are two companies.
- **Punctuation is a separator, whatever punctuation it is.** A six-character ASCII list missed the period, losing `Hewlett Packard` / `Hewlett.Packard`.
- **A brand written as its domain must keep its name.** `Capital.com` reduced to the token `com` and would have matched every other .com in the estate.
- **Compounding does not decide identity.** `Digital Ocean` and `DigitalOcean` share no token at all, and half of all brands are written both ways.
- **Short transliterations are real.** German turns an umlaut into a second vowel, landing `Bär`/`Baer` at three and four runes. Measured: every three-letter false pair scores at or below 0.85, every real transliteration at or above 0.93.
- **The token loop is bounded.** It is a nested loop inside `DedupeOrganizationForCreate`, which holds the workspace-wide name write lock, and `display_name` has no maxLength in the contract. Unbounded, one large name would pin every organization-name writer behind it.

## What this does not change

- `nameSimilarity` is untouched and stays the pinned Jaro-Winkler (PO-PARAM-JW-1) that person dedupe, lead dedupe and site-person matching read.
- Tier 1, the exact domain match, returns before this tier.
- Acronym-vs-expansion, rebrands and CJK/Cyrillic transliteration are still unreachable by name similarity — they scored below threshold before this change too, and are answered by domain evidence. A test pins that premise.

## Verification

- 22 genuine duplicate pairs must still meet; 24 unrelated pairs must not.
- An integration test seeds the nine real incumbents and requires all nine refused companies to create. **Verified to catch the bug**: with the gate disabled, seven collide at the confidences measured against the real workspace.
- `make check-backend` green, integration lane green.

Reviewed by Codex twice — once as a design, once as a diff. Seven findings from the second review are fixed in commit 2 and each is pinned by a test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces false positives in organization dedupe by only scoring name pairs that share a distinctive word instead of shared letters. Previously the fuzzy tier used Jaro‑Winkler alone, which triggered frequent false matches and blocked imports; now it gates scoring to pairs with a shared distinctive word or identical squashed name, cutting noise (measured 180→3).

- Treats any non‑alphanumeric as a separator and compares squashed names first to ignore compounding (e.g., DigitalOcean vs Digital Ocean).
- Uses a versioned stopword list (market generics, TLDs, ccTLDs) and never strips a name to empty; restores the first non‑article token when needed.
- Requires token near‑identity only when lengths differ by at most one and JW ≥ 0.90; equality still holds for short tokens; no prefix-as-word matches.
- Sets the fuzzy token floor at length ≥ 3 to keep short transliterations (e.g., Bär/Baer) while rejecting short unrelated pairs.
- Bounds the token comparison to 32 words per side to protect the workspace name write lock.
- Prevents empty squashed names from matching each other.
- Limits the gate to organization fuzzy matching; exact domain tier is unchanged and person/lead `nameSimilarity` remains Jaro‑Winkler.
- Adds unit and integration tests, including the nine previously refused companies now creating successfully and genuine duplicates still filing for review.

<sup>Written for commit 930814a78d2df13363ed91024e7dc1f5622ac5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization-name matching to prevent unrelated organizations with generic terms from being treated as potential duplicates.
  * Preserved matching for genuine duplicates, including short names, transliterations, and separator variations.
  * Prevented punctuation-only and domain-only names from generating misleading matches.
  * Added safeguards to keep matching behavior reliable for unusually long names.

* **Tests**
  * Added comprehensive coverage for organization deduplication and previously rejected import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->