### PR TITLE
docs(explanation): the enrichment whitepaper survives its own adversarial fact-check

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -8,7 +8,7 @@ build instead.**
 | **Author** | Lars Jankowfsky |
 | **Date** | 27 August 2026 |
 | **Scope** | European Union law (with German specifics) and Vietnamese law. Other jurisdictions can be added later; nothing here covers them yet. |
-| **Status** | Position paper. This is research to brief counsel with, not legal advice. Every load-bearing claim carries a named source. |
+| **Status** | Position paper, adversarially fact-checked. This is research to brief counsel with, not legal advice. Every load-bearing claim carries a named source. |
 
 ---
 
@@ -22,16 +22,18 @@ product to regulated companies and larger SMEs. A compliant product with an
 illegal feature is not a compliant product anymore. Punkt.
 
 Could we build it? In a week. That was never the question. The whole plugin
-model is a contract breach stacked on a privacy violation, and the fines
-stopped being theoretical years ago. Three European regulators have executed
-exactly this pattern since 2019. LinkedIn itself won in court against the most
-famous scraper.
+model breaches LinkedIn's contract and collides with European data protection
+law, and the fines stopped being theoretical years ago. Since 2019 three
+European regulators have fined enrichment databases over the same missing
+duty, telling the people in them: Bisnode's register-built database, Kaspr's
+LinkedIn-fed one, Lusha's multi-source broker one. LinkedIn itself walked the
+most famous scraper into a permanent injunction.
 
 Here is what actually surprised me in the research: the law does NOT force a
 CRM to stay dumb. There is a real set of enrichment features that are clean.
-One of them, notification automation, nobody in the market has built. This
-paper walks through the law, names the cases, and ends with what we build and
-what we refuse.
+One of them, notification automation, I have not found at any vendor in this
+market. This paper walks through the law, names the cases, and ends with what
+we build and what we refuse.
 
 ## 1. The industry standard is a contract breach
 
@@ -44,16 +46,21 @@ Now read LinkedIn's [User Agreement](https://www.linkedin.com/legal/user-agreeme
 Section 8.2. It prohibits to "develop, support or use software, devices,
 scripts, robots or any other means or processes (such as crawlers, **browser
 plugins** and add-ons or any other technology) to scrape or copy the Services,
