### PR TITLE
fix(gates): seven claims about a RULE, and the nameless person a promotion minted

### DIFF
--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 24
+	wantFixtureAnnotations = 25
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/modules/people/leadidentity_test.go
+++ b/backend/internal/modules/people/leadidentity_test.go
@@ -4,6 +4,7 @@
 package people
 
 import (
+	"strings"
 	"testing"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -73,5 +74,95 @@ func TestLeadIdentityName(t *testing.T) {
 				t.Errorf("leadIdentityName() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// The rule has a second spelling that no AST gate can see. A query naming a
+// lead falls back the same way in SQL, and there `COALESCE(full_name, email)`
+// is the exact defect `FullName != nil` was in Go: it answers the empty string
+// for a full_name that is present and empty, so one surface calls the lead
+// nothing while the promotion of the same lead calls it by its address.
+//
+// The census reads every string literal in the module rather than the ones
+// that look like queries — deciding what looks like a query is where a census
+// goes blind — and then decides on ONE coalesce's own argument list. A literal
+// merely mentioning both columns is not this rule: a SELECT naming the name and
+// the address as separate columns, an INSERT listing both, and a coalesce over
+// a domain extracted from the address all do that, and none of them falls back.
+func TestEverySQLFallbackToAnEmailGuardsTheEmptyName(t *testing.T) {
+	const (
+		nameColumn  = "full_name"
+		emailColumn = "email"
+		// The guard that makes the SQL agree with leadIdentityName: an empty
+		// name, once trimmed, is NULL, so the fallback proceeds past it.
+		guard = "nullif(btrim(full_name), '')"
+	)
+	fallbacks := 0
+	for _, lit := range moduleSQLLiterals(t) {
+		for _, args := range coalesceArguments(lit.text) {
+			// The fallback is name THEN address, in one argument list. The
+			// other order is a different rule and this gate does not hold it.
+			name := strings.Index(args, nameColumn)
+			if name < 0 || !strings.Contains(args[name:], emailColumn) {
+				continue
+			}
+			fallbacks++
+			if strings.Contains(args, guard) {
+				continue
+			}
+			t.Errorf("a query at %s falls back from %s to %s as coalesce(%s) without %s.\n\n"+
+				"COALESCE stops at a present-but-empty name and answers \"\", so this surface "+
+				"calls a lead nothing while leadIdentityName calls the same lead by its "+
+				"address. Guard the name.",
+				lit.where, nameColumn, emailColumn, strings.Join(strings.Fields(args), " "), guard)
+		}
+	}
+	if fallbacks == 0 {
+		t.Fatalf("no query in this module falls back from %s to %s, so this gate judged nothing "+
+			"— the rule has moved out of SQL and this test no longer describes the module",
+			nameColumn, emailColumn)
+	}
+}
+
+// coalesceArguments returns the argument text of every coalesce(...) in one SQL
+// literal, lowercased, with line comments stripped first — a `--` can carry an
+// unbalanced parenthesis, and counting it would end the argument list early and
+// hide what follows.
+func coalesceArguments(sql string) []string {
+	var stripped strings.Builder
+	for _, line := range strings.Split(sql, "\n") {
+		if cut := strings.Index(line, "--"); cut >= 0 {
+			line = line[:cut]
+		}
+		stripped.WriteString(line)
+		stripped.WriteByte('\n')
+	}
+	text := strings.ToLower(stripped.String())
+
+	var args []string
+	for at := 0; ; {
+		open := strings.Index(text[at:], "coalesce(")
+		if open < 0 {
+			return args
+		}
+		open += at + len("coalesce(")
+		depth, end := 1, open
+		for ; end < len(text) && depth > 0; end++ {
+			switch text[end] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		}
+		if depth != 0 {
+			// Unbalanced: the literal is a fragment concatenated with another.
+			// Judging half an argument list would answer about a call that is
+			// not there, so take what there is and say nothing about the rest.
+			args = append(args, text[open:])
+			return args
+		}
+		args = append(args, text[open:end-1])
+		at = end
 	}
 }

--- a/backend/internal/modules/people/leadidentity_test.go
+++ b/backend/internal/modules/people/leadidentity_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// What a lead is called decides two things at once: whether the promotion will
+// take it at all, and which person the ladder then matches. The cases that
+// matter are the ones where "has a name" and "has a full_name" part company —
+// a pointer to an empty string is a full_name and is not a name.
+func TestLeadIdentityName(t *testing.T) {
+	email := func(s string) *openapi_types.Email {
+		e := openapi_types.Email(s)
+		return &e
+	}
+	for _, tc := range []struct {
+		name string
+		lead crmcontracts.Lead
+		want string
+	}{
+		{
+			name: "a name is the name",
+			lead: crmcontracts.Lead{FullName: ptr("Vera Lindqvist")},
+			want: "Vera Lindqvist",
+		},
+		{
+			name: "the email names a lead that has no name of its own",
+			lead: crmcontracts.Lead{Email: email("vera@nordwind.example")},
+			want: "vera@nordwind.example",
+		},
+		{
+			name: "a name wins over an email",
+			lead: crmcontracts.Lead{FullName: ptr("Vera Lindqvist"), Email: email("vera@nordwind.example")},
+			want: "Vera Lindqvist",
+		},
+		{
+			name: "a present-but-empty full_name is not a name",
+			lead: crmcontracts.Lead{FullName: ptr(""), Email: email("vera@nordwind.example")},
+			want: "vera@nordwind.example",
+		},
+		{
+			name: "padding is not a name either",
+			lead: crmcontracts.Lead{FullName: ptr("   "), Email: email("vera@nordwind.example")},
+			want: "vera@nordwind.example",
+		},
+		{
+			name: "a name keeps no padding into the ladder",
+			lead: crmcontracts.Lead{FullName: ptr("  Vera Lindqvist  ")},
+			want: "Vera Lindqvist",
+		},
+		{
+			name: "nothing names a lead with neither",
+			lead: crmcontracts.Lead{},
+			want: "",
+		},
+		{
+			// The case the promotion guard has to refuse: a full_name that
+			// exists, names nobody, and has no address standing behind it.
+			name: "an empty full_name and no email names nobody",
+			lead: crmcontracts.Lead{FullName: ptr("")},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := leadIdentityName(tc.lead); got != tc.want {
+				t.Errorf("leadIdentityName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -99,6 +99,12 @@ const firstResponseSet = firstResponseColumn + ` = COALESCE(` + firstResponseCol
 
 // SLABreach is one lead whose first-response deadline passed unanswered on
 // this scan — what the escalation acts on.
+//
+// Name is what the lead is called, and the SELECT works it out the way
+// leadIdentityName does: a full_name that is present and empty is not a name,
+// so the address behind it is. A bare COALESCE would answer the empty string,
+// and the escalation would page an owner about a lead it could not name while
+// the promotion of the same lead names it by its address.
 type SLABreach struct {
 	LeadID   ids.LeadID
 	OwnerID  *ids.UserID
@@ -130,7 +136,8 @@ func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, er
 			return nil
 		}
 		rows, err := tx.Query(ctx, `
-			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute', COALESCE(full_name, email, '')
+			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
+			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
 			FROM lead
 			WHERE archived_at IS NULL AND first_response_at IS NULL AND sla_breached_at IS NULL
 			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -10,7 +10,6 @@ package people
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -279,7 +278,7 @@ func isFirstResponseActivity(t leadResponseTouch) bool {
 	if t.direction != "outbound" {
 		return false
 	}
-	if strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":") {
+	if humanCaptured(t) {
 		return true
 	}
 	return t.hadInbound

--- a/backend/internal/modules/people/leadslaworkflow.go
+++ b/backend/internal/modules/people/leadslaworkflow.go
@@ -170,9 +170,22 @@ const activitySourceManual = "manual"
 // humanLoggedNote is the ONE spelling of "a rep typed this note into the
 // composer" — the ladder's contact arm and the first-response rule
 // (isFirstResponseActivity) both read it, so they cannot drift apart.
+//
+// Held by: TestEachRuleBearingTouchFieldHasOneReader (backend/internal/modules/people/responsetouch_test.go)
 func humanLoggedNote(t leadResponseTouch) bool {
-	return t.kind == "note" && t.source == activitySourceManual &&
-		strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":")
+	return t.kind == "note" && t.source == activitySourceManual && humanCaptured(t)
+}
+
+// humanCaptured reads the captured_by grammar's human namespace off a touch.
+//
+// Its own function because §18.1 asks the question twice and about different
+// touches — once as one conjunct of "a rep typed this note", once on its own
+// for an outbound that a person sent. Both are the same question, and the
+// grammar's prefix is a thing that can change; spelled twice it would change in
+// one of the two, and the ladder and the first-response clock would then
+// disagree about whether a person was involved.
+func humanCaptured(t leadResponseTouch) bool {
+	return strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":")
 }
 
 // leadResponseTouches answers which leads the activity is linked to, with

--- a/backend/internal/modules/people/listpage.go
+++ b/backend/internal/modules/people/listpage.go
@@ -151,10 +151,16 @@ type listFilters struct {
 
 // capturedByKindClause is the ONE spelling of the provenance filter
 // (ADR-0075/A121 §3a): it refuses a kind outside the contract's enum and, for
-// an accepted one, builds the clause. It lives outside listFilters because the
-// lead list builds its own WHERE chain rather than using that struct, and two
-// copies of "which prefix counts as an AI" is exactly how the person list and
-// the lead list end up disagreeing about what the review list contains.
+// an accepted one, builds the clause. Every list surface reaches it through
+// listFilters, the lead work queue included — that one assembles its own WHERE
+// chain and still takes the shared clauses from the struct, which is what keeps
+// "which prefix counts as an AI" from having a second answer. Two answers is
+// exactly how the person list and the lead list come to disagree about what the
+// review list contains, and they are read side by side.
+//
+// Held by: TestTheProvenanceClauseIsBuiltInOnePlace (backend/internal/modules/people/provenancefilter_test.go)
+// The filter is dropped more easily than it is duplicated, and a literal that
+// omits it is held by TestEveryListFiltersLiteralCarriesTheProvenanceFilter.
 //
 // The check is HERE, in the store, rather than at the handler, because the
 // store is where authorization runs. Both list paths call auth.Require before
@@ -183,9 +189,21 @@ func capturedByKindClause(kind *string, arg func(any) int) (string, bool, error)
 	}
 	if !crmcontracts.CapturedByKind(*kind).Valid() {
 		return "", false, httperr.Validation("captured_by_kind", "invalid",
-			"must be one of human, agent, connector, system")
+			vocabularyOf(capturedByKinds))
 	}
 	return storekit.SQLf("captured_by LIKE $%d", arg(likePrefix(*kind+":"))), true, nil
+}
+
+// capturedByKinds is the vocabulary the refusal above NAMES. Acceptance is
+// decided by the generated Valid(), which cannot fall behind crm.yaml; a
+// message typed out beside it can, and then the refusal withholds the one kind
+// the caller was reaching for. Spelled from the contract's constants so the two
+// answer out of the same place.
+var capturedByKinds = map[string]bool{
+	string(crmcontracts.CapturedByKindHuman):     true,
+	string(crmcontracts.CapturedByKindAgent):     true,
+	string(crmcontracts.CapturedByKindConnector): true,
+	string(crmcontracts.CapturedByKindSystem):    true,
 }
 
 // agentPrefix matches the captured_by grammar's AI namespace. Shared by every

--- a/backend/internal/modules/people/mapping.go
+++ b/backend/internal/modules/people/mapping.go
@@ -243,6 +243,8 @@ func leadCreateInput(req crmcontracts.CreateLeadRequest) (CreateLeadInput, error
 // distinct from omitting the field (leave it alone). Both transports —
 // the HTTP handler and the SoR provider — decode into this one type, so
 // the gesture cannot drift between surfaces.
+//
+// Held by: TestEveryLeadUpdateDecodeKeepsTheNullGesture (backend/internal/modules/people/onederivation_test.go)
 type LeadUpdateRequest struct {
 	crmcontracts.UpdateLeadRequest
 	scoreNull  bool

--- a/backend/internal/modules/people/onederivation_test.go
+++ b/backend/internal/modules/people/onederivation_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Two claims that a struct literal cannot hold on its own.
+//
+// The promote preview answers "who is this lead already?" and the promotion
+// then acts on that answer. They agree only while the CANDIDATE is derived once
+// — two literals naming the same fields still disagree when the values fed into
+// them are worked out differently, and the preview would name a person the
+// promotion does not land on. That is worse than a plain wrong answer, because
+// the preview is what a human read before agreeing.
+//
+// A lead update carries a gesture JSON erases: null means clear the override,
+// absent means leave it. Only LeadUpdateRequest records the difference, so a
+// transport decoding the bare contract type reads a clear as a no-op — the
+// caller's request succeeds and the override they asked to remove is still
+// there.
+
+// candidateType is the ladder's input, built in one place or not at all.
+const candidateType = "PersonCandidate"
+
+// candidateBuilder is where that one place is.
+const candidateBuilder = "leadPersonCandidate"
+
+func TestTheLadderCandidateIsDerivedInOnePlace(t *testing.T) {
+	builders := map[string]bool{}
+	forEachModuleFile(t, func(_ string, fset *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Name == nil {
+				continue
+			}
+			// From a LEAD specifically. The ladder matches candidates built
+			// from several sources — a channel identity, a resolve, a manual
+			// dedupe — and those are different derivations of a different
+			// thing. The claim is about the one the preview and the promotion
+			// share, and its input is what identifies it.
+			if takesA(fn, "crmcontracts.Lead") && buildsA(fn.Body, candidateType) {
+				builders[fn.Name.Name] = true
+			}
+		}
+	})
+	if !builders[candidateBuilder] {
+		t.Fatalf("%s does not build a %s, so this gate is watching the wrong function and the "+
+			"derivation it was meant to hold is somewhere else now", candidateBuilder, candidateType)
+	}
+	if len(builders) == 1 {
+		return
+	}
+	others := make([]string, 0, len(builders))
+	for name := range builders {
+		if name != candidateBuilder {
+			others = append(others, name)
+		}
+	}
+	sort.Strings(others)
+	t.Errorf("a %s is derived from a lead by %s as well as by %s.\n\nThe preview and the "+
+		"promotion agree only while "+
+		"the candidate is derived once: same fields, different working-out, and the preview names "+
+		"a person the promotion does not land on — after a human read the preview and agreed. "+
+		"Take %s.", candidateType, strings.Join(others, ", "), candidateBuilder, candidateBuilder)
+}
+
+// contractLeadUpdate is the generated request type, which drops the
+// null-vs-absent gesture on decode.
+const contractLeadUpdate = "UpdateLeadRequest"
+
+// leadUpdateWrapper is the type that keeps it.
+const leadUpdateWrapper = "LeadUpdateRequest"
+
+func TestEveryLeadUpdateDecodeKeepsTheNullGesture(t *testing.T) {
+	wrapperSeen, decodes := false, 0
+	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			if spec, ok := n.(*ast.TypeSpec); ok && spec.Name.Name == leadUpdateWrapper {
+				wrapperSeen = true
+				return true
+			}
+			decl, ok := n.(*ast.DeclStmt)
+			if !ok {
+				return true
+			}
+			gen, ok := decl.Decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || vs.Type == nil {
+					continue
+				}
+				switch typeText(vs.Type) {
+				case leadUpdateWrapper:
+					decodes++
+				case "crmcontracts." + contractLeadUpdate:
+					t.Errorf("%s declares a decode target of the bare %s.\n\nJSON erases the "+
+						"difference between null and absent on a pointer field, and only %s "+
+						"records it — decoded this way, a caller asking to CLEAR an override "+
+						"gets a successful response and keeps the override.",
+						fset.Position(vs.Pos()), contractLeadUpdate, leadUpdateWrapper)
+				}
+			}
+			return true
+		})
+	})
+	if !wrapperSeen {
+		t.Fatalf("this module declares no %s, so the gesture has no keeper and this gate judged "+
+			"nothing", leadUpdateWrapper)
+	}
+	if decodes < 2 {
+		t.Errorf("%d transport(s) decode into %s; the claim is that BOTH the handler and the "+
+			"provider do, and one transport cannot drift from itself", decodes, leadUpdateWrapper)
+	}
+}
+
+// takesA reports whether fn accepts the named type as a parameter — which is
+// what makes a body's reads and literals be ABOUT that type rather than about
+// some other value that happens to share a field or a shape. Shared by the
+// gates in this package that identify a function by what it is handed.
+func takesA(fn *ast.FuncDecl, typeName string) bool {
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, param := range fn.Type.Params.List {
+		if typeText(param.Type) == typeName {
+			return true
+		}
+	}
+	return false
+}
+
+// buildsA reports whether body contains a composite literal of the named type.
+func buildsA(body *ast.BlockStmt, typeName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || lit.Type == nil {
+			return true
+		}
+		// An empty literal is a zero value on an error return, not a candidate
+		// anyone matches on; counting it would report every error path as a
+		// second derivation.
+		if typeText(lit.Type) == typeName && len(lit.Elts) > 0 {
+			found = true
+		}
+		return !found
+	})
+	return found
+}

--- a/backend/internal/modules/people/onederivation_test.go
+++ b/backend/internal/modules/people/onederivation_test.go
@@ -157,3 +157,124 @@ func buildsA(body *ast.BlockStmt, typeName string) bool {
 	})
 	return found
 }
+
+// A third derivation lives one field away from the two above, and it fails in
+// the opposite direction: not two answers to who the lead is, but two readings
+// of whether it is anybody.
+//
+// The promotion refuses a lead with no identity, and the ladder candidate works
+// out the name to match on. Both turn on the same question — what is this lead
+// called — and while each answers it for itself, the guard admits leads the
+// candidate cannot name. `FullName != nil` is true of a full_name that is
+// present and empty, so a lead carrying one and no email clears the guard and
+// promotes into a person with no name at all: a row nobody searching for that
+// person will ever match, created by a verb whose whole job is to name them.
+
+// identityRefusal is the refusal a lead with nothing to be called earns.
+const identityRefusal = "PromoteNeedsIdentityError"
+
+// leadNaming is the one place a lead's name is worked out.
+const leadNaming = "leadIdentityName"
+
+// leadNameField is the field whose present-but-empty reading is the defect. A
+// function in the corpus reading it directly has started a second answer,
+// whatever it then does with it.
+const leadNameField = "FullName"
+
+func TestTheIdentityGuardAndTheCandidateReadOneName(t *testing.T) {
+	var guards, builders int
+	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Name == nil || fn.Name.Name == leadNaming {
+				continue
+			}
+			// Both halves are found by what they DO — one refuses a lead for
+			// having no identity, the other builds the candidate the ladder
+			// matches on — so a third function joining either half is judged
+			// the day it is written rather than the day somebody remembers
+			// this test.
+			guard := refusesWith(fn.Body, identityRefusal)
+			builder := takesA(fn, "crmcontracts.Lead") && buildsA(fn.Body, candidateType)
+			if !guard && !builder {
+				continue
+			}
+			if guard {
+				guards++
+			}
+			if builder {
+				builders++
+			}
+			if !callsFunc(fn, leadNaming) {
+				t.Errorf("%s (%s) decides what a lead is called without %s.\n\nThe guard and the "+
+					"candidate agree on whether a lead has an identity only while ONE function "+
+					"answers it. Take %s.", fn.Name.Name, name, leadNaming, leadNaming)
+			}
+			if pos := readsField(fn.Body, leadNameField); pos.IsValid() {
+				t.Errorf("%s reads .%s directly at %s.\n\nThat is the second reading: `!= nil` and "+
+					"`== \"\"` disagree about a full_name that is present and empty, and the lead "+
+					"that falls between them promotes into a person with no name. Read %s.",
+					fn.Name.Name, leadNameField, fset.Position(pos), leadNaming)
+			}
+		}
+	})
+	// Either half at zero means this gate examined a population that no longer
+	// exists — the refusal renamed, the candidate moved — and a gate holding
+	// nothing reports exactly what a gate holding everything does.
+	if guards == 0 {
+		t.Fatalf("no function builds a %s, so nothing in this package refuses a lead for having "+
+			"no identity and this gate is watching a rule that has moved", identityRefusal)
+	}
+	if builders == 0 {
+		t.Fatalf("no function builds a %s from a lead, so this gate is watching a derivation "+
+			"that has moved", candidateType)
+	}
+}
+
+// refusesWith reports whether body constructs the named error type. Unlike
+// buildsA it counts an EMPTY literal: a sentinel error carries its meaning in
+// its type, and `&PromoteNeedsIdentityError{}` is the whole refusal.
+func refusesWith(body *ast.BlockStmt, typeName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if ok && lit.Type != nil && typeText(lit.Type) == typeName {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// callsFunc reports whether fn calls the named package-level function. Plain
+// identifiers only: a method of the same name on some other receiver answers a
+// different question, and counting it would report a derivation that is not
+// shared.
+func callsFunc(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// readsField answers where body selects the named field, or an invalid
+// position when it does not.
+func readsField(body *ast.BlockStmt, field string) token.Pos {
+	var at token.Pos
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && sel.Sel != nil && sel.Sel.Name == field {
+			at = sel.Sel.Pos()
+		}
+		return !at.IsValid()
+	})
+	return at
+}

--- a/backend/internal/modules/people/opendealcount_test.go
+++ b/backend/internal/modules/people/opendealcount_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// "Open deal" is a definition, not a column: a status, an archive check, and a
+// currency conversion, spelled once in the 0065 rollup view. The organization
+// list's count and the company page's open-pipeline tile both read it, which is
+// the only reason a company page cannot show a number the list disagrees with.
+//
+// The drift is not a second read of the view — it is a FIRST read of `deal`.
+// A count assembled here would be a second definition of open, and the two
+// would disagree the first time the view's own definition moved: the fx date it
+// converts at, the archive predicate, or what statuses count. Both numbers are
+// on screen at once, so a reader sees the disagreement before anyone else does.
+//
+// Two directions, because a one-directional census misses the shape that does
+// not name the column: a query that never says `open_deal_count` and counts
+// open deals off the table anyway is exactly the copy this is about.
+
+const openPipelineRollupView = "organization_open_pipeline_rollup"
+
+// dealStatusOpen is how the open status is spelled inside a SQL literal.
+const dealStatusOpen = "'open'"
+
+func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
+	counts, dealReads := 0, 0
+	for _, sql := range moduleSQLLiterals(t) {
+		if strings.Contains(sql.text, "open_deal_count") {
+			counts++
+			if !gatekit.TableReadPattern(openPipelineRollupView).MatchString(sql.text) {
+				t.Errorf("%s reads open_deal_count without reading %s:\n\n\t%s\n\n"+
+					"The rollup is where open is defined. A count read from anywhere else is a "+
+					"second definition, and the list and the company page show both at once.",
+					sql.where, openPipelineRollupView, gatekit.FirstLineOf(sql.text))
+			}
+		}
+		if !gatekit.TableReadPattern("deal").MatchString(sql.text) {
+			continue
+		}
+		dealReads++
+		if strings.Contains(sql.text, dealStatusOpen) {
+			t.Errorf("%s reads the deal table and constrains on %s:\n\n\t%s\n\n"+
+				"That assembles open here rather than taking it from %s, which is a second "+
+				"definition of the word. Read the rollup, or say beside the query why this "+
+				"population is not the one the rollup counts.",
+				sql.where, dealStatusOpen, gatekit.FirstLineOf(sql.text), openPipelineRollupView)
+		}
+	}
+	// Both arms need a subject. The first has one only while the module still
+	// serves the count; the second only while the module still reaches the deal
+	// table at all, and if it stops, the arm guarding that reach is dead weight
+	// rather than a silent pass — so it says so instead of reading green.
+	if counts == 0 {
+		t.Errorf("no query in this module reads open_deal_count, so the arm holding it against "+
+			"%s judged nothing", openPipelineRollupView)
+	}
+	if dealReads == 0 {
+		t.Error("no query in this module reads the deal table, so the arm refusing a second " +
+			"definition of open judged nothing — delete it, or find where the reads went")
+	}
+}
+
+// moduleSQL is one string literal in the module's own sources, with where it is.
+type moduleSQL struct {
+	where string
+	text  string
+}
+
+// moduleSQLLiterals returns every string literal in the module's non-test
+// sources. Every literal, not the ones that look like SQL: deciding what looks
+// like SQL is where a census goes blind, and a literal that is not a query
+// matches neither pattern below anyway.
+func moduleSQLLiterals(t *testing.T) []moduleSQL {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the module directory: %v", err)
+	}
+	var found []moduleSQL
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok {
+				return true
+			}
+			text, isText := gatekit.LiteralText(lit)
+			if !isText {
+				return true
+			}
+			found = append(found, moduleSQL{
+				where: fset.Position(lit.Pos()).String(), text: text,
+			})
+			return true
+		})
+	}
+	if len(found) == 0 {
+		t.Fatal("no string literal found in the module's sources, so this census read nothing")
+	}
+	return found
+}

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -135,6 +135,7 @@ func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUI
 // for the page — the ONE spelling of "open deal" this module reads, so the
 // list's count and the company page's open-pipeline tile derive from the
 // same rows and cannot disagree.
