### PR TITLE
fix(deals,attention,migrations): one idle rule, four claims that name what holds them, and the arch-lint finding they were deadlocked with

### DIFF
--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 24
+	wantFixtureAnnotations = 25
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -972,6 +972,8 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 
 // A withheld lane is named ONCE. Naming it twice is what a duplicate read looks
 // like on the wire, and a client rendering the list would say it twice.
+//
+// Held by: TestAWithheldLaneIsNamedOnce (backend/internal/compose/attention/feed_test.go) — this test, which counts the namings.
 func TestAWithheldLaneIsNamedOnce(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},

--- a/backend/internal/compose/attention/optionallanes.go
+++ b/backend/internal/compose/attention/optionallanes.go
@@ -97,8 +97,8 @@ func (s *Service) optionalLanes(
 	}
 }
 
-// renderEach turns one producer's rows into wire items. The lanes differ in
-// what they read and how a row is drawn; the loop between them is spelled once.
+// renderEach turns one producer's rows into wire items, so a lane supplies only
+// what differs: the rows it read and how one of them is drawn.
 //
 // Never nil: the empty slice rather than a null the contract promised was a list.
 func renderEach[T any](rows []T, draw func(T) crmcontracts.AttentionItem) []crmcontracts.AttentionItem {

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/idlebase"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -91,15 +92,15 @@ func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, erro
 	return risky, nil
 }
 
-// idleDaysOf is how long the deal has been quiet, counted from the same base
-// the idle rule itself measures from: the last activity, or the deal's creation
-// when nothing has ever touched it.
+// idleDaysOf is how long the deal has been quiet, counted from the base the
+// idle rule measures from rather than from a second answer to that question.
+//
+// The number a reader is shown and the number the rule decides on are the same
+// fact, so a copy of the base here would let the queue say "quiet 19 days" about
+// a deal the rule does not think is quiet at all — and the two would agree in
+// every test written on the day the copy was made.
 func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
-	since := deal.CreatedAt
-	if deal.LastActivityAt != nil {
-		since = *deal.LastActivityAt
-	}
-	days := int(now.Sub(since).Hours() / 24)
+	days := int(now.Sub(idlebase.Since(deal.CreatedAt, deal.LastActivityAt)).Hours() / 24)
 	if days < 0 {
 		return 0
 	}

--- a/backend/internal/modules/deals/formulas.go
+++ b/backend/internal/modules/deals/formulas.go
@@ -31,6 +31,8 @@ const StalledThresholdDays = 60
 // surface asking at this window is asking the same question with a different
 // patience, which is why the copy beside it must name the window it used —
 // "quiet 19 days" and "stalled" are different claims about the same deal.
+//
+// Held by: TestAThresholdEntryPointCarriesNoRuleOfItsOwn (backend/internal/modules/deals/oneidlerule_test.go)
 const QuietThresholdDays = 19
 
 // IsStalled evaluates §8.1 at one instant. Idle is an absolute-duration
