### PR TITLE
fix(approvals): a drafted follow-up is composed as the deal's owner

### DIFF
--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // closeDateStager adapts the approvals service onto the deals module's
@@ -85,21 +84,19 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 // denial, never empty permission), and an owner whose grants do not reach the
 // correspondence. A deal's date hygiene must not depend on any of them.
 type quietReviewReader struct {
-	db    *database.DB
-	users *identity.Service
+	db *database.DB
+	// owner resolves the reading authority. Shared with the overnight drafter,
+	// which has the same obligation for the same reason.
+	owner dealOwnerAuthority
 }
 
 func (r quietReviewReader) ReadForOwner(ctx context.Context, dealID ids.DealID) (deals.QuietFacts, deals.QuietNames, error) {
-	owner, err := r.dealOwner(ctx, dealID)
-	if err != nil {
-		return deals.QuietFacts{}, nil, err
-	}
-	if owner.IsZero() {
+	ownerCtx, err := r.owner.contextFor(ctx, dealID.UUID)
+	if errors.Is(err, errNoDealOwner) {
 		// An unowned deal still gets its review; nobody's authority is the
 		// right one to read its correspondence under, so it goes unnamed.
 		return deals.QuietFacts{}, nil, nil
 	}
-	ownerCtx, err := r.asOwner(ctx, owner)
 	if err != nil {
 		return deals.QuietFacts{}, nil, err
 	}
@@ -126,49 +123,6 @@ func (r quietReviewReader) ReadForOwner(ctx context.Context, dealID ids.DealID) 
 		return deals.QuietFacts{}, nil, err
 	}
 	return facts, names, nil
-}
-
-// dealOwner reads who the deal belongs to. It runs under the caller's own
-// principal — the sweep's — because owner_id is what CHOOSES the reading
-// authority, and a read that needed the authority to find it could not start.
-func (r quietReviewReader) dealOwner(ctx context.Context, dealID ids.DealID) (ids.UUID, error) {
-	var owner *ids.UUID
-	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `SELECT owner_id FROM deal WHERE id = $1`, dealID).Scan(&owner)
-	})
-	if err != nil {
-		return ids.Nil, fmt.Errorf("compose: deal %s owner: %w", dealID, err)
-	}
-	if owner == nil {
-		return ids.Nil, nil
-	}
-	return *owner, nil
-}
-
-// asOwner binds the deal owner as the acting principal.
-//
-// EffectiveAuthority reads the grants and the seat as ONE snapshot: composed
-// from separate reads they can describe an authority the owner never held —
-// permissions from before a role change with a seat from after. SeatType is
-// carried rather than omitted because its zero value fails closed to read-only,
-// which would silently narrow a read that is supposed to mirror the owner's.
-func (r quietReviewReader) asOwner(ctx context.Context, owner ids.UUID) (context.Context, error) {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return nil, errors.New("compose: quiet review outside a bound workspace")
-	}
-	rbac, seat, err := r.users.EffectiveAuthority(ctx, wsID, owner)
-	if err != nil {
-		return nil, fmt.Errorf("compose: deal owner %s authority: %w", owner, err)
-	}
-	return principal.WithActor(ctx, principal.Principal{
-		Type:        principal.PrincipalHuman,
-		ID:          principal.HumanIDPrefix + owner.String(),
-		UserID:      owner,
-		SeatType:    seat,
-		TeamIDs:     rbac.TeamIDs,
-		Permissions: rbac.Permissions,
-	}), nil
 }
 
 // nameCounterparties resolves both sides' people in ONE call, so a deal whose
@@ -198,7 +152,7 @@ func NewCloseDateCorrector(pool *pgxpool.Pool, log *slog.Logger) *deals.CloseDat
 	db := InstallationDB(pool)
 	return deals.NewCloseDateCorrector(db,
 		closeDateStager{svc: approvals.NewService(db)},
-		quietReviewReader{db: db, users: identity.NewServiceFor(db)},
+		quietReviewReader{db: db, owner: dealOwnerAuthority{db: db, users: identity.NewServiceFor(db)}},
 		log, installseam.Deals())
 }
 

