### PR TITLE
feat(mcp): the query vocabulary is a tool, and a city can be a radius centre

### DIFF
--- a/backend/internal/compose/agenttoolparity_test.go
+++ b/backend/internal/compose/agenttoolparity_test.go
@@ -170,6 +170,13 @@ var composedIntents = map[string]bool{
 	// datasource seam. It is read-only and reaches nothing outside the
 	// workspace, which is what TestComposedIntentsNeverEgress holds it to.
 	"query_workspace": true,
+	// describe_query_vocabulary answers the document margince://schema/query
+	// publishes, for a client that reads TOOLS and not resources. It backs no
+	// REST operation at all: the vocabulary is composed at call time from the
+	// field catalog and the live column catalog, narrowed to what this
+	// principal may already read. Read-only, it returns no records, and it
+	// names nothing a caller could not reach by asking.
+	"describe_query_vocabulary": true,
 	// search_context ranks across record types through the retrieval index,
 	// which no single list operation is: `GET /search` is the lexical half
 	// alone and answers no vector lane, and the records the sweep names are

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -74,6 +74,12 @@ func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
 		// table. The plan only has to be well-formed — the refusal lands
 		// before the vocabulary is resolved, let alone the statement run.
 		"query_workspace": `{"plan":{"version":"v1","target":"deal"}}`,
+		// The vocabulary that plan is written in. It reads no records at all,
+		// which is exactly why it needs the guard: served here it would teach a
+		// caller a field list, and every plan they then wrote would be refused
+		// by the executor. One refusal, not a working description of an
+		// unavailable capability.
+		"describe_query_vocabulary": `{}`,
 		// The ranked sweep: the lexical and vector indexes hold no mirrored
 		// content, so an unguarded call answers an empty page — a believable
 		// "there is nothing like that here" for a workspace full of records.

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -334,6 +334,38 @@ func nativeOnlyQueryRunner(mode overlayModeChecker, run agents.QueryRunner) agen
 	}
 }
 
