### PR TITLE
fix(capture): a Google app set in Settings can actually connect Gmail

### DIFF
--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -76,7 +76,7 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 		ClientID:     cfg.graphClientID,
 		ClientSecret: cfg.graphClientSecret,
 		Tenant:       cfg.graphTenant,
-	}, cfg.captureConfig).WithSyncInterval(cfg.gmailSyncInterval)
+	}, cfg.captureConfig, logger).WithSyncInterval(cfg.gmailSyncInterval)
 	watchCfg := gmailWatchConfig(cfg, cfg.gmailAppWired())
 	configuredVault := vault
 	if !vaultConfigured {

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -304,12 +304,40 @@ func newGcalOAuth(c GmailConfig) gcal.OAuth {
 // can resolve each by name. A deployment without the app configured gets a
 // plain registry (both absent by omission). Returns nil only if pool is nil.
 func NewCaptureRegistryWithGmail(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, cfg CaptureConfig) *capture.Registry {
+	return newCaptureRegistryWithGoogle(pool, vault, nil, c, cfg)
+}
+
+// newCaptureRegistryWithGoogle registers the Google connectors where the app
+// can be resolved from EITHER source: the stored setting this installation
+// wrote, or the pair the deployment composed.
+//
+// The registration used to require the environment's pair, which made the
+// stored app unusable rather than merely unread: the transport asks the
+// registry whether a connector exists before it will run the consent flow, so
+// an installation that set its app through Settings was sent to the declared
+// 501 and had no way to connect Gmail at all. A resolver is enough to register
+// on, because the connector resolves the app when it uses it.
+func newCaptureRegistryWithGoogle(
+	pool *pgxpool.Pool,
+	vault keyvault.Vault,
+	resolve googleAppResolver,
+	c GmailConfig,
+	cfg CaptureConfig,
+) *capture.Registry {
 	reg := NewCaptureRegistry(pool, vault, cfg)
-	if c.canSync() {
-		reg.Register(gmail.New(newGmailOAuth(c), gmail.NewAPI(nil, "")))
-		reg.Register(gcal.New(newGcalOAuth(c), gcal.NewAPI(nil, "")))
+	if googleAppReachable(resolve, c) {
+		reg.Register(gmail.New(newGmailAuthorizer(resolve, c), gmail.NewAPI(nil, "")))
+		reg.Register(gcal.New(newGcalAuthorizer(resolve, c), gcal.NewAPI(nil, "")))
 	}
 	return reg
+}
+
+// googleAppReachable reports whether anything in this composition could supply
+// the Google app. Registering on neither would leave a connector that fails
+// every call with "no app configured", which is a worse answer than the
+// declared 501: it looks configured and is not.
+func googleAppReachable(resolve googleAppResolver, c GmailConfig) bool {
+	return resolve != nil || c.canSync()
 }
 
 // GmailPollRegistry returns a Google-registered capture registry for the
@@ -327,13 +355,12 @@ func GmailPollRegistry(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, 
 // the standing IMAP connector needs no deployment config — with the gmail
 // and graph connectors added when their OAuth apps are configured. A provider
 // nobody registered simply never appears in the dispatcher's provider list.
-func CaptureSyncRegistry(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, g GraphConfig, cfg CaptureConfig) *capture.Registry {
-	var reg *capture.Registry
-	if c.canSync() {
-		reg = NewCaptureRegistryWithGmail(pool, vault, c, cfg)
-	} else {
-		reg = NewCaptureRegistry(pool, vault, cfg)
-	}
+func CaptureSyncRegistry(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, g GraphConfig, cfg CaptureConfig, log *slog.Logger) *capture.Registry {
+	// The worker resolves the STORED app exactly as the api does. Without this
+	// a mailbox connected against a stored app would connect and then never
+	// sync: the poll would find no Google connector registered and skip it
+	// silently, which reads as an empty inbox rather than as a broken one.
+	reg := newCaptureRegistryWithGoogle(pool, vault, newGoogleAppResolver(pool, vault, log), c, cfg)
 	if g.canSync() {
 		reg.Register(graph.New(newGraphOAuth(g), graph.NewAPI(nil, "")))
 	}
@@ -386,7 +413,7 @@ func WithGmailCapture(c GmailConfig, cfg CaptureConfig) Option {
 			gmailOAuth, gcalOAuth = newGmailOAuth(c), newGcalOAuth(c)
 		}
 		s.connectorHandlers = connectorHandlers{
-			registry:      NewCaptureRegistryWithGmail(pool, s.vault, c, cfg),
+			registry:      newCaptureRegistryWithGoogle(pool, s.vault, s.googleAppResolver, c, cfg),
 			authority:     identity.NewService(pool),
 			oauth:         gmailOAuth,
 			gmailAPI:      gmail.NewAPI(nil, ""),

--- a/backend/internal/compose/capture_wiring_test.go
+++ b/backend/internal/compose/capture_wiring_test.go
@@ -81,7 +81,7 @@ func TestCoreChannelProvidersEnumeratesEveryComposedCoreTransport(t *testing.T) 
 	richest := CaptureSyncRegistry(nil, nil,
 		GmailConfig{ClientID: "id", ClientSecret: "secret"},
 		GraphConfig{ClientID: "id", ClientSecret: "secret"},
-		CaptureConfig{}).ChannelProviders()
+		CaptureConfig{}, nil).ChannelProviders()
 	if !slices.Equal(enumerated, richest) {
 		t.Errorf("the fully-composed registry supplies transports %v, but the boot step would register %v — "+
 			"a transport the boot step cannot see is one no captured message may name",

--- a/backend/internal/compose/connectors_graph_test.go
+++ b/backend/internal/compose/connectors_graph_test.go
@@ -200,13 +200,13 @@ func TestWithGraphCaptureWiresSharesOrSkips(t *testing.T) {
 func TestCaptureSyncRegistryRegistersConfiguredProviders(t *testing.T) {
 	both := CaptureSyncRegistry(nil, nil,
 		GmailConfig{ClientID: "id", ClientSecret: "sec"},
-		GraphConfig{ClientID: "ms-id", ClientSecret: "ms-sec"}, CaptureConfig{})
+		GraphConfig{ClientID: "ms-id", ClientSecret: "ms-sec"}, CaptureConfig{}, nil)
 	names := registeredNames(both.Connectors())
 	if !names["imap"] || !names["gmail"] || !names["graph"] {
 		t.Errorf("connectors = %v, want imap+gmail+graph", names)
 	}
 
-	bare := CaptureSyncRegistry(nil, nil, GmailConfig{}, GraphConfig{}, CaptureConfig{})
+	bare := CaptureSyncRegistry(nil, nil, GmailConfig{}, GraphConfig{}, CaptureConfig{}, nil)
 	names = registeredNames(bare.Connectors())
 	if !names["imap"] || names["gmail"] || names["graph"] {
 		t.Errorf("connectors = %v, want imap only when neither app is configured", names)

--- a/backend/internal/compose/googleappauthorizer.go
+++ b/backend/internal/compose/googleappauthorizer.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/gcal"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/googleconn"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/oauthflow"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// googleAppResolver reports the installation's STORED Google app: the pair, and
+// whether there was one to find. Named because three constructions and one
+// Server field all have to spell the same shape, and an unnamed one drifts.
+type googleAppResolver func(ctx context.Context) (clientID, clientSecret string, stored bool, err error)
+
+// errNoGoogleApp is what a connector reports when neither source can supply the
+// installation's Google app. It wraps the shared auth-rejected sentinel so the
+// registry parks the connection instead of retrying a call that cannot start:
+// no amount of backoff produces an app nobody has configured.
+var errNoGoogleApp = fmt.Errorf(
+	"capture: this installation has no Google OAuth app configured; "+
+		"set the client id and secret under Settings, Capture: %w",
+	connector.ErrAuthRejected,
+)
+
+// googleAppAuthorizer performs the token half of the Google handshake against
+// the app the installation is using AT THE MOMENT OF THE CALL.
+//
+// A connector used to hold a client built at boot from the process environment,
+// which is why an app set through Settings could not be connected: the registry
+// registered the Google connectors only where the environment carried the pair,
+// so a stored app reached a transport with no connector behind it and the
+// surface answered its declared 501. Resolving per call is what lets the same
+// connector serve either source, and lets a changed app take effect without a
+// restart.
+//
+// Only Exchange and AccessToken live here. Building a consent URL cannot report
+// an error, so it stays with the transport, which resolves the app itself and
+// builds a concrete client from it.
+type googleAppAuthorizer struct {
+	// resolve reports the stored app; `stored` false means this installation has
+	// none and the environment's app, where there is one, is what to use.
+	resolve func(ctx context.Context) (clientID, clientSecret string, stored bool, err error)
+	// env is the app the deployment composed, or nil where it composed none.
+	env googleconn.Authorizer
+	// build turns a resolved pair into a client for one provider — the one thing
+	// that differs between mail and calendar, which own separate OAuth types and
+	// request separate scopes.
+	build func(clientID, clientSecret string) googleconn.Authorizer
+}
+
+// client resolves the app for this call. A resolution error is returned rather
+// than falling back: a sealed secret that will not open means the vault's root
+// key moved, and quietly connecting with an older environment copy would hide
+// that behind a flow that half works.
+//
+//nolint:ireturn // returns the Authorizer seam by design — the caller holds an interface so tests substitute a stub
+func (a googleAppAuthorizer) client(ctx context.Context) (googleconn.Authorizer, error) {
+	if a.resolve != nil {
+		id, secret, stored, err := a.resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if stored {
+			return a.build(id, secret), nil
+		}
+	}
+	if a.env != nil {
+		return a.env, nil
+	}
+	return nil, errNoGoogleApp
+}
+
+func (a googleAppAuthorizer) Exchange(ctx context.Context, code, redirectURI string) (oauthflow.TokenGrant, error) {
+	c, err := a.client(ctx)
+	if err != nil {
+		return oauthflow.TokenGrant{}, err
+	}
+	return c.Exchange(ctx, code, redirectURI)
+}
+
+func (a googleAppAuthorizer) AccessToken(ctx context.Context, refreshToken string) (string, error) {
+	c, err := a.client(ctx)
+	if err != nil {
+		return "", err
+	}
+	return c.AccessToken(ctx, refreshToken)
+}
+
+// newGmailAuthorizer builds the mail connector's per-call authorizer over the
+// given stored-app resolver, with the environment's app as the fallback.
+func newGmailAuthorizer(resolve googleAppResolver, c GmailConfig) googleAppAuthorizer {
+	var env googleconn.Authorizer
+	if c.canSync() {
+		env = newGmailOAuth(c)
+	}
+	return googleAppAuthorizer{
+		resolve: resolve,
+		env:     env,
+		build: func(id, secret string) googleconn.Authorizer {
+			return gmail.NewOAuth(gmail.OAuthConfig{ClientID: id, ClientSecret: secret, Scopes: gmailScopes})
+		},
+	}
+}
+
+// newGcalAuthorizer is the calendar half of the SAME app. It requests the
+// calendar scope alone, which is why it builds its own client rather than
+// sharing the mail one: a shared credential would accrete the other's grant.
+func newGcalAuthorizer(resolve googleAppResolver, c GmailConfig) googleAppAuthorizer {
+	var env googleconn.Authorizer
+	if c.canSync() {
+		env = newGcalOAuth(c)
+	}
+	return googleAppAuthorizer{
+		resolve: resolve,
+		env:     env,
+		build: func(id, secret string) googleconn.Authorizer {
+			return gcal.NewOAuth(gcal.OAuthConfig{ClientID: id, ClientSecret: secret})
+		},
+	}
+}
+
+// newGoogleAppResolver reads the installation's stored Google app.
+//
+// One constructor for both process roles. The api resolves it to run a person's
+// consent flow and the worker to refresh a token on the sync poll, and those
+// two asking the same question in two hand-written spellings is how they would
+// come to disagree about which Google project this installation is.
+//
+// On a system principal: the caller is usually a rep connecting their own
+// mailbox, who holds no capture grant, and on the worker there is no human
+// caller at all. The installation's own configuration is not the rep's to be
+// entitled to — it is what the server uses to do what they ARE entitled to.
+// Same reasoning the model binding is resolved under, and it keeps the object
+// gate rather than declaring the entry ungated.
+func newGoogleAppResolver(pool *pgxpool.Pool, vault keyvault.Vault, log *slog.Logger) googleAppResolver {
+	if pool == nil || vault == nil {
+		return nil
+	}
+	store := capture.NewGoogleAppStore(NewSettingsStore(pool), vault, log)
+	return googleAppCredentialsFrom(store)
+}
+
+// googleAppCredentialsFrom adapts the store to the resolver shape. Split from
+// the constructor so a test can drive the workspace rule against a store it
+// built itself.
+func googleAppCredentialsFrom(store *capture.GoogleAppStore) googleAppResolver {
+	return func(ctx context.Context) (string, string, bool, error) {
+		ws, ok := principal.WorkspaceID(ctx)
+		if !ok {
+			// No workspace bound is a caller that has not authenticated; the
+			// transport's own gate judges that, and answering "no app" here
+			// would let it read as an unconfigured installation.
+			return "", "", false, nil
+		}
+		return store.Credentials(bootCtx(ctx, ws, googleAppReadActor))
+	}
+}

--- a/backend/internal/compose/googleappauthorizer_test.go
+++ b/backend/internal/compose/googleappauthorizer_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/capture/googleconn"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/oauthflow"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// recordingAuthorizer stands in for a built OAuth client and reports which
+// credentials it was built from, which is the fact every test here turns on.
+type recordingAuthorizer struct {
+	clientID string
+	used     *string
+}
+
+func (r recordingAuthorizer) Exchange(context.Context, string, string) (oauthflow.TokenGrant, error) {
+	*r.used = r.clientID
+	return oauthflow.TokenGrant{RefreshToken: "refresh"}, nil
+}
+
+func (r recordingAuthorizer) AccessToken(context.Context, string) (string, error) {
+	*r.used = r.clientID
+	return "access", nil
+}
+
+// authorizerFor builds the subject with a recording client on each side, so a
+// test can tell WHICH app answered rather than only that something did.
+func authorizerFor(t *testing.T, resolve googleAppResolver, envApp string) (googleAppAuthorizer, *string) {
+	t.Helper()
+	used := new(string)
+	a := googleAppAuthorizer{
+		resolve: resolve,
+		build:   func(id, _ string) googleconn.Authorizer { return recordingAuthorizer{clientID: id, used: used} },
+	}
+	if envApp != "" {
+		a.env = recordingAuthorizer{clientID: envApp, used: used}
+	}
+	return a, used
+}
+
+// What an admin sets through Settings outranks the environment: the environment
+// is how the pair ARRIVES, and the stored app is where it lives.
+func TestTheStoredAppOutranksTheEnvironment(t *testing.T) {
+	a, used := authorizerFor(t, func(context.Context) (string, string, bool, error) {
+		return "stored-id", "stored-secret", true, nil
+	}, "env-id")
+
+	if _, err := a.AccessToken(context.Background(), "refresh"); err != nil {
+		t.Fatalf("AccessToken: %v", err)
+	}
+	if *used != "stored-id" {
+		t.Errorf("refreshed against %q, want the STORED app; the environment is not the authority once an app is set", *used)
+	}
+}
+
+// An installation that never stored one keeps running on what the deployment
+// composed, with no action required of its operator.
+func TestTheEnvironmentStillServesWhenNothingIsStored(t *testing.T) {
+	a, used := authorizerFor(t, func(context.Context) (string, string, bool, error) {
+		return "", "", false, nil
+	}, "env-id")
+
+	if _, err := a.Exchange(context.Background(), "code", "https://app/cb"); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if *used != "env-id" {
+		t.Errorf("exchanged against %q, want the environment's app", *used)
+	}
+}
+
+// A sealed secret that will not open means the vault's root key moved under the
+// installation. Connecting anyway with an older environment copy would hide
+// that behind a flow that half works.
+func TestAResolutionFailureIsReportedNotPaperedOverWithTheEnvironment(t *testing.T) {
+	boom := errors.New("vault: sealed secret will not open")
+	a, used := authorizerFor(t, func(context.Context) (string, string, bool, error) {
+		return "", "", false, boom
+	}, "env-id")
+
+	_, err := a.AccessToken(context.Background(), "refresh")
+	if !errors.Is(err, boom) {
+		t.Fatalf("AccessToken err = %v, want the resolution failure surfaced", err)
+	}
+	if *used != "" {
+		t.Errorf("fell back to %q after a resolution error, hiding a broken vault behind a working-looking flow", *used)
+	}
+}
+
+// With neither source the connector refuses in a way the registry PARKS on: no
+// amount of backoff produces an app nobody configured.
+func TestNoAppAnywhereRefusesAsRejectedRatherThanRetryable(t *testing.T) {
+	a, _ := authorizerFor(t, nil, "")
+
+	_, err := a.AccessToken(context.Background(), "refresh")
+	if !errors.Is(err, connector.ErrAuthRejected) {
+		t.Errorf("AccessToken err = %v, want it to wrap connector.ErrAuthRejected so the connection parks instead of retrying forever", err)
+	}
+}
+
+// The registration rule, asserted through what the registry actually holds.
+//
+// This is the defect the operator hit: the Google connectors were registered
+// only where the ENVIRONMENT carried the pair, and the transport asks the
+// registry whether a connector exists before it will run the consent flow. An
+// installation that set its app through Settings was therefore refused with the
+// declared 501 and had no way to connect Gmail at all.
+func TestAStoredAppRegistersTheGoogleConnectors(t *testing.T) {
+	resolve := googleAppResolver(func(context.Context) (string, string, bool, error) {
+		return "stored-id", "stored-secret", true, nil
+	})
+	for _, c := range []struct {
+		name    string
+		resolve googleAppResolver
+		cfg     GmailConfig
+		want    bool
+	}{
+		{"stored app only", resolve, GmailConfig{}, true},
+		{"environment only", nil, GmailConfig{ClientID: "id", ClientSecret: "sec"}, true},
+		{"both", resolve, GmailConfig{ClientID: "id", ClientSecret: "sec"}, true},
+		{"neither", nil, GmailConfig{}, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := googleAppReachable(c.resolve, c.cfg); got != c.want {
+				t.Errorf("googleAppReachable = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// End to end through the options the api actually applies: an app that exists
+// only in the database has to carry a person all the way to Google's consent
+// screen.
+func TestAStoredAppCanRunTheConsentFlow(t *testing.T) {
+	var s Server
+	s.vault = fakeVault{}
+	WithKeyvault(fakeVault{})(&s, nil)
+	// WithKeyvault builds the real resolver over a nil pool; stand a working one
+	// in its place so this test is about the WIRING, not about the store.
+	s.googleAppResolver = func(context.Context) (string, string, bool, error) {
+		return "stored-id", "stored-secret", true, nil
+	}
+	// Only what a deployment must supply. No client id or secret anywhere in the
+	// environment — the operator's case.
+	WithGmailCapture(GmailConfig{
+		StateKey: "0123456789abcdef0123456789abcdef", PublicBaseURL: "https://app",
+	}, CaptureConfig{})(&s, nil)
+
+	for _, provider := range []string{providerGmail, providerGcal} {
+		t.Run(provider, func(t *testing.T) {
+			if !s.providerWired(provider) {
+				t.Fatalf("%s answers its declared 501 with an app stored; the installation cannot connect it at all", provider)
+			}
+			app, ok, err := s.oauthApp(context.Background(), provider)
+			if err != nil || !ok {
+				t.Fatalf("oauthApp(%s) ok=%v err=%v, want the stored app", provider, ok, err)
+			}
+			url := app.authCodeURL("state", "https://app/cb")
+			if !strings.Contains(url, "stored-id") {
+				t.Errorf("consent URL = %q, want it built from the STORED client id", url)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -231,7 +231,7 @@ type Server struct {
 	// composite literal is one the next literal drops without a word — which is
 	// exactly how this arrived inert the first time. Kept here, each construction
 	// has to name it, and a reader sees the omission.
-	googleAppResolver func(ctx context.Context) (clientID, clientSecret string, ok bool, err error)
+	googleAppResolver googleAppResolver
 
 	// schemaPoolReady is the /readyz schema-pool probe, injected only by
 	// WithSchemaPool — a role that never mounted --schema-dsn declares

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/mailer"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // Option customizes the wiring for one process role; everything not
@@ -205,24 +204,10 @@ func WithKeyvault(vault keyvault.Vault) Option {
 		googleApp := capture.NewGoogleAppStore(NewSettingsStore(pool), vault, s.log)
 		s.googleAppHandlers = googleAppHandlers{store: googleApp}
 		// And the connect transport resolves the STORED app per request, so an
-		// app set through Settings works without restarting the api.
-		//
-		// On a system principal: the caller is usually a rep connecting their own
-		// mailbox, who holds no capture grant, and the installation's own
-		// configuration is not theirs to be entitled to — it is what the server
-		// uses to do what they ARE entitled to. Same reasoning the model binding
-		// is resolved under, and it keeps the object gate rather than declaring
-		// the entry ungated.
-		s.googleAppResolver = func(ctx context.Context) (string, string, bool, error) {
-			ws, ok := principal.WorkspaceID(ctx)
-			if !ok {
-				// No workspace bound is a caller that has not authenticated; the
-				// transport's own gate judges that, and answering "no app" here
-				// would let it read as an unconfigured installation.
-				return "", "", false, nil
-			}
-			return googleApp.Credentials(bootCtx(ctx, ws, googleAppReadActor))
-		}
+		// app set through Settings works without restarting the api. The worker
+		// resolves it the same way for the sync poll's token refresh, which is
+		// why the resolver is built by a shared constructor rather than here.
+		s.googleAppResolver = googleAppCredentialsFrom(googleApp)
 		// And the setup surface, which reads all three. It is wired here rather
 		// than beside the AI block because the Google half only exists once the
 		// vault does — a setup answer composed from two of the three stores

--- a/backend/internal/modules/capture/gcal/gcal.go
+++ b/backend/internal/modules/capture/gcal/gcal.go
@@ -36,13 +36,15 @@ const connectorName = "gcal"
 // never race. (owner is a field only for the pure Normalize surface, which is
 // test-only — Sync never touches it.)
 type Connector struct {
-	oauth OAuth
+	oauth googleconn.Authorizer
 	api   API
 	owner string // used ONLY by Normalize (the test-guarded pure mapping); never set by Sync
 }
 
 // New returns a Calendar connector over the given OAuth + API surfaces.
-func New(oauth OAuth, api API) *Connector { return &Connector{oauth: oauth, api: api} }
+func New(oauth googleconn.Authorizer, api API) *Connector {
+	return &Connector{oauth: oauth, api: api}
+}
 
 var (
 	_ connector.Connector      = (*Connector)(nil)

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -78,9 +78,8 @@ var ErrMessageGone = fmt.Errorf("gmail: message no longer exists: %w", connector
 // authorization code for a refresh token, and mint a fresh access token from
 // a stored refresh token.
 type OAuth interface {
+	googleconn.Authorizer
 	AuthCodeURL(state, redirectURI string) string
-	Exchange(ctx context.Context, code, redirectURI string) (oauthflow.TokenGrant, error)
-	AccessToken(ctx context.Context, refreshToken string) (accessToken string, err error)
 }
 
 // sentLabelID is Gmail's system label for the mailbox owner's own sent mail.

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/modules/capture/googleconn"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/mailmap"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -43,13 +44,15 @@ const (
 // never race. (owner is a field only for the pure Normalize surface, which is
 // test-only — Sync never touches it.)
 type Connector struct {
-	oauth OAuth
+	oauth googleconn.Authorizer
 	api   API
 	owner string // used ONLY by Normalize (the test-guarded pure mapping); never set by Sync
 }
 
 // New returns a Gmail connector over the given OAuth + API surfaces.
-func New(oauth OAuth, api API) *Connector { return &Connector{oauth: oauth, api: api} }
+func New(oauth googleconn.Authorizer, api API) *Connector {
+	return &Connector{oauth: oauth, api: api}
+}
 
 var (
 	_ connector.Connector      = (*Connector)(nil)

--- a/backend/internal/modules/capture/googleconn/googleconn.go
+++ b/backend/internal/modules/capture/googleconn/googleconn.go
@@ -295,7 +295,7 @@ func Descriptor(name string) connector.Descriptor {
 // (the internal-vs-external anchor) and the short-lived access token. A stored
 // bundle we cannot read is a corruption, surfaced as an error rather than
 // silently treated as a fresh connection.
-func Session(ctx context.Context, oauth OAuth, auth connector.Auth) (owner, accessToken string, err error) {
+func Session(ctx context.Context, oauth Authorizer, auth connector.Auth) (owner, accessToken string, err error) {
 	var st AuthState
 	if err := json.Unmarshal(auth, &st); err != nil {
 		return "", "", fmt.Errorf("googleconn: malformed auth state: %w", err)
@@ -307,12 +307,27 @@ func Session(ctx context.Context, oauth OAuth, auth connector.Auth) (owner, acce
 	return st.Owner, access, nil
 }
 
-// OAuth is the OAuth2 handshake surface each Google connector supplies to
-// Authenticate — the same three-method shape gmail and gcal implement.
-type OAuth interface {
-	AuthCodeURL(state, redirectURI string) string
+// Authorizer is the half of the handshake a CONNECTOR performs: trade an
+// authorization code for a grant, and mint an access token from a stored
+// refresh token.
+//
+// Split from OAuth because both of these carry a context and can report an
+// error, which is what lets an implementation resolve the installation's app
+// when the call is made rather than holding a copy from boot. Building the
+// consent URL can do neither — it returns a bare string — so it stays on OAuth,
+// which the transport holds; a connector is handed this narrower half so the
+// type says it cannot start a consent flow.
+type Authorizer interface {
 	Exchange(ctx context.Context, code, redirectURI string) (oauthflow.TokenGrant, error)
 	AccessToken(ctx context.Context, refreshToken string) (accessToken string, err error)
+}
+
+// OAuth is the full handshake surface: an Authorizer that can also send a
+// person to the provider's consent screen. The transport holds this; a
+// connector holds the narrower half.
+type OAuth interface {
+	Authorizer
+	AuthCodeURL(state, redirectURI string) string
 }
 
 // AuthState is the persisted credential bundle (the opaque connector.Auth). The
@@ -368,7 +383,7 @@ type OwnerResolver func(ctx context.Context, accessToken string) (string, error)
 // connector's declared scopes, frozen into the bundle; resolveOwner is the
 // per-connector call that names the account. The access token is discarded —
 // only the durable refresh token persists.
-func Authenticate(ctx context.Context, oauth OAuth, req connector.AuthRequest, scopes []principal.Scope, resolveOwner OwnerResolver) (connector.Auth, error) {
+func Authenticate(ctx context.Context, oauth Authorizer, req connector.AuthRequest, scopes []principal.Scope, resolveOwner OwnerResolver) (connector.Auth, error) {
 	var p authPayload
 	if err := json.Unmarshal(req.Payload, &p); err != nil {
 		return nil, fmt.Errorf("googleconn: malformed auth payload: %w", err)


### PR DESCRIPTION
## The report

An operator set the Gmail client id and secret in Settings, and connecting a mailbox still failed. The credentials were in the database and the screen showed them saved.

## What was actually wrong

Not the reading of the credentials. The resolver was wired and returned them correctly. The refusal was one gate in front:

`connectorHandlers.canRunConsent` asks the **registry** whether a connector for the provider exists before it will run a consent flow. `NewCaptureRegistryWithGmail` registered the Google connectors only when `GmailConfig.canSync()` — that is, only when the **process environment** carried the pair. So an app that arrived at runtime reached a transport with no connector behind it, and the surface answered its declared 501: indistinguishable, from the outside, from an installation that had configured nothing.

The behaviour was known and recorded in a comment rather than fixed:

> an installation whose app arrived at runtime has the transport and not the connector. […] Registering the connectors from the stored app is the change that turns this on, and it is deliberately not this one.

This is that change.

## Why per-call resolution is available

A connector never builds a consent URL. It only calls `Exchange` and `AccessToken`, and **both carry a context and can report an error** — so the app can be resolved when the call is made rather than copied at boot.

`googleconn.Authorizer` is that narrower half. `OAuth` keeps `AuthCodeURL` for the transport, which resolves the app and builds its own client. A connector now cannot start a consent flow by construction, which is true and was previously only conventional.

## The worker

It resolves the app through the same constructor. Without that half, a mailbox connected against a stored app would connect and then never sync — which reads as an empty inbox rather than a broken one.

## Rules held

- what an admin stored **outranks** the environment
- an installation that stored nothing keeps running on what the deployment composed, with no action required
- a resolution failure is **returned, never turned into a fallback** — a sealed secret that will not open means the vault's root key moved, and quietly connecting with an older environment copy would hide that behind a flow that half works
- with neither source, the refusal wraps `connector.ErrAuthRejected` so the registry **parks** the connection instead of retrying forever for an app nobody configured

## Verification

Every new test was mutation-checked; each of these fails the suite:

| mutation | caught by |
|---|---|
| the environment wins over the stored app | `TestTheStoredAppOutranksTheEnvironment` |
| a resolution error falls back to the environment | `TestAResolutionFailureIsReportedNotPaperedOverWithTheEnvironment` |
| registration returns to environment-only (the original defect) | `TestAStoredAppRegistersTheGoogleConnectors`, `TestAStoredAppCanRunTheConsentFlow` |
| the refusal stops wrapping `ErrAuthRejected` | `TestNoAppAnywhereRefusesAsRejectedRatherThanRetryable` |

`make check-backend` green (exit 0). `make craft-static` green, 0 findings.

## Noted, not fixed here

`compose.GmailPollRegistry` has **no production caller** — only tests — and its doc claims one (`nil tells NewJobRunner to skip the polls entirely`) that does not call it. Its environment-only gate now contradicts this fix, so it is a trap for whoever wires it up next. Filed separately rather than widening this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gmail and Google Calendar connections can now use OAuth apps configured in saved settings.
  - Existing deployment-level Google credentials remain supported when no saved app is available.
  - Saved Google apps now support connector registration, synchronization, and consent flows.
  - Gmail and Calendar continue using separate authorization scopes.

- **Bug Fixes**
  - Improved handling when Google OAuth credentials are unavailable or cannot be resolved, providing clearer authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->