### PR TITLE
test(ac): the axe sweep measures a page that has stopped moving

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -11,25 +11,63 @@ declare global {
 }
 
 /**
- * Wait for every FINITE animation to finish before measuring the page.
+ * Settle the page's motion before measuring the colours it paints.
  *
  * A contrast check reads the colours that are painted, and an element mid-fade
  * paints a blend: the login screen's staggered entry made axe see the runtime
  * line at #bfc3c1 on #fafbfa (1.71:1) instead of its settled #36433d on #eef1f0
  * (8.9:1), so the sweep failed or passed depending on how fast the machine got
- * to `networkidle`. Infinite animations are excluded because the Core breathes
- * forever — waiting on those would hang rather than settle.
+ * to `networkidle`.
+ *
+ * WAITING for `getAnimations()` to report every finite animation finished
+ * cannot settle a page. That set is empty both BEFORE the first entrance starts
+ * and AFTER the last one ends, and `[].every()` is true of an empty set, so the
+ * wait returns on a page whose content has not begun arriving. On a loaded
+ * runner that is the ordinary outcome rather than a rare one: `.wrap > *` holds
+ * each block back by up to five steps of `--stagger-enter` before fading it in
+ * over `--dur-enter`, and a whole screen of half-painted text is what such a
+ * wait hands to axe.
+ *
+ * Reduced motion settles it instead. The design system answers that with
+ * `animation: none` on every arrival, which lands the content already mounted
+ * AND the content still to mount at its resting colour, leaving no window to
+ * race. The assertions are the half that cannot pass vacuously: an arrival that
+ * outlives the guard fails here, naming itself, rather than being measured
+ * mid-flight.
  */
-async function animationsSettled(page: Page) {
-  await page.waitForFunction(() =>
-    document
-      .getAnimations()
-      .filter(
-        (animation) =>
-          animation.effect?.getTiming().iterations !== Number.POSITIVE_INFINITY,
-      )
-      .every((animation) => animation.playState === "finished"),
-  );
+async function settleAnimations(page: Page) {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const motion = await page.evaluate(() => {
+    const describe = (element: Element) =>
+      `${element.tagName.toLowerCase()}.${element.className}`;
+    return {
+      running: document
+        .getAnimations()
+        .filter((animation) => animation.playState === "running")
+        .map((animation) => {
+          const effect = animation.effect;
+          return effect instanceof KeyframeEffect &&
+            effect.target instanceof Element
+            ? describe(effect.target)
+            : "an element the effect does not name";
+        }),
+      // The guard itself, read off the cascade rather than off the clock: an
+      // arrival that still names an animation here will fade whenever it
+      // mounts, including after this check has run. Timing cannot see that one;
+      // the computed style can.
+      stillArriving: [...document.querySelectorAll(".arrive, .wrap > *")]
+        .filter((element) => getComputedStyle(element).animationName !== "none")
+        .map(describe),
+    };
+  });
+  expect(
+    motion.stillArriving,
+    "an arrival outlived the reduced-motion guard in enter.css, so content fades in whenever it mounts and axe reads the blend rather than the colours a reader sees",
+  ).toEqual([]);
+  expect(
+    motion.running,
+    "an animation kept running under prefers-reduced-motion, so axe would read a frame mid-flight",
+  ).toEqual([]);
 }
 
 // B-EP09.22a/b: the AC-<screen>-N criteria as named tests — a failing test
@@ -1191,7 +1229,7 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
       // sweep. #/settings/maintenance scored zero violations while showing the
       // app error boundary.
       await expectShellRendered(page);
-      await animationsSettled(page);
+      await settleAnimations(page);
       await expectNoAaViolations(page, screen);
     });
   }
@@ -1219,7 +1257,7 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
     // The sweep is only meaningful once the record chrome is on screen: axe
     // finds nothing to complain about in an empty shell.
     await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
-    await animationsSettled(page);
+    await settleAnimations(page);
     await expectShellRendered(page);
     await expectNoAaViolations(page, "companies/o-brandt");
   });
