### PR TITLE
fix(desktop): the start message names the admin the installation was created with

### DIFF
--- a/desktop/launcher/layout.go
+++ b/desktop/launcher/layout.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"bufio"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // layout is the installation directory — everything is relative to it, so the
@@ -97,6 +99,63 @@ func (l layout) adminPasswordPath() string { return filepath.Join(l.data(), "adm
 // copies data/ has the attachments a row points at rather than dangling keys.
 func (l layout) blobs() string { return filepath.Join(l.data(), "blobs") }
 
+// defaultAdminEmail is the bootstrap admin this launcher creates when it writes
+// margince.yaml itself, and the address the start message offers when the file
+// cannot answer. ONE constant because the two must agree: a start message naming
+// an account the configuration did not create hands a reader a credential that
+// cannot sign in, and nothing else in the folder would contradict it.
+const defaultAdminEmail = "owner@margince.local"
+
+// configuredAdminEmail is the address margince.yaml names as the bootstrap
+// admin, or defaultAdminEmail when the file cannot be read or does not say.
+//
+// A DELIBERATELY NARROW READER, not a YAML parser. This module is stdlib-only
+// and outside go.work by design (see go.mod), and a parser dependency bought for
+// one line of a start message would not pay for itself. It finds `email:` under
+// `bootstrap_admin:` and stops.
+//
+// Every failure answers with the default rather than an error. The address is
+// informational, so a shape this reader cannot follow must cost a reader the
+// precision and not the launch.
+func (l layout) configuredAdminEmail() string {
+	file, err := os.Open(l.configPath())
+	if err != nil {
+		return defaultAdminEmail
+	}
+	//craft:ignore swallowed-errors best-effort close of a file opened for reading
+	defer func() { _ = file.Close() }()
+
+	inBlock := false
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = line[:i]
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// A key at column zero ends whatever block preceded it. bootstrap_admin's
+		// own line is such a key, so one test both enters and leaves the block.
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			inBlock = strings.TrimSpace(line) == "bootstrap_admin:"
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		value, found := strings.CutPrefix(strings.TrimSpace(line), "email:")
+		if !found {
+			continue
+		}
+		if email := strings.Trim(strings.TrimSpace(value), `"'`); email != "" {
+			return email
+		}
+		return defaultAdminEmail
+	}
+	return defaultAdminEmail
+}
+
 // ensureConfig writes the deployment configuration on first run and leaves an
 // existing one alone, matching the create-if-missing / leave-if-exists rule
 // the api documents for margince.yaml (A107/ADR-0061). Overwriting it would
@@ -129,10 +188,10 @@ organization:
   timezone: %s
 
 bootstrap_admin:
-  email: owner@margince.local
+  email: %s
   display_name: Owner
   password_file: data/admin-password
-`, localTimezone())
+`, localTimezone(), defaultAdminEmail)
 
 	if err := writeFileAtomic(l.configPath(), []byte(config), 0o600); err != nil {
 		return "", err

--- a/desktop/launcher/layout.go
+++ b/desktop/launcher/layout.go
@@ -185,7 +185,15 @@ func scalarValue(rest string) string {
 		if closing < 0 {
 			return ""
 		}
-		return rest[1 : 1+closing]
+		value := rest[1 : 1+closing]
+		// A double-quoted scalar may carry escapes, and `"admin@demo.test"`
+		// is a legal spelling of an ordinary address. Decoding them is a YAML
+		// parser's job, so an escaped value is declined outright: the default is
+		// a reader's own address, where a half-decoded one is nobody's.
+		if quote == '"' && strings.ContainsRune(value, '\\') {
+			return ""
+		}
+		return value
 	}
 	for i := 1; i < len(rest); i++ {
 		if rest[i] == '#' && (rest[i-1] == ' ' || rest[i-1] == '\t') {

--- a/desktop/launcher/layout.go
+++ b/desktop/launcher/layout.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"bufio"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -111,49 +110,89 @@ const defaultAdminEmail = "owner@margince.local"
 //
 // A DELIBERATELY NARROW READER, not a YAML parser. This module is stdlib-only
 // and outside go.work by design (see go.mod), and a parser dependency bought for
-// one line of a start message would not pay for itself. It finds `email:` under
-// `bootstrap_admin:` and stops.
+// one line of a start message would not pay for itself. It accepts `email:` as a
+// DIRECT child of `bootstrap_admin:` and nothing else, so a nested key of the
+// same name is not mistaken for the installation's own.
 //
 // Every failure answers with the default rather than an error. The address is
 // informational, so a shape this reader cannot follow must cost a reader the
 // precision and not the launch.
 func (l layout) configuredAdminEmail() string {
-	file, err := os.Open(l.configPath())
+	// Read whole rather than streamed: the file is small and write-once, and one
+	// read has one error to answer, where a scanner has a second that is easy to
+	// leave unasked.
+	//
+	// #nosec G304 -- the path is layout's own, derived from the installation directory
+	raw, err := os.ReadFile(l.configPath())
 	if err != nil {
 		return defaultAdminEmail
 	}
-	//craft:ignore swallowed-errors best-effort close of a file opened for reading
-	defer func() { _ = file.Close() }()
 
-	inBlock := false
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if i := strings.IndexByte(line, '#'); i >= 0 {
-			line = line[:i]
-		}
-		if strings.TrimSpace(line) == "" {
+	blockIndent, fieldIndent := -1, -1
+	for _, line := range strings.Split(string(raw), "\n") {
+		body := strings.TrimLeft(strings.TrimRight(line, "\r"), " \t")
+		if body == "" || strings.HasPrefix(body, "#") {
 			continue
 		}
-		// A key at column zero ends whatever block preceded it. bootstrap_admin's
-		// own line is such a key, so one test both enters and leaves the block.
-		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
-			inBlock = strings.TrimSpace(line) == "bootstrap_admin:"
+		key, rest, isKey := strings.Cut(body, ":")
+		if !isKey {
 			continue
 		}
-		if !inBlock {
+		key = strings.TrimSpace(key)
+		indent := len(strings.TrimRight(line, "\r")) - len(body)
+
+		if blockIndent < 0 {
+			if key == "bootstrap_admin" {
+				blockIndent = indent
+			}
 			continue
 		}
-		value, found := strings.CutPrefix(strings.TrimSpace(line), "email:")
-		if !found {
+		// A key back at or outside the block's own column has ended it, and
+		// nothing after it can be the installation's admin.
+		if indent <= blockIndent {
+			return defaultAdminEmail
+		}
+		// The block's first field fixes the column its own keys sit in. Anything
+		// deeper belongs to a nested key — bootstrap_admin.contact.email is not
+		// bootstrap_admin.email.
+		if fieldIndent < 0 {
+			fieldIndent = indent
+		}
+		if indent != fieldIndent || key != "email" {
 			continue
 		}
-		if email := strings.Trim(strings.TrimSpace(value), `"'`); email != "" {
+		if email := scalarValue(rest); email != "" {
 			return email
 		}
 		return defaultAdminEmail
 	}
 	return defaultAdminEmail
+}
+
+// scalarValue reads a YAML scalar written on one line: a quoted string up to its
+// closing quote, or a bare value up to an end-of-line comment.
+//
+// A '#' opens a comment only at the start of a line or after whitespace. It is
+// legal in the local part of an address, so cutting at every '#' would hand a
+// reader a truncated one — which is the failure the caller exists to prevent.
+func scalarValue(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return ""
+	}
+	if quote := rest[0]; quote == '"' || quote == '\'' {
+		closing := strings.IndexByte(rest[1:], quote)
+		if closing < 0 {
+			return ""
+		}
+		return rest[1 : 1+closing]
+	}
+	for i := 1; i < len(rest); i++ {
+		if rest[i] == '#' && (rest[i-1] == ' ' || rest[i-1] == '\t') {
+			return strings.TrimRight(rest[:i], " \t")
+		}
+	}
+	return rest
 }
 
 // ensureConfig writes the deployment configuration on first run and leaves an

--- a/desktop/launcher/layout_test.go
+++ b/desktop/launcher/layout_test.go
@@ -122,3 +122,77 @@ func TestEnsureAdminPasswordDisclosesOnlyOnFirstRun(t *testing.T) {
 		}
 	})
 }
+
+// TestConfiguredAdminEmailAgreesWithTheFileTheLauncherWrites pins the pair that
+// must agree: ensureConfig writes an address into margince.yaml, and the start
+// message offers one to sign in with. Derived from one constant, a launcher
+// cannot create an account under a name it will not go on to report.
+func TestConfiguredAdminEmailAgreesWithTheFileTheLauncherWrites(t *testing.T) {
+	l := newTestLayout(t)
+	if _, err := l.ensureConfig(); err != nil {
+		t.Fatalf("write the config: %v", err)
+	}
+
+	if got := l.configuredAdminEmail(); got != defaultAdminEmail {
+		t.Fatalf("the launcher wrote a config its own start message cannot read back:\n"+
+			"  announce would say %q\n  margince.yaml names %q", got, defaultAdminEmail)
+	}
+}
+
+// TestConfiguredAdminEmailReadsTheInstallationsOwnAddress covers the case that
+// matters: margince.yaml is write-once and the organization is bootstrapped from
+// it, so an operator who names the admin before the first run owns that name for
+// good and the start message follows the file rather than its own default.
+func TestConfiguredAdminEmailReadsTheInstallationsOwnAddress(t *testing.T) {
+	for name, yaml := range map[string]string{
+		"a plain value": "" +
+			"version: 1\n\nbootstrap_admin:\n  email: admin@demo.test\n  display_name: Owner\n",
+		"a quoted value": "" +
+			"version: 1\n\nbootstrap_admin:\n  email: \"admin@demo.test\"\n",
+		"a trailing comment": "" +
+			"version: 1\n\nbootstrap_admin:\n  email: admin@demo.test # the demo account\n",
+		// The block test is what stops an `email:` belonging to some other
+		// section being reported as the sign-in address.
+		"an email under another key first": "" +
+			"organization:\n  email: billing@example.com\n\nbootstrap_admin:\n  email: admin@demo.test\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := newTestLayout(t)
+			if err := os.WriteFile(l.configPath(), []byte(yaml), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if got := l.configuredAdminEmail(); got != "admin@demo.test" {
+				t.Fatalf("start message would name %q, but margince.yaml bootstraps admin@demo.test", got)
+			}
+		})
+	}
+}
+
+// TestConfiguredAdminEmailFallsBackRatherThanFailing keeps the address
+// informational. Reading it must never decide whether a launcher can report
+// where the app is running, so every shape this reader cannot follow answers
+// with the address the launcher would itself have written.
+func TestConfiguredAdminEmailFallsBackRatherThanFailing(t *testing.T) {
+	for name, yaml := range map[string]*string{
+		"no file at all":             nil,
+		"no bootstrap_admin block":   ptr("version: 1\n\norganization:\n  name: Margince\n"),
+		"the block names no email":   ptr("bootstrap_admin:\n  display_name: Owner\n"),
+		"the email is commented out": ptr("bootstrap_admin:\n  # email: admin@demo.test\n"),
+		"the value is empty":         ptr("bootstrap_admin:\n  email:\n"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := newTestLayout(t)
+			if yaml != nil {
+				if err := os.WriteFile(l.configPath(), []byte(*yaml), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+			if got := l.configuredAdminEmail(); got != defaultAdminEmail {
+				t.Fatalf("answered %q; an unreadable config must fall back to %q rather than\n"+
+					"reporting an address no one can sign in with", got, defaultAdminEmail)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/desktop/launcher/layout_test.go
+++ b/desktop/launcher/layout_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -155,14 +156,25 @@ func TestConfiguredAdminEmailReadsTheInstallationsOwnAddress(t *testing.T) {
 		// section being reported as the sign-in address.
 		"an email under another key first": "" +
 			"organization:\n  email: billing@example.com\n\nbootstrap_admin:\n  email: admin@demo.test\n",
+		// '#' is legal in the local part of an address (RFC 5322 atext), so a
+		// reader that cut at every one would announce a truncated address —
+		// the failure this whole function exists to prevent.
+		"a hash inside the address": "" +
+			"bootstrap_admin:\n  email: admin#demo@demo.test\n",
+		"a quoted hash inside the address": "" +
+			"bootstrap_admin:\n  email: \"admin#demo@demo.test\"\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			l := newTestLayout(t)
 			if err := os.WriteFile(l.configPath(), []byte(yaml), 0o600); err != nil {
 				t.Fatalf("write config: %v", err)
 			}
-			if got := l.configuredAdminEmail(); got != "admin@demo.test" {
-				t.Fatalf("start message would name %q, but margince.yaml bootstraps admin@demo.test", got)
+			want := "admin@demo.test"
+			if strings.Contains(yaml, "admin#demo") {
+				want = "admin#demo@demo.test"
+			}
+			if got := l.configuredAdminEmail(); got != want {
+				t.Fatalf("start message would name %q, but margince.yaml bootstraps %q", got, want)
 			}
 		})
 	}
@@ -179,6 +191,9 @@ func TestConfiguredAdminEmailFallsBackRatherThanFailing(t *testing.T) {
 		"the block names no email":   ptr("bootstrap_admin:\n  display_name: Owner\n"),
 		"the email is commented out": ptr("bootstrap_admin:\n  # email: admin@demo.test\n"),
 		"the value is empty":         ptr("bootstrap_admin:\n  email:\n"),
+		// bootstrap_admin.contact.email is not bootstrap_admin.email. Announcing
+		// a nested address would name an account nothing bootstrapped.
+		"only a nested email": ptr("bootstrap_admin:\n  contact:\n    email: ops@demo.test\n"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			l := newTestLayout(t)

--- a/desktop/launcher/layout_test.go
+++ b/desktop/launcher/layout_test.go
@@ -194,6 +194,11 @@ func TestConfiguredAdminEmailFallsBackRatherThanFailing(t *testing.T) {
 		// bootstrap_admin.contact.email is not bootstrap_admin.email. Announcing
 		// a nested address would name an account nothing bootstrapped.
 		"only a nested email": ptr("bootstrap_admin:\n  contact:\n    email: ops@demo.test\n"),
+		// A double-quoted scalar may carry YAML escapes, and decoding them is a
+		// parser's job. Returning the literal would announce an address nothing
+		// bootstrapped, so an escaped value is declined.
+		"a double-quoted value carrying an escape": ptr(
+			"bootstrap_admin:\n  email: \"admin\\u0040demo.test\"\n"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			l := newTestLayout(t)

--- a/desktop/launcher/main.go
+++ b/desktop/launcher/main.go
@@ -194,7 +194,11 @@ func announce(baseURL string, l layout, adminPassword string) {
 	// Every launch says how to sign in, not just the first. A user who
 	// closed the window on the first run would otherwise have no way to
 	// discover where the credentials went — and the file is the only copy.
-	say("\n  Sign in as  owner@margince.local\n")
+	// From margince.yaml, because that file decides it: it is write-once and the
+	// organization is bootstrapped from it, so an installation whose admin was
+	// named before its first run carries that name for good. A literal here could
+	// only ever agree with the default.
+	say("\n  Sign in as  %s\n", l.configuredAdminEmail())
 	if adminPassword != "" {
 		say("  Password    %s\n", adminPassword)
 		say("              (shown once — also saved in data/admin-password)\n")

--- a/desktop/launcher/main_test.go
+++ b/desktop/launcher/main_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAnnounceNamesTheConfiguredAdmin holds the start message to the file.
+//
+// configuredAdminEmail's own tests pass just as well while announce carries a
+// literal, so the address a reader is actually offered has to be asserted on
+// where they read it.
+func TestAnnounceNamesTheConfiguredAdmin(t *testing.T) {
+	l := layout{root: t.TempDir()}
+	const configured = "admin@demo.test"
+	if err := os.WriteFile(l.configPath(),
+		[]byte("bootstrap_admin:\n  email: "+configured+"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	printed := capture(t, func() { announce("http://127.0.0.1:8800", l, "") })
+
+	if !strings.Contains(printed, configured) {
+		t.Fatalf("the start message never names the address the installation was bootstrapped\n"+
+			"with, so a reader has nothing that works to type:\n%s", printed)
+	}
+	if strings.Contains(printed, defaultAdminEmail) {
+		t.Fatalf("the start message still names %q alongside the configured address — the\n"+
+			"literal is back, and a reader is offered an account that does not exist:\n%s",
+			defaultAdminEmail, printed)
+	}
+}
+
+// capture swaps os.Stdout for a pipe, because say() IS fmt.Printf on purpose
+// (console.go) and the console deliberately has no seam to inject.
+func capture(t *testing.T, run func()) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = write
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		//craft:ignore swallowed-errors a copy from a pipe this test owns; a short read shows up as a failed assertion on the text
+		_, _ = io.Copy(&buf, read)
+		done <- buf.String()
+	}()
+
+	run()
+
+	os.Stdout = saved
+	if err := write.Close(); err != nil {
+		t.Fatalf("close the write end: %v", err)
+	}
+	return <-done
+}

--- a/desktop/launcher/main_test.go
+++ b/desktop/launcher/main_test.go
@@ -47,12 +47,15 @@ func capture(t *testing.T, run func()) string {
 	}
 	saved := os.Stdout
 	os.Stdout = write
-	done := make(chan string, 1)
+	type read1 struct {
+		text string
+		err  error
+	}
+	done := make(chan read1, 1)
 	go func() {
 		var buf bytes.Buffer
-		//craft:ignore swallowed-errors a copy from a pipe this test owns; a short read shows up as a failed assertion on the text
-		_, _ = io.Copy(&buf, read)
-		done <- buf.String()
+		_, err := io.Copy(&buf, read)
+		done <- read1{text: buf.String(), err: err}
 	}()
 
 	run()
@@ -61,5 +64,11 @@ func capture(t *testing.T, run func()) string {
 	if err := write.Close(); err != nil {
 		t.Fatalf("close the write end: %v", err)
 	}
-	return <-done
+	// A partial copy would otherwise read as an absent line, failing the caller's
+	// assertion for a reason that has nothing to do with what was printed.
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("read the captured console: %v", got.err)
+	}
+	return got.text
 }

--- a/desktop/launcher/main_test.go
+++ b/desktop/launcher/main_test.go
@@ -55,6 +55,12 @@ func capture(t *testing.T, run func()) string {
 	go func() {
 		var buf bytes.Buffer
 		_, err := io.Copy(&buf, read)
+		// io.Copy does not close what it read from, and a helper called once per
+		// test would leak a descriptor per call. The copy's own failure is the
+		// more informative one, so it wins where both have something to say.
+		if closeErr := read.Close(); err == nil {
+			err = closeErr
+		}
 		done <- read1{text: buf.String(), err: err}
 	}()
 


### PR DESCRIPTION
## The problem

`announce()` carried the bootstrap admin address as a literal while `ensureConfig()` wrote it into `margince.yaml`. One fact, spelled twice.

`margince.yaml` is write-once and the organization is bootstrapped from it, so the first run is the only moment that address can be chosen. An installation created under any other address had **every launch** offering an account that does not exist:

```
  Sign in as  owner@margince.local     ← always, whatever the file says
```

A reader types what the console tells them and is refused. Nothing else on screen or in the folder contradicts it, so there is nothing to work back from.

## The change

Both sides now derive from one `defaultAdminEmail`, and `announce` reads the file.

The reader is deliberately narrow rather than a YAML parse. `desktop/launcher/go.mod` states the module is stdlib-only and outside `go.work` by design, and a parser dependency bought for one line of a start message would not pay for itself. It finds `email:` under `bootstrap_admin:` and stops.

Every shape it cannot follow — no file, no block, a commented-out or empty value — answers with the default. The address is informational, so reading it must cost a reader precision, never the launch.

## Tests

`TestAnnounceNamesTheConfiguredAdmin` asserts on the console text itself, because `configuredAdminEmail`'s own tests pass just as well while `announce` carries a literal. I verified that by reverting the one line and watching it fail. It captures `os.Stdout` because `say()` is `fmt.Printf` on purpose and the console has no seam to inject.

The helper's own tests cover a quoted value, a trailing comment, an `email:` belonging to a different block, and five fallback shapes.

## Verification

- `go build`, `go vet`, `gofmt`, `go test` on `desktop/launcher` — clean
- `craft static --strict --root ../../desktop` — 0 blocker, 0 major, 0 minor

`make check` ran green except `TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim`, which fails while walking the tree — my working tree carries symlinks it correctly refuses to follow, before it reaches any file in this diff. CI walks a clean checkout.

## AI disclosure

**Generated** — AI produced substantial portions, reviewed and owned by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The launcher now displays the configured administrator email from `margince.yaml`.
  * Custom administrator emails support quoted values, inline comments, and `#` characters in email addresses.
  * Nested administrator contact values are ignored unless directly configured.
  * Unsupported or invalid configuration safely falls back to `owner@margince.local`.
  * First-run configuration uses the shared default administrator email.
* **Tests**
  * Added coverage for email parsing, fallback behavior, nested configuration handling, and displayed administrator details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->