### PR TITLE
fix(i18n): the plural gate carries a ceiling measured on what it does

### DIFF
--- a/frontend/src/i18n/one-plural-rule.test.ts
+++ b/frontend/src/i18n/one-plural-rule.test.ts
@@ -206,24 +206,67 @@ function findingsIn(path: string, source: string): Finding[] {
   return found;
 }
 
+/**
+ * This gate's own ceiling, because it does not belong to the population
+ * `vitest.budget.ts` measures.
+ *
+ * That ceiling is arithmetic over WAITING — the longest chain of one-second
+ * waiters a test legitimately composes, plus the slowest measured test. This
+ * gate waits for nothing. It type-parses every source file in the tree, so its
+ * cost is the corpus, and the two numbers have no relationship at all. It sat
+ * under that ceiling only while the tree was small enough for the coincidence
+ * to hold, and stopped when the tree grew: `Test timed out in 13437ms` on main,
+ * on two consecutive runs, with every assertion in it passing.
+ *
+ * Derived per FILE and then multiplied out, not picked whole: 1400 files at
+ * 40ms each. The corpus is 1066 today, so the headroom is ~330 files — chosen
+ * against this tree's merge rate rather than as a round margin, because a
+ * budget with thirty files of slack is one that fails next week. Measured at ~3.3ms per file on an idle ten-core machine and
+ * unchanged under eight spinners — the cost is the parse, not contention for a
+ * core. A CI runner is smaller and saturated by the rest of the suite running
+ * in parallel, and needed more than 12.5ms per file there, so the allowance is
+ * an order of magnitude over the local measurement rather than a margin
+ * trimmed to fit.
+ *
+ * A LITERAL, not the product, because scripts/test-budget.test.ts refuses a
+ * timeout it cannot statically fold — correctly, since a ceiling no reader can
+ * evaluate is one no reader can audit. The cost of that is the number cannot
+ * scale itself, so the corpus size it assumes is asserted in the test body
+ * instead: the tree outgrowing this budget fails by name rather than by
+ * timeout.
+ */
+const PARSE_BUDGET_PER_FILE_MS = 40;
+const BUDGETED_CORPUS_FILES = 1_400;
+const SCAN_TIMEOUT_MS = 56_000;
+
 describe("one plural rule", () => {
-  it("finds no count-picks-the-key outside i18n/", () => {
-    const files = sourceFiles();
-    // Fail closed. A walk pointed at the wrong tree reports PASS over nothing,
-    // and under-recognition is the one way a gate must not break.
-    expect(files.length).toBeGreaterThan(100);
+  it(
+    "finds no count-picks-the-key outside i18n/",
+    () => {
+      const files = sourceFiles();
+      // Fail closed. A walk pointed at the wrong tree reports PASS over
+      // nothing, and under-recognition is the one way a gate must not break.
+      expect(files.length).toBeGreaterThan(100);
+      // And fail LOUDLY when the tree outgrows the ceiling's premise. The
+      // ceiling above is a literal because scripts/test-budget.test.ts must be
+      // able to read it, which means it cannot scale itself — so the premise it
+      // rests on is asserted here instead. Without this the next growth spurt
+      // returns as `Test timed out`, which names this test and not the reason.
+      expect(files.length).toBeLessThanOrEqual(BUDGETED_CORPUS_FILES);
 
-    const findings = files.flatMap((path) =>
-      findingsIn(path, readFileSync(path, "utf8")),
-    );
+      const findings = files.flatMap((path) =>
+        findingsIn(path, readFileSync(path, "utf8")),
+      );
 
-    expect(
-      findings.map((f) => `${f.file}:${f.line} — ${f.text}`),
-      "A count picks a message key outside i18n/. Use usePlural() and a " +
-        "<base>_one / <base>_other pair, so the form comes from the reader's " +
-        "own plural rule rather than from a comparison with 1.",
-    ).toEqual([]);
-  });
+      expect(
+        findings.map((f) => `${f.file}:${f.line} — ${f.text}`),
+        "A count picks a message key outside i18n/. Use usePlural() and a " +
+          "<base>_one / <base>_other pair, so the form comes from the reader's " +
+          "own plural rule rather than from a comparison with 1.",
+      ).toEqual([]);
+    },
+    SCAN_TIMEOUT_MS,
+  );
 
   // The gate's own census. It reads a smaller tree than it claims, or matches a
   // shape the real defect does not take, and it reports PASS either way — so

--- a/frontend/src/i18n/one-plural-rule.test.ts
+++ b/frontend/src/i18n/one-plural-rule.test.ts
@@ -228,16 +228,19 @@ function findingsIn(path: string, source: string): Finding[] {
  * an order of magnitude over the local measurement rather than a margin
  * trimmed to fit.
  *
- * A LITERAL, not the product, because scripts/test-budget.test.ts refuses a
- * timeout it cannot statically fold — correctly, since a ceiling no reader can
- * evaluate is one no reader can audit. The cost of that is the number cannot
- * scale itself, so the corpus size it assumes is asserted in the test body
- * instead: the tree outgrowing this budget fails by name rather than by
- * timeout.
+ * Written as the product so the derivation is in the code and not only here.
+ * scripts/test-budget.test.ts refuses a timeout it cannot statically fold —
+ * correctly, since a ceiling no reader can evaluate is one no reader can audit
+ * — and it rejected a first version that multiplied by `sourceFiles().length`
+ * at runtime. Two constants fold; a directory walk does not.
+ *
+ * What that costs is that the number cannot scale ITSELF, so the corpus size it
+ * assumes is asserted in the test body instead: the tree outgrowing this budget
+ * fails by name and count rather than returning as an opaque timeout.
  */
 const PARSE_BUDGET_PER_FILE_MS = 40;
 const BUDGETED_CORPUS_FILES = 1_400;
-const SCAN_TIMEOUT_MS = 56_000;
+const SCAN_TIMEOUT_MS = BUDGETED_CORPUS_FILES * PARSE_BUDGET_PER_FILE_MS;
 
 describe("one plural rule", () => {
   it(


### PR DESCRIPTION
**main is red.** `fe-unit` and `frontend` fail, and `uat` and `sonarcloud` **skip** as a consequence — one break deleting two more lanes' coverage.

```
FAIL src/i18n/one-plural-rule.test.ts > finds no count-picks-the-key outside i18n/
Error: Test timed out in 13437ms.
```

**Not an assertion.** Every assertion in that test passed. It ran out of time.

## The number is the diagnosis

`13437ms` is `TEST_TIMEOUT_MS` from `frontend/vitest.budget.ts`, and that file is explicit about what it is:

```
TEST_TIMEOUT_MS = MAX_DEFAULT_WAITER_BUDGET_MS (10_000)
                + SLOWEST_MEASURED_TEST_MS      (3_437)
```

It is arithmetic over **waiting** — the longest chain of one-second `waitFor`s a test legitimately composes, plus the slowest measured test.

**This gate waits for nothing.** It type-parses every source file in the tree with the TypeScript compiler, so its cost is the corpus. The two numbers have no relationship at all. It sat under that ceiling only while the tree was small enough for the coincidence to hold, and stopped when the tree grew.

Reproducible, not flake: two consecutive `main-health` runs, different commits, same test, same timeout.

## The fix is the one that file already prescribes

> *"A test that deliberately raises its OWN waiters above the default — a slow settle, a poll it has to outlast — owes its own per-test ceiling and then leaves this population."*

This gate leaves that population for the opposite reason (it never waits), and the remedy is the same. Ceiling: **1400 files × 40ms**.

- ~3.3ms per file measured on an idle ten-core machine
- **unchanged under eight spinners on ten cores** — so the cost is the parse, not contention for a core
- a CI runner is smaller and saturated by the rest of the suite in parallel, and needed **>12.5ms per file** there

So the allowance is an order of magnitude over the local measurement rather than a margin trimmed to fit.

## Why a literal, and what that costs

My first version computed `sourceFiles().length * PARSE_BUDGET_PER_FILE_MS` at runtime so it would scale with the tree. **`scripts/test-budget.test.ts` rejected it:**

```
src/i18n/one-plural-rule.test.ts:233 states a timeout this reader cannot fold: SCAN_TIMEOUT_MS
```

That gate is right and it caught me. A ceiling no reader can statically evaluate is one no reader can audit, which is the whole point of having a budget file.

The cost of a literal is that it cannot scale itself — so the corpus size it assumes is asserted in the test body instead:

```ts
expect(files.length).toBeLessThanOrEqual(BUDGETED_CORPUS_FILES);
```

The tree outgrowing this budget now fails **by name and number** rather than returning as an opaque timeout that points at this test and not at the reason.

Headroom is ~330 files against a corpus of **1066**, sized against this tree's merge rate. My first attempt used 1100 — thirty files of slack, which this repo would consume in days. Mutation-testing the assertion is what surfaced the real corpus size and made that obvious.

## Verification

- Both gates pass: `one-plural-rule.test.ts` (7) and `scripts/test-budget.test.ts` (6).
- Mutation-tested the new corpus assertion: setting `BUDGETED_CORPUS_FILES = 10` fails with `expected 1066 to be less than or equal to 10`, and the mutant was confirmed present in the file before the run.
- `biome check` clean.

The gate's logic is untouched — this changes only what it is allowed to spend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `one-plural-rule.test.ts` gate timing out on `main` by giving it a timeout measured on the work it actually does: it parses the whole tree, while the shared budget it was using is measured over waiting.

- Sets its own 56s timeout, derived as 1400 files × 40ms, via constants the test body references.
- Asserts the corpus stays at or under 1400 files, so the tree outgrowing the budget fails with a specific count instead of an opaque timeout.
- Writes the ceiling as a product of two constants, because `scripts/test-budget.test.ts` only audits timeouts it can fold statically.

<sup>Written for commit 5ce58134c899e676af1a034ee192d6410ce29368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved pluralization validation reliability with explicit limits for source-file scanning and test execution.
  * Added safeguards that detect unexpectedly large test corpora and provide clearer timeout reporting.

* **Documentation**
  * Clarified how pluralization test limits are calculated and why they remain fixed for consistent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->