### PR TITLE
fix(gates): eight claims that two sites cannot drift apart now fail when they do

### DIFF
--- a/backend/claimedspelling_test.go
+++ b/backend/claimedspelling_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H3
+
+package backendarch
+
+// A constant whose doc comment says it is spelled once is making a checkable
+// statement, and until now nothing checked it. The failure it describes is a
+// second WRITER: a new audit image, event delta or clause that types the value
+// instead of taking the name, after which the two sites the comment promised
+// would agree drift on the next rename of either.
+//
+// Scope is derived, not declared. A claim's blast radius is the set of files
+// that USE the constant — those are the sites the comment is about, and they
+// are the sites a raw spelling would sit beside. Reading the prose for a scope
+// ("the three merges", "the two refusal sites") would make this gate a second
+// reading of the same sentence.
+//
+// Non-test sources only. A literal in a test is the test naming a value on
+// purpose, and a test written through the constant proves LESS: it would agree
+// with the code about a value neither of them spells correctly.
+//
+// The corpus is the claims themselves, so this gate cannot drift from what the
+// register describes. Claims already bound to another gate are out: their own
+// gate is what holds them, and re-judging them here would make binding a claim
+// depend on satisfying a rule its author never wrote.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// thisGate is the name a claim writes in `Held by:` to be judged here. Spelled
+// as the constant the test function is named after, so a rename moves both.
+const thisGate = "TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed"
+
+// driftShape is the claim shape this gate judges: a comment promising that two
+// sites stay in step is promising they read one name, which is what a raw
+// spelling breaks. The other shapes make different promises — `once` is about a
+// declaration rather than a value — and each one that joins this corpus brings
+// its own findings to read and rule on, so widening is its own piece of work
+// and not a line change here.
+//
+// The key is checked against the detector rather than assumed, so a shape that
+// is renamed or retired empties this gate loudly instead of quietly.
+const driftShape = "cannot-drift"
+
+// sharedSpellings ratifies a value whose second appearance is a DIFFERENT
+// subject that happens to be spelled the same way. Keyed by the constant, never
+// by the file: one file can hold two claims, and a file-keyed entry would
+// ratify the one nobody read.
+//
+// Each entry says what the other spelling IS. That is the whole judgement — a
+// reader checking this entry later has to be able to tell "different subject"
+// from "second writer", and only naming the other subject does that.
+var sharedSpellings = gatekit.Waive(map[string]string{
+	"internal/modules/ai/feedback.go:fieldSubjectType":           "the second is the same word as a key in the AuditEvent image, where it names a column of the ledger row rather than the request field a refusal points at",
+	"internal/modules/automation/engine.go:systemSource":         "the second is the actor id on principal.Principal, which identifies WHO acted; systemSource is the provenance stamped on what was written",
+	"internal/modules/search/queryjoins.go:objectRelationship":   "the second is the relationship TABLE's name in the join spec beside it, not the RBAC object governing it — the two agree today and are free to diverge",
+	"internal/shared/ports/datasource/shapewords.go:objectShape": "the second is the same two words inside a rendered sentence, where they are English rather than the shape word this constant names",
+})
+
+// claimedConst is one string constant a claim sits on.
+type claimedConst struct {
+	claimPath string // the file the claim was found in, as the register keys it
+	dir       string // the package directory the scope is swept over
+	name      string
+	value     string
+}
+
+func TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed(t *testing.T) {
+	if claimShapes[driftShape] == nil {
+		t.Fatalf("the detector no longer declares the %q shape, so this gate's corpus is empty and "+
+			"every claim it used to judge is unjudged", driftShape)
+	}
+	consts := claimedConsts(t)
+	if len(consts) == 0 {
+		t.Fatal("no claimed string constant found — the corpus derivation has broken, and a " +
+			"gate with an empty corpus reads exactly like a tree with nothing to fix")
+	}
+	for _, c := range consts {
+		key := fmt.Sprintf("%s:%s", c.claimPath, c.name)
+		raw := rawSpellingsOf(t, c)
+		if len(raw) == 0 {
+			if sharedSpellings.Waived(t, key) {
+				t.Errorf("%s %s is ratified as sharing its spelling with another subject and no "+
+					"second spelling remains. A waiver over a value spelled once ratifies nothing "+
+					"and hides the next raw one: drop the entry.", c.claimPath, c.name)
+			}
+			continue
+		}
+		if sharedSpellings.Waived(t, key) {
+			continue
+		}
+		t.Errorf("%s %s claims one spelling of %q and the files that use it also spell it raw, at "+
+			"%s.\n\nThe comment promises those sites cannot drift; a raw spelling is how they do — "+
+			"the next rename moves the constant and leaves the literal behind. Take the constant "+
+			"at that site, or, if the second is a different subject wearing the same word, ratify "+
+			"it in sharedSpellings and say what that subject is.",
+			c.claimPath, c.name, c.value, strings.Join(raw, ", "))
+	}
+	sharedSpellings.AssertAllMatched(t)
+}
+
+// claimedConsts reads every claim sitting on a const declaration and returns
+// the string values it binds.
+func claimedConsts(t *testing.T) []claimedConst {
+	t.Helper()
+	seen := map[string]bool{}
+	var out []claimedConst
+	fset := token.NewFileSet()
+	for _, c := range allClaims(t) {
+		if c.shape != driftShape || !strings.Contains(c.decl, "const") ||
+			(c.held != "" && c.held != thisGate) {
+			continue
+		}
+		file, err := parser.ParseFile(fset, c.path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", c.path, err)
+		}
+		for name, value := range constValuesAt(fset, file, c.line) {
+			// One const block can match two claim shapes. The subject is the
+			// constant, so judging it twice reports one finding twice.
+			if key := c.path + ":" + name; !seen[key] {
+				seen[key] = true
+				out = append(out, claimedConst{
+					claimPath: c.path, dir: filepath.Dir(c.path), name: name, value: value,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].claimPath+out[i].name < out[j].claimPath+out[j].name
+	})
+	return out
+}
+
+// constValuesAt returns the string constants the declaration at line binds.
+//
+// The line the claim carries is the doc comment's, not the keyword's, so the
+// declaration is matched by the span that INCLUDES its doc — a claim sits on
+// the comment, and the comment is what names the constant below it.
+func constValuesAt(fset *token.FileSet, file *ast.File, line int) map[string]string {
+	values := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		start := fset.Position(gen.Pos()).Line
+		if gen.Doc != nil {
+			start = fset.Position(gen.Doc.Pos()).Line
+		}
+		if line < start || line > fset.Position(gen.End()).Line {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, value := range vs.Values {
+				lit, ok := value.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING || i >= len(vs.Names) {
+					continue
+				}
+				if text, err := strconv.Unquote(lit.Value); err == nil && text != "" {
+					values[vs.Names[i].Name] = text
+				}
+			}
+		}
+	}
+	return values
+}
+
+// rawSpellingsOf reports every string literal equal to the constant's value in
+// the non-test files of its package that reference it, other than the
+// declaration's own.
+func rawSpellingsOf(t *testing.T, c claimedConst) []string {
+	t.Helper()
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", c.dir, err)
+	}
+	var raw []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(c.dir, entry.Name())
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		if !mentions(file, c.name) {
+			continue
+		}
+		raw = append(raw, rawLiteralsIn(fset, file, c)...)
+	}
+	sort.Strings(raw)
+	return raw
+}
+
+func mentions(file *ast.File, name string) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// rawLiteralsIn reports the raw spellings in one file.
+//
+// Every declared value is skipped, not just this constant's own: a sibling
+// constant binding the same string is a second NAME for the value, which is a
+// different finding with a different fix, and reporting it here would send the
+// reader to replace a constant with itself.
+func rawLiteralsIn(fset *token.FileSet, file *ast.File, c claimedConst) []string {
+	declared := map[ast.Expr]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for _, value := range vs.Values {
+			declared[value] = true
+		}
+		return true
+	})
+	var raw []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING || declared[ast.Expr(lit)] {
+			return true
+		}
+		if text, err := strconv.Unquote(lit.Value); err == nil && text == c.value {
+			raw = append(raw, fmt.Sprint(fset.Position(lit.Pos())))
+		}
+		return true
+	})
+	return raw
+}

