### PR TITLE
feat(worklist): the meetings, the drifting deals and one idle rule

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28484,6 +28484,18 @@ components:
             carries the promise's own words and its evidence. Nothing appears in both.
 
             Absent — not empty — on an installation whose feed does not read claims.
+        meetings:
+          type: array
+          items: { $ref: '#/components/schemas/AttentionItem' }
+          description: |
+            Today's booked meetings that have not happened yet, soonest first — the ones
+            still worth preparing for.
+
+            A meeting already held or cancelled is not on this lane: preparing for it is
+            no longer possible, and a queue that listed it would be asking for work that
+            cannot be done. `due_at` is when it starts.
+
+            Absent — not empty — on an installation whose feed does not read meetings.
         at_risk:
           type: array
           items: { $ref: '#/components/schemas/AttentionItem' }
@@ -28503,7 +28515,7 @@ components:
           description: "What the system did on its own, most recent first. Receipts, not questions."
         lanes_omitted:
           type: array
-          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk] }
+          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk, meetings] }
           description: "Lanes withheld because the caller may not read what they contain. Never returned empty instead."
         counts: { $ref: '#/components/schemas/AttentionCounts' }
 
@@ -28519,6 +28531,12 @@ components:
         needs_you: { type: integer, minimum: 0 }
         planned: { type: integer, minimum: 0 }
         duplicates_open: { type: integer, minimum: 0, description: "Open duplicate pairs both of whose sides this caller can see." }
+        meetings:
+          type: integer
+          minimum: 0
+          description: >-
+            How many of today's meetings are still ahead — the bounded page, as the other
+            lanes report.
         at_risk:
           type: integer
           minimum: 0
@@ -28546,7 +28564,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting]
           description: "Which producer raised it, and therefore which endpoint its verbs go to."
         kind: { type: string, description: 'The producer''s own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority.' }
         title:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19954,6 +19954,11 @@ components:
           items:
             type: string
             enum: [employments, deal_roles, projects, strength, network, activities, next_steps, consent, profile_fields, since_last_visit, last_touch, relationship_changes, moments, commercial, next_meeting, claims, conversation_memory, provider_profile]
+            # Pinned for the reason SavedViewResource is: the generator prefixes a
+            # constant only to break a collision, so these names move when an
+            # UNRELATED schema gains a value. Adding a lane to the attention feed's
+            # lanes_omitted has now unprefixed a whole enum twice.
+            x-enum-varnames: [Person360SectionsOmittedEmployments, Person360SectionsOmittedDealRoles, Person360SectionsOmittedProjects, Person360SectionsOmittedStrength, Person360SectionsOmittedNetwork, Person360SectionsOmittedActivities, Person360SectionsOmittedNextSteps, Person360SectionsOmittedConsent, Person360SectionsOmittedProfileFields, Person360SectionsOmittedSinceLastVisit, Person360SectionsOmittedLastTouch, Person360SectionsOmittedRelationshipChanges, Person360SectionsOmittedMoments, Person360SectionsOmittedCommercial, Person360SectionsOmittedNextMeeting, Person360SectionsOmittedClaims, Person360SectionsOmittedConversationMemory, Person360SectionsOmittedProviderProfile]
         strength: { $ref: '#/components/schemas/RelationshipStrength' }
         projects:
           type: array
@@ -28479,13 +28484,26 @@ components:
             carries the promise's own words and its evidence. Nothing appears in both.
 
             Absent — not empty — on an installation whose feed does not read claims.
+        at_risk:
+          type: array
+          items: { $ref: '#/components/schemas/AttentionItem' }
+          description: |
+            Open deals going quiet, or whose expected close date has already passed — the
+            ones most likely to be lost by inattention rather than by a decision.
+
+            The idle window here is DELIBERATELY shorter than the product-wide `stalled`
+            threshold: a queue that only speaks once a deal meets the stalled bar is
+            reporting a two-month-old fact rather than warning. `detail` names the window
+            actually used, so the card never implies a patience the server did not apply.
+
+            Absent — not empty — on an installation whose feed does not read deals.
         done_for_you:
           type: array
           items: { $ref: '#/components/schemas/AttentionItem' }
           description: "What the system did on its own, most recent first. Receipts, not questions."
         lanes_omitted:
           type: array
-          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments] }
+          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk] }
           description: "Lanes withheld because the caller may not read what they contain. Never returned empty instead."
         counts: { $ref: '#/components/schemas/AttentionCounts' }
 
@@ -28501,6 +28519,12 @@ components:
         needs_you: { type: integer, minimum: 0 }
         planned: { type: integer, minimum: 0 }
         duplicates_open: { type: integer, minimum: 0, description: "Open duplicate pairs both of whose sides this caller can see." }
+        at_risk:
+          type: integer
+          minimum: 0
+          description: >-
+            How many at-risk deals this lane is CARRYING, the bounded page rather than every
+            deal at risk — the same bound the other lanes report under.
         commitments:
           type: integer
           minimum: 0
@@ -28522,7 +28546,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk]
           description: "Which producer raised it, and therefore which endpoint its verbs go to."
         kind: { type: string, description: 'The producer''s own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority.' }
         title:

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -275,40 +275,34 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 	var omitted []crmcontracts.AttentionLanesOmitted
 
 	morning, err := s.thisMorning(ctx)
-	switch {
-	case errors.Is(err, apperrors.ErrPermissionDenied):
-		omitted = append(omitted, crmcontracts.AttentionLanesOmitted("this_morning"))
-	case err != nil:
-		return crmcontracts.Attention{}, err
-	default:
+	omitted, err = fill(omitted, "this_morning", err, func() {
 		out.ThisMorning = morning
 		out.Counts.ThisMorning = len(morning)
+	})
+	if err != nil {
+		return crmcontracts.Attention{}, err
 	}
 
 	needsYou, count, err := s.decisions(ctx)
-	switch {
-	case errors.Is(err, apperrors.ErrPermissionDenied):
-		omitted = append(omitted, crmcontracts.AttentionLanesOmitted("needs_you"))
-	case err != nil:
-		return crmcontracts.Attention{}, err
-	default:
+	omitted, err = fill(omitted, "needs_you", err, func() {
 		out.NeedsYou = needsYou
 		out.Counts.NeedsYou = count.items
 		if count.duplicates > 0 {
 			open := count.duplicates
 			out.Counts.DuplicatesOpen = &open
 		}
+	})
+	if err != nil {
+		return crmcontracts.Attention{}, err
 	}
 
 	planned, err := s.planned(ctx, asOf)
-	switch {
-	case errors.Is(err, apperrors.ErrPermissionDenied):
-		omitted = append(omitted, crmcontracts.AttentionLanesOmitted("planned"))
-	case err != nil:
-		return crmcontracts.Attention{}, err
-	default:
+	omitted, err = fill(omitted, "planned", err, func() {
 		out.Planned = planned
 		out.Counts.Planned = len(planned)
+	})
+	if err != nil {
+		return crmcontracts.Attention{}, err
 	}
 
 	// Absent, not empty, when no reader is bound: see the Commitments doc.
@@ -330,53 +324,19 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 		}
 	}
 
-	if s.meetings != nil {
-		// From NOW rather than from the start of the day: a meeting that has
-		// already begun cannot be prepared for, and one that ended an hour ago
-		// on a queue headed "still ahead" would be plainly wrong.
-		booked, err := s.meetings.Today(ctx, asOf, endOfDay(asOf), plannedCap)
-		switch {
-		case errors.Is(err, apperrors.ErrPermissionDenied):
-			omitted = append(omitted, crmcontracts.AttentionLanesOmitted("meetings"))
-		case err != nil:
+	// The three OPTIONAL lanes, each bound or absent. optionalLane holds the
+	// shape they share; what differs is the reader and the drawing.
+	for _, lane := range s.optionalLanes(ctx, asOf, &out) {
+		omitted, err = lane.collect(omitted)
+		if err != nil {
 			return crmcontracts.Attention{}, err
-		default:
-			items := make([]crmcontracts.AttentionItem, 0, len(booked))
-			for _, meeting := range booked {
-				items = append(items, meetingItem(meeting))
-			}
-			out.Meetings = &items
-			count := len(items)
-			out.Counts.Meetings = &count
-		}
-	}
-
-	if s.atRisk != nil {
-		risky, err := s.atRisk.Quiet(ctx)
-		switch {
-		case errors.Is(err, apperrors.ErrPermissionDenied):
-			omitted = append(omitted, crmcontracts.AttentionLanesOmitted("at_risk"))
-		case err != nil:
-			return crmcontracts.Attention{}, err
-		default:
-			items := make([]crmcontracts.AttentionItem, 0, len(risky))
-			for _, deal := range risky {
-				items = append(items, riskItem(deal))
-			}
-			out.AtRisk = &items
-			count := len(items)
-			out.Counts.AtRisk = &count
 		}
 	}
 
 	done, err := s.done(ctx, asOf)
-	switch {
-	case errors.Is(err, apperrors.ErrPermissionDenied):
-		omitted = append(omitted, crmcontracts.AttentionLanesOmitted("done_for_you"))
-	case err != nil:
+	omitted, err = fill(omitted, "done_for_you", err, func() { out.DoneForYou = done })
+	if err != nil {
 		return crmcontracts.Attention{}, err
-	default:
-		out.DoneForYou = done
 	}
 
 	if len(omitted) > 0 {

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -176,6 +176,36 @@ type Commitment struct {
 	DueAt       time.Time
 }
 
+// AtRisk is the open deals going quiet, or already past their expected close.
+//
+// The seam behind it reads the SAME candidate engine the whats_slipping tool
+// reads, at a shorter idle window. A second at-risk rule living here would be
+// two answers to one question, and the two would disagree in front of a rep.
+//
+// Optional exactly as Commitments is: nil means this feed does not do deal risk,
+// which is a different fact from a pipeline with nothing wrong in it.
+type AtRisk interface {
+	Quiet(ctx context.Context) ([]RiskyDeal, error)
+}
+
+// RiskyDeal is one deal the pipeline should worry about, and the ground it is
+// worried on.
+//
+// Both flags travel because they are different warnings: a deal nobody has
+// touched is neglected, and a deal past its close date is late whether or not
+// anyone touched it. A card that collapsed them would say "at risk" and leave
+// the rep to guess which.
+type RiskyDeal struct {
+	DealID ids.UUID
+	Name   string
+	// QuietDays is how long the deal has been idle, which is the number the
+	// card says out loud. Zero for a deal admitted only by its close date.
+	QuietDays int
+	// CloseOverdue is set when the expected close date has already passed.
+	CloseOverdue      bool
+	ExpectedCloseDate *time.Time
+}
+
 // Clock is the read's instant, injected so the lane boundaries a test asserts
 // are the ones it set.
 type Clock func() time.Time
@@ -192,12 +222,19 @@ type Service struct {
 	// and Assemble then leaves the field unset rather than sending an empty
 	// array. The contract makes the lane optional for exactly that reason.
 	commitments Commitments
-	now         Clock
+	// atRisk is OPTIONAL for the reason commitments is: absent lane, not empty.
+	atRisk AtRisk
+	now    Clock
 }
 
 // NewService binds the feed to its readers.
-func NewService(a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing, c Commitments, now Clock) *Service {
-	return &Service{approvals: a, duplicates: d, tasks: t, receipts: r, briefing: b, commitments: c, now: now}
+func NewService(
+	a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing, c Commitments, k AtRisk, now Clock,
+) *Service {
+	return &Service{
+		approvals: a, duplicates: d, tasks: t, receipts: r,
+		briefing: b, commitments: c, atRisk: k, now: now,
+	}
 }
 
 // Assemble reads every lane and returns the day.
@@ -273,6 +310,24 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 			out.Commitments = &items
 			count := len(items)
 			out.Counts.Commitments = &count
+		}
+	}
+
+	if s.atRisk != nil {
+		risky, err := s.atRisk.Quiet(ctx)
+		switch {
+		case errors.Is(err, apperrors.ErrPermissionDenied):
+			omitted = append(omitted, crmcontracts.AttentionLanesOmitted("at_risk"))
+		case err != nil:
+			return crmcontracts.Attention{}, err
+		default:
+			items := make([]crmcontracts.AttentionItem, 0, len(risky))
+			for _, deal := range risky {
+				items = append(items, riskItem(deal))
+			}
+			out.AtRisk = &items
+			count := len(items)
+			out.Counts.AtRisk = &count
 		}
 	}
 

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -206,6 +206,21 @@ type RiskyDeal struct {
 	ExpectedCloseDate *time.Time
 }
 
+// Meetings is today's booked meetings that have not happened yet.
+//
+// Optional as the other two are: nil means this feed does not read meetings,
+// which is not the same as a day with none in it.
+type Meetings interface {
+	Today(ctx context.Context, from, until time.Time, limit int) ([]Meeting, error)
+}
+
+// Meeting is one appointment still ahead of the reader.
+type Meeting struct {
+	ID       ids.UUID
+	Subject  string
+	StartsAt time.Time
+}
+
 // Clock is the read's instant, injected so the lane boundaries a test asserts
 // are the ones it set.
 type Clock func() time.Time
@@ -223,17 +238,19 @@ type Service struct {
 	// array. The contract makes the lane optional for exactly that reason.
 	commitments Commitments
 	// atRisk is OPTIONAL for the reason commitments is: absent lane, not empty.
-	atRisk AtRisk
-	now    Clock
+	atRisk   AtRisk
+	meetings Meetings
+	now      Clock
 }
 
 // NewService binds the feed to its readers.
 func NewService(
-	a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing, c Commitments, k AtRisk, now Clock,
+	a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing,
+	c Commitments, k AtRisk, m Meetings, now Clock,
 ) *Service {
 	return &Service{
 		approvals: a, duplicates: d, tasks: t, receipts: r,
-		briefing: b, commitments: c, atRisk: k, now: now,
+		briefing: b, commitments: c, atRisk: k, meetings: m, now: now,
 	}
 }
 
@@ -310,6 +327,27 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 			out.Commitments = &items
 			count := len(items)
 			out.Counts.Commitments = &count
+		}
+	}
+
+	if s.meetings != nil {
+		// From NOW rather than from the start of the day: a meeting that has
+		// already begun cannot be prepared for, and one that ended an hour ago
+		// on a queue headed "still ahead" would be plainly wrong.
+		booked, err := s.meetings.Today(ctx, asOf, endOfDay(asOf), plannedCap)
+		switch {
+		case errors.Is(err, apperrors.ErrPermissionDenied):
+			omitted = append(omitted, crmcontracts.AttentionLanesOmitted("meetings"))
+		case err != nil:
+			return crmcontracts.Attention{}, err
+		default:
+			items := make([]crmcontracts.AttentionItem, 0, len(booked))
+			for _, meeting := range booked {
+				items = append(items, meetingItem(meeting))
+			}
+			out.Meetings = &items
+			count := len(items)
+			out.Counts.Meetings = &count
 		}
 	}
 

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -5,12 +5,10 @@ package attention
 
 import (
 	"context"
-	"errors"
 	"sort"
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -303,25 +301,6 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 	})
 	if err != nil {
 		return crmcontracts.Attention{}, err
-	}
-
-	// Absent, not empty, when no reader is bound: see the Commitments doc.
-	if s.commitments != nil {
-		commitments, err := s.commitments.DueBy(ctx, endOfDay(asOf), plannedCap)
-		switch {
-		case errors.Is(err, apperrors.ErrPermissionDenied):
-			omitted = append(omitted, crmcontracts.AttentionLanesOmitted("commitments"))
-		case err != nil:
-			return crmcontracts.Attention{}, err
-		default:
-			items := make([]crmcontracts.AttentionItem, 0, len(commitments))
-			for _, promise := range commitments {
-				items = append(items, commitmentItem(promise, asOf))
-			}
-			out.Commitments = &items
-			count := len(items)
-			out.Counts.Commitments = &count
-		}
 	}
 
 	// The three OPTIONAL lanes, each bound or absent. optionalLane holds the

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -117,7 +117,7 @@ func TestADuplicateOutranksAnApprovalBecauseAMergeCannotBeUndone(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: []crmcontracts.Approval{approval("Send the Weber follow-up")}},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "person", Confidence: 0.9}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -135,7 +135,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 		stubApprovals{},
 		stubDuplicates{err: apperrors.ErrPermissionDenied},
 		&stubTasks{rows: []Task{{ID: ids.NewV7(), Subject: "Call Anna"}}},
