### PR TITLE
feat(deals): the overnight pass drafts the reply, not a note to write one

### DIFF
--- a/backend/dealtargettype_test.go
+++ b/backend/dealtargettype_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// Every deal-scoped staging names its target type through one constant.
+//
+// Three stagers file proposals against a deal — the close-date corrector, the
+// nightly follow-up task and the drafted reply — and a fourth is cheap to add.
+// A target type that disagreed between them files a proposal the inbox cannot
+// resolve to a record, so the reader sees a card about nothing and the deal it
+// was raised on never hears about it.
+//
+// Held here rather than by a linter threshold: goconst noticed the third
+// occurrence only because a count crossed a number, which would have let the
+// first two disagree indefinitely.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEveryStagingNamesItsDealTargetThroughOneConstant(t *testing.T) {
+	root := filepath.Join("internal", "compose")
+	fset := token.NewFileSet()
+	var offenders []string
+	found := 0
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		parsed, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || !isStageInputLit(lit) {
+				return true
+			}
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || key.Name != "TargetType" {
+					continue
+				}
+				found++
+				// A string literal here is the defect: the value must come
+				// through a named constant so the four sites cannot drift.
+				if str, isLiteral := kv.Value.(*ast.BasicLit); isLiteral && str.Value == `"deal"` {
+					offenders = append(offenders, fset.Position(kv.Pos()).String())
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	// A scan that found no staging at all read a smaller tree than it thinks,
+	// and would report PASS with nothing examined.
+	if found == 0 {
+		t.Fatal("no StageInput carrying a TargetType found under internal/compose")
+	}
+	for _, at := range offenders {
+		t.Errorf("%s spells the deal target type as a literal — use approvalTargetDeal, "+
+			"so a proposal cannot be filed against a target the inbox fails to resolve", at)
+	}
+}
+
+// isStageInputLit reports whether this composite literal is an approvals
+// StageInput, written either qualified or bare.
+func isStageInputLit(lit *ast.CompositeLit) bool {
+	switch typ := lit.Type.(type) {
+	case *ast.SelectorExpr:
+		return typ.Sel.Name == "StageInput"
+	case *ast.Ident:
+		return typ.Name == "StageInput"
+	}
+	return false
+}

--- a/backend/dealtargettype_test.go
+++ b/backend/dealtargettype_test.go
@@ -31,8 +31,12 @@ func TestEveryStagingNamesItsDealTargetThroughOneConstant(t *testing.T) {
 	root := filepath.Join("internal", "compose")
 	fset := token.NewFileSet()
 	var offenders []string
-	found := 0
+	found, dealSites := 0, 0
 
+	// Parsed once, then read twice: the constants must ALL be collected before
+	// any identifier is resolved, or a staging in a file walked before the one
+	// declaring its constant resolves to nothing and passes.
+	var files []*ast.File
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
@@ -41,6 +45,15 @@ func TestEveryStagingNamesItsDealTargetThroughOneConstant(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		files = append(files, parsed)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	consts := composeStringConsts(files)
+
+	for _, parsed := range files {
 		ast.Inspect(parsed, func(n ast.Node) bool {
 			lit, ok := n.(*ast.CompositeLit)
 			if !ok || !isStageInputLit(lit) {
@@ -56,29 +69,85 @@ func TestEveryStagingNamesItsDealTargetThroughOneConstant(t *testing.T) {
 					continue
 				}
 				found++
-				// A string literal here is the defect: the value must come
-				// through a named constant so the four sites cannot drift.
-				if str, isLiteral := kv.Value.(*ast.BasicLit); isLiteral && str.Value == `"deal"` {
-					offenders = append(offenders, fset.Position(kv.Pos()).String())
+				// Only the ONE approved spelling passes. Reporting just the
+				// bare literal let every other drift through — a second
+				// constant, an alias, a value assigned after construction —
+				// which is the same regression under a different spelling.
+				if ident, isIdent := kv.Value.(*ast.Ident); isIdent && ident.Name == dealTargetConstName {
+					dealSites++
+				}
+				if spellsDealLiterally(kv.Value, consts) {
+					offenders = append(offenders, fset.Position(kv.Pos()).String()+
+						" ("+exprText(fset, kv.Value)+")")
 				}
 			}
 			return true
 		})
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking %s: %v", root, err)
 	}
 
-	// A scan that found no staging at all read a smaller tree than it thinks,
-	// and would report PASS with nothing examined.
-	if found == 0 {
-		t.Fatal("no StageInput carrying a TargetType found under internal/compose")
+	// A scan that found no DEAL staging read a smaller tree than it thinks and
+	// would report PASS with nothing examined. Counting every TargetType would
+	// not do: the gate stayed green if every deal staging vanished while an
+	// unrelated target remained.
+	if dealSites == 0 {
+		t.Fatalf("no staging naming approvalTargetDeal found under internal/compose "+
+			"(%d TargetType fields seen) — this gate read a smaller tree than it thinks", found)
 	}
 	for _, at := range offenders {
-		t.Errorf("%s spells the deal target type as a literal — use approvalTargetDeal, "+
-			"so a proposal cannot be filed against a target the inbox fails to resolve", at)
+		t.Errorf("%s does not name its target through a shared constant — use "+
+			"approvalTargetDeal, so a proposal cannot be filed against a target "+
+			"the inbox fails to resolve", at)
 	}
+}
+
+// spellsDealLiterally reports whether this value is the deal target written as
+// anything other than the one shared constant.
+//
+// It resolves an identifier through the package's own string constants, so a
+// SECOND constant carrying "deal" is caught too — a gate that only rejected the
+// bare literal would wave through the same drift under a new name, which is
+// what it exists to stop. A forwarded field or a conversion from another
+// target's vocabulary resolves to neither and is left alone.
+func spellsDealLiterally(v ast.Expr, consts map[string]string) bool {
+	switch e := v.(type) {
+	case *ast.BasicLit:
+		return e.Value == `"deal"`
+	case *ast.Ident:
+		return e.Name != dealTargetConstName && consts[e.Name] == "deal"
+	}
+	return false
+}
+
+// dealTargetConstName is the one name a deal staging may use.
+const dealTargetConstName = "approvalTargetDeal"
+
+// composeStringConsts maps every package-level string constant under
+// internal/compose to its value, so an identifier can be resolved.
+func composeStringConsts(files []*ast.File) map[string]string {
+	out := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range value.Names {
+					if i >= len(value.Values) {
+						continue
+					}
+					if lit, isLit := value.Values[i].(*ast.BasicLit); isLit && lit.Kind == token.STRING {
+						out[name.Name] = strings.Trim(lit.Value, `"`)
+					}
+				}
+			}
+		}
+	}
+	return out
 }
 
 // isStageInputLit reports whether this composite literal is an approvals

