### PR TITLE
fix(seed): an activity links to the person who actually wrote it

### DIFF
--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -175,6 +175,16 @@ type demoActivity struct {
 	MeetingStatus   string `json:"meeting_status"`
 	DurationSeconds int    `json:"duration_seconds"`
 	Assignee        string `json:"assignee"`
+	// Person is WHO AT THE CUSTOMER this was with, by their full name as the
+	// crawl recorded it. Omitted, the link falls back to the account's most
+	// senior employee, which is what every activity used to get.
+	//
+	// That fallback is why this field exists. A mail signed "Karoline Juettner"
+	// linked to the Geschaeftsfuehrer instead, because he sorts first — so the
+	// body named one person and the record named another. An assistant asked
+	// who raised the complaint read the signature, answered with a name the
+	// CRM did not hold, and looked like it had invented one.
+	Person string `json:"person"`
 }
 
 // demoContract is one agreement. Status is ASSERTED where it can be — the

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -3,14 +3,17 @@
 
 package main
 
-// The rest of the demo record set: what happened on a company (activities),
-// what it signed (contracts), what it was quoted (products and offers), and
-// what it agreed to be contacted about (consent).
+// What HAPPENED on a company: the correspondence, calls, meetings and tasks,
+// and who each of them was with.
+//
+// Where an account STANDS — its lifecycle, the rate card, the offers on the
+// table — is next door in standing.go. The two split because this file grew
+// past the 500-line cap, and the seam was already there: these phases record
+// events, those ones record state.
 
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strings"
 )
 
@@ -151,12 +154,12 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 
 	// A note or a task is internal — it is about the account, not with anybody.
 	if act.Kind == "email" || act.Kind == "call" || act.Kind == "meeting" {
-		staff, err := staffBySeniority(c, orgID)
+		personID, err := counterpartFor(c, act, orgID)
 		if err != nil {
 			return nil, err
 		}
-		if len(staff) > 0 {
-			links = append(links, jsonBody{"entity_type": "person", "entity_id": staff[0]})
+		if personID != "" {
+			links = append(links, jsonBody{"entity_type": "person", "entity_id": personID})
 		}
 	}
 
@@ -171,6 +174,68 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 		links = append(links, jsonBody{"entity_type": "project", "entity_id": project})
 	}
 	return links, nil
