### PR TITLE
feat(agents): name the owner on every query_workspace row

### DIFF
--- a/backend/internal/compose/approvalsadapter.go
+++ b/backend/internal/compose/approvalsadapter.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// approvalsAdapter maps the tool surface's staging/redemption dependency
+// onto the approvals module.
+type approvalsAdapter struct{ svc *approvals.Service }
+
+// StageCall forwards a refused 🟡 tool call to the approvals engine. It passes
+// NO target_version: the engine resolves the pin itself inside the staging
+// transaction, for every target type that has a version column to read. This
+// adapter used to nil a caller-supplied pin for the types redemption could
+// not re-verify — correct as far as it went, but it also meant the pin was
+// whatever the caller happened to offer for the types it COULD, which on the
+// REST path was an optional request header.
+func (a approvalsAdapter) StageCall(ctx context.Context, in agents.StageRequest) (ids.ApprovalID, bool, error) {
+	return a.svc.StageAgentCall(ctx, approvals.StageInput{
+		Kind:           in.Tool,
+		ProposedChange: in.ProposedChange,
+		DiffHash:       in.DiffHash,
+		TargetType:     in.TargetType,
+		TargetID:       in.TargetID,
+		Summary:        in.Summary,
+	})
+}
+
+// StageQuotaRelease puts a §2.4 step-up in front of the human who lent the
+// calling passport.
+//
+// It stages through the DECLINED-AWARE path, unlike Stage above, and both
+// differences that drives are deliberate. JoinPending + Identity means ONE
+// question per counter per window: an agent looping on a refusal re-asks
+// nothing, where the ordinary path would fill an inbox with copies of one
+// question and leave the rest to be dismissed after the first was answered. And
+// a human's NO is remembered — a rejected step-up is not re-offered on the next
+// call, which is the difference between a control and a nag.
+//
+// It carries NO target, because a step-up is about a credential's volume rather
+// than about a record. That shape is what makes it decidable by the lender alone
+// (approvals' selfOnlyKinds over a target-less staging), and it is why the
+// identity carries the discrimination a diff hash carries for every other kind:
+// there is no diff.
+func (a approvalsAdapter) StageQuotaRelease(ctx context.Context, in agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+	payload, err := json.Marshal(in.Proposal)
+	if err != nil {
+		return ids.ApprovalID{}, false, fmt.Errorf("compose: encoding a step-up proposal: %w", err)
+	}
+	identity, err := in.Proposal.Identity()
+	if err != nil {
+		return ids.ApprovalID{}, false, err
+	}
+	_, diffHash, err := diffhash.Object(map[string]any{"quota_release": string(identity)})
+	if err != nil {
+		return ids.ApprovalID{}, false, fmt.Errorf("compose: hashing a step-up proposal: %w", err)
+	}
+	return a.svc.StageUnlessDeclined(ctx, approvals.StageInput{
+		Kind:           approvals.KindQuotaRelease,
+		ProposedChange: payload,
+		DiffHash:       diffHash,
+		Summary:        in.Summary,
+		JoinPending:    true,
+		Identity:       identity,
+	})
+}
+
+func (a approvalsAdapter) Redeem(ctx context.Context, approvalID ids.ApprovalID, tool, diffHash string) (int64, bool, error) {
+	return a.svc.Redeem(ctx, approvalID, tool, diffHash)
+}
+
+// State answers a polling MCP task whether a human has decided yet. The
+// module's effective status is passed through rather than re-derived: a pending
+// row past its window is expired on every other surface, and a poll told
+// "pending" about a dead proposal would wait forever.
+func (a approvalsAdapter) State(ctx context.Context, approvalID ids.ApprovalID) (agents.ApprovalState, error) {
+	state, err := a.svc.TaskState(ctx, approvalID)
+	if err != nil {
+		return agents.ApprovalState{}, err
+	}
+	decided, ok := approvalDecisions[state.Status]
+	if !ok {
+		// A status this adapter has no word for must not be guessed at: the
+		// safe-looking guess is "pending", and it would leave a released
+		// approval unperformed forever.
+		return agents.ApprovalState{}, fmt.Errorf("compose: unknown approval status %q", state.Status)
+	}
+	return agents.ApprovalState{Decided: decided, ExpiresAt: state.ExpiresAt, Consumed: state.Consumed}, nil
+}
+
+// approvalDecisions maps the approvals module's status vocabulary onto the tool
+// surface's. They are the same four words today, and the map exists so they are
+// not required to STAY the same by coincidence — a rename on either side lands
+// on the unknown-status refusal above rather than silently reading as pending.
+var approvalDecisions = map[string]agents.ApprovalDecision{
+	approvals.StatusPending:  agents.ApprovalPending,
+	approvals.StatusApproved: agents.ApprovalApproved,
+	approvals.StatusRejected: agents.ApprovalRejected,
+	approvals.StatusExpired:  agents.ApprovalExpired,
+}
+
+// ProposedChange answers what a redemption would perform — the human's edit
+// where there was one. See agents.Approvals for why an executor must read this
+// rather than replay what it staged.
+func (a approvalsAdapter) ProposedChange(ctx context.Context, approvalID ids.ApprovalID) (json.RawMessage, error) {
+	return a.svc.ProposedChange(ctx, approvalID)
+}
+
+// Withdraw retracts the proposal behind a cancelled task, so no decision is
+// left in a person's inbox that could no longer take effect. It reports whether
+// there was still an offer to take: a proposal a human already decided is
+// untouched, and a task that claimed otherwise would say the decision was gone
+// while it sat live in the inbox.
+func (a approvalsAdapter) Withdraw(ctx context.Context, approvalID ids.ApprovalID) (bool, error) {
+	return a.svc.Withdraw(ctx, approvalID, "the agent cancelled the task waiting on this decision")
+}

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -11,7 +11,6 @@ package compose
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -26,8 +25,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // NewRegistry wires the full 🟢/🟡 tool set over the composite provider.
@@ -176,7 +173,10 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// against their read bound. The guard is outermost for
 	// the same reason the intent tools' is: the executor queries native tables
 	// an overlay workspace has no rows in.
-	agents.RegisterQueryTool(registry, provider, nativeOnlyQueryRunner(sorMode, queryRunner(pool, embedder)))
+	// The seat namer names each row's owner; seatNamer says why.
+	agents.RegisterQueryTool(registry, provider,
+		nativeOnlyQueryRunner(sorMode, queryRunner(pool, embedder)),
+		seatNamer(identity.NewService(pool)))
 	// The vocabulary that plan is written in, as a TOOL and not only as the
 	// margince://schema/query resource — because a client that reads tools and
 	// not resources could otherwise watch query_workspace refuse a name and
@@ -385,115 +385,4 @@ func decidingApprovalsService(pool *pgxpool.Pool, send SendPath, log *slog.Logge
 		svc = svc.WithLogger(log)
 	}
 	return svc
