### PR TITLE
fix(ci-tests): the conformance brief run is stamped with the day the read asks for

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -390,10 +390,20 @@ func TestTheConformanceCheckFailsAgainstAMisdeclaredSchema(t *testing.T) {
 func snapshotBriefRun(ctx context.Context, t *testing.T, e *Env) {
 	t.Helper()
 	engine := briefs.NewBriefEngine(e.Pool, people.NewStore(e.DB()))
-	// A fixed instant. The run only has to EXIST for read_brief to have
-	// something to re-read, and ranking against the wall clock would make what
-	// this lane certifies depend on the day it ran.
-	if _, err := engine.SnapshotRun(ctx, time.Date(2026, 8, 8, 6, 0, 0, 0, time.UTC)); err != nil {
+	// The reader's own instant, because brief_run is keyed by LOCAL DAY and
+	// read_brief asks for today's: briefseam.go reads `LatestRun(ctx,
+	// time.Now().UTC())`, which resolves a calendar day and matches
+	// `WHERE user_id = $1 AND local_day = $2`. A run stamped with any other day
+	// is a run that read cannot see, so a fixed instant here does not freeze
+	// what the lane certifies — it dates the fixture, and the sweep certifies a
+	// not-found from the morning after.
+	//
+	// Sharing the clock is what keeps the two ends honest; nothing here rests on
+	// WHICH day it is, only that one run exists under the day the read will ask
+	// for. The two agree by asking the same question, not by holding one answer
+	// between them — so a reader that moves to an injected clock leaves this
+	// behind, silently and the same way. Follow it here when it does.
+	if _, err := engine.SnapshotRun(ctx, time.Now().UTC()); err != nil {
 		t.Fatalf("assembling a brief run for the acting rep: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -138,6 +138,11 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		// precisely so an absent one cannot read as a complete one.
 		{"query_workspace", `{"plan":{"version":"v1","target":"deal","where":[{"field":"status","op":"eq","value":"open"}]}}`},
 		{"query_workspace", `{"plan":{"version":"v1","target":"deal","where":[{"field":"name","op":"eq","value":"nothing here matches this"}]}}`},
+		// The vocabulary the two plans above are written against. It takes no
+		// arguments and needs no seam the lane is missing, so it is a call here
+		// rather than a waiver: the census does not accept "registered and
+		// unproven" for a tool this sweep can simply invoke.
+		{"describe_query_vocabulary", `{}`},
 		{"read_record", `{"record_type":"deal","id":"` + deal.String() + `"}`},
 		// A ranked sweep that finds rows and one that finds none. The empty page
 		// is the one worth pinning: it still carries `coverage` and `notes`, and


### PR DESCRIPTION
main is red on `integration / integration shard (4/6)` — [main-health 32922529439](https://github.com/margince/margince/actions/runs/32922529439) on `792f0a455`:

```
--- FAIL: TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas/read_brief_{}
    toolschema_conformance_integration_test.go:227: read_brief({}): not found
```

**No commit broke this.** It is a time bomb, which is why blame and bisect find nothing.

## The mechanism

`brief_run` is keyed by LOCAL DAY — #2727's own migration. `briefseam.go` reads:

```go
run, err := engine.LatestRun(ctx, time.Now().UTC())
```

and `LatestRun` resolves that instant to a calendar day and selects `WHERE user_id = $1 AND local_day = $2`.

The lane's fixture is not missing — it already seeds through the real engine. But it pinned the assembly to a **fixed instant**:

```go
engine.SnapshotRun(ctx, time.Date(2026, 8, 8, 6, 0, 0, 0, time.UTC))
```

So the sweep asks for today's day and the only run on file is stamped a morning that has passed. The test certified an answer on 2026-08-08 and a not-found every day since — meaning the lane has been reporting on a tool whose schema it never actually read.

Two clocks in one fixture: a frozen seed and a wall-clock reader.

The part worth naming is that the fixed instant was chosen **for determinism** — the comment says so. The instinct was right; it became the defect the moment the read grew a day key underneath it. What the sweep needs is not a stable day but the *same* day at both ends.

## Why not fix the other end

Serving an empty brief for an unassembled one would break an existing gate and contradict the tool's own contract:

- `TestBriefReadServesTodaysRunAndNotAnOlderOne` asserts a day with no run answers not-found, because *"a stale ranking under today's date is the defect this filter exists to prevent"*.
- `tools_brief.go` argues separately that an empty `items` must not stand in for an unread queue: *"An agent reading `null` has to decide whether it means 'nothing is queued' or 'the queue was not read'."*

The not-found is correct and already held. The fixture is what was wrong.

## A bound I am not closing

The fixture and the reader now agree by both asking `time.Now().UTC()` — by asking the same question, not by sharing one answer. A reader that moves to an injected clock leaves this behind, silently and in exactly the same way. That is stated in the comment rather than papered over; a shared helper would mean a test reaching into the seam, which is a larger change than this red warrants. Credit to the review that raised it.

## Verification

`go vet -tags integration` clean, `gofmt` clean. The integration lane needs a real Postgres, so CI is the proof here — the failing test is in this PR's own lane.

## Also on main, not fixed here

`dco (main)` fails: commit `2736937c0` (#2728) carries no `Signed-off-by`. A sign-off is an attestation only its author can give, so no patch can clear it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated brief snapshot timestamps to use the current UTC time, ensuring daily brief lookups consistently return the correct current-day snapshot.
  * Improved validation of query vocabulary responses to help ensure consistent tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->