+}
+
+// counterpartFor answers WHO at the customer an activity was with.
+//
+// The dataset's own answer wins. `person` names somebody by their full name,
+// and that is the only way the record can agree with what the mail SAYS: the
+// body is signed by a named human, and until this existed the link went to
+// whoever sorted most senior instead. A mail signed "Karoline Juettner" filed
+// against the Geschaeftsfuehrer is not a near-miss — asked who complained, an
+// assistant reads the signature and answers with a name the CRM does not hold.
+//
+// A name the account does not employ is an ERROR rather than a silent
+// fallback. Getting the senior contact when the dataset asked for a specific
+// person would restore the exact defect this closes, and quietly.
+//
+// Without `person` the old behaviour stands: the most senior employee, which
+// is a heuristic and better than an empty timeline for the ~180 companies the
+// dataset never names.
+func counterpartFor(c *client, act demoActivity, orgID string) (string, error) {
+	staff, err := staffBySeniority(c, orgID)
+	if err != nil {
+		return "", err
+	}
+	if act.Person == "" {
+		if len(staff) == 0 {
+			return "", nil
+		}
+		return staff[0], nil
+	}
+	for _, personID := range staff {
+		name, err := personName(c, personID)
+		if err != nil {
+			return "", err
+		}
+		if strings.EqualFold(strings.TrimSpace(name), strings.TrimSpace(act.Person)) {
+			return personID, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"activity on %s names person %q, who is not employed there — the body's sign-off and the dataset have to agree",
+		act.Company, act.Person)
+}
+
+// personNames caches a person's name for the run.
+//
+// The lookup is per ACTIVITY and a story account carries a dozen of them
+// against the same handful of colleagues, so without this the same rows are
+// re-read tens of times. A person's name does not change mid-run.
+var personNames = map[string]string{}
+
+func personName(c *client, personID string) (string, error) {
+	if name, ok := personNames[personID]; ok {
+		return name, nil
+	}
+	var out struct {
+		FullName string `json:"full_name"`
+	}
+	if err := c.get("/v1/people/"+personID, nil, &out); err != nil {
+		return "", fmt.Errorf("reading person %s: %w", personID, err)
+	}
+	personNames[personID] = out.FullName
+	return out.FullName, nil
 }
 
 // loadActivitySourceIDs reads the source_id of every activity ONCE.
@@ -250,249 +315,4 @@ type seededActivity struct {
 	// reordering the activities array silently remaps which stored row an
 	// index names, and relinking the wrong one cannot be undone.
 	OrganizationID string
-}
-
-// seedLifecycle says where each account stands with us.
-//
-// It runs after the deals exist, because the two have to agree: an account
-// with a won deal is a customer and one with an open deal is at least an
-// opportunity. A demo where every company sits at the default teaches the
-// lifecycle filter to return everything.
-//
-// A company the dataset does not place takes the lifecycle its PROFILE was
-// planned with, which is what spreads the accounts across customer, former
-// customer, opportunity, prospect and target instead of leaving everything at
-// two values. demo.json still overrides whenever the story needs something
-// specific, and a company with no profile at all falls back to what its
-// records show — an open deal makes it an opportunity, otherwise a target.
-func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
-	changed := 0
-	placed := map[string]bool{}
-	for _, domains := range cfg.Lifecycle {
-		for _, domain := range domains {
-			placed[strings.ToLower(domain)] = true
-		}
-	}
-	for domain := range refs.orgsByDom {
-		if placed[domain] {
-			continue
-		}
-		stage := plan[domain].Lifecycle
-		if stage == "" {
-			stage = "target"
-			if len(refs.dealsByCompany[domain]) > 0 {
-				stage = "opportunity"
-			}
-		}
-		cfg.Lifecycle[stage] = append(cfg.Lifecycle[stage], domain)
-	}
-	for stage, domains := range cfg.Lifecycle {
-		for _, domain := range domains {
-			orgID, ok := refs.orgsByDom[strings.ToLower(domain)]
-			if !ok {
-				return changed, fmt.Errorf("lifecycle names company %q, which is not seeded", domain)
-			}
-			if mode == modeDryRun {
-				changed++
-				continue
-			}
-			current, version, source, err := organizationLifecycle(c, orgID)
-			if err != nil {
-				return changed, err
-			}
-			// A company whose record somebody else owns keeps the lifecycle
-			// stage it carries. Moving an account along the pipeline by hand is
-			// the demo's whole point; a re-seed must not walk it back.
-			if !seederOwns(source) {
-				continue
-			}
-			if current == stage {
-				continue
-			}
-			// The write is version-checked, so a concurrent edit loses rather
-			// than being silently overwritten.
-			body := jsonBody{"lifecycle": stage, "if_version": version}
-			if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
-				return changed, fmt.Errorf("setting %s to %s: %w", domain, stage, err)
-			}
-			changed++
-		}
-	}
-	return changed, nil
-}
-
-func organizationLifecycle(c *client, orgID string) (stage string, version int, source string, err error) {
-	var out struct {
-		Lifecycle string `json:"lifecycle"`
-		Source    string `json:"source"`
-		Version   int    `json:"version"`
-	}
-	if err := c.get("/v1/organizations/"+orgID, nil, &out); err != nil {
-		return "", 0, "", fmt.Errorf("reading organization %s: %w", orgID, err)
-	}
-	return out.Lifecycle, out.Version, out.Source, nil
-}
-
-// seedProducts fills the rate card the offers draw their line items from.
-func seedProducts(c *client, cfg demoConfig, mode runMode) (map[string]string, int, error) {
-	ids := map[string]string{}
-	created := 0
-
-	var page struct {
-		Data []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"data"`
-	}
-	if mode != modeDryRun {
-		if err := c.get("/v1/products", url.Values{"limit": {"100"}}, &page); err != nil {
-			return nil, 0, fmt.Errorf("listing products: %w", err)
-		}
-	}
-	byName := map[string]string{}
-	for _, row := range page.Data {
-		byName[strings.ToLower(row.Name)] = row.ID
-	}
-
-	for _, product := range cfg.Products {
-		if id, ok := byName[strings.ToLower(product.Name)]; ok {
-			ids[product.Ref] = id
-			continue
-		}
-		if mode == modeDryRun {
-			created++
-			continue
-		}
-		body := jsonBody{
-			"name":             product.Name,
-			"unit_price_minor": product.UnitPriceMinor,
-			"currency":         product.Currency,
-			"source":           seedSource,
-		}
-		addIfSet(body, "sku", product.SKU)
-		addIfSet(body, "unit", product.Unit)
-		addIfSet(body, "description", product.Description)
-
-		var out struct {
-			ID string `json:"id"`
-		}
-		if err := c.post("/v1/products", body, &out); err != nil {
-			return nil, created, fmt.Errorf("product %s: %w", product.Ref, err)
-		}
-		ids[product.Ref] = out.ID
-		created++
-	}
-	return ids, created, nil
-}
-
-// seedOffers quotes the open deals, and drives each offer to its dataset
-// state through the real send/accept/reject transitions rather than writing a
-// state column: an accepted offer that was never sent is not a state the
-// product can reach.
-func seedOffers(c *client, cfg demoConfig, refs pipelineRefs, products map[string]string, mode runMode) (int, error) {
-	created := 0
-	for _, offer := range cfg.Offers {
-		dealID, err := dealIDFor(c, cfg, refs, offer.Deal)
-		if err != nil {
-			return created, err
-		}
-		if dealID == "" {
-			continue // the deal is not seeded (dry run, or a -limit subset)
-		}
-		if mode == modeDryRun {
-			created++
-			continue
-		}
-		if has, err := dealHasOffer(c, dealID); err != nil {
-			return created, err
-		} else if has {
-			continue
-		}
-
-		lines := make([]jsonBody, 0, len(offer.Lines))
-		for _, line := range offer.Lines {
-			productID, ok := products[line.Product]
-			if !ok {
-				return created, fmt.Errorf("offer %s names product %q, which is not seeded", offer.Ref, line.Product)
-			}
-			item := jsonBody{"product_id": productID, "quantity": line.Quantity}
-			// Only sent when the dataset states one. Otherwise the line takes
-			// the product's own price, which is what every same-currency
-			// offer wants.
-			if line.UnitPriceMinor > 0 {
-				item["unit_price_minor"] = line.UnitPriceMinor
-			}
-			lines = append(lines, item)
-		}
-		body := jsonBody{"currency": offer.Currency, "source": seedSource, "line_items": lines}
-		addIfSet(body, "intro_text", offer.IntroText)
-		if offer.ValidInDays != 0 {
-			body["valid_until"] = refs.date(offer.ValidInDays)
-		}
-
-		var out struct {
-			ID string `json:"id"`
-		}
-		if err := c.post("/v1/deals/"+dealID+"/offers", body, &out); err != nil {
-			return created, fmt.Errorf("offer %s: %w", offer.Ref, err)
-		}
-		created++
-
-		if err := driveOfferTo(c, out.ID, offer.State); err != nil {
-			return created, fmt.Errorf("offer %s: %w", offer.Ref, err)
-		}
-	}
-	return created, nil
-}
-
-// driveOfferTo walks an offer to its target state. Accept and reject both
-// require a sent offer, so the send is not optional scaffolding.
-func driveOfferTo(c *client, offerID, state string) error {
-	if state == "" || state == "draft" {
-		return nil
-	}
-	if err := c.post("/v1/offers/"+offerID+"/send", jsonBody{}, nil); err != nil {
-		return fmt.Errorf("sending: %w", err)
-	}
-	switch state {
-	case "sent":
-		return nil
-	case "accepted":
-		if err := c.post("/v1/offers/"+offerID+"/accept", jsonBody{}, nil); err != nil {
-			return fmt.Errorf("accepting: %w", err)
-		}
-	case "rejected":
-		if err := c.post("/v1/offers/"+offerID+"/reject", jsonBody{}, nil); err != nil {
-			return fmt.Errorf("rejecting: %w", err)
-		}
-	default:
-		return fmt.Errorf("unknown offer state %q", state)
-	}
-	return nil
-}
-
-func dealIDFor(c *client, cfg demoConfig, refs pipelineRefs, dealRef string) (string, error) {
-	for _, deal := range cfg.Deals {
-		if deal.Ref != dealRef {
-			continue
-		}
-		orgID, ok := refs.orgsByDom[strings.ToLower(deal.Company)]
-		if !ok {
-			return "", nil
-		}
-		return findDeal(c, deal.Name, orgID)
-	}
-	return "", fmt.Errorf("no deal has ref %q", dealRef)
-}
-
-func dealHasOffer(c *client, dealID string) (bool, error) {
-	var page struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := c.get("/v1/deals/"+dealID+"/offers", url.Values{"limit": {"5"}}, &page); err != nil {
-		return false, fmt.Errorf("listing offers for deal %s: %w", dealID, err)
-	}
-	return len(page.Data) > 0, nil
 }

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -203,18 +203,33 @@ func counterpartFor(c *client, act demoActivity, orgID string) (string, error) {
 		}
 		return staff[0], nil
 	}
+	// Every match, not the first. staffBySeniority orders by title, so taking
+	// the first would hand the activity to the more SENIOR of two colleagues
+	// who share a name — silently, and that is the same wrong-person link this
+	// function exists to stop. Two people called "Alex Kim" at one account is
+	// a question the dataset has to answer, not one to guess at.
+	var matched []string
 	for _, personID := range staff {
 		name, err := personName(c, personID)
 		if err != nil {
 			return "", err
 		}
 		if strings.EqualFold(strings.TrimSpace(name), strings.TrimSpace(act.Person)) {
-			return personID, nil
+			matched = append(matched, personID)
 		}
 	}
-	return "", fmt.Errorf(
-		"activity on %s names person %q, who is not employed there — the body's sign-off and the dataset have to agree",
-		act.Company, act.Person)
+	switch len(matched) {
+	case 1:
+		return matched[0], nil
+	case 0:
+		return "", fmt.Errorf(
+			"activity on %s names person %q, who is not employed there — the body's sign-off and the dataset have to agree",
+			act.Company, act.Person)
+	default:
+		return "", fmt.Errorf(
+			"activity on %s names person %q, and %d people there answer to it — the dataset cannot say which, so it must not guess",
+			act.Company, act.Person, len(matched))
+	}
 }
 
 // personNames caches a person's name for the run.

--- a/backend/tools/seed-demo/standing.go
+++ b/backend/tools/seed-demo/standing.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Where each account stands, what we sell, and what we quoted.
+//
+// Split from records.go, which files what HAPPENED on an account. These three
+// phases answer a different question -- not "what was said" but "where does
+// this account stand and what is on the table" -- and they run after the
+// activities because a lifecycle reads the deals and an offer names one.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// seedLifecycle says where each account stands with us.
+//
+// It runs after the deals exist, because the two have to agree: an account
+// with a won deal is a customer and one with an open deal is at least an
+// opportunity. A demo where every company sits at the default teaches the
+// lifecycle filter to return everything.
+//
+// A company the dataset does not place takes the lifecycle its PROFILE was
+// planned with, which is what spreads the accounts across customer, former
+// customer, opportunity, prospect and target instead of leaving everything at
+// two values. demo.json still overrides whenever the story needs something
+// specific, and a company with no profile at all falls back to what its
+// records show — an open deal makes it an opportunity, otherwise a target.
+func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	changed := 0
+	placed := map[string]bool{}
+	for _, domains := range cfg.Lifecycle {
+		for _, domain := range domains {
+			placed[strings.ToLower(domain)] = true
+		}
+	}
+	for domain := range refs.orgsByDom {
+		if placed[domain] {
+			continue
+		}
+		stage := plan[domain].Lifecycle
+		if stage == "" {
+			stage = "target"
+			if len(refs.dealsByCompany[domain]) > 0 {
+				stage = "opportunity"
+			}
+		}
+		cfg.Lifecycle[stage] = append(cfg.Lifecycle[stage], domain)
+	}
+	for stage, domains := range cfg.Lifecycle {
+		for _, domain := range domains {
+			orgID, ok := refs.orgsByDom[strings.ToLower(domain)]
+			if !ok {
+				return changed, fmt.Errorf("lifecycle names company %q, which is not seeded", domain)
+			}
+			if mode == modeDryRun {
+				changed++
+				continue
+			}
+			current, version, source, err := organizationLifecycle(c, orgID)
+			if err != nil {
+				return changed, err
+			}
+			// A company whose record somebody else owns keeps the lifecycle
+			// stage it carries. Moving an account along the pipeline by hand is
+			// the demo's whole point; a re-seed must not walk it back.
+			if !seederOwns(source) {
+				continue
+			}
+			if current == stage {
+				continue
+			}
+			// The write is version-checked, so a concurrent edit loses rather
+			// than being silently overwritten.
+			body := jsonBody{"lifecycle": stage, "if_version": version}
+			if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
+				return changed, fmt.Errorf("setting %s to %s: %w", domain, stage, err)
+			}
+			changed++
+		}
+	}
+	return changed, nil
+}
+
+func organizationLifecycle(c *client, orgID string) (stage string, version int, source string, err error) {
+	var out struct {
+		Lifecycle string `json:"lifecycle"`
+		Source    string `json:"source"`
+		Version   int    `json:"version"`
+	}
+	if err := c.get("/v1/organizations/"+orgID, nil, &out); err != nil {
+		return "", 0, "", fmt.Errorf("reading organization %s: %w", orgID, err)
+	}
+	return out.Lifecycle, out.Version, out.Source, nil
+}
+
+// seedProducts fills the rate card the offers draw their line items from.
+func seedProducts(c *client, cfg demoConfig, mode runMode) (map[string]string, int, error) {
+	ids := map[string]string{}
+	created := 0
+
+	var page struct {
+		Data []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if mode != modeDryRun {
+		if err := c.get("/v1/products", url.Values{"limit": {"100"}}, &page); err != nil {
+			return nil, 0, fmt.Errorf("listing products: %w", err)
+		}
+	}
+	byName := map[string]string{}
+	for _, row := range page.Data {
+		byName[strings.ToLower(row.Name)] = row.ID
+	}
+
+	for _, product := range cfg.Products {
+		if id, ok := byName[strings.ToLower(product.Name)]; ok {
+			ids[product.Ref] = id
+			continue
+		}
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		body := jsonBody{
+			"name":             product.Name,
+			"unit_price_minor": product.UnitPriceMinor,
+			"currency":         product.Currency,
+			"source":           seedSource,
+		}
+		addIfSet(body, "sku", product.SKU)
+		addIfSet(body, "unit", product.Unit)
+		addIfSet(body, "description", product.Description)
+
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/products", body, &out); err != nil {
+			return nil, created, fmt.Errorf("product %s: %w", product.Ref, err)
+		}
+		ids[product.Ref] = out.ID
+		created++
+	}
+	return ids, created, nil
+}
+
+// seedOffers quotes the open deals, and drives each offer to its dataset
+// state through the real send/accept/reject transitions rather than writing a
+// state column: an accepted offer that was never sent is not a state the
+// product can reach.
+func seedOffers(c *client, cfg demoConfig, refs pipelineRefs, products map[string]string, mode runMode) (int, error) {
+	created := 0
+	for _, offer := range cfg.Offers {
+		dealID, err := dealIDFor(c, cfg, refs, offer.Deal)
+		if err != nil {
+			return created, err
+		}
+		if dealID == "" {
+			continue // the deal is not seeded (dry run, or a -limit subset)
+		}
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		if has, err := dealHasOffer(c, dealID); err != nil {
+			return created, err
+		} else if has {
+			continue
+		}
+
+		lines := make([]jsonBody, 0, len(offer.Lines))
+		for _, line := range offer.Lines {
+			productID, ok := products[line.Product]
+			if !ok {
+				return created, fmt.Errorf("offer %s names product %q, which is not seeded", offer.Ref, line.Product)
+			}
+			item := jsonBody{"product_id": productID, "quantity": line.Quantity}
+			// Only sent when the dataset states one. Otherwise the line takes
+			// the product's own price, which is what every same-currency
+			// offer wants.
+			if line.UnitPriceMinor > 0 {
+				item["unit_price_minor"] = line.UnitPriceMinor
+			}
+			lines = append(lines, item)
+		}
+		body := jsonBody{"currency": offer.Currency, "source": seedSource, "line_items": lines}
+		addIfSet(body, "intro_text", offer.IntroText)
+		if offer.ValidInDays != 0 {
+			body["valid_until"] = refs.date(offer.ValidInDays)
+		}
+
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/deals/"+dealID+"/offers", body, &out); err != nil {
+			return created, fmt.Errorf("offer %s: %w", offer.Ref, err)
+		}
+		created++
+
+		if err := driveOfferTo(c, out.ID, offer.State); err != nil {
+			return created, fmt.Errorf("offer %s: %w", offer.Ref, err)
+		}
+	}
+	return created, nil
+}
+
+// driveOfferTo walks an offer to its target state. Accept and reject both
+// require a sent offer, so the send is not optional scaffolding.
+func driveOfferTo(c *client, offerID, state string) error {
+	if state == "" || state == "draft" {
+		return nil
+	}
+	if err := c.post("/v1/offers/"+offerID+"/send", jsonBody{}, nil); err != nil {
+		return fmt.Errorf("sending: %w", err)
+	}
+	switch state {
+	case "sent":
+		return nil
+	case "accepted":
+		if err := c.post("/v1/offers/"+offerID+"/accept", jsonBody{}, nil); err != nil {
+			return fmt.Errorf("accepting: %w", err)
+		}
+	case "rejected":
+		if err := c.post("/v1/offers/"+offerID+"/reject", jsonBody{}, nil); err != nil {
+			return fmt.Errorf("rejecting: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown offer state %q", state)
+	}
+	return nil
+}
+
+func dealIDFor(c *client, cfg demoConfig, refs pipelineRefs, dealRef string) (string, error) {
+	for _, deal := range cfg.Deals {
+		if deal.Ref != dealRef {
+			continue
+		}
+		orgID, ok := refs.orgsByDom[strings.ToLower(deal.Company)]
+		if !ok {
+			return "", nil
+		}
+		return findDeal(c, deal.Name, orgID)
+	}
+	return "", fmt.Errorf("no deal has ref %q", dealRef)
+}
+
+func dealHasOffer(c *client, dealID string) (bool, error) {
+	var page struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := c.get("/v1/deals/"+dealID+"/offers", url.Values{"limit": {"5"}}, &page); err != nil {
+		return false, fmt.Errorf("listing offers for deal %s: %w", dealID, err)
+	}
+	return len(page.Data) > 0, nil
+}


### PR DESCRIPTION
## The bug

An assistant asked who raised the Reply complaint answered **"Andrea Gebhardt"**. No such person is in the CRM.

It was not hallucinating. It read the sign-off in the mail body — exactly what a human would do. The record disagreed: `activity_link` pointed at Thomas Hartmann, because `activityLinks` linked `staff[0]`, the account's most senior employee, with no reference to who the body says wrote it.

That is worse than a near-miss. The answer *looks* like a model defect and is a data defect, invisible until somebody quotes it back to a customer.

Three accounts had it visibly — Adsmasters, NETFORMIC, Reply. Every other account had the same shape, invisible only because nobody had asked yet.

## The fix

`demoActivity` gains `person`, naming who at the **customer** an activity was with. `counterpartFor` resolves it against that company's own staff.

**A name the account does not employ is an error, not a fallback.** A silent fallback to the senior contact would restore the exact defect while looking like it worked — which is how this shipped in the first place.

Without `person`, the old behaviour stands, so the ~180 companies the dataset never names keep the heuristic and their timelines.

## The file split

`records.go` crossed the 500-line cap with the addition, so it splits along a seam that was already there:

- `records.go` — what **happened** on an account (activities)
- `standing.go` — where an account **stands** (lifecycle, rate card, offers)

No logic moved with it.

## Verified

On an isolated `DEV_SLUG` stack seeded from the dataset (never touching :8080):

- **45 activities carry a person**, every one employed at the company named
- every one is named in the body it is linked to
- `verify: OK`
- `make check-backend` green, `craft-static` PASS, `rls-store-path` and `no-jurisdiction` OK

Dataset half is on `margince-demo-database` main (`735a172`) — it rewrites the two sign-offs that named nobody real (Andrea Gebhardt → Tatiana Rizzante, Susanne Körber → Anne Wiegert), both people the crawl actually found at those companies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo data can associate activities with specific customer contacts by full name.
  * Demo setup now supports organization lifecycle stages, products, and offers, including pricing, validity dates, and offer statuses.
* **Bug Fixes**
  * Improved contact matching and validation prevents activities from referencing contacts who are not employed by the selected account.
  * Duplicate offers are avoided, while existing organization configuration is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->