-}
-
-// approvalsAdapter maps the tool surface's staging/redemption dependency
-// onto the approvals module.
-type approvalsAdapter struct{ svc *approvals.Service }
-
-// StageCall forwards a refused 🟡 tool call to the approvals engine. It passes
-// NO target_version: the engine resolves the pin itself inside the staging
-// transaction, for every target type that has a version column to read. This
-// adapter used to nil a caller-supplied pin for the types redemption could
-// not re-verify — correct as far as it went, but it also meant the pin was
-// whatever the caller happened to offer for the types it COULD, which on the
-// REST path was an optional request header.
-func (a approvalsAdapter) StageCall(ctx context.Context, in agents.StageRequest) (ids.ApprovalID, bool, error) {
-	return a.svc.StageAgentCall(ctx, approvals.StageInput{
-		Kind:           in.Tool,
-		ProposedChange: in.ProposedChange,
-		DiffHash:       in.DiffHash,
-		TargetType:     in.TargetType,
-		TargetID:       in.TargetID,
-		Summary:        in.Summary,
-	})
-}
-
-// StageQuotaRelease puts a §2.4 step-up in front of the human who lent the
-// calling passport.
-//
-// It stages through the DECLINED-AWARE path, unlike Stage above, and both
-// differences that drives are deliberate. JoinPending + Identity means ONE
-// question per counter per window: an agent looping on a refusal re-asks
-// nothing, where the ordinary path would fill an inbox with copies of one
-// question and leave the rest to be dismissed after the first was answered. And
-// a human's NO is remembered — a rejected step-up is not re-offered on the next
-// call, which is the difference between a control and a nag.
-//
-// It carries NO target, because a step-up is about a credential's volume rather
-// than about a record. That shape is what makes it decidable by the lender alone
-// (approvals' selfOnlyKinds over a target-less staging), and it is why the
-// identity carries the discrimination a diff hash carries for every other kind:
-// there is no diff.
-func (a approvalsAdapter) StageQuotaRelease(ctx context.Context, in agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
-	payload, err := json.Marshal(in.Proposal)
-	if err != nil {
-		return ids.ApprovalID{}, false, fmt.Errorf("compose: encoding a step-up proposal: %w", err)
-	}
-	identity, err := in.Proposal.Identity()
-	if err != nil {
-		return ids.ApprovalID{}, false, err
-	}
-	_, diffHash, err := diffhash.Object(map[string]any{"quota_release": string(identity)})
-	if err != nil {
-		return ids.ApprovalID{}, false, fmt.Errorf("compose: hashing a step-up proposal: %w", err)
-	}
-	return a.svc.StageUnlessDeclined(ctx, approvals.StageInput{
-		Kind:           approvals.KindQuotaRelease,
-		ProposedChange: payload,
-		DiffHash:       diffHash,
-		Summary:        in.Summary,
-		JoinPending:    true,
-		Identity:       identity,
-	})
-}
-
-func (a approvalsAdapter) Redeem(ctx context.Context, approvalID ids.ApprovalID, tool, diffHash string) (int64, bool, error) {
-	return a.svc.Redeem(ctx, approvalID, tool, diffHash)
-}
-
-// State answers a polling MCP task whether a human has decided yet. The
-// module's effective status is passed through rather than re-derived: a pending
-// row past its window is expired on every other surface, and a poll told
-// "pending" about a dead proposal would wait forever.
-func (a approvalsAdapter) State(ctx context.Context, approvalID ids.ApprovalID) (agents.ApprovalState, error) {
-	state, err := a.svc.TaskState(ctx, approvalID)
-	if err != nil {
-		return agents.ApprovalState{}, err
-	}
-	decided, ok := approvalDecisions[state.Status]
-	if !ok {
-		// A status this adapter has no word for must not be guessed at: the
-		// safe-looking guess is "pending", and it would leave a released
-		// approval unperformed forever.
-		return agents.ApprovalState{}, fmt.Errorf("compose: unknown approval status %q", state.Status)
-	}
-	return agents.ApprovalState{Decided: decided, ExpiresAt: state.ExpiresAt, Consumed: state.Consumed}, nil
-}
-
-// approvalDecisions maps the approvals module's status vocabulary onto the tool
-// surface's. They are the same four words today, and the map exists so they are
-// not required to STAY the same by coincidence — a rename on either side lands
-// on the unknown-status refusal above rather than silently reading as pending.
-var approvalDecisions = map[string]agents.ApprovalDecision{
-	approvals.StatusPending:  agents.ApprovalPending,
-	approvals.StatusApproved: agents.ApprovalApproved,
-	approvals.StatusRejected: agents.ApprovalRejected,
-	approvals.StatusExpired:  agents.ApprovalExpired,
-}
-
-// ProposedChange answers what a redemption would perform — the human's edit
-// where there was one. See agents.Approvals for why an executor must read this
-// rather than replay what it staged.
-func (a approvalsAdapter) ProposedChange(ctx context.Context, approvalID ids.ApprovalID) (json.RawMessage, error) {
-	return a.svc.ProposedChange(ctx, approvalID)
-}
-
-// Withdraw retracts the proposal behind a cancelled task, so no decision is
-// left in a person's inbox that could no longer take effect. It reports whether
-// there was still an offer to take: a proposal a human already decided is
-// untouched, and a task that claimed otherwise would say the decision was gone
-// while it sat live in the inbox.
-func (a approvalsAdapter) Withdraw(ctx context.Context, approvalID ids.ApprovalID) (bool, error) {
-	return a.svc.Withdraw(ctx, approvalID, "the agent cancelled the task waiting on this decision")
 }