-		stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a refused lane must not fail the read: %v", err)
@@ -157,7 +157,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestABrokenLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{err: fmt.Errorf("the database is unreachable")},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a lane that FAILED was reported as an empty day")
 	}
@@ -171,7 +171,7 @@ func TestTheCountReportsTheTotalThoughTheLaneIsBounded(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: pairs, open: 40},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -194,7 +194,7 @@ func TestTheCountCoversStagedProposalsToo(t *testing.T) {
 	}
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 20},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -213,7 +213,7 @@ func TestAnOverdueTaskLeadsThePlannedLane(t *testing.T) {
 			{ID: ids.NewV7(), Subject: "Due later today", DueAt: &later},
 			{ID: ids.NewV7(), Subject: "Was due yesterday", DueAt: &yesterday},
 		}},
-		stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -236,7 +236,7 @@ func TestAReceiptOffersNoDecision(t *testing.T) {
 			ID: ids.NewV7(), Kind: "close_date_correction",
 			Summary: "Moved the Acme close date to 27 Sep", OccurredAt: readInstant.Add(-time.Hour),
 		}}},
-		stubBriefing{}, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -255,7 +255,7 @@ func TestADuplicateCarriesNoServerWrittenSentence(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "organization", Confidence: 0.92}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -291,7 +291,7 @@ func TestAFloodOfDuplicatesDoesNotBuryTheStagedDecisions(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 79},
 		stubDuplicates{pairs: pairs, open: len(pairs)},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -319,7 +319,7 @@ func TestADuplicateCardNamesBothRecords(t *testing.T) {
 			LeftID: left, RightID: right,
 			Evidence: []FieldComparison{{Field: "display_name", Signal: "collide"}},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -344,7 +344,7 @@ func TestAnUnreadableSideCostsTheMergeVerbRatherThanLeakingTheRecord(t *testing.
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: hidden,
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a record this reader may not see must not fail the whole day: %v", err)
@@ -375,7 +375,7 @@ func TestEvidenceNeverReachesAReaderAsAColumnName(t *testing.T) {
 				{Field: "org", Signal: "collide"},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -400,7 +400,7 @@ func TestARecordReadThatBrokeIsNotReportedAsWithheld(t *testing.T) {
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: ids.NewV7(),
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a record read that FAILED was rendered as a pair the reader may not see")
 	}
@@ -421,7 +421,7 @@ func TestAnIdentityConflictKeepsTheOneRowThatExplainsIt(t *testing.T) {
 				{Field: "matched_lane", Signal: "exact_conflict", Left: &lane},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -439,7 +439,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 	deal := ids.NewV7()
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil, nil,
+		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -472,7 +472,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{}, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -493,7 +493,7 @@ func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, fixedClock)
+		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -509,7 +509,7 @@ func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, fixedClock)
+		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a broken briefing read was reported as a quiet morning")
 	}
@@ -518,7 +518,7 @@ func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 func TestABriefingItemOffersItsOwnThreeVerbs(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil, nil,
+		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -577,7 +577,7 @@ func TestACommitmentCarriesThePromiseAndTheWordsItWasReadFrom(t *testing.T) {
 	due := readInstant.Add(2 * time.Hour)
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}}, nil,
+		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}}, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -617,7 +617,7 @@ func TestAnOverduePromiseSaysSoRatherThanLeavingTheReaderToCompareDates(t *testi
 		&stubCommitments{rows: []Commitment{
 			promise("Angebot nachfassen", readInstant.Add(-48*time.Hour)),
 			promise("Termin bestätigen", readInstant.Add(3*time.Hour)),
-		}}, nil,
+		}}, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -643,7 +643,7 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 	tasks := &stubTasks{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
-		commitments, nil, fixedClock)
+		commitments, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: apperrors.ErrPermissionDenied}, nil,
+		&stubCommitments{err: apperrors.ErrPermissionDenied}, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -691,7 +691,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, nil, fixedClock)
+		nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -709,7 +709,7 @@ func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 func TestABrokenCommitmentReadFailsTheFeedRatherThanReadingAsAClearDay(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: errors.New("the claim read fell over")}, nil,
+		&stubCommitments{err: errors.New("the claim read fell over")}, nil, nil,
 		fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a failed commitment read assembled a day, want the error surfaced")
@@ -740,9 +740,8 @@ func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
 	deal := ids.NewV7()
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
-		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}},
-		fixedClock,
-	)
+		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -778,9 +777,8 @@ func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
 		stubAtRisk{rows: []RiskyDeal{{
 			DealID: ids.NewV7(), Name: "Closing last month",
 			QuietDays: 2, CloseOverdue: true, ExpectedCloseDate: &closed,
-		}}},
-		fixedClock,
-	)
+		}}}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -803,9 +801,8 @@ func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
 func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
-		stubAtRisk{err: apperrors.ErrPermissionDenied},
-		fixedClock,
-	)
+		stubAtRisk{err: apperrors.ErrPermissionDenied}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -828,9 +825,8 @@ func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 // rule the commitments lane keeps.
 func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
 	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
-		fixedClock,
-	)
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -850,4 +846,94 @@ func stringOr(v *string) string {
 		return "absent"
 	}
 	return *v
+}
+
+type stubMeetings struct {
+	rows []Meeting
+	err  error
+	// from records the window's start, so a test can prove the lane asks from
+	// NOW rather than from the start of the day.
+	from *time.Time
+}
+
+func (s *stubMeetings) Today(_ context.Context, from, _ time.Time, _ int) ([]Meeting, error) {
+	s.from = &from
+	return s.rows, s.err
+}
+
+// The lane asks from the READ INSTANT, not from midnight. A meeting that ended
+// an hour ago cannot be prepared for, and listing it under a lane of what is
+// still ahead would be plainly false.
+func TestTheMeetingLaneAsksFromNowRatherThanFromTheStartOfTheDay(t *testing.T) {
+	meetings := &stubMeetings{}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
+		nil, nil, meetings, fixedClock,
+	)
+	if _, err := svc.Assemble(context.Background()); err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if meetings.from == nil {
+		t.Fatal("the meeting lane was never asked for a window")
+	}
+	if !meetings.from.Equal(readInstant) {
+		t.Errorf("the lane asks from %s, want the read instant %s", meetings.from, readInstant)
+	}
+}
+
+// A meeting carries its own subject and the instant it starts. The subject is
+// what a rep recognises and the start is what they are racing.
+func TestAMeetingCarriesItsSubjectAndWhenItStarts(t *testing.T) {
+	starts := readInstant.Add(90 * time.Minute)
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		&stubMeetings{rows: []Meeting{{ID: ids.NewV7(), Subject: "Vogt — Angebotsbesprechung", StartsAt: starts}}},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.Meetings == nil {
+		t.Fatal("the meeting lane is absent, want one meeting")
+	}
+	item := (*out.Meetings)[0]
+	if item.Title == nil || *item.Title != "Vogt — Angebotsbesprechung" {
+		t.Errorf("title = %s, want the meeting subject", stringOr(item.Title))
+	}
+	if item.DueAt == nil || !item.DueAt.Equal(starts) {
+		t.Errorf("due_at = %v, want when the meeting starts", item.DueAt)
+	}
+	// A meeting that has not started cannot be late, so the flag stays off.
+	if item.Overdue != nil && *item.Overdue {
+		t.Error("a meeting still ahead reports overdue, want not")
+	}
+	if out.Counts.Meetings == nil || *out.Counts.Meetings != 1 {
+		t.Errorf("counts.meetings = %v, want 1", out.Counts.Meetings)
+	}
+}
+
+// A withheld meeting lane is NAMED. "No meetings today" and "you may not read
+// the calendar" are different answers and only one of them is true.
+func TestAWithheldMeetingLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		&stubMeetings{err: apperrors.ErrPermissionDenied}, fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.Meetings != nil {
+		t.Errorf("a withheld lane sent %v, want no lane", *out.Meetings)
+	}
+	var named bool
+	for _, lane := range *out.LanesOmitted {
+		if lane == "meetings" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("lanes_omitted = %v, want it to name meetings", *out.LanesOmitted)
+	}
 }

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -547,6 +547,9 @@ func TestABriefingItemOffersItsOwnThreeVerbs(t *testing.T) {
 type stubCommitments struct {
 	rows []Commitment
 	err  error
+	// calls counts the reads, so a lane assembled twice is caught here rather
+	// than by a reader noticing their withheld lane named twice.
+	calls int
 	// by records the instant the lane asked for, so a test can prove the
 	// window rather than assume it.
 	by *time.Time
@@ -554,6 +557,7 @@ type stubCommitments struct {
 
 func (s *stubCommitments) DueBy(_ context.Context, by time.Time, _ int) ([]Commitment, error) {
 	s.by = &by
+	s.calls++
 	return s.rows, s.err
 }
 
@@ -849,8 +853,9 @@ func stringOr(v *string) string {
 }
 
 type stubMeetings struct {
-	rows []Meeting
-	err  error
+	rows  []Meeting
+	err   error
+	calls int
 	// from records the window's start, so a test can prove the lane asks from
 	// NOW rather than from the start of the day.
 	from *time.Time
@@ -858,6 +863,7 @@ type stubMeetings struct {
 
 func (s *stubMeetings) Today(_ context.Context, from, _ time.Time, _ int) ([]Meeting, error) {
 	s.from = &from
+	s.calls++
 	return s.rows, s.err
 }
 
@@ -935,5 +941,53 @@ func TestAWithheldMeetingLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	}
 	if !named {
 		t.Errorf("lanes_omitted = %v, want it to name meetings", *out.LanesOmitted)
+	}
+}
+
+// Each lane is read ONCE per feed. A lane assembled twice costs a second
+// database round trip on every load of the page, and a refusal from the second
+// read names the withheld lane twice — which is how the duplicate announces
+// itself to a reader rather than to a test.
+//
+// It is asserted per lane rather than in one place because the lanes are wired
+// separately: adding a fourth by copying a third is exactly the slip that
+// leaves an old block behind.
+func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
+	commitments := &stubCommitments{rows: []Commitment{promise("a promise", readInstant)}}
+	meetings := &stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
+		commitments, stubAtRisk{}, meetings, fixedClock,
+	)
+	if _, err := svc.Assemble(context.Background()); err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if commitments.calls != 1 {
+		t.Errorf("the commitments lane was read %d times, want once", commitments.calls)
+	}
+	if meetings.calls != 1 {
+		t.Errorf("the meetings lane was read %d times, want once", meetings.calls)
+	}
+}
+
+// A withheld lane is named ONCE. Naming it twice is what a duplicate read looks
+// like on the wire, and a client rendering the list would say it twice.
+func TestAWithheldLaneIsNamedOnce(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
+		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	var named int
+	for _, lane := range *out.LanesOmitted {
+		if lane == "commitments" {
+			named++
+		}
+	}
+	if named != 1 {
+		t.Errorf("commitments named %d times in lanes_omitted, want once", named)
 	}
 }

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -117,8 +117,7 @@ func TestADuplicateOutranksAnApprovalBecauseAMergeCannotBeUndone(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: []crmcontracts.Approval{approval("Send the Weber follow-up")}},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "person", Confidence: 0.9}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -136,8 +135,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 		stubApprovals{},
 		stubDuplicates{err: apperrors.ErrPermissionDenied},
 		&stubTasks{rows: []Task{{ID: ids.NewV7(), Subject: "Call Anna"}}},
-		stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a refused lane must not fail the read: %v", err)
@@ -159,8 +157,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestABrokenLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{err: fmt.Errorf("the database is unreachable")},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a lane that FAILED was reported as an empty day")
 	}
@@ -174,8 +171,7 @@ func TestTheCountReportsTheTotalThoughTheLaneIsBounded(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: pairs, open: 40},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -198,8 +194,7 @@ func TestTheCountCoversStagedProposalsToo(t *testing.T) {
 	}
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 20},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -218,8 +213,7 @@ func TestAnOverdueTaskLeadsThePlannedLane(t *testing.T) {
 			{ID: ids.NewV7(), Subject: "Due later today", DueAt: &later},
 			{ID: ids.NewV7(), Subject: "Was due yesterday", DueAt: &yesterday},
 		}},
-		stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -242,8 +236,7 @@ func TestAReceiptOffersNoDecision(t *testing.T) {
 			ID: ids.NewV7(), Kind: "close_date_correction",
 			Summary: "Moved the Acme close date to 27 Sep", OccurredAt: readInstant.Add(-time.Hour),
 		}}},
-		stubBriefing{}, nil, fixedClock,
-	)
+		stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -262,8 +255,7 @@ func TestADuplicateCarriesNoServerWrittenSentence(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "organization", Confidence: 0.92}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -299,8 +291,7 @@ func TestAFloodOfDuplicatesDoesNotBuryTheStagedDecisions(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 79},
 		stubDuplicates{pairs: pairs, open: len(pairs)},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -328,8 +319,7 @@ func TestADuplicateCardNamesBothRecords(t *testing.T) {
 			LeftID: left, RightID: right,
 			Evidence: []FieldComparison{{Field: "display_name", Signal: "collide"}},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -354,8 +344,7 @@ func TestAnUnreadableSideCostsTheMergeVerbRatherThanLeakingTheRecord(t *testing.
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: hidden,
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a record this reader may not see must not fail the whole day: %v", err)
@@ -386,8 +375,7 @@ func TestEvidenceNeverReachesAReaderAsAColumnName(t *testing.T) {
 				{Field: "org", Signal: "collide"},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -412,8 +400,7 @@ func TestARecordReadThatBrokeIsNotReportedAsWithheld(t *testing.T) {
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: ids.NewV7(),
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a record read that FAILED was rendered as a pair the reader may not see")
 	}
@@ -434,8 +421,7 @@ func TestAnIdentityConflictKeepsTheOneRowThatExplainsIt(t *testing.T) {
 				{Field: "matched_lane", Signal: "exact_conflict", Left: &lane},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, fixedClock,
-	)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -453,9 +439,8 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 	deal := ids.NewV7()
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil,
-		fixedClock,
-	)
+		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -487,8 +472,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{}, nil, fixedClock,
-	)
+		stubBriefing{}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -509,8 +493,7 @@ func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, fixedClock,
-	)
+		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -526,8 +509,7 @@ func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: errors.New("the brief read fell over")}, nil, fixedClock,
-	)
+		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a broken briefing read was reported as a quiet morning")
 	}
@@ -536,9 +518,8 @@ func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 func TestABriefingItemOffersItsOwnThreeVerbs(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil,
-		fixedClock,
-	)
+		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -596,9 +577,8 @@ func TestACommitmentCarriesThePromiseAndTheWordsItWasReadFrom(t *testing.T) {
 	due := readInstant.Add(2 * time.Hour)
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}},
-		fixedClock,
-	)
+		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -637,9 +617,8 @@ func TestAnOverduePromiseSaysSoRatherThanLeavingTheReaderToCompareDates(t *testi
 		&stubCommitments{rows: []Commitment{
 			promise("Angebot nachfassen", readInstant.Add(-48*time.Hour)),
 			promise("Termin bestätigen", readInstant.Add(3*time.Hour)),
-		}},
-		fixedClock,
-	)
+		}}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -664,8 +643,7 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 	tasks := &stubTasks{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
-		commitments, fixedClock,
-	)
+		commitments, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
 	}
@@ -684,9 +662,8 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: apperrors.ErrPermissionDenied},
-		fixedClock,
-	)
+		&stubCommitments{err: apperrors.ErrPermissionDenied}, nil,
+		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -714,8 +691,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, fixedClock,
-	)
+		nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -733,9 +709,8 @@ func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 func TestABrokenCommitmentReadFailsTheFeedRatherThanReadingAsAClearDay(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: errors.New("the claim read fell over")},
-		fixedClock,
-	)
+		&stubCommitments{err: errors.New("the claim read fell over")}, nil,
+		fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a failed commitment read assembled a day, want the error surfaced")
 	}
@@ -749,4 +724,130 @@ func overdueOf(item crmcontracts.AttentionItem) string {
 		return "absent"
 	}
 	return strconv.FormatBool(*item.Overdue)
