### PR TITLE
fix(ci-tests): an unsigned commit on main can be attested, so the census stops shrinking

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -308,11 +308,19 @@ jobs:
         env:
           # The last commit this gate does NOT cover — `A..B` excludes A, so a
           # baseline naming the first COVERED commit would leave that commit
-          # itself unchecked. This names the unsigned commit instead, so
-          # everything after it is in range and it is not, which is exactly the
-          # boundary. It moves to the unsigned commit's own parent once that
-          # commit is remediated by its author.
-          DCO_MAIN_BASELINE: 85bd56dc1
+          # itself unchecked. History predating the DCO rule sits before it.
+          #
+          # It moves BACKWARD as holes close, and only forward for a hole that
+          # cannot: three squashes landed unsigned (2736937c0, cd388fa09,
+          # 85bd56dc1) and this named the newest of them, so all three sat out
+          # of range. Each has since been attested by its own author, which the
+          # gate now reads, so the baseline returns to the parent of the oldest
+          # — the three are covered again and pass on their attestations.
+          #
+          # Moving it forward is what a hole costs, and it is why remediation is
+          # worth reading: every advance is a stretch of main this gate stops
+          # asking about, and nothing afterwards reports that it stopped.
+          DCO_MAIN_BASELINE: c4a230155
         # The ancestry is asserted before the range is used, because
         # `git rev-list A..B` does not complain when A is not behind B — it
         # answers with whatever that range happens to mean. A baseline that has

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,12 +129,8 @@ sandboxed.
 4. Push and open a PR.
 5. CI, DCO, CodeRabbit and SonarCloud must all pass. Address review findings
    rather than dismissing them.
-6. Merge only when everything is green: `gh pr merge <n> --squash`. Then delete
-   the branch. **Do not replace the squash message body** (`--body`, or editing
-   it in the UI): the default body is the branch commits, and their
-   `Signed-off-by` trailers are the only sign-off the squash will ever carry.
-   Three squashes landed on main unsigned that way, each needing its author's
-   retroactive attestation.
+6. Merge only when everything is green: `gh pr merge <n> --squash`, never with a
+   replaced body — it drops the commits' sign-off. Then delete the branch.
 
 **Commit only product.** Before `git add`, check `git status` for build caches
 (`node_modules/`, `.pnpm-store/`, binaries), working notes — those go in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,11 @@ sandboxed.
 5. CI, DCO, CodeRabbit and SonarCloud must all pass. Address review findings
    rather than dismissing them.
 6. Merge only when everything is green: `gh pr merge <n> --squash`. Then delete
-   the branch.
+   the branch. **Do not replace the squash message body** (`--body`, or editing
+   it in the UI): the default body is the branch commits, and their
+   `Signed-off-by` trailers are the only sign-off the squash will ever carry.
+   Three squashes landed on main unsigned that way, each needing its author's
+   retroactive attestation.
 
 **Commit only product.** Before `git add`, check `git status` for build caches
 (`node_modules/`, `.pnpm-store/`, binaries), working notes — those go in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,15 +56,18 @@ the branch commits in its body. Replacing that body drops every one of
 them, and the commit that lands on `main` is then unsigned.
 
 A commit already on `main` cannot be amended, so its **author** attests
-to it afterwards, in the message of any later signed-off commit of
+to it afterward, in the message of any later signed-off commit of
 theirs — one line, the full 40-character sha:
 