--- a/backend/internal/compose/seatnames.go
+++ b/backend/internal/compose/seatnames.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// seatNamer is the edge from the agent surface to identity's seat read.
+//
+// A query row names the colleague who owns the record, which is what makes a
+// workspace-wide read safe to act on: a company is visible to every rep by
+// design (auth/tableclass.go — a rep who cannot see that an account belongs to
+// another team contacts it again), so the row has to say whose it is.
+//
+// It lives here rather than in agents because a module never imports a sibling.
+// The conversion is the whole body: agents speaks in bare ids because it knows
+// nothing of seats, and identity answers about ids.UserID.
+func seatNamer(seats *identity.Service) agents.SeatNamer {
+	return func(ctx context.Context, owners []ids.UUID) (map[ids.UUID]string, error) {
+		seatIDs := make([]ids.UserID, 0, len(owners))
+		for _, owner := range owners {
+			seatIDs = append(seatIDs, ids.From[ids.UserKind](owner))
+		}
+		return seats.SeatNames(ctx, seatIDs)
+	}
+}

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -203,7 +203,7 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterEnrichTool(r, nil, inertLifecycle{})
 	RegisterQueryTool(r, nil, func(context.Context, json.RawMessage) (QueryAnswer, error) {
 		return QueryAnswer{Coverage: CoverageCompleteExact}, nil
-	})
+	}, nil)
 	RegisterVocabularyTool(r, inertVocabulary{})
 	RegisterContextSearchTool(r, nil, inertRetriever{})
 	RegisterResolveTool(r, nil, func(context.Context, []ResolveCandidate) ([]ResolveOutcome, error) {

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -268,7 +268,7 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterEnrichTool(r, seamProbeProvider{}, seamProbeLifecycle{})
 	RegisterQueryTool(r, seamProbeProvider{}, func(context.Context, json.RawMessage) (QueryAnswer, error) {
 		return QueryAnswer{}, errSeamReached
-	})
+	}, nil)
 	RegisterVocabularyTool(r, seamProbeVocabulary{})
 	RegisterContextSearchTool(r, seamProbeProvider{}, seamProbeRetriever{})
 	RegisterResolveTool(r, seamProbeProvider{}, func(context.Context, []ResolveCandidate) ([]ResolveOutcome, error) {

--- a/backend/internal/modules/agents/queryowner.go
+++ b/backend/internal/modules/agents/queryowner.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Who owns a record the caller was handed, said in a way a reader can act on.
+//
+// A company is readable across the whole workspace by design: `organization`
+// is an identity table, so the ownership arm of its row scope renders TRUE and
+// a rep sees every account. auth/tableclass.go states the reason — a rep who
+// cannot see that a company already belongs to another team contacts it again.
+//
+// That trade only pays if the answer SAYS who the account belongs to. The
+// record already carries `owner_id`, so the fact was never withheld; it was
+// unreadable. A bare UUID tells a human nothing and tells a model less, and a
+// model reading a page of them has no way to tell an account it may approach
+// from one a colleague is already working. The failure is concrete: asked who
+// is nearby, an assistant recommended visiting an account whose owner had an
+// unsent contract with that customer, and never mentioned the owner existed.
+//
+// So the id is resolved to a name and marked against the caller, which is the
+// same argument HandoffProject's OwnerName already makes for a project —
+// "who owns this work now" answered as a UUID restates the question.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// SeatNamer resolves user ids to display names. An owner is a SEAT rather than
+// a record, so it is named through identity's read and not the people store's
+// — and this module may not import identity, so compose injects it.
+//
+// Batch, because a page of rows shares owners: twenty companies owned by three
+// reps is one call, not twenty.
+type SeatNamer func(ctx context.Context, seats []ids.UUID) (map[ids.UUID]string, error)
+
+// RecordOwner is who a served record belongs to.
+//
+// The three members answer three different questions and none substitutes for
+// another. ID is the durable handle. Name is what makes it legible. IsYou is
+// the one a reader acts on, and it is stated rather than left to be derived —
+// a client comparing ID against its own seat would have to know its own seat,
+// which an assistant reading a tool result does not.
+type RecordOwner struct {
+	ID ids.UUID `json:"id"`
+	// Name is absent when the seat no longer resolves — an archived member, or
+	// a row whose owner was removed. The id stays, so the answer says "owned,
+	// by someone not currently a member" rather than silently reading as
+	// unowned.
+	Name string `json:"name,omitempty"`
+	// IsYou is false for an agent principal, and that is correct rather than a
+	// gap: an agent holds no seat, so no record is its own, and every record it
+	// reports belongs to a human it should name.
+	IsYou bool `json:"is_you"`
+}
+
+// ownerIDOf reads `owner_id` out of a hydrated record's fields.
+//
+// It reads the JSON rather than the typed contract struct because that is what
+// hydration carries — the datasource seam hands back json.RawMessage, and the
+// record type is known only as a string. Every record type that has an owner
+// spells it `owner_id` in the contract, so one accessor serves all of them and
+// a new owned record type is covered the moment it exists.
+//
+// A record with no owner, or a type that has no owner at all, answers false —
+// not a zero UUID, which would read as an owner nobody can name.
+func ownerIDOf(fields json.RawMessage) (ids.UUID, bool) {
+	if len(fields) == 0 {
+		return ids.UUID{}, false
+	}
+	var envelope struct {
+		OwnerID *ids.UUID `json:"owner_id"`
+	}
+	if err := json.Unmarshal(fields, &envelope); err != nil {
+		return ids.UUID{}, false
+	}
+	if envelope.OwnerID == nil || *envelope.OwnerID == (ids.UUID{}) {
+		return ids.UUID{}, false
+	}
+	return *envelope.OwnerID, true
+}
+
+// callerSeat is the human seat asking, when there is one.
+//
+// An agent or a system principal has no seat, so nothing is "yours" to it. It
+// answers not-ok rather than a zero UUID for the same reason ownerIDOf does:
+// a zero seat compared against a zero owner would mark an unowned record as
+// the caller's own.
+func callerSeat(ctx context.Context) (ids.UUID, bool) {
+	p, ok := principal.Actor(ctx)
+	if !ok || p.Type != principal.PrincipalHuman {
+		return ids.UUID{}, false
+	}
+	if p.UserID == (ids.UUID{}) {
+		return ids.UUID{}, false
+	}
+	return p.UserID, true
+}
+
+// attachOwners names the owner on every row that has one, in ONE lookup.
+//
+// It runs after the rows are assembled rather than during, so the query is
+// per PAGE and not per row. A naming failure is not fatal and does not fail
+// the read: the rows are already admitted and already the caller's to see, and
+// answering them unnamed is strictly better than answering nothing. The id and
+// is_you still ride out, so the disclosure degrades rather than disappearing.
+func attachOwners(ctx context.Context, name SeatNamer, rows []QueryWorkspaceRow) []QueryWorkspaceRow {
+	owners := make(map[int]ids.UUID, len(rows))
+	seats := make([]ids.UUID, 0, len(rows))
+	seen := make(map[ids.UUID]bool, len(rows))
+	for i, row := range rows {
+		owner, ok := ownerIDOf(row.Record.Fields)
+		if !ok {
+			continue
+		}
+		owners[i] = owner
+		if !seen[owner] {
+			seen[owner] = true
+			seats = append(seats, owner)
+		}
+	}
+	if len(owners) == 0 {
+		return rows
+	}
+	named := map[ids.UUID]string{}
+	if name != nil {
+		if resolved, err := name(ctx, seats); err == nil {
+			named = resolved
+		}
+	}
+	me, haveSeat := callerSeat(ctx)
+	for i, owner := range owners {
+		rows[i].Owner = &RecordOwner{
+			ID: owner, Name: named[owner], IsYou: haveSeat && owner == me,
+		}
+	}
+	return rows
+}

--- a/backend/internal/modules/agents/queryowner.go
+++ b/backend/internal/modules/agents/queryowner.go
@@ -52,9 +52,11 @@ type RecordOwner struct {
 	// by someone not currently a member" rather than silently reading as
 	// unowned.
 	Name string `json:"name,omitempty"`
-	// IsYou is false for an agent principal, and that is correct rather than a
-	// gap: an agent holds no seat, so no record is its own, and every record it
-	// reports belongs to a human it should name.
+	// IsYou answers for the HUMAN the call is made as — the caller themselves,
+	// or the person whose authority an agent is acting under. An assistant
+	// reading a page on your behalf must see your own accounts as yours; an
+	// agent that marked them as somebody else's would send you to check with
+	// yourself and bury the colleague-owned rows in the same noise.
 	IsYou bool `json:"is_you"`
 }
 
@@ -84,22 +86,41 @@ func ownerIDOf(fields json.RawMessage) (ids.UUID, bool) {
 	return *envelope.OwnerID, true
 }
 
-// callerSeat is the human seat asking, when there is one.
+// callerSeat is the human a call is made AS: the caller themselves, or the
+// person whose authority an agent or connector is acting under.
 //
-// An agent or a system principal has no seat, so nothing is "yours" to it. It
-// answers not-ok rather than a zero UUID for the same reason ownerIDOf does:
-// a zero seat compared against a zero owner would mark an unowned record as
-// the caller's own.
+// This is identity's actingHuman rule, and it has to be the same rule. A
+// passport carries its represented human in UserID and OnBehalfOf both, so
+// reading only a human principal's seat would leave every assistant-driven
+// read marking its own operator's accounts as a colleague's — the exact
+// inversion this disclosure exists to prevent.
+//
+// A system principal has no human behind it and answers not-ok, rather than a
+// zero UUID: a zero seat compared against a zero owner would mark an unowned
+// record as the caller's own.
 func callerSeat(ctx context.Context) (ids.UUID, bool) {
 	p, ok := principal.Actor(ctx)
-	if !ok || p.Type != principal.PrincipalHuman {
+	if !ok {
 		return ids.UUID{}, false
 	}
-	if p.UserID == (ids.UUID{}) {
+	seat := p.UserID
+	if seat.IsZero() {
+		seat = p.OnBehalfOf
+	}
+	if seat.IsZero() {
 		return ids.UUID{}, false
 	}
-	return p.UserID, true
+	return seat, true
 }
+
+// CodeOwnerNamesUnavailable says the seat lookup failed, so the rows carry
+// owner ids and is_you markers but no names.
+//
+// It exists because the alternative reading is WRONG in a way that matters: an
+// unnamed owner otherwise looks exactly like a departed one, and a caller
+// cannot tell a database timeout from a colleague who left. Only one of those
+// means "ask around before you contact this account".
+const CodeOwnerNamesUnavailable = "owner_names_unavailable"
 
 // attachOwners names the owner on every row that has one, in ONE lookup.
 //
@@ -107,8 +128,9 @@ func callerSeat(ctx context.Context) (ids.UUID, bool) {
 // per PAGE and not per row. A naming failure is not fatal and does not fail
 // the read: the rows are already admitted and already the caller's to see, and
 // answering them unnamed is strictly better than answering nothing. The id and
-// is_you still ride out, so the disclosure degrades rather than disappearing.
-func attachOwners(ctx context.Context, name SeatNamer, rows []QueryWorkspaceRow) []QueryWorkspaceRow {
+// is_you still ride out, so the disclosure degrades rather than disappearing —
+// and the caller is TOLD it degraded, which is what keeps "no name" honest.
+func attachOwners(ctx context.Context, name SeatNamer, rows []QueryWorkspaceRow) ([]QueryWorkspaceRow, *QueryNote) {
 	owners := make(map[int]ids.UUID, len(rows))
 	seats := make([]ids.UUID, 0, len(rows))
 	seen := make(map[ids.UUID]bool, len(rows))
@@ -124,13 +146,24 @@ func attachOwners(ctx context.Context, name SeatNamer, rows []QueryWorkspaceRow)
 		}
 	}
 	if len(owners) == 0 {
-		return rows
+		return rows, nil
 	}
 	named := map[ids.UUID]string{}
+	var note *QueryNote
+	// A nil namer is not a failure and is not noted: the installation cannot
+	// name seats at all, which is a standing property, and noting it per call
+	// would put the same warning on every answer it ever gives.
 	if name != nil {
-		if resolved, err := name(ctx, seats); err == nil {
-			named = resolved
+		resolved, err := name(ctx, seats)
+		if err != nil {
+			note = &QueryNote{
+				Code: CodeOwnerNamesUnavailable,
+				Detail: "the owner of one or more of these records could not be named; " +
+					"each row still says who owns it by id and whether it is yours, " +
+					"but a missing name here does not mean the owner has left",
+			}
 		}
+		named = resolved
 	}
 	me, haveSeat := callerSeat(ctx)
 	for i, owner := range owners {
@@ -138,5 +171,5 @@ func attachOwners(ctx context.Context, name SeatNamer, rows []QueryWorkspaceRow)
 			ID: owner, Name: named[owner], IsYou: haveSeat && owner == me,
 		}
 	}
-	return rows
+	return rows, note
 }

--- a/backend/internal/modules/agents/queryowner_test.go
+++ b/backend/internal/modules/agents/queryowner_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// ownedRecord is a served record carrying an owner, which is what the query
+// path actually hands to attachOwners: hydrated contract JSON, not a struct.
+func ownedRecord(entity datasource.EntityType, owner ids.UUID) datasource.Record {
+	fields := `{"source":"ui:company-form"}`
+	if owner != (ids.UUID{}) {
+		fields = `{"source":"ui:company-form","owner_id":"` + owner.String() + `"}`
+	}
+	return datasource.Record{
+		Ref:       datasource.EntityRef{Type: entity, ID: ids.NewV7()},
+		Fields:    json.RawMessage(fields),
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+	}
+}
+
+func humanCtx(seat ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + seat.String(), UserID: seat,
+		Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+}
+
+func rowsFor(records ...datasource.Record) []QueryWorkspaceRow {
+	rows := make([]QueryWorkspaceRow, 0, len(records))
+	for _, rec := range records {
+		rows = append(rows, QueryWorkspaceRow{Record: wireRecord{
+			RecordType: string(rec.Ref.Type), ID: rec.Ref.ID, Fields: rec.Fields,
+		}})
+	}
+	return rows
+}
+
+// The defect this whole file exists for: a company owned by a COLLEAGUE came
+// back with a bare owner_id and nothing saying whose it was, so an assistant
+// recommended visiting an account another rep was mid-contract on. The row has
+// to name the owner and say it is not the caller.
+func TestARecordOwnedByAColleagueIsNamedAndMarkedNotYours(t *testing.T) {
+	me, sofia := ids.NewV7(), ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
+
+	named := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{sofia: "Sofia Meier"}, nil
+	}, rows)
+
+	if named[0].Owner == nil {
+		t.Fatal("a company owned by a colleague came back with no owner at all, which is the defect")
+	}
+	if named[0].Owner.Name != "Sofia Meier" {
+		t.Errorf("the owner is not named: %q — a bare uuid is what a reader cannot act on", named[0].Owner.Name)
+	}
+	if named[0].Owner.IsYou {
+		t.Error("a colleague's account is marked as the caller's own")
+	}
+	if named[0].Owner.ID != sofia {
+		t.Error("the owner id did not survive naming")
+	}
+}
+
+// The other half: the caller's OWN record must not read as someone else's, or
+// the signal is noise and a reader learns to ignore it.
+func TestYourOwnRecordIsMarkedAsYours(t *testing.T) {
+	me := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, me))
+
+	named := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{me: "Lars"}, nil
+	}, rows)
+
+	if named[0].Owner == nil || !named[0].Owner.IsYou {
+		t.Fatal("the caller's own account is not marked as theirs")
+	}
+}
+
+// An unowned record has no owner to check with, and saying it has one would be
+// a false claim about a colleague who does not exist.
+func TestAnUnownedRecordCarriesNoOwner(t *testing.T) {
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, ids.UUID{}))
+
+	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		t.Error("an unowned record still asked for a seat name")
+		return map[ids.UUID]string{}, nil
+	}, rows)
+
+	if named[0].Owner != nil {
+		t.Errorf("an unowned record claims an owner: %+v", named[0].Owner)
+	}
+}
+
+// A page of rows sharing owners must cost ONE lookup, not one per row — the
+// reason the naming runs after the page is assembled rather than inside serve.
+func TestAPageOfRowsIsNamedInOneLookup(t *testing.T) {
+	sofia, lena := ids.NewV7(), ids.NewV7()
+	rows := rowsFor(
+		ownedRecord(datasource.EntityOrganization, sofia),
+		ownedRecord(datasource.EntityOrganization, lena),
+		ownedRecord(datasource.EntityOrganization, sofia),
+		ownedRecord(datasource.EntityOrganization, sofia),
+	)
+
+	calls, asked := 0, 0
+	attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		calls, asked = calls+1, len(seats)
+		return map[ids.UUID]string{sofia: "Sofia Meier", lena: "Lena Fischer"}, nil
+	}, rows)
+
+	if calls != 1 {
+		t.Errorf("four rows cost %d seat lookups; a page must cost one", calls)
+	}
+	if asked != 2 {
+		t.Errorf("asked for %d seats across rows owned by 2 people — the ids are not deduplicated", asked)
+	}
+}
+
+// A seat that no longer resolves — an archived member — keeps its id and its
+// not-yours marker. Dropping the owner entirely would read as UNOWNED, which
+// is the one wrong answer: it invites exactly the contact this disclosure
+// exists to prevent.
+func TestAnArchivedOwnerStillReadsAsOwnedBySomeoneElse(t *testing.T) {
+	gone := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, gone))
+
+	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{}, nil
+	}, rows)
+
+	if named[0].Owner == nil {
+		t.Fatal("an unresolvable owner made the record read as unowned")
+	}
+	if named[0].Owner.Name != "" {
+		t.Errorf("a name was invented for an archived seat: %q", named[0].Owner.Name)
+	}
+	if named[0].Owner.IsYou {
+		t.Error("an archived colleague's record is marked as the caller's own")
+	}
+}
+
+// Naming is a courtesy on rows the caller has ALREADY been granted. A namer
+// that fails must not fail the read — the rows are admitted either way, and
+// the id plus the marker still disclose that someone else holds the account.
+func TestANamingFailureStillDisclosesTheOwner(t *testing.T) {
+	sofia := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
+
+	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return nil, context.DeadlineExceeded
+	}, rows)
+
+	if named[0].Owner == nil || named[0].Owner.ID != sofia {
+		t.Fatal("a failed seat lookup swallowed the ownership disclosure entirely")
+	}
+	if named[0].Owner.IsYou {
+		t.Error("a failed lookup marked a colleague's record as the caller's own")
+	}
+}
+
+// An installation with no seat namer wired still serves the query and still
+// discloses ownership, unnamed.
+func TestNoSeatNamerStillDisclosesTheOwner(t *testing.T) {
+	sofia := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
+
+	named := attachOwners(humanCtx(ids.NewV7()), nil, rows)
+	if named[0].Owner == nil || named[0].Owner.ID != sofia {
+		t.Fatal("without a namer the owner vanished rather than going unnamed")
+	}
+}
+
+// An AGENT holds no seat, so no record is its own. Marking one is_you would
+// tell a model it owns an account it cannot own, and suppress the very
+// check-in the disclosure asks for.
+func TestAnAgentOwnsNothing(t *testing.T) {
+	owner := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, owner))
+
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:probe", OnBehalfOf: owner,
+		Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	named := attachOwners(ctx, func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{owner: "Sofia Meier"}, nil
+	}, rows)
+
+	if named[0].Owner == nil {
+		t.Fatal("an agent's read lost the owner")
+	}
+	if named[0].Owner.IsYou {
+		t.Error("an agent is marked as owning a record; an agent holds no seat")
+	}
+}
+
+// Every owned record type gets the same treatment — the accessor reads the
+// contract's own spelling, so a new owned type is covered when it appears.
+func TestEveryOwnedRecordTypeIsNamed(t *testing.T) {
+	owner := ids.NewV7()
+	for _, entity := range []datasource.EntityType{
+		datasource.EntityOrganization, datasource.EntityDeal,
+		datasource.EntityPerson, datasource.EntityLead,
+	} {
+		rows := rowsFor(ownedRecord(entity, owner))
+		named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+			return map[ids.UUID]string{owner: "Sofia Meier"}, nil
+		}, rows)
+		if named[0].Owner == nil || named[0].Owner.Name != "Sofia Meier" {
+			t.Errorf("%s did not carry a named owner", entity)
+		}
+	}
+}
+
+// The model only checks with the owner if the copy tells it to. This is the
+// half of the fix that lives in words rather than in the payload.
+func TestTheCopyTellsTheModelWhatAnOwnerMeans(t *testing.T) {
+	described := queryWorkspaceCopy.render()
+	if !strings.Contains(described, "owner") {
+		t.Fatal("the description never mentions the owner a row now carries")
+	}
+	if !strings.Contains(described, "is_you") {
+		t.Error("the description never names is_you, so a model cannot branch on it")
+	}
+}
+
+// The wiring, held end to end through Handle.
+//
+// Every test above calls attachOwners directly, so all of them stay green if
+// hydrate stops calling it — which is the whole feature silently gone. This is
+// the one that fails when the call is dropped, and it is checked in the RAW
+// BYTES because that is what a client actually reads.
+func TestAServedRowCarriesItsOwnerThroughTheWholeCall(t *testing.T) {
+	me, sofia := ids.NewV7(), ids.NewV7()
+	owned := ownedRecord(datasource.EntityOrganization, sofia)
+
+	tool := queryWorkspace{
+		p: &queryProbeProvider{records: map[ids.UUID]datasource.Record{owned.Ref.ID: owned}},
+		run: func(context.Context, json.RawMessage) (QueryAnswer, error) {
+			return QueryAnswer{
+				Refs:     []QueryRef{{Type: "organization", ID: owned.Ref.ID}},
+				Coverage: CoverageCompleteExact, Limit: 25,
+			}, nil
+		},
+		name: func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+			return map[ids.UUID]string{sofia: "Sofia Meier"}, nil
+		},
+	}
+
+	raw, err := tool.Handle(humanCtx(me), json.RawMessage(`{"plan":{"version":"v1","target":"organization"}}`))
+	if err != nil {
+		t.Fatalf("handling a plan over an owned record: %v", err)
+	}
+	if !strings.Contains(string(raw), `"owner"`) {
+		t.Fatalf("a served row carries no owner — hydrate is not naming them:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), `"name":"Sofia Meier"`) {
+		t.Errorf("the owner rode out unnamed:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), `"is_you":false`) {
+		t.Errorf("the row never says the account is not the caller's:\n%s", raw)
+	}
+}

--- a/backend/internal/modules/agents/queryowner_test.go
+++ b/backend/internal/modules/agents/queryowner_test.go
@@ -54,7 +54,7 @@ func TestARecordOwnedByAColleagueIsNamedAndMarkedNotYours(t *testing.T) {
 	me, sofia := ids.NewV7(), ids.NewV7()
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
 
-	named := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	named, _ := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		return map[ids.UUID]string{sofia: "Sofia Meier"}, nil
 	}, rows)
 
