### PR TITLE
docs(events): the generator names the gates that read what it generates

### DIFF
--- a/backend/tools/gen-payloads/main.go
+++ b/backend/tools/gen-payloads/main.go
@@ -201,7 +201,7 @@ func structifyEmptyEventPayloads(body string, spec *openapi3.T) (string, error) 
 // subscribable event type must be a key) and the version gate (the catalog's
 // VersionOf must agree with the value) read — both in
 // backend/publicevents_test.go, as TestEverySubscribableEventHasAPayloadSchema
-// and the VersionOf comparison beside it.
+// and TestPayloadVersionsMatchCatalog.
 func eventMethodsAndVersions(spec *openapi3.T, versionsVar string) (methods, versions string, err error) {
 	if spec.Components == nil {
 		return "", "", nil

--- a/backend/tools/gen-payloads/main.go
+++ b/backend/tools/gen-payloads/main.go
@@ -199,9 +199,9 @@ func structifyEmptyEventPayloads(body string, spec *openapi3.T) (string, error) 
 // x-version extension (default 1 when absent). PublicEventVersions is the
 // single generated source of truth both the coverage gate (every
 // subscribable event type must be a key) and the version gate (the catalog's
-// VersionOf must agree with the value) read — see
-// backend/internal/modules/webhooks/payload_coverage_test.go and
-// payload_version_test.go.
+// VersionOf must agree with the value) read — both in
+// backend/publicevents_test.go, as TestEverySubscribableEventHasAPayloadSchema
+// and the VersionOf comparison beside it.
 func eventMethodsAndVersions(spec *openapi3.T, versionsVar string) (methods, versions string, err error) {
 	if spec.Components == nil {
 		return "", "", nil


### PR DESCRIPTION
The comment over `eventMethodsAndVersions` in `backend/tools/gen-payloads/main.go` sends a reader to two files for the obligations `PublicEventVersions` carries. **Neither holds one.**

| cited | reality |
|---|---|
| `backend/internal/modules/webhooks/payload_coverage_test.go` | does not exist anywhere in the tree |
| `backend/internal/modules/webhooks/payload_version_test.go` | exists, but holds wire snapshots — `TestDealStageChangedWireSnapshot` and friends |

Both obligations actually live in `backend/publicevents_test.go`:

- **coverage** — `TestEverySubscribableEventHasAPayloadSchema` (line 80), which checks `crmcontracts.PublicEventVersions[tp]` for every subscribable type
- **version** — the comparison beside it at line 107, `events.VersionOf(tp) != wantVersion`, erroring with *"contract x-version and catalog.go disagree"*

## The half that existed is the worse half

A citation to a **missing** file breaks the moment anyone follows it — annoying, self-announcing, fixed in a minute.

A citation to a **real** file that holds something else survives being followed. The reader opens `payload_version_test.go`, finds a screenful of tests about payload versions, and stops. They have checked, and they have checked wrong. That is the shape where a comment naming a guarantee hides the gap rather than merely failing to fill it.

Naming the *test* as well as the file leaves nothing to infer.

## How it was found

Swept non-test Go source for cited `*_test.go` names that resolve to no file in the tree:

```
grep -rhoE "[A-Za-z0-9_/.-]+_test\.go" --include="*.go" backend/ extensions/ cli/
```

432 distinct cited names, 2 unresolvable in production source. The other is `backend/internal/platform/config/config.go` citing `backend/configseam_test.go` — a real obligation held by `scripts/check-env-reads.sh` — and it is being fixed alongside a rename in another change, so it is deliberately not touched here.

Worth noting the sweep only catches the *missing* half. The `payload_version_test.go` case — a citation that resolves but points at the wrong gate — is invisible to it, and was only found by reading what the named file actually contains. A grep can prove a citation is broken; nothing but reading proves one is right.

## Verification

`TestEverySubscribableEventHasAPayloadSchema` and `TestNoOrphanPayloadSchema` both pass at this commit, so the newly-named gate exists and holds. `go vet` and `gofmt` clean. Comment-only change; no generated output moves.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the comment over `eventMethodsAndVersions` so it names the tests that actually enforce `PublicEventVersions`; the files it previously cited held no such gate.

- The old comment cited `backend/internal/modules/webhooks/payload_coverage_test.go`, which doesn't exist in the tree.
- It also cited `payload_version_test.go`, which holds wire snapshots rather than the version gate.
- Both gates live in `backend/publicevents_test.go` as `TestEverySubscribableEventHasAPayloadSchema` and `TestPayloadVersionsMatchCatalog`.
- Comment-only change; no behavior or generated output changes.

<sup>Written for commit 0f82747c80efb8d8ed3de25ad37a128fbe02db2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generator documentation to reference the relocated public event payload coverage and version tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->