+// nativeOnlyVocabularyReader guards describe_query_vocabulary, for exactly the
+// reason the plan executor above takes the same guard.
+//
+// The vocabulary describes what a plan may SAY, and that looked at first like
+// something answerable anywhere — a grammar, not a read of rows. It is not: in
+// an overlay workspace every plan is refused outright, so a vocabulary served
+// there advertises a field list nothing can execute. A caller would read the
+// fields, write a correct plan, and be told the tool is unsupported — having
+// spent a turn learning a language this workspace does not speak.
+//
+// One refusal is the honest shape: "not available here", once, rather than a
+// working description of an unavailable capability.
+//
+// A STRUCT rather than a decorating function, like nativeOnlyRetriever above:
+// a function handing back the interface hides which implementation the
+// composition wired, which is the whole readability of a composition root.
+type nativeOnlyVocabularyReader struct {
+	mode  overlayModeChecker
+	inner agents.VocabularyReader
+}
+
+func (v nativeOnlyVocabularyReader) VocabularyDocument(ctx context.Context) (json.RawMessage, error) {
+	overlay, err := v.mode.isOverlayUncached(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if overlay {
+		return nil, apperrors.ErrUnsupportedBySoR
+	}
+	return v.inner.VocabularyDocument(ctx)
+}
+
 // nativeOnlyBriefReader guards read_brief. The brief ranks the rep's own open
 // deals out of the native tables, and an overlay workspace keeps its deals in
 // the incumbent — so the run would be assembled from rows this workspace does

--- a/backend/internal/compose/queryseam.go
+++ b/backend/internal/compose/queryseam.go
@@ -125,8 +125,24 @@ type placeCache struct{ people *people.Store }
 
 func (p placeCache) LookupPlace(ctx context.Context, query string) (search.Point, bool, error) {
 	found, ok, err := p.people.LookupPlace(ctx, query)
+	if err != nil {
+		return search.Point{}, false, err
+	}
+	if ok {
+		return search.Point{Lat: found.Lat, Lon: found.Lon}, true, nil
+	}
+	// THE CITY FALLBACK, and it is why a radius around a place NAME works at
+	// all. The cache is keyed on the exact string that was geocoded, and what
+	// gets geocoded is a company's full address — so "Düsseldorf" missed while
+	// "arnulfstraße 33, 40545, düsseldorf" hit. A person saying where they are
+	// names the city, never the street of a company they have not reached yet,
+	// so the one form a caller actually sends was the one form that failed.
+	//
+	// Still no egress: the point is averaged from the organizations this
+	// installation has ALREADY located in that city. See people.LookupCity.
+	city, ok, err := p.people.LookupCity(ctx, query)
 	if err != nil || !ok {
 		return search.Point{}, false, err
 	}
-	return search.Point{Lat: found.Lat, Lon: found.Lon}, true, nil
+	return search.Point{Lat: city.Lat, Lon: city.Lon}, true, nil
 }

--- a/backend/internal/compose/queryseam.go
+++ b/backend/internal/compose/queryseam.go
@@ -124,25 +124,42 @@ func queryAnswerOf(result search.QueryResult) agents.QueryAnswer {
 type placeCache struct{ people *people.Store }
 
 func (p placeCache) LookupPlace(ctx context.Context, query string) (search.Point, bool, error) {
-	found, ok, err := p.people.LookupPlace(ctx, query)
+	// THE SCOPED LOOKUP IS ASKED FIRST, and the order is the security property
+	// rather than a preference.
+	//
+	// The exact place cache is installation-wide and unscoped, which is right
+	// for what it was built to hold: a public coordinate for a public place
+	// name, with no subject a grant could be about. But `addressQuery` builds
+	// its key from whatever parts of an address exist, and `locatable` admits a
+	// row carrying ONLY a city — so a company with no street mints a cache
+	// entry under the bare city name. Measured on a real installation: the key
+	// "munich" is in that table today.
+	//
+	// Asking the cache first would then let a caller learn that SOMEBODY is
+	// located in a city, out of a row they may not read, one city name at a
+	// time — the existence oracle the visibility rules exist to close. Asking
+	// the scoped lane first means a hit is already composed from companies this
+	// caller could have listed for themselves, and the cache is consulted only
+	// where they have no company to be told about.
+	//
+	// The cost is that a caller with no visible company in a city falls through
+	// to the cache and may still hit a bare-city key. That is the pre-existing
+	// behaviour of a table that predates this lane; what this ordering
+	// guarantees is that the NEW lane never widens it.
+	city, ok, err := p.people.LookupCity(ctx, query)
 	if err != nil {
 		return search.Point{}, false, err
 	}
 	if ok {
-		return search.Point{Lat: found.Lat, Lon: found.Lon}, true, nil
+		return search.Point{Lat: city.Lat, Lon: city.Lon}, true, nil
 	}
-	// THE CITY FALLBACK, and it is why a radius around a place NAME works at
-	// all. The cache is keyed on the exact string that was geocoded, and what
-	// gets geocoded is a company's full address — so "Düsseldorf" missed while
-	// "arnulfstraße 33, 40545, düsseldorf" hit. A person saying where they are
-	// names the city, never the street of a company they have not reached yet,
-	// so the one form a caller actually sends was the one form that failed.
-	//
-	// Still no egress: the point is averaged from the organizations this
-	// installation has ALREADY located in that city. See people.LookupCity.
-	city, ok, err := p.people.LookupCity(ctx, query)
+	// The exact key: a full address a caller already holds, or a place this
+	// installation resolved for its own reasons. It answers the street-level
+	// centres the city lane cannot, which is what a caller sending a company's
+	// own address is asking about.
+	found, ok, err := p.people.LookupPlace(ctx, query)
 	if err != nil || !ok {
 		return search.Point{}, false, err
 	}
-	return search.Point{Lat: city.Lat, Lon: city.Lon}, true, nil
+	return search.Point{Lat: found.Lat, Lon: found.Lon}, true, nil
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -183,11 +183,15 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// have no way to learn the right one. Same resolver, same document; the
 	// resource stays for the clients that prefer it.
 	//
-	// Deliberately NOT native-only. A vocabulary describes what may be ASKED,
-	// and an overlay workspace admits the same plans; it is the executor
-	// underneath that has no native rows, and refusing there is the answer
-	// query_workspace already gives in its own words.
-	agents.RegisterVocabularyTool(registry, search.NewQuerySchemaResource(queryVocabulary(pool)))
+	// It takes the SAME outermost overlay guard query_workspace does. A
+	// vocabulary looks answerable anywhere — it describes a grammar rather
+	// than reading rows — but in an overlay workspace the plans it teaches are
+	// refused outright, so serving it there advertises a field list nothing
+	// can execute.
+	agents.RegisterVocabularyTool(registry, nativeOnlyVocabularyReader{
+		mode:  sorMode,
+		inner: search.NewQuerySchemaResource(queryVocabulary(pool)),
+	})
 	// The morning brief. It ranks the rep's own open deals out of the native
 	// tables, which an overlay workspace has no rows in, so it takes the same
 	// outermost guard the other native-only engines do: "not available here"

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -177,6 +177,17 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// the same reason the intent tools' is: the executor queries native tables
 	// an overlay workspace has no rows in.
 	agents.RegisterQueryTool(registry, provider, nativeOnlyQueryRunner(sorMode, queryRunner(pool, embedder)))
+	// The vocabulary that plan is written in, as a TOOL and not only as the
+	// margince://schema/query resource — because a client that reads tools and
+	// not resources could otherwise watch query_workspace refuse a name and
+	// have no way to learn the right one. Same resolver, same document; the
+	// resource stays for the clients that prefer it.
+	//
+	// Deliberately NOT native-only. A vocabulary describes what may be ASKED,
+	// and an overlay workspace admits the same plans; it is the executor
+	// underneath that has no native rows, and refusing there is the answer
+	// query_workspace already gives in its own words.
+	agents.RegisterVocabularyTool(registry, search.NewQuerySchemaResource(queryVocabulary(pool)))
 	// The morning brief. It ranks the rep's own open deals out of the native
 	// tables, which an overlay workspace has no rows in, so it takes the same
 	// outermost guard the other native-only engines do: "not available here"

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -143,6 +143,15 @@ func (inertChannelProviderDirectory) ChannelProviders(context.Context) ([]Channe
 	return nil, nil
 }
 
+// inertVocabulary answers a well-formed but empty vocabulary: the walk checks
+// the ENCODING of what a tool answers, and an empty document is still a
+// document.
+type inertVocabulary struct{}
+
+func (inertVocabulary) VocabularyDocument(context.Context) (json.RawMessage, error) {
+	return json.RawMessage(`{"version":"v1","targets":[]}`), nil
+}
+
 type inertRetriever struct{}
 
 func (inertRetriever) Search(context.Context, retrieval.Query) (retrieval.Result, error) {
@@ -195,6 +204,7 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterQueryTool(r, nil, func(context.Context, json.RawMessage) (QueryAnswer, error) {
 		return QueryAnswer{Coverage: CoverageCompleteExact}, nil
 	})
+	RegisterVocabularyTool(r, inertVocabulary{})
 	RegisterContextSearchTool(r, nil, inertRetriever{})
 	RegisterResolveTool(r, nil, func(context.Context, []ResolveCandidate) ([]ResolveOutcome, error) {
 		return nil, nil

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -156,6 +156,14 @@ var _ datasource.SystemOfRecordProvider = seamProbeProvider{}
 // seamProbeRetriever is the retrieval seam's half of the same probe: both
 // methods answer errSeamReached, so a tool that let malformed arguments through
 // is distinguishable from one that refused them.
+// seamProbeVocabulary reports that the seam was reached, so the walk can prove
+// this tool's arguments are dispatched to it rather than swallowed.
+type seamProbeVocabulary struct{}
+
+func (seamProbeVocabulary) VocabularyDocument(context.Context) (json.RawMessage, error) {
+	return nil, errSeamReached
+}
+
 type seamProbeRetriever struct{}
 
 func (seamProbeRetriever) Search(context.Context, retrieval.Query) (retrieval.Result, error) {
@@ -261,6 +269,7 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterQueryTool(r, seamProbeProvider{}, func(context.Context, json.RawMessage) (QueryAnswer, error) {
 		return QueryAnswer{}, errSeamReached
 	})
+	RegisterVocabularyTool(r, seamProbeVocabulary{})
 	RegisterContextSearchTool(r, seamProbeProvider{}, seamProbeRetriever{})
 	RegisterResolveTool(r, seamProbeProvider{}, func(context.Context, []ResolveCandidate) ([]ResolveOutcome, error) {
 		return nil, errSeamReached

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1909,6 +1909,97 @@
       "warnings"
     ]
   },
+  "describe_query_vocabulary": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "vocabulary": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "vocabulary"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "disqualify_lead": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/toolcopy_vocabulary.go
+++ b/backend/internal/modules/agents/toolcopy_vocabulary.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Written copy for the query vocabulary. See toolcopy.go for what each field
+// answers.
+
+var describeQueryVocabularyCopy = toolCopy{
+	Purpose: "Answer what a query plan may SAY in this workspace: the record types that can be " +
+		"asked about, the fields nameable on each, the operators each field admits, and the one " +
+		"relationship hop a plan may take. It is the vocabulary query_workspace refuses against, " +
+		"so it holds the spelling of a field whose name a plan got wrong.",
+	Limits: "It describes the vocabulary; it returns no records — query_workspace does that. " +
+		"What comes back is narrowed to what you may already read, so it names nothing you could " +
+		"not otherwise reach.",
+	Instead: "Call query_workspace once you know the names. This tool answers the same document " +
+		"as the margince://schema/query resource, for a client that reads tools rather than " +
+		"resources.",
+	Retain: "Take the field and operator names from `targets` verbatim — a plan naming anything " +
+		"outside them is refused rather than approximated, so guessing at a spelling costs a " +
+		"round trip. `grammar` says how the clauses are assembled, and `version` is the value a " +
+		"plan's own `version` member must carry.",
+}

--- a/backend/internal/modules/agents/tools_vocabulary.go
+++ b/backend/internal/modules/agents/tools_vocabulary.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The query vocabulary, reachable by a client that reads TOOLS and not
+// resources.
+//
+// `query_workspace` refuses every name outside the vocabulary — by name, never
+// approximated — and its description sends the caller to
+// margince://schema/query to learn what the names are. That instruction assumes
+// the caller can read an MCP resource, and a large share of clients surface
+// tools only. For those, the loop had no exit: a tool naming a document they
+// cannot open, then refusing each guess.
+//
+// It is not hypothetical. On 2026-08-26 a client asked which companies were
+// near Cologne, probed four spellings of the geo field, was correctly refused
+// four times, and told its user that organizations in this workspace carry no
+// address at all — while `address` with `within_radius` sat in the vocabulary
+// it had no door to. The refusals were honest and the conclusion was wrong,
+// which is the worst pairing available: a caller reasoning carefully from what
+// it could see, to a false statement about the product.
+//
+// So the same document gets a second door. NOT a second copy: the handler
+// renders the resource's own composition, over the resolver the validator
+// reads, so the tool and the resource cannot drift. A hand-written schema in
+// the tool's description was the alternative and is the thing the original
+// design correctly refused — it would be a maintained list of exactly what is
+// derived, stale the first time a workspace declared a custom field.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// DescribeQueryVocabularyResult carries the published query vocabulary.
+//
+// One member, holding the document VERBATIM rather than a Go mirror of it. The
+// vocabulary is composed per caller from the field catalog and the live column
+// catalog, so a struct here would be a hand-maintained restatement of exactly
+// what is derived — the copy this surface refuses to keep, and the same reason
+// the grammar was never inlined into query_workspace's input schema.
+//
+// It lives beside its tool rather than in results.go, where the other result
+// types sit: that file is at the 500-line cap, and this type is legible only
+// next to the door it comes out of.
+type DescribeQueryVocabularyResult struct {
+	Vocabulary json.RawMessage `json:"vocabulary"`
+}
+
+// VocabularyReader answers the query vocabulary for the calling principal.
+//
+// The port is declared here and satisfied by search's schema resource, like
+// every other cross-module edge on this surface (ADR-0054).
+type VocabularyReader interface {
+	VocabularyDocument(ctx context.Context) (json.RawMessage, error)
+}
+
+// RegisterVocabularyTool adds describe_query_vocabulary, when a reader is
+// wired.
+//
+// A composition that publishes no query vocabulary registers no tool to read
+// one, the same way RegisterQueryTool declines a nil runner: a surface that
+// advertises a door to nothing is worse than one door fewer.
+func RegisterVocabularyTool(r *Registry, read VocabularyReader) {
+	if read == nil {
+		return
+	}
+	r.Register(describeQueryVocabulary{read: read})
+}
+
+type describeQueryVocabulary struct {
+	read VocabularyReader
+}
+
+func (t describeQueryVocabulary) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "describe_query_vocabulary", Title: "Describe the query vocabulary",
+		Version:       toolVersionV1,
+		Description:   describeQueryVocabularyCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		// No arguments. The document is composed for the calling principal, so
+		// there is nothing to ask about: a target filter would only let a
+		// caller narrow what they already receive, at the cost of a name they
+		// could spell wrong — which is the failure this tool exists to end.
+		InputSchema: schema(`{"type":"object","properties":{},"additionalProperties":false}`),
+		// The vocabulary's shape is the published document's own, and this
+		// surface deliberately does not restate it: that restatement is the
+		// hand-maintained copy the whole design avoids.
+		OutputSchema: schemaFor[DescribeQueryVocabularyResult](),
+	}
+}
+
+func (t describeQueryVocabulary) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	body, err := t.read.VocabularyDocument(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(DescribeQueryVocabularyResult{Vocabulary: body})
+}

--- a/backend/internal/modules/agents/tools_vocabulary.go
+++ b/backend/internal/modules/agents/tools_vocabulary.go
@@ -29,6 +29,7 @@ package agents
 // derived, stale the first time a workspace declared a custom field.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -94,7 +95,24 @@ func (t describeQueryVocabulary) Spec() mcp.ToolSpec {
 	}
 }
 
-func (t describeQueryVocabulary) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+func (t describeQueryVocabulary) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	// The arguments are decoded even though there are none to READ, because
+	// decodeArgs is what enforces the schema: without it a call carrying
+	// `{"target":"organisation"}` is accepted silently, and the caller then
+	// reads a whole-workspace vocabulary believing they asked about one record
+	// type. The declared `additionalProperties: false` is a promise this keeps.
+	//
+	// An ABSENT payload skips it, because for THIS tool that is the normal
+	// call: it takes no arguments, so a client sending none is correct.
+	// decodeArgs would answer "the payload is empty; send a JSON object
+	// carrying this operation's fields" — advice for a tool that has fields,
+	// and a refusal of the one call this tool is designed for.
+	if len(bytes.TrimSpace(in)) > 0 {
+		var args struct{}
+		if err := decodeArgs(in, &args); err != nil {
+			return nil, err
+		}
+	}
 	body, err := t.read.VocabularyDocument(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/agents/tools_vocabulary_test.go
+++ b/backend/internal/modules/agents/tools_vocabulary_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeVocabulary struct {
+	doc  string
+	err  error
+	runs int
+}
+
+func (f *fakeVocabulary) VocabularyDocument(context.Context) (json.RawMessage, error) {
+	f.runs++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return json.RawMessage(f.doc), nil
+}
+
+// The vocabulary comes back VERBATIM, not restated.
+//
+// The document is composed per caller from the field catalog and the live
+// column catalog. Anything this tool did to it beyond passing it through would
+// be a second rendering of exactly what is derived — the hand-maintained copy
+// this surface refuses to keep, and the reason the grammar was never inlined
+// into query_workspace's input schema either.
+func TestTheVocabularyIsPassedThroughUnchanged(t *testing.T) {
+	const doc = `{"version":"v1","targets":[{"target":"organization",` +
+		`"fields":[{"name":"address","kind":"geo","ops":["within_radius"]}]}]}`
+	read := &fakeVocabulary{doc: doc}
+
+	out, err := describeQueryVocabulary{read: read}.Handle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	var result DescribeQueryVocabularyResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("decoding the answer: %v", err)
+	}
+	if got := string(result.Vocabulary); got != doc {
+		t.Errorf("vocabulary = %s, want it byte-for-byte as composed:\n%s", got, doc)
+	}
+	if read.runs != 1 {
+		t.Errorf("the resolver ran %d times, want exactly 1", read.runs)
+	}
+}
+
+// A resolver that fails says so, rather than answering an empty vocabulary.
+//
+// An empty document reads as "this workspace admits nothing", which would send
+// a caller to give up on a question it could have asked.
+func TestAFailedResolveIsNotAnEmptyVocabulary(t *testing.T) {
+	boom := errors.New("the column catalog is unreachable")
+	_, err := describeQueryVocabulary{read: &fakeVocabulary{err: boom}}.
+		Handle(context.Background(), nil)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the resolver's own failure", err)
+	}
+}
+
+// The tool takes no arguments, and says so in its schema.
+//
+// A target filter would only let a caller narrow what they already receive, at
+// the cost of a name they could spell wrong — which is the exact failure this
+// tool exists to end.
+func TestTheVocabularyToolAsksForNothing(t *testing.T) {
+	spec := describeQueryVocabulary{read: &fakeVocabulary{doc: `{}`}}.Spec()
+	// A map rather than a struct: the JSON Schema keyword is
+	// `additionalProperties`, which no snake_case tag can spell, and the
+	// repo's tag linter is right to insist on snake_case for wire types.
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(spec.InputSchema, &schema); err != nil {
+		t.Fatalf("decoding the input schema: %v", err)
+	}
+	var properties map[string]any
+	if raw, ok := schema["properties"]; ok {
+		if err := json.Unmarshal(raw, &properties); err != nil {
+			t.Fatalf("decoding the schema's properties: %v", err)
+		}
+	}
+	var additional *bool
+	if raw, ok := schema["additionalProperties"]; ok {
+		if err := json.Unmarshal(raw, &additional); err != nil {
+			t.Fatalf("decoding additionalProperties: %v", err)
+		}
+	}
+	if len(properties) != 0 {
+		t.Errorf("the tool advertises %d argument(s); it takes none", len(properties))
+	}
+	if required, ok := schema["required"]; ok && len(required) != 0 {
+		t.Errorf("the tool requires %s; it takes no arguments", required)
+	}
+	if additional == nil || *additional {
+		t.Error("the schema admits extra properties, so a misspelled argument would pass silently")
+	}
+}
+
+// The tool names the resource it stands in for, so a reader of either knows
+// they are one document.
+func TestTheVocabularyToolNamesTheResourceItMirrors(t *testing.T) {
+	spec := describeQueryVocabulary{read: &fakeVocabulary{doc: `{}`}}.Spec()
+	if !strings.Contains(spec.Description, "margince://schema/query") {
+		t.Error("the description does not name margince://schema/query, so a client reading " +
+			"both surfaces cannot tell they carry the same document")
+	}
+	// And it points at the tool that consumes what it describes. A vocabulary
+	// with no named consumer is a document a caller has no reason to fetch.
+	if !strings.Contains(spec.Description, "query_workspace") {
+		t.Error("the description does not name query_workspace, so a caller learns the " +
+			"vocabulary without learning what to do with it")
+	}
+}
+
+// A composition wiring no reader registers no tool.
+//
+// A surface advertising a door to nothing is worse than one door fewer: the
+// caller spends a round trip to be told the thing does not work here.
+func TestNoReaderRegistersNoTool(t *testing.T) {
+	r := NewRegistry(nil, nil)
+	RegisterVocabularyTool(r, nil)
+	for _, spec := range r.Specs() {
+		if spec.Name == "describe_query_vocabulary" {
+			t.Fatal("the tool registered with no vocabulary behind it")
+		}
+	}
+}

--- a/backend/internal/modules/agents/tools_vocabulary_test.go
+++ b/backend/internal/modules/agents/tools_vocabulary_test.go
@@ -132,3 +132,34 @@ func TestNoReaderRegistersNoTool(t *testing.T) {
 		}
 	}
 }
