### PR TITLE
feat(runner): the overnight agent runs for every rep who granted it

### DIFF
--- a/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
@@ -5,7 +5,7 @@ source: hand_authored
 sanitized_by: hand_authored/claude-opus-5
 fixture:
   goal: Which of my deals are about to slip this week?
-  trigger_ref: morning_brief:2026-08-07:d48b383f3e8a
+  trigger_ref: morning_brief:2026-08-07:d48b383f3e8acec5d620c82b8c9b4202
   grounding:
     - source_id: user:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e0a
       trust_tier: T1

--- a/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
@@ -5,7 +5,7 @@ source: hand_authored
 sanitized_by: hand_authored/claude-opus-5
 fixture:
   goal: Which of my deals are about to slip this week?
-  trigger_ref: morning_brief:2026-08-07
+  trigger_ref: morning_brief:2026-08-07:d48b383f3e8a
   grounding:
     - source_id: user:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e0a
       trust_tier: T1

--- a/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
@@ -508,3 +508,108 @@ func grantedSpec(t *testing.T) runner.AgentSpec {
 	t.Fatalf("no catalog entry named %s", grantSpec)
 	return runner.AgentSpec{}
 }
+
+// TestOneSeatWhoseSeedingFailsDoesNotStopTheOthersRunning is the starvation
+// case, and it is about the ORDER of the two halves of a pass rather than
+// about seeding.
+//
+// Seeding and claiming are independent: claiming runs work that is ALREADY
+// queued, which does not care whether tonight's seeding succeeded. A pass that
+// returned as soon as one seat's insert raised would therefore hold every
+// other rep's queued brief hostage to that one broken seat, on every tick, for
+// as long as the fault lasted — and the failing seat is stable, so the fault
+// does not rotate away on its own.
+func TestOneSeatWhoseSeedingFailsDoesNotStopTheOthersRunning(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	me := re.sessionUser(t)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant: %v", err)
+	}
+
+	// Work already queued from an earlier night, waiting to be claimed. This is
+	// what the failing seat must not be able to hold up.
+	const waiting = "morning_brief:already-queued"
+	seedDueRunnerJob(t, owner, waiting)
+
+	// Now make THIS seat's seeding raise, and only the insert: claiming updates
+	// the row it is executing, so a fault covering updates too would stop the
+	// claim for reasons that have nothing to do with seeding.
+	failRunnerJobInsertsFor(t, owner, grantedSpec(t).TriggerRef(afterEveryDueHour(), me))
+
+	now := afterEveryDueHour()
+	err := re.svc.Tick(schedulerPassCtx(re.wsID), now)
+	if err == nil {
+		t.Fatal("the pass reported success though a seat's seeding raised — the failure has no row and no reader, and nobody learns that rep gets no brief")
+	}
+
+	// The pass still reported the fault, AND still ran the work that was
+	// waiting. Both halves matter: reporting without claiming is the starvation
+	// bug, and claiming without reporting hides a rep's broken night.
+	status, lastError := runnerJobOutcome(t, owner, waiting)
+	if status == "queued" {
+		t.Errorf("the already-queued brief is still queued after a pass that failed to seed one seat: "+
+			"one broken seat stops every other rep's queued work from running, every tick, "+
+			"for as long as the fault lasts (pass reported: %v)", err)
+	}
+	if status != "failed" || lastError == "" {
+		t.Fatalf("the claimed job is %s (%q), want the loud passport-less failure — the claim did not reach it, so this test proves nothing about starvation", status, lastError)
+	}
+}
+
+// failRunnerJobInsertsFor makes the INSERT of one specific trigger ref raise,
+// leaving every other seat's seeding and all claiming untouched.
+//
+// Narrower than failRunnerJobWrites on purpose: that one fails the whole
+// table, so a pass under it has no successful seat to be starved and could not
+// tell the two failure shapes apart.
+func failRunnerJobInsertsFor(t *testing.T, owner *pgx.Conn, triggerRef string) {
+	t.Helper()
+	ctx := context.Background()
+	// The ref to fail lives in a row rather than in the function's text: a
+	// value spliced into a CREATE FUNCTION body would be a hand-built SQL
+	// literal, which is the one thing this tree never does.
+	if _, err := owner.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS runner_job_seat_fault_ref (trigger_ref text PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating the fault-ref table: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`DROP TABLE IF EXISTS runner_job_seat_fault_ref CASCADE`); err != nil {
+			t.Errorf("dropping the fault-ref table: %v", err)
+		}
+	})
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO runner_job_seat_fault_ref (trigger_ref) VALUES ($1)`, triggerRef); err != nil {
+		t.Fatalf("pinning the faulting trigger ref: %v", err)
+	}
+	if _, err := owner.Exec(ctx, `
+		CREATE OR REPLACE FUNCTION runner_job_seat_fault() RETURNS trigger
+		LANGUAGE plpgsql AS $$
+		BEGIN
+		  IF EXISTS (SELECT 1 FROM runner_job_seat_fault_ref WHERE trigger_ref = NEW.trigger_ref) THEN
+		    RAISE EXCEPTION 'runner job seeding fault injection';
+		  END IF;
+		  RETURN NEW;
+		END $$`); err != nil {
+		t.Fatalf("creating the seat fault-injection function: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`DROP FUNCTION IF EXISTS runner_job_seat_fault() CASCADE`); err != nil {
+			t.Errorf("dropping the seat fault-injection function: %v", err)
+		}
+	})
+	if _, err := owner.Exec(ctx, `
+		CREATE TRIGGER runner_job_seat_fault BEFORE INSERT ON runner_job
+		FOR EACH ROW EXECUTE FUNCTION runner_job_seat_fault()`); err != nil {
+		t.Fatalf("arming the seat fault trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(),
+			`DROP TRIGGER IF EXISTS runner_job_seat_fault ON runner_job`); err != nil {
+			t.Errorf("dropping the seat fault trigger: %v", err)
+		}
+	})
+}

--- a/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
@@ -126,22 +126,26 @@ func runnerJobOutcome(t *testing.T, owner *pgx.Conn, trigger string) (status, la
 	return status, lastError
 }
 
-// assertOccurrencesSeeded fails unless every catalog occurrence due at now
-// exists. This is the half of a pass that has no other trace: an unseeded
+// assertSpecSeededFor fails unless this seat holds the given spec's occurrence
+// for the day. This is the half of a pass that has no other trace: an unseeded
 // occurrence is simply a brief that never happens, with no row anywhere to
 // notice its absence.
-func assertOccurrencesSeeded(t *testing.T, owner *pgx.Conn, now time.Time) {
+//
+// It asks about ONE spec rather than the whole catalog, because a grant is per
+// agent. A rep who said yes to the morning brief has said nothing about the
+// at-risk sweep, and a helper that demanded both would be asserting a
+// consent-everywhere model the product deliberately does not have.
+func assertSpecSeededFor(t *testing.T, owner *pgx.Conn, spec runner.AgentSpec, now time.Time, seat ids.UserID) {
 	t.Helper()
-	for _, spec := range runner.Catalog() {
-		var seeded bool
-		if err := owner.QueryRow(context.Background(), `
-			SELECT EXISTS (SELECT 1 FROM runner_job WHERE trigger_ref = $1)`,
-			spec.TriggerRef(now)).Scan(&seeded); err != nil {
-			t.Fatalf("reading the seeded occurrences of %s: %v", spec.Name, err)
-		}
-		if !seeded {
-			t.Errorf("no %s occurrence exists for %s — that agent simply never runs, and no row records it", spec.Name, now.Format(time.DateOnly))
-		}
+	var seeded bool
+	if err := owner.QueryRow(context.Background(), `
+		SELECT EXISTS (SELECT 1 FROM runner_job WHERE trigger_ref = $1)`,
+		spec.TriggerRef(now, seat)).Scan(&seeded); err != nil {
+		t.Fatalf("reading the seeded occurrences of %s: %v", spec.Name, err)
+	}
+	if !seeded {
+		t.Errorf("no %s occurrence exists for %s on seat %s — that rep's agent simply never runs, and no row records it",
+			spec.Name, now.Format(time.DateOnly), seat)
 	}
 }
 
@@ -184,11 +188,18 @@ func TestAgentSchedulerSeedsAndClaimsWhatIsDue(t *testing.T) {
 	const trigger = "morning_brief:seed-and-claim"
 	seedDueRunnerJob(t, owner, trigger)
 
+	// The pass seeds for the reps who granted, so a seat that said yes is what
+	// gives the seeding half anything to prove.
+	me := re.sessionUser(t)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant: %v", err)
+	}
+
 	now := afterEveryDueHour()
 	if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
 		t.Fatalf("the scheduling pass: %v", err)
 	}
-	assertOccurrencesSeeded(t, owner, now)
+	assertSpecSeededFor(t, owner, grantedSpec(t), now, me)
 
 	status, lastError := runnerJobOutcome(t, owner, trigger)
 	if status == "queued" {
@@ -277,4 +288,223 @@ func TestAgentSchedulerWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(
 		t.Errorf("%d %s rows exist after a runner was given no scheduler interval, want only the one queued here — a zero duration is not a cadence, and River spins on it rather than refusing it",
 			dispatched, compose.AgentSchedulerArgs{}.Kind())
 	}
+}
+
+// TestEverySeatThatGrantedGetsItsOwnNightlyOccurrence is the regression this
+// whole change exists for.
+//
+// Before the trigger ref carried a seat, both uniqueness rules made the night
+// workspace-wide: the first rep seeded took the row and every other rep's
+// insert conflicted away. NOTHING FAILED WHEN THAT HAPPENED — ON CONFLICT DO
+// NOTHING is the intended re-seed path, the pass returned nil, and the only
+// symptom was reps quietly not getting briefs. So the assertion is a count
+// across seats, not the success of the pass.
+func TestEverySeatThatGrantedGetsItsOwnNightlyOccurrence(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	me := re.sessionUser(t)
+	colleague := seedColleague(t, owner)
+	theirs := re.mintPassportForColleague(t, colleague)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant for %s: %v", me, err)
+	}
+	if err := re.recordDecision(t, colleague, runner.GrantStateGranted, &theirs); err != nil {
+		t.Fatalf("record the grant for %s: %v", colleague, err)
+	}
+
+	now := afterEveryDueHour()
+	if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
+		t.Fatalf("the scheduling pass: %v", err)
+	}
+
+	// Count the DISTINCT rows first. Asking per seat whether "a row for this
+	// ref exists" is satisfied by one shared row answering for both seats —
+	// which is precisely the workspace-wide behaviour this test exists to
+	// catch, so that form of the assertion passes exactly when the bug is
+	// present. The count is what cannot be satisfied by one row.
+	spec := grantedSpec(t)
+	var rows int
+	if err := owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM runner_job WHERE agent_spec = $1`, grantSpec).Scan(&rows); err != nil {
+		t.Fatalf("counting the seeded occurrences: %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("%d occurrence(s) were seeded for 2 granting seats: the trigger ref does not "+
+			"distinguish reps, so the uniqueness constraints admit one run for the whole "+
+			"workspace and every seat after the first silently gets nothing", rows)
+	}
+	for _, seat := range []ids.UserID{me, colleague} {
+		var passport *string
+		if err := owner.QueryRow(context.Background(),
+			`SELECT passport_id::text FROM runner_job WHERE agent_spec = $1 AND trigger_ref = $2`,
+			grantSpec, spec.TriggerRef(now, seat)).Scan(&passport); err != nil {
+			t.Fatalf("seat %s has no occurrence of its own — the night ran for somebody else and this rep silently got nothing: %v", seat, err)
+		}
+		if passport == nil {
+			t.Fatalf("seat %s was seeded with no passport: the run can only fail at execution, which is a broken night rather than an honest refusal", seat)
+		}
+	}
+}
+
+// TestASeatIsSeededWithItsOwnCredentialAndNobodyElses pins WHOSE authority the
+// night carries.
+//
+// A fan-out that seeded the right number of rows against one shared passport
+// would satisfy the count above while acting for every rep as one person —
+// which is the exact thing the standing grant exists to prevent.
+func TestASeatIsSeededWithItsOwnCredentialAndNobodyElses(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	me := re.sessionUser(t)
+	colleague := seedColleague(t, owner)
+	theirs := re.mintPassportForColleague(t, colleague)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant for %s: %v", me, err)
+	}
+	if err := re.recordDecision(t, colleague, runner.GrantStateGranted, &theirs); err != nil {
+		t.Fatalf("record the grant for %s: %v", colleague, err)
+	}
+
+	now := afterEveryDueHour()
+	if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
+		t.Fatalf("the scheduling pass: %v", err)
+	}
+
+	spec := grantedSpec(t)
+	for seat, want := range map[ids.UserID]ids.PassportID{me: re.passportID, colleague: theirs} {
+		var got string
+		if err := owner.QueryRow(context.Background(),
+			`SELECT passport_id::text FROM runner_job WHERE trigger_ref = $1`,
+			spec.TriggerRef(now, seat)).Scan(&got); err != nil {
+			t.Fatalf("reading seat %s's occurrence: %v", seat, err)
+		}
+		if got != want.String() {
+			t.Errorf("seat %s is seeded with passport %s, want its own %s — the night would act for this rep under somebody else's authority", seat, got, want)
+		}
+	}
+}
+
+// TestARepWhoDeclinedIsNotSeeded holds the other direction: the standing grant
+// is a real gate on the fan-out, not a row the seeder reads past.
+//
+// The declining rep is the case that makes the feature honest. A pass that
+// seeded them anyway would run an agent overnight for somebody who said no,
+// and the only reason it would not act is that they hold no passport — which
+// is a failure at 2am rather than a decision respected at seeding time.
+func TestARepWhoDeclinedIsNotSeeded(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	me := re.sessionUser(t)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant for %s: %v", me, err)
+	}
+
+	colleague := seedColleague(t, owner)
+	if err := re.recordDecision(t, colleague, runner.GrantStateDeclined, nil); err != nil {
+		t.Fatalf("recording the decline: %v", err)
+	}
+
+	now := afterEveryDueHour()
+	if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
+		t.Fatalf("the scheduling pass: %v", err)
+	}
+
+	spec := grantedSpec(t)
+	var seeded bool
+	if err := owner.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM runner_job WHERE trigger_ref = $1)`,
+		spec.TriggerRef(now, colleague)).Scan(&seeded); err != nil {
+		t.Fatalf("reading the declining rep's occurrence: %v", err)
+	}
+	if seeded {
+		t.Error("a rep who declined was seeded an overnight run: the grant is not gating the fan-out, and the agent works for somebody who said no")
+	}
+	// The granting rep still got theirs, or the assertion above passes for the
+	// wrong reason — a pass that seeded nobody satisfies it too.
+	assertSpecSeededFor(t, owner, grantedSpec(t), now, me)
+}
+
+// TestAWorkspaceWhereNobodyGrantedSeedsNothing is the empty case, and it is a
+// PASS rather than a fault: no live grant means nobody has said yes yet.
+func TestAWorkspaceWhereNobodyGrantedSeedsNothing(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	now := afterEveryDueHour()
+	if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
+		t.Fatalf("a pass over a workspace where nobody granted must succeed, not fault: %v", err)
+	}
+
+	var jobs int
+	if err := owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM runner_job WHERE agent_spec = $1`, grantSpec).Scan(&jobs); err != nil {
+		t.Fatalf("counting the seeded occurrences: %v", err)
+	}
+	if jobs != 0 {
+		t.Errorf("%d occurrence(s) were seeded with no live grant behind them — a run nothing can authorize, which fails in the small hours with nobody watching", jobs)
+	}
+}
+
+// TestASecondPassSeedsNoSecondRunForTheSameSeat keeps the idempotency the seat
+// segment could have broken. Uniqueness is per seat per day now, and a ref that
+// varied per pass would queue a rep the same brief every tick.
+func TestASecondPassSeedsNoSecondRunForTheSameSeat(t *testing.T) {
+	re := setupRunner(t)
+	owner := integration.OwnerConn(t)
+
+	me := re.sessionUser(t)
+	if err := re.recordDecision(t, me, runner.GrantStateGranted, &re.passportID); err != nil {
+		t.Fatalf("record the grant for %s: %v", me, err)
+	}
+
+	now := afterEveryDueHour()
+	for pass := 0; pass < 2; pass++ {
+		if err := re.svc.Tick(schedulerPassCtx(re.wsID), now); err != nil {
+			t.Fatalf("scheduling pass %d: %v", pass+1, err)
+		}
+	}
+
+	var jobs int
+	if err := owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM runner_job WHERE agent_spec = $1 AND trigger_ref = $2`,
+		grantSpec, grantedSpec(t).TriggerRef(now, me)).Scan(&jobs); err != nil {
+		t.Fatalf("counting this seat's occurrences: %v", err)
+	}
+	if jobs != 1 {
+		t.Errorf("this seat holds %d occurrences of one day's brief, want exactly 1 — a rep queued the same brief every tick", jobs)
+	}
+}
+
+// seedColleague adds a second real seat to the workspace.
+func seedColleague(t *testing.T, owner *pgx.Conn) ids.UserID {
+	t.Helper()
+	var raw string
+	if err := owner.QueryRow(context.Background(), `
+		INSERT INTO app_user (email, display_name, status)
+		VALUES ($1, 'Second Seat', 'active')
+		RETURNING id::text`, "seat-"+ids.NewV7().String()+"@fable.test").Scan(&raw); err != nil {
+		t.Fatalf("seeding a second seat: %v", err)
+	}
+	id, err := ids.ParseAs[ids.UserKind](raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// grantedSpec resolves the catalog entry these tests grant, so a test builds
+// its trigger ref the way production does rather than formatting a second copy
+// of the shape.
+func grantedSpec(t *testing.T) runner.AgentSpec {
+	t.Helper()
+	for _, spec := range runner.Catalog() {
+		if spec.Name == grantSpec {
+			return spec
+		}
+	}
+	t.Fatalf("no catalog entry named %s", grantSpec)
+	return runner.AgentSpec{}
 }

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -11,6 +11,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -133,9 +134,7 @@ func (s *RunnerService) Tick(ctx context.Context, now time.Time) error {
 	s.reapAbandonedRuns(ctx)
 	for _, spec := range mustScheduledAgents() {
 		if due := spec.DueAt(now); !now.Before(due) {
-			// Cron-seeded jobs carry no passport yet: execution fails
-			// loudly rather than running with ambient authority.
-			if err := s.store.EnqueueJob(ctx, spec.Name, spec.TriggerRef(now), nil, due); err != nil {
+			if err := s.seedSeats(ctx, spec, now, due); err != nil {
 				return err
 			}
 		}
@@ -146,6 +145,47 @@ func (s *RunnerService) Tick(ctx context.Context, now time.Time) error {
 	}
 	for _, job := range jobs {
 		s.executeJob(ctx, job)
+	}
+	return nil
+}
+
+// seedSeats queues tonight's occurrence of one spec for every rep who granted
+// it, each job carrying that rep's own passport.
+//
+// WHY THE GRANTS DRIVE THE LOOP. An agent run acts as a person, and the only
+// credential it may act with is one that person minted for themselves. There
+// is no workspace-wide authority to fall back on and deliberately so, so a
+// spec with no live grants has nothing to run tonight — that is a workspace
+// where nobody has said yes yet, not a fault, and it queues nothing.
+//
+// A rep whose seeding fails does not cost the others theirs. The loop records
+// the failure and carries on, then returns them joined: stopping at the first
+// would leave a whole team unseeded because one seat's row was bad, and the
+// next tick would arrive at the same seat first and stop there again.
+func (s *RunnerService) seedSeats(ctx context.Context, spec runner.AgentSpec, now, due time.Time) error {
+	grants, err := s.store.LiveGrantsFor(ctx, spec.Name)
+	if err != nil {
+		return fmt.Errorf("read who granted %s: %w", spec.Name, err)
+	}
+	var failures []error
+	for _, grant := range grants {
+		// Live() is the reader's guarantee, asserted rather than assumed: the
+		// passport is what authorizes the run, and a job seeded against a dead
+		// one is a run that can only fail in the small hours with nobody
+		// watching. The query already filters for this; the check is here so
+		// that a later edit loosening the query cannot quietly widen the
+		// fan-out to credentials that stopped working.
+		if !grant.Live() || grant.PassportID == nil {
+			continue
+		}
+		passportID := *grant.PassportID
+		if err := s.store.EnqueueJob(ctx, spec.Name, spec.TriggerRef(now, grant.UserID), &passportID, due); err != nil {
+			failures = append(failures, fmt.Errorf("seat %s: %w", grant.UserID, err))
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("seeding %s for %d of %d seats: %w",
+			spec.Name, len(failures), len(grants), errors.Join(failures...))
 	}
 	return nil
 }

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -132,21 +132,29 @@ func (s *RunnerService) Tick(ctx context.Context, now time.Time) error {
 	// and the rail would silently never learn that the 06:00 brief was queued.
 	ctx = schedulerContext(ctx)
 	s.reapAbandonedRuns(ctx)
+	// Seeding failures are collected, NOT returned here. Claiming is what makes
+	// already-queued work run, and it is independent of whether tonight's
+	// seeding succeeded — so returning early would let one seat whose seeding
+	// keeps failing stop every other seat's queued brief from executing, on
+	// every tick, for as long as the fault lasts. The pass still reports the
+	// failure at the end, on its own job row, which is where an operator reads
+	// it.
+	var seeding []error
 	for _, spec := range mustScheduledAgents() {
 		if due := spec.DueAt(now); !now.Before(due) {
 			if err := s.seedSeats(ctx, spec, now, due); err != nil {
-				return err
+				seeding = append(seeding, err)
 			}
 		}
 	}
 	jobs, err := s.store.ClaimDueJobs(ctx, claimBatch)
 	if err != nil {
-		return err
+		return errors.Join(append(seeding, err)...)
 	}
 	for _, job := range jobs {
 		s.executeJob(ctx, job)
 	}
-	return nil
+	return errors.Join(seeding...)
 }
 
 // seedSeats queues tonight's occurrence of one spec for every rep who granted

--- a/backend/internal/modules/agents/runner/catalog.go
+++ b/backend/internal/modules/agents/runner/catalog.go
@@ -4,8 +4,12 @@
 package runner
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // AgentSpec is one catalog entry: a named, scheduled, budgeted goal.
@@ -78,10 +82,39 @@ func Catalog() []AgentSpec {
 	}
 }
 
-// TriggerRef names one occurrence of a scheduled spec; the runner's
-// idempotency (one run per trigger occurrence) hangs off this string.
-func (a AgentSpec) TriggerRef(day time.Time) string {
-	return fmt.Sprintf("%s:%s", a.Name, day.UTC().Format("2006-01-02"))
+// TriggerRef names one occurrence of a scheduled spec FOR ONE SEAT; the
+// runner's idempotency (one run per trigger occurrence) hangs off this string.
+//
+// The seat belongs in the identity because the agent acts for a person. Both
+// uniqueness rules that stop a double run are keyed on this ref —
+// agent_run_trigger_unique on the ref alone, runner_job_trigger_unique on
+// (agent_spec, ref) — so a ref naming only the spec and the day makes the
+// night's work workspace-wide: whichever seat is seeded first wins the
+// constraint and every other rep silently gets no run. Nothing errors, because
+// one row inserting and the rest conflicting is exactly what a correct
+// re-seed looks like.
+//
+// The seat is a DIGEST, not the user's uuid. This value is printed in the
+// prompt in the runner's own voice, one line above grounding refs of the form
+// `<type>:<uuid>` that name records the run actually read — so a raw id here
+// gives a model a record-shaped string it may prepare against, though nothing
+// was ever read to obtain it. The digest carries no such shape. It is an
+// identity, never a lookup key: no reader resolves a seat from it, and the
+// passport on the job row is what says who the run acts for.
+func (a AgentSpec) TriggerRef(day time.Time, seat ids.UserID) string {
+	return fmt.Sprintf("%s:%s:%s", a.Name, day.UTC().Format("2006-01-02"), seatDigest(seat))
+}
+
+// seatDigest is the short, stable, non-record-shaped name of one seat.
+//
+// Truncated to 12 hex characters: this distinguishes seats within one
+// workspace-day, which is all the ref has to do, and the uniqueness that
+// matters is still enforced by the database rather than by this string being
+// unguessable. A collision would cost one rep one night's run, and at 48 bits
+// across the seats of a single workspace it is not a risk anyone will meet.
+func seatDigest(seat ids.UserID) string {
+	sum := sha256.Sum256([]byte(seat.String()))
+	return hex.EncodeToString(sum[:6])
 }
 
 // DueAt is when the given day's occurrence becomes runnable.

--- a/backend/internal/modules/agents/runner/catalog.go
+++ b/backend/internal/modules/agents/runner/catalog.go
@@ -110,8 +110,16 @@ func (a AgentSpec) TriggerRef(day time.Time, seat ids.UserID) string {
 // Truncated to 12 hex characters: this distinguishes seats within one
 // workspace-day, which is all the ref has to do, and the uniqueness that
 // matters is still enforced by the database rather than by this string being
-// unguessable. A collision would cost one rep one night's run, and at 48 bits
-// across the seats of a single workspace it is not a risk anyone will meet.
+// unguessable.
+//
+// WHAT A COLLISION COSTS, stated honestly. It is authority-safe — EnqueueJob
+// conflicts to DO NOTHING, so the losing seat gets no job rather than
+// inheriting the winner's passport. But it does not cost one night: the digest
+// is a pure function of a stable user id, so the same seat loses every day and
+// for every spec it granted, silently, until somebody notices one rep never
+// gets a brief. The probability is n(n-1)/2^49 — around 1.8e-7 at ten thousand
+// seats — and this trades that against printing a record-shaped uuid into a
+// model prompt, which is a certainty rather than a chance.
 func seatDigest(seat ids.UserID) string {
 	sum := sha256.Sum256([]byte(seat.String()))
 	return hex.EncodeToString(sum[:6])

--- a/backend/internal/modules/agents/runner/catalog.go
+++ b/backend/internal/modules/agents/runner/catalog.go
@@ -107,22 +107,21 @@ func (a AgentSpec) TriggerRef(day time.Time, seat ids.UserID) string {
 
 // seatDigest is the short, stable, non-record-shaped name of one seat.
 //
-// Truncated to 12 hex characters: this distinguishes seats within one
-// workspace-day, which is all the ref has to do, and the uniqueness that
-// matters is still enforced by the database rather than by this string being
-// unguessable.
+// WHAT A COLLISION WOULD COST is why this is not truncated further. It would be
+// authority-safe — EnqueueJob conflicts to DO NOTHING, so the losing seat gets
+// no job rather than inheriting the winner's passport — but it would not cost
+// one night. The digest is a pure function of a stable user id, so the SAME
+// seat would lose every day, for every spec it granted, silently, until
+// somebody noticed one rep never gets a brief. There is no ceiling on
+// installation size to bound that against, and a starvation nothing reports is
+// exactly the failure this whole change exists to remove.
 //
-// WHAT A COLLISION COSTS, stated honestly. It is authority-safe — EnqueueJob
-// conflicts to DO NOTHING, so the losing seat gets no job rather than
-// inheriting the winner's passport. But it does not cost one night: the digest
-// is a pure function of a stable user id, so the same seat loses every day and
-// for every spec it granted, silently, until somebody notices one rep never
-// gets a brief. The probability is n(n-1)/2^49 — around 1.8e-7 at ten thousand
-// seats — and this trades that against printing a record-shaped uuid into a
-// model prompt, which is a certainty rather than a chance.
+// So it keeps the full 32 hex characters. A shorter digest reads no better in
+// a log line, and the only thing brevity would buy is a probability nobody has
+// a reason to accept.
 func seatDigest(seat ids.UserID) string {
 	sum := sha256.Sum256([]byte(seat.String()))
-	return hex.EncodeToString(sum[:6])
+	return hex.EncodeToString(sum[:16])
 }
 
 // DueAt is when the given day's occurrence becomes runnable.

--- a/backend/internal/modules/agents/runner/window.go
+++ b/backend/internal/modules/agents/runner/window.go
@@ -295,8 +295,10 @@ func ToolListing(specs []mcp.ToolSpec) string {
 // `record_type: activity` on offer can read the occurrence that woke the run as
 // a record it may prepare against. It is not one: nothing was read to obtain it.
 //
-// Today's scheduled specs mint `<spec>:<date>`, which no model would mistake for
-// an id. The confusable shape is the one an OCCURRENCE-driven trigger would
+// Today's scheduled specs mint `<spec>:<date>:<seat digest>` — a catalog name,
+// a fixed-format UTC date and hex bytes, none of which a model would mistake
+// for an id. The seat is a digest rather than the rep's uuid for exactly this
+// reason: the confusable shape is the one an OCCURRENCE-driven trigger would
 // carry — `calendar:<uuid>` — which the certification corpus already exercises
 // and no production writer mints yet. Whoever adds that writer should also give
 // TriggerRef the bounding groundingRef applies below, since it becomes a seam

--- a/backend/seatfanout_test.go
+++ b/backend/seatfanout_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package backendarch
+
+// A nightly agent acts FOR A PERSON, and the identity of one night's work has
+// to say which person. This gate holds the half that fails silently.
+//
+// Two uniqueness rules stop a scheduled occurrence running twice:
+// agent_run_trigger_unique on trigger_ref alone, and runner_job_trigger_unique
+// on (agent_spec, trigger_ref). Both are keyed on the trigger ref, so what that
+// string distinguishes is exactly what the database will let run in parallel. A
+// ref of `<spec>:<date>` therefore makes the whole night workspace-wide: the
+// first seat seeded takes the row and every other rep's insert conflicts away.
+//
+// NOTHING ERRORS WHEN THAT HAPPENS. One row inserting and the rest conflicting
+// is byte-for-byte what a correct re-seed looks like — ON CONFLICT DO NOTHING
+// is the intended path, the tick returns nil, and the log is quiet. The team
+// simply does not get briefs, and the first person to notice is a rep who
+// wonders where theirs went. That is why this is a gate and not a test: the
+// defect's signature is the absence of work, and absence is what a passing
+// suite looks like.
+//
+// So the obligation is on the CALL: every production caller of TriggerRef
+// passes a seat. The signature already forces an argument, but a signature
+// cannot stop the next author threading a constant, a zero value, or one seat
+// resolved outside the loop through it — which compiles, reads fine, and
+// restores the workspace-wide behaviour exactly.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The two constraints whose key IS the trigger ref. Named here because the
+// gate's whole argument rests on them: if a later migration re-keys either one
+// to include a user column, the ref no longer has to carry the seat and this
+// gate is describing a rule that moved.
+var triggerKeyedConstraints = []string{
+	"agent_run_trigger_unique",
+	"runner_job_trigger_unique",
+}
+
+// TestEveryScheduledOccurrenceIsNamedForOneSeat holds the seeding half: no
+// production call may build a trigger ref without a per-seat value.
+//
+// It checks that the argument is a SELECTOR on a range variable — the
+// `grant.UserID` shape — rather than merely non-empty. A constant, a captured
+// variable from outside the loop, or a zero id all satisfy "an argument was
+// passed" while seeding one identical ref for every seat, which is the bug
+// this exists to prevent.
+func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
+	calls := triggerRefCalls(t)
+	if len(calls) == 0 {
+		t.Fatal("no production call to TriggerRef was found: this gate proves nothing " +
+			"unless it can see the seeding path, so either the scan broke or the " +
+			"caller moved and this gate must move with it")
+	}
+	for _, c := range calls {
+		if c.seatArg == "" {
+			t.Errorf("%s: TriggerRef is called without a seat, so every rep in the "+
+				"workspace shares one trigger ref and only the first seeded gets a run", c.pos)
+			continue
+		}
+		if !strings.Contains(c.seatArg, ".") {
+			t.Errorf("%s: TriggerRef is called with %q, which is not a field read off a "+
+				"per-seat value — a ref built from a constant or a captured id is the "+
+				"same one for every rep, and the uniqueness constraints then admit exactly "+
+				"one run for the whole workspace", c.pos, c.seatArg)
+		}
+	}
+}
+
+// TestTheTriggerRefStillCarriesTheWholeUniquenessKey fails when a migration
+// re-keys either constraint away from the trigger ref.
+//
+// The gate above is only correct while these two constraints are what stops a
+// double run. A migration that adds a user column to either key makes the seat
+// segment redundant rather than load-bearing, and a later author reading only
+// the gate above would be told to preserve a rule that no longer holds.
+func TestTheTriggerRefStillCarriesTheWholeUniquenessKey(t *testing.T) {
+	sql := readMigrations(t)
+	for _, name := range triggerKeyedConstraints {
+		idx := strings.Index(sql, name)
+		if idx < 0 {
+			t.Errorf("constraint %s is gone from the migrations: the seat segment in "+
+				"TriggerRef exists to make THIS key per-seat, so if the key moved, "+
+				"TestEveryScheduledOccurrenceIsNamedForOneSeat is now guarding a rule "+
+				"that no longer decides anything", name)
+			continue
+		}
+		clause := sql[idx:]
+		if end := strings.Index(clause, ";"); end >= 0 {
+			clause = clause[:end]
+		}
+		if strings.Contains(clause, "user_id") || strings.Contains(clause, "passport_id") {
+			t.Errorf("constraint %s now keys on a seat column directly: %s\n"+
+				"the trigger ref no longer has to carry the seat, so revisit "+
+				"TriggerRef and this gate together", name, strings.TrimSpace(clause))
+		}
+	}
+}
+
+// triggerRefCall is one production call site and the expression it passes as
+// the seat.
+type triggerRefCall struct {
+	pos     string
+	seatArg string
+}
+
+// triggerRefCalls parses the non-test tree and returns every call whose
+// selector is TriggerRef.
+//
+// It reads the syntax tree rather than the file text: a text scan counts the
+// name inside a comment or a string literal, so a gate built that way stays
+// green while the real call loses its argument. Under-recognition is the one
+// way a census must not break.
+func triggerRefCalls(t *testing.T) []triggerRefCall {
+	t.Helper()
+	var out []triggerRefCall
+	fset := token.NewFileSet()
+	const root = "internal"
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "TriggerRef" {
+				return true
+			}
+			c := triggerRefCall{pos: fset.Position(call.Pos()).String()}
+			// The seat is the LAST argument: the day names the occurrence and
+			// the seat names whose occurrence it is.
+			if n := len(call.Args); n >= 2 {
+				c.seatArg = exprText(fset, call.Args[n-1])
+			}
+			out = append(out, c)
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanning for TriggerRef callers: %v", err)
+	}
+	return out
+}
+
+// readMigrations concatenates the core migrations so a constraint can be read
+// as it will actually exist.
+func readMigrations(t *testing.T) string {
+	t.Helper()
+	var b strings.Builder
+	dir := filepath.Join("migrations", "core")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the core migrations: %v", err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".up.sql") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", e.Name(), err)
+		}
+		b.Write(raw)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/backend/seatfanout_test.go
+++ b/backend/seatfanout_test.go
@@ -69,11 +69,12 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 				"workspace shares one trigger ref and only the first seeded gets a run", c.pos)
 			continue
 		}
-		if !strings.Contains(c.seatArg, ".") {
-			t.Errorf("%s: TriggerRef is called with %q, which is not a field read off a "+
-				"per-seat value — a ref built from a constant or a captured id is the "+
-				"same one for every rep, and the uniqueness constraints then admit exactly "+
-				"one run for the whole workspace", c.pos, c.seatArg)
+		if !c.fromRangeVar {
+			t.Errorf("%s: TriggerRef is called with %q, which does not resolve to the "+
+				"variable of the loop it sits in — a ref built from a constant, a captured "+
+				"id, or one seat resolved outside the loop is the SAME ref for every rep, "+
+				"and the uniqueness constraints then admit exactly one run for the whole "+
+				"workspace", c.pos, c.seatArg)
 		}
 	}
 }
@@ -88,7 +89,11 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 func TestTheTriggerRefStillCarriesTheWholeUniquenessKey(t *testing.T) {
 	sql := readMigrations(t)
 	for _, name := range triggerKeyedConstraints {
-		idx := strings.Index(sql, name)
+		// The LAST mention, not the first: the baseline defines these
+		// constraints, so reading the first occurrence would keep answering from
+		// the baseline even after a later migration dropped or re-keyed one —
+		// the gate would stay green about a rule that no longer exists.
+		idx := strings.LastIndex(sql, name)
 		if idx < 0 {
 			t.Errorf("constraint %s is gone from the migrations: the seat segment in "+
 				"TriggerRef exists to make THIS key per-seat, so if the key moved, "+
@@ -113,6 +118,13 @@ func TestTheTriggerRefStillCarriesTheWholeUniquenessKey(t *testing.T) {
 type triggerRefCall struct {
 	pos     string
 	seatArg string
+	// fromRangeVar is whether the seat traces to the range variable of a loop
+	// enclosing the call. That is the property the fan-out actually needs: a
+	// value that varies per iteration. "an argument was passed" and "it has a
+	// dot in it" are both satisfied by a seat resolved ONCE outside the loop,
+	// which compiles, reads correctly, and seeds one identical ref for the
+	// whole workspace.
+	fromRangeVar bool
 }
 
 // triggerRefCalls parses the non-test tree and returns every call whose
@@ -138,7 +150,22 @@ func triggerRefCalls(t *testing.T) []triggerRefCall {
 		if perr != nil {
 			return perr
 		}
-		ast.Inspect(file, func(n ast.Node) bool {
+		// The range variables currently in scope, innermost last. A call is
+		// only per-seat if its seat argument is rooted in one of them.
+		var inScope []string
+		var walk func(ast.Node) bool
+		walk = func(n ast.Node) bool {
+			if rng, ok := n.(*ast.RangeStmt); ok {
+				before := len(inScope)
+				for _, key := range []ast.Expr{rng.Key, rng.Value} {
+					if id, ok := key.(*ast.Ident); ok && id.Name != "_" {
+						inScope = append(inScope, id.Name)
+					}
+				}
+				ast.Inspect(rng.Body, walk)
+				inScope = inScope[:before]
+				return false
+			}
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
 				return true
@@ -152,16 +179,38 @@ func triggerRefCalls(t *testing.T) []triggerRefCall {
 			// the seat names whose occurrence it is.
 			if n := len(call.Args); n >= 2 {
 				c.seatArg = exprText(fset, call.Args[n-1])
+				c.fromRangeVar = rootedIn(call.Args[n-1], inScope)
 			}
 			out = append(out, c)
 			return true
-		})
+		}
+		ast.Inspect(file, walk)
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("scanning for TriggerRef callers: %v", err)
 	}
 	return out
+}
+
+// rootedIn reports whether an expression bottoms out in one of the named
+// variables: `grant`, `grant.UserID`, `grant.Seat.ID` all count for "grant".
+func rootedIn(expr ast.Expr, names []string) bool {
+	for {
+		switch e := expr.(type) {
+		case *ast.SelectorExpr:
+			expr = e.X
+		case *ast.Ident:
+			for _, name := range names {
+				if e.Name == name {
+					return true
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
 }
 
 // readMigrations concatenates the core migrations so a constraint can be read

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -53,7 +53,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (53)
+## Census (54)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -107,6 +107,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
 | `satellite_lifecycle_test.go` | H2 | Person-satellite lifecycle reach as a fitness function. |
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
+| `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
 | `uniquenessclaimscorpus_test.go` | H2 | WHERE the claim sweep looks, as against what it looks for. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |


### PR DESCRIPTION
## What was wrong

The nightly scheduler seeded one job per agent spec per day, with no seat in its identity. Both uniqueness rules that stop a double run are keyed on the trigger ref — `agent_run_trigger_unique` on the ref alone, `runner_job_trigger_unique` on `(agent_spec, trigger_ref)` — so the first seat seeded took the row and every other rep's insert conflicted away.

**Nothing failed when that happened.** `ON CONFLICT DO NOTHING` is the intended re-seed path, the pass returned nil, and the log was quiet. The only symptom was reps not getting their briefs, and the first person to notice would be a rep wondering where theirs went.

## What changed

`AgentSpec.TriggerRef` now takes the seat, and `RunnerService.Tick` fans out over the standing grants added in #2769 — one job per granting rep, each bound to the passport that rep minted themselves. Both existing constraints become per-seat-per-day with no migration.

- A rep who declined is not seeded. The grant gates the fan-out at seeding time, rather than the run failing at 2am for want of a credential.
- A workspace where nobody granted seeds nothing and reports success — that is a workspace where nobody has said yes yet, not a fault.
- One rep's seeding failure does not cost the others theirs: failures are joined and returned.

The seat is a **digest, not the raw user id**. The ref is printed into the model prompt one line above grounding refs of the form `<type>:<uuid>` that name records the run actually read, so a raw id there would hand a model a record-shaped string it may prepare against though nothing was read to obtain it. `window.go` already flagged this exact hazard for whoever added a uuid-carrying trigger.

## Gates

`backend/seatfanout_test.go` (new):

- `TestEveryScheduledOccurrenceIsNamedForOneSeat` — every production `TriggerRef` call passes a per-seat value. It requires a field read off a range variable, so a constant, a captured id or a zero value fails: those compile and read fine while seeding one identical ref for every seat.
- `TestTheTriggerRefStillCarriesTheWholeUniquenessKey` — fails if a migration re-keys either constraint onto a seat column, which would make the seat segment redundant and leave the gate above guarding a rule that no longer decides anything.

Both mutation-checked.

## Verification

- `make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` — all green.
- `make test-it DIR=backend/internal/compose/integration/jobfanout` — 33 pass, including 5 new ones covering two seats seeded separately, each with its own credential, the declining rep, the empty workspace, and re-seed idempotency.
- Mutation-checked the regression test itself: stripping the seat from the ref must fail `TestEverySeatThatGrantedGetsItsOwnNightlyOccurrence`. **The first version passed under that mutation** — it asked per seat whether a row existed, and one shared row answered for both. It now counts distinct rows, which one row cannot satisfy.
- Two real rep seats on a dev stack, each minting a passport through `POST /v1/passports` and granting: the two refs come out distinct and neither carries a uuid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The nightly scheduler silently gave only the first granting rep a run. It seeded one job per agent spec with no seat identity, so under both trigger-ref keyed uniqueness rules every other rep's insert conflicted away — and `ON CONFLICT DO NOTHING` meant nothing errored. The pass now fans out over the standing grants, one job per granting rep, each bound to that rep's own passport.

- A rep who declined is not seeded; the grant gates the fan-out at seeding time, and a workspace where nobody granted seeds nothing and reports success.
- One seat's seeding failure doesn't cost the others theirs; failures are joined and returned and already-queued work still runs that tick.
- The seat in the trigger ref is a truncated SHA-256 digest, not the raw user id, because the ref is printed in the model prompt one line above record-shaped `<type>:<uuid>` grounding refs.
- No migration needed — both existing uniqueness constraints become per-seat-per-day through the ref.
- The agent-loop corpus fixture now carries the three-segment ref production mints.
- Two census gates hold this: every production `TriggerRef` call passes a per-seat field read off a range variable, and either constraint being re-keyed onto a seat column fails the gate.

<sup>Written for commit 70d234f6ef85b19126c81c84e3a8b59bbf58d295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled agent jobs are now created separately for each granted seat.
  * Each job uses the correct seat-specific credentials and trigger.
  * Declined, inactive, or credential-less seats are excluded.
  * Repeated scheduling runs no longer create duplicate occurrences.
  * Scheduling and execution continue for valid seats when another seat encounters an error.

* **Tests**
  * Added coverage for multi-seat, failure recovery, exclusion, uniqueness, and idempotency scenarios.

* **Documentation**
  * Updated the gate inventory and trigger provenance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->