### PR TITLE
fix(dedupe): a Vietnamese company is matched on its brand, not its legal form

### DIFF
--- a/backend/internal/modules/people/dedupeorg.go
+++ b/backend/internal/modules/people/dedupeorg.go
@@ -204,16 +204,32 @@ func fuzzyOrganization(ctx context.Context, tx pgx.Tx, c OrganizationCandidate) 
 	}, nil
 }
 
-// orgTrigramArms builds one `%` arm per (non-empty candidate axis × stored
+// orgTrigramArms builds one `<%` arm per (non-empty candidate axis × stored
 // column), appending each value to args once.
 //
-// An EMPTY axis is dropped rather than passed as "". A `%` arm whose right
-// side is empty matches nothing, but Postgres cannot satisfy it from the GIN
-// index, so its presence makes the planner abandon the index for the whole OR
-// group and sequentially scan the table — on the common case, since most
-// organizations carry no registered name. Measured: two arms with a real value
-// give a BitmapOr across both trigram indexes; adding the empty arms turns the
-// same query into a Seq Scan.
+// An EMPTY axis is dropped rather than passed as "". An arm whose left side is
+// empty matches nothing, but Postgres cannot satisfy it from the GIN index, so
+// its presence makes the planner abandon the index for the whole OR group and
+// sequentially scan the table — on the common case, since most organizations
+// carry no registered name. Measured: two arms with a real value give a
+// BitmapOr across both trigram indexes; adding the empty arms turns the same
+// query into a Seq Scan.
+//
+// WORD similarity (`<%`), not whole-string similarity (`%`). The question this
+// tier asks is whether the candidate name appears INSIDE the stored one, and
+// `%` cannot ask it: it compares the two strings entire, so a short name loses
+// against a long one on length alone. A market that writes its legal form into
+// the name makes that the common case rather than the exception — measured
+// against the stored names, "Hòa Bình" scores 0.265 against its own company's
+// registered name "CÔNG TY TNHH MỘT THÀNH VIÊN HÒA BÌNH", under the 0.3 limit,
+// so the true duplicate was never returned for scoring at all. "FPT" scored
+// 0.174 and "An Bình" 0.167. Under `<%` each scores 1.0, because the candidate
+// is exactly a run of words in the stored name.
+//
+// This WIDENS the candidate set and decides nothing: everything returned is
+// still put to the gate and the score, which is where identity is judged. The
+// same GIN indexes serve it — `<%` uses gin_trgm_ops through the `%>`
+// commutator, so no index changes and the plan stays a Bitmap Index Scan.
 func orgTrigramArms(args *[]any, axes ...string) []string {
 	var arms []string
 	for _, axis := range axes {
@@ -224,7 +240,7 @@ func orgTrigramArms(args *[]any, axes ...string) []string {
 		n := len(*args)
 		for _, column := range []string{fieldDisplayName, fieldLegalName} {
 			arms = append(arms, fmt.Sprintf(
-				"f_fold_apostrophes(lower(%s)) %% f_fold_apostrophes(lower($%d))", column, n))
+				"f_fold_apostrophes(lower($%d)) <%% f_fold_apostrophes(lower(%s))", n, column))
 		}
 	}
 	return arms