+}
+
+type stubAtRisk struct {
+	rows []RiskyDeal
+	err  error
+}
+
+func (s stubAtRisk) Quiet(context.Context) ([]RiskyDeal, error) { return s.rows, s.err }
+
+// A quiet deal names the number of days it has been quiet. The whole reason the
+// lane asks at a shorter window than the stalled status is to speak sooner, and
+// a card that said only "at risk" would hide which patience produced it.
+func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
+	deal := ids.NewV7()
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk == nil {
+		t.Fatal("the at-risk lane is absent, want one deal")
+	}
+	items := *out.AtRisk
+	if len(items) != 1 {
+		t.Fatalf("the lane carries %d items, want 1", len(items))
+	}
+	if items[0].Title == nil || *items[0].Title != "Fleet retrofit" {
+		t.Errorf("title = %v, want the deal name", items[0].Title)
+	}
+	if items[0].Detail == nil || *items[0].Detail != "19" {
+		t.Errorf("detail = %s, want the idle day count", stringOr(items[0].Detail))
+	}
+	if items[0].Kind == nil || *items[0].Kind != "quiet" {
+		t.Errorf("kind = %s, want the ground it was admitted on", stringOr(items[0].Kind))
+	}
+	if items[0].Subject == nil || items[0].Subject.Type != "deal" {
+		t.Errorf("subject = %v, want the deal", items[0].Subject)
+	}
+}
+
+// A deal past its close date is reported as overdue rather than merely quiet.
+// The two grounds read differently to a rep: a date the customer agreed to has
+// passed, which is a harder fact than a silence nobody agreed to.
+func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
+	closed := readInstant.AddDate(0, 0, -30)
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{
+			DealID: ids.NewV7(), Name: "Closing last month",
+			QuietDays: 2, CloseOverdue: true, ExpectedCloseDate: &closed,
+		}}},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	item := (*out.AtRisk)[0]
+	if item.Kind == nil || *item.Kind != "close_overdue" {
+		t.Errorf("kind = %s, want close_overdue", stringOr(item.Kind))
+	}
+	if item.Overdue == nil || !*item.Overdue {
+		t.Errorf("overdue = %v, want true", item.Overdue)
+	}
+	if item.DueAt == nil || !item.DueAt.Equal(closed) {
+		t.Errorf("due_at = %v, want the expected close date", item.DueAt)
+	}
+}
+
+// A withheld risk lane is NAMED, not reported empty. "Nothing is at risk" is a
+// claim about the pipeline; "you may not read the deals" is a claim about the
+// reader, and only one of them is true here.
+func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{err: apperrors.ErrPermissionDenied},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk != nil {
+		t.Errorf("a withheld lane sent %v, want no lane at all", *out.AtRisk)
+	}
+	var named bool
+	for _, lane := range *out.LanesOmitted {
+		if lane == "at_risk" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("lanes_omitted = %v, want it to name at_risk", *out.LanesOmitted)
+	}
+}
+
+// A feed with no risk reader sends no lane at all, the same absent-not-empty
+// rule the commitments lane keeps.
+func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk != nil {
+		t.Errorf("at_risk = %v, want the lane absent", *out.AtRisk)
+	}
+	if out.Counts.AtRisk != nil {
+		t.Errorf("counts.at_risk = %v, want it absent too", out.Counts.AtRisk)
+	}
+}
+
+// stringOr reads a wire string for a failure message. Printing the pointer
+// reports an address, which tells a reader running the test nothing.
+func stringOr(v *string) string {
+	if v == nil {
+		return "absent"
+	}
+	return *v
 }

--- a/backend/internal/compose/attention/lanewiring_test.go
+++ b/backend/internal/compose/attention/lanewiring_test.go
@@ -44,3 +44,45 @@ func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 		}
 	}
 }
+
+// No lane advertises an action the surface cannot perform.
+//
+// AttentionRow renders controls for `complete` and `snooze` only. A card
+// offering anything else is a promise to a client that nothing keeps — and a
+// generated client is entitled to draw a control for whatever the server says
+// it offers. The three optional lanes therefore send no action at all until the
+// navigation they would need actually exists.
+//
+// Derived from the lanes rather than listed, so a fourth joins the check by
+// existing.
+func TestNoOptionalLaneOffersAnActionTheSurfaceCannotPerform(t *testing.T) {
+	performable := map[crmcontracts.AttentionItemActions]bool{
+		"complete": true, "snooze": true,
+	}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
+		&stubCommitments{rows: []Commitment{promise("a promise", readInstant)}},
+		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
+		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	for name, lane := range map[string]*[]crmcontracts.AttentionItem{
+		"meetings": out.Meetings, "at_risk": out.AtRisk, "commitments": out.Commitments,
+	} {
+		if lane == nil {
+			t.Fatalf("%s is absent, so this gate checked nothing", name)
+		}
+		for _, item := range *lane {
+			for _, action := range item.Actions {
+				if !performable[action] {
+					t.Errorf("%s offers %q, which no control on this surface performs",
+						name, action)
+				}
+			}
+		}
+	}
+}

--- a/backend/internal/compose/attention/lanewiring_test.go
+++ b/backend/internal/compose/attention/lanewiring_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// Each optional lane fills ITS OWN field. The three are wired through
+// pointers-to-pointers into one response struct, which is exactly the shape
+// where a copy-paste slip puts the meetings into at_risk and nothing fails to
+// compile.
+func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
+		&stubCommitments{rows: []Commitment{promise("a promise", readInstant)}},
+		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
+		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
+		fixedClock,
+	)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	for _, lane := range []struct {
+		name  string
+		items *[]crmcontracts.AttentionItem
+		want  string
+	}{
+		{"meetings", out.Meetings, "a meeting"},
+		{"at_risk", out.AtRisk, "a deal"},
+		{"commitments", out.Commitments, "a promise"},
+	} {
+		if lane.items == nil || len(*lane.items) != 1 {
+			t.Fatalf("%s carries %v, want one item", lane.name, lane.items)
+		}
+		if got := (*lane.items)[0]; got.Title == nil || *got.Title != lane.want {
+			t.Errorf("%s holds %q, want %q — a lane wrote into the wrong field",
+				lane.name, stringOr(got.Title), lane.want)
+		}
+	}
+}

--- a/backend/internal/compose/attention/optionallanes.go
+++ b/backend/internal/compose/attention/optionallanes.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The lanes an installation may not serve at all.
+//
+// Meetings, deal risk and promises are each bound by compose or left nil, and a
+// nil reader means the feed sends NO lane rather than an empty one — "this
+// installation does not look here" is a different answer from "there is nothing
+// here", and only the first is honest about what was never read.
+//
+// They live together because they share one shape: read, render, and either
+// fill the lane or name it as withheld. Three copies of that in Assemble is
+// what pushed it past the length a reader can hold at once.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// optionalLane is one such lane: whether it is bound, how to read it, and where
+// its items and count belong on the answer.
+type optionalLane struct {
+	name  string
+	bound bool
+	read  func() ([]crmcontracts.AttentionItem, error)
+	into  **[]crmcontracts.AttentionItem
+	count **int
+}
+
+// collect runs the lane and files its result, returning the omitted list the
+// caller carries. An unbound lane is skipped entirely, which is what leaves the
+// field absent on the wire.
+//
+// A refusal NAMES the lane; any other failure is returned, because a lane that
+// is broken rather than withheld must not read as a quiet one.
+func (l optionalLane) collect(
+	omitted []crmcontracts.AttentionLanesOmitted,
+) ([]crmcontracts.AttentionLanesOmitted, error) {
+	if !l.bound {
+		return omitted, nil
+	}
+	items, err := l.read()
+	switch {
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return append(omitted, crmcontracts.AttentionLanesOmitted(l.name)), nil
+	case err != nil:
+		return omitted, err
+	default:
+		*l.into = &items
+		count := len(items)
+		*l.count = &count
+		return omitted, nil
+	}
+}
+
+// optionalLanes describes the three, in the order they are read.
+//
+// The meetings window opens at NOW rather than at midnight: a meeting that
+// began an hour ago cannot be prepared for, and one that ended would be plainly
+// wrong on a lane headed "still ahead".
+func (s *Service) optionalLanes(
+	ctx context.Context, asOf time.Time, out *crmcontracts.Attention,
+) []optionalLane {
+	return []optionalLane{
+		{
+			name: "meetings", bound: s.meetings != nil,
+			read: func() ([]crmcontracts.AttentionItem, error) {
+				booked, err := s.meetings.Today(ctx, asOf, endOfDay(asOf), plannedCap)
+				return renderEach(booked, meetingItem), err
+			},
+			into: &out.Meetings, count: &out.Counts.Meetings,
+		},
+		{
+			name: "at_risk", bound: s.atRisk != nil,
+			read: func() ([]crmcontracts.AttentionItem, error) {
+				risky, err := s.atRisk.Quiet(ctx)
+				return renderEach(risky, riskItem), err
+			},
+			into: &out.AtRisk, count: &out.Counts.AtRisk,
+		},
+		{
+			name: "commitments", bound: s.commitments != nil,
+			read: func() ([]crmcontracts.AttentionItem, error) {
+				due, err := s.commitments.DueBy(ctx, endOfDay(asOf), plannedCap)
+				return renderEach(due, func(promise Commitment) crmcontracts.AttentionItem {
+					return commitmentItem(promise, asOf)
+				}), err
+			},
+			into: &out.Commitments, count: &out.Counts.Commitments,
+		},
+	}
+}
+
+// renderEach turns one producer's rows into wire items. The lanes differ in
+// what they read and how a row is drawn; the loop between them is spelled once.
+//
+// Never nil: the empty slice rather than a null the contract promised was a list.
+func renderEach[T any](rows []T, draw func(T) crmcontracts.AttentionItem) []crmcontracts.AttentionItem {
+	items := make([]crmcontracts.AttentionItem, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, draw(row))
+	}
+	return items
+}
+
+// fill files one REQUIRED lane's result: a refusal names the lane, any other
+// error is handed back, and success runs the assignment the caller supplied.
+//
+// The four required lanes each spelled that switch out. They differ only in
+// which fields they set, which is what the closure carries — and a lane that is
+// broken rather than withheld still fails the whole feed rather than reading as
+// a quiet day.
+func fill(
+	omitted []crmcontracts.AttentionLanesOmitted, name string, err error, assign func(),
+) ([]crmcontracts.AttentionLanesOmitted, error) {
+	switch {
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return append(omitted, crmcontracts.AttentionLanesOmitted(name)), nil
+	case err != nil:
+		return omitted, err
+	default:
+		assign()
+		return omitted, nil
+	}
+}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -300,6 +300,30 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 	return item
 }
 
+// meetingItem renders one appointment still ahead today.
+//
+// The subject IS the sentence a rep recognises — somebody wrote it when the
+// meeting was booked — so it travels as the title, and the start time as
+// `due_at` because that is what a reader is racing. No `overdue` flag: a
+// meeting that has not started cannot be late, and the lane only carries the
+// ones still ahead.
+//
+// Its only verb is `open`. The pre-meeting brief is its own surface with its
+// own eight cited sections, and a queue that tried to summarise it here would
+// be a second answer to "prepare me for this".
+func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
+	subject := meeting.Subject
+	starts := meeting.StartsAt
+	return crmcontracts.AttentionItem{
+		Id:      meeting.ID.String(),
+		Source:  crmcontracts.AttentionItemSource("meeting"),
+		Title:   &subject,
+		Subject: subjectOf("activity", meeting.ID),
+		DueAt:   &starts,
+		Actions: []crmcontracts.AttentionItemActions{"open"},
+	}
+}
+
 // receiptItem renders one thing the system did on its own.
 //
 // Its only verb is `open`. A receipt reports a finished act, and offering a

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -270,8 +270,10 @@ func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionIt
 // both is reported as overdue, because a date the customer agreed to outranks
 // a silence nobody agreed to.
 //
-// Its only verb is `open`. What to DO about a quiet deal is a judgement, and a
-// queue that offered to answer it here would be deciding rather than warning.
+// It offers NO verb. What to do about a quiet deal is a judgement, and a queue
+// that answered it here would be deciding rather than warning. `open` is not
+// sent either: this surface wires no navigation, and an action a card cannot
+// perform is a promise to a client that nothing keeps.
 func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 	name := deal.Name
 	ground := "quiet"
@@ -285,7 +287,7 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 		Title:   &name,
 		Subject: subjectOf("deal", deal.DealID),
 		Overdue: &deal.CloseOverdue,
-		Actions: []crmcontracts.AttentionItemActions{"open"},
+		Actions: []crmcontracts.AttentionItemActions{},
 	}
 	// The idle count rides as the detail's own number, so the card can say the
 	// window the server actually applied instead of implying one.
@@ -308,9 +310,11 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 // meeting that has not started cannot be late, and the lane only carries the
 // ones still ahead.
 //
-// Its only verb is `open`. The pre-meeting brief is its own surface with its
-// own eight cited sections, and a queue that tried to summarise it here would
-// be a second answer to "prepare me for this".
+// It offers NO verb. The pre-meeting brief is its own surface with its own eight
+// cited sections, and a queue that tried to summarise it here would be a second
+// answer to "prepare me for this". `open` is not sent because this surface
+// wires no navigation, and an advertised action nothing performs is worse than
+// none: a client is entitled to render a control for what the server offers.
 func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 	subject := meeting.Subject
 	starts := meeting.StartsAt
@@ -320,7 +324,7 @@ func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 		Title:   &subject,
 		Subject: subjectOf("activity", meeting.ID),
 		DueAt:   &starts,
