### PR TITLE
A declared proposal keeps its fields on a row

### DIFF
--- a/frontend/src/design-system/decisioncard.test.tsx
+++ b/frontend/src/design-system/decisioncard.test.tsx
@@ -244,10 +244,13 @@ describe("DecisionCard — a kind that says what it shows", () => {
     expect(screen.queryByText("Date on it now")).not.toBeInTheDocument();
   });
 
-  // The reason survives the row layout even though the fact list does not. It
-  // is what turns a headline into a question somebody can answer without
-  // opening anything, which is exactly what a queue needs.
-  it("keeps the reason on a row while the facts stay in the deck", () => {
+  // A declared kind keeps its reason AND its fields on a row. The deck-only
+  // suppression exists for the raw reading — a queue of rows each unrolling
+  // nine wire keys — and a declared list is at most four short labelled rows.
+  // Suppressing them cost the reader what they were being asked about: the
+  // Worklist shows one decision at a time, and its close-date card rendered
+  // the reason with no proposed date beneath it.
+  it("keeps the reason and the declared fields on a row", () => {
     const { container } = render(
       card({
         approval: CLOSE_DATE,
@@ -258,7 +261,8 @@ describe("DecisionCard — a kind that says what it shows", () => {
     expect(container.querySelector(".dcard-lead")).toHaveTextContent(
       "deal has gone quiet",
     );
-    expect(screen.queryByText("Proposed date")).not.toBeInTheDocument();
+    expect(screen.getByText("Proposed date")).toBeInTheDocument();
+    expect(screen.getByText("01.10.2026")).toBeInTheDocument();
   });
 
   // The generic reading is the honest fallback, not a worse one: a kind

--- a/frontend/src/design-system/decisioncard.tsx
+++ b/frontend/src/design-system/decisioncard.tsx
@@ -669,13 +669,20 @@ function readPayload(
   const change = approval.proposed_change ?? {};
   const draft = draftOf(change);
   const diffs = diffsOf(change);
-  // The lead survives both layouts. The fact list is deck-only because a queue
-  // of rows each unrolling nine keys is unreadable, but the one sentence
-  // explaining why a decision is in front of somebody is the thing a row is
-  // MOST missing — it is what turns "Confirm the real close date for Riverty"
-  // into a question a reader can answer without opening anything.
+  // The lead survives both layouts: the one sentence explaining why a decision
+  // is in front of somebody is the thing a row is MOST missing.
   const lead = display.find((entry) => entry.lead)?.value ?? null;
-  const rest = layout === "deck" ? restOf(change, draft, diffs, display) : [];
+  // Declared fields survive a row too, and only declared ones. The deck-only
+  // rule was written against the RAW reading, where a row unrolling nine wire
+  // keys made a queue unreadable — a real defect, and the reason it stays for
+  // an undeclared kind. A declared list is at most four short labelled rows,
+  // and suppressing them cost the reader the thing they were being asked
+  // about: the Worklist shows one decision at a time, and its close-date card
+  // rendered the reason with no proposed date under it.
+  const rest =
+    layout === "deck" || display.length > 0
+      ? restOf(change, draft, diffs, display)
+      : [];
   return {
     draft,
     diffs,


### PR DESCRIPTION
Follow-up to #2737, found by opening the Worklist rather than the story.

## The defect

The Worklist shows one decision at a time and renders it through `ApprovalRow`, which is the `row` layout — where the fact list is suppressed. So a close-date card carried the reason:

> deal has gone quiet; confirm it is still alive — set a real date or mark it lost

with **no proposed date under it**. The reader got the question and not the answer they were being asked to agree to.

## The fix

The deck-only suppression was written against the RAW reading, and there it is right: a queue of rows each unrolling nine wire keys is not a queue anybody can work. That still holds for a kind with no display policy — the existing test at `decisioncard.test.tsx:147` pins it.

A declared list is at most four short labelled rows, so it survives both layouts.

## Verified live

Against the running stack on :8080, logged in, on the Worklist:

```
Confirm the real close date for "Riverty — Einführung" (proposed 2026-09-27)
deal has gone quiet; confirm it is still alive — set a real date or mark it lost
Proposed date          27/09/2026
What is wrong with it  nothing has moved on it
```

`make check-fe` green. Mutation-checked: restoring the deck-only rule fails exactly the one test written for this, and nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Declared decision details, such as proposed dates, now remain visible in row layouts alongside the reason.
  - Improved consistency between row and deck views while keeping undeclared details limited to deck layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->