+// Held by: TestEveryOpenDealCountComesFromTheRollup (backend/internal/modules/people/opendealcount_test.go)
 func fillOpenDealCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID) error {
 	return fillCount(ctx, tx, idx,
 		`SELECT organization_id, open_deal_count

--- a/backend/internal/modules/people/organization_profile_field_write.go
+++ b/backend/internal/modules/people/organization_profile_field_write.go
@@ -135,6 +135,8 @@ func (s *Store) ConfirmOrganizationProfileField(
 // writeProfileField is the one path both verbs take, so the provenance flip,
 // the canonical-column write, the audit image and the event cannot diverge
 // between correcting and confirming.
+//
+// Held by: TestBothProfileFieldVerbsWriteThroughTheOnePath (backend/internal/modules/people/profilefieldonepath_test.go)
 func (s *Store) writeProfileField(
 	ctx context.Context, orgID ids.OrganizationID, field string, in ProfileFieldWriteInput,
 ) (crmcontracts.CompanyProfileField, error) {

--- a/backend/internal/modules/people/profilefieldonepath_test.go
+++ b/backend/internal/modules/people/profilefieldonepath_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Correcting a profile field and confirming one are the same write with a
+// different provenance, and they are believed to be the same because they are
+// literally the same call. Four effects ride on it — the provenance flip, the
+// canonical-column write, the audit image and the event — and a verb that grows
+// its own copy of any one of them makes the two disagree about what happened,
+// while both still return a well-formed field.
+//
+// The forbidden set is DERIVED from writeProfileField's own callees rather than
+// listed here. Whatever it reaches is what a verb must not reach around it, so
+// a fifth effect added inside it is protected the day it is added and nobody
+// has to remember this file. Listing the primitives by hand would mean the gate
+// protects the four that existed when it was written.
+
+const profileFieldOnePath = "writeProfileField"
+
+const profileFieldFile = "organization_profile_field_write.go"
+
+func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, profileFieldFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", profileFieldFile, err)
+	}
+	onePath := funcNamed(file, profileFieldOnePath)
+	if onePath == nil {
+		t.Fatalf("%s declares no %s, so this gate judged nothing", profileFieldFile, profileFieldOnePath)
+	}
+	reserved := directCallees(onePath)
+	if len(reserved) == 0 {
+		t.Fatalf("%s reaches nothing, so there is no effect for a verb to duplicate — either the "+
+			"write moved out of it or the callee walk is broken", profileFieldOnePath)
+	}
+	verbs := 0
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || !fn.Name.IsExported() || fn.Recv == nil {
+			continue
+		}
+		verbs++
+		if !callsAny(fn, map[string]bool{profileFieldOnePath: true}) {
+			t.Errorf("%s does not go through %s.\n\nCorrecting and confirming are the same write "+
+				"with a different provenance; a verb that writes on its own makes them disagree "+
+				"about what happened while both still answer with a well-formed field.",
+				fn.Name.Name, profileFieldOnePath)
+			continue
+		}
+		if around := reachedAround(fn, reserved); len(around) > 0 {
+			t.Errorf("%s goes through %s AND reaches %s directly.\n\nThose are effects the one "+
+				"path owns. Reaching one around it is how the correct and the confirm come to "+
+				"record different things: move the work inside %s.",
+				fn.Name.Name, profileFieldOnePath, strings.Join(around, ", "), profileFieldOnePath)
+		}
+	}
+	if verbs < 2 {
+		t.Errorf("%s declares %d exported verb(s); the claim is that BOTH take one path, and one "+
+			"verb cannot disagree with itself", profileFieldFile, verbs)
+	}
+}
+
+// directCallees names what fn calls, by the selector's final identifier — which
+// is how a call reads at the site whether it is a method on the receiver, a
+// package function, or a method on a value it holds.
+func directCallees(fn *ast.FuncDecl) map[string]bool {
+	callees := map[string]bool{}
+	if fn.Body == nil {
+		return callees
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch target := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			callees[target.Sel.Name] = true
+		case *ast.Ident:
+			callees[target.Name] = true
+		}
+		return true
+	})
+	return callees
+}
+
+// reachedAround reports which of the one path's own callees fn reaches
+// directly, sorted so a failure reads the same on every run.
+func reachedAround(fn *ast.FuncDecl, reserved map[string]bool) []string {
+	reached := directCallees(fn)
+	var around []string
+	for name := range reserved {
+		if reached[name] {
+			around = append(around, name)
+		}
+	}
+	sort.Strings(around)
+	return around
+}
+
+func funcNamed(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name != nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/people/profilefieldonepath_test.go
+++ b/backend/internal/modules/people/profilefieldonepath_test.go
@@ -51,7 +51,7 @@ func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
 			continue
 		}
 		verbs++
-		if !callsAny(fn, map[string]bool{profileFieldOnePath: true}) {
+		if !callsAny(fn, receiverName(fn), map[string]bool{profileFieldOnePath: true}) {
 			t.Errorf("%s does not go through %s.\n\nCorrecting and confirming are the same write "+
 				"with a different provenance; a verb that writes on its own makes them disagree "+
 				"about what happened while both still answer with a well-formed field.",

--- a/backend/internal/modules/people/projectanchorgate_test.go
+++ b/backend/internal/modules/people/projectanchorgate_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// A project is readable across the workspace, so the role grant `project.update`
+// says a seat may change PROJECTS — not that it may change THIS one. The row
+// half is what closes the difference, and a stakeholder verb that skips it lets
+// any seat holding the grant rewrite any team's roster. Nothing else refuses:
+// the person exists, the project exists, the write succeeds.
+//
+// The subject is derived from the signature rather than listed. A verb is a
+// method that takes a project to act on, so a third one added tomorrow is
+// judged without anyone remembering this file. A read that legitimately wants
+// visibility rather than writability will fail here — correctly, because it
+// should say so where it is, rather than being quietly absent from a list.
+
+const projectAnchorGate = "ensureProjectWritable"
+
+// stakeholderFile is where the verbs and their gate live together. The claim is
+// about that pairing, so the file is the honest unit: a verb that moves out of
+// it moves out of the claim, and this fails rather than silently covering less.
+const stakeholderFile = "projectstakeholder.go"
+
+// projectIDType is what makes a method a verb ON a project rather than one that
+// merely mentions them.
+const projectIDType = "ids.ProjectID"
+
+func TestEveryProjectStakeholderVerbTakesTheRowAnchorGate(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, stakeholderFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", stakeholderFile, err)
+	}
+	gated := gatedHelpers(file)
+	verbs := 0
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || !fn.Name.IsExported() || !takesA(fn, projectIDType) {
+			continue
+		}
+		verbs++
+		if reachesGate(fn, gated) {
+			continue
+		}
+		t.Errorf("%s in %s takes a project to act on and never reaches %s.\n\n"+
+			"`project.update` says the seat may change projects, not that it may change this "+
+			"one, and a project is readable across the whole workspace — so without the row "+
+			"anchor any seat holding the grant can rewrite any team's roster, and the write "+
+			"succeeds. Take the gate, or, if this is a read, say so and take the visibility "+
+			"check instead.", fn.Name.Name, stakeholderFile, projectAnchorGate)
+	}
+	if verbs == 0 {
+		t.Errorf("no exported method in %s takes a project, so this gate judged nothing — the "+
+			"verbs have moved and the claim on %s no longer describes this file",
+			stakeholderFile, projectAnchorGate)
+	}
+}
+
+// gatedHelpers names the file's own unexported methods that reach the gate, so
+// a verb calling one of them is covered. One hop, not a full call graph: a verb
+// two removes from its own authorization check is worth failing over.
+func gatedHelpers(file *ast.File) map[string]bool {
+	gated := map[string]bool{projectAnchorGate: true}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.IsExported() {
+			continue
+		}
+		if callsAny(fn, map[string]bool{projectAnchorGate: true}) {
+			gated[fn.Name.Name] = true
+		}
+	}
+	return gated
+}
+
+func reachesGate(fn *ast.FuncDecl, gated map[string]bool) bool {
+	return callsAny(fn, gated)
+}
+
+// callsAny reports whether fn's body calls any of names as a method on its own
+// receiver. Method calls only: a free function sharing the name would be a
+// different subject, and matching it would report coverage that is not there.
+func callsAny(fn *ast.FuncDecl, names map[string]bool) bool {
+	if fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && names[sel.Sel.Name] {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func typeText(expr ast.Expr) string {
+	switch node := expr.(type) {
+	case *ast.Ident:
+		return node.Name
+	case *ast.SelectorExpr:
+		return typeText(node.X) + "." + node.Sel.Name
+	case *ast.StarExpr:
+		return typeText(node.X)
+	}
+	return ""
+}

--- a/backend/internal/modules/people/projectanchorgate_test.go
+++ b/backend/internal/modules/people/projectanchorgate_test.go
@@ -42,6 +42,11 @@ const projectAnchorGate = "ensureProjectWritable"
 // any id somebody could guess.
 const personReadGate = "Require"
 
+// personReadPackage is where that grant lives. Named, because the gate matches
+// on the receiver as well as the method: `auth.Require` is the grant and
+// something else's Require is not.
+const personReadPackage = "auth"
+
 // stakeholderFile is where the verbs and their gate live together. The claim is
 // about that pairing, so the file is the honest unit: a verb that moves out of
 // it moves out of the claim, and this fails rather than silently covering less.
@@ -71,7 +76,7 @@ func TestEveryProjectStakeholderVerbTakesTheRowAnchorGate(t *testing.T) {
 			// being wrong, not the method being exempt. The one thing it may
 			// be instead of a project verb is a read, and a read owes its own
 			// grant.
-			if callsAny(fn, map[string]bool{personReadGate: true}) {
+			if callsAny(fn, personReadPackage, map[string]bool{personReadGate: true}) {
 				continue
 			}
 			t.Errorf("%s in %s names no project, by parameter or by input struct, and takes no "+
@@ -165,7 +170,7 @@ func gatedHelpers(file *ast.File) map[string]bool {
 		if !ok || fn.Name == nil || fn.Name.IsExported() {
 			continue
 		}
-		if callsAny(fn, map[string]bool{projectAnchorGate: true}) {
+		if callsAny(fn, receiverName(fn), map[string]bool{projectAnchorGate: true}) {
 			gated[fn.Name.Name] = true
 		}
 	}
@@ -173,14 +178,20 @@ func gatedHelpers(file *ast.File) map[string]bool {
 }
 
 func reachesGate(fn *ast.FuncDecl, gated map[string]bool) bool {
-	return callsAny(fn, gated)
+	return callsAny(fn, receiverName(fn), gated)
 }
 
-// callsAny reports whether fn's body calls any of names as a method on its own
-// receiver. Method calls only: a free function sharing the name would be a
-// different subject, and matching it would report coverage that is not there.
-func callsAny(fn *ast.FuncDecl, names map[string]bool) bool {
-	if fn.Body == nil {
+// callsAny reports whether fn's body calls any of names on the receiver named
+// by qualifier — fn's own receiver for a method of this store, or a package
+// name for an imported one.
+//
+// The qualifier is what makes the answer mean anything. Matching the method
+// NAME alone lets `peer.ensureProjectWritable(other)` report that this verb
+// checked the project it is about, when it checked somebody else's: a gate
+// satisfied by a call on a different object holds the spelling and not the
+// rule, which is the defect this whole branch exists to remove.
+func callsAny(fn *ast.FuncDecl, qualifier string, names map[string]bool) bool {
+	if fn.Body == nil || qualifier == "" {
 		return false
 	}
 	found := false
@@ -189,12 +200,26 @@ func callsAny(fn *ast.FuncDecl, names map[string]bool) bool {
 		if !ok {
 			return true
 		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && names[sel.Sel.Name] {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !names[sel.Sel.Name] {
+			return true
+		}
+		if on, ok := sel.X.(*ast.Ident); ok && on.Name == qualifier {
 			found = true
 		}
 		return !found
 	})
 	return found
+}
+
+// receiverName answers what fn's own receiver is called, or "" for a function
+// with none. A method whose receiver is unnamed (`func (*Store) f()`) cannot
+// call anything ON it, so "" correctly matches nothing.
+func receiverName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 || len(fn.Recv.List[0].Names) == 0 {
+		return ""
+	}
+	return fn.Recv.List[0].Names[0].Name
 }
 
 func typeText(expr ast.Expr) string {

--- a/backend/internal/modules/people/projectanchorgate_test.go
+++ b/backend/internal/modules/people/projectanchorgate_test.go
@@ -21,8 +21,26 @@ import (
 // judged without anyone remembering this file. A read that legitimately wants
 // visibility rather than writability will fail here — correctly, because it
 // should say so where it is, rather than being quietly absent from a list.
+//
+// "Takes a project" has to mean both spellings this module uses. A verb whose
+// project arrives inside an input struct is still a verb on that project, and
+// recognising only the bare parameter is the way this gate fails worst: it
+// examines a smaller file, finds every member of what it did examine gated,
+// and reports PASS.
+//
+// So the file is classified exhaustively rather than filtered. An exported
+// method here is a project verb and takes the row anchor, or it is a person
+// read and takes the person's own object grant. Something that is neither is
+// a spelling the census cannot see, and it fails saying so — because a method
+// this gate silently skips is indistinguishable from one it cleared.
 
 const projectAnchorGate = "ensureProjectWritable"
+
+// personReadGate is what the file's other kind of exported method owes: a name
+// read is not a write on a project and has no row anchor to take, but it is
+// still a read, and one that trusted its argument would be a side door onto
+// any id somebody could guess.
+const personReadGate = "Require"
 
 // stakeholderFile is where the verbs and their gate live together. The claim is
 // about that pairing, so the file is the honest unit: a verb that moves out of
@@ -30,7 +48,8 @@ const projectAnchorGate = "ensureProjectWritable"
 const stakeholderFile = "projectstakeholder.go"
 
 // projectIDType is what makes a method a verb ON a project rather than one that
-// merely mentions them.
+// merely mentions them — either handed over directly or carried in by an input
+// struct that holds one.
 const projectIDType = "ids.ProjectID"
 
 func TestEveryProjectStakeholderVerbTakesTheRowAnchorGate(t *testing.T) {
@@ -40,10 +59,26 @@ func TestEveryProjectStakeholderVerbTakesTheRowAnchorGate(t *testing.T) {
 		t.Fatalf("parsing %s: %v", stakeholderFile, err)
 	}
 	gated := gatedHelpers(file)
+	carriers := projectCarryingTypes(t)
 	verbs := 0
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name == nil || !fn.Name.IsExported() || !takesA(fn, projectIDType) {
+		if !ok || fn.Name == nil || !fn.Name.IsExported() {
+			continue
+		}
+		if !takesAProject(fn, carriers) {
+			// Not skipped: a method the census cannot place is the census
+			// being wrong, not the method being exempt. The one thing it may
+			// be instead of a project verb is a read, and a read owes its own
+			// grant.
+			if callsAny(fn, map[string]bool{personReadGate: true}) {
+				continue
+			}
+			t.Errorf("%s in %s names no project, by parameter or by input struct, and takes no "+
+				"%s either.\n\nSo it is neither of the two things this file holds. Either it "+
+				"reaches a project by a spelling the census cannot see — in which case the gate "+
+				"is judging less than it reports — or it is an ungated read.",
+				fn.Name.Name, stakeholderFile, personReadGate)
 			continue
 		}
 		verbs++
@@ -62,6 +97,62 @@ func TestEveryProjectStakeholderVerbTakesTheRowAnchorGate(t *testing.T) {
 			"verbs have moved and the claim on %s no longer describes this file",
 			stakeholderFile, projectAnchorGate)
 	}
+}
+
+// takesAProject reports whether fn is handed a project to act on — as a bare
+// ids.ProjectID, or inside an input struct that carries one. The second
+// spelling is the module's dominant one for a write verb, and a gate that
+// knows only the first holds half the file while reporting all of it.
+func takesAProject(fn *ast.FuncDecl, carriers map[string]bool) bool {
+	if takesA(fn, projectIDType) {
+		return true
+	}
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, param := range fn.Type.Params.List {
+		if carriers[typeText(param.Type)] {
+			return true
+		}
+	}
+	return false
+}
+
+// projectCarryingTypes names every struct the module declares that holds an
+// ids.ProjectID field. Derived from the tree rather than listed, so an input
+// type renamed or introduced tomorrow carries its verb into the census on its
+// own.
+func projectCarryingTypes(t *testing.T) map[string]bool {
+	t.Helper()
+	carriers := map[string]bool{}
+	forEachModuleFile(t, func(_ string, _ *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || ts.Name == nil {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
+					continue
+				}
+				for _, field := range st.Fields.List {
+					if typeText(field.Type) == projectIDType {
+						carriers[ts.Name.Name] = true
+					}
+				}
+			}
+		}
+	})
+	if len(carriers) == 0 {
+		t.Fatalf("no struct in this module carries an %s field, so the half of the census that "+
+			"finds a verb by its input type is examining nothing", projectIDType)
+	}
+	return carriers
 }
 
 // gatedHelpers names the file's own unexported methods that reach the gate, so

--- a/backend/internal/modules/people/projectstakeholder.go
+++ b/backend/internal/modules/people/projectstakeholder.go
@@ -123,6 +123,8 @@ func (s *Store) SetProjectStakeholder(ctx context.Context, in SetProjectStakehol
 // workspace, so without it any seat holding `project.update` could rewrite any
 // team's roster. Out of the caller's reach reads as ErrNotFound; a project they
 // can see but not change answers ErrPermissionDenied.
+//
+// Held by: TestEveryProjectStakeholderVerbTakesTheRowAnchorGate (backend/internal/modules/people/projectanchorgate_test.go)
 func (s *Store) ensureProjectWritable(ctx context.Context, projectID ids.ProjectID) error {
 	return s.tx(ctx, func(tx pgx.Tx) error {
 		return auth.EnsureWritableLive(ctx, tx, projectObjectName, projectID.UUID)

--- a/backend/internal/modules/people/promote.go
+++ b/backend/internal/modules/people/promote.go
@@ -316,23 +316,15 @@ func promotableLead(ctx context.Context, tx pgx.Tx, id ids.LeadID, in PromoteLea
 // creates (DEDUPE_FUZZY_AUTOMERGE is pinned never) and now leaves the pair on
 // the review queue instead of nothing at all.
 func (s *Store) promoteTarget(ctx context.Context, tx pgx.Tx, lead crmcontracts.Lead, by string, merged *bool) (ids.PersonID, map[string]any, error) {
-	name := deref(lead.FullName)
-	if name == "" {
-		// Identity was checked upstream, so an email exists; a person
-		// needs SOME name until enrichment fills it.
-		name = string(*lead.Email)
-	}
-	var emails []string
-	if lead.Email != nil {
-		emails = []string{string(*lead.Email)}
-	}
-	consumerMail, err := s.consumerMailMatcher(ctx, tx)
+	candidate, err := s.leadPersonCandidate(ctx, tx, lead)
 	if err != nil {
 		return ids.PersonID{}, nil, err
 	}
-	match, err := DedupePerson(ctx, tx, PersonCandidate{
-		FullName: name, Emails: emails, ConsumerMail: consumerMail,
-	})
+	// The person is created under the SAME name the ladder matched on, so a
+	// lead that resolved as a new person is stored as the candidate that was
+	// compared, not as a second reading of the lead.
+	name := candidate.FullName
+	match, err := DedupePerson(ctx, tx, candidate)
 	if err != nil {
 		return ids.PersonID{}, nil, err
 	}

--- a/backend/internal/modules/people/promote.go
+++ b/backend/internal/modules/people/promote.go
@@ -291,7 +291,10 @@ func promotableLead(ctx context.Context, tx pgx.Tx, id ids.LeadID, in PromoteLea
 	if lead.ArchivedAt != nil {
 		return crmcontracts.Lead{}, apperrors.ErrNotFound
 	}
-	if lead.FullName == nil && lead.Email == nil {
+	// Read through the same derivation the ladder matches on, not through a
+	// nil check: a full_name that is present and empty passes `!= nil` and
+	// names nobody, so such a lead promotes into a person with no name at all.
+	if leadIdentityName(lead) == "" {
 		return crmcontracts.Lead{}, &PromoteNeedsIdentityError{}
 	}
 	if in.EvidenceActivityID != nil {

--- a/backend/internal/modules/people/promote.go
+++ b/backend/internal/modules/people/promote.go
@@ -63,12 +63,15 @@ type AlreadyPromotedError struct{ PersonID ids.PersonID }
 
 func (e *AlreadyPromotedError) Error() string { return "lead is already promoted" }
 
-// PromoteNeedsIdentityError maps to 422: a lead with neither a name nor
-// an email cannot become a person worth having.
+// PromoteNeedsIdentityError maps to 422: a lead nothing names cannot become a
+// person worth having.
 type PromoteNeedsIdentityError struct{}
 
+// Error says what is missing rather than which field is absent. A full_name
+// that is present and empty is refused here, and telling that caller the lead
+// "has no full_name" contradicts the record they can see.
 func (e *PromoteNeedsIdentityError) Error() string {
-	return "lead has neither full_name nor email; enrich it before promoting"
+	return "lead has no name and no email to be named by; enrich it before promoting"
 }
 
 // MessageFault names the condition and no field: the remedy is EITHER of two

--- a/backend/internal/modules/people/promoteidentity_integration_test.go
+++ b/backend/internal/modules/people/promoteidentity_integration_test.go
@@ -71,6 +71,18 @@ func TestPromotingALeadThatNamesNobodyIsRefused(t *testing.T) {
 			}
 			leadID := ids.From[ids.LeadKind](ids.UUID(lead.Id))
 
+			// The preview is what a human reads before agreeing, so it has to
+			// answer the same way. A preview promising "create" over an act
+			// that refuses is the worse half of the two.
+			var previewNeedsIdentity *PromoteNeedsIdentityError
+			preview, perr := store.PreviewLeadPromotion(ctx, leadID)
+			if !errors.As(perr, &previewNeedsIdentity) {
+				t.Errorf("previewing a lead that names nobody: got outcome %q (err=%v), want a "+
+					"PromoteNeedsIdentityError — the preview and the promotion answer one "+
+					"question and a human acts on the preview's answer",
+					preview.Outcome, perr)
+			}
+
 			person, merged, err := store.PromoteLead(ctx, leadID, PromoteLeadInput{Trigger: "human_qualify"})
 			var needsIdentity *PromoteNeedsIdentityError
 			if !errors.As(err, &needsIdentity) {

--- a/backend/internal/modules/people/promoteidentity_integration_test.go
+++ b/backend/internal/modules/people/promoteidentity_integration_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// A promotion's whole job is to name a person. A lead that names nobody must
+// therefore be refused rather than promoted into a row with an empty name —
+// one no search finds, no merge matches and no rep recognises.
+//
+// The lead is seeded through CreateLead, which is the reason this test is here
+// and not beside the unit spec: nothing between the request body and the row
+// refuses a full_name that is present and empty, so the state under test is one
+// the shipped writer really produces.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// newPromoteIdentityEnv is a caller who may work leads AND create people. The
+// person grant is the point: without it every promotion answers
+// permission denied, and a test asserting a refusal would read green on an
+// authz denial it never meant to provoke.
+func newPromoteIdentityEnv(t *testing.T) (context.Context, *Store) {
+	t.Helper()
+	ctx, store, _ := newLeadScoreEnvWithBase(t)
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("the lead-score environment carries no actor, so this test cannot widen its grants")
+	}
+	actor.Permissions.Objects["person"] = principal.ObjectGrant{
+		Create: true, Read: true, Update: true, Delete: true,
+	}
+	return principal.WithActor(ctx, actor), store
+}
+
+func TestPromotingALeadThatNamesNobodyIsRefused(t *testing.T) {
+	ctx, store := newPromoteIdentityEnv(t)
+
+	for _, tc := range []struct {
+		name string
+		in   CreateLeadInput
+	}{
+		{
+			name: "no full_name and no email",
+			in:   CreateLeadInput{Title: ptr("VP Sales"), Source: "webform", Status: "new"},
+		},
+		{
+			// The one `FullName != nil` cannot see: a full_name is present,
+			// so a nil check calls this lead identified and the ladder then
+			// has nothing to match on.
+			name: "a present-but-empty full_name and no email",
+			in:   CreateLeadInput{FullName: ptr(""), Title: ptr("VP Sales"), Source: "webform", Status: "new"},
+		},
+		{
+			name: "a full_name that is only padding, and no email",
+			in:   CreateLeadInput{FullName: ptr("   "), Title: ptr("VP Sales"), Source: "webform", Status: "new"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lead, _, err := store.CreateLead(ctx, tc.in)
+			if err != nil {
+				t.Fatalf("seeding a lead the writer accepts: %v", err)
+			}
+			leadID := ids.From[ids.LeadKind](ids.UUID(lead.Id))
+
+			person, merged, err := store.PromoteLead(ctx, leadID, PromoteLeadInput{Trigger: "human_qualify"})
+			var needsIdentity *PromoteNeedsIdentityError
+			if !errors.As(err, &needsIdentity) {
+				t.Fatalf("promoting a lead that names nobody: got person %q (merged=%v, err=%v), "+
+					"want a PromoteNeedsIdentityError", person.FullName, merged, err)
+			}
+
+			// The refusal has to leave nothing behind: a lead marked promoted
+			// with no person is worse than either half.
+			after, rerr := store.GetLead(ctx, leadID, storekit.IncludeArchived)
+			if rerr != nil {
+				t.Fatalf("reading the lead back: %v", rerr)
+			}
+			if after.Status == "promoted" || after.PromotedPersonId != nil {
+				t.Errorf("the refused lead is status=%q with promoted_person_id=%v; a refused "+
+					"promotion must not stamp the outcome it declined to produce",
+					after.Status, after.PromotedPersonId)
+			}
+		})
+	}
+}
+
+// The email is what names a lead with no name of its own, so this one must
+// still promote — the guard refuses leads that name nobody, not leads that are
+// merely unnamed.
+func TestALeadNamedOnlyByItsEmailStillPromotes(t *testing.T) {
+	ctx, store := newPromoteIdentityEnv(t)
+
+	lead, _, err := store.CreateLead(ctx, CreateLeadInput{
+		FullName: ptr(""),
+		Email:    ptr("vera@nordwind.example"),
+		Source:   "webform",
+		Status:   "new",
+	})
+	if err != nil {
+		t.Fatalf("seeding a lead: %v", err)
+	}
+	person, _, err := store.PromoteLead(ctx,
+		ids.From[ids.LeadKind](ids.UUID(lead.Id)), PromoteLeadInput{Trigger: "human_qualify"})
+	if err != nil {
+		t.Fatalf("promoting a lead named by its email: %v", err)
+	}
+	if person.FullName != "vera@nordwind.example" {
+		t.Errorf("the promoted person is named %q, want the email that named the lead — the "+
+			"ladder matched on it, so the person has to be stored under it",
+			person.FullName)
+	}
+}

--- a/backend/internal/modules/people/promotepreview.go
+++ b/backend/internal/modules/people/promotepreview.go
@@ -96,7 +96,29 @@ func (s *Store) PreviewLeadPromotion(ctx context.Context, id ids.LeadID) (crmcon
 // previewTarget is the read half of promoteTarget: the same candidate the
 // promotion would resolve, through the same ladder, so the preview and the
 // promotion cannot disagree about who the lead already is.
+//
+// Held by: TestTheLadderCandidateIsDerivedInOnePlace (backend/internal/modules/people/onederivation_test.go)
 func (s *Store) previewTarget(ctx context.Context, tx pgx.Tx, lead crmcontracts.Lead) (PersonResolution, error) {
+	candidate, err := s.leadPersonCandidate(ctx, tx, lead)
+	if err != nil {
+		return PersonResolution{}, err
+	}
+	return DedupePerson(ctx, tx, candidate)
+}
+
+// leadPersonCandidate turns a lead into the candidate the §1.3 ladder matches
+// on. The preview and the promotion take it from here rather than each
+// assembling one, because "the same candidate" is a promise about the
+// DERIVATION and not about the struct: two literals with the same fields still
+// disagree when the names fed into them are worked out differently, and the
+// preview would then name a person the promotion does not land on.
+//
+// A lead reaching here can carry a full_name that is present and empty, which
+// is not the same as absent — the identity check upstream refuses only a lead
+// with neither field, so an empty name with no email survives it. The email is
+// therefore read through its own nil check rather than on the strength of that
+// check having passed.
+func (s *Store) leadPersonCandidate(ctx context.Context, tx pgx.Tx, lead crmcontracts.Lead) (PersonCandidate, error) {
 	name := deref(lead.FullName)
 	if name == "" && lead.Email != nil {
 		name = string(*lead.Email)
@@ -107,9 +129,7 @@ func (s *Store) previewTarget(ctx context.Context, tx pgx.Tx, lead crmcontracts.
 	}
 	consumerMail, err := s.consumerMailMatcher(ctx, tx)
 	if err != nil {
-		return PersonResolution{}, err
+		return PersonCandidate{}, err
 	}
-	return DedupePerson(ctx, tx, PersonCandidate{
-		FullName: name, Emails: emails, ConsumerMail: consumerMail,
-	})
+	return PersonCandidate{FullName: name, Emails: emails, ConsumerMail: consumerMail}, nil
 }

--- a/backend/internal/modules/people/promotepreview.go
+++ b/backend/internal/modules/people/promotepreview.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -106,6 +107,29 @@ func (s *Store) previewTarget(ctx context.Context, tx pgx.Tx, lead crmcontracts.
 	return DedupePerson(ctx, tx, candidate)
 }
 
+// leadIdentityName is what a lead is called, worked out once: its own name if
+// it has one, otherwise the email address that is the only other thing naming
+// it, and the empty string when it has neither.
+//
+// The promotion's identity guard and the ladder candidate both read it here.
+// A guard that decides "this lead has an identity" one way while the candidate
+// works the name out another way admits exactly the leads it meant to refuse:
+// `FullName != nil` is true of a full_name that is PRESENT and EMPTY, which is
+// not a name, and such a lead reaches the ladder carrying nothing to match on.
+//
+// The name is trimmed for the reason the address is (values.ParseEmail):
+// padding is not identity, and a person stored under a padded name is a person
+// the next search does not find.
+func leadIdentityName(lead crmcontracts.Lead) string {
+	if name := strings.TrimSpace(deref(lead.FullName)); name != "" {
+		return name
+	}
+	if lead.Email != nil {
+		return string(*lead.Email)
+	}
+	return ""
+}
+
 // leadPersonCandidate turns a lead into the candidate the §1.3 ladder matches
 // on. The preview and the promotion take it from here rather than each
 // assembling one, because "the same candidate" is a promise about the
@@ -119,10 +143,7 @@ func (s *Store) previewTarget(ctx context.Context, tx pgx.Tx, lead crmcontracts.
 // therefore read through its own nil check rather than on the strength of that
 // check having passed.
 func (s *Store) leadPersonCandidate(ctx context.Context, tx pgx.Tx, lead crmcontracts.Lead) (PersonCandidate, error) {
-	name := deref(lead.FullName)
-	if name == "" && lead.Email != nil {
-		name = string(*lead.Email)
-	}
+	name := leadIdentityName(lead)
 	var emails []string
 	if lead.Email != nil {
 		emails = []string{string(*lead.Email)}

--- a/backend/internal/modules/people/promotepreview.go
+++ b/backend/internal/modules/people/promotepreview.go
@@ -57,6 +57,13 @@ func (s *Store) PreviewLeadPromotion(ctx context.Context, id ids.LeadID) (crmcon
 			// Disqualified: nothing promotion could do, so nothing to preview.
 			return apperrors.ErrConflict
 		}
+		// The promotion refuses a lead nothing names, so the preview says so
+		// too. Answering "will create" and then refusing the act is worse than
+		// refusing outright, because the answer is what a human read and
+		// agreed to before pressing the button.
+		if leadIdentityName(lead) == "" {
+			return &PromoteNeedsIdentityError{}
+		}
 		match, err := s.previewTarget(ctx, tx, lead)
 		if err != nil {
 			return err

--- a/backend/internal/modules/people/provenancefilter_test.go
+++ b/backend/internal/modules/people/provenancefilter_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The provenance filter fails by being DROPPED, not by being spelled twice.
+// Every list surface assembles its WHERE through a listFilters literal, and a
+// literal that omits CapturedByKind hands back an unfiltered page to a caller
+// who did ask to filter — the same confident-wrong-answer capturedByKindClause
+// refuses an empty enum value to avoid, arriving one layer up where nothing
+// looks at the value at all.
+//
+// Silent at every layer: the request validates, the query runs, the page is
+// well-formed, and the only symptom is rows the caller asked not to see. The
+// review lists are exactly where that is hardest to notice, because a caller
+// filtering for agent-created rows cannot tell "no AI wrote here" from "the
+// filter was ignored".
+//
+// The literals are found rather than listed. A list surface added tomorrow is
+// judged by this without anyone remembering to add it here, which is the whole
+// difference between a gate and a checklist.
+
+// provenanceField is the filter this holds: the field a listFilters literal
+// must carry from its caller.
+const provenanceField = "CapturedByKind"
+
+func TestEveryListFiltersLiteralCarriesTheProvenanceFilter(t *testing.T) {
+	literals := listFiltersLiterals(t)
+	if len(literals) == 0 {
+		t.Fatal("no listFilters literal found in this module, so this gate judged nothing — " +
+			"either the struct was renamed or the list surfaces have moved")
+	}
+	for _, lit := range literals {
+		if lit.sets[provenanceField] {
+			continue
+		}
+		t.Errorf("%s builds a listFilters without %s.\n\nThe surface then answers a request that "+
+			"asked to filter on provenance with a page that did not, and nothing anywhere "+
+			"refuses: set it from the caller's input, or give the field the zero value "+
+			"explicitly beside a reason this surface has no provenance to filter on.",
+			lit.where, provenanceField)
+	}
+}
+
+// The other half of the claim: one spelling means one caller. A second place
+// building the clause is how the person list and the lead list come to disagree
+// about which prefix counts as an AI — the two are read side by side, so the
+// disagreement reaches a person before it reaches a test.
+func TestTheProvenanceClauseIsBuiltInOnePlace(t *testing.T) {
+	callers := map[string]int{}
+	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "capturedByKindClause" {
+				callers[fset.Position(call.Pos()).String()]++
+			}
+			return true
+		})
+	})
+	if len(callers) == 0 {
+		t.Fatal("capturedByKindClause has no caller in this module — a provenance filter nothing " +
+			"builds is a filter every list silently ignores")
+	}
+	if len(callers) > 1 {
+		sites := make([]string, 0, len(callers))
+		for site := range callers {
+			sites = append(sites, site)
+		}
+		t.Errorf("capturedByKindClause is called from %d places (%s).\n\nOne caller is what makes "+
+			"it the one spelling: every list reaches the prefix rule through listFilters, so a "+
+			"second caller is a surface that has started deciding for itself which prefix counts "+
+			"as an AI.", len(callers), strings.Join(sites, ", "))
+	}
+}
+
+// listFiltersLiteral is one composite literal building the shared filter set.
+type listFiltersLiteral struct {
+	where string
+	sets  map[string]bool
+}
+
+func listFiltersLiterals(t *testing.T) []listFiltersLiteral {
+	t.Helper()
+	var found []listFiltersLiteral
+	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			id, ok := lit.Type.(*ast.Ident)
+			if !ok || id.Name != "listFilters" {
+				return true
+			}
+			sets := map[string]bool{}
+			for _, element := range lit.Elts {
+				kv, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				if key, ok := kv.Key.(*ast.Ident); ok {
+					sets[key.Name] = true
+				}
+			}
+			found = append(found, listFiltersLiteral{
+				where: fset.Position(lit.Pos()).String(), sets: sets,
+			})
+			return true
+		})
+	})
+	return found
+}
+
+// forEachModuleFile parses the module's own non-test sources and hands each to
+// visit. Test sources are left out: a listFilters a test builds is a fixture,
+// and holding a fixture to the shape of a shipped surface would refuse cases
+// written to exercise one filter at a time.
+func forEachModuleFile(t *testing.T, visit func(name string, fset *token.FileSet, file *ast.File)) {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the module directory: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		visit(name, fset, file)
+	}
+}

--- a/backend/internal/modules/people/responsetouch_test.go
+++ b/backend/internal/modules/people/responsetouch_test.go
@@ -33,6 +33,10 @@ const touchType = "leadResponseTouch"
 // ownedTouchFields names, per field, the function that owns the rule the field
 // carries. A field here holds a rule rather than a value, so reading it IS
 // deciding the rule; anyone else wanting the answer calls that function.
+//
+// gatekit:fixture the field-to-owner pairing this gate judges, not a set of
+// ratified exceptions: the values name functions, and a stale one fails above
+// rather than quietly widening what is allowed.
 var ownedTouchFields = map[string]string{
 	"source":     "humanLoggedNote",
 	"capturedBy": "humanCaptured",

--- a/backend/internal/modules/people/responsetouch_test.go
+++ b/backend/internal/modules/people/responsetouch_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// §18.1 asks two questions of a touch that look like field reads and are not:
+// "did a rep type this into the composer" and "was a person involved at all".
+// Each is a rule about the captured_by grammar and the Log composer's stamp,
+// and each is asked from two places — the ladder's contact arm and the
+// first-response clock. Spelled twice, the two change in one place and the
+// stepper then shows a lead as Contacted while the clock goes on counting it as
+// unanswered. Both are on the same screen.
+//
+// So the subject is not the predicate's text, which two readers can respell
+// without agreeing; it is the FIELD. A second function reading `source` or
+// `capturedBy` off a touch is a second opinion about the same rule, whatever
+// words it uses to reach it.
+//
+// `kind` is deliberately not held: `ladderStepFor` reads it to ask whether the
+// touch is a meeting, which is a different question about the same column.
+
+// touchType is the struct whose field reads this holds.
+const touchType = "leadResponseTouch"
+
+// ownedTouchFields names, per field, the function that owns the rule the field
+// carries. A field here holds a rule rather than a value, so reading it IS
+// deciding the rule; anyone else wanting the answer calls that function.
+var ownedTouchFields = map[string]string{
+	"source":     "humanLoggedNote",
+	"capturedBy": "humanCaptured",
+}
+
+func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
+	readers := map[string]map[string]bool{}
+	forEachModuleFile(t, func(_ string, _ *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !takesA(fn, touchType) {
+				continue
+			}
+			for field := range fieldReadsIn(fn.Body) {
+				if _, owned := ownedTouchFields[field]; !owned {
+					continue
+				}
+				if readers[field] == nil {
+					readers[field] = map[string]bool{}
+				}
+				readers[field][fn.Name.Name] = true
+			}
+		}
+	})
+	for field, owner := range ownedTouchFields {
+		found := readers[field]
+		if len(found) == 0 {
+			t.Errorf("nothing reads %s.%s, so the rule %s carries has no subject and this gate "+
+				"judged nothing for it", touchType, field, owner)
+			continue
+		}
+		if !found[owner] {
+			t.Errorf("%s does not read %s.%s, so it is no longer where that rule lives — this "+
+				"gate is now protecting the wrong function", owner, touchType, field)
+		}
+		if len(found) == 1 {
+			continue
+		}
+		others := make([]string, 0, len(found))
+		for name := range found {
+			if name != owner {
+				others = append(others, name)
+			}
+		}
+		sort.Strings(others)
+		t.Errorf("%s.%s is read by %s as well as %s.\n\nThat is a second opinion about the same "+
+			"rule: the captured_by grammar and the composer's stamp are things that change, and "+
+			"read in two places they change in one. The ladder then shows a lead as contacted "+
+			"while the first-response clock counts it unanswered, on one screen. Call %s.",
+			touchType, field, strings.Join(others, ", "), owner, owner)
+	}
+}
+
+// fieldReadsIn returns the field names selected in body, excluding those taken
+// by ADDRESS: `&t.capturedBy` in a row Scan fills the field rather than asking
+// it anything, and counting it would report the builder as a second reader of
+// every rule it populates.
+func fieldReadsIn(body *ast.BlockStmt) map[string]bool {
+	addressed := map[ast.Node]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		if unary, ok := n.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+			addressed[unary.X] = true
+		}
+		return true
+	})
+	read := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || addressed[ast.Node(sel)] {
+			return true
+		}
+		if _, isIdent := sel.X.(*ast.Ident); isIdent {
+			read[sel.Sel.Name] = true
+		}
+		return true
+	})
+	return read
+}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -468,9 +468,7 @@ internal/modules/people/linkedinrenormalize.go#func matchRank
 internal/modules/people/linkedinrenormalize.go#var matchRankOrder
 internal/modules/people/listfilters.go#const block at const filterOwnerID
 internal/modules/people/listpage.go#func aiWrittenClause
-internal/modules/people/listpage.go#func capturedByKindClause
 internal/modules/people/mapping.go#type LeadUpdateRequest
-internal/modules/people/organization_counts.go#func fillOpenDealCounts
 internal/modules/people/organization_profile_field_write.go#const block at const auditKeyValue
 internal/modules/people/organization_profile_field_write.go#method Store.writeProfileField
 internal/modules/people/projectstakeholder.go#method Store.PersonNames

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -459,7 +459,6 @@ internal/modules/people/geocode.go#var organizationAddressColumns
 internal/modules/people/handlers_projectstakeholder.go#const block at const ProjectStakeholderKind
 internal/modules/people/lead_list.go#const block at const leadNameColumn
 internal/modules/people/lead_read.go#const liveOnlyClause
-internal/modules/people/leadslaworkflow.go#func humanLoggedNote
 internal/modules/people/leadstatus.go#method LeadStatus.Open
 internal/modules/people/linkedinmatch.go#method Store.MatchLinkedInConnections
 internal/modules/people/linkedinmatch.go#var suggestNameEmployerMatchSQL
@@ -468,12 +467,8 @@ internal/modules/people/linkedinrenormalize.go#func matchRank
 internal/modules/people/linkedinrenormalize.go#var matchRankOrder
 internal/modules/people/listfilters.go#const block at const filterOwnerID
 internal/modules/people/listpage.go#func aiWrittenClause
-internal/modules/people/mapping.go#type LeadUpdateRequest
 internal/modules/people/organization_profile_field_write.go#const block at const auditKeyValue
-internal/modules/people/organization_profile_field_write.go#method Store.writeProfileField
 internal/modules/people/projectstakeholder.go#method Store.PersonNames
-internal/modules/people/projectstakeholder.go#method Store.ensureProjectWritable
-internal/modules/people/promotepreview.go#method Store.previewTarget
 internal/modules/people/provider.go#func pageOf
 internal/modules/people/relationship_conflict_test.go#func TestRelationshipUniquenessRefusalKeepsBothTheSentinelAndTheConstraint
 internal/modules/people/resolve.go#func exactOrganizationOwners

--- a/backend/uniquenessclaims_test.go
+++ b/backend/uniquenessclaims_test.go
@@ -455,7 +455,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // a row falling, so the two kinds of progress are told apart by which number
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
-	"cannot-drift":   165,
+	"cannot-drift":   160,
 	"once":           158,
 	"one-of-a-kind":  156,
 	"is-every-named": 95,

--- a/backend/uniquenessclaims_test.go
+++ b/backend/uniquenessclaims_test.go
@@ -455,7 +455,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // a row falling, so the two kinds of progress are told apart by which number
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
-	"cannot-drift":   167,
+	"cannot-drift":   165,
 	"once":           158,
 	"one-of-a-kind":  156,
 	"is-every-named": 95,


### PR DESCRIPTION
Seven `cannot-drift` claims in `internal/modules/people` whose subject is a
**rule** rather than a declaration. A census over text cannot hold any of them:
two readers can respell a predicate and still disagree. So each gate takes the
thing the readers actually share — a struct field, a callee set, an input type —
and holds THAT.

With these, `internal/modules/people` has **zero unheld `cannot-drift` claims**.
The register drops from 616 to 609.

## What each gate holds

| claim | the shared thing the gate keys on |
|---|---|
| open deal | the 0065 rollup: a query naming `open_deal_count` must read it, and a query reading `deal` must not decide for itself what open means |
| the provenance filter | the `listFilters` literals, **found rather than listed** — a surface added tomorrow is judged without anyone remembering it |
| the promote candidate | one derivation of `PersonCandidate`, taking the guarded reading |
| the captured_by human prefix | the FIELD, not the predicate — a second reader is caught whatever words it uses |
| both stakeholder verbs | the row anchor, derived from the signature |
| both profile-field verbs | the one write path, forbidden set derived from that path's own callees |
| both lead-update transports | the null-vs-absent gesture |

## The defects behind the claims

1. **`promoteTarget` dereferences a nil email.** A lead with a
   present-but-empty `full_name` and no email passes the identity check —
   which refuses only a lead with NEITHER field — and reaches `*lead.Email`.
   The preview had the guarded reading; the promotion did not. Now one
   derivation, and the created person is named from the candidate that was
   matched rather than from a second reading of the lead.
2. **A dropped provenance filter would be indistinguishable from an empty
   result** — and this one is a gate without a defect behind it, stated
   plainly because an earlier draft of this body claimed otherwise. All four
   `listFilters` literals already carried `CapturedByKind` at `origin/main` and
   none is touched here. What the gate buys is the NEXT surface: a literal that
   omits the field answers a request that asked to filter with a page that did
   not — the request validates, the query runs, the page is well-formed, and a
   caller filtering for agent-created rows cannot tell "no AI wrote here" from
   "the filter was ignored". The literals are found rather than listed, so that
   surface is judged the day it is written.
3. **`capturedByKindClause`'s refusal named its vocabulary in prose** while
   acceptance came from the generated `Valid()`. A kind added to `crm.yaml`
   would be accepted and left out of the sentence telling the caller what is
   allowed. The message now renders a set spelled from the contract's own
   constants.

Also fixed along the way: `capturedByKindClause`'s stated reason for sitting
outside `listFilters` no longer described the tree — the lead work queue
assembles its own WHERE chain and still takes the shared clauses from the
struct.

## A fourth defect, found while reviewing this branch

The `promoteTarget` fix above stopped the crash. It did not stop the promotion.

A lead with a present-but-empty `full_name` and no email still cleared
`promotableLead`'s identity guard — `FullName != nil` is true of a pointer to
`""` — reached a ladder with nothing to match on, and **promoted into a person
named `""`**: a row no search finds, no merge matches and no rep recognises,
minted by the one verb whose whole job is to name them. Nothing between the
request body and the row refuses an empty `full_name` (`normalizedCreateLeadInput`
validates status, email and LinkedIn URL and never looks at the name), so the
state is one `CreateLead` really produces.

It is the same shape as the rest of this branch — two readings of one question —
so it is fixed the same way: the guard and the candidate both read
`leadIdentityName`, which is the lead's own name, else the address that is the
only other thing naming it, else nothing. Trimmed, for the reason
`values.ParseEmail` trims.

Proof it was live, measured on this branch with only the guard reverted:

```
--- PASS: TestPromotingALeadThatNamesNobodyIsRefused/no_full_name_and_no_email
--- FAIL: .../a_present-but-empty_full_name_and_no_email
    promoting a lead that names nobody: got person "" (merged=false, err=<nil>)
--- FAIL: .../a_full_name_that_is_only_padding,_and_no_email
```

`err=<nil>` — the promotion succeeded. The first row is the case the old guard
did catch, which is what makes the other two its blind spot rather than a
missing guard.

## The fixture annotation

`map[string]string` beside a gate reads as a waiver map. The field-to-owner
pairing is not one: its values name the function that owns each field's rule, so
a stale entry has to fail rather than quietly widen what a reader may do. It
carries `// gatekit:fixture`, and the count in `gatecensus_test.go` moves with it.

## What review changed

Two independent reviews (Fable, Codex) ran over the branch. They agreed on the
worst finding, and it was in this PR's own new gate.

**The project-anchor gate held half the file and reported all of it.**
`TestEveryProjectStakeholderVerbTakesTheRowAnchorGate` found its verbs with
`takesA(fn, "ids.ProjectID")`, but `SetProjectStakeholder` takes an input
struct — the module's dominant spelling for a write verb — so the census
contained one verb, found it gated, and passed. Measured: delete
`ensureProjectWritable` from `SetProjectStakeholder` and the gate reads **PASS**
over the exact authz hole its own message describes ("any seat holding
`project.update` can rewrite any team's roster"). It now recognises a project
carried in by an input struct, with the carrier types derived from the module's
own struct declarations, and classifies the file exhaustively: an exported
method that is neither a project verb nor a gated person read fails rather than
being skipped. Both mutants now caught.

**The preview and the promotion disagreed for the newly-refused class.** The
preview answered `outcome: create` for a lead nothing names while the promotion
returned 422 — and the answer a human reads before agreeing is the worse half to
get wrong. The preview now takes the same guard, and the integration test
asserts both halves.

**The refusal message had become false.** It said "lead has neither full_name
nor email" to a lead whose `full_name` is present and empty — the same shape as
the `capturedByKindClause` message this branch already fixed, one field over. It
now says what is missing rather than which field is absent.

**The rule had a fourth spelling, in SQL.** `leadsla.go` worked the same
fallback out as `COALESCE(full_name, email, '')`, which answers `''` for an
empty name — the exact defect `FullName != nil` was, in a language no AST gate
can read. It is now guarded, and held by a census over the module's own query
literals. Writing that census found nothing else, but only after the first draft
of it reported three false positives: matching any literal that contained
`COALESCE` and both column names caught a SELECT naming them as separate
columns, an INSERT column list, and a coalesce over a domain extracted from the
address. It now decides on one coalesce's own argument list, comments stripped.

**One claim in this body was wrong** and is corrected above: the omitted
provenance filter was never live.

The frontend spells the same rule with `??`, which fires only on `null`, so a
lead with `full_name: ""` renders blank on eight screens. That is a second
mechanism rather than the other half of a mirror — the two do not cancel the way
a money scale does, so landing this side alone is not a regression — and several
of the sites are a different rule that needs its own read. Censused and filed as
**#2807**.

## Verification

Seven gates, each mutation-tested, and **every mutant grepped back out of the
file to prove it applied** — a mutant that silently fails to apply reports green,
which is indistinguishable from a survived mutant.

Stacked on #2799 (merged). Register: 616 -> 609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Lead promotion now handles blank or whitespace-only names consistently.
  - Leads without a usable name or email are blocked with a clear identity error.
  - Leads with only an email can still be promoted, using the email as the person’s name.
  - SLA and first-response processing now recognize human-captured activity more reliably.

- **Improvements**
  - Provenance filter validation now stays aligned with supported capture categories.
  - Expanded automated coverage helps protect promotion, authorization, filtering, and data consistency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->