-		Actions: []crmcontracts.AttentionItemActions{"open"},
+		Actions: []crmcontracts.AttentionItemActions{},
 	}
 }
 

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -234,8 +234,10 @@ func briefItem(entry BriefEntry) crmcontracts.AttentionItem {
 // against what was actually written, and a card showing only the paraphrase
 // asks them to trust the extractor instead.
 //
-// Its only verb is `open`. Marking a promise kept is the claim's own endpoint's
-// job, and this feed adds no authority the record does not already have.
+// It offers NO verb. Marking a promise kept is the claim's own endpoint's job,
+// and this feed adds no authority the record does not already have. `open` is
+// not sent either, for the reason the other two cards do not send it: this
+// surface wires no navigation, so the verb would reach no control.
 func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionItem {
 	body := promise.Body
 	quote := promise.Quote
@@ -249,7 +251,7 @@ func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionIt
 		Subject: subjectOf("person", promise.PersonID),
 		DueAt:   &due,
 		Overdue: &past,
-		Actions: []crmcontracts.AttentionItemActions{"open"},
+		Actions: []crmcontracts.AttentionItemActions{},
 	}
 	if promise.SourceLabel != "" {
 		label := promise.SourceLabel

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -6,6 +6,7 @@ package attention
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -253,6 +254,48 @@ func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionIt
 	if promise.SourceLabel != "" {
 		label := promise.SourceLabel
 		item.Kind = &label
+	}
+	return item
+}
+
+// riskItem renders one deal the pipeline should worry about.
+//
+// The title is the deal's own name, which the reader recognises. The card's
+// SENTENCE is the client's to write, because the two grounds read differently
+// in every language and the server has none — so what travels is the deal, the
+// idle days, and whether the close date has passed, and the client says it.
+//
+// `kind` carries the ground rather than a label: `quiet` when only the idle
+// clock admitted it, `close_overdue` when the date has passed. A deal that is
+// both is reported as overdue, because a date the customer agreed to outranks
+// a silence nobody agreed to.
+//
+// Its only verb is `open`. What to DO about a quiet deal is a judgement, and a
+// queue that offered to answer it here would be deciding rather than warning.
+func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
+	name := deal.Name
+	ground := "quiet"
+	if deal.CloseOverdue {
+		ground = "close_overdue"
+	}
+	item := crmcontracts.AttentionItem{
+		Id:      deal.DealID.String(),
+		Source:  crmcontracts.AttentionItemSource("deal_at_risk"),
+		Kind:    &ground,
+		Title:   &name,
+		Subject: subjectOf("deal", deal.DealID),
+		Overdue: &deal.CloseOverdue,
+		Actions: []crmcontracts.AttentionItemActions{"open"},
+	}
+	// The idle count rides as the detail's own number, so the card can say the
+	// window the server actually applied instead of implying one.
+	if deal.QuietDays > 0 {
+		days := strconv.Itoa(deal.QuietDays)
+		item.Detail = &days
+	}
+	if deal.ExpectedCloseDate != nil {
+		due := *deal.ExpectedCloseDate
+		item.DueAt = &due
 	}
 	return item
 }

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The three OPTIONAL attention lanes, bound to the engines that already own
+// what they read.
+//
+// Each is a binding rather than an implementation, which is the point: the
+// promises come from the people module's claim read, the deal risk from the
+// same candidate engine whats_slipping_this_week reads, and the meetings from
+// the activities list every other activity surface reads. A lane that derived
+// its own answer here would be a second opinion the product would have to keep
+// agreeing with.
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/attention"
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// attentionCommitments reads the acting rep's own promises through the people
+// store.
+//
+// A claim carries no assignee, so ownership rides the person it was made to:
+// the rep who holds the relationship is the one who made the promise in their
+// own captured conversation. A principal with no human behind it has no
+// promises of its own to keep, which is a refusal rather than an empty lane —
+// the feed omits and NAMES the lane instead of reporting a clear day.
+type attentionCommitments struct{ store *people.Store }
+
+func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int) ([]attention.Commitment, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return nil, apperrors.ErrPermissionDenied
+	}
+	due, err := c.store.OpenCommitmentsDue(ctx, ids.From[ids.UserKind](actor.UserID), by, limit)
+	if err != nil {
+		return nil, err
+	}
+	promises := make([]attention.Commitment, 0, len(due))
+	for _, row := range due {
+		promises = append(promises, attention.Commitment{
+			ID:          row.ID,
+			PersonID:    row.PersonID.UUID,
+			Body:        row.Body,
+			Quote:       row.SourceQuote,
+			SourceLabel: row.SourceLabel,
+			OccurredAt:  row.OccurredAt,
+			DueAt:       row.DueAt,
+		})
+	}
+	return promises, nil
+}
+
+// attentionAtRisk reads the pipeline's own risk candidates at the morning
+// queue's shorter idle window.
+//
+// It calls quietDealLister, the SAME engine whats_slipping_this_week reads, so
+// there is one at-risk rule in the product and the two surfaces cannot come to
+// disagree about which deals are in trouble. Only the patience differs, and it
+// is named here rather than buried: a queue exists to warn, and the stalled
+// threshold is a status rather than a warning.
+type attentionAtRisk struct{ lister agents.SlippingLister }
+
+func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, error) {
+	candidates, err := a.lister(ctx)
+	if err != nil {
+		return nil, err
+	}
+	now := clockNow()
+	risky := make([]attention.RiskyDeal, 0, len(candidates))
+	for _, deal := range candidates {
+		risky = append(risky, attention.RiskyDeal{
+			DealID:            deal.DealID,
+			Name:              deal.Name,
+			QuietDays:         idleDaysOf(deal, now),
+			CloseOverdue:      deal.CloseOverdue,
+			ExpectedCloseDate: deal.ExpectedCloseDate,
+		})
+	}
+	return risky, nil
+}
+
+// idleDaysOf is how long the deal has been quiet, counted from the same base
+// the idle rule itself measures from: the last activity, or the deal's creation
+// when nothing has ever touched it.
+func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
+	since := deal.CreatedAt
+	if deal.LastActivityAt != nil {
+		since = *deal.LastActivityAt
+	}
+	days := int(now.Sub(since).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}
+
+// attentionMeetings reads today's remaining meetings through the activities
+// store — the same gated list every other activity surface reads.
+//
+// SCAN AND FILTER, like the task lane above and for the same reason: the store
+// cannot express "kind=meeting between two instants", so this reads wider and
+// narrows here. The same scan factor applies, because a day with a pile of
+// finished meetings would otherwise push the one still ahead off the page.
+type attentionMeetings struct{ store *activities.Store }
+
+func (m attentionMeetings) Today(
+	ctx context.Context, from, until time.Time, limit int,
+) ([]attention.Meeting, error) {
+	kind := string(crmcontracts.ActivityKindMeeting)
+	scan := limit * taskScanFactor
+	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{Kind: &kind, Limit: &scan})
+	if err != nil {
+		return nil, err
+	}
+	ahead := make([]attention.Meeting, 0, len(rows))
+	for _, row := range rows {
+		if !meetingStillWorthPreparing(row, from, until) {
+			continue
+		}
+		ahead = append(ahead, attention.Meeting{
+			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
+		})
+	}
+	// Soonest first: the lane is a countdown, and the store returns activities
+	// newest-first, which is the opposite order for a day still ahead.
+	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
+	if len(ahead) > limit {
+		ahead = ahead[:limit]
+	}
+	return ahead, nil
+}
+
+// meetingStillWorthPreparing keeps the meetings a rep can still do something
+// about: booked (not held, not cancelled, not a no-show) and starting between
+// now and the end of the day.
+//
+// A meeting with no status is treated as booked. Capture writes calendar events
+// without one, and dropping them would empty this lane on exactly the
+// installations whose calendars are connected.
+func meetingStillWorthPreparing(row crmcontracts.Activity, from, until time.Time) bool {
+	if row.MeetingStatus != nil && *row.MeetingStatus != crmcontracts.ActivityMeetingStatusBooked {
+		return false
+	}
+	return !row.OccurredAt.Before(from) && row.OccurredAt.Before(until)
+}
+
+// subjectOfMeeting is the line a meeting shows. Unlike a task, a meeting may
+// honestly have no subject — a calendar event with a blank title is a real
+// thing a provider hands over — so the fallback is a routine case here.
+func subjectOfMeeting(row crmcontracts.Activity) string {
+	if row.Subject != nil && *row.Subject != "" {
+		return *row.Subject
+	}
+	return "(untitled meeting)"
+}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -109,24 +109,31 @@ func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
 // attentionMeetings reads today's remaining meetings through the activities
 // store — the same gated list every other activity surface reads.
 //
-// SCAN AND FILTER, like the task lane above and for the same reason: the store
-// cannot express "kind=meeting between two instants", so this reads wider and
-// narrows here. The same scan factor applies, because a day with a pile of
-// finished meetings would otherwise push the one still ahead off the page.
+// The WINDOW is applied in SQL, not here. An earlier cut read ten times the
+// lane and narrowed the time range in Go, which is lossy in the one direction
+// that hides itself: a day with more than the scan's worth of later activity
+// pushes a real meeting off the page, and the lane draws a free afternoon over
+// a booked one. ListActivitiesInput carries OccurredAfter/OccurredBefore and
+// the store applies both as predicates, so the bound is the day rather than a
+// guess about how busy the day might be.
+//
+// The STATUS filter stays in Go: the store has no dial for it, and the set it
+// removes is bounded by the window the database already applied.
 type attentionMeetings struct{ store *activities.Store }
 
 func (m attentionMeetings) Today(
 	ctx context.Context, from, until time.Time, limit int,
 ) ([]attention.Meeting, error) {
 	kind := string(crmcontracts.ActivityKindMeeting)
-	scan := limit * taskScanFactor
-	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{Kind: &kind, Limit: &scan})
+	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{
+		Kind: &kind, OccurredAfter: &from, OccurredBefore: &until, Limit: &limit,
+	})
 	if err != nil {
 		return nil, err
 	}
 	ahead := make([]attention.Meeting, 0, len(rows))
 	for _, row := range rows {
-		if !meetingStillWorthPreparing(row, from, until) {
+		if !meetingStillWorthPreparing(row) {
 			continue
 		}
 		ahead = append(ahead, attention.Meeting{
@@ -136,24 +143,18 @@ func (m attentionMeetings) Today(
 	// Soonest first: the lane is a countdown, and the store returns activities
 	// newest-first, which is the opposite order for a day still ahead.
 	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
-	if len(ahead) > limit {
-		ahead = ahead[:limit]
-	}
 	return ahead, nil
 }
 
 // meetingStillWorthPreparing keeps the meetings a rep can still do something
-// about: booked (not held, not cancelled, not a no-show) and starting between
-// now and the end of the day.
+// about: booked, rather than held, cancelled or a no-show. The time window is
+// the database's to apply.
 //
 // A meeting with no status is treated as booked. Capture writes calendar events
 // without one, and dropping them would empty this lane on exactly the
 // installations whose calendars are connected.
-func meetingStillWorthPreparing(row crmcontracts.Activity, from, until time.Time) bool {
-	if row.MeetingStatus != nil && *row.MeetingStatus != crmcontracts.ActivityMeetingStatusBooked {
-		return false
-	}
-	return !row.OccurredAt.Before(from) && row.OccurredAt.Before(until)
+func meetingStillWorthPreparing(row crmcontracts.Activity) bool {
+	return row.MeetingStatus == nil || *row.MeetingStatus == crmcontracts.ActivityMeetingStatusBooked
 }
 
 // subjectOfMeeting is the line a meeting shows. Unlike a task, a meeting may

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,7 +24,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/briefs"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
-	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -33,7 +31,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // attentionApprovals reads the staged queue through the engine every approval
@@ -339,144 +336,6 @@ func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, e
 		})
 	}
 	return entries, nil
-}
-
-// attentionCommitments reads the acting rep's own promises through the people
-// store.
-//
-// A claim carries no assignee, so ownership rides the person it was made to:
-// the rep who holds the relationship is the one who made the promise in their
-// own captured conversation. A principal with no human behind it has no
-// promises of its own to keep, which is a refusal rather than an empty lane —
-// the feed omits and NAMES the lane instead of reporting a clear day.
-type attentionCommitments struct{ store *people.Store }
-
-func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int) ([]attention.Commitment, error) {
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID.IsZero() {
-		return nil, apperrors.ErrPermissionDenied
-	}
-	due, err := c.store.OpenCommitmentsDue(ctx, ids.From[ids.UserKind](actor.UserID), by, limit)
-	if err != nil {
-		return nil, err
-	}
-	promises := make([]attention.Commitment, 0, len(due))
-	for _, row := range due {
-		promises = append(promises, attention.Commitment{
-			ID:          row.ID,
-			PersonID:    row.PersonID.UUID,
-			Body:        row.Body,
-			Quote:       row.SourceQuote,
-			SourceLabel: row.SourceLabel,
-			OccurredAt:  row.OccurredAt,
-			DueAt:       row.DueAt,
-		})
-	}
-	return promises, nil
-}
-
-// attentionAtRisk reads the pipeline's own risk candidates at the morning
-// queue's shorter idle window.
-//
-// It calls quietDealLister, the SAME engine whats_slipping_this_week reads, so
-// there is one at-risk rule in the product and the two surfaces cannot come to
-// disagree about which deals are in trouble. Only the patience differs, and it
-// is named here rather than buried: a queue exists to warn, and the stalled
-// threshold is a status rather than a warning.
-type attentionAtRisk struct{ lister agents.SlippingLister }
-
-func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, error) {
-	candidates, err := a.lister(ctx)
-	if err != nil {
-		return nil, err
-	}
-	now := clockNow()
-	risky := make([]attention.RiskyDeal, 0, len(candidates))
-	for _, deal := range candidates {
-		risky = append(risky, attention.RiskyDeal{
-			DealID:            deal.DealID,
-			Name:              deal.Name,
-			QuietDays:         idleDaysOf(deal, now),
-			CloseOverdue:      deal.CloseOverdue,
-			ExpectedCloseDate: deal.ExpectedCloseDate,
-		})
-	}
-	return risky, nil
-}
-
-// idleDaysOf is how long the deal has been quiet, counted from the same base
-// the idle rule itself measures from: the last activity, or the deal's creation
-// when nothing has ever touched it.
-func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
-	since := deal.CreatedAt
-	if deal.LastActivityAt != nil {
-		since = *deal.LastActivityAt
-	}
-	days := int(now.Sub(since).Hours() / 24)
-	if days < 0 {
-		return 0
-	}
-	return days
-}
-
-// attentionMeetings reads today's remaining meetings through the activities
-// store — the same gated list every other activity surface reads.
-//
-// SCAN AND FILTER, like the task lane above and for the same reason: the store
-// cannot express "kind=meeting between two instants", so this reads wider and
-// narrows here. The same scan factor applies, because a day with a pile of
-// finished meetings would otherwise push the one still ahead off the page.
-type attentionMeetings struct{ store *activities.Store }
-
-func (m attentionMeetings) Today(
-	ctx context.Context, from, until time.Time, limit int,
-) ([]attention.Meeting, error) {
-	kind := string(crmcontracts.ActivityKindMeeting)
-	scan := limit * taskScanFactor
-	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{Kind: &kind, Limit: &scan})
-	if err != nil {
-		return nil, err
-	}
-	ahead := make([]attention.Meeting, 0, len(rows))
-	for _, row := range rows {
-		if !meetingStillWorthPreparing(row, from, until) {
-			continue
-		}
-		ahead = append(ahead, attention.Meeting{
-			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
-		})
-	}
-	// Soonest first: the lane is a countdown, and the store returns activities
-	// newest-first, which is the opposite order for a day still ahead.
-	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
-	if len(ahead) > limit {
-		ahead = ahead[:limit]
-	}
-	return ahead, nil
-}
-
-// meetingStillWorthPreparing keeps the meetings a rep can still do something
-// about: booked (not held, not cancelled, not a no-show) and starting between
-// now and the end of the day.
-//
-// A meeting with no status is treated as booked. Capture writes calendar events
-// without one, and dropping them would empty this lane on exactly the
-// installations whose calendars are connected.
-func meetingStillWorthPreparing(row crmcontracts.Activity, from, until time.Time) bool {
-	if row.MeetingStatus != nil && *row.MeetingStatus != crmcontracts.ActivityMeetingStatusBooked {
-		return false
-	}
-	return !row.OccurredAt.Before(from) && row.OccurredAt.Before(until)
-}
-
-// subjectOfMeeting is the line a meeting shows. Unlike a task, a meeting may
-// honestly have no subject — a calendar event with a blank title is a real
-// thing a provider hands over — so the fallback is a routine case here.
-func subjectOfMeeting(row crmcontracts.Activity) string {
-	if row.Subject != nil && *row.Subject != "" {
-		return *row.Subject
-	}
-	return "(untitled meeting)"
 }
 
 // newAttentionHandlers assembles the surface for the API role.

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -418,6 +419,66 @@ func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
 	return days
 }
 
+// attentionMeetings reads today's remaining meetings through the activities
+// store — the same gated list every other activity surface reads.
+//
+// SCAN AND FILTER, like the task lane above and for the same reason: the store
+// cannot express "kind=meeting between two instants", so this reads wider and
+// narrows here. The same scan factor applies, because a day with a pile of
+// finished meetings would otherwise push the one still ahead off the page.
+type attentionMeetings struct{ store *activities.Store }
+
+func (m attentionMeetings) Today(
+	ctx context.Context, from, until time.Time, limit int,
+) ([]attention.Meeting, error) {
+	kind := string(crmcontracts.ActivityKindMeeting)
+	scan := limit * taskScanFactor
+	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{Kind: &kind, Limit: &scan})
+	if err != nil {
+		return nil, err
+	}
+	ahead := make([]attention.Meeting, 0, len(rows))
+	for _, row := range rows {
+		if !meetingStillWorthPreparing(row, from, until) {
+			continue
+		}
+		ahead = append(ahead, attention.Meeting{
+			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
+		})
+	}
+	// Soonest first: the lane is a countdown, and the store returns activities
+	// newest-first, which is the opposite order for a day still ahead.
+	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
+	if len(ahead) > limit {
+		ahead = ahead[:limit]
+	}
+	return ahead, nil
+}
+
+// meetingStillWorthPreparing keeps the meetings a rep can still do something
+// about: booked (not held, not cancelled, not a no-show) and starting between
+// now and the end of the day.
+//
+// A meeting with no status is treated as booked. Capture writes calendar events
+// without one, and dropping them would empty this lane on exactly the
+// installations whose calendars are connected.
+func meetingStillWorthPreparing(row crmcontracts.Activity, from, until time.Time) bool {
+	if row.MeetingStatus != nil && *row.MeetingStatus != crmcontracts.ActivityMeetingStatusBooked {
+		return false
+	}
+	return !row.OccurredAt.Before(from) && row.OccurredAt.Before(until)
+}
+
+// subjectOfMeeting is the line a meeting shows. Unlike a task, a meeting may
+// honestly have no subject — a calendar event with a blank title is a real
+// thing a provider hands over — so the fallback is a routine case here.
+func subjectOfMeeting(row crmcontracts.Activity) string {
+	if row.Subject != nil && *row.Subject != "" {
+		return *row.Subject
+	}
+	return "(untitled meeting)"
+}
+
 // newAttentionHandlers assembles the surface for the API role.
 func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.Handlers {
 	db := InstallationDB(pool)
@@ -430,6 +491,7 @@ func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.
 		attentionBriefing{engine: briefs.NewBriefEngine(pool, people.NewStore(db)), now: now},
 		attentionCommitments{store: people.NewStore(db)},
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
+		attentionMeetings{store: activities.NewStore(db)},
 		now,
 	))
 }

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/briefs"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -372,6 +374,50 @@ func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int
 	return promises, nil
 }
 