-including profiles". Three verbs. The clause binds the vendor AND the user. A
-separate clause prohibits using LinkedIn data obtained "through third parties
-(such as search tools or **data aggregators or brokers**)". That one reaches a
-CRM that merely stores bought data.
+including profiles". Three verbs. The clause binds everyone who agreed to the
+agreement, and in practice that is both sides of the plugin economy: the user
+by definition, and the vendor through the accounts it holds to build and test
+(the hiQ court held hiQ's own corporate account against it). A separate clause
+prohibits using LinkedIn data obtained "through third parties (such as search
+tools or **data aggregators or brokers**)" without the content owner's
+consent. A CRM that stores bought profile data sits inside that clause's
+reach.
 
 A Sales Navigator seat changes nothing. The
 [subscription agreement](https://www.linkedin.com/legal/l/lsa) calls
 unauthorized scraping an "Incurable Breach". There is no CSV export. The only
-sanctioned exit into a CRM is CRM Sync on the top tier, into Salesforce or
-Microsoft Dynamics only.
+sanctioned exit into a CRM is CRM Sync on the Advanced Plus tier, into a short
+list of big incumbents: Salesforce, Microsoft Dynamics 365, HubSpot, Oracle
+Sales ([LinkedIn's CRM matrix](https://www.linkedin.com/help/linkedin/answer/a106005/?lang=en)).
 
 "But hiQ won. Scraping public profiles is legal." I hear this a lot. It is
 the most expensive misreading in our industry. What the 9th Circuit actually
@@ -62,12 +69,16 @@ said (2019, reaffirmed
 scraping public pages is likely not a federal *hacking crime* under the CFAA.
 That is all it said. On remand, in
 [November 2022](https://caselaw.findlaw.com/court/us-dis-crt-n-d-cal/2182242.html),
-LinkedIn won summary judgment: hiQ breached the User Agreement. The case ended
-in a
-[consent judgment](https://www.privacyworld.blog/2022/12/linkedins-data-scraping-battle-with-hiq-labs-ends-with-proposed-judgment/).
-USD 500,000. A permanent injunction with no public/private distinction.
-Deletion of all scraped data and code. The company that "made scraping legal"
-went broke doing it. LinkedIn has since sued
+the district court held LinkedIn's anti-scraping terms enforceable and granted
+LinkedIn summary judgment on hiQ's fake-account "turker" conduct; liability
+for the scraping itself stayed open on waiver and estoppel questions. It never
+got answered, because hiQ folded and
+[settled](https://www.zwillgen.com/alternative-data/hiq-v-linkedin-wrapped-up-web-scraping-lessons-learned/):
+a negotiated consent judgment of USD 500,000, a permanent injunction with no
+public/private distinction, deletion of all scraped data and code. No
+precedent was set. Something better than precedent was set: the company that
+"made scraping legal" ended the fight enjoined and gone. LinkedIn has since
+sued
 [Mantheos](https://news.linkedin.com/2022/february/taking-legal-action-to-protect-members-against-scraping)
 (settled) and
 [ProAPIs](https://securityaffairs.com/183001/security/linkedin-sues-proapis-for-15k-month-linkedin-data-scraping-scheme.html)
@@ -93,80 +104,103 @@ that a purely commercial interest can be a legitimate interest under
 Art. 6(1)(f)
 ([*KNLTB*, C-621/22](https://privacymatters.dlapiper.com/2024/10/eu-cjeu-confirms-that-legitimate-interests-can-cover-purely-commercial-interests/)).
 Recital 47 names direct marketing as a candidate. The French CNIL and the UK
-ICO both accept B2B prospecting on legitimate interest with opt-out,
-professional-capacity data only, and roughly a three-year retention benchmark.
+ICO both accept B2B prospecting on legitimate interest with opt-out and
+professional-capacity data only. On retention, CNIL works with a benchmark of
+roughly three years after last contact; the ICO
+[sets no fixed period](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/plan-direct-marketing/)
+and demands you justify whatever you keep.
 
 What kills enrichment products is Article 14. You did not collect the data
 from the person? Then you must tell them. Individually. Within one month, or
 at the first contact, whichever comes first. A privacy policy on your own
-website does not count, because the person has never heard of you. And
-"notifying millions is too expensive" does not count as disproportionate
-effort. Three cases prove each part of that sentence:
+website does not count, because the person has never heard of you. The
+disproportionate-effort exception in Art. 14(5)(b) exists, but it comes with
+conditions and compensating safeguards, and the leading case shows how little
+"it's expensive" buys you on its own. Three cases, three flavours of the same
+missing duty:
 
 **Bisnode (Poland, 2019 to 2023).** Bisnode built a database of 7.5 million
 sole traders and directors from *public government registers*. It emailed the
-682,000 people whose address it had and posted a website notice for the rest.
-The Polish DPA [fined it](https://uodo.gov.pl/en/553/1572) roughly EUR 220,000
-and ordered individual notification. The Supreme Administrative Court
-dismissed the final appeal on 19 September 2023. Public-register origin did
-not help. The duty follows the data.
+682,000 people whose address it had and posted a website notice for the rest,
+arguing postal notice was disproportionate. The Polish DPA
+[fined it](https://uodo.gov.pl/en/553/1572) roughly EUR 220,000 and ordered
+individual notification. The Supreme Administrative Court dismissed the final
+appeal on 19 September 2023: transparency is the rule, the exceptions are read
+restrictively, and on these facts cost alone did not carry the exemption.
+Public-register origin did not help. The duty follows the data.
 
 **Kaspr (France, 5 December 2024, EUR 240,000).**
 [CNIL fined Kaspr](https://www.cnil.fr/en/data-scraping-kaspr-fined-eu240000),
 whose extension fed a 160-million-contact database from LinkedIn. The
 findings: collecting contacts of members who had *restricted their visibility*
 (that choice defeats the balancing test), five-year retention, no Art. 14
-notice at all until 2022, and answering access requests with "publicly
-available sources" instead of the actual source. CNIL later
-[closed the injunction](https://www.cnil.fr/en/closure-order-issued-against-kaspr)
-after remediation. Read that closure carefully. It is the closest thing to a
-regulator-reviewed acceptable model: public-by-choice data only, real
-individual notification, bounded retention.
+notice at all until 2022, and access-request answers naming only "publicly
+available sources" when CNIL held Kaspr had to hand over all the source
+information it actually possessed. CNIL later
+[closed the injunction](https://www.cnil.fr/en/closure-order-issued-against-kaspr).
+Read that closure carefully before anyone calls it a blessing: Kaspr complied
+by deleting the offending data and ceasing the LinkedIn collection. The
+regulator approved the exit, not the model.
 
 **Lusha (Italy, July 2026, EUR 2 million).** The Garante
 [fined Lusha](https://www.garanteprivacy.it/home/docweb/-/docweb-display/docweb/10275230)
 and ordered erasure of ALL Italian contact data within 60 days. Lusha is a US
 company with no EU establishment. Did not matter. It carried a TrustArc
-compliance seal. Did not matter either.
+compliance seal. That did not prevent the finding; the Garante weighed the
+certification when setting the amount, and the answer was still two million.
 
-Around these sit the harder precedents. Clearview AI has collected over
-EUR 110 million in fines across five European authorities for scraping public
-photos. Sweden's IMY
+Around these sit the harder precedents. Clearview AI has been fined roughly
+EUR 100 million in total across five European authorities for scraping public
+photos (Italy, Greece and France EUR 20M each, the Netherlands EUR 30.5M,
+plus the UK's GBP 7.5M,
+[still in litigation](https://ico.org.uk/about-the-ico/media-centre/news-and-blogs/2025/10/uk-upper-tribunal-hands-down-judgment-on-clearview-ai-inc/),
+and a later French EUR 5.2M non-compliance penalty). Sweden's IMY
 [fined the police](https://www.imy.se/en/about-us/arkiv/nyhetsarkiv/police-unlawfully-used-facial-recognition-app/)
 EUR 250,000 merely for *using* Clearview. Think about that one: customers of
 unlawful scraping carry their own liability. Twelve DPAs signed a
 [joint statement on data scraping](https://ico.org.uk/media2/migrated/4026232/joint-statement-data-scraping-202308.pdf)
 in August 2023. And the Irish DPC fined Meta
 [EUR 265 million](https://www.dataprotection.ie/en/news-media/press-releases/data-protection-commission-announces-decision-in-facebook-data-scraping-inquiry)
-for failing to engineer *against* scraping. Platforms are now legally required
-to fight the exact tools the CRM industry sells.
+over its own data-protection-by-design failures after the 533M-user scraped
+dataset surfaced. That decision binds Meta, not every platform. The direction
+it points is still uncomfortable for the plugin industry: the host platform's
+design duty runs *against* scraping, not with it.
 
-Two consequences follow for anyone holding enriched data. First: an access
-request must name the actual source, per field. "Public sources" was one of
-Kaspr's violations. Second: erasure must propagate. A re-sync that resurrects
-a deleted contact is a fresh violation, so a suppression list is mandatory
-infrastructure, not a nice-to-have. Margince ships one; see
+Two consequences follow for anyone holding enriched data. First: Art. 15(1)(g)
+gives the person a right to "any available information" about the source, and
+Kaspr shows a regulator will not accept "public sources" from a company that
+knows more. Our answer is per-field provenance, which is more than the letter
+requires and exactly what makes the DSAR answer easy. Second: erasure has to
+stick. The law does not
+[literally mandate a suppression list](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/respect-peoples-preferences/),
+but without one the next re-sync quietly resurrects the deleted contact and
+puts you back in front of the same lawful-basis question with worse facts. The
+ICO recommends one. We ship one; see
 [privacy-and-consent.md](privacy-and-consent.md).
 
 And here is the distinction that decides product design. It took me the whole
-research to understand it. A salesperson looking up ONE prospect they are
-about to contact is proportionate, and Art. 14(3)(b) lets the notice ride
-along with the first outreach at zero marginal cost. A silent background
-database of a whole market is the Bisnode pattern. Same data. Opposite legal
-outcomes. The trigger and the scale are the dividing line, and regulators say
-so consistently: scale, source-combination and profiling are the aggravating
-factors in every decision above.
+research to understand it. Scale is the aggravating factor in every decision
+above: the standing database of a whole market, sources combined, nobody
+told. A salesperson looking up ONE prospect they are about to contact still
+needs the Art. 6 balancing like any other processing, but it walks into that
+test with the best facts available: narrow purpose, minimal fields, and the
+Art. 14(3)(b) notice riding along with the first outreach at zero marginal
+cost. Same data. Opposite posture. The trigger and the scale are what
+separate a defensible lookup from the Bisnode pattern.
 
 One more split to respect: *storing* a business email address is a GDPR
-question. *Emailing* it is a separate marketing-law question, and Germany's
-§7 UWG requires consent for email marketing even B2B. Your CRM can lawfully
-hold what you may not lawfully cold-email from Frankfurt.
+question. *Emailing* it is a separate marketing-law question. Germany's
+[§7 UWG](https://www.gesetze-im-internet.de/englisch_uwg/englisch_uwg.pdf)
+requires prior express consent for email marketing even B2B, with one narrow
+exception (§7(3), existing customers, same-product context, opt-out at every
+step). Your CRM can lawfully hold what you may not lawfully cold-email from
+Frankfurt.
 
 ## 3. Vietnam: consent or nothing
 
-I live and we build global - not only in Germany but also in Vietnam. This jurisdiction is not academic for us. It is
-also the strictest one in this paper, and most Western vendors have not even
-noticed it exists.
+I live and we build global - not only in Germany but also in Vietnam. This
+jurisdiction is not academic for us. It is also the strictest one in this
+paper, and most Western vendors have not even noticed it exists.
 
 Vietnam ran on
 [Decree 13/2023/ND-CP](https://thuvienphapluat.vn/van-ban/EN/Cong-nghe-thong-tin/Decree-No-13-2023-ND-CP-dated-April-17-2023-on-protection-of-personal-data/564343/tieng-anh.aspx)
@@ -186,11 +220,14 @@ publicly-available-data basis at all. Making data public waives nothing.
 Marketing needs consent, no soft opt-in, on top of the Decree 91/2020
 anti-spam regime with its do-not-call register.
 
-Article 8 bans buying and selling personal data outright. "Personal data is
-not a commodity." Fines run up to ten times the revenue gained, minimum around
-USD 115,000. Cross-border violations reach 5% of prior-year revenue. Buying
-broker data about Vietnamese contacts is the single highest-risk act in this
-entire space.
+Article 7(6) prohibits buying and selling personal data, except where the law
+itself provides otherwise. "Personal data is not a commodity." The penalty
+rules (Article 8 and the sanctions regime) run up to ten times the revenue
+gained from illegal data trading, and up to 5% of prior-year revenue for
+violations of the cross-border transfer rules
+([official text via the Ministry of Public Security](https://bocongan.gov.vn/media/bca-media/photo-library/20250728100402_a4c3955c-ea1d-48a0-9998-c262b14864af-Lu%E1%BA%ADt-B%E1%BA%A3o-v%E1%BB%87-d%E1%BB%AF-li%E1%BB%87u-c%C3%A1-nh%C3%A2n.pdf)).
+Buying broker data about Vietnamese contacts is the single highest-risk act
+in this entire space.
 
 Enforcement is young. The Ministry of Public Security's A05 department ran
 its first compliance campaign in late 2024, and no published fine has hit a
@@ -198,9 +235,12 @@ foreign B2B SaaS yet. I would not bet a product on that lasting. Vietnam's
 data-trading black market is the stated reason this law exists. Scraping and
 aggregation sit in the political crosshairs, not in a tolerated gray zone.
 
-The product consequence is blunt: a Vietnamese data subject needs a
-consent-backed path. The contact confirms their own details, connects their
-own profile, or hands over their card. Nothing else.
+The product consequence is blunt: a Vietnamese data subject needs consent
+that the law recognizes, and Law 91 wants it voluntary, informed, specific
+and verifiable. A handed-over business card starts a business relationship;
+it does not prove consent to enrichment, marketing or onward disclosure. The
+verifiable path is the confirm-your-details flow (A6 below), where the
+contact sees the record and says yes on the record.
 
 ## 4. The Betriebsrat will read this paper too
 
@@ -216,33 +256,50 @@ for SAP (1 ABR 45/11), for Office 365
 and in 2024 for a retail headset system that stored nothing at all
 ([1 ABR 16/23](https://www.bundesarbeitsgericht.de/wp-content/uploads/2024/11/1-ABR-16-23.pdf)).
 A CRM with an audit trail and per-rep pipeline numbers is co-determined,
-period. That part is routine. Every German Salesforce rollout has a
-Betriebsvereinbarung, and the works agreement even doubles as the GDPR legal
-basis for the employee-side processing (Art. 88 GDPR, §26(4) BDSG).
+period. That part is routine. A German enterprise CRM rollout normally comes
+with a Betriebsvereinbarung, and a well-made one can itself serve as the
+GDPR basis for the employee-side processing, provided it meets the
+requirements Art. 88(2) GDPR and
+[§26(4) BDSG](https://www.gesetze-im-internet.de/englisch_bdsg/englisch_bdsg.html)
+put on such agreements.
 
 What decides whether that negotiation takes six weeks or eighteen months is
 the feature list. Server-side enrichment of *external* contacts barely
 registers. The only employee datum it touches is the audit-trail fact that
-user X clicked. The scraping plugins fail on all three points works councils
+user X clicked. The scraping plugins fail on the three points works councils
 actually fight: an extension in the employee's browser that watches what they
 view, work forced through the employee's personal LinkedIn account, and
-correspondence mining that builds per-employee communication profiles. The
-Kaspr fine hands any works council a ready-made argument that the tool itself
-is legally toxic.
+mining that turns the team's correspondence into per-employee conduct
+profiles. The Kaspr fine hands any works council a ready-made argument that
+the tool itself is legally toxic.
 
 Since 2021 there is an AI layer on top. §90 BetrVG obliges the employer to
 inform the works council at the *planning* stage of AI use, and the EU AI Act
 classifies systems that monitor and evaluate worker performance as high-risk
-(Annex III 4(b), obligations binding since 2 August 2026). Our rule is simple:
-the AI evaluates records, deals and companies. Never a named rep's work
-quality.
+(Annex III 4(b)). The compliance deadline for Annex III systems was moved by
+the 2026 AI omnibus
+([Regulation (EU) 2026/1744](https://www.steptoe.com/en/news-publications/steptechtoe-blog/eu-ai-act-amendments-enter-into-force.html))
+from 2 August 2026 to 2 December 2027. A delayed deadline, not a cancelled
+category. Our rule stands regardless of the date: the AI evaluates records,
+deals and companies. Never a named rep's work quality.
 
-Margince's architecture already satisfies the properties works councils
-negotiate for. No browser extension, everything server-side, no per-employee
-analytics by default, signature and header fields instead of mailbox content
-mining, access-restricted audit data. In a DACH sales cycle that list
-shortens the negotiation by months, and the competitor's plugin is the thing
-the Betriebsrat vetoes.
+Where does Margince stand on its own test? Honestly, like this. We are a
+correspondence CRM: connected mailboxes are captured, stored and processed,
+including message bodies, because that is the product (see
+[capture-connectors.md](capture-connectors.md) and
+[ingress-gate-and-auto-capture.md](ingress-gate-and-auto-capture.md)). The
+[relationship graph](relationship-graph.md) computes from that correspondence
+a per-colleague warmth toward each *contact*, because "who here can open this
+door" is an account question a sales team genuinely has. Both of these are
+squarely co-determined, and both are designed to be governable: no browser
+extension, everything server-side, no rep leaderboards and no performance
+scores, warmth bands deliberately built not to be comparable across people or
+merged into a ranking, exclusion lists for mailboxes and domains that must
+never be captured, audit data access-restricted. The Betriebsvereinbarung
+then pins the purpose in writing: account coverage yes, performance
+evaluation never, with a Verwertungsverbot on top. That conversation is
+winnable because the design gives the works council something to hold. A
+scraping plugin gives them something to veto.
 
 ## 5. What we build, what we gate, what we refuse
 
@@ -252,26 +309,32 @@ works-council temperature.
 
 ### Tier A: build freely
 
-**A1. Company enrichment from official sources.** Legal-entity data sits
-outside the GDPR entirely (Recital 14). [VIES](https://ec.europa.eu/taxation_customs/vies/)
-VAT validation, free, returns name and address in 16 member states; we store
-the consultation number as proof. [GLEIF LEI](https://www.gleif.org/en/about/open-data),
-CC0-licensed, free API and bulk files, including the ownership tree. Swiss
-Zefix with its free REST API and daily change feed. UK Companies House, free
-API and streaming. German Handelsregister lookups, free since the 2022 DiRUG
-reform, but strictly per-lookup: the portal caps queries and bans bulk
-retrieval, so bulk always goes through a licensed aggregator such as North
-Data. Named directors inside register data are personal data, but published
-under statutory duty. That is the strongest legitimate-interest fact pattern
-that exists. Identifier spine: EUID, LEI, VAT ID, and the Vietnamese MST.
+**A1. Company enrichment from official sources.** Data about the legal
+person as such sits outside the GDPR (Recital 14): name, legal form, VAT
+number, registered address. [VIES](https://ec.europa.eu/taxation_customs/vies/)
+VAT validation, free, returns the registered name and address for many member
+states; we store the consultation number as proof.
+[GLEIF LEI](https://www.gleif.org/en/about/open-data), CC0-licensed, free API
+and bulk files, including the ownership tree. Swiss Zefix with its free REST
+API and daily change feed. UK Companies House, free API and streaming. German
+Handelsregister lookups, free since the 2022 DiRUG reform, but strictly
+per-lookup: the portal caps queries and bans bulk retrieval, so bulk always
+goes through a licensed aggregator such as North Data. And the line to keep
+sharp: the moment a natural person appears inside that data, a director, a
+sole trader, a named representative, it is personal data again. Published
+under statutory duty, which is the strongest legitimate-interest fact pattern
+there is, but personal data with all the duties attached. Identifier spine:
+EUID, LEI, VAT ID, and the Vietnamese MST.
 
 **A2. The counterparty's own website, read deeper.** Margince already reads
 company sites (see [company-context.md](company-context.md)), and a deep read
 already handles the people a site names, in exactly the shape this paper
-argues for: a stranger on the team page stages as a lead and stays staged
-until a human accepts, and a person the workspace already records at that
-company gets only empty fields filled, evidence-backed, with the source on the
-row. Nothing person-shaped is auto-written behind the user's back. The clean
+argues for. A stranger on the team page stages as a lead and stays staged
+until a human accepts; no new person is ever auto-created. When the published
+person is unmistakably someone the workspace already records at that company
+(exact email match, or a single high-confidence name match), the read fills
+their empty fields, role, title, profile link, evidence-backed with the
+source on the row, and never overwrites what a human wrote. The clean
 extensions from here: parse the Impressum, whose publication German law
 *mandates* (§5 DDG), and consume newsroom RSS for company events, storing the
 signal plus a link and never the cached full text. Polite crawling, robots.txt
@@ -280,107 +343,130 @@ automatic read stages.
 
 **A3. Technical enrichment.** MX and DNS records, TLS certificate
 transparency logs, tech-stack fingerprints from the company's public pages.
-Company-level, no personal data, works identically in Hamburg and in Da Nang.
+Company-level signals that work identically in Hamburg and in Da Nang, with
+the same caveat as A1: a personal name inside a certificate or a domain
+record is personal data, so we keep what we store at the company level.
 
 **A4. First-party person capture.** The contact sent you their details.
-Email signature parsing (stated fields only, never inferred scores,
-per-mailbox opt-in with exclusion lists), calendar attendees of your own
-meetings, vCard import. This is the only person-data channel that scales
-cleanly, and it is already how Margince capture works: see
+Margince's capture already works this way: connected mailboxes are processed
+automatically, a nightly pass lifts the stated fields from email signatures
+(name, title, phone, nothing inferred), and workspace exclusion lists keep
+whole addresses and domains out of capture entirely. What this tier cleanly
+extends to next: vCard import and a per-mailbox switch for the signature
+pass, so an organization can turn the granularity all the way down. First
+party is the only person-data channel that scales cleanly. See
 [capture-connectors.md](capture-connectors.md) and
 [ingress-gate-and-auto-capture.md](ingress-gate-and-auto-capture.md).
 
-**A5. LinkedIn as a link, plus subject-side connect.** We store the profile
-URL as a clickable link and never fetch it server-side. The user reads the
-profile in their own browser and types what they learned into a structured
-form. The one automated path LinkedIn explicitly permits is the member
-exporting their own data: that is exactly what
-[import-your-linkedin-network.md](../how-to/import-your-linkedin-network.md)
-implements with the user's own `Connections.csv`. What we will not build is a
-parser for pasted profile text. The moment software copies the page for you,
-you are back inside the scraping clause.
+**A5. LinkedIn as a link, plus the member's own export.** We store the
+profile URL as a clickable link and never fetch it server-side. The user
+reads the profile in their own browser and types what they learned into a
+structured form. And LinkedIn gives every member a download of their own
+data; [import-your-linkedin-network.md](../how-to/import-your-linkedin-network.md)
+imports that `Connections.csv` deliberately small: as private graph
+substrate ("ghosts") for reach and warmth, visible only to the importer,
+never as contact records, never creating people. Whether LinkedIn's terms
+would tolerate more than that is exactly why we built no more than that.
+What we will not build is a parser for pasted profile text. The moment
+software copies the page for you, the scraping clause is back in play, and
+our line is drawn on the safe side of it.
 
 **A6. The "confirm your details" flow.** Send the contact a link to view and
 correct their own card. One feature, three legal jobs: it is the Art. 14
 transparency notice, the Art. 16 accuracy mechanism, and, because it collects
-consent, the one enrichment channel that works for Vietnamese contacts. It
-actively de-risks everything else on this page.
+verifiable consent, the one enrichment channel that satisfies Vietnam's
+Law 91 standard. It actively de-risks everything else on this page.
 
 ### Tier B: build with controls, counsel signs off first
 
 **B1. Widening person lookup beyond the counterparty's own site.** The
 shipped shape described in A2 (staged leads, fill-only-empty, evidence on
 every field, per-field provenance through the write shape; see
-[write-backbone.md](write-backbone.md)) is already the proportionate pattern:
-one company at a time, sources the person published for business contact, a
-human between the suggestion and the record. What stays gated on counsel is
-widening it. New sources beyond the company's own site (speaker bios,
-conference pages, Impressum contact lines of third parties) enter only under
-the same staging discipline. And before we widen anything, the missing
+[write-backbone.md](write-backbone.md)) is the right chassis: one company at
+a time, sources the person published for business contact, a human between
+the suggestion and the record. What stays gated on counsel is widening it.
+New sources beyond the company's own site (speaker bios, conference pages,
+Impressum contact lines of third parties) enter only under the same staging
+discipline, and each widening needs its own Art. 6 balancing on paper, not a
+generalized "single lookups are fine". Before we widen anything, the missing
 controls land: the Art. 14 notice generated and delivered with the first
-outreach or within one month of a staged lead being accepted, roughly
-three-year retention with refresh-or-delete, the erasure suppression list
-consulted before a re-read can re-stage a deleted person, visibility
-restrictions honored wherever a platform offers them (that is precisely where
-Kaspr lost), and Vietnamese subjects excluded and routed to A6.
+outreach or within one month of a staged lead being accepted, a justified
+retention rule with refresh-or-delete (CNIL's three-year benchmark as the
+starting point), the erasure suppression list consulted before a re-read can
+re-stage a deleted person, visibility restrictions honored wherever a
+platform offers them (that is precisely where Kaspr lost), and Vietnamese
+subjects excluded and routed to A6.
 
 **B2. Art. 14 notice automation as a customer feature.** The CRM generates,
 sends and logs the notification our customer owes for any contact not
 collected from the subject, with objection handling wired into the
-suppression list. No competitor's plugin does this, because their model
-cannot survive transparency. Ours is built on it. Needs per-market legal
-review of the notice texts before shipping.
+suppression list. I have not found this at any vendor, and I think I know
+why: their model cannot survive transparency. Ours is built on it. Needs
+per-market legal review of the notice texts before shipping.
 
 **B3. Licensed notified-database providers.** Providers like
 [Cognism](https://www.cognism.com/compliance) and Dealfront run a "notified
 database": they claim Art. 6(1)(f) with a documented balancing test and
 discharge Art. 14 by emailing the data subjects. That model is
 provider-asserted, not regulator-certified, and the customer remains an
-independent controller with their own duties. Margince's side of the bargain
-is already built the right way around: what a licensed provider asserts about
-a person lands as a claim row with the purchasing run attached
-(`person_provider_claim`), separate from the record itself, so
-purge-on-termination and downstream erasure signals are executable per
-provider. Adding a specific provider stays a per-contract counsel question,
-and never for Vietnamese subjects; Article 8 forbids the trade itself.
+independent controller with their own duties. On our side, what a licensed
+provider asserts about a person lands as a claim row with the purchasing run
+attached (`person_provider_claim`), separate from the record itself, and a
+delete-data action removes the local claims and scrubs the run metadata.
+What does NOT exist yet, and goes on the same counsel checklist as the
+provider contract: automatic purge when a provider is disconnected, and
+plumbing for provider-side erasure signals to flow downstream. Until both
+exist, B3 stays a gated integration, and never for Vietnamese subjects;
+Article 7(6) forbids the trade itself.
 
 ### Tier C: refuse
 
 - **Bulk background enrichment of a market.** The Bisnode and Lusha pattern:
   a standing shadow database of everyone, built before any user asked. No
-  Art. 14 story, scale defeats the balancing test, and Italy has shown a
-  regulator will order erasure of the entire national dataset. Reading one
-  company's own site for a human working that company (A2) is the opposite
-  end of the proportionality scale.
-- **LinkedIn or Xing ingestion in any automated form.** Contract breach for
-  vendor and user, the Kaspr fine replayed, and the sanctioned API path is
-  closed. "The user's browser does it" defends nothing. LinkedIn sues over
-  exactly this model.
-- **Any browser extension.** Disqualified twice over: LinkedIn's contract
-  names plugins, and a tool observing what an employee views is textbook
-  §87(1)(6) surveillance.
+  realistic Art. 14 story, scale wrecks the balancing test, and Italy has
+  shown a regulator will order erasure of the entire national dataset.
+  Reading one company's own site for a human working that company (A2) is
+  the opposite end of the proportionality scale.
+- **LinkedIn or Xing ingestion in any automated form.** For LinkedIn this
+  breaches the quoted contract for everyone who agreed to it, replays the
+  Kaspr fine, and the sanctioned API path is closed. "The user's browser
+  does it" defends nothing. LinkedIn sues over exactly this model. For Xing
+  I cite no contract clause; the GDPR analysis and the works-council
+  analysis alone put it here, and that is enough.
+- **Any browser extension.** Twice disqualified: LinkedIn's clause names
+  plugins, and a tool that observes what an employee views in their browser
+  is textbook §87(1)(6) surveillance. Even where some narrow extension might
+  survive a lawyer's reading, this product line does not want to be in that
+  argument.
 - **Purchased lists and broker data of unclear provenance.** The recipient
   becomes controller of data with no lawful-basis chain. For Vietnamese
   subjects, add the trading ban and its ten-times-revenue fine.
-- **Correspondence content mining and relationship scoring per employee.**
-  Reading mailbox content beyond signature and header fields fails the §26
-  BDSG necessity test, and per-employee "who knows whom, how well" scoring is
-  the works-council red line.
+- **Evaluating employees from their communications.** The refusal here is
+  precise, because we DO compute from correspondence (section 4): no
+  inferred traits or conduct profiles about employees, no performance
+  evaluation from communication data, no surface that ranks reps against
+  each other. The relationship graph answers "who can open this door for
+  this account", per contact, in bands built not to be summed into a
+  scoreboard. Whether mailbox processing passes §26 BDSG is a
+  purpose-by-purpose assessment, and account coverage with those guardrails
+  is a purpose we can defend in writing. Rep scoring is not, and it stays
+  refused.
 
 ## 6. Why this wins deals
 
 I did not write this paper to excuse a gap. The scraping vendors made a bet:
 LinkedIn's enforcement stays slow, DPAs stay busy elsewhere, no works council
 reads the CNIL's press releases. Every year that bet gets worse. Since 2022
-the count reads: one permanent injunction, two LinkedIn lawsuits, three DPA
-fines executing the same pattern, one nationwide erasure order.
+the count reads: one permanent injunction (consented, and no less permanent
+for it), two more LinkedIn lawsuits, three DPA fines over untold data
+subjects, one nationwide erasure order.
 
 We took the other side of the bet. Verified registers, the counterparty's own
 site, first-party signals, consent flows, and notification automation give
 real data quality with an audit trail behind every field. Our market is DACH
 companies with works councils, DPOs and regulators on the buying committee.
-For them the compliance IS the product. And for Vietnamese contacts we are,
-as far as I can tell, the only CRM with a considered answer at all.
+For them the compliance IS the product. And for Vietnamese contacts I have
+yet to see another CRM with a considered answer at all.
 
 So ask your current vendor two questions. Who indemnifies you when your reps'
 LinkedIn accounts get banned? And who sends the Art. 14 notices for the ten
@@ -393,19 +479,21 @@ Primary decisions and rulings, verified against the issuing body where linked
 above: CJEU C-621/22 (*KNLTB*); UODO v. Bisnode with the NSA ruling of
 19 Sep 2023; CNIL v. Kaspr, EUR 240,000, 5 Dec 2024, plus the closure notice;
 Garante v. Lusha, EUR 2M, Jul 2026; the Clearview AI fine series (IT, GR, FR,
-NL, UK); IMY v. the Swedish police; Irish DPC v. Meta, EUR 265M; hiQ v.
-LinkedIn (9th Cir. 2022, N.D. Cal. Nov 2022, consent judgment Dec 2022);
-LinkedIn v. Mantheos and v. ProAPIs; BAG 1 ABN 36/18, 1 ABR 45/11,
-1 ABR 20/21, 1 ABR 16/23. Statutes: GDPR Arts. 5, 6(1)(f), 14, 15(1)(g), 17,
-21, 88; Recitals 14 and 47; §87(1)(6), §90, §80(3) BetrVG; §26 BDSG; §5 DDG;
-§7 UWG; EU AI Act Annex III 4(b); Vietnam Decree 13/2023/ND-CP, PDPL Law
-91/2025/QH15, Decree 356/2025, Decree 91/2020. Vietnamese-law readings rest on
-concurring commentary from Tilleke & Gibbins, DLA Piper, Baker McKenzie, Rouse
-and DFDL, since English primary text exists only for Decree 13.
+NL, UK; UK in litigation); IMY v. the Swedish police; Irish DPC v. Meta,
+EUR 265M; hiQ v. LinkedIn (9th Cir. 2022, N.D. Cal. Nov 2022, consent
+judgment Dec 2022); LinkedIn v. Mantheos and v. ProAPIs; BAG 1 ABN 36/18,
+1 ABR 45/11, 1 ABR 20/21, 1 ABR 16/23. Statutes: GDPR Arts. 5, 6(1)(f), 14,
+15(1)(g), 17, 21, 88; Recitals 14 and 47; §87(1)(6), §90, §80(3) BetrVG; §26
+BDSG; §5 DDG; §7 UWG; EU AI Act Annex III 4(b) as amended by Regulation (EU)
+2026/1744; Vietnam Decree 13/2023/ND-CP, PDPL Law 91/2025/QH15 (Arts. 7(6),
+8, 9), Decree 356/2025, Decree 91/2020. Vietnamese-law readings rest on the
+official texts plus concurring commentary from Tilleke & Gibbins, DLA Piper,
+Baker McKenzie, Rouse and DFDL.
 
-Open flags a lawyer should close before Tier B ships: the final adoption
-status of the EDPB's Guidelines 1/2024 on legitimate interest (still draft as
-of this writing); Vietnam's sanctions decree (reported as Decree 330/2026,
-single-source); the exact section numbering of LinkedIn's subscription
-agreement; the §7 UWG detail for each outreach channel. None of these flags
-changes a tier placement.
+This paper survived an adversarial fact-check (26 findings, all reconciled
+into this version on 27 Aug 2026). Open flags a lawyer should still close
+before Tier B ships: the final adoption status of the EDPB's Guidelines
+1/2024 on legitimate interest (still draft as of this writing); Vietnam's
+administrative sanctions decree (in flux through 2026); the exact section
+numbering of LinkedIn's subscription agreement; the §7 UWG detail per
+outreach channel. None of these flags changes a tier placement.


### PR DESCRIPTION
Reconciles all 26 findings from the Codex redteam of the whitepaper (#2826, #2827, #2828). Nothing was rejected; two disputed points were independently re-verified (the AI Act deferral to 2 Dec 2027 via Regulation (EU) 2026/1744, confirmed against secondary coverage of the Official Journal text; the Vietnam PDPL article numbering, adopted per the official ministry text Codex cited).

The three critical fixes:
- **AI Act date**: Annex III high-risk obligations were deferred from 2 Aug 2026 to 2 Dec 2027 by the 2026 AI omnibus. The paper now cites the amendment and keeps the design rule independent of the date.
- **Relationship graph**: the paper no longer refuses a capability the product ships. It describes per-colleague warmth as the account question it answers, and narrows the Tier C refusal to evaluating employees: no conduct profiles, no performance evaluation from communication data, no rep ranking.
- **Mailbox honesty**: Margince is a correspondence CRM that stores and processes message bodies; the paper says so and draws the refusal line at inferred traits and rep scoring, instead of the false claim that only signature/header fields are touched.

Plus the 23 high/medium/low corrections: hiQ summary-judgment nuance (enforceability affirmed, scraping liability never adjudicated, consent judgment without precedent), Kaspr's closure described as an approved exit rather than an approved model, the CRM Sync partner list (Salesforce, Dynamics, HubSpot, Oracle), Vietnam Art. 7(6)/Art. 8 corrections and dropped minimum-fine claim, Clearview total restated as ~EUR 100M with the UK fine in litigation, Art. 14(5)(b) exception restored, Art. 15(1)(g) restated as "any available information", suppression list and retention benchmarks correctly attributed, Betriebsvereinbarung-as-legal-basis conditioned on Art. 88(2), TrustArc weighting in the Lusha fine, §7(3) UWG exception, Recital 14 scope tightened in A1/A3, VIES count softened, the LinkedIn CSV import described as private graph ghosts, provider purge-on-termination named as unshipped and gated, and every uncited market superlative softened to a first-person claim.

Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles all 26 findings from the adversarial fact-check of the enrichment whitepaper in `docs/explanation/data-enrichment-position.md`. Markdown-only change; no behavior or product code affected.

**Critical fixes**
- Corrects the AI Act Annex III deadline to 2 Dec 2027 per Regulation (EU) 2026/1744, and keeps the paper's design rule independent of the date.
- Makes the relationship graph description match the shipped product: per-colleague warmth toward contacts is described, and the Tier C refusal narrows to evaluating employees, not computing warmth.
- States honestly that Margince stores and processes mailbox message bodies, and draws the refusal line at inferred traits and rep scoring.

**Other notable corrections**
- Adds the hiQ summary-judgment nuance: enforceability affirmed, scraping liability never adjudicated, no precedent set.
- Describes Kaspr's closure as an approved exit, not an approved model.
- Fixes Vietnam PDPL citations: Art. 7(6) instead of Art. 8, drops the minimum-fine claim.
- Restates the Clearview total as roughly EUR 100M with the UK fine in litigation.
- Corrects Art. 14(5)(b) and Art. 15(1)(g) descriptions.
- Restores the §7(3) UWG exception and the CRM Sync partner list.
- Conditions Betriebsvereinbarung-as-legal-basis on Art. 88(2).
- Names provider purge-on-termination as unshipped and gated.
- Softens every uncited market superlative to a first-person claim.

<sup>Written for commit a1de9d07e1b58f34451f0a16444a6812405221cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the data-enrichment position paper with updated legal findings and supporting sources.
  * Clarified GDPR, EU AI Act, Vietnamese data-trading, consent, and works-council considerations.
  * Documented safeguards, unresolved legal questions, and refined product boundaries.
  * Clarified limitations for LinkedIn exports, Vietnamese contact workflows, provider integrations, and employee performance evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->