### PR TITLE
feat(shell): neutral chrome grounds, an elevated nav plate and one card shadow

### DIFF
--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -777,16 +777,19 @@
   margin-bottom: var(--space-2);
   /* Filled rather than outlined: it is the way OUT of a level, standing above a
      column of rows, and a hairline would read as a field at the head of them. A
-     recessed ground says "control" in a different word than a border does. */
+     recessed ground says "control" in a different word than a border does.
+     Only the RESTING ground is stated here. This element carries `navitem` too,
+     so `.rail .navitem:hover` already gives it the panel's one hover — it used to
+     restate that in --bgHover, which is LIGHTER than the sidebar's ground, and so
+     this control was the single thing in the rail that brightened under a pointer
+     while every row beside it darkened. A second spelling of one hover is how the
+     two got to disagree; there is one now. */
   background: var(--bgCard);
   color: var(--textPrimary);
   font-family: var(--f-body);
   font-size: var(--fs-body);
   font-weight: var(--fw-medium);
   text-align: left;
-}
-.rail .navback:hover {
-  background: var(--bgHover);
 }
 /* The chevron leads the movement it stands for: it pulls back the way the reader
    is about to go, which is the whole gesture in 2px. */

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -543,39 +543,59 @@
   align-items: center;
   gap: 9px;
   flex: 1;
-  min-height: 34px;
-  padding: 0 14px;
+  min-height: 36px;
+  /* 13 and not 14, with the transparent border below making up the difference:
+     the active row is a PLATE with an edge, and a border that appears only when
+     the row is current would shift its glyph and its label by a pixel on every
+     navigation. Held at every state instead, and coloured by one. */
+  padding: 0 13px;
+  border: 1px solid transparent;
   border-radius: 8px;
   /* A pointer-tracked highlight reads as lag past ~200ms; Carbon times this
-     class of change at 70–110ms. */
+     class of change at 70–110ms. The border-colour is in the same transition:
+     the plate's edge arrives with its fill or the two read as separate events. */
   transition:
     background var(--dur-state) var(--ease-in-out),
+    border-color var(--dur-state) var(--ease-in-out),
     color var(--dur-state) var(--ease-in-out);
   cursor: pointer;
-  border: 0;
   background: transparent;
   color: var(--textContent);
   text-decoration: none;
   font-size: var(--fs-body);
 }
-/* Collapsed keeps the SAME row height as expanded, and the 14px padding centres
-   the 18px icon either way (14 + 18 + 14 = 46), so no icon moves on either axis
-   across the collapse. Target size is therefore 46x38 in both states — past WCAG
-   2.2 2.5.8 (AA, 24x24), giving up the 44x44 of 2.5.5 (AAA) that AC-shell-1c
-   asks for in favour of the compact row rhythm the design direction sets. */
+/* Collapsed keeps the SAME row height as expanded, and the 13px padding plus the
+   1px edge centres the 18px icon either way (1 + 13 + 18 + 13 + 1 = 46), so no
+   icon moves on either axis across the collapse, and none moves when a row
+   becomes the current one. Target size is therefore 46x36 at the floor — past
+   WCAG 2.2 2.5.8 (AA, 24x24), giving up the 44x44 of 2.5.5 (AAA) that
+   AC-shell-1c asks for in favour of the compact row rhythm the design direction
+   sets. */
+/* Hover moves DOWN off the sidebar's ground and the current row moves UP to the
+   elevated one, so the two states are never the same gesture read twice — which
+   is why this is --bgSidebarHover and not --bgHover: --bgHover is lighter than
+   the rail, so it would brighten toward the active plate rather than away from
+   it. */
 .rail .navitem:hover {
-  background: var(--bgHover);
+  background: var(--bgSidebarHover);
   color: var(--textPrimary);
 }
-/* The current row, in three signals — a tint, a weight, and the accent on the
-   glyph — because a tint alone is colour-only (WCAG 1.4.1, Level A) and the tint
-   itself measures ~1.1:1 against the sidebar ground, so it cannot carry the state
-   on its own. The INK stays neutral: the accent as 13.5px text measures 3.9:1 on
-   the dark theme's tinted row, under the 4.5:1 AA needs, and weight does not
-   rescue that below 18.66px. The glyph is where the accent goes, and at 3:1
-   non-text (1.4.11) it clears. */
+/* The current row is a PLATE: the elevated surface, lifted off the sidebar's own
+   recessed ground the same way a card is lifted off the page — the rail's ladder
+   and the content's are one ladder.
+   Still three signals, and for the reason it always was: the lift measures
+   1.21:1 light / 1.20:1 dark against the ground, which is a difference a reader
+   sees and not one that carries a state on its own (WCAG 1.4.1, Level A). So the
+   weight and the accent on the glyph stay, and the plate gains an EDGE —
+   --borderSubtle is what makes it a surface with a boundary rather than a pale
+   smudge, and it is the same hairline every card in the product draws.
+   The INK stays neutral: the accent as 13.5px text measures 3.9:1 on the dark
+   theme's plate, under the 4.5:1 AA needs, and weight does not rescue that below
+   18.66px. The glyph is where the accent goes, and at 3:1 non-text (1.4.11) it
+   clears. */
 .rail .navitem.active {
-  background: var(--accentLight);
+  background: var(--bgElevated);
+  border-color: var(--borderSubtle);
   color: var(--textPrimary);
   font-weight: var(--fw-semibold);
 }
@@ -1161,10 +1181,26 @@
     overflow: visible;
     /* Here the panel IS a floating object — it hovers over the content rather
        than bounding it — so it takes the card chrome the flush sidebar gives
-       up: all four sides, a radius, and a shadow to sit on. */
+       up: all four sides, a radius, a shadow to sit on, and the ELEVATED ground
+       instead of the sidebar's recessed one. That last part is the whole reason
+       the ground is restated here: --bgSidebar is a shade DARKER than the page
+       because a left edge should recede behind what it frames, and this bar is
+       not an edge — it is a card lying on top of the content, and a card that
+       reads darker than the page it covers reads as a hole in it. */
+    background: var(--bgElevated);
     border: 1px solid var(--borderSubtle);
     border-radius: var(--r-md);
     box-shadow: var(--shadow-pop);