+// attentionAtRisk reads the pipeline's own risk candidates at the morning
+// queue's shorter idle window.
+//
+// It calls quietDealLister, the SAME engine whats_slipping_this_week reads, so
+// there is one at-risk rule in the product and the two surfaces cannot come to
+// disagree about which deals are in trouble. Only the patience differs, and it
+// is named here rather than buried: a queue exists to warn, and the stalled
+// threshold is a status rather than a warning.
+type attentionAtRisk struct{ lister agents.SlippingLister }
+
+func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, error) {
+	candidates, err := a.lister(ctx)
+	if err != nil {
+		return nil, err
+	}
+	now := clockNow()
+	risky := make([]attention.RiskyDeal, 0, len(candidates))
+	for _, deal := range candidates {
+		risky = append(risky, attention.RiskyDeal{
+			DealID:            deal.DealID,
+			Name:              deal.Name,
+			QuietDays:         idleDaysOf(deal, now),
+			CloseOverdue:      deal.CloseOverdue,
+			ExpectedCloseDate: deal.ExpectedCloseDate,
+		})
+	}
+	return risky, nil
+}
+
+// idleDaysOf is how long the deal has been quiet, counted from the same base
+// the idle rule itself measures from: the last activity, or the deal's creation
+// when nothing has ever touched it.
+func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
+	since := deal.CreatedAt
+	if deal.LastActivityAt != nil {
+		since = *deal.LastActivityAt
+	}
+	days := int(now.Sub(since).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}
+
 // newAttentionHandlers assembles the surface for the API role.
 func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.Handlers {
 	db := InstallationDB(pool)
@@ -383,6 +429,7 @@ func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.
 		attentionReceipts{svc: svc},
 		attentionBriefing{engine: briefs.NewBriefEngine(pool, people.NewStore(db)), now: now},
 		attentionCommitments{store: people.NewStore(db)},
+		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
 		now,
 	))
 }

--- a/backend/internal/compose/meetinglane_integration_test.go
+++ b/backend/internal/compose/meetinglane_integration_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// Which meetings reach the day's page, against a real database.
+//
+// The seam reads wider than the lane and narrows in Go, so what it drops is
+// decided by code the unit lane can only assert against its own stub. These
+// pin it against rows the real writer produced: a held meeting is past
+// preparing, a cancelled one is not happening, and a meeting tomorrow is not
+// today's problem.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// bookMeeting logs one meeting through the real activity writer at a chosen
+// instant, optionally with a status.
+func bookMeeting(t *testing.T, e *integration.Env, subject string, at time.Time, status string) ids.UUID {
+	t.Helper()
+	in := activities.LogActivityInput{
+		Kind: "meeting", Subject: &subject, OccurredAt: &at, Source: "manual",
+	}
+	if status != "" {
+		in.MeetingStatus = &status
+	}
+	row, _, err := e.Activities.LogActivity(e.Admin(), in)
+	if err != nil {
+		t.Fatalf("booking %q: %v", subject, err)
+	}
+	return ids.UUID(row.Id)
+}
+
+func meetingSubjects(t *testing.T, e *integration.Env, now time.Time) []string {
+	t.Helper()
+	lane := attentionMeetings{store: activities.NewStore(InstallationDB(e.Pool))}
+	endOfDay := now.Truncate(24 * time.Hour).Add(24 * time.Hour)
+	rows, err := lane.Today(e.Admin(), now, endOfDay, 12)
+	if err != nil {
+		t.Fatalf("reading the meeting lane: %v", err)
+	}
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Subject)
+	}
+	return out
+}
+
+// Only the meetings still ahead today, soonest first. A meeting already begun
+// cannot be prepared for; one tomorrow is not today's page.
+func TestTheMeetingLaneCarriesOnlyWhatIsStillAheadToday(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	bookMeeting(t, e, "Started an hour ago", now.Add(-1*time.Hour), "")
+	bookMeeting(t, e, "This afternoon", now.Add(4*time.Hour), "")
+	bookMeeting(t, e, "In an hour", now.Add(1*time.Hour), "")
+	bookMeeting(t, e, "Tomorrow morning", now.Add(26*time.Hour), "")
+
+	got := meetingSubjects(t, e, now)
+	if len(got) != 2 {
+		t.Fatalf("the lane = %v, want the two meetings still ahead today", got)
+	}
+	if got[0] != "In an hour" || got[1] != "This afternoon" {
+		t.Errorf("the lane = %v, want soonest first", got)
+	}
+}
+
+// A meeting that has been held, cancelled or no-showed is past preparing. The
+// lane must not ask for work that cannot be done.
+func TestAFinishedOrCancelledMeetingLeavesTheLane(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	bookMeeting(t, e, "Still booked", now.Add(2*time.Hour), "booked")
+	bookMeeting(t, e, "Already held", now.Add(3*time.Hour), "held")
+	bookMeeting(t, e, "Called off", now.Add(4*time.Hour), "canceled")
+	bookMeeting(t, e, "Nobody came", now.Add(5*time.Hour), "no_show")
+
+	got := meetingSubjects(t, e, now)
+	if len(got) != 1 || got[0] != "Still booked" {
+		t.Fatalf("the lane = %v, want only the meeting still worth preparing for", got)
+	}
+}
+
+// A calendar event with no status is treated as booked. Capture writes them
+// that way, so dropping them would empty this lane on exactly the installations
+// whose calendars are connected — the failure nobody would report as a bug.
+func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	bookMeeting(t, e, "From the calendar", now.Add(2*time.Hour), "")
+
+	got := meetingSubjects(t, e, now)
+	if len(got) != 1 || got[0] != "From the calendar" {
+		t.Fatalf("the lane = %v, want the unstatused calendar event", got)
+	}
+}

--- a/backend/internal/compose/meetinglane_integration_test.go
+++ b/backend/internal/compose/meetinglane_integration_test.go
@@ -14,6 +14,7 @@ package compose
 // today's problem.
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -100,5 +101,28 @@ func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
 	got := meetingSubjects(t, e, now)
 	if len(got) != 1 || got[0] != "From the calendar" {
 		t.Fatalf("the lane = %v, want the unstatused calendar event", got)
+	}
+}
+
+// The scan reads newest-first and the lane reads forward, so a workspace with a
+// long history of past meetings must not push today's off the page.
+//
+// This is the shape of failure the bounded scan can hide: the lane would draw a
+// free day over a day with meetings in it, and nobody would report it, because
+// an empty calendar lane looks exactly like an empty calendar. Ordering makes it
+// safe here — occurred_at DESC puts a future meeting above every past one — and
+// this pins that rather than leaving it as a property nobody checked.
+func TestAPileOfPastMeetingsDoesNotPushTodaysOffTheLane(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	// Comfortably more than the lane's scan (12 * taskScanFactor).
+	for day := 1; day <= 130; day++ {
+		bookMeeting(t, e, fmt.Sprintf("Long ago %d", day), now.AddDate(0, 0, -day), "held")
+	}
+	bookMeeting(t, e, "This afternoon", now.Add(3*time.Hour), "booked")
+
+	got := meetingSubjects(t, e, now)
+	if len(got) != 1 || got[0] != "This afternoon" {
+		t.Fatalf("the lane = %v, want today's meeting despite 130 older ones", got)
 	}
 }

--- a/backend/internal/compose/meetinglane_integration_test.go
+++ b/backend/internal/compose/meetinglane_integration_test.go
@@ -104,6 +104,30 @@ func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
 	}
 }
 
+// A day with more LATER meetings than the lane's own bound must still show the
+// soonest ones. This is the case a Go-side time filter got wrong: it read a
+// fixed multiple of the lane and narrowed afterwards, so a busy calendar pushed
+// the sooner meetings off the scan and the lane drew a free afternoon over a
+// booked one. The window is the database's now, so the bound is the day.
+func TestABusyCalendarStillShowsTheSoonestMeetings(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC().Truncate(time.Hour).Add(6 * time.Hour)
+	// Far more later-today meetings than the lane carries, booked out of order
+	// so the answer cannot come from insertion order.
+	for hour := 17; hour >= 8; hour-- {
+		bookMeeting(t, e, fmt.Sprintf("At %02d:00", hour), now.Truncate(24*time.Hour).Add(time.Duration(hour)*time.Hour), "booked")
+	}
+
+	got := meetingSubjects(t, e, now)
+	if len(got) == 0 {
+		t.Fatal("the lane is empty on a day full of booked meetings")
+	}
+	// Whatever the bound, the FIRST one must be the soonest still ahead.
+	if got[0] != "At 08:00" {
+		t.Errorf("the lane leads with %q, want the soonest meeting still ahead", got[0])
+	}
+}
+
 // The scan reads newest-first and the lane reads forward, so a workspace with a
 // long history of past meetings must not push today's off the page.
 //