--- a/backend/contractvocabulary_test.go
+++ b/backend/contractvocabulary_test.go
@@ -5,12 +5,22 @@
 
 package backendarch
 
-// A membership set spelled out of the generated contract's own constants reads
-// as though it cannot drift from crm.yaml — every value in it IS the contract's
-// value, so no rename can slip past. What that spelling does not carry is the
-// SET: crm.yaml gains a member, the generator emits it, the enum's Valid()
-// accepts it, and a map written this way keeps the members it had. The refusal
-// that follows names a field and rejects a value the contract publishes.
+// A membership set built from a generated enum's own constants must hold every
+// member of that enum.
+//
+// Spelling the constants reads as though the set cannot drift from crm.yaml —
+// every value in it IS the contract's value, so no rename slips past. What that
+// spelling does not carry is the SET: crm.yaml gains a member, the generator
+// emits it, the enum's Valid() accepts it, and a map written this way keeps the
+// members it had. The refusal that follows names a field and rejects a value
+// the contract publishes.
+//
+// Only completeness is checked, because the other direction cannot fail: the
+// corpus admits a set only when EVERY key names a constant of one enum, so a
+// set that is in scope is a subset by construction and holding it whole is set
+// equality. A stray key does not make the set wrong here — it takes the set out
+// of this gate's reach, which is why the corpus rule is stated with the
+// detector rather than left implicit.
 //
 // oapi-codegen emits Valid() and no member list, which is why these maps exist
 // at all — a refusal has to render the vocabulary it accepted, and Valid()