+  }
+  /* And so the current cell cannot be the elevated plate it is on the desktop
+     rail: the plate and the bar would be the same colour. The accent tint is
+     what marks it here — the same signal `.railmore.active` below already uses
+     for a destination that lives in the sheet, so the bar has ONE way of saying
+     "this one", whichever cell is carrying it. The weight and the accent glyph
+     from the desktop rule still apply, so the state keeps its three signals. */
+  .rail .navitem.active {
+    background: var(--accentLight);
+    border-color: transparent;
   }
   /* The layer the sheet sits on. It fades in rather than appearing, because the
      page under it does not move and an instant dim reads as a flash. */

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -548,7 +548,10 @@
      the active row is a PLATE with an edge, and a border that appears only when
      the row is current would shift its glyph and its label by a pixel on every
      navigation. Held at every state instead, and coloured by one. */
-  padding: 0 13px;
+  /* Optical, not rhythm: 13 + the 1px edge is the 14 this row has always had,
+     and the --space-* rung either side of it moves every glyph in the rail off
+     the axis the collapsed and expanded states share. */
+  padding: 0 13px; /* ds:ignore 13 + the 1px edge is one 14px inset, not a rung */
   border: 1px solid transparent;
   border-radius: 8px;
   /* A pointer-tracked highlight reads as lag past ~200ms; Carbon times this

--- a/frontend/src/app/topbar.css
+++ b/frontend/src/app/topbar.css
@@ -1,8 +1,11 @@
 /* ===== the top bar =====
  * The session's own strip: the sidebar control, the trail, the search, and the
- * person. It stands on the SAME ground as the sidebar (--bgElevated) with one
- * hairline under it, so the chrome reads as a single L around the content
- * instead of two panels that happen to meet at a corner.
+ * person. It stands on the PAGE's ground (--bgTopbar is --bgPage with an alpha)
+ * with one hairline under it, so the strip reads as the top of the room the
+ * content is in rather than as a second panel meeting the sidebar at a corner.
+ * The sidebar's own ground is a step darker on purpose (--bgSidebar), and the
+ * two are deliberately not the same: an L of identical chrome around the content
+ * makes the frame the loudest thing on the screen.
  *
  * It never scrolls: it is the first row of the content column's flex box and
  * the scroller is its sibling, which is cheaper than `position: sticky` and

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -22,15 +22,21 @@
    * (--accent, --success/--warn/--danger, --ai) and the grounds stay out of the
    * way. tokens.test.ts pins these values in the retired mockup's place.
    *
-   * Five rungs, read as a ladder from the recessed chrome up to the surface a
-   * card floats on. Each is one visible step off its neighbours, and the step
-   * is what the next rule's contrast note is measuring:
+   * A ladder, darkest first, from the recessed chrome up to the surface a card
+   * floats on. Each rung is one visible step off its neighbours, and the ORDER
+   * is the part that carries meaning — tokens.test.ts asserts the ordering in
+   * both themes rather than trusting six plausible values to stay in sequence:
    *
-   *   --bgSidebar   #e9e9ec   the application's left edge, BELOW the page
-   *   --bgCard      #eaeaee   a well inside a card: a chip, an inset row
-   *   --bgHover     #ededf0   a pointer resting on a row
-   *   --bgPage      #f5f5f6   the reading ground
-   *   --bgElevated  #ffffff   a card, a panel, a menu — the top of the ladder
+   *   --bgSidebarHover #dfdfe4  a pointer resting on a rail row
+   *   --bgSidebar      #e9e9ec  the application's left edge, BELOW the page
+   *   --bgCard         #eaeaee  a well inside a card: a chip, an inset row
+   *   --bgHover        #ededf0  a pointer resting on a row on the page
+   *   --bgPage         #f5f5f6  the reading ground
+   *   --bgElevated     #ffffff  a card, a panel, a menu, and the ACTIVE rail row
+   *
+   * The dark theme is NOT this list mirrored. On a dark ground every surface
+   * lifts toward the light, so the ladder runs the other way and only the
+   * DIRECTION of each step is shared; the dark block states its own order.
    *
    * The page is no longer the brightest thing on screen; --bgElevated is, and
    * a card is therefore separated by its own lightness rather than by the
@@ -63,19 +69,32 @@
   --bgTopbar: rgba(245, 245, 246, 0.9);
 
   --accent: #0b7a53;
-  /* The accent as TEXT, split from the accent as a FILL. They are the same
-   * value here and diverge in dark mode, which is the whole reason the split
-   * exists: --accent lightens to the ADR-0040 mandate #16a34a, and that tone
-   * sitting as text on the --accentLight tint derived from it measures 4.03:1
-   * — under the 4.5:1 AA needs for text this size. The fill cannot move, so
-   * the text does. Same shape as --tealText and the --mono*Text pairs. */
-  --accentText: #0b7a53;
+  /* The accent as TEXT, split from the accent as a FILL, and now diverging from
+   * it in BOTH themes. Dark was the original reason: --accent lightens to the
+   * ADR-0040 mandate #16a34a, and that tone sitting as text on the --accentLight
+   * tint derived from it measures 4.03:1, under the 4.5:1 AA needs for text this
+   * size.
+   * Light diverges for the same reason one step removed. --accentLight is an
+   * alpha tint, so what sits BEHIND it decides what the text is read against,
+   * and the grounds went grey: the home glance's count chip (--accentText on
+   * --accentLight, 15px) measured 4.36:1 once the page stopped being white.
+   * The fill cannot move either way — #0b7a53 is the brand emerald — so the text
+   * does: 5.04:1 on that chip now, and clear of 4.5:1 on every ground in the
+   * ladder. Same shape as --tealText and the --mono*Text pairs. */
+  --accentText: #0a6f4b;
   --accentLight: rgba(11, 122, 83, 0.09);
   --accentMed: rgba(11, 122, 83, 0.17);
 
   --textPrimary: #15201b;
   --textContent: #36433d;
-  --textSecondary: #68756e;
+  /* Darkened with the grounds, not independently of them: this is body text on
+   * every surface in the ladder, and the darkest one it sits on is the rail
+   * (--bgSidebar). At #68756e it measured 4.42:1 on the page and 3.98:1 on the
+   * rail once those stopped being white — under the 4.5:1 AA needs for text this
+   * size, which axe caught on seven elements of the home glance alone. 4.64:1 at
+   * its worst ground now. A text tone answers to the ground it is read on, so
+   * moving one without the other is what breaks it. */
+  --textSecondary: #5f6a64;
   --textTertiary: #9aa6a0;
   --textMuted: #cbd2cd;
   --textOnAccent: #fff;
