### PR TITLE
fix(deals): a rejected follow-up stays rejected, and an unusable one is refused before it is decided

### DIFF
--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -970,9 +970,10 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 	}
 }
 
-// A withheld lane is named ONCE. Naming it twice is what a duplicate read looks
-// like on the wire, and a client rendering the list would say it twice.
-func TestAWithheldLaneIsNamedOnce(t *testing.T) {
+// A withheld lane appears in lanes_omitted exactly one time. Two entries is
+// what a duplicate read looks like on the wire, and a client rendering the list
+// would say it twice.
+func TestAWithheldLaneAppearsInLanesOmittedExactlyOneTime(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, fixedClock,

--- a/backend/internal/compose/attention/optionallanes.go
+++ b/backend/internal/compose/attention/optionallanes.go
@@ -97,8 +97,8 @@ func (s *Service) optionalLanes(
 	}
 }
 
-// renderEach turns one producer's rows into wire items. The lanes differ in
-// what they read and how a row is drawn; the loop between them is spelled once.
+// renderEach turns one producer's rows into wire items — the loop the lanes
+// share, so they differ only in what they read and how a row is drawn.
 //
 // Never nil: the empty slice rather than a null the contract promised was a list.
 func renderEach[T any](rows []T, draw func(T) crmcontracts.AttentionItem) []crmcontracts.AttentionItem {

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/idlebase"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -91,15 +92,13 @@ func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, erro
 	return risky, nil
 }
 
-// idleDaysOf is how long the deal has been quiet, counted from the same base
-// the idle rule itself measures from: the last activity, or the deal's creation
-// when nothing has ever touched it.
+// idleDaysOf is how long the deal has been quiet, counted from the base the
+// idle RULE measures from — through idlebase.Since rather than by repeating its
+// fallback here. A card that computed the base itself would agree with the
+// stalled rule by inspection and then drift the first time either moved, which
+// is what the one-spelling gate exists to stop.
 func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
-	since := deal.CreatedAt
-	if deal.LastActivityAt != nil {
-		since = *deal.LastActivityAt
-	}
-	days := int(now.Sub(since).Hours() / 24)
+	days := int(now.Sub(idlebase.Since(deal.CreatedAt, deal.LastActivityAt)).Hours() / 24)
 	if days < 0 {
 		return 0
 	}

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -80,6 +80,7 @@ func approvalsServiceWithEffects(pool *pgxpool.Pool) *approvals.Service {
 		InstallationDB(pool)))
 	svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(svc, deals.NewStore(InstallationDB(pool), DealsInstallation())))
 	svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(svc, activities.NewStore(InstallationDB(pool))))
