### PR TITLE
feat(agents): account_coverage names the stakeholder it flags

### DIFF
--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -223,12 +223,21 @@ func TestCoverageNamesItsColleaguesForTheAgent(t *testing.T) {
 		t.Fatalf("seeding the deal: %v", err)
 	}
 
-	answer, err := coverageReader(e.Pool)(e.Admin(), dealID)
+	answer, err := coverageReader(e.Pool, people.NewStore(InstallationDB(e.Pool)))(e.Admin(), dealID)
 	if err != nil {
 		t.Fatalf("coverage seam: %v", err)
 	}
 	if len(answer.OurSide) == 0 {
 		t.Fatal("coverage named no colleagues though one exchanged mail with the stakeholder")
+	}
+	// And the stakeholder is NAMED, against a real person row and a real
+	// gate. The unit tests hand toAgentCoverage a prepared map; only this one
+	// proves PersonNamesTx is actually reached and actually answers.
+	if len(answer.Stakeholders) == 0 {
+		t.Fatal("coverage seated no stakeholder though one was captured")
+	}
+	if answer.Stakeholders[0].PersonName == "" {
+		t.Error("the stakeholder came back as a bare uuid — a rep cannot act on an id")
 	}
 	// A bare id leaves a model unable to say who to ask, which is the only
 	// reason it asked.

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -237,7 +237,7 @@ const atRiskScanLimit = 25
 // sweep sees precisely the book the caller sees. Deals are assessed in the
 // order that list returns them, and the sweep stops at the cap rather than
 // sampling: a deterministic prefix can be explained to a rep, a sample cannot.
-func atRiskLister(pool *pgxpool.Pool) agents.AtRiskLister {
+func atRiskLister(pool *pgxpool.Pool, ppl *people.Store) agents.AtRiskLister {
 	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
 	return func(ctx context.Context) (agents.AtRiskReport, error) {
 		var out agents.AtRiskReport
@@ -274,10 +274,57 @@ func atRiskLister(pool *pgxpool.Pool) agents.AtRiskLister {
 				case dealNoFinding:
 				}
 			}
-			return nil
+			// The findings are named ONCE for the whole sweep, not once per
+			// deal. A first cut left this surface unnamed on a cost argument —
+			// twenty-five deals, one gated person read each — but the ids can
+			// simply be collected across every finding and resolved in a
+			// single batched read, so the cost was never twenty-five reads. It
+			// matters because the SAME CoverageRisk shape is named under
+			// account_coverage: a model seeing names on one tool and bare ids
+			// on the other reads the absence as "withheld" rather than "not
+			// looked up".
+			return nameSweepFindings(ctx, tx, ppl, out.Deals)
 		})
 		return out, err
 	}
+}
+
+// nameSweepFindings names the people every finding in the sweep is about, in
+// one read.
+//
+// Same gate as the coverage read: people.PersonNamesTx carries the person
+// object check as well as the row scope, and a caller who may read the deals
+// but not people gets the findings unnamed rather than no findings — the
+// findings are about the DEALS.
+func nameSweepFindings(ctx context.Context, tx pgx.Tx, ppl *people.Store, flagged []agents.AtRiskDeal) error {
+	seen := map[ids.UUID]bool{}
+	wanted := make([]ids.PersonID, 0)
+	for _, d := range flagged {
+		for _, r := range d.Risks {
+			for _, id := range r.PersonIDs {
+				if !seen[id] {
+					seen[id] = true
+					wanted = append(wanted, ids.From[ids.PersonKind](id))
+				}
+			}
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	names, err := ppl.PersonNamesTx(ctx, tx, wanted)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return nil
+		}
+		return err
+	}
+	for i, d := range flagged {
+		for j, r := range d.Risks {
+			flagged[i].Risks[j].People = namedPeople(r.PersonIDs, names)
+		}
+	}
+	return nil
 }
 
 // dealAssessment is what the sweep learned about one deal.
@@ -326,11 +373,9 @@ func dealAtRisk(ctx context.Context, tx pgx.Tx, d crmcontracts.Deal, now time.Ti
 	if len(coverage.Risks) == 0 {
 		return agents.AtRiskDeal{}, dealNoFinding, nil
 	}
-	// No stakeholder names on the SWEEP. It assesses up to atRiskScanLimit
-	// deals, so naming them would be one gated person read per deal to answer
-	// a question the list does not ask — which deals are at risk, not who sits
-	// on each. A caller who wants the names calls account_coverage on the one
-	// deal they picked, and that read names them.
+	// Unnamed HERE and named by the caller: nameSweepFindings resolves every
+	// finding's people in one read once the sweep is done, rather than each
+	// deal paying for its own.
 	return agents.AtRiskDeal{
 		DealID: ids.UUID(d.Id), Name: d.Name, Risks: toAgentRisks(coverage.Risks, nil),
 	}, dealFlagged, nil

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -326,7 +326,12 @@ func dealAtRisk(ctx context.Context, tx pgx.Tx, d crmcontracts.Deal, now time.Ti
 	if len(coverage.Risks) == 0 {
 		return agents.AtRiskDeal{}, dealNoFinding, nil
 	}
+	// No stakeholder names on the SWEEP. It assesses up to atRiskScanLimit
+	// deals, so naming them would be one gated person read per deal to answer
+	// a question the list does not ask — which deals are at risk, not who sits
+	// on each. A caller who wants the names calls account_coverage on the one
+	// deal they picked, and that read names them.
 	return agents.AtRiskDeal{
-		DealID: ids.UUID(d.Id), Name: d.Name, Risks: toAgentRisks(coverage.Risks),
+		DealID: ids.UUID(d.Id), Name: d.Name, Risks: toAgentRisks(coverage.Risks, nil),
 	}, dealFlagged, nil
 }

--- a/backend/internal/compose/networkseams.go
+++ b/backend/internal/compose/networkseams.go
@@ -12,6 +12,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -19,9 +20,11 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/network"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
@@ -106,7 +109,7 @@ const agentWhoKnowsCap = 10
 const agentWhoKnowsFetch = 100
 
 // coverageReader answers "how is this deal covered" for the tool surface.
-func coverageReader(pool *pgxpool.Pool) agents.CoverageReader {
+func coverageReader(pool *pgxpool.Pool, ppl *people.Store) agents.CoverageReader {
 	return func(ctx context.Context, dealID ids.UUID) (agents.DealCoverageAnswer, error) {
 		var out agents.DealCoverageAnswer
 		err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
@@ -127,14 +130,23 @@ func coverageReader(pool *pgxpool.Pool) agents.CoverageReader {
 			if err != nil {
 				return err
 			}
-			out = toAgentCoverage(coverage, names)
+			// And the same for THEIR side, which the argument above applies to
+			// at least as strongly: the tool's whole question is which named
+			// human is missing from the deal. The HTTP surface has named its
+			// stakeholders since this read existed (`person_name` in the
+			// contract); only the tool shape was left with bare ids.
+			seated, err := coveragePersonNames(ctx, tx, ppl, coverage)
+			if err != nil {
+				return err
+			}
+			out = toAgentCoverage(coverage, names, seated)
 			return nil
 		})
 		return out, err
 	}
 }
 
-func toAgentCoverage(c network.DealCoverage, names map[ids.UUID]string) agents.DealCoverageAnswer {
+func toAgentCoverage(c network.DealCoverage, names, seated map[ids.UUID]string) agents.DealCoverageAnswer {
 	// Both collections start EMPTY, never nil: a deal with no stakeholder seat
 	// and nobody on our side is the answer that says the deal is uncovered, and
 	// it is the answer a rep most needs. Marshalled from a nil slice it reaches a
@@ -154,7 +166,8 @@ func toAgentCoverage(c network.DealCoverage, names map[ids.UUID]string) agents.D
 	}
 	for _, s := range c.Stakeholders {
 		out.Stakeholders = append(out.Stakeholders, agents.CoverageSeat{
-			PersonID: s.PersonID, Role: s.Role, Engaged: s.Engaged,
+			PersonID: s.PersonID, PersonName: seated[s.PersonID],
+			Role: s.Role, Engaged: s.Engaged,
 		})
 	}
 	for _, e := range c.OurSide {
@@ -168,18 +181,19 @@ func toAgentCoverage(c network.DealCoverage, names map[ids.UUID]string) agents.D
 		}
 		out.OurSide = append(out.OurSide, colleague)
 	}
-	out.Risks = toAgentRisks(c.Risks)
+	out.Risks = toAgentRisks(c.Risks, seated)
 	return out
 }
 
 // toAgentRisks maps the findings onto the tool shape. Spelled once because two
 // tools return risks — the coverage read and the at-risk sweep — and a second
 // copy would be a second place for the day-count rule below to be wrong.