@@ -243,6 +259,12 @@ func orgTrigramArms(args *[]any, axes ...string) []string {
 // names — where every name in a market ends in the same nouns — that made it
 // read shared vocabulary as shared identity: measured at 179 false pairs
 // against 1 true one across one real workspace.
+//
+// The gate and the score read the SAME string (orgNameForMatching), so a word
+// the gate refused to count cannot come back to lift the score. A Vietnamese
+// name carries its legal form in front, where Jaro-Winkler's prefix boost is
+// strongest, so scoring the unstripped name put two unrelated companies over
+// the threshold on their boilerplate alone.
 func bestOrgNamePairing(candidateDisplay, candidateLegal, rowDisplay, rowLegal string) OrganizationCandidateScore {
 	sides := []struct {
 		value string
@@ -252,7 +274,7 @@ func bestOrgNamePairing(candidateDisplay, candidateLegal, rowDisplay, rowLegal s
 	var best OrganizationCandidateScore
 	for _, left := range []string{candidateDisplay, candidateLegal} {
 		for _, right := range sides {
-			normalizedLeft, normalizedRight := NormalizeOrgName(left), NormalizeOrgName(right.value)
+			normalizedLeft, normalizedRight := orgNameForMatching(left), orgNameForMatching(right.value)
 			if normalizedLeft == "" || normalizedRight == "" {
 				continue
 			}

--- a/backend/internal/modules/people/dedupeorg.go
+++ b/backend/internal/modules/people/dedupeorg.go
@@ -215,21 +215,26 @@ func fuzzyOrganization(ctx context.Context, tx pgx.Tx, c OrganizationCandidate) 
 // BitmapOr across both trigram indexes; adding the empty arms turns the same
 // query into a Seq Scan.
 //
-// WORD similarity (`<%`), not whole-string similarity (`%`). The question this
-// tier asks is whether the candidate name appears INSIDE the stored one, and
-// `%` cannot ask it: it compares the two strings entire, so a short name loses
-// against a long one on length alone. A market that writes its legal form into
-// the name makes that the common case rather than the exception — measured
-// against the stored names, "Hòa Bình" scores 0.265 against its own company's
-// registered name "CÔNG TY TNHH MỘT THÀNH VIÊN HÒA BÌNH", under the 0.3 limit,
-// so the true duplicate was never returned for scoring at all. "FPT" scored
-// 0.174 and "An Bình" 0.167. Under `<%` each scores 1.0, because the candidate
-// is exactly a run of words in the stored name.
+// TWO ARMS PER PAIRING, and each catches what the other cannot.
+//
+// `%` compares the two strings ENTIRE, so a short name loses against a long one
+// on length alone. A market that writes its legal form into the name makes that
+// the common case: measured against the stored names, "Hòa Bình" scores 0.265
+// against its own company's registered name "CÔNG TY TNHH MỘT THÀNH VIÊN HÒA
+// BÌNH", under the 0.3 limit, so the true duplicate was never returned for
+// scoring at all. "FPT" scored 0.174 and "An Bình" 0.167.
+//
+// `<%` asks the other question — does the candidate appear as a RUN OF WORDS
+// inside the stored name — and answers 1.0 for all three. But it is asymmetric
+// and its threshold is higher (0.6 against 0.3), so it cannot replace `%`:
+// reversed, a long candidate against a short stored name scores 0.429, and the
+// spelling variant "Roehm" against "Röhm" scores 0.375. Both are recall this
+// tier already had and must keep.
 //
 // This WIDENS the candidate set and decides nothing: everything returned is
 // still put to the gate and the score, which is where identity is judged. The
-// same GIN indexes serve it — `<%` uses gin_trgm_ops through the `%>`
-// commutator, so no index changes and the plan stays a Bitmap Index Scan.
+// same GIN indexes serve both — `<%` reaches gin_trgm_ops through the `%>`
+// commutator — so no index changes and the plan stays a Bitmap Index Scan.
 func orgTrigramArms(args *[]any, axes ...string) []string {
 	var arms []string
 	for _, axis := range axes {
@@ -238,9 +243,20 @@ func orgTrigramArms(args *[]any, axes ...string) []string {
 		}
 		*args = append(*args, axis)
 		n := len(*args)
+		// The containment arm is offered only for a name that still says something
+		// once its market's boilerplate is removed. "The" is a run of words inside
+		// every stored name beginning with it, and an all-boilerplate Vietnamese
+		// name is a run of words inside every other one — each would return a large
+		// share of the table for the gate to reject one row at a time, while the
+		// workspace-wide organization-name write lock is held.
+		containment := len(distinctiveOrgTokens(axis)) > 0
 		for _, column := range []string{fieldDisplayName, fieldLegalName} {
 			arms = append(arms, fmt.Sprintf(
-				"f_fold_apostrophes(lower($%d)) <%% f_fold_apostrophes(lower(%s))", n, column))
+				"f_fold_apostrophes(lower(%s)) %% f_fold_apostrophes(lower($%d))", column, n))
+			if containment {
+				arms = append(arms, fmt.Sprintf(
+					"f_fold_apostrophes(lower($%d)) <%% f_fold_apostrophes(lower(%s))", n, column))
+			}
 		}
 	}
 	return arms

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The Vietnamese half of org-name matching: a name whose legal form and trade
+// vocabulary come FIRST, with the brand at the end.
+//
+// WHY THIS EXISTS. PO-PARAM-1 strips a legal form that TRAILS the name — "Acme
+// Inc", "Acme GmbH" — because that is where English and German put it. Vietnam
+// puts it in front and spells it in several words: "CÔNG TY CỔ PHẦN SỮA VIỆT
+// NAM" is Vinamilk, and the first three words are "joint-stock company". Every
+// Vietnamese company therefore begins with the same run of words, and a
+// character metric reads that shared run as shared identity: Jaro-Winkler
+// boosts a shared PREFIX specifically, so two unrelated Vietnamese companies
+// scored above the review threshold on their boilerplate alone.
+//
+// A PHRASE, NEVER A WORD. The folded syllables of the legal form are also real
+// brand syllables: "cổ" and "cô" and "có" all fold to "co", "phần" and "phân"
+// to "phan", and "Cỏ May" is a rice company whose whole name folds to "co may".
+// So a word of a legal form is only removed as part of the WHOLE phrase, at the
+// front of the name. Deleting the token "phan" wherever it appears would take
+// the brand off "Phan Minh", which is the failure this file is written to
+// avoid.
+//
+// WHAT THIS IS NOT. Not a second normalizer for the org-name KEY:
+// NormalizeOrgName (namesim.go) is unchanged, and still produces the exact and
+// grouping keys, so no stored key moves. This one is consulted only where two
+// names are COMPARED — the gate (orgnamegate.go) and the score (dedupeorg.go).
+// The difference matters: "Công ty CP Đầu tư ABC" and "Công ty CP Thương mại
+// ABC" must compare as one candidate pair and must NOT group under one key.
+
+import "strings"
+
+// vietnameseLegalFormPrefixes are the forms a Vietnamese company name opens
+// with, written as they appear AFTER folding (lowercase, unaccented, đ→d).
+//
+// A HAND-WRITTEN, VERSIONED LIST, read the same way as orgNameStopwords and for
+// the same reason: a list derived from the workspace's own names would make two
+// names match in one workspace and not in another, and would put a query inside
+// the transaction that holds the organization-name write lock.
+//
+// Both spellings of each form, because both are how companies write themselves:
+// the legal "công ty trách nhiệm hữu hạn" and the everyday "công ty tnhh", and
+// "cty" for "công ty". A duplicate pair in this market is very often one
+// company written out in full against the same company abbreviated.
+//
+// Order does not matter here — matching takes the LONGEST phrase that fits, so
+// "cong ty co phan" wins over "cong ty" on the same name regardless of position
+// in this slice.
+//
+// The syllables recur because the language builds its legal forms out of them,
+// and the point of writing the table this way is that a reader can check it
+// against the language. Naming "cong" as a constant would hide what the entries
+// say, so the repetition is the readable form here rather than a smell.
+//
+//nolint:goconst // Vietnamese words, not repeated magic strings — see above.
+var vietnameseLegalFormPrefixes = [][]string{
+	{"cong", "ty", "trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
+	{"cong", "ty", "trach", "nhiem", "huu", "han"},
+	{"cong", "ty", "tnhh", "hai", "thanh", "vien", "tro", "len"},
+	{"cong", "ty", "tnhh", "mot", "thanh", "vien"},
+	{"cong", "ty", "tnhh", "mtv"},
+	{"cong", "ty", "tnhh"},
+	{"cty", "tnhh", "mtv"},
+	{"cty", "tnhh"},
+	{"ngan", "hang", "thuong", "mai", "co", "phan"},
+	{"ngan", "hang", "tmcp"},
+	{"cong", "ty", "co", "phan"},
+	{"cong", "ty", "cp"},
+	{"cty", "co", "phan"},
+	{"cty", "cp"},
+	{"ctcp"},
+	{"cong", "ty", "hop", "danh"},
+	{"cong", "ty", "lien", "doanh"},
+	{"doanh", "nghiep", "tu", "nhan"},
+	{"dntn"},
+	{"tong", "cong", "ty"},
+	{"tap", "doan"},
+	{"hop", "tac", "xa"},
+	{"cong", "ty"},
+	{"cty"},
+}
+
+// vietnameseLegalFormContinuations are the forms that appear only as the SECOND
+// half of a stacked one, where they arrive stripped of their leading "công ty".
+//
+// "TỔNG CÔNG TY CỔ PHẦN BIA RƯỢU SÀI GÒN" is a corporation that is also a
+// joint-stock company: once "tổng công ty" is taken off the front, what remains
+// opens with a bare "cổ phần".
+//
+// SEPARATE FROM THE TABLE ABOVE, because these words are only boilerplate in
+// that position. A company that simply calls itself "Cổ Phần Xanh" has those
+// words as its name, and a strip that ran them from the front of any name would
+// take it. So they are consulted only after a form has already been removed.
+var vietnameseLegalFormContinuations = [][]string{
+	{"co", "phan"},
+	{"trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
+	{"trach", "nhiem", "huu", "han"},
+	{"tnhh", "mot", "thanh", "vien"},
+	{"tnhh", "mtv"},
+	{"tnhh"},
+}
+
+// vietnameseSectorFillers are the trade words that stack between the legal form
+// and the brand: "CÔNG TY TNHH THƯƠNG MẠI DỊCH VỤ TÂN HIỆP PHÁT" is a trading
+// and services company called Tân Hiệp Phát.
+//
+// They are the market's vocabulary, not an identity — unrelated companies share
+// long identical runs of them, and the same run appears in different orders. So
+// they are removed for the purposes of comparison, exactly as "solutions" and
+// "systems" are dropped by orgNameStopwords on the English side.
+//
+// STRIPPED ONLY AT THE FRONT, after the legal form. A filler word that appears
+// later is part of the brand — "SỮA VIỆT NAM" ends in a word that is elsewhere
+// a filler, and it is the name of the company.
+var vietnameseSectorFillers = [][]string{
+	{"xuat", "nhap", "khau"},
+	{"thuong", "mai"},
+	{"dich", "vu"},
+	{"dau", "tu"},
+	{"phat", "trien"},
+	{"xay", "dung"},
+	{"san", "xuat"},
+	{"cong", "nghe"},
+	{"ky", "thuat"},
+	{"giai", "phap"},
+	{"quoc", "te"},
+	{"xnk"},
+	{"tm"},
+	{"dv"},
+	{"sx"},
+	{"dt"},
+	{"va"},
+}
+
+// foldDStroke maps đ to d.
+//
+// U+0111 LATIN SMALL LETTER D WITH STROKE has no canonical decomposition, so
+// the NFD pass in normalizeName cannot separate a combining mark from it and
+// the letter survives the fold intact: "ĐẦU TƯ" becomes "đau tu", not "dau tu".
+// Postgres f_unaccent DOES map it, so without this the same name folds two ways
+// — "dau tu" in the database and "đau tu" in Go — and no entry in the tables
+// above could ever match a name typed with the letter Vietnamese uses for one
+// of its most common trade words.
+//
+// Deliberately NOT inside normalizeName, which is pinned as the input to the
+// similarity metric (PO-PARAM-JW-2) and shared with person and lead matching.
+// This is an org-name concern and stays on the org-name path.
+func foldDStroke(s string) string {
+	if !strings.ContainsAny(s, "đĐ") {
+		return s
+	}
+	return strings.NewReplacer("đ", "d", "Đ", "D").Replace(s)
+}
+
+// stripLeadingPhrases removes phrases from the FRONT of a name, longest first,
+// for as long as one matches.
+//
+// Repeated, because the forms stack: "TỔNG CÔNG TY CỔ PHẦN …" carries two, and
+// a name may open with a legal form followed by three trade words.
+//
+// Longest-match, because the short phrases are prefixes of the long ones.
+// Taking "cong ty" off "cong ty co phan x" would leave "co phan x" and put the
+// remains of a legal form into the comparison.
+func stripLeadingPhrases(fields []string, table [][]string) []string {
+	for {
+		longest := 0
+		for _, phrase := range table {
+			if len(phrase) > longest && len(phrase) <= len(fields) &&
+				matchesAt(fields, phrase) {
+				longest = len(phrase)
+			}
+		}
+		if longest == 0 {
+			return fields
+		}
+		fields = fields[longest:]
+	}
+}
+
+// matchesAt answers whether the name opens with exactly this phrase.
+func matchesAt(fields, phrase []string) bool {
+	for i, word := range phrase {
+		if strings.Trim(fields[i], ".") != word {
+			return false
+		}
+	}
+	return true
+}
+
+// orgNameForMatching is the name reduced to what could identify a company: the
+// key with a Vietnamese legal form and its trailing trade vocabulary removed.
+//
+// IT MAY RETURN EMPTY, and that is an answer rather than a failure. A name that
+// is nothing but a legal form and trade words — "CÔNG TY CỔ PHẦN THƯƠNG MẠI
+// DỊCH VỤ" — has said nothing about WHICH company it is, and two such names
+// have said nothing about being the same one. Callers treat empty as no
+// evidence, never as a wildcard.
+//
+// This is the one place it differs from NormalizeOrgName, which must never
+// empty a name because it produces a stored key and an empty key would collide
+// with every other empty key. A comparison has no such obligation: it is
+// allowed to say "I cannot tell these apart on their names".
+func orgNameForMatching(s string) string {
+	fields := strings.Fields(NormalizeOrgName(foldDStroke(s)))
+	stripped := stripLeadingPhrases(fields, vietnameseLegalFormPrefixes)
+	if len(stripped) < len(fields) {
+		stripped = stripLeadingPhrases(stripped, vietnameseLegalFormContinuations)
+	}
+	return strings.Join(stripLeadingPhrases(stripped, vietnameseSectorFillers), " ")
+}

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -203,10 +203,26 @@ func matchesAt(fields, phrase []string) bool {
 // with every other empty key. A comparison has no such obligation: it is
 // allowed to say "I cannot tell these apart on their names".
 func orgNameForMatching(s string) string {
+	name, _ := matchingFormOf(s)
+	return name
+}
+
+// matchingFormOf is orgNameForMatching plus the fact the caller sometimes needs:
+// whether this name declared itself Vietnamese by carrying a legal form.
+//
+// THE TRADE VOCABULARY IS ONLY STRIPPED FROM A NAME THAT DID. Its abbreviations
+// are two letters — "tm", "dv", "dt", "va" — and two letters mean something else
+// in every other market: "VA Software" and "DT Systems" are companies whose
+// first word this table would otherwise eat, leaving them equal to "Software"
+// and "Systems". A legal form is a strong enough signal to act on; a bare
+// two-letter word at the front of a name is not.
+func matchingFormOf(s string) (string, bool) {
 	fields := strings.Fields(NormalizeOrgName(foldDStroke(s)))
 	stripped := stripLeadingPhrases(fields, vietnameseLegalFormPrefixes)
-	if len(stripped) < len(fields) {
-		stripped = stripLeadingPhrases(stripped, vietnameseLegalFormContinuations)
+	vietnamese := len(stripped) < len(fields)
+	if !vietnamese {
+		return strings.Join(stripped, " "), false
 	}
-	return strings.Join(stripLeadingPhrases(stripped, vietnameseSectorFillers), " ")
+	stripped = stripLeadingPhrases(stripped, vietnameseLegalFormContinuations)
+	return strings.Join(stripLeadingPhrases(stripped, vietnameseSectorFillers), " "), true
 }

--- a/backend/internal/modules/people/orgnameforms_integration_test.go
+++ b/backend/internal/modules/people/orgnameforms_integration_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+import "testing"
+
+// The Vietnamese market against a live database.
+//
+// The unit tests ask the scorer directly. This asks the LADDER — the trigram
+// candidate query, then the gate, then the score — which is the only place two
+// of these claims can be decided at all: whether the candidate query RETURNS
+// the incumbent, and whether Go and Postgres fold a name the same way. A name
+// that never comes back from the query scores nothing and reads exactly like a
+// name that scored badly.
+func TestVietnameseCompaniesResolveThroughTheLadder(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// Seeded WITHOUT domains on purpose. exactOrgByDomain is tier 1 and returns
+	// before any name is looked at, so a shared domain would decide every case
+	// below and the name tiers would go untested.
+	incumbents := []string{
+		"CÔNG TY CỔ PHẦN TẬP ĐOÀN HÒA PHÁT",
+		"CÔNG TY CỔ PHẦN ĐẦU TƯ XÂY DỰNG RICONS",
+		"CÔNG TY TRÁCH NHIỆM HỮU HẠN THƯƠNG MẠI VĨNH PHÁT",
+		"CÔNG TY CỔ PHẦN CÔNG NGHỆ CMC",
+		"CTCP Sữa Việt Nam",
+		"CÔNG TY CỔ PHẦN ĐẦU TƯ NAM LONG",
+		"CÔNG TY TNHH MỘT THÀNH VIÊN HÒA BÌNH",
+	}
+	for _, name := range incumbents {
+		if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: name, Source: "manual",
+		}); err != nil {
+			t.Fatalf("seeding %q: %v", name, err)
+		}
+	}
+
+	// None of these is any of the above, and each shares a legal form with all
+	// of them — which is what used to be enough to collide.
+	for _, name := range []string{
+		"CÔNG TY CỔ PHẦN ĐẦU TƯ XÂY DỰNG TRUNG NAM",
+		"CÔNG TY TNHH THƯƠNG MẠI DỊCH VỤ TÂN HIỆP PHÁT",
+		"CÔNG TY CỔ PHẦN CÔNG NGHỆ FPT",
+		"TẬP ĐOÀN VINGROUP",
+	} {
+		m := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{DisplayName: name})
+		if m.Decision != DecisionNoMatch {
+			t.Errorf("%q collided (decision %s, confidence %.4f) — no company of "+
+				"that name is in the estate", name, m.Decision, m.Confidence)
+		}
+	}
+
+	// THE RECALL CLAIM, and the reason this tier uses word similarity. Each of
+	// these is a bare brand whose own registered name is seeded above, and each
+	// scores below the 0.3 trigram limit against it as a whole string: the
+	// candidate query never returned the incumbent, so the duplicate could not
+	// be found however well the scorer worked.
+	for _, name := range []string{"Hòa Bình", "Sữa Việt Nam", "Nam Long"} {
+		m := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{DisplayName: name})
+		if m.Decision != DecisionFuzzyReview {
+			t.Errorf("%q got %s (confidence %.4f), want fuzzy_review — its own "+
+				"company is in the estate under its registered name",
+				name, m.Decision, m.Confidence)
+		}
+	}
+
+	// GO AND POSTGRES MUST FOLD ONE NAME THE SAME WAY. "Đ" has no canonical
+	// decomposition, so Go's unaccenting pass leaves it where f_unaccent maps it
+	// to "d" — a name typed on a keyboard without Vietnamese diacritics has to
+	// reach the same company as the name typed with them.
+	ascii := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
+		DisplayName: "Cong ty co phan dau tu Nam Long",
+	})
+	if ascii.Decision != DecisionFuzzyReview {
+		t.Errorf("the ASCII spelling got %s (confidence %.4f), want fuzzy_review "+
+			"— it is the seeded company written without diacritics",
+			ascii.Decision, ascii.Confidence)
+	}
+
+	// And tier 1 still outranks every name judgement: a shared domain is an
+	// exact key, whatever the two names look like.
+	withDomain, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "TẬP ĐOÀN ĐIỆN LỰC VIỆT NAM", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "evn.com.vn", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seeding the domain-carrying company: %v", err)
+	}
+	sharedDomain := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
+		DisplayName: "HỢP TÁC XÃ NÔNG NGHIỆP ĐẠI THÀNH",
+		Domains:     []string{"evn.com.vn"},
+	})
+	if sharedDomain.Decision != DecisionExactCollision {
+		t.Fatalf("a shared domain got %s, want exact_collision — the domain tier "+
+			"decides before any name is read", sharedDomain.Decision)
+	}
+	if sharedDomain.OrganizationID.String() != withDomain.Id.String() {
+		t.Fatalf("the domain tier named %s, want the company holding the domain (%s)",
+			sharedDomain.OrganizationID, withDomain.Id)
+	}
+}

