### PR TITLE
fix(ci-tests): the busy-calendar lane test anchors the day it books into

### DIFF
--- a/backend/internal/compose/meetinglane_integration_test.go
+++ b/backend/internal/compose/meetinglane_integration_test.go
@@ -111,7 +111,13 @@ func TestAMeetingWithNoStatusIsStillWorthPreparingFor(t *testing.T) {
 // booked one. The window is the database's now, so the bound is the day.
 func TestABusyCalendarStillShowsTheSoonestMeetings(t *testing.T) {
 	e := integration.Setup(t)
-	now := time.Now().UTC().Truncate(time.Hour).Add(6 * time.Hour)
+	// Anchored to the START of a day, not to the wall clock like its siblings
+	// above. They book RELATIVE to `now`, so the hour the suite runs cannot
+	// reach them; this one books at ABSOLUTE hours and then names 08:00, so a
+	// `now` carried off the wall decides whether 08:00 is still ahead at all.
+	// Derived from the clock it did pass between 00:00 and 02:00 UTC and failed
+	// the rest of the day.
+	now := time.Now().UTC().Truncate(24 * time.Hour).Add(7 * time.Hour)
 	// Far more later-today meetings than the lane carries, booked out of order
 	// so the answer cannot come from insertion order.
 	for hour := 17; hour >= 8; hour-- {


### PR DESCRIPTION
main is red on `integration / integration shard (1/6)` — [main-health 32925316794](https://github.com/margince/margince/actions/runs/32925316794) on `2702ed0db`:

```
--- FAIL: TestABusyCalendarStillShowsTheSoonestMeetings
    meetinglane_integration_test.go:127: the lane leads with "At 09:00",
      want the soonest meeting still ahead
```

**The lane is right. The test is wall-clock dependent.**

## The arithmetic

```go
now := time.Now().UTC().Truncate(time.Hour).Add(6 * time.Hour)
for hour := 17; hour >= 8; hour-- {
    bookMeeting(..., now.Truncate(24*time.Hour).Add(hour*time.Hour), "booked")
}
...
if got[0] != "At 08:00" { … }
```

`now` is derived from the wall clock, but the meetings are booked at **absolute** hours 08:00–17:00 of that day — and the assertion names 08:00. So whether 08:00 is still ahead depends on the hour the suite ran. The failing run started at 03:16 UTC, which puts `now` at 09:00; the lane then correctly leads with the 09:00 meeting.

Simulating the derivation at every hour of the day:

```
old: fails at UTC hours [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]
new: leads with 'At 08:00' at ALL 24 hours
```

**It passes 8 hours in 24 and fails 16.** It survived because the runs that happened to exercise it fell before 02:00 UTC — including two earlier tonight.

## Why only this test

Its siblings in the file book **relative** to `now` (`now.Add(2*time.Hour)`), so the hour of the run shifts the fixture and the expectation together and cannot separate them. I checked all five `now :=` sites in the file; this is the only one that mixes a wall-derived instant with absolute hours-of-day and then names one of those hours in its assertion. The others need no change.

## The fix

Anchor `now` to the start of a day. The meetings and the instant they are measured against then move together, which is the relationship the assertion actually rests on. Nothing about what the test proves changes — it still books ten out-of-order meetings and still demands the soonest-ahead one lead.

## Verification

The simulation above, run against both forms. `go vet -tags integration` and `gofmt` clean. The lane itself is untouched.

## Note

This is the third wall-clock time bomb on main tonight, after `read_brief` (#2753) and the same-shaped fixture inside it. The family is worth a name: **a test whose fixture and whose assertion are anchored to different clocks passes on the day it is written and fails on a schedule nobody chose.** Blame and bisect find nothing, because no commit broke it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the busy-calendar integration test to use a consistent daily reference time.
  * Preserved validation that meetings are returned in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->