@@ -78,7 +78,7 @@ func TestYourOwnRecordIsMarkedAsYours(t *testing.T) {
 	me := ids.NewV7()
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, me))
 
-	named := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	named, _ := attachOwners(humanCtx(me), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		return map[ids.UUID]string{me: "Lars"}, nil
 	}, rows)
 
@@ -92,7 +92,7 @@ func TestYourOwnRecordIsMarkedAsYours(t *testing.T) {
 func TestAnUnownedRecordCarriesNoOwner(t *testing.T) {
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, ids.UUID{}))
 
-	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	named, _ := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		t.Error("an unowned record still asked for a seat name")
 		return map[ids.UUID]string{}, nil
 	}, rows)
@@ -114,7 +114,7 @@ func TestAPageOfRowsIsNamedInOneLookup(t *testing.T) {
 	)
 
 	calls, asked := 0, 0
-	attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	_, _ = attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		calls, asked = calls+1, len(seats)
 		return map[ids.UUID]string{sofia: "Sofia Meier", lena: "Lena Fischer"}, nil
 	}, rows)
@@ -135,7 +135,7 @@ func TestAnArchivedOwnerStillReadsAsOwnedBySomeoneElse(t *testing.T) {
 	gone := ids.NewV7()
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, gone))
 
-	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	named, _ := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		return map[ids.UUID]string{}, nil
 	}, rows)
 
