### PR TITLE
feat(onboarding): a first run asks for the models, then the Google app

### DIFF
--- a/backend/frontendsetupproviders_test.go
+++ b/backend/frontendsetupproviders_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+//go:build !integration
+
+package backendarch
+
+// Onboarding offers a first-time admin a provider and a model, and the server
+// has to be able to price and serve exactly what it offered.
+//
+// The frontend cannot read Go, so `frontend/src/screens/setup-providers.ts` is a
+// declared MIRROR — and this is what makes "mirror" true rather than "two lists
+// that happen to agree today". It compares both directions: a model the screen
+// offers that SeedModelRates does not price fails, and so does a provider name
+// SelectBrain would not accept.
+//
+// An unpriced model is not a crash, which is why it needs a gate: the binding
+// works, and every call it serves reports UNPRICED instead of a cost. Nobody
+// notices until someone opens the usage report and finds the first week of
+// their installation missing from it.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+)
+
+const setupProvidersFile = "../frontend/src/screens/setup-providers.ts"
+
+// setupOffer is one entry of the screen's table, as this gate reads it.
+type setupOffer struct {
+	id, provider, chatModel, embedModel string
+}
+
+// providerEntry matches one preset block. Anchored on the fields rather than on
+// the whole literal so reformatting the file — biome moving a brace — does not
+// silently stop the gate matching, which is the one failure a mirror must not
+// have.
+var providerEntry = regexp.MustCompile(
+	`(?s)(\w+):\s*\{\s*label:[^}]*?provider:\s*"([^"]+)"[^}]*?chatModel:\s*"([^"]+)"[^}]*?embedModel:\s*"([^"]+)"`)
+
+func readSetupOffers(t *testing.T) []setupOffer {
+	t.Helper()
+	raw, err := os.ReadFile(setupProvidersFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", setupProvidersFile, err)
+	}
+	// Only the table, never the doc comment above it: the prose names models as
+	// examples, and matching those would have this gate check sentences.
+	body := string(raw)
+	if i := strings.Index(body, "const PRESETS"); i >= 0 {
+		body = body[i:]
+	}
+	matches := providerEntry.FindAllStringSubmatch(body, -1)
+	offers := make([]setupOffer, 0, len(matches))
+	for _, m := range matches {
+		offers = append(offers, setupOffer{id: m[1], provider: m[2], chatModel: m[3], embedModel: m[4]})
+	}
+	// NOT a tolerated zero: the screen offers providers, so an empty read means
+	// the shape moved and this gate reports PASS having compared nothing.
+	if len(offers) == 0 {
+		t.Fatalf("no provider presets parsed from %s — the mirror has gone blind", setupProvidersFile)
+	}
+	return offers
+}
+
+func TestOnboardingOffersOnlyModelsTheServerPrices(t *testing.T) {
+	priced := map[string]bool{}
+	for _, r := range ai.SeedModelRates(time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)) {
+		priced[r.Provider+"/"+r.ModelID] = true
+	}
+	for _, o := range readSetupOffers(t) {
+		for lane, model := range map[string]string{"chat": o.chatModel, "embeddings": o.embedModel} {
+			if !priced[o.provider+"/"+model] {
+				t.Errorf("onboarding offers %s as %s's %s lane, and SeedModelRates does not price %s/%s — "+
+					"every call an admin makes in their first week would report UNPRICED",
+					model, o.id, lane, o.provider, model)
+			}
+		}
+	}
+}
+
+func TestOnboardingOffersOnlyProvidersTheServerServes(t *testing.T) {
+	known := map[string]bool{}
+	for _, p := range ai.KnownProviders() {
+		known[p] = true
+	}
+	for _, o := range readSetupOffers(t) {
+		if !known[o.provider] {
+			t.Errorf("onboarding offers provider %q for %s, which SelectBrain does not serve — "+
+				"the first write would be refused with a message about an adapter the reader never named",
+				o.provider, o.id)
+		}
+	}
+}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -91,6 +91,20 @@ const (
 // JSON-schema drift test. Add a provider here when you add its case.
 var knownProviders = []string{ProviderFake, providerAnthropic, providerOllama, providerVLLM, providerOpenAICompatible, providerOpenAI, providerGemini}
 
+// KnownProviders lists the adapter names knownProviders holds, which is the
+// same slice SelectBrain's switch and the config enum read.
+//
+// Exported for the gate that holds onboarding's provider list to this one: the
+// screen offers a first-time admin a vendor, and a name this switch does not
+// accept is a write refused with a message about an adapter they never chose.
+// Returned as a copy — a caller that sorted the package's own slice in place
+// would reorder the config enum's source.
+func KnownProviders() []string {
+	out := make([]string, len(knownProviders))
+	copy(out, knownProviders)
+	return out
+}
+
 // SelectBrain turns one binding into a Client (interfaces.md §4):
 // "offline fake ↔ API key ↔ local, one line" — swapping providers is a
 // config change, never a code change.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (30)
+## Parity (31)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -36,6 +36,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendidlebase_test.go` | H3 | The deal board and the server must measure silence from the SAME timestamp, or a card ages differently from the list that filed the deal stalled. |
 | `frontendlaneparity_test.go` | H3 | The frontend gate is spelled once as `make check-fe` and run by CI as three parallel jobs. |
 | `frontendminorunits_test.go` | H3 | The browser and the server must scale money by the SAME table, or the integer they exchange means two different amounts. |
+| `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |
 | `idempotencymap_test.go` | H3 | The idempotency allowlist as a fitness function: the contract is the authority on which operations promise Idempotency-Key retry safety, and internal/compose's hand-maintained replayableOperations map must mirror it exactly. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5488,7 +5488,7 @@ export const de = {
   "googleApp.replace": "App ersetzen",
   "googleApp.removeConfirmTitle": "Google-App entfernen?",
   "googleApp.removeConfirmBody":
-    "Das Client-Secret lässt sich nicht wieder auslesen — nach dem Entfernen müssen beide Hälften erneut aus der Google-Konsole eingetragen werden. Jedes Postfach ist über diese App verbunden, und die Ersteinrichtung fragt wieder danach.",
+    "Das Client-Secret lässt sich nicht wieder auslesen — nach dem Entfernen müssen beide Hälften erneut aus der Google-Konsole eingetragen werden. Gmail- und Kalender-Verbindungen laufen über diese App — Microsoft- und IMAP-Postfächer sind nicht betroffen —, und die Ersteinrichtung fragt wieder danach.",
   "googleApp.remove": "App entfernen",
   "firstRun.continue": "Weiter",
   "firstRun.ai.title": "Modellanbieter wählen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5476,6 +5476,36 @@ export const de = {
   "installationSettings.edit": "Ändern",
   "installationSettings.editField": "{field} ändern",
   "installationSettings.save": "Speichern",
+  "googleApp.title": "Google-App",
+  "googleApp.sub":
+    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört — Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen, nicht mit unseren.",
+  "googleApp.configured": "In Verwendung: {clientId}",
+  "googleApp.absent":
+    "Keine App hinterlegt. Gmail und Kalender lassen sich erst danach verbinden.",
+  "googleApp.replaceHint":
+    "Ein neues Paar ersetzt das hinterlegte. Bereits bestehende Verbindungen laufen weiter, bis sie neu verbunden werden.",
+  "googleApp.store": "App hinterlegen",
+  "googleApp.replace": "App ersetzen",
+  "googleApp.remove": "App entfernen",
+  "firstRun.continue": "Weiter",
+  "firstRun.ai.title": "Modellanbieter wählen",
+  "firstRun.ai.sub":
+    "Margince stellt keine eigene Inferenz bereit und arbeitet über Ihr Anbieterkonto. Alles davon lässt sich später unter Einstellungen → KI ändern.",
+  "firstRun.ai.provider": "Anbieter",
+  "firstRun.ai.key": "API-Schlüssel",
+  "firstRun.ai.keyHint":
+    "Einmal gesendet und im Schlüsseltresor versiegelt. Ist stattdessen {envVar} in der Umgebung gesetzt, liest der Server ihn von dort.",
+  "firstRun.ai.chatModel": "Modell",
+  "firstRun.ai.modelHint":
+    "Ein Ausgangspunkt. Jede Modell-ID, die Ihr Anbieter bedient, ist möglich.",
+  "firstRun.ai.embedModel": "Embedding-Modell",
+  "firstRun.google.title": "Google-App verbinden",
+  "firstRun.google.sub":
+    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört — Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen. Später unter Einstellungen änderbar.",
+  "firstRun.google.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
+  "firstRun.google.clientId": "Client-ID",
+  "firstRun.google.clientSecret": "Client-Secret",
   "aiProviderKeys.title": "Anbieter-Schlüssel",
   "aiProviderKeys.sub":
     "Die Zugangsdaten, mit denen diese Installation die Modellanbieter aufruft. Ein Schlüssel wird im Schlüsseltresor versiegelt und nie wieder angezeigt — ersetze ihn, wenn du ihn ändern willst.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5486,6 +5486,9 @@ export const de = {
     "Ein neues Paar ersetzt das hinterlegte. Bereits bestehende Verbindungen laufen weiter, bis sie neu verbunden werden.",
   "googleApp.store": "App hinterlegen",
   "googleApp.replace": "App ersetzen",
+  "googleApp.removeConfirmTitle": "Google-App entfernen?",
+  "googleApp.removeConfirmBody":
+    "Das Client-Secret lässt sich nicht wieder auslesen — nach dem Entfernen müssen beide Hälften erneut aus der Google-Konsole eingetragen werden. Jedes Postfach ist über diese App verbunden, und die Ersteinrichtung fragt wieder danach.",
   "googleApp.remove": "App entfernen",
   "firstRun.continue": "Weiter",
   "firstRun.ai.title": "Modellanbieter wählen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5504,11 +5504,9 @@ export const en = {
   "installationSettings.edit": "Edit",
   "installationSettings.editField": "Edit {field}",
   "installationSettings.save": "Save",
-  // Which vendor this installation's text is sent to. Admin/ops only, on both
-  // verbs â see the ai_routing RBAC object.
   "googleApp.title": "Google app",
   "googleApp.sub":
-    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organisation’s own credentials rather than ours.",
+    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organization’s own credentials rather than ours.",
   "googleApp.configured": "In use: {clientId}",
   "googleApp.absent":
     "No app stored. Gmail and Calendar cannot be connected until one is.",
@@ -5516,6 +5514,9 @@ export const en = {
     "Entering a new pair replaces the stored one. Connections already made keep working until they are reconnected.",
   "googleApp.store": "Store app",
   "googleApp.replace": "Replace app",
+  "googleApp.removeConfirmTitle": "Remove the Google app?",
+  "googleApp.removeConfirmBody":
+    "The client secret cannot be read back, so removing it means re-entering both halves from the Google console. Every mailbox is connected through this app, and first-run setup will ask for one again.",
   "googleApp.remove": "Remove app",
   "firstRun.continue": "Continue",
   "firstRun.ai.title": "Choose a model provider",
@@ -5531,11 +5532,13 @@ export const en = {
   "firstRun.ai.embedModel": "Embedding model",
   "firstRun.google.title": "Connect a Google app",
   "firstRun.google.sub":
-    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organisation’s own credentials. You can change this later under Settings.",
+    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organization’s own credentials. You can change this later under Settings.",
   "firstRun.google.clientIdPlaceholder":
     "000000000000-xxxx.apps.googleusercontent.com",
   "firstRun.google.clientId": "Client ID",
   "firstRun.google.clientSecret": "Client secret",
+  // Which vendor this installation's text is sent to. Admin/ops only, on both
+  // verbs â see the ai_routing RBAC object.
   "aiProviderKeys.title": "Model provider keys",
   "aiProviderKeys.sub":
     "The credentials this installation calls each model vendor with. A key is sealed in the key vault and never shown again — replace it if you need to change it.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5506,6 +5506,36 @@ export const en = {
   "installationSettings.save": "Save",
   // Which vendor this installation's text is sent to. Admin/ops only, on both
   // verbs â see the ai_routing RBAC object.
+  "googleApp.title": "Google app",
+  "googleApp.sub":
+    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organisation’s own credentials rather than ours.",
+  "googleApp.configured": "In use: {clientId}",
+  "googleApp.absent":
+    "No app stored. Gmail and Calendar cannot be connected until one is.",
+  "googleApp.replaceHint":
+    "Entering a new pair replaces the stored one. Connections already made keep working until they are reconnected.",
+  "googleApp.store": "Store app",
+  "googleApp.replace": "Replace app",
+  "googleApp.remove": "Remove app",
+  "firstRun.continue": "Continue",
+  "firstRun.ai.title": "Choose a model provider",
+  "firstRun.ai.sub":
+    "Margince provides no inference of its own, so it works through your vendor account. You can change any of this later under Settings → AI.",
+  "firstRun.ai.provider": "Provider",
+  "firstRun.ai.key": "API key",
+  "firstRun.ai.keyHint":
+    "Sent once and sealed in the key vault. The server reads it as {envVar} when one is set in the environment instead.",
+  "firstRun.ai.chatModel": "Model",
+  "firstRun.ai.modelHint":
+    "A starting point. Any model id your provider serves will do.",
+  "firstRun.ai.embedModel": "Embedding model",
+  "firstRun.google.title": "Connect a Google app",
+  "firstRun.google.sub":
+    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organisation’s own credentials. You can change this later under Settings.",
+  "firstRun.google.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
+  "firstRun.google.clientId": "Client ID",
+  "firstRun.google.clientSecret": "Client secret",
   "aiProviderKeys.title": "Model provider keys",
   "aiProviderKeys.sub":
     "The credentials this installation calls each model vendor with. A key is sealed in the key vault and never shown again — replace it if you need to change it.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5516,7 +5516,7 @@ export const en = {
   "googleApp.replace": "Replace app",
   "googleApp.removeConfirmTitle": "Remove the Google app?",
   "googleApp.removeConfirmBody":
-    "The client secret cannot be read back, so removing it means re-entering both halves from the Google console. Every mailbox is connected through this app, and first-run setup will ask for one again.",
+    "The client secret cannot be read back, so removing it means re-entering both halves from the Google console. Gmail and Calendar connections are made through this app — Microsoft and IMAP mailboxes are not affected — and first-run setup will ask for one again.",
   "googleApp.remove": "Remove app",
   "firstRun.continue": "Continue",
   "firstRun.ai.title": "Choose a model provider",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -30,6 +30,14 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // Vietnamese uses "Email" for the noun; German has its own spelling and
   // carries it. Only the vi value matches English, and it is the right word.
   "dealmail.title",
+  // Google's own field names. An admin reads these off the Google Cloud
+  // console, which shows them in English whatever the reader's locale, so
+  // translating them here would have the form ask for something the page they
+  // are copying from does not call by that name. The placeholder is an id
+  // SHAPE rather than prose and is the same string everywhere.
+  "firstRun.google.clientId",
+  "firstRun.google.clientSecret",
+  "firstRun.google.clientIdPlaceholder",
   // The same noun, captioning a staged proposal's email field.
   "approval.field.email",
   // Vietnamese sales usage keeps "pipeline" as the loanword, the same way it

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5426,6 +5426,36 @@ export const vi = {
   "installationSettings.edit": "Sửa",
   "installationSettings.editField": "Sửa {field}",
   "installationSettings.save": "Lưu",
+  "googleApp.title": "Ứng dụng Google",
+  "googleApp.sub":
+    "Hộp thư được kết nối qua ứng dụng Google OAuth của bạn, nên thư được đọc bằng thông tin xác thực của tổ chức bạn chứ không phải của chúng tôi.",
+  "googleApp.configured": "Đang dùng: {clientId}",
+  "googleApp.absent":
+    "Chưa lưu ứng dụng nào. Chưa thể kết nối Gmail và Lịch cho tới khi có.",
+  "googleApp.replaceHint":
+    "Nhập cặp mới sẽ thay thế cặp đã lưu. Các kết nối đã tạo vẫn chạy cho tới khi kết nối lại.",
+  "googleApp.store": "Lưu ứng dụng",
+  "googleApp.replace": "Thay ứng dụng",
+  "googleApp.remove": "Xoá ứng dụng",
+  "firstRun.continue": "Tiếp tục",
+  "firstRun.ai.title": "Chọn nhà cung cấp mô hình",
+  "firstRun.ai.sub":
+    "Margince không tự suy luận mà hoạt động qua tài khoản nhà cung cấp của bạn. Bạn có thể đổi mọi thứ ở đây sau, trong Cài đặt → AI.",
+  "firstRun.ai.provider": "Nhà cung cấp",
+  "firstRun.ai.key": "Khóa API",
+  "firstRun.ai.keyHint":
+    "Gửi một lần và niêm phong trong két khóa. Nếu môi trường đã đặt {envVar}, máy chủ đọc từ đó.",
+  "firstRun.ai.chatModel": "Mô hình",
+  "firstRun.ai.modelHint":
+    "Chỉ là điểm khởi đầu. Bất kỳ mã mô hình nào nhà cung cấp phục vụ đều dùng được.",
+  "firstRun.ai.embedModel": "Mô hình embedding",
+  "firstRun.google.title": "Kết nối ứng dụng Google",
+  "firstRun.google.sub":
+    "Hộp thư được kết nối qua ứng dụng Google OAuth của bạn, nên thư được đọc bằng thông tin xác thực của tổ chức bạn. Có thể đổi sau trong Cài đặt.",
+  "firstRun.google.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
+  "firstRun.google.clientId": "Client ID",
+  "firstRun.google.clientSecret": "Client secret",
   "aiProviderKeys.title": "Khóa nhà cung cấp mô hình",
   "aiProviderKeys.sub":
     "Thông tin xác thực mà bản cài đặt này dùng để gọi từng nhà cung cấp mô hình. Khóa được niêm phong trong kho khóa và không bao giờ hiển thị lại — hãy thay thế nếu bạn cần đổi.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5436,6 +5436,9 @@ export const vi = {
     "Nhập cặp mới sẽ thay thế cặp đã lưu. Các kết nối đã tạo vẫn chạy cho tới khi kết nối lại.",
   "googleApp.store": "Lưu ứng dụng",
   "googleApp.replace": "Thay ứng dụng",
+  "googleApp.removeConfirmTitle": "Xoá ứng dụng Google?",
+  "googleApp.removeConfirmBody":
+    "Không thể đọc lại client secret, nên xoá xong phải nhập lại cả hai phần từ bảng điều khiển Google. Mọi hộp thư đều kết nối qua ứng dụng này, và bước thiết lập lần đầu sẽ hỏi lại.",
   "googleApp.remove": "Xoá ứng dụng",
   "firstRun.continue": "Tiếp tục",
   "firstRun.ai.title": "Chọn nhà cung cấp mô hình",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5438,7 +5438,7 @@ export const vi = {
   "googleApp.replace": "Thay ứng dụng",
   "googleApp.removeConfirmTitle": "Xoá ứng dụng Google?",
   "googleApp.removeConfirmBody":
-    "Không thể đọc lại client secret, nên xoá xong phải nhập lại cả hai phần từ bảng điều khiển Google. Mọi hộp thư đều kết nối qua ứng dụng này, và bước thiết lập lần đầu sẽ hỏi lại.",
+    "Không thể đọc lại client secret, nên xoá xong phải nhập lại cả hai phần từ bảng điều khiển Google. Kết nối Gmail và Lịch đi qua ứng dụng này — hộp thư Microsoft và IMAP không bị ảnh hưởng — và bước thiết lập lần đầu sẽ hỏi lại.",
   "googleApp.remove": "Xoá ứng dụng",
   "firstRun.continue": "Tiếp tục",
   "firstRun.ai.title": "Chọn nhà cung cấp mô hình",

--- a/frontend/src/screens/ai-provider-keys.tsx
+++ b/frontend/src/screens/ai-provider-keys.tsx
@@ -46,7 +46,11 @@ function useProviderKeys(enabled: boolean) {
   });
 }
 
-function useSetProviderKey() {
+// Exported for onboarding's AI step, which writes the same credential through
+// the same endpoint. A second mutation there would be a second set of rules
+// about how long a key lives in memory, and the ones below are not obvious
+// enough to expect anybody to rediscover them.
+export function useSetProviderKey() {
   const queryClient = useQueryClient();
   return useMutation({
     // Collected the moment nothing observes it, because what this mutation's

--- a/frontend/src/screens/google-app.test.tsx
+++ b/frontend/src/screens/google-app.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { jsonResponse } from "./company.fixtures";
+import { GoogleAppCard } from "./google-app";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const CLIENT_ID = "111-abc.apps.googleusercontent.com";
+
+function mount(stored: { configured: boolean; client_id: string }) {
+  const calls: { method: string; url: string; body?: unknown }[] = [];
+  const fetchMock = vi.fn(async (request: Request) => {
+    const url = new URL(request.url).pathname;
+    if (request.method === "GET") {
+      if (url.endsWith("/me")) {
+        // Through the fixture rather than a hand-built body: the grant shape is
+        // the capability layer's, and a test that spelled its own would prove
+        // nothing about what the real /me returns.
+        return jsonResponse(
+          meFixture({ allow: { capture_settings: ["read", "update"] } }),
+        );
+      }
+      return jsonResponse(stored);
+    }
+    calls.push({
+      method: request.method,
+      url,
+      body: request.body ? JSON.parse(await request.text()) : undefined,
+    });
+    return new Response(null, { status: 204 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrap = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <LocaleProvider>{children}</LocaleProvider>
+    </QueryClientProvider>
+  );
+  render(<GoogleAppCard />, { wrapper: Wrap });
+  return { calls };
+}
+
+describe("the Google app card", () => {
+  // The client id is NOT a secret — it travels in every authorization redirect,
+  // and an operator has to see which app their installation uses to check it
+  // against the Google console.
+  it("names the app in use", async () => {
+    mount({ configured: true, client_id: CLIENT_ID });
+    expect(await screen.findByText(`In use: ${CLIENT_ID}`)).toBeTruthy();
+  });
+
+  // An installation with none has not failed at anything, but it cannot connect
+  // a mailbox either, and the card says which.
+  it("says no app is stored, and what that costs", async () => {
+    mount({ configured: false, client_id: "" });
+    expect(
+      await screen.findByText(/No app stored\. Gmail and Calendar cannot/),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Remove app" })).toBeNull();
+  });
+
+  it("sends the pair together and then holds neither", async () => {
+    const user = userEvent.setup();
+    const { calls } = mount({ configured: false, client_id: "" });
+    await screen.findByText(/No app stored/);
+    const secret = screen.getByLabelText("Client secret") as HTMLInputElement;
+    await user.type(screen.getByLabelText("Client ID"), CLIENT_ID);
+    await user.type(secret, "GOCSPX-secret");
+    await user.click(screen.getByRole("button", { name: "Store app" }));
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0]).toMatchObject({
+      method: "PUT",
+      url: "/v1/installation/google-app",
+      body: { client_id: CLIENT_ID, client_secret: "GOCSPX-secret" },
+    });
+    // Cleared on the way out: the field was the only copy this app held.
+    await waitFor(() => expect(secret.value).toBe(""));
+  });
+
+  it("offers removal only for an app that is there", async () => {
+    const user = userEvent.setup();
+    const { calls } = mount({ configured: true, client_id: CLIENT_ID });
+    await user.click(await screen.findByRole("button", { name: "Remove app" }));
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0]).toMatchObject({
+      method: "DELETE",
+      url: "/v1/installation/google-app",
+    });
+  });
+});

--- a/frontend/src/screens/google-app.test.tsx
+++ b/frontend/src/screens/google-app.test.tsx
@@ -1,6 +1,12 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -72,7 +78,7 @@ describe("the Google app card", () => {
     const user = userEvent.setup();
     const { calls } = mount({ configured: false, client_id: "" });
     await screen.findByText(/No app stored/);
-    const secret = screen.getByLabelText("Client secret") as HTMLInputElement;
+    const secret = screen.getByLabelText<HTMLInputElement>("Client secret");
     await user.type(screen.getByLabelText("Client ID"), CLIENT_ID);
     await user.type(secret, "GOCSPX-secret");
     await user.click(screen.getByRole("button", { name: "Store app" }));
@@ -90,10 +96,26 @@ describe("the Google app card", () => {
     const user = userEvent.setup();
     const { calls } = mount({ configured: true, client_id: CLIENT_ID });
     await user.click(await screen.findByRole("button", { name: "Remove app" }));
+    // The first press opens the question; it does not answer it.
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Remove app" }),
+    );
     await waitFor(() => expect(calls.length).toBe(1));
     expect(calls[0]).toMatchObject({
       method: "DELETE",
       url: "/v1/installation/google-app",
     });
+  });
+
+  // The secret cannot be read back, every mailbox is connected through this
+  // app, and removing it re-opens the first-run gate — so a stray click must
+  // not be enough.
+  it("deletes nothing until the removal is confirmed", async () => {
+    const user = userEvent.setup();
+    const { calls } = mount({ configured: true, client_id: CLIENT_ID });
+    await user.click(await screen.findByRole("button", { name: "Remove app" }));
+    await screen.findByRole("dialog");
+    expect(calls).toEqual([]);
   });
 });

--- a/frontend/src/screens/google-app.tsx
+++ b/frontend/src/screens/google-app.tsx
@@ -1,0 +1,189 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import { useCanWrite } from "../app/capability";
+import { Button, Field, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+/**
+ * The Google OAuth app a mailbox connection is made through.
+ *
+ * This file owns the endpoint's hooks and onboarding's first-run step borrows
+ * them, rather than each writing its own: how long a client SECRET lives in a
+ * mutation's `variables` is not a rule worth having two answers to, and the
+ * onboarding screen is the one most likely to be written in a hurry.
+ *
+ * The secret is never read back. `GET` answers whether one is stored and the
+ * client id, which is not a secret — it travels in every authorization redirect,
+ * and an operator needs to see WHICH app their installation uses to check it
+ * against the Google console.
+ */
+
+export function useGoogleApp() {
+  return useQuery({
+    queryKey: ["installation-google-app"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/installation/google-app",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+export function useSetGoogleApp() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // Collected the moment nothing observes it, because what this mutation's
+    // `variables` hold is a credential rather than a form field. The caller
+    // resets it once settled for the same reason.
+    gcTime: 0,
+    mutationFn: async (vars: { clientId: string; clientSecret: string }) => {
+      const { error } = await api.PUT("/installation/google-app", {
+        body: { client_id: vars.clientId, client_secret: vars.clientSecret },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      // Both: the card's own view, and the first-run report that gates
+      // onboarding on this very step.
+      await queryClient.invalidateQueries({
+        queryKey: ["installation-google-app"],
+      });
+      await queryClient.invalidateQueries({ queryKey: ["installation-setup"] });
+    },
+  });
+}
+
+function useRemoveGoogleApp() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await api.DELETE("/installation/google-app");
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["installation-google-app"],
+      });
+      await queryClient.invalidateQueries({ queryKey: ["installation-setup"] });
+    },
+  });
+}
+
+export function GoogleAppCard() {
+  const t = useT();
+  const canManage = useCanWrite("capture_settings", "update");
+  const app = useGoogleApp();
+  const save = useSetGoogleApp();
+  const remove = useRemoveGoogleApp();
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+
+  const busy = save.isPending || remove.isPending;
+  const ready = clientId.trim() !== "" && clientSecret.trim() !== "";
+  const failure = save.error ?? remove.error;
+
+  return (
+    <Panel title={t("googleApp.title")}>
+      <PanelBody>
+        <p className="t-body">{t("googleApp.sub")}</p>
+        <QueryGate query={app}>
+          {(status) => (
+            <>
+              {failure && (
+                <Callout tone="danger">{problemMessageOf(failure, t)}</Callout>
+              )}
+              <p className="t-body">
+                {status.configured
+                  ? t("googleApp.configured", { clientId: status.client_id })
+                  : t("googleApp.absent")}
+              </p>
+              <Field
+                label={t("firstRun.google.clientId")}
+                hint={
+                  status.configured ? t("googleApp.replaceHint") : undefined
+                }
+              >
+                {(control) => (
+                  <TextInput
+                    {...control}
+                    value={clientId}
+                    autoComplete="off"
+                    disabled={!canManage || busy}
+                    placeholder={t("firstRun.google.clientIdPlaceholder")}
+                    onChange={(e) => setClientId(e.target.value)}
+                  />
+                )}
+              </Field>
+              <Field label={t("firstRun.google.clientSecret")}>
+                {(control) => (
+                  <TextInput
+                    {...control}
+                    type="password"
+                    autoComplete="off"
+                    value={clientSecret}
+                    disabled={!canManage || busy}
+                    onChange={(e) => setClientSecret(e.target.value)}
+                  />
+                )}
+              </Field>
+              <div className="row-inline">
+                <Button
+                  variant="primary"
+                  pending={save.isPending}
+                  disabled={!canManage || remove.isPending || !ready}
+                  onClick={() => {
+                    remove.reset();
+                    save.mutate(
+                      {
+                        clientId: clientId.trim(),
+                        clientSecret: clientSecret.trim(),
+                      },
+                      {
+                        onSuccess: () => {
+                          // The field is the only copy this app holds, and it
+                          // has done its job.
+                          setClientSecret("");
+                          setClientId("");
+                          save.reset();
+                        },
+                      },
+                    );
+                  }}
+                >
+                  {status.configured
+                    ? t("googleApp.replace")
+                    : t("googleApp.store")}
+                </Button>
+                {status.configured && (
+                  <Button
+                    variant="danger"
+                    pending={remove.isPending}
+                    disabled={!canManage || save.isPending}
+                    onClick={() => {
+                      save.reset();
+                      remove.mutate();
+                    }}
+                  >
+                    {t("googleApp.remove")}
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/google-app.tsx
+++ b/frontend/src/screens/google-app.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { api } from "../api/client";
 import { useCanWrite } from "../app/capability";
 import { Button, Field, TextInput } from "../design-system/atoms";
@@ -91,6 +91,11 @@ export function GoogleAppCard() {
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [confirming, setConfirming] = useState(false);
+  // Focus has to land somewhere that still exists. The button that opened the
+  // dialog is the natural target and the one that disappears: a successful
+  // removal invalidates the query, the app reads as absent, and the Remove
+  // button is gone by the time focus is restored to it.
+  const clientIdRef = useRef<HTMLInputElement>(null);
 
   const busy = save.isPending || remove.isPending;
   const ready = clientId.trim() !== "" && clientSecret.trim() !== "";
@@ -120,6 +125,7 @@ export function GoogleAppCard() {
                 {(control) => (
                   <TextInput
                     {...control}
+                    ref={clientIdRef}
                     value={clientId}
                     autoComplete="off"
                     disabled={!canManage || busy}
@@ -186,6 +192,12 @@ export function GoogleAppCard() {
                 confirmLabel={t("googleApp.remove")}
                 confirmVariant="danger"
                 pending={remove.isPending}
+                // A refused DELETE leaves this dialog OPEN, so the reason has
+                // to be inside it: the background Callout is behind a modal the
+                // reader cannot see past, which reads as a button that did
+                // nothing.
+                error={remove.error ? problemMessageOf(remove.error, t) : null}
+                returnFocusTo={() => clientIdRef.current}
                 onConfirm={() => {
                   save.reset();
                   remove.mutate(undefined, {

--- a/frontend/src/screens/google-app.tsx
+++ b/frontend/src/screens/google-app.tsx
@@ -4,6 +4,7 @@ import { api } from "../api/client";
 import { useCanWrite } from "../app/capability";
 import { Button, Field, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
+import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
@@ -89,6 +90,7 @@ export function GoogleAppCard() {
   const remove = useRemoveGoogleApp();
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [confirming, setConfirming] = useState(false);
 
   const busy = save.isPending || remove.isPending;
   const ready = clientId.trim() !== "" && clientSecret.trim() !== "";
@@ -171,15 +173,28 @@ export function GoogleAppCard() {
                     variant="danger"
                     pending={remove.isPending}
                     disabled={!canManage || save.isPending}
-                    onClick={() => {
-                      save.reset();
-                      remove.mutate();
-                    }}
+                    onClick={() => setConfirming(true)}
                   >
                     {t("googleApp.remove")}
                   </Button>
                 )}
               </div>
+              <ConfirmModal
+                open={confirming}
+                onClose={() => setConfirming(false)}
+                title={t("googleApp.removeConfirmTitle")}
+                confirmLabel={t("googleApp.remove")}
+                confirmVariant="danger"
+                pending={remove.isPending}
+                onConfirm={() => {
+                  save.reset();
+                  remove.mutate(undefined, {
+                    onSuccess: () => setConfirming(false),
+                  });
+                }}
+              >
+                {t("googleApp.removeConfirmBody")}
+              </ConfirmModal>
             </>
           )}
         </QueryGate>

--- a/frontend/src/screens/installation-setup.test.tsx
+++ b/frontend/src/screens/installation-setup.test.tsx
@@ -30,12 +30,19 @@ function setupReport(
   };
 }
 
-function mount(report: ReturnType<typeof setupReport>) {
+function mount(
+  report: ReturnType<typeof setupReport>,
+  /** Paths whose write should fail, so a half-finished run can be exercised. */
+  refuse: readonly string[] = [],
+) {
   const writes: { url: string; body: unknown }[] = [];
   const fetchMock = vi.fn(async (request: Request) => {
     const url = new URL(request.url).pathname;
     if (request.method !== "GET") {
       writes.push({ url, body: JSON.parse(await request.text()) });
+      if (refuse.some((p) => url.endsWith(p))) {
+        return jsonResponse({ title: "refused" }, 500);
+      }
       return new Response(null, { status: 204 });
     }
     return jsonResponse(report);
@@ -140,6 +147,26 @@ describe("the first-run setup gate", () => {
       expect(bound.base_url).toBe("https://openrouter.ai/api");
     }
     expect(routing.embeddings.base_url).toBe("https://openrouter.ai/api");
+  });
+
+  // The key is the reader's only copy. Clearing it after the FIRST write left a
+  // failed binding with an empty field, a disabled Continue, a step still
+  // unconfigured and a reload that restored exactly that — the only way on was
+  // to re-paste a key the server already held.
+  it("keeps the key on screen when the binding fails, so Continue still works", async () => {
+    const user = userEvent.setup();
+    const { writes } = mount(setupReport(false, false), ["/ai/routing"]);
+    await screen.findByText("Choose a model provider");
+    const key = screen.getByLabelText<HTMLInputElement>("API key");
+    await user.type(key, "AIza-secret");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(writes.length).toBe(2));
+
+    // The field still holds it, and the button is pressable again.
+    await waitFor(() => expect(key.value).toBe("AIza-secret"));
+    expect(
+      screen.getByRole("button", { name: "Continue" }).getAttribute("disabled"),
+    ).toBeNull();
   });
 
   it("sends the Google app as one pair", async () => {

--- a/frontend/src/screens/installation-setup.test.tsx
+++ b/frontend/src/screens/installation-setup.test.tsx
@@ -1,0 +1,162 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
+import { LocaleProvider } from "../i18n";
+import { jsonResponse } from "./company.fixtures";
+import { InstallationSetup } from "./installation-setup";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+type Step = { step: string; configured: boolean; blocking: boolean };
+
+/** The server's answer, in the order the server gives it. */
+function setupReport(
+  ai: boolean,
+  google: boolean,
+): { complete: boolean; steps: Step[] } {
+  return {
+    complete: ai && google,
+    steps: [
+      { step: "ai_models", configured: ai, blocking: true },
+      { step: "google_app", configured: google, blocking: true },
+    ],
+  };
+}
+
+function mount(report: ReturnType<typeof setupReport>) {
+  const writes: { url: string; body: unknown }[] = [];
+  const fetchMock = vi.fn(async (request: Request) => {
+    const url = new URL(request.url).pathname;
+    if (request.method !== "GET") {
+      writes.push({ url, body: JSON.parse(await request.text()) });
+      return new Response(null, { status: 204 });
+    }
+    return jsonResponse(report);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrap = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <LocaleProvider>{children}</LocaleProvider>
+    </QueryClientProvider>
+  );
+  render(<InstallationSetup />, { wrapper: Wrap });
+  return { writes };
+}
+
+describe("the first-run setup gate", () => {
+  // The order is the product decision the server pins: somebody with no model
+  // bound cannot be shown a cold start, while the mailbox can wait.
+  it("asks for the model binding before the Google app", async () => {
+    mount(setupReport(false, false));
+    expect(await screen.findByText("Choose a model provider")).toBeTruthy();
+    expect(screen.queryByText("Connect a Google app")).toBeNull();
+  });
+
+  it("asks for the Google app once the models are bound", async () => {
+    mount(setupReport(true, false));
+    expect(await screen.findByText("Connect a Google app")).toBeTruthy();
+    expect(screen.queryByText("Choose a model provider")).toBeNull();
+  });
+
+  // Nothing at all when there is nothing outstanding, so a caller can put this
+  // in front of the next screen without asking the same question twice.
+  it("draws nothing once every blocking step is done", async () => {
+    mount(setupReport(true, true));
+    await waitFor(() =>
+      expect(screen.queryByText("Choose a model provider")).toBeNull(),
+    );
+    expect(screen.queryByText("Connect a Google app")).toBeNull();
+  });
+
+  // The key BEFORE the binding: a binding whose vendor has no key reads as
+  // configured and fails on the first real call, where a key with no binding is
+  // simply a key and the next attempt completes it.
+  it("stores the key before it binds the models", async () => {
+    const user = userEvent.setup();
+    const { writes } = mount(setupReport(false, false));
+    await screen.findByText("Choose a model provider");
+    await user.type(screen.getByLabelText("API key"), "AIza-secret");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(writes.length).toBe(2));
+    expect(writes[0].url).toBe("/v1/ai/provider-keys/gemini");
+    expect(writes[1].url).toBe("/v1/ai/routing");
+  });
+
+  // Every chat tier, not just one. A half-bound installation answers for one
+  // task and refuses another, with nothing on screen saying which was configured.
+  it("binds every chat tier and the embedding lane", async () => {
+    const user = userEvent.setup();
+    const { writes } = mount(setupReport(false, false));
+    await screen.findByText("Choose a model provider");
+    await user.type(screen.getByLabelText("API key"), "AIza-secret");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(writes.length).toBe(2));
+    const routing = writes[1].body as {
+      tiers: Record<string, { provider: string; model: string }>;
+      embeddings: { provider: string; model: string };
+    };
+    expect(Object.keys(routing.tiers).sort()).toEqual([
+      "cheap_cloud",
+      "frontier",
+      "local_small",
+      "premium",
+    ]);
+    for (const bound of Object.values(routing.tiers)) {
+      expect(bound.provider).toBe("gemini");
+      expect(bound.model).toBe("gemini-3.1-flash-lite");
+    }
+    expect(routing.embeddings.model).toBe("gemini-embedding-001");
+  });
+
+  // OpenRouter is a preset, and openai_compatible fails closed without a
+  // base_url — so choosing it must carry the endpoint on every lane rather than
+  // leaving the reader to discover an adapter name.
+  it("carries the broker endpoint when OpenRouter is chosen", async () => {
+    const user = userEvent.setup();
+    const { writes } = mount(setupReport(false, false));
+    await screen.findByText("Choose a model provider");
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Provider" }),
+      "OpenRouter",
+    );
+    await user.type(screen.getByLabelText("API key"), "sk-or-secret");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(writes.length).toBe(2));
+    expect(writes[0].url).toBe("/v1/ai/provider-keys/openai_compatible");
+    const routing = writes[1].body as {
+      tiers: Record<string, { base_url?: string }>;
+      embeddings: { base_url?: string };
+    };
+    for (const bound of Object.values(routing.tiers)) {
+      expect(bound.base_url).toBe("https://openrouter.ai/api");
+    }
+    expect(routing.embeddings.base_url).toBe("https://openrouter.ai/api");
+  });
+
+  it("sends the Google app as one pair", async () => {
+    const user = userEvent.setup();
+    const { writes } = mount(setupReport(true, false));
+    await screen.findByText("Connect a Google app");
+    await user.type(
+      screen.getByLabelText("Client ID"),
+      "123-abc.apps.googleusercontent.com",
+    );
+    await user.type(screen.getByLabelText("Client secret"), "GOCSPX-secret");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(writes.length).toBe(1));
+    expect(writes[0].url).toBe("/v1/installation/google-app");
+    expect(writes[0].body).toEqual({
+      client_id: "123-abc.apps.googleusercontent.com",
+      client_secret: "GOCSPX-secret",
+    });
+  });
+});

--- a/frontend/src/screens/installation-setup.tsx
+++ b/frontend/src/screens/installation-setup.tsx
@@ -140,27 +140,45 @@ function AiStep() {
     apiKey.trim() !== "" && chatModel.trim() !== "" && embedModel.trim() !== "";
   const failure = saveKey.error ?? bind.error;
 
-  const submit = async () => {
+  // The KEY first, then the binding. A binding whose vendor has no key is an
+  // installation that reads as configured and fails on its first real call; a
+  // key with no binding is simply a key, and the next attempt completes it.
+  //
+  // Chained through callbacks rather than awaited: mutateAsync REJECTS, and the
+  // rejection has to be handled somewhere or it is an unhandled promise. More
+  // importantly the field is cleared only after BOTH writes land. Clearing it
+  // after the first one locked the reader out — a failed binding left `ready`
+  // false with the Continue button disabled, the step still unconfigured, and a
+  // reload restoring exactly that, so the only way on was to re-paste a key the
+  // server already held.
+  const submit = () => {
     saveKey.reset();
     bind.reset();
-    // The KEY first, then the binding. A binding whose vendor has no key is an
-    // installation that reads as configured and fails on its first real call;
-    // a key with no binding is simply a key, and the next attempt completes it.
-    await saveKey.mutateAsync({
-      provider: preset.provider,
-      apiKey: apiKey.trim(),
-    });
-    setApiKey("");
-    await bind.mutateAsync({
-      provider: preset.provider,
-      baseUrl: preset.baseUrl,
-      chatModel: chatModel.trim(),
-      embedModel: embedModel.trim(),
-    });
-    saveKey.reset();
-    // No "next" call: both mutations invalidate the setup query, so the answer
-    // to what is still outstanding comes back from the server rather than from
-    // this component's guess about what it just did.
+    saveKey.mutate(
+      { provider: preset.provider, apiKey: apiKey.trim() },
+      {
+        onSuccess: () =>
+          bind.mutate(
+            {
+              provider: preset.provider,
+              baseUrl: preset.baseUrl,
+              chatModel: chatModel.trim(),
+              embedModel: embedModel.trim(),
+            },
+            {
+              onSuccess: () => {
+                // Both landed, so the field has done its job and this is the
+                // only copy of the key the app was holding.
+                setApiKey("");
+                saveKey.reset();
+                // Nothing else: both mutations invalidate the setup query, so
+                // what is still outstanding comes back from the server rather
+                // than from this component's guess about what it just did.
+              },
+            },
+          ),
+      },
+    );
   };
 
   return (
@@ -176,7 +194,15 @@ function AiStep() {
               {...control}
               value={choice}
               disabled={busy}
-              onChange={(v) => pick(v as SetupProviderId)}
+              // Narrowed THROUGH the id list rather than asserted into it: a
+              // Select answers with a string, and an answer that is not one of
+              // these is not a provider this screen can bind.
+              onChange={(v) => {
+                const next = SETUP_PROVIDER_IDS.find((id) => id === v);
+                if (next) {
+                  pick(next);
+                }
+              }}
               options={SETUP_PROVIDER_IDS.map((id) => ({
                 value: id,
                 label: SETUP_PROVIDERS[id].label,
@@ -229,9 +255,7 @@ function AiStep() {
           variant="primary"
           pending={busy}
           disabled={!ready}
-          onClick={() => {
-            void submit();
-          }}
+          onClick={submit}
         >
           {t("firstRun.continue")}
         </Button>

--- a/frontend/src/screens/installation-setup.tsx
+++ b/frontend/src/screens/installation-setup.tsx
@@ -1,0 +1,329 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Button, Field, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import { useSetProviderKey } from "./ai-provider-keys";
+import { problemMessageOf, throwProblem } from "./common";
+import { useSetGoogleApp } from "./google-app";
+import {
+  SETUP_PROVIDER_IDS,
+  SETUP_PROVIDERS,
+  type SetupProviderId,
+} from "./setup-providers";
+
+/**
+ * What a fresh installation must be told before it can be used, asked in the
+ * order the server lists it: the model binding, then the Google app.
+ *
+ * WHY THIS IS NOT THE SETTINGS CARDS. `AiRoutingCard` re-points lanes an
+ * installation ALREADY binds — it says so and refuses an empty one, which is
+ * precisely the cold start. This asks a different question: one vendor, one
+ * key, two models, from nothing. The two surfaces write the same endpoints, and
+ * the credential goes through `useSetProviderKey` rather than a second mutation,
+ * because how long a key lives in memory is not a rule worth having two of.
+ *
+ * WHY IT READS THE SERVER RATHER THAN COUNTING STEPS ITSELF. The reader signs
+ * in, changes their password and signs in AGAIN before they arrive here, and
+ * they may close the tab in the middle. `GET /installation/setup` is the only
+ * thing that knows what is still outstanding, so the screen resumes rather than
+ * restarting — and it walks `steps` in the order it arrives, because that order
+ * is the server's to decide.
+ */
+
+type Setup = components["schemas"]["InstallationSetup"];
+type Step = components["schemas"]["InstallationSetupStep"];
+
+export function useInstallationSetup() {
+  return useQuery({
+    queryKey: ["installation-setup"],
+    queryFn: async (): Promise<Setup> => {
+      const { data, error, response } = await api.GET("/installation/setup");
+      if (error || !response.ok || !data) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+/**
+ * The first step that is not done yet, in the server's order.
+ *
+ * `steps` is optional-chained as well as `setup`: an answer that arrives
+ * without it is not an answer, and the alternative is this throwing inside a
+ * render — which takes down the screen it was meant to stand in front of.
+ * Undefined here reads as "nothing outstanding", which lets the reader past
+ * rather than trapping them behind a gate that cannot say what it wants.
+ */
+export function outstandingStep(setup: Setup | undefined): Step | undefined {
+  return setup?.steps?.find((s) => s.blocking && !s.configured);
+}
+
+function useBindModels() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // Same reasoning as the provider-key mutation: nothing here is a secret,
+    // but the two settle together and a stale binding on screen after a
+    // success is the same confusion.
+    gcTime: 0,
+    mutationFn: async (vars: {
+      provider: string;
+      baseUrl?: string;
+      chatModel: string;
+      embedModel: string;
+    }) => {
+      // Every chat tier on the one model the reader chose. A tier left unbound
+      // degrades honestly at runtime, but an onboarding that bound only some of
+      // them would have the product answer for one task and refuse another with
+      // no way for the reader to tell which they had configured.
+      const binding = {
+        provider: vars.provider,
+        model: vars.chatModel,
+        ...(vars.baseUrl ? { base_url: vars.baseUrl } : {}),
+      };
+      const { error } = await api.PUT("/ai/routing", {
+        body: {
+          // eu_hosted rather than a question: `sovereign` forbids the cloud
+          // vendors this screen offers, and asking a first-time admin to choose
+          // a location ladder before they have bound anything is asking them to
+          // answer a question they cannot yet have.
+          profile: "eu_hosted",
+          tiers: {
+            local_small: binding,
+            cheap_cloud: binding,
+            premium: binding,
+            frontier: binding,
+          },
+          embeddings: {
+            provider: vars.provider,
+            model: vars.embedModel,
+            ...(vars.baseUrl ? { base_url: vars.baseUrl } : {}),
+          },
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["installation-setup"] }),
+  });
+}
+
+/** The AI step: one vendor, one key, the two models it will serve. */
+function AiStep() {
+  const t = useT();
+  const [choice, setChoice] = useState<SetupProviderId>("gemini");
+  const preset = SETUP_PROVIDERS[choice];
+  const [apiKey, setApiKey] = useState("");
+  const [chatModel, setChatModel] = useState(preset.chatModel);
+  const [embedModel, setEmbedModel] = useState(preset.embedModel);
+  const saveKey = useSetProviderKey();
+  const bind = useBindModels();
+
+  // Switching vendor re-seeds the models, because the previous vendor's ids
+  // mean nothing to this one — leaving them would offer a binding that cannot
+  // serve a single call.
+  const pick = (next: SetupProviderId) => {
+    setChoice(next);
+    setChatModel(SETUP_PROVIDERS[next].chatModel);
+    setEmbedModel(SETUP_PROVIDERS[next].embedModel);
+  };
+
+  const busy = saveKey.isPending || bind.isPending;
+  const ready =
+    apiKey.trim() !== "" && chatModel.trim() !== "" && embedModel.trim() !== "";
+  const failure = saveKey.error ?? bind.error;
+
+  const submit = async () => {
+    saveKey.reset();
+    bind.reset();
+    // The KEY first, then the binding. A binding whose vendor has no key is an
+    // installation that reads as configured and fails on its first real call;
+    // a key with no binding is simply a key, and the next attempt completes it.
+    await saveKey.mutateAsync({
+      provider: preset.provider,
+      apiKey: apiKey.trim(),
+    });
+    setApiKey("");
+    await bind.mutateAsync({
+      provider: preset.provider,
+      baseUrl: preset.baseUrl,
+      chatModel: chatModel.trim(),
+      embedModel: embedModel.trim(),
+    });
+    saveKey.reset();
+    // No "next" call: both mutations invalidate the setup query, so the answer
+    // to what is still outstanding comes back from the server rather than from
+    // this component's guess about what it just did.
+  };
+
+  return (
+    <Panel title={t("firstRun.ai.title")}>
+      <PanelBody>
+        <p className="t-body">{t("firstRun.ai.sub")}</p>
+        {failure && (
+          <Callout tone="danger">{problemMessageOf(failure, t)}</Callout>
+        )}
+        <Field label={t("firstRun.ai.provider")}>
+          {(control) => (
+            <Select
+              {...control}
+              value={choice}
+              disabled={busy}
+              onChange={(v) => pick(v as SetupProviderId)}
+              options={SETUP_PROVIDER_IDS.map((id) => ({
+                value: id,
+                label: SETUP_PROVIDERS[id].label,
+              }))}
+            />
+          )}
+        </Field>
+        <Field
+          label={t("firstRun.ai.key")}
+          hint={t("firstRun.ai.keyHint", { envVar: preset.keyEnv })}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              // A password field so the browser does not offer to remember a
+              // credential this app never stores client-side, and a screenshare
+              // does not carry it.
+              type="password"
+              autoComplete="off"
+              value={apiKey}
+              disabled={busy}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+          )}
+        </Field>
+        <Field
+          label={t("firstRun.ai.chatModel")}
+          hint={t("firstRun.ai.modelHint")}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              value={chatModel}
+              disabled={busy}
+              onChange={(e) => setChatModel(e.target.value)}
+            />
+          )}
+        </Field>
+        <Field label={t("firstRun.ai.embedModel")}>
+          {(control) => (
+            <TextInput
+              {...control}
+              value={embedModel}
+              disabled={busy}
+              onChange={(e) => setEmbedModel(e.target.value)}
+            />
+          )}
+        </Field>
+        <Button
+          variant="primary"
+          pending={busy}
+          disabled={!ready}
+          onClick={() => {
+            void submit();
+          }}
+        >
+          {t("firstRun.continue")}
+        </Button>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+/** The Google step: the OAuth app a mailbox connection is made through. */
+function GoogleStep() {
+  const t = useT();
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const save = useSetGoogleApp();
+  const ready = clientId.trim() !== "" && clientSecret.trim() !== "";
+
+  return (
+    <Panel title={t("firstRun.google.title")}>
+      <PanelBody>
+        <p className="t-body">{t("firstRun.google.sub")}</p>
+        {save.error && (
+          <Callout tone="danger">{problemMessageOf(save.error, t)}</Callout>
+        )}
+        <Field label={t("firstRun.google.clientId")}>
+          {(control) => (
+            <TextInput
+              {...control}
+              value={clientId}
+              disabled={save.isPending}
+              autoComplete="off"
+              placeholder={t("firstRun.google.clientIdPlaceholder")}
+              onChange={(e) => setClientId(e.target.value)}
+            />
+          )}
+        </Field>
+        <Field label={t("firstRun.google.clientSecret")}>
+          {(control) => (
+            <TextInput
+              {...control}
+              type="password"
+              autoComplete="off"
+              value={clientSecret}
+              disabled={save.isPending}
+              onChange={(e) => setClientSecret(e.target.value)}
+            />
+          )}
+        </Field>
+        <Button
+          variant="primary"
+          pending={save.isPending}
+          disabled={!ready}
+          onClick={() => {
+            save.reset();
+            save.mutate(
+              { clientId: clientId.trim(), clientSecret: clientSecret.trim() },
+              {
+                onSuccess: () => {
+                  // Cleared on the way out rather than left in state: the field
+                  // is the only copy this app holds, and it has done its job.
+                  setClientSecret("");
+                  save.reset();
+                },
+              },
+            );
+          }}
+        >
+          {t("firstRun.continue")}
+        </Button>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+/**
+ * The setup gate. Renders nothing once the server says the installation is
+ * complete, so the caller can put it in front of whatever comes next without
+ * asking a second time whether it should.
+ */
+export function InstallationSetup() {
+  const setup = useInstallationSetup();
+  const step = outstandingStep(setup.data);
+
+  // While the answer has not arrived, nothing: a step drawn from a guess would
+  // be replaced a moment later by the real one, and the reader would have
+  // started typing into it.
+  //
+  // Nothing again once every blocking step is done — so a caller can put this
+  // in front of whatever comes next without asking the same question twice, and
+  // there is ONE reader of what is outstanding rather than a component and its
+  // parent each holding an opinion.
+  if (setup.isPending || !step) {
+    return null;
+  }
+  return step.step === "ai_models" ? <AiStep /> : <GoogleStep />;
+}

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -13,6 +13,11 @@ import {
   throwProblem,
   useMe,
 } from "../common";
+import {
+  InstallationSetup,
+  outstandingStep,
+  useInstallationSetup,
+} from "../installation-setup";
 import type { CompanyDraft } from "../onboarding";
 import {
   changeDraftField,
@@ -718,6 +723,12 @@ export function CompanyAct({
   // for the length of one request.
   const beforeReview =
     state.phase === "co.intro" || state.phase === "co.reading";
+  // Only asked before there is anything to review. Once a read is running the
+  // installation is plainly configured, and a query fired then would be a
+  // request per render of a screen whose answer cannot have changed.
+  const setup = useInstallationSetup();
+  const setupOutstanding =
+    beforeReview && outstandingStep(setup.data) !== undefined;
   const scanning =
     state.phase === "co.reading" && state.activeReadId !== null && read
       ? { read, host: normalizeUrl(read.root_url).host, locale }
@@ -727,6 +738,15 @@ export function CompanyAct({
   // twice in half a second.
   const awaitingRead =
     state.phase === "co.reading" && state.activeReadId !== null && !read;
+
+  // BEFORE the website question, and before the read theatre: an installation
+  // that has bound no model cannot perform a cold-start read at all, so asking
+  // for a website first would take an answer and then refuse to act on it. The
+  // component draws nothing once the server says every blocking step is done,
+  // which is what lets this sit in front of the gate rather than beside it.
+  if (setupOutstanding) {
+    return <InstallationSetup />;
+  }
 
   if (beforeReview) {
     return (

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -111,6 +111,7 @@ import { EmbedReindexCard } from "./embedreindex";
 import { EntityRef } from "./entityref";
 import { ExtensionAccessCard } from "./extension-access";
 import { ExtensionUnitsCard } from "./extension-units";
+import { GoogleAppCard } from "./google-app";
 import { ImportCard } from "./import";
 import { InstallationSettingsCard } from "./installation-settings";
 import { ProviderCard } from "./integrations-provider";
@@ -274,7 +275,15 @@ function tabContent(id: SettingsTabId): ReactNode {
         </>
       );
     case "connections":
-      return <ConnectionsTab />;
+      return (
+        <>
+          {/* Above the connections themselves: this is the app they are made
+              THROUGH, so a reader who cannot connect a mailbox finds the reason
+              before the empty list rather than after it. */}
+          <GoogleAppCard />
+          <ConnectionsTab />
+        </>
+      );
     // Beside `connections` and after it on purpose: that tab says what you are
     // connected to, this one says what those connections did with your mail.
     case "capture-activity":

--- a/frontend/src/screens/setup-providers.ts
+++ b/frontend/src/screens/setup-providers.ts
@@ -1,0 +1,70 @@
+/**
+ * The providers onboarding offers, and what each one starts bound to.
+ *
+ * A DELIBERATE MIRROR of the server, not a second answer: every model named
+ * here must carry a rate row in `SeedModelRates`, or a call on it reports
+ * UNPRICED — a materially different signal from free, and a poor thing to hand
+ * somebody in their first five minutes. `backend/frontendsetupproviders_test.go`
+ * compares both directions.
+ *
+ * WHY ONLY TWO. A routing document REQUIRES an embeddings binding, and the two
+ * listed here are the vendors that serve chat and embeddings from ONE key.
+ * Anthropic publishes no embedding model at all and OpenAI's is not in the
+ * price sheet, so offering either would walk a first-time admin into a form
+ * they cannot complete, or quietly bind their retrieval lane to a fake. Both
+ * remain available in Settings → AI, where an operator who already has two
+ * vendor accounts can bind the lanes separately.
+ *
+ * WHY DEFAULTS RATHER THAN A CLOSED PICKER. The server accepts any model id its
+ * vendor offers and publishes no catalogue, so a fixed dropdown would be this
+ * file inventing a list and calling it the truth — wrong the week a vendor ships
+ * a model. These are a starting point, and the field can be typed over.
+ *
+ * OpenRouter is a PRESET rather than a fifth adapter: on the wire it is
+ * `openai_compatible`, which fails closed without a `base_url`, and asking an
+ * admin to know that is asking them to know our adapter names.
+ */
+export type SetupProvider = {
+  /** What onboarding calls it. */
+  readonly label: string;
+  /** The adapter the wire names. */
+  readonly provider: string;
+  /** Required for the OpenAI-wire brokers, absent for a native vendor. */
+  readonly baseUrl?: string;
+  /** The variable the server reads this key from, shown so an operator can find it. */
+  readonly keyEnv: string;
+  /** Where the chat lanes start. Editable. */
+  readonly chatModel: string;
+  /** The embedding lane, a different model even on the same vendor. */
+  readonly embedModel: string;
+};
+
+const PRESETS = {
+  gemini: {
+    label: "Google Gemini",
+    provider: "gemini",
+    keyEnv: "GEMINI_API_KEY",
+    chatModel: "gemini-3.1-flash-lite",
+    embedModel: "gemini-embedding-001",
+  },
+  openrouter: {
+    label: "OpenRouter",
+    provider: "openai_compatible",
+    baseUrl: "https://openrouter.ai/api",
+    keyEnv: "OPENAI_COMPATIBLE_API_KEY",
+    chatModel: "mistralai/mistral-small-3.2-24b-instruct",
+    embedModel: "openai/text-embedding-3-small",
+  },
+} as const;
+
+export type SetupProviderId = keyof typeof PRESETS;
+
+// Typed as the shared shape rather than left as the literal union: a caller
+// reading `baseUrl` should not have to know which entries happen to carry one,
+// which is the difference between an optional field and two different types.
+export const SETUP_PROVIDERS: Readonly<Record<SetupProviderId, SetupProvider>> =
+  PRESETS;
+
+export const SETUP_PROVIDER_IDS = Object.keys(
+  SETUP_PROVIDERS,
+) as readonly SetupProviderId[];

--- a/frontend/src/screens/setup-providers.ts
+++ b/frontend/src/screens/setup-providers.ts
@@ -39,7 +39,17 @@ export type SetupProvider = {
   readonly embedModel: string;
 };
 
-const PRESETS = {
+/**
+ * The ids, as a tuple so a caller can narrow a value THROUGH it rather than
+ * asserting one INTO it. The table below is typed by these, which makes the two
+ * a compile-time pair in both directions: an id here with no preset fails, and
+ * a preset whose id is not here fails too.
+ */
+export const SETUP_PROVIDER_IDS = ["gemini", "openrouter"] as const;
+
+export type SetupProviderId = (typeof SETUP_PROVIDER_IDS)[number];
+
+const PRESETS: Readonly<Record<SetupProviderId, SetupProvider>> = {
   gemini: {
     label: "Google Gemini",
     provider: "gemini",
@@ -55,16 +65,7 @@ const PRESETS = {
     chatModel: "mistralai/mistral-small-3.2-24b-instruct",
     embedModel: "openai/text-embedding-3-small",
   },
-} as const;
+};
 
-export type SetupProviderId = keyof typeof PRESETS;
-
-// Typed as the shared shape rather than left as the literal union: a caller
-// reading `baseUrl` should not have to know which entries happen to carry one,
-// which is the difference between an optional field and two different types.
 export const SETUP_PROVIDERS: Readonly<Record<SetupProviderId, SetupProvider>> =
   PRESETS;
-
-export const SETUP_PROVIDER_IDS = Object.keys(
-  SETUP_PROVIDERS,
-) as readonly SetupProviderId[];


### PR DESCRIPTION
The cold start's website question now sits behind the two things an installation must be told first, **in the order the server lists them**: the model binding, then the Google app.

Asking for a website before a model is bound takes an answer and then refuses to act on it — the read cannot run at all.

## Flow

`Login → change password → login → AI key & routing → Google app → website`

It **reads the server rather than counting steps itself**. A reader signs in, changes their password and signs in *again* before arriving here, and may close the tab in the middle. `GET /installation/setup` is the only thing that knows what is still outstanding, so the screen resumes rather than restarting — and it walks `steps` in the order it arrives, because that order is the server's to decide (pinned in https://github.com/margince/margince/pull/2590).

## Two providers, deliberately

A routing document **requires** an embeddings binding, and Gemini and OpenRouter are the vendors that serve chat and embeddings from one key.

Anthropic publishes **no embedding model at all**, and OpenAI's is not in the price sheet. Offering either would walk a first-time admin into a form they cannot complete, or quietly bind their retrieval lane to a fake. Both stay available in Settings → AI, where somebody with two vendor accounts can bind the lanes separately.

OpenRouter is a **preset**, not a fifth adapter: on the wire it is `openai_compatible`, which fails closed without a `base_url`, and asking an admin to know that is asking them to know our adapter names.

## Order of writes

The **key before the binding**. A binding whose vendor has no key reads as configured and fails on the first real call; a key with no binding is simply a key, and the next attempt completes it.

## Reuse

- The credential goes through the existing `useSetProviderKey`, whose rules about how long an API key lives in a mutation's `variables` (`gcTime: 0`, reset after settle) are not obvious enough to expect anybody to rediscover.
- The Google app's hooks live with its **Settings card** and onboarding borrows them — so the same endpoint has one set of rules, and the app is editable later as intended.
- `AiRoutingCard` is **not** reused and could not be: it re-points lanes an installation *already* binds and explicitly refuses an empty one, which is exactly the cold start.

## The presets are a declared mirror

`backend/frontendsetupproviders_test.go` compares both directions: a model the screen offers that `SeedModelRates` does not price fails, and so does a provider name `SelectBrain` would not accept. Mutation-checked both ways.

An unpriced model is not a crash, which is *why* it needs a gate — the binding works, every call reports `UNPRICED`, and nobody notices until the usage report is missing its first week.

## Three things caught during the build

- My first typecheck ran against the wrong tsconfig and reported clean while the file was not in scope. `tsconfig.app.json` then surfaced 15 errors.
- An **existing** test caught a crash in this code: `outstandingStep` threw on a response without `steps`, taking down the screen it was meant to stand in front of. The new tests missed it because their stub always returns well-formed data.
- The mirror gate's not-a-tolerated-zero guard fired when a rename moved its anchor, refusing to pass blind rather than silently comparing nothing.

## Verification

`make check-fe` exit 0 — 4847 tests. `make check-backend` exit 0. Both captured rather than inferred.

**Not included:** stories for the two new screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-run setup for AI providers, chat and embedding models, and Google OAuth credentials.
  * Added Google OAuth app management in Connections settings, including configuration, replacement, and confirmed removal.
  * Added onboarding guidance through required setup steps before continuing.
  * Added provider presets for Google Gemini and OpenRouter.

* **Localization**
  * Added English, German, and Vietnamese translations for setup and Google OAuth workflows.

* **Tests**
  * Added coverage for setup flows, Google OAuth management, and provider configuration parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->