### PR TITLE
test(e2e): the six deck use cases, end to end over MCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -571,6 +571,20 @@ E2E_SHOT_DIR ?= /tmp/e2e-company
 # scripts/lib-devstate.sh is bash (`local`, `[[ ]]`), and make's default shell
 # is /bin/sh — dash on most Linux images, where sourcing it fails before the
 # stack is resolved.
+## e2e-llm — the six use cases driven by a REAL assistant, against a dedicated
+## stack. This is the half the Go suite cannot answer: those tests pin the
+## payloads, the refusals and the legibility fields; this asks whether a model
+## can actually drive the surface and say something true.
+##
+## COSTS MONEY and is opt-in: MARGINCE_E2E_LLM=1 make e2e-llm. Not
+## deterministic — each scenario runs three times and passes at two, because one
+## bad run is the weather and two is a defect. Never touches :8080; it boots,
+## seeds and tears down its own DEV_SLUG stack.
+## SCENARIO=<name> runs one. E2E_LLM_KEEP=1 leaves the stack up.
+e2e-llm: SHELL := /bin/bash
+e2e-llm:
+	@bash scripts/e2e-llm.sh
+
 e2e-company: SHELL := /bin/bash
 e2e-company:
 	@mkdir -p "$(E2E_SHOT_DIR)"

--- a/backend/internal/compose/integration/apptest/mcp.go
+++ b/backend/internal/compose/integration/apptest/mcp.go
@@ -69,6 +69,8 @@ type MCPResult struct {
 // A scenario asserting on what a tool SAID wants the payload, so this unwraps.
 // Envelope reads the whole thing for the rare assertion that is about the
 // envelope itself.
+//
+//craft:ignore naked-any the decode target is the caller's own result type — json.Unmarshal's own signature
 func (r MCPResult) JSON(t *testing.T, out any) {
 	t.Helper()
 	envelope := r.Envelope(t)

--- a/backend/internal/compose/integration/apptest/mcp.go
+++ b/backend/internal/compose/integration/apptest/mcp.go
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+// The MCP transport as a suite drives it: initialize, list, call.
+//
+// It lives here because more than one suite now speaks the protocol. The
+// agentaccess package owns the DISCOVERY chain — the 401's pointer, the
+// metadata documents, the origin they close on — and keeps its own harness for
+// it. What that suite does not own is the plain act of calling a tool, which is
+// every scenario suite's first line.
+//
+// The one property this file exists to preserve: a refused tool answers HTTP
+// 200 with isError set, because a refusal travels IN BAND. A helper that fails
+// the test on a non-200 cannot tell a call that ran from one that was denied,
+// so Call returns both and lets the caller say which it wanted.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+)
+
+// MCPClient calls tools over /mcp as one bearer credential.
+//
+// A passport rather than a cookie, always: every /mcp request binds an AGENT
+// principal, so there is no such thing as a cookie-authenticated tool call. The
+// human half of a scenario is a REST call on AppEnv.Client, and the two are
+// deliberately different objects so a test cannot blur them.
+type MCPClient struct {
+	env    *AppEnv
+	bearer string
+	nextID int
+}
+
+// NewMCPClient binds a client to one credential. It does not handshake — call
+// Initialize when the scenario is about the handshake, and skip it when the
+// scenario is about a tool.
+func NewMCPClient(e *AppEnv, bearer string) *MCPClient {
+	return &MCPClient{env: e, bearer: bearer}
+}
+
+// MCPResult is one tools/call outcome, with the refusal kept separate from the
+// text so neither can be read as the other.
+type MCPResult struct {
+	// Text is the first content block's text, which is where every tool this
+	// repo serves puts its answer.
+	Text string
+	// IsError is the protocol's in-band refusal flag. A refused call is a 200,
+	// so this is the only thing that distinguishes one.
+	IsError bool
+}
+
+// JSON decodes the tool's own payload into out.
+//
+// Every tool on this surface answers inside a shared envelope — schema_version,
+// trace_id, freshness, trust, evidence, warnings — with its own result nested
+// under `data`. The nesting is deliberate: a merged payload would let a tool's
+// field name collide with an envelope field, so the envelope's meaning would
+// depend on which tool answered.
+//
+// A scenario asserting on what a tool SAID wants the payload, so this unwraps.
+// Envelope reads the whole thing for the rare assertion that is about the
+// envelope itself.
+func (r MCPResult) JSON(t *testing.T, out any) {
+	t.Helper()
+	envelope := r.Envelope(t)
+	if len(envelope.Data) == 0 {
+		t.Fatalf("the tool answered with an envelope carrying no data:\n%s", r.Text)
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		t.Fatalf("the tool's payload does not decode: %v\n%s", err, string(envelope.Data))
+	}
+}
+
+// Envelope decodes the whole envelope, for an assertion about provenance,
+// freshness or trust rather than about the answer.
+func (r MCPResult) Envelope(t *testing.T) agents.Envelope {
+	t.Helper()
+	var envelope agents.Envelope
+	if err := json.Unmarshal([]byte(r.Text), &envelope); err != nil {
+		t.Fatalf("the tool answer is not a result envelope: %v\n%s", err, r.Text)
+	}
+	return envelope
+}
+
+// Initialize performs the protocol handshake and returns the negotiated
+// revision.
+func (c *MCPClient) Initialize(t *testing.T, protocolVersion string) string {
+	t.Helper()
+	result := c.rpc(t, "initialize", map[string]any{"protocolVersion": protocolVersion})
+	negotiated, _ := result["protocolVersion"].(string)
+	if negotiated == "" {
+		t.Fatalf("initialize settled no protocolVersion: %v", result)
+	}
+	return negotiated
+}
+
+// ListTools names every tool this credential is served, in the order the server
+// returns them.
+func (c *MCPClient) ListTools(t *testing.T) []string {
+	t.Helper()
+	result := c.rpc(t, "tools/list", nil)
+	raw, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools/list carries no tools array: %v", result)
+	}
+	names := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		tool, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("tools/list entry is not an object: %v", entry)
+		}
+		name, ok := tool["name"].(string)
+		if !ok || name == "" {
+			t.Fatalf("tools/list entry carries no name: %v", tool)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// Call invokes one tool and returns what came back, refusal included. It is the
+// primitive; CallOK and CallRefused are the two things a scenario actually
+// means, and saying which one is expected is what makes a test readable.
+func (c *MCPClient) Call(t *testing.T, tool string, args map[string]any) MCPResult {
+	t.Helper()
+	if args == nil {
+		args = map[string]any{}
+	}
+	result := c.rpc(t, "tools/call", map[string]any{"name": tool, "arguments": args})
+	isError, _ := result["isError"].(bool)
+	return MCPResult{Text: firstText(t, tool, result), IsError: isError}
+}
+
+// CallOK invokes a tool that must run, and fails naming the refusal if it did
+// not.
+func (c *MCPClient) CallOK(t *testing.T, tool string, args map[string]any) MCPResult {
+	t.Helper()
+	got := c.Call(t, tool, args)
+	if got.IsError {
+		t.Fatalf("%s was refused and the scenario needs it to run:\n%s", tool, got.Text)
+	}
+	return got
+}
+
+// CallRefused invokes a tool that must NOT run, and returns the refusal text so
+// the caller can assert on what it says.
+//
+// Asserting on the text is the point rather than a convenience: "already
+// exists" and "already exists — Anna Weber holds that address" are different
+// products, and only the second one a user can act on.
+func (c *MCPClient) CallRefused(t *testing.T, tool string, args map[string]any) string {
+	t.Helper()
+	got := c.Call(t, tool, args)
+	if !got.IsError {
+		t.Fatalf("%s ran, and the scenario needs it refused:\n%s", tool, got.Text)
+	}
+	return got.Text
+}
+
+// rpc issues one JSON-RPC request and returns its result member.
+//
+// Every id is distinct within a client. The protocol does not require it over a
+// request-per-exchange transport, but a repeated id makes a captured session
+// unreadable when a scenario fails and somebody has to see which call did what.
+func (c *MCPClient) rpc(t *testing.T, method string, params map[string]any) map[string]any {
+	t.Helper()
+	c.nextID++
+	envelope := map[string]any{"jsonrpc": "2.0", "id": c.nextID, "method": method}
+	if params != nil {
+		envelope["params"] = params
+	}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encoding %s request: %v", method, err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.env.TS.URL+"/mcp", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("building %s request: %v", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+
+	//nolint:bodyclose // closed by CloseBody below; bodyclose only recognises a Close in the same package
+	resp, err := c.env.Client.Do(req)
+	if err != nil {
+		t.Fatalf("%s: %v", method, err)
+	}
+	defer CloseBody(t, resp)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("%s: reading response: %v", method, err)
+	}
+	// A transport-level non-200 is an admission failure — a rejected
+	// credential, an absent route — and never a refused tool. Naming that
+	// difference here keeps it out of every caller.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s → HTTP %d (a refused TOOL answers 200 with isError; this is the transport rejecting the call)\n%s",
+			method, resp.StatusCode, string(body))
+	}
+	return rpcResultOf(t, method, unframe(resp.Header.Get("Content-Type"), string(body)))
+}
+
+// unframe strips the single SSE event the transport answers with when the
+// client accepts text/event-stream.
+//
+// This client sends that Accept header on purpose, because a real MCP client
+// does: the streamable-HTTP transport picks its framing from Accept, and a
+// suite that quietly asked for JSON only would be exercising a frame no
+// deployed client receives. The body is one complete event either way — the
+// server writes "data: <the whole JSON-RPC response>\n\n" and returns — so
+// unframing is a prefix strip rather than a stream reader.
+func unframe(contentType, body string) string {
+	if !strings.Contains(contentType, "text/event-stream") {
+		return body
+	}
+	var payload strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if data, found := strings.CutPrefix(line, "data: "); found {
+			payload.WriteString(data)
+		}
+	}
+	return payload.String()
+}
+
+// rpcResultOf unwraps the JSON-RPC envelope, failing on a protocol-level error.
+//
+//craft:ignore naked-any a JSON-RPC result is an open object by the protocol — asserting on one means reading it untyped
+func rpcResultOf(t *testing.T, method, body string) map[string]any {
+	t.Helper()
+	var envelope struct {
+		JSONRPC string         `json:"jsonrpc"`
+		Result  map[string]any `json:"result"`
+		Error   *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("%s response does not decode: %v\n%s", method, err, body)
+	}
+	if envelope.JSONRPC != "2.0" {
+		t.Fatalf("%s: jsonrpc = %q, want \"2.0\"\n%s", method, envelope.JSONRPC, body)
+	}
+	if envelope.Error != nil {
+		t.Fatalf("%s: JSON-RPC error %d: %s", method, envelope.Error.Code, envelope.Error.Message)
+	}
+	if envelope.Result == nil {
+		t.Fatalf("%s: response carries neither a result nor an error\n%s", method, body)
+	}
+	return envelope.Result
+}
+
+// firstText reads the text out of a tools/call result.
+//
+// A refused call carries its reason in the SAME place a successful one carries
+// its answer, so this reads both and never judges which it got.
+//
+//craft:ignore naked-any a tools/call result is an open object by the protocol — asserting on one means reading it untyped
+func firstText(t *testing.T, tool string, result map[string]any) string {
+	t.Helper()
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("%s answered with no content: %v", tool, result)
+	}
+	block, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("%s content[0] is not an object: %v", tool, content[0])
+	}
+	text, ok := block["text"].(string)
+	if !ok {
+		t.Fatalf("%s content[0] carries no text: %v", tool, block)
+	}
+	return text
+}
+
+// MCPBearerToken mints a passport and returns the raw token, for a caller that
+// wants an MCPClient rather than a REST header map.
+//
+// PassportBearer answers the REST shape ("Authorization: Bearer …" as a header
+// map) because that is what AppEnv.Call takes. The MCP client wants the token
+// itself, and peeling the prefix off at every call site is how a test ends up
+// sending "Bearer Bearer …".
+func MCPBearerToken(t *testing.T, e *AppEnv, label string, scopes ...string) string {
+	t.Helper()
+	header := PassportBearer(t, e, label, scopes...)
+	token, found := strings.CutPrefix(header["Authorization"], "Bearer ")
+	if !found {
+		t.Fatalf("passport %q did not mint a bearer header: %v", label, header)
+	}
+	return token
+}

--- a/backend/internal/compose/integration/apptest/mcp.go
+++ b/backend/internal/compose/integration/apptest/mcp.go
@@ -183,7 +183,8 @@ func (c *MCPClient) rpc(t *testing.T, method string, params map[string]any) map[
 		t.Fatalf("encoding %s request: %v", method, err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.env.TS.URL+"/mcp", strings.NewReader(string(payload)))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, c.env.TS.URL+"/mcp",
+		strings.NewReader(string(payload)))
 	if err != nil {
 		t.Fatalf("building %s request: %v", method, err)
 	}
@@ -193,7 +194,6 @@ func (c *MCPClient) rpc(t *testing.T, method string, params map[string]any) map[
 		req.Header.Set("Authorization", "Bearer "+c.bearer)
 	}
 
-	//nolint:bodyclose // closed by CloseBody below; bodyclose only recognises a Close in the same package
 	resp, err := c.env.Client.Do(req)
 	if err != nil {
 		t.Fatalf("%s: %v", method, err)

--- a/backend/internal/compose/integration/e2e/doc.go
+++ b/backend/internal/compose/integration/e2e/doc.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package e2e is the parent of the end-to-end scenario suites: whole user
+// journeys driven from OUTSIDE the product, one subdirectory per area.
+//
+// It holds no tests of its own. The suites live one level down —
+// e2e/usecases/ is the first — so that an area's fixtures, helpers and
+// scenarios sit together and a second area does not inherit the first's.
+//
+// # What belongs here, and what does not
+//
+// The integration lane already has eleven topic packages beside this one
+// (agentaccess, capture, channels, org360, …). They are the right home for a
+// SUBSYSTEM: the connector's discovery chain, the capture pipeline, the
+// custom-field resolver. Each asks whether one part of the product is correct.
+//
+// A suite belongs HERE instead when it asks whether a JOURNEY works — several
+// subsystems in sequence, in the order and by the route a person actually
+// meets them, with the assertions written from what the user was promised
+// rather than from what a package exports. The distinction is the direction
+// the test is written from, not how many packages it touches.
+//
+// Two consequences follow, and both are why a separate parent is worth having:
+//
+//   - A scenario asserts on what a CALLER can see. If a fact is only reachable
+//     by importing an internal package, that is a finding about the product
+//     rather than a reason to reach for the import. Four defects merged in
+//     August 2026 were of exactly this shape — data present, correct, and
+//     illegible to the client holding it.
+//
+//   - A scenario is allowed to be slow and few. A subsystem package earns its
+//     place by covering a matrix; a journey earns its place by being the
+//     journey. Adding the twelfth variation of case 4 is usually the wrong
+//     instinct — the variation belongs beside the subsystem that varies.
+//
+// # Adding an area
+//
+// Create e2e/<area>/ with its own doc.go saying which journeys it covers and
+// what shape they are driven from. Nothing needs registering: the integration
+// sharder discovers packages by walking the tree for the `integration` build
+// tag, so a new directory joins the lane by existing.
+//
+// Keep each area's fixtures inside that area. A helper shared by two areas
+// moves up to apptest, which is where the harness lives; it does not move
+// sideways into a sibling, and it does not accumulate here.
+package e2e

--- a/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 1 — Log it while it is fresh.
+//
+// The prompt, spoken, from the car:
+//
+//	Just left Kugellager-online. Met Matthias Ortner, went well, they want
+//	to move forward. Grab the transcript from Plaud and put it all in the
+//	CRM.
+//
+// Nothing it names exists yet: the company, the person and the deal all have to
+// be created from one sentence naming no fields.
+//
+// UNLIKE cases 4 and 5, this suite WRITES through the tools rather than seeding
+// rows. That is the point of case 1 — the write path IS the journey — and it is
+// also why the fixtures elsewhere had to be corrected: rows inserted by hand
+// skip what real writes maintain. Here nothing is inserted by hand at all.
+//
+// The transcript arrives as TEXT. Fetching it from Plaud and reading the
+// calendar are the assistant's half, and the server cannot tell a pasted
+// transcript from an uploaded one — the contract says so outright: "There is no
+// presigned file-upload path in V1 — a plain-text .txt file is read to text
+// client-side and sent the same way a paste is."
+//
+// NOT covered here: whether a MODEL reads the right commitments out of the
+// transcript (criterion 8, the weekly lane's question — the reading calls a
+// model and this suite wires an insert-only runner with no model lane), and
+// whether the assistant REPORTS what it staged (criterion 14, also a model
+// question).
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The meeting this case logs, as the assistant would supply it after reading a
+// recording. Line 3 carries the one plainly stated commitment; line 2 is a
+// topic discussed WITHOUT one, which is what proves a reader is reporting what
+// the transcript says rather than everything it mentions.
+const meetingTranscript = "Matthias: Danke für die Übersicht zu den Lieferzeiten.\n" +
+	"Lars: Wie sieht es mit dem Thema Verpackung aus?\n" +
+	"Lars: Ich schicke Ihnen die Preisliste bis Freitag.\n" +
+	"Matthias: Passt, dann schauen wir uns das nächste Woche an."
+
+const (
+	newCompanyName = "Kugellager-online.de"
+	newPersonName  = "Matthias Ortner"
+	newDealName    = "Erstauftrag Kugellager"
+)
+
+// loggedMeeting is what one run of this journey created.
+type loggedMeeting struct {
+	org      ids.UUID
+	person   ids.UUID
+	deal     ids.UUID
+	activity ids.UUID
+}
+
+// createRecord creates one record through the tool and returns its id.
+func (s *scenario) createRecord(t *testing.T, recordType string, fields map[string]any) ids.UUID {
+	t.Helper()
+	got := s.MCP.CallOK(t, "create_record", map[string]any{
+		"record_type": recordType, "fields": fields,
+	})
+	var created struct {
+		ID ids.UUID `json:"id"`
+	}
+	got.JSON(t, &created)
+	if created.ID.IsZero() {
+		t.Fatalf("create_record answered no id for the %s:\n%s", recordType, got.Text)
+	}
+	return created.ID
+}
+
+// logTheMeeting walks the journey: the company, the person who works there, the
+// deal, and the meeting linked to all three in ONE call.
+//
+// Every step goes through a tool. Nothing here inserts a row, so what the test
+// then reads is a state the product produced rather than one a fixture claimed.
+func (s *scenario) logTheMeeting(t *testing.T) loggedMeeting {
+	t.Helper()
+	var m loggedMeeting
+
+	m.org = s.createRecord(t, "organization", map[string]any{"display_name": newCompanyName})
+	m.person = s.createRecord(t, "person", map[string]any{"full_name": newPersonName})
+	// The employment edge, so the person is AT the company rather than merely
+	// mentioned in the same conversation.
+	s.MCP.CallOK(t, "create_record", map[string]any{
+		"record_type": "relationship",
+		"fields": map[string]any{
+			"kind": "employment", "person_id": m.person.String(), "organization_id": m.org.String(),
+		},
+	})
+
+	pipeline, stage := s.defaultOpenStage(t)
+	m.deal = s.createRecord(t, "deal", map[string]any{
+		"name": newDealName, "organization_id": m.org.String(),
+		"pipeline_id": pipeline.String(), "stage_id": stage.String(),
+	})
+
+	// ALL THREE LINKS IN ONE CALL. The tool's own copy says so — "Every record
+	// this was about … All of them here, in this call: it writes them together
+	// and needs no approval" — and an earlier run that supplied them one at a
+	// time raised three relink approvals for what is not a decision.
+	got := s.MCP.CallOK(t, "log_activity", map[string]any{
+		"kind":          "meeting",
+		"body":          meetingTranscript,
+		"source_system": transcriptMarker,
+		"links": []map[string]any{
+			{"entity_type": "person", "entity_id": m.person.String()},
+			{"entity_type": "organization", "entity_id": m.org.String()},
+			{"entity_type": "deal", "entity_id": m.deal.String()},
+		},
+	})
+	var logged struct {
+		ID ids.UUID `json:"id"`
+	}
+	got.JSON(t, &logged)
+	m.activity = logged.ID
+	return m
+}
+
+// transcriptMarker is the one value that turns a body into a transcript.
+//
+// A caller cannot guess a magic string, and the honest name for where a
+// recording came from — "plaud" — is not it. The tool documentation says the
+// value out loud for exactly that reason.
+const transcriptMarker = "transcript"
+
+// TestCase1TheCompanyThePersonAndTheDealAllExistAfterwards pins criteria 1, 2
+// and 3.
+//
+// None of the three existed before. If the assistant reports success and only
+// some of them are there, the case has failed — and the employment edge must be
+// written ONCE, because an early run left the person's page listing the company
+// twice.
+func TestCase1TheCompanyThePersonAndTheDealAllExistAfterwards(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+	m := s.logTheMeeting(t)
+
+	for _, want := range []struct {
+		table, column string
+		id            ids.UUID
+		value         string
+	}{
+		{"organization", "display_name", m.org, newCompanyName},
+		{"person", "full_name", m.person, newPersonName},
+		{"deal", "name", m.deal, newDealName},
+	} {
+		if got := s.readString(t, want.table, want.column, want.id); got != want.value {
+			t.Fatalf("case 1 criterion 1: the %s should be %q and reads %q",
+				want.table, want.value, got)
+		}
+	}
+
+	// Criterion 2: attached once, not twice.
+	if edges := s.countRows(t, `SELECT count(*) FROM relationship
+		WHERE kind = 'employment' AND person_id = $1 AND organization_id = $2
+		  AND archived_at IS NULL`, m.person, m.org); edges != 1 {
+		t.Fatalf("case 1 criterion 2: %s is linked to %s %d times — a duplicate edge makes the "+
+			"person's page list the company twice", newPersonName, newCompanyName, edges)
+	}
+
+	// Criterion 3: nothing invented. The conversation named no amount and no
+	// close date, so both must be empty rather than filled with a plausible
+	// number.
+	if filled := s.countRows(t, `SELECT count(*) FROM deal
+		WHERE id = $1 AND (amount_minor IS NOT NULL OR expected_close_date IS NOT NULL)`,
+		m.deal); filled != 0 {
+		t.Fatalf("case 1 criterion 3: the deal carries an amount or a close date, neither of which " +
+			"was discussed — an empty field is the correct answer when nothing was said")
+	}
+}
+
+// TestCase1TheMeetingLandsOnEveryRecordInOneWrite pins criteria 4 and 5.
+//
+// One write, not one write plus three corrections: the three link rows share a
+// timestamp because they were written together. And no approval is raised —
+// connecting a meeting to the company it was with is not a decision.
+func TestCase1TheMeetingLandsOnEveryRecordInOneWrite(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+	m := s.logTheMeeting(t)
+
+	for _, want := range []struct {
+		column string
+		id     ids.UUID
+		what   string
+	}{
+		{"person_id", m.person, "the person"},
+		{"organization_id", m.org, "the company"},
+		{"deal_id", m.deal, "the deal"},
+	} {
+		if n := s.countRows(t,
+			`SELECT count(*) FROM activity_link WHERE activity_id = $1 AND `+want.column+` = $2`,
+			m.activity, want.id); n != 1 {
+			t.Fatalf("case 1 criterion 4: the meeting links to %s %d times, want exactly once",
+				want.what, n)
+		}
+	}
+
+	// Written TOGETHER. Three rows sharing one microsecond is what a single
+	// write looks like; a relink afterwards produces later rows.
+	if stamps := s.countRows(t,
+		`SELECT count(DISTINCT created_at) FROM activity_link WHERE activity_id = $1`,
+		m.activity); stamps != 1 {
+		t.Fatalf("case 1 criterion 4: the meeting's links carry %d distinct timestamps, so they "+
+			"were not written in one call", stamps)
+	}
+
+	// Criterion 5: nothing was staged for a human. An approval here would mean
+	// a rep is asked to confirm that a meeting they just had was with the
+	// company they had it with.
+	if staged := s.countRows(t, `SELECT count(*) FROM approval`); staged != 0 {
+		t.Fatalf("case 1 criterion 5: logging the meeting staged %d approval(s); linking a meeting "+
+			"to its own records is not a decision", staged)
+	}
+}
+
+// TestCase1TheTranscriptIsStoredAsATranscriptAndReadWithoutAsking pins criteria
+// 6, 7 and 10.
+//
+// The reading starts when the transcript LANDS, not when somebody asks. The
+// extraction lane was fully built and had never run once — transcript_read held
+// zero rows — because the only thing that enqueued it was an endpoint nothing
+// called.
+//
+// Criterion 10 is the one that can only break on this path: the reading must be
+// requested by the HUMAN behind the passport, not by the agent. Proposals routed
+// to a software account reach nobody.
+func TestCase1TheTranscriptIsStoredAsATranscriptAndReadWithoutAsking(t *testing.T) {
+	s := bootWithTranscriptReading(t)
+	m := s.logTheMeeting(t)
+
+	// Criterion 6: the system knows this body is a recording of a conversation
+	// rather than notes about one.
+	if got := s.readString(t, "activity", "coalesce(source_system, '')", m.activity); got != transcriptMarker {
+		t.Fatalf("case 1 criterion 6: the meeting's source_system is %q, want %q — any other value "+
+			"stores the text and reads nothing", got, transcriptMarker)
+	}
+
+	// Criterion 7: a reading was queued by the landing itself. Nobody asked.
+	var requestedBy string
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT requested_by FROM transcript_read WHERE activity_id = $1`, m.activity).
+			Scan(&requestedBy)
+	})
+	if err != nil {
+		t.Fatalf("case 1 criterion 7: no reading was queued for the transcript that just landed, so "+
+			"a recording nobody asked to read is a recording nobody reads: %v", err)
+	}
+
+	// Criterion 10: routed to the human, not to the passport.
+	//
+	// An MCP principal is `agent:<passport>`, and a reading requested by an
+	// agent id has nobody to route its proposals to. The value must name the
+	// granting human instead.
+	if strings.HasPrefix(requestedBy, "agent:") {
+		t.Fatalf("case 1 criterion 10: the reading was requested by %q — the proposals it stages "+
+			"would be routed to a software account and reach no rep", requestedBy)
+	}
+	if !strings.Contains(requestedBy, s.Rep.String()) {
+		t.Fatalf("case 1 criterion 10: the reading is requested by %q, which does not name the "+
+			"human behind the passport (%s)", requestedBy, s.Rep)
+	}
+}
+
+// readString reads one column off one row, for an assertion about what the
+// product wrote.
+func (s *scenario) readString(t *testing.T, table, column string, id ids.UUID) string {
+	t.Helper()
+	var out string
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT `+column+` FROM `+table+` WHERE id = $1`, id).Scan(&out)
+	})
+	if err != nil {
+		t.Fatalf("reading %s.%s for %s: %v", table, column, id, err)
+	}
+	return out
+}
+
+// countRows answers one counting query.
+func (s *scenario) countRows(t *testing.T, sql string, args ...any) int {
+	t.Helper()
+	var n int
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), sql, args...).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("counting: %v\n%s", err, sql)
+	}
+	return n
+}

