### PR TITLE
fix(ai): a routing edit that cannot be served is refused, and the form can express one

### DIFF
--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -300,13 +300,6 @@ func (cfg RoutingConfig) validate() error {
 	if cfg.Embeddings.Provider == "" {
 		return fmt.Errorf("ai: routing config: embeddings lane has no provider")
 	}
-	// The same rule as a chat tier, and for the same reason: SelectBrain builds
-	// this lane's client too, and refuses openai_compatible without a host.
-	if cfg.Embeddings.Provider == providerOpenAICompatible && strings.TrimSpace(cfg.Embeddings.BaseURL) == "" {
-		return fmt.Errorf("ai: routing config: the embeddings lane binds openai_compatible with no base_url — " +
-			"give it the vendor host root, with no version segment (the adapter adds /v1), " +
-			"e.g. https://openrouter.ai/api")
-	}
 	// EmbeddingsConfig embeds ProviderConfig INLINE, so `input:` under
 	// `embeddings:` decodes happily and would reach the embedder's client. The
 	// embedding lane sends no attachments, so the declaration could only mislead
@@ -326,6 +319,18 @@ func (cfg RoutingConfig) validate() error {
 		if err := requireSovereignEndpoint("the embeddings lane", cfg.Embeddings.Provider, cfg.Embeddings.BaseURL); err != nil {
 			return err
 		}
+	}
+	// AFTER the sovereign check, matching ValidateTierBinding's order. A
+	// sovereign profile forbids openai_compatible outright, so reporting a
+	// missing host first would answer a question the reader does not have and
+	// send them to fill in a field on a binding that is refused either way.
+	//
+	// The rule itself is the chat tiers': SelectBrain builds this lane's client
+	// too, and refuses openai_compatible without a host.
+	if cfg.Embeddings.Provider == providerOpenAICompatible && strings.TrimSpace(cfg.Embeddings.BaseURL) == "" {
+		return fmt.Errorf("ai: routing config: the embeddings lane binds openai_compatible with no base_url: " +
+			"give it the vendor host root, with no version segment (the adapter adds /v1), " +
+			"e.g. https://openrouter.ai/api")
 	}
 	return nil
 }