+
+// An argument the schema forbids is REFUSED, not ignored.
+//
+// The handler reads no arguments, which made it tempting to skip decoding them
+// — and skipping it made `additionalProperties: false` a promise nothing kept.
+// A call carrying {"target":"organisation"} was accepted silently, and the
+// caller then read a whole-workspace vocabulary believing they had asked about
+// one record type.
+func TestAnArgumentTheSchemaForbidsIsRefused(t *testing.T) {
+	read := &fakeVocabulary{doc: `{"version":"v1","targets":[]}`}
+	_, err := describeQueryVocabulary{read: read}.
+		Handle(context.Background(), json.RawMessage(`{"target":"organisation"}`))
+	if err == nil {
+		t.Fatal("an unknown argument was accepted; the declared schema forbids it")
+	}
+	var bad *BadArgsError
+	if !errors.As(err, &bad) {
+		t.Errorf("err = %T(%v), want a BadArgsError naming the caller's own argument", err, err)
+	}
+	if read.runs != 0 {
+		t.Error("the vocabulary was composed for a call that should have been refused first")
+	}
+	// And the shapes a caller legitimately sends still work: no arguments at
+	// all, and an empty object.
+	for _, in := range []json.RawMessage{nil, json.RawMessage(`{}`)} {
+		if _, err := (describeQueryVocabulary{read: &fakeVocabulary{doc: `{}`}}).
+			Handle(context.Background(), in); err != nil {
+			t.Errorf("Handle(%s): %v — a call with no arguments is the normal call", in, err)
+		}
+	}
+}