-```
+```text
 DCO-Remediation-Commit: I, Your Name <you@example.com>, hereby add my Signed-off-by to commit: <sha>
 ```
 
-Nobody else can give that attestation, which is why the gate reads it
-and why an unsigned commit is otherwise permanent.
+Nobody else can give that attestation, and the gate holds you to it
+rather than taking your word: the attesting commit must be signed off,
+authored by the same person as the commit it names, under the address
+its own sentence claims, and it must come after that commit. An unsigned
+commit is otherwise permanent.
 
 ## A working tree in four commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,21 @@ license. The DCO check is required — a pull-request commit without the
 trailer blocks the merge. Amend with `git commit --amend -s` if you
 forget.
 
+Squash-merging keeps those trailers only while the squash message keeps
+the branch commits in its body. Replacing that body drops every one of
+them, and the commit that lands on `main` is then unsigned.
+
+A commit already on `main` cannot be amended, so its **author** attests
+to it afterwards, in the message of any later signed-off commit of
+theirs — one line, the full 40-character sha:
+
+```
+DCO-Remediation-Commit: I, Your Name <you@example.com>, hereby add my Signed-off-by to commit: <sha>
+```
+
+Nobody else can give that attestation, which is why the gate reads it
+and why an unsigned commit is otherwise permanent.
+
 ## A working tree in four commands
 
 You need **Go ≥ 1.26**, **Docker**, `golangci-lint`, and Node with pnpm

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -102,7 +102,7 @@ install: fe-install tools hooks
 ## #1639 is about: a backend-only author never runs the lane that would
 ## otherwise catch a stranded frontend schema. On a pull request CI covers the
 ## same ground from the other side, through fe-quality's fe-drift.
-check-backend: check-craft-doc craft-test test-dev-isolation test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze
+check-backend: check-craft-doc craft-test test-dev-isolation test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -690,6 +690,14 @@ test-scheduled-report:
 ## the real thing on every dashboard.
 test-ci-verdict:
 	@./scripts/test-ci-verdict.sh
+
+## test-check-dco — prove the DCO gate still catches, and that an author's
+## retroactive attestation excuses exactly the commit it names. Remediation is
+## the permissive direction: its whole purpose is to make a commit stop failing,
+## so a loose sha match or an unanchored trailer turns the gate into a rubber
+## stamp that reports the same clean history as a strict one.
+test-check-dco:
+	@./scripts/test-check-dco.sh
 
 ## test-laneorder — prove the integration lane still dispatches its long pole
 ## first. The order is only a scheduling hint, so a regression here never turns

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -48,7 +48,11 @@ signed_off() {
 attestations="$(mktemp)"
 trap 'rm -f "$attestations"' EXIT HUP INT TERM
 
-for sha in $(git rev-list --no-merges "$range"); do
+# Merges included, unlike the judging loop below: a merge commit needs no
+# sign-off, but one that HAS a sign-off is a commit of its author's like any
+# other, and CONTRIBUTING.md promises an attestation may live in any later
+# signed-off commit of theirs.
+for sha in $(git rev-list "$range"); do
 	# Condition 1. An attestation carried by an unsigned commit is not read at
 	# all, so a chain of unsigned commits cannot certify itself.
 	signed_off "$sha" || continue
@@ -61,7 +65,14 @@ for sha in $(git rev-list --no-merges "$range"); do
 		sed -n -E 's/^DCO-Remediation-Commit: I, .+ <(.+@.+)>, hereby add my Signed-off-by to commit: ([0-9a-f]{40})[[:space:]]*$/\1 \2/p' |
 		while read -r claimed target; do
 			claimed="$(printf '%s' "$claimed" | tr '[:upper:]' '[:lower:]')"
-			# Condition 3.
+			# Condition 3. The ADDRESS is the identity, and the name beside it
+			# deliberately is not. A person signs commits under whatever display
+			# name their account carries and writes their own name in prose, so
+			# the two rarely match: both attestations on this repository's main
+			# are authored by `luit-nfq` and `LarsGradion` while claiming
+			# "Luitpold Alexander" and "Lars Jankowfsky". Comparing names would
+			# reject exactly the attestations it exists to accept, and it buys
+			# nothing — the address is what identifies the account that pushed.
 			[ "$claimed" = "$author" ] || continue
 			echo "$target $sha $author" >>"$attestations"
 		done

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -16,6 +16,20 @@
 # unsigned commit is to move the baseline past it, which buys a green gate by
 # reading less history every time — the failure mode this repository names
 # outright: a census that can fail short has already failed.
+#
+# AUTHOR-ONLY, held here rather than asked for. A certification nobody but the
+# author may give is worth exactly what the check on it is worth: if any
+# contributor can attest to anyone's commit, the trailer certifies that somebody
+# typed a sha. Four conditions, each one a way the attestation could otherwise
+# be somebody else's:
+#
+#   1. the attesting commit is itself signed off — an unsigned commit cannot
+#      lend a signature it does not have;
+#   2. its author is the author of the commit it attests to;
+#   3. the identity it CLAIMS ("I, …") is that same author, so the sentence and
+#      the commit cannot disagree about who is speaking;
+#   4. it descends from that commit, which is the only order in which somebody
+#      can attest to what they already wrote.
 set -eu
 
 base="${1:?usage: check-dco.sh <base-sha> <head-sha>}"
@@ -24,27 +38,56 @@ head="${2:?usage: check-dco.sh <base-sha> <head-sha>}"
 range="${base}..${head}"
 missing=0
 
-# Attestations are collected from the WHOLE range before any commit is judged,
-# because remediation is necessarily backward-looking: the commit that attests
-# is always later than the one it attests for.
-#
-# The sha is matched as 40 hex characters, anchored. An abbreviation would make
-# the trailer's reach depend on how much of a sha somebody happened to paste,
-# and a prefix match would let one attestation silently cover a second commit
-# that shares its first characters.
-remediated="$(
-	git log --format='%B' "$range" |
-		sed -n -E 's/^DCO-Remediation-Commit: I, .+ <.+@.+>, hereby add my Signed-off-by to commit: ([0-9a-f]{40})[[:space:]]*$/\1/p'
-)"
+signed_off() {
+	git log -1 --format='%B' "$1" | grep -qiE '^Signed-off-by: .+ <.+@.+>'
+}
+
+# One record per accepted attestation: `<target-sha> <attesting-sha> <email>`.
+# Collected across the WHOLE range before any commit is judged, because
+# remediation is necessarily backward-looking.
+attestations="$(mktemp)"
+trap 'rm -f "$attestations"' EXIT HUP INT TERM
 
 for sha in $(git rev-list --no-merges "$range"); do
-	if git log -1 --format='%B' "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+	# Condition 1. An attestation carried by an unsigned commit is not read at
+	# all, so a chain of unsigned commits cannot certify itself.
+	signed_off "$sha" || continue
+	author="$(git log -1 --format='%ae' "$sha" | tr '[:upper:]' '[:lower:]')"
+	# The sha is matched as 40 hex characters, anchored. An abbreviation would
+	# make the trailer's reach depend on how much of a sha somebody happened to
+	# paste, and a prefix match would let one attestation silently cover a
+	# second commit that shares its first characters.
+	git log -1 --format='%B' "$sha" |
+		sed -n -E 's/^DCO-Remediation-Commit: I, .+ <(.+@.+)>, hereby add my Signed-off-by to commit: ([0-9a-f]{40})[[:space:]]*$/\1 \2/p' |
+		while read -r claimed target; do
+			claimed="$(printf '%s' "$claimed" | tr '[:upper:]' '[:lower:]')"
+			# Condition 3.
+			[ "$claimed" = "$author" ] || continue
+			echo "$target $sha $author" >>"$attestations"
+		done
+done
+
+# attested_by <target-sha> — echoes the attesting sha, or nothing.
+attested_by() {
+	target="$1"
+	target_author="$(git log -1 --format='%ae' "$target" | tr '[:upper:]' '[:lower:]')"
+	grep "^${target} " "$attestations" 2>/dev/null | while read -r _ attester email; do
+		# Condition 2.
+		[ "$email" = "$target_author" ] || continue
+		# Condition 4.
+		git merge-base --is-ancestor "$target" "$attester" || continue
+		echo "$attester"
+		break
+	done
+}
+
+for sha in $(git rev-list --no-merges "$range"); do
+	if signed_off "$sha"; then
 		continue
 	fi
-	# `grep -x` on the collected list: an attestation names one whole sha, and
-	# the commit it names is the only one it excuses.
-	if printf '%s\n' "$remediated" | grep -qxF "$sha"; then
-		echo "DCO: commit ${sha} is unsigned but attested by its author in a later commit"
+	attester="$(attested_by "$sha")"
+	if [ -n "$attester" ]; then
+		echo "DCO: commit ${sha} is unsigned but attested by its author in ${attester}"
 		continue
 	fi
 	subject="$(git log -1 --format='%s' "$sha")"
@@ -56,8 +99,10 @@ if [ "$missing" -ne 0 ]; then
 	echo "" >&2
 	echo "Every commit must be signed off (git commit -s). See CONTRIBUTING.md." >&2
 	echo "A commit already on a protected branch cannot be signed after the fact;" >&2
-	echo "its AUTHOR attests to it instead, in a later signed-off commit message:" >&2
+	echo "its AUTHOR attests to it instead, in a later signed-off commit of theirs:" >&2
 	echo "  DCO-Remediation-Commit: I, Name <mail@example.com>, hereby add my Signed-off-by to commit: <full-sha>" >&2
+	echo "The attesting commit must be signed off and authored by the same person," >&2
+	echo "under the same address the sentence names — nobody can attest for anybody else." >&2
 	exit 1
 fi
 

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -3,6 +3,19 @@
 # carry a `Signed-off-by:` trailer (git commit -s). Called by the `dco` CI job
 # with the PR's base and head SHAs; the range excludes history already on the
 # base branch, so only the PR's own commits are checked.
+#
+# A commit already on a protected branch cannot grow a trailer — the history is
+# immutable and rewriting it is not on the table — so an unsigned one is
+# attested instead, by its own author, in a later commit:
+#
+#   DCO-Remediation-Commit: I, A Name <a@example.com>, hereby add my
+#   Signed-off-by to commit: <full 40-character sha>
+#
+# (one line, wrapped here only for the reader). That is the ecosystem's own
+# form, and it is what lets a hole CLOSE. Without it the only answer to an
+# unsigned commit is to move the baseline past it, which buys a green gate by
+# reading less history every time — the failure mode this repository names
+# outright: a census that can fail short has already failed.
 set -eu
 
 base="${1:?usage: check-dco.sh <base-sha> <head-sha>}"
@@ -11,21 +24,40 @@ head="${2:?usage: check-dco.sh <base-sha> <head-sha>}"
 range="${base}..${head}"
 missing=0
 
-# %H is the full hash; the trailer is matched case-insensitively against the
-# whole commit message body via git log's grep, per commit.
-# --no-merges: skip merge commits — notably the ephemeral merge commit GitHub
-# synthesizes for pull_request runs, which has no sign-off and never can.
+# Attestations are collected from the WHOLE range before any commit is judged,
+# because remediation is necessarily backward-looking: the commit that attests
+# is always later than the one it attests for.
+#
+# The sha is matched as 40 hex characters, anchored. An abbreviation would make
+# the trailer's reach depend on how much of a sha somebody happened to paste,
+# and a prefix match would let one attestation silently cover a second commit
+# that shares its first characters.
+remediated="$(
+	git log --format='%B' "$range" |
+		sed -n -E 's/^DCO-Remediation-Commit: I, .+ <.+@.+>, hereby add my Signed-off-by to commit: ([0-9a-f]{40})[[:space:]]*$/\1/p'
+)"
+
 for sha in $(git rev-list --no-merges "$range"); do
-	if ! git log -1 --format='%B' "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
-		subject="$(git log -1 --format='%s' "$sha")"
-		echo "DCO: commit ${sha} missing Signed-off-by trailer: ${subject}" >&2
-		missing=1
+	if git log -1 --format='%B' "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+		continue
 	fi
+	# `grep -x` on the collected list: an attestation names one whole sha, and
+	# the commit it names is the only one it excuses.
+	if printf '%s\n' "$remediated" | grep -qxF "$sha"; then
+		echo "DCO: commit ${sha} is unsigned but attested by its author in a later commit"
+		continue
+	fi
+	subject="$(git log -1 --format='%s' "$sha")"
+	echo "DCO: commit ${sha} missing Signed-off-by trailer: ${subject}" >&2
+	missing=1
 done
 
 if [ "$missing" -ne 0 ]; then
 	echo "" >&2
 	echo "Every commit must be signed off (git commit -s). See CONTRIBUTING.md." >&2
+	echo "A commit already on a protected branch cannot be signed after the fact;" >&2
+	echo "its AUTHOR attests to it instead, in a later signed-off commit message:" >&2
+	echo "  DCO-Remediation-Commit: I, Name <mail@example.com>, hereby add my Signed-off-by to commit: <full-sha>" >&2
 	exit 1
 fi
 

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -41,6 +41,12 @@ commit_with() {
 }
 
 # case_is <name> <base> <head> <expected-exit> [substring the output must carry]
+#
+# A refusal case asserts the REFUSAL SENTENCE, never the bare sha: the line that
+# ACCEPTS an attestation names that same sha, so a sha-only assertion is
+# satisfied by either verdict. One case proved it — with the attester's own
+# sign-off requirement deleted, it stayed green on an exit code it was owed for
+# an unrelated reason.
 case_is() {
 	local name="$1" base="$2" head="$3" want="$4" must_say="${5:-}"
 	local out status=0
@@ -109,6 +115,78 @@ In review somebody asked for: $attest $other
 
 $signed")"
 case_is "an attestation must start its own line" "$base" "$quoted" 1 "$other"
+
+# Author-only, which is the whole worth of the certification: if anybody can
+# attest to anybody's commit, the trailer certifies that somebody typed a sha.
+# Each case below is one way the attestation could be somebody else's.
+#
+# Every one runs on a branch of its own, off a base of its own, holding exactly
+# the target and the attestation under test. Sharing a mainline is what made the
+# first draft of these cases meaningless: an unsigned commit left behind by an
+# earlier case failed every range after it, so a case could report the verdict
+# it expected while proving nothing about the property in its own name.
+stranger_name="Other Person"
+stranger_mail="other@example.com"
+stranger_attest="DCO-Remediation-Commit: I, $stranger_name <$stranger_mail>, hereby add my Signed-off-by to commit:"
+
+# case_branch <name> — a fresh branch at $base, and the unsigned commit each of
+# these cases attests to (or fails to). Echoes that commit's sha.
+case_branch() {
+	git -C "$repo" checkout -q -b "$1" "$base"
+	commit_with "an unsigned change to attest to"
+}
+
+target="$(case_branch stranger)"
+git -C "$repo" -c user.name="$stranger_name" -c user.email="$stranger_mail" \
+	commit -q --no-verify --allow-empty -m "a stranger attests to it
+
+$stranger_attest $target
+
+Signed-off-by: $stranger_name <$stranger_mail>"
+case_is "a stranger cannot attest to somebody else's commit" "$base" "$(git -C "$repo" rev-parse HEAD)" 1 "commit $target missing"
+
+# The claimed identity and the commit carrying it must be the same person, or
+# the sentence and the signature disagree about who is speaking — and the
+# sentence is the half a human reads.
+target="$(case_branch misclaimed)"
+head_sha="$(commit_with "claim to be somebody else
+
+$stranger_attest $target
+
+$signed")"
+case_is "a claimed identity must match the attesting author" "$base" "$head_sha" 1 "commit $target missing"
+
+# An unsigned commit cannot lend a signature it does not have, so a run of
+# unsigned commits cannot certify itself.
+target="$(case_branch unsigned-attest)"
+head_sha="$(commit_with "attest without signing off
+
+$attest $target")"
+case_is "an unsigned commit cannot carry an attestation" "$base" "$head_sha" 1 "commit $target missing"
+
+# Somebody can only attest to what they already wrote. Two branches off one
+# base, merged: the attestation is in range and is the target's author's own,
+# and it still does not descend from the commit it names.
+target="$(case_branch aside-target)"
+git -C "$repo" checkout -q -b aside-attest "$base"
+commit_with "attest from a branch the target is not on
+
+$attest $target
+
+$signed" >/dev/null
+git -C "$repo" merge -q --no-ff --no-verify -m "Merge the attestation branch" aside-target
+case_is "an attestation must descend from what it attests to" "$base" "$(git -C "$repo" rev-parse HEAD)" 1 "commit $target missing"
+
+# The same commit, attested properly by its own author, passes — so the four
+# refusals above are about identity and order, not about the gate having quietly
+# stopped accepting attestations at all.
+target="$(case_branch proper)"
+head_sha="$(commit_with "the author attests to their own commit
+
+$attest $target
+
+$signed")"
+case_is "the author's own attestation is accepted" "$base" "$head_sha" 0 "attested by its author"
 
 # A merge commit carries no sign-off and never can — GitHub synthesizes one for
 # every pull_request run — so the gate skips merges. Proven rather than assumed:

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -177,6 +177,24 @@ $signed" >/dev/null
 git -C "$repo" merge -q --no-ff --no-verify -m "Merge the attestation branch" aside-target
 case_is "an attestation must descend from what it attests to" "$base" "$(git -C "$repo" rev-parse HEAD)" 1 "commit $target missing"
 
+# A merge commit needs no sign-off, but one that HAS a sign-off is a commit of
+# its author's like any other — and the guidance promises an attestation may
+# live in any later signed-off commit of theirs. The collection pass therefore
+# reads merges even though the judging pass skips them; before that split this
+# case was red.
+target="$(case_branch merge-attester)"
+git -C "$repo" checkout -q -b merge-attester-side "$target"
+commit_with "a signed change to merge back
+
+$signed" >/dev/null
+git -C "$repo" checkout -q merge-attester
+git -C "$repo" merge -q --no-ff --no-verify -m "Merge, and attest while doing it
+
+$attest $target
+
+$signed" merge-attester-side
+case_is "a signed merge commit can attest" "$base" "$(git -C "$repo" rev-parse HEAD)" 0 "attested by its author"
+
 # The same commit, attested properly by its own author, passes — so the four
 # refusals above are about identity and order, not about the gate having quietly
 # stopped accepting attestations at all.

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test-check-dco.sh — prove the DCO gate still catches, and that an attestation
+# excuses exactly one commit.
+#
+# The gate can only fail by being too permissive, and a permissive DCO gate
+# reports the same "all commits are signed off" as a strict one. Remediation is
+# where that risk actually lives: the whole point of the trailer is to let a
+# commit stop failing, so a sloppy match turns the gate into a rubber stamp —
+# a prefix match excuses a second commit sharing the first characters, an
+# unanchored one excuses whatever a body happens to quote, and either reads as a
+# clean history.
+#
+# Every case runs against a throwaway repository built here, because the gate's
+# subject is COMMIT MESSAGES and this repository's own history is not a fixture
+# anybody may edit. `git commit -s` is never used: the trailers are written out,
+# so a case proves what it says rather than what the local git config supplies.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gate="$root/scripts/check-dco.sh"
+failures=0
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+repo="$work/repo"
+git init -q "$repo"
+git -C "$repo" config user.name "Test Author"
+git -C "$repo" config user.email "test@example.com"
+git -C "$repo" config commit.gpgsign false
+
+# commit_with <message> — one commit whose message is exactly what is passed,
+# and whose sha is echoed for the caller to attest against.
+commit_with() {
+	local message="$1" n
+	n="$(git -C "$repo" rev-list --count HEAD 2>/dev/null || echo 0)"
+	echo "$n" >"$repo/file-$n"
+	git -C "$repo" add -A
+	git -C "$repo" commit -q --no-verify -m "$message"
+	git -C "$repo" rev-parse HEAD
+}
+
+# case_is <name> <base> <head> <expected-exit> [substring the output must carry]
+case_is() {
+	local name="$1" base="$2" head="$3" want="$4" must_say="${5:-}"
+	local out status=0
+	out="$(cd "$repo" && "$gate" "$base" "$head" 2>&1)" || status=$?
+	if [[ "$status" -ne "$want" ]]; then
+		echo "FAIL: $name — expected exit $want, got $status" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	if [[ -n "$must_say" ]] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
+		echo "FAIL: $name — exited $want but never named '$must_say'" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	echo "ok: $name"
+}
+
+signed="Signed-off-by: Test Author <test@example.com>"
+attest="DCO-Remediation-Commit: I, Test Author <test@example.com>, hereby add my Signed-off-by to commit:"
+
+base="$(commit_with "root
+
+$signed")"
+
+# The happy path first, so a suite that somehow signs everything by accident is
+# not the thing proving the failure cases.
+signed_head="$(commit_with "a signed change
+
+$signed")"
+case_is "a signed commit passes" "$base" "$signed_head" 0 "are signed off"
+
+unsigned="$(commit_with "an unsigned change")"
+case_is "an unsigned commit fails, and is named" "$base" "$unsigned" 1 "$unsigned"
+
+# The attestation arrives LATER than the commit it covers, which is the only
+# order remediation can happen in — and therefore the order the gate has to
+# read the range in.
+attested_head="$(commit_with "attest the one above
+
+$attest $unsigned
+
+$signed")"
+case_is "an attested commit passes" "$base" "$attested_head" 0 "attested by its author"
+
+# Everything below is a way the match could be too generous. Each was written as
+# the naive version first and rejected here.
+other="$(commit_with "another unsigned change")"
+case_is "an attestation covers only the commit it names" "$base" "$other" 1 "$other"
+
+abbreviated="$(commit_with "attest by abbreviation
+
+${attest} ${other:0:12}
+
+$signed")"
+case_is "an abbreviated sha attests nothing" "$base" "$abbreviated" 1 "$other"
+
+# The line ENDS at the sha, so the trailing anchor cannot be what rejects this
+# and the leading one is the only thing left holding it. Written the other way
+# first — with prose after the sha — the case passed against a gate whose `^`
+# had been deleted, which is a case asserting nothing.
+quoted="$(commit_with "a body that merely quotes the words
+
+In review somebody asked for: $attest $other
+
+$signed")"
+case_is "an attestation must start its own line" "$base" "$quoted" 1 "$other"
+
+# A merge commit carries no sign-off and never can — GitHub synthesizes one for
+# every pull_request run — so the gate skips merges. Proven rather than assumed:
+# without --no-merges this case is red.
+#
+# It runs on a branch of its own, off a base of its own. Sharing the mainline
+# would put the unsigned commits above in range, and the case would then be red
+# for a reason that has nothing to do with merges — which is how it was first
+# written, and it looked exactly like a gate that rejects merge commits.
+git -C "$repo" checkout -q -b merge-case "$base"
+merge_base="$(commit_with "the merge case starts here
+
+$signed")"
+git -C "$repo" checkout -q -b merge-side "$merge_base"
+commit_with "a signed change on a side branch
+
+$signed" >/dev/null
+git -C "$repo" checkout -q merge-case
+git -C "$repo" merge -q --no-ff --no-verify -m "Merge the side branch" merge-side
+merged="$(git -C "$repo" rev-parse HEAD)"
+case_is "a merge commit needs no sign-off" "$merge_base" "$merged" 0 "are signed off"
+
+if [[ "$failures" -ne 0 ]]; then
+	echo "" >&2
+	echo "$failures DCO gate case(s) failed" >&2
+	exit 1
+fi
+
+echo "DCO gate: every case holds"


### PR DESCRIPTION
Closes #2765. Fixes the `dco (main)` red on [run 32928657539](https://github.com/margince/margince/actions/runs/32928657539).

## The cause, which #2765 asked for

A healthy squash on this repository carries one to three `Signed-off-by` trailers: GitHub composes the squash body out of the branch commits, and each of those was signed. The three that landed unsigned had that body **replaced** at merge time — `gh pr merge --squash --body "…"`, or the same edit in the UI. The branch commits were signed in every case; the commit that landed was not.

`85bd56dc1` (#2680) is mine, and that is exactly how I merged it.

## What an unsigned commit costs today

`main` is protected, so the commit cannot be amended. The only move left was to advance `DCO_MAIN_BASELINE` past it, which is what #2762 had to do. That buys a green gate by reading less of `main` — and it is the failure this repository names outright: a census that can fail short has already failed. Under-recognition reports PASS over a shorter history, and nothing afterwards says a stretch of `main` stopped being asked about. Three squashes in one week moved the boundary three commits forward.

## What changed

**1. The attestation.** `85bd56dc1` is attested in this branch's commit message, in the form #2765 specified. Only its author can give it, which is why it was deferred to me.

**2. `check-dco.sh` reads remediation trailers.** The ecosystem's own form:

```
DCO-Remediation-Commit: I, A Name <a@example.com>, hereby add my Signed-off-by to commit: <full 40-char sha>
```

Attestations are collected across the whole range before any commit is judged, because remediation is necessarily backward-looking. Both matching rules are the permissive direction, and both are planted against: an **abbreviated sha attests nothing** (a prefix match would let one attestation cover a second commit sharing its first characters) and the trailer **must start its own line** (an unanchored match excuses whatever a body happens to quote).

**3. The baseline moves BACKWARD, for the first time.** With all three attested — two by @LarsGradion in #2762, the third here — it returns from `85bd56dc1` to `c4a230155`, the parent of the oldest offender. The three are covered again and pass on their attestations rather than by being out of range.

**4. The cause is written at the step that produced it**, in AGENTS.md and CONTRIBUTING.md: do not replace the squash body, because those trailers are the only sign-off a squash will ever carry.

## The test

`scripts/test-check-dco.sh`, wired into `check-backend`. Seven cases against a throwaway repository, because the subject is commit messages and this repository's history is not a fixture anybody may edit. `git commit -s` is never used — the trailers are written out, so each case proves what it says rather than what the local git config supplies.

Mutation-proven rather than asserted:

| planted regression | case that goes red |
|---|---|
| loose sha match (7–40 hex + prefix compare) | an abbreviated sha attests nothing |
| trailer anchor `^` deleted | an attestation must start its own line |
| remediation support removed | an attested commit passes |

The merge-commit case was green for the wrong reason first: sharing a mainline with the unsigned commits above it, it failed for a reason unrelated to merges, and it passed against a gate with `--no-merges` deleted. It has its own base now. The quoted-trailer case had the same defect in reverse — prose after the sha meant the TRAILING anchor rejected it, so it passed against a gate whose leading anchor was gone.

## Verified

- `./scripts/check-dco.sh c4a230155 HEAD` — exactly what `dco (main)` will run after this merges — reports all three as attested and passes.
- `make check`: green, `test-check-dco` included.
- `make lint-modules` — the cross-worktree golangci cache condition I reported as environmental on #2680 — is green here after the cache clean the gate's own diagnosis prescribes. It was never about that branch.

## One thing about merging this

**Do not replace the squash body.** The attestation for `85bd56dc1` lives in this branch's commit message, so a custom body would drop it and `dco (main)` would go red again on the same commit — the bug, reproduced by the fix for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved contribution signoff validation to recognize valid author attestations for previously unsigned commits.
  * Added stricter checks for attestation identity, signoff, commit ancestry, and exact commit references.
  * Updated merge instructions to prevent accidentally replacing pull request descriptions.

* **Documentation**
  * Clarified guidance for resolving signoff issues on protected branches.

* **Tests**
  * Added comprehensive automated coverage for signoff validation and integrated it into backend verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->