### PR TITLE
fix(ac): the uat lane names the helper that exists and the lane that ships

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -223,7 +223,7 @@ test("AC-shell-1: the rail renders the canonical 10 items in order", async ({
     "Firmen",
     "Leads",
     "Filter & Ansichten",
-    "Heute",
+    "Arbeitsliste",
     "Pipeline",
     "Projekte",
     "Berichte",
@@ -1251,7 +1251,7 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
       await page.goto(`/#/${view}`);
       await page.waitForLoadState("networkidle");
       await expectShellRendered(page);
-      await animationsSettled(page);
+      await settleAnimations(page);
       await expectNoAaViolations(page, view);
     });
   }


### PR DESCRIPTION
main is red on `uat (main)` — [run 32916607681](https://github.com/margince/margince/actions/runs/32916607681), 4 failed / 105 passed. Two independent causes, both a test disagreeing with the tree around it rather than a product defect.

## 1. A rename and a new call site that never met

`ADDRESSED_VIEWS` calls `animationsSettled`. That helper is now `settleAnimations` (#2722). Three axe sweeps die on `ReferenceError: animationsSettled is not defined`.

Neither change was wrong. They never conflicted: the rename and the new call site are **different lines**, so git merged both cleanly and nothing warned. #2722's own CI was green because the loop that calls the helper was not yet on its base — the two landed in an order where no single commit was ever tested with both.

This is my regression, from #2722.

## 2. A rail label the product renamed

`AC-shell-1` expects the rail's sixth item to read `"Heute"`. It renders `"Arbeitsliste"` — `nav.today` is `"Arbeitsliste"`, and the worklist lane it names is what ships. I checked the other `"Heute"` strings before touching this: `home.panel.today` and `person.strip.today` are different keys and still correct, so this is the one reader that went stale.

## Verification

Full suite on this branch: **109 passed / 14 skipped**, against 105 passed / 4 failed on main. Same 123 collected.

## What let a call to a nonexistent function reach main

Nothing typechecks these specs. No `tsconfig` in `frontend/` includes `e2e/` — I checked all five with `tsc --listFiles`; every one reports 0 for `ac.spec.ts`. Playwright transpiles them, so an undefined identifier is only discoverable by running the test.

A trial run typechecking `e2e/` standalone surfaces just **2 real errors**, both in `seed.ts`, so closing this is not a large job — but it needs its own tsconfig plus Makefile and CI wiring, which would more than double this diff while main is red. Filed separately; this PR gets the lane green.

## Not fixed here

main is also red on `dco (main)`, `backend gate`, `integration shard (4/6)`, `integration shard (5/6)` and `integration (RLS + erasure + HTTP e2e)`. Those are unrelated to this diff:

- **`dco`** — commit `2736937c0` (#2728) has no `Signed-off-by`. Only its author can remediate that; it is not fixable by a patch.
- **shard 4/6** — `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas/read_brief_{}`.
- **shard 5/6** — `TestConcurrentCallsOfOneTaskAllReachTheProjection`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated accessibility checks to reflect the renamed “Arbeitsliste” view.
  * Improved accessibility test stability by waiting for animations to settle before analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->