### PR TITLE
test(channels): the poll wait reads the cursor it is waiting on

### DIFF
--- a/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
@@ -436,6 +436,13 @@ func (c *telegramEnv) pollNow(t *testing.T, sub <-chan *river.Event, wantOffset 
 	// and the wait still ends the moment the cursor moves.
 	pace := time.NewTicker(25 * time.Millisecond)
 	defer pace.Stop()
+	// A CLOSED subscription is ready forever, and a ready case wins over a
+	// ticker that is not — so leaving it in the select would switch the pacing
+	// off at exactly the moment the hint stops coming, and spin this loop
+	// through one database read per iteration for the rest of the deadline.
+	// Dropping the channel leaves the ticker as the only wake-up, which is the
+	// state the loop is already written to survive.
+	events := sub
 	for {
 		if c.pollCursor(t) >= wantOffset {
 			return
@@ -444,7 +451,11 @@ func (c *telegramEnv) pollNow(t *testing.T, sub <-chan *river.Event, wantOffset 
 		case <-ctx.Done():
 			t.Fatalf("timed out waiting for poll cursor to reach %d: %v", wantOffset, ctx.Err())
 		case <-pace.C:
-		case ev := <-sub:
+		case ev, open := <-events:
+			if !open {
+				events = nil
+				continue
+			}
 			if ev == nil || ev.Job == nil || ev.Job.Kind != (compose.TelegramPollArgs{}).Kind() {
 				continue
 			}

--- a/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
@@ -421,17 +421,29 @@ func (c *telegramEnv) pollNow(t *testing.T, sub <-chan *river.Event, wantOffset 
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	// The cursor is the durable evidence and the event is only a hint to look
+	// again, which is why a hint that never arrives must not be able to hold
+	// this open. The enqueue above dedupes into any poll already in flight
+	// (per-bot uniqueness), and THAT poll's completion event may have been
+	// consumed by an earlier await — so the run where no further event is
+	// published is not an edge case, it is the ordinary outcome of the dedupe
+	// working. Checking once before blocking covers the poll that finished
+	// before this call; it does nothing for the poll that finishes after it,
+	// and blocking on `sub` alone then waits out the whole deadline.
+	//
+	// So the read is paced as well as woken. The ticker is not a delay: every
+	// tick re-reads the same committed row the event would have sent us to,
+	// and the wait still ends the moment the cursor moves.
+	pace := time.NewTicker(25 * time.Millisecond)
+	defer pace.Stop()
 	for {
-		// Checked before blocking: the enqueue above dedupes into any poll already
-		// in flight (per-bot uniqueness), and that poll's completion event may have
-		// been consumed by an earlier await — the cursor itself is the durable
-		// evidence, the event only says when to look again.
 		if c.pollCursor(t) >= wantOffset {
 			return
 		}
 		select {
 		case <-ctx.Done():
 			t.Fatalf("timed out waiting for poll cursor to reach %d: %v", wantOffset, ctx.Err())
+		case <-pace.C:
 		case ev := <-sub:
 			if ev == nil || ev.Job == nil || ev.Job.Kind != (compose.TelegramPollArgs{}).Kind() {
 				continue


### PR DESCRIPTION
## main is red on integration shard 6

main-health 32866249785 on `24a6c0fc7`:

```
telegram_ingress_integration_test.go:248: timed out waiting for poll cursor to reach 5302: context deadline exceeded
--- FAIL: TestAC_TG_4_RedeliveryYieldsExactlyOneActivity (62.72s)
FAIL github.com/gradionhq/margince/backend/internal/compose/integration/channels
```

62.72s is the whole sixty-second deadline. Locally it passes 3/3 in 5.3s.

## The wait was woken but never paced

`pollNow` read the cursor **once**, then blocked on the job-event subscription and re-read only when an event arrived. Its own comment already said an event may never come:

> the enqueue above dedupes into any poll already in flight (per-bot uniqueness), and that poll's completion event may have been consumed by an earlier await — the cursor itself is the durable evidence, the event only says when to look again

So the run where no further event is published is **not an edge case — it is the ordinary outcome of the dedupe working.** The single check before blocking covers a poll that finished *before* the call and does nothing for one that finishes *after* it. Then the loop waits out the full deadline.

That makes it an ordering race, and CI is where the ordering flips: fast machine, event lands after the pre-check; loaded runner, it lands before, gets consumed, and nothing wakes the loop again.

## The fix follows the comment's own authority

The cursor is the durable evidence; the event is a hint. So the evidence is read without needing the hint — a ticker paces the same committed read, **beside** the event branch rather than instead of it, using the `pace := time.NewTicker(...)` idiom already in this suite (`stage_removal_race`, `project_closewon`). The wait still ends the moment the cursor moves; nothing is slowed.

This removes real-clock flakiness rather than adding a sleep: every tick re-reads a committed row, and the deadline that already existed is unchanged.

## Verification

- `go test -tags integration ./internal/compose/integration/channels/` — **ok**, whole package, 10.7s
- The named test, `-count=3` — ok

**The pacing is what does the work, not decoration beside a branch that was already sufficient.** Checked by deleting the event branch outright and re-running: the test still passes, in 3.0s. So the ticker alone observes the cursor, which is exactly the property the wait was missing.

## Scope

Not caused by any one merge — the race has been latent. It surfaced now because `24a6c0fc7` is the first tip main-health has measured since the shard timings shifted. No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll completion detection when an existing poll is reused or no completion event is emitted.
  * Poll status is now periodically rechecked, helping prevent waits until timeout in these scenarios.
  * Improved polling reliability when completion notifications are unavailable, preventing stalled polling and unnecessary repeated activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->