@@ -153,11 +153,15 @@ func TestAnArchivedOwnerStillReadsAsOwnedBySomeoneElse(t *testing.T) {
 // Naming is a courtesy on rows the caller has ALREADY been granted. A namer
 // that fails must not fail the read — the rows are admitted either way, and
 // the id plus the marker still disclose that someone else holds the account.
-func TestANamingFailureStillDisclosesTheOwner(t *testing.T) {
+//
+// But it must SAY it failed. Without the note, a lookup timeout and a
+// colleague who left the company produce the same unnamed owner, and only one
+// of those means "ask around before you contact this account".
+func TestANamingFailureDisclosesTheOwnerAndSaysItFailed(t *testing.T) {
 	sofia := ids.NewV7()
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
 
-	named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+	named, note := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 		return nil, context.DeadlineExceeded
 	}, rows)
 
@@ -167,6 +171,27 @@ func TestANamingFailureStillDisclosesTheOwner(t *testing.T) {
 	if named[0].Owner.IsYou {
 		t.Error("a failed lookup marked a colleague's record as the caller's own")
 	}
+	if note == nil {
+		t.Fatal("a failed lookup is indistinguishable from an owner who left the company")
+	}
+	if note.Code != CodeOwnerNamesUnavailable {
+		t.Errorf("the note carries %q rather than the code a client branches on", note.Code)
+	}
+}
+
+// The mirror of the above: a seat that simply does not resolve is NOT a
+// failure, and must not raise the alarm. An owner who left is an ordinary
+// answer.
+func TestAnArchivedOwnerRaisesNoFailureNote(t *testing.T) {
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, ids.NewV7()))
+
+	_, note := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{}, nil
+	}, rows)
+
+	if note != nil {
+		t.Errorf("an owner who left was reported as a lookup failure: %+v", note)
+	}
 }
 
 // An installation with no seat namer wired still serves the query and still
