### PR TITLE
ci(main-health): main is asked whether its own history is signed off

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -275,6 +275,43 @@ jobs:
 
   # Say what broke and who landed it. This is the job the whole workflow exists
   # for: a red lane nobody is told about is the state we already had.
+  # Whether main's own history is signed off, which nothing was asking.
+  #
+  # The `dco` job in ci.yml runs PR-side over the branch's commits. main takes
+  # the SQUASH, whose message GitHub composes from the pull request — so the two
+  # are not the same text, and once the branch is deleted the check is attached
+  # to a ref that no longer exists. An unsigned commit on main is therefore
+  # invisible FROM main, which is how ab64ef038 landed carrying no trailer at
+  # all while its PR's dco check was red.
+  #
+  # The baseline is a start point, not a skip list: everything after it is
+  # checked, every time, and nothing is exempted by pattern. It names where this
+  # gate was armed. Move it back — to the baseline commit — once the unsigned
+  # commit before it has been remediated by its author, which is a sign-off only
+  # they can give.
+  dco:
+    name: dco (main)
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The range starts at the baseline, which is many merges back.
+          fetch-depth: 0
+      - name: Every commit on main since the baseline is signed off
+        env:
+          # The first commit this gate covers. A SHA that has left the history
+          # makes `git rev-list` fail loudly rather than check nothing, which is
+          # the failure mode a baseline has to avoid.
+          DCO_MAIN_BASELINE: 250f692f7
+        run: ./scripts/check-dco.sh "$DCO_MAIN_BASELINE" "${{ github.sha }}"
+
   report:
     name: report
     timeout-minutes: 10
@@ -285,7 +322,7 @@ jobs:
     # working one on every dashboard. Left out of this list, the job that exists
     # to publish main's verdict was the one job whose failure nobody was told
     # about.