@@ -43,6 +45,8 @@ func IsStalled(status string, createdAt time.Time, lastActivityAt, waitUntil *ti
 // IsQuietFor is IsStalled with the idle window named by the caller. Every rule
 // bar the number is identical, so the two cannot drift: a closed deal is never
 // quiet, an explicit deferral suppresses it, and idle is measured the same way.
+//
+// Held by: TestAThresholdEntryPointCarriesNoRuleOfItsOwn (backend/internal/modules/deals/oneidlerule_test.go)
 func IsQuietFor(days int, status string, createdAt time.Time, lastActivityAt, waitUntil *time.Time, now time.Time) bool {
 	if DealStatus(status) != DealOpen {
 		return false // closed deals never stall

--- a/backend/internal/modules/deals/oneidlerule_test.go
+++ b/backend/internal/modules/deals/oneidlerule_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// "Has this deal gone quiet?" is one rule asked at two patiences, and the
+// product answers it on two surfaces — in Go for a decision taken at an
+// instant, in SQL for a list the database filters.
+//
+// The threshold-named entry points are meant to carry NO rule of their own:
+// each is its windowed sibling with the number filled in. That is what makes
+// the stalled bar and the morning queue's shorter window the same question
+// rather than two, and it is the half nothing else checks — a hand-inlined
+// copy compiles, passes every behaviour test written the day it is made, and
+// only disagrees later, when somebody changes one side.
+//
+// The rule the gate applies is DELEGATION, not text: the body must be a single
+// return of a call to the windowed function. A body that grew a second
+// condition, or that stopped calling its sibling at all, fails here.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// delegations pairs each threshold-named entry point with the windowed
+// function it must be nothing more than a call to.
+//
+// gatekit:fixture the windowed function each entry point must delegate to — the
+// values are the subject of the assertion, not the cost of waiving one.
+var delegations = map[string]string{
+	"IsStalled":  "IsQuietFor",
+	"StalledSQL": "QuietSQL",
+}
+
+func TestAThresholdEntryPointCarriesNoRuleOfItsOwn(t *testing.T) {
+	const source = "formulas.go"
+	file, err := parser.ParseFile(token.NewFileSet(), source, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", source, err)
+	}
+	found := map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil {
+			continue
+		}
+		want, governed := delegations[fn.Name.Name]
+		if !governed {
+			continue
+		}
+		found[fn.Name.Name] = true
+		if callee := soleReturnedCall(fn); callee != want {
+			t.Errorf("%s is the %s-day spelling of %s and must be a single call to it; its body "+
+				"returns %q.\n\n"+
+				"A rule spelled here as well as in %s is two answers to \"has this deal gone "+
+				"quiet\", and they agree until one of them is edited. Pass the window to %s "+
+				"instead.",
+				fn.Name.Name, "threshold", want, callee, want, want)
+		}
+	}
+	// The names are written here and the declarations live elsewhere, so a
+	// rename empties this test rather than failing it — which reads exactly
+	// like a clean tree.
+	for name := range delegations {
+		if !found[name] {
+			t.Errorf("%s is not declared in %s — this gate judged nothing about it, which is "+
+				"indistinguishable from it delegating correctly", name, source)
+		}
+	}
+}
+
+// soleReturnedCall names the function a body consists of returning a call to,
+// and "" when the body is anything else — several statements, a bare value, or
+// a call built from more than a plain identifier.
+func soleReturnedCall(fn *ast.FuncDecl) string {
+	if fn.Body == nil || len(fn.Body.List) != 1 {
+		return ""
+	}
+	ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return ""
+	}
+	call, ok := ret.Results[0].(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	callee, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return callee.Name
+}

--- a/backend/migrations/briefrunlocalday_integration_test.go
+++ b/backend/migrations/briefrunlocalday_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -143,17 +142,18 @@ func TestTheLocalDayBackfillUsesTheInstallationZoneNotUTC(t *testing.T) {
 
 // The fixture the two tests above share: one rep and two deals, which is the
 // smallest shape brief_run and brief_item's foreign keys will accept.
-var (
-	briefFixtureUser     = mustParseUUID("01920000-0000-7000-8000-000000000001")
-	briefFixtureDealA    = mustParseUUID("01920000-0000-7000-8000-00000000000a")
-	briefFixtureDealB    = mustParseUUID("01920000-0000-7000-8000-00000000000b")
-	briefFixturePipeline = mustParseUUID("01920000-0000-7000-8000-0000000000c1")
-	briefFixtureStage    = mustParseUUID("01920000-0000-7000-8000-0000000000d1")
+//
+// Held as strings, which is also all this component may say: `migrations` is
+// allowed pgx and nothing else, and pgx binds a string to a uuid column and
+// scans one back. A dedicated id type would widen the architecture rule to buy
+// a type this file never uses as a type.
+const (
+	briefFixtureUser     = "01920000-0000-7000-8000-000000000001"
+	briefFixtureDealA    = "01920000-0000-7000-8000-00000000000a"
+	briefFixtureDealB    = "01920000-0000-7000-8000-00000000000b"
+	briefFixturePipeline = "01920000-0000-7000-8000-0000000000c1"
+	briefFixtureStage    = "01920000-0000-7000-8000-0000000000d1"
 )
-
-func mustParseUUID(s string) uuid.UUID {
-	return uuid.MustParse(s)
-}
 
 // seedBriefRunFixture writes the rows brief_run and brief_item foreign-key to:
 // one rep, and two deals on a pipeline stage. It inserts them directly rather
@@ -177,7 +177,7 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 		briefFixtureStage, briefFixturePipeline); err != nil {
 		t.Fatalf("seeding the fixture stage: %v", err)
 	}
-	for _, deal := range []uuid.UUID{briefFixtureDealA, briefFixtureDealB} {
+	for _, deal := range []string{briefFixtureDealA, briefFixtureDealB} {
 		if _, err := conn.Exec(ctx,
 			`INSERT INTO deal (id, pipeline_id, stage_id, name, owner_id, status, source, captured_by)
 			 VALUES ($1, $2, $3, 'Deal', $4, 'open', 'manual', 'test')`,
@@ -189,9 +189,9 @@ func seedBriefRunFixture(t *testing.T, conn *pgx.Conn) {
 
 // insertBriefRun writes one pre-migration run — no local_day, which is the
 // whole point: the column does not exist yet when the migration replays.
-func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UUID {
+func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) string {
 	t.Helper()
-	var id uuid.UUID
+	var id string
 	if err := conn.QueryRow(context.Background(),
 		`INSERT INTO brief_run (user_id, generated_at, as_of, candidate_count, revenue_norm_minor)
 		 VALUES ($1, $2, $2, 3, 5000000) RETURNING id`,
@@ -203,7 +203,7 @@ func insertBriefRun(t *testing.T, conn *pgx.Conn, generatedAt time.Time) uuid.UU
 
 // insertBriefItem writes one queue entry with the per-rep state the collapse
 // must carry forward.
-func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal uuid.UUID, rank int,
+func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal string, rank int,
 	state string, stateAt, snoozedUntil *time.Time,
 ) {
 	t.Helper()


### PR DESCRIPTION
## #2740 left three gates red on main

Two of them are bookkeeping. **The first is a real duplication defect** — the
kind this tree's gates exist to catch, caught working.

### A second answer to "how long has this deal been quiet"

`internal/compose/attentionlanesseam.go` grew its own idle-base computation:

```go
since := deal.CreatedAt
if deal.LastActivityAt != nil {
    since = *deal.LastActivityAt
}
```

under a doc comment saying it counts *"from the same base the idle rule itself
measures from"* — an agreement nothing held. `TestTheIdleBaseIsSpelledOnce`
named it exactly:

```
internal/compose/attentionlanesseam.go holds a site this gate must judge
but lies outside every root (internal/shared/kernel/idlebase)
```

The number a reader is shown and the number the rule decides on are the **same
fact**. A copy lets the morning queue say "quiet 19 days" about a deal
`IsQuietFor` does not think is quiet at all — and the two agree in every test
written the day the copy is made. It now calls `idlebase.Since`.

**Routed, not ratified.** Adding the file to the scope's `Exempt` set would also
have gone green. That is the "a gate's exception is its attack surface" trade,
and the exception outlives the convenience that bought it.

### The two `formulas.go` claims are now held

> *"the one rule is spelled once"* — `QuietThresholdDays`
> *"Every rule bar the number is identical, so the two cannot drift"* — `IsQuietFor`

Both true, and both resting on one structural fact: the **threshold-named entry
points carry no rule of their own**. So that is what the new gate asserts, on
both surfaces:

| entry point | must be a single call to |
|---|---|
| `IsStalled` | `IsQuietFor` |
| `StalledSQL` | `QuietSQL` |

Delegation rather than text, so a body that grows a second condition fails
whatever it is spelled like.

**Mutation-tested**, each mutant grepped to prove it landed:

| mutant | result |
|---|---|
| inline a status+idle predicate into `IsStalled` | FAIL — *"must be a single call to it; its body returns `""`"* |
| gate lists a subject the file no longer declares | FAIL — *"this gate judged nothing about it, which is indistinguishable from it delegating correctly"* |

The second arm exists because a rename **empties** a gate rather than failing it,
which reads exactly like a clean tree.

### The other two claims

- **`TestAWithheldLaneIsNamedOnce`** — self-bound. The test counts the namings,
  which is precisely the claim its doc comment makes.
- **`renderEach`** — loses its claim instead. Nothing held *"the loop between
  them is spelled once"*, so the sentence keeps the reason and drops the
  assertion.

I deliberately did **not** register any of the four. The register is closed to
new entries; registering is the cheap fix that launders the debt and makes the
number stop meaning anything. Each claim got a test or lost the sentence.

### Two meta-gates caught the new gate on the way through

`delegations` read as a waiver map until declared `gatekit:fixture`, and the
fixture count is itself pinned — so adding one is a line somebody agrees to.
Both are the same discipline the gate itself applies, applied to it.

## How #2740 got three gates past everyone

The backend gate was **already red** on #2725's arch-lint finding. A lane that is
already red hides the next break in the same lane: nobody re-reads the log of a
job they already know is failing, and a stale red reports *identically* whether
it has one cause or four. Worse than a skip, which at least announces itself.

Worth a follow-up on `main-health`: key the filed issue on the set of failing
**test names** rather than the lane, so a new name appearing under an
already-red lane opens a new issue instead of being absorbed into the old one.

## Verification

- `make check-backend` — green except `arch-lint`, which is #2746's subject
  (`migrations` → `github.com/google/uuid`, from #2725) and fails identically at
  `origin/main`. Not this diff.
- `craft static --strict`, diff-scoped: **0 blocker / 0 major / 0 minor**.
- Root gate suite green; `deals` and `compose/attention` green.

> **Note on sequencing:** this PR and #2746 are mutually blocking — #2746 is red
> only on the gates fixed here, and this is red only on the arch-lint finding
> fixed there. One of the two needs to carry both commits. Coordinating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when calculating how long deal activity has been idle.
  - Updated expected annotation results to reflect current behavior.

- **Tests**
  - Expanded coverage for quiet and stalled deal thresholds.
  - Added safeguards for consistent threshold evaluation.
  - Confirmed withheld lanes are named only once.
  - Improved fixture compatibility for database identifiers.

- **Documentation**
  - Clarified guidance for rendering lane data and maintaining threshold-related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->