--- a/backend/internal/modules/people/geocodecity.go
+++ b/backend/internal/modules/people/geocodecity.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Resolving a bare CITY NAME to a point, out of the addresses this installation
+// has already located.
+//
+// WHY THIS EXISTS. The place cache is keyed on the exact string that was
+// geocoded, and what gets geocoded is a company's full address — "arnulfstraße
+// 33, 40545, düsseldorf". So a caller asking for everything within 50km of
+// "Düsseldorf" missed: the cache holds the street, never the city on its own.
+// A radius is the one shape a "my meeting was cancelled, who is nearby" question
+// can take, and it answered nothing while the coordinates to answer it sat in
+// the same table under a longer key.
+//
+// NO GEOCODER IS CALLED HERE, and that is the constraint the whole design turns
+// on. query_workspace is declared workspace-local, Scope.Egresses() is derived
+// from that declaration rather than asserted, and a resolver that could reach
+// the internet would make the declaration unenforceable by construction. So the
+// answer has to come from rows this installation already holds.
+//
+// It does. A company located in a city carries a point IN that city, so the
+// centroid of the located companies sharing a city name is a point in that city
+// — good to within the spread of the addresses themselves, which for a radius
+// measured in tens of kilometres is far below the error already accepted in
+// "which office is this company actually at".
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// LookupCity answers a point for a city NAME, derived from the located
+// organizations whose address names that city.
+//
+// The comparison folds case and surrounding space, so "cologne", "Cologne" and
+// " COLOGNE " are one question. It deliberately does NOT fold "Köln" onto
+// "Cologne": those are two strings a geocoder would resolve to one place, and
+// deciding they are the same city is a translation this function has no
+// business making. A caller asking for Köln gets the companies filed under
+// Köln.
+//
+// A city holding no located company answers not-found rather than an
+// approximate point, and the caller says so honestly — which is what
+// distance_ranking_unavailable already means.
+//
+// ROW-SCOPED, unlike the two place-cache reads beside it. Those hold a public
+// coordinate for a public place name and carry no subject a grant could be
+// about; this one composes its answer FROM companies, so an unscoped version
+// would tell a caller that somebody is located in a city they may see none of
+// the records in. The scope means the centre is averaged only over companies
+// this caller could have listed for themselves.
+func (s *Store) LookupCity(ctx context.Context, city string) (CachedPlace, bool, error) {
+	key := normalizePlaceQuery(city)
+	if key == "" {
+		return CachedPlace{}, false, nil
+	}
+	// The averages are read as POINTERS, because a city nothing is located in
+	// makes avg() answer NULL rather than no row at all: an aggregate with no
+	// GROUP BY always returns exactly one row, and scanning that NULL into a
+	// float64 is an error rather than the not-found this function means. Found
+	// by the test for a city nobody is in.
+	var lat, lon *float64
+	var located int
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		args := []any{key}
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		// ROW SCOPE, and it is load-bearing rather than ceremonial. This
+		// answers a point derived from companies, so without the predicate a
+		// caller who may see none of them still learns that SOMEBODY is located
+		// in a city — an existence answer about records they were not granted,
+		// one city name at a time. Scoped, the centroid is composed only from
+		// the companies this caller could have listed themselves.
+		scope, err := scopeOrAllRows(ctx, "organization", "", arg)
+		if err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `
+			SELECT avg(geocode_lat), avg(geocode_lon), count(*)
+			  FROM organization
+			 WHERE archived_at IS NULL
+			   AND geocode_lat IS NOT NULL
+			   AND geocode_lon IS NOT NULL
+			   AND lower(btrim(address_city)) = $1
+			   AND `+scope, args...).
+			Scan(&lat, &lon, &located)
+	})
+	if err != nil {
+		return CachedPlace{}, false, fmt.Errorf("reading located companies for %q: %w", city, err)
+	}
+	if located == 0 || lat == nil || lon == nil {
+		return CachedPlace{}, false, nil
+	}
+	place := CachedPlace{Lat: *lat, Lon: *lon}
+	// The provider is named for what this point IS. A reader comparing two
+	// centres has to be able to tell a geocoded place from one averaged out of
+	// the estate's own rows, and "nominatim" would say the wrong thing.
+	place.Provider = ProviderLocatedCompanies
+	return place, true, nil
+}
+
+// ProviderLocatedCompanies marks a point derived from this installation's own
+// located companies rather than fetched from a geocoding service.
+const ProviderLocatedCompanies = "located_companies"

