### PR TITLE
feat(shell): the agent stands in the middle of the phone bar

### DIFF
--- a/docs/explanation/frontend-architecture.md
+++ b/docs/explanation/frontend-architecture.md
@@ -111,8 +111,8 @@ order. It is **ten items**: Home standing alone, then three labeled groups.
 | Group | Route ids |
 |---|---|
 | *(ungrouped)* | `home` |
-| Records | `contacts`, `companies`, `leads`, `dedupe` |
-| Work | `deals`, `tasks`, `inbox` |
+| Records | `contacts`, `companies`, `leads`, `filters` |
+| Work | `today`, `deals`, `projects` |
 | Intelligence | `reports`, `ai` |
 
 The groups are the **expanded sidebar's** own structure. Collapsed, each group
@@ -123,13 +123,25 @@ additive rather than a replacement. Collapse is a persisted preference
 animates between 250px and 64px on one shared `--shellAnim` (0.36s), and a
 `SETTLE_MS` of 420ms suppresses hover reveal until the width settles.
 
-At **≤700px** the same `<nav>` element becomes a fixed bottom bar. `MOBILE_PRIMARY`
-(`home`, `contacts`, `deals`, `inbox`) rides the bar; everything else lives
-behind **More**, which expands the same element into a sheet. One nav element
-means one navigation landmark and no second item list to keep in sync — and
-because the hidden routes' own rows are `display:none` at this width, **More**
-carries `aria-current="page"` for them, dropping it once the sheet is open so
-two elements never both claim the current page.
+At **≤700px** the same `<nav>` element becomes a fixed bottom bar of five equal
+cells. `MOBILE_PRIMARY` (`home`, `contacts`, `deals`) rides the bar; everything
+else lives behind **More**, which expands the same element into a sheet. One nav
+element means one navigation landmark and no second item list to keep in sync —
+and because the hidden routes' own rows are `display:none` at this width,
+**More** carries `aria-current="page"` for them, dropping it once the sheet is
+open so two elements never both claim the current page.
+
+The **middle** cell is not a destination: it is the agent, which reports rather
+than navigates and belongs to the whole session rather than to any one screen.
+`NavLevelView` takes it as a `centre` slot and renders it into the row stream,
+after the bar row that leaves as many cells to its left as to its right, so the
+bar's tab order is the order a thumb reads it in — a cell placed by a grid
+column alone would be third on screen and last to the keyboard. It rises clear
+of the bar's top edge by `--phoneAgentRise`, which `--phoneNavClearance` adds to
+the bar's own height so a sticky element never lands behind it. Above the
+breakpoint the same block is the sidebar's foot (`.railagent`) instead; it moves
+rather than being drawn twice, because two of them would be two Cores reporting
+one session.
 
 `RAIL_LESS_SCREENS` is the documented layout exception: `onboarding`, `book`,
 `client`, `preferences`, `oauth-consent`. These render full-bleed with their own

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1103,6 +1103,85 @@ test.describe("§3.8: 390px mobile", () => {
     ).toBeVisible();
     await page.getByRole("button", { name: "Übernehmen" }).click();
   });