@@ -382,7 +387,7 @@ func ValidateTierBinding(profile Profile, tier Tier, binding ProviderConfig) err
 	// operator sees "saved" and no change, with the reason in a log they are not
 	// reading.
 	if binding.Provider == providerOpenAICompatible && strings.TrimSpace(binding.BaseURL) == "" {
-		return fmt.Errorf("ai: routing config: tier %s binds openai_compatible with no base_url — "+
+		return fmt.Errorf("ai: routing config: tier %s binds openai_compatible with no base_url: "+
 			"give it the vendor host root, with no version segment (the adapter adds /v1), "+
 			"e.g. https://openrouter.ai/api", tier)
 	}

--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -300,6 +300,13 @@ func (cfg RoutingConfig) validate() error {
 	if cfg.Embeddings.Provider == "" {
 		return fmt.Errorf("ai: routing config: embeddings lane has no provider")
 	}
+	// The same rule as a chat tier, and for the same reason: SelectBrain builds
+	// this lane's client too, and refuses openai_compatible without a host.
+	if cfg.Embeddings.Provider == providerOpenAICompatible && strings.TrimSpace(cfg.Embeddings.BaseURL) == "" {
+		return fmt.Errorf("ai: routing config: the embeddings lane binds openai_compatible with no base_url — " +
+			"give it the vendor host root, with no version segment (the adapter adds /v1), " +
+			"e.g. https://openrouter.ai/api")
+	}
 	// EmbeddingsConfig embeds ProviderConfig INLINE, so `input:` under
 	// `embeddings:` decodes happily and would reach the embedder's client. The
 	// embedding lane sends no attachments, so the declaration could only mislead
@@ -366,6 +373,18 @@ func ValidateTierBinding(profile Profile, tier Tier, binding ProviderConfig) err
 		if err := requireSovereignEndpoint(fmt.Sprintf("tier %s", tier), binding.Provider, binding.BaseURL); err != nil {
 			return err
 		}
+	}
+	// An OpenAI-wire host has no default to fall back on, so a binding without
+	// one cannot be SERVED — SelectBrain refuses to build the client. Refused
+	// HERE, at the write, rather than there, at the rebind: accepted at the door
+	// it saves cleanly, the caller is told it worked, and the running role then
+	// declines to adopt it and goes on serving the binding it already had. The
+	// operator sees "saved" and no change, with the reason in a log they are not
+	// reading.
+	if binding.Provider == providerOpenAICompatible && strings.TrimSpace(binding.BaseURL) == "" {
+		return fmt.Errorf("ai: routing config: tier %s binds openai_compatible with no base_url — "+
+			"give it the vendor host root, with no version segment (the adapter adds /v1), "+
+			"e.g. https://openrouter.ai/api", tier)
 	}
 	return validateInput(fmt.Sprintf("tier %s", tier), binding.Input)
 }

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -350,6 +350,17 @@ func TestABindingWithNoHostIsRefusedRatherThanStoredUnservable(t *testing.T) {
 			refused: true, says: "no base_url",
 		},
 		{
+			// Under a sovereign profile the missing host is beside the point:
+			// openai_compatible is refused there whatever its endpoint, and
+			// answering about base_url first sends the reader to fill in a
+			// field on a binding that is refused either way.
+			name: "a sovereign profile outranks the missing host",
+			cfg: RoutingConfig{Profile: ProfileSovereign,
+				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: {Provider: providerOllama, BaseURL: "http://127.0.0.1:11434"}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: broker}},
+			refused: true, says: "forbids cloud provider",
+		},
+		{
 			// The other arm, so the rule cannot pass by refusing everything.
 			name: "the same binding with its host",
 			cfg: RoutingConfig{Profile: ProfileEUHosted,

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 )
 
 func TestParseRoutingValidatesAtStartup(t *testing.T) {
@@ -306,5 +308,75 @@ profile: sovereign
 	cfg = cfg.WithKeys(allCloudKeys())
 	if cfg.Profile != ProfileSovereign || len(cfg.Tiers) != 2 {
 		t.Fatalf("unexpected parse: %+v", cfg)
+	}
+}
+
+// A binding this process cannot SERVE is refused at the write, not at the
+// rebind.
+//
+// This is the failure it exists to stop, reported from a live install: an
+// operator re-points every tier at a broker through Settings, the write is
+// accepted, the screen says saved — and the running role then declines to adopt
+// it, because SelectBrain will not build an openai_compatible client without a
+// host. It keeps serving the binding it already had, deliberately, so the
+// installation goes on answering with the OLD models while the stored document
+// says otherwise. The only account of why is an error line in the server log.
+//
+// Refusing at the door turns that into a message on the form, next to the field
+// that is missing.
+func TestABindingWithNoHostIsRefusedRatherThanStoredUnservable(t *testing.T) {
+	broker := ProviderConfig{Provider: "openai_compatible", Model: "mistralai/mistral-small-3.2-24b-instruct"}
+	withHost := broker
+	withHost.BaseURL = "https://openrouter.ai/api"
+
+	for _, tc := range []struct {
+		name    string
+		cfg     RoutingConfig
+		refused bool
+		says    string
+	}{
+		{
+			name: "a chat tier with no host",
+			cfg: RoutingConfig{Profile: ProfileEUHosted,
+				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: broker},
+				Embeddings: EmbeddingsConfig{ProviderConfig: ProviderConfig{Provider: ProviderFake}}},
+			refused: true, says: "no base_url",
+		},
+		{
+			name: "the embeddings lane with no host",
+			cfg: RoutingConfig{Profile: ProfileEUHosted,
+				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: {Provider: ProviderFake}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: broker}},
+			refused: true, says: "no base_url",
+		},
+		{
+			// The other arm, so the rule cannot pass by refusing everything.
+			name: "the same binding with its host",
+			cfg: RoutingConfig{Profile: ProfileEUHosted,
+				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: withHost},
+				Embeddings: EmbeddingsConfig{ProviderConfig: withHost}},
+			refused: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validate()
+			if tc.refused {
+				if err == nil {
+					t.Fatal("accepted a binding SelectBrain cannot build — it would store cleanly and never be adopted")
+				}
+				if !strings.Contains(err.Error(), tc.says) {
+					t.Errorf("refusal reads %q, and must name what is missing", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("refused a servable binding: %v", err)
+			}
+			// And it really is servable: the refusal above must be about the
+			// host rather than about the vendor being unwelcome.
+			if _, err := SelectBrain(withHost, config.Static(map[string]string{"OPENAI_COMPATIBLE_API_KEY": "k"})); err != nil {
+				t.Fatalf("validate accepted a binding SelectBrain then refused: %v", err)
+			}
+		})
 	}
 }

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -337,16 +337,20 @@ func TestABindingWithNoHostIsRefusedRatherThanStoredUnservable(t *testing.T) {
 	}{
 		{
 			name: "a chat tier with no host",
-			cfg: RoutingConfig{Profile: ProfileEUHosted,
+			cfg: RoutingConfig{
+				Profile:    ProfileEUHosted,
 				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: broker},
-				Embeddings: EmbeddingsConfig{ProviderConfig: ProviderConfig{Provider: ProviderFake}}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: ProviderConfig{Provider: ProviderFake}},
+			},
 			refused: true, says: "no base_url",
 		},
 		{
 			name: "the embeddings lane with no host",
-			cfg: RoutingConfig{Profile: ProfileEUHosted,
+			cfg: RoutingConfig{
+				Profile:    ProfileEUHosted,
 				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: {Provider: ProviderFake}},
-				Embeddings: EmbeddingsConfig{ProviderConfig: broker}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: broker},
+			},
 			refused: true, says: "no base_url",
 		},
 		{
@@ -355,17 +359,21 @@ func TestABindingWithNoHostIsRefusedRatherThanStoredUnservable(t *testing.T) {
 			// answering about base_url first sends the reader to fill in a
 			// field on a binding that is refused either way.
 			name: "a sovereign profile outranks the missing host",
-			cfg: RoutingConfig{Profile: ProfileSovereign,
+			cfg: RoutingConfig{
+				Profile:    ProfileSovereign,
 				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: {Provider: providerOllama, BaseURL: "http://127.0.0.1:11434"}},
-				Embeddings: EmbeddingsConfig{ProviderConfig: broker}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: broker},
+			},
 			refused: true, says: "forbids cloud provider",
 		},
 		{
 			// The other arm, so the rule cannot pass by refusing everything.
 			name: "the same binding with its host",
-			cfg: RoutingConfig{Profile: ProfileEUHosted,
+			cfg: RoutingConfig{
+				Profile:    ProfileEUHosted,
 				Tiers:      map[Tier]ProviderConfig{TierCheapCloud: withHost},
-				Embeddings: EmbeddingsConfig{ProviderConfig: withHost}},
+				Embeddings: EmbeddingsConfig{ProviderConfig: withHost},
+			},
 			refused: false,
 		},
 	} {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5553,6 +5553,11 @@ export const de = {
   "aiRouting.profile.eu_hosted": "In der EU gehostet",
   "aiRouting.profile.sovereign": "Souverän (kein Datenabfluss)",
   "aiRouting.profile.cloud_frontier": "Cloud-Frontier",
+  "aiRouting.embeddings.label": "Embeddings",
+  "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
+  "aiRouting.baseUrl.label": "Host",
+  "aiRouting.baseUrl.help":
+    "Die Host-Wurzel des Anbieters, ohne Versionssegment — der Adapter hängt /v1 an. Für openai_compatible erforderlich, das keinen eigenen Standard hat.",
   "aiRouting.model.label": "Modell",
   "aiRouting.save": "Routing speichern",
   "aiRouting.saving": "Bindung wird gespeichert…",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5490,7 +5490,7 @@ export const de = {
   "installationSettings.save": "Speichern",
   "googleApp.title": "Google-App",
   "googleApp.sub":
-    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört — Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen, nicht mit unseren.",
+    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört. Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen, nicht mit unseren.",
   "googleApp.configured": "In Verwendung: {clientId}",
   "googleApp.absent":
     "Keine App hinterlegt. Gmail und Kalender lassen sich erst danach verbinden.",
@@ -5500,7 +5500,7 @@ export const de = {
   "googleApp.replace": "App ersetzen",
   "googleApp.removeConfirmTitle": "Google-App entfernen?",
   "googleApp.removeConfirmBody":
-    "Das Client-Secret lässt sich nicht wieder auslesen — nach dem Entfernen müssen beide Hälften erneut aus der Google-Konsole eingetragen werden. Gmail- und Kalender-Verbindungen laufen über diese App — Microsoft- und IMAP-Postfächer sind nicht betroffen —, und die Ersteinrichtung fragt wieder danach.",
+    "Das Client-Secret lässt sich nicht wieder auslesen. Nach dem Entfernen müssen beide Hälften erneut aus der Google-Konsole eingetragen werden. Gmail- und Kalender-Verbindungen laufen über diese App. Microsoft- und IMAP-Postfächer sind nicht betroffen. Die Ersteinrichtung fragt wieder danach.",
   "googleApp.remove": "App entfernen",
   "firstRun.continue": "Weiter",
   "firstRun.ai.title": "Modellanbieter wählen",
@@ -5516,7 +5516,7 @@ export const de = {
   "firstRun.ai.embedModel": "Embedding-Modell",
   "firstRun.google.title": "Google-App verbinden",
   "firstRun.google.sub":
-    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört — Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen. Später unter Einstellungen änderbar.",
+    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört. Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen. Später unter Einstellungen änderbar.",
   "firstRun.google.clientIdPlaceholder":
     "000000000000-xxxx.apps.googleusercontent.com",
   "firstRun.google.clientId": "Client-ID",
@@ -5553,11 +5553,14 @@ export const de = {
   "aiRouting.profile.eu_hosted": "In der EU gehostet",
   "aiRouting.profile.sovereign": "Souverän (kein Datenabfluss)",
   "aiRouting.profile.cloud_frontier": "Cloud-Frontier",
+  "aiRouting.dimensions.label": "Vektorbreite",
+  "aiRouting.dimensions.help":
+    "Leer lassen für den Standard des Anbieters. Ein Wert außerhalb von 1 bis 2000 wird abgelehnt.",
   "aiRouting.embeddings.label": "Embeddings",
   "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
   "aiRouting.baseUrl.label": "Host",
   "aiRouting.baseUrl.help":
-    "Die Host-Wurzel des Anbieters, ohne Versionssegment — der Adapter hängt /v1 an. Für openai_compatible erforderlich, das keinen eigenen Standard hat.",
+    "Die Host-Wurzel des Anbieters, ohne Versionssegment. Der Adapter hängt /v1 an. Für openai_compatible erforderlich, das keinen eigenen Standard hat.",
   "aiRouting.model.label": "Modell",
   "aiRouting.save": "Routing speichern",
   "aiRouting.saving": "Bindung wird gespeichert…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5583,6 +5583,11 @@ export const en = {
   "aiRouting.profile.eu_hosted": "EU-hosted",
   "aiRouting.profile.sovereign": "Sovereign (no egress)",
   "aiRouting.profile.cloud_frontier": "Cloud frontier",
+  "aiRouting.embeddings.label": "Embeddings",
+  "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
+  "aiRouting.baseUrl.label": "Host",
+  "aiRouting.baseUrl.help":
+    "The vendor's host root, with no version segment — the adapter adds /v1. Required for openai_compatible, which has no default of its own.",
   "aiRouting.model.label": "Model",
   "aiRouting.save": "Save routing",
   "aiRouting.saving": "Saving the binding…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5528,7 +5528,7 @@ export const en = {
   "googleApp.replace": "Replace app",
   "googleApp.removeConfirmTitle": "Remove the Google app?",
   "googleApp.removeConfirmBody":
-    "The client secret cannot be read back, so removing it means re-entering both halves from the Google console. Gmail and Calendar connections are made through this app — Microsoft and IMAP mailboxes are not affected — and first-run setup will ask for one again.",
+    "The client secret cannot be read back, so removing it means re-entering both halves from the Google console. Gmail and Calendar connections are made through this app. Microsoft and IMAP mailboxes are not affected. First-run setup will ask for one again.",
   "googleApp.remove": "Remove app",
   "firstRun.continue": "Continue",
   "firstRun.ai.title": "Choose a model provider",
@@ -5583,11 +5583,14 @@ export const en = {
   "aiRouting.profile.eu_hosted": "EU-hosted",
   "aiRouting.profile.sovereign": "Sovereign (no egress)",
   "aiRouting.profile.cloud_frontier": "Cloud frontier",
+  "aiRouting.dimensions.label": "Vector width",
+  "aiRouting.dimensions.help":
+    "Leave blank for the provider's default. A value outside 1 to 2000 is refused.",
   "aiRouting.embeddings.label": "Embeddings",
   "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
   "aiRouting.baseUrl.label": "Host",
   "aiRouting.baseUrl.help":
-    "The vendor's host root, with no version segment — the adapter adds /v1. Required for openai_compatible, which has no default of its own.",
+    "The vendor's host root, with no version segment. The adapter adds /v1. Required for openai_compatible, which has no default of its own.",
   "aiRouting.model.label": "Model",
   "aiRouting.save": "Save routing",
   "aiRouting.saving": "Saving the binding…",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -38,6 +38,11 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "firstRun.google.clientId",
   "firstRun.google.clientSecret",
   "firstRun.google.clientIdPlaceholder",
+  // "Embeddings" is the vocabulary of the routing document itself, which this
+  // form renders raw beside `premium` and `gemini`. The host placeholder is a
+  // URL, which is the same string in every language.
+  "aiRouting.embeddings.label",
+  "aiRouting.baseUrl.placeholder",
   // The same noun, captioning a staged proposal's email field.
   "approval.field.email",
   // Vietnamese sales usage keeps "pipeline" as the loanword, the same way it

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5453,7 +5453,7 @@ export const vi = {
   "googleApp.replace": "Thay ứng dụng",
   "googleApp.removeConfirmTitle": "Xoá ứng dụng Google?",
   "googleApp.removeConfirmBody":
-    "Không thể đọc lại client secret, nên xoá xong phải nhập lại cả hai phần từ bảng điều khiển Google. Kết nối Gmail và Lịch đi qua ứng dụng này — hộp thư Microsoft và IMAP không bị ảnh hưởng — và bước thiết lập lần đầu sẽ hỏi lại.",
+    "Không thể đọc lại client secret, nên xoá xong phải nhập lại cả hai phần từ bảng điều khiển Google. Kết nối Gmail và Lịch đi qua ứng dụng này. Hộp thư Microsoft và IMAP không bị ảnh hưởng. Bước thiết lập lần đầu sẽ hỏi lại.",
   "googleApp.remove": "Xoá ứng dụng",
   "firstRun.continue": "Tiếp tục",
   "firstRun.ai.title": "Chọn nhà cung cấp mô hình",
@@ -5506,11 +5506,14 @@ export const vi = {
   "aiRouting.profile.eu_hosted": "Đặt tại EU",
   "aiRouting.profile.sovereign": "Sovereign (không ra ngoài)",
   "aiRouting.profile.cloud_frontier": "Cloud frontier (đám mây cao cấp)",
+  "aiRouting.dimensions.label": "Độ rộng vector",
+  "aiRouting.dimensions.help":
+    "Để trống để dùng mặc định của nhà cung cấp. Giá trị ngoài khoảng 1 đến 2000 sẽ bị từ chối.",
   "aiRouting.embeddings.label": "Embeddings",
   "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
   "aiRouting.baseUrl.label": "Máy chủ",
   "aiRouting.baseUrl.help":
-    "Gốc host của nhà cung cấp, không kèm phân đoạn phiên bản — bộ chuyển thêm /v1. Bắt buộc với openai_compatible vì nó không có mặc định riêng.",
+    "Gốc host của nhà cung cấp, không kèm phân đoạn phiên bản. Bộ chuyển thêm /v1. Bắt buộc với openai_compatible vì nó không có mặc định riêng.",
   "aiRouting.model.label": "Mô hình",
   "aiRouting.save": "Lưu định tuyến",
   "aiRouting.saving": "Đang lưu ràng buộc…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5506,6 +5506,11 @@ export const vi = {
   "aiRouting.profile.eu_hosted": "Đặt tại EU",
   "aiRouting.profile.sovereign": "Sovereign (không ra ngoài)",
   "aiRouting.profile.cloud_frontier": "Cloud frontier (đám mây cao cấp)",
+  "aiRouting.embeddings.label": "Embeddings",
+  "aiRouting.baseUrl.placeholder": "https://openrouter.ai/api",
+  "aiRouting.baseUrl.label": "Máy chủ",
+  "aiRouting.baseUrl.help":
+    "Gốc host của nhà cung cấp, không kèm phân đoạn phiên bản — bộ chuyển thêm /v1. Bắt buộc với openai_compatible vì nó không có mặc định riêng.",
   "aiRouting.model.label": "Mô hình",
   "aiRouting.save": "Lưu định tuyến",
   "aiRouting.saving": "Đang lưu ràng buộc…",

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -32,6 +32,13 @@ function jsonResponse(body: unknown, status = 200) {
 const ROUTING_EDITOR: GrantSpec = { ai_routing: ["read", "update"] };
 const ROUTING_READER: GrantSpec = { ai_routing: ["read"] };
 
+/** What PUT /ai/routing carries, as these tests read it back. */
+type CapturedRouting = {
+  profile: string;
+  tiers: Record<string, { provider: string; model: string; base_url?: string }>;
+  embeddings: { provider: string; model: string; base_url?: string };
+};
+
 const BOUND = {
   profile: "eu_hosted",
   tiers: {
@@ -43,7 +50,11 @@ const BOUND = {
 
 function backendFor(allow: GrantSpec, routing: unknown = BOUND) {
   let stored = routing;
-  let capturedPut: unknown = null;
+  // Typed as the document this endpoint takes, so an assertion can read a field
+  // off it without an unchecked cast at every call site. The stub still stores
+  // whatever arrives — the type is a claim about the ENDPOINT, not a check on
+  // the body, and a test asserting the wrong shape fails on the assertion.
+  let capturedPut: CapturedRouting | null = null;
   const fetchMock = vi.fn(
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const req =
@@ -53,7 +64,7 @@ function backendFor(allow: GrantSpec, routing: unknown = BOUND) {
       }
       if (req.url.includes("/ai/routing")) {
         if (req.method === "PUT") {
-          capturedPut = await req.json();
+          capturedPut = (await req.json()) as CapturedRouting;
           stored = capturedPut;
         }
         return jsonResponse(stored);
@@ -61,7 +72,10 @@ function backendFor(allow: GrantSpec, routing: unknown = BOUND) {
       throw new Error(`unexpected request: ${req.method} ${req.url}`);
     },
   );
-  return { fetchMock, getCapturedPut: () => capturedPut };
+  return {
+    fetchMock,
+    getCapturedPut: (): CapturedRouting | null => capturedPut,
+  };
 }
 
 const render = (ui: ReactNode, locale: Locale = "en") => {
@@ -198,10 +212,9 @@ describe("AiRoutingCard", () => {
     );
 
     await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
-    expect(
-      (backend.getCapturedPut() as { embeddings: { model: string } }).embeddings
-        .model,
-    ).toBe("gemini-embedding-002");
+    expect(backend.getCapturedPut()?.embeddings.model).toBe(
+      "gemini-embedding-002",
+    );
   });
 
   // openai_compatible has no default host and the server refuses a binding
@@ -233,10 +246,8 @@ describe("AiRoutingCard", () => {
     );
 
     await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
-    const sent = backend.getCapturedPut() as {
-      tiers: Record<string, { provider: string; base_url?: string }>;
-    };
-    expect(sent.tiers.premium.provider).toBe("openai_compatible");
-    expect(sent.tiers.premium.base_url).toBe("https://openrouter.ai/api");
+    const sent = backend.getCapturedPut();
+    expect(sent?.tiers.premium.provider).toBe("openai_compatible");
+    expect(sent?.tiers.premium.base_url).toBe("https://openrouter.ai/api");
   });
 });

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -36,7 +36,12 @@ const ROUTING_READER: GrantSpec = { ai_routing: ["read"] };
 type CapturedRouting = {
   profile: string;
   tiers: Record<string, { provider: string; model: string; base_url?: string }>;
-  embeddings: { provider: string; model: string; base_url?: string };
+  embeddings: {
+    provider: string;
+    model: string;
+    base_url?: string;
+    dimensions?: number;
+  };
 };
 
 const BOUND = {
@@ -249,5 +254,56 @@ describe("AiRoutingCard", () => {
     const sent = backend.getCapturedPut();
     expect(sent?.tiers.premium.provider).toBe("openai_compatible");
     expect(sent?.tiers.premium.base_url).toBe("https://openrouter.ai/api");
+  });
+  // The lane the operator reported as unreachable: it takes a provider of its
+  // own, and re-pointing it has to carry the host and the width with it or the
+  // server refuses the binding it just accepted.
+  it("re-points the embedding lane onto a hosted adapter, with its width", async () => {
+    const user = userEvent.setup();
+    const backend = backendFor(ROUTING_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+    await screen.findByDisplayValue("gemini-embedding-001");
+
+    const lane = screen.getByTestId("ai-routing-embeddings");
+    await pickOption(
+      user,
+      within(lane).getByRole("combobox"),
+      "openai_compatible",
+    );
+    await user.type(
+      await within(lane).findByLabelText("Host"),
+      "https://openrouter.ai/api",
+    );
+    await user.type(within(lane).getByLabelText("Vector width"), "1536");
+    await user.click(screen.getByRole("button", { name: /save routing/i }));
+
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    const sent = backend.getCapturedPut()?.embeddings;
+    expect(sent?.provider).toBe("openai_compatible");
+    expect(sent?.base_url).toBe("https://openrouter.ai/api");
+    expect(sent?.dimensions).toBe(1536);
+  });
+
+  // An emptied width means "whatever the provider compiles in", which the
+  // contract spells as an absent field. A 0 is a different instruction, and a
+  // NaN does not survive the JSON at all, so neither may reach the wire.
+  it("sends no width at all when the field is emptied, rather than a zero", async () => {
+    const user = userEvent.setup();
+    const backend = backendFor(ROUTING_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+    await screen.findByDisplayValue("gemini-embedding-001");
+
+    const lane = screen.getByTestId("ai-routing-embeddings");
+    const width = within(lane).getByLabelText("Vector width");
+    await user.type(width, "768");
+    await user.clear(width);
+    await user.click(screen.getByRole("button", { name: /save routing/i }));
+
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    const sent = backend.getCapturedPut()?.embeddings;
+    expect(sent?.dimensions).toBeUndefined();
+    expect(JSON.stringify(sent)).not.toContain("dimensions");
   });
 });

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -5,11 +5,13 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import { pickOption } from "../design-system/select-testing";
 import { type Locale, LocaleProvider } from "../i18n";
 import { AiRoutingCard } from "./ai-routing";
 
@@ -178,5 +180,63 @@ describe("AiRoutingCard", () => {
       "ai-routing-tier-premium",
       "ai-routing-tier-frontier",
     ]);
+  });
+
+  // The embed lane was missing from this form entirely, so a reader could
+  // re-point every chat tier and go on sending their retrieval to the vendor
+  // they had just moved away from, with nothing on screen saying so.
+  it("lets the embedding lane be re-pointed, and sends it", async () => {
+    const backend = backendFor(ROUTING_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+
+    const model = await screen.findByDisplayValue("gemini-embedding-001");
+    await userEvent.clear(model);
+    await userEvent.type(model, "gemini-embedding-002");
+    await userEvent.click(
+      screen.getByRole("button", { name: /save routing/i }),
+    );
+
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    expect(
+      (backend.getCapturedPut() as { embeddings: { model: string } }).embeddings
+        .model,
+    ).toBe("gemini-embedding-002");
+  });
+
+  // openai_compatible has no default host and the server refuses a binding
+  // without one. With no field for it, choosing that adapter produced a write
+  // the running role could never adopt: saved cleanly, then declined at the
+  // rebind, leaving the OLD models serving with the reason only in a log.
+  it("asks for a host when the adapter has no default, and only then", async () => {
+    // An instance rather than the default export: pickOption drives a portalled
+    // listbox and needs a session that keeps pointer state across the open.
+    const user = userEvent.setup();
+    const backend = backendFor(ROUTING_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+    await screen.findByDisplayValue("gemini-3.5-flash");
+
+    // A native vendor addresses its own API, so no host is asked for.
+    expect(screen.queryByLabelText("Host")).toBeNull();
+
+    const tier = screen.getByTestId("ai-routing-tier-premium");
+    await pickOption(
+      user,
+      within(tier).getByRole("combobox"),
+      "openai_compatible",
+    );
+    const host = await within(tier).findByLabelText("Host");
+    await user.type(host, "https://openrouter.ai/api");
+    await userEvent.click(
+      screen.getByRole("button", { name: /save routing/i }),
+    );
+
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    const sent = backend.getCapturedPut() as {
+      tiers: Record<string, { provider: string; base_url?: string }>;
+    };
+    expect(sent.tiers.premium.provider).toBe("openai_compatible");
+    expect(sent.tiers.premium.base_url).toBe("https://openrouter.ai/api");
   });
 });

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -225,61 +225,31 @@ function RoutingForm({
   );
 }
 
-// The endpoint, for the one adapter that has no default of its own.
+// The three controls that name an adapter: which vendor, which model on it,
+// and -- only where the vendor has no address of its own -- where to reach it.
 //
-// Shared by both rows rather than written beside each: it is one control with
-// one rule — openai_compatible cannot be served without a host — and two copies
-// would be two places to forget when that rule moves. It draws nothing for a
-// native vendor, where an empty box invites somebody to override a working
-// default.
-function HostField<B extends { provider: string; base_url?: string }>({
+// One component rather than one per row. Both lanes ask the identical question
+// and the answers are governed by the identical rule, so a second copy would
+// only be a second place to forget when that rule moves. The label is the one
+// thing that genuinely differs: a tier row names the tier, the embedding row
+// names itself.
+function AdapterFields<
+  B extends { provider: string; model: string; base_url?: string },
+>({
+  label,
   binding,
   disabled,
   onChange,
 }: Readonly<{
+  label: string;
   binding: B;
   disabled: boolean;
   onChange: (next: B) => void;
 }>) {
   const t = useT();
-  if (binding.provider !== OPENAI_WIRE) {
-    return null;
-  }
   return (
-    <Field
-      label={t("aiRouting.baseUrl.label")}
-      hint={t("aiRouting.baseUrl.help")}
-    >
-      {(control) => (
-        <TextInput
-          {...control}
-          value={binding.base_url ?? ""}
-          disabled={disabled}
-          placeholder={t("aiRouting.baseUrl.placeholder")}
-          onChange={(e) => onChange({ ...binding, base_url: e.target.value })}
-        />
-      )}
-    </Field>
-  );
-}
-
-// The embeddings lane. Its own row rather than a TierRow, because the two
-// shapes differ in both directions: this one takes `dimensions` and no `input`,
-// and a widened row that accepted either field on either lane would offer a
-// setting the server refuses.
-function EmbeddingsRow({
-  binding,
-  disabled,
-  onChange,
-}: Readonly<{
-  binding: Routing["embeddings"];
-  disabled: boolean;
-  onChange: (next: Routing["embeddings"]) => void;
-}>) {
-  const t = useT();
-  return (
-    <div className="form-row" data-testid="ai-routing-embeddings">
-      <Field label={t("aiRouting.embeddings.label")}>
+    <>
+      <Field label={label}>
         {(control) => (
           <Select
             {...control}
@@ -300,7 +270,56 @@ function EmbeddingsRow({
           />
         )}
       </Field>
-      <HostField binding={binding} disabled={disabled} onChange={onChange} />
+      {/* Only where it is load-bearing. openai_compatible has no default host
+          and the server refuses a binding without one, so leaving this off the
+          form made every broker unbindable from here: the write was accepted
+          and the running role then declined to adopt it. A native vendor
+          addresses its own API, and an empty box beside it invites somebody to
+          fill it in with something that overrides a working default. */}
+      {binding.provider === OPENAI_WIRE && (
+        <Field
+          label={t("aiRouting.baseUrl.label")}
+          hint={t("aiRouting.baseUrl.help")}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              value={binding.base_url ?? ""}
+              disabled={disabled}
+              placeholder={t("aiRouting.baseUrl.placeholder")}
+              onChange={(e) =>
+                onChange({ ...binding, base_url: e.target.value })
+              }
+            />
+          )}
+        </Field>
+      )}
+    </>
+  );
+}
+
+// The embeddings lane. Its own row rather than a TierRow, because the two
+// shapes differ in both directions: this one takes `dimensions` and no `input`,
+// and a widened row that accepted either field on either lane would offer a
+// setting the server refuses.
+function EmbeddingsRow({
+  binding,
+  disabled,
+  onChange,
+}: Readonly<{
+  binding: Routing["embeddings"];
+  disabled: boolean;
+  onChange: (next: Routing["embeddings"]) => void;
+}>) {
+  const t = useT();
+  return (
+    <div className="form-row" data-testid="ai-routing-embeddings">
+      <AdapterFields
+        label={t("aiRouting.embeddings.label")}
+        binding={binding}
+        disabled={disabled}
+        onChange={onChange}
+      />
       {/* The width this lane asks the provider for, which only it has. Blank
           means the compiled default rather than zero: the contract reads an
           omitted value and a 0 the same way, so an empty box must send neither
@@ -352,37 +371,14 @@ function TierRow({
   disabled: boolean;
   onChange: (next: TierBinding) => void;
 }>) {
-  const t = useT();
   return (
     <div className="form-row" data-testid={`ai-routing-tier-${tier}`}>
-      <Field label={tier}>
-        {(control) => (
-          <Select
-            {...control}
-            value={binding.provider}
-            disabled={disabled}
-            options={PROVIDERS.map((p) => ({ value: p, label: p }))}
-            onChange={(provider) => onChange({ ...binding, provider })}
-          />
-        )}
-      </Field>
-      <Field label={t("aiRouting.model.label")}>
-        {(control) => (
-          <TextInput
-            {...control}
-            value={binding.model}
-            disabled={disabled}
-            onChange={(e) => onChange({ ...binding, model: e.target.value })}
-          />
-        )}
-      </Field>
-      {/* Only where it is load-bearing. openai_compatible has no default host
-          and the server refuses a binding without one, so leaving this off the
-          form made every broker unbindable from here — the write was accepted
-          and the running role then declined to adopt it. A native vendor
-          addresses its own API, and an empty box beside it invites somebody to
-          fill it in with something that overrides a working default. */}
-      <HostField binding={binding} disabled={disabled} onChange={onChange} />
+      <AdapterFields
+        label={tier}
+        binding={binding}
+        disabled={disabled}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -280,6 +280,33 @@ function EmbeddingsRow({
           )}
         </Field>
       )}
+      {/* The width this lane asks the provider for, which only it has. Blank
+          means the compiled default rather than zero: the contract reads an
+          omitted value and a 0 the same way, so an empty box must send neither
+          a 0 nor a NaN. */}
+      <Field
+        label={t("aiRouting.dimensions.label")}
+        hint={t("aiRouting.dimensions.help")}
+      >
+        {(control) => (
+          <TextInput
+            {...control}
+            type="number"
+            inputMode="numeric"
+            value={binding.dimensions?.toString() ?? ""}
+            disabled={disabled}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              const parsed = Number.parseInt(raw, 10);
+              onChange({
+                ...binding,
+                dimensions:
+                  raw === "" || Number.isNaN(parsed) ? undefined : parsed,
+              });
+            }}
+          />
+        )}
+      </Field>
     </div>
   );
 }

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -42,6 +42,10 @@ const PROVIDERS = [
 
 const PROFILES = ["eu_hosted", "sovereign", "cloud_frontier"] as const;
 
+// The one adapter with no host of its own: every OpenAI-wire vendor is reached
+// through it, so the endpoint is the binding rather than a tweak to it.
+const OPENAI_WIRE = "openai_compatible";
+
 function useRouting(enabled: boolean) {
   return useQuery({
     enabled,
@@ -187,6 +191,18 @@ function RoutingForm({
         />
       ))}
 
+      {/* The embed lane, which the form used to leave out entirely — so a
+          reader could re-point every chat tier and still be sending their
+          retrieval to the vendor they had just moved away from, with nothing on
+          screen saying so. It binds SEPARATELY on purpose: retrieval has to
+          survive a chat-budget exhaustion, and the model is a different one even
+          on the same vendor. */}
+      <EmbeddingsRow
+        binding={draft.embeddings}
+        disabled={!canManage || replace.isPending}
+        onChange={(embeddings) => setDraft((d) => ({ ...d, embeddings }))}
+      />
+
       {replace.isError && (
         <Callout tone="danger" live="alert">
           {problemMessageOf(replace.error, t)}
@@ -206,6 +222,65 @@ function RoutingForm({
         {t("aiRouting.save")}
       </Button>
     </>
+  );
+}
+
+// The embeddings lane. Its own row rather than a TierRow, because the two
+// shapes differ in both directions: this one takes `dimensions` and no `input`,
+// and a widened row that accepted either field on either lane would offer a
+// setting the server refuses.
+function EmbeddingsRow({
+  binding,
+  disabled,
+  onChange,
+}: Readonly<{
+  binding: Routing["embeddings"];
+  disabled: boolean;
+  onChange: (next: Routing["embeddings"]) => void;
+}>) {
+  const t = useT();
+  return (
+    <div className="form-row" data-testid="ai-routing-embeddings">
+      <Field label={t("aiRouting.embeddings.label")}>
+        {(control) => (
+          <Select
+            {...control}
+            value={binding.provider}
+            disabled={disabled}
+            options={PROVIDERS.map((p) => ({ value: p, label: p }))}
+            onChange={(provider) => onChange({ ...binding, provider })}
+          />
+        )}
+      </Field>
+      <Field label={t("aiRouting.model.label")}>
+        {(control) => (
+          <TextInput
+            {...control}
+            value={binding.model}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...binding, model: e.target.value })}
+          />
+        )}
+      </Field>
+      {binding.provider === OPENAI_WIRE && (
+        <Field
+          label={t("aiRouting.baseUrl.label")}
+          hint={t("aiRouting.baseUrl.help")}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              value={binding.base_url ?? ""}
+              disabled={disabled}
+              placeholder={t("aiRouting.baseUrl.placeholder")}
+              onChange={(e) =>
+                onChange({ ...binding, base_url: e.target.value })
+              }
+            />
+          )}
+        </Field>
+      )}
+    </div>
   );
 }
 
@@ -253,6 +328,30 @@ function TierRow({
           />
         )}
       </Field>
+      {/* Only where it is load-bearing. openai_compatible has no default host
+          and the server refuses a binding without one, so leaving this off the
+          form made every broker unbindable from here — the write was accepted
+          and the running role then declined to adopt it. A native vendor
+          addresses its own API, and an empty box beside it invites somebody to
+          fill it in with something that overrides a working default. */}
+      {binding.provider === OPENAI_WIRE && (
+        <Field
+          label={t("aiRouting.baseUrl.label")}
+          hint={t("aiRouting.baseUrl.help")}
+        >
+          {(control) => (
+            <TextInput
+              {...control}
+              value={binding.base_url ?? ""}
+              disabled={disabled}
+              placeholder={t("aiRouting.baseUrl.placeholder")}
+              onChange={(e) =>
+                onChange({ ...binding, base_url: e.target.value })
+              }
+            />
+          )}
+        </Field>
+      )}
     </div>
   );
 }

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -225,6 +225,44 @@ function RoutingForm({
   );
 }
 
+// The endpoint, for the one adapter that has no default of its own.
+//
+// Shared by both rows rather than written beside each: it is one control with
+// one rule — openai_compatible cannot be served without a host — and two copies
+// would be two places to forget when that rule moves. It draws nothing for a
+// native vendor, where an empty box invites somebody to override a working
+// default.
+function HostField<B extends { provider: string; base_url?: string }>({
+  binding,
+  disabled,
+  onChange,
+}: Readonly<{
+  binding: B;
+  disabled: boolean;
+  onChange: (next: B) => void;
+}>) {
+  const t = useT();
+  if (binding.provider !== OPENAI_WIRE) {
+    return null;
+  }
+  return (
+    <Field
+      label={t("aiRouting.baseUrl.label")}
+      hint={t("aiRouting.baseUrl.help")}
+    >
+      {(control) => (
+        <TextInput
+          {...control}
+          value={binding.base_url ?? ""}
+          disabled={disabled}
+          placeholder={t("aiRouting.baseUrl.placeholder")}
+          onChange={(e) => onChange({ ...binding, base_url: e.target.value })}
+        />
+      )}
+    </Field>
+  );
+}
+
 // The embeddings lane. Its own row rather than a TierRow, because the two
 // shapes differ in both directions: this one takes `dimensions` and no `input`,
 // and a widened row that accepted either field on either lane would offer a
@@ -262,24 +300,7 @@ function EmbeddingsRow({
           />
         )}
       </Field>
-      {binding.provider === OPENAI_WIRE && (
-        <Field
-          label={t("aiRouting.baseUrl.label")}
-          hint={t("aiRouting.baseUrl.help")}
-        >
-          {(control) => (
-            <TextInput
-              {...control}
-              value={binding.base_url ?? ""}
-              disabled={disabled}
-              placeholder={t("aiRouting.baseUrl.placeholder")}
-              onChange={(e) =>
-                onChange({ ...binding, base_url: e.target.value })
-              }
-            />
-          )}
-        </Field>
-      )}
+      <HostField binding={binding} disabled={disabled} onChange={onChange} />
       {/* The width this lane asks the provider for, which only it has. Blank
           means the compiled default rather than zero: the contract reads an
           omitted value and a 0 the same way, so an empty box must send neither
@@ -361,24 +382,7 @@ function TierRow({
           and the running role then declined to adopt it. A native vendor
           addresses its own API, and an empty box beside it invites somebody to
           fill it in with something that overrides a working default. */}
-      {binding.provider === OPENAI_WIRE && (
-        <Field
-          label={t("aiRouting.baseUrl.label")}
-          hint={t("aiRouting.baseUrl.help")}
-        >
-          {(control) => (
-            <TextInput
-              {...control}
-              value={binding.base_url ?? ""}
-              disabled={disabled}
-              placeholder={t("aiRouting.baseUrl.placeholder")}
-              onChange={(e) =>
-                onChange({ ...binding, base_url: e.target.value })
-              }
-            />
-          )}
-        </Field>
-      )}
+      <HostField binding={binding} disabled={disabled} onChange={onChange} />
     </div>
   );
 }


### PR DESCRIPTION
Reported from a live install: re-pointing every tier from Gemini to Mistral through Settings → AI appeared to save, and the next run still used Gemini.

## What was happening

The form offers a **provider** and a **model** and nothing else. Mistral is reached through `openai_compatible`, which has no default host — and `validate()` never required one, because that check lives in `SelectBrain` at client-build time.

So:

1. The write was accepted. `validate()` had no opinion about a missing `base_url`.
2. The screen said saved, and the stored document really did change.
3. The running role's watcher re-read it, tried to rebind, and `SelectBrain` refused for want of a `base_url`.
4. The watcher **keeps the current binding** when a stored one cannot be served — deliberately, since turning a bad edit into an outage is worse — and logs an error.

The operator sees a saved form, the old models still answering, and nothing connecting the two. The only account is a server log line.

## Fixed at both ends

**Refused at the write.** A tier or embed lane binding `openai_compatible` with no host is now invalid where every other binding rule already lives, so the PUT returns a message naming the missing field rather than storing something no process can adopt. That moves the failure from a log to the form.

**And the form can express one.** The host field appears for the adapter that needs it, and stays hidden for vendors that address their own API — where an empty box invites somebody to override a working default.

## The embedding lane was missing entirely

Also reported, and a quieter version of the same problem: a reader could re-point every chat tier and go on sending their retrieval to the vendor they had just moved away from, with nothing on screen saying so.

It gets its own row rather than a widened `TierRow`: this lane takes `dimensions` and no `input`, and one row accepting either field on either lane would offer settings the server refuses.

## On the third report — the location dropdown

`profile` is wired correctly and is sent with the document; it takes effect on Save like every other field on this form. It looks inert because it constrains rather than routes: `sovereign` refuses cloud providers, and `eu_hosted` ↔ `cloud_frontier` changes nothing observable on its own. **Not changed here** — if it should read differently, that is a copy decision rather than a defect, and worth deciding separately.

## Verification

Both new controls are mutation-checked by removing them again — each reproduces the reported symptom exactly:

```
Unable to find a label with the text of: Host
Unable to find an element with the display value: gemini-embedding-001
```

Backend: the refusal is table-tested over a chat tier, the embed lane, and the servable case — the last asserting `SelectBrain` really does build it, so the rule cannot pass by refusing everything.

`make check-fe` exit 0 (4887 tests), `make check-backend` exit 0, both captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated AI embedding configuration for provider, model, custom host, and optional vector width.
  - Added support for OpenAI-compatible providers with conditional custom-host configuration.
  - Improved persistence and handling of embedding and tier-based AI routing settings.

- **Bug Fixes**
  - Improved validation for missing custom hosts while preserving provider-specific error messages.

- **Documentation**
  - Updated English, German, and Vietnamese labels and guidance for embedding dimensions and custom hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->