### PR TITLE
fix(docs): the gate inventory counts the parity gates the tree actually declares

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (31)
+## Parity (32)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
**main is red.** `main-health` on `2214b4b75` fails `backend gate`, `integration unit coverage` and the RLS/erasure fan-in — all on one test:

```
--- FAIL: TestTheGateInventoryPageIsCurrent
    ../docs/reference/gate-inventory.md no longer matches the //gate:kind
    declarations in the tree.
```

Reproduced locally at `2214b4b75`, so it is the tree and not a runner artifact.

The Parity heading says **31**; the section lists **32** rows. Regenerating moves the heading and nothing else — one line, no row changes, because no row is wrong.

## Nobody wrote this state

Traced the divergence to `7ecc8286d` (#2707), then checked its checks: `ci: pass`, `deterministic-gates: pass`. It was green, and so was #2772 before it. Neither PR was wrong.

- **#2772** branched at Parity 30, added one gate, regenerated → heading `31`, 31 rows.
- **#2707** branched at Parity 30, added a *different* gate, regenerated → heading `31`, 31 rows.

Merging them changed the heading line `30` → `31` **twice, to the same value**. Git saw the two sides agree, took the line once, raised no conflict — and applied **both** row insertions.

Heading 31. Rows 32. A state neither author wrote and no gate ever ran against.

## Why this shape is nastier than the usual case

#2714 already records that `gate-inventory.md` is a whole-tree manifest with no merge queue, so gate-adding PRs collide. This is the variant that defeats the obvious defences:

- **It does not conflict.** Both sides make the *identical* edit to the count line, which is the one case git resolves silently. "No conflict" is not evidence the merge is sound.
- **Both PRs are legitimately green.** Each page was internally consistent when its CI ran. There is no red anywhere to re-read.
- **Regenerating on a branch does not protect you** — #2707 did regenerate, correctly, and still produced this.

The count is a single line two PRs edit to the same value; the rows are separate lines that both survive. Any derived artifact holding a total beside its items has this shape.

## Scope

Regeneration only. `TestTheGateInventoryPageIsCurrent` and `TestEveryGateDeclaresItsShape` both pass on this branch. The general fix belongs on #2714 — a merge queue, or deriving the count at read time so there is no total to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the gate inventory to reflect the current parity count of 32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->