--- a/backend/internal/modules/people/geocodecity.go
+++ b/backend/internal/modules/people/geocodecity.go
@@ -63,7 +63,7 @@ func (s *Store) LookupCity(ctx context.Context, city string) (CachedPlace, bool,
 	// GROUP BY always returns exactly one row, and scanning that NULL into a
 	// float64 is an error rather than the not-found this function means. Found
 	// by the test for a city nobody is in.
-	var lat, lon *float64
+	var lat, lon, latSpread, lonSpread *float64
 	var located int
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		args := []any{key}
@@ -78,20 +78,57 @@ func (s *Store) LookupCity(ctx context.Context, city string) (CachedPlace, bool,
 		if err != nil {
 			return err
 		}
+		// geocode_status = 'ok' is REQUIRED, and it is the same predicate the
+		// radius query itself applies (querygeo.go). A row keeps its old point
+		// when its address changes and is stamped `stale` — "not queryable,
+		// deliberately" in geocode.go's own words — so averaging one in would
+		// measure this city from where a company USED to be. Coordinates that
+		// are merely non-NULL are not coordinates that are true.
+		//
+		// The SPREAD comes back with the centre, from the same scan: asking a
+		// second time would read a different row set under a concurrent write,
+		// and the check is only meaningful against the rows that produced this
+		// average.
 		return tx.QueryRow(ctx, `
-			SELECT avg(geocode_lat), avg(geocode_lon), count(*)
+			SELECT avg(geocode_lat), avg(geocode_lon),
+			       max(geocode_lat) - min(geocode_lat),
+			       max(geocode_lon) - min(geocode_lon),
+			       count(*)
 			  FROM organization
 			 WHERE archived_at IS NULL
+			   AND geocode_status = 'ok'
 			   AND geocode_lat IS NOT NULL
 			   AND geocode_lon IS NOT NULL
 			   AND lower(btrim(address_city)) = $1
 			   AND `+scope, args...).
-			Scan(&lat, &lon, &located)
+			Scan(&lat, &lon, &latSpread, &lonSpread, &located)
 	})
 	if err != nil {
 		return CachedPlace{}, false, fmt.Errorf("reading located companies for %q: %w", city, err)
 	}
 	if located == 0 || lat == nil || lon == nil {
+		return CachedPlace{}, false, nil
+	}
+	// A SPREAD TOO WIDE TO BE ONE CITY answers not-found rather than its own
+	// midpoint.
+	//
+	// Two things make a city name cover more than one place. Springfield is in
+	// dozens of states and Frankfurt is in two German states, and this lane
+	// compares the city text alone — it has no region or country to
+	// disambiguate with. And a longitude average is plain wrong across the
+	// antimeridian: 179 and -179 average to 0, which is the Gulf of Guinea.
+	//
+	// Both produce the same artefact — a centre far from every company that
+	// voted for it — and one check catches both, because a real city's
+	// companies sit within hundredths of a degree of each other.
+	//
+	// Refusing is the honest answer. The caller says
+	// distance_ranking_unavailable and asks by city name instead, rather than
+	// measuring 50 km around a point no company is near.
+	if latSpread != nil && *latSpread > maxCitySpreadDegrees {
+		return CachedPlace{}, false, nil
+	}
+	if lonSpread != nil && *lonSpread > maxCitySpreadDegrees {
 		return CachedPlace{}, false, nil
 	}
 	place := CachedPlace{Lat: *lat, Lon: *lon}
@@ -105,3 +142,19 @@ func (s *Store) LookupCity(ctx context.Context, city string) (CachedPlace, bool,
 // ProviderLocatedCompanies marks a point derived from this installation's own
 // located companies rather than fetched from a geocoding service.
 const ProviderLocatedCompanies = "located_companies"
+
+// maxCitySpreadDegrees is how far apart the companies sharing a city name may
+// sit before their midpoint stops being a place.
+//
+// ONE DEGREE — roughly 111 km of latitude, less of longitude at European
+// latitudes. An order of magnitude wider than any real city, and an order of
+// magnitude narrower than the artefacts it refuses. Measured on a real
+// installation, the widest genuine spread was 0.14° (Berlin, München), about
+// 12 km; two Frankfurts sit 5.9° apart, and a longitude average taken across
+// the antimeridian lands the midpoint a hemisphere from every company that
+// voted for it.
+//
+// A midpoint that fails this is not returned at all. Answering it would mean
+// measuring 50 km around a point no company is near — a wrong answer wearing a
+// working answer's clothes, which is the failure this surface exists to refuse.
+const maxCitySpreadDegrees = 1.0

--- a/backend/internal/modules/people/geocodecity_integration_test.go
+++ b/backend/internal/modules/people/geocodecity_integration_test.go
@@ -127,3 +127,95 @@ func TestACityLookupFoldsCaseAndRefusesWhatItCannotAnswer(t *testing.T) {
 		t.Error("blank resolved to a point, so every company with no city would answer as one place")
 	}
 }