@@ -175,34 +200,79 @@ func TestNoSeatNamerStillDisclosesTheOwner(t *testing.T) {
 	sofia := ids.NewV7()
 	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
 
-	named := attachOwners(humanCtx(ids.NewV7()), nil, rows)
+	named, _ := attachOwners(humanCtx(ids.NewV7()), nil, rows)
 	if named[0].Owner == nil || named[0].Owner.ID != sofia {
 		t.Fatal("without a namer the owner vanished rather than going unnamed")
 	}
 }
 
-// An AGENT holds no seat, so no record is its own. Marking one is_you would
-// tell a model it owns an account it cannot own, and suppress the very
-// check-in the disclosure asks for.
-func TestAnAgentOwnsNothing(t *testing.T) {
-	owner := ids.NewV7()
-	rows := rowsFor(ownedRecord(datasource.EntityOrganization, owner))
+// An agent reads on a HUMAN's behalf, so "yours" means that human's.
+//
+// This is the case the first cut of this file got backwards. Reading only a
+// human principal's seat left every assistant-driven query marking its own
+// operator's accounts as a colleague's — the exact inversion the disclosure
+// exists to prevent, and worse than saying nothing, because it sends someone
+// to check with themselves.
+func TestAnAgentReadsAsTheHumanItActsFor(t *testing.T) {
+	me := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, me))
 
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:probe", OnBehalfOf: owner,
+		Type: principal.PrincipalAgent, ID: "agent:probe", OnBehalfOf: me,
 		Scopes: principal.NewScopeSet(principal.ScopeRead),
 	})
 