-    needs: [gates, integration, frontend, uat, sonar]
+    needs: [gates, integration, frontend, uat, sonar, dco]
     if: >-
       !cancelled()
       && (needs.gates.result == 'failure'
@@ -329,5 +366,6 @@ jobs:
           MAIN_FRONTEND_RESULT: ${{ needs.frontend.result }}
           MAIN_UAT_RESULT: ${{ needs.uat.result }}
           MAIN_SONAR_RESULT: ${{ needs.sonar.result }}
+          MAIN_DCO_RESULT: ${{ needs.dco.result }}
           MAIN_SUSPECTS: ${{ steps.range.outputs.suspects }}
         run: ./scripts/scheduled-report.sh

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -306,8 +306,13 @@ jobs:
           fetch-depth: 0
       - name: Every commit on main since the baseline is signed off
         env:
-          # The first commit this gate covers.
-          DCO_MAIN_BASELINE: 250f692f7
+          # The last commit this gate does NOT cover — `A..B` excludes A, so a
+          # baseline naming the first COVERED commit would leave that commit
+          # itself unchecked. This names the unsigned commit instead, so
+          # everything after it is in range and it is not, which is exactly the
+          # boundary. It moves to the unsigned commit's own parent once that
+          # commit is remediated by its author.
+          DCO_MAIN_BASELINE: ab64ef038
         # The ancestry is asserted before the range is used, because
         # `git rev-list A..B` does not complain when A is not behind B — it
         # answers with whatever that range happens to mean. A baseline that has

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -306,11 +306,25 @@ jobs:
           fetch-depth: 0
       - name: Every commit on main since the baseline is signed off
         env:
-          # The first commit this gate covers. A SHA that has left the history
-          # makes `git rev-list` fail loudly rather than check nothing, which is
-          # the failure mode a baseline has to avoid.
+          # The first commit this gate covers.
           DCO_MAIN_BASELINE: 250f692f7
-        run: ./scripts/check-dco.sh "$DCO_MAIN_BASELINE" "${{ github.sha }}"
+        # The ancestry is asserted before the range is used, because
+        # `git rev-list A..B` does not complain when A is not behind B — it
+        # answers with whatever that range happens to mean. A baseline that has
+        # left the history fails loudly on rev-parse, but one that RESOLVES and
+        # is not an ancestor is the dangerous case: if it sits ahead of the tip
+        # the range is empty and this gate reports a clean main having read
+        # nothing. A census that can fail short has already failed, so it is
+        # checked rather than assumed.
+        run: |
+          set -eu
+          git rev-parse --verify "$DCO_MAIN_BASELINE^{commit}" >/dev/null
+          if ! git merge-base --is-ancestor "$DCO_MAIN_BASELINE" "${{ github.sha }}"; then
+            echo "DCO: baseline $DCO_MAIN_BASELINE is not an ancestor of ${{ github.sha }} —" >&2
+            echo "the range would not cover main's history. Update DCO_MAIN_BASELINE." >&2
+            exit 1
+          fi
+          ./scripts/check-dco.sh "$DCO_MAIN_BASELINE" "${{ github.sha }}"
 
   report:
     name: report
@@ -329,7 +343,8 @@ jobs:
       || needs.integration.result == 'failure'
       || needs.frontend.result == 'failure'
       || needs.uat.result == 'failure'
-      || needs.sonar.result == 'failure')
+      || needs.sonar.result == 'failure'
+      || needs.dco.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -288,6 +288,29 @@ no running stack — but it does need the browser: \`pnpm exec playwright instal
     || unreported=1
 fi
 
+if [[ "${MAIN_DCO_RESULT:-}" = "failure" ]]; then
+  report "main carries a commit with no Signed-off-by" bug \
+"The \`dco (main)\` job failed on the two-hourly health check: $RUN_URL
+
+The \`dco\` job in \`ci.yml\` runs PR-side, over the branch's own commits. \`main\`
+takes the SQUASH, whose message GitHub composes from the pull request — so the
+two are not the same text, and once the branch is deleted the check is attached
+to a ref that no longer exists. An unsigned commit on \`main\` is invisible FROM
+\`main\`, which is why this job exists.
+
+It is filed as a bug rather than a chore because a missing trailer is the
+licence model's provenance obligation, not a style rule, and because the repair
+is not ours: a sign-off is a certification BY THE AUTHOR. Nobody else may add
+one on their behalf. The fix is a follow-up commit from whoever wrote the commit
+this run names.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Reproduce locally with \`./scripts/check-dco.sh <baseline> HEAD\` — the same
+script the PR lane runs, over a range instead of a branch."\
+    || unreported=1
+fi
+
 if [[ "${MAIN_SONAR_RESULT:-}" = "failure" ]]; then
   report "main's SonarCloud analysis was not published" bug \
 "The \`sonarcloud (main)\` job failed on the two-hourly health check, with every

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -299,6 +299,32 @@ for lane in $lanes; do
 	esac
 done
 
+# --- the other half of the same invariant ---------------------------------------
+#
+# An arm in the reporter is only reachable if main-health both RUNS the report
+# job for that lane and passes the lane's result in. Those are two lines in a
+# different file, and the reporter's own test cannot see them — which is how a
+# `dco` lane was added with its arm, its env line and both cases, and still
+# filed nothing: the report job's `if:` did not select it, so a DCO-only failure
+# skipped the job entirely and the arm was never reached.
+#
+# One invariant spelled on both sides of a wire is one item. So the census asks
+# the workflow the same question it asks the reporter, and fails in the
+# direction that was missed rather than only the one that was covered.
+health="$root/.github/workflows/main-health.yml"
+for lane in $lanes; do
+	# MAIN_UAT_RESULT -> uat
+	job="$(printf '%s' "$lane" | sed -E 's/^MAIN_(.+)_RESULT$/\1/' | tr '[:upper:]' '[:lower:]')"
+	if ! grep -qE "needs\.${job}\.result == 'failure'" "$health"; then
+		echo "FAIL: $lane has a reporter arm, but main-health's report job does not run for a failing '${job}' — the arm is unreachable"
+		failures=$((failures + 1))
+	fi
+	if ! grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}" "$health"; then
+		echo "FAIL: $lane has a reporter arm, but main-health never passes needs.${job}.result in as $lane"
+		failures=$((failures + 1))
+	fi
+done
+
 if [ "$failures" -ne 0 ]; then
 	echo "FAIL: $failures case(s)" >&2
 	exit 1

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -129,6 +129,7 @@ readonly INTEGRATION_TITLE="main is red: the integration lane fails on the tip"
 readonly FRONTEND_TITLE="main is red: the frontend lane fails on the tip"
 readonly UAT_TITLE="main is red: the screen-acceptance UAT fails on the tip"
 readonly SONAR_TITLE="main's SonarCloud analysis was not published"
+readonly DCO_TITLE="main carries a commit with no Signed-off-by"
 readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
 
 # What the cases below actually exercised, recorded as they run rather than
@@ -235,6 +236,15 @@ expect_health "a failed publish of main's analysis is filed with its suspect ran
 
 expect_health "a failed publish with no range still files" \
 	MAIN_SONAR_RESULT "$SONAR_TITLE" ""
+
+# The provenance arm. It exists because the PR-side `dco` job checks the
+# BRANCH's commits and main takes the squash, so an unsigned commit on main is
+# invisible from main once the branch is gone.
+expect_health "an unsigned commit on main is filed with its suspect range" \
+	MAIN_DCO_RESULT "$DCO_TITLE" "$SUSPECTS"
+
+expect_health "an unsigned commit with no range still files" \
+	MAIN_DCO_RESULT "$DCO_TITLE" ""
 
 # --- the census -----------------------------------------------------------------
 #

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -312,14 +312,27 @@ done
 # the workflow the same question it asks the reporter, and fails in the
 # direction that was missed rather than only the one that was covered.
 health="$root/.github/workflows/main-health.yml"
+# The REPORT JOB's own block, not the whole file. Searching the file would let
+# any other job's matching line stand in for the one that was removed — the
+# gate would go on passing while the job it is about lost the wiring, which is
+# the same "matched something, therefore fine" mistake it exists to catch.
+#
+# The slice runs from the job key at two-space indent to the next one; an empty
+# slice means the job was renamed or removed, and that fails rather than
+# silently checking nothing.
+report_job="$(awk '/^  report:/{inside=1} inside&&/^  [a-z_-]+:/&&!/^  report:/{exit} inside' "$health")"
+if [ -z "$report_job" ]; then
+	echo "FAIL: no 'report' job found in main-health.yml — the wiring checks below would pass by scanning nothing"
+	failures=$((failures + 1))
+fi
 for lane in $lanes; do
 	# MAIN_UAT_RESULT -> uat
 	job="$(printf '%s' "$lane" | sed -E 's/^MAIN_(.+)_RESULT$/\1/' | tr '[:upper:]' '[:lower:]')"
-	if ! grep -qE "needs\.${job}\.result == 'failure'" "$health"; then
+	if ! printf '%s' "$report_job" | grep -qE "needs\.${job}\.result == 'failure'"; then
 		echo "FAIL: $lane has a reporter arm, but main-health's report job does not run for a failing '${job}' — the arm is unreachable"
 		failures=$((failures + 1))
 	fi
-	if ! grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}" "$health"; then
+	if ! printf '%s' "$report_job" | grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}"; then
 		echo "FAIL: $lane has a reporter arm, but main-health never passes needs.${job}.result in as $lane"
 		failures=$((failures + 1))
 	fi

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -320,7 +320,13 @@ health="$root/.github/workflows/main-health.yml"
 # The slice runs from the job key at two-space indent to the next one; an empty
 # slice means the job was renamed or removed, and that fails rather than
 # silently checking nothing.
-report_job="$(awk '/^  report:/{inside=1} inside&&/^  [a-z_-]+:/&&!/^  report:/{exit} inside' "$health")"
+#
+# The boundary matches every id GitHub Actions accepts — uppercase and digits
+# included — because a boundary NARROWER than its subject is how this check
+# would reacquire the hole it was written to close: a job the pattern does not
+# recognise never ends the slice, so the slice swallows it and that job's wiring
+# can satisfy the census on the report job's behalf.
+report_job="$(awk '/^  report:/{inside=1} inside&&/^  [A-Za-z_][A-Za-z0-9_-]*:/&&!/^  report:/{exit} inside' "$health")"
 if [ -z "$report_job" ]; then
 	echo "FAIL: no 'report' job found in main-health.yml — the wiring checks below would pass by scanning nothing"
 	failures=$((failures + 1))


### PR DESCRIPTION
Closes the gate half of #2719. It does **not** repair the unsigned commit — see below.

## Nothing on main was asking

`ab64ef038` is on `main` with **zero** `Signed-off-by` trailers, and its PR's `dco` check was red when it merged. It is the only one of the last twelve commits with none:

```
250f692f7 signoffs=7    ab64ef038 signoffs=0  ←
0e4ca11f2 signoffs=1    c55fa42a3 signoffs=3
53d7b1ec2 signoffs=6    cd4b93d30 signoffs=3
```

Nothing on `main` noticed, and nothing could have. The `dco` job in `ci.yml` runs PR-side over the **branch's** commits; `main` takes the **squash**, whose message GitHub composes from the pull request — so the two are not the same text. Once the branch is deleted the check is attached to a ref that no longer exists. **An unsigned commit on `main` is invisible from `main`.**

That is the same shape main-health closed for the screens in #2629: a lane that only ever runs PR-side leaves no main-side signal, so a merge over it is unrecoverable from the branch view.

## What this adds

A `dco (main)` job that reuses `scripts/check-dco.sh` over a range rather than spelling the rule a second time — the script already takes one, which is exactly what a branchless check needs.

**The baseline is a start point, not a skip list.** Everything after it is checked on every run and nothing is exempted by pattern, so the gate cannot pass by matching less. It names where the gate was armed, and it moves back once the commit before it is remediated.

A baseline SHA that has left the history makes `git rev-list` **fail loudly** rather than check nothing — the failure mode a start point has to avoid.

## What this deliberately does not do

**It does not sign the commit.** A sign-off is a certification *by the author*; nobody else may add one on their behalf, and a `Signed-off-by:` trailer naming someone who did not write it would be worse than the gap. The repair for `ab64ef038` is a follow-up from its author, and that is why the gate reports rather than fixes. #2719 keeps `status: needs-decision` for that half.

## Verification

Real exit codes, not `tail`'s:

```
./scripts/check-dco.sh 250f692f7 origin/main   → exit 0   ("all commits are signed off")
./scripts/check-dco.sh 0e4ca11f2 origin/main   → exit 1   (names ab64ef038 by SHA and subject)
```

So the gate passes over the range it will actually run, and fires — naming the commit — on a range containing the unsigned one.

**The census caught the reporter arm before a human did.** Adding `MAIN_DCO_RESULT` without its two cases failed `test-scheduled-report.sh` on both:

```
FAIL: the reporter has a MAIN_DCO_RESULT arm that no case exercises with a suspect range
FAIL: the reporter has a MAIN_DCO_RESULT arm that no case exercises without a suspect range
```

That is the gate deriving its corpus from the reporter rather than from a list beside it. Both cases added; `./scripts/test-scheduled-report.sh` now exits 0.

- `bash -n scripts/scheduled-report.sh` clean
- `main-health.yml` parses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated validation now confirms sign-off checks use a valid commit baseline.
  * Scheduled health reports create an issue for commits missing the required sign-off, including run details, affected ranges, and troubleshooting guidance.
  * Health reporting now includes sign-off check failures.

* **Bug Fixes**
  * Invalid baseline ranges now fail clearly instead of producing unreliable results.

* **Tests**
  * Added coverage for sign-off reporting across available and unavailable commit ranges, including failure-reporting paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->