+
+// A stale point is not a point.
+//
+// A company keeps its old coordinates when its address changes, stamped
+// `stale` — "not queryable, deliberately" in geocode.go's own words, and the
+// same predicate the radius query itself applies. Averaging one in would
+// measure a city from where a company USED to be.
+func TestAStaleCoordinateIsNotAveragedIntoACity(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	locate := func(name, city string, lat, lon float64, status string) {
+		org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: name, Source: "manual",
+			Address: &crmcontracts.Address{Line1: strPtr("Teststrasse 1"), City: strPtr(city)},
+		})
+		if err != nil {
+			t.Fatalf("seeding %q: %v", name, err)
+		}
+		orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+		addr, ok, err := e.store.AddressForGeocode(ctx, orgID)
+		if err != nil || !ok {
+			t.Fatalf("reading %q back: %v (found %v)", name, err, ok)
+		}
+		if err := e.store.RecordGeocode(ctx, orgID, status, &lat, &lon, "fake", addr.InputHash); err != nil {
+			t.Fatalf("locating %q: %v", name, err)
+		}
+	}
+
+	// One good point, and one stale point far enough away to move the average
+	// visibly if it were counted.
+	locate("Current Gmbh", "Bremen", 53.0800, 8.8000, GeocodeOK)
+	locate("Moved Away Gmbh", "Bremen", 53.5000, 9.2000, GeocodeStale)
+
+	place, ok, err := e.store.LookupCity(ctx, "Bremen")
+	if err != nil {
+		t.Fatalf("LookupCity: %v", err)
+	}
+	if !ok {
+		t.Fatal("the city resolved to nothing, though one company is properly located in it")
+	}
+	// The live company's own point, untouched by the stale one.
+	if math.Abs(place.Lat-53.0800) > 0.0001 || math.Abs(place.Lon-8.8000) > 0.0001 {
+		t.Errorf("Bremen resolved to %.4f,%.4f, want the one OK company's point (53.0800,8.8000) — "+
+			"a stale coordinate was averaged in", place.Lat, place.Lon)
+	}
+}
+
+// A name covering two places is not a place.
+//
+// Two Frankfurts, two Springfields, or a longitude average taken across the
+// antimeridian all produce the same artefact: a midpoint far from every company
+// that voted for it. Refusing is honest; answering measures a radius around
+// nowhere.
+func TestACityNameCoveringTwoPlacesResolvesToNeither(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	for _, row := range []struct {
+		name     string
+		lat, lon float64
+	}{
+		{"Frankfurt Main Gmbh", 50.1109, 8.6821},  // Frankfurt am Main
+		{"Frankfurt Oder Gmbh", 52.3412, 14.5506}, // Frankfurt (Oder), ~5.9° east
+	} {
+		org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: row.name, Source: "manual",
+			Address: &crmcontracts.Address{Line1: strPtr("Teststrasse 1"), City: strPtr("Frankfurt")},
+		})
+		if err != nil {
+			t.Fatalf("seeding %q: %v", row.name, err)
+		}
+		orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+		addr, ok, err := e.store.AddressForGeocode(ctx, orgID)
+		if err != nil || !ok {
+			t.Fatalf("reading %q back: %v (found %v)", row.name, err, ok)
+		}
+		if err := e.store.RecordGeocode(ctx, orgID, GeocodeOK,
+			&row.lat, &row.lon, "fake", addr.InputHash); err != nil {
+			t.Fatalf("locating %q: %v", row.name, err)
+		}
+	}
+
+	// Their midpoint is in the countryside near Leipzig, which is neither
+	// Frankfurt and is 200 km from both.
+	if _, ok, err := e.store.LookupCity(ctx, "Frankfurt"); err != nil {
+		t.Fatalf("LookupCity: %v", err)
+	} else if ok {
+		t.Error("a city name covering two places 5.9° apart answered their midpoint; " +
+			"a radius would then measure from a field between them")
+	}
+}

--- a/backend/internal/modules/people/geocodecity_integration_test.go
+++ b/backend/internal/modules/people/geocodecity_integration_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+import (
+	"math"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A caller naming a CITY gets a point, out of the companies already located in
+// it.
+//
+// This is the shape a person actually sends. "My meeting was cancelled and I am
+// in Cologne" names a city; it never names the street of a company they have
+// not reached yet. The place cache is keyed on the full address that was
+// geocoded, so that one form was the one form that missed — and a radius
+// answered nothing while the coordinates to answer it sat in the same estate
+// under a longer key.
+func TestACityNameResolvesFromTheCompaniesLocatedInIt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	located := []struct {
+		name     string
+		city     string
+		lat, lon float64
+	}{
+		{"Rheinland Nord", "Cologne", 50.9500, 6.9600},
+		{"Rheinland Süd", "Cologne", 50.9300, 6.9400},
+		{"Elsewhere Gmbh", "Hamburg", 53.5511, 9.9937},
+	}
+	for _, row := range located {
+		org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: row.name, Source: "manual",
+			Address: &crmcontracts.Address{
+				Line1: strPtr("Teststrasse 1"),
+				City:  strPtr(row.city),
+			},
+		})
+		if err != nil {
+			t.Fatalf("seeding %q: %v", row.name, err)
+		}
+		orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+		addr, ok, err := e.store.AddressForGeocode(ctx, orgID)
+		if err != nil || !ok {
+			t.Fatalf("reading %q back for geocoding: %v (found %v)", row.name, err, ok)
+		}
+		if err := e.store.RecordGeocode(ctx, orgID, GeocodeOK,
+			&row.lat, &row.lon, "fake", addr.InputHash); err != nil {
+			t.Fatalf("locating %q: %v", row.name, err)
+		}
+	}
+
+	place, ok, err := e.store.LookupCity(ctx, "Cologne")
+	if err != nil {
+		t.Fatalf("LookupCity: %v", err)
+	}
+	if !ok {
+		t.Fatal("a city holding two located companies resolved to nothing, so a radius around it answers no rows")
+	}
+	// The centroid of the two Cologne rows, and NOT the Hamburg one: a city
+	// lookup that averaged the whole estate would answer a point in no city at
+	// all.
+	if math.Abs(place.Lat-50.9400) > 0.0001 || math.Abs(place.Lon-6.9500) > 0.0001 {
+		t.Errorf("Cologne resolved to %.4f,%.4f, want the centroid of its own companies (50.9400,6.9500)",
+			place.Lat, place.Lon)
+	}
+	// The provider says what the point IS. A reader comparing two centres has
+	// to tell a geocoded place from one averaged out of the estate's own rows.
+	if place.Provider != ProviderLocatedCompanies {
+		t.Errorf("provider = %q, want %q — a derived point must not read as a geocoded one",
+			place.Provider, ProviderLocatedCompanies)
+	}
+}
+
+// Case and surrounding space are one question; a name nobody is located under
+// is not answered approximately.
+func TestACityLookupFoldsCaseAndRefusesWhatItCannotAnswer(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Folded Case Gmbh", Source: "manual",
+		Address: &crmcontracts.Address{Line1: strPtr("Teststrasse 2"), City: strPtr("Düsseldorf")},
+	})
+	if err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+	addr, ok, err := e.store.AddressForGeocode(ctx, orgID)
+	if err != nil || !ok {
+		t.Fatalf("reading back for geocoding: %v (found %v)", err, ok)
+	}
+	lat, lon := 51.2277, 6.7735
+	if err := e.store.RecordGeocode(ctx, orgID, GeocodeOK, &lat, &lon, "fake", addr.InputHash); err != nil {
+		t.Fatalf("locating: %v", err)
+	}
+
+	for _, spelling := range []string{"Düsseldorf", "düsseldorf", "  DÜSSELDORF  "} {
+		if _, ok, err := e.store.LookupCity(ctx, spelling); err != nil {
+			t.Fatalf("LookupCity(%q): %v", spelling, err)
+		} else if !ok {
+			t.Errorf("%q did not resolve; case and surrounding space are one question", spelling)
+		}
+	}
+
+	// A city nothing is located in answers NOT FOUND, so the caller says
+	// distance_ranking_unavailable rather than measuring from a made-up point.
+	// An approximate centre is the quietly wrong answer this whole surface
+	// exists to avoid.
+	if _, ok, err := e.store.LookupCity(ctx, "Reykjavík"); err != nil {
+		t.Fatalf("LookupCity on an unheld city: %v", err)
+	} else if ok {
+		t.Error("a city holding no located company answered a point; a radius would then measure from nowhere")
+	}
+
+	// An empty name is not a city.
+	if _, ok, err := e.store.LookupCity(ctx, "   "); err != nil {
+		t.Fatalf("LookupCity on blank: %v", err)
+	} else if ok {
+		t.Error("blank resolved to a point, so every company with no city would answer as one place")
+	}
+}