@@ -1471,7 +1509,7 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
     // would never see it. Run it here too rather than leave the one part of the
     // surface a user of an SSO installation actually clicks unmeasured.
     await page.waitForLoadState("networkidle");
-    await animationsSettled(page);
+    await settleAnimations(page);
     await expectNoAaViolations(page, "login (with SSO providers)");
   });
 
@@ -1483,7 +1521,7 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Bei Margince anmelden" }),
     ).toBeVisible();
-    await animationsSettled(page);
+    await settleAnimations(page);
     await expectNoAaViolations(page, "login");
   });
 });


### PR DESCRIPTION
## The red

`main-health` failed twice today on the `uat (main)` lane — runs [32853813449](https://github.com/margince/margince/actions/runs/32853813449) (13:31) and [32874821157](https://github.com/margince/margince/actions/runs/32874821157) (17:03) — both `axe found 36 AA violation(s) on #/home`. The second ran on `a4dfaced7`, a commit whose *other* main-health run 22 minutes earlier was green on all 16 jobs. Same tree, opposite verdicts.

## It is not a palette bug

Every reported colour is an opacity composite of the settled one. `.glance-intro` computes to `#68756e`; the failure reported it as `#7b8781`. Solving for the alpha that maps one to the other over white, per channel:

| reported | R | G | B |
|---|---|---|---|
| `#7b8781` | 0.874 | 0.870 | 0.869 |
| `#818c86` | 0.834 | 0.833 | 0.834 |
| `#98a19d` | 0.682 | 0.681 | 0.679 |
| `#9ea7a2` | 0.642 | 0.638 | 0.641 |

Three channels agreeing to within 0.005, at four *different* alphas. That is a staggered fade caught at four points, not a token that is wrong.

## Why the existing gate could not stop it

`animationsSettled` waited for `getAnimations()` to report every finite animation `finished`. That set is empty **both** before the first entrance starts **and** after the last one ends — and `[].every()` is true of an empty set. The wait cannot tell the two apart, so it returns on a page whose content has not begun arriving.

Probed directly, at CPU throttle 1×, 4×, 10× and 20×:

```
PROBEx1  settleCount=0 vacuous=true
PROBEx4  settleCount=0 vacuous=true
PROBEx10 settleCount=0 vacuous=true
PROBEx20 settleCount=0 vacuous=true
```

The predicate has *never* waited for anything on this page. `.wrap > *` (`enter.css`) holds each block back by up to five steps of `--stagger-enter` (40ms) before fading it over `--dur-enter` (360ms) — up to 560ms of arrival that begins after the gate has already returned. On a loaded runner, where React mounts content after `networkidle`, that is the ordinary case rather than a rare one. The helper's own docblock described this exact failure on the login screen; the gate simply could not hold it.

## The fix

Ask for reduced motion. The design system already answers that with `animation: none` on every arrival, which lands content already mounted **and** content still to mount at its resting colour — there is no window left to race, rather than a narrower one.

Two assertions replace the wait, because a settle gate that cannot fail is the defect it was written against:

- **`stillArriving`** reads the *cascade*, not the clock: an arrival whose computed `animation-name` is not `none` will fade whenever it mounts, including after this check has run. Timing cannot see that one.
- **`running`** catches anything still in flight at measurement time.

## Verification

- **Mutation test** — removed the `prefers-reduced-motion` block from `enter.css`, rebuilt, confirmed the mutant reached the bundle, and the gate failed naming `header.glance arrive` and four siblings. Guard restored and re-verified clean.
- Full e2e suite: **94 passed / 14 skipped**, identical to the green CI run.
- `biome check` clean.

## One thing I did not fix

No `tsconfig` in `frontend/` includes `e2e/` — checked all five with `tsc --listFiles`, every one reports 0 for `ac.spec.ts`. These specs are transpiled by Playwright and never typechecked. Out of scope here; worth a decision separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved accessibility checks by accounting for reduced-motion settings and detecting animations that remain active.
  * Added clearer diagnostic information when animations prevent checks from settling.
  * Accessibility sweeps now provide more consistent results across animated interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->