-func toAgentRisks(risks []network.Risk) []agents.CoverageRisk {
+func toAgentRisks(risks []network.Risk, seated map[ids.UUID]string) []agents.CoverageRisk {
 	out := make([]agents.CoverageRisk, 0, len(risks))
 	for _, r := range risks {
 		risk := agents.CoverageRisk{
 			Kind: r.Kind, Summary: r.Summary, PersonIDs: r.PersonIDs, UserIDs: r.UserIDs,
+			PersonNames: namedPeople(r.PersonIDs, seated),
 		}
 		// Only going-cold carries a day count; a zero on the others would read
 		// as "touched today", which is the opposite of what a departure finding
@@ -213,6 +227,61 @@ func requireVisibleDeal(ctx context.Context, tx pgx.Tx, dealID ids.UUID) error {
 
 // coverageUserNames resolves the display names for a coverage answer's
 // colleagues.
+// coveragePersonNames names the stakeholders on a coverage payload.
+//
+// It delegates to people.PersonNamesTx rather than reading `person` here, for
+// the reason network.seatNames states about its own copy: PersonNamesTx
+// carries BOTH halves of the gate — the person object check and the row-scope
+// clause — and a second copy of that read is a second place for one half to go
+// missing. It went missing on the HTTP side once already, as a local query
+// with the row scope and no object gate, which named a deal's contacts to a
+// caller holding deal:read without person:read.
+//
+// A caller who may read the deal but not people gets their coverage with the
+// seats unnamed rather than no coverage at all: the findings are about the
+// DEAL, and taking them away to withhold a name withholds the wrong thing.
+func coveragePersonNames(ctx context.Context, tx pgx.Tx, ppl *people.Store, c network.DealCoverage) (map[ids.UUID]string, error) {
+	if len(c.Stakeholders) == 0 {
+		return map[ids.UUID]string{}, nil
+	}
+	seated := make([]ids.PersonID, 0, len(c.Stakeholders))
+	for _, s := range c.Stakeholders {
+		seated = append(seated, ids.From[ids.PersonKind](s.PersonID))
+	}
+	names, err := ppl.PersonNamesTx(ctx, tx, seated)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return map[ids.UUID]string{}, nil
+		}
+		return nil, err
+	}
+	return names, nil
+}
+
+// namedPeople is the names a finding can put in a sentence, for the people it
+// names that the caller may read.
+//
+// A person with no name resolved is SKIPPED rather than rendered as an empty
+// string: a finding reading "the deal rests on one relationship: ”" is worse
+// than one that names nobody, and the ids are still there to look up. The
+// result is deliberately not positionally paired with PersonIDs — see the
+// field's own comment.
+func namedPeople(people []ids.UUID, seated map[ids.UUID]string) []string {
+	if len(people) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(people))
+	for _, id := range people {
+		if name := seated[id]; name != "" {
+			out = append(out, name)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func coverageUserNames(ctx context.Context, tx pgx.Tx, c network.DealCoverage) (map[ids.UUID]string, error) {
 	edges := make([]search.InteractionEdge, 0, len(c.OurSide))
 	for _, e := range c.OurSide {

--- a/backend/internal/compose/networkseams.go
+++ b/backend/internal/compose/networkseams.go
@@ -193,7 +193,7 @@ func toAgentRisks(risks []network.Risk, seated map[ids.UUID]string) []agents.Cov
 	for _, r := range risks {
 		risk := agents.CoverageRisk{
 			Kind: r.Kind, Summary: r.Summary, PersonIDs: r.PersonIDs, UserIDs: r.UserIDs,
-			PersonNames: namedPeople(r.PersonIDs, seated),
+			People: namedPeople(r.PersonIDs, seated),
 		}
 		// Only going-cold carries a day count; a zero on the others would read
 		// as "touched today", which is the opposite of what a departure finding
@@ -237,9 +237,12 @@ func requireVisibleDeal(ctx context.Context, tx pgx.Tx, dealID ids.UUID) error {
 // with the row scope and no object gate, which named a deal's contacts to a
 // caller holding deal:read without person:read.
 //
-// A caller who may read the deal but not people gets their coverage with the
-// seats unnamed rather than no coverage at all: the findings are about the
-// DEAL, and taking them away to withhold a name withholds the wrong thing.
+// The ErrPermissionDenied fallback below is defence in depth rather than a
+// live path: a caller without person:read is already refused upstream, by
+// deals.Stakeholders, and never reaches a payload to name. Swallowing it here
+// means a future change that softened that refusal would ship unnamed seats
+// rather than a failed read — the safe direction. Every other error still
+// propagates.
 func coveragePersonNames(ctx context.Context, tx pgx.Tx, ppl *people.Store, c network.DealCoverage) (map[ids.UUID]string, error) {
 	if len(c.Stakeholders) == 0 {
 		return map[ids.UUID]string{}, nil
@@ -266,14 +269,22 @@ func coveragePersonNames(ctx context.Context, tx pgx.Tx, ppl *people.Store, c ne
 // than one that names nobody, and the ids are still there to look up. The
 // result is deliberately not positionally paired with PersonIDs — see the
 // field's own comment.
-func namedPeople(people []ids.UUID, seated map[ids.UUID]string) []string {
+// namedPeople is the people a finding can put in a sentence, each id carrying
+// its own name.
+//
+// A person with no name resolved is SKIPPED rather than shipped with an empty
+// name: "the deal rests on one relationship: ”" is worse than naming nobody,
+// and CoverageRisk.PersonIDs still carries every id to look up. Because each
+// name travels WITH its id, skipping one cannot shift another — which is the
+// whole reason this returns objects rather than a second array.
+func namedPeople(people []ids.UUID, seated map[ids.UUID]string) []agents.FindingPerson {
 	if len(people) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(people))
+	out := make([]agents.FindingPerson, 0, len(people))
 	for _, id := range people {
 		if name := seated[id]; name != "" {
-			out = append(out, name)
+			out = append(out, agents.FindingPerson{PersonID: id, Name: name})
 		}
 	}
 	if len(out) == 0 {

--- a/backend/internal/compose/networkseams_test.go
+++ b/backend/internal/compose/networkseams_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/network"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -22,7 +23,7 @@ import (
 // handed `null` reads it as "unknown" and hedges. Every sibling read on this
 // surface normalizes; found by UAT on the one that did not.
 func TestAnUncoveredDealAnswersEmptyArraysNotNulls(t *testing.T) {
-	answer := toAgentCoverage(network.DealCoverage{DealID: ids.NewV7()}, nil)
+	answer := toAgentCoverage(network.DealCoverage{DealID: ids.NewV7()}, nil, nil)
 
 	raw, err := json.Marshal(answer)
 	if err != nil {
@@ -33,5 +34,108 @@ func TestAnUncoveredDealAnswersEmptyArraysNotNulls(t *testing.T) {
 			t.Errorf("payload = %s, want %s — a null reads to a model as \"unknown\", which is a "+
 				"different claim from \"nobody\"", raw, member)
 		}
+	}
+}
+
+// A stakeholder is NAMED, not left as a uuid.
+//
+// The tool's whole question is which named human is missing from a deal. A seat
+// reading "economic_buyer, engaged: false" against a bare uuid has not answered
+// it — a rep cannot act on an id, and a model cannot put one in a sentence.
+// Found reviewing case 5 on real data, where account_coverage reported a
+// disengaged economic buyer and never said Athina Kanioura.
+func TestAStakeholderSeatCarriesTheirName(t *testing.T) {
+	athina, jim := ids.NewV7(), ids.NewV7()
+	answer := toAgentCoverage(network.DealCoverage{
+		DealID: ids.NewV7(),
+		Stakeholders: []deals.DealStakeholder{
+			{PersonID: athina, Role: "economic_buyer", Engaged: false},
+			{PersonID: jim, Role: "champion", Engaged: true},
+		},
+	}, nil, map[ids.UUID]string{athina: "Athina Kanioura", jim: "Jim Roth"})
+
+	if len(answer.Stakeholders) != 2 {
+		t.Fatalf("seated %d stakeholders, want 2", len(answer.Stakeholders))
+	}
+	if answer.Stakeholders[0].PersonName != "Athina Kanioura" {
+		t.Errorf("the economic buyer is unnamed: %+v", answer.Stakeholders[0])
+	}
+	if answer.Stakeholders[0].PersonID != athina {
+		t.Error("naming a seat lost its id, which is the handle for a follow-up read")
+	}
+}
+
+// A person the caller may not read keeps their SEAT and loses only their name.
+//
+// Dropping the seat would hide that the deal has an economic buyer at all,
+// which is the opposite of what a coverage answer is for: how many people carry
+// a deal is not the secret, only who they are.
+func TestAnUnreadablePersonKeepsTheirSeat(t *testing.T) {
+	hidden := ids.NewV7()
+	answer := toAgentCoverage(network.DealCoverage{
+		DealID:       ids.NewV7(),
+		Stakeholders: []deals.DealStakeholder{{PersonID: hidden, Role: "economic_buyer"}},
+	}, nil, map[ids.UUID]string{})
+
+	if len(answer.Stakeholders) != 1 {
+		t.Fatalf("a seat vanished with its name: %+v", answer.Stakeholders)
+	}
+	if answer.Stakeholders[0].PersonName != "" {
+		t.Errorf("a name was invented for an unreadable person: %q", answer.Stakeholders[0].PersonName)
+	}
+	if answer.Stakeholders[0].Role != "economic_buyer" {
+		t.Error("the role was lost, so the gap is no longer legible")
+	}
+}
+
+// A finding names the people it is about, so the sentence a model writes has a
+// person in it rather than a uuid.
+func TestAFindingNamesThePeopleItIsAbout(t *testing.T) {
+	jim := ids.NewV7()
+	risks := toAgentRisks([]network.Risk{{
+		Kind: "single_threaded_theirs", Summary: "the deal rests on one relationship",
+		PersonIDs: []ids.UUID{jim},
+	}}, map[ids.UUID]string{jim: "Jim Roth"})
+
+	if len(risks) != 1 {
+		t.Fatalf("mapped %d risks, want 1", len(risks))
+	}
+	if len(risks[0].PersonNames) != 1 || risks[0].PersonNames[0] != "Jim Roth" {
+		t.Errorf("the finding names nobody: %+v", risks[0])
+	}
+	if len(risks[0].PersonIDs) != 1 {
+		t.Error("naming lost the ids, which stay the handle")
+	}
+}
+
+// The names on a finding are a SET, never a parallel array.
+//
+// A private contact resolves to no name, so pairing the two lists by index
+// would attach the wrong person's name to the wrong id the first time that
+// happens — silently, and in a sentence a rep then repeats.
+func TestFindingNamesAreNotPositionallyPairedWithIDs(t *testing.T) {
+	hidden, jim := ids.NewV7(), ids.NewV7()
+	risks := toAgentRisks([]network.Risk{{
+		Kind: "single_threaded_theirs", Summary: "the deal rests on one relationship",
+		PersonIDs: []ids.UUID{hidden, jim},
+	}}, map[ids.UUID]string{jim: "Jim Roth"})
+
+	if len(risks[0].PersonIDs) != 2 {
+		t.Fatalf("an id was dropped: %+v", risks[0].PersonIDs)
+	}
+	if len(risks[0].PersonNames) != 1 || risks[0].PersonNames[0] != "Jim Roth" {
+		t.Fatalf("names %+v — the readable person must be named and the hidden one skipped",
+			risks[0].PersonNames)
+	}
+}
+
+// No name resolved at all omits the field rather than shipping [""].
+func TestAFindingWithNoReadableNamesOmitsThem(t *testing.T) {
+	risks := toAgentRisks([]network.Risk{{
+		Kind: "going_cold", Summary: "nobody is talking", PersonIDs: []ids.UUID{ids.NewV7()},
+	}}, map[ids.UUID]string{})
+
+	if risks[0].PersonNames != nil {
+		t.Errorf("empty names shipped as %+v rather than being omitted", risks[0].PersonNames)
 	}
 }

--- a/backend/internal/compose/networkseams_test.go
+++ b/backend/internal/compose/networkseams_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/network"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -65,23 +66,26 @@ func TestAStakeholderSeatCarriesTheirName(t *testing.T) {
 	}
 }
 
-// A person the caller may not read keeps their SEAT and loses only their name.
+// A seat whose name did not resolve keeps its seat and its role.
 //
-// Dropping the seat would hide that the deal has an economic buyer at all,
-// which is the opposite of what a coverage answer is for: how many people carry
-// a deal is not the secret, only who they are.
-func TestAnUnreadablePersonKeepsTheirSeat(t *testing.T) {
-	hidden := ids.NewV7()
+// This is the MAPPING's contract, not a privacy claim: the integration test
+// TestCoverageWithoutPersonReadIsRefusedRatherThanUnnamed proves a caller who
+// may not read people gets no seats at all, refused upstream. What this pins
+// is that if a name is ever missing for an ordinary reason — a person row with
+// no full_name, a lookup that came back short — the seat still carries its
+// role, so the gap stays legible instead of vanishing.
+func TestASeatWithNoResolvedNameKeepsItsRole(t *testing.T) {
+	unnamed := ids.NewV7()
 	answer := toAgentCoverage(network.DealCoverage{
 		DealID:       ids.NewV7(),
-		Stakeholders: []deals.DealStakeholder{{PersonID: hidden, Role: "economic_buyer"}},
+		Stakeholders: []deals.DealStakeholder{{PersonID: unnamed, Role: "economic_buyer"}},
 	}, nil, map[ids.UUID]string{})
 
 	if len(answer.Stakeholders) != 1 {
 		t.Fatalf("a seat vanished with its name: %+v", answer.Stakeholders)
 	}
 	if answer.Stakeholders[0].PersonName != "" {
-		t.Errorf("a name was invented for an unreadable person: %q", answer.Stakeholders[0].PersonName)
+		t.Errorf("a name was invented: %q", answer.Stakeholders[0].PersonName)
 	}
 	if answer.Stakeholders[0].Role != "economic_buyer" {
 		t.Error("the role was lost, so the gap is no longer legible")
@@ -100,20 +104,26 @@ func TestAFindingNamesThePeopleItIsAbout(t *testing.T) {
 	if len(risks) != 1 {
 		t.Fatalf("mapped %d risks, want 1", len(risks))
 	}
-	if len(risks[0].PersonNames) != 1 || risks[0].PersonNames[0] != "Jim Roth" {
+	if len(risks[0].People) != 1 || risks[0].People[0].Name != "Jim Roth" {
 		t.Errorf("the finding names nobody: %+v", risks[0])
+	}
+	if risks[0].People[0].PersonID != jim {
+		t.Error("the name did not travel with its own id")
 	}
 	if len(risks[0].PersonIDs) != 1 {
 		t.Error("naming lost the ids, which stay the handle")
 	}
 }
 
-// The names on a finding are a SET, never a parallel array.
+// A name that did not resolve cannot shift another name onto the wrong person.
 //
-// A private contact resolves to no name, so pairing the two lists by index
-// would attach the wrong person's name to the wrong id the first time that
-// happens — silently, and in a sentence a rep then repeats.
-func TestFindingNamesAreNotPositionallyPairedWithIDs(t *testing.T) {
+// This is why the finding carries {person_id, name} objects rather than a
+// second array beside person_ids. Two arrays can diverge — a caller with
+// deal:read and no person:read has ids and no names, and the transaction is
+// Read Committed, so a person archived mid-read leaves one list shorter. A
+// consumer indexing across them would then repeat the wrong name in a
+// sentence. Codex found the isolation case; the shape makes it impossible.
+func TestAnUnresolvedNameCannotShiftOntoAnotherPerson(t *testing.T) {
 	hidden, jim := ids.NewV7(), ids.NewV7()
 	risks := toAgentRisks([]network.Risk{{
 		Kind: "single_threaded_theirs", Summary: "the deal rests on one relationship",
@@ -123,9 +133,14 @@ func TestFindingNamesAreNotPositionallyPairedWithIDs(t *testing.T) {
 	if len(risks[0].PersonIDs) != 2 {
 		t.Fatalf("an id was dropped: %+v", risks[0].PersonIDs)
 	}
-	if len(risks[0].PersonNames) != 1 || risks[0].PersonNames[0] != "Jim Roth" {
-		t.Fatalf("names %+v — the readable person must be named and the hidden one skipped",
-			risks[0].PersonNames)
+	if len(risks[0].People) != 1 {
+		t.Fatalf("people %+v — the readable person is named and the unreadable one skipped",
+			risks[0].People)
+	}
+	// The whole point: the surviving name is attached to ITS OWN id, not to
+	// the first id in the list.
+	if risks[0].People[0].PersonID != jim {
+		t.Errorf("Jim Roth's name landed on %v, which is somebody else", risks[0].People[0].PersonID)
 	}
 }
 
@@ -135,7 +150,48 @@ func TestAFindingWithNoReadableNamesOmitsThem(t *testing.T) {
 		Kind: "going_cold", Summary: "nobody is talking", PersonIDs: []ids.UUID{ids.NewV7()},
 	}}, map[ids.UUID]string{})
 
-	if risks[0].PersonNames != nil {
-		t.Errorf("empty names shipped as %+v rather than being omitted", risks[0].PersonNames)
+	if risks[0].People != nil {
+		t.Errorf("empty names shipped as %+v rather than being omitted", risks[0].People)
+	}
+}
+
+// The at-risk SWEEP names its findings too, in one read for the whole sweep.
+//
+// A first cut left this surface unnamed, arguing twenty-five deals meant
+// twenty-five gated person reads. Codex pointed out the ids can be collected
+// across every finding and resolved once — so the cost was never per deal, and
+// the inconsistency was real: the SAME CoverageRisk shape carried names under
+// account_coverage and bare ids here, which a model reads as "withheld" rather
+// than "not looked up".
+func TestTheSweepNamesEveryFindingInOneRead(t *testing.T) {
+	jim, athina := ids.NewV7(), ids.NewV7()
+	flagged := []agents.AtRiskDeal{
+		{DealID: ids.NewV7(), Name: "one", Risks: []agents.CoverageRisk{
+			{Kind: "single_threaded_theirs", PersonIDs: []ids.UUID{jim}},
+		}},
+		{DealID: ids.NewV7(), Name: "two", Risks: []agents.CoverageRisk{
+			{Kind: "going_cold", PersonIDs: []ids.UUID{athina, jim}},
+		}},
+	}
+	names := map[ids.UUID]string{jim: "Jim Roth", athina: "Athina Kanioura"}
+
+	// The mapping half, exercised directly: nameSweepFindings' own read needs a
+	// transaction, and what has to be right here is that EVERY finding across
+	// EVERY deal is named, not only the first.
+	for i, d := range flagged {
+		for j, r := range d.Risks {
+			flagged[i].Risks[j].People = namedPeople(r.PersonIDs, names)
+		}
+	}
+
+	if len(flagged[0].Risks[0].People) != 1 {
+		t.Fatalf("the first deal's finding is unnamed: %+v", flagged[0].Risks[0])
+	}
+	if len(flagged[1].Risks[0].People) != 2 {
+		t.Fatalf("the second deal's finding named %d of 2 people — a later deal was skipped",
+			len(flagged[1].Risks[0].People))
+	}
+	if flagged[1].Risks[0].People[0].Name != "Athina Kanioura" {
+		t.Errorf("names are attached in the wrong order: %+v", flagged[1].Risks[0].People)
 	}
 }

--- a/backend/internal/compose/networktools_integration_test.go
+++ b/backend/internal/compose/networktools_integration_test.go
@@ -16,6 +16,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -23,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -109,7 +111,7 @@ func TestTheAtRiskSweepReportsItsOwnReach(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	seedOpenDeal(t, e)
 
-	report, err := atRiskLister(e.Pool)(ctx)
+	report, err := atRiskLister(e.Pool, people.NewStore(InstallationDB(e.Pool)))(ctx)
 	if err != nil {
 		t.Fatalf("at-risk sweep: %v", err)
 	}
@@ -254,7 +256,7 @@ func TestTheAtRiskSweepSaysADealCouldNotBeAssessedRatherThanCallingItClean(t *te
 	e := integration.Setup(t)
 	seedOpenDeal(t, e)
 
-	granted, err := atRiskLister(e.Pool)(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms))
+	granted, err := atRiskLister(e.Pool, people.NewStore(InstallationDB(e.Pool)))(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms))
 	if err != nil {
 		t.Fatalf("the granted sweep: %v", err)
 	}
@@ -263,7 +265,7 @@ func TestTheAtRiskSweepSaysADealCouldNotBeAssessedRatherThanCallingItClean(t *te
 			"nothing about the denied caller", len(granted.Deals), granted.CoverageWithheld)
 	}
 
-	denied, err := atRiskLister(e.Pool)(e.As(e.Rep1, []ids.UUID{e.Team1}, coverageDeniedPerms()))
+	denied, err := atRiskLister(e.Pool, people.NewStore(InstallationDB(e.Pool)))(e.As(e.Rep1, []ids.UUID{e.Team1}, coverageDeniedPerms()))
 	if err != nil {
 		t.Fatalf("the denied sweep failed instead of reporting what it could not assess: %v", err)
 	}
@@ -314,4 +316,76 @@ func sectionNamed(ctx retrieval.Context, name string) *retrieval.Section {
 		}
 	}
 	return nil
+}
+
+// personDeniedPerms reads deals and their relationships but no people: the
+// caller who may see that a deal has an economic buyer and not who it is.
+func personDeniedPerms() principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"deal":         {Read: true},
+			"relationship": {Read: true},
+			"organization": {Read: true},
+			"activity":     {Read: true},
+		},
+		RowScope: principal.RowScopeAll,
+	}
+}
+
+// A caller who may read the deal but NOT people gets NO seats — not seats with
+// the names blanked.
+//
+// This is the boundary the naming touches, and asserting it is what stopped a
+// wrong claim shipping in the contract. The first version of CoverageSeat's
+// comment said an unreadable person's seat still ships and only its name is
+// withheld. It cannot: deals.Stakeholders carries the edge's own admission and
+// refuses before any row is read — "knowing a deal does not license learning
+// who sits on it" — so the seat, the uuid and the risks all go together, and
+// there is no state in which a seat exists with an empty name.
+//
+// The test therefore pins the REFUSAL, not a degraded payload. A future change
+// that started returning half-populated seats here would be a disclosure
+// regression wearing the shape of an improvement.
+func TestCoverageWithoutPersonReadIsRefusedRatherThanUnnamed(t *testing.T) {
+	e := integration.Setup(t)
+	dealID := seedOpenDeal(t, e)
+	ppl := people.NewStore(InstallationDB(e.Pool))
+
+	// seedOpenDeal seats nobody — it exists to test a THREADLESS deal — so this
+	// test seats its own stakeholder. Without one there is no name to lose and
+	// the granted assertion below would pass over an empty list.
+	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
+		var personID ids.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO person (full_name, source, captured_by)
+			VALUES ('Athina Kanioura', 'manual', 'human:test') RETURNING id`).Scan(&personID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+			VALUES ('deal_stakeholder', $1, $2, 'economic_buyer', 'manual', 'human:test')`,
+			personID, dealID)
+		return err
+	}, "seating an economic buyer")
+
+	// The granted caller first, so the fixture is proven to name somebody
+	// before the denied caller's silence is read as meaningful.
+	named, err := coverageReader(e.Pool, ppl)(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms), dealID)
+	if err != nil {
+		t.Fatalf("the granted coverage: %v", err)
+	}
+	if len(named.Stakeholders) == 0 {
+		t.Fatal("the fixture seats no stakeholder, so it proves nothing about the denied caller")
+	}
+	if named.Stakeholders[0].PersonName != "Athina Kanioura" {
+		t.Fatalf("the granted caller sees %q rather than the seated name — this is the naming "+
+			"the whole change is for", named.Stakeholders[0].PersonName)
+	}
+
+	_, err = coverageReader(e.Pool, ppl)(e.As(e.Rep1, []ids.UUID{e.Team1}, personDeniedPerms()), dealID)
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a caller without person:read got %v — the seats are an EDGE and the read is "+
+			"refused whole, so anything else here is a disclosure", err)
+	}
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -267,7 +267,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// change nothing.
 	agents.RegisterNetworkTools(registry, whoKnowsLister(pool), coverageReader(pool, people.NewStore(InstallationDB(pool))),
 		nativeOnlyIntroPath(sorMode, introPathLister(pool)),
-		nativeOnlyAtRisk(sorMode, atRiskLister(pool)))
+		nativeOnlyAtRisk(sorMode, atRiskLister(pool, people.NewStore(InstallationDB(pool)))))
 	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send), provider)
 	// The location check (🟢), and the verb the probe card hangs off. It reads
 	// no record and takes no seam, so it registers unconditionally.

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -264,7 +265,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// how a deal is covered, who can get us into an account, and which of the
 	// caller's deals the coverage rules flag. All 🟢 — they name people, they
 	// change nothing.
-	agents.RegisterNetworkTools(registry, whoKnowsLister(pool), coverageReader(pool),
+	agents.RegisterNetworkTools(registry, whoKnowsLister(pool), coverageReader(pool, people.NewStore(InstallationDB(pool))),
 		nativeOnlyIntroPath(sorMode, introPathLister(pool)),
 		nativeOnlyAtRisk(sorMode, atRiskLister(pool)))
 	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send), provider)

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -50,17 +50,30 @@
                 "kind": {
                   "type": "string"
                 },
+                "people": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "person_id": {
+                        "type": "string",
+                        "format": "uuid"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "person_id"
+                    ]
+                  }
+                },
                 "person_ids": {
                   "type": "array",
                   "items": {
                     "type": "string",
                     "format": "uuid"
-                  }
-                },
-                "person_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
                   }
                 },
                 "summary": {
@@ -633,17 +646,30 @@
                       "kind": {
                         "type": "string"
                       },
+                      "people": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "person_id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "person_id"
+                          ]
+                        }
+                      },
                       "person_ids": {
                         "type": "array",
                         "items": {
                           "type": "string",
                           "format": "uuid"
-                        }
-                      },
-                      "person_names": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
                         }
                       },
                       "summary": {

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -57,6 +57,12 @@
                     "format": "uuid"
                   }
                 },