--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -71,7 +71,7 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 	e.svc = approvals.NewService(e.DB())
 	e.svc.WithEffect(deals.CloseDateCorrectionKind, closeDateConfirmEffect(e.svc, deals.NewStore(e.DB(), DealsInstallation())))
 	e.corrector = deals.NewCloseDateCorrector(e.DB(), closeDateStager{svc: e.svc},
-		quietReviewReader{db: e.DB(), users: identity.NewServiceFor(e.DB())}, quiet, installseam.Deals())
+		quietReviewReader{db: e.DB(), owner: dealOwnerAuthority{db: e.DB(), users: identity.NewServiceFor(e.DB())}}, quiet, installseam.Deals())
 	return e
 }
 

--- a/backend/internal/compose/dealownerseam.go
+++ b/backend/internal/compose/dealownerseam.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Reading a deal's world as the person the deal belongs to.
+//
+// A nightly sweep runs as a system principal, which auth.Require passes
+// unconditionally and which no row scope bounds. That is right for the sweep's
+// own WRITES — nobody asked for them, and the audit trail should say the system
+// did it. It is wrong for anything the sweep reads and then STORES into an
+// approval payload, because that payload is read back later by whoever holds the
+// card's decide grant, and the grant set is narrower than the principal that
+// filled it. A string resolved under the system principal and frozen into a row
+// is a disclosure no read-side gate can undo.
+//
+// So a producer that puts human-identifying data or message content on a card
+// resolves it under the deal owner's own authority instead. Two producers do:
+// the close-date review names who went quiet, and the overnight drafter puts a
+// counterparty's address and the message it answers into a draft. They share
+// this seam rather than each carrying a copy — the rule is one rule, and a
+// second spelling of it would be the one that stops matching.
+//
+// The owner is the right authority because the card is FOR them: it lands in
+// their queue, about their deal. Nothing here widens what they may see.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// dealOwnerAuthority answers "read this deal's world as its owner would".
+type dealOwnerAuthority struct {
+	db    *database.DB
+	users *identity.Service
+}
+
+// errNoDealOwner reports a deal nobody owns, which is a real state rather than
+// a failure: owner_id is nullable and ON DELETE SET NULL clears it when a member
+// is removed. There is no authority to read under, so the caller degrades —
+// it does not fail the pass over every other deal in the workspace.
+var errNoDealOwner = errors.New("compose: the deal has no owner to read as")
+
+// contextFor binds the deal's owner as the acting principal.
+//
+// Returns errNoDealOwner for an unowned deal, and wraps apperrors.ErrNotFound
+// from EffectiveAuthority for an owner who is suspended, archived or removed —
+// absence of authority is denial, never empty permission.
+func (a dealOwnerAuthority) contextFor(ctx context.Context, dealID ids.UUID) (context.Context, error) {
+	owner, err := a.dealOwner(ctx, dealID)
+	if err != nil {
+		return nil, err
+	}
+	if owner.IsZero() {
+		return nil, errNoDealOwner
+	}
+	return a.asOwner(ctx, owner)
+}
+
+// dealOwner reads who the deal belongs to. It runs under the CALLER's own
+// principal — the sweep's — because owner_id is what chooses the reading
+// authority, and a read that needed the authority to find it could not start.
+func (a dealOwnerAuthority) dealOwner(ctx context.Context, dealID ids.UUID) (ids.UUID, error) {
+	var owner *ids.UUID
+	err := a.db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT owner_id FROM deal WHERE id = $1`, dealID).Scan(&owner)
+	})
+	if err != nil {
+		return ids.Nil, fmt.Errorf("compose: deal %s owner: %w", dealID, err)
+	}
+	if owner == nil {
+		return ids.Nil, nil
+	}
+	return *owner, nil
+}
+
+// asOwner binds one member as the acting principal.
+//
+// EffectiveAuthority reads the grants and the seat as ONE snapshot: composed
+// from separate reads they can describe an authority the member never held —
+// permissions from before a role change with a seat from after. SeatType is
+// carried rather than omitted because its zero value fails closed to read-only,
+// which would silently narrow a read that is supposed to mirror the owner's.
+func (a dealOwnerAuthority) asOwner(ctx context.Context, owner ids.UUID) (context.Context, error) {
+	wsID, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return nil, errors.New("compose: reading as a deal owner outside a bound workspace")
+	}
+	rbac, seat, err := a.users.EffectiveAuthority(ctx, wsID, owner)
+	if err != nil {
+		return nil, fmt.Errorf("compose: deal owner %s authority: %w", owner, err)
+	}
+	return principal.WithActor(ctx, principal.Principal{
+		Type:        principal.PrincipalHuman,
+		ID:          principal.HumanIDPrefix + owner.String(),
+		UserID:      owner,
+		SeatType:    seat,
+		TeamIDs:     rbac.TeamIDs,
+		Permissions: rbac.Permissions,
+	}), nil
+}

--- a/backend/internal/compose/followupdraft.go
+++ b/backend/internal/compose/followupdraft.go
@@ -92,6 +92,14 @@ func draftFollowUpReply(
 		// database failure — is a real failure and must not be reported as a
 		// nightly pass that quietly chose the other proposal. That reading hid
 		// the failure and never retried the draft.
+		//
+		// A denial stays a failure HERE on purpose, even though the caller
+		// treats one as a fallback. The two are different questions. This
+		// function is handed an authority and asked to draft under it, so a
+		// refusal means the authority did not match the work — a defect worth
+		// surfacing. The caller knows something this cannot: that the authority
+		// is the deal owner's, and that an owner who lacks the grant is a
+		// settled fact about the workspace rather than a fault to retry.
 		return automation.HeldDraftProposal{}, false, nil
 	case err != nil:
 		return automation.HeldDraftProposal{}, false,

--- a/backend/internal/compose/followupdraft_integration_test.go
+++ b/backend/internal/compose/followupdraft_integration_test.go
@@ -407,12 +407,15 @@ func TestTheDraftedFollowUpUsesTheExistingHeldDraftKind(t *testing.T) {
 // opens with a person-read gate whose own comment forbids exactly this — "a
 // caller who may read activities but not people must not be told through this
 // door what the people surface withholds" — and auth.Require passes a system
-// principal unconditionally, so the overnight pass walked straight past it.
-// Every string it then resolved (the counterparty's address, the subject and
-// body of their message) was stored in proposed_change, where reading the card
-// back needs only activity:create plus deal visibility. Neither person:read nor
-// activity:read is in that set, so the card handed a reader an address they may
-// not look up and content from a message they cannot open.
+// principal unconditionally, so the overnight pass walked straight past it. The
+// address it resolved was stored in proposed_change, where reading the card
+// back needs only activity:create plus deal visibility, and person:read is not
+// in that set.
+//
+// The message the draft answers is already safe by a different rule: the
+// reconciler picks evidence only from audience = 'workspace' activities, so its
+// subject and body are readable by every decider. The address is the one field
+// with no such filter behind it.
 //
 // An owner who lacks person:read gets the TASK proposal: the rep is still told
 // the deal has no next step, and no address reaches the card.

--- a/backend/internal/compose/followupdraft_integration_test.go
+++ b/backend/internal/compose/followupdraft_integration_test.go
@@ -400,3 +400,64 @@ func TestTheDraftedFollowUpUsesTheExistingHeldDraftKind(t *testing.T) {
 			kinds, automation.HeldDraftKind)
 	}
 }
+
+// The reply is composed under the DEAL OWNER's authority, never the sweep's.
+//
+// This is the security argument for the whole drafting path. ReplyAddressFor
+// opens with a person-read gate whose own comment forbids exactly this — "a
+// caller who may read activities but not people must not be told through this
+// door what the people surface withholds" — and auth.Require passes a system
+// principal unconditionally, so the overnight pass walked straight past it.
+// Every string it then resolved (the counterparty's address, the subject and
+// body of their message) was stored in proposed_change, where reading the card
+// back needs only activity:create plus deal visibility. Neither person:read nor
+// activity:read is in that set, so the card handed a reader an address they may
+// not look up and content from a message they cannot open.
+//
+// An owner who lacks person:read gets the TASK proposal: the rep is still told
+// the deal has no next step, and no address reaches the card.
+func TestADraftIsNotComposedForAnOwnerWhoMayNotReadPeople(t *testing.T) {
+	e := setupReconcileWithOwnerPolicy(t, `{"objects":{"activity":{"create":true,"read":true,"update":true},
+		  "deal":{"read":true,"update":true},"organization":{"read":true},
+		  "pipeline":{"read":true}},"row_scope":"all"}`)
+	deal := e.SeedDeal(t, "No person read", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Kickoff")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1`, deal); n != 0 {
+		t.Errorf("staged %d drafts for an owner without person:read, want 0 — "+
+			"the address on that card is one they may not look up", n)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("task proposals = %d, want 1 — the rep is still told the deal "+
+			"has no next step, they simply get no draft", got)
+	}
+}
+
+// A deal nobody owns has no authority to compose under. owner_id is nullable
+// and ON DELETE SET NULL clears it when a member is removed, so this is an
+// ordinary state rather than an edge case — and it must degrade to the task
+// proposal rather than falling back to the sweep's own unbounded principal.
+func TestAnUnownedDealGetsTheTaskProposalRatherThanADraft(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Orphaned", e.pipeline, e.open, &e.Rep1)
+	e.seedAnswerableThread(t, deal, "Kickoff")
+	e.WsExec(t, `UPDATE deal SET owner_id = NULL WHERE id = $1`, deal)
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM approval
+		WHERE kind = 'held_draft' AND target_entity_id = $1`, deal); n != 0 {
+		t.Errorf("staged %d drafts on an unowned deal, want 0 — there is no "+
+			"authority under which a reply may be composed", n)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("task proposals = %d, want 1", got)
+	}
+}

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -169,15 +169,18 @@ func (s followUpStager) stageDraftedReply(
 ) (bool, error) {
 	// The draft is composed under the DEAL OWNER's authority, not the sweep's.
 	//
-	// ReplyAddress resolves a person's email and DraftEmail reads the anchor
-	// message's subject and body — both gated on person and activity reads that
-	// a system principal walks straight past (auth.Require passes it
-	// unconditionally). Every one of those strings is then stored in
-	// proposed_change, where the card's own decide grant (activity:create plus
-	// deal visibility) is what governs reading it back. Neither person:read nor
-	// activity:read is in that set, so composing under the sweep's principal
-	// handed a reader an address they may not look up and content from a
-	// message they cannot open.
+	// ReplyAddress resolves the counterparty's email off the person record,
+	// behind an object grant AND a row scope that a system principal walks
+	// straight past — auth.Require and auth.ScopeClauseFor both pass it
+	// unconditionally. That address is then stored in proposed_change, where
+	// the card's own decide grant (activity:create plus deal visibility) is
+	// what governs reading it back, and person:read is not in that set.
+	//
+	// The message the draft answers is NOT the same question: the reconciler
+	// only ever picks evidence with audience = 'workspace', so its subject and
+	// body are readable by every decider already. The address has no such
+	// filter behind it, which is what makes this the field that needed the
+	// owner's authority.
 	//
 	// A deal nobody owns, or one whose owner is no longer live, gets the TASK
 	// proposal instead of a draft. The rep is still told about the deal; there

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -15,6 +15,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -27,6 +28,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -52,6 +55,11 @@ type followUpStager struct {
 	// wired stages the task proposal for every candidate, which is what the
 	// pass did before the drafted reply existed.
 	draft followUpReplySeam
+	// owner resolves the authority the DRAFT is read under. The reply carries a
+	// counterparty's address and the message it answers, both of which end up
+	// stored on the card — so they are read as the person the card is for, never
+	// under the sweep's own unbounded principal.
+	owner dealOwnerAuthority
 }
 
 // HasPendingFollowUp answers for BOTH shapes a follow-up can take.
@@ -159,7 +167,41 @@ func answerableThread(proposal deals.FollowUpProposal) bool {
 func (s followUpStager) stageDraftedReply(
 	ctx context.Context, dealID ids.UUID, proposal deals.FollowUpProposal,
 ) (bool, error) {
-	draft, answerable, err := draftFollowUpReply(ctx, s.draft, proposal)
+	// The draft is composed under the DEAL OWNER's authority, not the sweep's.
+	//
+	// ReplyAddress resolves a person's email and DraftEmail reads the anchor
+	// message's subject and body — both gated on person and activity reads that
+	// a system principal walks straight past (auth.Require passes it
+	// unconditionally). Every one of those strings is then stored in
+	// proposed_change, where the card's own decide grant (activity:create plus
+	// deal visibility) is what governs reading it back. Neither person:read nor
+	// activity:read is in that set, so composing under the sweep's principal
+	// handed a reader an address they may not look up and content from a
+	// message they cannot open.
+	//
+	// A deal nobody owns, or one whose owner is no longer live, gets the TASK
+	// proposal instead of a draft. The rep is still told about the deal; there
+	// is simply no authority under which a reply may be composed.
+	ownerCtx, err := s.owner.contextFor(ctx, dealID)
+	if err != nil {
+		if errors.Is(err, errNoDealOwner) || errors.Is(err, apperrors.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	draft, answerable, err := draftFollowUpReply(ownerCtx, s.draft, proposal)
+	if errors.Is(err, apperrors.ErrPermissionDenied) || errors.Is(err, apperrors.ErrNotFound) {
+		// The owner may not read what a reply would have to quote. That is the
+		// gate working rather than a fault: composing under their authority is
+		// exactly what stops a card carrying a read they could not have made.
+		// It is also SETTLED — a grant, not an outage — so retrying tomorrow
+		// changes nothing, and the rep gets the task proposal instead.
+		//
+		// draftFollowUpReply itself treats a denial as a failure, correctly: it
+		// is handed an authority and cannot know whose. Only here is it known
+		// to be the deal owner's, which is what makes a refusal ordinary.
+		return false, nil
+	}
 	if err != nil || !answerable {
 		return false, err
 	}
@@ -188,7 +230,11 @@ func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUp
 	// engine. The zero SendPath matches that surface: nothing here sends, the
 	// held-draft release does, through the fully wired path it builds itself.
 	drafter := newCommsAdapter(pool, nil, SendPath{})
-	stager := followUpStager{svc: approvals.NewService(db), draft: drafter}
+	stager := followUpStager{
+		svc:   approvals.NewService(db),
+		draft: drafter,
+		owner: dealOwnerAuthority{db: db, users: identity.NewServiceFor(db)},
+	}
 	return deals.NewFollowUpReconciler(db, stager, log)
 }
 

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -69,9 +70,67 @@ func setupReconcile(t *testing.T) *reconcileEnv {
 	// the drafting seam would exercise a stager that can only ever propose a
 	// task, and would report the drafted-reply branch as working while nothing
 	// in production reached it.
-	stager := followUpStager{svc: e.svc, draft: newCommsAdapter(e.Pool, nil, SendPath{})}
+	stager := followUpStager{
+		svc:   e.svc,
+		draft: newCommsAdapter(e.Pool, nil, SendPath{}),
+		owner: dealOwnerAuthority{db: e.DB(), users: identity.NewServiceFor(e.DB())},
+	}
 	e.reconciler = deals.NewFollowUpReconciler(e.DB(), stager, quiet)
+	// The deal owner needs REAL grants, not the harness's in-memory ones: the
+	// drafter composes under the owner's authority resolved from the database,
+	// which is the whole point — a draft is only written under grants that
+	// person actually holds. Without this every deal falls back to the task
+	// proposal, which is correct behaviour and would make the draft tests
+	// silently prove nothing.
+	e.grantOwner(t, e.Rep1, reconcileOwnerPolicy)
 	return e
+}
+
+// setupReconcileWithOwnerPolicy is setupReconcile with the deal owner's stored
+// grants named by the caller, for the suites that prove WHICH grant the drafting
+// path depends on. Everything else is identical, so a test using it isolates the
+// one grant it varies.
+//
+// The default role is REPLACED rather than added to. Grants accumulate across
+// role assignments, so layering a narrow document on the broad one would leave
+// the owner holding everything and the test would pass while proving nothing.
+func setupReconcileWithOwnerPolicy(t *testing.T, document string) *reconcileEnv {
+	t.Helper()
+	e := setupReconcile(t)
+	if _, err := e.owner.Exec(context.Background(),
+		`DELETE FROM role_assignment WHERE user_id = $1`, e.Rep1); err != nil {
+		t.Fatalf("clearing the default owner role: %v", err)
+	}
+	e.grantOwner(t, e.Rep1, document)
+	return e
+}
+
+// reconcileOwnerPolicy mirrors reconcilePerms as a stored role document: an
+// activity-and-deal rep WITH person read, since composing a reply resolves the
+// counterparty's address. The suite that proves the gate bites uses the
+// narrower policy below instead.
+const reconcileOwnerPolicy = `{"objects":{"activity":{"create":true,"read":true,"update":true},
+	  "deal":{"read":true,"update":true},"person":{"read":true},
+	  "organization":{"read":true},"pipeline":{"read":true}},"row_scope":"all"}`
+
+// grantOwner gives a member an actual role row, which is what
+// EffectiveAuthority reads. The harness's As(...) permissions never reach this
+// path, deliberately: the drafter resolves authority from the database so a
+// card is only ever composed under grants the owner really holds.
+func (e *reconcileEnv) grantOwner(t *testing.T, userID ids.UUID, document string) {
+	t.Helper()
+	ctx := context.Background()
+	roleID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO role (id, key, name, permissions) VALUES ($1, $2, 'Reconcile rep', $3)`,
+		roleID, "reconcile_rep_"+roleID.String(), document); err != nil {
+		t.Fatalf("seeding the owner's role: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO role_assignment (id, user_id, role_id) VALUES ($1, $2, $3)`,
+		ids.NewV7(), userID, roleID); err != nil {
+		t.Fatalf("assigning the owner's role: %v", err)
+	}
 }
 
 // reconcile runs the reconciler over this env's workspace under exactly the