@@ -107,8 +126,12 @@
   --teal: #0e7490;
   /* Readable teal text for a chip on the --tealLight fill. Split from --teal
    * (a fill/accent) so the dark theme can lift the text without shifting the
-   * pill fills that read --teal. */
-  --tealText: #0e7490;
+   * pill fills that read --teal — and so LIGHT can darken it without them, which
+   * the grey grounds now require: --tealLight is an alpha tint over whatever is
+   * behind it, and on the grey page the pair measured 4.30:1. 5.08:1 now. The
+   * same move as --accentText, for the same reason; neither --teal nor
+   * --tealLight shifts. */
+  --tealText: #0d6882;
   /* low-alpha teal fill — the read-access pill's tint, tonally distinct from
    * the emerald --accentLight the write pill uses (record-share safety split,
    * mirrors share.html's read/write pill colours). Derived from --teal. */
@@ -453,10 +476,12 @@
      what it frames. */
   --bgSidebar: #06100d;
   /* Up off the sidebar, not down: on a dark ground the room only has one
-     direction to go, so hover lifts (1.11:1) and the active row lifts further,
-     all the way to --bgElevated. The ORDER is what carries the state, and it is
-     the same order in both themes. */
-  --bgSidebarHover: #0f1d18;
+     direction to go, so hover lifts (1.06:1) and the active row lifts further,
+     all the way to --bgElevated (1.20:1 off the rail). What has to hold is the
+     GAP between hover and that plate — they are the pair a reader decodes — and
+     here it is 1.13:1. It was #0f1d18, which read 1.08:1 against the plate: an
+     ordering that was correct and a difference nobody could see. */
+  --bgSidebarHover: #0c1814;
   /* The page's own ground, translucent — the light theme's rule, in this
      theme's page colour. It used to be the ELEVATED ground, which made the
      strip read as a card laid over the top of the window. */
@@ -581,7 +606,7 @@
     --bgCard: #1a2c26;
     --bgHover: #1f332c;
     --bgSidebar: #06100d;
