### PR TITLE
docs(changelog): the Unreleased link opens this repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,4 +569,4 @@ numbers appear here when releases start.
   without touching a committed file; the annotated template stays the
   parse-guarded source of truth.
 
-[Unreleased]: https://github.com/gradionhq/margince
+[Unreleased]: https://github.com/margince/margince


### PR DESCRIPTION
The `[Unreleased]` link definition at the foot of `CHANGELOG.md` pointed at
`gradionhq/margince` — an empty placeholder repository (zero bytes, never
pushed since it was created) that exists only to back the
`github.com/gradionhq/margince/...` Go module path. A reader following the
changelog’s one outbound link landed on nothing.

The repository-wide rename to `margince/margince` reached every other outbound
link — 43 of them, plus the SonarCloud project key — and missed this one
because it is the sole reference with no `-poc-v1` segment to match on.

## Left deliberately

Each of these still contains `gradionhq` or `margince-poc-v1`, and each is
correct as it stands:

| Location | Why it stays |
|---|---|
| `.grant.yaml`, `.syft.yaml`, `docs/reference/supply-chain.md` | `github.com/gradionhq/margince/*` globs that mirror `go.mod`. The module path is module identity, not a repo link; changing it is a breaking refactor across ~10.9k references. |
| `infra/docker-compose.dev.yml` (`name: margince-poc-v1`) and `scripts/migration-baseline.sh` (`margince-poc-v1-postgres-1`) | A coupled Docker Compose project namespace, not a reference to the repo. Renaming it orphans every engineer’s existing local volumes and buys nothing. |
| `backend/api/ai-tasks.yaml:3` | Ratification provenance — a historical record of what was ratified where, not a link a reader follows. |

## Verification

- `TestPublicTreeCitesNothingPrivate` — PASS
- `git grep` for `github.com/gradionhq/margince$` and `github.com/gradionhq/margince-poc-v1` — no residue
- Every remaining `https://github.com/…` repo URL in the tree now resolves to `margince/margince`

Related: private vulnerability reporting has been enabled on this repository,
so the reporting path [SECURITY.md](SECURITY.md) documents now works for
contributors who are not repo admins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Unreleased changelog link to point to the correct project repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->