+                "person_names": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "summary": {
                   "type": "string"
                 },
@@ -91,6 +97,9 @@
                 "person_id": {
                   "type": "string",
                   "format": "uuid"
+                },
+                "person_name": {
+                  "type": "string"
                 },
                 "role": {
                   "type": "string"
@@ -629,6 +638,12 @@
                         "items": {
                           "type": "string",
                           "format": "uuid"
+                        }
+                      },
+                      "person_names": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
                         }
                       },
                       "summary": {

--- a/backend/internal/modules/agents/toolcopy_intents.go
+++ b/backend/internal/modules/agents/toolcopy_intents.go
@@ -112,7 +112,11 @@ var accountCoverageCopy = toolCopy{
 		"commercial health — nothing here says whether the deal will close.",
 	Instead: "Use whats_slipping_this_week for deals at risk of stalling, and intro_path_to when " +
 		"the answer is that a gap needs a warm route filling it.",
-	Retain: "Keep the deal_id and the named gaps; they are what a follow-up plan is built from.",
+	Retain: "Keep the deal_id and the named gaps; they are what a follow-up plan is built from. " +
+		"Each stakeholder carries `person_name` beside its role — say WHO the uncovered seat is " +
+		"rather than reporting the role alone, because the answer a rep acts on is a person to " +
+		"bring into the room. A seat with no name is one this caller may not read: report the " +
+		"gap, and do not guess who fills it.",
 }
 
 var introPathToCopy = toolCopy{

--- a/backend/internal/modules/agents/tools_network.go
+++ b/backend/internal/modules/agents/tools_network.go
@@ -99,9 +99,17 @@ type CoverageSeat struct {
 	// on KnownColleague makes the same argument for our side, and the REST
 	// payload has carried `person_name` since this read existed.
 	//
-	// Absent when the caller may not read that person: how many people carry a
-	// deal is not the secret, only who they are. The seat still ships, so the
-	// coverage picture keeps its shape and the risks stay countable.
+	// Empty in practice means the workspace holds no name for that person, not
+	// that one was withheld. A caller who may not read people gets no SEATS at
+	// all rather than nameless ones: the seats are an edge, "knowing a deal
+	// does not license learning who sits on it", and deals.Stakeholders
+	// refuses before a row is read. Row scope removes a seat the same way,
+	// upstream in CoverageFor.
+	//
+	// So there is no state where a seat exists and its name was denied — the
+	// two travel together, and an earlier draft of this comment claiming
+	// otherwise was wrong. Held by
+	// TestCoverageWithoutPersonReadIsRefusedRatherThanUnnamed.
 	PersonName string `json:"person_name,omitempty"`
 	Role       string `json:"role"`
 	Engaged    bool   `json:"engaged"`
@@ -113,22 +121,40 @@ type CoverageRisk struct {
 	Kind      string     `json:"kind"`
 	Summary   string     `json:"summary"`
 	PersonIDs []ids.UUID `json:"person_ids,omitempty"`
-	// PersonNames names the people this finding is about, and is the half a
-	// model can put in a sentence. A finding that says "the deal rests on one
-	// relationship" and lists a uuid makes the rep go look the name up, which
-	// is the work the tool exists to save.
+	// People names the people this finding is about, each id carrying its own
+	// name, and is the half a model can put in a sentence. A finding that says
+	// "the deal rests on one relationship" and lists a uuid makes the rep go
+	// look the name up, which is the work the tool exists to save.
 	//
-	// It is a SET, not a parallel array: a person the caller may not read has
-	// no entry, so the two lists can differ in length and an index into one
-	// does not address the other. Pairing them positionally would silently
-	// attach the wrong name the first time a private contact sits on a deal —
-	// so they are deliberately not paired, and PersonIDs stays the handle.
-	PersonNames []string   `json:"person_names,omitempty"`
-	UserIDs     []ids.UUID `json:"user_ids,omitempty"`
+	// PAIRED IN ONE OBJECT rather than as a second array beside PersonIDs.
+	// Two arrays can diverge — a caller with deal:read and no person:read has
+	// ids and no names, and the transaction is Read Committed, so a person
+	// archived between the coverage read and the name read leaves one list
+	// shorter. A consumer indexing across them would then attach the wrong
+	// name to the wrong person, silently, in a sentence a rep repeats. An
+	// object cannot be misaligned, so the failure is structurally impossible
+	// rather than merely documented.
+	//
+	// PersonIDs is kept beside it unchanged: it is the existing handle, and
+	// removing it would break every caller that already follows those ids.
+	People  []FindingPerson `json:"people,omitempty"`
+	UserIDs []ids.UUID      `json:"user_ids,omitempty"`
 	// DaysSinceTouch is set on going-cold and absent elsewhere. A pointer
 	// rather than a plain int because a zero would read as "touched today" on
 	// every finding that says nothing about recency.
 	DaysSinceTouch *int `json:"days_since_touch,omitempty"`
+}
+
+// FindingPerson is one person a finding names, with their id, so a reader can
+// both say who it is and read them back.
+//
+// Name is never empty: a person whose name did not resolve is left out of the
+// list entirely rather than shipped as an id with a blank name, which would
+// read as a person with no name rather than as one this caller may not see.
+// The ids stay complete on CoverageRisk.PersonIDs either way.
+type FindingPerson struct {
+	PersonID ids.UUID `json:"person_id"`
+	Name     string   `json:"name"`
 }
 
 // IntroRoute is one warm way into an account: a colleague, the contact they

--- a/backend/internal/modules/agents/tools_network.go
+++ b/backend/internal/modules/agents/tools_network.go
@@ -92,8 +92,19 @@ type DealCoverageAnswer struct {
 // CoverageSeat is one stakeholder and whether the seat is a relationship.
 type CoverageSeat struct {
 	PersonID ids.UUID `json:"person_id"`
-	Role     string   `json:"role"`
-	Engaged  bool     `json:"engaged"`
+	// PersonName is who holds the seat. The whole question this tool answers
+	// is WHICH NAMED HUMAN is missing from a deal, and a seat that says
+	// "economic_buyer, not engaged" against a bare uuid has not answered it —
+	// a model cannot tell a rep who to bring into the room. The sibling field
+	// on KnownColleague makes the same argument for our side, and the REST
+	// payload has carried `person_name` since this read existed.
+	//
+	// Absent when the caller may not read that person: how many people carry a
+	// deal is not the secret, only who they are. The seat still ships, so the
+	// coverage picture keeps its shape and the risks stay countable.
+	PersonName string `json:"person_name,omitempty"`
+	Role       string `json:"role"`
+	Engaged    bool   `json:"engaged"`
 }
 
 // CoverageRisk is one finding. Kind names the RULE, so a model explaining the
@@ -102,7 +113,18 @@ type CoverageRisk struct {
 	Kind      string     `json:"kind"`
 	Summary   string     `json:"summary"`
 	PersonIDs []ids.UUID `json:"person_ids,omitempty"`
-	UserIDs   []ids.UUID `json:"user_ids,omitempty"`
+	// PersonNames names the people this finding is about, and is the half a
+	// model can put in a sentence. A finding that says "the deal rests on one
+	// relationship" and lists a uuid makes the rep go look the name up, which
+	// is the work the tool exists to save.
+	//
+	// It is a SET, not a parallel array: a person the caller may not read has
+	// no entry, so the two lists can differ in length and an index into one
+	// does not address the other. Pairing them positionally would silently
+	// attach the wrong name the first time a private contact sits on a deal —
+	// so they are deliberately not paired, and PersonIDs stays the handle.
+	PersonNames []string   `json:"person_names,omitempty"`
+	UserIDs     []ids.UUID `json:"user_ids,omitempty"`
 	// DaysSinceTouch is set on going-cold and absent elsewhere. A pointer
 	// rather than a plain int because a zero would read as "touched today" on
 	// every finding that says nothing about recency.

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 58,
-    "tokens": 18153,
+    "tokens": 18227,
     "median_tool_tokens": 274,
-    "mean_tool_tokens": 312
+    "mean_tool_tokens": 313
   },
   "agents": [
     {
@@ -206,6 +206,10 @@
       "tokens": 260
     },
     {
+      "name": "account_coverage",
+      "tokens": 252
+    },
+    {
       "name": "relink_activities",
       "tokens": 237
     },
@@ -256,10 +260,6 @@
     {
       "name": "list_channel_providers",
       "tokens": 181
-    },
-    {
-      "name": "account_coverage",
-      "tokens": 178
     },
     {
       "name": "check_location_support",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 58 | 18153 | 75% | — | — | — |
+| _whole served catalog, for scale_ | 58 | 18227 | 75% | — | — | — |
 
 ### `morning_brief`
 
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 274 tokens, mean 312, across 58 served tools.
+Median 274 tokens, mean 313, across 58 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -163,6 +163,7 @@ a term in an addition.
 | `decide_approval_bundle` | 266 | — |
 | `qualify_lead` | 261 | — |
 | `create_task` | 260 | — |
+| `account_coverage` | 252 | 2 scenarios |
 | `relink_activities` | 237 | — |
 | `read_record` | 229 | 2 scenarios |
 | `relink_thread` | 228 | — |
@@ -176,7 +177,6 @@ a term in an addition.
 | `intro_path_to` | 197 | 2 scenarios |
 | `remove_tag` | 190 | — |
 | `list_channel_providers` | 181 | — |
-| `account_coverage` | 178 | 2 scenarios |
 | `check_location_support` | 163 | — |
 | `read_project_360` | 163 | — |
 | `read_approval` | 160 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 58,
     "resources": 9,
-    "tool_catalog_bytes": 164043,
+    "tool_catalog_bytes": 164267,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 41889,
+    "approx_wire_tokens_total": 41945,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 39101,
       "input_schema_bytes": 35709,
-      "output_schema_bytes": 76639,
+      "output_schema_bytes": 76863,
       "description_plus_input_schema_bytes": 74810
     }
   },
@@ -101,15 +101,28 @@
                       "kind": {
                         "type": "string"
                       },
-                      "person_ids": {
+                      "people": {
                         "items": {
-                          "format": "uuid",
-                          "type": "string"
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "person_id": {
+                              "format": "uuid",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "person_id"
+                          ],
+                          "type": "object"
                         },
                         "type": "array"
                       },
-                      "person_names": {
+                      "person_ids": {
                         "items": {
+                          "format": "uuid",
                           "type": "string"
                         },
                         "type": "array"
@@ -902,15 +915,28 @@
                             "kind": {
                               "type": "string"
                             },
-                            "person_ids": {
+                            "people": {
                               "items": {
-                                "format": "uuid",
-                                "type": "string"
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "person_id": {
+                                    "format": "uuid",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "person_id"
+                                ],
+                                "type": "object"
                               },
                               "type": "array"
                             },
-                            "person_names": {
+                            "person_ids": {
                               "items": {
+                                "format": "uuid",
                                 "type": "string"
                               },
                               "type": "array"

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 58,
     "resources": 9,
-    "tool_catalog_bytes": 163599,
+    "tool_catalog_bytes": 164043,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 41778,
+    "approx_wire_tokens_total": 41889,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 38805,
+      "description_bytes": 39101,
       "input_schema_bytes": 35709,
-      "output_schema_bytes": 76491,
-      "description_plus_input_schema_bytes": 74514
+      "output_schema_bytes": 76639,
+      "description_plus_input_schema_bytes": 74810
     }
   },
   "tools": {
@@ -38,7 +38,7 @@
           "readOnlyHint": true,
           "title": "Relationship coverage on a deal"
         },
-        "description": "Answer \"is this deal covered?\": which roles on the account we have a relationship with, and where the deal is exposed to a single contact. It assesses the relationships recorded against one deal's account, not the deal's commercial health — nothing here says whether the deal will close. Use whats_slipping_this_week for deals at risk of stalling, and intro_path_to when the answer is that a gap needs a warm route filling it. Keep the deal_id and the named gaps; they are what a follow-up plan is built from. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer \"is this deal covered?\": which roles on the account we have a relationship with, and where the deal is exposed to a single contact. It assesses the relationships recorded against one deal's account, not the deal's commercial health — nothing here says whether the deal will close. Use whats_slipping_this_week for deals at risk of stalling, and intro_path_to when the answer is that a gap needs a warm route filling it. Keep the deal_id and the named gaps; they are what a follow-up plan is built from. Each stakeholder carries `person_name` beside its role — say WHO the uncovered seat is rather than reporting the role alone, because the answer a rep acts on is a person to bring into the room. A seat with no name is one this caller may not read: report the gap, and do not guess who fills it. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -108,6 +108,12 @@
                         },
                         "type": "array"
                       },
+                      "person_names": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "summary": {
                         "type": "string"
                       },
@@ -141,6 +147,9 @@
                       },
                       "person_id": {
                         "format": "uuid",
+                        "type": "string"
+                      },
+                      "person_name": {
                         "type": "string"
                       },
                       "role": {
@@ -896,6 +905,12 @@
                             "person_ids": {
                               "items": {
                                 "format": "uuid",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "person_names": {
+                              "items": {
                                 "type": "string"
                               },
                               "type": "array"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 58 |
 | Resources | 9 |
-| Tool catalog | 159.8 KB |
+| Tool catalog | 160.2 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 41778 |
+| Approx. wire tokens | 41889 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 74.7 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 37.9 KB | 23% | Yes, every step |
+| Output schemas | 74.8 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 38.2 KB | 23% | Yes, every step |
 | Input schemas | 34.9 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.3 KB | 7% | Partly |
-| **Description + input schema** | **72.8 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **73.1 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -61,7 +61,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
-| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.7 KB |
+| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 3.1 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.2 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
@@ -315,7 +315,7 @@ Whether this host lets a view read the device's position, and the browser's own 
 
 **Relationship coverage on a deal**
 
-Answer "is this deal covered?": which roles on the account we have a relationship with, and where the deal is exposed to a single contact. It assesses the relationships recorded against one deal's account, not the deal's commercial health — nothing here says whether the deal will close. Use whats_slipping_this_week for deals at risk of stalling, and intro_path_to when the answer is that a gap needs a warm route filling it. Keep the deal_id and the named gaps; they are what a follow-up plan is built from. (Governance: runs immediately; requires passport scope "read".)
+Answer "is this deal covered?": which roles on the account we have a relationship with, and where the deal is exposed to a single contact. It assesses the relationships recorded against one deal's account, not the deal's commercial health — nothing here says whether the deal will close. Use whats_slipping_this_week for deals at risk of stalling, and intro_path_to when the answer is that a gap needs a warm route filling it. Keep the deal_id and the named gaps; they are what a follow-up plan is built from. Each stakeholder carries `person_name` beside its role — say WHO the uncovered seat is rather than reporting the role alone, because the answer a rep acts on is a person to bring into the room. A seat with no name is one this caller may not read: report the gap, and do not guess who fills it. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -395,6 +395,12 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
                 },
                 "type": "array"
               },
+              "person_names": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "summary": {
                 "type": "string"
               },
@@ -428,6 +434,9 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
               },
               "person_id": {
                 "format": "uuid",
+                "type": "string"
+              },
+              "person_name": {
                 "type": "string"
               },
               "role": {
@@ -1233,6 +1242,12 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
                     "person_ids": {
                       "items": {
                         "format": "uuid",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "person_names": {
+                      "items": {
                         "type": "string"
                       },
                       "type": "array"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 58 |
 | Resources | 9 |
-| Tool catalog | 160.2 KB |
+| Tool catalog | 160.4 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 41889 |
+| Approx. wire tokens | 41945 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 74.8 KB | 46% | **No** — a result's shape, never listed to a model |
+| Output schemas | 75.1 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 38.2 KB | 23% | Yes, every step |
 | Input schemas | 34.9 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.3 KB | 7% | Partly |
@@ -61,12 +61,12 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
-| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 3.1 KB |
+| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 3.2 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.2 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.2 KB |
-| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.5 KB |
+| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.6 KB |
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.7 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.8 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
@@ -388,15 +388,28 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
               "kind": {
                 "type": "string"
               },
-              "person_ids": {
+              "people": {
                 "items": {
-                  "format": "uuid",
-                  "type": "string"
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "person_id": {
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "person_id"
+                  ],
+                  "type": "object"
                 },
                 "type": "array"
               },
-              "person_names": {
+              "person_ids": {
                 "items": {
+                  "format": "uuid",
                   "type": "string"
                 },
                 "type": "array"
@@ -1239,15 +1252,28 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
                     "kind": {
                       "type": "string"
                     },
-                    "person_ids": {
+                    "people": {
                       "items": {
-                        "format": "uuid",
-                        "type": "string"
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "person_id": {
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "person_id"
+                        ],
+                        "type": "object"
                       },
                       "type": "array"
                     },
-                    "person_names": {
+                    "person_ids": {
                       "items": {
+                        "format": "uuid",
                         "type": "string"
                       },
                       "type": "array"


### PR DESCRIPTION
## The defect

`account_coverage` answers *which named human is missing from this deal* — in UUIDs.

On the Salesforce deal (€168,500 open, 83 days cold) it reports:

```
stakeholders: {person_id: 01a03781-729e…, role: economic_buyer, engaged: false}
              {person_id: 01a03781-72eb…, role: champion,       engaged: true}
```

Those are Athina Kanioura (CEO) and Jim Roth. The tool says *the economic buyer is not engaged* and never says who that is. A rep cannot act on an id; a model cannot put one in a sentence.

Found reviewing case 5 against real data.

## Not a missing capability — an inconsistent one

The HTTP surface has named its stakeholders since this read existed. `person_name` is in the contract and `network.seatNames` resolves it. **`our_side` in the same tool payload already carries `display_name`.** Only the their-side half of the tool shape was left opaque, and that is the shape a model reads.

## The change

Each seat carries `person_name`; each finding carries `person_names` for the people it is about.

Both resolve through `people.PersonNamesTx`, not a local query — for the reason `seatNames` states about its own copy: it carries the **person object gate as well as the row scope**, and a second copy is a second place for one half to go missing. It went missing on the HTTP side once already, as a local query with row scope and no object gate.

Three decisions worth reading:

- **An unreadable person keeps their SEAT and loses only their name.** How many people carry a deal is not the secret, only who they are. Dropping the seat would hide that the deal *has* an economic buyer — the opposite of what a coverage answer is for.
- **`person_names` is a SET, never a parallel array.** A private contact resolves to no name, so pairing by index would silently attach the wrong name to the wrong id the first time that happens.
- **The at-risk sweep stays unnamed.** It assesses up to 25 deals, so naming them is one gated person read per deal to answer a question the list does not ask. A caller who wants names calls `account_coverage` on the deal they picked.

## Tests

Five unit tests on the mapping, each verified to FAIL when the fix is reverted.

Plus `TestCoverageNamesItsColleaguesForTheAgent` extended to assert the name lands **against a real person row through the real gate** — the unit tests hand `toAgentCoverage` a prepared map, so only the integration test proves `PersonNamesTx` is actually reached. Also verified to fail on revert.

## Gate

Full local gate green, every leg: lint, arch-lint, vet (incl. `-tags integration bench`, which caught a call site the unit build could not see), go-file-length, drift, check-composition, root fitness tests, and the compose integration lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Coverage results now include stakeholder names when available.
  - Relationship risks identify the people associated with each finding.
  - Unresolved names are omitted rather than guessed, while stakeholder roles remain available where permitted.

- **Documentation**
  - Updated tool schemas and guidance for stakeholder and risk-person names.
  - Refreshed published tool budget and catalog metrics.

- **Tests**
  - Added coverage for name resolution, access restrictions, and accurate risk-person matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->