### PR TITLE
feat(approvals): the gone-quiet review says what actually happened

### DIFF
--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -15,17 +15,24 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose/installseam"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // closeDateStager adapts the approvals service onto the deals module's
@@ -59,10 +66,140 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 	return err
 }
 
+// quietReviewReader adapts the deals module's QuietReviewReader seam: read one
+// deal's correspondence as the DEAL'S OWNER, never as the sweep's own system
+// principal.
+//
+// The reason it composes is stored in the approval payload and read later by
+// anyone holding deal:update on that deal. A system principal passes
+// auth.Require unconditionally and no row scope bounds it, so a name resolved
+// under it would be any name in the workspace, frozen into a record no
+// read-side gate can re-filter. Resolving the owner's real grants — their
+// permissions, their teams, their seat, in ONE snapshot — makes the read no
+// wider than the person the card is for.
+//
+// Every failure here is the same answer: no facts, so the review falls back to
+// a reason with no name in it. That covers a deal with no owner (owner_id is
+// nullable and ON DELETE SET NULL), an owner who has been suspended, archived
+// or removed (EffectiveAuthority answers ErrNotFound — absence of authority is
+// denial, never empty permission), and an owner whose grants do not reach the
+// correspondence. A deal's date hygiene must not depend on any of them.
+type quietReviewReader struct {
+	db    *database.DB
+	users *identity.Service
+}
+
+func (r quietReviewReader) ReadForOwner(ctx context.Context, dealID ids.DealID) (deals.QuietFacts, deals.QuietNames, error) {
+	owner, err := r.dealOwner(ctx, dealID)
+	if err != nil {
+		return deals.QuietFacts{}, nil, err
+	}
+	if owner.IsZero() {
+		// An unowned deal still gets its review; nobody's authority is the
+		// right one to read its correspondence under, so it goes unnamed.
+		return deals.QuietFacts{}, nil, nil
+	}
+	ownerCtx, err := r.asOwner(ctx, owner)
+	if err != nil {
+		return deals.QuietFacts{}, nil, err
+	}
+	var facts deals.QuietFacts
+	var names deals.QuietNames
+	err = r.db.Tx(ownerCtx, func(tx pgx.Tx) error {
+		var readErr error
+		if facts, readErr = deals.ReadQuietFacts(ownerCtx, tx, dealID); readErr != nil {
+			return readErr
+		}
+		names, readErr = r.nameCounterparties(ownerCtx, tx, facts)
+		// An owner who may not read people still gets the dates. The two
+		// answers are different sizes — WHEN the silence started is on the
+		// deal's own correspondence, WHO it was with belongs to the person
+		// record — and collapsing the first into the second's refusal throws
+		// away a fact the reader is entitled to.
+		if errors.Is(readErr, apperrors.ErrPermissionDenied) {
+			names = deals.QuietNames{}
+			return nil
+		}
+		return readErr
+	})
+	if err != nil {
+		return deals.QuietFacts{}, nil, err
+	}
+	return facts, names, nil
+}
+
+// dealOwner reads who the deal belongs to. It runs under the caller's own
+// principal — the sweep's — because owner_id is what CHOOSES the reading
+// authority, and a read that needed the authority to find it could not start.
+func (r quietReviewReader) dealOwner(ctx context.Context, dealID ids.DealID) (ids.UUID, error) {
+	var owner *ids.UUID
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT owner_id FROM deal WHERE id = $1`, dealID).Scan(&owner)
+	})
+	if err != nil {
+		return ids.Nil, fmt.Errorf("compose: deal %s owner: %w", dealID, err)
+	}
+	if owner == nil {
+		return ids.Nil, nil
+	}
+	return *owner, nil
+}
+
+// asOwner binds the deal owner as the acting principal.
+//
+// EffectiveAuthority reads the grants and the seat as ONE snapshot: composed
+// from separate reads they can describe an authority the owner never held —
+// permissions from before a role change with a seat from after. SeatType is
+// carried rather than omitted because its zero value fails closed to read-only,
+// which would silently narrow a read that is supposed to mirror the owner's.
+func (r quietReviewReader) asOwner(ctx context.Context, owner ids.UUID) (context.Context, error) {
+	wsID, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return nil, errors.New("compose: quiet review outside a bound workspace")
+	}
+	rbac, seat, err := r.users.EffectiveAuthority(ctx, wsID, owner)
+	if err != nil {
+		return nil, fmt.Errorf("compose: deal owner %s authority: %w", owner, err)
+	}
+	return principal.WithActor(ctx, principal.Principal{
+		Type:        principal.PrincipalHuman,
+		ID:          principal.HumanIDPrefix + owner.String(),
+		UserID:      owner,
+		SeatType:    seat,
+		TeamIDs:     rbac.TeamIDs,
+		Permissions: rbac.Permissions,
+	}), nil
+}
+
+// nameCounterparties resolves both sides' people in ONE call, so a deal whose
+// two directions share a contact costs one read rather than two. It runs inside
+// the owner's transaction, so a person the owner may not see simply has no
+// entry and the reason says "the contact".
+func (r quietReviewReader) nameCounterparties(ctx context.Context, tx pgx.Tx, facts deals.QuietFacts) (deals.QuietNames, error) {
+	var persons []ids.PersonID
+	for _, side := range []*deals.QuietSide{facts.LastInbound, facts.LastOutbound} {
+		if side != nil && !side.PersonID.IsZero() {
+			persons = append(persons, ids.From[ids.PersonKind](side.PersonID))
+		}
+	}
+	if len(persons) == 0 {
+		return deals.QuietNames{}, nil
+	}
+	found, err := people.NewStore(r.db).PersonNamesTx(ctx, tx, persons)
+	if err != nil {
+		return nil, err
+	}
+	return deals.QuietNames(found), nil
+}
+
 // NewCloseDateCorrector assembles the nightly close-date corrector for
 // the worker process role.
 func NewCloseDateCorrector(pool *pgxpool.Pool, log *slog.Logger) *deals.CloseDateCorrector {
-	return deals.NewCloseDateCorrector(InstallationDB(pool), closeDateStager{svc: approvals.NewService(InstallationDB(pool))}, log, installseam.Deals())
+	db := InstallationDB(pool)
+	return deals.NewCloseDateCorrector(db,
+		closeDateStager{svc: approvals.NewService(db)},
+		quietReviewReader{db: db, users: identity.NewServiceFor(db)},
+		log, installseam.Deals())
 }
 
 // closeDateConfirmEffect executes an approved close-date confirmation:

--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -69,7 +70,8 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 	quiet := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	e.svc = approvals.NewService(e.DB())
 	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.DB(), DealsInstallation())))
-	e.corrector = deals.NewCloseDateCorrector(e.DB(), closeDateStager{svc: e.svc}, quiet, installseam.Deals())
+	e.corrector = deals.NewCloseDateCorrector(e.DB(), closeDateStager{svc: e.svc},
+		quietReviewReader{db: e.DB(), users: identity.NewServiceFor(e.DB())}, quiet, installseam.Deals())
 	return e
 }
 
@@ -96,10 +98,13 @@ func (e *closeDateEnv) seedSweepDeal(t *testing.T, name string, stage ids.UUID, 
 	}
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, forecast_category, expected_close_date, last_activity_at, created_at, source, captured_by)
+		// The deal carries an owner because the gone-quiet review reads its
+		// correspondence under that person's authority — an unowned deal is
+		// reviewed unnamed, which is a case its own test covers.
+		`INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, forecast_category, expected_close_date, last_activity_at, created_at, source, captured_by, owner_id)
 		 VALUES ($1, $2, $3, $4, 10000, 'EUR', $5, $6,
-		         now() - make_interval(days => $7), now() - interval '120 days', 'manual', 'human:x')`,
-		id, name, e.pipeline, stage, category, expectedClose, lastActivityDaysAgo); err != nil {
+		         now() - make_interval(days => $7), now() - interval '120 days', 'manual', 'human:x', $8)`,
+		id, name, e.pipeline, stage, category, expectedClose, lastActivityDaysAgo, e.Rep1); err != nil {
 		t.Fatalf("seeding deal %q: %v", name, err)
 	}
 	return id