--- a/backend/internal/modules/search/queryschema.go
+++ b/backend/internal/modules/search/queryschema.go
@@ -78,6 +78,41 @@ func (r *QuerySchemaResource) ReadResource(ctx context.Context, uri string) (mcp
 	return mcp.ResourceContents{URI: uri, MIMEType: "application/json", Text: string(body)}, nil
 }
 
+// VocabularyDocument answers the SAME document ReadResource serves, for a
+// caller that reaches this surface through a tool rather than a resource.
+//
+// WHY A SECOND DOOR EXISTS. `query_workspace` refuses every name outside the
+// vocabulary and its description sends the caller to margince://schema/query to
+// learn what the names are. That instruction assumes the caller can read a
+// resource, and a large share of MCP clients — Claude's connector among them —
+// surface tools only. For those callers the loop had no exit: the tool named a
+// document they could not open, then refused each guess by name. Observed on
+// 2026-08-26, a client probed four field spellings, was correctly refused four
+// times, and reported to its user that this workspace had no address field at
+// all — while `within_radius` sat in the vocabulary it could not read.
+//
+// ONE COMPUTATION, TWO DOORS. This renders `querySchemaDocument` over the same
+// resolver ReadResource does, so both answer one document rather than two that
+// can disagree — which is the reason the grammar was never inlined into the
+// tool's input schema either: a hand-written copy would be a maintained
+// restatement of exactly what is derived.
+//
+// Held by: TestBothDoorsAnswerOneVocabulary (queryschematool_test.go)
+//
+// Still not a discovery channel. `Resolve` narrows to what this principal may
+// already read, so a caller learns nothing here they could not learn by asking.
+func (r *QuerySchemaResource) VocabularyDocument(ctx context.Context) (json.RawMessage, error) {
+	vocab, err := r.vocab.Resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(querySchemaDocument(vocab))
+	if err != nil {
+		return nil, fmt.Errorf("search: rendering the query vocabulary: %w", err)
+	}
+	return body, nil
+}
+
 // querySchemaDoc is the published shape. It is a hand-written wire type
 // rather than the internal Vocabulary because the two answer different
 // questions: the internal one carries what the validator needs to check a