### PR DESCRIPTION
## What changes

The overnight pass composes its drafted reply under the **deal owner's** authority instead of its own system principal.

A system principal passes `auth.Require` unconditionally and no row scope bounds it. That is right for the sweep's own writes — nobody asked for them, and the audit trail should say the system did it. It is wrong for anything the sweep reads and then **stores** on an approval card, because the card is read back later under a narrower grant set than the principal that filled it, and a stored string cannot be re-filtered at read time.

## The one field at risk

`ReplyAddressFor` resolves the counterparty's email off the person record, behind an object grant and a row scope. Both are bypassed for a system principal, so the address reached `proposed_change` — where reading the card back needs `activity:create` plus visibility of its `deal` target, and **not** `person:read`.

**The message the draft answers was never at risk**, and it is worth being precise about that. The reconciler selects evidence only from activities with `audience = 'workspace'` ([reconcile.go:171-175](backend/internal/modules/deals/reconcile.go#L171-L175)), with a comment stating why: *"The subject lands in an approval every decider of the deal reads, so only a message the whole workspace may read is evidence here."* The draft anchors on that same activity, so its subject and body are readable by every decider already.

One field, not three. The second commit corrects comments that had claimed otherwise — a comment that overstates what a gate is for is worse than none, because the next reader who checks it stops trusting the accurate part.

## Degradations, each with a test

| case | result |
|---|---|
| owner lacks `person:read` | task proposal, no draft |
| owner is suspended, archived or removed | task proposal, no draft |
| deal has no owner (`owner_id` is nullable, `ON DELETE SET NULL`) | task proposal, no draft |

In every case the rep is still told the deal has no next step. They simply get "write a follow-up" rather than a draft to send.

## One split worth reading

`draftFollowUpReply` still treats a denied read as a **failure**, and that is deliberate — an existing test asserts it, with a good reason: *"a real failure reported as a fallback is a nightly run that hides it and never retries."*

I nearly overturned that rule and shouldn't have. The two contexts genuinely differ:

- `draftFollowUpReply` is handed an authority and asked to draft under it. A refusal means the authority did not match the work — a defect worth surfacing.
- The **caller** knows the authority is the deal owner's, and that an owner lacking a grant is a settled fact about the workspace rather than a fault. Retrying tomorrow changes nothing.

So the denial is absorbed at the caller, and the drafter's rule stands untouched.

## Shared, not copied

The owner resolution moves into `dealOwnerAuthority`. The close-date review (#2752) carries the same obligation for the same reason, and two spellings of one security rule is the pair that stops matching. That refactor is behaviour-preserving — all 10 close-date integration tests pass unchanged.

## How this was found

By auditing all 16 approval-staging producers against the pattern established in #2752. Fifteen came back clear, several with reasons already encoded in their grant sets — `lifecycle_change` requires `signal:update` precisely because its payload quotes signal prose, and `site_lead` already narrows to a human principal before probing. `deal_follow_up`, initially suspected, turned out to be protected by the `audience = 'workspace'` filter described above.

## Verification

- `make check-backend` — green, zero failures
- integration lane — whole `compose` package green, including 2 new tests and the 10 close-date tests the shared seam touches
- `make craft-static` — clean across all four trees
- mutation-checked: reverting to the sweep's context fails exactly the new security test and nothing else

Backend-only; no contract or frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Follow-up drafts are created only when the deal owner has the required permissions.
  - Deals without an owner, inactive owners, or unauthorized owners now fall back to a task proposal.
  - Close-date reviews preserve unnamed reviews for unowned deals and handle owner access failures consistently.
  - Deal-related content now respects owner permissions, team membership, and workspace context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->