--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -51,7 +51,7 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 		Kind:           deals.CloseDateCorrectionKind,
 		ProposedChange: canonical,
 		DiffHash:       hash,
-		TargetType:     "deal",
+		TargetType:     approvalTargetDeal,
 		TargetID:       dealID,
 		TargetVersion:  &targetVersion,
 		Summary:        summary,

--- a/backend/internal/compose/followupdraft.go
+++ b/backend/internal/compose/followupdraft.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The nightly pass's SECOND answer: when the conversation it found was an
+// email, propose the reply itself rather than a task to write one.
+//
+// A task says "follow up on this". A drafted reply says it in words the rep
+// reads and sends. Only the second is something a person can finish in the
+// morning inbox, and only an email thread makes it possible — a call or a
+// meeting has no thread to answer and no address to answer it at, so those
+// keep the task proposal.
+//
+// WHY held_draft AND NOT A NEW KIND. held_draft is already the drafted-email
+// approval: its release effect prepares and sends the message, its precheck
+// re-runs that preparation so a withdrawn consent surfaces while the row is
+// still pending, and refuseRetargetedDraft pins the addressee against the edit
+// path. A second kind here would be a second send path, a second consent call
+// and a second card — two answers to the one question "may this message go
+// out", drifting until they disagree in front of a rep.
+//
+// The one thing held_draft carries that this caller has no use for is the
+// workflow run: releaseHeldDraft completes the run that parked the approval.
+// That completion is a conditional UPDATE matching on the approval id, so with
+// no parked run it touches nothing and returns nil. Nothing about the release
+// assumes an automation raised the draft.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/automation"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// followUpDraftPurpose is the lawful basis a drafted reply is sent under.
+//
+// Answering somebody who wrote to us individually rests on contract or
+// legitimate interest, not on consent — the consent purpose whose German
+// evidence standard applies belongs to marketing. The nightly pass only ever
+// drafts a reply INTO an existing thread, which is exactly that case.
+const followUpDraftPurpose = "business_correspondence"
+
+// approvalTargetDeal is the target type every deal-scoped staging names.
+//
+// Three stagers write it — the close-date corrector, the follow-up task and
+// the drafted reply — and a target type that disagreed between them would file
+// a proposal against a record the inbox then cannot resolve. It is the
+// approvals target vocabulary, not the commission entity vocabulary that
+// happens to spell the same word.
+//
+// Held by: TestEveryStagingNamesItsDealTargetThroughOneConstant
+// (backend/dealtargettype_test.go)
+const approvalTargetDeal = "deal"
+
+// followUpReplySeam composes the reply and resolves who it answers.
+//
+// It is the automation module's Comms seam, filled by the same adapter the
+// workflow executors use, so a drafted follow-up and an automation's draft are
+// one drafting engine rather than two. With no model configured the adapter
+// falls back to a deterministic draft, which is what a nightly pass wants: the
+// rep still gets a reply to edit rather than an empty card.
+type followUpReplySeam interface {
+	DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (subject, body string, err error)
+	ReplyAddress(ctx context.Context, anchor ids.UUID) (string, error)
+}
+
+// draftFollowUpReply builds the held-draft proposal for one email-evidenced
+// follow-up, or reports that this conversation cannot be answered.
+//
+// A thread with no resolvable counterparty is the honest failure here, and it
+// is not an error: an internal note, a message whose sender never became a
+// person, or a thread the pass may read but whose address it may not. The
+// caller falls back to the task proposal, so the rep is still told about the
+// deal — they simply get "write a follow-up" instead of a draft to send.
+func draftFollowUpReply(
+	ctx context.Context, drafter followUpReplySeam, proposal deals.FollowUpProposal,
+) (automation.HeldDraftProposal, bool, error) {
+	anchor := proposal.EvidenceActivityID.UUID
+	to, err := drafter.ReplyAddress(ctx, anchor)
+	if err != nil || to == "" {
+		return automation.HeldDraftProposal{}, false, nil //nolint:nilerr // an unanswerable thread is the task proposal's case, not a failure
+	}
+	intent := fmt.Sprintf("Follow up: %s", proposal.Subject)
+	subject, body, err := drafter.DraftEmail(ctx, anchor, intent)
+	if err != nil {
+		return automation.HeldDraftProposal{}, false, fmt.Errorf("compose: draft the follow-up reply: %w", err)
+	}
+	return automation.HeldDraftProposal{
+		AnchorActivityID: anchor,
+		To:               to,
+		Subject:          subject,
+		Body:             body,
+		ConsentPurpose:   followUpDraftPurpose,
+		Intent:           intent,
+	}, true, nil
+}
+
+// stageFollowUpDraft stages the drafted reply under held_draft, remembering a
+// rejection the way the task proposal does.
+//
+// The identity is the deal and the interaction the draft answers — the same
+// two fields the task proposal is keyed on, for the same reason. Keyed on the
+// deal alone, one "no" would bury every later follow-up on it; keyed on the
+// message text, tomorrow's reworded draft would read as a new question the rep
+// had already answered.
+//
+// The anchor is the TARGET as well as an identity field. held_draft's release
+// reads the anchor from the payload rather than from the target, and the
+// version pin waiver in approvals covers exactly that: the target is context
+// here, and the anchor's liveness is the send path's own check.
+func stageFollowUpDraft(
+	ctx context.Context, svc *approvals.Service, summary string,
+	dealID ids.UUID, evidence ids.UUID, draft automation.HeldDraftProposal,
+) error {
+	raw, err := json.Marshal(draft)
+	if err != nil {
+		return fmt.Errorf("compose: marshal the drafted follow-up: %w", err)
+	}
+	canonical, hash, err := diffhash.Canonical(raw)
+	if err != nil {
+		return fmt.Errorf("compose: canonicalize the drafted follow-up: %w", err)
+	}
+	// anchor_activity_id is the identity field that appears in the payload;
+	// deal_id does not, so it cannot be one — canonicalIdentity requires every
+	// identity field to be present in the proposed change with the same value.
+	// The deal is carried by the approval's own target instead, and the anchor
+	// is what actually separates one conversation from the next.
+	identity, err := json.Marshal(map[string]string{"anchor_activity_id": evidence.String()})
+	if err != nil {
+		return fmt.Errorf("compose: marshal the drafted follow-up identity: %w", err)
+	}
+	_, _, err = svc.StageUnlessDeclined(ctx, approvals.StageInput{
+		Kind:           automation.HeldDraftKind,
+		ProposedChange: canonical,
+		DiffHash:       hash,
+		TargetType:     approvalTargetDeal,
+		TargetID:       dealID,
+		Summary:        summary,
+		Identity:       identity,
+		JoinPending:    true,
+	})
+	return err
+}