--- a/backend/contractvocabulary_test.go
+++ b/backend/contractvocabulary_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package backendarch
+
+// A membership set spelled out of the generated contract's own constants reads
+// as though it cannot drift from crm.yaml — every value in it IS the contract's
+// value, so no rename can slip past. What that spelling does not carry is the
+// SET: crm.yaml gains a member, the generator emits it, the enum's Valid()
+// accepts it, and a map written this way keeps the members it had. The refusal
+// that follows names a field and rejects a value the contract publishes.
+//
+// oapi-codegen emits Valid() and no member list, which is why these maps exist
+// at all — a refusal has to render the vocabulary it accepted, and Valid()
+// cannot enumerate. So the maps stay and this gate holds them whole.
+//
+// Completeness is the DEFAULT and a selection is the exception, because the two
+// fail in opposite directions: a set meant to be closed and left short refuses a
+// valid value silently, while a set meant to be a selection and widened here
+// fails loudly on the next run. Over-collecting costs a reason; over-suppressing
+// costs a vocabulary nobody notices went short.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+const contractsImportPath = "github.com/gradionhq/margince/backend/internal/contracts"
+
+// contractsPkgDir is where the generated enums live, relative to the module root.
+const contractsPkgDir = "internal/contracts"
+
+// deliberateSelections ratifies a set that draws on a contract enum WITHOUT
+// meaning to hold all of it. Keyed by the declaration, never by the file: two
+// selections over two enums share a file in this tree, and a file-keyed entry
+// would ratify the second one nobody read.
+var deliberateSelections = gatekit.Waive(map[string]string{
+	"internal/compose/enrichextract.go:legalPageFields":         "the fields a legal/imprint page can carry, which is a property of that page kind rather than of the cold-start vocabulary; widening it would send the extractor looking for an ICP on an imprint",
+	"internal/compose/siteprofile.go:hardGateProfileFields":     "the fields whose absence blocks the profile gate, deliberately the smallest set that makes a profile usable; every further field is wanted, not required",
+	"internal/compose/orgdossier/growthfitwrite.go:suggestions": "the one sentence nature a growth-fit suggestion may carry; a fact or an assessment written here would be a claim the dossier never evidenced",
+})
+
+// contractEnumIndex reads the generated package and answers, for a constant
+// name, which enum declares it. Derived rather than listed: the enums are
+// regenerated from crm.yaml and a hand-kept index would be the second copy this
+// gate exists to refuse.
+func contractEnumIndex(t *testing.T) (byName map[string]string, byEnum map[string][]string) {
+	t.Helper()
+	byName, byEnum = map[string]string{}, map[string][]string{}
+	entries, err := os.ReadDir(contractsPkgDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", contractsPkgDir, err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(contractsPkgDir, entry.Name()), nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", entry.Name(), err)
+		}
+		indexConsts(t, file, byName, byEnum)
+	}
+	if len(byEnum) == 0 {
+		t.Fatalf("no generated enum constants found under %s — the derivation is broken, "+
+			"and a gate deriving nothing judges nothing", contractsPkgDir)
+	}
+	return byName, byEnum
+}
+
+func indexConsts(t *testing.T, file *ast.File, byName map[string]string, byEnum map[string][]string) {
+	t.Helper()
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			enum, ok := vs.Type.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			for i, value := range vs.Values {
+				lit, ok := value.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING || i >= len(vs.Names) {
+					continue
+				}
+				byName[vs.Names[i].Name] = enum.Name
+				byEnum[enum.Name] = append(byEnum[enum.Name], vs.Names[i].Name)
+			}
+		}
+	}
+}
+
+// vocabularySet is one package-level `map[string]bool` whose every key names a
+// constant of ONE generated enum.
+type vocabularySet struct {
+	path, name, enum string
+	members          []string
+}
+
+func TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt(t *testing.T) {
+	byName, byEnum := contractEnumIndex(t)
+	scope := gatekit.Scope{
+		Roots:   []string{"internal/compose", "internal/modules"},
+		Subject: func(_ string, file *ast.File) bool { return len(vocabularySetsIn("", file, byName)) > 0 },
+		Exempt: gatekit.Waive(map[string]string{
+			contractsPkgDir + "/api_gen.go": "the generated source of the vocabularies themselves; a set here would be the contract, not a copy of it",
+		}),
+	}
+	found := 0
+	for _, parsed := range scope.Files(t) {
+		for _, set := range vocabularySetsIn(parsed.Path, parsed.File, byName) {
+			found++
+			key := fmt.Sprintf("%s:%s", set.path, set.name)
+			whole := byEnum[set.enum]
+			missing := missingFrom(set.members, whole)
+			if len(missing) == 0 {
+				if deliberateSelections.Waived(t, key) {
+					t.Errorf("%s %s is ratified as a deliberate selection over %s and now holds "+
+						"every member of it. A waiver over a set that is complete ratifies nothing "+
+						"and hides the next member that goes missing: drop the entry.",
+						set.path, set.name, set.enum)
+				}
+				continue
+			}
+			if deliberateSelections.Waived(t, key) {
+				continue
+			}
+			t.Errorf("%s %s draws on the generated enum %s and holds %d of its %d members, "+
+				"missing %v.\n\nA set spelled out of the contract's constants cannot drift on a "+
+				"VALUE and says nothing about the SET: crm.yaml grew and this did not, so a value "+
+				"the contract publishes is refused here. Add the members, or ratify the set as a "+
+				"deliberate selection in deliberateSelections with what the narrowing buys.",
+				set.path, set.name, set.enum, len(set.members), len(whole), missing)
+		}
+	}
+	if found == 0 {
+		t.Error("no vocabulary set found anywhere under the roots — the detector has stopped " +
+			"seeing its subject, and a gate that judges nothing reads exactly like a clean tree")
+	}
+	deliberateSelections.AssertAllMatched(t)
+}
+
+// vocabularySetsIn returns every package-level `map[string]bool` in file whose
+// keys are ALL constants of one generated enum.
+//
+// All, not most: a map mixing contract constants with local strings is a
+// vocabulary this gate cannot reason about — the local half has no member list
+// to be complete against — and judging it on the contract half alone would
+// report a shortfall that is not one.
+func vocabularySetsIn(path string, file *ast.File, byName map[string]string) []vocabularySet {
+	qualifier, dotImported := gatekit.ImportedAs(file, contractsImportPath)
+	if qualifier == "" && !dotImported {
+		return nil
+	}
+	var sets []vocabularySet
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, value := range vs.Values {
+				lit, ok := value.(*ast.CompositeLit)
+				if !ok || !isStringBoolMap(lit.Type) || i >= len(vs.Names) {
+					continue
+				}
+				members, whole := enumKeysOf(lit, qualifier, dotImported, byName)
+				if !whole || len(members) == 0 {
+					continue
+				}
+				sets = append(sets, vocabularySet{
+					path: path, name: vs.Names[i].Name,
+					enum: byName[members[0]], members: members,
+				})
+			}
+		}
+	}
+	return sets
+}
+
+func isStringBoolMap(expr ast.Expr) bool {
+	mapType, ok := expr.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	key, keyOK := mapType.Key.(*ast.Ident)
+	value, valueOK := mapType.Value.(*ast.Ident)
+	return keyOK && valueOK && key.Name == "string" && value.Name == "bool"
+}
+
+// enumKeysOf reports the enum constants the map's keys name, and whether EVERY
+// key named one of a single enum.
+func enumKeysOf(lit *ast.CompositeLit, qualifier string, dotImported bool, byName map[string]string) ([]string, bool) {
+	var members []string
+	enums := map[string]bool{}
+	for _, element := range lit.Elts {
+		kv, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, false
+		}
+		name, ok := contractConstNamed(kv.Key, qualifier, dotImported, byName)
+		if !ok {
+			return nil, false
+		}
+		members = append(members, name)
+		enums[byName[name]] = true
+	}
+	return members, len(enums) == 1
+}
+
+// contractConstNamed unwraps the `string(crmcontracts.Member)` a map key is
+// written as and answers which generated constant it names.
+func contractConstNamed(expr ast.Expr, qualifier string, dotImported bool, byName map[string]string) (string, bool) {
+	if call, ok := expr.(*ast.CallExpr); ok && len(call.Args) == 1 {
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "string" {
+			expr = call.Args[0]
+		}
+	}
+	switch node := expr.(type) {
+	case *ast.SelectorExpr:
+		id, ok := node.X.(*ast.Ident)
+		if !ok || id.Name != qualifier {
+			return "", false
+		}
+		_, known := byName[node.Sel.Name]
+		return node.Sel.Name, known
+	case *ast.Ident:
+		if !dotImported {
+			return "", false
+		}
+		_, known := byName[node.Name]
+		return node.Name, known
+	}
+	return "", false
+}
+
+func missingFrom(have, whole []string) []string {
+	held := map[string]bool{}
+	for _, name := range have {
+		held[name] = true
+	}
+	var missing []string
+	for _, name := range whole {
+		if !held[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/backend/internal/compose/csvfields.go
+++ b/backend/internal/compose/csvfields.go
@@ -366,7 +366,9 @@ func addressMergedOnto(current []byte, mapped *crmcontracts.Address) (*crmcontra
 //
 // The vocabulary is read off the generated contract, not hand-copied, for the
 // same reason people.validSizeBands is: a band added to crm.yaml must not
-// leave a second list behind saying otherwise.
+// leave a second list behind saying otherwise. That obligation is on the set
+// rather than on the spelling, so it is gated rather than stated.
+// Held by: TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt (backend/contractvocabulary_test.go)
 func unwritableReason(object string, fields map[string]string) string {
 	if object == migration.ObjectPerson {
 		// A person's addresses are parsed before the write transaction opens

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -202,4 +202,5 @@ const relationshipOriginCapture = "capture"
 
 // employmentKind is the relationship kind this file plants, spelled once so the
 // SQL, the audit row and the event delta cannot drift apart.
+// Held by: TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed (backend/claimedspelling_test.go)
 const employmentKind = "employment"

--- a/backend/internal/modules/people/leadmanualsignal.go
+++ b/backend/internal/modules/people/leadmanualsignal.go
@@ -39,6 +39,7 @@ var leadManualFactorBands = map[string]map[string]int{
 // The audit and problem-field keys this surface spells more than once.
 // Named so the audit trail and the 422 body cannot drift apart from the
 // wire field they both describe.
+// Held by: TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed (backend/claimedspelling_test.go)
 const (
 	auditKeyManualSignal = "manual_signal"
 	fieldKeyFactor       = "factor"

--- a/backend/internal/modules/people/leadrouting.go
+++ b/backend/internal/modules/people/leadrouting.go
@@ -52,8 +52,14 @@ type RoutingConfig struct {
 // RoutableLeadFields is the closed set a routing rule may match on —
 // lead-local columns only (segregation-in-scoring: routing never reads
 // the contact graph). leadRoutingFacts.field must resolve exactly these
-// keys; the agents catalog mirrors this set for the editor schema, and a
-// compose fitness test binds the two so they cannot drift.
+// keys, and the agents catalog mirrors this set for the editor schema.
+//
+// Two gates, because the halves fail differently: a name this list offers
+// that `field` cannot resolve routes on the empty string and refuses
+// nothing, while a set the catalog does not mirror 422s a field the engine
+// supports. The mirror is TestRoutableLeadFieldVocabularyIsSingleSourced,
+// in compose — the only place both modules are visible.
+// Held by: TestEveryRoutableLeadFieldResolvesToItsOwnFact (backend/internal/modules/people/leadroutingvocab_test.go)
 var RoutableLeadFields = []string{"source", "company_name", "candidate_org_key"}
 
 // ParseRoutingConfig decodes automation params into a RoutingConfig.

--- a/backend/internal/modules/people/leadroutingvocab_test.go
+++ b/backend/internal/modules/people/leadroutingvocab_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// A routable field the fact lookup cannot resolve routes every lead on it to
+// the empty string: `field` answers "" for a name it does not know, and a rule
+// comparing that to a literal simply never matches. Nothing refuses the config
+// — the editor accepts it, the engine reads it, and the leads it was meant to
+// assign go to round-robin instead. The failure is silent at every layer.
+//
+// Compose already binds this vocabulary to the automation catalog's mirror
+// (TestRoutableLeadFieldVocabularyIsSingleSourced). That holds the two LISTS
+// against each other and says nothing about whether either one resolves, which
+// is the half that decides where a lead lands.
+//
+// Each fact carries its own marker, so a `field` arm returning the wrong struct
+// member fails here rather than reading as a pass.
+func TestEveryRoutableLeadFieldResolvesToItsOwnFact(t *testing.T) {
+	facts := leadRoutingFacts{
+		Source:          "the source",
+		CompanyName:     "the company name",
+		CandidateOrgKey: "the candidate org key",
+	}
+	markers := map[string]bool{
+		facts.Source: true, facts.CompanyName: true, facts.CandidateOrgKey: true,
+	}
+	if len(markers) != 3 {
+		t.Fatal("the markers are no longer distinct, so a mixed-up arm would read as a pass")
+	}
+	seen := map[string]string{}
+	for _, name := range RoutableLeadFields {
+		got := facts.field(name)
+		if got == "" {
+			t.Errorf("RoutableLeadFields offers %q and leadRoutingFacts.field does not resolve it, "+
+				"so every rule matching on that field compares the empty string and never fires",
+				name)
+			continue
+		}
+		if !markers[got] {
+			t.Errorf("leadRoutingFacts.field(%q) returned %q, which is no fact this test seeded", name, got)
+			continue
+		}
+		if other, taken := seen[got]; taken {
+			t.Errorf("leadRoutingFacts.field resolves both %q and %q to the same fact %q, "+
+				"so one of the two routes on a value that is not its own", other, name, got)
+		}
+		seen[got] = name
+	}
+	if len(seen) != len(markers) {
+		t.Errorf("RoutableLeadFields reaches %d of the %d facts leadRoutingFacts carries — "+
+			"a fact no field name resolves is one no rule can ever route on", len(seen), len(markers))
+	}
+}
+
+// The inverse: an unknown name resolves to nothing rather than to whichever
+// fact the switch happens to fall through to. This is what makes the empty
+// string above a reliable signal instead of an accident of arm order.
+func TestAnUnroutableFieldNameResolvesToNothing(t *testing.T) {
+	facts := leadRoutingFacts{Source: "s", CompanyName: "c", CandidateOrgKey: "k"}
+	if got := facts.field("owner_id"); got != "" {
+		t.Errorf("leadRoutingFacts.field resolved the unroutable name %q to %q; routing is "+
+			"lead-local by design and a name outside RoutableLeadFields must reach no fact",
+			"owner_id", got)
+	}
+}

--- a/backend/internal/modules/people/linkedinheaderkeys_test.go
+++ b/backend/internal/modules/people/linkedinheaderkeys_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// The alias table and the row reader meet at a field key, and the way they
+// disagree is not a typo — the compiler catches an undefined constant. It is a
+// key one side uses and the other never produces: a header alias pointing at a
+// field the reader never asks for imports nothing from that column, and a field
+// the reader asks for that no alias produces reads empty from every export
+// forever. Both are silent. `at` answers "" for an unindexed field, and an
+// import that quietly ignored a column while reporting success is the outcome
+// LinkedInImportResult exists to prevent.
+//
+// Driven through headerIndex and linkedInRowFrom rather than compared against a
+// list of the keys: a test restating the seven constants is a second copy of
+// them, and would agree with the reader about a field neither one reads.
+
+// probeValues are the shapes a probed cell is tried with. A field is reachable
+// if ANY of them changes the row, which keeps this test from carrying a
+// per-field table — the one thing that would make it a second copy of the
+// vocabulary. The date is here because `connected` is parsed rather than
+// copied, so only a value that parses can prove that column is read.
+var probeValues = []string{"probe-value", "02 Jan 2006", "probe@example.com"}
+
+// headerAliasFor picks one alias per field, so the probe header carries every
+// field exactly once. Sorted, so the header this test builds is the same on
+// every run and a failure names the same alias twice running.
+func headerAliasFor(t *testing.T) map[string]string {
+	t.Helper()
+	byField := map[string][]string{}
+	for alias, field := range linkedInHeaderAliases {
+		byField[field] = append(byField[field], alias)
+	}
+	if len(byField) == 0 {
+		t.Fatal("linkedInHeaderAliases is empty, so this test probes nothing")
+	}
+	chosen := make(map[string]string, len(byField))
+	for field, aliases := range byField {
+		sort.Strings(aliases)
+		chosen[field] = aliases[0]
+	}
+	return chosen
+}
+
+func TestEveryFieldTheAliasTableProducesIsReadFromTheRow(t *testing.T) {
+	aliases := headerAliasFor(t)
+	fields := make([]string, 0, len(aliases))
+	for field := range aliases {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	header := make([]string, len(fields))
+	for i, field := range fields {
+		header[i] = aliases[field]
+	}
+	index := headerIndex(header)
+	if index == nil {
+		t.Fatalf("headerIndex refused a header carrying one alias for each of the %d fields "+
+			"the alias table produces (%v) — it cannot recognize its own vocabulary", len(fields), header)
+	}
+	if len(index) != len(fields) {
+		t.Errorf("headerIndex placed %d of the %d fields the alias table produces; a field the "+
+			"index never carries reads empty from every export", len(index), len(fields))
+	}
+
+	// The name columns are what headerIndex requires before it accepts a header
+	// at all, so the baseline fills them: without a name linkedInRowFrom refuses
+	// the row and every probe below would compare two refusals.
+	baseline, ok := rowFrom(header, index, map[string]string{csvFirst: "Baseline", csvLast: "Person"})
+	if !ok {
+		t.Fatal("linkedInRowFrom refused a row carrying a first and last name, so no probe can be read against it")
+	}
+	for _, field := range fields {
+		if reached(t, header, index, baseline, field) {
+			continue
+		}
+		t.Errorf("the alias %q maps a column onto the field %q and linkedInRowFrom reads nothing "+
+			"from it: every value in that column is dropped, and the import reports the row as "+
+			"imported. Read the field, or stop mapping a header onto it.",
+			aliases[field], field)
+	}
+}
+
+// reached reports whether filling field's column changes the row the reader
+// builds, trying each probe shape in turn.
+func reached(t *testing.T, header []string, index map[string]int, baseline linkedInRow, field string) bool {
+	t.Helper()
+	for _, value := range probeValues {
+		cells := map[string]string{csvFirst: "Baseline", csvLast: "Person", field: value}
+		row, ok := rowFrom(header, index, cells)
+		if ok && !reflect.DeepEqual(row, baseline) {
+			return true
+		}
+	}
+	return false
+}
+
+// rowFrom assembles a record positioned by index and reads it back through the
+// real reader, so what this test exercises is the production path.
+func rowFrom(header []string, index map[string]int, cells map[string]string) (linkedInRow, bool) {
+	record := make([]string, len(header))
+	for field, value := range cells {
+		if at, ok := index[field]; ok {
+			record[at] = value
+		}
+	}
+	return linkedInRowFrom(record, index)
+}

--- a/backend/internal/modules/people/linkedinimport.go
+++ b/backend/internal/modules/people/linkedinimport.go
@@ -48,8 +48,11 @@ type LinkedInImportResult struct {
 	Skipped  int
 }
 
-// The header fields this importer reads, named so the alias table and the
-// row reader cannot disagree about a key by a typo.
+// The header fields this importer reads. Naming them stops the alias table and
+// the row reader disagreeing by a typo — the compiler settles that — and leaves
+// the disagreement that stays silent: a key one side uses and the other never
+// produces, which drops a whole column while the import reports success.
+// Held by: TestEveryFieldTheAliasTableProducesIsReadFromTheRow (backend/internal/modules/people/linkedinheaderkeys_test.go)
 const (
 	csvFirst     = "first"
 	csvLast      = "last"

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -52,6 +52,7 @@ import (
 
 // The audit keys a merge writes, spelled once so the person, organization
 // and lead merges cannot drift apart in what they record.
+// Held by: TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed (backend/claimedspelling_test.go)
 const (
 	auditKeyMergedInto = "merged_into_id"
 	auditKeyFilled     = "filled"

--- a/backend/internal/modules/people/organization_relationship_types.go
+++ b/backend/internal/modules/people/organization_relationship_types.go
@@ -36,6 +36,7 @@ const relationshipTypePartner = string(crmcontracts.OrganizationRelationshipType
 // validRelationshipTypes is the closed vocabulary, checked before the database
 // sees it so a bad value is a 422 naming the field rather than a CHECK
 // violation surfacing as a 500.
+// Held by: TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt (backend/contractvocabulary_test.go)
 var validRelationshipTypes = map[string]bool{
 	string(crmcontracts.OrganizationRelationshipTypesCustomer):         true,
 	string(crmcontracts.OrganizationRelationshipTypesPartner):          true,
@@ -274,6 +275,7 @@ func lifecycleValue(l *crmcontracts.OrganizationLifecycle) string {
 
 // validLifecycles is the closed vocabulary, checked before the database sees
 // it so a bad value is a 422 naming the field rather than a CHECK violation.
+// Held by: TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt (backend/contractvocabulary_test.go)
 var validLifecycles = map[string]bool{
 	string(crmcontracts.OrganizationLifecycleUnknown):        true,
 	string(crmcontracts.OrganizationLifecycleTarget):         true,
@@ -309,8 +311,13 @@ func checkSizeBand(value string) error {
 		fmt.Sprintf("%q is not a size band; %s", value, vocabularyOf(validSizeBands)))
 }
 
-// validSizeBands is the closed vocabulary, read off the generated contract so it
-// cannot drift from crm.yaml the way a hand-copied list would.
+// validSizeBands is the closed vocabulary, read off the generated contract so a
+// renamed band cannot drift from crm.yaml the way a hand-copied list would.
+//
+// Spelling the contract's constants carries the VALUES and not the SET: a band
+// crm.yaml gains reaches the generated Valid() and would not reach here, and
+// checkSizeBand would then refuse a band the contract publishes.
+// Held by: TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt (backend/contractvocabulary_test.go)
 var validSizeBands = map[string]bool{
 	string(crmcontracts.OrganizationSizeBandN110):      true,
 	string(crmcontracts.OrganizationSizeBandN1150):     true,

--- a/backend/internal/modules/people/organizationlogo.go
+++ b/backend/internal/modules/people/organizationlogo.go
@@ -29,6 +29,7 @@ import (
 // logoFieldName is how the logo is spelled in field_provenance and in the
 // audit/event delta. One spelling, so the provenance display and the write
 // cannot disagree about which field was set.
+// Held by: TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed (backend/claimedspelling_test.go)
 const logoFieldName = "logo"
 
 // SetOrganizationLogo records a resolved company mark: the storage key its

--- a/backend/internal/modules/people/projectcompany.go
+++ b/backend/internal/modules/people/projectcompany.go
@@ -45,6 +45,7 @@ const projectCompanyDefaultRole = "customer"
 
 // relationshipRoleField is the audit key the edge's role is recorded under,
 // spelled once so the three writers cannot disagree about it.
+// Held by: TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed (backend/claimedspelling_test.go)
 const relationshipRoleField = "role"
 
 // AttachCompanyToProjectTx puts one company on a project, inside the caller's

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -461,7 +461,6 @@ internal/modules/people/handlers_projectstakeholder.go#const block at const Proj
 internal/modules/people/lead_list.go#const block at const leadNameColumn
 internal/modules/people/lead_read.go#const liveOnlyClause
 internal/modules/people/leadmanualsignal.go#const block at const auditKeyManualSignal
-internal/modules/people/leadrouting.go#var RoutableLeadFields
 internal/modules/people/leadslaworkflow.go#func humanLoggedNote
 internal/modules/people/leadstatus.go#method LeadStatus.Open
 internal/modules/people/linkedinimport.go#const block at const csvFirst
@@ -478,7 +477,6 @@ internal/modules/people/merge.go#const block at const auditKeyMergedInto
 internal/modules/people/organization_counts.go#func fillOpenDealCounts
 internal/modules/people/organization_profile_field_write.go#const block at const auditKeyValue
 internal/modules/people/organization_profile_field_write.go#method Store.writeProfileField
-internal/modules/people/organization_relationship_types.go#var validSizeBands
 internal/modules/people/organizationlogo.go#const logoFieldName
 internal/modules/people/projectcompany.go#const relationshipRoleField
 internal/modules/people/projectstakeholder.go#method Store.PersonNames

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -453,17 +453,14 @@ internal/modules/overlay/usermapadmin.go#func auditRevokedMappings
 internal/modules/overlay/usermapservice.go#func requireUserMapAdmin
 internal/modules/people/companysitereadcomparison.go#func PrintedSiteReadValue
 internal/modules/people/domainadmission.go#func reopenAdmittedDomainTx
-internal/modules/people/employmentedge.go#const employmentKind
 internal/modules/people/employmentedge.go#const relationshipOriginCapture
 internal/modules/people/ensure.go#const block at const evidenceFieldKey
 internal/modules/people/geocode.go#var organizationAddressColumns
 internal/modules/people/handlers_projectstakeholder.go#const block at const ProjectStakeholderKind
 internal/modules/people/lead_list.go#const block at const leadNameColumn
 internal/modules/people/lead_read.go#const liveOnlyClause
-internal/modules/people/leadmanualsignal.go#const block at const auditKeyManualSignal
 internal/modules/people/leadslaworkflow.go#func humanLoggedNote
 internal/modules/people/leadstatus.go#method LeadStatus.Open
-internal/modules/people/linkedinimport.go#const block at const csvFirst
 internal/modules/people/linkedinmatch.go#method Store.MatchLinkedInConnections
 internal/modules/people/linkedinmatch.go#var suggestNameEmployerMatchSQL
 internal/modules/people/linkedinorgplace.go#func orgKeys
@@ -473,12 +470,9 @@ internal/modules/people/listfilters.go#const block at const filterOwnerID
 internal/modules/people/listpage.go#func aiWrittenClause
 internal/modules/people/listpage.go#func capturedByKindClause
 internal/modules/people/mapping.go#type LeadUpdateRequest
-internal/modules/people/merge.go#const block at const auditKeyMergedInto
 internal/modules/people/organization_counts.go#func fillOpenDealCounts
 internal/modules/people/organization_profile_field_write.go#const block at const auditKeyValue
 internal/modules/people/organization_profile_field_write.go#method Store.writeProfileField
-internal/modules/people/organizationlogo.go#const logoFieldName
-internal/modules/people/projectcompany.go#const relationshipRoleField
 internal/modules/people/projectstakeholder.go#method Store.PersonNames
 internal/modules/people/projectstakeholder.go#method Store.ensureProjectWritable
 internal/modules/people/promotepreview.go#method Store.previewTarget

--- a/backend/uniquenessclaims_test.go
+++ b/backend/uniquenessclaims_test.go
@@ -455,7 +455,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // a row falling, so the two kinds of progress are told apart by which number
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
-	"cannot-drift":   175,
+	"cannot-drift":   173,
 	"once":           158,
 	"one-of-a-kind":  156,
 	"is-every-named": 95,

--- a/backend/uniquenessclaims_test.go
+++ b/backend/uniquenessclaims_test.go
@@ -455,7 +455,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // a row falling, so the two kinds of progress are told apart by which number
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
-	"cannot-drift":   173,
+	"cannot-drift":   167,
 	"once":           158,
 	"one-of-a-kind":  156,
 	"is-every-named": 95,

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (32)
+## Parity (33)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -28,6 +28,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `configschema_test.go` | H3 | The margince.yaml schema is editor tooling, and editor tooling that lies is worse than none: an operator trusts the squiggle. |
 | `contextanchorenum_test.go` | H3 | GET /records/{entity\_type}/{id}/context accepts exactly the record types the search module can search, and the contract has to say the same set. |
 | `contractfrontendlane_test.go` | H3 | A contract change owes three regenerations, and the one that strands the FRONTEND types is enforced in two different places for two different readers. |
+| `contractvocabulary_test.go` | H3 | A membership set spelled out of the generated contract's own constants reads as though it cannot drift from crm.yaml — every value in it IS the contract's value, so no rename can slip past. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |
@@ -52,7 +53,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (52)
+## Census (53)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -64,6 +65,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `basecurrencyguard_test.go` | H2 | The base-currency lock as a fitness function. |
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
+| `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -28,7 +28,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `configschema_test.go` | H3 | The margince.yaml schema is editor tooling, and editor tooling that lies is worse than none: an operator trusts the squiggle. |
 | `contextanchorenum_test.go` | H3 | GET /records/{entity\_type}/{id}/context accepts exactly the record types the search module can search, and the contract has to say the same set. |
 | `contractfrontendlane_test.go` | H3 | A contract change owes three regenerations, and the one that strands the FRONTEND types is enforced in two different places for two different readers. |
-| `contractvocabulary_test.go` | H3 | A membership set spelled out of the generated contract's own constants reads as though it cannot drift from crm.yaml — every value in it IS the contract's value, so no rename can slip past. |
+| `contractvocabulary_test.go` | H3 | A membership set built from a generated enum's own constants must hold every member of that enum. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |


### PR DESCRIPTION
The duplication audit's first slice through the `cannot-drift` uniqueness claims. Eight leave the register by being **held**; none leaves by narrowing. `shapeCensus`'s `cannot-drift` row falls 175 → 167.

## Two gates, one template each

**`contractvocabulary_test.go`** — a membership set spelled out of the generated contract's own constants (`string(crmcontracts.OrganizationSizeBandN110)`) cannot drift on a VALUE and says nothing about the SET. crm.yaml gains a member, the generator emits it, `Valid()` accepts it, and the map keeps the members it had — so the refusal beside it names a field and rejects a value the contract publishes. Five sets were exposed; three are the vocabularies behind organization's 422s. oapi-codegen emits `Valid()` and no member list, which is why the maps exist at all, so the fix is a gate rather than a deletion.

**`claimedspelling_test.go`** — a constant whose doc comment says it is spelled once is making a checkable statement, and nothing checked it. Both halves are derived: the corpus is the claims themselves, the scope is the files that USE each constant. Reading the prose for a scope — "the three merges", "the two refusal sites" — would make the gate a second reading of the same sentence.

## What the audit found

Every claim read turned out to be **half true** rather than false — the comment asserted something real and was silent about the failure that actually stays silent.

| claim | asserted | silent about |
|---|---|---|
| `RoutableLeadFields` | the catalog mirrors this set | whether `leadRoutingFacts.field` RESOLVES a name. One it cannot answer routes on `""` — matches nothing, refuses nothing, at every layer |
| `validSizeBands` | values cannot drift from crm.yaml | the set. A band crm.yaml gains never reaches this map |
| `csvFirst` block | the alias table and row reader cannot disagree by a typo | the compiler settles typos. A key one side uses and the other never produces drops a whole column while the import reports success |

The compose test binding `RoutableLeadFields` already stated its own gap in prose — "the engine's field lookup returns "" for an unknown key" — with nothing enforcing it. So did `csvfields.go`: "a band added to crm.yaml must not leave a second list behind saying otherwise."

## Boundaries measured, not assumed

Six candidate mass templates for `cannot-drift`; five refuted. **Value equality does not track subject identity** at every scope available — tree-wide (`"person"` ×1503), file-scoped, and reference-scoped. `"relationship"` the table vs. the RBAC object; `"system"` the actor id vs. the write provenance; `"company"` LinkedIn's header text vs. the importer's field key. Two boundaries in `claimedspelling_test.go` come straight out of that: non-test sources only, and a sibling *constant* binding the same string is skipped — that is a second NAME, a different finding with a different fix, and reporting it would send the reader to replace a constant with itself.

Four values are genuinely two subjects wearing one word. Each waiver says which subject the second one is; that is the whole judgement a later reader has to re-make.

## Verification

Ten mutants across the two gates, every one caught — and every one grepped back out of the file to prove it applied. One mutant silently failed to apply and reported a green run, which is indistinguishable from a survived mutant.

Both gates fail rather than pass on an empty corpus: one checks the claim-shape key still exists in the detector, the other fails when no vocabulary set is found under its roots.

## Scope

Held: `RoutableLeadFields`, `validSizeBands`, the `csvFirst` block, `employmentKind`, `auditKeyManualSignal`, `auditKeyMergedInto`, `logoFieldName`, `relationshipRoleField`. The completeness gate also covers four sibling sets that had no claim and no gate.

Left for the next slice, deliberately:

- **Seven func/method/type claims in `people`** (`humanLoggedNote`, `capturedByKindClause`, `LeadUpdateRequest`, `fillOpenDealCounts`, `writeProfileField`, `ensureProjectWritable`, `previewTarget`) — a different template, so a different PR.
- **Eighteen sites** where a claimed-once spelling has a raw twin, surfaced by widening `claimedspelling_test.go`'s corpus past `cannot-drift`: `contractObject` "contract" raw at four sites, `auditFieldIncumbent` at three, `buildLeadPatch` typing `"full_name"` and `"company_name"` past `lead_list.go`'s column constants. Each needs its own fix-or-waive read.
- **Two second-name findings**: `people` binds `"filled"` under `auditKeyFilled` and `signatureFieldFilled`; `dealrooms` binds three lifecycle states twice (`state*` / `access*`).

`docs/reference/gate-inventory.md` is regenerated in its own trailing commit, off this base. It bumps two section counts, so per #2714 an identical `## Parity (33)` from any other gate-adding PR would merge silently — auto-merge is armed to keep that window small, and I will re-run `TestTheGateInventoryPageIsCurrent` at main after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of imported LinkedIn data to ensure available columns are read consistently.
  * Strengthened checks for supported vocabularies and field mappings to detect inconsistencies before release.

* **Documentation**
  * Expanded guidance for relationship types, size bands, routing fields, and import headers.
  * Updated the validation inventory to reflect current consistency checks.

* **Tests**
  * Added safeguards against spelling, vocabulary, and field-mapping drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->