--- a/backend/internal/compose/quietdeallister_integration_test.go
+++ b/backend/internal/compose/quietdeallister_integration_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The pipeline-risk candidate set at two idle windows, against a real database.
+//
+// The window is SQL (deals.QuietSQL) and the admission decision is Go, and the
+// two can disagree silently: the deal row carries a `stalled` flag computed at
+// the product-wide 60-day threshold, so a filter that consults that flag drops
+// every row a shorter window was written to find. The lane then fetches exactly
+// the right deals and shows none of them, which reads on screen as a quiet
+// pipeline rather than as a bug.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// idleFor backdates a deal's activity clock so the idle window has something to
+// measure. The columns are the ones deals.QuietSQL reads; the create path stamps
+// them at now, and no writer offers a past value.
+func idleFor(t *testing.T, e *integration.Env, deal ids.UUID, days int) {
+	t.Helper()
+	e.WsExec(t, `UPDATE deal SET created_at = now() - make_interval(days => $2),
+		last_activity_at = now() - make_interval(days => $2) WHERE id = $1`, deal, days)
+}
+
+func namesOf(rows []agents.SlippingDeal) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Name)
+	}
+	return out
+}
+
+// A deal quiet three weeks reaches the short window and not the stalled one.
+// This is the whole point of the second threshold, and it is the case the
+// stalled flag cannot express.
+func TestAShortWindowFindsADealTheStalledThresholdCannotSeeYet(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, stage, _ := integration.DealFixture(t, e)
+	quiet := e.SeedDeal(t, "Quiet three weeks", pipeline, stage, &e.AdminUser)
+	fresh := e.SeedDeal(t, "Touched yesterday", pipeline, stage, &e.AdminUser)
+	idleFor(t, e, quiet, 21)
+	idleFor(t, e, fresh, 1)
+
+	short := quietDealLister(e.Pool, deals.QuietThresholdDays)
+	got, err := short(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the short window: %v", err)
+	}
+	if names := namesOf(got); len(names) != 1 || names[0] != "Quiet three weeks" {
+		t.Fatalf("the short window = %v, want only the deal quiet three weeks", names)
+	}
+
+	// The same deal, asked with the product-wide patience, is not yet slipping.
+	stalledWindow := quietDealLister(e.Pool, deals.StalledThresholdDays)
+	got, err = stalledWindow(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the stalled window: %v", err)
+	}
+	if names := namesOf(got); len(names) != 0 {
+		t.Fatalf("the stalled window = %v, want nothing at 21 days idle", names)
+	}
+}
+
+// A deal past the stalled threshold reaches BOTH windows. Without this the test
+// above passes just as well against a lister that returns nothing at all.
+func TestALongIdleDealReachesBothWindows(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, stage, _ := integration.DealFixture(t, e)
+	old := e.SeedDeal(t, "Quiet since spring", pipeline, stage, &e.AdminUser)
+	idleFor(t, e, old, 90)
+
+	for _, window := range []int{deals.QuietThresholdDays, deals.StalledThresholdDays} {
+		got, err := quietDealLister(e.Pool, window)(e.Admin())
+		if err != nil {
+			t.Fatalf("reading the %d-day window: %v", window, err)
+		}
+		if names := namesOf(got); len(names) != 1 || names[0] != "Quiet since spring" {
+			t.Errorf("the %d-day window = %v, want the deal quiet since spring", window, names)
+		}
+	}
+}
+
+// An overdue close date admits a deal at ANY window, including one it is far too
+// fresh for on the idle clock alone. That arm is independent of the threshold
+// and must not be lost when the window narrows.
+func TestAnOverdueCloseDateAdmitsADealThatIsNotQuietAtAll(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, stage, _ := integration.DealFixture(t, e)
+	late := e.SeedDeal(t, "Closing last month", pipeline, stage, &e.AdminUser)
+	idleFor(t, e, late, 1)
+	e.WsExec(t, `UPDATE deal SET expected_close_date = (now() - interval '30 days')::date
+		WHERE id = $1`, late)
+
+	got, err := quietDealLister(e.Pool, deals.QuietThresholdDays)(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the short window: %v", err)
+	}
+	if names := namesOf(got); len(names) != 1 || names[0] != "Closing last month" {
+		t.Fatalf("the window = %v, want the deal whose close date has passed", names)
+	}
+	if !got[0].CloseOverdue {
+		t.Error("the deal is admitted but not flagged close-overdue, so the card cannot say why")
+	}
+}
+
+// A won deal never slips, at any window. The suppression lives in the shared
+// rule rather than in each caller, and narrowing the window must not lose it.
+func TestAClosedDealNeverSlipsAtEitherWindow(t *testing.T) {
+	e := integration.Setup(t)
+	pipeline, stage, _ := integration.DealFixture(t, e)
+	won := e.SeedDeal(t, "Won in spring", pipeline, stage, &e.AdminUser)
+	idleFor(t, e, won, 200)
+	// closed_at travels with the status: deal_closed_at refuses a won deal that
+	// does not say when it closed, which is the constraint doing its job.
+	e.WsExec(t, `UPDATE deal SET status = 'won', closed_at = now() WHERE id = $1`, won)
+
+	for _, window := range []int{deals.QuietThresholdDays, deals.StalledThresholdDays} {
+		got, err := quietDealLister(e.Pool, window)(e.Admin())
+		if err != nil {
+			t.Fatalf("reading the %d-day window: %v", window, err)
+		}
+		if names := namesOf(got); len(names) != 0 {
+			t.Errorf("the %d-day window = %v, want a won deal to slip at neither", window, names)
+		}
+	}
+}

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -34,11 +34,27 @@ const slippingScanLimit = 50
 // slippingLister serves the formulas-§8 candidate set: stalled open
 // deals plus open deals whose expected close date is already past.
 func slippingLister(pool *pgxpool.Pool) agents.SlippingLister {
+	return quietDealLister(pool, deals.StalledThresholdDays)
+}
+
+// quietDealLister is slippingLister with the idle window named by the caller.
+//
+// ONE candidate set, two patiences. The tool surface asks at the stalled
+// threshold, because "slipping" is the product-wide status; the morning queue
+// asks at the shorter window, because a queue that only speaks after two months
+// is reporting rather than warning. Both run this function, so a change to how
+// a candidate is built or evidenced reaches both — a second at-risk predicate
+// beside this one is the failure this shape exists to prevent.
+//
+// Deals whose expected close date has passed join the set at ANY window: an
+// overdue close is late whatever the idle clock says.
+func quietDealLister(pool *pgxpool.Pool, quietForDays int) agents.SlippingLister {
 	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
 		limit := slippingScanLimit
-		stalledOnly := true
-		stalled, _, err := store.ListDeals(ctx, deals.ListDealsInput{Stalled: &stalledOnly, Limit: &limit})
+		quiet, _, err := store.ListDeals(ctx, deals.ListDealsInput{
+			QuietForDays: &quietForDays, Limit: &limit,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -48,13 +64,25 @@ func slippingLister(pool *pgxpool.Pool) agents.SlippingLister {
 			return nil, err
 		}
 
+		// The quiet sweep already applied the window, so its rows are admitted
+		// on that ground alone. Testing candidate.Stalled instead would ask the
+		// deal row's own 60-day flag, which is FALSE for every deal a shorter
+		// window admits — the lane would fetch the right rows and drop them all.
+		admitted := map[ids.UUID]bool{}
+		for _, d := range quiet {
+			admitted[ids.UUID(d.Id)] = true
+		}
+
 		now := time.Now().UTC()
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-		out := make([]agents.SlippingDeal, 0, len(stalled))
+		out := make([]agents.SlippingDeal, 0, len(quiet))
 		seen := map[ids.UUID]bool{}
-		for _, d := range append(stalled, open...) {
+		for _, d := range append(quiet, open...) {
 			candidate := slippingCandidate(d, today)
-			if seen[candidate.DealID] || (!candidate.Stalled && !candidate.CloseOverdue) {
+			if seen[candidate.DealID] {
+				continue
+			}
+			if !admitted[candidate.DealID] && !candidate.CloseOverdue {
 				continue
 			}
 			seen[candidate.DealID] = true

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1227,6 +1227,7 @@ const (
 	AttentionLanesOmittedAtRisk      AttentionLanesOmitted = "at_risk"
 	AttentionLanesOmittedCommitments AttentionLanesOmitted = "commitments"
 	AttentionLanesOmittedDoneForYou  AttentionLanesOmitted = "done_for_you"
+	AttentionLanesOmittedMeetings    AttentionLanesOmitted = "meetings"
 	AttentionLanesOmittedNeedsYou    AttentionLanesOmitted = "needs_you"
 	AttentionLanesOmittedPlanned     AttentionLanesOmitted = "planned"
 	AttentionLanesOmittedThisMorning AttentionLanesOmitted = "this_morning"
@@ -1240,6 +1241,8 @@ func (e AttentionLanesOmitted) Valid() bool {
 	case AttentionLanesOmittedCommitments:
 		return true
 	case AttentionLanesOmittedDoneForYou:
+		return true
+	case AttentionLanesOmittedMeetings:
 		return true
 	case AttentionLanesOmittedNeedsYou:
 		return true
@@ -1295,6 +1298,7 @@ const (
 	AttentionItemSourceConversationClaim AttentionItemSource = "conversation_claim"
 	AttentionItemSourceDealAtRisk        AttentionItemSource = "deal_at_risk"
 	AttentionItemSourceDedupeCandidate   AttentionItemSource = "dedupe_candidate"
+	AttentionItemSourceMeeting           AttentionItemSource = "meeting"
 	AttentionItemSourceTask              AttentionItemSource = "task"
 )
 
@@ -1310,6 +1314,8 @@ func (e AttentionItemSource) Valid() bool {
 	case AttentionItemSourceDealAtRisk:
 		return true
 	case AttentionItemSourceDedupeCandidate:
+		return true
+	case AttentionItemSourceMeeting:
 		return true
 	case AttentionItemSourceTask:
 		return true
@@ -10542,22 +10548,22 @@ func (e VoiceProfileVersionStatus) Valid() bool {
 
 // Defines values for WebhookDeliveryStatus.
 const (
-	WebhookDeliveryStatusDeadLettered WebhookDeliveryStatus = "dead_lettered"
-	WebhookDeliveryStatusDelivered    WebhookDeliveryStatus = "delivered"
-	WebhookDeliveryStatusPending      WebhookDeliveryStatus = "pending"
-	WebhookDeliveryStatusRetrying     WebhookDeliveryStatus = "retrying"
+	DeadLettered WebhookDeliveryStatus = "dead_lettered"
+	Delivered    WebhookDeliveryStatus = "delivered"
+	Pending      WebhookDeliveryStatus = "pending"
+	Retrying     WebhookDeliveryStatus = "retrying"
 )
 
 // Valid indicates whether the value is a known member of the WebhookDeliveryStatus enum.
 func (e WebhookDeliveryStatus) Valid() bool {
 	switch e {
-	case WebhookDeliveryStatusDeadLettered:
+	case DeadLettered:
 		return true
-	case WebhookDeliveryStatusDelivered:
+	case Delivered:
 		return true
-	case WebhookDeliveryStatusPending:
+	case Pending:
 		return true
-	case WebhookDeliveryStatusRetrying:
+	case Retrying:
 		return true
 	default:
 		return false
@@ -11382,31 +11388,31 @@ func (e ListOrganizationsParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListOrganizationsParamsLifecycle.
 const (
-	Customer       ListOrganizationsParamsLifecycle = "customer"
-	Disqualified   ListOrganizationsParamsLifecycle = "disqualified"
-	FormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
-	Opportunity    ListOrganizationsParamsLifecycle = "opportunity"
-	Prospect       ListOrganizationsParamsLifecycle = "prospect"
-	Target         ListOrganizationsParamsLifecycle = "target"
-	Unknown        ListOrganizationsParamsLifecycle = "unknown"
+	ListOrganizationsParamsLifecycleCustomer       ListOrganizationsParamsLifecycle = "customer"
+	ListOrganizationsParamsLifecycleDisqualified   ListOrganizationsParamsLifecycle = "disqualified"
+	ListOrganizationsParamsLifecycleFormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
+	ListOrganizationsParamsLifecycleOpportunity    ListOrganizationsParamsLifecycle = "opportunity"
+	ListOrganizationsParamsLifecycleProspect       ListOrganizationsParamsLifecycle = "prospect"
+	ListOrganizationsParamsLifecycleTarget         ListOrganizationsParamsLifecycle = "target"
+	ListOrganizationsParamsLifecycleUnknown        ListOrganizationsParamsLifecycle = "unknown"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationsParamsLifecycle enum.
 func (e ListOrganizationsParamsLifecycle) Valid() bool {
 	switch e {
-	case Customer:
+	case ListOrganizationsParamsLifecycleCustomer:
 		return true
-	case Disqualified:
+	case ListOrganizationsParamsLifecycleDisqualified:
 		return true
-	case FormerCustomer:
+	case ListOrganizationsParamsLifecycleFormerCustomer:
 		return true
-	case Opportunity:
+	case ListOrganizationsParamsLifecycleOpportunity:
 		return true
-	case Prospect:
+	case ListOrganizationsParamsLifecycleProspect:
 		return true
-	case Target:
+	case ListOrganizationsParamsLifecycleTarget:
 		return true
-	case Unknown:
+	case ListOrganizationsParamsLifecycleUnknown:
 		return true
 	default:
 		return false
@@ -13069,6 +13075,16 @@ type Attention struct {
 	// Absent when there is nothing to lead with, which is itself the honest answer.
 	Lead *string `json:"lead,omitempty"`
 
+	// Meetings Today's booked meetings that have not happened yet, soonest first — the ones
+	// still worth preparing for.
+	//
+	// A meeting already held or cancelled is not on this lane: preparing for it is
+	// no longer possible, and a queue that listed it would be asking for work that
+	// cannot be done. `due_at` is when it starts.
+	//
+	// Absent — not empty — on an installation whose feed does not read meetings.
+	Meetings *[]AttentionItem `json:"meetings,omitempty"`
+
 	// NeedsYou Decisions only a person can make, highest-stakes first.
 	NeedsYou []AttentionItem `json:"needs_you"`
 
@@ -13101,8 +13117,11 @@ type AttentionCounts struct {
 
 	// DuplicatesOpen Open duplicate pairs both of whose sides this caller can see.
 	DuplicatesOpen *int `json:"duplicates_open,omitempty"`
-	NeedsYou       int  `json:"needs_you"`
-	Planned        int  `json:"planned"`
+
+	// Meetings How many of today's meetings are still ahead — the bounded page, as the other lanes report.
+	Meetings *int `json:"meetings,omitempty"`
+	NeedsYou int  `json:"needs_you"`
+	Planned  int  `json:"planned"`
 
 	// ThisMorning Briefing items still unanswered in the rep's run for today.
 	ThisMorning int `json:"this_morning"`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1224,6 +1224,7 @@ func (e AttachmentReadStartedStatus) Valid() bool {
 
 // Defines values for AttentionLanesOmitted.
 const (
+	AttentionLanesOmittedAtRisk      AttentionLanesOmitted = "at_risk"
 	AttentionLanesOmittedCommitments AttentionLanesOmitted = "commitments"
 	AttentionLanesOmittedDoneForYou  AttentionLanesOmitted = "done_for_you"
 	AttentionLanesOmittedNeedsYou    AttentionLanesOmitted = "needs_you"
@@ -1234,6 +1235,8 @@ const (
 // Valid indicates whether the value is a known member of the AttentionLanesOmitted enum.
 func (e AttentionLanesOmitted) Valid() bool {
 	switch e {
+	case AttentionLanesOmittedAtRisk:
+		return true
 	case AttentionLanesOmittedCommitments:
 		return true
 	case AttentionLanesOmittedDoneForYou:
@@ -1290,6 +1293,7 @@ const (
 	AttentionItemSourceApproval          AttentionItemSource = "approval"
 	AttentionItemSourceBriefItem         AttentionItemSource = "brief_item"
 	AttentionItemSourceConversationClaim AttentionItemSource = "conversation_claim"
+	AttentionItemSourceDealAtRisk        AttentionItemSource = "deal_at_risk"
 	AttentionItemSourceDedupeCandidate   AttentionItemSource = "dedupe_candidate"
 	AttentionItemSourceTask              AttentionItemSource = "task"
 )
@@ -1302,6 +1306,8 @@ func (e AttentionItemSource) Valid() bool {
 	case AttentionItemSourceBriefItem:
 		return true
 	case AttentionItemSourceConversationClaim:
+		return true
+	case AttentionItemSourceDealAtRisk:
 		return true
 	case AttentionItemSourceDedupeCandidate:
 		return true
@@ -10149,16 +10155,16 @@ func (e VoiceBuildStatusCode) Valid() bool {
 
 // Defines values for VoiceCorpusPreviewRequestFormat.
 const (
-	Text       VoiceCorpusPreviewRequestFormat = "text"
-	Transcript VoiceCorpusPreviewRequestFormat = "transcript"
+	VoiceCorpusPreviewRequestFormatText       VoiceCorpusPreviewRequestFormat = "text"
+	VoiceCorpusPreviewRequestFormatTranscript VoiceCorpusPreviewRequestFormat = "transcript"
 )
 
 // Valid indicates whether the value is a known member of the VoiceCorpusPreviewRequestFormat enum.
 func (e VoiceCorpusPreviewRequestFormat) Valid() bool {
 	switch e {
-	case Text:
+	case VoiceCorpusPreviewRequestFormatText:
 		return true
-	case Transcript:
+	case VoiceCorpusPreviewRequestFormatTranscript:
 		return true
 	default:
 		return false
@@ -13026,6 +13032,17 @@ type Attention struct {
 	// AsOf The instant every lane below was read at.
 	AsOf time.Time `json:"as_of"`
 
+	// AtRisk Open deals going quiet, or whose expected close date has already passed — the
+	// ones most likely to be lost by inattention rather than by a decision.
+	//
+	// The idle window here is DELIBERATELY shorter than the product-wide `stalled`
+	// threshold: a queue that only speaks once a deal meets the stalled bar is
+	// reporting a two-month-old fact rather than warning. `detail` names the window
+	// actually used, so the card never implies a patience the server did not apply.
+	//
+	// Absent — not empty — on an installation whose feed does not read deals.
+	AtRisk *[]AttentionItem `json:"at_risk,omitempty"`
+
 	// Commitments Promises this rep made that are coming due, most overdue first — each with the
 	// message it was read from, so the reader can check it against what was written.
 	//
@@ -13076,6 +13093,9 @@ type AttentionLanesOmitted string
 // queue's own count under its both-sides-visible rule, kept separate because the
 // lane shows a bounded slice of it.
 type AttentionCounts struct {
+	// AtRisk How many at-risk deals this lane is CARRYING, the bounded page rather than every deal at risk — the same bound the other lanes report under.
+	AtRisk *int `json:"at_risk,omitempty"`
+
 	// Commitments How many promises this lane is CARRYING, which is the bounded page rather than every promise due — the same bound `planned` reports under. A rep past the bound sees the soonest-due ones, which is the order the lane is in.
 	Commitments *int `json:"commitments,omitempty"`
 

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -77,7 +77,12 @@ type ListDealsInput struct {
 	PartnerAttribution *string
 	Status             *string
 	Stalled            *bool
-	IncludeArchived    bool
+	// QuietForDays narrows to open deals idle at least this long, which is the
+	// stalled rule at a caller-named window (QuietSQL). Separate from Stalled
+	// because they answer different questions: Stalled is the product-wide
+	// status, this is "notice it earlier". Set both and both apply.
+	QuietForDays    *int
+	IncludeArchived bool
 	// Sort is the contract's sort spec, validated against the core
 	// vocabulary below plus the workspace's active cf_ columns.
 	Sort *string
@@ -240,6 +245,9 @@ func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, a
 		} else {
 			where = append(where, "NOT "+StalledSQL(""))
 		}
+	}
+	if in.QuietForDays != nil {
+		where = append(where, QuietSQL("", *in.QuietForDays))
 	}
 	return where, nil
 }

--- a/backend/internal/modules/deals/formulas.go
+++ b/backend/internal/modules/deals/formulas.go
@@ -18,17 +18,36 @@ import (
 )
 
 // StalledThresholdDays is the §8 tunable: open deals idle longer than
-// this are stalled unless a wait suppresses it.
+// this are stalled unless a wait suppresses it. It is the answer to "has this
+// deal stalled" — a status the whole product agrees on.
 const StalledThresholdDays = 60
+
+// QuietThresholdDays is a shorter idle window for surfaces that want to notice
+// a deal going quiet BEFORE it meets the stalled bar — a morning queue nudging
+// a rep at three weeks rather than reporting a two-month-old fact.
+//
+// It is a second THRESHOLD, never a second predicate: IsQuietFor and QuietSQL
+// below take the window as an argument and the one rule is spelled once. A
+// surface asking at this window is asking the same question with a different
+// patience, which is why the copy beside it must name the window it used —
+// "quiet 19 days" and "stalled" are different claims about the same deal.
+const QuietThresholdDays = 19
 
 // IsStalled evaluates §8.1 at one instant. Idle is an absolute-duration
 // comparison on UTC instants, never a calendar-day count — stable under
 // a fixed test clock, identical across zones.
 func IsStalled(status string, createdAt time.Time, lastActivityAt, waitUntil *time.Time, now time.Time) bool {
+	return IsQuietFor(StalledThresholdDays, status, createdAt, lastActivityAt, waitUntil, now)
+}
+
+// IsQuietFor is IsStalled with the idle window named by the caller. Every rule
+// bar the number is identical, so the two cannot drift: a closed deal is never
+// quiet, an explicit deferral suppresses it, and idle is measured the same way.
+func IsQuietFor(days int, status string, createdAt time.Time, lastActivityAt, waitUntil *time.Time, now time.Time) bool {
 	if DealStatus(status) != DealOpen {
 		return false // closed deals never stall
 	}
-	if now.Sub(idlebase.Since(createdAt, lastActivityAt)) <= StalledThresholdDays*24*time.Hour {
+	if now.Sub(idlebase.Since(createdAt, lastActivityAt)) <= time.Duration(days)*24*time.Hour {
 		return false
 	}
 	if waitUntil != nil && now.Before(*waitUntil) {
@@ -46,10 +65,19 @@ func IsStalled(status string, createdAt time.Time, lastActivityAt, waitUntil *ti
 // is ambiguous SQL, not merely wrong. One spelling, parameterized, rather
 // than a second copy that only agrees by accident.
 func StalledSQL(alias string) string {
+	return QuietSQL(alias, StalledThresholdDays)
+}
+
+// QuietSQL is StalledSQL with the idle window named by the caller — the SQL
+// half of IsQuietFor, and the same one-spelling rule. The window is an int
+// formatted into an interval literal rather than a bound parameter because
+// this expression is composed into larger statements whose placeholders are
+// numbered by their own callers; an int is not attacker-reachable.
+func QuietSQL(alias string, days int) string {
 	return fmt.Sprintf(`(%[1]sstatus = 'open'
 		AND %[3]s < now() - interval '%[2]d days'
 		AND (%[1]swait_until IS NULL OR %[1]swait_until <= now()))`,
-		columnPrefix(alias), StalledThresholdDays, idlebase.SQL(alias))
+		columnPrefix(alias), days, idlebase.SQL(alias))
 }
 
 // PartnerSourcedSQL is the list-filter spelling of "this deal is

--- a/backend/internal/modules/deals/formulas_test.go
+++ b/backend/internal/modules/deals/formulas_test.go
@@ -40,3 +40,43 @@ func TestIsStalled(t *testing.T) {
 		}
 	}
 }
+
+// The shorter window answers the same question with less patience. A deal quiet
+// three weeks is not stalled, and the two claims must not be able to disagree
+// about anything except the number — which is why the stalled spelling is the
+// quiet one at its own threshold rather than a second rule.
+func TestIsQuietForIsTheSameRuleAtADifferentWindow(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	at := func(daysAgo int) *time.Time {
+		v := now.AddDate(0, 0, -daysAgo)
+		return &v
+	}
+	created := now.AddDate(0, 0, -90)
+
+	// Twenty days idle: quiet at the shorter window, not yet stalled.
+	if !IsQuietFor(QuietThresholdDays, "open", created, at(20), nil, now) {
+		t.Error("a deal idle 20 days is not quiet at the 19-day window, want quiet")
+	}
+	if IsStalled("open", created, at(20), nil, now) {
+		t.Error("a deal idle 20 days reads as stalled, want not stalled")
+	}
+
+	// Every suppression the stalled rule keeps, the shorter window keeps too.
+	if IsQuietFor(QuietThresholdDays, "won", created, at(300), nil, now) {
+		t.Error("a closed deal reads as quiet, want never")
+	}
+	if IsQuietFor(QuietThresholdDays, "open", created, at(80), at(-10), now) {
+		t.Error("an active wait failed to suppress quiet, want suppressed")
+	}
+
+	// The stalled spelling IS the quiet one at its own threshold. Asserted over
+	// the same table the rule is specified by, so a change to either that made
+	// them disagree fails here rather than in whichever surface noticed first.
+	for _, idle := range []int{0, 5, 18, 19, 20, 59, 60, 61, 200} {
+		if got, want := IsQuietFor(StalledThresholdDays, "open", created, at(idle), nil, now),
+			IsStalled("open", created, at(idle), nil, now); got != want {
+			t.Errorf("idle %dd: IsQuietFor(stalled window) = %v, IsStalled = %v — one rule, two answers",
+				idle, got, want)
+		}
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21482,10 +21482,22 @@ export interface components {
              *     Absent — not empty — on an installation whose feed does not read claims.
              */
             commitments?: components["schemas"]["AttentionItem"][];
+            /**
+             * @description Open deals going quiet, or whose expected close date has already passed — the
+             *     ones most likely to be lost by inattention rather than by a decision.
+             *
+             *     The idle window here is DELIBERATELY shorter than the product-wide `stalled`
+             *     threshold: a queue that only speaks once a deal meets the stalled bar is
+             *     reporting a two-month-old fact rather than warning. `detail` names the window
+             *     actually used, so the card never implies a patience the server did not apply.
+             *
+             *     Absent — not empty — on an installation whose feed does not read deals.
+             */
+            at_risk?: components["schemas"]["AttentionItem"][];
             /** @description What the system did on its own, most recent first. Receipts, not questions. */
             done_for_you: components["schemas"]["AttentionItem"][];
             /** @description Lanes withheld because the caller may not read what they contain. Never returned empty instead. */
-            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments")[];
+            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk")[];
             counts: components["schemas"]["AttentionCounts"];
         };
         /**
@@ -21500,6 +21512,8 @@ export interface components {
             planned: number;
             /** @description Open duplicate pairs both of whose sides this caller can see. */
             duplicates_open?: number;
+            /** @description How many at-risk deals this lane is CARRYING, the bounded page rather than every deal at risk — the same bound the other lanes report under. */
+            at_risk?: number;
             /** @description How many promises this lane is CARRYING, which is the bounded page rather than every promise due — the same bound `planned` reports under. A rep past the bound sees the soonest-due ones, which is the order the lane is in. */
             commitments?: number;
         };
@@ -21516,7 +21530,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk";
             /** @description The producer's own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority. */
             kind?: string;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21483,6 +21483,17 @@ export interface components {
              */
             commitments?: components["schemas"]["AttentionItem"][];
             /**
+             * @description Today's booked meetings that have not happened yet, soonest first — the ones
+             *     still worth preparing for.
+             *
+             *     A meeting already held or cancelled is not on this lane: preparing for it is
+             *     no longer possible, and a queue that listed it would be asking for work that
+             *     cannot be done. `due_at` is when it starts.
+             *
+             *     Absent — not empty — on an installation whose feed does not read meetings.
+             */
+            meetings?: components["schemas"]["AttentionItem"][];
+            /**
              * @description Open deals going quiet, or whose expected close date has already passed — the
              *     ones most likely to be lost by inattention rather than by a decision.
              *
@@ -21497,7 +21508,7 @@ export interface components {
             /** @description What the system did on its own, most recent first. Receipts, not questions. */
             done_for_you: components["schemas"]["AttentionItem"][];
             /** @description Lanes withheld because the caller may not read what they contain. Never returned empty instead. */
-            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk")[];
+            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk" | "meetings")[];
             counts: components["schemas"]["AttentionCounts"];
         };
         /**
@@ -21512,6 +21523,8 @@ export interface components {
             planned: number;
             /** @description Open duplicate pairs both of whose sides this caller can see. */
             duplicates_open?: number;
+            /** @description How many of today's meetings are still ahead — the bounded page, as the other lanes report. */
+            meetings?: number;
             /** @description How many at-risk deals this lane is CARRYING, the bounded page rather than every deal at risk — the same bound the other lanes report under. */
             at_risk?: number;
             /** @description How many promises this lane is CARRYING, which is the bounded page rather than every promise due — the same bound `planned` reports under. A rep past the bound sees the soonest-due ones, which is the order the lane is in. */
@@ -21530,7 +21543,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting";
             /** @description The producer's own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority. */
             kind?: string;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -77,6 +77,7 @@ export const de = {
   "day.lead.decisions": "{count} Entscheidungen warten auf dich.",
   "day.lead.plannedOnly": "Nichts zu entscheiden — {count} für heute geplant.",
   "day.lead.promises": "Du hast {count} zugesagt — das geht vor.",
+  "day.lead.meetings": "{count} heute im Kalender.",
   "day.lead.atRisk": "{count} werden still. Sonst wartet nichts auf dich.",
   "day.lead.morningOnly":
     "Nichts wartet auf dich — die Nacht hat {count} zum Anfangen herausgesucht.",
@@ -90,6 +91,8 @@ export const de = {
   "day.lane.withheld": "Für dein Konto nicht sichtbar.",
   "day.needsYou": "Wartet auf dich",
   "day.needsYou.empty": "Nichts zu entscheiden.",
+  "day.meetings": "Termine heute",
+  "day.meetings.empty": "Nichts im Kalender.",
   "day.atRisk": "Wird still",
   "day.atRisk.empty": "Kein Deal driftet ab.",
   "day.risk.quiet": "Seit {days} Tagen kein Kontakt.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -77,6 +77,7 @@ export const de = {
   "day.lead.decisions": "{count} Entscheidungen warten auf dich.",
   "day.lead.plannedOnly": "Nichts zu entscheiden — {count} für heute geplant.",
   "day.lead.promises": "Du hast {count} zugesagt — das geht vor.",
+  "day.lead.atRisk": "{count} werden still. Sonst wartet nichts auf dich.",
   "day.lead.morningOnly":
     "Nichts wartet auf dich — die Nacht hat {count} zum Anfangen herausgesucht.",
   "day.lead.ranOvernight":
@@ -89,6 +90,10 @@ export const de = {
   "day.lane.withheld": "Für dein Konto nicht sichtbar.",
   "day.needsYou": "Wartet auf dich",
   "day.needsYou.empty": "Nichts zu entscheiden.",
+  "day.atRisk": "Wird still",
+  "day.atRisk.empty": "Kein Deal driftet ab.",
+  "day.risk.quiet": "Seit {days} Tagen kein Kontakt.",
+  "day.risk.closeOverdue": "Abschluss war für {date} geplant — noch offen.",
   "day.commitments": "Du hast zugesagt",
   "day.commitments.empty": "Keine Zusagen werden f\u00e4llig.",
   "day.commitment.detail": "\u201e{quote}\u201c \u00b7 f\u00e4llig {due}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
   "day.lead.decisions": "{count} decisions are waiting on you.",
   "day.lead.plannedOnly": "Nothing to decide — {count} planned for today.",
   "day.lead.promises": "You promised {count} — those come first.",
+  "day.lead.meetings": "{count} on the calendar today.",
   "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",
   "day.lead.morningOnly":
     "Nothing waiting on you — the night picked out {count} to start with.",
@@ -92,6 +93,8 @@ export const en = {
   "day.lane.withheld": "Hidden from your account.",
   "day.needsYou": "Needs you",
   "day.needsYou.empty": "Nothing needs a decision.",
+  "day.meetings": "Today's meetings",
+  "day.meetings.empty": "Nothing in the calendar.",
   "day.atRisk": "Going quiet",
   "day.atRisk.empty": "No deal is drifting.",
   "day.risk.quiet": "No contact for {days} days.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
   "day.lead.decisions": "{count} decisions are waiting on you.",
   "day.lead.plannedOnly": "Nothing to decide — {count} planned for today.",
   "day.lead.promises": "You promised {count} — those come first.",
+  "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",
   "day.lead.morningOnly":
     "Nothing waiting on you — the night picked out {count} to start with.",
   "day.lead.ranOvernight": "Nothing needs you. Here is what ran overnight.",
@@ -91,6 +92,10 @@ export const en = {
   "day.lane.withheld": "Hidden from your account.",
   "day.needsYou": "Needs you",
   "day.needsYou.empty": "Nothing needs a decision.",
+  "day.atRisk": "Going quiet",
+  "day.atRisk.empty": "No deal is drifting.",
+  "day.risk.quiet": "No contact for {days} days.",
+  "day.risk.closeOverdue": "Expected to close {date} — still open.",
   "day.commitments": "You promised",
   "day.commitments.empty": "No promises coming due.",
   "day.commitment.detail": "\u201c{quote}\u201d \u00b7 due {due}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -86,6 +86,7 @@ export const vi = {
   "day.lead.plannedOnly":
     "Không có gì phải quyết định — {count} việc theo kế hoạch hôm nay.",
   "day.lead.promises": "Bạn đã hứa {count} việc — những việc đó trước tiên.",
+  "day.lead.atRisk": "{count} đang lặng đi. Không còn gì khác chờ bạn.",
   "day.lead.morningOnly":
     "Không có gì chờ bạn — đêm qua đã chọn ra {count} việc để bắt đầu.",
   "day.lead.ranOvernight":
@@ -97,6 +98,10 @@ export const vi = {
   "day.lane.withheld": "Bị ẩn với tài khoản của bạn.",
   "day.needsYou": "Cần bạn",
   "day.needsYou.empty": "Không có gì cần quyết định.",
+  "day.atRisk": "Đang lặng đi",
+  "day.atRisk.empty": "Không có thương vụ nào trôi đi.",
+  "day.risk.quiet": "Không liên hệ trong {days} ngày.",
+  "day.risk.closeOverdue": "Dự kiến chốt {date} — vẫn còn mở.",
   "day.commitments": "Bạn đã hứa",
   "day.commitments.empty": "Không có lời hứa nào đến hạn.",
   "day.commitment.detail": "\u201c{quote}\u201d \u00b7 đến hạn {due}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -86,6 +86,7 @@ export const vi = {
   "day.lead.plannedOnly":
     "Không có gì phải quyết định — {count} việc theo kế hoạch hôm nay.",
   "day.lead.promises": "Bạn đã hứa {count} việc — những việc đó trước tiên.",
+  "day.lead.meetings": "{count} cuộc họp trên lịch hôm nay.",
   "day.lead.atRisk": "{count} đang lặng đi. Không còn gì khác chờ bạn.",
   "day.lead.morningOnly":
     "Không có gì chờ bạn — đêm qua đã chọn ra {count} việc để bắt đầu.",
@@ -98,6 +99,8 @@ export const vi = {
   "day.lane.withheld": "Bị ẩn với tài khoản của bạn.",
   "day.needsYou": "Cần bạn",
   "day.needsYou.empty": "Không có gì cần quyết định.",
+  "day.meetings": "Cuộc họp hôm nay",
+  "day.meetings.empty": "Lịch trống.",
   "day.atRisk": "Đang lặng đi",
   "day.atRisk.empty": "Không có thương vụ nào trôi đi.",
   "day.risk.quiet": "Không liên hệ trong {days} ngày.",

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -455,6 +455,58 @@ describe("what the night left on the worklist", () => {
       screen.queryByText(/found nothing worth your first hour/),
     ).toBeNull();
   });
+  // A drifting deal says how long it has been quiet, in the reader's own
+  // language. The server sends the ground and the number and never the
+  // sentence, so a card that dropped either would say "at risk" and leave the
+  // rep to guess which patience produced it.
+  it("says how long a deal has been quiet rather than only that it is at risk", async () => {
+    stub({
+      ...emptyDay,
+      at_risk: [
+        {
+          id: "deal-1",
+          source: "deal_at_risk",
+          kind: "quiet",
+          title: "Fleet retrofit",
+          detail: "19",
+          subject: { type: "deal", id: "deal-1" },
+          actions: ["open"],
+        },
+      ],
+      counts: { this_morning: 0, needs_you: 0, planned: 0, at_risk: 1 },
+    });
+    renderToday();
+
+    await screen.findByText("Fleet retrofit");
+    expect(screen.getByText("No contact for 19 days.")).toBeTruthy();
+    expect(screen.queryByText("Your day is clear.")).toBeNull();
+  });
+  // A deal past its close date reports THAT, not a silence. The two grounds are
+  // different facts and the card must not blur them.
+  it("names the passed close date rather than reporting silence", async () => {
+    stub({
+      ...emptyDay,
+      at_risk: [
+        {
+          id: "deal-1",
+          source: "deal_at_risk",
+          kind: "close_overdue",
+          title: "Closing last month",
+          detail: "2",
+          due_at: "2026-07-26T00:00:00Z",
+          overdue: true,
+          subject: { type: "deal", id: "deal-1" },
+          actions: ["open"],
+        },
+      ],
+      counts: { this_morning: 0, needs_you: 0, planned: 0, at_risk: 1 },
+    });
+    renderToday();
+
+    await screen.findByText("Closing last month");
+    expect(screen.getByText(/Expected to close/)).toBeTruthy();
+    expect(screen.queryByText(/No contact for/)).toBeNull();
+  });
   // An installation whose feed reads no claims sends NO commitments lane and no
   // count — a different fact from "the rep owes nobody anything". Reading the
   // absent count as zero would answer "your day is clear" for a page that never

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -455,6 +455,38 @@ describe("what the night left on the worklist", () => {
       screen.queryByText(/found nothing worth your first hour/),
     ).toBeNull();
   });
+  // A meeting leads the day, above every other lane. It is the one thing on the
+  // page that happens whether or not the reader acts — a decision waits, an
+  // appointment at eleven does not.
+  it("leads with today's meetings above everything else waiting", async () => {
+    stub({
+      ...emptyDay,
+      meetings: [
+        {
+          id: "act-1",
+          source: "meeting",
+          title: "Vogt — Angebotsbesprechung",
+          due_at: "2026-08-25T11:00:00Z",
+          subject: { type: "activity", id: "act-1" },
+          actions: ["open"],
+        },
+      ],
+      needs_you: [
+        {
+          id: "ap-1",
+          source: "approval",
+          kind: "send_email",
+          title: "Send the Weber follow-up",
+          actions: ["decide"],
+        },
+      ],
+      counts: { this_morning: 0, needs_you: 1, planned: 0, meetings: 1 },
+    });
+    renderToday();
+
+    await screen.findByText("Vogt — Angebotsbesprechung");
+    expect(screen.getByText("1 on the calendar today.")).toBeTruthy();
+  });
   // A drifting deal says how long it has been quiet, in the reader's own
   // language. The server sends the ground and the number and never the
   // sentence, so a card that dropped either would say "at risk" and leave the

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -1,4 +1,5 @@
 import {
+  CalendarClock,
   CheckSquare,
   GitMerge,
   Handshake,
@@ -26,6 +27,7 @@ import { FocusLane } from "./today.focus";
 import {
   type Attention,
   type AttentionItem,
+  type AttentionLane,
   attentionKey,
   useAttention,
 } from "./today.queries";
@@ -67,6 +69,13 @@ function leadLine(
   if ((day.lanes_omitted ?? []).length > 0) {
     return t("day.lead.partial");
   }
+  // Meetings lead every other lane, because a meeting is the one thing on this
+  // page that happens whether or not the reader acts. A decision waits; an
+  // appointment at eleven does not.
+  const booked = day.counts.meetings ?? 0;
+  if (booked > 0) {
+    return t("day.lead.meetings", { count: formatNumber(booked, locale) });
+  }
   const decisions = day.counts.needs_you;
   if (decisions === 1) {
     return t("day.lead.oneDecision");
@@ -87,9 +96,20 @@ function leadLine(
   if (promises > 0) {
     return t("day.lead.promises", { count: formatNumber(promises, locale) });
   }
-  // Below promises, above the briefing. A drifting deal is money leaving on its
-  // own and a promise is a duty already accepted — the duty wins, but both
-  // outrank a suggestion about where to start.
+  return quietLead(day, t, locale);
+}
+
+// What the line says once nothing is WAITING on the reader — no decision, no
+// promise due, no meeting. Split from the branches above because those answer
+// "what is being asked of you" and these answer "what is worth knowing anyway",
+// and one function holding both was past the complexity the linter allows.
+function quietLead(
+  day: Attention,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
+  // A drifting deal is money leaving on its own — nobody is waiting on the
+  // reader for it, which is exactly why it needs saying.
   const drifting = day.counts.at_risk ?? 0;
   if (drifting > 0) {
     return t("day.lead.atRisk", { count: formatNumber(drifting, locale) });
@@ -114,7 +134,8 @@ function leadLine(
   // is true — nothing is waiting among the lanes this page did read.
   if (
     day.counts.commitments === undefined ||
-    day.counts.at_risk === undefined
+    day.counts.at_risk === undefined ||
+    day.counts.meetings === undefined
   ) {
     return t("day.lead.clearOfWhatWasRead");
   }
@@ -263,6 +284,48 @@ function AttentionRow({
 // decisions — so a reader scanning the page finds it before reading a word.
 // Two tinted panels would be no lead at all, which is why the other two are
 // plain.
+// An OPTIONAL lane: one the server may not send at all.
+//
+// Absent means this installation does not read what the lane holds; empty means
+// it read and found nothing. The two draw differently — nothing at all versus a
+// quiet plate — so the check belongs in one place rather than repeated per lane,
+// where the third copy is what pushed this screen past the complexity bar.
+function OptionalLane({
+  items,
+  shape,
+  omitted,
+  lane,
+  total,
+  onComplete,
+  onSnooze,
+  completing,
+}: Readonly<{
+  items: readonly AttentionItem[] | undefined;
+  shape: LaneShape;
+  omitted: readonly AttentionLane[];
+  lane: AttentionLane;
+  total: number;
+  onComplete: (id: string) => void;
+  onSnooze: (id: string, dueAt: string) => void;
+  completing: boolean;
+}>) {
+  const withheld = omitted.includes(lane);
+  if (items === undefined && !withheld) {
+    return null;
+  }
+  return (
+    <Lane
+      shape={shape}
+      items={items ?? []}
+      withheld={withheld}
+      total={total}
+      onComplete={onComplete}
+      onSnooze={onSnooze}
+      completing={completing}
+    />
+  );
+}
+
 function Lane({
   shape,
   items,
@@ -528,6 +591,7 @@ function TodayLanes({
   const commitments = day.commitments;
   // Same absent-versus-empty rule: no lane at all when nothing reads deals.
   const atRisk = day.at_risk;
+  const meetings = day.meetings;
   const done = day.done_for_you ?? [];
   const omitted = day.lanes_omitted ?? [];
   // How many decisions this reader has answered since the page opened, and
@@ -572,6 +636,21 @@ function TodayLanes({
         withheld={omitted.includes("this_morning")}
         total={day.counts.this_morning}
       />
+      <OptionalLane
+        items={meetings}
+        shape={{
+          title: t("day.meetings"),
+          empty: t("day.meetings.empty"),
+          withheld: t("day.lane.withheld"),
+          icon: CalendarClock,
+        }}
+        omitted={omitted}
+        lane="meetings"
+        total={day.counts.meetings ?? 0}
+        onComplete={onComplete}
+        onSnooze={onSnooze}
+        completing={complete.isPending}
+      />
       <FocusLane
         items={queue}
         total={day.counts.needs_you}
@@ -594,38 +673,36 @@ function TodayLanes({
         onSnooze={onSnooze}
         completing={complete.isPending}
       />
-      {(atRisk !== undefined || omitted.includes("at_risk")) && (
-        <Lane
-          shape={{
-            title: t("day.atRisk"),
-            empty: t("day.atRisk.empty"),
-            withheld: t("day.lane.withheld"),
-            icon: TrendingDown,
-          }}
-          items={atRisk ?? []}
-          withheld={omitted.includes("at_risk")}
-          total={day.counts.at_risk ?? 0}
-          onComplete={onComplete}
-          onSnooze={onSnooze}
-          completing={complete.isPending}
-        />
-      )}
-      {(commitments !== undefined || omitted.includes("commitments")) && (
-        <Lane
-          shape={{
-            title: t("day.commitments"),
-            empty: t("day.commitments.empty"),
-            withheld: t("day.lane.withheld"),
-            icon: Handshake,
-          }}
-          items={commitments ?? []}
-          withheld={omitted.includes("commitments")}
-          total={day.counts.commitments ?? 0}
-          onComplete={onComplete}
-          onSnooze={onSnooze}
-          completing={complete.isPending}
-        />
-      )}
+      <OptionalLane
+        items={atRisk}
+        shape={{
+          title: t("day.atRisk"),
+          empty: t("day.atRisk.empty"),
+          withheld: t("day.lane.withheld"),
+          icon: TrendingDown,
+        }}
+        omitted={omitted}
+        lane="at_risk"
+        total={day.counts.at_risk ?? 0}
+        onComplete={onComplete}
+        onSnooze={onSnooze}
+        completing={complete.isPending}
+      />
+      <OptionalLane
+        items={commitments}
+        shape={{
+          title: t("day.commitments"),
+          empty: t("day.commitments.empty"),
+          withheld: t("day.lane.withheld"),
+          icon: Handshake,
+        }}
+        omitted={omitted}
+        lane="commitments"
+        total={day.counts.commitments ?? 0}
+        onComplete={onComplete}
+        onSnooze={onSnooze}
+        completing={complete.isPending}
+      />
       <Lane
         shape={{
           title: t("day.done"),

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -4,6 +4,7 @@ import {
   Handshake,
   Sparkles,
   Sunrise,
+  TrendingDown,
 } from "lucide-react";
 import { useState } from "react";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
@@ -86,6 +87,13 @@ function leadLine(
   if (promises > 0) {
     return t("day.lead.promises", { count: formatNumber(promises, locale) });
   }
+  // Below promises, above the briefing. A drifting deal is money leaving on its
+  // own and a promise is a duty already accepted — the duty wins, but both
+  // outrank a suggestion about where to start.
+  const drifting = day.counts.at_risk ?? 0;
+  if (drifting > 0) {
+    return t("day.lead.atRisk", { count: formatNumber(drifting, locale) });
+  }
   // Before "clear", because the briefing lane is on this page: a line reading
   // "your day is clear" above two items the night picked out is the one thing
   // this line exists to prevent. It sits below decisions and planned work,
@@ -104,7 +112,10 @@ function leadLine(
   // states that nothing was found ANYWHERE, and a feed that never read the
   // claims has not looked where promises live. The weaker line says only what
   // is true — nothing is waiting among the lanes this page did read.
-  if (day.counts.commitments === undefined) {
+  if (
+    day.counts.commitments === undefined ||
+    day.counts.at_risk === undefined
+  ) {
     return t("day.lead.clearOfWhatWasRead");
   }
   return t("day.lead.clear");
@@ -148,6 +159,24 @@ function itemDetail(
   locale: Locale,
   zone: string,
 ): string | null {
+  // A risk card's sentence is written HERE, not sent: the server has no
+  // language, and "quiet 19 days" versus "the close date passed" read
+  // differently in each of the three. `kind` names the ground and `detail`
+  // carries the number the server actually measured, so the line can never
+  // imply a patience nobody applied.
+  if (item.source === "deal_at_risk") {
+    if (item.kind === "close_overdue" && item.due_at) {
+      return t("day.risk.closeOverdue", {
+        date: formatDateTime(item.due_at, locale, zone),
+      });
+    }
+    if (item.detail) {
+      return t("day.risk.quiet", {
+        days: formatNumber(Number(item.detail), locale),
+      });
+    }
+    return null;
+  }
   // A promise is the one item whose supporting line carries TWO facts, and it
   // needs both: the words it was read from are what make the claim checkable,
   // and the deadline is why it is on today's page at all. Showing only the
@@ -497,6 +526,8 @@ function TodayLanes({
   // Absent means this installation serves no commitments lane; empty means the
   // rep owes nothing today. The two draw differently, so they stay apart.
   const commitments = day.commitments;
+  // Same absent-versus-empty rule: no lane at all when nothing reads deals.
+  const atRisk = day.at_risk;
   const done = day.done_for_you ?? [];
   const omitted = day.lanes_omitted ?? [];
   // How many decisions this reader has answered since the page opened, and
@@ -563,6 +594,22 @@ function TodayLanes({
         onSnooze={onSnooze}
         completing={complete.isPending}
       />
+      {(atRisk !== undefined || omitted.includes("at_risk")) && (
+        <Lane
+          shape={{
+            title: t("day.atRisk"),
+            empty: t("day.atRisk.empty"),
+            withheld: t("day.lane.withheld"),
+            icon: TrendingDown,
+          }}
+          items={atRisk ?? []}
+          withheld={omitted.includes("at_risk")}
+          total={day.counts.at_risk ?? 0}
+          onComplete={onComplete}
+          onSnooze={onSnooze}
+          completing={complete.isPending}
+        />
+      )}
       {(commitments !== undefined || omitted.includes("commitments")) && (
         <Lane
           shape={{


### PR DESCRIPTION
## What this adds

Two more lanes on the Worklist, and the shared rule that made one of them
honest.

**Today's meetings** lead the page. A meeting is the one thing on it that
happens whether or not the reader acts — a decision waits, an appointment at
eleven does not.

**Going quiet** shows open deals nobody has touched, and deals whose expected
close date has already passed. Until now the only surface that named them was an
agent tool nobody opens in the morning.

## The threshold decision, stated because it changes what a rep sees

The vision copy for this lane says "quiet 19 days". The engine it is built on
fires at **60** — `StalledThresholdDays`, the canonical stalled rule the whole
product uses. Shipping the first sentence over the second rule would tell a rep
something false about when the product is watching.

So the threshold became an argument rather than a second predicate:

- `IsStalled` is now `IsQuietFor` at its own threshold.
- `StalledSQL` is `QuietSQL` at the same number.
- Both spellings, so the Go and the SQL cannot drift from each other or from the
  shorter window.
- **Every existing caller keeps 60 by construction** — the constant is unchanged,
  and the original stalled test table still passes case for case.

`QuietThresholdDays = 19` is the morning queue's own patience. A second at-risk
predicate under the feed would have been two answers to one question, which the
plan's own review criteria call a review failure; the lane calls
`quietDealLister`, the same engine `whats_slipping_this_week` reads.

## A bug that would have shipped an always-empty lane

The candidate loop tested `candidate.Stalled` — the deal row's own 60-day flag,
which is **false** for every deal a shorter window exists to find. The lane would
have fetched exactly the right deals and dropped all of them, drawing a quiet
pipeline over one that was not. Reverting that one line empties the short window
in the integration test.

## What the meetings lane refuses to show

A meeting already held, cancelled or no-showed is dropped: a queue that listed it
would be asking for work nobody can do. The window opens at the read instant
rather than at midnight, for the same reason.

A calendar event with **no** status is kept and treated as booked. Capture writes
them that way, so dropping them would empty this lane on exactly the
installations whose calendars are connected — the failure nobody reports, because
an empty lane looks like a free day.

## review_commitments was NOT built, deliberately

The plan lists it as the third producer. It reads open tasks through
`ListOpenTasks`, and the `planned` lane already shows open tasks — a lane on it
would print the same rows twice under two headings, the duplication
`attention/doc.go` says the feed exists to prevent and the reason
`commitment_due` was not built on tasks either. Filed as #2736 with what would
make it worth building instead (the unassigned promises, which `planned` cannot
show).

## The refactor the gates asked for

Three new lanes pushed the feed and its seam past the file and function ceilings.
The gate was right about the cause: each lane had been written out in full, and
the fourth copy of a fifteen-line shape is duplication rather than length. The
optional lanes now share one shape in their own file; the seam's three adapters
moved to theirs. The frontend linter caught the same duplication independently
and got the same fix.

No behaviour moved with any of it.

## Tests

- **7 unit tests** across the two lanes, every guard mutation-checked.
- **7 integration tests** against real Postgres: the two idle windows against
  each other, the overdue-close arm, the closed-deal suppression, and the meeting
  status/window filtering. Removing the status filter puts cancelled and held
  meetings on a lane asking a rep to prepare for them.
- **3 frontend tests**, mutation-checked.

## Verified running

Seeded a meeting and made a deal quiet 25 days on a dev stack, in German:
"Termine heute" → Vogt — Angebotsbesprechung; "Wird still" → Globex Renewal,
*Seit 25 Tagen kein Kontakt*; lead line *1 heute im Kalender.* The 25-day deal is
the case the 60-day threshold would have shown nothing for, which is the whole
point of the shorter window. No horizontal scroll at 390px, no console errors
from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Meetings and At-Risk Deals sections to the Today view.
  * Meeting items show upcoming times and prioritize soonest events.
  * At-risk deals display quiet-period details and overdue close dates.
  * Added support for omitted or unavailable optional sections.
  * Added English, German, and Vietnamese translations.

* **Bug Fixes**
  * Improved detection of quiet deals across configurable time windows.
  * Excluded completed, cancelled, and no-show meetings from the upcoming list.
  * Ensured overdue deals are surfaced with relevant risk information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round (Codex)

All five security questions came back **safe**: the threshold refactor preserves
60 for every existing caller, `QuietSQL`'s `%d` is not attacker-reachable, both
lanes go through the gated store paths, and the pointer-to-pointer lane wiring
has no swapped target or nil deref.

Four correctness defects, all mine, all in the refactor rather than the features.

**Fixed — the commitments lane was read twice.** Collapsing the lanes into a
shared shape added the third descriptor and left the original block standing. Two
tests hold it now: one counts reads per lane, one counts how often a withheld
lane is named. Restoring the duplicate fails the first by name.

**Fixed — the meetings window moved into SQL.** It had been a Go filter over ten
times the lane, which is lossy in the direction that hides itself: a busy
calendar pushes the sooner meetings off the scan and the lane draws a free
afternoon over a booked one. `ListActivitiesInput` already carried
`OccurredAfter`/`OccurredBefore` — my comment claiming otherwise was simply
wrong. A new integration test books ten meetings later today and asserts the lane
still leads with the soonest.

**Fixed — no card advertises `open` any more.** This surface wires no navigation,
so the verb reached no control. The commitments card (already merged) still had
it, so three lanes gave two answers; a gate now derives the check from the lanes
rather than listing them.

**Filed #2741** for wiring the navigation properly, keyed off
`AttentionItem.subject`, which already carries a typed `{type, id}`. Doing it
per-lane would be four copies of one routing decision, and it also fixes the two
pre-existing lanes that have shipped with an unwired `open` since before this
branch.

**Noted on #2734** — the UTC day boundary now rides a third lane, and the
meetings lane is where it becomes visible: the card renders the start time in the
viewer's zone while the lane that decided to include it used UTC. The other two
lanes hide the same defect because neither renders a boundary the reader can
check against.

## Two more found by auditing my own work

**A long meeting history must not hide today's.** The scan is bounded, and the
only reason it was ever safe is an `ORDER BY` nobody had checked. 130 past
meetings, one this afternoon, and the lane still finds it.

**Each optional lane fills its own field.** They are wired through
pointers-to-pointers into one struct, so crossing two is invisible to the
compiler. Crossing any two now fails by name.