--- a/backend/internal/compose/followupdraft.go
+++ b/backend/internal/compose/followupdraft.go
@@ -29,8 +29,10 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
@@ -83,11 +85,28 @@ func draftFollowUpReply(
 ) (automation.HeldDraftProposal, bool, error) {
 	anchor := proposal.EvidenceActivityID.UUID
 	to, err := drafter.ReplyAddress(ctx, anchor)
-	if err != nil || to == "" {
-		return automation.HeldDraftProposal{}, false, nil //nolint:nilerr // an unanswerable thread is the task proposal's case, not a failure
+	switch {
+	case errors.As(err, new(*activities.NoReplyAddressError)), err == nil && to == "":
+		// The ONE case the task proposal is the answer to: this thread carries
+		// no counterparty. Anything else — a denied read, a row-scope miss, a
+		// database failure — is a real failure and must not be reported as a
+		// nightly pass that quietly chose the other proposal. That reading hid
+		// the failure and never retried the draft.
+		return automation.HeldDraftProposal{}, false, nil
+	case err != nil:
+		return automation.HeldDraftProposal{}, false,
+			fmt.Errorf("compose: resolve who the follow-up answers: %w", err)
 	}
-	intent := fmt.Sprintf("Follow up: %s", proposal.Subject)
-	subject, body, err := drafter.DraftEmail(ctx, anchor, intent)
+	// The intent is EMPTY, and that is the whole care here.
+	//
+	// DeterministicEmailDraft appends the intent to the body verbatim, so
+	// whatever is passed becomes a sentence in a message a rep sends to a
+	// customer. The obvious "Follow up on <deal>" label reads as a machine
+	// note dropped into the middle of a German email, and the deal name is
+	// our internal word for the account, not theirs. The floor already writes
+	// a complete reply from the thread it is answering; there is nothing this
+	// caller knows to add that a recipient should read.
+	subject, body, err := drafter.DraftEmail(ctx, anchor, "")
 	if err != nil {
 		return automation.HeldDraftProposal{}, false, fmt.Errorf("compose: draft the follow-up reply: %w", err)
 	}
@@ -97,7 +116,8 @@ func draftFollowUpReply(
 		Subject:          subject,
 		Body:             body,
 		ConsentPurpose:   followUpDraftPurpose,
-		Intent:           intent,
+		// Intent is the rep-facing note on the card, never body text.
+		Intent: "no next step was planned after this message",
 	}, true, nil
 }
 

--- a/backend/internal/compose/followupdraft_integration_test.go
+++ b/backend/internal/compose/followupdraft_integration_test.go
@@ -118,6 +118,120 @@ func TestAnEmailThreadWithNoNextStepStagesADraftedReply(t *testing.T) {
 	}
 }
 
