### PR TITLE
chore(platform): the dev stack and the AI contract stop naming the old repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ numbers appear here when releases start.
 
 ### Changed
 
+- **The dev stack's Docker Compose project is named `margince`**, not
+  `margince-poc-v1`. The old name outlived the repository it was named after.
+  A project name namespaces the stack's volumes, so **the first `make db-up`
+  after this change starts on an empty database**: the `margince-poc-v1_*`
+  volumes are orphaned rather than migrated. They are not deleted — their data
+  survives until someone removes them, and a stack brought up with
+  `-p margince-poc-v1` still reads it — but the renamed stack will not pick it
+  up, so re-seed with `make seed-dev`. `margince-dev` was not an option: the
+  frozen poc-era stack left `margince-dev_*` volumes behind, Postgres skips
+  initdb on a non-empty volume, and the owner role would then silently never
+  be created. `MARGINCE_PG_CONTAINER` still overrides the container name that
+  `scripts/migration-baseline.sh` reaches for.
+
 - **The AI routing FILE is gone, format and all.** The binding moved to the
   database earlier; what stayed behind was a file format three DB-less lanes
   still read, and the example yamls that fed them. Those lanes are now TOLD

--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -1,6 +1,6 @@
 # ai-tasks.yaml — the AI task contract (spec §1.2, ai-operational-spec.md).
 #
-# Authority relationship (ratified: margince-poc-v1 AI runtime contract +
+# Authority relationship (ratified: this repository's AI runtime contract +
 # certification arc): THIS file is the normative authority for the AI task
 # DECLARATION — the task list, its tiers, each task's fallback ladder, execution
 # mode (interactive | background), budget-exhaustion posture (degrade | queue),

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -75,7 +75,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "b24df949152675911659509883eb61ada4a56c9508aa5b83745a459872efe31d"
+const TaskContractHash = "13ad74561cc40652b4c3b5352f3c14c24cc9da56b3e533e2a7b116f320232b44"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -36,11 +36,15 @@
 # compose file via `make db-up`, so these are the only pins). Bump tag and
 # digest together. The check-image-pins gate fails a floating tag here.
 #
-# The project name is repo-specific: a generic name (margince-dev) collides
-# with stale volumes from the frozen poc-era stack on machines that ran it,
-# and Postgres skips initdb on a non-empty volume — the owner role would
-# silently never be created.
-name: margince-poc-v1
+# The project name namespaces this stack's volumes, so it may not collide with
+# a name any earlier stack used: Postgres skips initdb on a non-empty volume,
+# and the owner role would then silently never be created. `margince-dev` is
+# spent — the frozen poc-era stack left `margince-dev_*` volumes behind on
+# every machine that ran it. `margince` is clear of both that stack and the
+# `margince-poc-v1_*` volumes this one used before the repository was renamed;
+# those older volumes are now orphaned, so the first `make db-up` after this
+# change builds a fresh database.
+name: margince
 
 services:
   postgres:

--- a/scripts/migration-baseline.sh
+++ b/scripts/migration-baseline.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-CONTAINER="${MARGINCE_PG_CONTAINER:-margince-poc-v1-postgres-1}"
+CONTAINER="${MARGINCE_PG_CONTAINER:-margince-postgres-1}"
 OWNER="${MARGINCE_PG_OWNER:-margince_owner}"
 
 # Tracking tables are excluded from every dump: they record which migrations ran,


### PR DESCRIPTION
⚠️ **After this merges, everyone's next `make db-up` starts on an empty database** and wants a re-seed. The old volumes are orphaned, not deleted. See *Operator impact* below.

Two references outlived the repository they were named after.

## The Compose project is now `margince`

The project name namespaces the stack's volumes, so this is not cosmetic. `scripts/migration-baseline.sh` derived a container name from the old project, so its default moves in the same change.

Verified against `docker compose config`, which resolves:

```
project name: margince
  postgres -> margince-postgres-1   ← matches the new script default
  redis    -> margince-redis-1
  minio    -> margince-minio-1
```

`MARGINCE_PG_CONTAINER` still overrides it.

**`margince-dev` was not available**, and the comment above the name now says why instead of leaving the next reader to rediscover it: the frozen poc-era stack left `margince-dev_*` volumes behind, Postgres skips initdb on a non-empty volume, and the owner role would then silently never be created. Both volume sets are present on a machine that ran both — the collision is real, not theoretical:

```
$ docker volume ls | grep margince
margince-dev_pgdata          ← frozen poc-era stack
margince-poc-v1_pgdata       ← this stack, pre-rename
```

## `api/ai-tasks.yaml`'s ratification note

It said `margince-poc-v1`; it now says "this repository", which cannot go stale the next time the repository is renamed.

The contract is hashed **whole — comments included** — into `TaskContractHash`, so a comment-only edit moves the fingerprint. `tasks_gen.go` is regenerated here through `make gen`, and the new constant matches a fresh `sha256` of the contract file:

```
sha256(backend/api/ai-tasks.yaml) = 13ad7456…232b44
const TaskContractHash           = "13ad7456…232b44"
```

## Operator impact

The first `make db-up` after this merges **starts on an empty database**. The `margince-poc-v1_*` volumes are orphaned rather than migrated — they are **not deleted**: their data survives until somebody removes them, and a stack brought up with `-p margince-poc-v1` still reads it. What changes is that the renamed stack will not pick it up, so re-seed with `make seed-dev`.

This is recorded in `CHANGELOG.md` under Unreleased, since nothing in the gates can warn an engineer about it.

## Verification

- `make check-backend` — **EXIT=0**, green end to end, no advisories
- `check-image-pins`, `check-host-ports`, `test-dev-dsn`, `test-dev-isolation` — all EXIT=0
- `docker compose config` — project and container names as above

**The dev stack was deliberately not brought up.** A stack is running under the old project name on this machine's dev ports (15432/16379/29000), and starting the renamed one would have taken those ports from it — likely from a parallel session. The verification above is static for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration validation guidance to cover complete `margince.yaml` files and generated schema references.
  - Documented the updated Docker Compose project naming and database reseeding requirements.

- **Chores**
  - Development environments now use the `margince` project name by default.
  - Existing database container overrides remain supported for compatibility.
  - Existing volumes from the previous project name may require reseeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->