### PR TITLE
fix(frontend): the Google app is the installation's, so it sits with the admin settings

### DIFF
--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import { isValidElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { pickOption } from "../design-system/select-testing";
@@ -479,14 +479,16 @@ describe("installation-wide cards live under the admin group", () => {
         return false;
       }
       seen.add(node);
-      const el = node as {
-        type?: { name?: string };
-        props?: { children?: ReactNode };
-      };
-      if (typeof el.type === "function" && el.type.name === componentName) {
+      // The props generic is what lets `children` be read without asserting a
+      // shape nothing checked: isValidElement narrows both halves at once.
+      if (!isValidElement<{ children?: ReactNode }>(node)) {
+        return false;
+      }
+      // A function component's `name` is what the register renders it under.
+      if (typeof node.type === "function" && node.type.name === componentName) {
         return true;
       }
-      return walk(el.props?.children);
+      return walk(node.props.children);
     };
     return walk(tabContent(id));
   }

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1,11 +1,18 @@
 /** @vitest-environment jsdom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { pickOption } from "../design-system/select-testing";
 import { LOCALES, localeNameKey, translate } from "../i18n";
-import { SettingsScreen, settingsAddress } from "./settings";
+import {
+  SETTINGS_TABS,
+  SettingsScreen,
+  type SettingsTabId,
+  settingsAddress,
+  tabContent,
+} from "./settings";
 import {
   auditEntry,
   IDLE_JOB_HEALTH,
@@ -438,5 +445,57 @@ describe("SettingsScreen restructured entries", () => {
       screen.getByText(/Only an admin can see background-job health/),
     ).toBeTruthy();
     expect(screen.queryByText(/reset data/i)).toBeNull();
+  });
+});
+
+// Where a settings card LIVES is a claim about whose setting it is, and the two
+// groups mean different things: "you" is a credential or connection the reader
+// personally holds, "admin" is the installation's posture.
+//
+// The Google app is one app per installation, supplied by whoever operates it,
+// and every rep's mailbox is connected through it. It shipped on `connections`
+// — a personal entry — which put installation configuration on a page the
+// register describes as holding "their own mailbox and their own LinkedIn
+// network". The server gates the read on capture_settings, so a rep saw a
+// refused card rather than the operator's client id; the defect was that the
+// page offered them a setting that was never theirs.
+//
+// Walked from the register rather than asserted against a hard-coded tab name:
+// the rule is "admin group", so a future move to any other admin entry passes
+// and a move back to a personal one fails.
+describe("installation-wide cards live under the admin group", () => {
+  // The card names itself; searching the returned tree for that name avoids
+  // rendering fourteen tabs and their API calls.
+  function tabRenders(id: SettingsTabId, componentName: string): boolean {
+    const seen = new Set<unknown>();
+    const walk = (node: ReactNode): boolean => {
+      if (!node || typeof node !== "object") {
+        return false;
+      }
+      if (Array.isArray(node)) {
+        return node.some(walk);
+      }
+      if (seen.has(node)) {
+        return false;
+      }
+      seen.add(node);
+      const el = node as {
+        type?: { name?: string };
+        props?: { children?: ReactNode };
+      };
+      if (typeof el.type === "function" && el.type.name === componentName) {
+        return true;
+      }
+      return walk(el.props?.children);
+    };
+    return walk(tabContent(id));
+  }
+
+  it("puts the Google app on an admin entry, not beside a person's own connections", () => {
+    const hosts = SETTINGS_TABS.filter((tab) =>
+      tabRenders(tab.id, "GoogleAppCard"),
+    );
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]?.group).toBe("admin");
   });
 });

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -251,7 +251,10 @@ export const SETTINGS_TABS = [
 // raw key and lets a test validate a label that does not exist.
 export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
 
-function tabContent(id: SettingsTabId): ReactNode {
+// Exported for the placement gate below the register: a settings card that
+// configures the INSTALLATION has to sit on an admin entry, and the only way to
+// check that without rendering every tab is to walk what each one returns.
+export function tabContent(id: SettingsTabId): ReactNode {
   switch (id) {
     case "account":
       return <AccountCard />;
@@ -275,15 +278,7 @@ function tabContent(id: SettingsTabId): ReactNode {
         </>
       );
     case "connections":
-      return (
-        <>
-          {/* Above the connections themselves: this is the app they are made
-              THROUGH, so a reader who cannot connect a mailbox finds the reason
-              before the empty list rather than after it. */}
-          <GoogleAppCard />
-          <ConnectionsTab />
-        </>
-      );
+      return <ConnectionsTab />;
     // Beside `connections` and after it on purpose: that tab says what you are
     // connected to, this one says what those connections did with your mail.
     case "capture-activity":
@@ -293,6 +288,13 @@ function tabContent(id: SettingsTabId): ReactNode {
     case "capture":
       return (
         <>
+          {/* First, because everything below presupposes it: the Google app
+              every mailbox on this installation is connected THROUGH. One app
+              per installation, supplied by whoever operates it, so it belongs
+              to the operator rather than to the rep whose mailbox rides it —
+              which is why it is here and not beside a person's own
+              connections. */}
+          <GoogleAppCard />
           {/* Which domains are OURS, then what to do with mail from the rest,
               then which of the rest are consumer mailboxes — the posture, then
               the two judgements that read it. Before this they sat on two


### PR DESCRIPTION
## The report

The Gmail app configuration was under the personal settings group, not the admin one — but it configures the whole organization.

## Confirmed

`SETTINGS_TABS` puts `connections` in `group: "you"`, and the register's own comment says why that group is personal:

> The personal group is where a credential or a connection the PERSON holds lives […] `connections` carries their own mailbox and their own LinkedIn network.

`GoogleAppCard` was rendered there. The Google app is the opposite of personal: one app per installation, supplied by whoever operates it, and every rep's mailbox is connected *through* it.

## Where it goes

To `capture`, an admin entry gated on `capture_settings` — the same RBAC object `GoogleAppStore` writes under (`captureSettingsObject`). It goes **first** on that tab, because the rules below it (own domains, capture posture, consumer-mail domains, exclusions, blocked domains) all presuppose there is an app to capture through.

## Not a disclosure

Worth stating plainly, since a settings card on the wrong page can be either. `GoogleAppStore.Read` gates on `capture_settings` read server-side, so a rep opening that tab got a refused card, never the operator's client id. The defect was that the page offered them a setting that was never theirs — a misplacement, not a leak.

## Held now

Nothing asserted the placement: all 505 tests in the settings and nav suites passed with the card on the wrong page. The new gate walks the tree each tab returns, finds which entry renders `GoogleAppCard`, and asserts that entry's **group** is `admin`.

Derived from the register rather than naming a tab, so it states the rule and not today's answer — moving the card to any other admin entry passes; moving it back beside a person's own connections fails.

Both mutations checked:

| mutation | result |
|---|---|
| card returns to `connections` (the original defect) | fails |
| card rendered on **both** tabs | fails |

`make check-fe` green (exit 0), 4896 + 36 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Settings**
  * Moved the Google app connection card from personal Connections settings to the admin Capture settings.
  * Kept the personal Connections tab focused on connection management.

* **Bug Fixes**
  * Ensured the Google app card appears only once in the appropriate settings area.

* **Tests**
  * Improved coverage for settings navigation and card placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->