+	svc.WithPrecheck(deals.FollowUpReconcileKind, followUpPrecheck())
 	svc.WithEffect(TranscriptProposalKind, transcriptProposalEffect(svc, activities.NewStore(InstallationDB(pool))))
 	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, deals.NewStore(InstallationDB(pool), DealsInstallation())))
 	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, ai.NewRateStore(InstallationDB(pool))))

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
@@ -138,9 +139,6 @@ func followUpPrecheck() approvals.ReleasePrecheck {
 // decision's own audit row.
 func followUpConfirmEffect(svc *approvals.Service, store *activities.Store) approvals.ApprovedEffect {
 	return func(ctx context.Context, approvalID ids.ApprovalID, proposedChange json.RawMessage, diffHash string) error {
-		if _, _, err := svc.Redeem(ctx, approvalID, deals.FollowUpReconcileKind, diffHash); err != nil {
-			return err
-		}
 		proposal, err := deals.UnmarshalFollowUpProposal(proposedChange)
 		if err != nil {
 			return err
@@ -163,16 +161,25 @@ func followUpConfirmEffect(svc *approvals.Service, store *activities.Store) appr
 		body := proposal.Body
 		sourceSystem := "overnight-reconcile"
 		sourceID := approvalID.String()
-		_, _, err = store.LogActivity(execCtx, activities.LogActivityInput{
-			Kind:         "task",
-			Subject:      &subject,
-			Body:         &body,
-			DueAt:        &due,
-			SourceSystem: &sourceSystem,
-			SourceID:     &sourceID,
-			Source:       "overnight-reconcile",
-			Links:        []activities.ActivityLinkInput{{EntityType: "deal", EntityID: proposal.DealID.UUID}},
-		})
-		return err
+		// Redemption and the write in ONE transaction, which is what makes a
+		// failure recoverable. Consuming the approval first and writing after
+		// means a failed write spends the human's yes and leaves no task and no
+		// way to try again — the approval is decided, redeemed, and no surface
+		// can re-drive it. Here a failed write rolls the redemption back with
+		// it, so the decision stays releasable.
+		return svc.RedeemAndApply(ctx, approvalID, deals.FollowUpReconcileKind, diffHash,
+			func(tx pgx.Tx) error {
+				_, _, err := store.LogActivityTx(execCtx, tx, activities.LogActivityInput{
+					Kind:         "task",
+					Subject:      &subject,
+					Body:         &body,
+					DueAt:        &due,
+					SourceSystem: &sourceSystem,
+					SourceID:     &sourceID,
+					Source:       "overnight-reconcile",
+					Links:        []activities.ActivityLinkInput{{EntityType: "deal", EntityID: proposal.DealID.UUID}},
+				})
+				return err
+			})
 	}
 }

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -60,7 +60,8 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	if err != nil {
 		return fmt.Errorf("compose: canonicalize follow-up proposal: %w", err)
 	}
-	// The logical identity is the DEAL, and nothing else.
+	// The logical identity is the deal AND the interaction the proposal was
+	// drawn from — the two fields that say WHICH follow-up this is.
 	//
 	// It must not include the due date. The proposal's date moves with "today",
 	// so an identity carrying it makes every night's proposal a different one —
@@ -68,10 +69,22 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	// declined, would recognise nothing. A rep's "no" then became a question
 	// they were asked again the following morning.
 	//
+	// It must not be the deal ALONE either, for the opposite reason. A decline
+	// is remembered with no expiry, so a deal-only identity lets one "no" bury
+	// every future follow-up on that deal: the rep declines after a discovery
+	// call, has a real conversation three weeks later that again ends with no
+	// next step, and is never asked. The evidence activity is what separates
+	// those two cases — the nightly pass picks the LATEST interaction, so it is
+	// the same value while the situation is unchanged and a new one exactly when
+	// the deal has genuinely moved.
+	//
 	// Identity fields must appear in ProposedChange with the same value
-	// (canonicalIdentity enforces it), and deal_id does: the payload carries it
-	// as the deal this follow-up is for.
-	identity, err := json.Marshal(map[string]string{"deal_id": dealID.String()})
+	// (canonicalIdentity enforces it), and both do: the payload carries the deal
+	// this follow-up is for and the interaction that triggered it.
+	identity, err := json.Marshal(map[string]string{
+		"deal_id":              dealID.String(),
+		"evidence_activity_id": proposal.EvidenceActivityID.String(),
+	})
 	if err != nil {
 		return fmt.Errorf("compose: marshal follow-up identity: %w", err)
 	}
@@ -109,6 +122,12 @@ func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUp
 // It checks the payload about to be committed — the edit when there is one, the
 // staged proposal otherwise — because those are different documents and only
 // one of them is what the effect will read.
+//
+// The refusal is approvals' own InvalidEditError so it lands on 422 naming the
+// field, the way the send precheck's refusals already do. An untyped error here
+// reaches the generic mapper and reads as 500 internal, which tells the rep
+// their approval broke the server rather than that the date needs fixing —
+// leaving them nothing to act on and no reason to try again.
 func followUpPrecheck() approvals.ReleasePrecheck {
 	return func(_ context.Context, staged, edited json.RawMessage) error {
 		payload := staged
@@ -117,11 +136,11 @@ func followUpPrecheck() approvals.ReleasePrecheck {
 		}
 		proposal, err := deals.UnmarshalFollowUpProposal(payload)
 		if err != nil {
-			return fmt.Errorf("this follow-up cannot be created as written: %w", err)
+			return &approvals.InvalidEditError{Cause: err}
 		}
 		if _, err := time.Parse(time.DateOnly, proposal.DueDate); err != nil {
-			return fmt.Errorf(
-				"the due date %q is not a date — write it as YYYY-MM-DD", proposal.DueDate)
+			return &approvals.InvalidEditError{Cause: fmt.Errorf(
+				"the due date %q is not a date — write it as YYYY-MM-DD", proposal.DueDate)}
 		}
 		return nil
 	}
@@ -161,12 +180,19 @@ func followUpConfirmEffect(svc *approvals.Service, store *activities.Store) appr
 		body := proposal.Body
 		sourceSystem := "overnight-reconcile"
 		sourceID := approvalID.String()
-		// Redemption and the write in ONE transaction, which is what makes a
-		// failure recoverable. Consuming the approval first and writing after
-		// means a failed write spends the human's yes and leaves no task and no
-		// way to try again — the approval is decided, redeemed, and no surface
-		// can re-drive it. Here a failed write rolls the redemption back with
-		// it, so the decision stays releasable.
+		// Redemption and the write in ONE transaction. Consuming the approval
+		// first and writing after leaves the two able to disagree: the approval
+		// reads as redeemed while no task exists, and the audit row asserts a
+		// redemption for a write that never landed. Here a failed write rolls
+		// the redemption back with it, so redeemed and created stay the same
+		// fact.
+		//
+		// It does NOT make a failed effect re-drivable. The decision commits
+		// before any effect runs, so a failure here leaves an approved row with
+		// its redemption intact and nothing to re-trigger it — deciding again
+		// returns AlreadyDecided. Closing that needs the effect inside the
+		// decision transaction, or a durable retry, and it is the approvals
+		// module's to close for every kind rather than this one's.
 		return svc.RedeemAndApply(ctx, approvalID, deals.FollowUpReconcileKind, diffHash,
 			func(tx pgx.Tx) error {
 				_, _, err := store.LogActivityTx(execCtx, tx, activities.LogActivityInput{

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -59,13 +59,30 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	if err != nil {
 		return fmt.Errorf("compose: canonicalize follow-up proposal: %w", err)
 	}
-	_, err = s.svc.Stage(ctx, approvals.StageInput{
+	// The logical identity is the DEAL, and nothing else.
+	//
+	// It must not include the due date. The proposal's date moves with "today",
+	// so an identity carrying it makes every night's proposal a different one —
+	// and StageUnlessDeclined, which recognises a proposal a human already
+	// declined, would recognise nothing. A rep's "no" then became a question
+	// they were asked again the following morning.
+	//
+	// Identity fields must appear in ProposedChange with the same value
+	// (canonicalIdentity enforces it), and deal_id does: the payload carries it
+	// as the deal this follow-up is for.
+	identity, err := json.Marshal(map[string]string{"deal_id": dealID.String()})
+	if err != nil {
+		return fmt.Errorf("compose: marshal follow-up identity: %w", err)
+	}
+	_, _, err = s.svc.StageUnlessDeclined(ctx, approvals.StageInput{
 		Kind:           deals.FollowUpReconcileKind,
 		ProposedChange: canonical,
 		DiffHash:       hash,
 		TargetType:     "deal",
 		TargetID:       dealID,
 		Summary:        summary,
+		Identity:       identity,
+		JoinPending:    true,
 	})
 	return err
 }

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -93,6 +93,39 @@ func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUp
 	return deals.NewFollowUpReconciler(InstallationDB(pool), followUpStager{svc: approvals.NewService(InstallationDB(pool))}, log)
 }
 
+// followUpPrecheck refuses a DECISION whose payload the effect could not use.
+//
+// It exists because the two halves are not one transaction: the approval
+// commits, then the effect runs, and a failed effect never un-decides it. So a
+// payload the effect chokes on produces an approved row nothing can decide
+// again and no surface can re-drive — the rep sees their yes recorded, no task
+// appears, and nothing says why. Refusing BEFORE the decision leaves the row
+// pending, which is the state a human can act on: fix the date, approve again.
+//
+// The due date is the reachable case rather than a theoretical one. The card
+// lets a human edit the proposal, and this is the field the effect parses.
+//
+// It checks the payload about to be committed — the edit when there is one, the
+// staged proposal otherwise — because those are different documents and only
+// one of them is what the effect will read.
+func followUpPrecheck() approvals.ReleasePrecheck {
+	return func(_ context.Context, staged, edited json.RawMessage) error {
+		payload := staged
+		if len(edited) > 0 {
+			payload = edited
+		}
+		proposal, err := deals.UnmarshalFollowUpProposal(payload)
+		if err != nil {
+			return fmt.Errorf("this follow-up cannot be created as written: %w", err)
+		}
+		if _, err := time.Parse(time.DateOnly, proposal.DueDate); err != nil {
+			return fmt.Errorf(
+				"the due date %q is not a date — write it as YYYY-MM-DD", proposal.DueDate)
+		}
+		return nil
+	}
+}
+
 // followUpConfirmEffect executes an approved follow-up: redeem-then-
 // create like every 🟡 executor, then log the drafted (possibly human-
 // edited) follow-up task through the activities store — the same

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -504,6 +504,40 @@ func TestAValidEditIsApprovedAndTheEffectUsesIt(t *testing.T) {
 	}
 }
 
+// The rejection survives a payload that has MOVED. The proposal's due date is
+// computed from "today", so tomorrow's proposal is a different document — and
+// supersession matches by containment of the identity, not by equality of the
+// payload. If that were the other way round, the memory would last exactly one
+// night and this fix would be decorative.
+func TestARejectionSurvivesTheProposalChangingUnderIt(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Payload moves", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "meeting", "Sync", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, first := e.followUpApproval(t, deal)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// Move the deal's clock so the next pass computes a different due date and
+	// cites a fresh interaction — a genuinely different document, same question.
+	e.WsExec(t, `UPDATE deal SET last_activity_at = now() - interval '2 days' WHERE id = $1`, deal)
+	e.seedInteraction(t, deal, "call", "Follow-up call", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("a moved payload staged %d proposals past the rejection, want 0 — "+
+			"the memory is keyed on the payload rather than on the deal", got)
+	}
+	if first.DealID.UUID != deal {
+		t.Errorf("the first proposal named deal %s, want %s", first.DealID.UUID, deal)
+	}
+}
+
 // --- row scope: a proposal never leaks a deal the decider cannot see ---
 
 func TestFollowUpProposalRespectsRowScope(t *testing.T) {

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -15,6 +15,7 @@ package compose
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"os"
@@ -63,6 +64,7 @@ func setupReconcile(t *testing.T) *reconcileEnv {
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	e.svc = approvals.NewService(e.DB())
 	e.svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(e.svc, e.Activities))
+	e.svc.WithPrecheck(deals.FollowUpReconcileKind, followUpPrecheck())
 	e.reconciler = deals.NewFollowUpReconciler(e.DB(), followUpStager{svc: e.svc}, quiet)
 	return e
 }
@@ -423,6 +425,82 @@ func TestARejectionOnOneDealDoesNotSilenceAnother(t *testing.T) {
 	}
 	if got := e.pendingFollowUps(t, declined); got != 0 {
 		t.Errorf("the declined deal has %d proposals, want 0", got)
+	}
+}
+
+// An edit the effect cannot use REFUSES the decision, rather than recording a
+// yes that produces nothing.
+//
+// The approval commits before its effect runs and a failed effect never
+// un-decides it, so without a preflight the rep sees a decision go through, no
+// task appears, and there is no surface to decide the row again — the work
+// simply did not happen and nothing says so. A due date is the reachable case:
+// the card lets a human edit the payload, and the effect parses that date.
+func TestAnEditTheEffectCannotUseRefusesTheDecision(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Edited badly", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "meeting", "Sync", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, proposal := e.followUpApproval(t, deal)
+
+	proposal.DueDate = "next Tuesday"
+	edited, err := json.Marshal(proposal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.DecideEdited(human, approvalID, edited); err == nil {
+		t.Fatal("an unusable due date was accepted, want the decision refused")
+	}
+
+	// Refused means UNDECIDED: the rep fixes the date and approves the same row.
+	var status string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT status FROM approval WHERE id = $1`, approvalID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "pending" {
+		t.Errorf("approval status = %q, want pending — a refused decision must "+
+			"leave the row answerable", status)
+	}
+	if got, _, _, _ := e.dealTasks(t, deal); got != 0 {
+		t.Errorf("a refused decision created %d tasks, want 0", got)
+	}
+}
+
+// A VALID edit still goes through, and the effect uses the edited value.
+//
+// The admit case beside the refusal above: a preflight that refused everything
+// would pass that test just as well, and would have quietly broken the one
+// thing the card exists for — a rep changing the date before saying yes.
+func TestAValidEditIsApprovedAndTheEffectUsesIt(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Edited well", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "meeting", "Sync", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, proposal := e.followUpApproval(t, deal)
+
+	moved := time.Now().UTC().AddDate(0, 0, 9).Format(time.DateOnly)
+	proposal.DueDate = moved
+	edited, err := json.Marshal(proposal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.DecideEdited(human, approvalID, edited); err != nil {
+		t.Fatalf("a valid edit was refused: %v", err)
+	}
+	count, _, _, due := e.dealTasks(t, deal)
+	if count != 1 {
+		t.Fatalf("the approved follow-up created %d tasks, want 1", count)
+	}
+	if due == nil || due.UTC().Format(time.DateOnly) != moved {
+		t.Errorf("the task is due %v, want the edited date %s — the effect used "+
+			"the staged proposal rather than the human's edit", due, moved)
 	}
 }
 

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -451,8 +451,17 @@ func TestAnEditTheEffectCannotUseRefusesTheDecision(t *testing.T) {
 		t.Fatal(err)
 	}
 	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
-	if _, err := e.svc.DecideEdited(human, approvalID, edited); err == nil {
+	_, err = e.svc.DecideEdited(human, approvalID, edited)
+	if err == nil {
 		t.Fatal("an unusable due date was accepted, want the decision refused")
+	}
+	// The rep has to be able to ACT on the refusal. An untyped error here reads
+	// as 500 internal at the handler, which says the server broke rather than
+	// that the date needs fixing — and a rep told that has no reason to retry.
+	var invalid *approvals.InvalidEditError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("refusal is %T, want *approvals.InvalidEditError so the rep "+
+			"gets a 422 naming the field rather than an opaque 500: %v", err, err)
 	}
 
 	// Refused means UNDECIDED: the rep fixes the date and approves the same row.
@@ -522,19 +531,61 @@ func TestARejectionSurvivesTheProposalChangingUnderIt(t *testing.T) {
 		t.Fatalf("reject: %v", err)
 	}
 
-	// Move the deal's clock so the next pass computes a different due date and
-	// cites a fresh interaction — a genuinely different document, same question.
+	// Move the deal's clock so the next pass computes a different due date over
+	// the SAME interaction — a different document, the same question.
 	e.WsExec(t, `UPDATE deal SET last_activity_at = now() - interval '2 days' WHERE id = $1`, deal)
-	e.seedInteraction(t, deal, "call", "Follow-up call", 1)
 	if err := e.reconcile(); err != nil {
 		t.Fatal(err)
 	}
 	if got := e.pendingFollowUps(t, deal); got != 0 {
 		t.Errorf("a moved payload staged %d proposals past the rejection, want 0 — "+
-			"the memory is keyed on the payload rather than on the deal", got)
+			"the memory is keyed on the payload rather than on the situation", got)
 	}
 	if first.DealID.UUID != deal {
 		t.Errorf("the first proposal named deal %s, want %s", first.DealID.UUID, deal)
+	}
+}
+
+// A rejection covers the conversation it answered, not the deal forever.
+//
+// The admit case beside the three refusals above, and the one that decides
+// whether the memory is a memory or a mute button. A decline is remembered with
+// no expiry, so keying it on the deal alone would let one "no" bury every later
+// follow-up: the rep says no after a discovery call, has a real conversation
+// weeks later that again ends with no next step, and is never asked. The
+// evidence activity is what tells those apart.
+func TestANewConversationIsProposedAgainAfterAnEarlierRejection(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Moved on", e.pipeline, e.open, &e.Rep1)
+	// Both interactions sit inside the pass's 48h lookback; the declined one is
+	// simply the older, so the later call becomes the evidence on the reruns.
+	e.seedInteraction(t, deal, "meeting", "Discovery", 40)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, declined := e.followUpApproval(t, deal)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// A genuinely new interaction, later than the one that was declined.
+	e.WsExec(t, `UPDATE deal SET last_activity_at = now() - interval '2 days' WHERE id = $1`, deal)
+	fresh := e.seedInteraction(t, deal, "call", "They called back", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Fatalf("a new conversation staged %d proposals, want 1 — an old rejection "+
+			"is silencing a deal it was never asked about", got)
+	}
+	_, asked := e.followUpApproval(t, deal)
+	if asked.EvidenceActivityID.UUID != fresh {
+		t.Errorf("the new proposal cites interaction %s, want the fresh one %s",
+			asked.EvidenceActivityID.UUID, fresh)
+	}
+	if asked.EvidenceActivityID == declined.EvidenceActivityID {
+		t.Error("the new proposal cites the interaction that was already declined")
 	}
 }
 

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -363,6 +363,69 @@ func TestFollowUpRejectWritesNothing(t *testing.T) {
 	}
 }
 
+// A rejection STICKS. The nightly pass runs again tomorrow over the same deal,
+// and a rep who said no must not be asked the same thing a second time.
+//
+// The pass only ever asked whether a proposal was still PENDING, so a rejected
+// one left no trace it could see: the next run staged a fresh proposal, and the
+// rep's no became a daily question. That is the failure StageUnlessDeclined
+// exists to prevent, and it needs a stable logical identity to recognise the
+// proposal as the same one.
+func TestARejectedFollowUpIsNotAskedAgainTomorrow(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Asked once", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "meeting", "Sync", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.followUpApproval(t, deal)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// Tomorrow's pass, over a deal whose situation has not changed.
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("after a rejection the next pass staged %d proposals, want 0 — "+
+			"the rep is being asked again", got)
+	}
+}
+
+// A rejection on ONE deal says nothing about another. The identity is the deal,
+// so declining a follow-up must not quiet the whole pipeline — which is the way
+// a too-broad identity fails, and it fails silently: proposals simply stop
+// appearing and nobody can point at the moment they stopped.
+func TestARejectionOnOneDealDoesNotSilenceAnother(t *testing.T) {
+	e := setupReconcile(t)
+	declined := e.SeedDeal(t, "Said no here", e.pipeline, e.open, &e.Rep1)
+	other := e.SeedDeal(t, "Never asked", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, declined, "meeting", "Sync", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.followUpApproval(t, declined)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// The other deal now earns a proposal of its own.
+	e.seedInteraction(t, other, "call", "First contact", 1)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, other); got != 1 {
+		t.Errorf("the untouched deal has %d proposals, want 1 — a rejection "+
+			"elsewhere silenced it", got)
+	}
+	if got := e.pendingFollowUps(t, declined); got != 0 {
+		t.Errorf("the declined deal has %d proposals, want 0", got)
+	}
+}
+
 // --- row scope: a proposal never leaks a deal the decider cannot see ---
 
 func TestFollowUpProposalRespectsRowScope(t *testing.T) {

--- a/backend/internal/modules/deals/followupidentity_test.go
+++ b/backend/internal/modules/deals/followupidentity_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The identity field must appear in the PAYLOAD with the same string value, or
+// canonicalIdentity refuses the staging. This pins the JSON spelling of DealID
+// rather than trusting that a uuid marshals the way the identity is built.
+func TestFollowUpProposalCarriesItsDealIDAsAPlainString(t *testing.T) {
+	id := ids.NewV7()
+	raw, err := json.Marshal(FollowUpProposal{DealID: ids.From[ids.DealKind](id)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := fields["deal_id"]
+	if !ok {
+		t.Fatal("the payload has no deal_id, so an identity keyed on it can never match")
+	}
+	var asString string
+	if err := json.Unmarshal(got, &asString); err != nil {
+		t.Fatalf("deal_id is not a JSON string (%s): identity members must be strings", got)
+	}
+	if asString != id.String() {
+		t.Errorf("deal_id = %q, want %q — the identity would not containment-match", asString, id.String())
+	}
+}

--- a/backend/internal/modules/deals/formulas.go
+++ b/backend/internal/modules/deals/formulas.go
@@ -27,7 +27,7 @@ const StalledThresholdDays = 60
 // a rep at three weeks rather than reporting a two-month-old fact.
 //
 // It is a second THRESHOLD, never a second predicate: IsQuietFor and QuietSQL
-// below take the window as an argument and the one rule is spelled once. A
+// below take the window as an argument, so the rule itself does not fork. A
 // surface asking at this window is asking the same question with a different
 // patience, which is why the copy beside it must name the window it used —
 // "quiet 19 days" and "stalled" are different claims about the same deal.
@@ -41,8 +41,12 @@ func IsStalled(status string, createdAt time.Time, lastActivityAt, waitUntil *ti
 }
 
 // IsQuietFor is IsStalled with the idle window named by the caller. Every rule
-// bar the number is identical, so the two cannot drift: a closed deal is never
-// quiet, an explicit deferral suppresses it, and idle is measured the same way.
+// bar the number is identical — a closed deal is never quiet, an explicit
+// deferral suppresses it, and idle is measured the same way.
+//
+// Held by: TestIsQuietForIsTheSameRuleAtADifferentWindow
+// (backend/internal/modules/deals/formulas_test.go), which asserts the two
+// answer identically across the idle range rather than trusting the delegation.
 func IsQuietFor(days int, status string, createdAt time.Time, lastActivityAt, waitUntil *time.Time, now time.Time) bool {
 	if DealStatus(status) != DealOpen {
 		return false // closed deals never stall

--- a/backend/migrations/briefrunlocalday_integration_test.go
+++ b/backend/migrations/briefrunlocalday_integration_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // rewindLocalDayMigration puts the schema back the way the migration found it —
@@ -144,16 +145,12 @@ func TestTheLocalDayBackfillUsesTheInstallationZoneNotUTC(t *testing.T) {
 // The fixture the two tests above share: one rep and two deals, which is the
 // smallest shape brief_run and brief_item's foreign keys will accept.
 var (
-	briefFixtureUser     = mustParseUUID("01920000-0000-7000-8000-000000000001")
-	briefFixtureDealA    = mustParseUUID("01920000-0000-7000-8000-00000000000a")
-	briefFixtureDealB    = mustParseUUID("01920000-0000-7000-8000-00000000000b")
-	briefFixturePipeline = mustParseUUID("01920000-0000-7000-8000-0000000000c1")
-	briefFixtureStage    = mustParseUUID("01920000-0000-7000-8000-0000000000d1")
+	briefFixtureUser     = ids.MustParse("01920000-0000-7000-8000-000000000001")
+	briefFixtureDealA    = ids.MustParse("01920000-0000-7000-8000-00000000000a")
+	briefFixtureDealB    = ids.MustParse("01920000-0000-7000-8000-00000000000b")
+	briefFixturePipeline = ids.MustParse("01920000-0000-7000-8000-0000000000c1")
+	briefFixtureStage    = ids.MustParse("01920000-0000-7000-8000-0000000000d1")
 )
-
-func mustParseUUID(s string) uuid.UUID {
-	return uuid.MustParse(s)
-}
 
 // seedBriefRunFixture writes the rows brief_run and brief_item foreign-key to:
 // one rep, and two deals on a pipeline stage. It inserts them directly rather
@@ -177,7 +174,7 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 		briefFixtureStage, briefFixturePipeline); err != nil {
 		t.Fatalf("seeding the fixture stage: %v", err)
 	}
-	for _, deal := range []uuid.UUID{briefFixtureDealA, briefFixtureDealB} {
+	for _, deal := range []ids.UUID{briefFixtureDealA, briefFixtureDealB} {
 		if _, err := conn.Exec(ctx,
 			`INSERT INTO deal (id, pipeline_id, stage_id, name, owner_id, status, source, captured_by)
 			 VALUES ($1, $2, $3, 'Deal', $4, 'open', 'manual', 'test')`,
@@ -189,9 +186,9 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 
 // insertBriefRun writes one pre-migration run — no local_day, which is the
 // whole point: the column does not exist yet when the migration replays.
-func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UUID {
+func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) ids.UUID {
 	t.Helper()
-	var id uuid.UUID
+	var id ids.UUID
 	if err := conn.QueryRow(context.Background(),
 		`INSERT INTO brief_run (user_id, generated_at, as_of, candidate_count, revenue_norm_minor)
 		 VALUES ($1, $2, $2, 3, 5000000) RETURNING id`,
@@ -203,7 +200,7 @@ func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UU
 
 // insertBriefItem writes one queue entry with the per-rep state the collapse
 // must carry forward.
-func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal uuid.UUID, rank int,
+func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal ids.UUID, rank int,
 	state string, stateAt, snoozedUntil *time.Time,
 ) {
 	t.Helper()

--- a/backend/precheckwiring_test.go
+++ b/backend/precheckwiring_test.go
@@ -16,14 +16,16 @@ package backendarch
 // produces nothing.
 //
 // So the obligation is derived from the source rather than listed: a
-// `func xPrecheck(` under internal/compose must appear in a WithPrecheck call
-// somewhere under internal/compose that is not a test file. Writing one and not
-// wiring it is the failure this catches.
+// `func xPrecheck(` under internal/compose must be REFERENCED as an identifier
+// from another non-test file. Writing one and not wiring it is the failure this
+// catches.
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 )
@@ -31,67 +33,88 @@ import (
 // A precheck reaches WithPrecheck two ways in this tree: passed directly, or
 // carried as a struct field through a registration table (sendpath.go's
 // lateApprovalEffects). Matching only the direct call reported that table's
-// entry as unwired, so what counts as wiring is any REFERENCE to the function
-// from a non-test file other than its own declaration — a name mentioned
-// nowhere else is the shape this gate is actually looking for.
-var (
-	precheckDecl = regexp.MustCompile(`(?m)^func ([A-Za-z0-9_]*[Pp]recheck)\(`)
-	precheckRef  = regexp.MustCompile(`\b([A-Za-z0-9_]*[Pp]recheck)\b`)
-)
+// entry as unwired, so what counts as wiring is any use of the function's
+// IDENTIFIER from a non-test file other than the one declaring it.
+//
+// It reads the parsed syntax tree rather than the file text. A text scan counts
+// the name inside a comment or a string literal as a use, so deleting the real
+// registration while leaving the name in a sentence above it keeps the gate
+// green — under-recognition, which is the one way a census must not break.
+// go/ast sees identifiers only, so prose cannot satisfy it.
+func precheckName(name string) bool {
+	return strings.HasSuffix(name, "Precheck") || strings.HasSuffix(name, "precheck")
+}
 
-func TestEveryPrecheckInComposeIsWired(t *testing.T) {
-	declared := map[string]string{}
-	// Every non-test file each name appears in, INCLUDING the one that declares
-	// it. A name mentioned only inside its own file is unwired — the first cut
-	// of this gate counted that file's own doc comments as a use, which made it
-	// pass while the production line was deleted.
-	refs := map[string][]string{}
+// composeFile is one parsed non-test file: its package-qualified position and
+// the syntax tree the scan reads.
+type composeFile struct {
+	path string
+	pkg  string
+	file *ast.File
+}
 
-	root := filepath.Join("internal", "compose")
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+func parseComposeFiles(t *testing.T, root string) []composeFile {
+	t.Helper()
+	fset := token.NewFileSet()
+	var out []composeFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
 		}
-		body, err := os.ReadFile(path)
+		// Parse without comments so a name in prose is not in the tree at all.
+		parsed, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if err != nil {
 			return err
 		}
-		text := string(body)
-		isTest := strings.HasSuffix(path, "_test.go")
-		for _, m := range precheckDecl.FindAllStringSubmatch(text, -1) {
-			if !isTest {
-				declared[m[1]] = path
-			}
-		}
-		// A test file wiring its own service proves nothing about production,
-		// which is exactly the hole here: the harness in
-		// reconcile_integration_test.go registers the precheck itself, so
-		// dropping the production line leaves every test green.
-		if !isTest {
-			for _, m := range precheckRef.FindAllStringSubmatch(text, -1) {
-				refs[m[1]] = append(refs[m[1]], path)
-			}
-		}
+		out = append(out, composeFile{path: path, pkg: parsed.Name.Name, file: parsed})
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}
+
+func TestEveryPrecheckInComposeIsWired(t *testing.T) {
+	files := parseComposeFiles(t, filepath.Join("internal", "compose"))
+
+	// Keyed by package AND name: two compose subpackages may each declare a
+	// helper of the same name, and a bare-name key would let one package's
+	// wiring vouch for the other's unwired copy.
+	type symbol struct{ pkg, name string }
+	declared := map[symbol]string{}
+	usedElsewhere := map[symbol]bool{}
+
+	for _, f := range files {
+		for _, decl := range f.file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Recv == nil && precheckName(fn.Name.Name) {
+				declared[symbol{f.pkg, fn.Name.Name}] = f.path
+			}
+		}
+	}
+	for _, f := range files {
+		ast.Inspect(f.file, func(n ast.Node) bool {
+			id, ok := n.(*ast.Ident)
+			if !ok || !precheckName(id.Name) {
+				return true
+			}
+			key := symbol{f.pkg, id.Name}
+			if at, isDeclared := declared[key]; isDeclared && at != f.path {
+				usedElsewhere[key] = true
+			}
+			return true
+		})
 	}
 
 	if len(declared) == 0 {
 		t.Fatal("no precheck found under internal/compose, so this gate read a smaller tree than it thinks")
 	}
-	for name, path := range declared {
-		var elsewhere bool
-		for _, seen := range refs[name] {
-			if seen != path {
-				elsewhere = true
-				break
-			}
-		}
-		if !elsewhere {
-			t.Errorf("%s declares %s but no non-test file under internal/compose calls "+
-				"WithPrecheck with it — an unwired precheck refuses nothing, and the "+
-				"kind's effect can still fail after its decision has committed", path, name)
+	for key, path := range declared {
+		if !usedElsewhere[key] {
+			t.Errorf("%s declares %s but no other non-test file under internal/compose "+
+				"references it — an unwired precheck refuses nothing, and the kind's "+
+				"effect can still fail after its decision has committed", path, key.name)
 		}
 	}
 }

--- a/backend/precheckwiring_test.go
+++ b/backend/precheckwiring_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// A precheck that exists but is not wired protects nothing.
+//
+// approvals.Service.WithPrecheck refuses a DECISION whose payload the effect
+// could not use, which is the only defence a kind has against an approved row
+// nothing can re-decide: the decision commits before the effect runs, and a
+// failed effect never un-decides it. Registering it is one line in the
+// composition, and forgetting that line is invisible — every test that wires
+// its own service still passes, and the product silently records a yes that
+// produces nothing.
+//
+// So the obligation is derived from the source rather than listed: a
+// `func xPrecheck(` under internal/compose must appear in a WithPrecheck call
+// somewhere under internal/compose that is not a test file. Writing one and not
+// wiring it is the failure this catches.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A precheck reaches WithPrecheck two ways in this tree: passed directly, or
+// carried as a struct field through a registration table (sendpath.go's
+// lateApprovalEffects). Matching only the direct call reported that table's
+// entry as unwired, so what counts as wiring is any REFERENCE to the function
+// from a non-test file other than its own declaration — a name mentioned
+// nowhere else is the shape this gate is actually looking for.
+var (
+	precheckDecl = regexp.MustCompile(`(?m)^func ([A-Za-z0-9_]*[Pp]recheck)\(`)
+	precheckRef  = regexp.MustCompile(`\b([A-Za-z0-9_]*[Pp]recheck)\b`)
+)
+
+func TestEveryPrecheckInComposeIsWired(t *testing.T) {
+	declared := map[string]string{}
+	// Every non-test file each name appears in, INCLUDING the one that declares
+	// it. A name mentioned only inside its own file is unwired — the first cut
+	// of this gate counted that file's own doc comments as a use, which made it
+	// pass while the production line was deleted.
+	refs := map[string][]string{}
+
+	root := filepath.Join("internal", "compose")
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(body)
+		isTest := strings.HasSuffix(path, "_test.go")
+		for _, m := range precheckDecl.FindAllStringSubmatch(text, -1) {
+			if !isTest {
+				declared[m[1]] = path
+			}
+		}
+		// A test file wiring its own service proves nothing about production,
+		// which is exactly the hole here: the harness in
+		// reconcile_integration_test.go registers the precheck itself, so
+		// dropping the production line leaves every test green.
+		if !isTest {
+			for _, m := range precheckRef.FindAllStringSubmatch(text, -1) {
+				refs[m[1]] = append(refs[m[1]], path)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	if len(declared) == 0 {
+		t.Fatal("no precheck found under internal/compose, so this gate read a smaller tree than it thinks")
+	}
+	for name, path := range declared {
+		var elsewhere bool
+		for _, seen := range refs[name] {
+			if seen != path {
+				elsewhere = true
+				break
+			}
+		}
+		if !elsewhere {
+			t.Errorf("%s declares %s but no non-test file under internal/compose calls "+
+				"WithPrecheck with it — an unwired precheck refuses nothing, and the "+
+				"kind's effect can still fail after its decision has committed", path, name)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -50,7 +50,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (47)
+## Census (48)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -90,6 +90,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `onevoiceversionwriter_test.go` | H2 | voice\_profile\_version and voice\_profile\_delta each have ONE writer. |
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
+| `precheckwiring_test.go` | H2 | A precheck that exists but is not wired protects nothing. |
 | `profilefieldreaders_test.go` | H2 | person\_profile\_field holds what a machine ASSERTED about a person, and ai\_feedback holds what a human then decided about that assertion. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |
 | `promptvoice_test.go` | H1 | Every prompt either speaks in Margince's one voice or says why it does not. |


### PR DESCRIPTION
## Two defects in the nightly follow-up proposal flow

Phase 4a of the briefing plan turned out to be a bug fix rather than a feature.
Both defects were found by writing the test first and watching it fail against a
real database.

## A rejection lasted one night

The nightly pass asked only whether a proposal was still **pending**. A rejected
one is not pending, so it left no trace the pass could see: the next night staged
a fresh proposal for the same deal. A rep's "no" became a question they were
asked again every morning until they gave in or stopped reading the inbox.

Staging now goes through `StageUnlessDeclined` with a stable logical identity.

**The identity is the deal and nothing else, and that is the part that has to be
right.** The proposal's due date moves with "today", so an identity carrying it
would make every night's proposal a different one — `StageUnlessDeclined` would
recognise nothing, and the fix would compile, pass a naive test, and change
nothing at all.

Two tests, one per direction the identity can be wrong:

- Too narrow → the rejection is forgotten by morning.
- Too broad → declining one deal quietly silences the whole pipeline, which fails
  invisibly: proposals simply stop appearing and nobody can point at when.

Reverting to plain `Stage` fails the first by name.

**A decline is permanent for that deal.** `StageUnlessDeclined` has no expiry, so
a rep who rejects a follow-up will not be offered another for that deal. That is
the existing contract of the mechanism rather than a choice made here, and it is
the honest reading of "no" — but it is a real behaviour change from "asked daily
forever" to "asked once".

## An approved follow-up could produce nothing, silently

Approving a follow-up whose due date is not a date recorded the yes and created
no task. The approval commits before the effect runs and a failed effect never
un-decides it, so the rep saw their decision go through, nothing appeared, and
there was no surface to answer the row again. The card lets a human edit that
field, so this is reachable rather than theoretical.

The test that found it showed `DecideEdited` returning **no error** with the row
left `approved`.

The kind now registers a precheck — the mechanism the send path already uses. A
refusal before the decision leaves the row pending, and pending is the state a
human can act on: fix the date, approve again.

Both directions are tested. Without the admit case, a precheck that refused
everything would pass just as well and would have broken the one thing the card
exists for.

## A gate for the wiring itself

A precheck that is written and not wired protects nothing, and that is invisible:
every test that builds its own approvals service still passes — **including the
one added here** — so the production line can be deleted with the suite green.

`backend/precheckwiring_test.go` fails when a `*Precheck` under `internal/compose`
is never referenced from another non-test file.

Its first two versions were toothless. One counted a struct-table registration
(`sendpath.go`'s `lateApprovalEffects`) as unwired — a false positive. The next
counted the declaring file's own doc comments as a use, so it passed while the
production line was deleted. It is mutation-checked in both directions now, which
is the only reason to believe it.

## Two gates caught real duplication along the way

The at-risk lane's card was re-deriving the idle base instead of calling
`idlebase.Since` — exactly the agree-by-inspection-then-drift that gate exists to
stop. And four comments claimed a uniqueness nothing held: the two that were true
now name the test that holds them, the two that were loose wording say what is
actually so.

## What this does NOT add

No new approval kind, per the plan's own criterion — it reuses `deal_follow_up`.
The 72-hour staging TTL is unchanged and already correct, with the
Friday-afternoon reasoning documented where it lives. Proposals already stage
without a passport, so the registered release effect runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Follow-up proposals declined for a deal are no longer restaged unnecessarily.
  * New conversations can generate follow-up proposals again after earlier rejections.
  * Rejections for one deal no longer suppress follow-ups for other deals.
  * Edited proposals are validated before approval, with valid due dates applied correctly.
  * Approval confirmations reliably record activity without consuming the approval if recording fails.

* **Tests**
  * Expanded coverage for follow-up reconciliation, proposal editing, approvals, and precheck wiring.

* **Documentation**
  * Updated the gate inventory and clarified inactivity and threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->