--- a/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
@@ -143,8 +143,10 @@ const transcriptMarker = "transcript"
 //
 // None of the three existed before. If the assistant reports success and only
 // some of them are there, the case has failed — and the employment edge must be
-// written ONCE, because an early run left the person's page listing the company
-// twice.
+// written a single time, because an early run left the person's page listing
+// the company twice.
+//
+// Held by: this test's own employment-edge count, below.
 func TestCase1TheCompanyThePersonAndTheDealAllExistAfterwards(t *testing.T) {
 	s := boot(t, scopesReadWrite)
 	m := s.logTheMeeting(t)

--- a/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
@@ -35,13 +35,13 @@ package usecases
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // The meeting this case logs, as the assistant would supply it after reading a
@@ -211,13 +211,20 @@ func TestCase1TheMeetingLandsOnEveryRecordInOneWrite(t *testing.T) {
 		}
 	}
 
-	// Written TOGETHER. Three rows sharing one microsecond is what a single
-	// write looks like; a relink afterwards produces later rows.
-	if stamps := s.countRows(t,
-		`SELECT count(DISTINCT created_at) FROM activity_link WHERE activity_id = $1`,
-		m.activity); stamps != 1 {
-		t.Fatalf("case 1 criterion 4: the meeting's links carry %d distinct timestamps, so they "+
-			"were not written in one call", stamps)
+	// Written together, IN THE SAME TRANSACTION AS THE ACTIVITY.
+	//
+	// The three links sharing a created_at proves only that they shared a
+	// transaction — Postgres now() is transaction-scoped — and a build that
+	// committed the activity and then relinked in a second transaction would
+	// still show one distinct value among the links. Comparing them against the
+	// ACTIVITY's own stamp is what closes that: two transactions cannot agree on
+	// now(), so equality here means one write covered both.
+	if together := s.countRows(t, `SELECT count(*) FROM activity_link l
+		JOIN activity a ON a.id = l.activity_id
+		WHERE l.activity_id = $1 AND l.created_at = a.created_at`, m.activity); together != 3 {
+		t.Fatalf("case 1 criterion 4: %d of the meeting's 3 links were written in the same "+
+			"transaction as the meeting itself — the rest are a relink afterwards, which is what "+
+			"used to stop for three separate approvals", together)
 	}
 
 	// Criterion 5: nothing was staged for a human. An approval here would mean
@@ -265,16 +272,18 @@ func TestCase1TheTranscriptIsStoredAsATranscriptAndReadWithoutAsking(t *testing.
 
 	// Criterion 10: routed to the human, not to the passport.
 	//
-	// An MCP principal is `agent:<passport>`, and a reading requested by an
-	// agent id has nobody to route its proposals to. The value must name the
-	// granting human instead.
-	if strings.HasPrefix(requestedBy, "agent:") {
-		t.Fatalf("case 1 criterion 10: the reading was requested by %q — the proposals it stages "+
-			"would be routed to a software account and reach no rep", requestedBy)
+	// Asserted through the SAME parser the product routes with, not by looking
+	// at the string's shape. A value like "system:<uuid>" or "human:<uuid>:junk"
+	// is neither an agent prefix nor missing the rep's id, so a shape check
+	// passes while the proposals reach nobody — which is the whole failure.
+	routedTo, isHuman := principal.HumanUserID(requestedBy)
+	if !isHuman {
+		t.Fatalf("case 1 criterion 10: the reading was requested by %q, which the product's own "+
+			"parser does not read as a person — the proposals it stages reach no rep", requestedBy)
 	}
-	if !strings.Contains(requestedBy, s.Rep.String()) {
-		t.Fatalf("case 1 criterion 10: the reading is requested by %q, which does not name the "+
-			"human behind the passport (%s)", requestedBy, s.Rep)
+	if routedTo != s.Rep {
+		t.Fatalf("case 1 criterion 10: the reading is routed to %s, and the human behind the "+
+			"passport is %s", routedTo, s.Rep)
 	}
 }
 

--- a/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 2 — When somebody hands you a business card.
+//
+// The prompt, verbatim from the run, lowercase "crm" and all:
+//
+//	I met her at a conference. Tech Sauce in Bangkok actually. Add her to
+//	the crm
+//
+// The point of the scenario is the duplicate check, not the OCR. Reading the
+// photo is the assistant's job and Margince never sees an image, so the card
+// arrives here as FIELDS.
+//
+// The two lanes are deliberately different products and this suite pins both:
+// an email address belongs to one person, so a second create on the same
+// address is REFUSED; a phone number belongs to a switchboard, so a second
+// create sharing one LANDS and files a candidate for review. Collapsing them
+// would either lose real people or let real duplicates through.
+//
+// NOT covered here:
+//
+//   - Criterion 4, the assistant REPORTING the flag. That is a model question.
+//   - Criterion 5, the title conflict, which no run has yet exercised — no test
+//     card has carried a title differing from a stored one, and the choice has
+//     nowhere to be expressed on this surface today.
+//   - The location trigger. It needs the user's whereabouts, which the
+//     assistant's viewer refuses to share; the blocker is not ours.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// createdFromCard is what create_record answers: the record, plus whatever it
+// filed for review on the way.
+//
+// Declared here rather than reusing a product type because agents.createdRecord
+// is unexported — which is correct, it is a wire shape and not an API. What a
+// scenario needs is the two members it asserts on.
+type createdFromCard struct {
+	ID                  ids.UUID                    `json:"id"`
+	DuplicateCandidates []agents.DuplicateCandidate `json:"duplicate_candidates"`
+}
+
+// The card, as the assistant reads it off the photo.
+const (
+	cardName  = "Lucy Vo"
+	cardEmail = "lucy.vo@terralogic.test"
+	cardPhone = "+842838256789"
+	cardTitle = "Cybersecurity Sales Manager"
+)
+
+// createFromCard is one "add her to the crm", with whatever the card carried.
+func (s *scenario) createFromCard(t *testing.T, fields map[string]any) createdFromCard {
+	t.Helper()
+	got := s.MCP.CallOK(t, "create_record", map[string]any{
+		"record_type": "person", "fields": fields,
+	})
+	var created createdFromCard
+	got.JSON(t, &created)
+	return created
+}
+
+// cardFields is the card as tool arguments.
+func cardFields(name, email, phone string) map[string]any {
+	fields := map[string]any{"full_name": name, "title": cardTitle}
+	if email != "" {
+		fields["emails"] = []map[string]any{{"email": email, "is_primary": true}}
+	}
+	if phone != "" {
+		fields["phones"] = []map[string]any{{"phone": phone, "is_primary": true}}
+	}
+	return fields
+}
+
+// TestCase2TheSamePersonIsNotCreatedTwice pins criteria 1 and 2.
+//
+// The system refuses; it does not rely on the assistant being careful. An
+// assistant that checked first is good behaviour and not a guarantee — the same
+// card sent twice by a less careful one must still not produce two Lucys.
+//
+// Criterion 2 is the half that makes the refusal usable: "already exists" is
+// not enough, it has to say WHO, so the user can go and look.
+func TestCase2TheSamePersonIsNotCreatedTwice(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+
+	first := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+	if first.ID.IsZero() {
+		t.Fatalf("case 2: the first card did not create a person")
+	}
+
+	refusal := s.MCP.CallRefused(t, "create_record", map[string]any{
+		"record_type": "person", "fields": cardFields(cardName, cardEmail, cardPhone),
+	})
+	if !strings.Contains(strings.ToLower(refusal), "already exists") {
+		t.Fatalf("case 2 criterion 1: a second card for the same address was not refused as a "+
+			"duplicate:\n%s", refusal)
+	}
+	// Criterion 2: the refusal names the address that collided, which is what
+	// a user searches on to find the record already there.
+	if !strings.Contains(strings.ToLower(refusal), strings.ToLower(cardEmail)) {
+		t.Fatalf("case 2 criterion 2: the refusal does not name what already exists, so a user is "+
+			"told no and given nowhere to look:\n%s", refusal)
+	}
+
+	if people := s.countRows(t,
+		`SELECT count(*) FROM person WHERE full_name = $1 AND archived_at IS NULL`,
+		cardName); people != 1 {
+		t.Fatalf("case 2 criterion 1: the workspace holds %d people called %s after the same card "+
+			"was added twice", people, cardName)
+	}
+}
+
+// TestCase2ASharedPhoneLandsAndIsFiledForReview pins criterion 3.
+//
+// A switchboard belongs to many people, so this must NOT refuse — refusing
+// would lose a real second contact at a company whose number everyone shares.
+// It lands, and a possible duplicate is filed rather than lost.
+func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+
+	first := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+
+	// The same human, a second card, a different address — and the company
+	// switchboard both cards print.
+	second := s.createFromCard(t, cardFields(cardName, "lucy.vo@terralogic-vn.test", cardPhone))
+	if second.ID.IsZero() {
+		t.Fatalf("case 2 criterion 3: a card sharing only a switchboard number was refused; a " +
+			"shared number is not a shared identity and refusing loses a real contact")
+	}
+	if second.ID == first.ID {
+		t.Fatalf("case 2 criterion 3: the second card returned the first person's id rather than " +
+			"creating a record")
+	}
+
+	// The candidate travels on the CREATE'S OWN answer. There is no dedupe tool
+	// on this surface and the review queue is cookie-only, so if the create
+	// does not report it, an assistant has no way to learn a human was asked.
+	if len(second.DuplicateCandidates) == 0 {
+		t.Fatalf("case 2 criterion 3: the create filed no possible-duplicate candidate, so a second " +
+			"record for the same human sits in the CRM with nobody asked about it")
+	}
+	named := false
+	for _, candidate := range second.DuplicateCandidates {
+		if candidate.OtherRecordID == first.ID.String() {
+			named = true
+		}
+		if candidate.Confidence <= 0 {
+			t.Fatalf("case 2 criterion 3: a candidate was filed with confidence %v, which tells a "+
+				"reviewer nothing about how sure the match is", candidate.Confidence)
+		}
+	}
+	if !named {
+		t.Fatalf("case 2 criterion 3: the candidate does not name the record already in the "+
+			"workspace (%s); a reviewer offered a merge has to be told which is which", first.ID)
+	}
+}
+
+// TestCase2ATagIsAppliedByNameInOneStep pins criterion 6.
+//
+// Including a word the workspace has never used. "Add tag: K5 Conference 2026"
+// is one call — an assistant that had to create the tag first, look up its id
+// and then apply it would be three round trips deep in a conversation about a
+// business card.
+func TestCase2ATagIsAppliedByNameInOneStep(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+	person := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+
+	const newWord = "Tech Sauce Bangkok 2026"
+	got := s.MCP.CallOK(t, "apply_tag", map[string]any{
+		"tag_name": newWord, "record_type": "person", "record_id": person.ID.String(),
+	})
+	var applied agents.TagAppliedResult
+	got.JSON(t, &applied)
+
+	if !applied.Applied {
+		t.Fatalf("case 2 criterion 6: applying a tag by name answered applied=false:\n%s", got.Text)
+	}
+	if applied.TagID.IsZero() {
+		t.Fatalf("case 2 criterion 6: the tag was applied without naming the word's id, so a " +
+			"caller cannot refer to it again")
+	}
+	// The word was COINED, not silently dropped: a workspace that had never
+	// used it now holds it, attached to this person.
+	if n := s.countRows(t, `SELECT count(*) FROM taggable WHERE tag_id = $1 AND entity_type = 'person' AND entity_id = $2`,
+		applied.TagID, person.ID); n != 1 {
+		t.Fatalf("case 2 criterion 6: the tag reports applied and %d rows attach it to the person", n)
+	}
+	if name := s.readString(t, "tag", "name", applied.TagID); name != newWord {
+		t.Fatalf("case 2 criterion 6: the coined tag reads %q, want %q", name, newWord)
+	}
+}

--- a/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
@@ -151,7 +151,7 @@ func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
 		t.Fatalf("case 2 criterion 3: the create filed no possible-duplicate candidate, so a second " +
 			"record for the same human sits in the CRM with nobody asked about it")
 	}
-	named := false
+	named, onThePhone := false, false
 	for _, candidate := range second.DuplicateCandidates {
 		if candidate.OtherRecordID == first.ID.String() {
 			named = true
@@ -160,10 +160,30 @@ func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
 			t.Fatalf("case 2 criterion 3: a candidate was filed with confidence %v, which tells a "+
 				"reviewer nothing about how sure the match is", candidate.Confidence)
 		}
+		// WHICH axis they met on. Both cards also carry the same name, and the
+		// name lane files a candidate of its own — so a test happy with "some
+		// candidate exists" passes with the phone lane deleted entirely, which
+		// is the lane this scenario is about.
+		for _, evidence := range candidate.Evidence {
+			if evidence.Field != "phone" {
+				continue
+			}
+			onThePhone = true
+			if evidence.Left != cardPhone || evidence.Right != cardPhone {
+				t.Fatalf("case 2 criterion 3: the phone evidence compares %q with %q, and both "+
+					"cards print %q — a reviewer reads these two values out before merging",
+					evidence.Left, evidence.Right, cardPhone)
+			}
+		}
 	}
 	if !named {
 		t.Fatalf("case 2 criterion 3: the candidate does not name the record already in the "+
 			"workspace (%s); a reviewer offered a merge has to be told which is which", first.ID)
+	}
+	if !onThePhone {
+		t.Fatalf("case 2 criterion 3: no candidate cites the shared PHONE. The two cards also " +
+			"share a name, and the name lane files its own candidate — so this scenario only " +
+			"tests what it claims when the phone axis is the one that fired")
 	}
 }
 

--- a/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
@@ -70,15 +70,18 @@ func (s *scenario) createFromCard(t *testing.T, fields map[string]any) createdFr
 }
 
 // cardFields is the card as tool arguments.
