### PR TITLE
docs(explanation): the author's own wording lands in the enrichment whitepaper

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -14,10 +14,10 @@ build instead.**
 
 ## The position
 
-Every CRM you have ever demoed offers LinkedIn enrichment. A plugin reads the
+Most CRM you have ever demoed offers LinkedIn enrichment. A plugin reads the
 profile, the record fills itself, everybody claps. Margince will never sell
 this. There will always be third-party vendors happy to serve people who want
-to ignore the legal situation, and I can't stop them. But we sell a compliant
+to ignore the legal situation, and I won't stop them. But we sell a compliant
 product to regulated companies and larger SMEs. A compliant product with an
 illegal feature is not a compliant product anymore. Punkt.
 
@@ -149,7 +149,7 @@ infrastructure, not a nice-to-have. Margince ships one; see
 [privacy-and-consent.md](privacy-and-consent.md).
 
 And here is the distinction that decides product design. It took me the whole
-research to see it sharply. A salesperson looking up ONE prospect they are
+research to understand it. A salesperson looking up ONE prospect they are
 about to contact is proportionate, and Art. 14(3)(b) lets the notice ride
 along with the first outreach at zero marginal cost. A silent background
 database of a whole market is the Bisnode pattern. Same data. Opposite legal
@@ -164,7 +164,7 @@ hold what you may not lawfully cold-email from Frankfurt.
 
 ## 3. Vietnam: consent or nothing
 
-I live and build in Vietnam. This jurisdiction is not academic for us. It is
+I live and we build global - not only in Germany but also in Vietnam. This jurisdiction is not academic for us. It is
 also the strictest one in this paper, and most Western vendors have not even
 noticed it exists.
 


### PR DESCRIPTION
Four line edits by Lars to the whitepaper from #2826/#2827: "Most CRM" instead of "Every CRM", "won't stop them" instead of "can't stop them", plainer phrasing on the proportionality insight, and the global-build framing ("I live and we build global - not only in Germany but also in Vietnam") opening the Vietnam section. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the enrichment whitepaper with the author's own wording: "Most CRM" instead of "Every CRM", "won't stop them" instead of "can't stop them", a plainer phrasing for the proportionality insight, and a global-build framing for the Vietnam section. Markdown-only change; no prose beyond these four lines is affected.

<sup>Written for commit a109cae312f18e3cfeca0be5e7f153844cb66473. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