+
+  // The bar's centre cell and the panel it opens, neither of which exists above
+  // this breakpoint: there the agent is the sidebar's foot and the panel stands
+  // beside it. So every sweep in this file runs with that panel shut, and it is
+  // the largest surface in the product no other case opens.
+  //
+  // Three things at once, because they are one act: it opens ABOVE the well
+  // rather than across it (a frame measured from the cell behind the well would
+  // cover the orb that opened it), the page does not grow sideways under it, and
+  // it scores no AA violation.
+  test("the agent's panel opens clear of the bar and fits 390px", async ({
+    page,
+  }) => {
+    await page.goto("/#/home");
+    await page.waitForLoadState("networkidle");
+    await expectShellRendered(page);
+
+    await page
+      .getByRole("button", { name: "Expand the agent panel" })
+      .click();
+    const panel = page.locator(".arpanel");
+    await expect(panel).toBeVisible();
+    await settleAnimations(page);
+
+    // By class, not by name: the control renames itself the moment it is open
+    // ("Collapse the agent panel"), which is the point of it — and what is
+    // measured here is a BOX, not an identity.
+    const panelBox = await panel.boundingBox();
+    const wellBox = await page.locator(".arhit").boundingBox();
+    if (!panelBox || !wellBox) {
+      throw new Error("the panel or the well it points at is not laid out");
+    }
+    expect(panelBox.y + panelBox.height).toBeLessThanOrEqual(wellBox.y);
+    expect(panelBox.y).toBeGreaterThanOrEqual(0);
+    expect(await pageOverflow(page)).toEqual([]);
+    await expectNoAaViolations(page, "home — the agent's panel (390px)");
+  });
+
+  // The whole keyboard path this surface has: it opens from the bar, Escape
+  // closes it from inside, and focus lands back on the control that opened it
+  // rather than on <body> — from where the next Tab starts at the top of a page
+  // the reader had not left.
+  test("the agent's panel closes on Escape and hands focus back to the orb", async ({
+    page,
+  }) => {
+    await page.goto("/#/home");
+    await page.waitForLoadState("networkidle");
+    await expectShellRendered(page);
+
+    const orb = page.getByRole("button", { name: "Expand the agent panel" });
+    await orb.click();
+    await expect(page.locator(".arpanel")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".arpanel")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Expand the agent panel" }),
+    ).toBeFocused();
+  });
+});
+
+// The same panel under the dark palette. It is the one surface where the
+// stylesheet paints a fill of its own at this width — the well's ground and the
+// notch's — and tokens.css publishes dark as its own set of values, so passing
+// in light says nothing about it.
+test.describe("B-EP09.21: WCAG 2.2 AA (axe), the agent's panel at 390px in dark", () => {
+  test.use({ viewport: { width: 390, height: 844 }, colorScheme: "dark" });
+
+  test("no AA violations with the agent's panel open", async ({ page }) => {
+    await page.goto("/#/home");
+    await page.waitForLoadState("networkidle");
+    await expectShellRendered(page);
+    await page
+      .getByRole("button", { name: "Expand the agent panel" })
+      .click();
+    await expect(page.locator(".arpanel")).toBeVisible();
+    await settleAnimations(page);
+    await expectNoAaViolations(page, "home — the agent's panel (390px, dark)");
+  });
 });
 
 /**

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -345,6 +345,94 @@
   --coreHalo: 0.5;
 }
 
+/* ===== The phone bar's centre cell =====
+ *
+ * At phone width the rail is a bottom bar of destinations, and the agent is the
+ * one cell on it that is not a place to go. So it does not dress as one: it
+ * RISES out of the bar's top edge on the bar's own material, which is the same
+ * claim the sidebar makes with a hairline and a lit floor, made in the one
+ * currency a five-cell bar has left — position.
+ *
+ * Nothing here is a second Core. The block is the same component in the same
+ * document; only its box changes (app/shell.tsx renders it in the bar's middle
+ * at this width and at the foot of the column above it).
+ */
+@media (max-width: 700px) {
+  .rail .arblock {
+    /* The cell's own height, so the bar's row is the destinations' 48px whatever
+       the circle above does. The circle is taken out of the flow below: sized in
+       it, it would make the agent's cell taller than every other one and stand
+       the bar on two heights. */
+    min-height: 48px; /* ds:ignore the bar's own cell height, set in app/shell.css */
+    margin: 0;
+  }
+  /* The well: the bar's material, its edge and its shadow, drawn as a circle and
+     lifted clear of the bar's top edge by exactly --phoneAgentRise. The lip is
+     what the bar publishes about its own padding and border (app/shell.css), so
+     the rise is measured from the edge a reader sees rather than from the cell
+     behind it. */
+  .rail .arhit {
+    position: absolute;
+    left: 50%;
+    top: calc(-1 * (var(--phoneBarLip) + var(--phoneAgentRise)));
+    translate: -50% 0;
+    /* A hair over the 48px minimum in both axes, because a circle's corners are
+       not a target: 56px of circle is 48px of reachable middle. */
+    width: 56px; /* ds:ignore the well's diameter, which is its own geometry */
+    height: 56px; /* ds:ignore the well's diameter, which is its own geometry */
+    flex-direction: row;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--borderSubtle);
+    border-radius: 50%;
+    /* The bar's ground, not the page's: the well is the bar rising, and a
+       different fill would read as an object resting on it. The tone the orb
+       spills sits over that ground rather than replacing it. */
+    background:
+      radial-gradient(
+        70% 70% at 50% 42%,
+        color-mix(in srgb, var(--arTone) 14%, transparent),
+        transparent 72%
+      ),
+      var(--bgSidebar);
+    box-shadow: var(--shadow-pop);
+  }
+  /* Outside the shape rather than inset: this control has an edge of its own
+     here, and a ring drawn inside it lands on the glass instead of around the
+     well. It follows the circle, because `outline` follows `border-radius`. */
+  .rail .arhit:focus-visible {
+    outline-offset: 2px;
+  }
+  /* No line and no figure under it. The bar carries no captions at all
+     (app/shell.css drops every `.navlabel`), and a reading under the one cell
+     that has room for one would be the only words on the bar — which reads as a
+     label for the bar rather than for the agent. The button keeps its accessible
+     name, so nothing is lost to a screen reader, and the panel it opens is where
+     the line and the month's spend are said. */
+  .rail .arwords,
+  .rail .archev {
+    display: none;
+  }
+  .rail .arorb {
+    /* Sized to the well, not to the rail: the sidebar gives the ball 196px and
+       this gives it the inside of a 56px circle. Still twice a destination's
+       20px glyph, which is the point — the one live object in the bar. */
+    --coreSize: 44px; /* ds:ignore the ball's diameter inside the well */
+    --coreGlass: 38px; /* ds:ignore the glass inside that ball */
+    /* More halo than the rail's, less than a hero's: here the ball has an edge
+       to bloom against, and the bloom is what makes the well read as lit from
+       the inside rather than as a grey disc with a marble in it. */
+    --coreHalo: 0.4;
+  }
+  /* The sheet is destinations and nothing else. The agent is a cell of the BAR,
+     and the bar is not on screen while the sheet is: a row for it in a list of
+     ten places would be the agent filed as an eleventh place to go, which is
+     what taking it out of that list was for. */
+  .rail.sheetopen .arblock {
+    display: none;
+  }
+}
+
 /* ===== The panel =====
  *
  * Beside the rail, and OUT of it: the rail scrolls its destinations and so
@@ -407,8 +495,65 @@
     transform: none;
   }
 }
-@media (prefers-reduced-motion: reduce) {
+/* On the phone bar the card is UNDER the panel, not to its left, so the arrival
+   comes from below and a notch says which cell it came out of. Both are declared
+   above the reduced-motion rule below, because that rule turns the animation off
+   and a later declaration of equal specificity would quietly turn it back on. */
+@media (max-width: 700px) {
   .arpanel {
+    animation-name: arpanelup;
+  }
+  @keyframes arpanelup {
+    from {
+      opacity: 0;
+      transform: translateY(6px) scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  /* The notch, on the WRAPPER rather than on the panel: the panel scrolls its
+     own body and would clip anything drawn outside it. It is a square standing
+     on a corner, filled and edged like the panel, sitting half behind it — the
+     half that shows is the tail, and the half that does not covers the panel's
+     own bottom hairline so the two read as one piece of glass.
+     Its position is the frame's, handed down as custom properties by
+     app/agentrail.tsx: the notch points at the orb that was MEASURED, not at the
+     middle of the screen, so it still lands if the bar's cells stop being even. */
+  .arloose::after {
+    content: "";
+    position: fixed;
+    left: var(--arCaretX);
+    bottom: calc(var(--arPanelBottom) - 3px);
+    width: 14px; /* ds:ignore the notch's own diagonal, not spacing */
+    height: 14px; /* ds:ignore the notch's own diagonal, not spacing */
+    translate: -50% 0;
+    rotate: 45deg;
+    border-right: 1px solid var(--borderSubtle);
+    border-bottom: 1px solid var(--borderSubtle);
+    border-bottom-right-radius: 3px; /* ds:ignore the notch's own tip */
+    background: var(--bgElevated);
+    z-index: 28;
+    /* Opacity alone. The notch already carries `rotate` and `translate` of its
+       own, and `transform` composes AFTER both — so the panel's 6px rise would
+       reach this element as a 6px slide along its own rotated axis, which is
+       diagonal. It fades over the same window instead, and the two arrive
+       together. */
+    animation: arnotchin 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  @keyframes arnotchin {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .arpanel,
+  .arloose::after {
     animation: none;
   }
 }

--- a/frontend/src/app/agentrail.stories.tsx
+++ b/frontend/src/app/agentrail.stories.tsx
@@ -86,7 +86,7 @@ function Rail({
   return (
     <nav className={collapsed ? "rail collapsed" : "rail expanded"}>
       <div className="grow" />
-      <div className="railfoot">{children}</div>
+      <div className="railagent">{children}</div>
     </nav>
   );
 }

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -644,24 +644,20 @@ describe("AgentRail", () => {
     const user = userEvent.setup();
     stubPhoneViewport();
     stubAgentRailApi();
-    const well = { top: 700, left: 167, width: 56 };
-    const cell = { top: 716, left: 151, width: 88 };
-    const nowhere = { top: 0, left: 0, width: 0 };
+    // Real DOMRects rather than object literals cast into the shape: a rect
+    // whose `top` was supplied and whose `bottom` was not is a box no element
+    // has, and the derived fields would then be whatever the literal happened to
+    // spell. The well stands 16px clear of the cell behind it, which is the one
+    // difference every assertion below turns on.
+    const well = new DOMRect(167, 700, 56, 56);
+    const cell = new DOMRect(151, 716, 88, 48);
+    const nowhere = new DOMRect(0, 0, 0, 0);
     vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
       function (this: Element) {
-        const seen = this.classList.contains("arhit")
-          ? well
-          : this.classList.contains("arblock")
-            ? cell
-            : nowhere;
-        return {
-          ...seen,
-          bottom: 0,
-          height: 0,
-          right: 0,
-          x: 0,
-          y: 0,
-        } as DOMRect;
+        if (this.classList.contains("arhit")) {
+          return well;
+        }
+        return this.classList.contains("arblock") ? cell : nowhere;
       },
     );
     const { container } = render(ROUTE);

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -16,7 +16,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent, { type UserEvent } from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
@@ -256,7 +256,11 @@ function PendingWrite() {
 
 function render(
   route: Route,
-  options: Readonly<{ client?: QueryClient; children?: ReactNode }> = {},
+  options: Readonly<{
+    client?: QueryClient;
+    children?: ReactNode;
+    bar?: RefObject<HTMLElement | null>;
+  }> = {},
 ) {
   const client =
     options.client ??
@@ -267,7 +271,7 @@ function render(
     <QueryClientProvider client={client}>
       <LocaleProvider initial="en">
         {options.children}
-        <AgentRail route={route} />
+        <AgentRail route={route} bar={options.bar} />
       </LocaleProvider>
     </QueryClientProvider>,
   );
@@ -630,7 +634,8 @@ describe("AgentRail", () => {
     expect(container.querySelector(".arbadge")).toBeNull();
   });
 
-  // Where the panel is measured from at phone width, and what points at it.
+  // Where the panel is measured from at phone width, what it spans, and what
+  // points at it.
   //
   // There it stands OVER its anchor rather than beside it, and the anchor is the
   // round well the orb sits in — which rises clear of the bar's top edge. Take
@@ -640,7 +645,7 @@ describe("AgentRail", () => {
   // stop being even. Both come off the same measured box, and this is the case
   // that says so: the well and the cell are deliberately given different boxes,
   // and every number below is the well's.
-  it("measures the phone panel from the well the orb sits in", async () => {
+  it("spans the bar and measures the phone panel from the well the orb sits in", async () => {
     const user = userEvent.setup();
     stubPhoneViewport();
     stubAgentRailApi();
@@ -651,22 +656,36 @@ describe("AgentRail", () => {
     // difference every assertion below turns on.
     const well = new DOMRect(167, 700, 56, 56);
     const cell = new DOMRect(151, 716, 88, 48);
+    const rail = new DOMRect(12, 716, 366, 58);
     const nowhere = new DOMRect(0, 0, 0, 0);
+    const boxFor = (element: Element) => {
+      if (element.classList.contains("arhit")) {
+        return well;
+      }
+      if (element.classList.contains("arblock")) {
+        return cell;
+      }
+      return element.classList.contains("rail") ? rail : nowhere;
+    };
     vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
       function (this: Element) {
-        if (this.classList.contains("arhit")) {
-          return well;
-        }
-        return this.classList.contains("arblock") ? cell : nowhere;
+        return boxFor(this);
       },
     );
-    const { container } = render(ROUTE);
+    const bar = document.createElement("nav");
+    bar.className = "rail";
+    const { container } = render(ROUTE, { bar: { current: bar } });
 
     await openPanel(user, container);
     const loose = panel();
     const surface = loose.querySelector<HTMLElement>(".arpanel");
     // 8px of air over the WELL's top edge, not over the cell 16px below it.
     expect(surface?.style.bottom).toBe(`${globalThis.innerHeight - 700 + 8}px`);
+    // The bar's own span, edge to edge: the panel and the bar are one object,
+    // and a panel inset by a margin of its own reads as a sheet that happened to
+    // arrive over it.
+    expect(surface?.style.left).toBe("12px");
+    expect(surface?.style.right).toBe(`${globalThis.innerWidth - 378}px`);
     // The well's own middle: 167 + 56 / 2.
     expect(loose.getAttribute("style")).toContain("--arCaretX: 195px");
   });

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -26,6 +26,7 @@ import { AgentRail } from "./agentrail";
 import { LABELS, REVIEW_ONLY, TASK_SAID, VOCABULARY } from "./agentrail-copy";
 import { type GrantSpec, meFixture } from "./mefixture";
 import type { Route } from "./router";
+import { stubPhoneViewport } from "./testing/shellharness";
 
 // The agent section at the foot of the workspace rail reads every one of its
 // facts off the wire (approvals, connectors, dedupe, AI posture, licence
@@ -319,6 +320,10 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  // The frame case spies on Element.prototype.getBoundingClientRect, which every
+  // later case in this file shares. Restored here rather than there: a spy left
+  // on a prototype is the kind of leak whose failure names a case that is fine.
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -623,6 +628,63 @@ describe("AgentRail", () => {
       ).toBeNull(),
     );
     expect(container.querySelector(".arbadge")).toBeNull();
+  });
+
+  // Where the panel is measured from at phone width, and what points at it.
+  //
+  // There it stands OVER its anchor rather than beside it, and the anchor is the
+  // round well the orb sits in — which rises clear of the bar's top edge. Take
+  // the measurement from the CELL behind that well and the panel opens across
+  // the orb it belongs to; take the notch's x from the middle of the SCREEN and
+  // it stops pointing at the thing that was pressed the moment the bar's cells
+  // stop being even. Both come off the same measured box, and this is the case
+  // that says so: the well and the cell are deliberately given different boxes,
+  // and every number below is the well's.
+  it("measures the phone panel from the well the orb sits in", async () => {
+    const user = userEvent.setup();
+    stubPhoneViewport();
+    stubAgentRailApi();
+    const well = { top: 700, left: 167, width: 56 };
+    const cell = { top: 716, left: 151, width: 88 };
+    const nowhere = { top: 0, left: 0, width: 0 };
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        const seen = this.classList.contains("arhit")
+          ? well
+          : this.classList.contains("arblock")
+            ? cell
+            : nowhere;
+        return {
+          ...seen,
+          bottom: 0,
+          height: 0,
+          right: 0,
+          x: 0,
+          y: 0,
+        } as DOMRect;
+      },
+    );
+    const { container } = render(ROUTE);
+
+    await openPanel(user, container);
+    const loose = panel();
+    const surface = loose.querySelector<HTMLElement>(".arpanel");
+    // 8px of air over the WELL's top edge, not over the cell 16px below it.
+    expect(surface?.style.bottom).toBe(`${globalThis.innerHeight - 700 + 8}px`);
+    // The well's own middle: 167 + 56 / 2.
+    expect(loose.getAttribute("style")).toContain("--arCaretX: 195px");
+  });
+
+  // Beside the card on a sidebar, and nothing pointing at anything: the panel
+  // and the block it came from are side by side and a notch would have no gap to
+  // cross. The variable is absent rather than set to a value the sheet ignores.
+  it("carries no notch on the sidebar", async () => {
+    const user = userEvent.setup();
+    stubAgentRailApi();
+    const { container } = render(ROUTE);
+
+    await openPanel(user, container);
+    expect(panel().getAttribute("style")).not.toContain("--arCaretX");
   });
 
   it("opens the panel on a click of the section and flips its expanded state", async () => {

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -4,6 +4,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
 import {
+  type CSSProperties,
   type RefObject,
   useCallback,
   useEffect,
@@ -781,7 +782,32 @@ type PanelFrame = Readonly<{
   bottom: number;
   width?: number;
   maxHeight: number;
+  /**
+   * Where the notch under the panel points, in viewport coordinates.
+   *
+   * Only the phone frame carries one: there the panel stands OVER the anchor
+   * rather than beside it, and a full-width sheet with nothing pointing at what
+   * opened it is a panel that could have come from anywhere. Measured from the
+   * anchor rather than assumed to be the middle of the screen, so the notch
+   * still lands on the orb if the bar's cells ever stop being symmetric.
+   */
+  caret?: number;
 }>;
+
+/**
+ * The notch's place, handed to the stylesheet rather than drawn here.
+ *
+ * Where it points is a MEASUREMENT and how it is drawn is the sheet's business,
+ * so the frame travels as custom properties on the portalled wrapper. Beside a
+ * sidebar there is no notch and no `--arCaretX`: the panel and the card that
+ * opened it are already touching, and a tail would have no gap to cross.
+ */
+function looseStyle(frame: PanelFrame): CSSProperties {
+  return {
+    "--arCaretX": frame.caret === undefined ? undefined : `${frame.caret}px`,
+    "--arPanelBottom": `${frame.bottom}px`,
+  } as CSSProperties;
+}
 
 /**
  * Where the panel goes, in viewport coordinates.
@@ -797,7 +823,8 @@ type PanelFrame = Readonly<{
  * block instead.
  */
 function usePanelFrame(
-  anchor: RefObject<HTMLElement | null>,
+  card: RefObject<HTMLElement | null>,
+  well: RefObject<HTMLElement | null>,
   open: boolean,
   phone: boolean,
 ): PanelFrame | null {
@@ -809,7 +836,12 @@ function usePanelFrame(
       return;
     }
     const place = () => {
-      const box = anchor.current?.getBoundingClientRect();
+      // Two anchors, because the panel stands in two places. Beside the whole
+      // CARD on the sidebar, where the card is what the reader is looking at;
+      // above the round WELL on the phone bar, which rises out of the bar's top
+      // edge — a frame measured from the cell behind it would open the panel
+      // across the orb it belongs to.
+      const box = (phone ? well : card).current?.getBoundingClientRect();
       if (!box) {
         return;
       }
@@ -820,6 +852,7 @@ function usePanelFrame(
           right: PANEL_MARGIN,
           bottom: height - box.top + PANEL_GAP,
           maxHeight: box.top - PANEL_GAP * 2,
+          caret: box.left + box.width / 2,
         });
         return;
       }
@@ -840,7 +873,7 @@ function usePanelFrame(
       globalThis.removeEventListener("resize", place);
       globalThis.removeEventListener("scroll", place, true);
     };
-  }, [anchor, open, phone]);
+  }, [card, well, open, phone]);
   return frame;
 }
 
@@ -1093,7 +1126,7 @@ export function AgentRail({ route }: Readonly<{ route: Route }>) {
     }
   }, []);
 
-  const frame = usePanelFrame(block, open, phone);
+  const frame = usePanelFrame(block, trigger, open, phone);
   const money =
     spend.minor === undefined
       ? ""
@@ -1145,7 +1178,11 @@ export function AgentRail({ route }: Readonly<{ route: Route }>) {
       {open &&
         frame &&
         createPortal(
-          <div className="arloose" data-core-state={state}>
+          <div
+            className="arloose"
+            data-core-state={state}
+            style={looseStyle(frame)}
+          >
             <AgentPanel
               state={state}
               setState={setOverride}

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -795,6 +795,20 @@ type PanelFrame = Readonly<{
 }>;
 
 /**
+ * The two custom properties the portalled wrapper is placed by.
+ *
+ * Declared rather than asserted onto `CSSProperties`: React's own type carries
+ * the CSS properties it knows, and a cast to it would say these two are among
+ * them. The intersection says what is true — the wrapper takes a style object
+ * that is one of those PLUS the two this file mints.
+ */
+type NotchPlacement = CSSProperties &
+  Readonly<{
+    "--arCaretX"?: string;
+    "--arPanelBottom": string;
+  }>;
+
+/**
  * The notch's place, handed to the stylesheet rather than drawn here.
  *
  * Where it points is a MEASUREMENT and how it is drawn is the sheet's business,
@@ -802,11 +816,11 @@ type PanelFrame = Readonly<{
  * sidebar there is no notch and no `--arCaretX`: the panel and the card that
  * opened it are already touching, and a tail would have no gap to cross.
  */
-function looseStyle(frame: PanelFrame): CSSProperties {
+function looseStyle(frame: PanelFrame): NotchPlacement {
   return {
     "--arCaretX": frame.caret === undefined ? undefined : `${frame.caret}px`,
     "--arPanelBottom": `${frame.bottom}px`,
-  } as CSSProperties;
+  };
 }
 
 /**

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -824,6 +824,39 @@ function looseStyle(frame: PanelFrame): NotchPlacement {
 }
 
 /**
+ * The frame over the phone bar: the bar's own span, clear of the well.
+ *
+ * Edge to edge with the BAR rather than inset by a margin of its own. The panel
+ * hangs off one of the bar's cells, so the two are one object seen from two
+ * distances — a panel inset by a different amount reads as a sheet that happened
+ * to arrive over the bar. Falls back to its own margin only where no bar was
+ * handed in, which is a caller that has none.
+ */
+function overTheBar(well: DOMRect, bar: DOMRect | undefined): PanelFrame {
+  return {
+    left: bar ? bar.left : PANEL_MARGIN,
+    right: bar ? globalThis.innerWidth - bar.right : PANEL_MARGIN,
+    bottom: globalThis.innerHeight - well.top + PANEL_GAP,
+    maxHeight: well.top - PANEL_GAP * 2,
+    caret: well.left + well.width / 2,
+  };
+}
+
+/**
+ * The frame beside the sidebar: bottom-aligned to the card, so opening the panel
+ * does not move the thing that opened it.
+ */
+function besideTheCard(card: DOMRect): PanelFrame {
+  const height = globalThis.innerHeight;
+  return {
+    left: card.right + PANEL_GAP,
+    bottom: Math.max(PANEL_MARGIN, height - card.bottom),
+    width: PANEL_WIDTH,
+    maxHeight: height - PANEL_MARGIN * 2,
+  };
+}
+
+/**
  * Where the panel goes, in viewport coordinates.
  *
  * It is FIXED and portalled to the body rather than positioned inside the block
@@ -839,6 +872,7 @@ function looseStyle(frame: PanelFrame): NotchPlacement {
 function usePanelFrame(
   card: RefObject<HTMLElement | null>,
   well: RefObject<HTMLElement | null>,
+  bar: RefObject<HTMLElement | null> | undefined,
   open: boolean,
   phone: boolean,
 ): PanelFrame | null {
@@ -859,23 +893,11 @@ function usePanelFrame(
       if (!box) {
         return;
       }
-      const height = globalThis.innerHeight;
-      if (phone) {
-        setFrame({
-          left: PANEL_MARGIN,
-          right: PANEL_MARGIN,
-          bottom: height - box.top + PANEL_GAP,
-          maxHeight: box.top - PANEL_GAP * 2,
-          caret: box.left + box.width / 2,
-        });
-        return;
-      }
-      setFrame({
-        left: box.right + PANEL_GAP,
-        bottom: Math.max(PANEL_MARGIN, height - box.bottom),
-        width: PANEL_WIDTH,
-        maxHeight: height - PANEL_MARGIN * 2,
-      });
+      setFrame(
+        phone
+          ? overTheBar(box, bar?.current?.getBoundingClientRect())
+          : besideTheCard(box),
+      );
     };
     place();
     // The anchor moves when the rail collapses, when the window changes size and
@@ -887,7 +909,7 @@ function usePanelFrame(
       globalThis.removeEventListener("resize", place);
       globalThis.removeEventListener("scroll", place, true);
     };
-  }, [card, well, open, phone]);
+  }, [bar, card, well, open, phone]);
   return frame;
 }
 
@@ -1082,7 +1104,20 @@ function barLine(
   return LABELS.idle;
 }
 
-export function AgentRail({ route }: Readonly<{ route: Route }>) {
+export function AgentRail({
+  route,
+  bar,
+}: Readonly<{
+  route: Route;
+  /**
+   * The bottom bar this block is a cell of, at phone width.
+   *
+   * Only the panel needs it, and only there: it spans the bar rather than
+   * insetting itself, so the two read as one object. Absent on the sidebar,
+   * where the panel stands beside the card and the bar does not exist.
+   */
+  bar?: RefObject<HTMLElement | null>;
+}>) {
   const t = useT();
   // The switcher's choice, and null while the rail is reporting what it read.
   const [override, setOverride] = useState<MarginceCoreState | null>(null);
@@ -1140,7 +1175,7 @@ export function AgentRail({ route }: Readonly<{ route: Route }>) {
     }
   }, []);
 
-  const frame = usePanelFrame(block, trigger, open, phone);
+  const frame = usePanelFrame(block, trigger, bar, open, phone);
   const money =
     spend.minor === undefined
       ? ""

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -127,15 +127,20 @@ export const NAV: readonly NavItem[] = NAV_GROUPS.flatMap(
 // one, and a decorative count contradicts the badge rule.
 export const BADGE_SCREENS: ReadonlySet<Screen> = new Set();
 
-// At phone width the sidebar becomes a bottom bar, which fits four thumb-sized
-// destinations plus More — ten would need horizontal scrolling, and a nav you
-// have to scroll is a nav you cannot see. Today is non-negotiable here: the
-// 390px approval path is required for V1, and Today is where it now runs.
+// At phone width the sidebar becomes a bottom bar, which fits five thumb-sized
+// cells — ten destinations would need horizontal scrolling, and a nav you have
+// to scroll is a nav you cannot see. The CENTRE cell is not a destination: it is
+// the agent, which is app-level chrome and reports rather than navigates, so
+// three destinations ride the bar and More carries the rest.
+//
+// Today is one of the three the bar gives up, and it is the one worth saying out
+// loud: the 390px approval path runs on it. It is a tap away in the sheet, which
+// is the same distance every destination this list omits already is, and what
+// the centre cell buys instead is the agent reachable without opening anything.
 export const MOBILE_PRIMARY: ReadonlySet<Screen> = new Set([
   "home",
   "contacts",
   "deals",
-  "today",
 ]);
 
 // Which RECORD screens keep the reading column instead of taking the width they

--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -4,6 +4,8 @@
 import { ChevronLeft } from "lucide-react";
 import {
   createContext,
+  Fragment,
+  type ReactNode,
   type RefObject,
   useCallback,
   useContext,
@@ -249,6 +251,8 @@ function NavLevelGroupView({
   counts,
   state,
   onSelect,
+  centre,
+  centreAfter,
 }: Readonly<{
   level: NavTrailLevel;
   group: NavLevelGroup;
@@ -256,6 +260,8 @@ function NavLevelGroupView({
   counts?: NavCounts;
   state: TipState;
   onSelect: (entry: NavLevelEntry) => void;
+  centre?: ReactNode;
+  centreAfter?: string;
 }>) {
   const t = useT();
   return (
@@ -267,22 +273,28 @@ function NavLevelGroupView({
         <Heading className="navheading">{t(group.headingKey)}</Heading>
       )}
       {group.items.map((entry) => (
-        <div
-          className={
-            level.barIds?.has(entry.id) ? "navwrap primary" : "navwrap"
-          }
-          key={entry.id}
-        >
-          <NavLevelRow
-            level={level}
-            entry={entry}
-            count={
-              level.badgeIds?.has(entry.id) ? counts?.[entry.id] : undefined
+        <Fragment key={entry.id}>
+          <div
+            className={
+              level.barIds?.has(entry.id) ? "navwrap primary" : "navwrap"
             }
-            state={state}
-            onSelect={onSelect}
-          />
-        </div>
+          >
+            <NavLevelRow
+              level={level}
+              entry={entry}
+              count={
+                level.badgeIds?.has(entry.id) ? counts?.[entry.id] : undefined
+              }
+              state={state}
+              onSelect={onSelect}
+            />
+          </div>
+          {/* The centre cell stands in the ROW STREAM rather than beside it, so
+              the bar's tab order is the order a thumb reads it in. Placing it
+              with a grid column alone would have left it third on screen and
+              last to the keyboard. */}
+          {entry.id === centreAfter && centre}
+        </Fragment>
       ))}
     </div>
   );
@@ -338,6 +350,25 @@ function levelTitle(
   return level.titleKey ? t(level.titleKey) : "";
 }
 
+/**
+ * Which bar row the centre cell stands after.
+ *
+ * The phone bar is this level's bar rows, plus More on the right, plus the one
+ * cell the caller hands in — and that cell is its MIDDLE, so half of everything
+ * else stands to its left. Derived from the level's own bar set rather than
+ * pinned to a screen id: a destination added to or taken off the bar has to move
+ * the cell, not leave it standing off-centre.
+ */
+function centreAfterId(level: NavTrailLevel): string | undefined {
+  const bar = level.groups
+    .flatMap((group) => group.items)
+    .filter((entry) => level.barIds?.has(entry.id));
+  if (bar.length === 0) {
+    return undefined;
+  }
+  return bar[Math.ceil((bar.length + 1) / 2) - 1]?.id;
+}
+
 export function NavLevelView({
   level,
   parent,
@@ -345,6 +376,7 @@ export function NavLevelView({
   state,
   onSelect,
   onWalkUp,
+  centre,
 }: Readonly<{
   level: NavTrailLevel;
   // Absent on the primary level, which is where the sidebar already is: there
@@ -354,8 +386,13 @@ export function NavLevelView({
   state: TipState;
   onSelect: (entry: NavLevelEntry) => void;
   onWalkUp: () => void;
+  // One cell that is NOT a destination, standing in the middle of the phone
+  // bar's row of them. The sidebar passes nothing: a column of places to go has
+  // no middle for a reading to stand in, and the agent keeps its own foot there.
+  centre?: ReactNode;
 }>) {
   const t = useT();
+  const centreAfter = centre ? centreAfterId(level) : undefined;
   return (
     <div className={parent ? "navlevel drilled" : "navlevel"}>
       {parent && (
@@ -375,6 +412,8 @@ export function NavLevelView({
           counts={counts}
           state={state}
           onSelect={onSelect}
+          centre={centre}
+          centreAfter={centreAfter}
         />
       ))}
     </div>

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -294,24 +294,24 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
   });
 
   // TEMPORARY, with the marker it covers: delete this case in the change that
-  // takes the product out of pre-alpha.
+  // takes the product out of alpha.
   //
   // What it holds is the half that is easy to break — the marker has to survive
   // the collapse. At 64px the rail drops every label it has, so a release marker
   // that rode the wordmark would be gone exactly where the product is hardest to
   // identify. It hangs off the head instead, which is present in both states.
-  it("keeps the pre-alpha marker in the head at both rail widths", () => {
+  it("keeps the release marker in the head at both rail widths", () => {
     const expanded = render(<WorkspaceRail route={{ screen: "home" }} />);
     expect(
-      expanded.container.querySelectorAll(".railhead .prealpha"),
+      expanded.container.querySelectorAll(".railhead .alphamark"),
     ).toHaveLength(1);
     cleanup();
 
     const collapsed = render(
       <WorkspaceRail route={{ screen: "home" }} collapsed />,
     );
-    const marker = collapsed.container.querySelector(".railhead .prealpha");
-    expect(marker?.textContent).toBe("Pre-alpha");
+    const marker = collapsed.container.querySelector(".railhead .alphamark");
+    expect(marker?.textContent).toBe("Alpha");
   });
 
   // The bar is five cells and only three of them are destinations. The agent is

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -293,6 +293,57 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
     expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(1);
   });
 
+  // The bar is five cells and only three of them are destinations. The agent is
+  // the middle one — it reports rather than navigates, so it is not filed among
+  // the places to go — and it stands in the ROW STREAM rather than beside it,
+  // because a cell placed by a grid column alone is third to the eye and last to
+  // the Tab key. What this asserts is that ONE order describes both.
+  it("puts the agent in the middle of the phone bar, in the order a thumb reads", () => {
+    stubPhoneViewport();
+    const { container } = render(<WorkspaceRail route={{ screen: "home" }} />);
+    const nav = container.querySelector(".rail");
+    const cells = [
+      ...(nav?.querySelectorAll(".navwrap.primary, .arblock, .railmore") ?? []),
+    ].map((cell) =>
+      cell.classList.contains("navwrap")
+        ? (cell.querySelector(".navitem")?.getAttribute("aria-label") ?? "")
+        : cell.classList.contains("arblock")
+          ? "agent"
+          : "more",
+    );
+    expect(cells).toEqual(["Home", "Contacts", "agent", "Pipeline", "more"]);
+  });
+
+  // The Worklist is the destination the bar gave up for that cell. Off the bar
+  // is not gone: it is a row in the sheet like every other destination the bar
+  // cannot carry, and More reports it as the current page while it is open.
+  it("keeps the Worklist off the bar and in the sheet", async () => {
+    const user = userEvent.setup();
+    stubPhoneViewport();
+    const { container } = render(<WorkspaceRail route={{ screen: "today" }} />);
+    expect(container.querySelectorAll(".navwrap.primary")).toHaveLength(3);
+    expect(
+      container.querySelector(".railmore.active")?.getAttribute("aria-current"),
+    ).toBe("page");
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+    expect(levelLabels()).toContain("Worklist");
+  });
+
+  // The agent is a cell of the BAR, and the bar is not on screen while the sheet
+  // is. It is not re-parented into the sheet either: a row for it in a list of
+  // ten places would file the agent as an eleventh place to go, which is what
+  // taking it out of that list was for. One block, still mounted, still one Core.
+  it("keeps exactly one agent when the sheet takes the bar's place", async () => {
+    const user = userEvent.setup();
+    stubPhoneViewport();
+    const { container } = render(<WorkspaceRail route={{ screen: "home" }} />);
+    expect(container.querySelectorAll(".arblock")).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+    expect(container.querySelectorAll(".arblock")).toHaveLength(1);
+  });
+
   // The sheet is the phone's whole sidebar, and it is navigation and nothing
   // else: the account menu lives in the top bar, which is on screen at this
   // width too. A second copy of it down here would be two account affordances

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -293,6 +293,27 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
     expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(1);
   });
 
+  // TEMPORARY, with the marker it covers: delete this case in the change that
+  // takes the product out of pre-alpha.
+  //
+  // What it holds is the half that is easy to break — the marker has to survive
+  // the collapse. At 64px the rail drops every label it has, so a release marker
+  // that rode the wordmark would be gone exactly where the product is hardest to
+  // identify. It hangs off the head instead, which is present in both states.
+  it("keeps the pre-alpha marker in the head at both rail widths", () => {
+    const expanded = render(<WorkspaceRail route={{ screen: "home" }} />);
+    expect(
+      expanded.container.querySelectorAll(".railhead .prealpha"),
+    ).toHaveLength(1);
+    cleanup();
+
+    const collapsed = render(
+      <WorkspaceRail route={{ screen: "home" }} collapsed />,
+    );
+    const marker = collapsed.container.querySelector(".railhead .prealpha");
+    expect(marker?.textContent).toBe("Pre-alpha");
+  });
+
   // The bar is five cells and only three of them are destinations. The agent is
   // the middle one — it reports rather than navigates, so it is not filed among
   // the places to go — and it stands in the ROW STREAM rather than beside it,

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -756,14 +756,14 @@
   flex: 1;
   min-height: var(--space-3);
 }
-/* `:has()` rather than a bare selector: without `license:read` the row inside
-   returns nothing, and a foot that drew its rule anyway left a 12px band with a
-   hairline over it under the navigation — a divider dividing one thing from
-   nothing. */
-.rail .railfoot:not(:has(*)) {
+/* `:has()` rather than a bare selector: the agent draws nothing on the Ask
+   screen (app/agentrail.tsx), and a foot that drew its band anyway left a 12px
+   strip with a hairline over it under the navigation — a divider dividing one
+   thing from nothing. */
+.rail .railagent:not(:has(*)) {
   display: none;
 }
-.rail .railfoot {
+.rail .railagent {
   /* As the head: the reading keeps its height whether the panel scrolls or not. */
   flex: none;
   /* No rule and barely any air. This band held a rule and a `--space-3` on each
@@ -774,55 +774,6 @@
   margin: var(--space-1) calc(-1 * var(--space-2)) 0;
   padding: 0 var(--space-2);
 }
-.rail .raillicense {
-  display: flex;
-  align-items: center;
-  /* The destinations' own geometry, to the pixel: same gap, same inset, same
-     type, same glyph size. It is a different KIND of row — a reading, not a
-     place to go — and it says so in its ink, not by standing on a second grid. */
-  gap: 9px; /* ds:ignore matches .navitem's icon-to-label gap so the rows align */
-  position: relative;
-  min-height: 34px;
-  padding: 0 14px; /* ds:ignore the nav rows' own inset, which this row stands in */
-  border-radius: 8px; /* ds:ignore the nav rows' own radius */
-  color: var(--textMeta);
-  font-size: var(--fs-body);
-  text-decoration: none;
-}
-.rail .raillicense:hover {
-  background: var(--bgHover);
-  color: var(--textPrimary);
-}
-/* `--accent`, not `--accentBrand`: the brand token is deliberately unthemed
-   (tokens.css) and in the dark theme it falls to 3.0:1 against the panel — and to
-   2.5:1 over a hovered row, which is where this ring is actually drawn. A focus
-   ring is a UI state and takes the state colour. */
-.rail .raillicense:focus-visible {
-  outline: var(--focus-ring);
-  outline-offset: -2px;
-}
-.rail .raillicense svg {
-  width: 18px;
-  height: 18px;
-  flex: none;
-}
-/* Something to act on rather than merely know: over the cap, refused, in grace,
-   or due for renewal. Reported here and explained on the surface this leads to —
-   the chrome enforces nothing. */
-.rail .raillicense.pressing {
-  color: var(--warn);
-}
-/* Collapsed, this row changes exactly what a destination's row changes: the
-   reading goes and the glyph stays where it was. It keeps the destinations'
-   height and their 14px inset, so the whole column — ten places and the reading
-   under them — holds still through the collapse instead of re-spacing itself.
-   The label is absolutely positioned like theirs and fades with them; it is
-   taken out of the flow here as well so a screen reader is not offered a name
-   that is no longer drawn. */
-.rail.collapsed .raillicense .navlabel {
-  display: none;
-}
-
 /* The More control belongs to the phone-width bottom bar only. */
 .rail .railmore {
   display: none;
@@ -1146,11 +1097,23 @@
        ledge everywhere else. */
     bottom: max(var(--space-2), env(safe-area-inset-bottom));
     z-index: 30;
-    flex-direction: row;
+    /* A GRID of equal cells, not a flex row: the cells are thumb targets and a
+       thumb learns where a destination is by its position, so a bar whose cells
+       resize with their glyph moves every target the day a row is added. Equal
+       columns also put the agent's cell on the bar's own centre line without
+       anything measuring it. `grid-auto-flow: column` keeps the whole bar on one
+       row; the cells are the level's rows, the agent and More, in that order. */
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
     align-items: center;
-    justify-content: space-between;
     padding: var(--space-1) var(--space-1);
     gap: 2px;
+    /* How far the bar's own top edge stands above a cell: its padding and its
+       border. Published because the agent's cell rises out of that edge and has
+       to measure the rise from it (app/agentrail.css) — a second opinion about
+       this bar's padding is a rise that drifts the day the padding changes. */
+    --phoneBarLip: calc(var(--space-1) + 1px);
     overflow: visible;
     /* Here the panel IS a floating object — it hovers over the content rather
        than bounding it — so it takes the card chrome the flush sidebar gives
@@ -1203,9 +1166,15 @@
      below is where they come back. */
   .rail .navheading,
   .rail .ws,
-  .rail .railfoot,
   .rail .grow,
   .rail .navtip {
+    display: none;
+  }
+  /* The head is the brand block's box, and the brand block is hidden above: what
+     is left is an empty cell, which a flex row gave no width and this grid would
+     give a whole column. The sheet brings the head back (below), where there is
+     a row for it to stand on. */
+  .rail .railhead {
     display: none;
   }
   /* No captions in the bar. Five glyphs at 9.5px carried five words nobody
@@ -1233,9 +1202,11 @@
     align-items: center;
     justify-content: center;
     gap: 0;
-    width: 56px;
+    /* The cell's whole width: the bar's columns are the target grid, and a
+       56px control inside a wider cell is a target that ends before the cell a
+       thumb aimed at does. */
+    width: 100%;
     min-height: 48px;
-    flex: none;
     border: 0;
     border-radius: 10px;
     background: transparent;
@@ -1247,7 +1218,7 @@
     height: 20px;
   }
   .rail .navwrap {
-    flex: 1;
+    display: flex;
     justify-content: center;
   }
   .rail .navitem,
@@ -1288,6 +1259,9 @@
   .rail.sheetopen,
   .rail.sheetopen.expanded,
   .rail.sheetopen.collapsed {
+    /* The sheet is a COLUMN of rows, not a bar of cells: the grid above is the
+       bar's arrangement and says nothing about a list of ten places. */
+    display: flex;
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
@@ -1424,39 +1398,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
-  }
-  /* The foot comes back with the sheet: the entitlement is as true on a phone as
-     anywhere, and the sheet is the one place at this width with room to say it.
-     It divides the sheet on the sheet's own 4px gutter rather than the sidebar's
-     8px one.
-     The `.rail.collapsed …` variants are restated for the row and its label for
-     the reason this block states three times over: the desktop preference
-     survives a resize and outranks a bare `.rail` selector — without it a reader
-     who left the sidebar collapsed opened the sheet to a centred glyph with no
-     seat count and nothing saying what it was. */
-  /* `:has(*)` carried through: the bar hides this foot at this width and the
-     sheet brings it back, but only when there IS a reading in it. Without it the
-     re-show outranks the empty-foot guard above by one class, and a reader
-     without `license:read` — for whom `RailLicense` renders nothing — opened the
-     sheet to the bare rule and 12px of band that guard exists to prevent. */
-  .rail.sheetopen .railfoot:has(*) {
-    display: block;
-    margin: var(--space-3) calc(-1 * var(--space-2)) 0;
-    padding: var(--space-3) var(--space-2) 0;
-  }
-  .rail.sheetopen .raillicense,
-  .rail.sheetopen.collapsed .raillicense {
-    justify-content: flex-start;
-    min-height: 48px;
-    padding: 0 var(--space-3);
-  }
-  .rail.sheetopen .raillicense .navlabel,
-  .rail.sheetopen.collapsed .raillicense .navlabel {
-    display: block;
-    opacity: 1;
-  }
-  .rail.sheetopen .raillicense {
-    min-height: 48px;
   }
   /* Open, the sheet shows the active row itself, and More has become its close
      control — a state on a close button would name the wrong thing. */

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -355,45 +355,42 @@
 }
 /* TEMPORARY — the release marker.
  *
- * The whole thing goes when the product leaves pre-alpha: this rule, the span in
- * app/shell.tsx and the `shell.preAlpha` key, in one change.
+ * The whole thing goes when the product leaves alpha: this rule, the span in
+ * app/shell.tsx, the `shell.alpha` key and the case in rail.test.tsx that holds
+ * it through the collapse, in one change.
+ *
+ * A corner ribbon across the head's top-left, which is the one place a marker
+ * can go without competing with anything: the head holds the mark and the
+ * wordmark and nothing else, and this crosses the corner both of them leave
+ * empty.
  *
  * ABSOLUTE, so it takes no space: the head's height is the strip's to the pixel
  * and every row below it is aligned to that, so a marker in the flow would move
- * the whole column. And placed off the MARK rather than off the head — the mark
- * sits at the same x in both rail states and the head is what narrows around it,
- * so one placement is on screen at 252px and at 64px with nothing restated.
- *
- * It sits under the mark, on the head's bottom edge, which is the one band that
- * is empty in both states: the wordmark beside it ends above this line and the
- * collapsed rail has nothing there at all.
- *
- * Warn, not danger and not the AI hue: it is a caveat about how finished the
- * product is, which is the thing that goes wrong if a reader assumes otherwise.
- * Not a `Badge` — that primitive owns its own geometry (design-system/atoms.tsx)
- * and this is 8px chrome pinned to a corner, so reaching for it would mean
- * overriding every property it has. Chrome the rail applies to itself, like
- * `.railmore`. */
-.rail .prealpha {
+ * the whole column. And it hangs off the HEAD's own corner, which is at the same
+ * place in both rail states — the head narrows around the mark rather than
+ * moving it — so one placement is on screen at 252px, at 64px, and in the phone
+ * sheet's head. */
+.rail .alphamark {
   position: absolute;
-  /* The mark's own centre INSIDE the head: 7px of head inset plus half of a
-     32px mark. Stated rather than measured, because a stylesheet cannot measure
-     — and it is the one number that has to hold, since the collapsed rail is
-     64px wide and this pill is most of it. */
-  left: 23px; /* ds:ignore the mark's centre line, which this hangs from */
-  bottom: -2px; /* ds:ignore the head's own bottom edge */
+  left: 2px; /* ds:ignore the ribbon's own corner anchor */
+  top: 10px; /* ds:ignore the ribbon's own corner anchor */
   translate: -50% 0;
-  padding: 1px 4px; /* ds:ignore a cap-height pill, not spaced content */
-  border: 1px solid var(--warnBorder);
-  border-radius: 999px; /* ds:ignore a pill's own corner */
-  background: var(--warnBg);
-  color: var(--warn);
-  /* The body face, not the mono one an identifier takes: this is a word, and at
-     8px the mono face is 6px wider than the collapsed rail can hold. */
+  rotate: -45deg;
+  transform-origin: 50% 0;
+  width: 75px; /* ds:ignore the ribbon's own span across the corner */
+  padding: 1px 0; /* ds:ignore a cap-height band, not spaced content */
+  border-radius: 4px; /* ds:ignore the ribbon's own corner */
+  /* The status amber, and a fixed dark ink on it. `--bgRail` is the one near
+     black this palette holds STILL across both themes (tokens.css says so where
+     it is declared) — every other dark ink here lightens with the theme, and
+     this ribbon's ground does not, so it would go unreadable in one of them. */
+  background: var(--away);
+  color: var(--bgRail);
+  font-family: var(--f-mono);
   font-size: 8px; /* ds:ignore below the type scale on purpose — it must not compete with the mark */
-  font-weight: var(--fw-semibold);
-  letter-spacing: 0.02em;
+  font-weight: var(--fw-bold);
   line-height: 1.4;
+  text-align: center;
   text-transform: uppercase;
   white-space: nowrap;
   pointer-events: none;

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -344,12 +344,59 @@
   height: var(--topbarH);
   margin-top: calc(-1 * var(--space-3));
   margin-bottom: 0;
+  /* The release marker below hangs off this box. */
+  position: relative;
 }
 /* Collapsed, the head is the logomark alone, centred: the control that opens
    and closes this panel now stands in the top bar, where it does not travel
    with the panel it opens and does not have to be discovered on hover. */
 .rail.collapsed .railhead {
   justify-content: center;
+}
+/* TEMPORARY — the release marker.
+ *
+ * The whole thing goes when the product leaves pre-alpha: this rule, the span in
+ * app/shell.tsx and the `shell.preAlpha` key, in one change.
+ *
+ * ABSOLUTE, so it takes no space: the head's height is the strip's to the pixel
+ * and every row below it is aligned to that, so a marker in the flow would move
+ * the whole column. And placed off the MARK rather than off the head — the mark
+ * sits at the same x in both rail states and the head is what narrows around it,
+ * so one placement is on screen at 252px and at 64px with nothing restated.
+ *
+ * It sits under the mark, on the head's bottom edge, which is the one band that
+ * is empty in both states: the wordmark beside it ends above this line and the
+ * collapsed rail has nothing there at all.
+ *
+ * Warn, not danger and not the AI hue: it is a caveat about how finished the
+ * product is, which is the thing that goes wrong if a reader assumes otherwise.
+ * Not a `Badge` — that primitive owns its own geometry (design-system/atoms.tsx)
+ * and this is 8px chrome pinned to a corner, so reaching for it would mean
+ * overriding every property it has. Chrome the rail applies to itself, like
+ * `.railmore`. */
+.rail .prealpha {
+  position: absolute;
+  /* The mark's own centre INSIDE the head: 7px of head inset plus half of a
+     32px mark. Stated rather than measured, because a stylesheet cannot measure
+     — and it is the one number that has to hold, since the collapsed rail is
+     64px wide and this pill is most of it. */
+  left: 23px; /* ds:ignore the mark's centre line, which this hangs from */
+  bottom: -2px; /* ds:ignore the head's own bottom edge */
+  translate: -50% 0;
+  padding: 1px 4px; /* ds:ignore a cap-height pill, not spaced content */
+  border: 1px solid var(--warnBorder);
+  border-radius: 999px; /* ds:ignore a pill's own corner */
+  background: var(--warnBg);
+  color: var(--warn);
+  /* The body face, not the mono one an identifier takes: this is a word, and at
+     8px the mono face is 6px wider than the collapsed rail can hold. */
+  font-size: 8px; /* ds:ignore below the type scale on purpose — it must not compete with the mark */
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  text-transform: uppercase;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 /* brand block */
@@ -1268,10 +1315,20 @@
     gap: 1px;
     padding: var(--space-2) var(--space-2)
       max(var(--space-2), env(safe-area-inset-bottom));
-    /* dvh, not vh: on iOS the browser chrome is subtracted from the wrong side
+    /* Everything between the two ledges. The sheet already stands on the bar's
+       own bottom inset, so what it may take is the viewport less that, less the
+       same air again at the top — a sheet that ended flush with the top edge
+       would read as a page rather than as a layer over one, and would leave the
+       reader nothing to press to dismiss it. Ten destinations do not fill it, so
+       this is a CEILING for the locales and the levels that come closer.
+       dvh, not vh: on iOS the browser chrome is subtracted from the wrong side
        of vh, and a sheet measured against the larger viewport runs its last row
        under the address bar. */
-    max-height: 80dvh;
+    max-height: calc(
+      100dvh -
+      max(var(--space-2), env(safe-area-inset-bottom)) -
+      var(--space-6)
+    );
     overflow-y: auto;
     /* The page behind is already locked; this stops the scroll chaining into
        the page's scroller when the sheet itself hits its end. */

--- a/frontend/src/app/shell.stories.tsx
+++ b/frontend/src/app/shell.stories.tsx
@@ -580,7 +580,7 @@ export const SectionPhone: Story = {
 /**
  * The More sheet, open — the phone's whole sidebar.
  *
- * The bar it grew out of is five glyphs with no captions, which is all a 390px
+ * The bar it grew out of is five cells with no captions, which is all a 390px
  * row can hold; the sheet is where the ten destinations become a LIST again, and
  * everything the bar had to give up comes back with them:
  *
@@ -592,15 +592,13 @@ export const SectionPhone: Story = {
  *   rail's hairline, because the sheet is 600px wide whatever the desktop
  *   preference it inherited was left at;
  * - the badge as a TRAILING figure in its row rather than a chip pinned to a
- *   tab — a list row has somewhere to put a number;
- * - the entitlement row in the foot, because what the installation is entitled
- *   to is as true on a phone as anywhere.
+ *   tab — a list row has somewhere to put a number.
  *
- * That last one is below the fold in the captured frame, honestly: the sheet is
- * `max-height: 80dvh` over 821px of content, so it is a scroller, and the foot
- * sits about 70px past its bottom edge. It is there and it is reachable — scroll
- * the sheet — but a screenshot of the sheet's head is not a screenshot of its
- * foot, and saying so is cheaper than a second frame scrolled to the end.
+ * What does NOT come back is the agent. It is a cell of the BAR, and the bar is
+ * not on screen while this is; a row for it in a list of ten places would file
+ * the one thing in the chrome that reports rather than navigates as an eleventh
+ * place to go. The sheet is `max-height: 80dvh` over a list this long, so it is a
+ * scroller either way — the captured frame is its head, not its end.
  *
  * The close control is the same More button in its other state, renamed, and it
  * is PINNED to the head's corner rather than left at the end of a scrolling list
@@ -657,6 +655,105 @@ export const PhoneMoreSheet: Story = {
       <StoryProviders>
         <SeedInstallation>
           <PhoneSheetExample />
+        </SeedInstallation>
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * The phone bar, closed — three destinations, the agent, and More.
+ *
+ * Five cells of equal width, and only three of them are places to go. The middle
+ * one is the agent, and everything about how it is drawn is one claim: it is a
+ * different KIND of thing from the four glyphs around it. It rises out of the
+ * bar's top edge in a round well of the bar's own material, it carries the only
+ * lit object in the chrome, and it has no caption — the bar has no captions at
+ * all, and a word under the one cell with room for one would read as a label for
+ * the bar rather than for the agent. Its accessible name says the rest.
+ *
+ * The Worklist is what the bar gave up for that cell. It is a tap away in the
+ * sheet, which is the same distance the other six destinations already are.
+ *
+ * Position is load-bearing twice over. It is the CENTRE because the agent
+ * belongs to the whole session rather than to any destination, so it stands
+ * outside the row of them rather than at one end. And it is the third cell in
+ * the DOM as well as on screen (app/navlevel.tsx renders it into the row stream),
+ * so a thumb and a Tab key read the bar in the same order — a cell placed by a
+ * grid column alone would have been third to the eye and last to the keyboard.
+ */
+function PhoneBarExample() {
+  const route: Route = { screen: "home" };
+  const { openSearch, palette } = usePaletteSeam();
+  return (
+    <div className="app railexpanded">
+      <WorkspaceRail route={route} counts={COUNTS} />
+      <main className="main">
+        <TopBar route={route} collapsed={false} onOpenSearch={openSearch} />
+        <div className="scroll">
+          <PageTitle route={route} />
+          <div className="wrap">
+            <Card as="div">The page the bar floats over.</Card>
+          </div>
+        </div>
+      </main>
+      {palette}
+    </div>
+  );
+}
+
+export const PhoneBar: Story = {
+  name: "phone — the bar, with the agent in the middle",
+  globals: { viewport: { value: "phone" } },
+  tags: ["uat-phone"],
+  render: () => {
+    stubEntitlement(WITHIN_CAP);
+    return (
+      <StoryProviders>
+        <SeedInstallation>
+          <PhoneBarExample />
+        </SeedInstallation>
+      </StoryProviders>
+    );
+  },
+};
+
+/**
+ * The agent's panel, open over the phone bar.
+ *
+ * The same panel the sidebar opens beside its own card, in the only place a
+ * bottom bar leaves for it: above. Two things make it read as this cell's panel
+ * rather than as a sheet that arrived from nowhere.
+ *
+ * It is MEASURED from the well, not from the cell behind it — the well rises
+ * clear of the bar, and a frame taken from the cell would open the panel across
+ * the orb it belongs to. And it carries a notch that points back down at that
+ * well, drawn on the portalled wrapper rather than on the panel, because the
+ * panel scrolls its own body and would clip anything outside it. The notch's x
+ * is the measured middle of the well, so it still lands if the bar's cells ever
+ * stop being even.
+ *
+ * There is no scrim. This is a popover, not the More sheet: the page behind it
+ * stays live and readable, an outside tap or Escape closes it, and focus goes
+ * back to the orb. A dimmed page would claim the reader has to answer something
+ * before carrying on, and there is nothing here to answer.
+ */
+export const PhoneAgentPanel: Story = {
+  name: "phone — the agent's panel over the bar",
+  globals: { viewport: { value: "phone" } },
+  tags: ["uat-phone"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Expand the agent panel" }),
+    );
+  },
+  render: () => {
+    stubEntitlement(WITHIN_CAP);
+    return (
+      <StoryProviders>
+        <SeedInstallation>
+          <PhoneBarExample />
         </SeedInstallation>
       </StoryProviders>
     );

--- a/frontend/src/app/shell.stories.tsx
+++ b/frontend/src/app/shell.stories.tsx
@@ -597,8 +597,11 @@ export const SectionPhone: Story = {
  * What does NOT come back is the agent. It is a cell of the BAR, and the bar is
  * not on screen while this is; a row for it in a list of ten places would file
  * the one thing in the chrome that reports rather than navigates as an eleventh
- * place to go. The sheet is `max-height: 80dvh` over a list this long, so it is a
- * scroller either way — the captured frame is its head, not its end.
+ * place to go. What the cell it left behind buys the sheet is the room for the
+ * whole list: the ceiling is the viewport less the ledge it stands on and the
+ * same air again at the top, and the ten destinations now sit inside it without
+ * scrolling. It is still a scroller — a longer locale or a level with more rows
+ * will reach that ceiling.
  *
  * The close control is the same More button in its other state, renamed, and it
  * is PINNED to the head's corner rather than left at the end of a scrolling list

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -574,11 +574,27 @@ describe("Shell", () => {
     const agents = container.querySelectorAll(".arblock");
     expect(agents).toHaveLength(1);
     expect(
-      container.querySelector(".rail .railfoot")?.contains(agents[0]),
+      container.querySelector(".rail .railagent")?.contains(agents[0]),
     ).toBe(true);
     expect(
       container.querySelector("main")?.querySelector(".arblock"),
     ).toBeNull();
+  });
+
+  // The same one agent, in the one place a bottom bar has for a thing that is
+  // not a destination. A foot needs a column to be at the foot OF, so at this
+  // width the block moves into the bar's row of cells instead — and it MOVES: a
+  // second one rendered in the bar beside the one in the foot would be two Cores
+  // reporting the same session at two sizes.
+  it("mounts the agent once, in the bar's centre at phone width", () => {
+    stubPhoneViewport();
+    window.location.hash = "#/contacts";
+    const { container } = render(
+      <Shell onOpenSearch={ignoreSearch}>{null}</Shell>,
+    );
+    expect(container.querySelectorAll(".arblock")).toHaveLength(1);
+    expect(container.querySelector(".railagent")).toBeNull();
+    expect(container.querySelector(".rail .navlevel .arblock")).not.toBeNull();
   });
 
   // A sidebar showing a section's entries is navigation inside ONE destination,
@@ -601,7 +617,7 @@ describe("Shell", () => {
       await within(rail).findByRole("link", { name: "Account" }),
     ).toBeTruthy();
     expect(container.querySelector(".arblock")).toBeNull();
-    expect(container.querySelector(".railfoot")).toBeNull();
+    expect(container.querySelector(".railagent")).toBeNull();
   });
 
   it("renders rail-less for the documented exceptions (AC-shell layout exception)", () => {

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -319,13 +319,13 @@ export function WorkspaceRail({
         <div className="railhead">
           <BrandBlock />
           {/* TEMPORARY, and the whole element goes when the product leaves
-              pre-alpha: this span, its rule in shell.css and the `shell.preAlpha`
-              key, together. It is absolutely positioned so it takes no space and
+              alpha: this span, its rule in shell.css, the `shell.alpha` key and
+              the case in rail.test.tsx, together. A ribbon across the head's
+              top-left corner, absolutely positioned so it takes no space and
               moves nothing — the head is the same box with it and without it —
-              and it hangs off the mark rather than off the head, because the
-              mark stands at the same x in both rail states and the head is what
-              narrows. That is what keeps it on screen at 64px. */}
-          <span className="prealpha">{t("shell.preAlpha")}</span>
+              and anchored to the corner rather than to the wordmark, which is
+              what keeps it on screen at 64px where every label is gone. */}
+          <span className="alphamark">{t("shell.alpha")}</span>
         </div>
         {/* Keyed by depth so a level that arrives is a new element and plays its
             entrance; two addresses at the SAME depth are the same level with

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -330,6 +330,12 @@ export function WorkspaceRail({
           state={{ collapsed, tip, onTip: setTip }}
           onSelect={level.onSelect}
           onWalkUp={level.onWalkUp}
+          // At phone width the agent stands in the MIDDLE of the bar rather
+          // than at the foot of a column that is not there — inside the row
+          // stream, so a thumb and a Tab key read the bar in the same order.
+          // One Core either way: the foot below renders only above the
+          // breakpoint.
+          centre={phone ? <AgentRail route={route} /> : undefined}
         />
         {/* Phone-width only: expands the bar into a sheet carrying every
           destination. Hidden by CSS on the desktop sidebar.
@@ -359,16 +365,18 @@ export function WorkspaceRail({
           </span>
         </button>
         <div className="grow" />
-        {/* The foot is the agent. It is the one thing in the chrome that reports
-            rather than navigates, and it never claims the current page. What the
-            installation is ENTITLED to used to sit here as its own grey row, and
-            it now reaches a reader through the Core instead: a licence fault
-            turns the orb amber, which is a thing somebody notices.
+        {/* The sidebar's foot is the agent. It is the one thing in the chrome
+            that reports rather than navigates, and it never claims the current
+            page. What the installation is ENTITLED to used to sit here as its
+            own grey row, and it now reaches a reader through the Core instead: a
+            licence fault turns the orb amber, which is a thing somebody notices.
             The whole foot goes on a drilled-in level, element and all: an empty
             box left behind would still hold the band and the rule that divide a
-            reading from the rows above it. */}
-        {!leveled && (
-          <div className="railfoot">
+            reading from the rows above it. And it goes at phone width, where
+            there is no column to have a foot: the bar's centre cell above is
+            where the agent stands there, and two of these would be two Cores. */}
+        {!leveled && !phone && (
+          <div className="railagent">
             <AgentRail route={route} />
           </div>
         )}

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -318,6 +318,14 @@ export function WorkspaceRail({
       >
         <div className="railhead">
           <BrandBlock />
+          {/* TEMPORARY, and the whole element goes when the product leaves
+              pre-alpha: this span, its rule in shell.css and the `shell.preAlpha`
+              key, together. It is absolutely positioned so it takes no space and
+              moves nothing — the head is the same box with it and without it —
+              and it hangs off the mark rather than off the head, because the
+              mark stands at the same x in both rail states and the head is what
+              narrows. That is what keeps it on screen at 64px. */}
+          <span className="prealpha">{t("shell.preAlpha")}</span>
         </div>
         {/* Keyed by depth so a level that arrives is a new element and plays its
             entrance; two addresses at the SAME depth are the same level with
@@ -335,7 +343,7 @@ export function WorkspaceRail({
           // stream, so a thumb and a Tab key read the bar in the same order.
           // One Core either way: the foot below renders only above the
           // breakpoint.
-          centre={phone ? <AgentRail route={route} /> : undefined}
+          centre={phone ? <AgentRail route={route} bar={nav} /> : undefined}
         />
         {/* Phone-width only: expands the bar into a sheet carrying every
           destination. Hidden by CSS on the desktop sidebar.

--- a/frontend/src/app/viewport.ts
+++ b/frontend/src/app/viewport.ts
@@ -5,10 +5,11 @@ import { useEffect, useState } from "react";
 
 // The phone breakpoint, spelled once for the code that has to KNOW it rather
 // than merely be laid out by it: at this width the sidebar is a bottom bar of
-// four destinations, which changes what the panel renders and not only how it
-// looks. The `@media (max-width: 700px)` block in app/shell.css is the other
-// half of the same rule — a stylesheet cannot read a TypeScript constant, so
-// that block cites this file and the two are changed together.
+// three destinations, the agent and More, which changes what the panel renders
+// and where it is measured from, not only how it looks. The
+// `@media (max-width: 700px)` block in app/shell.css is the other half of the
+// same rule — a stylesheet cannot read a TypeScript constant, so that block
+// cites this file and the two are changed together.
 export const PHONE_MAX_WIDTH = 700;
 
 const PHONE_QUERY = `(max-width: ${PHONE_MAX_WIDTH}px)`;

--- a/frontend/src/design-system/atoms.test.tsx
+++ b/frontend/src/design-system/atoms.test.tsx
@@ -106,8 +106,10 @@ it("stays open when an item inside the portalled panel is clicked", async () => 
 it("opens the panel toward whichever side of the trigger has room", () => {
   const viewport = 800;
   vi.stubGlobal("innerHeight", viewport);
-  const near = (top: number) =>
-    ({ top, bottom: top + 30 }) as unknown as DOMRect;
+  // A real DOMRect, not a two-field literal cast into the shape: a box whose
+  // `top` was supplied and whose height was not is a box no element has, and
+  // `verticalPlacement` is free to read a field the literal never spelled.
+  const near = (top: number) => new DOMRect(0, top, 0, 30);
 
   // Room below: the panel hangs from the trigger.
   const down = verticalPlacement(near(100), 200);

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -248,6 +248,19 @@ function sizeOf(column: {
  */
 const WIDTHS_PREFIX = "margince.table.widths.v2.";
 
+/**
+ * The table's width floor, as the custom property the stylesheet reads.
+ *
+ * Declared rather than asserted onto `CSSProperties`: React's own type carries
+ * the CSS properties it knows, and a cast to it would say this one is among
+ * them. The intersection says what is true.
+ */
+type FloorStyle = CSSProperties & Readonly<{ "--lt-floor": string }>;
+
+function floorStyle(floor: number): FloorStyle {
+  return { "--lt-floor": `${floor}px` };
+}
+
 function readWidths(key?: string): Record<string, number> {
   if (!key) {
     return {};
@@ -973,7 +986,7 @@ export function ListTable<Row>({
             // itself: an inline width cannot be overridden by a stylesheet, and
             // the phone layout has to drop this floor to lay the rows out as
             // cards that fit the screen.
-            style={{ "--lt-floor": `${floor}px` } as CSSProperties}
+            style={floorStyle(floor)}
           >
             {/* The widths live here rather than on the header cells: under fixed
               layout a col wins over the cell below it, so one place decides

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -214,11 +214,20 @@
   --space-12: 48px;
   --space-16: 64px;
 
+  /* How far the agent's cell rises above the top edge of the phone bar. The bar
+   * is a row of destinations and the agent is not one, so it breaks the bar's
+   * plane rather than sitting in it — and what it overhangs is the content
+   * column, which is why the clearance below has to know this number rather than
+   * agentrail.css keeping it to itself. */
+  --phoneAgentRise: 16px;
+
   /* How far a page-level sticky element must stay clear of the bottom of a
    * phone viewport: the app's navigation is fixed there (shell.css, inset 8px)
    * and anything that ignored it would render underneath the nav. Named rather
-   * than repeated so the two cannot drift apart. */
-  --phoneNavClearance: 64px;
+   * than repeated so the two cannot drift apart. The 66px is the bar itself —
+   * a 48px cell, 4px of padding and a 1px edge on each side of it, on the 8px
+   * ledge it stands on — and the rise is the agent overhanging its top edge. */
+  --phoneNavClearance: calc(66px + var(--phoneAgentRise));
 
   /* How far a sticky element inside the content column must stand off the foot
    * of the scroll area. The default is the plain 8px ledge, because most of the

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -151,6 +151,7 @@ export const de = {
   "shell.railAria": "Hauptnavigation",
   "shell.skipToContent": "Zum Inhalt springen",
   "shell.logoAria": "Margince",
+  "shell.preAlpha": "Pre-Alpha",
   "shell.searchEverything": "Alles durchsuchen…",
   "shell.breadcrumbAria": "Navigationspfad",
   "shell.license.none": "Keine Lizenz",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -151,7 +151,7 @@ export const de = {
   "shell.railAria": "Hauptnavigation",
   "shell.skipToContent": "Zum Inhalt springen",
   "shell.logoAria": "Margince",
-  "shell.preAlpha": "Pre-Alpha",
+  "shell.alpha": "Alpha",
   "shell.searchEverything": "Alles durchsuchen…",
   "shell.breadcrumbAria": "Navigationspfad",
   "shell.license.none": "Keine Lizenz",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -157,7 +157,7 @@ export const en = {
   "shell.railAria": "Primary navigation",
   "shell.skipToContent": "Skip to content",
   "shell.logoAria": "Margince",
-  "shell.preAlpha": "Pre-alpha",
+  "shell.alpha": "Alpha",
   "shell.searchEverything": "Search everything…",
   "shell.breadcrumbAria": "Breadcrumb",
   "shell.license.none": "No license",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -157,6 +157,7 @@ export const en = {
   "shell.railAria": "Primary navigation",
   "shell.skipToContent": "Skip to content",
   "shell.logoAria": "Margince",
+  "shell.preAlpha": "Pre-alpha",
   "shell.searchEverything": "Search everything…",
   "shell.breadcrumbAria": "Breadcrumb",
   "shell.license.none": "No license",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -47,6 +47,10 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "room.create.defaultTitle",
   "buyer.poweredBy",
   "buyer.poweredByMargince",
+  // TEMPORARY, with the release marker it labels (app/shell.tsx): "Alpha" is
+  // the release stage's own name and Vietnamese keeps it, the same way it keeps
+  // "Email" and "pipeline". Delete this entry with the marker.
+  "shell.alpha",
   // A placeholder and a percent sign. Vietnamese writes a percentage the way
   // English does — digits then the sign, no space — so the value is identical by
   // agreement rather than by omission. German differs (it takes the space) and

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -158,6 +158,7 @@ export const vi = {
   "shell.railAria": "Điều hướng chính",
   "shell.skipToContent": "Bỏ qua tới nội dung",
   "shell.logoAria": "Margince",
+  "shell.preAlpha": "Tiền alpha",
   "shell.searchEverything": "Tìm kiếm mọi thứ…",
   "shell.breadcrumbAria": "Đường dẫn",
   "shell.license.none": "Chưa có giấy phép",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -158,7 +158,7 @@ export const vi = {
   "shell.railAria": "Điều hướng chính",
   "shell.skipToContent": "Bỏ qua tới nội dung",
   "shell.logoAria": "Margince",
-  "shell.preAlpha": "Tiền alpha",
+  "shell.alpha": "Alpha",
   "shell.searchEverything": "Tìm kiếm mọi thứ…",
   "shell.breadcrumbAria": "Đường dẫn",
   "shell.license.none": "Chưa có giấy phép",


### PR DESCRIPTION
## What changed

**Task 1 — the Worklist comes off the mobile bar.** `MOBILE_PRIMARY` drops `today`. The bar keeps Home, Contacts and Pipeline; the Worklist is a row in the More sheet like every other destination the bar cannot carry, and More reports it as the current page while a reader is on it.

`nav.ts` carried a comment saying Today was "non-negotiable here: the 390px approval path is required for V1". That is now false, and the comment says so plainly instead of being deleted: the approval path still runs on that screen, and the screen is one tap away in the sheet — the same distance the six other omitted destinations already are.

**Task 2 — the orb takes that cell.** The agent moves out of the More sheet and into the bar's centre. Five cells, three of them destinations.

Two things about *where* it sits are load-bearing:

- It is the **centre** because the agent belongs to the whole session rather than to any destination, so it stands outside the row of them rather than at one end.
- It is the **third cell in the DOM as well as on screen.** `NavLevelView` grew a `centre` slot and renders the block into the row stream; which row it stands after is derived from the level's own bar set (`centreAfterId`), not pinned to a screen id, so adding a destination to the bar moves the cell instead of leaving it off-centre. Placed by a grid column alone the orb would have been third to the eye and last to the Tab key — a WCAG 2.4.3 defect that no axe rule can see.

The bar itself becomes a **grid** of equal auto-columns. Equal cells put the agent on the bar's own centre line with nothing measuring it, and they stop a thumb target from moving the day a row is added. On `#/ask` the agent renders nothing (one Core per product), so the cell simply is not there and the bar collapses to four even cells.

**Task 2, the dress.** It is not drawn as a fifth glyph: a round well of the bar's own material and edge, rising clear of the bar's top edge by `--phoneAgentRise`, the Core lit inside it at 44px against the destinations' 20px, and no caption. The bar carries no captions at all, and a word under the one cell with room for one would read as a label for the bar rather than for the agent — the button's accessible name carries it instead. The rise is a token because `--phoneNavClearance` has to know it: a sticky element that ignored it would sit behind the orb.

**Task 3 — tapping it opens the desktop panel, above the bar.** Same panel, same component. Two things make it read as *this cell's* panel:

- It is **measured from the well**, not from the cell behind it. `usePanelFrame` now takes both anchors and picks by width — measured from the cell, the panel opens across the orb it belongs to.
- It carries a **notch** pointing back down at the measured middle of that well, drawn on the portalled wrapper rather than on the panel, because the panel scrolls its own body and would clip anything outside it. The x comes off the measurement, so it still lands if the bar's cells ever stop being even.

No scrim. This is a popover, not the More sheet: the page behind stays live, an outside tap or Escape closes it, focus goes back to the orb. Mutual exclusion with the sheet needed no new code — `usePopoverDismiss` already closes the panel on any outside click, and the orb is not rendered while the sheet is up.

## Fixed along the way

- `.railfoot` → `.railagent`. It names what it holds rather than a position that is only true in one of the two layouts.
- The phone bar now hides `.railhead`. Its brand block was already hidden, so what was left was an empty box — free as a zero-width flex item, a whole grid column once the bar became a grid.
- **`.raillicense` deleted** — ~30 lines of CSS, plus a comment explaining the behaviour of `RailLicense`, for a class no file in the tree renders. The sheet's re-show of the agent foot went with it.
- `--phoneNavClearance` was 64px for a bar that measures 66px from the ledge (two 1px borders were never counted). Corrected while the token was open, and its comment now shows the arithmetic.
- `viewport.ts` said the bar was "four destinations".
- `docs/explanation/frontend-architecture.md` described a bar of four plus More and a nav group table still listing `dedupe`, `tasks` and `inbox` — three route ids the product no longer has.

## Follow-ups from review

**The More sheet takes the viewport.** Its ceiling was `80dvh`, which left a third of a phone empty under a list that had to scroll to reach its last two destinations. It is now everything between the two ledges — the viewport less the inset the sheet already stands on, less the same air again at the top so it still reads as a layer over a page rather than as a page. At 390×844 that is 812px against 749px of content: ten destinations, no scroll. It stays a CEILING rather than a height, so a longer locale or a deeper level still scrolls.

**The panel takes the bar's span.** It was inset by a 12px margin of its own while the bar stands on `--pageGutter`, so the two edges disagreed and the panel read as a sheet that happened to arrive over the bar. `usePanelFrame` now takes the bar's ref and uses its MEASURED span — measured rather than reading the gutter token, so the two cannot drift. The frame's two arrangements became `overTheBar()` and `besideTheCard()` rather than two branches of one function, which is also what brought the placement back under the complexity ceiling.

**A pre-alpha marker in the rail's head.** Temporary, and every part of it says so.

It is absolutely positioned, so the head is the same box with it and without it and no row below moves. The decision worth knowing is what it hangs off: the **mark**, not the head. The mark stands at x=15 whether the rail is 252px or 64px — the head is what narrows around it — so one placement is on screen in both rail states and in the phone sheet's head, with nothing restated per state. At 8px in the body face it measures 56px, which fits inside the 64px collapsed rail.

Warn tokens, because it is a caveat about how finished the product is. Not a `Badge`: that primitive owns its geometry, and this is 8px chrome pinned to a corner, so reaching for it would mean overriding every property it has — it is a class in `shell.css`, like `.railmore`. Copy goes through `t("shell.preAlpha")` in all three locales.

Removal is a four-part change and each part names the others: the span in `shell.tsx`, the rule in `shell.css`, the `shell.preAlpha` key, and the `rail.test.tsx` case that holds it through the collapse.

## Acceptance criteria

| | |
|---|---|
| Bar composition | `[Home][Contacts][agent][Pipeline][More]`, five equal cells, agent centred |
| DOM order = visual order | `rail.test.tsx` asserts the one sequence describes both |
| Worklist | off the bar, in the sheet, More claims the page on `#/today` |
| One Core | one `.arblock` in the tree at either width, and across a sheet toggle |
| Agent absent on `#/ask` | bar collapses to four even cells, no empty column |
| Panel anchor | measured from the well; notch at the well's measured middle; no notch on the sidebar |
| Keyboard | five tab stops in visual order, Escape closes, focus returns to the orb |
| Desktop | unchanged — sidebar foot, panel beside, no notch |
| Sheet height | ceiling is the viewport less both ledges; ten destinations fit unscrolled at 390×844 |
| Panel span | left and right equal the bar's own, measured (`agentrail.test.tsx`) |
| Pre-alpha marker | in the head at 252px and at 64px, and in the sheet's head; takes no space |

## Verified in a browser

Seeded stack at 390×844 and 1400×900, both themes.

- Bar closed, panel open, More sheet open, `#/ask` (agent absent), the amber `warning` state carrying through to the well's wash, light and dark.
- Escape closes the panel and returns focus to the orb (`aria-label` back to "Expand the agent panel").
- Opening More closes the panel; the orb is not reachable while the sheet is up.
- No horizontal scroll at 390px on any of those states.
- Console: the only errors are pre-existing and unrelated — `EmbedReindexStatus is specified but not yet implemented` (501) and the dev-only `VITE_UI_PREVIEW_TASKBAR` notice.

Reduced motion is held mechanically rather than by eye: `conformance.test.ts` → *"declares every reduced-motion rule after the rule it has to beat"* sweeps every `.css` file, and both new animations (`arpanelup`, `arnotchin`) are declared above the rule that turns them off.

## Gates

All green.

- `make frontend-check` — 385 files, 4842 tests
- `make fe-uat` — 54 stories after the review round
- `make native-controls`, `make frontend-e2e` — 130 passed, including three new 390px agent-panel cases
- `make check` — see below
- CI on `ac11047a` — every lane green (deterministic-gates, frontend ×3, uat, live-boot, govulncheck, craftsmanship, secret-scan, Sonar, DCO)

`make fe-clock-drift` was not run: no test this branch touches reads a date.

### Two local `make check` failures that are not this branch

Both were another session's leftovers on the same machine, and both are named here rather than worked around:

1. `lint-modules` reported 16 findings under `.tmp/worktrees/url-state/` — a worktree that no longer exists on disk, replayed out of golangci's machine-wide cache. `golangci-lint cache clean` → `OK: lint-modules — 8 module(s) outside backend/ lint clean`.
2. `TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim` failed on twelve modules under `.tmp/worktrees/dco-signoff/` — another session's live worktree, which I did not touch. Proved it is not this branch by cloning the branch clean and running that test alone: `ok github.com/gradionhq/margince/backend`. `.tmp/` is gitignored, so no CI checkout can contain it, and CI's `deterministic-gates` lane passes.

## Review round

CodeRabbit raised one Major finding: `as CSSProperties` / `as DOMRect` against the rule forbidding assertions. Valid, fixed, and the sweep found two siblings it had not named — `listtable.tsx`, which carried the same `as CSSProperties` and is where the pattern was copied from, and `atoms.test.tsx`, which carried the same literal-cast-as-`DOMRect`. Both style objects now declare the intersection; both rectangles are now real `DOMRect`s, so their derived fields are derived rather than being whatever the cast let through.

Not fixed, and said in the thread rather than left silent: `as unknown as <T>` is used in about a dozen screen tests and stories to shape API fixtures. Different pattern, tree-wide population, not this PR's subject.

## Stories

Two new, both `uat-phone` tagged: `Shell/Navigation shell` → *phone — the bar, with the agent in the middle* and *phone — the agent's panel over the bar*. The `PhoneMoreSheet` doc block was describing an entitlement row in a foot that no longer exists.

## Worth flagging separately

**CI skips every lane on a draft PR.** `ci.yml` gates each job on `pull_request.draft == false`, so this PR's two draft runs finished in 13s with everything skipped. AGENTS.md says to "open the PR as a DRAFT right after the first commit so CI runs while you work", which this pipeline does not do. One of the two should move; that is a call for whoever owns the lane rather than a change to make inside this PR.

## Left out

Nothing from the three tasks. The demo verifier reports two broken rules (`people work somewhere`, `accounts have a lifecycle`) — both name records `make seed-dev` creates and the demo dataset does not know about, present before this branch and unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated mobile navigation with a centered, raised agent control and additional destinations available through More.
  - Added responsive agent-panel positioning, animations, and improved phone layouts.
  - Added a visible “Alpha” status label with English, German, and Vietnamese translations.
  - Added translated labels for setup, Google app configuration, approvals, and conversation history.

- **Bug Fixes**
  - Improved mobile agent-panel sizing, focus restoration, Escape-to-close behavior, overflow handling, and reduced-motion support.

- **Documentation**
  - Updated navigation and mobile breakpoint documentation to reflect the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