+// The drafted body is a message, not a machine note.
+//
+// This is what clicking through caught and seven passing tests did not: the
+// deterministic floor appends the caller's intent to the body VERBATIM, so an
+// internal label like "Follow up on <deal>" became a sentence in the middle of
+// a German email addressed to a customer. The deal name is our word for the
+// account, not theirs, and a rep who sends it without noticing has sent our
+// CRM's internal shorthand to the buyer.
+func TestTheDraftedBodyCarriesNoInternalLabels(t *testing.T) {
+	e := setupReconcile(t)
+	const dealName = "Weber GmbH — Rahmenvertrag"
+	deal := e.SeedDeal(t, dealName, e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Rueckfragen zum Angebot")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	_, draft := e.heldDraftFor(t, deal)
+
+	if strings.Contains(draft.Body, dealName) {
+		t.Errorf("the drafted body names the deal %q — that is our word for the "+
+			"account, not the recipient's, and this text is sent to them:\n%s",
+			dealName, draft.Body)
+	}
+	// "I wanted to follow up on <thread subject>" is the drafting floor's own
+	// prose and belongs here — it names the THREAD, in the counterparty's
+	// words. What must not appear is the label this caller could have passed,
+	// which names the deal and reads as a note to ourselves.
+	if strings.Contains(draft.Body, "Follow up on "+dealName) ||
+		strings.Contains(draft.Body, "Follow up: ") {
+		t.Errorf("the drafted body carries the internal follow-up label, which reads "+
+			"as a machine note dropped into a message to a customer:\n%s", draft.Body)
+	}
+}
+
+// The card's line describes a reply waiting, not a task to write one.
+func TestTheDraftedReplySummaryDescribesAReply(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Weber GmbH", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Rueckfragen zum Angebot")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	var summary string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT summary FROM approval WHERE kind = 'held_draft' AND target_entity_id = $1`,
+		deal).Scan(&summary); err != nil {
+		t.Fatal(err)
+	}
+	// The task proposal's line opens "Draft a follow-up on" — a reply that is
+	// already written is not that, and saying so asks the rep to do work the
+	// product already did.
+	if strings.HasPrefix(summary, "Draft a follow-up") {
+		t.Errorf("the drafted reply reuses the TASK proposal's line (%q), which tells "+
+			"the rep to write something that is already written", summary)
+	}
+	if !strings.Contains(summary, "drafted") {
+		t.Errorf("the summary %q does not say a reply is drafted, which is the one "+
+			"thing that distinguishes this card from the task proposal", summary)
+	}
+}
+
+// OUR OWN last email is not a message to answer.
+//
+// The candidate query never filtered direction, and ReplyAddressFor is built
+// to resolve the counterparty on an outbound message too — so the pass would
+// draft a "reply" to a mail the rep themselves had sent. Approving it creates
+// another outbound email, which becomes the next night's latest evidence, and
+// the deal generates a fresh approval every night forever.
+func TestOurOwnOutboundEmailIsNotAThreadToAnswer(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "We wrote last", e.pipeline, e.open, &e.Rep1)
+	sent := e.seedInteraction(t, deal, "email", "Unser Angebot", 1)
+	e.WsExec(t, `UPDATE activity SET direction = 'outbound' WHERE id = $1`, sent)
+	e.attachReachableCounterparty(t, sent, "kunde@example.test")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1`, deal); n != 0 {
+		t.Errorf("the pass drafted %d replies to a message WE sent, want 0 — "+
+			"approving one sends mail that becomes tomorrow's evidence, and the "+
+			"deal proposes a reply every night from then on", n)
+	}
+	// The deal still has no next step, so the rep is still told.
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("task proposals = %d, want 1", got)
+	}
+}
+
+// One deal, one pending reply — never two a rep can approve independently.
+//
+// The pending check asks about the TASK kind, and a drafted reply is staged
+// under held_draft, so a second email arriving while the first draft still
+// waits produced two approvable replies on one deal. Approving both sends both.
+func TestASecondEmailDoesNotStackASecondPendingReply(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Wrote twice", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Erste Frage")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	// A second thread, while the first draft is still pending and undecided.
+	e.seedAnswerableThread(t, deal, "Zweite Frage")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1 AND status = 'pending'`, deal); n != 1 {
+		t.Errorf("pending drafted replies on one deal = %d, want 1 — two independently "+
+			"approvable replies means approving both sends two mails", n)
+	}
+}
+
 // A call has no thread to answer, so it keeps the task proposal.
 func TestACallWithNoNextStepStillStagesTheTaskProposal(t *testing.T) {
 	e := setupReconcile(t)

--- a/backend/internal/compose/followupdraft_integration_test.go
+++ b/backend/internal/compose/followupdraft_integration_test.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The nightly pass's drafted reply, over real migrated Postgres.
+//
+// What these hold is the claim the design rests on: held_draft's release path
+// was written for an automation that parked a workflow run, and the overnight
+// pass parks none. If completing that run were required rather than
+// conditional, every drafted follow-up would fail at release — after a human
+// had already approved it, which is the worst place to find out.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/automation"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedAnswerableThread plants the inbound email a reply can be drafted to: a
+// person with an address, that address on the thread, and the consent purpose
+// the send is gated against. It returns the anchor activity.
+// The address is derived from the subject so two threads on one deal are two
+// counterparties: person_email is unique per address, and a helper that always
+// seeded the same one could only ever be called once per test.
+func (e *reconcileEnv) seedAnswerableThread(t *testing.T, dealID ids.UUID, subject string) ids.UUID {
+	t.Helper()
+	to := strings.ToLower(strings.ReplaceAll(subject, " ", ".")) + "@example.test"
+	person := e.SeedPerson(t, "Anna Weber ("+subject+")", nil)
+	anchor := e.seedInteraction(t, dealID, "email", subject, 1)
+	e.WsExec(t, `UPDATE activity SET direction = 'inbound' WHERE id = $1`, anchor)
+	e.attachReachableCounterpartyAs(t, anchor, person, to)
+	return anchor
+}
+
+// attachReachableCounterparty puts a person with a real address on the
+// activity, which is what makes a reply address resolvable.
+func (e *reconcileEnv) attachReachableCounterparty(t *testing.T, activityID ids.UUID, address string) {
+	t.Helper()
+	e.attachReachableCounterpartyAs(t, activityID, e.SeedPerson(t, "Counterparty "+address, nil), address)
+}
+
+func (e *reconcileEnv) attachReachableCounterpartyAs(
+	t *testing.T, activityID, person ids.UUID, address string,
+) {
+	t.Helper()
+	// The purpose the send is gated against. Its class is the one that is never
+	// consent-gated: answering somebody who wrote to you rests on contract or
+	// legitimate interest, not on a consent record.
+	e.WsExec(t, `
+		INSERT INTO consent_purpose (key, label, requires_double_opt_in, class)
+		VALUES ('business_correspondence', 'Business correspondence', false, 'business_correspondence')
+		ON CONFLICT (key) DO NOTHING`)
+	e.WsExec(t, `
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ($1, $2, true, 'test', 'human:seed')`, person, address)
+	e.WsExec(t, `
+		INSERT INTO activity_participant (id, activity_id, role, person_id, address)
+		VALUES ($1, $2, 'from', $3, $4)`, ids.NewV7(), activityID, person, address)
+	e.WsExec(t, `
+		INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), activityID, person)
+}
+
+// heldDraftFor reads the drafted reply the pass staged on this deal.
+func (e *reconcileEnv) heldDraftFor(t *testing.T, dealID ids.UUID) (ids.ApprovalID, automation.HeldDraftProposal) {
+	t.Helper()
+	var id ids.ApprovalID
+	var raw []byte
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id, proposed_change FROM approval
+		 WHERE kind = 'held_draft' AND target_entity_id = $1 AND status = 'pending'`,
+		dealID).Scan(&id, &raw); err != nil {
+		t.Fatalf("no drafted reply staged on the deal: %v", err)
+	}
+	var proposal automation.HeldDraftProposal
+	if err := json.Unmarshal(raw, &proposal); err != nil {
+		t.Fatalf("the staged draft does not decode: %v", err)
+	}
+	return id, proposal
+}
+
+// An email thread earns the reply itself, not a task telling a rep to write one.
+func TestAnEmailThreadWithNoNextStepStagesADraftedReply(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Answerable", e.pipeline, e.open, &e.Rep1)
+	anchor := e.seedAnswerableThread(t, deal, "Kickoff")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, draft := e.heldDraftFor(t, deal)
+	if draft.AnchorActivityID != anchor {
+		t.Errorf("the draft answers activity %s, want the thread %s", draft.AnchorActivityID, anchor)
+	}
+	if draft.To == "" {
+		t.Error("the draft has no recipient — a draft that hides who it is to cannot be approved meaningfully")
+	}
+	if draft.Body == "" || draft.Subject == "" {
+		t.Errorf("the draft is empty (subject %q, body %q), want words the rep can read and send",
+			draft.Subject, draft.Body)
+	}
+	if draft.ConsentPurpose != followUpDraftPurpose {
+		t.Errorf("consent purpose = %q, want %q — a send with no lawful basis is refused at the gate",
+			draft.ConsentPurpose, followUpDraftPurpose)
+	}
+	// And NOT the task proposal beside it: one conversation, one question.
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("the pass staged %d task proposals beside the draft, want 0 — "+
+			"a rep asked twice about one conversation answers neither", got)
+	}
+}
+
+// A call has no thread to answer, so it keeps the task proposal.
+func TestACallWithNoNextStepStillStagesTheTaskProposal(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Unanswerable", e.pipeline, e.open, &e.Rep1)
+	// A counterparty WITH a reachable address, so what keeps this on the task
+	// proposal is the kind rule and nothing else. Without the address the
+	// unanswerable-thread fallback would carry the test, and dropping the kind
+	// check entirely would not fail it.
+	call := e.seedInteraction(t, deal, "call", "Discovery call", 1)
+	e.attachReachableCounterparty(t, call, "caller@example.test")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("task proposals on a call-evidenced deal = %d, want 1", got)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1`, deal); n != 0 {
+		t.Errorf("the pass drafted %d replies to a call, want 0 — there is no thread to answer", n)
+	}
+}
+
+// An email thread whose counterparty cannot be reached falls back to the task.
+//
+// The rep is still told about the deal. Dropping the candidate would be the
+// tempting alternative and the wrong one: the deal genuinely has no next step,
+// which is the thing worth saying, and the missing address only decides HOW it
+// can be answered.
+func TestAThreadWithNoReplyAddressFallsBackToTheTaskProposal(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "No address", e.pipeline, e.open, &e.Rep1)
+	// An inbound email with no participant and no person behind it.
+	anchor := e.seedInteraction(t, deal, "email", "From a stranger", 1)
+	e.WsExec(t, `UPDATE activity SET direction = 'inbound' WHERE id = $1`, anchor)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("task proposals = %d, want 1 — an unanswerable thread must still "+
+			"tell the rep the deal has no next step", got)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1`, deal); n != 0 {
+		t.Errorf("the pass staged %d drafts with no address to send to, want 0", n)
+	}
+}
+
+// A rejected draft is not redrafted the next night.
+func TestARejectedDraftedReplyIsNotOfferedAgain(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Declined draft", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Kickoff")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.heldDraftFor(t, deal)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1 AND status = 'pending'`, deal); n != 0 {
+		t.Errorf("a declined draft came back as %d pending offers, want 0", n)
+	}
+}
+
+// The identity is the THREAD, so a later conversation is drafted again.
+func TestANewThreadIsDraftedAfterAnEarlierDraftWasDeclined(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Wrote again", e.pipeline, e.open, &e.Rep1)
+	declined := e.seedAnswerableThread(t, deal, "Kickoff")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.heldDraftFor(t, deal)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, reconcilePerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	fresh := e.seedAnswerableThread(t, deal, "They wrote again")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	_, draft := e.heldDraftFor(t, deal)
+	if draft.AnchorActivityID != fresh {
+		t.Errorf("the new draft answers %s, want the fresh thread %s", draft.AnchorActivityID, fresh)
+	}
+	if draft.AnchorActivityID == declined {
+		t.Error("the new draft answers the thread whose reply was already declined")
+	}
+}
+
+// The claim the whole design rests on: the release path completes a parked
+// workflow run, and the overnight pass parks none.
+//
+// If that completion were required rather than conditional, this send would
+// fail AFTER a human approved it — the one place a failure cannot be taken
+// back. The assertion is that the mail goes out and the approval is spent.
+func TestADraftedFollowUpReleasesWithNoWorkflowRunBehindIt(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Send it", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Kickoff")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	approvalID, _ := e.heldDraftFor(t, deal)
+
+	// The release path as production binds it: registered LATE, over a
+	// configured send path. A bare one would refuse for reasons that have
+	// nothing to do with the question here.
+	releaser := releaseService(t, e.Env)
+	if _, err := releaser.Decide(decider(e.Env), approvalID, true, nil); err != nil {
+		t.Fatalf("releasing a drafted follow-up → %v, want the send to succeed", err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM activity
+		WHERE direction = 'outbound' AND kind = 'email'`); n != 1 {
+		t.Errorf("outbound emails = %d, want exactly 1", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM comms_outbound`); n != 1 {
+		t.Errorf("delivery rows = %d, want exactly 1 — the activity and its delivery are one fact", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE id = $1 AND consumed_at IS NOT NULL`, approvalID); n != 1 {
+		t.Error("the approval was not consumed — a send whose authority is still redeemable can be sent twice")
+	}
+}
+
+// A drafted reply is a held_draft, and the pass may not invent a second kind
+// for the same question.
+func TestTheDraftedFollowUpUsesTheExistingHeldDraftKind(t *testing.T) {
+	if automation.HeldDraftKind == deals.FollowUpReconcileKind {
+		t.Fatal("the two proposal kinds collapsed into one, so this test proves nothing")
+	}
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "One kind", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Kickoff")
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	var kinds []string
+	rows, err := e.owner.Query(context.Background(),
+		`SELECT DISTINCT kind FROM approval WHERE target_entity_id = $1`, deal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var kind string
+		if err := rows.Scan(&kind); err != nil {
+			t.Fatal(err)
+		}
+		kinds = append(kinds, kind)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(kinds) != 1 || kinds[0] != automation.HeldDraftKind {
+		t.Errorf("the pass staged kinds %v, want exactly [%s] — a second drafted-email "+
+			"kind is a second send path and a second consent call",
+			kinds, automation.HeldDraftKind)
+	}
+}

--- a/backend/internal/compose/followupdraft_test.go
+++ b/backend/internal/compose/followupdraft_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What draftFollowUpReply does with each answer the address resolver can give.
+//
+// The fallback to the task proposal must cover exactly one case — this thread
+// has no counterparty. An earlier cut treated EVERY error as that case, so a
+// denied read or a database failure was reported as a successful nightly pass
+// that chose the other proposal, and the draft was never retried.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// addressStub answers ReplyAddress with whatever the case under test needs.
+type addressStub struct {
+	address string
+	err     error
+}
+
+func (s addressStub) ReplyAddress(context.Context, ids.UUID) (string, error) {
+	return s.address, s.err
+}
+
+func (s addressStub) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
+	return "Re: something", "some words", nil
+}
+
+func TestOnlyAMissingCounterpartyFallsBackToTheTaskProposal(t *testing.T) {
+	proposal := deals.FollowUpProposal{EvidenceActivityID: ids.From[ids.ActivityKind](ids.NewV7())}
+	cases := []struct {
+		name       string
+		stub       addressStub
+		wantDraft  bool
+		wantFailed bool
+	}{
+		{
+			name:      "a thread with a counterparty is drafted",
+			stub:      addressStub{address: "anna@example.test"},
+			wantDraft: true,
+		},
+		{
+			name: "a thread carrying no address falls back",
+			stub: addressStub{err: &activities.NoReplyAddressError{}},
+		},
+		{
+			name: "an empty address with no error falls back",
+			stub: addressStub{address: ""},
+		},
+		{
+			name:       "a denied read is a failure, not a fallback",
+			stub:       addressStub{err: apperrors.ErrPermissionDenied},
+			wantFailed: true,
+		},
+		{
+			name:       "a database failure is a failure, not a fallback",
+			stub:       addressStub{err: errors.New("connection reset")},
+			wantFailed: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, drafted, err := draftFollowUpReply(context.Background(), tc.stub, proposal)
+			if tc.wantFailed {
+				if err == nil {
+					t.Fatal("the pass reported success — a real failure reported as a " +
+						"fallback is a nightly run that hides it and never retries")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected failure: %v", err)
+			}
+			if drafted != tc.wantDraft {
+				t.Errorf("drafted = %v, want %v", drafted, tc.wantDraft)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/meetinglane_integration_test.go
+++ b/backend/internal/compose/meetinglane_integration_test.go
@@ -40,6 +40,17 @@ func bookMeeting(t *testing.T, e *integration.Env, subject string, at time.Time,
 	return ids.UUID(row.Id)
 }
 
+// todayAt pins the pass's clock to a fixed hour of TODAY.
+//
+// The date must be real — the lane's window is a SQL predicate against the
+// database's own now, so a fabricated day matches nothing. The hour must not
+// be: truncating to the hour keeps the hour the suite happens to run in, so
+// "still ahead today" changed meaning through the day and these tests passed
+// in the morning and failed in the afternoon.
+func todayAt(offset time.Duration) time.Time {
+	return time.Now().UTC().Truncate(24 * time.Hour).Add(offset)
+}
+
 func meetingSubjects(t *testing.T, e *integration.Env, now time.Time) []string {
 	t.Helper()
 	lane := attentionMeetings{store: activities.NewStore(InstallationDB(e.Pool))}
@@ -59,7 +70,7 @@ func meetingSubjects(t *testing.T, e *integration.Env, now time.Time) []string {
 // cannot be prepared for; one tomorrow is not today's page.
 func TestTheMeetingLaneCarriesOnlyWhatIsStillAheadToday(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	now := todayAt(9 * time.Hour)
 	bookMeeting(t, e, "Started an hour ago", now.Add(-1*time.Hour), "")
 	bookMeeting(t, e, "This afternoon", now.Add(4*time.Hour), "")
 	bookMeeting(t, e, "In an hour", now.Add(1*time.Hour), "")
@@ -78,7 +89,7 @@ func TestTheMeetingLaneCarriesOnlyWhatIsStillAheadToday(t *testing.T) {
 // lane must not ask for work that cannot be done.
 func TestAFinishedOrCancelledMeetingLeavesTheLane(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	now := todayAt(9 * time.Hour)
 	bookMeeting(t, e, "Still booked", now.Add(2*time.Hour), "booked")
 	bookMeeting(t, e, "Already held", now.Add(3*time.Hour), "held")
 	bookMeeting(t, e, "Called off", now.Add(4*time.Hour), "canceled")
@@ -95,7 +106,7 @@ func TestAFinishedOrCancelledMeetingLeavesTheLane(t *testing.T) {
 // whose calendars are connected — the failure nobody would report as a bug.
 func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	now := todayAt(9 * time.Hour)
 	bookMeeting(t, e, "From the calendar", now.Add(2*time.Hour), "")
 
 	got := meetingSubjects(t, e, now)
@@ -111,7 +122,7 @@ func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
 // booked one. The window is the database's now, so the bound is the day.
 func TestABusyCalendarStillShowsTheSoonestMeetings(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(6 * time.Hour)
+	now := todayAt(6 * time.Hour)
 	// Far more later-today meetings than the lane carries, booked out of order
 	// so the answer cannot come from insertion order.
 	for hour := 17; hour >= 8; hour-- {
@@ -138,7 +149,7 @@ func TestABusyCalendarStillShowsTheSoonestMeetings(t *testing.T) {
 // this pins that rather than leaving it as a property nobody checked.
 func TestAPileOfPastMeetingsDoesNotPushTodaysOffTheLane(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(9 * time.Hour)
+	now := todayAt(9 * time.Hour)
 	// Comfortably more than the lane's scan (12 * taskScanFactor).
 	for day := 1; day <= 130; day++ {
 		bookMeeting(t, e, fmt.Sprintf("Long ago %d", day), now.AddDate(0, 0, -day), "held")

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
@@ -45,6 +46,11 @@ import (
 // long as that entry exists.
 type followUpStager struct {
 	svc *approvals.Service
+	// draft composes the reply when the evidence is an email thread. Nil is a
+	// real configuration rather than a missing one: a role with no send path
+	// wired stages the task proposal for every candidate, which is what the
+	// pass did before the drafted reply existed.
+	draft followUpReplySeam
 }
 
 func (s followUpStager) HasPendingFollowUp(ctx context.Context, dealID ids.UUID) (bool, error) {
@@ -52,6 +58,18 @@ func (s followUpStager) HasPendingFollowUp(ctx context.Context, dealID ids.UUID)
 }
 
 func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summary string, proposal deals.FollowUpProposal) error {
+	// An email thread can be ANSWERED, so the rep gets the reply itself rather
+	// than a task telling them to write one. A call or a meeting has no thread
+	// and no address, and a drafted reply to one would be a message to nobody.
+	if s.draft != nil && proposal.EvidenceKind == string(crmcontracts.ActivityKindEmail) {
+		staged, err := s.stageDraftedReply(ctx, dealID, summary, proposal)
+		if err != nil {
+			return err
+		}
+		if staged {
+			return nil
+		}
+	}
 	raw, err := json.Marshal(proposal)
 	if err != nil {
 		return fmt.Errorf("compose: marshal follow-up proposal: %w", err)
@@ -92,7 +110,7 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 		Kind:           deals.FollowUpReconcileKind,
 		ProposedChange: canonical,
 		DiffHash:       hash,
-		TargetType:     "deal",
+		TargetType:     approvalTargetDeal,
 		TargetID:       dealID,
 		Summary:        summary,
 		Identity:       identity,
@@ -101,10 +119,36 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	return err
 }
 
+// stageDraftedReply offers the drafted reply, and reports whether it was
+// taken. A thread with no answerable counterparty falls back to the task
+// proposal rather than dropping the candidate — the rep is still told about
+// the deal, they simply get "write a follow-up" instead of a draft to send.
+func (s followUpStager) stageDraftedReply(
+	ctx context.Context, dealID ids.UUID, summary string, proposal deals.FollowUpProposal,
+) (bool, error) {
+	draft, answerable, err := draftFollowUpReply(ctx, s.draft, proposal)
+	if err != nil || !answerable {
+		return false, err
+	}
+	replySummary := fmt.Sprintf("%s — a reply is drafted and waiting", summary)
+	if err := stageFollowUpDraft(ctx, s.svc, replySummary,
+		dealID, proposal.EvidenceActivityID.UUID, draft); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // NewFollowUpReconciler assembles the nightly follow-up reconciler for
 // the worker process role.
 func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUpReconciler {
-	return deals.NewFollowUpReconciler(InstallationDB(pool), followUpStager{svc: approvals.NewService(InstallationDB(pool))}, log)
+	db := InstallationDB(pool)
+	// The drafting seam is the same adapter the workflow executors compose
+	// through, so an overnight reply and an automation's draft are one drafting
+	// engine. The zero SendPath matches that surface: nothing here sends, the
+	// held-draft release does, through the fully wired path it builds itself.
+	drafter := newCommsAdapter(pool, nil, SendPath{})
+	stager := followUpStager{svc: approvals.NewService(db), draft: drafter}
+	return deals.NewFollowUpReconciler(db, stager, log)
 }
 
 // followUpPrecheck refuses a DECISION whose payload the effect could not use.

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -25,6 +25,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -53,16 +54,41 @@ type followUpStager struct {
 	draft followUpReplySeam
 }
 
+// HasPendingFollowUp answers for BOTH shapes a follow-up can take.
+//
+// The pass proposes either a task or a drafted reply, and they are different
+// approval kinds. Asking only about the task let a second email stack a second
+// drafted reply on a deal whose first was still pending — two independently
+// approvable messages, and approving both sends both. The question the caller
+// is really asking is "has this deal already been asked about", which neither
+// kind answers alone.
 func (s followUpStager) HasPendingFollowUp(ctx context.Context, dealID ids.UUID) (bool, error) {
-	return s.svc.HasPendingKind(ctx, deals.FollowUpReconcileKind, dealID)
+	for _, kind := range []string{deals.FollowUpReconcileKind, automation.HeldDraftKind} {
+		pending, err := s.svc.HasPendingKind(ctx, kind, dealID)
+		if err != nil {
+			return false, err
+		}
+		if pending {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summary string, proposal deals.FollowUpProposal) error {
-	// An email thread can be ANSWERED, so the rep gets the reply itself rather
-	// than a task telling them to write one. A call or a meeting has no thread
-	// and no address, and a drafted reply to one would be a message to nobody.
-	if s.draft != nil && proposal.EvidenceKind == string(crmcontracts.ActivityKindEmail) {
-		staged, err := s.stageDraftedReply(ctx, dealID, summary, proposal)
+	// An INBOUND email can be answered, so the rep gets the reply itself rather
+	// than a task telling them to write one.
+	//
+	// Both halves of that condition matter. A call or a meeting has no thread
+	// and no address, so a drafted reply to one would be a message to nobody.
+	// And OUR OWN last email is not a message anybody is waiting on: the
+	// address resolver deliberately answers the counterparty on an outbound
+	// message too, so without the direction check the pass drafts a reply to
+	// mail the rep sent — and approving it creates another outbound email,
+	// which becomes the next night's latest evidence. The deal would then
+	// propose a reply every night, forever.
+	if s.draft != nil && answerableThread(proposal) {
+		staged, err := s.stageDraftedReply(ctx, dealID, proposal)
 		if err != nil {
 			return err
 		}
@@ -119,18 +145,33 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	return err
 }
 
+// answerableThread reports whether the evidence is a message somebody is
+// waiting for a reply to.
+func answerableThread(proposal deals.FollowUpProposal) bool {
+	return proposal.EvidenceKind == string(crmcontracts.ActivityKindEmail) &&
+		proposal.EvidenceDirection == string(crmcontracts.ActivityDirectionInbound)
+}
+
 // stageDraftedReply offers the drafted reply, and reports whether it was
 // taken. A thread with no answerable counterparty falls back to the task
 // proposal rather than dropping the candidate — the rep is still told about
 // the deal, they simply get "write a follow-up" instead of a draft to send.
 func (s followUpStager) stageDraftedReply(
-	ctx context.Context, dealID ids.UUID, summary string, proposal deals.FollowUpProposal,
+	ctx context.Context, dealID ids.UUID, proposal deals.FollowUpProposal,
 ) (bool, error) {
 	draft, answerable, err := draftFollowUpReply(ctx, s.draft, proposal)
 	if err != nil || !answerable {
 		return false, err
 	}
-	replySummary := fmt.Sprintf("%s — a reply is drafted and waiting", summary)
+	// Its OWN summary rather than the task proposal's with a clause appended.
+	// The task's line names a task ("Draft a follow-up on …"), and a reply
+	// waiting to be sent is a different thing to tell a rep — appending to it
+	// produced a sentence that described both and read as neither.
+	//
+	// The draft's own subject is what the rep recognises: it is the thread
+	// they are answering, in the words the counterparty used.
+	replySummary := fmt.Sprintf("A reply to %q is drafted and waiting to be sent — "+
+		"the conversation left no next step planned", draft.Subject)
 	if err := stageFollowUpDraft(ctx, s.svc, replySummary,
 		dealID, proposal.EvidenceActivityID.UUID, draft); err != nil {
 		return false, err

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -65,7 +65,12 @@ func setupReconcile(t *testing.T) *reconcileEnv {
 	e.svc = approvals.NewService(e.DB())
 	e.svc.WithEffect(deals.FollowUpReconcileKind, followUpConfirmEffect(e.svc, e.Activities))
 	e.svc.WithPrecheck(deals.FollowUpReconcileKind, followUpPrecheck())
-	e.reconciler = deals.NewFollowUpReconciler(e.DB(), followUpStager{svc: e.svc}, quiet)
+	// The stager production builds, drafter included. A harness that omitted
+	// the drafting seam would exercise a stager that can only ever propose a
+	// task, and would report the drafted-reply branch as working while nothing
+	// in production reached it.
+	stager := followUpStager{svc: e.svc, draft: newCommsAdapter(e.Pool, nil, SendPath{})}
+	e.reconciler = deals.NewFollowUpReconciler(e.DB(), stager, quiet)
 	return e
 }
 

--- a/backend/internal/modules/deals/reconcile.go
+++ b/backend/internal/modules/deals/reconcile.go
@@ -75,7 +75,10 @@ type FollowUpProposal struct {
 	// proposal; EvidenceKind/EvidenceOccurredAt render it without a join.
 	EvidenceActivityID ids.ActivityID `json:"evidence_activity_id"`
 	EvidenceKind       string         `json:"evidence_kind"`
-	EvidenceOccurredAt time.Time      `json:"evidence_occurred_at"`
+	// EvidenceDirection says whether the evidence was a message TO us or FROM
+	// us. Only the first can be replied to.
+	EvidenceDirection  string    `json:"evidence_direction,omitempty"`
+	EvidenceOccurredAt time.Time `json:"evidence_occurred_at"`
 }
 
 // UnmarshalFollowUpProposal decodes a staged (possibly human-edited)
@@ -138,8 +141,13 @@ type followUpCandidate struct {
 	dealName     string
 	activityID   ids.ActivityID
 	activityKind string
-	occurredAt   time.Time
-	subject      *string
+	// activityDirection is 'inbound' or 'outbound' on a message, and empty on
+	// a kind that has no direction. It travels because "can this be answered"
+	// is a different question from "what kind was it": our own last email is a
+	// real interaction and not a message anybody is waiting for a reply to.
+	activityDirection string
+	occurredAt        time.Time
+	subject           *string
 }
 
 func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
@@ -152,10 +160,10 @@ func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
 		// A note or a done task is not a next step; an undone task is (so
 		// the sweep does not nag a rep who already has one queued).
 		rows, err := tx.Query(ctx, `
-			SELECT d.id, d.name, ev.activity_id, ev.kind, ev.occurred_at, ev.subject
+			SELECT d.id, d.name, ev.activity_id, ev.kind, ev.direction, ev.occurred_at, ev.subject
 			FROM deal d
 			JOIN LATERAL (
-				SELECT a.id AS activity_id, a.kind, a.occurred_at, a.subject
+				SELECT a.id AS activity_id, a.kind, coalesce(a.direction, '') AS direction, a.occurred_at, a.subject
 				FROM activity a
 				JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
 				WHERE a.kind IN ('call','email','meeting')
@@ -182,7 +190,8 @@ func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
 		defer rows.Close()
 		for rows.Next() {
 			var c followUpCandidate
-			if err := rows.Scan(&c.dealID, &c.dealName, &c.activityID, &c.activityKind, &c.occurredAt, &c.subject); err != nil {
+			if err := rows.Scan(&c.dealID, &c.dealName, &c.activityID, &c.activityKind,
+				&c.activityDirection, &c.occurredAt, &c.subject); err != nil {
 				return err
 			}
 			candidates = append(candidates, c)
@@ -219,6 +228,7 @@ func (r *FollowUpReconciler) stage(ctx context.Context, cand followUpCandidate, 
 		Body:               followUpBody(cand),
 		EvidenceActivityID: cand.activityID,
 		EvidenceKind:       cand.activityKind,
+		EvidenceDirection:  cand.activityDirection,
 		EvidenceOccurredAt: cand.occurredAt,
 	}
 	summary := fmt.Sprintf("Draft a follow-up on %q — a %s on %s left no next step planned",

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -50,7 +50,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (48)
+## Census (49)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -65,6 +65,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
+| `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
 | `docslinktargets_test.go` | H3 | Every relative link under docs/ points at a file that exists. |
 | `edgereaders_test.go` | H2 | `relationship` is a first-class RBAC object, and it is the only join table in the schema that is one. |


### PR DESCRIPTION
## What changes for a rep

When the nightly pass finds a deal whose last real conversation was an **email**
and no next step is planned, the morning inbox now carries **the reply itself** —
subject and body the rep reads, edits, and sends. Before, they got a task saying
"follow up on this", and still had to write the message.

A call or a meeting keeps the task proposal. There is no thread to answer and no
address to answer it at, so a drafted reply would be a message to nobody.

## Why held_draft, and not a new approval kind

`held_draft` is already the drafted-email approval. Its release effect prepares
and sends the message, its precheck re-runs that preparation so a withdrawn
consent or an archived thread surfaces while the row is still **pending**, and
`refuseRetargetedDraft` pins the addressee and the lawful basis against the edit
path.

A new kind would mean a second send path, a second consent gate call, a second
precheck and a second card — two answers to "may this message go out", drifting
until they disagree in front of a rep. It would also carry all eight declaration
obligations in `approval_kinds_test.go`; reusing the kind carries none, and the
kind-census gates confirm that.

## The claim this rests on, and how it is proven

`releaseHeldDraft` completes the workflow run that parked the approval, and the
overnight pass parks none. If that completion were required rather than
conditional, every drafted follow-up would fail **after** a human approved it —
the one place a failure cannot be taken back.

It is a conditional `UPDATE` matching on the approval id, so with no parked run
it touches nothing. `TestADraftedFollowUpReleasesWithNoWorkflowRunBehindIt`
releases a pass-staged draft through the production-shaped send path and asserts
the outbound activity, the delivery row and the consumed approval.

## Rejection memory

Keyed on the **thread**, so a declined draft is not rewritten tomorrow, and a
genuinely later conversation is drafted again. Both directions are held by tests.

## Fixed along the way

- The reconcile test harness built its own stager without the drafting seam, so
  it would have reported the drafted-reply branch as working while nothing in
  production reached it. It now builds the stager production builds.
- Three stagers spelled the deal target type as a literal. It is one constant
  now, with `TestEveryStagingNamesItsDealTargetThroughOneConstant` holding it —
  `goconst` only noticed because a count crossed a threshold, which would have
  let the first two disagree indefinitely.

## Verification

- Full `make check-backend`, `make craft-static` (4/4), `rls-store-path`,
  `no-jurisdiction` — all green.
- Full `internal/compose` integration lane green.
- Every guard mutation-checked: dropping the email-kind test, using plain
  `Stage`, and falling back to a placeholder address each fail a test. The
  call-evidenced test initially passed under mutation because the missing
  address masked the kind rule — it now seeds a reachable counterparty so the
  kind rule is what it proves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email conversations without a next step can now generate drafted follow-up replies for review.
  - Conversations that cannot support a draft continue to receive task-based follow-up proposals.
  - Drafted replies are suppressed after rejection and can be regenerated for newer conversations.
  - Follow-up proposals now indicate whether supporting communication was inbound or outbound.
  - Duplicate pending follow-ups are prevented across tasks and drafted replies.

- **Documentation**
  - Updated the gate inventory to include validation for consistent deal-target labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->