-	named := attachOwners(ctx, func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
-		return map[ids.UUID]string{owner: "Sofia Meier"}, nil
+	named, _ := attachOwners(ctx, func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{me: "Lars"}, nil
 	}, rows)
 
 	if named[0].Owner == nil {
 		t.Fatal("an agent's read lost the owner")
 	}
-	if named[0].Owner.IsYou {
-		t.Error("an agent is marked as owning a record; an agent holds no seat")
+	if !named[0].Owner.IsYou {
+		t.Error("an assistant reading on my behalf marked MY OWN account as somebody else's")
+	}
+}
+
+// And the other half: a colleague's account stays a colleague's when an agent
+// reads it, or the marker means nothing.
+func TestAnAgentStillSeesAColleaguesRecordAsTheirs(t *testing.T) {
+	me, sofia := ids.NewV7(), ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, sofia))
+
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:probe", OnBehalfOf: me,
+		Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	named, _ := attachOwners(ctx, func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{sofia: "Sofia Meier"}, nil
+	}, rows)
+
+	if named[0].Owner == nil || named[0].Owner.IsYou {
+		t.Fatal("a colleague's account read as the operator's own")
+	}
+}
+
+// A system principal has no human behind it, so nothing is its own.
+func TestASystemPrincipalOwnsNothing(t *testing.T) {
+	owner := ids.NewV7()
+	rows := rowsFor(ownedRecord(datasource.EntityOrganization, owner))
+
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:sweep",
+		Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	named, _ := attachOwners(ctx, func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		return map[ids.UUID]string{owner: "Sofia Meier"}, nil
+	}, rows)
+
+	if named[0].Owner == nil || named[0].Owner.IsYou {
+		t.Error("a system principal is marked as owning a record")
 	}
 }
 
@@ -215,7 +285,7 @@ func TestEveryOwnedRecordTypeIsNamed(t *testing.T) {
 		datasource.EntityPerson, datasource.EntityLead,
 	} {
 		rows := rowsFor(ownedRecord(entity, owner))
-		named := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
+		named, _ := attachOwners(humanCtx(ids.NewV7()), func(_ context.Context, seats []ids.UUID) (map[ids.UUID]string, error) {
 			return map[ids.UUID]string{owner: "Sofia Meier"}, nil
 		}, rows)
 		if named[0].Owner == nil || named[0].Owner.Name != "Sofia Meier" {

--- a/backend/internal/modules/agents/results.go
+++ b/backend/internal/modules/agents/results.go
@@ -95,6 +95,12 @@ type QueryWorkspaceRow struct {
 	// a traversal. It is what makes a hop legible as a reason rather than as an
 	// invisible filter, and it is never null for the same reason Notes is not.
 	Evidence []QueryEvidence `json:"evidence"`
+	// Owner is who this record belongs to, named and marked against the caller.
+	// Absent for a record that carries no owner, which is the honest answer —
+	// an unowned account is nobody's to check with. Present and NOT `is_you`
+	// means a colleague is working this record: see queryowner.go for why that
+	// has to be said out loud rather than left in the fields as a raw id.
+	Owner *RecordOwner `json:"owner,omitempty"`
 }
 
 // QueryEvidence is one related record that admitted a row, and the relationship

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4671,6 +4671,25 @@
                     ]
                   }
                 },