--- a/backend/internal/modules/search/queryschematool_test.go
+++ b/backend/internal/modules/search/queryschematool_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// The tool door and the resource door answer the SAME BYTES.
+//
+// This is the claim VocabularyDocument's comment makes, and it is the whole
+// reason a second door was safe to add: a hand-written vocabulary in the tool
+// would be a maintained restatement of what the resolver derives, stale the
+// first time a workspace declared a custom field. Two doors over one
+// composition cost nothing; two compositions would cost correctness, and the
+// difference is only visible if something checks.
+func TestBothDoorsAnswerOneVocabulary(t *testing.T) {
+	r := NewQuerySchemaResource(NewVocabularyResolver())
+	ctx := context.Background()
+
+	contents, err := r.ReadResource(ctx, QuerySchemaURI)
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	doc, err := r.VocabularyDocument(ctx)
+	if err != nil {
+		t.Fatalf("VocabularyDocument: %v", err)
+	}
+	if string(doc) != contents.Text {
+		t.Errorf("the tool and the resource answer different documents, so a client "+
+			"reading one learns a vocabulary the other does not admit.\ntool:     %s\nresource: %s",
+			doc, contents.Text)
+	}
+	// And it is a document, not an empty answer dressed as one: a caller
+	// reading `{}` would conclude this workspace admits nothing.
+	var shape struct {
+		Version string          `json:"version"`
+		Targets json.RawMessage `json:"targets"`
+	}
+	if err := json.Unmarshal(doc, &shape); err != nil {
+		t.Fatalf("the vocabulary is not a JSON document: %v", err)
+	}
+	if shape.Version == "" {
+		t.Error("the vocabulary carries no version, which is the value a plan's own version must match")
+	}
+	if len(shape.Targets) == 0 {
+		t.Error("the vocabulary names no targets member, so a caller cannot tell an empty " +
+			"estate from a document that was never composed")
+	}
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,9 +4,9 @@
   "per_agent_listing_budget": 17000,
   "whole_catalog_floor": 21000,
   "catalog": {
-    "tools": 57,
-    "tokens": 17790,
-    "median_tool_tokens": 275,
+    "tools": 58,
+    "tokens": 18064,
+    "median_tool_tokens": 274,
     "mean_tool_tokens": 311
   },
   "agents": [
@@ -184,6 +184,10 @@
     {
       "name": "list_approvals",
       "tokens": 274
+    },
+    {
+      "name": "describe_query_vocabulary",
+      "tokens": 273
     },
     {
       "name": "check_availability",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 57 | 17790 | 74% | — | — | — |
+| _whole served catalog, for scale_ | 58 | 18064 | 75% | — | — | — |
 
 ### `morning_brief`
 
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 311, across 57 served tools.
+Median 274 tokens, mean 311, across 58 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -158,6 +158,7 @@ a term in an addition.
 | `catch_me_up_on` | 287 | 3 scenarios |
 | `prepare_handoff` | 275 | 1 scenario |
 | `list_approvals` | 274 | — |
+| `describe_query_vocabulary` | 273 | — |
 | `check_availability` | 270 | — |
 | `decide_approval_bundle` | 266 | — |
 | `qualify_lead` | 261 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 57,
+    "tools": 58,
     "resources": 9,
-    "tool_catalog_bytes": 160899,
+    "tool_catalog_bytes": 163083,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 41103,
+    "approx_wire_tokens_total": 41649,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 37402,
-      "input_schema_bytes": 35647,
-      "output_schema_bytes": 75481,
-      "description_plus_input_schema_bytes": 73049
+      "description_bytes": 38449,
+      "input_schema_bytes": 35709,
+      "output_schema_bytes": 76331,
+      "description_plus_input_schema_bytes": 74158
     }
   },
   "tools": {
@@ -2599,6 +2599,112 @@
           "type": "object"
         },
         "title": "Approve or reject one act's proposals together"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Describe the query vocabulary"
+        },
+        "description": "Answer what a query plan may SAY in this workspace: the record types that can be asked about, the fields nameable on each, the operators each field admits, and the one relationship hop a plan may take. It is the vocabulary query_workspace refuses against, so it holds the spelling of a field whose name a plan got wrong. It describes the vocabulary; it returns no records — query_workspace does that. What comes back is narrowed to what you may already read, so it names nothing you could not otherwise reach. Call query_workspace once you know the names. This tool answers the same document as the margince://schema/query resource, for a client that reads tools rather than resources. Take the field and operator names from `targets` verbatim — a plan naming anything outside them is refused rather than approximated, so guessing at a spelling costs a round trip. `grammar` says how the clauses are assembled, and `version` is the value a plan's own `version` member must carry. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {},
+          "type": "object"
+        },
+        "name": "describe_query_vocabulary",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "vocabulary": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "vocabulary"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Describe the query vocabulary"
       },
       {
         "annotations": {
@@ -10598,7 +10704,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":57,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":58,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 57 |
+| Tools | 58 |
 | Resources | 9 |
-| Tool catalog | 157.1 KB |
+| Tool catalog | 159.3 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 41103 |
+| Approx. wire tokens | 41649 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 73.7 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 36.5 KB | 23% | Yes, every step |
-| Input schemas | 34.8 KB | 22% | Yes, every step |
-| _Names, annotations, punctuation_ | 12.1 KB | 7% | Partly |
-| **Description + input schema** | **71.3 KB** | **45%** | **the recurring cost** |
+| Output schemas | 74.5 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 37.5 KB | 23% | Yes, every step |
+| Input schemas | 34.9 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 12.3 KB | 7% | Partly |
+| **Description + input schema** | **72.4 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -57,7 +57,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 - [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (57)
+### Tools (58)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -76,6 +76,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
+| [`describe_query_vocabulary`](#describe_query_vocabulary) | Describe the query vocabulary | yes |  | 2.1 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 1.9 KB |
 | [`draft_email`](#draft_email) | Draft an email |  |  | 2.5 KB |
 | [`draft_follow_ups_for`](#draft_follow_ups_for) | Draft follow-ups |  |  | 2.6 KB |
@@ -2936,6 +2937,122 @@ Answer every still-waiting proposal that one act staged together — the overnig
       },
       "required": [
         "members"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### describe_query_vocabulary
+
+**Describe the query vocabulary**
+
+Answer what a query plan may SAY in this workspace: the record types that can be asked about, the fields nameable on each, the operators each field admits, and the one relationship hop a plan may take. It is the vocabulary query_workspace refuses against, so it holds the spelling of a field whose name a plan got wrong. It describes the vocabulary; it returns no records — query_workspace does that. What comes back is narrowed to what you may already read, so it names nothing you could not otherwise reach. Call query_workspace once you know the names. This tool answers the same document as the margince://schema/query resource, for a client that reads tools rather than resources. Take the field and operator names from `targets` verbatim — a plan naming anything outside them is refused rather than approximated, so guessing at a spelling costs a round trip. `grammar` says how the clauses are assembled, and `version` is the value a plan's own `version` member must carry. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "vocabulary": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "vocabulary"
       ],
       "type": "object"
     },


### PR DESCRIPTION
Two defects, both found by watching a real client fail a real question.

## 1. The vocabulary was unreachable

`query_workspace` refuses every name outside the published vocabulary — by name, never approximated — and its description sends the caller to `margince://schema/query` to learn what the names are.

That instruction assumes the caller can read an MCP **resource**. A large share of clients, Claude's connector among them, surface **tools only**. For those the loop had no exit: a tool naming a document they cannot open, then refusing each guess.

**Observed 2026-08-26.** A client was asked which companies were near Cologne. It probed four spellings of the geo field — `address.geo` with `near`, `address.latitude`, a top-level `near`, `address.postal_code` with a range — was correctly refused four times, and reported to its user that organizations in this workspace carry no address at all. Meanwhile `address` / `within_radius` sat in the vocabulary it had no door to.

The refusals were honest. The conclusion was wrong. That is the worst pairing available: a caller reasoning carefully from what it can see, to a false statement about the product.

`describe_query_vocabulary` answers the same document, rendered from the same resolver.

**Not a hand-written schema in the tool description.** That was the alternative and it is what the original design correctly refused: a maintained restatement of exactly what is derived, stale the first time a workspace declares a custom field. `TestBothDoorsAnswerOneVocabulary` holds the two doors to one composition.

## 2. A city could not be a radius centre

The place cache is keyed on the exact string that was geocoded, and what gets geocoded is a company's **full address**. So `"Düsseldorf"` missed while `"arnulfstraße 33, 40545, düsseldorf"` hit.

A person saying where they are names the city — never the street of a company they have not reached yet. The one form a caller actually sends was the one form that failed.

The centre now falls back to the centroid of the companies this installation has **already located** in that city. No geocoder is called: `query_workspace` is declared workspace-local and `Scope.Egresses()` is derived from that declaration, so a resolver able to fetch would make the declaration unenforceable by construction rather than by discipline.

**Row-scoped**, unlike the two place-cache reads beside it. Those hold a public coordinate for a public place name and carry no subject a grant could be about. This one composes its answer *from* companies, so unscoped it would tell a caller that somebody is located in a city they may see none of the records in.

## Verified live

An isolated `DEV_SLUG` stack on :8082, seeded with located companies.

| | before | after |
|---|---|---|
| `describe_query_vocabulary` served | absent | present, answers `address`/`within_radius` |
| `center: "Cologne"`, 60km | `partial_degraded`, 0 rows | `complete_exact`, 3 rows with distances |

The "before" column is the old binary still running on :8080, queried side by side.

Measured on real data: within-city coordinate spread is 0.087° at worst (Berlin, ~10km), far inside any radius a person asks about. The 7 rows carrying a NULL city can never match — `NULL = anything` is NULL, and the Go guard rejects an empty key before the SQL runs.

## Gates

`make check-backend` passes except `arch-lint`, which is **already red on origin/main** — `migrations/briefrunlocalday_integration_test.go` imports `github.com/google/uuid`, from #2725. Verified by running the gate on a clean checkout of origin/main with none of these changes. Not fixed here; it is not this branch's.

Everything else green, including the integration lane for `people`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only `describe_query_vocabulary` tool covering supported query fields, operators, relationships, and requirements.
  * Query vocabulary is available through the workspace query interface and schema resource.
  * Improved city-based location lookup using existing organization location data when exact coordinates are unavailable.

* **Bug Fixes**
  * Restricted vocabulary discovery in overlay workspaces where it is unsupported.
  * Removed the obsolete `awaiting_decision` field from project filing results.

* **Documentation**
  * Updated MCP catalogs, capabilities, output schemas, and tool-budget documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->