--- a/backend/internal/modules/people/orgnameforms_test.go
+++ b/backend/internal/modules/people/orgnameforms_test.go
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"strings"
+	"testing"
+)
+
+// vietnameseCompany is one real-shaped name and the brand it must reduce to.
+//
+// `group` names the company behind the name. Two entries sharing a group are
+// the same company written two ways and MUST meet at the fuzzy tier; two
+// entries with different groups are different companies and must not. That one
+// field is what lets every test below read the same corpus: precision asks
+// about pairs across groups, recall about pairs within one.
+type vietnameseCompany struct {
+	name  string
+	brand string
+	group string
+	// ambiguous marks a name that a HUMAN cannot separate from its neighbours
+	// on the name alone. "Vàng Bạc Đá Quý Phú Nhuận" and "Vàng Bạc Phú Quý" are
+	// two jewellers sharing four of six words; "Hòa Bình" and "An Bình" differ
+	// in one syllable of two. The fuzzy tier's answer for these is to ask a
+	// person, which is what it is for — so they are held out of the precision
+	// census rather than being forced to a verdict the names do not support.
+	//
+	// Held out of the RECALL census too: an ambiguous pair may go either way,
+	// and a test that demanded either answer would be asserting a coin toss.
+	ambiguous bool
+}
+
+// The corpus: every legal form Vietnam uses, the trade vocabulary that stacks
+// after it, and the spellings a real CRM receives — written out in full,
+// abbreviated, and typed without diacritics by someone on a foreign keyboard.
+//
+// WHY IT IS THIS BIG. The names in this market differ in a smaller part of
+// themselves than names anywhere else in the estate: two unrelated companies
+// can share their first six words. A handful of hand-picked pairs would pass
+// against a fix that is still wrong for the seventh form, so the precision test
+// below asks EVERY pair rather than a chosen few, and this list is what makes
+// that census worth running. A new form or a new filler belongs here, and every
+// test gains the case at once.
+var vietnameseCorpus = []vietnameseCompany{
+	// Cổ phần — the joint-stock form, and the one in the bug report.
+	{name: "CÔNG TY CỔ PHẦN SỮA VIỆT NAM", brand: "sua viet nam", group: "vinamilk"},
+	{name: "CTCP Sữa Việt Nam", brand: "sua viet nam", group: "vinamilk"},
+	{name: "Sữa Việt Nam", brand: "sua viet nam", group: "vinamilk"},
+	{name: "CÔNG TY CỔ PHẦN TẬP ĐOÀN HÒA PHÁT", brand: "hoa phat", group: "hoaphat"},
+	{name: "CÔNG TY CỔ PHẦN CÔNG NGHỆ FPT", brand: "fpt", group: "fpt"},
+	{name: "CÔNG TY CỔ PHẦN CÔNG NGHỆ CMC", brand: "cmc", group: "cmc"},
+	{name: "CÔNG TY CỔ PHẦN VÀNG BẠC ĐÁ QUÝ PHÚ NHUẬN", brand: "vang bac da quy phu nhuan", group: "pnj", ambiguous: true},
+
+	// Cổ phần with a long filler run — the pairs that share six leading words.
+	{name: "CÔNG TY CỔ PHẦN ĐẦU TƯ XÂY DỰNG TRUNG NAM", brand: "trung nam", group: "trungnam"},
+	{name: "CÔNG TY CỔ PHẦN ĐẦU TƯ XÂY DỰNG RICONS", brand: "ricons", group: "ricons"},
+	{name: "CÔNG TY CỔ PHẦN ĐẦU TƯ XÂY DỰNG COTECCONS", brand: "coteccons", group: "coteccons"},
+
+	// đ-carrying names, and the same company typed without diacritics.
+	{name: "CÔNG TY CỔ PHẦN ĐẦU TƯ NAM LONG", brand: "nam long", group: "namlong"},
+	{name: "Cong ty co phan dau tu Nam Long", brand: "nam long", group: "namlong"},
+	{name: "Nam Long", brand: "nam long", group: "namlong"},
+
+	// TNHH — limited liability, written both legally and colloquially.
+	{name: "CÔNG TY TNHH THƯƠNG MẠI DỊCH VỤ TÂN HIỆP PHÁT", brand: "tan hiep phat", group: "thp"},
+	{name: "Cty TNHH TM DV Tân Hiệp Phát", brand: "tan hiep phat", group: "thp"},
+	{name: "Tân Hiệp Phát", brand: "tan hiep phat", group: "thp"},
+	{name: "CÔNG TY TRÁCH NHIỆM HỮU HẠN THƯƠNG MẠI VĨNH PHÁT", brand: "vinh phat", group: "vinhphat"},
+	{name: "CÔNG TY TNHH KỸ THUẬT MINH ĐỨC", brand: "minh duc", group: "minhduc"},
+
+	// TNHH một thành viên — the single-member company, three spellings.
+	{name: "CÔNG TY TNHH MỘT THÀNH VIÊN HÒA BÌNH", brand: "hoa binh", group: "hoabinh", ambiguous: true},
+	{name: "CÔNG TY TRÁCH NHIỆM HỮU HẠN MỘT THÀNH VIÊN HÒA BÌNH", brand: "hoa binh", group: "hoabinh", ambiguous: true},
+	{name: "Hòa Bình", brand: "hoa binh", group: "hoabinh", ambiguous: true},
+	{name: "CÔNG TY TNHH MTV XUẤT NHẬP KHẨU AN BÌNH", brand: "an binh", group: "anbinh", ambiguous: true},
+	{name: "CÔNG TY TNHH MỘT THÀNH VIÊN XUẤT NHẬP KHẨU AN BÌNH", brand: "an binh", group: "anbinh", ambiguous: true},
+	{name: "An Bình", brand: "an binh", group: "anbinh", ambiguous: true},
+
+	// TNHH hai thành viên trở lên — the multi-member form.
+	{name: "CÔNG TY TNHH HAI THÀNH VIÊN TRỞ LÊN MINH QUANG", brand: "minh quang", group: "minhquang"},
+
+	// The remaining forms, one company each.
+	{name: "CÔNG TY HỢP DANH KIỂM TOÁN VIỆT", brand: "kiem toan viet", group: "kiemtoanviet"},
+	{name: "CÔNG TY LIÊN DOANH PHÚ MỸ HƯNG", brand: "phu my hung", group: "phumyhung"},
+	{name: "DOANH NGHIỆP TƯ NHÂN VÀNG BẠC PHÚ QUÝ", brand: "vang bac phu quy", group: "phuquy", ambiguous: true},
+	{name: "DNTN Vàng Bạc Phú Quý", brand: "vang bac phu quy", group: "phuquy", ambiguous: true},
+	{name: "TỔNG CÔNG TY HÀNG KHÔNG VIỆT NAM", brand: "hang khong viet nam", group: "vietnamairlines"},
+	{name: "TỔNG CÔNG TY CỔ PHẦN BIA RƯỢU SÀI GÒN", brand: "bia ruou sai gon", group: "sabeco"},
+	{name: "TẬP ĐOÀN VINGROUP", brand: "vingroup", group: "vingroup"},
+	{name: "TẬP ĐOÀN ĐIỆN LỰC VIỆT NAM", brand: "dien luc viet nam", group: "evn"},
+	{name: "HỢP TÁC XÃ NÔNG NGHIỆP ĐẠI THÀNH", brand: "nong nghiep dai thanh", group: "daithanh"},
+	{name: "NGÂN HÀNG THƯƠNG MẠI CỔ PHẦN Á CHÂU", brand: "a chau", group: "acb"},
+	{name: "NGÂN HÀNG TMCP KỸ THƯƠNG VIỆT NAM", brand: "ky thuong viet nam", group: "techcombank"},
+
+	// Brands built from words that are elsewhere boilerplate. Each of these is
+	// a real naming pattern and each would lose its identity to a fix that
+	// deleted tokens instead of matching phrases.
+	{name: "CÔNG TY TNHH CỎ MAY", brand: "co may", group: "comay"},
+	{name: "CÔNG TY TNHH PHAN MINH", brand: "phan minh", group: "phanminh"},
+	{name: "CÔNG TY CỔ PHẦN VIỆT AN", brand: "viet an", group: "vietan"},
+	{name: "CÔNG TY CỔ PHẦN PHÁT ĐẠT", brand: "phat dat", group: "phatdat"},
+	{name: "CÔNG TY CỔ PHẦN THƯƠNG MẠI BÁCH HÓA XANH", brand: "bach hoa xanh", group: "bachhoaxanh"},
+
+	// Names whose last syllable is "an", which is also an English article. Long
+	// An is a province; both are ordinary company names here, and both lost
+	// that syllable to the article list before it was made position-aware.
+	{name: "CÔNG TY CỔ PHẦN LONG AN", brand: "long an", group: "longan"},
+	{name: "CÔNG TY TNHH HÒA AN", brand: "hoa an", group: "hoaan"},
+}
+
+// crossCompanyPairCount is how many pairs the precision census owes: every
+// unambiguous name against every other belonging to a different company.
+//
+// The census asserts against this rather than a written-down number, so adding
+// a name to the corpus cannot silently leave the count behind and let the scan
+// run short while still reporting PASS.
+// Counted from the SHAPE of the corpus — how many names each company has —
+// rather than by walking the pairs again, so it is an independent arithmetic
+// check rather than a second copy of the loop it is holding.
+func crossCompanyPairCount() int {
+	perCompany := map[string]int{}
+	total := 0
+	for _, c := range vietnameseCorpus {
+		if c.ambiguous {
+			continue
+		}
+		perCompany[c.group]++
+		total++
+	}
+	// Every pair of names, less the pairs that name one company twice.
+	pairs := total * (total - 1) / 2
+	for _, n := range perCompany {
+		pairs -= n * (n - 1) / 2
+	}
+	return pairs
+}
+
+// Every name in the market reduces to the company inside it.
+//
+// The single assertion the rest of the file rests on: if a name does not reduce
+// to its brand, every pair it takes part in is being judged on the wrong string.
+func TestEveryVietnameseNameReducesToItsBrand(t *testing.T) {
+	for _, company := range vietnameseCorpus {
+		if got := orgNameForMatching(company.name); got != company.brand {
+			t.Errorf("%q reduces to %q, want %q — the comparison will be made "+
+				"on the wrong words", company.name, got, company.brand)
+		}
+	}
+}
+
+// THE REGRESSION, asked of every pair rather than a chosen few.
+//
+// Before this change a Vietnamese name carried its legal form into the score,
+// and Jaro-Winkler boosts a shared prefix — so companies that share nothing but
+// the words "công ty cổ phần" scored above the review threshold and an operator
+// was told a company was already in the CRM when it was not.
+//
+// EXHAUSTIVE ON PURPOSE. Every cross-company pair in the corpus, which is what
+// a hand-picked list cannot be: the pair that breaks next is the one nobody
+// thought to write down. A census that can fail short has already failed.
+func TestNoVietnameseCompanyMatchesAnyOther(t *testing.T) {
+	pairs := 0
+	for i, left := range vietnameseCorpus {
+		for _, right := range vietnameseCorpus[i+1:] {
+			if left.group == right.group || left.ambiguous || right.ambiguous {
+				continue
+			}
+			pairs++
+			got := bestOrgNamePairing(left.name, "", right.name, "").Confidence
+			if got >= dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, at or above the %.2f review "+
+					"threshold — these are different companies",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+	// The census must not quietly shrink: a corpus that stopped producing pairs
+	// would report PASS while testing air. Counted from the corpus rather than
+	// written as a number, so it cannot drift out of date as names are added.
+	if want := crossCompanyPairCount(); pairs != want {
+		t.Fatalf("compared %d pairs, expected %d — the census is running short",
+			pairs, want)
+	}
+}
+
+// The fix must not cost recall. Every pairing inside a group is one company
+// written two ways, and every one has to reach a human.
+func TestEveryVietnameseDuplicateStillMeets(t *testing.T) {
+	for i, left := range vietnameseCorpus {
+		for _, right := range vietnameseCorpus[i+1:] {
+			if left.group != right.group || left.ambiguous {
+				continue
+			}
+			got := bestOrgNamePairing(left.name, "", right.name, "").Confidence
+			if got < dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold "+
+					"— this is one company and the duplicate would be missed",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+}
+
+// A BRAND IS NOT BOILERPLATE BECAUSE IT IS SPELLED LIKE IT.
+//
+// The folded legal form is made of syllables that are also brand syllables:
+// "cổ" folds to "co" and so does "Cỏ" in "Cỏ May"; "phần" folds to "phan" and so
+// does the surname "Phan". A fix that deleted those tokens wherever they
+// appeared would strip the identity out of these companies and match them
+// against anything — which is why the strip matches whole phrases at the front
+// of a name and nothing else.
+func TestABrandIsNotDeletedBecauseItLooksLikeBoilerplate(t *testing.T) {
+	kept := []struct{ name, brand string }{
+		{"Cỏ May", "co may"},
+		{"CÔNG TY TNHH CỎ MAY", "co may"},
+		{"Phan Minh", "phan minh"},
+		{"CÔNG TY TNHH PHAN MINH", "phan minh"},
+		{"Việt An", "viet an"},
+		{"CÔNG TY CỔ PHẦN VIỆT AN", "viet an"},
+		{"Phát Đạt", "phat dat"},
+		{"Long An", "long an"},
+		{"Hòa An", "hoa an"},
+		{"Việt An", "viet an"},
+		{"CÔNG TY CỔ PHẦN SỮA VIỆT NAM", "sua viet nam"},
+		// The brand is what is LEFT, and trade words in front of it are not part
+		// of it however the company writes them: "Đầu Tư Xanh" is the green
+		// investment company, and the company is "Xanh". This is the same answer
+		// the English side gives "Digital Solutions GmbH".
+		{"Đầu Tư Xanh", "xanh"},
+		{"Tập Đoàn Xanh", "xanh"},
+	}
+	for _, k := range kept {
+		if got := orgNameForMatching(k.name); got != k.brand {
+			t.Errorf("%q reduces to %q, want %q — the brand was taken for "+
+				"boilerplate", k.name, got, k.brand)
+		}
+		// AND THE GATE MUST STILL SEE THE WHOLE BRAND. Reducing the name
+		// correctly is not enough: the gate drops stopwords from what is left,
+		// so a Vietnamese syllable listed there would take half the company with
+		// it — "Cỏ May" becomes the single word "may", "Hòa Phát" becomes "hoa".
+		// The name still looks right; the identity the gate compares does not.
+		if got, want := distinctiveOrgTokens(k.name), strings.Fields(k.brand); len(got) != len(want) {
+			t.Errorf("the gate reads %q as %v, want the whole brand %v — a word "+
+				"of the company is being dropped as market vocabulary",
+				k.name, got, want)
+		}
+	}
+}
+
+// A name of nothing but boilerplate has not said which company it is, and two
+// of them have not said they are the same one.
+//
+// The gate compares what is LEFT of a name. When nothing is left, there is no
+// evidence — and an empty string must not match another empty string, which is
+// the same rule bestOrgNamePairing already applies to two blank legal names.
+func TestAllBoilerplateNamesDoNotMatchEachOther(t *testing.T) {
+	boilerplate := []string{
+		"CÔNG TY CỔ PHẦN THƯƠNG MẠI DỊCH VỤ",
+		"CÔNG TY TNHH THƯƠNG MẠI",
+		"CÔNG TY TNHH MỘT THÀNH VIÊN",
+		"Công ty Cổ phần",
+	}
+	for _, name := range boilerplate {
+		if got := orgNameForMatching(name); got != "" {
+			t.Errorf("%q reduces to %q, want empty — it names no company",
+				name, got)
+		}
+	}
+	for i, left := range boilerplate {
+		for _, right := range boilerplate[i+1:] {
+			// The GATE is asked its own question, not only the score. The score
+			// refuses an empty normalized name before the gate is reached, so a
+			// test that asked only for the score would report PASS however the
+			// gate answered — and the gate is what decides this for every
+			// caller that reaches it another way.
+			if sharesADistinctiveWord(left, right) {
+				t.Errorf("the gate admits %q vs %q — neither names a company, so "+
+					"there is nothing for them to share", left, right)
+			}
+			got := bestOrgNamePairing(left, "", right, "").Confidence
+			if got >= dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f — two names made only of legal "+
+					"form and trade words are not one company", left, right, got)
+			}
+		}
+	}
+}
+
+// An entry that is not written the way a folded name is written can never
+// match, and nothing else in the suite would notice: the phrase simply never
+// fires, the legal form stays in the name, and the false positives come back.
+//
+// Reads the real tables, never a copy — a census over a copied list is the
+// shape that fails short and reports PASS.
+func TestPhraseTableEntriesMatchTheirOwnNormalization(t *testing.T) {
+	tables := map[string][][]string{
+		"vietnameseLegalFormPrefixes": vietnameseLegalFormPrefixes,
+		"vietnameseSectorFillers":     vietnameseSectorFillers,
+	}
+	for name, table := range tables {
+		if len(table) == 0 {
+			t.Fatalf("%s is empty — the census would pass against nothing", name)
+		}
+		for _, phrase := range table {
+			if len(phrase) == 0 {
+				t.Errorf("%s carries an empty phrase, which matches every name", name)
+				continue
+			}
+			joined := strings.Join(phrase, " ")
+			if got := NormalizeOrgName(foldDStroke(joined)); got != joined {
+				t.Errorf("%s entry %q normalizes to %q — written this way it can "+
+					"never match a real name", name, joined, got)
+			}
+		}
+	}
+}
+
+// The Vietnamese path must be invisible to every other market.
+//
+// orgNameForMatching only differs from NormalizeOrgName when a Vietnamese
+// phrase is present, so on the corpus this tree was measured against the two
+// must agree exactly. If they ever diverge here, the strip has reached a name
+// it was never meant to touch.
+func TestWesternNamesAreUnchanged(t *testing.T) {
+	western := []string{
+		"Acme Inc", "Acme GmbH", "Siemens AG", "basecom GmbH & Co. KG",
+		"Co", "AG Systems", "Capital.com", "giba.or.kr", "Digital Ocean",
+		"PricewaterhouseCoopers", "Hewlett.Packard", "3M Company",
+		"Fenwick Software Pty Ltd", "The Alta Group", "Media Markt",
+		"Health Care", "Arvato Systems", "Bytesforce", "Salesforce",
+	}
+	for _, name := range western {
+		if got, want := orgNameForMatching(name), NormalizeOrgName(name); got != want {
+			t.Errorf("%q: matching normalization gives %q but the key gives %q — "+
+				"the Vietnamese strip reached a name it does not own",
+				name, got, want)
+		}
+	}
+}

--- a/backend/internal/modules/people/orgnameforms_test.go
+++ b/backend/internal/modules/people/orgnameforms_test.go
@@ -223,12 +223,17 @@ func TestABrandIsNotDeletedBecauseItLooksLikeBoilerplate(t *testing.T) {
 		{"Hòa An", "hoa an"},
 		{"Việt An", "viet an"},
 		{"CÔNG TY CỔ PHẦN SỮA VIỆT NAM", "sua viet nam"},
-		// The brand is what is LEFT, and trade words in front of it are not part
-		// of it however the company writes them: "Đầu Tư Xanh" is the green
-		// investment company, and the company is "Xanh". This is the same answer
-		// the English side gives "Digital Solutions GmbH".
-		{"Đầu Tư Xanh", "xanh"},
+		// Trade words are only boilerplate in a name that DECLARED its market by
+		// carrying a legal form. "Tập Đoàn Xanh" says it is a Vietnamese group,
+		// so "tập đoàn" is its form and "Xanh" is the company. "Đầu Tư Xanh"
+		// says nothing of the kind, and its two-letter abbreviations are words
+		// in other markets — "VA Software" and "DT Systems" are companies whose
+		// first word this table would otherwise eat.
 		{"Tập Đoàn Xanh", "xanh"},
+		{"Đầu Tư Xanh", "dau tu xanh"},
+		{"CÔNG TY CỔ PHẦN ĐẦU TƯ XANH", "xanh"},
+		{"VA Trading", "va trading"},
+		{"DT Robotics", "dt robotics"},
 	}
 	for _, k := range kept {
 		if got := orgNameForMatching(k.name); got != k.brand {
@@ -245,6 +250,61 @@ func TestABrandIsNotDeletedBecauseItLooksLikeBoilerplate(t *testing.T) {
 				"of the company is being dropped as market vocabulary",
 				k.name, got, want)
 		}
+	}
+}
+
+// THE VIETNAMESE RULES REACH ONLY VIETNAMESE NAMES.
+//
+// Three of them would each be a regression somewhere else if they applied to
+// every name, and each pair below is the case that catches it. They are English
+// names, and they belong in this file because it is the Vietnamese support that
+// endangers them.
+func TestTheVietnameseRulesDoNotReachOtherMarkets(t *testing.T) {
+	// A two-letter trade abbreviation is a word in another market. Stripping
+	// "va" and "dt" as Vietnamese fillers made these equal to the bare sector
+	// word, which every company in that sector shares.
+	for _, k := range []struct{ name, want string }{
+		{"VA Trading", "va trading"},
+		{"DT Robotics", "dt robotics"},
+		{"TM Forum", "tm forum"},
+	} {
+		if got := orgNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q — a Vietnamese trade abbreviation "+
+				"was read out of a name that never claimed the market",
+				k.name, got, k.want)
+		}
+	}
+	// One distinctive word is enough in English, where brands are built from
+	// rare words. Demanding a majority here loses a real duplicate.
+	for _, p := range [][2]string{
+		{"Amazon AWS", "Amazon Web Services"},
+		{"Arvato", "Arvato Systems"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f threshold — one shared "+
+				"distinctive word is the English rule and this is one company",
+				p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+	// An English article is an article wherever it sits. "Bank of the West" and
+	// "Bank of the East" must reduce to two words each, not four: a pair that
+	// kept "of" and "the" would agree on three words of four and look like one
+	// company on its function words.
+	//
+	// The pair still scores above the threshold on the shared "bank" alone —
+	// that is the English one-distinctive-word rule, it predates this change and
+	// is unchanged by it. What is asserted here is the token reduction this
+	// change is responsible for.
+	for _, name := range []string{"Bank of the West", "Bank of the East"} {
+		if got := distinctiveOrgTokens(name); len(got) != 2 {
+			t.Errorf("the gate reads %q as %v, want two words — an English "+
+				"article is not evidence wherever it sits", name, got)
+		}
+	}
+	// A repeated word is one piece of evidence, not two.
+	if sharedTokenCount([]string{"acme", "acme"}, []string{"acme", "beta"}) != 1 {
+		t.Error("a word repeated on one side drew two matches from one word on " +
+			"the other — repetition is not evidence")
 	}
 }
 

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -215,13 +215,13 @@ func distinctiveOrgTokens(name string) []string {
 	fields := strings.FieldsFunc(orgNameForMatching(name), orgTokenSeparators)
 	out := make([]string, 0, min(len(fields), orgGateTokenBudget))
 	for i, token := range fields {
-		// AN ARTICLE IS ONLY AN ARTICLE AT THE FRONT. English puts one there and
-		// nowhere else — "The Group", "Bank of the West" — so dropping it costs
-		// that market nothing. Elsewhere the same letters are a word: Vietnamese
-		// names end in the syllable "an" ("Việt An", "Long An", the province),
-		// and dropping it left those companies as a single syllable that matched
-		// half the market.
-		if i > 0 && orgNameArticles[token] {
+		// AN ARTICLE THAT WOULD LEAVE A ONE-WORD NAME IS NOT AN ARTICLE. English
+		// puts a real one beside other real words — "Bank of the West" keeps
+		// "bank" and "west" without it — so dropping it there costs nothing.
+		// A two-word name whose second word is "an" is a different thing: "Việt
+		// An", "Long An" and "Hòa An" are companies, and dropping the syllable
+		// left each of them a single word that matched half the market.
+		if i > 0 && orgNameArticles[token] && len(fields) == 2 {
 			out = append(out, token)
 			continue
 		}
@@ -323,6 +323,8 @@ func sharesADistinctiveWord(a, b string) bool {
 		return true
 	}
 	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
+	_, leftVN := matchingFormOf(a)
+	_, rightVN := matchingFormOf(b)
 	// A name that reduced to NOTHING shares no word and stops here. Vietnamese
 	// names carry their legal form and trade vocabulary in front of the brand,
 	// so a name made only of those strips to empty (orgnameforms.go) — and two
@@ -344,16 +346,22 @@ func sharesADistinctiveWord(a, b string) bool {
 	// Phát" share the word "hoa" — and they are Vietnam's largest construction
 	// firm and its largest steelmaker.
 	//
-	// The rule that separates the two cases without knowing the language: MORE
-	// than half of the shorter name must be accounted for. "Arvato" is one word
-	// of one — all of it — so "Arvato Systems" passes. "hoa binh" against "hoa
-	// phat" shares one word of two, which is exactly half, and half of a
-	// two-word name is the coincidence this exists to reject.
+	// ASKED ONLY OF A VIETNAMESE COMPARISON, because only there is a shared word
+	// weak evidence. English builds a brand from words that are themselves rare,
+	// so one is enough, and demanding more loses real duplicates: "Amazon AWS"
+	// and "Amazon Web Services" share only "amazon" of two distinctive words.
 	//
-	// Strictly more than half, not at least: at half, the two names disagree
+	// EITHER side declaring the market is enough. A company does not stop being
+	// Vietnamese when someone types its bare brand — "Tân Hiệp Phát" carries no
+	// legal form, and it still must not meet "Hòa Phát" on the shared syllable.
+	//
+	// Strictly more than half, not at least: at half the two names disagree
 	// about as much as they agree, and the disagreement is the part that names
 	// the company.
-	return 2*shared > min(len(left), len(right))
+	if leftVN || rightVN {
+		return 2*shared > min(len(left), len(right))
+	}
+	return true
 }
 
 // sharedTokenCount is how many words of the shorter name appear in the longer.
@@ -366,10 +374,15 @@ func sharedTokenCount(left, right []string) int {
 	if len(longer) < len(shorter) {
 		shorter, longer = longer, shorter
 	}
+	// One word of the longer name answers for at most one word of the shorter.
+	// Without that, "Acme Acme" drew two matches from the single "acme" in
+	// "Acme Beta" and counted a repetition as a second piece of evidence.
+	taken := make([]bool, len(longer))
 	shared := 0
 	for _, x := range shorter {
-		for _, y := range longer {
-			if sameOrgToken(x, y) {
+		for j, y := range longer {
+			if !taken[j] && sameOrgToken(x, y) {
+				taken[j] = true
 				shared++
 				break
 			}

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -53,14 +53,15 @@ import (
 // dedupe parameter in this package is an auditable constant (dedupe.go), and
 // this one is read the same way.
 //
-// English, German and Vietnamese, because those are the markets the estate
-// currently holds. A NEW market needs its own generics added here — the list is
-// a precision policy, not a language model, and a market whose generics are
-// missing simply keeps today's false positives rather than gaining new ones.
+// English and German, the markets whose names this list was measured against.
+// A NEW market needs its own generics added here — the list is a precision
+// policy, not a language model, and a market whose generics are missing simply
+// keeps today's false positives rather than gaining new ones.
 //
-// "phat" earns its place the same way "group" does: it is Vietnamese for
-// "prosper" and ends company names the way "Group" ends English ones. Measured
-// in the corpus, it appeared in three unrelated names.
+// A market only belongs here if its generic words are generic AS WORDS. Where a
+// name is built by stacking a legal form and trade vocabulary in front of the
+// brand, the phrase is what is generic and the words are not, and it is removed
+// in position instead — see orgnameforms.go for the Vietnamese case.
 var orgNameStopwords = map[string]bool{
 	// Corporate form that survives NormalizeOrgName's legal-suffix strip.
 	"group": true, "holding": true, "holdings": true, "company": true,
@@ -74,15 +75,18 @@ var orgNameStopwords = map[string]bool{
 	"hospital": true, "clinic": true,
 	"engineering": true, "industries": true, "manufacturing": true,
 	"media": true, "marketing": true, "communications": true, "logistics": true,
-	// Vietnamese generics.
-	"cong": true, "ty": true, "co": true, "phat": true,
+	// NO VIETNAMESE WORDS HERE, deliberately. A Vietnamese name carries its
+	// legal form and trade vocabulary as a multi-word PHRASE in front of the
+	// brand, and orgnameforms.go removes it in that position. This map deletes a
+	// token wherever it appears, which for Vietnamese takes the company with it:
+	// "phát" is the second syllable of Hòa Phát, the country's largest
+	// steelmaker, and "cổ" folds onto the "cỏ" of the rice company Cỏ May. The
+	// syllables are shared across brands, not generic within them.
 	// A brand written as its domain — "Capital.com", "Digital.ai" — splits into
 	// the name and the top-level domain. The TLD is the most generic token
 	// there is: every company that writes its name this way shares one. Without
 	// these, "Capital.com" reduces to the single token "com" and matches every
 	// other .com in the estate.
-	//
-	// "co" is already above, as a Vietnamese generic and an English legal form.
 	"com": true, "net": true, "org": true, "io": true, "ai": true,
 	"app": true, "dev": true, "inc": true, "gmbh": true,
 	// Country codes and the second level beneath them. "giba.or.kr" and
@@ -208,9 +212,19 @@ func orgTokenSeparators(r rune) bool {
 // three runes was wrong: it threw away "3M", whose two characters ARE the
 // company. A word is dropped for being generic, never for being short.
 func distinctiveOrgTokens(name string) []string {
-	fields := strings.FieldsFunc(NormalizeOrgName(name), orgTokenSeparators)
+	fields := strings.FieldsFunc(orgNameForMatching(name), orgTokenSeparators)
 	out := make([]string, 0, min(len(fields), orgGateTokenBudget))
-	for _, token := range fields {
+	for i, token := range fields {
+		// AN ARTICLE IS ONLY AN ARTICLE AT THE FRONT. English puts one there and
+		// nowhere else — "The Group", "Bank of the West" — so dropping it costs
+		// that market nothing. Elsewhere the same letters are a word: Vietnamese
+		// names end in the syllable "an" ("Việt An", "Long An", the province),
+		// and dropping it left those companies as a single syllable that matched
+		// half the market.
+		if i > 0 && orgNameArticles[token] {
+			out = append(out, token)
+			continue
+		}
 		if orgNameStopwords[token] {
 			continue
 		}
@@ -283,7 +297,7 @@ func sameOrgToken(a, b string) bool {
 // The same separators the token split uses, so "E-Commerce" and "E Commerce"
 // take one path rather than two.
 func squashedOrgName(name string) string {
-	return strings.Join(strings.FieldsFunc(NormalizeOrgName(name), orgTokenSeparators), "")
+	return strings.Join(strings.FieldsFunc(orgNameForMatching(name), orgTokenSeparators), "")
 }
 
 // sharesADistinctiveWord is the gate itself: may these two names be scored?
@@ -309,12 +323,57 @@ func sharesADistinctiveWord(a, b string) bool {
 		return true
 	}
 	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
-	for _, x := range left {
-		for _, y := range right {
+	// A name that reduced to NOTHING shares no word and stops here. Vietnamese
+	// names carry their legal form and trade vocabulary in front of the brand,
+	// so a name made only of those strips to empty (orgnameforms.go) — and two
+	// such names have said nothing about being one company, any more than two
+	// blank legal names have.
+	shared := sharedTokenCount(left, right)
+	if shared == 0 {
+		return false
+	}
+	// ONE SHARED WORD IS NOT ALWAYS ENOUGH, and how much it is worth depends on
+	// how much of the name it is.
+	//
+	// In English a distinctive word is nearly the whole of the evidence:
+	// "Arvato" appears in "Arvato Systems" and the two are one company. In
+	// Vietnamese it is not, because a brand is built from two or three syllables
+	// drawn from a small common pool. Measured on the corpus in
+	// orgnameforms_test.go: across 30 distinct brands, "nam" and "viet" each
+	// appear in 6 of them and "hoa" and "minh" in 3. So "Hòa Bình" and "Hòa
+	// Phát" share the word "hoa" — and they are Vietnam's largest construction
+	// firm and its largest steelmaker.
+	//
+	// The rule that separates the two cases without knowing the language: MORE
+	// than half of the shorter name must be accounted for. "Arvato" is one word
+	// of one — all of it — so "Arvato Systems" passes. "hoa binh" against "hoa
+	// phat" shares one word of two, which is exactly half, and half of a
+	// two-word name is the coincidence this exists to reject.
+	//
+	// Strictly more than half, not at least: at half, the two names disagree
+	// about as much as they agree, and the disagreement is the part that names
+	// the company.
+	return 2*shared > min(len(left), len(right))
+}
+
+// sharedTokenCount is how many words of the shorter name appear in the longer.
+//
+// Counted against the SHORTER side so the answer does not change with argument
+// order, and each of its words is counted at most once: a name that repeats a
+// word must not accumulate evidence from the repetition.
+func sharedTokenCount(left, right []string) int {
+	shorter, longer := left, right
+	if len(longer) < len(shorter) {
+		shorter, longer = longer, shorter
+	}
+	shared := 0
+	for _, x := range shorter {
+		for _, y := range longer {
 			if sameOrgToken(x, y) {
-				return true
+				shared++
+				break
 			}
 		}
 	}
-	return false
+	return shared
 }


### PR DESCRIPTION
Every Vietnamese company matched every other. A name in that market is built `[legal form][trade vocabulary][brand]`, so "CÔNG TY CỔ PHẦN SỮA VIỆT NAM" is Vinamilk and the first three words are "joint-stock company". `NormalizeOrgName` only strips a TRAILING legal suffix, so the form survived into the score, and Jaro-Winkler boosts a shared prefix — two unrelated companies cleared the 0.72 review threshold on their boilerplate alone. The distinctive-word gate did not stop it because the folded `phan` of CỔ PHẦN was not a stopword.

## What changed

`orgNameForMatching` (new, `orgnameforms.go`) strips Vietnamese legal-form phrases and trade vocabulary from the front of a name, and the gate and the score both read it. **`NormalizeOrgName` is untouched** — it produces the exact and grouping keys, and two names that must be compared as candidates must not group under one key.

The strip matches whole phrases, never single words. The folded syllables of the legal form are also brand syllables: "cổ" and "cỏ" both fold to `co`, so deleting the token would take the rice company Cỏ May with it. For the same reason the four Vietnamese words previously in `orgNameStopwords` are gone — that map deletes a token wherever it appears, and "phát" is the second syllable of Hòa Phát.

## Three defects the corpus found

- **One shared word is not enough in Vietnamese.** Measured across 30 brands in the corpus, "nam" and "viet" appear in 6 each and "hoa" in 3, so "Hòa Bình" met "Hòa Phát" on the shared syllable. The gate now asks that more than half the shorter name be accounted for — but only when one side carries a Vietnamese form, because in English one rare word is the whole of the evidence ("Amazon AWS" / "Amazon Web Services").
- **An article was dropped wherever it appeared**, so "Việt An", "Long An" and "Hòa An" each lost a syllable to the English word "an" and matched half the market as a single word. It is now kept only where dropping it would leave a one-word name.
- **A bare brand did not retrieve its own company.** Measured against the database, `similarity('hoa binh', 'CÔNG TY TNHH MỘT THÀNH VIÊN HÒA BÌNH')` is 0.265, under the 0.3 trigram limit — the true duplicate was never returned for scoring. "FPT" scored 0.174, "An Bình" 0.167. The query gains a `<%` word-similarity arm, which scores 1.0 on all three.

Both trigram arms are kept: `<%` alone loses recall in the other direction (a long candidate against a short stored name scores 0.429, and "Roehm" against "Röhm" 0.375, both under that operator's 0.6 threshold). The containment arm is withheld from a name with no distinctive words left, which would otherwise return a large share of the table while the organization-name write lock is held. No migration — the existing GIN indexes serve `<%` through the `%>` commutator.

Also fixes a fold gap: `đ` (U+0111) has no canonical decomposition, so Go kept it where Postgres `f_unaccent` maps it to `d`.

## Tests

`orgnameforms_test.go` carries 42 real-shaped names across every legal form Vietnam uses, in full, abbreviated and ASCII spellings. Precision is asked of **every** cross-company pair rather than a chosen few, and the expected count is derived from the corpus so the census cannot silently run short. Pairs a human cannot separate on the name alone ("Vàng Bạc Đá Quý Phú Nhuận" against "Vàng Bạc Phú Quý") are marked ambiguous and held out of both censuses rather than forced to a verdict the names do not support.

`TestTheVietnameseRulesDoNotReachOtherMarkets` holds the four leaks a reviewer found: the trade table eating "VA Trading", the majority rule losing "Amazon AWS", articles surviving mid-name, and a repeated word counting twice.

The integration test seeds without domains on purpose — `exactOrgByDomain` returns before any name is read and would otherwise decide every case — and asserts the bare-brand recall through real SQL, the ASCII/diacritic pair, and that a shared domain still outranks every name judgement.

## Verified

`make check-backend` green, `make craft-static` clean, the people integration lane green under a private template, and each guard mutation-checked: reverting it turns the named test red.

Bank of the West against Bank of the East still scores 0.975 on the shared "bank". That is the English one-distinctive-word rule, it behaves identically on `main`, and it is out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dedupe so Vietnamese companies no longer match on shared legal boilerplate: every company previously cleared the review threshold on the front words "CÔNG TY CỔ PHẦN" ("joint-stock company") alone. Comparison now reads a new `orgNameForMatching` that strips Vietnamese legal forms and trade vocabulary from the front of a name; `NormalizeOrgName` is untouched, so grouping keys and indexes do not change.

**Bug Fixes**
- Phrases are stripped whole, never word by word, so brands built from legal-form syllables (`Cỏ May`, `Phan Minh`) keep their identity.
- A Vietnamese-side comparison now needs more than half of the shorter name shared, since one syllable ("hoa" in 3 of 30 corpus brands) is not identity there.
- The article `an` is kept when dropping it would leave a one-word name (`Việt An`, `Long An`, `Hòa An`).
- The four Vietnamese stopwords left `orgNameStopwords`; deleting a token wherever it appears took `phát` out of `Hòa Phát`.
- The candidate query adds a word-containment (`<%`) arm so a bare brand finds its own registered company ("Hòa Bình" scores 0.265 whole vs 1.0 as a word run), keeps both trigram arms, and withholds the containment arm from all-boilerplate names.
- `đ` now folds to `d` in Go as Postgres already does.

<sup>Written for commit 154fcf86bbdc777b6ab7c0d8097720c532cbbe2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved organization-name matching for Vietnamese names, including legal forms, sector terms, abbreviations, and diacritic variations.
  * Added safer handling for boilerplate-only names and brand names resembling legal terminology.
  * Enhanced fuzzy matching with distinctive-token and containment checks.

* **Bug Fixes**
  * Reduced false organization matches while improving duplicate detection.
  * Preserved accurate matching behavior for existing Western-style organization names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->