-    --bgSidebarHover: #0f1d18;
+    --bgSidebarHover: #0c1814;
     --bgTopbar: rgba(14, 27, 22, 0.9);
 
     --accent: #16a34a;

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -10,26 +10,57 @@
  * success stays a brighter grass-green than the brand emerald on purpose.
  */
 :root {
-  /* The page is WHITE. It used to be #fbfcfb, and the near-white it was is now
-   * the SIDEBAR's ground — the two surfaces swapped so the chrome reads as the
-   * quieter of the pair and the reading surface is the brightest thing on
-   * screen. The mockup this palette was mirrored from says #fbfcfb here; that
-   * document is retired and this is the shipped choice, which tokens.test.ts
-   * pins in its place. */
-  --bgPage: #ffffff;
+  /*
+   * The GROUNDS are neutral grey; the green is the accent, the states and the
+   * status families. This is the one place the §2 Ledger-Green identity is
+   * deliberately not carried, and the reason is what a tinted ground does to a
+   * whole application rather than to one surface: a green-cast page reads as a
+   * business tool from two decades ago, and it casts every neutral above it —
+   * a grey border, a monogram fill, a screenshot pasted into a record — toward
+   * the same hue. An accent is a choice a reader sees; a ground is the light
+   * everything else is seen in. The hue therefore lives where it is a decision
+   * (--accent, --success/--warn/--danger, --ai) and the grounds stay out of the
+   * way. tokens.test.ts pins these values in the retired mockup's place.
+   *
+   * Five rungs, read as a ladder from the recessed chrome up to the surface a
+   * card floats on. Each is one visible step off its neighbours, and the step
+   * is what the next rule's contrast note is measuring:
+   *
+   *   --bgSidebar   #e9e9ec   the application's left edge, BELOW the page
+   *   --bgCard      #eaeaee   a well inside a card: a chip, an inset row
+   *   --bgHover     #ededf0   a pointer resting on a row
+   *   --bgPage      #f5f5f6   the reading ground
+   *   --bgElevated  #ffffff   a card, a panel, a menu — the top of the ladder
+   *
+   * The page is no longer the brightest thing on screen; --bgElevated is, and
+   * a card is therefore separated by its own lightness rather than by the
+   * shadow alone. That is what lets --shadow-card be as slight as it now is.
+   */
+  --bgPage: #f5f5f6;
   --bgElevated: #ffffff;
-  --bgCard: #eef1f0;
-  --bgHover: #f3f6f4;
-  /* The sidebar's own ground: a shade off the page rather than the page's own
-   * white, so the application's left edge is visible without a second border.
-   * A token rather than `--bgCard` because the sidebar is not a card and must
-   * not follow one when card grounds are re-tuned. */
-  --bgSidebar: #fbfcfb;
-  /* The top strip, which the content scrolls UNDER: translucent over whatever
-   * passes beneath it, with an 8px blur behind it (app/topbar.css). Stated as
-   * an alpha colour rather than a solid because the blur is only visible where
-   * the ground is see-through. */
-  --bgTopbar: rgba(255, 255, 255, 0.9);
+  /* 1.20:1 against --bgElevated, which it usually sits on, and 1.10:1 against
+   * --bgPage: one step off BOTH its hosts. The old value was one step off white
+   * only, which is invisible once the page stops being white. */
+  --bgCard: #eaeaee;
+  --bgHover: #ededf0;
+  /* The sidebar's own ground, DARKER than the page rather than lighter: the
+   * application's left edge is visible without a second border, and chrome that
+   * recedes is chrome that stops competing with what it frames. A token rather
+   * than `--bgCard` because the sidebar is not a card and must not follow one
+   * when card grounds are re-tuned. The rail's own hover is --bgSidebarHover
+   * below, because --bgHover is LIGHTER than this ground and a hover that
+   * brightens the row it is on collides with the active row's plate. */
+  --bgSidebar: #e9e9ec;
+  /* A pointer resting on a rail row: one step DOWN from --bgSidebar (1.10:1),
+   * the same direction --bgHover moves off --bgPage. The active row moves the
+   * other way — up to --bgElevated — so the two states cannot be confused. */
+  --bgSidebarHover: #dfdfe4;
+  /* The top strip, which the content scrolls UNDER: the page's own ground,
+   * translucent, with an 8px blur behind it (app/topbar.css). Stated as an
+   * alpha colour rather than a solid because the blur is only visible where the
+   * ground is see-through, and the alpha is what makes the strip show the
+   * content sliding past it. */
+  --bgTopbar: rgba(245, 245, 246, 0.9);
 
   --accent: #0b7a53;
   /* The accent as TEXT, split from the accent as a FILL. They are the same
@@ -68,7 +99,7 @@
      a rectangle accepts typing, and WCAG 1.4.11 therefore asks it for 3:1
      against its background. --borderStrong measures 1.45:1 on white and cannot
      be raised to 3:1 without turning every content divider into a hard rule.
-     Chosen to clear 3:1 against BOTH --bgElevated and --bgPage (3.33 / 3.24),
+     Chosen to clear 3:1 against BOTH --bgElevated and --bgPage (3.33 / 3.06),
      since controls sit on both. */
   --borderControl: #868f89;
 
@@ -304,8 +335,18 @@
   --overlayLight: #ffffff;
   --overlayDark: #000000;
 
-  --shadow-card:
-    0 1px 2px rgba(41, 37, 36, 0.04), 0 4px 16px rgba(41, 37, 36, 0.05);
+  /* ONE layer, and a tight one: a card is separated from the page by its own
+   * lightness (--bgElevated white on the --bgPage grey above), so the shadow's
+   * job is only to say which of the two is in front. The two-layer version this
+   * replaces was carrying the separation on its own, because the page it sat on
+   * was also white — a 16px ambient wash under every card, on every screen,
+   * which read as a product of soft floating tiles rather than of surfaces. The
+   * negative spread is what keeps the shadow narrower than the card: it hugs the
+   * bottom edge instead of haloing all four.
+   *
+   * Read by every panel and card in the tree through this one token, so the
+   * elevation of a card is not a decision any screen gets to make. */
+  --shadow-card: 0 2px 4px -1px #0000000f;
   --shadow-pop: 0 8px 30px rgba(41, 37, 36, 0.14);
 
   /*
@@ -403,11 +444,23 @@
   --bgElevated: #142420;
   --bgCard: #1a2c26;
   --bgHover: #1f332c;
-  /* The dark theme's page is already darker than its cards, so the sidebar
-     keeps the elevated ground it has always had here — the light theme is the
-     one whose two surfaces swapped. */
-  --bgSidebar: #142420;
-  --bgTopbar: rgba(20, 36, 32, 0.9);
+  /* The same RELATION the light theme states, mirrored rather than copied: the
+     sidebar is one step off the page in the direction away from the elevated
+     surface, so the chrome recedes in both themes. Dark is where that means
+     DARKER than the page — the light theme's #e9e9ec against #f5f5f6 measures
+     1.11:1, and this pair measures 1.09:1, which is the same step a reader
+     sees. It used to be the elevated ground, which put the frame in FRONT of
+     what it frames. */
+  --bgSidebar: #06100d;
+  /* Up off the sidebar, not down: on a dark ground the room only has one
+     direction to go, so hover lifts (1.11:1) and the active row lifts further,
+     all the way to --bgElevated. The ORDER is what carries the state, and it is
+     the same order in both themes. */
+  --bgSidebarHover: #0f1d18;
+  /* The page's own ground, translucent — the light theme's rule, in this
+     theme's page colour. It used to be the ELEVATED ground, which made the
+     strip read as a card laid over the top of the window. */
+  --bgTopbar: rgba(14, 27, 22, 0.9);
 
   --accent: #16a34a;
   /* --textOnAccent stays light in dark mode: it is the shared ink for every
@@ -469,13 +522,15 @@
      control boundary, held to the same 1.4.11 floor. */
   --borderControl: #5f7a6e;
 
-  /* Themed, because the light values are a 4-5% WARM BLACK — invisible on
-     #0e1b16. Any card whose separation depends on its shadow simply lost its
-     edge in dark, and the login surface's brand pane is exactly that case: its
-     fill sits within a couple of ΔE of the pane behind it, so with no shadow the
-     two-pane split had no visible boundary at all. Pure black at a much higher
-     alpha is what reads on a dark surface. */
-  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 16px rgba(0, 0, 0, 0.36);
+  /* Themed, because the light value is a 6% black — invisible on #0e1b16. Any
+     card whose separation depends on its shadow simply lost its edge in dark,
+     and the login surface's brand pane is exactly that case: its fill sits
+     within a couple of ΔE of the pane behind it, so with no shadow the two-pane
+     split had no visible boundary at all. The GEOMETRY is the light theme's,
+     because a card sits the same distance off the page in either theme; only the
+     alpha is a theme's decision, and on a dark ground it has to be most of the
+     way to opaque to read at all. */
+  --shadow-card: 0 2px 4px -1px rgba(0, 0, 0, 0.5);
   --shadow-pop: 0 8px 30px rgba(0, 0, 0, 0.55);
 
   /* higher alpha so the teal read-pill fill stays legible on the darker card
@@ -525,8 +580,9 @@
     --bgElevated: #142420;
     --bgCard: #1a2c26;
     --bgHover: #1f332c;
-    --bgSidebar: #142420;
-    --bgTopbar: rgba(20, 36, 32, 0.9);
+    --bgSidebar: #06100d;
+    --bgSidebarHover: #0f1d18;
+    --bgTopbar: rgba(14, 27, 22, 0.9);
 
     --accent: #16a34a;
 
@@ -563,7 +619,7 @@
 
     --borderControl: #5f7a6e;
 
-    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 16px rgba(0, 0, 0, 0.36);
+    --shadow-card: 0 2px 4px -1px rgba(0, 0, 0, 0.5);
     --shadow-pop: 0 8px 30px rgba(0, 0, 0, 0.55);
 
     --tealLight: rgba(14, 116, 144, 0.28);

--- a/frontend/src/design-system/tokens.test.ts
+++ b/frontend/src/design-system/tokens.test.ts
@@ -355,7 +355,7 @@ describe("Ledger-Green token layer (B-EP09.1)", () => {
         "--bgCard": prose,
         "--bgHover": prose,
         "--bgSidebar": prose,
-        "--bgSidebarHover": ["--textPrimary", "--textContent"],
+        "--bgSidebarHover": ["--textPrimary", "--textContent", "--accentText"],
       };
       const failures: string[] = [];
       for (const [theme, pal] of [

--- a/frontend/src/design-system/tokens.test.ts
+++ b/frontend/src/design-system/tokens.test.ts
@@ -231,8 +231,10 @@ describe("Ledger-Green token layer (B-EP09.1)", () => {
         return [r, g, b, 1];
       }
       const inside = v.match(/rgba?\(([^)]+)\)/);
-      expect(inside, `${value} is neither a hex nor an rgb()`).not.toBeNull();
-      const parts = (inside as RegExpMatchArray)[1]
+      if (!inside) {
+        throw new Error(`${value} is neither a hex nor an rgb()`);
+      }
+      const parts = inside[1]
         .replace(/\//g, ",")
         .split(",")
         .map((n) => Number.parseFloat(n.trim()));

--- a/frontend/src/design-system/tokens.test.ts
+++ b/frontend/src/design-system/tokens.test.ts
@@ -22,16 +22,20 @@ const tokenDecls = tokensCss.replace(/\/\*[\s\S]*?\*\//g, "");
 // Values verbatim from the mockups; comparison normalizes case, whitespace and
 // a leading zero before a decimal point so formatting is free but values are not.
 //
-// --bgPage is the ONE value that no longer matches the mockup, and deliberately:
-// the page is white and the near-white the mockup put here is the sidebar's
-// ground (--bgSidebar). The two surfaces swapped, the decision is the shipped
-// one, and this table is what pins it now that the mockup does not.
+// The SURFACE rungs are the values that no longer match the mockup, and
+// deliberately: the grounds are neutral grey and the green lives in the accent,
+// the states and the status families. A tinted ground casts every neutral above
+// it toward the same hue and reads as a business tool from two decades ago,
+// which is a thing a whole application does rather than one surface. The hue
+// therefore stays where it is a decision a reader is meant to see. The mockups
+// are retired on these five; this table is what pins them in their place, and
+// tokens.css carries the ladder and the contrast steps in prose.
 const canonical: Record<string, string> = {
-  "--bgPage": "#ffffff",
-  "--bgSidebar": "#FBFCFB",
+  "--bgPage": "#f5f5f6",
+  "--bgSidebar": "#e9e9ec",
   "--bgElevated": "#ffffff",
-  "--bgCard": "#EEF1F0",
-  "--bgHover": "#F3F6F4",
+  "--bgCard": "#eaeaee",
+  "--bgHover": "#ededf0",
   "--accent": "#0B7A53",
   "--accentLight": "rgba(11,122,83,.09)",
   "--accentMed": "rgba(11,122,83,.17)",

--- a/frontend/src/design-system/tokens.test.ts
+++ b/frontend/src/design-system/tokens.test.ts
@@ -41,7 +41,7 @@ const canonical: Record<string, string> = {
   "--accentMed": "rgba(11,122,83,.17)",
   "--textPrimary": "#15201B",
   "--textContent": "#36433D",
-  "--textSecondary": "#68756E",
+  "--textSecondary": "#5f6a64",
   "--textTertiary": "#9AA6A0",
   "--textMuted": "#CBD2CD",
   "--textMeta": "#5E6C65",
@@ -175,6 +175,278 @@ describe("Ledger-Green token layer (B-EP09.1)", () => {
 
   it("keeps brand emerald and success grass-green tonally distinct (§2)", () => {
     expect(normalize(light["--accent"])).not.toBe(normalize(light["--online"]));
+  });
+
+  // The surface ladder is a set of RELATIONS, not five independent colours, and
+  // every one of them is load-bearing: the rail recedes below the page, a card
+  // rises above it, a rail row's hover moves AWAY from the plate its active
+  // sibling wears. A retune that keeps all five values plausible and inverts one
+  // pair breaks a state the eye reads without breaking anything a value test can
+  // see — hover and active becoming the same gesture, or chrome climbing in
+  // front of the content it frames. So the ordering is asserted rather than the
+  // values, in BOTH themes, from the sheet itself.
+  //
+  // Dark is not a mirror of light and must not be asserted as one: on a dark
+  // ground every surface lifts toward the light, so the ladder runs the other
+  // way and only the DIRECTION of each step is shared. Each theme therefore
+  // states its own expected order, and both are checked the same way.
+  describe("the surface ladder holds its order", () => {
+    // Relative luminance, WCAG 2.x §relativeluminancedef. Hex only, which is
+    // what every rung on this ladder is — an alpha colour has no luminance of
+    // its own, and none of these is one.
+    function luminance(hex: string): number {
+      const h = hex.trim().replace("#", "");
+      const full =
+        h.length === 3
+          ? h
+              .split("")
+              .map((d) => d + d)
+              .join("")
+          : h;
+      expect(full, `${hex} is not a 3- or 6-digit hex`).toHaveLength(6);
+      const [r, g, b] = [0, 2, 4].map((i) => {
+        const c = Number.parseInt(full.slice(i, i + 2), 16) / 255;
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+      });
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    }
+
+    // A token's channels, whether it is written as a hex or as an rgba(). The
+    // alpha comes back too, because a tint's alpha is the whole reason the
+    // composite tests below exist.
+    function channels(value: string): [number, number, number, number] {
+      const v = value.trim();
+      if (v.startsWith("#")) {
+        const h = v.slice(1);
+        const full =
+          h.length === 3
+            ? h
+                .split("")
+                .map((d) => d + d)
+                .join("")
+            : h.slice(0, 6);
+        const [r, g, b] = [0, 2, 4].map((i) =>
+          Number.parseInt(full.slice(i, i + 2), 16),
+        );
+        return [r, g, b, 1];
+      }
+      const inside = v.match(/rgba?\(([^)]+)\)/);
+      expect(inside, `${value} is neither a hex nor an rgb()`).not.toBeNull();
+      const parts = (inside as RegExpMatchArray)[1]
+        .replace(/\//g, ",")
+        .split(",")
+        .map((n) => Number.parseFloat(n.trim()));
+      return [parts[0], parts[1], parts[2], parts[3] ?? 1];
+    }
+
+    // Source-over, the compositing every alpha tint in this file goes through
+    // when a browser paints it on a ground.
+    function composite(fg: string, bg: string): string {
+      const [r, g, b, a] = channels(fg);
+      const [br, bg_, bb] = channels(bg);
+      const mix = [
+        r * a + br * (1 - a),
+        g * a + bg_ * (1 - a),
+        b * a + bb * (1 - a),
+      ].map((n) => Math.round(n));
+      return `rgb(${mix.join(", ")})`;
+    }
+
+    function contrastOf(fg: string, bg: string): number {
+      // Text is opaque in every role measured here; a ground never is not.
+      const lf = luminanceOf(fg);
+      const lb = luminanceOf(bg);
+      const [hi, lo] = lf > lb ? [lf, lb] : [lb, lf];
+      return (hi + 0.05) / (lo + 0.05);
+    }
+
+    function luminanceOf(value: string): number {
+      const [r, g, b] = channels(value);
+      const [lr, lg, lb] = [r, g, b].map((n) => {
+        const c = n / 255;
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+      });
+      return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+    }
+
+    // Darkest first, as measured. The two themes are deliberately DIFFERENT
+    // sequences: light recesses the rail's hover below its ground while dark
+    // lifts it above, because a dark surface has only one direction to move in.
+    // What both share is the invariant the rail's states depend on — hover on
+    // one side of the rail's ground and the active plate (--bgElevated) on the
+    // other, so the two states never converge.
+    const ladders = {
+      light: [
+        "--bgSidebarHover",
+        "--bgSidebar",
+        "--bgCard",
+        "--bgHover",
+        "--bgPage",
+        "--bgElevated",
+      ],
+      dark: [
+        "--bgSidebar",
+        "--bgSidebarHover",
+        "--bgPage",
+        "--bgElevated",
+        "--bgCard",
+        "--bgHover",
+      ],
+    };
+
+    for (const [theme, rungs] of Object.entries(ladders)) {
+      it(`${theme}: each rung is strictly lighter than the one below it`, () => {
+        const block =
+          theme === "light"
+            ? light
+            : { ...light, ...parseBlock(tokenDecls, '[data-theme="dark"]') };
+        const measured = rungs.map((name) => {
+          expect(block[name], `${name} missing`).toBeDefined();
+          return { name, l: luminance(block[name]) };
+        });
+        for (let i = 1; i < measured.length; i += 1) {
+          const below = measured[i - 1];
+          const above = measured[i];
+          expect(
+            above.l,
+            `${above.name} (${block[above.name]}) must be lighter than ` +
+              `${below.name} (${block[below.name]}) — the ladder inverted`,
+          ).toBeGreaterThan(below.l);
+        }
+      });
+    }
+
+    // The lesson that produced this whole block, as a gate. Darkening the
+    // grounds by a few percent dropped SEVENTEEN text/ground pairs under
+    // 4.5:1 — and the tokens themselves all still looked reasonable in
+    // isolation, because a contrast failure is never in a value, it is in a
+    // pair. axe on the e2e routes caught two of the seventeen, which is what a
+    // route sample can do: it sees the combinations those pages happened to
+    // render. This derives the obligation from the palette instead, so the next
+    // person who retunes a ground finds out here rather than from a user.
+    //
+    // Only TEXT roles, and only against grounds they can actually sit on.
+    // --textTertiary is deliberately not in the list: it is a decorative tone
+    // that never carries prose, and holding it to 4.5:1 would make it
+    // --textSecondary.
+    it("every text role clears AA on every ground it sits on, both themes", () => {
+      const dark = {
+        ...light,
+        ...parseBlock(tokenDecls, '[data-theme="dark"]'),
+      };
+      const prose = [
+        "--textPrimary",
+        "--textContent",
+        "--textSecondary",
+        "--textMeta",
+        "--accentText",
+        "--tealText",
+      ];
+      // Per ground, the roles that can actually be read on it — not a cross
+      // product. The two rungs that carry less than everything are the reason
+      // this is a map: a hovered RAIL row sets its own ink to --textPrimary
+      // (app/shell.css), so the mid-tones never land on --bgSidebarHover, and
+      // asserting they do would force that rung lighter than the rail it has to
+      // stay darker than. The rail's static ground does carry mid-tone prose —
+      // group headings, the entitlement row — so it is held to everything.
+      const carries: Record<string, string[]> = {
+        "--bgPage": prose,
+        "--bgElevated": prose,
+        "--bgCard": prose,
+        "--bgHover": prose,
+        "--bgSidebar": prose,
+        "--bgSidebarHover": ["--textPrimary", "--textContent"],
+      };
+      const failures: string[] = [];
+      for (const [theme, pal] of [
+        ["light", light],
+        ["dark", dark],
+      ] as const) {
+        for (const [ground, roles] of Object.entries(carries)) {
+          for (const role of roles) {
+            const ratio = contrastOf(pal[role], pal[ground]);
+            if (ratio < 4.5) {
+              failures.push(
+                `${theme}: ${role} (${pal[role]}) on ${ground} ` +
+                  `(${pal[ground]}) = ${ratio.toFixed(2)}:1, needs 4.5:1`,
+              );
+            }
+          }
+        }
+      }
+      expect(failures.join("\n")).toBe("");
+    });
+
+    // An alpha tint has no ground of its own: --accentLight over the page and
+    // the same tint over a card are two different colours behind the same text,
+    // and the second one is always the worse. So each tinted pair is measured
+    // COMPOSITED, over every ground the tint can be painted on.
+    //
+    // The rail is exempt at 4.5 and held to 3:1 instead: the only things wearing
+    // an accent tint on the rail are a 26px figure and a glyph, which is where
+    // 1.4.3's large-text allowance and 1.4.11's non-text floor apply.
+    it("tinted chips clear AA over every ground they composite on", () => {
+      const dark = {
+        ...light,
+        ...parseBlock(tokenDecls, '[data-theme="dark"]'),
+      };
+      const pairs = [
+        ["--accentText", "--accentLight"],
+        ["--tealText", "--tealLight"],
+        ["--aiText", "--aiLight"],
+      ] as const;
+      const grounds = ["--bgPage", "--bgElevated", "--bgCard", "--bgHover"];
+      const failures: string[] = [];
+      for (const [theme, pal] of [
+        ["light", light],
+        ["dark", dark],
+      ] as const) {
+        for (const [role, tint] of pairs) {
+          for (const ground of grounds) {
+            const behind = composite(pal[tint], pal[ground]);
+            const ratio = contrastOf(pal[role], behind);
+            if (ratio < 4.5) {
+              failures.push(
+                `${theme}: ${role} (${pal[role]}) on ${tint} over ${ground} ` +
+                  `= ${behind} = ${ratio.toFixed(2)}:1, needs 4.5:1`,
+              );
+            }
+          }
+          const onRail = composite(pal[tint], pal["--bgSidebar"]);
+          const railRatio = contrastOf(pal[role], onRail);
+          if (railRatio < 3) {
+            failures.push(
+              `${theme}: ${role} on ${tint} over --bgSidebar = ` +
+                `${railRatio.toFixed(2)}:1, needs 3:1 (large text / glyph)`,
+            );
+          }
+        }
+      }
+      expect(failures.join("\n")).toBe("");
+    });
+
+    // The rail's hover and its active plate are the pair a reader actually
+    // decodes, so the step between them is asserted as a MAGNITUDE and not only
+    // as an order: two rungs one hair apart pass an ordering test and look
+    // identical on a screen. 1.1:1 is the floor the ladder's own prose claims.
+    for (const theme of ["light", "dark"] as const) {
+      it(`${theme}: hover and the active plate are visibly apart`, () => {
+        const block =
+          theme === "light"
+            ? light
+            : { ...light, ...parseBlock(tokenDecls, '[data-theme="dark"]') };
+        const contrast = (a: string, b: string) => {
+          const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+          return (hi + 0.05) / (lo + 0.05);
+        };
+        expect(
+          contrast(block["--bgSidebarHover"], block["--bgElevated"]),
+        ).toBeGreaterThan(1.1);
+        expect(
+          contrast(block["--bgSidebarHover"], block["--bgSidebar"]),
+        ).toBeGreaterThan(1.05);
+      });
+    }
   });
 
   // The material overlays are the ONLY non-canon literals in this file, and they

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -716,9 +716,10 @@
 /* --borderControl, and for the same reason a field's outline reads a visible
    token: this chip's
    fill is one step off the pane it sits on (--bgCard over --bgElevated measures
-   1.10:1 in both themes), so the border is the only thing that makes it a chip at
-   all. --borderSubtle cannot carry that — it measures 1.24:1 against the pane and
-   1.13:1 against this fill, invisible in all three postures the line can report.
+   1.20:1 light / 1.10:1 dark), so the border is the only thing that makes it a
+   chip at all. --borderSubtle cannot carry that — it measures 1.24:1 against the
+   pane and 1.03:1 against this fill, invisible in all three postures the line
+   can report.
    A boundary nobody can see is not one; 1.4.11 asks 3:1, and this token measures
    3.33:1 light / 3.32:1 dark here. */
 .auth-runtime-state {


### PR DESCRIPTION
Four requested chrome changes, plus the contrast work they turned out to require.

## The four tasks

**1 — `.rail` ground.** `--bgSidebar` `#fbfcfb` → **`#e9e9ec`**. The rail now sits a step *below* the page it frames instead of above it, so the chrome recedes. Dark pendant **`#06100d`** (was `#142420`, the *elevated* ground — which put the frame in front of what it frames). The light pair measures 1.11:1 and the dark pair 1.09:1: the same step a reader sees. The phone bottom bar restates `--bgElevated`, so it stays **white** — there the rail is a card lying on the content, not the application's left edge.

**2 — `.app` ground and the top strip.** `--bgPage` `#ffffff` → **`#f5f5f6`**; dark unchanged at `#0e1b16`. `--bgTopbar` follows it — `rgba(245,245,246,.9)` light, `rgba(14,27,22,.9)` dark — with the `0.9` alpha and `backdrop-filter: blur(8px)` untouched.

**3 — the current nav row.** `--accentLight` tint → **`--bgElevated`** plus the `--borderSubtle` hairline every card draws; `min-height` 34px → **36px**. The plate is the top of the same ladder a card sits on, so the rail's surfaces and the content's are one system instead of two. Dark needed no new value: `--bgElevated` is `#142420` there, 1.20:1 against the new dark rail, against 1.21:1 for the light pair.

**4 — the card shadow.** `--shadow-card` → **`0 2px 4px -1px #0000000f`**, one tight layer; dark `0 2px 4px -1px rgba(0,0,0,.5)`. Every panel and card reads it through the one token. The two-layer version it replaces was carrying a card's separation by itself because the page under it was also white; now the card's own lightness does that and the shadow only says which surface is in front.

## What the change turned out to cost, and how it is paid

Darkening the grounds took **17 text/ground pairs under the 4.5:1 AA floor**. A contrast failure never lives in a value, it lives in a pair — every one of these tokens still looked reasonable on its own. `make frontend-e2e`'s axe sweep caught 2 of the 17, which is what a route sample can do: it sees the combinations those pages happen to render.

So the three mid-tone **text** roles move with the grounds:

| token | was | now | why |
|---|---|---|---|
| `--textSecondary` | `#68756e` | `#5f6a64` | 4.42:1 on the page, 3.98:1 on the rail. Body text on every rung; 4.64:1 at its worst ground now. |
| `--accentText` | `#0b7a53` | `#0a6f4b` | Sits on the `--accentLight` *alpha tint*, so what is behind the tint decides what it is read against. The home glance count chip measured 4.36:1 at 15px. 5.04:1 now. |
| `--tealText` | `#0e7490` | `#0d6882` | Same shape, same reason (the read-access pill on `--tealLight`): 4.30:1 → 5.08:1. |

The fills (`--accent`, `--teal`) do not move — that split is exactly why `--accentText` and `--tealText` exist, and light now diverges from the fill for the reason dark already did.

Then the obligation is **derived rather than re-checked by hand** (`tokens.test.ts`, +294 lines):

- **every text role against every ground it can sit on**, both themes;
- **every tinted chip composited over every ground it can be painted on** — an alpha tint has no ground of its own, and the composite is always the worse case;
- **the surface ladder's ordering**, per theme, because dark is not light mirrored;
- **hover vs. the active plate as a magnitude**, not just an order — two rungs one hair apart pass an ordering test and look identical on screen.

That last test **caught two of my own errors** before review: a light ladder I had declared in the wrong order, and a dark `--bgSidebarHover` (`#0f1d18`) that read 1.08:1 against the active plate — a correct ordering nobody could see. It is `#0c1814` now, 1.13:1.

## The rail's hover, streamlined

The settings **Back** control carries `navitem` as well as `navback`, so `.rail .navitem:hover` already reached it — and then a rule of its own restated that hover as `--bgHover`, which is *lighter* than the sidebar's ground. Under a pointer it was the one thing in the panel that brightened while every row beside it darkened.

The second spelling is what let the two disagree, so it is **removed** rather than corrected: `.rail .navitem:hover` is the only writer now, and the resting `--bgCard` ground is unchanged. Verified in the browser at `#/settings` in light mode — both the Back control and a destination row resolve to the same single rule, `.rail .navitem:hover -> var(--bgSidebarHover)`.

## Decisions worth reviewing

- **The geometry, not the number, is what holds the row still.** The 36px floor is on *every* `.rail .navitem`, not on `.active` — an active-only floor makes the current row 2px taller than its neighbours and reflows the column on every navigation. Same reason the 1px edge is `transparent` at every state and only *coloured* by `.active`, with padding dropped 14px → 13px to absorb it: `1 + 13 + 18 + 13 + 1 = 46`, so no glyph moves when a row becomes current. Verified in the browser: item box 47×36, icon at x=22 in the collapsed rail, exactly where it sat before.
- **Hover had to move.** `--bgHover` is *lighter* than the new rail ground, so it would have brightened a row *toward* the active plate. New `--bgSidebarHover` moves the opposite way from `.active` in both themes.
- **Three signals intact.** The plate's lift is ~1.2:1 — visible, but not a state-carrier on its own (WCAG 1.4.1 Level A). Semibold and the `--accentText` glyph are unchanged; the hairline is the third.
- **The ground map in the AA test is per-rung, not a cross product.** A hovered rail row sets its own ink to `--textPrimary`, so the mid-tones never land on `--bgSidebarHover`; asserting they do would force that rung lighter than the rail it has to stay darker than.

## Fixed along the way

- **`--bgCard`** lifted out of the green (`#eef1f0` → `#eaeaee`) — at its old value on a `#f5f5f6` page it was invisible as a surface. Now one step off *both* its hosts (1.20:1 on `--bgElevated`, 1.10:1 on `--bgPage`) where before it was one step off white only.
- **`--bgHover`** de-greened (`#f3f6f4` → `#ededf0`); at its old value it measured 1.00:1 against the new page — no hover at all on anything sitting on the page.
- **`--borderControl`**'s comment claimed 3.24:1 against `--bgPage`; on the grey page it is **3.06:1**, still clearing the 1.4.11 floor. Corrected rather than left to rot.
- **`app/topbar.css`** opened by saying the strip "stands on the SAME ground as the sidebar (`--bgElevated`)" — false before this change (it reads `--bgTopbar`) and wronger after. Rewritten to state the rule that now holds.
- **`screens/auth.css`**'s runtime chip carried the `--bgCard`-over-`--bgElevated` ratio as 1.10:1 in both themes; it is 1.20:1 light / 1.10:1 dark now. Its argument (the border is the only thing making it a chip) is unchanged.
- **`tokens.test.ts`**'s canonical map and the prose above it, which claimed the mockups were the source of truth for these five and that `--bgPage` was the single deliberate divergence.

## Verification

| gate | verdict |
|---|---|
| `make frontend-check` | **pass** (ds-gates, drift, lint, 388 files / 4891 tests, build) |
| `make frontend-e2e` | **pass** — 130 passed, axe clean on every route in **both** themes |
| `make native-controls` | **pass** — 35 tests |
| `make check` | **pass** after rebasing onto `origin/main` — see the note below |
| `make fe-uat` | **empty scope** — see the note below |
| `make fe-clock-drift` | not run: no test in this diff reads a date |

Verified by hand in Chrome against the seeded stack, logged in, light and dark, desktop and phone width: computed values read `--bgSidebar #e9e9ec`, `--bgPage #f5f5f6`, `--bgTopbar rgba(245,245,246,.9)` with `blur(8px)`, active plate `#fff` + `#e5e9e7` border at exactly 36px with all rows uniform, panel shadow `rgba(0,0,0,.06) 0 2px 4px -1px`, and the **phone bar white** (`rgb(255,255,255)`) with an accent-tinted active cell. Keyboard path walked: `Tab` reaches each row, `:focus-visible` matches, ring is `2px solid #0b7a53` at `-2px` offset. Console carries only a pre-existing `EmbedReindexStatus` 501 and a dev `VITE_UI_PREVIEW_TASKBAR` warning, neither touched by this diff.

### Two honest gaps

**`make fe-uat` reports "diff touches no component/story (empty scope)".** It scopes on changed `.tsx`/`.stories.tsx` and maps them to covering stories, so a **CSS/token-only diff is invisible to it** — the one change class that repaints every surface in the product gets no render gate at all. I got the visual receipt by driving fe-uat's own harness (`scripts/lib/storybook-harness.mjs`) over 108 shell/topbar/panel/statstrip/home stories × 2 themes × 2 viewports: no render or console errors. A real fix — mapping a changed `*.css` to the stories covering its co-located component, and treating `tokens.css` / `app/*.css` as tree-wide — is a change to the gate rather than to this diff, so it is written up here rather than half-done.

**`make check` failed on `origin/main`'s own drift, not on this diff.** At my branch point (`2214b4b7`) `TestTheGateInventoryPageIsCurrent` already failed — confirmed by running it in a clean worktree at that commit. `origin/main` had since landed #2788 for exactly that, so the branch is rebased onto current main and the gate passes. Separately, `make check`'s `lint-modules` first reported `G404` in `.tmp/worktrees/dco-signoff/extensions/yogi/yogi.go`, a path that no longer exists — a stale golangci-lint cache entry, cleared with `golangci-lint cache clean`.

`fe-unit` also produced 10–11 `Failed to start forks worker` timeouts on two runs with my dev stack and a Chrome instance up, and **zero assertion failures**; standalone on a quiet machine it is 388 files / 4891 tests green. Reported rather than ignored, per `frontend/AGENTS.md`'s own warning about reading these as load problems.

## Proposal, not done here

`--borderSubtle` (`#e5e9e7`) and `--borderStrong` (`#d2d8d4`) are still green-tinted, and on the `#e9e9ec` rail the right-hand hairline has nearly stopped being visible. De-greening the border family touches every divider, card edge and table rule in the tree — wider than these four tasks name, and it wants its own visual pass. Worth its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined navigation spacing, hover states, and active-state styling across desktop and mobile layouts.
  * Improved light and dark theme colors, contrast, borders, surface layering, and card shadows.
  * Updated top-bar and authentication styling documentation to reflect current theme behavior.

* **Tests**
  * Expanded theme and accessibility coverage, including surface contrast, transparency, color readability, visual separation, and WCAG AA validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->