--- a/backend/internal/compose/quietreview_integration_test.go
+++ b/backend/internal/compose/quietreview_integration_test.go
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What the gone-quiet review actually asks.
+//
+// The reason and the proposed date are both composed from the database, so a
+// unit test over the sentence proves nothing about the card a person sees.
+// These read the staged approval the sweep produced.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// stagedCorrection is the proposal as the card will read it.
+func (e *closeDateEnv) stagedCorrection(t *testing.T, dealID ids.UUID) deals.CloseDateCorrection {
+	t.Helper()
+	var raw json.RawMessage
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT proposed_change FROM approval
+		  WHERE kind = 'close_date_correction' AND target_entity_id = $1 AND status = 'pending'`,
+		dealID).Scan(&raw); err != nil {
+		t.Fatalf("no staged correction on deal %s: %v", dealID, err)
+	}
+	correction, err := deals.UnmarshalCloseDateCorrection(raw)
+	if err != nil {
+		t.Fatalf("staged payload does not decode: %v", err)
+	}
+	return correction
+}
+
+// grantOwnerRealPermissions gives the deal owner an ACTUAL role row.
+//
+// The harness's in-memory `As(...)` permissions do not reach this path on
+// purpose: the sweep resolves the owner's authority from the database through
+// EffectiveAuthority, which is the whole point — a card is named only under
+// grants the owner really holds, not under whatever a caller asserted. So a
+// test that wants a named reason has to grant the owner the objects for real.
+func (e *closeDateEnv) grantOwnerRealPermissions(t *testing.T, userID ids.UUID) {
+	t.Helper()
+	e.grantOwnerRole(t, userID, `{"objects":{"person":{"read":true},
+		   "deal":{"read":true,"update":true},"activity":{"read":true},
+		   "organization":{"read":true}},"row_scope":"all"}`)
+}
+
+// grantOwnerWithoutPeople is the same owner minus person:read — the reader the
+// name gate is supposed to refuse. Everything else is identical, so a test
+// using it isolates exactly the one grant.
+func (e *closeDateEnv) grantOwnerWithoutPeople(t *testing.T, userID ids.UUID) {
+	t.Helper()
+	e.grantOwnerRole(t, userID, `{"objects":{"deal":{"read":true,"update":true},
+		   "activity":{"read":true},"organization":{"read":true}},
+		  "row_scope":"all"}`)
+}
+
+func (e *closeDateEnv) grantOwnerRole(t *testing.T, userID ids.UUID, document string) {
+	t.Helper()
+	ctx := context.Background()
+	roleID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO role (id, key, name, permissions)
+		 VALUES ($1, $2, 'Quiet review rep', $3)`,
+		roleID, "quiet_rep_"+roleID.String()[:8], document); err != nil {
+		t.Fatalf("seeding the owner's role: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO role_assignment (id, user_id, role_id) VALUES ($1, $2, $3)`,
+		ids.NewV7(), userID, roleID); err != nil {
+		t.Fatalf("assigning the owner's role: %v", err)
+	}
+}
+
+// seedDealEmail links one message to the deal, in a direction, from or to a
+// named person — the correspondence the review reads to say what happened.
+//
+// Every message a test seeds must be OLDER than StalledThresholdDays. Linking
+// an activity fires activity_link_last_activity, which pushes the deal's
+// last_activity_at forward to the message's date; a recent message therefore
+// makes the deal active, the 🔻 tier never fires, and the test fails looking
+// for a card the sweep correctly declined to stage.
+func (e *closeDateEnv) seedDealEmail(t *testing.T, dealID ids.UUID, direction, personName string, daysAgo int) {
+	t.Helper()
+	ctx := context.Background()
+	personID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, $2, 'manual', 'human:x')`, personID, personName); err != nil {
+		t.Fatalf("seeding person %q: %v", personName, err)
+	}
+	activityID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity (id, kind, direction, occurred_at, source, captured_by)
+		 VALUES ($1, 'email', $2, now() - make_interval(days => $3), 'manual', 'human:x')`,
+		activityID, direction, daysAgo); err != nil {
+		t.Fatalf("seeding %s activity: %v", direction, err)
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity_link (id, activity_id, entity_type, deal_id)
+		 VALUES ($1, $2, 'deal', $3)`, ids.NewV7(), activityID, dealID); err != nil {
+		t.Fatalf("linking activity to deal: %v", err)
+	}
+	// The counterparty's role differs by direction: they SEND an inbound
+	// message and RECEIVE an outbound one.
+	role := "to"
+	if direction == "inbound" {
+		role = "from"
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity_participant (id, activity_id, person_id, role)
+		 VALUES ($1, $2, $3, $4)`, ids.NewV7(), activityID, personID, role); err != nil {
+		t.Fatalf("seeding participant: %v", err)
+	}
+}
+
+// addParticipant puts a SECOND person in the same role on the deal's newest
+// message, turning a one-to-one exchange into group correspondence.
+func (e *closeDateEnv) addParticipant(t *testing.T, dealID ids.UUID, personName, role string) {
+	t.Helper()
+	ctx := context.Background()
+	personID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, $2, 'manual', 'human:x')`, personID, personName); err != nil {
+		t.Fatalf("seeding person %q: %v", personName, err)
+	}
+	var activityID ids.UUID
+	if err := e.owner.QueryRow(ctx,
+		`SELECT a.id FROM activity a
+		  JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
+		 ORDER BY a.occurred_at DESC, a.id DESC LIMIT 1`, dealID).Scan(&activityID); err != nil {
+		t.Fatalf("finding the deal's newest activity: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity_participant (id, activity_id, person_id, role)
+		 VALUES ($1, $2, $3, $4)`, ids.NewV7(), activityID, personID, role); err != nil {
+		t.Fatalf("seeding the second participant: %v", err)
+	}
+}
+
+// addAddressParticipant puts an ADDRESS-ONLY participant on the deal's newest
+// message — a real and common shape, since an address that matched nobody still
+// gets a row, and privacy erasure nulls person_id on rows that once matched.
+func (e *closeDateEnv) addAddressParticipant(t *testing.T, dealID ids.UUID, address, role string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity_participant (id, activity_id, address, role)
+		 VALUES ($1, (SELECT a.id FROM activity a
+		               JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $2
+		              ORDER BY a.occurred_at DESC, a.id DESC LIMIT 1), $3, $4)`,
+		ids.NewV7(), dealID, address, role); err != nil {
+		t.Fatalf("seeding the address participant: %v", err)
+	}
+}
+
+// The review used to say "deal has gone quiet; confirm it is still alive" on
+// every quiet deal — a sentence with no fact in it. It must name who is
+// waiting, and it must say the silence is ours to break.
+func TestQuietReviewNamesTheContactWhoIsWaitingForAReply(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerRealPermissions(t, e.Rep1)
+	id := e.seedSweepDeal(t, "Gone quiet", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "outbound", "Boris Klein", 120)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if !strings.Contains(basis, "Anna Weber") {
+		t.Errorf("basis = %q, want it to name Anna Weber — she wrote last", basis)
+	}
+	if !strings.Contains(basis, "nobody has answered") {
+		t.Errorf("basis = %q, want it to say the reply is ours to send", basis)
+	}
+	if strings.Contains(basis, "Boris Klein") {
+		t.Errorf("basis = %q — Boris wrote earlier; naming him reports the wrong silence", basis)
+	}
+}
+
+// The other direction is a different finding and a different next action: the
+// prospect went cold, and nobody here dropped anything.
+func TestQuietReviewSaysWeGotNoReplyWhenWeWroteLast(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerRealPermissions(t, e.Rep1)
+	id := e.seedSweepDeal(t, "No reply", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 120)
+	e.seedDealEmail(t, id, "outbound", "Anna Weber", 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if !strings.Contains(basis, "We wrote to Anna Weber") {
+		t.Errorf("basis = %q, want it to say we wrote and got nothing back", basis)
+	}
+}
+
+// A deal with no correspondence at all still gets a reason, and it says so
+// rather than inventing one.
+func TestQuietReviewSaysSoWhenThereIsNoCorrespondence(t *testing.T) {
+	e := setupCloseDate(t)
+	// The owner is granted for real: without a grant the review would refuse the
+	// read and fall back, which is a DIFFERENT sentence with its own test. This
+	// one is about a deal that genuinely has no correspondence.
+	e.grantOwnerRealPermissions(t, e.Rep1)
+	id := e.seedSweepDeal(t, "Never contacted", e.late, stringp("commit"), intp(30), 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if !strings.Contains(basis, "no correspondence") {
+		t.Errorf("basis = %q, want it to say there is nothing to judge the deal by", basis)
+	}
+}
+
+// The name comes from a read under the DEAL OWNER's authority, so a deal with
+// no owner has no authority to read under. It is still reviewed — the date
+// hygiene does not depend on who owns it — but it is reviewed unnamed rather
+// than under the sweep's own unbounded system principal, which would resolve
+// any name in the workspace into a payload other people later read.
+func TestQuietReviewOnAnUnownedDealNamesNobody(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Orphaned", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE deal SET owner_id = NULL WHERE id = $1`, id); err != nil {
+		t.Fatalf("clearing the owner: %v", err)
+	}
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if strings.Contains(basis, "Anna Weber") {
+		t.Errorf("basis = %q — an unowned deal has no authority to read names under", basis)
+	}
+	if basis == "" {
+		t.Error("an unowned deal still gets a reason, just an unnamed one")
+	}
+}
+
+// A message to four people has no single person the silence belongs to.
+// Picking one — by id order or any other arbitrary rule — prints a name the
+// reader can check against the thread and find misleading, so group
+// correspondence reports its dates with no name attached.
+func TestQuietReviewNamesNobodyOnGroupCorrespondence(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerRealPermissions(t, e.Rep1)
+	id := e.seedSweepDeal(t, "Group thread", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+	e.addParticipant(t, id, "Boris Klein", "from")
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	for _, name := range []string{"Anna Weber", "Boris Klein"} {
+		if strings.Contains(basis, name) {
+			t.Errorf("basis = %q — two senders means no single one to name", basis)
+		}
+	}
+	if !strings.Contains(basis, "The contact wrote") {
+		t.Errorf("basis = %q, want the unnamed reading with the dates intact", basis)
+	}
+}
+
+// An address that never resolved to a person is still somebody on the thread.
+// Counting only the MATCHED participants would read "Anna plus two unknown
+// addresses" as a private exchange and name her for a silence three people
+// share — the same misnaming the group rule exists to prevent, reached by the
+// half of the data that is easy to forget.
+func TestQuietReviewCountsUnmatchedAddressesAsParticipants(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerRealPermissions(t, e.Rep1)
+	id := e.seedSweepDeal(t, "Mixed thread", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+	e.addAddressParticipant(t, id, "someone@unmatched.test", "from")
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if strings.Contains(basis, "Anna Weber") {
+		t.Errorf("basis = %q — an unmatched address is still a second participant", basis)
+	}
+}
+
+// The security property, stated as a test.
+//
+// The sweep runs as a system principal, which passes auth.Require
+// unconditionally and which no row scope bounds. If the review resolved names
+// under THAT, an owner who may not read people would still get the name written
+// into their card — a disclosure frozen into a stored record, which no
+// read-side gate can undo. Reading as the owner is what makes the refusal land.
+//
+// The dates survive the refusal: when the silence started is on the deal's own
+// correspondence, who it was with belongs to the person record, and losing the
+// second is no reason to throw away the first.
+func TestQuietReviewWithoutPersonReadGivesDatesButNoName(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerWithoutPeople(t, e.Rep1)
+	id := e.seedSweepDeal(t, "Gone quiet", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if strings.Contains(basis, "Anna Weber") {
+		t.Errorf("basis = %q — the owner holds no person:read, so the card must not name her", basis)
+	}
+	if !strings.Contains(basis, "The contact wrote") {
+		t.Errorf("basis = %q, want the unnamed reading with the dates still in it", basis)
+	}
+}
+
+// Row scope and object grant answer different questions — WHICH activities may
+// this caller see, and MAY they read activities at all. The discover clause is
+// only the first, so an owner with no activity grant would otherwise still have
+// their correspondence read and its dates written into the card.
+func TestQuietReviewWithoutActivityReadReadsNoCorrespondence(t *testing.T) {
+	e := setupCloseDate(t)
+	e.grantOwnerRole(t, e.Rep1, `{"objects":{"deal":{"read":true,"update":true},
+		   "person":{"read":true},"organization":{"read":true}},"row_scope":"all"}`)
+	id := e.seedSweepDeal(t, "No activity grant", e.late, stringp("commit"), intp(30), 90)
+	e.seedDealEmail(t, id, "inbound", "Anna Weber", 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	basis := e.stagedCorrection(t, id).Basis
+	if strings.Contains(basis, "Anna Weber") || strings.Contains(basis, "5 August") {
+		t.Errorf("basis = %q — an owner without activity:read gets no correspondence facts", basis)
+	}
+}
+
+// The card asks a human to confirm a date, so it must PROPOSE one. It used to
+// carry the deal's current date in both fields, which asked for agreement to a
+// change that was not one.
+func TestQuietReviewProposesADateThatDiffersFromTheCurrentOne(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Gone quiet", e.late, stringp("commit"), intp(30), 90)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	correction := e.stagedCorrection(t, id)
+	if correction.PreviousCloseDate == nil {
+		t.Fatal("the card must say what date the deal carries now")
+	}
+	if correction.ExpectedCloseDate == *correction.PreviousCloseDate {
+		t.Errorf("proposed %s and current %s are the same date — the card asks for nothing",
+			correction.ExpectedCloseDate, *correction.PreviousCloseDate)
+	}
+	proposed, err := time.Parse(time.DateOnly, correction.ExpectedCloseDate)
+	if err != nil {
+		t.Fatalf("proposed date does not parse: %v", err)
+	}
+	if proposed.Before(today()) {
+		t.Errorf("proposed %s is in the past — the invariant forbids it", correction.ExpectedCloseDate)
+	}
+}
+
+// Proposing a date on the card is not the same as writing one to the deal. The
+// zombie guard still holds: only a human confirming lifts it.
+func TestQuietReviewLeavesTheDealsOwnDateAlone(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Gone quiet", e.late, stringp("commit"), intp(30), 90)
+	originalDate := today().AddDate(0, 0, 30)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	swept := e.readSwept(t, id)
+	if swept.expectedClose == nil || !swept.expectedClose.Equal(originalDate) {
+		t.Errorf("date = %v, want the original %s — proposing is not writing",
+			swept.expectedClose, originalDate.Format(time.DateOnly))
+	}
+}

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -51,6 +51,29 @@ type CorrectionStager interface {
 	StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal CloseDateCorrection) error
 }
 
+// QuietReviewReader reads one deal's correspondence UNDER ITS OWNER'S OWN
+// AUTHORITY, and that principal is the whole security argument for the
+// gone-quiet review.
+//
+// The sweep runs as a system principal, which auth.Require passes
+// unconditionally and which no row scope bounds. A counterparty resolved under
+// it is resolvable whoever they are — and the review writes that name into
+// proposed_change, where anyone holding deal:update on the target reads it
+// later. An unbounded read frozen into a stored payload is a disclosure no
+// read-side gate can undo, so the read runs as the person the card is for: the
+// deal's owner, resolved per deal.
+//
+// The composition root fills this because resolving an authority means reading
+// app_user, which this module may not do.
+//
+// Best-effort by contract. A deal with no owner, or one whose owner is no
+// longer live, yields no facts and the review falls back to a reason carrying
+// no name. Absence of authority is denial rather than empty permission, and a
+// deal's date hygiene is not a reason to fail the pass.
+type QuietReviewReader interface {
+	ReadForOwner(ctx context.Context, dealID ids.DealID) (QuietFacts, QuietNames, error)
+}
+
 // CloseDateCorrection is the staged proposed_change payload: everything
 // a human needs to confirm (or edit) the replacement date, and the
 // confirm effect needs to apply it.
@@ -84,9 +107,10 @@ func UnmarshalCloseDateCorrection(raw json.RawMessage) (CloseDateCorrection, err
 // CloseDateCorrector drives the sweep; the worker ticks it nightly.
 type CloseDateCorrector struct {
 	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
-	db     *database.DB
-	stager CorrectionStager
-	log    *slog.Logger
+	db       *database.DB
+	stager   CorrectionStager
+	reviewer QuietReviewReader
+	log      *slog.Logger
 	// now is the corrector's clock so the fixed-clock invariant test
 	// ("no open deal survives the run with a past date") can pin a day.
 	now func() time.Time
@@ -98,11 +122,12 @@ type CloseDateCorrector struct {
 // NewCloseDateCorrector assembles the sweep over the pool it reads through,
 // the stager it raises corrections into, and the seam that answers which zone
 // its dates are computed in.
-func NewCloseDateCorrector(db *database.DB, stager CorrectionStager, log *slog.Logger,
-	inst Installation,
+func NewCloseDateCorrector(db *database.DB, stager CorrectionStager, reviewer QuietReviewReader,
+	log *slog.Logger, inst Installation,
 ) *CloseDateCorrector {
 	return &CloseDateCorrector{
-		db: db, stager: stager, log: log, now: time.Now, installation: inst.orRefusing(),
+		db: db, stager: stager, reviewer: reviewer, log: log,
+		now: time.Now, installation: inst.orRefusing(),
 	}
 }
 
@@ -201,7 +226,7 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 			InForecastCommit:    category == "commit" || category == "best_case",
 			StageVelocityDays:   velocity,
 		}, now, loc)
-		if err := c.correct(ctx, cand, hygiene, category); err != nil {
+		if err := c.correct(ctx, cand, hygiene, category, now, loc); err != nil {
 			return fmt.Errorf("close-date correction on %s: %w", cand.id, err)
 		}
 	}
@@ -270,7 +295,7 @@ func forecastDowngrade(category string) string {
 // correct applies one deal's A6 tier. The write runs in its own audited
 // transaction; the 🟡 staging follows it (Stage opens its own) — if the
 // staging fails the provisional row simply re-enters the next sweep.
-func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidate, hygiene CloseDateHygiene, category string) error {
+func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidate, hygiene CloseDateHygiene, category string, now time.Time, loc *time.Location) error {
 	if !hygiene.Flagged {
 		if cand.provisional {
 			// The date itself is clean (the sweep set it), but the human
@@ -280,7 +305,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 				DealID:            cand.id,
 				ExpectedCloseDate: cand.expectedClose.Format(time.DateOnly),
 				PreviousCloseDate: dateString(cand.expectedClose),
-				Basis:             "provisional date from an earlier nightly correction, still awaiting confirmation",
+				Basis:             quietHoldingBasis,
 			})
 		}
 		return nil
@@ -291,7 +316,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 		ExpectedCloseDate: hygiene.ProposedClose.Format(time.DateOnly),
 		PreviousCloseDate: dateString(cand.expectedClose),
 		Flags:             hygiene.Flags,
-		Basis:             fmt.Sprintf("%d open stage(s) remaining × stage velocity", max(1, cand.remainingOpen)),
+		Basis:             pacedBasis(max(1, cand.remainingOpen)),
 	}
 
 	switch hygiene.Action {
@@ -332,16 +357,33 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 		if err != nil {
 			return err
 		}
-		// The 🟡 review: gone quiet — still alive? A provisional date, if
-		// any, rides the same proposal so confirming it also re-dates.
+		// The 🟡 review: gone quiet — still alive? The proposal keeps the
+		// stage-velocity date the assessment computed, on BOTH branches. It
+		// used to be overwritten here with the deal's CURRENT date whenever the
+		// invariant did not force a re-date, which asked a human to confirm the
+		// date the deal already had — a card with nothing in it to approve.
 		review := proposal
-		if !hygiene.Provisional {
-			review.ExpectedCloseDate = cand.expectedClose.Format(time.DateOnly)
-			review.Basis = "deal has gone quiet; confirm it is still alive — set a real date or mark it lost"
-		}
+		review.Basis = c.quietBasis(ctx, cand.id, now, loc)
 		return c.ensureStaged(ctx, cand.id, version, cand.name, review)
 	}
 	return fmt.Errorf("close-date sweep: no executor for action %q", hygiene.Action)
+}
+
+// quietBasis is the reason the quiet review shows: which way the silence runs,
+// who is on the far end of it, and how long it has lasted.
+//
+// A failure to READ the correspondence is not a reason to fail the sweep — the
+// downgrade has already committed and the review is what is left to raise. So a
+// read error degrades to the generic sentence and is logged, rather than
+// aborting a pass over every other deal in the workspace.
+func (c *CloseDateCorrector) quietBasis(ctx context.Context, dealID ids.DealID, now time.Time, loc *time.Location) string {
+	facts, names, err := c.reviewer.ReadForOwner(ctx, dealID)
+	if err != nil {
+		c.log.WarnContext(ctx, "close-date quiet review fell back to a generic reason",
+			"deal_id", dealID, "error", err)
+		return quietFallbackBasis
+	}
+	return quietReason(facts, names, now, loc)
 }
 
 // apply runs one tier's write shape: re-verify the deal is still open

--- a/backend/internal/modules/deals/quietfacts.go
+++ b/backend/internal/modules/deals/quietfacts.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// What a deal's silence actually consists of.
+//
+// The nightly close-date sweep downgrades a deal that has gone quiet and asks a
+// human whether it is still alive. That question is unanswerable from the word
+// "quiet": the reader needs to know which way the silence runs. A deal where the
+// customer wrote and nobody answered is a dropped ball on our side; a deal where
+// we wrote and got nothing back is a prospect going cold. They call for opposite
+// actions, and both used to arrive as the same sentence.
+//
+// So this reads the last message in each direction, and who was on the far end
+// of it — under whatever principal the caller bound, which for the sweep is the
+// DEAL'S OWNER rather than its own system identity. The activity discover
+// clause below is what makes that choice bite: without it every reader would
+// get the same rows and the principal would be decoration.
+//
+// Names are deliberately NOT resolved here. This module cannot import people,
+// and the composition root attaches them inside the same owner-bound
+// transaction through PersonNamesTx, which carries the person object gate a
+// local copy would drop.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// QuietSide is the last message in one direction on a deal, and the
+// counterparty on it.
+type QuietSide struct {
+	At time.Time
+	// Kind is the activity kind the message was — an email, a call, a meeting.
+	// The reason says what actually happened, and "wrote" on a phone call is a
+	// small lie that costs the sentence its authority.
+	Kind string
+	// PersonID is the counterparty the message was from (inbound) or to
+	// (outbound). Zero when the address never matched a person — an unmatched
+	// address is common, and privacy erasure actively nulls the link — so a
+	// reader must treat this as "who, if we know".
+	PersonID ids.UUID
+}
+
+// QuietFacts is what the sweep knows about a deal's silence: the last time each
+// side spoke. Either may be absent on a deal that has only ever been one-way,
+// or that predates activity capture.
+type QuietFacts struct {
+	LastInbound  *QuietSide
+	LastOutbound *QuietSide
+}
+
+// The two directions, each paired with whose address identifies the
+// counterparty on it. On an inbound message the counterparty WROTE it, so they
+// are the sender; on an outbound one we wrote to them, so they are a recipient.
+// Reading 'from' on an outbound message would name our own colleague and report
+// the silence as theirs.
+const (
+	directionInbound  = "inbound"
+	directionOutbound = "outbound"
+
+	counterpartyRoleInbound  = "from"
+	counterpartyRoleOutbound = "to"
+)
+
+// ReadQuietFacts reads the last inbound and last outbound message on the deal.
+//
+// It takes the caller's transaction rather than opening two, so both directions
+// are read against one deal's state in one place.
+//
+// The two statements do NOT share a snapshot — the pool's transactions are
+// READ COMMITTED, so a reply landing between them could be seen by the second
+// arm and not the first. That is deliberate rather than overlooked: the worst
+// case is one night's card naming the previous direction of a silence that has
+// just ended, and the next sweep corrects it. Raising the isolation level to
+// buy a snapshot would put a serialization failure in the path of a nightly
+// hygiene pass, which is a worse trade than a card that is one day stale.
+//
+// Deliberately scoped by activity_link.deal_id rather than by the stakeholder
+// walk EngagedStakeholders uses. The question here is about THIS deal's
+// correspondence, and a stakeholder's unrelated mail about another deal at the
+// same account is not evidence that this one is alive.
+func ReadQuietFacts(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (QuietFacts, error) {
+	// The object gate as well as the row scope below. They answer different
+	// questions — MAY this caller read activities at all, and WHICH ones — and
+	// the discover clause is only the second. Without this, an owner holding
+	// deal:read but no activity grant would still have their correspondence
+	// dates read and written into the card.
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return QuietFacts{}, err
+	}
+	var facts QuietFacts
+	for _, arm := range []struct {
+		direction string
+		role      string
+		into      **QuietSide
+	}{
+		{directionInbound, counterpartyRoleInbound, &facts.LastInbound},
+		{directionOutbound, counterpartyRoleOutbound, &facts.LastOutbound},
+	} {
+		side, found, err := readQuietSide(ctx, tx, dealID, arm.direction, arm.role)
+		if err != nil {
+			return QuietFacts{}, fmt.Errorf("last %s message on deal %s: %w", arm.direction, dealID, err)
+		}
+		if found {
+			*arm.into = &side
+		}
+	}
+	return facts, nil
+}
+
+// readQuietSide is one direction's arm, reporting whether the deal has a
+// message that way at all. The participant lookup may find nobody: a message
+// whose address never matched a person still tells the reader WHEN the side
+// last spoke, and dropping it would report a deal as never-contacted because
+// the address is unknown.
+func readQuietSide(ctx context.Context, tx pgx.Tx, dealID ids.DealID, direction, role string) (QuietSide, bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	dealPos := arg(dealID)
+	directionPos := arg(direction)
+	rolePos := arg(role)
+	// The caller runs this as the deal's OWNER, and this clause is what makes
+	// that principal mean something: without it the read would return the same
+	// rows whoever asked, and binding the owner would gate only the names while
+	// the dates came from everywhere. Discover rather than content, because what
+	// this reads is a marker — when a side last spoke — not a message body.
+	scope, err := auth.ActivityDiscoverClause(ctx, "a", arg)
+	if err != nil {
+		return QuietSide{}, false, err
+	}
+	// ORDER BY occurred_at DESC LIMIT 1 rather than a FILTERed max(): the row
+	// is what carries the counterparty, and idx_activity_direction serves this
+	// shape directly.
+	//
+	// The discover clause carries the availability test (a retention-held row is
+	// unavailable to every reader), so it is not spelled a second time here.
+	//
+	// It is a Sprintf ARGUMENT rather than concatenated into the format string:
+	// a `%` ever appearing in it would otherwise be read as a verb and corrupt
+	// the statement at runtime with nothing to catch it.
+	//
+	// The counterparty is named only when there is exactly ONE participant in
+	// that role. A message to four people has no single person the silence
+	// belongs to, and picking one — by id order or any other arbitrary rule —
+	// would print a name the reader can check and find misleading. Group
+	// correspondence therefore reports its dates with no name attached, which is
+	// the true answer.
+	//
+	// The count is over EVERY participant in the role, not only the matched
+	// ones. An address that never resolved to a person is still somebody on the
+	// thread, so counting matches alone would read "one person plus three
+	// unknown addresses" as a private exchange and name them for it.
+	var side QuietSide
+	var personID *ids.UUID
+	err = tx.QueryRow(ctx, fmt.Sprintf(`
+		SELECT a.occurred_at, a.kind,
+		       (SELECT sole.person_id FROM activity_participant sole
+		         WHERE sole.activity_id = a.id AND sole.role = $%[3]d
+		           AND sole.person_id IS NOT NULL
+		           AND (SELECT count(*) FROM activity_participant every
+		                 WHERE every.activity_id = a.id AND every.role = $%[3]d) = 1)
+		FROM activity a
+		JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $%[1]d
+		WHERE a.archived_at IS NULL AND %[4]s AND a.direction = $%[2]d
+		ORDER BY a.occurred_at DESC, a.id DESC
+		LIMIT 1`, dealPos, directionPos, rolePos, scope), args...).
+		Scan(&side.At, &side.Kind, &personID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return QuietSide{}, false, nil
+	}
+	if err != nil {
+		return QuietSide{}, false, err
+	}
+	if personID != nil {
+		side.PersonID = *personID
+	}
+	return side, true, nil
+}

--- a/backend/internal/modules/deals/quietreason.go
+++ b/backend/internal/modules/deals/quietreason.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The sentence a person reads when asked whether a quiet deal is still alive.
+//
+// It replaced a fixed string ("deal has gone quiet; confirm it is still alive")
+// which was true of every quiet deal and therefore told the reader nothing they
+// could act on. A reason earns its place by naming what happened: which way the
+// silence runs, who is on the other end of it, and how long it has lasted.
+//
+// The three shapes below are not stylistic variants — they are three different
+// situations, and the verb changes because the next action does:
+//
+//	they wrote last  → we owe a reply, and the name is who we owe it to
+//	we wrote last    → they went cold, and the name is who stopped answering
+//	neither          → nobody has ever corresponded on this deal at all
+//
+// Names arrive already resolved. This module cannot read the person table, and
+// a reason that silently drops the name when the reader lacks person:read is
+// better than one that leaks it — so an unknown name degrades to "the contact"
+// rather than to an identifier or an empty gap.
+
+import (
+	"fmt"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The reasons that are not about a deal's correspondence, kept beside the ones
+// that are so all of this surface's prose reads as one voice.
+const (
+	// quietFallbackBasis stands in when the correspondence could not be read.
+	// It says the deal is quiet and does not pretend to know more, which is
+	// the honest version of what the sweep has at that point.
+	quietFallbackBasis = "This deal has gone quiet and we could not read its correspondence — check the account before confirming."
+
+	// quietHoldingBasis explains a card that is simply still waiting: the
+	// sweep already set this date, and nobody has confirmed it yet.
+	quietHoldingBasis = "This date was set automatically by an earlier nightly check and has not been confirmed by anyone yet."
+)
+
+// pacedBasis says where a proposed date came from, without showing the
+// arithmetic. "3 open stage(s) remaining × stage velocity" is the formula that
+// produced the number, and a formula is not a reason a salesperson can weigh.
+func pacedBasis(remainingStages int) string {
+	if remainingStages == 1 {
+		return "Based on how long deals like this usually take to clear their last stage."
+	}
+	return fmt.Sprintf(
+		"Based on how long deals like this usually take, with %d stages still to go.",
+		remainingStages)
+}
+
+// QuietNames maps the counterparty on each side of ReadQuietFacts to a display
+// name. A side whose person is unknown — an unmatched address, an erased link,
+// or a reader without person:read — is simply absent from the map.
+type QuietNames map[ids.UUID]string
+
+// quietReason composes the sentence. `today` is the sweep's own day so the
+// day counts land in the workspace's calendar rather than the server's.
+func quietReason(facts QuietFacts, names QuietNames, today time.Time, loc *time.Location) string {
+	inbound, outbound := facts.LastInbound, facts.LastOutbound
+	switch {
+	case inbound != nil && (outbound == nil || outbound.At.Before(inbound.At)):
+		// They spoke last: the ball is ours, and that is the sharper finding of
+		// the two because it is a thing WE failed to do.
+		return fmt.Sprintf("%s %s on %s and %s — %s.",
+			quietWho(inbound, names, "The contact"),
+			quietReached(inbound.Kind),
+			quietDay(inbound.At, loc),
+			quietUnanswered(inbound.Kind),
+			quietFor(inbound.At, today, loc))
+	case outbound != nil:
+		return fmt.Sprintf("We %s %s on %s and %s — %s.",
+			quietReachedOut(outbound.Kind),
+			quietWho(outbound, names, "the contact"),
+			quietDay(outbound.At, loc),
+			quietSilenceSince(outbound.Kind),
+			quietFor(outbound.At, today, loc))
+	default:
+		return "Nobody has been in touch on this deal either way — there is no correspondence to judge it by."
+	}
+}
+
+// quietReached and quietReachedOut say what actually happened, per direction.
+// The facts query accepts any directional activity, so a phone call would
+// otherwise be reported as something somebody "wrote" — a small falsehood, and
+// a reader who was actually on that call stops trusting the rest of the
+// sentence. An unrecognised kind degrades to the neutral verb rather than
+// guessing.
+func quietReached(kind string) string {
+	switch crmcontracts.ActivityKind(kind) {
+	case crmcontracts.ActivityKindCall:
+		return "called"
+	case crmcontracts.ActivityKindMeeting:
+		return "met us"
+	default:
+		return "wrote"
+	}
+}
+
+func quietReachedOut(kind string) string {
+	switch crmcontracts.ActivityKind(kind) {
+	case crmcontracts.ActivityKindCall:
+		return "called"
+	case crmcontracts.ActivityKindMeeting:
+		return "met"
+	default:
+		return "wrote to"
+	}
+}
+
+// quietUnanswered and quietSilenceSince close the sentence in the same terms it
+// opened. "Called ... and nobody has answered" reads as a missed phone call
+// rather than an unreturned one, and a meeting never gets a "reply" at all — so
+// the second half of the sentence follows the verb in the first.
+func quietUnanswered(kind string) string {
+	switch crmcontracts.ActivityKind(kind) {
+	case crmcontracts.ActivityKindCall, crmcontracts.ActivityKindMeeting:
+		return "nobody has followed up since"
+	default:
+		return "nobody has answered since"
+	}
+}
+
+func quietSilenceSince(kind string) string {
+	switch crmcontracts.ActivityKind(kind) {
+	case crmcontracts.ActivityKindCall, crmcontracts.ActivityKindMeeting:
+		return "nothing has happened since"
+	default:
+		return "there has been no reply"
+	}
+}
+
+// quietWho names the counterparty, falling back to a generic noun. The fallback
+// differs by position in the sentence, so the caller supplies it: "The contact
+// wrote" opens a sentence, "we wrote to the contact" does not.
+func quietWho(side *QuietSide, names QuietNames, unknown string) string {
+	if name, ok := names[side.PersonID]; ok && name != "" {
+		return name
+	}
+	return unknown
+}
+
+// quietDay is the date a reader recognises, not a wire timestamp — and it is
+// the date in the WORKSPACE's zone, the same zone the sweep decides which day a
+// deal is late on. A message at 23:00 local is otherwise reported as the next
+// day, which a reader can check against their own mailbox and find wrong.
+func quietDay(at time.Time, loc *time.Location) string {
+	return at.In(orUTC(loc)).Format("2 January")
+}
+
+// orUTC is the zone fallback. A sweep always has one; the guard exists so a
+// caller that does not cannot panic a nil dereference into the nightly pass.
+func orUTC(loc *time.Location) *time.Location {
+	if loc == nil {
+		return time.UTC
+	}
+	return loc
+}
+
+// dayIn reduces an instant to its calendar day in the given zone, so the span
+// counts the days a reader would count rather than 24-hour blocks.
+func dayIn(at time.Time, loc *time.Location) time.Time {
+	y, m, d := at.In(loc).Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// quietFor is the elapsed span, in the unit a person would say it in. Days up to
+// a fortnight, then weeks: "38 days" makes a reader do arithmetic to learn what
+// "5 weeks" says outright.
+func quietFor(since, today time.Time, loc *time.Location) string {
+	zone := orUTC(loc)
+	days := int(dayIn(today, zone).Sub(dayIn(since, zone)).Hours() / 24)
+	if days < 0 {
+		days = 0
+	}
+	switch {
+	case days == 0:
+		return "that was today"
+	case days == 1:
+		return "that was yesterday"
+	case days <= 14:
+		return fmt.Sprintf("%d days ago", days)
+	default:
+		return fmt.Sprintf("%d weeks ago", days/7)
+	}
+}

--- a/backend/internal/modules/deals/quietreason_test.go
+++ b/backend/internal/modules/deals/quietreason_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The reason exists to tell a reader which way the silence runs, because the
+// two directions call for opposite actions. These tests pin that distinction
+// and the facts that make it checkable.
+
+func quietAt(day int) time.Time {
+	return time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC).AddDate(0, 0, day)
+}
+
+var quietToday = quietAt(0)
+
+func TestQuietReasonNamesWhoWeOweAReplyTo(t *testing.T) {
+	anna := ids.NewV7()
+	facts := QuietFacts{
+		LastInbound:  &QuietSide{At: quietAt(-21), PersonID: anna},
+		LastOutbound: &QuietSide{At: quietAt(-30)},
+	}
+
+	got := quietReason(facts, QuietNames{anna: "Anna Weber"}, quietToday, time.UTC)
+
+	for _, want := range []string{"Anna Weber", "nobody has answered", "3 weeks ago", "5 August"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reason = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestQuietReasonSaysWeGotNoReplyWhenWeSpokeLast(t *testing.T) {
+	anna := ids.NewV7()
+	facts := QuietFacts{
+		LastInbound:  &QuietSide{At: quietAt(-40)},
+		LastOutbound: &QuietSide{At: quietAt(-10), PersonID: anna},
+	}
+
+	got := quietReason(facts, QuietNames{anna: "Anna Weber"}, quietToday, time.UTC)
+
+	if !strings.Contains(got, "We wrote to Anna Weber") {
+		t.Errorf("reason = %q, want it to say we wrote to Anna Weber", got)
+	}
+	if !strings.Contains(got, "no reply") {
+		t.Errorf("reason = %q, want it to say there was no reply", got)
+	}
+	if strings.Contains(got, "nobody has answered") {
+		t.Errorf("reason = %q — that phrasing blames us for a prospect who went cold", got)
+	}
+}
+
+// The direction is decided by which message is NEWER, not by which exists. A
+// deal with correspondence both ways is the normal case, and reading it wrong
+// tells a rep to chase somebody who is in fact waiting on them.
+func TestQuietReasonPicksTheDirectionOfTheNewerMessage(t *testing.T) {
+	them, us := ids.NewV7(), ids.NewV7()
+	names := QuietNames{them: "Anna Weber", us: "Boris Klein"}
+
+	theyRepliedLast := quietReason(QuietFacts{
+		LastInbound:  &QuietSide{At: quietAt(-5), PersonID: them},
+		LastOutbound: &QuietSide{At: quietAt(-9), PersonID: us},
+	}, names, quietToday, time.UTC)
+	if !strings.Contains(theyRepliedLast, "Anna Weber wrote") {
+		t.Errorf("reason = %q, want the inbound reading — they spoke most recently", theyRepliedLast)
+	}
+
+	weWroteLast := quietReason(QuietFacts{
+		LastInbound:  &QuietSide{At: quietAt(-9), PersonID: them},
+		LastOutbound: &QuietSide{At: quietAt(-5), PersonID: us},
+	}, names, quietToday, time.UTC)
+	if !strings.Contains(weWroteLast, "We wrote to Boris Klein") {
+		t.Errorf("reason = %q, want the outbound reading — we spoke most recently", weWroteLast)
+	}
+}
+
+// The facts query accepts any directional activity, so the verb has to match
+// what actually happened. Reporting a phone call as something somebody "wrote"
+// is a small falsehood, and a reader who was on that call stops trusting
+// everything else the card says.
+func TestQuietReasonSaysWhatActuallyHappened(t *testing.T) {
+	anna := ids.NewV7()
+	names := QuietNames{anna: "Anna Weber"}
+
+	for _, tc := range []struct {
+		kind     string
+		inbound  string
+		outbound string
+	}{
+		// Both halves of the sentence follow the verb: you do not "answer" a
+		// call, and a meeting never gets a "reply".
+		{
+			"call", "Anna Weber called on 6 August and nobody has followed up since",
+			"We called Anna Weber on 6 August and nothing has happened since",
+		},
+		{
+			"meeting", "Anna Weber met us on 6 August and nobody has followed up since",
+			"We met Anna Weber on 6 August and nothing has happened since",
+		},
+		{
+			"email", "Anna Weber wrote on 6 August and nobody has answered since",
+			"We wrote to Anna Weber on 6 August and there has been no reply",
+		},
+	} {
+		theyLast := quietReason(QuietFacts{
+			LastInbound: &QuietSide{At: quietAt(-20), PersonID: anna, Kind: tc.kind},
+		}, names, quietToday, time.UTC)
+		if !strings.Contains(theyLast, tc.inbound) {
+			t.Errorf("inbound %s reason = %q, want %q in it", tc.kind, theyLast, tc.inbound)
+		}
+
+		weLast := quietReason(QuietFacts{
+			LastOutbound: &QuietSide{At: quietAt(-20), PersonID: anna, Kind: tc.kind},
+		}, names, quietToday, time.UTC)
+		if !strings.Contains(weLast, tc.outbound) {
+			t.Errorf("outbound %s reason = %q, want %q in it", tc.kind, weLast, tc.outbound)
+		}
+	}
+}
+
+// An unrecognised kind takes the neutral verb rather than vanishing or
+// guessing — a new activity kind must not silently produce a broken sentence.
+func TestQuietReasonDegradesAnUnknownKindToTheNeutralVerb(t *testing.T) {
+	got := quietReason(QuietFacts{
+		LastInbound: &QuietSide{At: quietAt(-20), Kind: "carrier_pigeon"},
+	}, nil, quietToday, time.UTC)
+
+	if !strings.Contains(got, "The contact wrote") {
+		t.Errorf("reason = %q, want the neutral verb for an unknown kind", got)
+	}
+}
+
+// An unnamed counterparty is the common case, not an edge one: an unmatched
+// address carries no person, and privacy erasure nulls the link outright. The
+// reason must still read as a sentence.
+func TestQuietReasonDegradesToAGenericNounWithoutAName(t *testing.T) {
+	facts := QuietFacts{LastInbound: &QuietSide{At: quietAt(-8)}}
+
+	got := quietReason(facts, nil, quietToday, time.UTC)
+
+	if !strings.HasPrefix(got, "The contact wrote") {
+		t.Errorf("reason = %q, want it to open with the generic noun", got)
+	}
+	if strings.Contains(got, "00000000") {
+		t.Errorf("reason = %q — an identifier is never shown in place of a name", got)
+	}
+}
+
+func TestQuietReasonSaysSoWhenThereIsNoCorrespondenceAtAll(t *testing.T) {
+	got := quietReason(QuietFacts{}, nil, quietToday, time.UTC)
+
+	if !strings.Contains(got, "no correspondence") {
+		t.Errorf("reason = %q, want it to say there is nothing to judge the deal by", got)
+	}
+}
+
+// The span is what a person would say out loud. Days while a reader still
+// counts in days, weeks once they would not.
+func TestQuietForSpeaksInTheUnitAPersonWouldUse(t *testing.T) {
+	for _, tc := range []struct {
+		daysAgo int
+		want    string
+	}{
+		{0, "that was today"},
+		{1, "that was yesterday"},
+		{9, "9 days ago"},
+		{14, "14 days ago"},
+		{15, "2 weeks ago"},
+		{45, "6 weeks ago"},
+	} {
+		if got := quietFor(quietAt(-tc.daysAgo), quietToday, time.UTC); got != tc.want {
+			t.Errorf("quietFor(%d days ago) = %q, want %q", tc.daysAgo, got, tc.want)
+		}
+	}
+}
+
+// The date is the one the READER would write down, which is the date in the
+// workspace's own zone. A message at 22:00 in Berlin is 20:00 UTC the same day,
+// but one at 01:00 Berlin is the PREVIOUS day in UTC — and a card naming a day
+// the reader can check against their own mailbox has to name the right one.
+func TestQuietDayIsTheWorkspacesOwnCalendarDay(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("loading the zone: %v", err)
+	}
+	// 00:30 on 6 August in Berlin is 22:30 on 5 August in UTC.
+	justAfterMidnight := time.Date(2026, 8, 6, 0, 30, 0, 0, berlin)
+
+	if got := quietDay(justAfterMidnight, berlin); got != "6 August" {
+		t.Errorf("quietDay in Berlin = %q, want %q", got, "6 August")
+	}
+	if got := quietDay(justAfterMidnight, time.UTC); got != "5 August" {
+		t.Errorf("quietDay in UTC = %q, want %q — the zones must genuinely differ here", got, "5 August")
+	}
+}
+
+// A clock that has not caught up must not print a negative span.
+func TestQuietForNeverReportsTheFuture(t *testing.T) {
+	if got := quietFor(quietAt(3), quietToday, time.UTC); got != "that was today" {
+		t.Errorf("quietFor(future) = %q, want it clamped to today", got)
+	}
+}
+
+// The paced basis explains where a date came from. It must never show the
+// arithmetic that produced it — a formula is not a reason a rep can weigh.
+func TestPacedBasisExplainsWithoutShowingTheFormula(t *testing.T) {
+	for _, stages := range []int{1, 4} {
+		got := pacedBasis(stages)
+		for _, forbidden := range []string{"×", "*", "velocity", "stage(s)"} {
+			if strings.Contains(got, forbidden) {
+				t.Errorf("pacedBasis(%d) = %q, want no %q in it", stages, got, forbidden)
+			}
+		}
+	}
+	if got := pacedBasis(1); strings.Contains(got, "1 stages") {
+		t.Errorf("pacedBasis(1) = %q, want the singular reading", got)
+	}
+}

--- a/frontend/src/format/calendarday.test.ts
+++ b/frontend/src/format/calendarday.test.ts
@@ -6,6 +6,7 @@ import {
   calendarDay,
   calendarMonth,
   dueInstant,
+  isRealCalendarDay,
   localDateTimeValue,
   middayInstant,
 } from "./calendarday";
@@ -153,5 +154,38 @@ describe("calendarMonth", () => {
     for (const zone of ["UTC", "Asia/Ho_Chi_Minh", "America/Los_Angeles"]) {
       expect(calendarMonth(at, zone)).toBe(calendarDay(at, zone).slice(0, 7));
     }
+  });
+});
+
+describe("isRealCalendarDay", () => {
+  it("accepts a day the calendar actually holds", () => {
+    expect(isRealCalendarDay("2026-09-27")).toBe(true);
+    expect(isRealCalendarDay("2026-01-31")).toBe(true);
+    expect(isRealCalendarDay("2026-12-31")).toBe(true);
+  });
+
+  // The whole point: these are spelled correctly and are not dates. A shape
+  // check passes them and the date control then blanks them silently.
+  it("refuses a well-shaped day that does not exist", () => {
+    expect(isRealCalendarDay("2026-02-30")).toBe(false);
+    expect(isRealCalendarDay("2026-04-31")).toBe(false);
+    expect(isRealCalendarDay("2026-13-01")).toBe(false);
+    expect(isRealCalendarDay("2026-00-10")).toBe(false);
+    expect(isRealCalendarDay("2026-01-00")).toBe(false);
+    expect(isRealCalendarDay("2026-01-32")).toBe(false);
+  });
+
+  it("follows the Gregorian leap rule, centuries included", () => {
+    expect(isRealCalendarDay("2028-02-29")).toBe(true);
+    expect(isRealCalendarDay("2026-02-29")).toBe(false);
+    expect(isRealCalendarDay("2000-02-29")).toBe(true);
+    expect(isRealCalendarDay("2100-02-29")).toBe(false);
+  });
+
+  it("refuses anything that is not a bare YYYY-MM-DD", () => {
+    expect(isRealCalendarDay("27/09/2026")).toBe(false);
+    expect(isRealCalendarDay("2026-9-27")).toBe(false);
+    expect(isRealCalendarDay("2026-09-27T00:00:00Z")).toBe(false);
+    expect(isRealCalendarDay("")).toBe(false);
   });
 });

--- a/frontend/src/format/calendarday.ts
+++ b/frontend/src/format/calendarday.ts
@@ -39,6 +39,41 @@ function dayFormatter(zone: string): Intl.DateTimeFormat {
   return made;
 }
 
+/**
+ * Whether a `YYYY-MM-DD` string names a day that EXISTS.
+ *
+ * A shape test is not enough: `2026-02-30` and `2026-13-01` are both spelled
+ * correctly and neither is a date. This compares the parts against what a real
+ * calendar holds — which needs no clock and no zone at all, because the
+ * question is about the STRING, not about whose calendar it lands on.
+ *
+ * It lives beside calendarDay because it is the same subject: what a calendar
+ * day is, and which strings are one.
+ */
+export function isRealCalendarDay(day: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day);
+  if (!match) {
+    return false;
+  }
+  const [year, month, dayOfMonth] = match.slice(1).map(Number);
+  return (
+    month >= 1 &&
+    month <= 12 &&
+    dayOfMonth >= 1 &&
+    dayOfMonth <= daysIn(year, month)
+  );
+}
+
+// How many days a month holds, February following the Gregorian leap rule
+// (every four years, except centuries, except every four hundred).
+function daysIn(year: number, month: number): number {
+  if (month === 2) {
+    const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    return leap ? 29 : 28;
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
 export function calendarDay(at: Date, zone: string): string {
   const parts = new Map(
     dayFormatter(zone)

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2020,6 +2020,8 @@ export const de = {
   "inbox.expiresIn": "läuft ab in {countdown}",
   "inbox.detail": "Freigabe-Detail",
   "inbox.detailTechnical": "Technische Details",
+  "inbox.detailAsked": "Gefragt am",
+  "inbox.detailDecided": "Entschieden am",
   "inbox.status.approved": "Genehmigt",
   "inbox.status.rejected": "Abgelehnt",
   "inbox.status.expired": "Abgelaufen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2045,6 +2045,8 @@ export const en = {
   "inbox.expiresIn": "expires in {countdown}",
   "inbox.detail": "Approval detail",
   "inbox.detailTechnical": "Technical details",
+  "inbox.detailAsked": "Asked",
+  "inbox.detailDecided": "Decided",
   "inbox.status.approved": "Approved",
   "inbox.status.rejected": "Rejected",
   "inbox.status.expired": "Expired",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2005,6 +2005,8 @@ export const vi = {
   "inbox.expiresIn": "hết hạn sau {countdown}",
   "inbox.detail": "Chi tiết phê duyệt",
   "inbox.detailTechnical": "Chi tiết kỹ thuật",
+  "inbox.detailAsked": "Đã hỏi",
+  "inbox.detailDecided": "Đã quyết định",
   "inbox.status.approved": "Đã duyệt",
   "inbox.status.rejected": "Đã từ chối",
   "inbox.status.expired": "Đã hết hạn",

--- a/frontend/src/screens/approvaleditor.test.ts
+++ b/frontend/src/screens/approvaleditor.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { editableSeed, editableStrings } from "./approvaleditor";
+
+// What the inline editor OFFERS. A kind that declares its editable fields is
+// saying what a person may change; everything else in the payload is what the
+// question is about, and offering it as a text box invites an edit the server
+// will refuse.
+
+describe("a kind that declares what may be edited", () => {
+  const closeDate = {
+    deal_id: "01a03781-912c-774e-a74e-7cdceca98829",
+    expected_close_date: "2026-09-27",
+    previous_close_date: "2026-09-27",
+    basis: "This deal has gone quiet.",
+  };
+
+  it("offers the proposed date and nothing else", () => {
+    const fields = editableStrings("close_date_correction", closeDate);
+
+    expect(fields.map((f) => f.field)).toEqual(["expected_close_date"]);
+  });
+
+  it("never offers an identifier as something to retype", () => {
+    const fields = editableStrings("close_date_correction", closeDate);
+
+    expect(fields.map((f) => f.field)).not.toContain("deal_id");
+  });
+
+  it("never offers the server's own reason as the reader's to rewrite", () => {
+    const fields = editableStrings("close_date_correction", closeDate);
+
+    expect(fields.map((f) => f.field)).not.toContain("basis");
+  });
+
+  it("gives a date the calendar control rather than a text box", () => {
+    const [date] = editableStrings("close_date_correction", closeDate);
+
+    expect(date.as).toBe("date");
+  });
+
+  // A declared field the payload does not carry is skipped: rendering it empty
+  // would ADD the path on approve, which the server reads as a retargeted edit.
+  it("skips a declared field the payload does not carry", () => {
+    const fields = editableStrings("close_date_correction", {
+      deal_id: "01a03781-912c-774e-a74e-7cdceca98829",
+    });
+
+    expect(fields).toEqual([]);
+  });
+});
+
+describe("a kind that declares nothing", () => {
+  // The raw-args kinds carry an agent tool's arguments, and inventing labels
+  // for a bag of unknown keys would be guessing — so they keep the generic
+  // editor rather than losing their fields to a declaration nobody wrote.
+  it("still offers every string in the payload", () => {
+    const fields = editableStrings("some_agent_tool_call", {
+      note: "hello",
+      subject: "there",
+      count: 3,
+    });
+
+    expect(fields.map((f) => f.field)).toEqual(["note", "subject"]);
+    expect(fields.every((f) => f.as === "text")).toBe(true);
+  });
+
+  // `kind` is a wire string. A value naming an Object prototype member would
+  // otherwise find a function, pass the truthy check, and crash the queue.
+  it("does not mistake a prototype member for a declaration", () => {
+    const fields = editableStrings("constructor", { note: "hello" });
+
+    expect(fields.map((f) => f.field)).toEqual(["note"]);
+  });
+});
+
+describe("what the editor starts with", () => {
+  const dateField = { field: "expected_close_date", as: "date" } as const;
+  const textField = { field: "subject", as: "text" } as const;
+
+  it("keeps a wire date, which is what the control accepts", () => {
+    expect(editableSeed(dateField, "2026-09-27")).toBe("2026-09-27");
+  });
+
+  // The control discards a value it cannot parse. Seeding the raw string would
+  // show an empty box while the original still went out on approve — the editor
+  // displaying one thing and submitting another.
+  it("blanks a date the control cannot show, so shown and sent agree", () => {
+    expect(editableSeed(dateField, "27/09/2026")).toBe("");
+  });
+
+  // A shape check alone would pass this: it is spelled YYYY-MM-DD and there is
+  // no 30th of February. The control blanks it, so the seed must too, or the
+  // reader sees an empty box while the impossible date rides out on approve.
+  it("blanks a well-shaped date that does not exist", () => {
+    expect(editableSeed(dateField, "2026-02-30")).toBe("");
+    expect(editableSeed(dateField, "2026-13-01")).toBe("");
+  });
+
+  it("keeps a leap day in a year that has one", () => {
+    expect(editableSeed(dateField, "2028-02-29")).toBe("2028-02-29");
+    expect(editableSeed(dateField, "2026-02-29")).toBe("");
+  });
+
+  it("leaves a text field's value alone whatever it looks like", () => {
+    expect(editableSeed(textField, "27/09/2026")).toBe("27/09/2026");
+  });
+
+  // A non-string here means a payload that does not match its kind's
+  // declaration; inviting somebody to edit "[object Object]" is worse than
+  // an empty box.
+  it("blanks a value that is not a string rather than stringifying it", () => {
+    expect(editableSeed(textField, { nested: true })).toBe("");
+    expect(editableSeed(dateField, undefined)).toBe("");
+  });
+});

--- a/frontend/src/screens/approvaleditor.tsx
+++ b/frontend/src/screens/approvaleditor.tsx
@@ -9,8 +9,10 @@ import {
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { DateInput, type ISODate, isISODate } from "../design-system/dateinput";
 import { Select } from "../design-system/select";
 import { EvidenceChip } from "../design-system/trust";
+import { isRealCalendarDay } from "../format/calendarday";
 import { formatDateTime } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
@@ -91,9 +93,9 @@ function EvidenceList({
 }
 
 /**
- * AC-2: the row's "view everything" affordance — the full proposed_change
- * (key→value), evidence, target_version, proposed_by/on_behalf_of and
- * timestamps the summary/evidence-chip row necessarily elides.
+ * AC-2: the row's "view everything" affordance — the proposal's own fields, the
+ * evidence behind them and the timestamps the summary/evidence-chip row
+ * necessarily elides.
  */
 export function ApprovalDetailModal({
   approvalId,
@@ -148,18 +150,19 @@ export function ApprovalDetailModal({
  *
  * Ordered the way a person reads a decision rather than the way the row is
  * stored: the sentence saying what is being asked, then what the proposal says
- * in named fields, then the quoted evidence behind it, and only then — behind a
- * disclosure — the identifiers and versions.
+ * in named fields, then when it was asked, then the quoted evidence behind it.
  *
  * The summary leads and used to be absent entirely. It is the one field the
  * server documents as prose ("the sentence a human reads before deciding"), and
  * a dialog that opened on `deal_id` while omitting it was showing the reader
  * everything except the question.
  *
- * The technical block is kept rather than dropped. Somebody debugging a stuck
- * proposal needs the target version and the proposing actor, and a support
- * conversation needs the id — but none of that is why a person is being asked
- * to agree to something, so it does not open the dialog.
+ * Only the raw payload stays behind the disclosure, and only for a kind that has
+ * already said what its fields mean — there it is reference material for
+ * somebody checking what the server actually staged. The target version and the
+ * `agent:<id>` that proposed it are gone from this surface entirely: neither
+ * names a person or describes a change, so a reader can do nothing with them,
+ * and one click away rather than zero does not make them useful.
  */
 function ApprovalDetailBody({
   approval,
@@ -198,15 +201,15 @@ function ApprovalDetailBody({
             />
           ))
         : rawPayload}
+      {askedOn(approval, locale, zone, t).map(([label, value]) => (
+        <FieldLine key={label} name={label} value={value} />
+      ))}
       <EvidenceList evidence={approval.evidence} />
-      <Disclosure summary={t("inbox.detailTechnical")}>
-        <div className="approval-detail">
-          {named.length > 0 && rawPayload}
-          {detailMeta(approval, locale, zone).map(([key, value]) => (
-            <FieldLine key={key} name={key} mono value={value} />
-          ))}
-        </div>
-      </Disclosure>
+      {named.length > 0 && (
+        <Disclosure summary={t("inbox.detailTechnical")}>
+          <div className="approval-detail">{rawPayload}</div>
+        </Disclosure>
+      )}
     </div>
   );
 }
@@ -230,29 +233,36 @@ function RawPayload({
   );
 }
 
-// Wire field identifiers (contract shape), not translatable prose — rendered
-// raw, behind the technical disclosure where a payload path is what the reader
-// actually came for.
-function detailMeta(
+/**
+ * When the question was raised, and when it was settled.
+ *
+ * These two used to sit behind the technical disclosure, labelled `created_at`
+ * and `decided_at` in monospace beside a uuid. They are not technical: how long
+ * a proposal has been waiting is one of the few things on this dialog a reader
+ * actually weighs, and it was filed with the debugging material because it
+ * arrived on the wire next to it.
+ *
+ * The rest of that block is gone from this surface rather than moved. A target
+ * version and a `proposed_by` of `agent:<id>` name no person and describe no
+ * change — there is nothing a reader can do with either, and putting them one
+ * click away rather than zero does not make them useful.
+ */
+function askedOn(
   approval: Approval,
   locale: ReturnType<typeof useLocale>["locale"],
   zone: string,
+  t: ReturnType<typeof useT>,
 ): [string, string][] {
-  const meta: [string, string][] = [
-    ["target_version", String(approval.target_version ?? "—")],
-    ["proposed_by", approval.proposed_by],
+  const asked: [string, string][] = [
+    [t("inbox.detailAsked"), formatDateTime(approval.created_at, locale, zone)],
   ];
-  if (approval.on_behalf_of) {
-    meta.push(["on_behalf_of", approval.on_behalf_of]);
-  }
-  meta.push(["created_at", formatDateTime(approval.created_at, locale, zone)]);
   if (approval.decided_at) {
-    meta.push([
-      "decided_at",
+    asked.push([
+      t("inbox.detailDecided"),
       formatDateTime(approval.decided_at, locale, zone),
     ]);
   }
-  return meta;
+  return asked;
 }
 
 // `mono` marks a value the WIRE spells — a uuid, a version, a payload path.
@@ -315,6 +325,38 @@ export function DecideOutcome({
 }
 
 /**
+ * What the editor should START with for one field.
+ *
+ * This is the seed AND the display rule, deliberately in one function: a date
+ * control silently discards a value it cannot parse, so if the two disagreed
+ * the reader would see an empty box while the unparseable original still rode
+ * out on approve — an editor showing one thing and submitting another.
+ *
+ * "Cannot parse" covers more than a wrong shape. `2026-02-30` is spelled
+ * correctly and is not a day, and the element blanks it exactly as it blanks
+ * `27/09/2026` — so the seed asks whether the date EXISTS, through
+ * isRealCalendarDay, rather than only whether it looks like one.
+ *
+ * A non-string payload value seeds empty rather than being stringified. The
+ * editor only ever offers string fields, so a number or object arriving here is
+ * a payload that does not match its kind's declaration, and inviting somebody
+ * to edit `[object Object]` is worse than an empty box.
+ */
+export function editableSeed(entry: EditableField, staged: unknown): string {
+  if (typeof staged !== "string") {
+    return "";
+  }
+  return entry.as === "date" && !isRealCalendarDay(staged) ? "" : staged;
+}
+
+// The seeded value narrowed to what the date control's own type accepts. The
+// seed already dropped anything unshowable, so this is the type narrowing and
+// not a second rule.
+function isoOrBlank(staged: string | undefined): ISODate | "" {
+  return staged && isISODate(staged) ? staged : "";
+}
+
+/**
  * The inline staged-draft editor: the string fields of the proposed_change, in
  * the shape the kind declared for them, going up as `edited_payload`.
  *
@@ -365,6 +407,16 @@ export function StagedEditor({
                 })}
                 value={draft[entry.field] ?? ""}
                 onChange={(value) => onChange(entry.field, value)}
+              />
+            ) : entry.as === "date" ? (
+              <DateInput
+                {...control}
+                // A staged date the control cannot show is shown as empty
+                // rather than passed through: the element would blank a
+                // malformed value on its own, and an empty box a reader can
+                // fill beats one that silently drops what they typed.
+                value={isoOrBlank(draft[entry.field])}
+                onChange={(event) => onChange(entry.field, event.target.value)}
               />
             ) : entry.as === "textarea" ? (
               <Textarea

--- a/frontend/src/screens/approvalkind.ts
+++ b/frontend/src/screens/approvalkind.ts
@@ -91,6 +91,16 @@ export type EditableField =
   | {
       readonly field: string;
       /**
+       * A date-only wire value. It gets the calendar control rather than a text
+       * box: the payload wants `2026-09-27`, and a reader typing the date the
+       * way they say it out loud writes something the server refuses.
+       */
+      readonly as: "date";
+      readonly label?: MessageKey;
+    }
+  | {
+      readonly field: string;
+      /**
        * Prose that runs to paragraphs rather than a line. An email body in a
        * single-line input is technically editable and practically unreadable:
        * the reader can see about eight words of what they are being asked to
@@ -171,6 +181,18 @@ export const EDITABLE_FIELDS: Readonly<
   held_draft: [
     { field: "subject", as: "text", label: "inbox.draftSubject" },
     { field: "body", as: "textarea", label: "inbox.draftBody" },
+  ],
+  // The date is the entire question, and it is the only thing here a person may
+  // change. Undeclared, the generic editor offered every string in the payload:
+  // the deal's uuid as a text box to retype, the server's own reason sentence
+  // as if it were the reader's to rewrite, and the previous date beside the
+  // proposed one with nothing saying which was which.
+  close_date_correction: [
+    {
+      field: "expected_close_date",
+      as: "date",
+      label: "approval.field.expected_close_date",
+    },
   ],
 };
 

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -27,6 +27,7 @@ import { useLocale, useT } from "../i18n";
 import {
   ApprovalDetailModal,
   DecideOutcome,
+  editableSeed,
   editableStrings,
   StagedEditor,
 } from "./approvaleditor";
@@ -229,12 +230,17 @@ export function ApprovalRow({
   const skew = problem ? isVersionSkew(problem) : false;
   const alreadyDecided = problem ? isAlreadyDecided(problem) : false;
 
+  // The draft is seeded with what the CONTROL will show, not with what the
+  // payload holds. A date control silently discards a value it cannot parse, so
+  // seeding the raw string would leave the reader looking at an empty box while
+  // the original value still rode out on approve — the editor showing one thing
+  // and submitting another.
   const startEdit = () => {
     setDraft(
       Object.fromEntries(
         strings.map((entry) => [
           entry.field,
-          String(change[entry.field] ?? ""),
+          editableSeed(entry, change[entry.field]),
         ]),
       ),
     );


### PR DESCRIPTION
## What was wrong

A close-date approval asked a human to confirm a deal was still alive and gave them nothing to decide with:

- the card showed `deal_id`, a raw `flags` array and `target_version`
- its reason was a fixed string, `"deal has gone quiet; confirm it is still alive"`, true of every quiet deal and therefore useless
- it proposed the date the deal **already carried**, so both dates were identical and there was nothing to approve
- the inline editor offered every payload string as a text box, including the deal's uuid and the server's own reason sentence

## The reason now names facts

The sweep reads the last inbound and last outbound message on the deal and says which way the silence runs, who was on the other end, and how long it has lasted:

```
Anna Weber wrote on 5 August and nobody has answered since — 3 weeks ago.
We wrote to Anna Weber on 1 August and there has been no reply — 3 weeks ago.
Anna Weber called on 17 August and nobody has followed up since — 9 days ago.
The contact wrote on 17 July and nobody has answered since — 5 weeks ago.
Nobody has been in touch on this deal either way — there is no correspondence to judge it by.
```

The two directions are different findings needing opposite actions — a dropped ball on our side versus a prospect going cold — and both used to arrive as one sentence. The verb follows the activity kind, because you do not "answer" a phone call.

## The read runs as the deal's owner

This is the security argument for the whole change. The reason is stored in `proposed_change` and read later by anyone holding `deal:update` on the deal. The sweep runs as a system principal, which passes `auth.Require` unconditionally and which no row scope bounds — so a name resolved under it would be any name in the workspace, frozen into a record no read-side gate can re-filter.

The owner is resolved per deal via `identity.Service.EffectiveAuthority` (grants and seat in one snapshot), following `compose/briefjobs.go`. Degradations, each with a test:

| case | result |
|---|---|
| deal has no owner (`owner_id` is nullable, `ON DELETE SET NULL`) | dates, no name |
| owner suspended/archived/removed (`ErrNotFound`) | generic reason |
| owner lacks `person:read` | dates, no name |
| owner lacks `activity:read` | no correspondence facts at all |
| more than one participant in the role | dates, no name |

The domain writes — the forecast downgrade, its audit row and its outbox event — stay under the system principal. Only the correspondence read and the name resolution use the owner context.

## The card proposes a real date

The quiet path overwrote the computed forecast date with the deal's current one whenever the invariant did not force a re-date. The deal's own date is still never moved by the sweep — the zombie guard holds, and only a human confirming lifts it.

## The editor and dialog stop showing internals

`close_date_correction` declares its one editable field, so the editor offers the proposed date in the design system's `DateInput` rather than every payload string as free text. The dialog promotes when a proposal was raised and decided into labelled prose; `target_version` and the `agent:<id>` that proposed it are **removed rather than hidden**, since neither names a person or describes a change.

## Also here

- the paced basis no longer prints `"3 open stage(s) remaining × stage velocity"` to a salesperson
- `isRealCalendarDay` moves date validation into `format/`, so a well-shaped impossible date (`2026-02-30`) cannot be shown blank while riding out on approve

## Verification

- `make check-backend`, `make check-fe` (4841 tests), `make craft-static` — green
- integration lane: 10 new tests in `compose/quietreview_integration_test.go`, whole package green
- every guard mutation-checked: reverting the owner principal, the participant count, the activity gate, the date fix and the field declaration each fails exactly its own test and nothing else

`arch-lint` is red on `migrations/briefrunlocalday_integration_test.go` (a `github.com/google/uuid` import from #2725). Pre-existing — it fails identically with this branch's work stashed, and this diff touches no file under `migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approval details now show summaries, requested dates, and decision dates.
  - Close-date corrections provide clearer quiet-period explanations based on correspondence and proposed dates.
  - Close-date editing uses a dedicated, localized date field.
  - Quiet-period reviews identify relevant correspondence and contacts when available.

- **Bug Fixes**
  - Invalid calendar dates, including leap-day errors, are rejected or cleared before editing.
  - Restricted or unavailable correspondence no longer blocks close-date review processing.

- **Localization**
  - Added German and Vietnamese translations for approval dates, meetings, and at-risk deal labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->