### PR TITLE
fix(ci): the dco main baseline names the newest unsigned squash

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -312,7 +312,7 @@ jobs:
           # everything after it is in range and it is not, which is exactly the
           # boundary. It moves to the unsigned commit's own parent once that
           # commit is remediated by its author.
-          DCO_MAIN_BASELINE: ab64ef038
+          DCO_MAIN_BASELINE: 85bd56dc1
         # The ancestry is asserted before the range is used, because
         # `git rev-list A..B` does not complain when A is not behind B — it
         # answers with whatever that range happens to mean. A baseline that has


### PR DESCRIPTION
main-health's \`dco (main)\` job has been red since the squash of #2728 landed on main without a \`Signed-off-by\` trailer. Two more unsigned squashes followed: #2745 and #2680 (\`85bd56dc1\`, the current tip at the time of this fix).

The gate's documented boundary for an unsigned commit is the baseline itself: \`DCO_MAIN_BASELINE\` moves from \`ab64ef038\` to \`85bd56dc1\`, so everything after it is covered again. Verified locally: \`./scripts/check-dco.sh 85bd56dc1 HEAD\` reports all commits signed off, and the range above the new baseline was already clean.

Remediation, per the gate's rule that a sign-off is the author's alone to give:
- \`2736937c0\` (#2728) and \`cd388fa09\` (#2745) are mine — retroactive \`DCO-Remediation-Commit\` attestations are in this PR's commit message.
- \`85bd56dc1\` (#2680) is @luit-nfq's to attest — tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the main-branch compliance validation baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->