### PR TITLE
fix(migrations): the local-day replay holds its ids in what the component may say

### DIFF
--- a/backend/migrations/briefrunlocalday_integration_test.go
+++ b/backend/migrations/briefrunlocalday_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -143,17 +142,18 @@ func TestTheLocalDayBackfillUsesTheInstallationZoneNotUTC(t *testing.T) {
 
 // The fixture the two tests above share: one rep and two deals, which is the
 // smallest shape brief_run and brief_item's foreign keys will accept.
-var (
-	briefFixtureUser     = mustParseUUID("01920000-0000-7000-8000-000000000001")
-	briefFixtureDealA    = mustParseUUID("01920000-0000-7000-8000-00000000000a")
-	briefFixtureDealB    = mustParseUUID("01920000-0000-7000-8000-00000000000b")
-	briefFixturePipeline = mustParseUUID("01920000-0000-7000-8000-0000000000c1")
-	briefFixtureStage    = mustParseUUID("01920000-0000-7000-8000-0000000000d1")
+//
+// Held as strings, which is also all this component may say: `migrations` is
+// allowed pgx and nothing else, and pgx binds a string to a uuid column and
+// scans one back. A dedicated id type would widen the architecture rule to buy
+// a type this file never uses as a type.
+const (
+	briefFixtureUser     = "01920000-0000-7000-8000-000000000001"
+	briefFixtureDealA    = "01920000-0000-7000-8000-00000000000a"
+	briefFixtureDealB    = "01920000-0000-7000-8000-00000000000b"
+	briefFixturePipeline = "01920000-0000-7000-8000-0000000000c1"
+	briefFixtureStage    = "01920000-0000-7000-8000-0000000000d1"
 )
-
-func mustParseUUID(s string) uuid.UUID {
-	return uuid.MustParse(s)
-}
 
 // seedBriefRunFixture writes the rows brief_run and brief_item foreign-key to:
 // one rep, and two deals on a pipeline stage. It inserts them directly rather
@@ -177,7 +177,7 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 		briefFixtureStage, briefFixturePipeline); err != nil {
 		t.Fatalf("seeding the fixture stage: %v", err)
 	}
-	for _, deal := range []uuid.UUID{briefFixtureDealA, briefFixtureDealB} {
+	for _, deal := range []string{briefFixtureDealA, briefFixtureDealB} {
 		if _, err := conn.Exec(ctx,
 			`INSERT INTO deal (id, pipeline_id, stage_id, name, owner_id, status, source, captured_by)
 			 VALUES ($1, $2, $3, 'Deal', $4, 'open', 'manual', 'test')`,
@@ -189,9 +189,9 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 
 // insertBriefRun writes one pre-migration run — no local_day, which is the
 // whole point: the column does not exist yet when the migration replays.
-func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UUID {
+func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) string {
 	t.Helper()
-	var id uuid.UUID
+	var id string
 	if err := conn.QueryRow(context.Background(),
 		`INSERT INTO brief_run (user_id, generated_at, as_of, candidate_count, revenue_norm_minor)
 		 VALUES ($1, $2, $2, 3, 5000000) RETURNING id`,
@@ -203,7 +203,7 @@ func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UU
 
 // insertBriefItem writes one queue entry with the per-rep state the collapse
 // must carry forward.
-func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal uuid.UUID, rank int,
+func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal string, rank int,
 	state string, stateAt, snoozedUntil *time.Time,
 ) {
 	t.Helper()


### PR DESCRIPTION
main is red on `backend gate (main)` — [run 32916607681](https://github.com/margince/margince/actions/runs/32916607681). The failure is arch-lint:

```
Component migrations shouldn't depend on github.com/google/uuid
in backend/migrations/briefrunlocalday_integration_test.go:27
```

`.go-arch-lint.yml` gives the component `canUse: [pgx]` and nothing else.

## The fix

The five fixture ids were never used as a *type* — they are opaque values handed to pgx and scanned back, and pgx binds a string to a `uuid` column and scans one back. So they are `string` constants now, and `mustParseUUID` goes with them.

That is also what this package already does elsewhere: `schema_integration_test.go` leaves generation to `uuidv7()` and `gen_random_uuid()` and never names a Go uuid package. The `ARRAY[]::uuid[]` cast stays — that is SQL text, not a Go dependency.

## The alternative I did not take

Adding `uuid` to the component's `canUse` list would also have made the gate green. It widens an architecture rule to buy one test's convenience, and the rule is what keeps this package compiling against a schema rather than against the application — the exception would be permanent and the convenience momentary.

## Verification

- `go-arch-lint check` → **OK - No warnings found**.
- Proved that run actually reads this file rather than skipping the build-tagged package: re-introduced the import on top of the fix and arch-lint reported `total notices: 1`. Restored and re-verified clean.
- `go vet -tags integration ./migrations/` clean; `gofmt` clean.

The test's own assertions are untouched — this changes how the ids are spelled, not what the replay proves.

## Not fixed here

main is also red on `dco (main)`, `uat (main)`, `integration shard (4/6)`, `integration shard (5/6)` and `integration (RLS + erasure + HTTP e2e)`. Separate causes, separate diffs:

- **`uat`** — #2743, open.
- **`dco`** — commit `2736937c0` (#2728) has no `Signed-off-by`; only its author can remediate that.
- **shard 4/6** — `read_brief({}): not found` in the tool-schema conformance census. `read_brief` is new and its fixture is unseeded.
- **shard 5/6** — `TestConcurrentCallsOfOneTaskAllReachTheProjection`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test fixtures to use string-formatted identifiers.
  * Maintained compatibility with PostgreSQL UUID storage and retrieval.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->