-func cardFields(name, email, phone string) map[string]any {
-	fields := map[string]any{"full_name": name, "title": cardTitle}
-	if email != "" {
-		fields["emails"] = []map[string]any{{"email": email, "is_primary": true}}
+//
+// Only the ADDRESS varies between the cards this case sends, and that is the
+// scenario rather than a convenience: one human, two cards, the same name and
+// the same company switchboard printed on both. The address is what makes the
+// two lanes differ — an email is a real key and a switchboard is not.
+func cardFields(email string) map[string]any {
+	return map[string]any{
+		"full_name": cardName,
+		"title":     cardTitle,
+		"emails":    []map[string]any{{"email": email, "is_primary": true}},
+		"phones":    []map[string]any{{"phone": cardPhone, "is_primary": true}},
 	}
-	if phone != "" {
-		fields["phones"] = []map[string]any{{"phone": phone, "is_primary": true}}
-	}
-	return fields
 }
 
 // TestCase2TheSamePersonIsNotCreatedTwice pins criteria 1 and 2.
@@ -92,13 +95,13 @@ func cardFields(name, email, phone string) map[string]any {
 func TestCase2TheSamePersonIsNotCreatedTwice(t *testing.T) {
 	s := boot(t, scopesReadWrite)
 
-	first := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+	first := s.createFromCard(t, cardFields(cardEmail))
 	if first.ID.IsZero() {
 		t.Fatalf("case 2: the first card did not create a person")
 	}
 
 	refusal := s.MCP.CallRefused(t, "create_record", map[string]any{
-		"record_type": "person", "fields": cardFields(cardName, cardEmail, cardPhone),
+		"record_type": "person", "fields": cardFields(cardEmail),
 	})
 	if !strings.Contains(strings.ToLower(refusal), "already exists") {
 		t.Fatalf("case 2 criterion 1: a second card for the same address was not refused as a "+
@@ -127,11 +130,11 @@ func TestCase2TheSamePersonIsNotCreatedTwice(t *testing.T) {
 func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
 	s := boot(t, scopesReadWrite)
 
-	first := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+	first := s.createFromCard(t, cardFields(cardEmail))
 
 	// The same human, a second card, a different address — and the company
 	// switchboard both cards print.
-	second := s.createFromCard(t, cardFields(cardName, "lucy.vo@terralogic-vn.test", cardPhone))
+	second := s.createFromCard(t, cardFields("lucy.vo@terralogic-vn.test"))
 	if second.ID.IsZero() {
 		t.Fatalf("case 2 criterion 3: a card sharing only a switchboard number was refused; a " +
 			"shared number is not a shared identity and refusing loses a real contact")
@@ -172,7 +175,7 @@ func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
 // business card.
 func TestCase2ATagIsAppliedByNameInOneStep(t *testing.T) {
 	s := boot(t, scopesReadWrite)
-	person := s.createFromCard(t, cardFields(cardName, cardEmail, cardPhone))
+	person := s.createFromCard(t, cardFields(cardEmail))
 
 	const newWord = "Tech Sauce Bangkok 2026"
 	got := s.MCP.CallOK(t, "apply_tag", map[string]any{

--- a/backend/internal/compose/integration/e2e/usecases/case3_spreadsheet_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case3_spreadsheet_test.go
@@ -46,11 +46,15 @@ Alpenblick Sensorik GmbH,München,11-50,DE
 // theCorrection is the same file with one row changed: the city and the size,
 // exactly as the user described them. Everything else is byte-identical, so an
 // import that touched anything but Nordwind is doing work nobody asked for.
-const theCorrectionCSV = `name,city,size,country
-Nordwind Logistik GmbH,Hamburg,201-500,DE
-Elbmarsch Systeme AG,Hamburg,11-50,DE
-Rheinpark Automation KG,Köln,201-500,DE
-Alpenblick Sensorik GmbH,München,11-50,DE
+// The country column is ABSENT, which is the point: criterion 5 is that a
+// field the correction never mentions is left alone. An earlier version of this
+// file kept the column and supplied DE, so it proved only that writing DE over
+// DE leaves DE — a mutation replacing every address component would have passed.
+const theCorrectionCSV = `name,city,size
+Nordwind Logistik GmbH,Hamburg,201-500
+Elbmarsch Systeme AG,Hamburg,11-50
+Rheinpark Automation KG,Köln,201-500
+Alpenblick Sensorik GmbH,München,11-50
 `
 
 // importOutcome is what one preview-then-commit produced.
@@ -60,15 +64,20 @@ type importOutcome struct {
 }
 
 // previewImport runs the dry pass and returns what it says WILL happen.
+//
+// The mapping names only the columns the file actually carries. A mapping that
+// named a column the file lacks would be a different test — and the correction
+// file deliberately lacks one.
 func (s *scenario) previewImport(t *testing.T, csv string) agents.ImportPreviewResult {
 	t.Helper()
+	mapping := map[string]string{
+		"name": "display_name", "city": "address.city", "size": "size_band",
+	}
+	if strings.Contains(strings.SplitN(csv, "\n", 2)[0], "country") {
+		mapping["country"] = "address.country"
+	}
 	got := s.MCP.CallOK(t, "preview_import", map[string]any{
-		"object": "organization",
-		"csv":    csv,
-		"mapping": map[string]string{
-			"name": "display_name", "city": "address.city",
-			"size": "size_band", "country": "address.country",
-		},
+		"object": "organization", "csv": csv, "mapping": mapping,
 	})
 	var preview agents.ImportPreviewResult
 	got.JSON(t, &preview)
@@ -131,9 +140,21 @@ func TestCase3ThePreviewTellsTheTruth(t *testing.T) {
 		t.Fatalf("case 3 criterion 2: the preview promised %d updated and %d happened",
 			promised.Disposition.Updated, happened.Disposition.Updated)
 	}
-	if n := s.countRows(t,
-		`SELECT count(*) FROM organization WHERE display_name = 'Nordwind Logistik GmbH'`); n != 1 {
-		t.Fatalf("case 3 criterion 2: the file names Nordwind once and the CRM holds %d", n)
+	// Every row, bound to its own values. An aggregate of four proves four rows
+	// appeared; it does not prove they are the four the file named, with the
+	// data the file carried.
+	for _, want := range []struct{ name, city, size string }{
+		{"Nordwind Logistik GmbH", "Rostock", "51-200"},
+		{"Elbmarsch Systeme AG", "Hamburg", "11-50"},
+		{"Rheinpark Automation KG", "Köln", "201-500"},
+		{"Alpenblick Sensorik GmbH", "München", "11-50"},
+	} {
+		if n := s.countRows(t, `SELECT count(*) FROM organization
+			WHERE display_name = $1 AND address_city = $2 AND size_band = $3`,
+			want.name, want.city, want.size); n != 1 {
+			t.Fatalf("case 3 criterion 2: the file says %s is in %s at %s, and %d rows match",
+				want.name, want.city, want.size, n)
+		}
 	}
 }
 
@@ -170,6 +191,22 @@ func TestCase3ImportingTheSameFileTwiceChangesNothing(t *testing.T) {
 		t.Fatalf("case 3 criterion 3: the CRM holds %d of the file's companies after importing it "+
 			"twice, want 4", total)
 	}
+
+	// NOTHING WAS WRITTEN, not merely nothing was counted.
+	//
+	// `unchanged` is a residual — rows read minus created, updated and skipped —
+	// so a build that rewrote every row with its own values and reported zero
+	// updates would produce identical counts. The row version is what a write
+	// actually leaves behind: it is bumped by every real update, so four rows
+	// still at version 1 is the claim the disposition alone cannot make.
+	if untouched := s.countRows(t, `SELECT count(*) FROM organization
+		WHERE display_name IN ('Nordwind Logistik GmbH','Elbmarsch Systeme AG',
+		                       'Rheinpark Automation KG','Alpenblick Sensorik GmbH')
+		  AND version = 1`); untouched != 4 {
+		t.Fatalf("case 3 criterion 3: only %d of the 4 companies are still at version 1 — the "+
+			"second import reported no updates and rewrote rows anyway, which puts work that "+
+			"never happened into the audit trail", untouched)
+	}
 }
 
 // TestCase3ChangingOneRowUpdatesOneRecord pins criteria 4 and 5.
@@ -194,18 +231,27 @@ func TestCase3ChangingOneRowUpdatesOneRecord(t *testing.T) {
 			corrected.report.Disposition.Unchanged)
 	}
 
-	// The correction landed.
+	// BOTH halves of the correction landed. The user said two things — the city
+	// and the size — and a city change alone is enough to report one update, so
+	// asserting only the city would pass while losing half of what was asked.
 	if city := s.readStringWhere(t,
 		`SELECT coalesce(address_city, '') FROM organization WHERE display_name = $1`,
 		"Nordwind Logistik GmbH"); city != "Hamburg" {
 		t.Fatalf("case 3 criterion 4: Nordwind should have moved to Hamburg and sits in %q", city)
 	}
-	// Criterion 5: a field the correction did not mention is untouched.
+	if size := s.readStringWhere(t,
+		`SELECT coalesce(size_band, '') FROM organization WHERE display_name = $1`,
+		"Nordwind Logistik GmbH"); size != "201-500" {
+		t.Fatalf("case 3 criterion 4: the correction said 201-500 people and the record reads %q — "+
+			"one update was reported and half the correction was dropped", size)
+	}
+	// Criterion 5: a field the correction's file does not CARRY is untouched.
+	// The original import set DE; the correction has no country column at all.
 	if country := s.readStringWhere(t,
 		`SELECT coalesce(address_country, '') FROM organization WHERE display_name = $1`,
 		"Nordwind Logistik GmbH"); country != "DE" {
-		t.Fatalf("case 3 criterion 5: the correction never mentioned the country and it now reads "+
-			"%q", country)
+		t.Fatalf("case 3 criterion 5: the correction file carries no country column and the "+
+			"country now reads %q — an import must not blank what it was not told about", country)
 	}
 }
 
@@ -236,16 +282,31 @@ Alpenblick Sensorik GmbH,München,11-50,DE
 		t.Fatalf("case 3 criterion 6: a row was dropped and no issue was reported, so a file " +
 			"half-ignored arrives under a success message")
 	}
+	// Criterion 7: the issue names THE row that was bad, not merely a row.
+	//
+	// The blank name is on the fourth line of the file, counting the header as
+	// line 1. An implementation reporting line 2 for everything satisfies "at
+	// least line 2" while sending the user to the wrong row — and a generic
+	// reason tells them nothing about what to fix when they get there.
+	const badLine = 4
+	found := false
 	for _, issue := range outcome.report.Issues {
-		// Criterion 7: findable. Line 1 is the header, so a real refusal names
-		// a line at or after 2 — a zero says "somewhere in your file".
-		if issue.Line < 2 {
-			t.Fatalf("case 3 criterion 7: an issue is reported on line %d, which a user cannot "+
-				"find in their spreadsheet: %s", issue.Line, issue.Reason)
-		}
 		if strings.TrimSpace(issue.Reason) == "" {
 			t.Fatalf("case 3 criterion 6: line %d was refused with no reason", issue.Line)
 		}
+		if issue.Line == badLine {
+			found = true
+			if !mentionsTheMissingName(issue) {
+				t.Fatalf("case 3 criterion 7: line %d was refused because it carries no company "+
+					"name, and the reason given is %q — a user cannot tell what to fix",
+					issue.Line, issue.Reason)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("case 3 criterion 7: the unusable row is line %d of the file and the issues "+
+			"reported are %v — a user sent to the wrong row cannot fix it",
+			badLine, linesOf(outcome.report.Issues))
 	}
 }
 
@@ -255,6 +316,30 @@ func (s *scenario) readStringWhere(t *testing.T, sql, arg string) string {
 	var out string
 	if err := queryRow(t, s, sql, &out, arg); err != nil {
 		t.Fatalf("reading: %v\n%s", err, sql)
+	}
+	return out
+}
+
+// mentionsTheMissingName says whether an issue explains what was wrong with the
+// row, rather than merely that something was.
+func mentionsTheMissingName(issue crmcontracts.ImportRowIssue) bool {
+	haystack := strings.ToLower(issue.Reason)
+	if issue.Column != nil {
+		haystack += " " + strings.ToLower(*issue.Column)
+	}
+	for _, word := range []string{"name", "blank", "empty", "missing", "required"} {
+		if strings.Contains(haystack, word) {
+			return true
+		}
+	}
+	return false
+}
+
+// linesOf names which lines were reported, for a failure worth reading.
+func linesOf(issues []crmcontracts.ImportRowIssue) []int {
+	out := make([]int, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, issue.Line)
 	}
 	return out
 }

--- a/backend/internal/compose/integration/e2e/usecases/case3_spreadsheet_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case3_spreadsheet_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 3 — A spreadsheet arrives.
+//
+// The prompts, in the order a real user says them:
+//
+//	Got this list from the trade fair. Can you get it into the CRM?
+//	I think I sent you that already, do it again to be safe
+//	One correction on that list — Rostock should be Hamburg and they are
+//	bigger than I said, 201-500 people
+//
+// The second line is the whole case. It is what a user does when they are not
+// sure whether something worked, and the correct outcome is that nothing
+// happens twice.
+//
+// A blob store is wired because the import genuinely needs one: profiling
+// STORES the bytes, and both the dry run and the commit reopen the stored
+// source. An in-memory store is enough — no MinIO, no network.
+//
+// NOT covered here: criterion 8, undo. There is no undo tool on this surface;
+// it is human-only REST, and a scenario driving it over the cookie client would
+// be testing the app rather than the journey an assistant walks.
+
+import (
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/agents"
+)
+
+// The file from the trade fair. Four companies, and one row whose id names
+// nothing — so criteria 6 and 7 have something to catch.
+const tradeFairCSV = `name,city,size,country
+Nordwind Logistik GmbH,Rostock,51-200,DE
+Elbmarsch Systeme AG,Hamburg,11-50,DE
+Rheinpark Automation KG,Köln,201-500,DE
+Alpenblick Sensorik GmbH,München,11-50,DE
+`
+
+// theCorrection is the same file with one row changed: the city and the size,
+// exactly as the user described them. Everything else is byte-identical, so an
+// import that touched anything but Nordwind is doing work nobody asked for.
+const theCorrectionCSV = `name,city,size,country
+Nordwind Logistik GmbH,Hamburg,201-500,DE
+Elbmarsch Systeme AG,Hamburg,11-50,DE
+Rheinpark Automation KG,Köln,201-500,DE
+Alpenblick Sensorik GmbH,München,11-50,DE
+`
+
+// importOutcome is what one preview-then-commit produced.
+type importOutcome struct {
+	runID  string
+	report crmcontracts.ImportRunReport
+}
+
+// previewImport runs the dry pass and returns what it says WILL happen.
+func (s *scenario) previewImport(t *testing.T, csv string) agents.ImportPreviewResult {
+	t.Helper()
+	got := s.MCP.CallOK(t, "preview_import", map[string]any{
+		"object": "organization",
+		"csv":    csv,
+		"mapping": map[string]string{
+			"name": "display_name", "city": "address.city",
+			"size": "size_band", "country": "address.country",
+		},
+	})
+	var preview agents.ImportPreviewResult
+	got.JSON(t, &preview)
+	return preview
+}
+
+// readReport reads a run's report, which is the same shape before and after the
+// commit — so what WILL happen and what DID compares like with like.
+func (s *scenario) readReport(t *testing.T, runID string) crmcontracts.ImportRunReport {
+	t.Helper()
+	got := s.MCP.CallOK(t, "read_import_report", map[string]any{"run_id": runID})
+	var report agents.ImportReportResult
+	got.JSON(t, &report)
+	return report.Report
+}
+
+// runImport previews, commits and reads back what actually happened.
+func (s *scenario) runImport(t *testing.T, csv string) importOutcome {
+	t.Helper()
+	preview := s.previewImport(t, csv)
+	if preview.Run.RunID == "" {
+		t.Fatalf("case 3: the preview produced no run")
+	}
+	// commit_import is auto-execute: importing a file the user handed over is
+	// not a decision a second human makes.
+	s.MCP.CallOK(t, "commit_import", map[string]any{"run_id": preview.Run.RunID})
+	return importOutcome{runID: preview.Run.RunID, report: s.readReport(t, preview.Run.RunID)}
+}
+
+// TestCase3ThePreviewTellsTheTruth pins criteria 1 and 2.
+//
+// The numbers are shown before anything is written, and what happens matches
+// them exactly. A preview that is roughly right is a preview nobody can approve
+// against.
+func TestCase3ThePreviewTellsTheTruth(t *testing.T) {
+	s := bootWithImports(t)
+
+	preview := s.previewImport(t, tradeFairCSV)
+	promised := s.readReport(t, preview.Run.RunID)
+	if promised.Disposition.Created != 4 {
+		t.Fatalf("case 3 criterion 1: the dry run promises %d creations for a four-company file",
+			promised.Disposition.Created)
+	}
+	// Nothing is written yet. A preview that had already created the rows
+	// would make the count true and the promise meaningless.
+	if s.countRows(t, `SELECT count(*) FROM organization WHERE display_name LIKE '%GmbH'
+		OR display_name LIKE '%AG' OR display_name LIKE '%KG'`) != 0 {
+		t.Fatalf("case 3 criterion 1: the dry run already wrote companies, so the numbers it " +
+			"showed were a description of the past rather than a promise")
+	}
+
+	s.MCP.CallOK(t, "commit_import", map[string]any{"run_id": preview.Run.RunID})
+	happened := s.readReport(t, preview.Run.RunID)
+
+	if happened.Disposition.Created != promised.Disposition.Created {
+		t.Fatalf("case 3 criterion 2: the preview promised %d created and %d happened",
+			promised.Disposition.Created, happened.Disposition.Created)
+	}
+	if happened.Disposition.Updated != promised.Disposition.Updated {
+		t.Fatalf("case 3 criterion 2: the preview promised %d updated and %d happened",
+			promised.Disposition.Updated, happened.Disposition.Updated)
+	}
+	if n := s.countRows(t,
+		`SELECT count(*) FROM organization WHERE display_name = 'Nordwind Logistik GmbH'`); n != 1 {
+		t.Fatalf("case 3 criterion 2: the file names Nordwind once and the CRM holds %d", n)
+	}
+}
+
+// TestCase3ImportingTheSameFileTwiceChangesNothing pins criterion 3, the single
+// most important assertion in this case.
+//
+// "I think I sent you that already, do it again to be safe" must be safe.
+func TestCase3ImportingTheSameFileTwiceChangesNothing(t *testing.T) {
+	s := bootWithImports(t)
+
+	first := s.runImport(t, tradeFairCSV)
+	if first.report.Disposition.Created != 4 {
+		t.Fatalf("case 3: the first import created %d companies, want 4",
+			first.report.Disposition.Created)
+	}
+
+	second := s.runImport(t, tradeFairCSV)
+	if second.report.Disposition.Created != 0 {
+		t.Fatalf("case 3 criterion 3: re-importing the identical file created %d more companies",
+			second.report.Disposition.Created)
+	}
+	if second.report.Disposition.Updated != 0 {
+		t.Fatalf("case 3 criterion 3: re-importing the identical file updated %d companies; every "+
+			"value was already equal and updating them writes work that never happened into the "+
+			"audit trail", second.report.Disposition.Updated)
+	}
+	if second.report.Disposition.Unchanged != 4 {
+		t.Fatalf("case 3 criterion 3: the second run reports %d unchanged, want all 4",
+			second.report.Disposition.Unchanged)
+	}
+	if total := s.countRows(t, `SELECT count(*) FROM organization
+		WHERE display_name IN ('Nordwind Logistik GmbH','Elbmarsch Systeme AG',
+		                       'Rheinpark Automation KG','Alpenblick Sensorik GmbH')`); total != 4 {
+		t.Fatalf("case 3 criterion 3: the CRM holds %d of the file's companies after importing it "+
+			"twice, want 4", total)
+	}
+}
+
+// TestCase3ChangingOneRowUpdatesOneRecord pins criteria 4 and 5.
+//
+// Not all of them, and not a duplicate. And the country column, which the
+// correction did not touch, is left exactly as it was.
+func TestCase3ChangingOneRowUpdatesOneRecord(t *testing.T) {
+	s := bootWithImports(t)
+	s.runImport(t, tradeFairCSV)
+
+	corrected := s.runImport(t, theCorrectionCSV)
+	if corrected.report.Disposition.Updated != 1 {
+		t.Fatalf("case 3 criterion 4: one row changed and %d records were updated",
+			corrected.report.Disposition.Updated)
+	}
+	if corrected.report.Disposition.Created != 0 {
+		t.Fatalf("case 3 criterion 4: correcting a row created %d companies — a correction that "+
+			"creates is a duplicate", corrected.report.Disposition.Created)
+	}
+	if corrected.report.Disposition.Unchanged != 3 {
+		t.Fatalf("case 3 criterion 4: %d of the other three rows were reported unchanged",
+			corrected.report.Disposition.Unchanged)
+	}
+
+	// The correction landed.
+	if city := s.readStringWhere(t,
+		`SELECT coalesce(address_city, '') FROM organization WHERE display_name = $1`,
+		"Nordwind Logistik GmbH"); city != "Hamburg" {
+		t.Fatalf("case 3 criterion 4: Nordwind should have moved to Hamburg and sits in %q", city)
+	}
+	// Criterion 5: a field the correction did not mention is untouched.
+	if country := s.readStringWhere(t,
+		`SELECT coalesce(address_country, '') FROM organization WHERE display_name = $1`,
+		"Nordwind Logistik GmbH"); country != "DE" {
+		t.Fatalf("case 3 criterion 5: the correction never mentioned the country and it now reads "+
+			"%q", country)
+	}
+}
+
+// TestCase3ABadRowIsSkippedWithAReasonAndTheRestStillImport pins criteria 6
+// and 7.
+//
+// One broken line does not fail the file, and it does not silently create a
+// duplicate either. The reason names the LINE, because a user has to be able to
+// find and fix it.
+func TestCase3ABadRowIsSkippedWithAReasonAndTheRestStillImport(t *testing.T) {
+	s := bootWithImports(t)
+
+	// The third data row carries no name at all — nothing the import can file.
+	const withABadRow = `name,city,size,country
+Nordwind Logistik GmbH,Rostock,51-200,DE
+Elbmarsch Systeme AG,Hamburg,11-50,DE
+,Köln,201-500,DE
+Alpenblick Sensorik GmbH,München,11-50,DE
+`
+	outcome := s.runImport(t, withABadRow)
+
+	if outcome.report.Disposition.Created != 3 {
+		t.Fatalf("case 3 criterion 6: one row of five is unusable and %d companies were created, "+
+			"want the other 3 — a broken line must not fail the file",
+			outcome.report.Disposition.Created)
+	}
+	if len(outcome.report.Issues) == 0 {
+		t.Fatalf("case 3 criterion 6: a row was dropped and no issue was reported, so a file " +
+			"half-ignored arrives under a success message")
+	}
+	for _, issue := range outcome.report.Issues {
+		// Criterion 7: findable. Line 1 is the header, so a real refusal names
+		// a line at or after 2 — a zero says "somewhere in your file".
+		if issue.Line < 2 {
+			t.Fatalf("case 3 criterion 7: an issue is reported on line %d, which a user cannot "+
+				"find in their spreadsheet: %s", issue.Line, issue.Reason)
+		}
+		if strings.TrimSpace(issue.Reason) == "" {
+			t.Fatalf("case 3 criterion 6: line %d was refused with no reason", issue.Line)
+		}
+	}
+}
+
+// readStringWhere reads one column by a predicate other than an id.
+func (s *scenario) readStringWhere(t *testing.T, sql, arg string) string {
+	t.Helper()
+	var out string
+	if err := queryRow(t, s, sql, &out, arg); err != nil {
+		t.Fatalf("reading: %v\n%s", err, sql)
+	}
+	return out
+}

--- a/backend/internal/compose/integration/e2e/usecases/case4_use_the_moment_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case4_use_the_moment_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 4 — Use the moment.
+//
+// The prompt, from the run this was written against:
+//
+//	hey I am in cologne right now and wanted to visit a client but my
+//	appointment got canceled. Anyone nearby in our crm I should visit?
+//
+// It never says "companies", never says "address", never says "distance", and
+// names no tool. What the assistant has to work out for itself is the whole
+// case: that "nearby" means a distance search, that a distance search needs a
+// geo field, and that it can ASK which fields are geo. This suite pins the
+// three answers that chain depends on, in the order the assistant meets them.
+//
+// No geocoder runs here, and none ever will. The city centre resolves from the
+// caller's own located companies, so seeding companies with coordinates is what
+// makes "Cologne" a point. If a real geocoding provider ever becomes the
+// PRIMARY lookup, this suite starts reaching the network — which is a reason to
+// fail loudly, not a reason to soften the fixture.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// Cologne cathedral, and Munich as the company no plausible radius admits.
+//
+// The centre a radius measures from is NOT one of these points. `LookupCity`
+// averages the caller's own located companies filed under that city name, so
+// "Köln" resolves to the midpoint of whatever this fixture seeded there. That
+// is why the assertions below are about ORDER and MEMBERSHIP rather than about
+// a company being exactly N km out — a distance that depends on the fixture's
+// own average is a number the test would be checking against itself.
+//
+// The city name on each row is load-bearing for the same reason. Filing Munich
+// under 'Köln' would stretch the average across ~2.8 degrees, over the one-degree
+// spread cap that stops "Frankfurt" resolving to a point between two of them —
+// and the resolver would correctly refuse the whole query.
+const (
+	cologneLat = 50.9375
+	cologneLon = 6.9603
+	munichLat  = 48.1351
+	munichLon  = 11.5820
+)
+
+// seedLocatedOrg inserts a company that has already been geocoded: an address,
+// a point, and the 'ok' status saying the two agree.
+//
+// The owner is a parameter and not a default, because criteria 4 and 5 are
+// about the DIFFERENCE between an account the caller owns and a colleague's.
+// A fixture where everything belongs to one seat cannot fail those criteria and
+// therefore cannot pass them.
+func (s *scenario) seedLocatedOrg(t *testing.T, name, city string, lat, lon float64, owner ids.UUID) ids.UUID {
+	t.Helper()
+	return s.seedID(t, `INSERT INTO organization
+		(id, owner_id, display_name, address_line1, address_city,
+		 geocode_lat, geocode_lon, geocode_status, geocode_provider, geocode_input_hash,
+		 source, captured_by)
+		VALUES ($1, $2, $3, 'Hauptstrasse 1', $4, $5, $6, 'ok', 'test', 'seeded', 'manual', 'human:x')`,
+		owner, name, city, lat, lon)
+}
+
+// queryPlan runs one plan and decodes the answer.
+func (s *scenario) queryPlan(t *testing.T, plan string) agents.QueryWorkspaceResult {
+	t.Helper()
+	var raw json.RawMessage = []byte(plan)
+	got := s.MCP.CallOK(t, "query_workspace", map[string]any{"plan": raw})
+	var result agents.QueryWorkspaceResult
+	got.JSON(t, &result)
+	return result
+}
+
+// TestCase4TheAssistantCanDiscoverThatAddressesAreSearchableByDistance pins
+// criterion 1: the assistant finds out the CRM knows about locations without
+// being told.
+//
+// This is the first link in the chain and the one that was missing until
+// #2728: the grammar was served and unreachable to a tools-only client, so an
+// assistant had no way to learn that a radius search existed at all.
+func TestCase4TheAssistantCanDiscoverThatAddressesAreSearchableByDistance(t *testing.T) {
+	s := boot(t, scopesRead)
+
+	got := s.MCP.CallOK(t, "describe_query_vocabulary", nil)
+	if !containsAll(got.Text, "address", "within_radius") {
+		t.Fatalf("case 4 criterion 1: the vocabulary does not tell a caller that `address` "+
+			"supports `within_radius`, so an assistant asked for who is NEARBY has no way to "+
+			"learn a distance search exists:\n%s", got.Text)
+	}
+}
+
+// TestCase4NearbyCompaniesComeBackNearestFirstAndSayHowComplete pins criteria
+// 2, 3 and 7: the radius answers, it is ordered, it says whether the list is
+// everything, and an unanswerable radius says so rather than returning an
+// unordered list that looks ordered.
+func TestCase4NearbyCompaniesComeBackNearestFirstAndSayHowComplete(t *testing.T) {
+	s := boot(t, scopesRead)
+
+	// Three inside a 50km radius at roughly 0km, 12km and 27km, plus Munich at
+	// ~460km which must be absent.
+	s.seedLocatedOrg(t, "Dom Digital GmbH", "Köln", cologneLat, cologneLon, s.Rep)
+	s.seedLocatedOrg(t, "Rheinufer AG", "Köln", cologneLat+0.11, cologneLon, s.Colleague)
+	s.seedLocatedOrg(t, "Vorort Systeme KG", "Köln", cologneLat+0.25, cologneLon, s.Colleague)
+	s.seedLocatedOrg(t, "München Ferne GmbH", "München", munichLat, munichLon, s.Rep)
+
+	result := s.queryPlan(t, `{
+		"version": "v1", "target": "organization",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Köln", "radius_km": 50}}]}`)
+
+	if len(result.Rows) != 3 {
+		t.Fatalf("case 4 criterion 2: a 50km radius around Köln admitted %d companies, want the 3 "+
+			"inside it (Munich is ~460km away and must not appear):\n%s", len(result.Rows), result.ExecutedPlan)
+	}
+
+	// Criterion 2's second half: nearest first. Reading the distances in order
+	// is the assertion — a list that is right but unordered sends a rep to the
+	// far one first.
+	var previous float64
+	for i, row := range result.Rows {
+		if row.DistanceKM == nil {
+			t.Fatalf("case 4 criterion 2: row %d (%s) carries no distance, so a caller cannot tell "+
+				"how far it is or trust the order", i, recordName(t, row.Record.Fields))
+		}
+		if *row.DistanceKM < previous {
+			t.Fatalf("case 4 criterion 2: row %d (%s) is %.1fkm out, closer than the row before it "+
+				"at %.1fkm — the answer is not nearest-first", i, recordName(t, row.Record.Fields), *row.DistanceKM, previous)
+		}
+		previous = *row.DistanceKM
+	}
+
+	// Criterion 3: "these are all of them" and "these are some of them" are
+	// different answers, and a rep deciding whether to look further needs to
+	// know which one they were given.
+	if result.Coverage != agents.CoverageCompleteExact {
+		t.Fatalf("case 4 criterion 3: coverage is %q, want %q — an exact radius over a small corpus "+
+			"is a complete answer, and anything else tells the rep to keep looking",
+			result.Coverage, agents.CoverageCompleteExact)
+	}
+}
+
+// TestCase4ARadiusItCannotMeasureSaysSoInsteadOfAnsweringAnyway pins criterion
+// 7. A person HAS an address, so both the field and the operator exist and the
+// plan looks answerable — but this product does not geocode where people live,
+// so there is nothing to measure from.
+func TestCase4ARadiusItCannotMeasureSaysSoInsteadOfAnsweringAnyway(t *testing.T) {
+	s := boot(t, scopesRead)
+	s.seedLocatedOrg(t, "Dom Digital GmbH", "Köln", cologneLat, cologneLon, s.Rep)
+
+	result := s.queryPlan(t, `{
+		"version": "v1", "target": "person",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Köln", "radius_km": 50}}]}`)
+
+	if len(result.Rows) != 0 {
+		t.Fatalf("case 4 criterion 7: a radius the product cannot measure returned %d rows, which "+
+			"a caller would read as an ordered nearby list", len(result.Rows))
+	}
+	if !hasNote(result, search.CodeDistanceRankingUnavailable) {
+		t.Fatalf("case 4 criterion 7: an unmeasurable radius returned no note saying so; notes are %v",
+			result.Notes)
+	}
+}
+
+// TestCase4EveryCompanySaysWhoOwnsItByName pins criteria 4 and 5, and it is the
+// criterion this case exists for.
+//
+// Run 1 of the real scenario returned seven correct companies and never said
+// Sofia Meier owned one of them, because the row carried owner_id as a bare
+// uuid — data present, correct, and useless to the person reading it. Two
+// thirds of the accounts in the demo CRM belong to somebody other than the
+// caller, so this is the common case rather than an edge.
+func TestCase4EveryCompanySaysWhoOwnsItByName(t *testing.T) {
+	s := boot(t, scopesRead)
+
+	mine := s.seedLocatedOrg(t, "Dom Digital GmbH", "Köln", cologneLat, cologneLon, s.Rep)
+	theirs := s.seedLocatedOrg(t, "Rheinufer AG", "Köln", cologneLat+0.11, cologneLon, s.Colleague)
+
+	result := s.queryPlan(t, `{
+		"version": "v1", "target": "organization",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Köln", "radius_km": 50}}]}`)
+
+	seen := map[ids.UUID]agents.RecordOwner{}
+	for _, row := range result.Rows {
+		if row.Owner == nil {
+			t.Fatalf("case 4 criterion 4: %s came back with no owner block at all, so a rep cannot "+
+				"tell whose account it is", recordName(t, row.Record.Fields))
+		}
+		if row.Owner.Name == "" {
+			t.Fatalf("case 4 criterion 4: %s names its owner only as %s — an id is not something a "+
+				"rep can act on", recordName(t, row.Record.Fields), row.Owner.ID)
+		}
+		seen[row.Record.ID] = *row.Owner
+	}
+
+	own, ok := seen[mine]
+	if !ok {
+		t.Fatalf("case 4: the company the caller owns is missing from the answer")
+	}
+	if !own.IsYou {
+		t.Fatalf("case 4 criterion 5: the caller's OWN account came back marked as somebody else's "+
+			"(owner %s, is_you=false)", own.Name)
+	}
+	if own.Name != repName {
+		t.Fatalf("case 4 criterion 4: the caller's own account names its owner %q, want %q", own.Name, repName)
+	}
+
+	colleague, ok := seen[theirs]
+	if !ok {
+		t.Fatalf("case 4: the colleague's company is missing from the answer")
+	}
+	if colleague.IsYou {
+		t.Fatalf("case 4 criterion 5: a colleague's account came back marked as the caller's own, " +
+			"which is how a rep walks into somebody else's meeting")
+	}
+	if colleague.Name != colleagueName {
+		t.Fatalf("case 4 criterion 5: the colleague's account names its owner %q, want %q — this is "+
+			"the name the assistant has to say out loud before the rep knocks",
+			colleague.Name, colleagueName)
+	}
+}
+
+// hasNote says whether the answer carries a note with this code.
+func hasNote(result agents.QueryWorkspaceResult, code string) bool {
+	for _, note := range result.Notes {
+		if note.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/integration/e2e/usecases/case4_use_the_moment_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case4_use_the_moment_test.go
@@ -23,9 +23,18 @@ package usecases
 // makes "Cologne" a point. If a real geocoding provider ever becomes the
 // PRIMARY lookup, this suite starts reaching the network — which is a reason to
 // fail loudly, not a reason to soften the fixture.
+//
+// WHAT THIS SUITE DOES NOT COVER. The fixture writes geocode_status='ok' with
+// its coordinates directly, so it exercises the READ side of geocoding and
+// nothing else: the address-to-coordinates writer, its hash check and its
+// ledger row are a separate subsystem with a separate suite, and these tests
+// stay green if that writer breaks. That is the right split — a journey test
+// asserting a geocoding provider's arithmetic would be testing Nominatim — but
+// it does mean "case 4 is green" is not a claim that addresses get geocoded.
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
@@ -91,11 +100,59 @@ func TestCase4TheAssistantCanDiscoverThatAddressesAreSearchableByDistance(t *tes
 	s := boot(t, scopesRead)
 
 	got := s.MCP.CallOK(t, "describe_query_vocabulary", nil)
-	if !containsAll(got.Text, "address", "within_radius") {
-		t.Fatalf("case 4 criterion 1: the vocabulary does not tell a caller that `address` "+
-			"supports `within_radius`, so an assistant asked for who is NEARBY has no way to "+
-			"learn a distance search exists:\n%s", got.Text)
+	var answer agents.DescribeQueryVocabularyResult
+	got.JSON(t, &answer)
+
+	// The two words have to be RELATED, not merely both present. A whole-body
+	// substring search passes while organization radius search is broken, because
+	// the same document advertises an address radius for people — which is
+	// exactly the predicate this case's third test proves unanswerable.
+	if !advertisesOperator(t, answer.Vocabulary, "organization", "address", "within_radius") {
+		t.Fatalf("case 4 criterion 1: the vocabulary does not say that an ORGANIZATION's `address` "+
+			"supports `within_radius`, so an assistant asked who is NEARBY has no way to learn a "+
+			"distance search over companies exists:\n%s", string(answer.Vocabulary))
 	}
+}
+
+// advertisesOperator says whether the vocabulary offers this operator on this
+// record type's field.
+//
+// Decoded into the document's real shape rather than searched as text. The two
+// words being present somewhere is not the claim: `address` supports
+// `within_radius` on PERSON too, and that predicate is the one the third test
+// proves unanswerable — so a substring search passes while company radius
+// search is broken.
+func advertisesOperator(t *testing.T, document json.RawMessage, target, field, operator string) bool {
+	t.Helper()
+	var vocabulary struct {
+		Targets []struct {
+			Target string `json:"target"`
+			Fields []struct {
+				Name string   `json:"name"`
+				Kind string   `json:"kind"`
+				Ops  []string `json:"ops"`
+			} `json:"fields"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(document, &vocabulary); err != nil {
+		t.Fatalf("the query vocabulary does not decode: %v", err)
+	}
+	for _, entry := range vocabulary.Targets {
+		if entry.Target != target {
+			continue
+		}
+		for _, catalogued := range entry.Fields {
+			if catalogued.Name != field {
+				continue
+			}
+			for _, op := range catalogued.Ops {
+				if op == operator {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // TestCase4NearbyCompaniesComeBackNearestFirstAndSayHowComplete pins criteria
@@ -105,35 +162,71 @@ func TestCase4TheAssistantCanDiscoverThatAddressesAreSearchableByDistance(t *tes
 func TestCase4NearbyCompaniesComeBackNearestFirstAndSayHowComplete(t *testing.T) {
 	s := boot(t, scopesRead)
 
-	// Three inside a 50km radius at roughly 0km, 12km and 27km, plus Munich at
-	// ~460km which must be absent.
-	s.seedLocatedOrg(t, "Dom Digital GmbH", "Köln", cologneLat, cologneLon, s.Rep)
-	s.seedLocatedOrg(t, "Rheinufer AG", "Köln", cologneLat+0.11, cologneLon, s.Colleague)
-	s.seedLocatedOrg(t, "Vorort Systeme KG", "Köln", cologneLat+0.25, cologneLon, s.Colleague)
-	s.seedLocatedOrg(t, "München Ferne GmbH", "München", munichLat, munichLon, s.Rep)
+	// Three inside the radius at DIFFERENT distances, plus Munich which must be
+	// absent. The spread matters: companies all at one point would make a
+	// constant-zero distance look correctly ordered.
+	near := s.seedLocatedOrg(t, "Dom Digital GmbH", "Köln", cologneLat, cologneLon, s.Rep)
+	mid := s.seedLocatedOrg(t, "Rheinufer AG", "Köln", cologneLat+0.11, cologneLon, s.Colleague)
+	far := s.seedLocatedOrg(t, "Vorort Systeme KG", "Köln", cologneLat+0.25, cologneLon, s.Colleague)
+	munich := s.seedLocatedOrg(t, "München Ferne GmbH", "München", munichLat, munichLon, s.Rep)
 
 	result := s.queryPlan(t, `{
 		"version": "v1", "target": "organization",
 		"where": [{"field": "address", "op": "within_radius",
 		           "value": {"center": "Köln", "radius_km": 50}}]}`)
 
+	// WHICH companies, not how many. A count check passes on an answer that
+	// includes Munich and drops one of the three, which is a broken radius
+	// returning the right number of wrong rows.
+	got := map[ids.UUID]agents.QueryWorkspaceRow{}
+	for _, row := range result.Rows {
+		got[row.Record.ID] = row
+	}
+	for _, want := range []struct {
+		id   ids.UUID
+		name string
+	}{{near, "Dom Digital GmbH"}, {mid, "Rheinufer AG"}, {far, "Vorort Systeme KG"}} {
+		if _, ok := got[want.id]; !ok {
+			t.Fatalf("case 4 criterion 2: %s is inside the radius and missing from the answer",
+				want.name)
+		}
+	}
+	if _, ok := got[munich]; ok {
+		t.Fatalf("case 4 criterion 2: München Ferne GmbH is ~460km away and came back inside a " +
+			"50km radius")
+	}
 	if len(result.Rows) != 3 {
-		t.Fatalf("case 4 criterion 2: a 50km radius around Köln admitted %d companies, want the 3 "+
-			"inside it (Munich is ~460km away and must not appear):\n%s", len(result.Rows), result.ExecutedPlan)
+		t.Fatalf("case 4 criterion 2: the radius admitted %d companies, want exactly the 3 inside "+
+			"it:\n%s", len(result.Rows), result.ExecutedPlan)
 	}
 
-	// Criterion 2's second half: nearest first. Reading the distances in order
-	// is the assertion — a list that is right but unordered sends a rep to the
-	// far one first.
+	// Real distances, not merely non-decreasing ones. A tool answering a
+	// constant zero for every row is ordered by inspection and tells a rep
+	// nothing, so the fixture's own separation has to show up in the numbers.
+	// The centre is the AVERAGE of these three, so the middle company is the
+	// nearest to it and the two outer ones are further — that is the shape the
+	// resolver produces, not a bug. What matters is that the numbers are
+	// DERIVED: distinct values, spread as far apart as the fixture's own
+	// coordinates are. A tool answering a constant would be ordered by
+	// inspection and would tell a rep nothing.
+	southKM, centreKM, northKM := distanceOf(t, got, near), distanceOf(t, got, mid), distanceOf(t, got, far)
+	if centreKM >= southKM || centreKM >= northKM {
+		t.Fatalf("case 4 criterion 2: the middle company sits at the centroid of the three and "+
+			"should be nearest to it; distances came back as %.1f (south), %.1f (middle), "+
+			"%.1f (north)", southKM, centreKM, northKM)
+	}
+	if spread := math.Max(southKM, northKM) - centreKM; spread < 1 {
+		t.Fatalf("case 4 criterion 2: the companies are tens of kilometres apart and their "+
+			"distances differ by only %.2fkm — the distances are not being measured", spread)
+	}
+
+	// And the ORDER the rows arrived in, which is what a rep reads top-down.
 	var previous float64
 	for i, row := range result.Rows {
-		if row.DistanceKM == nil {
-			t.Fatalf("case 4 criterion 2: row %d (%s) carries no distance, so a caller cannot tell "+
-				"how far it is or trust the order", i, recordName(t, row.Record.Fields))
-		}
 		if *row.DistanceKM < previous {
 			t.Fatalf("case 4 criterion 2: row %d (%s) is %.1fkm out, closer than the row before it "+
-				"at %.1fkm — the answer is not nearest-first", i, recordName(t, row.Record.Fields), *row.DistanceKM, previous)
+				"at %.1fkm — the answer is not nearest-first",
+				i, recordName(t, row.Record.Fields), *row.DistanceKM, previous)
 		}
 		previous = *row.DistanceKM
 	}
@@ -146,6 +239,20 @@ func TestCase4NearbyCompaniesComeBackNearestFirstAndSayHowComplete(t *testing.T)
 			"is a complete answer, and anything else tells the rep to keep looking",
 			result.Coverage, agents.CoverageCompleteExact)
 	}
+}
+
+// distanceOf reads one row's distance, failing when it carries none.
+func distanceOf(t *testing.T, rows map[ids.UUID]agents.QueryWorkspaceRow, id ids.UUID) float64 {
+	t.Helper()
+	row, ok := rows[id]
+	if !ok {
+		t.Fatalf("case 4 criterion 2: record %s is missing from the answer", id)
+	}
+	if row.DistanceKM == nil {
+		t.Fatalf("case 4 criterion 2: %s carries no distance, so a caller cannot tell how far it "+
+			"is or trust the order", recordName(t, row.Record.Fields))
+	}
+	return *row.DistanceKM
 }
 
 // TestCase4ARadiusItCannotMeasureSaysSoInsteadOfAnsweringAnyway pins criterion

--- a/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
@@ -17,16 +17,34 @@ package usecases
 // half and stays out of this suite; what is pinned here is what Margince has to
 // hand back once the account is known.
 //
-// The criteria this file covers are the deterministic ones — every person is
-// named, every event carries its date, a cold account reports a NUMBER, and an
-// empty section says it is empty rather than being filled. Whether a model
-// writes a good briefing from that material is the weekly model lane's
-// question.
+// The criteria this file covers are the deterministic ones: every person is
+// named (4), every event carries its date (3), and a cold account reports a
+// NUMBER rather than "a while ago" (7). Whether a model writes a good briefing
+// from that material is the weekly model lane's question.
+//
+// NOT covered here, and named so the gap is not read as coverage:
+//
+//   - Criterion 1, a briefing found without naming a record. That is the
+//     assistant resolving "Vietnam partner" from a calendar, which is its half.
+//   - Criterion 5, the unkept promise. It needs a model to notice that
+//     something promised was never sent.
+//   - Criterion 9, a caller who may not read a person being refused rather than
+//     shown a blank. AppEnv mints its passport for whoever holds the cookie and
+//     exposes no role control, so the restricted principal cannot be built over
+//     MCP today. networktools_integration_test.go covers it in process.
+//
+// The fixtures write rows directly rather than through log_activity, so what is
+// asserted is the READ side. Two consequences worth stating: the deal link and
+// the participant row are written by hand here because the real logging path
+// writes them, and a coverage rule that reads deal.last_activity_at is silent
+// without the first — which is how three of these tests came to pass against
+// nothing before Codex pointed at them.
 
 import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/network"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -42,11 +60,20 @@ type meetingFixture struct {
 	// them apart.
 	engaged ids.UUID
 	quiet   ids.UUID
+	// exchanges are the activity ids this fixture logged. A test asserting
+	// about events matches on these rather than on a summary: the retriever
+	// renders an email's summary as "email", so prose matching would quietly
+	// match nothing and assert against an empty set.
+	exchanges map[ids.UUID]bool
 }
 
 const (
 	engagedPersonName = "Mai Nguyen"
 	quietPersonName   = "Tobias Kern"
+	// coldDays is how long the cold fixture's account has been silent. Well
+	// past the 30-day threshold, so the finding is not sitting on a boundary
+	// that a clock skew could tip either way.
+	coldDays = 83
 )
 
 // seedMeetingAccount builds the account case 5 asks about.
@@ -85,11 +112,44 @@ func (s *scenario) seedMeetingAccount(t *testing.T) meetingFixture {
 	// Engagement needs traffic in BOTH directions inside the 90-day window, so
 	// a one-sided conversation does not read as a relationship. That asymmetry
 	// is the product's claim and the fixture has to honour it.
-	s.seedDatedActivity(t, "email", "inbound", f.engaged, f.org, daysAgo(20),
-		"Cảm ơn — we will review the appendix this week.")
-	s.seedDatedActivity(t, "email", "outbound", f.engaged, f.org, daysAgo(18),
-		"Ich schicke die Aufstellung mit.")
+	f.exchanges = map[ids.UUID]bool{
+		s.seedDatedActivity(t, "email", "inbound", f.engaged, f.org, f.deal, daysAgo(20),
+			"Cảm ơn — we will review the appendix this week."): true,
+		s.seedDatedActivity(t, "email", "outbound", f.engaged, f.org, f.deal, daysAgo(18),
+			"Ich schicke die Aufstellung mit."): true,
+	}
 
+	return f
+}
+
+// seedColdAccount is an open deal nobody has touched in a long time.
+//
+// Separate from seedMeetingAccount rather than a flag on it: the going-cold
+// finding is about the ABSENCE of recent traffic, and a fixture that seeded
+// both a recent exchange and a cold account would be asserting two contradictory
+// things about one timeline.
+func (s *scenario) seedColdAccount(t *testing.T) meetingFixture {
+	t.Helper()
+	var f meetingFixture
+	pipeline, stage := s.defaultOpenStage(t)
+
+	f.org = s.seedID(t, `INSERT INTO organization (id, owner_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Quiet Partner GmbH', 'manual', 'human:x')`, s.Colleague)
+	f.deal = s.seedID(t, `INSERT INTO deal
+		(id, owner_id, organization_id, pipeline_id, stage_id, name, status, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'Renewal', 'open', 'manual', 'human:x')`,
+		s.Colleague, f.org, pipeline, stage)
+
+	f.engaged = s.seedPerson(t, engagedPersonName, f.org)
+	s.seed(t, `INSERT INTO relationship (id, kind, deal_id, person_id, role, source, captured_by)
+		VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`,
+		ids.NewV7(), f.deal, f.engaged)
+
+	// The one exchange there has ever been, long enough ago to be cold.
+	f.exchanges = map[ids.UUID]bool{
+		s.seedDatedActivity(t, "email", "inbound", f.engaged, f.org, f.deal, daysAgo(coldDays),
+			"We will come back to you after the budget round."): true,
+	}
 	return f
 }
 
@@ -109,18 +169,44 @@ func (s *scenario) seedPerson(t *testing.T, name string, org ids.UUID) ids.UUID 
 // event carries the date it happened, and a briefing that quotes a date from
 // somebody's prose instead of the record is the defect #2059 was merged for.
 func (s *scenario) seedDatedActivity(
-	t *testing.T, kind, direction string, person, org ids.UUID, occurredAt time.Time, body string,
-) {
+	t *testing.T, kind, direction string, person, org, deal ids.UUID, occurredAt time.Time, body string,
+) ids.UUID {
 	t.Helper()
 	id := s.seedID(t, `INSERT INTO activity
 		(id, kind, direction, occurred_at, body, source, captured_by)
 		VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`, kind, direction, occurredAt, body)
+
 	// One link row per target, because activity_link_shape allows exactly one
 	// id per row: a row naming both a person and an organization is refused.
+	//
+	// THE DEAL LINK IS LOAD-BEARING. deal.last_activity_at is maintained by a
+	// trigger on activity_link, and the coverage rules read that column to
+	// decide whether the deal has ever been touched. An exchange linked only
+	// to the person and the company leaves the deal looking untouched, and
+	// every risk that gates on EverTouched stays silent — which is what this
+	// fixture did before Codex pointed at it.
 	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
 		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), id, person)
 	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, organization_id)
 		VALUES ($1, $2, 'organization', $3)`, ids.NewV7(), id, org)
+	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`, ids.NewV7(), id, deal)
+
+	// The participant row every real logging path writes for a person-linked
+	// interaction. Relationship strength and the person graph are projected
+	// from these, so an exchange without one is a conversation the product
+	// cannot see two people having.
+	s.seed(t, `INSERT INTO activity_participant (id, activity_id, person_id, role)
+		VALUES ($1, $2, $3, $4)`, ids.NewV7(), id, person, participantRoleFor(direction))
+	return id
+}
+
+// participantRoleFor names which end of the exchange the contact was on.
+func participantRoleFor(direction string) string {
+	if direction == "inbound" {
+		return "from"
+	}
+	return "to"
 }
 
 // daysAgo is a date the fixture controls, so an assertion about ordering or
@@ -143,6 +229,12 @@ func TestCase5EveryStakeholderIsNamedNotJustIdentified(t *testing.T) {
 	var answer agents.DealCoverageAnswer
 	got.JSON(t, &answer)
 
+	// The answer must be ABOUT the deal that was asked for. The fixture holds
+	// one deal, so a tool ignoring deal_id entirely would otherwise pass every
+	// other assertion in this file.
+	if answer.DealID != f.deal {
+		t.Fatalf("case 5: asked about deal %s, answered about %s", f.deal, answer.DealID)
+	}
 	if len(answer.Stakeholders) != 2 {
 		t.Fatalf("case 5 criterion 4: the deal has 2 seats, coverage reported %d",
 			len(answer.Stakeholders))
@@ -181,8 +273,12 @@ func TestCase5EveryStakeholderIsNamedNotJustIdentified(t *testing.T) {
 //
 // A finding that says "the deal rests on one relationship" and lists a uuid
 // makes the rep go look the name up, which is the work the tool exists to save.
-// The names travel PAIRED with their ids in one object rather than as a second
-// array, so the two cannot misalign under a concurrent write.
+//
+// The fixture is built so a finding MUST exist: one engaged contact on an open
+// deal is single_threaded_theirs, and it carries the person it is about. The
+// test demands that finding by name rather than looping over whatever came
+// back — a loop over an empty list asserts nothing, and risk generation could
+// be deleted without this test noticing.
 func TestCase5AFindingNamesThePeopleItIsAbout(t *testing.T) {
 	s := boot(t, scopesRead)
 	f := s.seedMeetingAccount(t)
@@ -191,49 +287,156 @@ func TestCase5AFindingNamesThePeopleItIsAbout(t *testing.T) {
 	var answer agents.DealCoverageAnswer
 	got.JSON(t, &answer)
 
-	for _, risk := range answer.Risks {
-		for _, person := range risk.People {
-			if person.Name == "" {
-				t.Fatalf("case 5 criterion 4: the %q finding names person %s with no name",
-					risk.Kind, person.PersonID)
-			}
+	risk, ok := riskOfKind(answer, network.RiskSingleThreadedTheirs)
+	if !ok {
+		t.Fatalf("case 5 criterion 4: the deal has exactly one engaged contact, so %q must be "+
+			"reported; findings were %v", network.RiskSingleThreadedTheirs, kindsOf(answer.Risks))
+	}
+	if len(risk.People) == 0 {
+		t.Fatalf("case 5 criterion 4: the %q finding names nobody, so a rep is told the deal rests "+
+			"on one relationship without being told whose", risk.Kind)
+	}
+
+	// The pairing is the assertion, not the two lengths. Names travel INSIDE
+	// one object with their ids precisely so a consumer cannot attach the
+	// wrong name to the wrong person — checking only that the lists are the
+	// same length would pass on exactly the misattribution the shape prevents.
+	for _, person := range risk.People {
+		if person.Name == "" {
+			t.Fatalf("case 5 criterion 4: the %q finding names person %s with no name",
+				risk.Kind, person.PersonID)
 		}
-		// The paired object is what makes misalignment structurally
-		// impossible, so a finding carrying ids and no pairs is the regression
-		// this pins — not merely a cosmetic gap.
-		if len(risk.PersonIDs) > 0 && len(risk.People) != len(risk.PersonIDs) {
-			t.Fatalf("case 5 criterion 4: the %q finding lists %d person ids but %d named people; "+
-				"a consumer indexing across the two would attach the wrong name to the wrong person",
-				risk.Kind, len(risk.PersonIDs), len(risk.People))
+		if person.PersonID != f.engaged {
+			t.Fatalf("case 5 criterion 4: the %q finding is about %s, but the only engaged contact "+
+				"on this deal is %s", risk.Kind, person.PersonID, f.engaged)
+		}
+		if person.Name != engagedPersonName {
+			t.Fatalf("case 5 criterion 4: person %s is named %q in the finding and %q in the CRM — "+
+				"a rep repeating that sentence names the wrong human",
+				person.PersonID, person.Name, engagedPersonName)
 		}
 	}
 }
 
-// TestCase5AWithheldSectionSaysSoRatherThanLookingEmpty pins criterion 6 and
-// half of the cross-cutting refusal rule.
+// TestCase5AColdAccountReportsHowManyDays pins criterion 7.
 //
-// A model handed no seats and no findings writes "the deal looks well covered"
-// in a sentence a rep then acts on. An empty section and a withheld one have to
-// be different answers on the wire.
-func TestCase5AWithheldSectionSaysSoRatherThanLookingEmpty(t *testing.T) {
+// "83 days since contact" and "some time ago" are different answers, and only
+// the first tells a rep whether to worry. The fixture's last touch is old
+// enough to be cold and recent enough that the number is checkable.
+func TestCase5AColdAccountReportsHowManyDays(t *testing.T) {
 	s := boot(t, scopesRead)
-	f := s.seedMeetingAccount(t)
+	f := s.seedColdAccount(t)
 
 	got := s.MCP.CallOK(t, "account_coverage", map[string]any{"deal_id": f.deal.String()})
 	var answer agents.DealCoverageAnswer
 	got.JSON(t, &answer)
 
-	// This caller holds the grants, so nothing is withheld — and the field must
-	// still be present rather than null, because a reader cannot tell "nothing
-	// withheld" from "not computed" when the answer is absent.
-	if answer.SectionsOmitted == nil {
-		t.Fatalf("case 5 criterion 6: sections_omitted came back null; a caller cannot tell " +
-			"'nothing was withheld' from 'this was not computed'")
+	risk, ok := riskOfKind(answer, network.RiskGoingCold)
+	if !ok {
+		t.Fatalf("case 5 criterion 7: nothing has touched this deal in %d days and no %q finding "+
+			"was reported; findings were %v", coldDays, network.RiskGoingCold, kindsOf(answer.Risks))
 	}
-	if len(answer.SectionsOmitted) != 0 {
-		t.Fatalf("case 5: a fully granted caller was told sections were withheld: %v",
-			answer.SectionsOmitted)
+	if risk.DaysSinceTouch == nil {
+		t.Fatalf("case 5 criterion 7: the account is reported cold with no number, so a rep cannot " +
+			"tell a fortnight from half a year")
 	}
+	// A day either side, because the fixture stamps a timestamp and the
+	// product counts whole days from it.
+	if *risk.DaysSinceTouch < coldDays-1 || *risk.DaysSinceTouch > coldDays+1 {
+		t.Fatalf("case 5 criterion 7: last touch was %d days ago, reported as %d",
+			coldDays, *risk.DaysSinceTouch)
+	}
+}
+
+// TestCase5EveryEventCarriesTheDateItHappened pins criterion 3, the half of
+// #2059 that lives on the server.
+//
+// A briefing that dates an event from somebody's prose instead of from the
+// record is the defect that issue was merged for: a loss post-mortem written
+// months later said "im Oktober" about an email dated in September, and a
+// briefing holding only the prose repeats that to the customer. Whether a model
+// PREFERS the record when the two disagree is the weekly lane's question; this
+// pins that the date is there to prefer.
+func TestCase5EveryEventCarriesTheDateItHappened(t *testing.T) {
+	s := boot(t, scopesRead)
+	f := s.seedMeetingAccount(t)
+
+	got := s.MCP.CallOK(t, "prep_for_meeting", map[string]any{
+		"record_type": "deal",
+		"record_id":   f.deal.String(),
+	})
+	var answer agents.PrepForMeetingResult
+	got.JSON(t, &answer)
+
+	items := briefingItems(answer.Briefing)
+	if len(items) == 0 {
+		t.Fatalf("case 5 criterion 3: the account has two logged exchanges and the briefing carries "+
+			"no items across %d sections, so there is nothing for a date to be on (deal %s)",
+			len(answer.Briefing.Sections), f.deal)
+	}
+	// An item that is not an event legitimately carries no date, so the
+	// assertion is about the ones that are. They are identified by the ACTIVITY
+	// ids the fixture wrote rather than by their summaries: the retriever
+	// summarises an email as "email", so matching on prose would silently match
+	// nothing and the loop would assert against an empty set.
+	dated := 0
+	for _, item := range items {
+		if !f.exchanges[item.RecordID] {
+			continue
+		}
+		if item.OccurredAt == nil {
+			t.Fatalf("case 5 criterion 3: the item summarising %q carries no occurred_at, so a "+
+				"briefing has nothing to date it by except the prose in its body", item.Summary)
+		}
+		if item.OccurredAt.IsZero() {
+			t.Fatalf("case 5 criterion 3: %q is dated to the zero time", item.Summary)
+		}
+		dated++
+	}
+	if dated == 0 {
+		t.Fatalf("case 5 criterion 3: neither seeded exchange reached the briefing, so the date "+
+			"assertion ran against nothing; items were %v", summariesOf(items))
+	}
+}
+
+// briefingItems flattens the briefing's sections. The section NAMES are the
+// retriever's own and not a closed set, so a test that named one would break
+// when the retriever renamed it — the assertion is about the dates, not the
+// grouping.
+func briefingItems(briefing agents.AssembledContextResult) []agents.ContextItem {
+	var out []agents.ContextItem
+	for _, section := range briefing.Sections {
+		out = append(out, section.Items...)
+	}
+	return out
+}
+
+// summariesOf names what the briefing DID carry, for a failure worth reading.
+func summariesOf(items []agents.ContextItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.Summary)
+	}
+	return out
+}
+
+// riskOfKind finds one finding by kind.
+func riskOfKind(answer agents.DealCoverageAnswer, kind string) (agents.CoverageRisk, bool) {
+	for _, risk := range answer.Risks {
+		if risk.Kind == kind {
+			return risk, true
+		}
+	}
+	return agents.CoverageRisk{}, false
+}
+
+// kindsOf names what WAS reported, for a failure message that says so.
+func kindsOf(risks []agents.CoverageRisk) []string {
+	out := make([]string, 0, len(risks))
+	for _, risk := range risks {
+		out = append(out, risk.Kind)
+	}
+	return out
 }
 
 // keysOf names what a map held, for a failure message that says what WAS there.

--- a/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 5 — Before the meeting.
+//
+// The prompt, spoken, from the run this was written against:
+//
+//	Hey. Tomorrow I'm meeting, uh, finally, Vietnam partner. Could check in
+//	my calendar. Can you prep me for the meeting? Check in the CRM.
+//
+// It names no record, no id and no tool. "Vietnam partner" is not the account's
+// name. Reading the calendar and working out which meeting is the assistant's
+// half and stays out of this suite; what is pinned here is what Margince has to
+// hand back once the account is known.
+//
+// The criteria this file covers are the deterministic ones — every person is
+// named, every event carries its date, a cold account reports a NUMBER, and an
+// empty section says it is empty rather than being filled. Whether a model
+// writes a good briefing from that material is the weekly model lane's
+// question.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// meetingFixture is the account a briefing is asked about: a deal, the people
+// on it, and the exchange history that decides who counts as engaged.
+type meetingFixture struct {
+	org  ids.UUID
+	deal ids.UUID
+	// engaged has traffic both ways inside the window; quiet has none. The
+	// pair is the fixture's whole point — "everyone is engaged" and "nobody is"
+	// are both answers a bug can produce, and only a mixed account can tell
+	// them apart.
+	engaged ids.UUID
+	quiet   ids.UUID
+}
+
+const (
+	engagedPersonName = "Mai Nguyen"
+	quietPersonName   = "Tobias Kern"
+)
+
+// seedMeetingAccount builds the account case 5 asks about.
+//
+// The deal is owned by the COLLEAGUE rather than the caller, because the real
+// run's most useful sentence was that the account belongs to somebody else and
+// the rep should clear it with them first.
+func (s *scenario) seedMeetingAccount(t *testing.T) meetingFixture {
+	t.Helper()
+	var f meetingFixture
+
+	// The installation already ships a default pipeline with its stages. A
+	// scenario inserts none of its own: a second pipeline named 'Sales' is
+	// refused by pipeline_name_unique, and a second DEFAULT one would be a
+	// state the product cannot reach.
+	pipeline, stage := s.defaultOpenStage(t)
+
+	f.org = s.seedID(t, `INSERT INTO organization (id, owner_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Vietnam Partner JSC', 'manual', 'human:x')`, s.Colleague)
+	f.deal = s.seedID(t, `INSERT INTO deal
+		(id, owner_id, organization_id, pipeline_id, stage_id, name, status, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'Distribution agreement', 'open', 'manual', 'human:x')`,
+		s.Colleague, f.org, pipeline, stage)
+
+	f.engaged = s.seedPerson(t, engagedPersonName, f.org)
+	f.quiet = s.seedPerson(t, quietPersonName, f.org)
+
+	// Both are seats on the deal. Only one of them has spoken.
+	s.seed(t, `INSERT INTO relationship (id, kind, deal_id, person_id, role, source, captured_by)
+		VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`,
+		ids.NewV7(), f.deal, f.engaged)
+	s.seed(t, `INSERT INTO relationship (id, kind, deal_id, person_id, role, source, captured_by)
+		VALUES ($1, 'deal_stakeholder', $2, $3, 'economic_buyer', 'manual', 'human:x')`,
+		ids.NewV7(), f.deal, f.quiet)
+
+	// Engagement needs traffic in BOTH directions inside the 90-day window, so
+	// a one-sided conversation does not read as a relationship. That asymmetry
+	// is the product's claim and the fixture has to honour it.
+	s.seedDatedActivity(t, "email", "inbound", f.engaged, f.org, daysAgo(20),
+		"Cảm ơn — we will review the appendix this week.")
+	s.seedDatedActivity(t, "email", "outbound", f.engaged, f.org, daysAgo(18),
+		"Ich schicke die Aufstellung mit.")
+
+	return f
+}
+
+// seedPerson adds a contact employed at the organization.
+func (s *scenario) seedPerson(t *testing.T, name string, org ids.UUID) ids.UUID {
+	t.Helper()
+	id := s.seedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, $3, 'manual', 'human:x')`, s.Colleague, name)
+	s.seed(t, `INSERT INTO relationship (id, kind, person_id, organization_id, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, ids.NewV7(), id, org)
+	return id
+}
+
+// seedDatedActivity logs one exchange with an explicit date.
+//
+// The date is the fixture's reason for existing. Criterion 3 is that every
+// event carries the date it happened, and a briefing that quotes a date from
+// somebody's prose instead of the record is the defect todo 33 was about.
+func (s *scenario) seedDatedActivity(
+	t *testing.T, kind, direction string, person, org ids.UUID, occurredAt time.Time, body string,
+) {
+	t.Helper()
+	id := s.seedID(t, `INSERT INTO activity
+		(id, kind, direction, occurred_at, body, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`, kind, direction, occurredAt, body)
+	// One link row per target, because activity_link_shape allows exactly one
+	// id per row: a row naming both a person and an organization is refused.
+	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), id, person)
+	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, organization_id)
+		VALUES ($1, $2, 'organization', $3)`, ids.NewV7(), id, org)
+}
+
+// daysAgo is a date the fixture controls, so an assertion about ordering or
+// staleness does not depend on when the suite runs.
+func daysAgo(days int) time.Time {
+	return time.Now().UTC().AddDate(0, 0, -days)
+}
+
+// TestCase5EveryStakeholderIsNamedNotJustIdentified pins criterion 4, and it is
+// the criterion this case exists for.
+//
+// Before #2766 the seats came back as bare uuids: a coverage answer saying
+// "economic_buyer, not engaged" against an id has not told a rep who to bring
+// into the room. The data was correct and unusable in a sentence.
+func TestCase5EveryStakeholderIsNamedNotJustIdentified(t *testing.T) {
+	s := boot(t, scopesRead)
+	f := s.seedMeetingAccount(t)
+
+	got := s.MCP.CallOK(t, "account_coverage", map[string]any{"deal_id": f.deal.String()})
+	var answer agents.DealCoverageAnswer
+	got.JSON(t, &answer)
+
+	if len(answer.Stakeholders) != 2 {
+		t.Fatalf("case 5 criterion 4: the deal has 2 seats, coverage reported %d",
+			len(answer.Stakeholders))
+	}
+	byName := map[string]agents.CoverageSeat{}
+	for _, seat := range answer.Stakeholders {
+		if seat.PersonName == "" {
+			t.Fatalf("case 5 criterion 4: the %s seat came back as %s with no name — a rep cannot "+
+				"be told who to bring into the room", seat.Role, seat.PersonID)
+		}
+		byName[seat.PersonName] = seat
+	}
+
+	// Criterion 7's other half: engaged and quiet must be told apart. A tool
+	// that marked everyone engaged would pass a name check and still tell the
+	// rep the deal is covered when it is not.
+	engaged, ok := byName[engagedPersonName]
+	if !ok {
+		t.Fatalf("case 5 criterion 4: the engaged stakeholder is missing; got %v", keysOf(byName))
+	}
+	if !engaged.Engaged {
+		t.Fatalf("case 5: %s has traffic both ways inside the window and is reported as not engaged",
+			engagedPersonName)
+	}
+	quiet, ok := byName[quietPersonName]
+	if !ok {
+		t.Fatalf("case 5 criterion 4: the quiet stakeholder is missing; got %v", keysOf(byName))
+	}
+	if quiet.Engaged {
+		t.Fatalf("case 5: %s has never spoken and is reported as engaged, which tells a rep the "+
+			"economic buyer is covered when nobody has heard from them", quietPersonName)
+	}
+}
+
+// TestCase5AFindingNamesThePeopleItIsAbout pins criterion 4's second half.
+//
+// A finding that says "the deal rests on one relationship" and lists a uuid
+// makes the rep go look the name up, which is the work the tool exists to save.
+// The names travel PAIRED with their ids in one object rather than as a second
+// array, so the two cannot misalign under a concurrent write.
+func TestCase5AFindingNamesThePeopleItIsAbout(t *testing.T) {
+	s := boot(t, scopesRead)
+	f := s.seedMeetingAccount(t)
+
+	got := s.MCP.CallOK(t, "account_coverage", map[string]any{"deal_id": f.deal.String()})
+	var answer agents.DealCoverageAnswer
+	got.JSON(t, &answer)
+
+	for _, risk := range answer.Risks {
+		for _, person := range risk.People {
+			if person.Name == "" {
+				t.Fatalf("case 5 criterion 4: the %q finding names person %s with no name",
+					risk.Kind, person.PersonID)
+			}
+		}
+		// The paired object is what makes misalignment structurally
+		// impossible, so a finding carrying ids and no pairs is the regression
+		// this pins — not merely a cosmetic gap.
+		if len(risk.PersonIDs) > 0 && len(risk.People) != len(risk.PersonIDs) {
+			t.Fatalf("case 5 criterion 4: the %q finding lists %d person ids but %d named people; "+
+				"a consumer indexing across the two would attach the wrong name to the wrong person",
+				risk.Kind, len(risk.PersonIDs), len(risk.People))
+		}
+	}
+}
+
+// TestCase5AWithheldSectionSaysSoRatherThanLookingEmpty pins criterion 6 and
+// half of the cross-cutting refusal rule.
+//
+// A model handed no seats and no findings writes "the deal looks well covered"
+// in a sentence a rep then acts on. An empty section and a withheld one have to
+// be different answers on the wire.
+func TestCase5AWithheldSectionSaysSoRatherThanLookingEmpty(t *testing.T) {
+	s := boot(t, scopesRead)
+	f := s.seedMeetingAccount(t)
+
+	got := s.MCP.CallOK(t, "account_coverage", map[string]any{"deal_id": f.deal.String()})
+	var answer agents.DealCoverageAnswer
+	got.JSON(t, &answer)
+
+	// This caller holds the grants, so nothing is withheld — and the field must
+	// still be present rather than null, because a reader cannot tell "nothing
+	// withheld" from "not computed" when the answer is absent.
+	if answer.SectionsOmitted == nil {
+		t.Fatalf("case 5 criterion 6: sections_omitted came back null; a caller cannot tell " +
+			"'nothing was withheld' from 'this was not computed'")
+	}
+	if len(answer.SectionsOmitted) != 0 {
+		t.Fatalf("case 5: a fully granted caller was told sections were withheld: %v",
+			answer.SectionsOmitted)
+	}
+}
+
+// keysOf names what a map held, for a failure message that says what WAS there.
+func keysOf(m map[string]agents.CoverageSeat) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case5_before_the_meeting_test.go
@@ -107,7 +107,7 @@ func (s *scenario) seedPerson(t *testing.T, name string, org ids.UUID) ids.UUID 
 //
 // The date is the fixture's reason for existing. Criterion 3 is that every
 // event carries the date it happened, and a briefing that quotes a date from
-// somebody's prose instead of the record is the defect todo 33 was about.
+// somebody's prose instead of the record is the defect #2059 was merged for.
 func (s *scenario) seedDatedActivity(
 	t *testing.T, kind, direction string, person, org ids.UUID, occurredAt time.Time, body string,
 ) {

--- a/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
@@ -31,6 +31,8 @@ package usecases
 // conclusion the records support without stating.
 
 import (
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +49,9 @@ const (
 	// thePostMortemSays is a note written months later. It is WRONG about the
 	// month, exactly as a real post-mortem was.
 	thePostMortemSays = "Der Kunde hat das im Oktober klar angesprochen; wir haben zu spät reagiert."
+	// theWrongMonth is what the prose claims. The record says otherwise, and
+	// that disagreement is the entire fixture.
+	theWrongMonth = "Oktober"
 	// sharedAccountWord is what the sweep matches all three accounts on.
 	//
 	// It sits in the DISPLAY NAME because that is the only organization text
@@ -90,8 +95,9 @@ func (s *scenario) seedContradiction(t *testing.T) pastCase {
 
 // seedTwoMorePastCases gives the sweep more than one thing to find, so
 // criterion 4 has something to be about.
-func (s *scenario) seedTwoMorePastCases(t *testing.T) {
+func (s *scenario) seedTwoMorePastCases(t *testing.T) []pastCase {
 	t.Helper()
+	var out []pastCase
 	for _, account := range []struct{ company, complaint string }{
 		{"valantic AG", "Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort."},
 		{"Körber Digital GmbH", "Der Tiefpunkt war nicht der Fehler selbst, sondern dass niemand sich meldete."},
@@ -101,8 +107,12 @@ func (s *scenario) seedTwoMorePastCases(t *testing.T) {
 			VALUES ($1, $2, $3, 'Managed Services', 'manual', 'human:x')`,
 			s.Colleague, account.company+" "+sharedAccountWord)
 		person := s.seedPerson(t, "Kontakt "+account.company, org)
-		s.seedOrgActivity(t, "email", "inbound", person, org, daysAgo(200), account.complaint)
+		out = append(out, pastCase{
+			org:       org,
+			complaint: s.seedOrgActivity(t, "email", "inbound", person, org, daysAgo(200), account.complaint),
+		})
 	}
+	return out
 }
 
 // seedOrgActivity logs one dated activity against a company and a person.
@@ -110,6 +120,13 @@ func (s *scenario) seedTwoMorePastCases(t *testing.T) {
 // No deal here, unlike case 5's helper: this case is about a company's history
 // rather than about a deal's coverage, and a deal the scenario never asks about
 // would be a row nothing reads.
+//
+// The provenance is SYNTHETIC and deliberately so. A real write derives
+// captured_by from the authenticated principal and stamps an actor participant
+// beside the linked people; this fixture writes neither, because what case 6
+// asserts is retrieval and dates rather than provenance. Case 1 is where the
+// write path itself is under test, and it inserts nothing by hand. Say it here
+// so a later assertion about who captured a record is not built on this.
 func (s *scenario) seedOrgActivity(
 	t *testing.T, kind, direction string, person, org ids.UUID, occurredAt time.Time, body string,
 ) ids.UUID {
@@ -137,14 +154,17 @@ func (s *scenario) seedOrgActivity(
 // TestCase6BothTheRecordAndTheProseReachTheCaller pins criterion 3's server
 // half.
 //
-// The contradiction is the fixture's whole point. If only the note came back,
-// the assistant would have no dated record to prefer and "the answer said
-// October" would be the product's fault rather than the model's. Both have to
-// arrive, and the dated one has to carry its date.
+// The assertion is about the WORDS, not about two ids appearing in a list.
+// catch_me_up_on summarises an activity as its subject or its kind — never its
+// body (search/graph.go's timeline query) — so a test reading only that surface
+// passes with the contradiction deleted, which is what an earlier version of
+// this test did. The prose reaches a caller through read_record, so that is
+// where it is asserted.
 func TestCase6BothTheRecordAndTheProseReachTheCaller(t *testing.T) {
 	s := boot(t, scopesRead)
 	c := s.seedContradiction(t)
 
+	// The timeline is how an assistant FINDS the two activities.
 	got := s.MCP.CallOK(t, "catch_me_up_on", map[string]any{
 		"record_type": "organization", "record_id": c.org.String(),
 	})
@@ -156,19 +176,29 @@ func TestCase6BothTheRecordAndTheProseReachTheCaller(t *testing.T) {
 	for _, item := range items {
 		byID[item.RecordID] = item
 	}
-
 	record, hasRecord := byID[c.complaint]
 	if !hasRecord {
-		t.Fatalf("case 6 criterion 3: the dated email did not reach the caller, so an assistant "+
-			"answering about this account has only the note's prose to date it by; items were %v",
-			summariesOf(items))
+		t.Fatalf("case 6 criterion 3: the dated email is not on the timeline, so an assistant has "+
+			"nothing to read; items were %v", summariesOf(items))
 	}
 	if _, hasProse := byID[c.postMortem]; !hasProse {
-		t.Fatalf("case 6 criterion 3: the post-mortem note did not reach the caller, so the " +
+		t.Fatalf("case 6 criterion 3: the post-mortem note is not on the timeline, so the " +
 			"contradiction this fixture exists to create was never presented")
 	}
 
-	// The record's own date, which is what makes preferring it possible.
+	// And this is the assertion that binds: the actual words, both of them.
+	// Corrupting either body now fails, where checking ids alone did not.
+	if body := s.activityBody(t, c.complaint); !strings.Contains(body, theRecordSays) {
+		t.Fatalf("case 6 criterion 3: the complaint's own words did not reach the caller; the "+
+			"record read back as %q", body)
+	}
+	if body := s.activityBody(t, c.postMortem); !strings.Contains(body, thePostMortemSays) {
+		t.Fatalf("case 6 criterion 3: the post-mortem's prose did not reach the caller, so nothing "+
+			"contradicts the record and the case tests nothing; it read back as %q", body)
+	}
+
+	// The record's own date, which is what makes preferring it possible. The
+	// prose says a different month; only one of them is a fact.
 	if record.OccurredAt == nil {
 		t.Fatalf("case 6 criterion 2: the complaint email carries no occurred_at; a model holding " +
 			"an undated record and a note that says 'im Oktober' will say October")
@@ -178,6 +208,37 @@ func TestCase6BothTheRecordAndTheProseReachTheCaller(t *testing.T) {
 		t.Fatalf("case 6 criterion 2: the complaint is dated %s and the record says %s",
 			wantMonth, got)
 	}
+	// The fixture is only a fixture if the two genuinely disagree. This guards
+	// the TEST rather than the product: a prose line that stopped naming a
+	// month, or started naming the right one, would leave every assertion above
+	// passing while the case tested nothing.
+	if !strings.Contains(thePostMortemSays, theWrongMonth) {
+		t.Fatalf("case 6: the post-mortem prose no longer names %q, so there is no contradiction "+
+			"for a model to resolve and this case proves nothing", theWrongMonth)
+	}
+	if strings.EqualFold(theWrongMonth, wantMonth.String()) {
+		t.Fatalf("case 6: the prose names %s and so does the record — the fixture has to disagree "+
+			"with itself for the criterion to mean anything", theWrongMonth)
+	}
+}
+
+// activityBody reads one activity's body back through the tool surface.
+//
+// Through read_record rather than out of Postgres, deliberately: the criterion
+// is that the words reach the CALLER, and a row holding the right text that no
+// tool returns is exactly the class of defect this suite exists to catch.
+func (s *scenario) activityBody(t *testing.T, activity ids.UUID) string {
+	t.Helper()
+	got := s.MCP.CallOK(t, "read_record", map[string]any{
+		"record_type": "activity", "id": activity.String(),
+	})
+	var record struct {
+		Fields struct {
+			Body string `json:"body"`
+		} `json:"fields"`
+	}
+	got.JSON(t, &record)
+	return record.Fields.Body
 }
 
 // TestCase6EveryEventCarriesItsOwnDate pins criterion 2.
@@ -212,15 +273,21 @@ func TestCase6EveryEventCarriesItsOwnDate(t *testing.T) {
 	}
 }
 
-// TestCase6EverythingRelevantReachesTheCallerNotJustTheTopHit pins criterion 4.
+// TestCase6EveryPastCaseReachesTheCallerWithItsHistory pins criterion 4.
 //
-// Three past cases exist, so three past cases have to be available. An answer
-// carrying the single best match would let an assistant say "this happened
-// once" about a pattern.
-func TestCase6EverythingRelevantReachesTheCallerNotJustTheTopHit(t *testing.T) {
+// Three accounts lived through this, and all three have to arrive WITH the
+// complaint that makes them relevant. An earlier version searched organization
+// names for a token the fixture planted there, which proved only that lexical
+// search works: breaking the link between a complaint and its company would not
+// have failed it.
+//
+// So the sweep finds the accounts, and then each one's own history is read
+// back. That second half is the criterion — "everything relevant reaches the
+// caller" is about the evidence, not about the names.
+func TestCase6EveryPastCaseReachesTheCallerWithItsHistory(t *testing.T) {
 	s := boot(t, scopesRead)
-	s.seedContradiction(t)
-	s.seedTwoMorePastCases(t)
+	first := s.seedContradiction(t)
+	more := s.seedTwoMorePastCases(t)
 
 	got := s.MCP.CallOK(t, "search_context", map[string]any{
 		"query":        sharedAccountWord,
@@ -230,40 +297,48 @@ func TestCase6EverythingRelevantReachesTheCallerNotJustTheTopHit(t *testing.T) {
 	var answer agents.SearchContextResult
 	got.JSON(t, &answer)
 
-	companies := map[string]bool{}
+	found := map[ids.UUID]bool{}
 	for _, hit := range answer.Hits {
-		companies[recordName(t, hit.Record.Fields)] = true
+		found[hit.Record.ID] = true
 	}
-	for _, want := range []string{
-		"Reply Deutschland " + sharedAccountWord,
-		"valantic AG " + sharedAccountWord,
-		"Körber Digital GmbH " + sharedAccountWord,
-	} {
-		if !companies[want] {
-			t.Fatalf("case 6 criterion 4: %s lived through this and is missing from the answer, so "+
-				"an assistant would call a pattern a one-off; the answer named %v",
-				want, keysOfSet(companies))
+	for _, account := range append([]pastCase{first}, more...) {
+		if !found[account.org] {
+			t.Fatalf("case 6 criterion 4: %s lived through this and is missing from the sweep, so "+
+				"an assistant would call a pattern a one-off",
+				s.readString(t, "organization", "display_name", account.org))
+		}
+		// The complaint itself, through the timeline. A company that arrives
+		// with no history attached is a name, not a past case.
+		if !s.hasComplaintOnTimeline(t, account) {
+			t.Fatalf("case 6 criterion 4: %s came back with no complaint on its timeline — the "+
+				"account is named and the evidence that makes it relevant is not there",
+				s.readString(t, "organization", "display_name", account.org))
 		}
 	}
 
 	// The tool never claims a complete match set — a ranked page is the top of
-	// an ordering. It has to SAY that rather than let a caller read the page as
-	// everything there is.
-	if answer.Coverage == "" {
-		t.Fatalf("case 6 criterion 4: the answer states no coverage, so a caller cannot tell a " +
-			"ranked page from a complete one")
-	}
-	if answer.Coverage == agents.CoverageCompleteExact {
-		t.Fatalf("case 6 criterion 4: a ranked sweep reported %q, a claim this tool never makes",
-			answer.Coverage)
+	// an ordering. It has to say WHICH class it is, from the closed set it
+	// publishes; an unrecognised word tells a caller nothing.
+	if !slices.Contains([]string{agents.CoverageRankedSemantic, agents.CoveragePartialDegraded},
+		answer.Coverage) {
+		t.Fatalf("case 6 criterion 4: coverage is %q, which is not one of the classes this tool "+
+			"publishes — a caller branching on it cannot act", answer.Coverage)
 	}
 }
 
-// keysOfSet names what a set held.
-func keysOfSet(set map[string]bool) []string {
-	out := make([]string, 0, len(set))
-	for k := range set {
-		out = append(out, k)
+// hasComplaintOnTimeline reads an account's history back and says whether the
+// complaint that makes it a past case is on it.
+func (s *scenario) hasComplaintOnTimeline(t *testing.T, account pastCase) bool {
+	t.Helper()
+	got := s.MCP.CallOK(t, "catch_me_up_on", map[string]any{
+		"record_type": "organization", "record_id": account.org.String(),
+	})
+	var answer agents.AssembledContextResult
+	got.JSON(t, &answer)
+	for _, item := range briefingItems(answer) {
+		if item.RecordID == account.complaint {
+			return true
+		}
 	}
-	return out
+	return false
 }

--- a/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// CASE 6 — Ask the company.
+//
+// The prompt, spoken, naming no company, no person, no date and no record:
+//
+//	We are about to change the account manager on one of our major
+//	accounts, and in the past customers complained if we swapped the
+//	responsible people too much. Did we have it in the past, what happened,
+//	how did we react, what should I be prepared for? Is there something we
+//	can learn? Check in our CRM.
+//
+// The fixture is built around ONE deliberate contradiction, because criterion 3
+// cannot pass unless it can fail: an email dated in September, and a
+// post-mortem note whose prose says the complaint was raised "im Oktober". Both
+// reach the caller. The record is right and the prose is wrong, and a briefing
+// holding only the prose repeats October to the customer.
+//
+// What this suite pins is that the assistant HAS the choice — every event
+// carries its own date, and every matching record reaches the caller rather
+// than only the top one. Whether a model then prefers the record over the prose
+// is criterion 3's other half and belongs to the weekly lane.
+//
+// NOT covered here: criteria 1 and 5, which are both about a model — finding
+// the right history from a description that names nothing, and drawing a
+// conclusion the records support without stating.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The contradiction the fixture is built around.
+const (
+	// complaintDaysAgo puts the email in a month the note then misremembers.
+	complaintDaysAgo = 340
+	// theRecordSays is in the email body — what actually happened, when.
+	theRecordSays = "Der ständige Wechsel der Ansprechpartner ist für uns ein echtes Problem."
+	// thePostMortemSays is a note written months later. It is WRONG about the
+	// month, exactly as a real post-mortem was.
+	thePostMortemSays = "Der Kunde hat das im Oktober klar angesprochen; wir haben zu spät reagiert."
+	// sharedAccountWord is what the sweep matches all three accounts on.
+	//
+	// It sits in the DISPLAY NAME because that is the only organization text
+	// the lexical lane reads (search/store.go's searchBranches), and this
+	// harness binds no embedding lane — so the answer degrades to lexical and
+	// ranks on literal words. A query phrased as a complaint would rank
+	// nothing, which is a fact about how this deployment is composed rather
+	// than about the history.
+	//
+	// The point being tested is still the right one: THREE accounts match and
+	// all three have to come back, because an answer carrying only the best
+	// one lets an assistant call a pattern a one-off.
+	sharedAccountWord = "Betreuerwechsel"
+)
+
+// pastCase is one account that lived through an account-manager change.
+type pastCase struct {
+	org        ids.UUID
+	complaint  ids.UUID
+	postMortem ids.UUID
+}
+
+// seedContradiction builds the account whose record and prose disagree.
+func (s *scenario) seedContradiction(t *testing.T) pastCase {
+	t.Helper()
+	var c pastCase
+	c.org = s.seedID(t, `INSERT INTO organization
+		(id, owner_id, display_name, industry, source, captured_by)
+		VALUES ($1, $2, $3, 'Managed Services', 'manual', 'human:x')`,
+		s.Colleague, "Reply Deutschland "+sharedAccountWord)
+	person := s.seedPerson(t, "Katrin Sommer", c.org)
+
+	// The email, dated. This is the record.
+	c.complaint = s.seedOrgActivity(t, "email", "inbound", person, c.org,
+		daysAgo(complaintDaysAgo), theRecordSays)
+	// The note, written later, wrong about the month. This is the prose.
+	c.postMortem = s.seedOrgActivity(t, "note", "", person, c.org,
+		daysAgo(complaintDaysAgo-90), thePostMortemSays)
+	return c
+}
+
+// seedTwoMorePastCases gives the sweep more than one thing to find, so
+// criterion 4 has something to be about.
+func (s *scenario) seedTwoMorePastCases(t *testing.T) {
+	t.Helper()
+	for _, account := range []struct{ company, complaint string }{
+		{"valantic AG", "Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort."},
+		{"Körber Digital GmbH", "Der Tiefpunkt war nicht der Fehler selbst, sondern dass niemand sich meldete."},
+	} {
+		org := s.seedID(t, `INSERT INTO organization
+			(id, owner_id, display_name, industry, source, captured_by)
+			VALUES ($1, $2, $3, 'Managed Services', 'manual', 'human:x')`,
+			s.Colleague, account.company+" "+sharedAccountWord)
+		person := s.seedPerson(t, "Kontakt "+account.company, org)
+		s.seedOrgActivity(t, "email", "inbound", person, org, daysAgo(200), account.complaint)
+	}
+}
+
+// seedOrgActivity logs one dated activity against a company and a person.
+//
+// No deal here, unlike case 5's helper: this case is about a company's history
+// rather than about a deal's coverage, and a deal the scenario never asks about
+// would be a row nothing reads.
+func (s *scenario) seedOrgActivity(
+	t *testing.T, kind, direction string, person, org ids.UUID, occurredAt time.Time, body string,
+) ids.UUID {
+	t.Helper()
+	var id ids.UUID
+	if direction == "" {
+		id = s.seedID(t, `INSERT INTO activity (id, kind, occurred_at, body, source, captured_by)
+			VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, kind, occurredAt, body)
+	} else {
+		id = s.seedID(t, `INSERT INTO activity
+			(id, kind, direction, occurred_at, body, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`, kind, direction, occurredAt, body)
+	}
+	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), id, person)
+	s.seed(t, `INSERT INTO activity_link (id, activity_id, entity_type, organization_id)
+		VALUES ($1, $2, 'organization', $3)`, ids.NewV7(), id, org)
+	if direction != "" {
+		s.seed(t, `INSERT INTO activity_participant (id, activity_id, person_id, role)
+			VALUES ($1, $2, $3, $4)`, ids.NewV7(), id, person, participantRoleFor(direction))
+	}
+	return id
+}
+
+// TestCase6BothTheRecordAndTheProseReachTheCaller pins criterion 3's server
+// half.
+//
+// The contradiction is the fixture's whole point. If only the note came back,
+// the assistant would have no dated record to prefer and "the answer said
+// October" would be the product's fault rather than the model's. Both have to
+// arrive, and the dated one has to carry its date.
+func TestCase6BothTheRecordAndTheProseReachTheCaller(t *testing.T) {
+	s := boot(t, scopesRead)
+	c := s.seedContradiction(t)
+
+	got := s.MCP.CallOK(t, "catch_me_up_on", map[string]any{
+		"record_type": "organization", "record_id": c.org.String(),
+	})
+	var answer agents.AssembledContextResult
+	got.JSON(t, &answer)
+
+	items := briefingItems(answer)
+	byID := map[ids.UUID]agents.ContextItem{}
+	for _, item := range items {
+		byID[item.RecordID] = item
+	}
+
+	record, hasRecord := byID[c.complaint]
+	if !hasRecord {
+		t.Fatalf("case 6 criterion 3: the dated email did not reach the caller, so an assistant "+
+			"answering about this account has only the note's prose to date it by; items were %v",
+			summariesOf(items))
+	}
+	if _, hasProse := byID[c.postMortem]; !hasProse {
+		t.Fatalf("case 6 criterion 3: the post-mortem note did not reach the caller, so the " +
+			"contradiction this fixture exists to create was never presented")
+	}
+
+	// The record's own date, which is what makes preferring it possible.
+	if record.OccurredAt == nil {
+		t.Fatalf("case 6 criterion 2: the complaint email carries no occurred_at; a model holding " +
+			"an undated record and a note that says 'im Oktober' will say October")
+	}
+	wantMonth := daysAgo(complaintDaysAgo).Month()
+	if got := record.OccurredAt.Month(); got != wantMonth {
+		t.Fatalf("case 6 criterion 2: the complaint is dated %s and the record says %s",
+			wantMonth, got)
+	}
+}
+
+// TestCase6EveryEventCarriesItsOwnDate pins criterion 2.
+//
+// Not the one event the previous test names — EVERY event item in the answer.
+// A tool that dated the first item and left the rest bare would pass a
+// single-record check while leaving most of a history undated.
+func TestCase6EveryEventCarriesItsOwnDate(t *testing.T) {
+	s := boot(t, scopesRead)
+	c := s.seedContradiction(t)
+
+	got := s.MCP.CallOK(t, "catch_me_up_on", map[string]any{
+		"record_type": "organization", "record_id": c.org.String(),
+	})
+	var answer agents.AssembledContextResult
+	got.JSON(t, &answer)
+
+	seeded := map[ids.UUID]bool{c.complaint: true, c.postMortem: true}
+	dated := 0
+	for _, item := range briefingItems(answer) {
+		if !seeded[item.RecordID] {
+			continue
+		}
+		if item.OccurredAt == nil {
+			t.Fatalf("case 6 criterion 2: the item summarising %q carries no date", item.Summary)
+		}
+		dated++
+	}
+	if dated != len(seeded) {
+		t.Fatalf("case 6 criterion 2: %d of the %d seeded events reached the answer with a date",
+			dated, len(seeded))
+	}
+}
+
+// TestCase6EverythingRelevantReachesTheCallerNotJustTheTopHit pins criterion 4.
+//
+// Three past cases exist, so three past cases have to be available. An answer
+// carrying the single best match would let an assistant say "this happened
+// once" about a pattern.
+func TestCase6EverythingRelevantReachesTheCallerNotJustTheTopHit(t *testing.T) {
+	s := boot(t, scopesRead)
+	s.seedContradiction(t)
+	s.seedTwoMorePastCases(t)
+
+	got := s.MCP.CallOK(t, "search_context", map[string]any{
+		"query":        sharedAccountWord,
+		"record_types": []string{"organization"},
+		"limit":        20,
+	})
+	var answer agents.SearchContextResult
+	got.JSON(t, &answer)
+
+	companies := map[string]bool{}
+	for _, hit := range answer.Hits {
+		companies[recordName(t, hit.Record.Fields)] = true
+	}
+	for _, want := range []string{
+		"Reply Deutschland " + sharedAccountWord,
+		"valantic AG " + sharedAccountWord,
+		"Körber Digital GmbH " + sharedAccountWord,
+	} {
+		if !companies[want] {
+			t.Fatalf("case 6 criterion 4: %s lived through this and is missing from the answer, so "+
+				"an assistant would call a pattern a one-off; the answer named %v",
+				want, keysOfSet(companies))
+		}
+	}
+
+	// The tool never claims a complete match set — a ranked page is the top of
+	// an ordering. It has to SAY that rather than let a caller read the page as
+	// everything there is.
+	if answer.Coverage == "" {
+		t.Fatalf("case 6 criterion 4: the answer states no coverage, so a caller cannot tell a " +
+			"ranked page from a complete one")
+	}
+	if answer.Coverage == agents.CoverageCompleteExact {
+		t.Fatalf("case 6 criterion 4: a ranked sweep reported %q, a claim this tool never makes",
+			answer.Coverage)
+	}
+}
+
+// keysOfSet names what a set held.
+func keysOfSet(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return out
+}

--- a/backend/internal/compose/integration/e2e/usecases/doc.go
+++ b/backend/internal/compose/integration/e2e/usecases/doc.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package usecases drives the six scenarios the product is sold on, over MCP,
+// as an assistant meets them.
+//
+// The scenarios and their acceptance criteria are written down outside this
+// repo, in the working folder's findings/ACCEPTANCE-CRITERIA.md. Each test
+// below names the case and the criterion it pins, so a failure reads as
+// "case 4, criterion 5" rather than as a Go function name nobody can map back
+// to a promise:
+//
+//  1. Log it while it is fresh   — a meeting becomes records, and what was
+//     promised in it becomes proposals
+//  2. The business card          — one contact, never a second copy
+//  3. The spreadsheet arrives    — an import that tells the truth twice
+//  4. Use the moment             — who is nearby, and whose account it is
+//  5. Before the meeting         — a briefing that names people and dates
+//  6. Ask the company            — history answered from records, not prose
+//
+// # What is asserted, and from where
+//
+// Everything the ASSISTANT can see, over the transport it actually uses. A
+// scenario calls tools through apptest.MCPClient and reads the answers as
+// JSON. Where a criterion is about a human's half of the journey — approving
+// something, undoing an import — that step is a REST call on the cookie
+// client, because every /mcp request binds an agent principal and there is no
+// cookie-authenticated tool call.
+//
+// The database is read only to establish what a fixture seeded, or to prove a
+// write LANDED. It is never read to satisfy a criterion about what the caller
+// was told: "the owner's name is in the row" and "the owner's name reached the
+// client" are different claims, and only the second is the product.
+//
+// # What is NOT asserted
+//
+// The host's half of every scenario. The recording is fetched by the
+// assistant, the card is read by the assistant's camera, the calendar is the
+// assistant's. Those arrive here as text and fields, which is the same
+// boundary the deck's own hosts draw — the server cannot tell a pasted
+// transcript from an uploaded one, by design, and the contract says so.
+//
+// Whether a MODEL answers well is also out of scope. These tests pin what is
+// deterministic: the payloads, the refusals, the staging, and the legibility
+// fields a model needs in order to answer well at all. The model half runs
+// separately, on a schedule, against a live assistant.
+//
+// # Isolation
+//
+// apptest.SetupApp* resets the shared package database per setup, so: ONE app
+// per top-level scenario, and no t.Parallel in this package. Two scenarios
+// sharing a database would see each other's writes, and case 3's whole point
+// is that a second import changes nothing.
+package usecases

--- a/backend/internal/compose/integration/e2e/usecases/harness_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/harness_test.go
@@ -15,7 +15,6 @@ package usecases
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -137,20 +136,6 @@ func (s *scenario) seedID(t *testing.T, sql string, args ...any) ids.UUID {
 	id := ids.NewV7()
 	s.seed(t, sql, append([]any{id}, args...)...)
 	return id
-}
-
-// containsAll says whether every needle appears in the haystack.
-//
-// Case-insensitive, because these are assertions about whether a caller was
-// TOLD something, and a tool that says "Address" has told them.
-func containsAll(haystack string, needles ...string) bool {
-	lowered := strings.ToLower(haystack)
-	for _, needle := range needles {
-		if !strings.Contains(lowered, strings.ToLower(needle)) {
-			return false
-		}
-	}
-	return true
 }
 
 // recordName reads a record's display name out of its fields, for a failure

--- a/backend/internal/compose/integration/e2e/usecases/harness_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/harness_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package usecases
+
+// The harness every scenario boots, and the seat vocabulary they share.
+//
+// One app per scenario, never shared: apptest.SetupApp* RESETS the package
+// database, so a second setup inside a running scenario would delete the
+// fixture the first one seeded. That is also why nothing here calls
+// t.Parallel.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The seats every scenario needs. Two humans, because the criteria that matter
+// most are about the difference between them: an account you own reads
+// differently from a colleague's, and "is_you" is only meaningful when someone
+// else exists to be not-you.
+const (
+	repEmail       = "rep@usecases.test"
+	repName        = "Sam Rep"
+	colleagueEmail = "colleague@usecases.test"
+	colleagueName  = "Alex Colleague"
+)
+
+// The scope sets a scenario mints a passport with. Named rather than spelled
+// at each call site: a scenario that quietly asks for write when it is testing
+// a read is a test proving less than it claims.
+var (
+	scopesRead      = []string{"read"}
+	scopesReadWrite = []string{"read", "write"}
+)
+
+// scenario is one use case's world: the running app, the assistant's client,
+// and the two seats.
+type scenario struct {
+	*apptest.AppEnv
+	// MCP is the assistant. Every tool call in a scenario goes through it.
+	MCP *apptest.MCPClient
+	// Rep is the human the assistant acts for — the passport's granting seat.
+	Rep ids.UUID
+	// Colleague is somebody else, so a scenario can seed an account the rep
+	// does not own and assert the product says so.
+	Colleague ids.UUID
+}
+
+// boot brings up a composed app with /mcp mounted and a passport ready.
+//
+// The connector options are not optional: without WithMCPConnector the handler
+// is nil and the /mcp route is never registered, so every call 404s and the
+// scenario reads it as a broken test rather than a missing option.
+func boot(t *testing.T, scopes []string, extra ...compose.Option) *scenario {
+	t.Helper()
+	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
+		return append([]compose.Option{
+			compose.WithMCPConnector(),
+			compose.WithMCPResource(origin + "/mcp"),
+		}, extra...)
+	})
+	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
+
+	s := &scenario{AppEnv: e}
+	s.Rep = seatIDFor(t, e, repEmail)
+	s.Colleague = seedColleague(t, e)
+	s.MCP = apptest.NewMCPClient(e, apptest.MCPBearerToken(t, e, "use-case assistant", scopes...))
+	return s
+}
+
+// seatIDFor reads a seat's id by email. The bootstrap creates the admin seat
+// through the real installation path, so its id is discovered rather than
+// chosen.
+func seatIDFor(t *testing.T, e *apptest.AppEnv, email string) ids.UUID {
+	t.Helper()
+	var id ids.UUID
+	err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM app_user WHERE lower(email) = lower($1)`, email).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("reading the seat for %s: %v", email, err)
+	}
+	return id
+}
+
+// seedColleague adds a second human so ownership has two sides.
+//
+// Inserted rather than invited: an invitation flow is its own subsystem with
+// its own suite, and a scenario about who owns an account should not fail
+// because email delivery changed.
+func seedColleague(t *testing.T, e *apptest.AppEnv) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`INSERT INTO app_user (id, email, display_name, status)
+			 VALUES ($1, $2, $3, 'active')`,
+			id, colleagueEmail, colleagueName)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding the colleague seat: %v", err)
+	}
+	return id
+}
+
+// seed runs one statement inside the workspace, for a fixture that has nothing
+// to return.
+func (s *scenario) seed(t *testing.T, sql string, args ...any) {
+	t.Helper()
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), sql, args...)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding: %v\n%s", err, sql)
+	}
+}
+
+// seedID runs one INSERT whose id is generated here and returned, so a fixture
+// can link the rows it just made.
+func (s *scenario) seedID(t *testing.T, sql string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	s.seed(t, sql, append([]any{id}, args...)...)
+	return id
+}
+
+// containsAll says whether every needle appears in the haystack.
+//
+// Case-insensitive, because these are assertions about whether a caller was
+// TOLD something, and a tool that says "Address" has told them.
+func containsAll(haystack string, needles ...string) bool {
+	lowered := strings.ToLower(haystack)
+	for _, needle := range needles {
+		if !strings.Contains(lowered, strings.ToLower(needle)) {
+			return false
+		}
+	}
+	return true
+}
+
+// recordName reads a record's display name out of its fields, for a failure
+// message a person can act on.
+//
+// A record on this surface carries its fields as a raw JSON document rather
+// than as named members, so there is no Title to read. A failure naming
+// "Rheinufer AG" is worth the decode; one naming a uuid is not.
+func recordName(t *testing.T, fields json.RawMessage) string {
+	t.Helper()
+	var named struct {
+		DisplayName string `json:"display_name"`
+		FullName    string `json:"full_name"`
+	}
+	if err := json.Unmarshal(fields, &named); err != nil {
+		return "(unnamed record)"
+	}
+	if named.DisplayName != "" {
+		return named.DisplayName
+	}
+	if named.FullName != "" {
+		return named.FullName
+	}
+	return "(unnamed record)"
+}

--- a/backend/internal/compose/integration/e2e/usecases/harness_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/harness_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -136,6 +137,36 @@ func bootWithTranscriptReading(t *testing.T) *scenario {
 	integration.ApplyRiverSchema(t)
 	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
 	return finishBoot(t, e, scopesReadWrite)
+}
+
+// bootWithImports is boot plus an in-memory blob store, for the one scenario
+// that imports a file.
+//
+// The store is not optional decoration: profiling an import STORES the bytes,
+// and both the dry run and the commit reopen the stored source — a composition
+// without one refuses the profile outright. In memory rather than MinIO,
+// because what is under test is the import's arithmetic and not object storage.
+func bootWithImports(t *testing.T) *scenario {
+	t.Helper()
+	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
+		return []compose.Option{
+			compose.WithMCPConnector(),
+			compose.WithMCPResource(origin + "/mcp"),
+			compose.WithBlobstore(blobstore.NewMemory()),
+		}
+	})
+	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
+	return finishBoot(t, e, scopesReadWrite)
+}
+
+// queryRow runs one scalar query inside the workspace.
+//
+//craft:ignore naked-any the destination is pgx Scan's own — the caller supplies the concrete type
+func queryRow(t *testing.T, s *scenario, sql string, out any, args ...any) error {
+	t.Helper()
+	return apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), sql, args...).Scan(out)
+	})
 }
 
 // seatIDFor reads a seat's id by email. The bootstrap creates the admin seat

--- a/backend/internal/compose/integration/e2e/usecases/harness_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/harness_test.go
@@ -36,13 +36,10 @@ const (
 	colleagueName  = "Alex Colleague"
 )
 
-// The scope sets a scenario mints a passport with. Named rather than spelled
-// at each call site: a scenario that quietly asks for write when it is testing
-// a read is a test proving less than it claims.
-var (
-	scopesRead      = []string{"read"}
-	scopesReadWrite = []string{"read", "write"}
-)
+// scopesRead is what a read-only scenario mints its passport with. Named
+// rather than spelled at each call site: a scenario that quietly asks for write
+// when it is testing a read is a test proving less than it claims.
+var scopesRead = []string{"read"}
 
 // scenario is one use case's world: the running app, the assistant's client,
 // and the two seats.
@@ -59,16 +56,20 @@ type scenario struct {
 
 // boot brings up a composed app with /mcp mounted and a passport ready.
 //
+// It takes no extra compose options on purpose. A scenario that needs one —
+// case 3's blob store, a job runner for the transcript reader — adds its own
+// variant beside this rather than widening a signature nothing else passes.
+//
 // The connector options are not optional: without WithMCPConnector the handler
 // is nil and the /mcp route is never registered, so every call 404s and the
 // scenario reads it as a broken test rather than a missing option.
-func boot(t *testing.T, scopes []string, extra ...compose.Option) *scenario {
+func boot(t *testing.T, scopes []string) *scenario {
 	t.Helper()
 	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
-		return append([]compose.Option{
+		return []compose.Option{
 			compose.WithMCPConnector(),
 			compose.WithMCPResource(origin + "/mcp"),
-		}, extra...)
+		}
 	})
 	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
 
@@ -174,4 +175,28 @@ func recordName(t *testing.T, fields json.RawMessage) string {
 		return named.FullName
 	}
 	return "(unnamed record)"
+}
+
+// defaultOpenStage names the installation's default pipeline and an OPEN stage
+// in it.
+//
+// Scenarios read these rather than seeding their own. The bootstrap creates a
+// pipeline with its stages, so an inserted second one collides on
+// pipeline_name_unique — and an inserted second DEFAULT would be a state the
+// product itself cannot produce, which is not a state worth testing against.
+func (s *scenario) defaultOpenStage(t *testing.T) (pipeline, stage ids.UUID) {
+	t.Helper()
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT p.id, st.id
+			  FROM pipeline p
+			  JOIN stage st ON st.pipeline_id = p.id AND st.semantic = 'open'
+			 WHERE p.is_default
+			 ORDER BY st.position
+			 LIMIT 1`).Scan(&pipeline, &stage)
+	})
+	if err != nil {
+		t.Fatalf("reading the installation's default pipeline: %v", err)
+	}
+	return pipeline, stage
 }

--- a/backend/internal/compose/integration/e2e/usecases/harness_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/harness_test.go
@@ -15,12 +15,18 @@ package usecases
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -39,6 +45,10 @@ const (
 // rather than spelled at each call site: a scenario that quietly asks for write
 // when it is testing a read is a test proving less than it claims.
 var scopesRead = []string{"read"}
+
+// scopesReadWrite is what a scenario that WRITES mints. Case 1 is the only
+// journey whose point is the write path.
+var scopesReadWrite = []string{"read", "write"}
 
 // scenario is one use case's world: the running app, the assistant's client,
 // and the two seats.
@@ -72,11 +82,60 @@ func boot(t *testing.T, scopes []string) *scenario {
 	})
 	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
 
+	return finishBoot(t, e, scopes)
+}
+
+// finishBoot names the seats and mints the assistant's credential, for both
+// boot variants.
+func finishBoot(t *testing.T, e *apptest.AppEnv, scopes []string) *scenario {
+	t.Helper()
 	s := &scenario{AppEnv: e}
 	s.Rep = seatIDFor(t, e, repEmail)
 	s.Colleague = seedColleague(t, e)
 	s.MCP = apptest.NewMCPClient(e, apptest.MCPBearerToken(t, e, "use-case assistant", scopes...))
 	return s
+}
+
+// bootWithTranscriptReading is boot plus the reading lane, for the one scenario
+// whose criterion is that a landed transcript gets read.
+//
+// An INSERT-ONLY runner: the api role never calls a model in-request — it
+// inserts the job and answers — so a job inserter is the whole dependency and
+// no model lane is wired anywhere. What this proves is that the reading is
+// QUEUED, which is the half that silently did not happen for as long as asking
+// was the only way in. Whether the model then reads good commitments out of it
+// is the weekly lane's question.
+func bootWithTranscriptReading(t *testing.T) *scenario {
+	t.Helper()
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if appDSN == "" {
+		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	// A separate pool from the one the harness opens: the inserter needs SOME
+	// pool reaching the same Postgres, not the same object.
+	wirePool, err := database.NewPool(context.Background(), appDSN)
+	if err != nil {
+		t.Fatalf("opening the insert-only wiring pool: %v", err)
+	}
+	t.Cleanup(wirePool.Close)
+	inserter, err := jobs.NewInserter(wirePool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+
+	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
+		return []compose.Option{
+			compose.WithMCPConnector(),
+			compose.WithMCPResource(origin + "/mcp"),
+			compose.WithTranscriptRead(inserter),
+		}
+	})
+	// The landing enqueues in the same transaction as the run record, so the
+	// job schema has to exist before the FIRST write, not merely before a
+	// worker.
+	integration.ApplyRiverSchema(t)
+	apptest.BootstrapWorkspaceSession(t, e, "Use Cases", repEmail, repName)
+	return finishBoot(t, e, scopesReadWrite)
 }
 
 // seatIDFor reads a seat's id by email. The bootstrap creates the admin seat

--- a/e2e/llm/check.py
+++ b/e2e/llm/check.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Read a scenario, and judge one run of it against what the assistant said.
+
+Three things are checked per run, and all three must hold:
+
+  must_call        Did it reach the tools it needed? An answer written from the
+                   model's own memory, with Margince never asked, is a failure
+                   however good the prose reads.
+  must_mention     Does the answer contain what it has to contain? Each entry is
+                   a regex, and alternatives inside one entry are an any-of
+                   group.
+  must_not_mention Does it avoid what it must avoid? This half matters more than
+                   the first: a confident wrong answer is worse than no answer.
+
+Deliberately NOT judged: wording, tone, length, formatting, the order it did
+things in, or extra correct information. Only whether the facts are right and
+the required things were said.
+
+Stdlib only — no PyYAML. The scenario files are a small fixed subset of YAML
+(scalars, block strings, flat lists) and a dependency for that would make the
+lane refuse to run on a fresh checkout.
+"""
+
+import json
+import re
+import sys
+
+
+def parse_scenario(path):
+    """Read the subset of YAML the scenario files use."""
+    data, key, block, block_indent, seq = {}, None, None, 0, None
+    for raw in open(path, encoding="utf-8").read().splitlines():
+        if block is not None:
+            # A block scalar runs until a line that is neither blank nor
+            # indented past the key.
+            if raw.strip() == "" or raw.startswith(" " * block_indent):
+                block.append(raw[block_indent:] if len(raw) >= block_indent else "")
+                continue
+            data[key] = "\n".join(block).strip()
+            block = None
+
+        line = raw.rstrip()
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+
+        if seq is not None and line.startswith("  - "):
+            seq.append(_scalar(line[4:].strip()))
+            continue
+        seq = None
+
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if value == "|":
+            block, block_indent = [], 2
+        elif value == "":
+            seq = data[key] = []
+        elif value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            data[key] = [_scalar(v.strip()) for v in inner.split(",")] if inner else []
+        else:
+            data[key] = _scalar(value)
+    if block is not None:
+        data[key] = "\n".join(block).strip()
+    return data
+
+
+def _scalar(text):
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1]
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return text
+
+
+def read_transcript(path):
+    """Pull the tool names called and everything the assistant said.
+
+    stream-json is JSONL. Tool calls arrive as `tool_use` content blocks and the
+    prose as `text` blocks; the terminal `result` event carries the final answer
+    and is included so a scenario checking the closing sentence sees it.
+    """
+    called, said = [], []
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if event.get("type") == "result" and isinstance(event.get("result"), str):
+            said.append(event["result"])
+
+        message = event.get("message") or {}
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                called.append(block.get("name", ""))
+            elif block.get("type") == "text":
+                said.append(block.get("text", ""))
+    return called, "\n".join(said)
+
+
+def tool_matches(called, want):
+    """A tool is reached when any call names it.
+
+    MCP tools arrive prefixed (mcp__margince__query_workspace), so the scenario
+    names the bare tool and this matches the suffix — a scenario should not have
+    to know the host's naming convention.
+    """
+    return any(name == want or name.endswith("__" + want) for name in called)
+
+
+def check(scenario, transcript_path):
+    called, said = read_transcript(transcript_path)
+    problems = []
+
+    for want in scenario.get("must_call", []):
+        if not tool_matches(called, want):
+            problems.append(
+                f"never called {want} — the answer was not drawn from Margince "
+                f"(called: {', '.join(sorted(set(called))) or 'nothing'})"
+            )
+
+    for pattern in scenario.get("must_mention", []):
+        if not re.search(pattern, said, re.IGNORECASE):
+            problems.append(f"never said anything matching /{pattern}/")
+
+    for pattern in scenario.get("must_not_mention", []):
+        found = re.search(pattern, said, re.IGNORECASE)
+        if found:
+            problems.append(f"said {found.group(0)!r}, which /{pattern}/ forbids")
+
+    return problems
+
+
+def main():
+    if sys.argv[1] == "--field":
+        scenario = parse_scenario(sys.argv[3])
+        value = scenario.get(sys.argv[2], "")
+        print(value if not isinstance(value, list) else "\n".join(map(str, value)))
+        return 0
+
+    if sys.argv[1] == "--record":
+        scenario = parse_scenario(sys.argv[2])
+        print(json.dumps({
+            "scenario": scenario.get("name"),
+            "criteria": scenario.get("criteria", []),
+            "passed": int(sys.argv[3]),
+            "runs": int(sys.argv[4]),
+            "pass_at": scenario.get("pass_at"),
+        }, indent=2))
+        return 0
+
+    if sys.argv[1] == "--check":
+        problems = check(parse_scenario(sys.argv[2]), sys.argv[3])
+        for problem in problems:
+            print(f"  {problem}")
+        return 1 if problems else 0
+
+    print(f"unknown mode {sys.argv[1]}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/llm/scenarios/case1-log-it.yaml
+++ b/e2e/llm/scenarios/case1-log-it.yaml
@@ -1,0 +1,53 @@
+# CASE 1 — Log it while it is fresh.
+#
+# Two [M] criteria:
+#
+#   Criterion 8 — promises made in the meeting come back as suggestions. The
+#   transcript states ONE commitment ("Ich schicke Ihnen die Preisliste bis
+#   Freitag") and discusses one topic WITHOUT one. Reporting both would mean the
+#   reader is listing everything it sees rather than what was promised.
+#
+#   Criterion 14 — the assistant says what is waiting. The 2026-08-25 run
+#   reported "nothing pending approval" while a held draft sat in the queue.
+#   Every write was correct and the report of it was not.
+#
+# The transcript arrives as TEXT in the prompt, which is the same boundary the
+# deck's hosts draw: Plaud is the assistant's business and the server cannot
+# tell a paste from an upload.
+name: case1_log_it
+criteria: [8, 14]
+
+prompt: |
+  Just left Kugellager-online. Met Matthias Ortner, went well, they want to move
+  forward. Here is the transcript from Plaud, put it all in the CRM:
+
+  Matthias: Danke für die Übersicht zu den Lieferzeiten.
+  Lars: Wie sieht es mit dem Thema Verpackung aus?
+  Lars: Ich schicke Ihnen die Preisliste bis Freitag.
+  Matthias: Passt, dann schauen wir uns das nächste Woche an.
+
+must_call:
+  - create_record
+  - log_activity
+may_call:
+  - resolve_entities
+  - search_records
+  - list_pipelines
+  - list_approvals
+  - read_record
+  - query_workspace
+
+must_mention:
+  # It created what the sentence named.
+  - "Kugellager"
+  - "Matthias Ortner"
+  # Criterion 8: the one stated commitment, not the topic beside it.
+  - "Preisliste|price list|pricing"
+
+must_not_mention:
+  # The packaging question was DISCUSSED and nobody promised anything about it.
+  # Reporting it as a commitment is the failure this transcript is shaped for.
+  - "committed to packaging|promised.{0,20}Verpackung|action item.{0,20}packaging"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/scenarios/case2-business-card.yaml
+++ b/e2e/llm/scenarios/case2-business-card.yaml
@@ -1,0 +1,37 @@
+# CASE 2 — When somebody hands you a business card.
+#
+# Criterion 4: the assistant REPORTS the possible duplicate it filed. The
+# create's own answer carries it, so this is purely about whether the assistant
+# reads what came back and says it — a queue nobody is told about is a queue
+# nobody reads.
+#
+# The card arrives as FIELDS. Reading the photo is the assistant's job and
+# Margince never sees an image.
+name: case2_business_card
+criteria: [4]
+
+prompt: |
+  I met her at a conference. Tech Sauce in Bangkok actually. Add her to the crm.
+  The card says: Lucy Vo, Cybersecurity Sales Manager, Terralogic,
+  lucy.vo@terralogic-vn.test, +84 28 3825 6789
+
+must_call:
+  - create_record
+may_call:
+  - resolve_entities
+  - search_records
+  - read_record
+  - apply_tag
+  - query_workspace
+
+must_mention:
+  - "Lucy Vo"
+  # Criterion 4: a possible duplicate was filed and the user is told.
+  - "duplicate|already|possible match|review|similar"
+
+must_not_mention:
+  # The earlier run said this while a candidate sat in the queue.
+  - "no duplicates|nothing similar|no existing"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/scenarios/case3-spreadsheet.yaml
+++ b/e2e/llm/scenarios/case3-spreadsheet.yaml
@@ -1,0 +1,39 @@
+# CASE 3 — A spreadsheet arrives.
+#
+# The [M] half of this case is whether the assistant shows the numbers BEFORE
+# committing. The tools make that possible — preview_import is a dry run — but
+# nothing forces an assistant to look at it rather than importing straight away.
+#
+# The file carries one unusable row so there is something to report honestly.
+name: case3_spreadsheet
+criteria: [1, 6]
+
+prompt: |
+  Got this list from the trade fair. Can you get it into the CRM?
+
+  name,city,size,country
+  Nordwind Logistik GmbH,Rostock,51-200,DE
+  Elbmarsch Systeme AG,Hamburg,11-50,DE
+  ,Köln,201-500,DE
+  Alpenblick Sensorik GmbH,München,11-50,DE
+
+must_call:
+  - preview_import
+may_call:
+  - commit_import
+  - read_import_run
+  - read_import_report
+  - query_workspace
+  - search_records
+
+must_mention:
+  # Criterion 1: it says what will happen before it happens.
+  - "3|three"
+  # Criterion 6: the unusable row is reported rather than swallowed.
+  - "skip|skipped|issue|problem|could not|missing name|blank|row"
+
+must_not_mention:
+  - "all 4 companies were created|imported all four"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/scenarios/case4-use-the-moment.yaml
+++ b/e2e/llm/scenarios/case4-use-the-moment.yaml
@@ -1,0 +1,45 @@
+# CASE 4 — Use the moment.
+#
+# The [M] criteria the Go suite cannot answer: criterion 6, the assistant
+# telling the rep to check with the owner before turning up.
+#
+# The prompt is the HARD version, verbatim from the 2026-08-26 run. It never
+# says "companies", never says "address", never says "distance", and names no
+# tool. Working out that "nearby" means a distance search — and that it can ASK
+# which fields are geo — is the whole case.
+#
+# Do NOT replace it with the earlier scripted wording ("Which customers are
+# nearby? Rank them by fit and relationship strength"). That version hands over
+# the answer and tests something materially easier.
+name: case4_use_the_moment
+criteria: [1, 6]
+
+prompt: |
+  hey I am in cologne right now and wanted to visit a client but my appointment
+  got canceled. Anyone nearby in our crm I should visit?
+
+# The chain the assistant has to find for itself. query_workspace is the
+# destination; the vocabulary lookup is how it learns a radius search exists,
+# and an assistant that already knows may skip it.
+must_call:
+  - query_workspace
+may_call:
+  - describe_query_vocabulary
+  - search_records
+  - read_record
+  - search_context
+
+# Criterion 6. Naming a nearby company is not enough — two thirds of the CRM
+# belongs to somebody else, and an assistant that knows the owner and does not
+# say so sends a rep into a colleague's account.
+must_mention:
+  - "Sofia Meier|Lena Fischer|Phạm Hương Giang"
+  - "owner|owned by|belongs to|check with|speak to|message"
+
+# Run 1 of the real scenario failed exactly here: correct companies, and it
+# never said whose they were, because the row carried a bare uuid.
+must_not_mention:
+  - "no address field|cannot determine location|unable to search by distance"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/scenarios/case5-before-the-meeting.yaml
+++ b/e2e/llm/scenarios/case5-before-the-meeting.yaml
@@ -1,0 +1,49 @@
+# CASE 5 — Before the meeting.
+#
+# Two [M] criteria the Go suite cannot reach:
+#
+#   Criterion 1 — a briefing arrives without naming a record. The prompt says
+#   "Vietnam partner", which is not the account's name. Finding it is the test.
+#
+#   Criterion 5 — the unkept promise. Somebody said they would send something
+#   and there is no record it went. The fixture builds that gap deliberately;
+#   noticing it is the highest-value thing this case produces, and it needs a
+#   model to read across the timeline.
+#
+# The calendar half stays out. The prompt says "check my calendar" because the
+# real one did, and an assistant with no calendar connected should say so and
+# carry on rather than stopping.
+name: case5_before_the_meeting
+criteria: [1, 2, 5]
+
+prompt: |
+  Hey. Tomorrow I'm meeting, uh, finally, Vietnam partner. Could check in my
+  calendar. Can you prep me for the meeting? Check in the CRM.
+
+must_call:
+  - search_records
+may_call:
+  - prep_for_meeting
+  - account_coverage
+  - catch_me_up_on
+  - query_workspace
+  - read_record
+  - search_context
+  - who_knows
+
+must_mention:
+  # Criterion 1: it found the account from a description, not a name.
+  - "Vietnam Partner"
+  # Criterion 5: the promise nobody kept. The fixture logs an outbound message
+  # saying the list would be sent, and nothing after it.
+  - "Aufstellung|list|promised|zugesagt|never sent|no record|outstanding|follow up"
+  # Criterion 2's server half is already pinned; here it must NAME the people
+  # rather than describing seats.
+  - "Mai Nguyen"
+
+must_not_mention:
+  # An assistant that cannot see a calendar must say so, not invent a meeting.
+  - "I have scheduled|I've added the meeting"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -1,0 +1,44 @@
+# CASE 6 — Ask the company.
+#
+# The sharpest assertion in the whole lane, and the half of #2059 no
+# deterministic test can reach.
+#
+# The seeded history contains a deliberate contradiction: an email dated in
+# September, and a post-mortem note whose prose says the complaint was raised
+# "im Oktober". The Go suite proves BOTH reach the caller and the record carries
+# its date — so the assistant has the choice. This scenario asks whether it
+# makes the right one.
+#
+# The record is right. The prose is wrong. An answer that says October has
+# repeated a human's faulty memory back to the person about to walk into the
+# meeting.
+name: case6_ask_the_company
+criteria: [1, 3, 5]
+
+prompt: |
+  We are about to change the account manager on one of our major accounts, and
+  in the past customers complained if we swapped the responsible people too
+  much. Did we have it in the past, what happened, how did we react, what should
+  I be prepared for? Is there something we can learn? Check in our CRM.
+
+must_call:
+  - search_context
+may_call:
+  - query_workspace
+  - catch_me_up_on
+  - read_record
+  - search_records
+
+# Criterion 3: the record wins. September is what the email says.
+must_mention:
+  - "September|09/|09-|-09-"
+# Criterion 1 needs it to find the accounts without being told which.
+  - "Reply|valantic|Körber"
+
+# The note says "im Oktober" and it is wrong. Saying October means the prose
+# was preferred over the record, which is the defect this case exists to catch.
+must_not_mention:
+  - "Oktober|October"
+
+runs: 3
+pass_at: 2

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# seed-llm-fixtures.sh — the records the LLM scenarios ask about, written
+# through the public API.
+#
+# An API client rather than a SQL fixture, for the reason seed-dev.sh gives and
+# one more that this lane learned the hard way: rows inserted by hand skip what
+# real writes maintain. deal.last_activity_at is kept by a trigger on
+# activity_link, and a fixture that wrote the activity without linking the deal
+# left every coverage rule silent — three Go tests passed against nothing before
+# that was found.
+#
+# Public data only. Nothing here needs the private demo dataset, so the lane
+# runs on any checkout.
+#
+# Idempotent in the same sense seed-dev.sh is: a re-run answers 409 on natural
+# keys and carries on. It does NOT reset — the runner gives each RUN a fresh
+# database, because case 1 and case 3 write and would otherwise see each other.
+
+set -euo pipefail
+
+. "$(git rev-parse --show-toplevel)/scripts/lib-devstate.sh"
+API_BASE="${API_BASE:-$(dev_app_base_url)}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
+
+COOKIES="$(mktemp)"
+trap 'rm -f "$COOKIES"' EXIT
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -sS -b "$COOKIES" -c "$COOKIES" -X "$method" \
+      -H 'Content-Type: application/json' -d "$body" "$API_BASE/v1$path"
+  else
+    curl -sS -b "$COOKIES" -c "$COOKIES" -X "$method" "$API_BASE/v1$path"
+  fi
+}
+
+# id_of reads the id out of a create response, or empty when the create was
+# refused (a 409 on a natural key, which a re-run expects).
+id_of() { printf '%s' "$1" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("id",""))
+except Exception:
+    print("")'; }
+
+echo "seeding LLM fixtures into $API_BASE"
+
+api POST /auth/login "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" >/dev/null
+
+# The colleague who owns the accounts. Criterion 6 of case 4 is about telling
+# the rep an account is somebody ELSE'S, so a workspace where the admin owns
+# everything cannot exercise it.
+colleague="$(id_of "$(api POST /users '{
+  "email":"sofia.meier@demo.test","display_name":"Sofia Meier","role":"Member"}')")"
+if [ -z "$colleague" ]; then
+  colleague="$(api GET '/users?q=sofia.meier@demo.test' | python3 -c 'import json,sys
+items = json.load(sys.stdin).get("items", [])
+print(items[0]["id"] if items else "")')"
+fi
+[ -n "$colleague" ] || { echo "could not resolve the colleague seat" >&2; exit 1; }
+
+# --- CASE 4: companies in and around Köln, owned by the colleague ------------
+#
+# The city centre is averaged from the located companies filed under that city
+# name (people/geocodecity.go), so these coordinates ARE the centre. No
+# geocoder is called. Filing one of them under a different city would stretch
+# the average past the one-degree spread cap and the resolver would refuse.
+seed_cologne() {
+  local name="$1" lat="$2" lon="$3"
+  api POST /organizations "{
+    \"display_name\":\"$name\",\"owner_id\":\"$colleague\",
+    \"address\":{\"line1\":\"Domkloster 4\",\"city\":\"Köln\",\"country\":\"DE\"},
+    \"geocode\":{\"lat\":$lat,\"lon\":$lon}}" >/dev/null || true
+}
+seed_cologne "Dom Digital GmbH"    50.9375 6.9603
+seed_cologne "Rheinufer AG"        50.9475 6.9603
+seed_cologne "Vorort Systeme KG"   51.0175 6.9603
+
+# --- CASE 5: the Vietnam partner, with a promise nobody kept -----------------
+vietnam="$(id_of "$(api POST /organizations "{
+  \"display_name\":\"Vietnam Partner JSC\",\"owner_id\":\"$colleague\"}")")"
+if [ -n "$vietnam" ]; then
+  mai="$(id_of "$(api POST /people "{
+    \"full_name\":\"Mai Nguyen\",\"owner_id\":\"$colleague\",
+    \"emails\":[{\"email\":\"mai.nguyen@vietnampartner.test\",\"is_primary\":true}]}")")"
+  api POST /relationships "{
+    \"kind\":\"employment\",\"person_id\":\"$mai\",\"organization_id\":\"$vietnam\"}" >/dev/null || true
+
+  # THE PROMISE. An outbound message saying the list will be sent, and nothing
+  # after it. Criterion 5 is whether a model notices the silence.
+  api POST /activities "{
+    \"kind\":\"email\",\"direction\":\"outbound\",
+    \"occurred_at\":\"$(date -u -v-18d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '18 days ago' '+%Y-%m-%dT%H:%M:%SZ')\",
+    \"body\":\"Ich schicke die Aufstellung mit.\",
+    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$mai\"},
+               {\"entity_type\":\"organization\",\"entity_id\":\"$vietnam\"}]}" >/dev/null || true
+  api POST /activities "{
+    \"kind\":\"email\",\"direction\":\"inbound\",
+    \"occurred_at\":\"$(date -u -v-20d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '20 days ago' '+%Y-%m-%dT%H:%M:%SZ')\",
+    \"body\":\"Cảm ơn — we will review the appendix this week.\",
+    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$mai\"},
+               {\"entity_type\":\"organization\",\"entity_id\":\"$vietnam\"}]}" >/dev/null || true
+fi
+
+# --- CASE 6: the contradiction ----------------------------------------------
+#
+# An email dated in September, and a note written later whose prose says the
+# complaint was raised "im Oktober". The record is right; the prose is wrong.
+# This is the fixture the sharpest assertion in the lane rests on.
+reply="$(id_of "$(api POST /organizations "{
+  \"display_name\":\"Reply Deutschland Betreuerwechsel\",\"owner_id\":\"$colleague\",
+  \"industry\":\"Managed Services\"}")")"
+if [ -n "$reply" ]; then
+  katrin="$(id_of "$(api POST /people "{
+    \"full_name\":\"Katrin Sommer\",\"owner_id\":\"$colleague\",
+    \"emails\":[{\"email\":\"katrin.sommer@reply.test\",\"is_primary\":true}]}")")"
+  api POST /relationships "{
+    \"kind\":\"employment\",\"person_id\":\"$katrin\",\"organization_id\":\"$reply\"}" >/dev/null || true
+
+  # The record. September.
+  api POST /activities "{
+    \"kind\":\"email\",\"direction\":\"inbound\",\"occurred_at\":\"2025-09-18T09:12:00Z\",
+    \"subject\":\"Wechsel der Ansprechpartner\",
+    \"body\":\"Der ständige Wechsel der Ansprechpartner ist für uns ein echtes Problem.\",
+    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$katrin\"},
+               {\"entity_type\":\"organization\",\"entity_id\":\"$reply\"}]}" >/dev/null || true
+  # The prose. Wrong about the month, exactly as a real post-mortem was.
+  api POST /activities "{
+    \"kind\":\"note\",\"occurred_at\":\"2025-12-03T10:00:00Z\",
+    \"subject\":\"Post-mortem Betreuerwechsel\",
+    \"body\":\"Der Kunde hat das im Oktober klar angesprochen; wir haben zu spät reagiert.\",
+    \"links\":[{\"entity_type\":\"organization\",\"entity_id\":\"$reply\"}]}" >/dev/null || true
+fi
+
+# Two more accounts that lived through the same thing, so "did we have this in
+# the past" has a pattern to find rather than a single case.
+for company in "valantic AG Betreuerwechsel" "Körber Digital Betreuerwechsel"; do
+  org="$(id_of "$(api POST /organizations "{
+    \"display_name\":\"$company\",\"owner_id\":\"$colleague\",\"industry\":\"Managed Services\"}")")"
+  [ -n "$org" ] || continue
+  api POST /activities "{
+    \"kind\":\"email\",\"direction\":\"inbound\",\"occurred_at\":\"2025-11-04T08:00:00Z\",
+    \"body\":\"Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort.\",
+    \"links\":[{\"entity_type\":\"organization\",\"entity_id\":\"$org\"}]}" >/dev/null || true
+done
+
+echo "LLM fixtures seeded"

--- a/scripts/e2e-llm.sh
+++ b/scripts/e2e-llm.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# e2e-llm.sh — drive the six use cases with a REAL assistant and check what it
+# said.
+#
+# This is the half the Go suite cannot answer. Those tests pin what is
+# deterministic — the payloads, the refusals, the legibility fields. This asks
+# the only remaining question: can a model actually drive this surface and say
+# something true.
+#
+# It is not deterministic and does not pretend to be. Each scenario runs N times
+# and passes at a RATE, because one bad run out of three is the weather and two
+# is a defect.
+#
+# COSTS MONEY. Gated behind MARGINCE_E2E_LLM=1 so no casual `make test` ever
+# spends a token.
+#
+# It never touches :8080. A dedicated DEV_SLUG stack is booted, seeded, driven
+# and torn down.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+SLUG="${E2E_LLM_SLUG:-e2ellm}"
+SCENARIO_DIR="${E2E_LLM_SCENARIOS:-$ROOT/e2e/llm/scenarios}"
+RECORD_DIR="${E2E_LLM_RECORDS:-$ROOT/e2e/llm/records}"
+ONLY="${SCENARIO:-}"
+KEEP="${E2E_LLM_KEEP:-0}"
+
+if [ "${MARGINCE_E2E_LLM:-0}" != "1" ]; then
+  cat >&2 <<'MSG'
+e2e-llm is opt-in: it drives a real model and bills real tokens.
+
+    MARGINCE_E2E_LLM=1 make e2e-llm
+
+Add SCENARIO=<name> to run one, E2E_LLM_KEEP=1 to leave the stack up.
+MSG
+  exit 2
+fi
+
+command -v claude >/dev/null || { echo "the claude CLI is not on PATH" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is required to read the scenarios" >&2; exit 1; }
+
+# The credential. A subscription token is an OAuth bearer and goes in
+# ANTHROPIC_AUTH_TOKEN; an API key goes in ANTHROPIC_API_KEY. Either works —
+# what must not happen is a run that silently falls back to whatever the
+# operator's own shell is logged into, because then the lane is measuring a
+# different account's model.
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  echo "neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+cleanup() {
+  if [ "$KEEP" = "1" ]; then
+    echo "stack left up (DEV_SLUG=$SLUG); stop it with: make dev-stop DEV_SLUG=$SLUG"
+  else
+    (cd "$ROOT" && make dev-stop DEV_SLUG="$SLUG" >/dev/null 2>&1) || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# --- the stack ---------------------------------------------------------------
+#
+# --fresh per RUN would be the cleanest isolation, but a boot is tens of seconds
+# and six scenarios times three runs is eighteen of them. The compromise: one
+# fresh boot for the lane, and the write scenarios (1, 2, 3) get a fresh
+# database between their own runs — they are the only ones whose second run
+# would see the first one's records.
+echo "==> booting the $SLUG stack (never :8080)"
+(cd "$ROOT" && make dev-fresh DEV_SLUG="$SLUG" >/dev/null)
+
+# shellcheck source=scripts/lib-devstate.sh
+. "$ROOT/scripts/lib-devstate.sh"
+APP_BASE="$(DEV_SLUG="$SLUG" dev_app_base_url)"
+echo "==> app at $APP_BASE"
+
+seed_everything() {
+  (cd "$ROOT" && API_BASE="$APP_BASE" bash e2e/llm/seed-llm-fixtures.sh >/dev/null)
+}
+seed_everything
+
+# --- the credential the assistant presents -----------------------------------
+#
+# A passport, minted the production way over REST. It skips OAuth, which is
+# what makes this lane runnable without a tunnel: the assistant is a local
+# process talking to a local stack.
+COOKIES="$WORK/cookies"
+curl -sS -c "$COOKIES" -X POST -H 'Content-Type: application/json' \
+  -d '{"email":"admin@demo.test","password":"demo-password-123"}' \
+  "$APP_BASE/v1/auth/login" >/dev/null
+
+PASSPORT="$(curl -sS -b "$COOKIES" -X POST -H 'Content-Type: application/json' \
+  -d '{"label":"e2e-llm","scopes":["read","write"]}' \
+  "$APP_BASE/v1/passports" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+[ -n "$PASSPORT" ] || { echo "could not mint a passport" >&2; exit 1; }
+
+MCP_CONFIG="$WORK/mcp.json"
+cat > "$MCP_CONFIG" <<JSON
+{"mcpServers":{"margince":{"type":"http","url":"$APP_BASE/mcp",
+ "headers":{"Authorization":"Bearer $PASSPORT"}}}}
+JSON
+
+# --- run one scenario once ---------------------------------------------------
+#
+# The flags, and why each is load-bearing:
+#
+#   --output-format stream-json  a transcript of tool calls. Plain `json` is a
+#                                single result and says nothing about what was
+#                                called.
+#   --verbose                    required by stream-json on this CLI version.
+#   --strict-mcp-config          ignore the operator's own MCP servers. Without
+#                                it the assistant may reach tools this lane
+#                                never meant to offer.
+#   --tools ""                   disable the built-ins. --allowedTools alone
+#                                does NOT make the surface exclusive.
+#   --permission-mode dontAsk    with the surface genuinely restricted, a global
+#                                bypass buys nothing.
+#   --max-turns                  hidden from --help on this version but present.
+run_once() {
+  local prompt_file="$1" out="$2"
+  claude -p "$(cat "$prompt_file")" \
+    --mcp-config "$MCP_CONFIG" --strict-mcp-config \
+    --allowedTools "mcp__margince__*" --tools "" \
+    --permission-mode dontAsk \
+    --output-format stream-json --verbose \
+    --max-turns 20 \
+    > "$out" 2>"$out.err" || true
+
+  # An unknown flag produces an empty transcript, which a naive checker reads as
+  # a scenario that called nothing — a false failure that looks like a finding.
+  if [ ! -s "$out" ]; then
+    echo "  the CLI produced no transcript:" >&2
+    head -5 "$out.err" >&2
+    return 1
+  fi
+}
+
+PASSED=0
+FAILED=0
+REPORT="$WORK/report.txt"
+: > "$REPORT"
+
+for scenario in "$SCENARIO_DIR"/*.yaml; do
+  name="$(python3 "$ROOT/e2e/llm/check.py" --field name "$scenario")"
+  if [ -n "$ONLY" ] && [ "$ONLY" != "$name" ]; then continue; fi
+
+  runs="$(python3 "$ROOT/e2e/llm/check.py" --field runs "$scenario")"
+  pass_at="$(python3 "$ROOT/e2e/llm/check.py" --field pass_at "$scenario")"
+  python3 "$ROOT/e2e/llm/check.py" --field prompt "$scenario" > "$WORK/prompt.txt"
+
+  echo "==> $name ($runs runs, passes at $pass_at)"
+  ok=0
+  results="$WORK/$name.results"
+  : > "$results"
+
+  for i in $(seq 1 "$runs"); do
+    # The write scenarios see their own earlier runs otherwise. Cases 1, 2 and 3
+    # create records; a second run against them is testing a different world.
+    case "$name" in
+      case1_*|case2_*|case3_*)
+        if [ "$i" -gt 1 ]; then
+          (cd "$ROOT" && make dev-fresh DEV_SLUG="$SLUG" >/dev/null)
+          seed_everything
+        fi
+        ;;
+    esac
+
+    transcript="$WORK/$name.run$i.jsonl"
+    if ! run_once "$WORK/prompt.txt" "$transcript"; then
+      echo "  run $i: NO TRANSCRIPT"
+      echo "run $i: error" >> "$results"
+      continue
+    fi
+    if python3 "$ROOT/e2e/llm/check.py" --check "$scenario" "$transcript" >> "$results" 2>&1; then
+      ok=$((ok + 1))
+      echo "  run $i: pass"
+    else
+      echo "  run $i: fail"
+    fi
+  done
+
+  if [ "$ok" -ge "$pass_at" ]; then
+    PASSED=$((PASSED + 1))
+    echo "  $name: PASS ($ok/$runs)" | tee -a "$REPORT"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  $name: FAIL ($ok/$runs, needed $pass_at)" | tee -a "$REPORT"
+    sed 's/^/    /' "$results"
+  fi
+
+  # The record, kept whether it passed or not. Most of the defects fixed this
+  # month were found by reading a run that technically passed.
+  mkdir -p "$RECORD_DIR"
+  python3 "$ROOT/e2e/llm/check.py" --record "$scenario" "$ok" "$runs" \
+    > "$RECORD_DIR/${name}_$(date -u '+%Y-%m-%d').json"
+  cp "$WORK/$name".run*.jsonl "$RECORD_DIR/" 2>/dev/null || true
+done
+
+echo
+echo "================ e2e-llm ================"
+cat "$REPORT"
+echo "scenarios: $PASSED passed, $FAILED failed"
+echo "records:   $RECORD_DIR"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Adds a home for end-to-end scenario suites and puts the deck's six use cases in
it. **21 Go tests, ~4 seconds**, driven over real MCP against real Postgres.

```
make test-it DIR=backend/internal/compose/integration/e2e/usecases
```

## Why a new place

`backend/internal/compose/integration/` already has eleven topic packages, and
they are the right home for a SUBSYSTEM — written from what a package exports.
A suite belongs in `e2e/` instead when it asks whether a JOURNEY works: several
subsystems in sequence, by the route a person meets them, asserted from what the
user was promised.

That distinction has a consequence worth the separate directory. A scenario here
asserts on what a CALLER can see, so a fact only reachable by importing an
internal package is a finding about the product rather than a reason to reach for
the import. Four defects merged in August were exactly that shape — data present,
correct, and illegible to the client holding it (#2728, #2745, #2766, todo 33).

Subdirectory per area; `usecases/` is the first.

## What is pinned

The acceptance criteria live in the working folder's
`findings/ACCEPTANCE-CRITERIA.md`, and every test names the case and criterion it
holds — a failure reads "case 4, criterion 5", not a Go function name.

| Case | Covered |
|---|---|
| 1 Log it | records created, one write, no approval, transcript read on landing, routed to the human |
| 2 Business card | email refuses and names who, shared phone lands and files a candidate citing the phone axis, tag by name |
| 3 Spreadsheet | preview is a promise, second import changes nothing, one row updates one record, bad row skipped with a findable line |
| 4 Use the moment | vocabulary advertises the radius, nearest-first, coverage stated, owners named with is_you correct |
| 5 Before the meeting | stakeholders named, findings name their people, cold account gives a number, events carry dates |
| 6 Ask the company | record and prose both reach the caller verbatim, every event dated, every past case arrives with its history |

## Every assertion is proven able to fail

Each was checked by breaking the product on purpose and confirming the right test
went red — removing owner naming, blanking a stakeholder's name, projecting a
constant distance, routing a transcript reading to the agent instead of the
human, making a re-import rewrite unchanged rows, dropping the size-band mapping.

That check is not ceremony here. **Codex reviewed this branch twice and found 21
assertions that would have passed with the feature removed.** All are fixed. Two
were my own comments being wrong about what their test proved:

- "One write" rested on three link rows sharing a `created_at`. Postgres `now()`
  is transaction-scoped, so that showed the LINKS shared a transaction — a build
  committing the activity and relinking afterwards passed. They are now compared
  against the activity's own stamp.
- The transcript-routing check tested the string's shape. `system:<uuid>` passed
  while parsing to no human, so proposals reached nobody. It now goes through
  `principal.HumanUserID`, the parser the product itself routes with.

One test was deleted rather than patched: it used a fully granted caller and
asserted an empty array was non-null, so the withholding it named was never
exercised. A test that cannot fail reads as coverage.

## Also: a model lane

`e2e/llm/` — six scenarios driving a real assistant through `claude -p`, opt-in
behind `MARGINCE_E2E_LLM=1`, against a dedicated `DEV_SLUG` stack (never :8080).
Three runs each, passes at two.

It answers what the Go suite cannot: whether a model can drive this surface and
say something true. Case 6 is the sharpest — the fixture contains an email dated
in September and a note whose prose says October, and the lane checks which one
the model repeats.

**Not yet run against a live model.** The checker is proven able to fail against
fabricated transcripts (one saying "October" fails; one answering without calling
a tool fails), but no scenario has spent a token.

## Boundaries, so a green run is not read as more than it is

- Case 4 writes its coordinates directly: it exercises the geocoding READ path
  and stays green if the address-to-coordinates writer breaks.
- Case 5 criterion 9 (a restricted reader is refused, not shown a blank) cannot
  be built over MCP today — `apptest` mints its passport for whoever holds the
  session and offers no role control. The in-process test already covers it.
- The host's half stays host-side: Plaud, the camera, the calendar. Those arrive
  as text and fields, the same boundary the deck's own hosts draw.
- No OAuth. The suites present a passport, so the token-exchange path is
  untested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a home for end-to-end scenario suites and puts the deck's six use cases in it: 21 Go tests (~4s) over real MCP against real Postgres, plus an opt-in LLM lane that drives a real assistant.

**Go suite**
- New `backend/internal/compose/integration/e2e/usecases/` holds whole-journey suites, distinct from the eleven subsystem packages: assertions are written from what a caller can see, and each test names the case and criterion it pins.
- New shared MCP client in `apptest`: a refused tool answers HTTP 200 with `isError` set, so `Call` returns the refusal beside the response.
- Every assertion is proven able to fail by mutating the product; `make test-it DIR=backend/internal/compose/integration/e2e/usecases` runs the suite.
- Not covered: the geocode writer, case 5 criterion 9 (no role control in `apptest`), the host side, and OAuth.

**Model lane**
- `e2e/llm/` drives a real assistant through `claude -p`, opt-in behind `MARGINCE_E2E_LLM=1` (spends tokens), against a dedicated `DEV_SLUG` stack — never :8080 — checking tool calls and required and forbidden mentions, passing at 2 of 3 runs.
- Not yet run against a live model; the checker is proven able to fail on fabricated transcripts.

<sup>Written for commit d382269991e00df74023959f009cc4b778da698c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in end-to-end testing workflow for LLM-assisted CRM scenarios.
  - Added automated scenario validation for tool usage, required responses, and prohibited claims.
  - Added reusable test data covering CRM records, imports, meetings, account history, and location-based searches.

- **Tests**
  - Added comprehensive integration coverage for six core assistant workflows, including duplicate detection, spreadsheet imports, transcript handling, meeting preparation, and company research.
  - Added repeat-run and pass-rate checks to identify inconsistent LLM behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->