+                "owner": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "is_you": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "is_you"
+                  ]
+                },
                 "record": {
                   "type": "object",
                   "properties": {

--- a/backend/internal/modules/agents/toolcopy_query.go
+++ b/backend/internal/modules/agents/toolcopy_query.go
@@ -22,5 +22,9 @@ var queryWorkspaceCopy = toolCopy{
 		"the plan is here, `ranked_semantic` means these ranked highest and others may match, and " +
 		"`partial_degraded` means something in the plan could not be answered as asked — `notes` " +
 		"says which. Keep each row's record_type and id for any follow-up call, and its `evidence` " +
-		"for the related record that admitted it.",
+		"for the related record that admitted it. A row's `owner` is the colleague who holds that " +
+		"account: rows come back from across the whole workspace, so most of them belong to " +
+		"someone other than the person asking. When `owner.is_you` is false, say whose it is when " +
+		"you report the record, and treat contacting it as theirs to decide rather than advising " +
+		"an approach as though the account were unowned.",
 }

--- a/backend/internal/modules/agents/tools_query.go
+++ b/backend/internal/modules/agents/tools_query.go
@@ -236,7 +236,11 @@ func (t queryWorkspace) hydrate(ctx context.Context, answer QueryAnswer) (QueryW
 	// Named AFTER the page is assembled, so the seat lookup is one query for
 	// the whole page. Only served rows are named: a dropped row was never the
 	// caller's to see, and naming its owner would disclose it.
-	result.Rows = attachOwners(ctx, t.name, result.Rows)
+	rows, ownerNote := attachOwners(ctx, t.name, result.Rows)
+	result.Rows = rows
+	if ownerNote != nil {
+		result.Notes = append(result.Notes, *ownerNote)
+	}
 	if dropped {
 		result.Coverage = CoveragePartialDegraded
 		result.Notes = append(result.Notes, QueryNote{

--- a/backend/internal/modules/agents/tools_query.go
+++ b/backend/internal/modules/agents/tools_query.go
@@ -109,16 +109,23 @@ type QueryRef struct {
 // the same conditional registration the other injected-engine tools take. An
 // installation whose executor is unwired serves no query tool rather than one
 // that refuses every call.
-func RegisterQueryTool(r *Registry, p datasource.SystemOfRecordProvider, run QueryRunner) {
+// The seat namer is separately optional: an installation that cannot name
+// seats still serves the tool, and its rows carry an owner id and an is_you
+// marker without a name. Refusing to serve the query at all because ownership
+// cannot be spelled out would trade a whole capability for a label.
+func RegisterQueryTool(r *Registry, p datasource.SystemOfRecordProvider, run QueryRunner, name SeatNamer) {
 	if run == nil {
 		return
 	}
-	r.Register(queryWorkspace{p: p, run: run})
+	r.Register(queryWorkspace{p: p, run: run, name: name})
 }
 
 type queryWorkspace struct {
 	p   datasource.SystemOfRecordProvider
 	run QueryRunner
+	// name resolves owner ids to seat names. Nil is tolerated and degrades to
+	// an unnamed owner rather than a failed read — see attachOwners.
+	name SeatNamer
 }
 
 func (t queryWorkspace) Spec() mcp.ToolSpec {
@@ -226,6 +233,10 @@ func (t queryWorkspace) hydrate(ctx context.Context, answer QueryAnswer) (QueryW
 		}
 		result.Rows = append(result.Rows, t.serve(ctx, ref, row, served))
 	}
+	// Named AFTER the page is assembled, so the seat lookup is one query for
+	// the whole page. Only served rows are named: a dropped row was never the
+	// caller's to see, and naming its owner would disclose it.
+	result.Rows = attachOwners(ctx, t.name, result.Rows)
 	if dropped {
 		result.Coverage = CoveragePartialDegraded
 		result.Notes = append(result.Notes, QueryNote{

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 58,
-    "tokens": 18064,
+    "tokens": 18153,
     "median_tool_tokens": 274,
-    "mean_tool_tokens": 311
+    "mean_tool_tokens": 312
   },
   "agents": [
     {
@@ -90,6 +90,10 @@
       "tokens": 513
     },
     {
+      "name": "query_workspace",
+      "tokens": 491
+    },
+    {
       "name": "list_records",
       "tokens": 475
     },
@@ -112,10 +116,6 @@
     {
       "name": "create_record",
       "tokens": 429
-    },
-    {
-      "name": "query_workspace",
-      "tokens": 402
     },
     {
       "name": "search_records",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 58 | 18064 | 75% | — | — | — |
+| _whole served catalog, for scale_ | 58 | 18153 | 75% | — | — | — |
 
 ### `morning_brief`
 
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 274 tokens, mean 311, across 58 served tools.
+Median 274 tokens, mean 312, across 58 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -134,13 +134,13 @@ a term in an addition.
 | `log_activity` | 588 | 1 scenario |
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |
+| `query_workspace` | 491 | 3 scenarios |
 | `list_records` | 475 | — |
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |
 | `progress_deal` | 435 | 3 scenarios |
 | `book_meeting` | 431 | — |
 | `create_record` | 429 | 1 scenario |
-| `query_workspace` | 402 | 3 scenarios |
 | `search_records` | 392 | 6 scenarios |
 | `enrich` | 386 | — |
 | `search_context` | 352 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 58,
     "resources": 9,
-    "tool_catalog_bytes": 163083,
+    "tool_catalog_bytes": 163599,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 41649,
+    "approx_wire_tokens_total": 41778,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 38449,
+      "description_bytes": 38805,
       "input_schema_bytes": 35709,
-      "output_schema_bytes": 76331,
-      "description_plus_input_schema_bytes": 74158
+      "output_schema_bytes": 76491,
+      "description_plus_input_schema_bytes": 74514
     }
   },
   "tools": {
@@ -6065,7 +6065,7 @@
           "readOnlyHint": true,
           "title": "Query the workspace"
         },
-        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. A row's `owner` is the colleague who holds that account: rows come back from across the whole workspace, so most of them belong to someone other than the person asking. When `owner.is_you` is false, say whose it is when you report the record, and treat contacting it as theirs to decide rather than advising an approach as though the account were unowned. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -6149,6 +6149,25 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "owner": {
+                        "properties": {
+                          "id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
+                          "is_you": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "is_you"
+                        ],
+                        "type": "object"
                       },
                       "record": {
                         "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 58 |
 | Resources | 9 |
-| Tool catalog | 159.3 KB |
+| Tool catalog | 159.8 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 41649 |
+| Approx. wire tokens | 41778 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 74.5 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 37.5 KB | 23% | Yes, every step |
+| Output schemas | 74.7 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 37.9 KB | 23% | Yes, every step |
 | Input schemas | 34.9 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.3 KB | 7% | Partly |
-| **Description + input schema** | **72.4 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **72.8 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -96,7 +96,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
-| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.5 KB |
+| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 4.0 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
@@ -6678,7 +6678,7 @@ Fill in what a lead's own data already implies — today the company name, from 
 
 **Query the workspace**
 
-Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope "read".)
+Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. A row's `owner` is the colleague who holds that account: rows come back from across the whole workspace, so most of them belong to someone other than the person asking. When `owner.is_you` is false, say whose it is when you report the record, and treat contacting it as theirs to decide rather than advising an approach as though the account were unowned. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -6772,6 +6772,25 @@ Answer a question that has STRUCTURE — a record type, conditions on its fields
                   "type": "object"
                 },
                 "type": "array"
+              },
+              "owner": {
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "is_you": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "is_you"
+                ],
+                "type": "object"
               },
               "record": {
                 "properties": {


### PR DESCRIPTION
## The defect

`query_workspace` returned companies owned by other reps carrying only a bare `owner_id` UUID. Nothing said who that was, and nothing said it was not the caller.

The failure was concrete. Asked "anyone nearby I should visit?", an assistant returned seven Cologne companies and recommended visiting one whose owner had an unsent contract with that customer — never mentioning the owner existed.

## What is NOT the bug

Row scope. `organization` is an identity table, so the ownership arm renders `TRUE` and every rep sees every account by design. `auth/tableclass.go` states the reason:

> a rep who cannot see that a company is already a customer of another team contacts it again

That trade only pays if the answer says **whose** the account is. The record already carried `owner_id`, so the fact was never withheld — it was unreadable. A bare UUID tells a human nothing and tells a model less.

## The fix

Each served row gains an `owner`:

```json
{"id": "018f…", "name": "Sofia Meier", "is_you": false}
```

- **Resolved once per PAGE**, after rows are assembled: twenty companies owned by three reps cost one seat lookup.
- **Only SERVED rows.** A dropped row was never the caller's to see, and naming its owner would disclose it.
- **`is_you` is stated, not derived.** A client comparing ids would need to know its own seat, which an assistant reading a tool result does not.
- **Degrades, never fails.** A naming failure or an archived seat keeps the id and the marker — dropping the owner would read as UNOWNED, the one wrong answer, because it invites exactly the contact this prevents.
- **An agent owns nothing.** It holds no seat, so `is_you` is false and every record it reports belongs to a human it should name.

`identity` owns the seat read and a module never imports a sibling, so the namer is injected by compose as a func type, like `HandoffReader`. The tool copy carries the other half: a model only checks with the owner if told to.

## Tests

Eleven in `queryowner_test.go`, including one that goes through `Handle` end to end and checks the raw bytes — verified to FAIL when the `attachOwners` call is removed from `hydrate`, which the direct-call tests do not catch.

## Also here

`approvalsAdapter` moved out of `registry.go` into its own file — a pure extraction, no behaviour change. `registry.go` was at 499 of the 500-line cap, so any addition broke it.

## Pre-existing failures, not from this branch

Both reproduced on a clean detached checkout of `origin/main`:
- `arch-lint`: migrations imports `google/uuid` (#2729)
- `read_brief({}): not found` in the integration lane (#2744)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace query results now show record ownership, including the owner’s name, ID, and whether the record belongs to you.
  * Ownership details remain available for archived or unresolved owners, with a note when names cannot be retrieved.
  * Approval workflows support staging, status checks, proposed changes, redemption, and withdrawal.

* **Documentation**
  * Updated workspace-query guidance and reference schemas to describe ownership fields.
  * Refreshed tool catalog and usage metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->