### PR TITLE
fix(gates): the concurrency-guard census could not see a hoisted statement

### DIFF
--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -267,6 +267,12 @@ func packageLevelStatements(files []*ast.File) map[string][]string {
 					// nothing in either half. Both are kept because adding a
 					// reading can only widen what a consumer sees, and it is
 					// under-recognition that passes silently.
+					//
+					// So what a name holds is a SET OF READINGS of one value,
+					// overlapping on purpose, and not a list of the statements
+					// that value contains. A consumer that took the first entry
+					// as "the statement" would be reading whichever reading this
+					// walk happened to record first.
 					ast.Inspect(value.Values[i], func(node ast.Node) bool {
 						if binary, isBinary := node.(*ast.BinaryExpr); isBinary && binary.Op == token.ADD {
 							if folded, readable := concatenatedString(binary); readable {

--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -255,11 +255,25 @@ func packageLevelStatements(files []*ast.File) map[string][]string {
 					continue
 				}
 				for i, name := range value.Names {
-					// Every string LITERAL in the value, not the folded whole.
-					// These statements are assembled — a raw string plus a
-					// helper's output — so folding them returns nothing, and a
+					// Every string LITERAL in the value, not ONLY the folded
+					// whole. These statements are assembled — a raw string plus
+					// a helper's output — so folding them returns nothing, and a
 					// reader that gave up on the fold gave up on the statement.
+					//
+					// Where a fold DOES read whole, it is recorded beside the
+					// parts rather than instead of them: `UPDATE x SET a = $1 ` +
+					// `WHERE id = $2` carries neither the SET nor the WHERE on
+					// its own, so a census matching a statement shape sees
+					// nothing in either half. Both are kept because adding a
+					// reading can only widen what a consumer sees, and it is
+					// under-recognition that passes silently.
 					ast.Inspect(value.Values[i], func(node ast.Node) bool {
+						if binary, isBinary := node.(*ast.BinaryExpr); isBinary && binary.Op == token.ADD {
+							if folded, readable := concatenatedString(binary); readable {
+								held[name.Name] = append(held[name.Name], folded)
+							}
+							return true
+						}
 						literal, isLiteral := node.(*ast.BasicLit)
 						if !isLiteral || literal.Kind != token.STRING {
 							return true

--- a/backend/internal/modules/people/companyform.go
+++ b/backend/internal/modules/people/companyform.go
@@ -103,13 +103,19 @@ func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 	return applied, nil
 }
 
-// setCompanyColumn writes a column-backed field, clearing it to NULL rather
-// than storing an empty string — an unfilled field reads as absent, never as
-// the empty answer.
-// setCompanyColumn writes one column-backed field and reports whether the
-// value actually moved. Every statement carries IS DISTINCT FROM, so a
-// resubmission of an unchanged form touches no row and answers false — which is
-// what keeps the duplicate re-check below off a save that renamed nothing.
+// setCompanyColumn writes one column-backed field and reports whether the value
+// actually moved — which is what keeps the duplicate re-check off a save that
+// renamed nothing, and the description-author stamp off one that typed no
+// description.
+//
+// "Moved" is each statement's own question rather than one rule. The three
+// replacing arms answer it with IS DISTINCT FROM, so a resubmission of an
+// unchanged form touches no row; offer_summary FILLS, so it answers false for
+// every save after the first whether or not the text changed. Both are the
+// right answer for their column, and neither is the other's.
+//
+// A value clears to NULL rather than to the empty string — an unfilled field
+// reads as absent, never as the empty answer.
 func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) (bool, error) {
 	var stored *string
 	if value != "" {

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -315,25 +315,133 @@ func lockTableConsts(t *testing.T, fset *token.FileSet, cache map[string]map[str
 // Held by: TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor
 // (backend/updateguardcases_test.go)
 func statementsJudged(fn *ast.FuncDecl, held map[string][]string) []string {
-	shadowed := declaredNames(fn)
-	var out []string
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch node := n.(type) {
-		case *ast.Ident:
-			if !shadowed[node.Name] {
-				out = append(out, held[node.Name]...)
-			}
-		case *ast.BasicLit:
-			if node.Kind != token.STRING {
-				return true
-			}
-			if lit, err := strconv.Unquote(node.Value); err == nil {
-				out = append(out, lit)
+	walker := &lexicalStatements{held: held}
+	walker.open()
+	walker.declareFields(fn.Type.Params, fn.Type.Results)
+	if fn.Recv != nil {
+		walker.declareFields(fn.Recv)
+	}
+	ast.Walk(walker, fn.Body)
+	return walker.out
+}
+
+// lexicalStatements resolves each identifier against Go's own scoping while it
+// gathers, which declaredNames deliberately does not: that helper treats a name
+// declared anywhere in a function as shadowing the package value throughout, and
+// says so, because the privacy census it serves would rather miss a statement on
+// both sides than add one to the side that does not write it.
+//
+// This census wants the opposite conservatism. A local declared inside one
+// branch would suppress a package-level statement named before it and outside
+// it, and the whole point here is that a statement nobody judges produces no
+// finding — only a smaller silence. So scope is tracked rather than approximated.
+type lexicalStatements struct {
+	held   map[string][]string
+	scopes []map[string]bool
+	out    []string
+}
+
+func (l *lexicalStatements) open()  { l.scopes = append(l.scopes, map[string]bool{}) }
+func (l *lexicalStatements) close() { l.scopes = l.scopes[:len(l.scopes)-1] }
+
+func (l *lexicalStatements) declare(expr ast.Expr) {
+	if ident, isIdent := expr.(*ast.Ident); isIdent && ident.Name != "_" {
+		l.scopes[len(l.scopes)-1][ident.Name] = true
+	}
+}
+
+func (l *lexicalStatements) declareFields(lists ...*ast.FieldList) {
+	for _, list := range lists {
+		if list == nil {
+			continue
+		}
+		for _, field := range list.List {
+			for _, name := range field.Names {
+				l.declare(name)
 			}
 		}
-		return true
-	})
-	return out
+	}
+}
+
+func (l *lexicalStatements) shadowed(name string) bool {
+	for _, scope := range l.scopes {
+		if scope[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// Visit gathers on the way down, so a name is read against the bindings that
+// stood where it was written: `held` used before a later `held := …` in the same
+// block is still the package's, which is what Go compiles it to.
+func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case nil:
+		return nil
+	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt,
+		*ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt,
+		*ast.CaseClause, *ast.CommClause:
+		l.open()
+		return scopeCloser{l}
+	case *ast.FuncLit:
+		l.open()
+		l.declareFields(n.Type.Params, n.Type.Results)
+		return scopeCloser{l}
+	case *ast.AssignStmt:
+		// The right-hand side is evaluated against the bindings that stand
+		// BEFORE the declaration, so it is walked first and the names are
+		// declared after: `held := held` reads the package's value.
+		for _, rhs := range n.Rhs {
+			ast.Walk(l, rhs)
+		}
+		if n.Tok == token.DEFINE {
+			for _, lhs := range n.Lhs {
+				l.declare(lhs)
+			}
+		} else {
+			for _, lhs := range n.Lhs {
+				ast.Walk(l, lhs)
+			}
+		}
+		return nil
+	case *ast.ValueSpec:
+		for _, value := range n.Values {
+			ast.Walk(l, value)
+		}
+		for _, name := range n.Names {
+			l.declare(name)
+		}
+		return nil
+	case *ast.Ident:
+		if !l.shadowed(n.Name) {
+			l.out = append(l.out, l.held[n.Name]...)
+		}
+		return nil
+	case *ast.BasicLit:
+		if n.Kind == token.STRING {
+			if lit, err := strconv.Unquote(n.Value); err == nil {
+				l.out = append(l.out, lit)
+			}
+		}
+		return nil
+	}
+	return l
+}
+
+// scopeCloser pops the scope its node opened once ast.Walk has finished that
+// node's children. Nested inside the walker rather than folded into it because
+// ast.Walk signals "children done" by calling Visit(nil) on the visitor a node
+// RETURNED, and a walker that popped on every such call would pop for every
+// plain node too.
+type scopeCloser struct{ walker *lexicalStatements }
+
+func (c scopeCloser) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		c.walker.close()
+		return nil
+	}
+	return c.walker.Visit(node)
 }
 
 // heldStatements are the SQL statements a package holds in its package-level

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -188,6 +188,13 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	"internal/modules/privacy:anonymizeLead":              "terminal absolute write: the retention sweep anonymizes an over-age lead regardless of concurrent state, by design, and its selector already excludes an already-anonymized row",
 	"internal/modules/privacy:eraseActivityContent":       "terminal absolute write: the sweep's activity/erase action empties the body and stamps the tombstone subject regardless of concurrent state, by design",
 	"internal/modules/privacy:anonymizePersonRecord":      "terminal absolute write: the sweep's person/anonymize action overwrites the PII columns regardless of concurrent state, by design",
+
+	// A function the package-level folding attributes a statement to without its
+	// also executing it. Ratified here rather than smoothed away in the reader,
+	// because the shape recurs wherever a statement table is handed to an
+	// executor by value instead of by name, and a reader taught to excuse it
+	// would excuse the writers that DO need judging along with it.
+	"internal/modules/people:writeCompanyFields": "attributed by NAME rather than by execution: it iterates companyFields and hands each statement to setCompanyColumn, which answers on RowsAffected — the CAS this gate asks for, one frame down and out of a function-scoped witness's reach. The write is not read-modify-write besides: the form sends absolute values a human typed, every statement carries IS DISTINCT FROM so an unchanged resubmission touches no row, and SaveCompany serializes concurrent form saves on the workspace row (lockCompanyState). That lock is deliberately not credited above — it names workspace, not organization, and the narrowed witness declining it is the narrowing working",
 })
 
 // guardMarkers are the identifiers whose presence in the same function
@@ -291,6 +298,60 @@ func lockTableConsts(t *testing.T, fset *token.FileSet, cache map[string]map[str
 	return consts
 }
 
+// statementsJudged is every SQL statement a function answers for: the string
+// literals written in its own body, plus the package-level statements it names.
+//
+// A statement hoisted to a package-level table is executed by whoever names it,
+// and the guard is that function's to carry. Reading only the body's literals
+// left those statements outside the census entirely — not reported as a gap but
+// silently absent, which is the one way a census must not fail. The sibling
+// census in orgrenamerecheck_test.go already folds them; this one had stayed
+// narrower, and eight organization writes were sitting in the difference.
+//
+// A name the function DECLARES is its own, whatever the package calls something
+// of the same name — attributing by spelling alone hands a package-level
+// statement to any function with a local of that name.
+//
+// Held by: TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor
+// (backend/updateguardcases_test.go)
+func statementsJudged(fn *ast.FuncDecl, held map[string][]string) []string {
+	shadowed := declaredNames(fn)
+	var out []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.Ident:
+			if !shadowed[node.Name] {
+				out = append(out, held[node.Name]...)
+			}
+		case *ast.BasicLit:
+			if node.Kind != token.STRING {
+				return true
+			}
+			if lit, err := strconv.Unquote(node.Value); err == nil {
+				out = append(out, lit)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// heldStatements are the SQL statements a package holds in its package-level
+// vars and consts, keyed by the name that holds them, read once per package.
+//
+// The reading is the one packageCallGraph uses, rather than a second answer to
+// "what statement does this name hold" — a census whose reader is narrower than
+// its sibling's reports a clean tree over what the sibling can see.
+func heldStatements(t *testing.T, cache map[string]map[string][]string, dir string) map[string][]string {
+	t.Helper()
+	if held, ok := cache[dir]; ok {
+		return held
+	}
+	held := packageLevelStatements(parsePackageFiles(t, dir))
+	cache[dir] = held
+	return held
+}
+
 // lockedTable resolves the table a LockRow/LockPair call names: a string
 // literal, or an identifier declared as a package-level string constant. An
 // argument it cannot resolve returns "", which the caller treats as an
@@ -319,6 +380,7 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 	versioned := versionedTables(t)
 	fset := token.NewFileSet()
 	constCache := map[string]map[string]string{}
+	heldCache := map[string]map[string][]string{}
 	for _, root := range []string{"internal/modules", "internal/compose", "internal/platform"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
@@ -338,38 +400,35 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 				var guarded bool
 				updated := map[string]bool{}
 				locked := map[string]bool{}
-				ast.Inspect(fn.Body, func(n ast.Node) bool {
-					switch node := n.(type) {
-					case *ast.BasicLit:
-						if node.Kind != token.STRING {
-							return true
-						}
-						lit, err := strconv.Unquote(node.Value)
-						if err != nil {
-							return true
-						}
-						if m := byIDUpdate.FindStringSubmatch(lit); m != nil && versioned[m[1]] {
-							updated[m[1]] = true
-							// A version predicate in the statement's own WHERE
-							// IS the compare-and-set this gate asks for, and the
-							// most direct form of it — the UPDATE matches no row
-							// unless the version is still the one that was read.
-							// Crediting only the storekit helpers would push a
-							// correct fix toward a waiver.
-							if w := whereClause.FindStringSubmatch(lit); w != nil &&
-								versionPredicate.MatchString(w[1]) {
-								guarded = true
-							}
-						}
-						// A locking read guards the table it READS. An advisory
-						// lock names no table at all and is a workspace-wide
-						// mutex, so it keeps its unattributed credit.
-						for _, table := range lockedByRead(lit) {
-							locked[table] = true
-						}
-						if advisoryLock.MatchString(lit) {
+				readStatement := func(lit string) {
+					if m := byIDUpdate.FindStringSubmatch(lit); m != nil && versioned[m[1]] {
+						updated[m[1]] = true
+						// A version predicate in the statement's own WHERE
+						// IS the compare-and-set this gate asks for, and the
+						// most direct form of it — the UPDATE matches no row
+						// unless the version is still the one that was read.
+						// Crediting only the storekit helpers would push a
+						// correct fix toward a waiver.
+						if w := whereClause.FindStringSubmatch(lit); w != nil &&
+							versionPredicate.MatchString(w[1]) {
 							guarded = true
 						}
+					}
+					// A locking read guards the table it READS. An advisory
+					// lock names no table at all and is a workspace-wide
+					// mutex, so it keeps its unattributed credit.
+					for _, table := range lockedByRead(lit) {
+						locked[table] = true
+					}
+					if advisoryLock.MatchString(lit) {
+						guarded = true
+					}
+				}
+				for _, lit := range statementsJudged(fn, heldStatements(t, heldCache, filepath.Dir(path))) {
+					readStatement(lit)
+				}
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					switch node := n.(type) {
 					case *ast.CallExpr:
 						sel, ok := node.Fun.(*ast.SelectorExpr)
 						if !ok || !lockMarkers[sel.Sel.Name] {

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -55,6 +55,11 @@ var versionPredicate = regexp.MustCompile(`(?i)\bversion\s*=\s*\$\d+`)
 // the only part where a predicate can constrain which row is written.
 var whereClause = regexp.MustCompile(`(?is)\bWHERE\b(.*)$`)
 
+// byIDUpdateFloor is the smallest number of by-id-updating functions this
+// census may find and still be believed. Set well below the real count, because
+// its job is to catch a reader that has gone quiet, not to track the tree.
+const byIDUpdateFloor = 90
+
 var (
 	// createTableLine opens a CREATE TABLE block; versionColumnLine marks
 	// the block's table as optimistic-locking. Line-based on purpose:
@@ -118,6 +123,12 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// arrives as pgx.ErrNoRows, which the caller handles as the decline it is
 	// rather than as a failure.
 	"internal/modules/people:bindSiteReadLogo": "the bind is conditioned on logo_object_key IS NULL AND archived_at IS NULL, and ErrNoRows means the record already wears a mark or was archived, which releases the parked object instead",
+
+	// The second of that shape, and the reason it is ratified rather than
+	// taught to the witness: crediting a bare mention of pgx.ErrNoRows would
+	// hand a free pass to any function that checks it on an unrelated read. A
+	// third occurrence is the point at which that trade stops being worth it.
+	"internal/modules/privacy:PinToFloor": "the same QueryRow compare-and-set: `WHERE a.id = $1 AND a.restricted_at IS NULL ... RETURNING a.restricted_until` matches nothing once any restriction stands, and the zero-row result arrives as pgx.ErrNoRows, which the caller turns into ErrConflict — a second controller pinning the same record is declined rather than overwriting the first one's window. A version guard would be wrong besides: nothing pins a version here, the administrator is acting on a record rather than on a value they read",
 
 	// Archive is an absolute idempotent transition: the write sets
 	// archived_at unconditionally (no state derived from a pre-read),
@@ -379,7 +390,7 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 	switch n := node.(type) {
 	case nil:
 		return nil
-	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt,
+	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt,
 		*ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt,
 		*ast.CaseClause, *ast.CommClause:
 		l.open()
@@ -388,6 +399,61 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 		l.open()
 		l.declareFields(n.Type.Params, n.Type.Results)
 		return scopeCloser{l}
+	case *ast.RangeStmt:
+		// Its own scope, and its own declaration: the loop variables are
+		// declared by the clause rather than by an AssignStmt below it, so the
+		// generic arm above would open the scope and then never put them in it.
+		// The range expression is evaluated in the OUTER bindings.
+		l.open()
+		defer l.close()
+		ast.Walk(l, n.X)
+		if n.Tok == token.DEFINE {
+			l.declare(n.Key)
+			l.declare(n.Value)
+		} else {
+			for _, target := range []ast.Expr{n.Key, n.Value} {
+				if target != nil {
+					ast.Walk(l, target)
+				}
+			}
+		}
+		ast.Walk(l, n.Body)
+		return nil
+	case *ast.BinaryExpr:
+		// The same fold packageLevelStatements does, for the same reason:
+		// neither half of `UPDATE x SET a = $1 ` + `WHERE id = $2` carries the
+		// statement, so a census matching a shape sees nothing in either. The
+		// walk continues into the parts as well — adding a reading can only
+		// widen what is judged.
+		if n.Op == token.ADD {
+			if folded, readable := concatenatedString(n); readable {
+				l.out = append(l.out, folded)
+			}
+		}
+		return l
+	case *ast.LabeledStmt:
+		// A label shares the identifier namespace with nothing this reads —
+		// neither where it is declared nor where a break or continue names it.
+		ast.Walk(l, n.Stmt)
+		return nil
+	case *ast.BranchStmt:
+		return nil
+	case *ast.SelectorExpr:
+		// `spec.update` names a FIELD, not the package's `update`. The base is
+		// still walked, because that half can be a package value.
+		ast.Walk(l, n.X)
+		return nil
+	case *ast.KeyValueExpr:
+		// A struct literal's field name is not a variable reference either, and
+		// the AST cannot tell one from a map key without types. An identifier
+		// key is therefore left unread: a package-level SQL statement used as a
+		// map KEY would be a statement nobody sends, so declining it costs no
+		// coverage, while reading it credits every `{update: …}` in the tree.
+		if _, named := n.Key.(*ast.Ident); !named {
+			ast.Walk(l, n.Key)
+		}
+		ast.Walk(l, n.Value)
+		return nil
 	case *ast.AssignStmt:
 		// The right-hand side is evaluated against the bindings that stand
 		// BEFORE the declaration, so it is walked first and the names are
@@ -489,6 +555,7 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 	fset := token.NewFileSet()
 	constCache := map[string]map[string]string{}
 	heldCache := map[string]map[string][]string{}
+	judged := 0
 	for _, root := range []string{"internal/modules", "internal/compose", "internal/platform"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
@@ -560,7 +627,11 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 						guarded = true
 					}
 				}
-				if len(updated) > 0 && !guarded {
+				if len(updated) == 0 {
+					continue
+				}
+				judged++
+				if !guarded {
 					key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
 					if unguardedByIDUpdates.Waived(t, key) {
 						continue
@@ -574,5 +645,17 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	// A census that judged nothing certifies nothing, and this one has two ways
+	// to go quiet: the walk can stop finding files, and the reader can stop
+	// finding statements inside them. Neither produces a finding on its own —
+	// they produce a smaller silence, which is what the floor is for. It sits
+	// below the real count so it catches a broken reader rather than a tree
+	// that has changed.
+	if judged < byIDUpdateFloor { 
+		t.Fatalf("this census judged %d function(s) running a by-id UPDATE and expects at least %d — "+
+			"the reader has stopped seeing statements rather than the tree having lost them",
+			judged, byIDUpdateFloor)
 	}
 }

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -373,7 +373,7 @@ type lexicalStatements struct {
 	// silently, where looking too widely at worst raises a finding somebody
 	// answers.
 	imported []map[string][]string
-	scopes   []map[string]bool
+	scopes   []scope
 	// locals is what a string-valued local has been built up to so far, so an
 	// `x := "…"` / `x += "…"` pair is read as the one statement it becomes.
 	// Keyed by name across scopes on purpose: reconstructing more statements
@@ -381,6 +381,13 @@ type lexicalStatements struct {
 	// direction that produces a finding somebody can answer.
 	locals map[string]string
 	out    []string
+}
+
+// scope is one block's bindings: the names it declares, and what each of those
+// displaced in locals so close can put it back.
+type scope struct {
+	declared  map[string]bool
+	displaced map[string]*string
 }
 
 // foldAppend records what `target += addition` builds the target up to, and
@@ -410,13 +417,41 @@ func (l *lexicalStatements) seedLocal(target, value ast.Expr) {
 	}
 }
 
-func (l *lexicalStatements) open()  { l.scopes = append(l.scopes, map[string]bool{}) }
-func (l *lexicalStatements) close() { l.scopes = l.scopes[:len(l.scopes)-1] }
+func (l *lexicalStatements) open() {
+	l.scopes = append(l.scopes, scope{declared: map[string]bool{}, displaced: map[string]*string{}})
+}
+
+// close puts back what this scope's declarations displaced. An inner
+// `statement := "SELECT 1"` must not survive its block: the outer name goes on
+// being built up after it, and an accumulation that kept the inner value folds
+// to a statement with no SET clause — one the census then skips.
+func (l *lexicalStatements) close() {
+	closing := l.scopes[len(l.scopes)-1]
+	for name, previous := range closing.displaced {
+		if previous == nil {
+			delete(l.locals, name)
+			continue
+		}
+		l.locals[name] = *previous
+	}
+	l.scopes = l.scopes[:len(l.scopes)-1]
+}
 
 func (l *lexicalStatements) declare(expr ast.Expr) {
-	if ident, isIdent := expr.(*ast.Ident); isIdent && ident.Name != "_" {
-		l.scopes[len(l.scopes)-1][ident.Name] = true
+	ident, isIdent := expr.(*ast.Ident)
+	if !isIdent || ident.Name == "_" {
+		return
 	}
+	current := l.scopes[len(l.scopes)-1]
+	current.declared[ident.Name] = true
+	if _, already := current.displaced[ident.Name]; already {
+		return
+	}
+	if previous, held := l.locals[ident.Name]; held {
+		current.displaced[ident.Name] = &previous
+		return
+	}
+	current.displaced[ident.Name] = nil
 }
 
 func (l *lexicalStatements) declareFields(lists ...*ast.FieldList) {
@@ -433,8 +468,8 @@ func (l *lexicalStatements) declareFields(lists ...*ast.FieldList) {
 }
 
 func (l *lexicalStatements) shadowed(name string) bool {
-	for _, scope := range l.scopes {
-		if scope[name] {
+	for _, enclosing := range l.scopes {
+		if enclosing.declared[name] {
 			return true
 		}
 	}
@@ -536,13 +571,17 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 			ast.Walk(l, rhs)
 		}
 		if n.Tok == token.DEFINE {
+			// declare BEFORE seedLocal: declaring is what records the value
+			// this name displaces, and seeding is what displaces it. The other
+			// order records the new value as the old one, so closing the scope
+			// restores nothing.
+			for _, lhs := range n.Lhs {
+				l.declare(lhs)
+			}
 			if len(n.Lhs) == len(n.Rhs) {
 				for i, lhs := range n.Lhs {
 					l.seedLocal(lhs, n.Rhs[i])
 				}
-			}
-			for _, lhs := range n.Lhs {
-				l.declare(lhs)
 			}
 		} else {
 			for _, lhs := range n.Lhs {
@@ -554,13 +593,13 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 		for _, value := range n.Values {
 			ast.Walk(l, value)
 		}
+		for _, name := range n.Names {
+			l.declare(name)
+		}
 		if len(n.Names) == len(n.Values) {
 			for i, name := range n.Names {
 				l.seedLocal(name, n.Values[i])
 			}
-		}
-		for _, name := range n.Names {
-			l.declare(name)
 		}
 		return nil
 	case *ast.Ident:

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -58,6 +58,11 @@ var whereClause = regexp.MustCompile(`(?is)\bWHERE\b(.*)$`)
 // byIDUpdateFloor is the smallest number of by-id-updating functions this
 // census may find and still be believed. Set well below the real count, because
 // its job is to catch a reader that has gone quiet, not to track the tree.
+//
+// It is the coarser of the two under-recognition alarms and covers the UNWAIVED
+// remainder. The sharper one is unguardedByIDUpdates.AssertAllMatched: a waived
+// function the reader stops seeing is named outright, because its ratification
+// then matches nothing.
 const byIDUpdateFloor = 90
 
 var (
@@ -205,7 +210,13 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// because the shape recurs wherever a statement table is handed to an
 	// executor by value instead of by name, and a reader taught to excuse it
 	// would excuse the writers that DO need judging along with it.
-	"internal/modules/people:writeCompanyFields": "attributed by NAME rather than by execution: it iterates companyFields and hands each statement to setCompanyColumn, which answers on RowsAffected — the CAS this gate asks for, one frame down and out of a function-scoped witness's reach. The write is not read-modify-write besides: the form sends absolute values a human typed, every statement carries IS DISTINCT FROM so an unchanged resubmission touches no row, and SaveCompany serializes concurrent form saves on the workspace row (lockCompanyState). That lock is deliberately not credited above — it names workspace, not organization, and the narrowed witness declining it is the narrowing working",
+	//
+	// The lock this names is the ORGANIZATION row's, not the workspace row's.
+	// SaveCompany also takes lockCompanyState — `SELECT id FROM workspace … FOR
+	// UPDATE` — and that one is deliberately not what ratifies this: it names a
+	// different table from the one being written, which is exactly the free
+	// credit the table-scoped witness was narrowed to stop giving.
+	"internal/modules/people:writeCompanyFields": "runs under the row lock its callers hold on the organization being written. Both — SaveCompany and applySiteReadConfirmation — reach it through resolveOrCreateAnchor, whose anchorOrganization(ctx, tx, true) is `SELECT id FROM organization WHERE is_anchor AND archived_at IS NULL FOR UPDATE`, held for the rest of the transaction, so two company saves serialize on the row rather than racing on it. The census cannot see that lock for two reasons at once: it is taken two frames up, and anchorOrganization assembles the statement with `query += \" FOR UPDATE\"`, which no reading here folds. This function is attributed a statement by NAME rather than by execution besides — it iterates companyFields and hands each one to setCompanyColumn",
 })
 
 // guardMarkers are the identifiers whose presence in the same function
@@ -224,6 +235,13 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 // it would therefore mean 28 ratified waivers, which is a bigger change than
 // this witness is worth on its own; it is recorded here so the next reader knows
 // the looseness is a decision with a number behind it.
+//
+// That 28 was counted against a reader that saw only the literals typed in a
+// body, so read it as a floor rather than as the figure. A marker now absolves
+// every statement the function NAMES as well — one RowsAffected on an unrelated
+// write credits a whole hoisted statement table the same function indexes. The
+// looseness therefore grew with the reach, and narrowing it is its own change
+// rather than a line to slip into this one.
 var guardMarkers = map[string]bool{
 	"ApplyWithVersion": true,
 	"ApplyGuarded":     true,
@@ -325,8 +343,8 @@ func lockTableConsts(t *testing.T, fset *token.FileSet, cache map[string]map[str
 //
 // Held by: TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor
 // (backend/updateguardcases_test.go)
-func statementsJudged(fn *ast.FuncDecl, held map[string][]string) []string {
-	walker := &lexicalStatements{held: held}
+func statementsJudged(fn *ast.FuncDecl, held map[string][]string, imported []map[string][]string) []string {
+	walker := &lexicalStatements{held: held, imported: imported, locals: map[string]string{}}
 	walker.open()
 	walker.declareFields(fn.Type.Params, fn.Type.Results)
 	if fn.Recv != nil {
@@ -347,9 +365,49 @@ func statementsJudged(fn *ast.FuncDecl, held map[string][]string) []string {
 // it, and the whole point here is that a statement nobody judges produces no
 // finding — only a smaller silence. So scope is tracked rather than approximated.
 type lexicalStatements struct {
-	held   map[string][]string
-	scopes []map[string]bool
+	held map[string][]string
+	// imported is what the in-module packages this file imports hold, one map
+	// each. A qualified name is looked up in ALL of them rather than in the one
+	// its base resolves to: a package's declared name need not match its
+	// directory, and getting that mapping subtly wrong would drop the statement
+	// silently, where looking too widely at worst raises a finding somebody
+	// answers.
+	imported []map[string][]string
+	scopes   []map[string]bool
+	// locals is what a string-valued local has been built up to so far, so an
+	// `x := "…"` / `x += "…"` pair is read as the one statement it becomes.
+	// Keyed by name across scopes on purpose: reconstructing more statements
+	// than a function really sends over-reports, and over-reporting is the
+	// direction that produces a finding somebody can answer.
+	locals map[string]string
 	out    []string
+}
+
+// foldAppend records what `target += addition` builds the target up to, and
+// reads the accumulated whole. The parts are read separately anyway; this is
+// the reading that carries a SET and its WHERE together.
+func (l *lexicalStatements) foldAppend(target, addition ast.Expr) {
+	name, named := target.(*ast.Ident)
+	if !named {
+		return
+	}
+	added, readable := concatenatedString(addition)
+	if !readable {
+		return
+	}
+	l.locals[name.Name] += added
+	l.out = append(l.out, l.locals[name.Name])
+}
+
+// seedLocal starts that accumulation from a declaration's own value.
+func (l *lexicalStatements) seedLocal(target, value ast.Expr) {
+	name, named := target.(*ast.Ident)
+	if !named {
+		return
+	}
+	if seed, readable := concatenatedString(value); readable {
+		l.locals[name.Name] = seed
+	}
 }
 
 func (l *lexicalStatements) open()  { l.scopes = append(l.scopes, map[string]bool{}) }
@@ -439,8 +497,17 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 	case *ast.BranchStmt:
 		return nil
 	case *ast.SelectorExpr:
-		// `spec.update` names a FIELD, not the package's `update`. The base is
-		// still walked, because that half can be a package value.
+		// `spec.update` names a FIELD, not this package's `update`, so the Sel
+		// is not read as a local name. But `storekit.ProbeRenameOrg` is a
+		// statement held one import away, and dropping the Sel outright left
+		// that silence exactly where this change closed the same one inside a
+		// package. So the Sel is looked up in what the file's in-module imports
+		// hold — a field name matches nothing there, and a qualified statement
+		// matches. The base is walked either way, because that half can be a
+		// package value of this package's own.
+		for _, elsewhere := range l.imported {
+			l.out = append(l.out, elsewhere[n.Sel.Name]...)
+		}
 		ast.Walk(l, n.X)
 		return nil
 	case *ast.KeyValueExpr:
@@ -455,6 +522,13 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 		ast.Walk(l, n.Value)
 		return nil
 	case *ast.AssignStmt:
+		// `statement += " FOR UPDATE"` is the third spelling of the same
+		// assembly, and the one anchorOrganization uses to add the row lock that
+		// guards the company form. Each half is read on its own below; this
+		// folds them so the whole is read too.
+		if n.Tok == token.ADD_ASSIGN && len(n.Lhs) == 1 && len(n.Rhs) == 1 {
+			l.foldAppend(n.Lhs[0], n.Rhs[0])
+		}
 		// The right-hand side is evaluated against the bindings that stand
 		// BEFORE the declaration, so it is walked first and the names are
 		// declared after: `held := held` reads the package's value.
@@ -462,6 +536,11 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 			ast.Walk(l, rhs)
 		}
 		if n.Tok == token.DEFINE {
+			if len(n.Lhs) == len(n.Rhs) {
+				for i, lhs := range n.Lhs {
+					l.seedLocal(lhs, n.Rhs[i])
+				}
+			}
 			for _, lhs := range n.Lhs {
 				l.declare(lhs)
 			}
@@ -474,6 +553,11 @@ func (l *lexicalStatements) Visit(node ast.Node) ast.Visitor {
 	case *ast.ValueSpec:
 		for _, value := range n.Values {
 			ast.Walk(l, value)
+		}
+		if len(n.Names) == len(n.Values) {
+			for i, name := range n.Names {
+				l.seedLocal(name, n.Values[i])
+			}
 		}
 		for _, name := range n.Names {
 			l.declare(name)
@@ -508,6 +592,24 @@ func (c scopeCloser) Visit(node ast.Node) ast.Visitor {
 		return nil
 	}
 	return c.walker.Visit(node)
+}
+
+// modulePrefix is the backend module's own import path. An import outside it is
+// a dependency whose statements are not this tree's to judge.
+const modulePrefix = "github.com/gradionhq/margince/backend/"
+
+// inModuleImportDirs are the directories of the backend packages a file imports,
+// which is where a qualified statement name can have been declared.
+func inModuleImportDirs(file *ast.File) []string {
+	var dirs []string
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || !strings.HasPrefix(path, modulePrefix) {
+			continue
+		}
+		dirs = append(dirs, strings.TrimPrefix(path, modulePrefix))
+	}
+	return dirs
 }
 
 // heldStatements are the SQL statements a package holds in its package-level
@@ -567,6 +669,12 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 			if err != nil {
 				return err
 			}
+			// Read once per FILE rather than per function: the imports are the
+			// file's, and heldStatements caches per package anyway.
+			var imported []map[string][]string
+			for _, dir := range inModuleImportDirs(file) {
+				imported = append(imported, heldStatements(t, heldCache, dir))
+			}
 			for _, decl := range file.Decls {
 				fn, ok := decl.(*ast.FuncDecl)
 				if !ok || fn.Body == nil {
@@ -599,7 +707,7 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 						guarded = true
 					}
 				}
-				for _, lit := range statementsJudged(fn, heldStatements(t, heldCache, filepath.Dir(path))) {
+				for _, lit := range statementsJudged(fn, heldStatements(t, heldCache, filepath.Dir(path)), imported) {
 					readStatement(lit)
 				}
 				ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -653,7 +761,7 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 	// they produce a smaller silence, which is what the floor is for. It sits
 	// below the real count so it catches a broken reader rather than a tree
 	// that has changed.
-	if judged < byIDUpdateFloor { 
+	if judged < byIDUpdateFloor {
 		t.Fatalf("this census judged %d function(s) running a by-id UPDATE and expects at least %d — "+
 			"the reader has stopped seeing statements rather than the tree having lost them",
 			judged, byIDUpdateFloor)

--- a/backend/updateguardcases_test.go
+++ b/backend/updateguardcases_test.go
@@ -25,83 +25,116 @@ import (
 	"testing"
 )
 
-func TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor(t *testing.T) {
-	const marker = `UPDATE organization SET legal_name = $2 WHERE id = $1`
+// marker is the write every case either sends or does not. Shared by all of
+// them so that a case differs from its neighbours in WHERE the statement lives
+// and in nothing else.
+const marker = `UPDATE organization SET legal_name = $2 WHERE id = $1`
 
-	for _, tc := range []struct {
-		name   string
-		source string
-		judged bool
-	}{
-		{
-			name: "written in the body, which is the shape the census always saw",
-			source: `package p
+// statementReadingCase is one synthetic package and the verdict the reader owes
+// it.
+type statementReadingCase struct {
+	name   string
+	source string
+	// elsewhere is a second synthetic package the first one imports, for the
+	// cases where the statement is held across a package boundary.
+	elsewhere string
+	judged    bool
+}
+
+var statementReadingCases = []statementReadingCase{
+	{
+		name: "written in the body, which is the shape the census always saw",
+		source: `package p
 func write(tx T) { tx.Exec(ctx, ` + "`" + marker + "`" + `) }`,
-			judged: true,
-		}, {
-			// The shape the tree already wrote: coldStartColumns and
-			// companyFields held eight organization writes between them, and
-			// the function that sent each one named a table rather than a
-			// statement.
-			name: "held in a package-level table the function indexes",
-			source: `package p
+		judged: true,
+	}, {
+		// The shape the tree already wrote: coldStartColumns and
+		// companyFields held eight organization writes between them, and
+		// the function that sent each one named a table rather than a
+		// statement.
+		name: "held in a package-level table the function indexes",
+		source: `package p
 var held = map[string]string{"legal_name": ` + "`" + marker + "`" + `}
 func write(tx T, column string) { tx.Exec(ctx, held[column]) }`,
-			judged: true,
-		}, {
-			name: "held in a package-level table of structs",
-			source: `package p
+		judged: true,
+	}, {
+		name: "held in a package-level table of structs",
+		source: `package p
 type spec struct{ update string }
 var held = []spec{{update: ` + "`" + marker + "`" + `}}
 func write(tx T) { tx.Exec(ctx, held[0].update) }`,
-			judged: true,
-		}, {
-			name: "held in a package-level const the function names",
-			source: `package p
+		judged: true,
+	}, {
+		name: "held in a package-level const the function names",
+		source: `package p
 const held = ` + "`" + marker + "`" + `
 func write(tx T) { tx.Exec(ctx, held) }`,
-			judged: true,
-		}, {
-			// Neither half carries the statement: the first has no WHERE, the
-			// second no SET. A reader that kept only the parts saw two
-			// fragments and matched neither.
-			name: "assembled at package level from two literals",
-			source: `package p
+		judged: true,
+	}, {
+		// Neither half carries the statement: the first has no WHERE, the
+		// second no SET. A reader that kept only the parts saw two
+		// fragments and matched neither.
+		name: "assembled at package level from two literals",
+		source: `package p
 var held = ` + "`UPDATE organization SET legal_name = $2 `" + ` + ` + "`WHERE id = $1`" + `
 func write(tx T) { tx.Exec(ctx, held) }`,
-			judged: true,
-		}, {
-			// The same defect one line lower, and the shape five functions in
-			// this tree already write: a `+` chain assembled at the call site
-			// rather than at package level. Folding only the hoisted spelling
-			// would have fixed one half of one shape.
-			name: "assembled in the body from two literals",
-			source: `package p
+		judged: true,
+	}, {
+		// The same defect one line lower, and the shape five functions in
+		// this tree already write: a `+` chain assembled at the call site
+		// rather than at package level. Folding only the hoisted spelling
+		// would have fixed one half of one shape.
+		name: "assembled in the body from two literals",
+		source: `package p
 func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 `" + ` + ` + "`WHERE id = $1`" + `) }`,
-			judged: true,
-		}, {
-			name: "assembled in the body around a helper's output",
-			source: `package p
+		judged: true,
+	}, {
+		name: "assembled in the body around a helper's output",
+		source: `package p
 func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1 AND `" + ` + extra()) }`,
-			judged: true,
-		}, {
-			// The direction that MISSES a writer is the dangerous one, but this
-			// is the direction that invents one: a local of the same name is
-			// not the package's value, and crediting it would attribute a
-			// statement to a function that never sends it.
-			name: "a local shadowing the package name",
-			source: `package p
+		judged: true,
+	}, {
+		// The third spelling of the same assembly, and the one
+		// anchorOrganization uses to append the row lock that guards the
+		// company form — so a reader blind to it cannot see the guard
+		// either, not just the statement.
+		name: "appended to a local with +=",
+		source: `package p
+func write(tx T) {
+	statement := ` + "`UPDATE organization SET legal_name = $2 `" + `
+	statement += ` + "`WHERE id = $1`" + `
+	tx.Exec(ctx, statement)
+}`,
+		judged: true,
+	}, {
+		name: "appended to a var declared with a keyword",
+		source: `package p
+func write(tx T, cond bool) {
+	var statement = ` + "`UPDATE organization SET legal_name = $2 `" + `
+	if cond {
+		statement += ` + "`WHERE id = $1`" + `
+	}
+	tx.Exec(ctx, statement)
+}`,
+		judged: true,
+	}, {
+		// The direction that MISSES a writer is the dangerous one, but this
+		// is the direction that invents one: a local of the same name is
+		// not the package's value, and crediting it would attribute a
+		// statement to a function that never sends it.
+		name: "a local shadowing the package name",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T) { held := "SELECT 1"; tx.Exec(ctx, held) }`,
-			judged: false,
-		}, {
-			// A whole-function shadow set answers this one wrong, and wrong in
-			// the silent direction: the send is the package's statement, and a
-			// local declared in a branch that does not contain it says nothing
-			// about it. Go scopes the inner name to the inner block, and so
-			// does the reader.
-			name: "a local shadowing inside a branch the send is not in",
-			source: `package p
+		judged: false,
+	}, {
+		// A whole-function shadow set answers this one wrong, and wrong in
+		// the silent direction: the send is the package's statement, and a
+		// local declared in a branch that does not contain it says nothing
+		// about it. Go scopes the inner name to the inner block, and so
+		// does the reader.
+		name: "a local shadowing inside a branch the send is not in",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, cond bool) {
 	tx.Exec(ctx, held)
@@ -110,10 +143,10 @@ func write(tx T, cond bool) {
 		tx.Exec(ctx, held)
 	}
 }`,
-			judged: true,
-		}, {
-			name: "a send inside the branch that shadows, and nowhere else",
-			source: `package p
+		judged: true,
+	}, {
+		name: "a send inside the branch that shadows, and nowhere else",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, cond bool) {
 	if cond {
@@ -121,53 +154,53 @@ func write(tx T, cond bool) {
 		tx.Exec(ctx, held)
 	}
 }`,
-			judged: false,
-		}, {
-			// The right-hand side stands before the declaration it feeds, so
-			// this reads the package's statement and then sends it under a
-			// local name.
-			name: "a local initialised from the package value it shadows",
-			source: `package p
+		judged: false,
+	}, {
+		// The right-hand side stands before the declaration it feeds, so
+		// this reads the package's statement and then sends it under a
+		// local name.
+		name: "a local initialised from the package value it shadows",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T) { held := held; tx.Exec(ctx, held) }`,
-			judged: true,
-		}, {
-			name: "a parameter shadowing the package name",
-			source: `package p
+		judged: true,
+	}, {
+		name: "a parameter shadowing the package name",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, held string) { tx.Exec(ctx, held) }`,
-			judged: false,
-		}, {
-			// A range clause declares its own variables rather than through an
-			// assignment below it, so a reader that only opened the scope would
-			// leave them out of it and read every loop body as the package's.
-			name: "a range value shadowing the package name",
-			source: `package p
+		judged: false,
+	}, {
+		// A range clause declares its own variables rather than through an
+		// assignment below it, so a reader that only opened the scope would
+		// leave them out of it and read every loop body as the package's.
+		name: "a range value shadowing the package name",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, rows []string) { for _, held := range rows { tx.Exec(ctx, held) } }`,
-			judged: false,
-		}, {
-			name: "a range key shadowing the package name",
-			source: `package p
+		judged: false,
+	}, {
+		name: "a range key shadowing the package name",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, rows map[string]int) { for held := range rows { tx.Exec(ctx, held) } }`,
-			judged: false,
-		}, {
-			// The range EXPRESSION stands outside the loop's own scope, so a
-			// package statement ranged over is still the package's.
-			name: "the package value ranged over",
-			source: `package p
+		judged: false,
+	}, {
+		// The range EXPRESSION stands outside the loop's own scope, so a
+		// package statement ranged over is still the package's.
+		name: "the package value ranged over",
+		source: `package p
 var held = []string{` + "`" + marker + "`" + `}
 func write(tx T) { for _, q := range held { tx.Exec(ctx, q) } }`,
-			judged: true,
-		}, {
-			// Three identifiers that are not variable references at all. Each
-			// would be looked up in the package's statements by a reader that
-			// treated every ast.Ident alike, and each would credit a function
-			// that sends nothing — a finding that teaches the next author to
-			// distrust this census.
-			name: "a struct field, a label and a selector spelled like the package name",
-			source: `package p
+		judged: true,
+	}, {
+		// Three identifiers that are not variable references at all. Each
+		// would be looked up in the package's statements by a reader that
+		// treated every ast.Ident alike, and each would credit a function
+		// that sends nothing — a finding that teaches the next author to
+		// distrust this census.
+		name: "a struct field, a label and a selector spelled like the package name",
+		source: `package p
 type row struct{ held string }
 var held = ` + "`" + marker + "`" + `
 func write(tx T, v row) {
@@ -178,15 +211,40 @@ held:
 		break held
 	}
 }`,
-			judged: false,
-		}, {
-			name: "a package-level name this function never mentions",
-			source: `package p
+		judged: false,
+	}, {
+		name: "a package-level name this function never mentions",
+		source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T) { tx.Exec(ctx, "SELECT 1") }`,
-			judged: false,
-		},
-	} {
+		judged: false,
+	}, {
+		// The same silence one import away. Closing it inside a package
+		// and leaving it across one would have moved the blind spot rather
+		// than removed it.
+		name: "held in an imported package and sent under a qualified name",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, storekit.HeldRename) }`,
+		elsewhere: `package storekit
+const HeldRename = ` + "`" + marker + "`",
+		judged: true,
+	}, {
+		// A field access spelled like a name an imported package happens to
+		// hold is not a send of it — but the reader cannot tell them apart
+		// without types, so it reads too widely on purpose. Recorded as the
+		// over-report it is, in the direction that raises a finding rather
+		// than swallowing one.
+		name: "a field access colliding with an imported statement name",
+		source: `package p
+func write(tx T, v row) { _ = v.HeldRename; tx.Exec(ctx, "SELECT 1") }`,
+		elsewhere: `package storekit
+const HeldRename = ` + "`" + marker + "`",
+		judged: true,
+	},
+}
+
+func TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor(t *testing.T) {
+	for _, tc := range statementReadingCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fset := token.NewFileSet()
 			file, err := parser.ParseFile(fset, "synthetic.go", tc.source, 0)
@@ -194,6 +252,14 @@ func write(tx T) { tx.Exec(ctx, "SELECT 1") }`,
 				t.Fatalf("parsing the case source: %v", err)
 			}
 			held := packageLevelStatements([]*ast.File{file})
+			var imported []map[string][]string
+			if tc.elsewhere != "" {
+				other, otherErr := parser.ParseFile(fset, "elsewhere.go", tc.elsewhere, 0)
+				if otherErr != nil {
+					t.Fatalf("parsing the imported case source: %v", otherErr)
+				}
+				imported = append(imported, packageLevelStatements([]*ast.File{other}))
+			}
 			var fn *ast.FuncDecl
 			for _, decl := range file.Decls {
 				if candidate, isFunc := decl.(*ast.FuncDecl); isFunc && candidate.Name.Name == "write" {
@@ -205,7 +271,7 @@ func write(tx T) { tx.Exec(ctx, "SELECT 1") }`,
 			}
 
 			seen := false
-			for _, statement := range statementsJudged(fn, held) {
+			for _, statement := range statementsJudged(fn, held, imported) {
 				if strings.Contains(statement, "SET legal_name") && strings.Contains(statement, "WHERE id =") {
 					seen = true
 				}

--- a/backend/updateguardcases_test.go
+++ b/backend/updateguardcases_test.go
@@ -118,6 +118,23 @@ func write(tx T, cond bool) {
 }`,
 		judged: true,
 	}, {
+		// An accumulation that let an inner declaration outlive its block
+		// would fold this to "SELECT 1WHERE id = $1" — no SET clause, so the
+		// census skips the write entirely. Silence again, from the bookkeeping
+		// this time rather than from the reading.
+		name: "an inner declaration of a name the outer scope is still building",
+		source: `package p
+func write(tx T, cond bool) {
+	statement := ` + "`UPDATE organization SET legal_name = $2 `" + `
+	if cond {
+		statement := "SELECT 1"
+		_ = statement
+	}
+	statement += ` + "`WHERE id = $1`" + `
+	tx.Exec(ctx, statement)
+}`,
+		judged: true,
+	}, {
 		// The direction that MISSES a writer is the dangerous one, but this
 		// is the direction that invents one: a local of the same name is
 		// not the package's value, and crediting it would attribute a

--- a/backend/updateguardcases_test.go
+++ b/backend/updateguardcases_test.go
@@ -71,6 +71,20 @@ var held = ` + "`UPDATE organization SET legal_name = $2 `" + ` + ` + "`WHERE id
 func write(tx T) { tx.Exec(ctx, held) }`,
 			judged: true,
 		}, {
+			// The same defect one line lower, and the shape five functions in
+			// this tree already write: a `+` chain assembled at the call site
+			// rather than at package level. Folding only the hoisted spelling
+			// would have fixed one half of one shape.
+			name: "assembled in the body from two literals",
+			source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 `" + ` + ` + "`WHERE id = $1`" + `) }`,
+			judged: true,
+		}, {
+			name: "assembled in the body around a helper's output",
+			source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1 AND `" + ` + extra()) }`,
+			judged: true,
+		}, {
 			// The direction that MISSES a writer is the dangerous one, but this
 			// is the direction that invents one: a local of the same name is
 			// not the package's value, and crediting it would attribute a
@@ -122,6 +136,48 @@ func write(tx T) { held := held; tx.Exec(ctx, held) }`,
 			source: `package p
 var held = ` + "`" + marker + "`" + `
 func write(tx T, held string) { tx.Exec(ctx, held) }`,
+			judged: false,
+		}, {
+			// A range clause declares its own variables rather than through an
+			// assignment below it, so a reader that only opened the scope would
+			// leave them out of it and read every loop body as the package's.
+			name: "a range value shadowing the package name",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T, rows []string) { for _, held := range rows { tx.Exec(ctx, held) } }`,
+			judged: false,
+		}, {
+			name: "a range key shadowing the package name",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T, rows map[string]int) { for held := range rows { tx.Exec(ctx, held) } }`,
+			judged: false,
+		}, {
+			// The range EXPRESSION stands outside the loop's own scope, so a
+			// package statement ranged over is still the package's.
+			name: "the package value ranged over",
+			source: `package p
+var held = []string{` + "`" + marker + "`" + `}
+func write(tx T) { for _, q := range held { tx.Exec(ctx, q) } }`,
+			judged: true,
+		}, {
+			// Three identifiers that are not variable references at all. Each
+			// would be looked up in the package's statements by a reader that
+			// treated every ast.Ident alike, and each would credit a function
+			// that sends nothing — a finding that teaches the next author to
+			// distrust this census.
+			name: "a struct field, a label and a selector spelled like the package name",
+			source: `package p
+type row struct{ held string }
+var held = ` + "`" + marker + "`" + `
+func write(tx T, v row) {
+held:
+	for {
+		_ = row{held: "SELECT 1"}
+		_ = v.held
+		break held
+	}
+}`,
 			judged: false,
 		}, {
 			name: "a package-level name this function never mentions",

--- a/backend/updateguardcases_test.go
+++ b/backend/updateguardcases_test.go
@@ -81,6 +81,49 @@ var held = ` + "`" + marker + "`" + `
 func write(tx T) { held := "SELECT 1"; tx.Exec(ctx, held) }`,
 			judged: false,
 		}, {
+			// A whole-function shadow set answers this one wrong, and wrong in
+			// the silent direction: the send is the package's statement, and a
+			// local declared in a branch that does not contain it says nothing
+			// about it. Go scopes the inner name to the inner block, and so
+			// does the reader.
+			name: "a local shadowing inside a branch the send is not in",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T, cond bool) {
+	tx.Exec(ctx, held)
+	if cond {
+		held := "SELECT 1"
+		tx.Exec(ctx, held)
+	}
+}`,
+			judged: true,
+		}, {
+			name: "a send inside the branch that shadows, and nowhere else",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T, cond bool) {
+	if cond {
+		held := "SELECT 1"
+		tx.Exec(ctx, held)
+	}
+}`,
+			judged: false,
+		}, {
+			// The right-hand side stands before the declaration it feeds, so
+			// this reads the package's statement and then sends it under a
+			// local name.
+			name: "a local initialised from the package value it shadows",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T) { held := held; tx.Exec(ctx, held) }`,
+			judged: true,
+		}, {
+			name: "a parameter shadowing the package name",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T, held string) { tx.Exec(ctx, held) }`,
+			judged: false,
+		}, {
 			name: "a package-level name this function never mentions",
 			source: `package p
 var held = ` + "`" + marker + "`" + `

--- a/backend/updateguardcases_test.go
+++ b/backend/updateguardcases_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind falsification H2
+
+package backendarch
+
+// What the concurrency-guard census judges a function on, driven with SYNTHETIC
+// source rather than the tree — the same reason retainedcolumncases_test.go
+// gives for its own cases. That census is supposed to pass, so a reader proven
+// only by "the tree is clean" is one that keeps passing after it stops working:
+// a statement it stops seeing produces no finding, only a smaller silence.
+//
+// The MISSED rows below are shapes the reader could not see before the
+// package-level folding was added. Every one of them was green while an
+// unguarded by-id UPDATE ran, because the statement was held one identifier
+// away from the function that sent it. Rule 8 asks what shape of the defect a
+// gate cannot see and says to plant that case; this is that list.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor(t *testing.T) {
+	const marker = `UPDATE organization SET legal_name = $2 WHERE id = $1`
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		judged bool
+	}{
+		{
+			name: "written in the body, which is the shape the census always saw",
+			source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`" + marker + "`" + `) }`,
+			judged: true,
+		}, {
+			// The shape the tree already wrote: coldStartColumns and
+			// companyFields held eight organization writes between them, and
+			// the function that sent each one named a table rather than a
+			// statement.
+			name: "held in a package-level table the function indexes",
+			source: `package p
+var held = map[string]string{"legal_name": ` + "`" + marker + "`" + `}
+func write(tx T, column string) { tx.Exec(ctx, held[column]) }`,
+			judged: true,
+		}, {
+			name: "held in a package-level table of structs",
+			source: `package p
+type spec struct{ update string }
+var held = []spec{{update: ` + "`" + marker + "`" + `}}
+func write(tx T) { tx.Exec(ctx, held[0].update) }`,
+			judged: true,
+		}, {
+			name: "held in a package-level const the function names",
+			source: `package p
+const held = ` + "`" + marker + "`" + `
+func write(tx T) { tx.Exec(ctx, held) }`,
+			judged: true,
+		}, {
+			// Neither half carries the statement: the first has no WHERE, the
+			// second no SET. A reader that kept only the parts saw two
+			// fragments and matched neither.
+			name: "assembled at package level from two literals",
+			source: `package p
+var held = ` + "`UPDATE organization SET legal_name = $2 `" + ` + ` + "`WHERE id = $1`" + `
+func write(tx T) { tx.Exec(ctx, held) }`,
+			judged: true,
+		}, {
+			// The direction that MISSES a writer is the dangerous one, but this
+			// is the direction that invents one: a local of the same name is
+			// not the package's value, and crediting it would attribute a
+			// statement to a function that never sends it.
+			name: "a local shadowing the package name",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T) { held := "SELECT 1"; tx.Exec(ctx, held) }`,
+			judged: false,
+		}, {
+			name: "a package-level name this function never mentions",
+			source: `package p
+var held = ` + "`" + marker + "`" + `
+func write(tx T) { tx.Exec(ctx, "SELECT 1") }`,
+			judged: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "synthetic.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the case source: %v", err)
+			}
+			held := packageLevelStatements([]*ast.File{file})
+			var fn *ast.FuncDecl
+			for _, decl := range file.Decls {
+				if candidate, isFunc := decl.(*ast.FuncDecl); isFunc && candidate.Name.Name == "write" {
+					fn = candidate
+				}
+			}
+			if fn == nil {
+				t.Fatal("the case source declares no write function, so it proves nothing")
+			}
+
+			seen := false
+			for _, statement := range statementsJudged(fn, held) {
+				if strings.Contains(statement, "SET legal_name") && strings.Contains(statement, "WHERE id =") {
+					seen = true
+				}
+			}
+			if seen != tc.judged {
+				t.Errorf("statementsJudged saw the write = %t, want %t — a statement the census does not "+
+					"judge is one it reports PASS over rather than reporting a gap in", seen, tc.judged)
+			}
+		})
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -192,7 +192,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooklength_test.go` | H3 | A rulebook is read in full by every session and, for its Craftsmanship section, by every gate prompt — so its length is a running cost rather than a matter of taste. |
 | `workflowtimeouts_test.go` | H3 | Every workflow job carries a wall-clock ceiling. |
 
-## Falsification (5)
+## Falsification (6)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -201,3 +201,4 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobkindgate_test.go` | H2 | The registration gate's own falsification. |
 | `rbacbaselineerafixture_test.go` | H3 | The pre-state the RBAC composition gate replays over must not be hand-editable. |
 | `retainedcolumncases_test.go` | H1 | The retained-column check, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
+| `updateguardcases_test.go` | H2 | What the concurrency-guard census judges a function on, driven with SYNTHETIC source rather than the tree — the same reason retainedcolumncases\_test.go gives for its own cases. |


### PR DESCRIPTION
## The defect

`TestEveryByIDUpdateCarriesAConcurrencyGuard` reads SQL literals out of
**function bodies**, and it has to: the guard it asks for — a version pin, a
held row lock, a `RowsAffected` compare-and-set — belongs to the function that
sends the statement, not to the statement.

So a statement held in a package-level table fell outside the census
altogether. Not reported as a gap. It read a smaller tree and passed, which is
the one failure a census must not have.

Eight organization writes were sitting in that difference, held between
`coldStartColumns` and `companyFields`:

```
internal/modules/people/coldstartprofile.go:266  UPDATE organization SET legal_name   = $2 WHERE id = $1 ...
internal/modules/people/coldstartprofile.go:267  UPDATE organization SET industry     = $2 WHERE id = $1 ...
internal/modules/people/coldstartprofile.go:270  UPDATE organization SET address_line1= $2 WHERE id = $1 ...
internal/modules/people/coldstartprofile.go:280  UPDATE organization SET description  = $2 WHERE id = $1 ...
internal/modules/people/company.go:97/99/105/107 (the same four, from the form)
```

They were the **only** package-level by-id UPDATEs of a versioned table under
`internal/` — which is how a blind spot this narrow stays invisible.

## The fix

The reader now folds package-level statements into whoever names them, through
`packageLevelStatements` — the reading `orgrenamerecheck_test.go` already used.
A census whose reader is narrower than its sibling's reports a clean tree over
what the sibling can see, and this one had stayed narrower.

**`statementsJudged`** — a function answers for the literals in its own body
plus the package-level statements it names, minus any name it declares itself.
Extracted rather than inlined so it can be driven with synthetic source.

**`packageLevelStatements`** now records a `+`-assembled statement's folded
whole *beside* its parts. Neither half of ``` `UPDATE x SET a = $1 ` + `WHERE id = $2` ```
carries the statement, so a census matching a shape saw nothing in either.
Both readings are kept — adding one can only widen what a consumer sees, and
under-recognition is what passes silently.

**`updateguardcases_test.go`** drives the reader with synthetic packages: the
four hoisted shapes it could not see before (a map indexed by column, a slice
of structs, a bare const, a `+`-assembled value) and the two it must still
decline (a local shadowing the package name; a name the function never
mentions). That census is supposed to pass, so a reader proven only by "the
tree is clean" is one that keeps passing after it stops working.

## One ratified exception falls out

`writeCompanyFields` names `companyFields` and hands each statement to
`setCompanyColumn`, which answers on `RowsAffected` — the CAS this gate asks
for, one frame down and out of a function-scoped witness's reach. The write is
not read-modify-write besides, and `SaveCompany` serializes concurrent form
saves on the workspace row.

The rationale says so rather than the reader excusing the shape: a reader
taught to excuse it would excuse the writers that *do* need judging along with
it.

## Verified by mutation

Each of these was applied to the tree and confirmed to make the census fail,
then reverted:

| Mutation | Result |
|---|---|
| drop `RowsAffected` from `applyUnclaimedOrgColumn` (reads `coldStartColumns`) | FAIL — the case the widening exists for; **silent before this change** |
| drop `RowsAffected` from `setCompanyColumn` | FAIL |
| add an unguarded package-level `UPDATE organization ... WHERE id = $1` | FAIL |
| the shadowing and never-mentioned cases | decline, as the cases assert |

## Scope

Test-only. No production code changes.

- `make check-backend` — exit 0
- `craft static --strict` on the three changed Go files — 0 findings
- `docs/reference/gate-inventory.md` regenerated for the new gate file

## Provenance

Found while attempting ruling 7 of #2145 — merging the three near-identical
organization-column statement lists. That merge is **refused** for a separate
reason, recorded on #2145: two other censuses attribute a statement to the
function that *names* it, so consolidating three writers behind one resolver
collapses the writer population they count. This PR is the defect the attempt
uncovered from the other side.

Refs #2145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguard analysis for SQL assembled incrementally, defined at package level, or imported from other packages.
  * Reduced incorrect findings involving shadowed variables, range variables, selectors, labels, branches, and declarations.
  * Added minimum coverage enforcement and clarified approved exceptions.

* **Tests**
  * Expanded coverage for direct and indirectly defined SQL statements and complex lexical scopes.

* **Documentation**
  * Updated the gate inventory and clarified company-field update behavior, including replacement and fill-only semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->