### PR TITLE
fix(frontend): a sweep of open frontend issues

### DIFF
--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -19,6 +19,7 @@ import {
   MarginceCoreScene,
   type MarginceCoreState,
 } from "../design-system/margince-core";
+import { type CappedCount, cappedCountLabel } from "../format/cappedcount";
 import { formatMoney, formatNumber, INTL_LOCALE } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -85,23 +86,6 @@ const MARK_FADE = 0.16;
 
 /** Where the whole trace lives, and where a model gets bound. Same tab. */
 const AI_SETTINGS_HREF = "#/settings/admin/ai";
-
-/**
- * A count read off ONE page of a keyset-paged list.
- *
- * The dedupe queue returns no total and this rail reads a single 50-row page,
- * so a full page means "at least this many" and nothing more. Printing the
- * page length flat reads as a total: a workspace with two hundred open pairs
- * said "50", and the reader who cleared fifty of them found the number
- * unmoved. (The approvals count beside it needs none of this — its query walks
- * every page before counting.)
- */
-type CappedCount = Readonly<{ seen: number; more: boolean }>;
-
-/** The count as the rail prints it: "50+" when the page was full. */
-function countLabel(count: CappedCount): string {
-  return count.more ? `${count.seen}+` : String(count.seen);
-}
 
 /** What the installation can actually tell us, and what it cannot. */
 type Signals = Readonly<{
@@ -693,9 +677,9 @@ function AgentPanel({
               <a
                 className="arbox artile"
                 href="#/today"
-                aria-label={`${LABELS.duplicatesRow} ${countLabel(signals.duplicates)}`}
+                aria-label={`${LABELS.duplicatesRow} ${cappedCountLabel(signals.duplicates, locale)}`}
               >
-                <b>{countLabel(signals.duplicates)}</b>
+                <b>{cappedCountLabel(signals.duplicates, locale)}</b>
                 <span>{LABELS.duplicatesRow}</span>
               </a>
             )}
@@ -922,12 +906,12 @@ function usePanelFrame(
  * ranks under the licence because it is true of one screen rather than of the
  * whole installation.
  */
-function warningLine(signals: Signals): string {
+function warningLine(signals: Signals, locale: Locale): string {
   if (signals.license === "none" || signals.license === "refused") {
     return signals.licenseLine;
   }
   if (signals.duplicates?.seen) {
-    return `${countLabel(signals.duplicates)} ${LABELS.duplicates}`;
+    return `${cappedCountLabel(signals.duplicates, locale)} ${LABELS.duplicates}`;
   }
   return LABELS.review;
 }
@@ -996,6 +980,7 @@ function idleLines(
   spend: Readonly<{ allowed: boolean; minor: number | undefined }>,
   money: string,
   devLine: string,
+  locale: Locale,
   /** The newest run that settled today, or null when there is none to name. */
   settledLine: string | null,
 ): readonly string[] {
@@ -1011,7 +996,7 @@ function idleLines(
         : undefined,
     duplicates:
       signals.duplicates !== undefined && signals.duplicates.seen > 0
-        ? `${countLabel(signals.duplicates)} ${LABELS.duplicatesIdle}`
+        ? `${cappedCountLabel(signals.duplicates, locale)} ${LABELS.duplicatesIdle}`
         : undefined,
     spend:
       spend.allowed && spend.minor !== undefined
@@ -1064,6 +1049,7 @@ function barLine(
   signals: Signals,
   record: Readonly<{ reading: boolean }>,
   devLine: string,
+  locale: Locale,
   /** What the server says it is doing, or null when it says nothing this
    *  surface has words for. */
   serverLine: string | null,
@@ -1081,7 +1067,7 @@ function barLine(
     return LABELS.unreachable;
   }
   if (state === "warning") {
-    return warningLine(signals);
+    return warningLine(signals, locale);
   }
   if (state === "working") {
     // The named run outranks the generic word: "Working" is true of both a local
@@ -1187,7 +1173,14 @@ export function AgentRail({
   // The bar keeps the live run because that is what is true this second.
   const settledLine = server.recent[0] ? lineFor(server.recent[0], t) : null;
   const resting = useIdleLine(
-    idleLines(signals, spend, money, t("auth.coreDevelopment"), settledLine),
+    idleLines(
+      signals,
+      spend,
+      money,
+      t("auth.coreDevelopment"),
+      locale,
+      settledLine,
+    ),
   );
 
   // The one screen it absents itself from, and the reason is not layout: the Ask
@@ -1214,7 +1207,14 @@ export function AgentRail({
     (override && REVIEW_ONLY[override]) ??
     (state === "idle"
       ? resting
-      : barLine(state, signals, record, t("auth.coreDevelopment"), serverLine));
+      : barLine(
+          state,
+          signals,
+          record,
+          t("auth.coreDevelopment"),
+          locale,
+          serverLine,
+        ));
   return (
     <section
       className="arblock"

--- a/frontend/src/format/cappedcount.test.ts
+++ b/frontend/src/format/cappedcount.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { cappedCountLabel } from "./cappedcount";
+
+describe("a count read off one page", () => {
+  it("prints flat when the page held everything", () => {
+    expect(cappedCountLabel({ seen: 7, more: false }, "en")).toBe("7");
+  });
+
+  it("says it is a floor when there was another page behind it", () => {
+    expect(cappedCountLabel({ seen: 50, more: true }, "en")).toBe("50+");
+  });
+
+  it("groups its digits the way the reader's locale groups them", () => {
+    expect(cappedCountLabel({ seen: 1234, more: true }, "de")).toBe("1.234+");
+  });
+
+  // Zero is a real reading and never a cap: a page that came back empty had no
+  // page behind it, so nothing here may turn "none" into "none or more".
+  it("prints an empty page as none", () => {
+    expect(cappedCountLabel({ seen: 0, more: false }, "en")).toBe("0");
+  });
+});

--- a/frontend/src/format/cappedcount.ts
+++ b/frontend/src/format/cappedcount.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Locale } from "../i18n";
+import { formatNumber } from "./format";
+
+/**
+ * A count read off ONE page of a keyset-paged list.
+ *
+ * The list endpoints carry no total, so a screen counting the rows it received
+ * knows only that there are AT LEAST that many. Printing that flat reads as a
+ * total: a workspace with two hundred open pairs said "50", and the reader who
+ * cleared fifty of them found the number unmoved.
+ *
+ * `more` is the page's own `has_more`. It is not optional and has no default,
+ * because a caller that forgot it is exactly the caller this type exists for.
+ */
+export type CappedCount = Readonly<{ seen: number; more: boolean }>;
+
+/** The count as a surface prints it: the figure, and "+" when the page was
+ *  full. The digits go through `formatNumber` so a four-figure count is
+ *  grouped the way the reader's locale groups it. */
+export function cappedCountLabel(count: CappedCount, locale: Locale): string {
+  const figure = formatNumber(count.seen, locale);
+  return count.more ? `${figure}+` : figure;
+}

--- a/frontend/src/format/leadname-coverage.test.ts
+++ b/frontend/src/format/leadname-coverage.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// Fitness function for a screen that works out for itself what a lead is
+// called.
+//
+// The rule is one fact: a lead's own name if it has one, otherwise the email
+// address that is the only other thing naming it. `format/leadname.ts` is where
+// this application answers it, mirroring `leadIdentityName` in the people
+// module and the SQL census that holds the query side.
+//
+// It is not a tidiness argument. The spelling this gate refuses —
+// `lead.full_name ?? lead.email` — fires on `null` alone, so a lead carrying a
+// present-but-empty `full_name` renders BLANK on every screen that spells it,
+// while the server promotes the same lead into a person named by its address.
+// Nothing between a `CreateLead` body and the stored row refuses an empty name,
+// so that lead is one the product makes. Eight screens carried the spelling.
+//
+// The subject is DERIVED: every `??` or `||` chain under `src/` that falls back
+// from a `full_name` to an `email`, found by parsing rather than by matching
+// lines. Both operators, because the second is the same rule in a coat that
+// happens to answer correctly today — and a second author of one rule is what
+// this gate is about, not one operator.
+//
+// WHAT THIS DOES NOT CATCH, deliberately:
+//
+//  - `full_name ?? ""` with no address behind it. Seeding a form field with the
+//    stored value is a different question, and empty is the right answer there.
+//  - `email ?? full_name`. Address-first is a different rule, and a gate that
+//    conflated the two would push somebody to "fix" a surface that meant it.
+//  - a name resolved through a variable or a helper of the caller's own. That
+//    needs the type checker, and a gate whose rules are fiddly is a gate that
+//    gets worked around rather than fixed.
+
+const formatDir = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(formatDir, "..");
+
+/** The operators a fallback is spelled with. `||` is included because it is the
+ *  same rule; `??` is the one that carries the defect. */
+function isFallbackOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.QuestionQuestionToken ||
+    kind === ts.SyntaxKind.BarBarToken
+  );
+}
+
+/** The operands of one fallback chain, left to right. `a ?? b ?? c` parses as
+ *  `(a ?? b) ?? c`, so the chain has to be flattened before the ORDER of the
+ *  two fields can be read — and the order is the whole distinction between this
+ *  rule and the address-first one. */
+function chainOperands(node: ts.BinaryExpression): ts.Expression[] {
+  const left = node.left;
+  const head =
+    ts.isBinaryExpression(left) && isFallbackOperator(left.operatorToken.kind)
+      ? chainOperands(left)
+      : [left];
+  return [...head, node.right];
+}
+
+/** The property a term reads, or null for a term that reads none. */
+function fieldRead(expression: ts.Expression): string | null {
+  const inner = ts.isParenthesizedExpression(expression)
+    ? expression.expression
+    : expression;
+  if (ts.isPropertyAccessExpression(inner)) {
+    return inner.name.text;
+  }
+  if (ts.isElementAccessExpression(inner)) {
+    const argument = inner.argumentExpression;
+    return ts.isStringLiteral(argument) ? argument.text : null;
+  }
+  return null;
+}
+
+/** `<file>:<line>` for every hand-spelled lead name in one file. */
+function fallbacksIn(fileName: string, text: string): string[] {
+  const source = ts.createSourceFile(
+    fileName,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const found: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isBinaryExpression(node) &&
+      isFallbackOperator(node.operatorToken.kind) &&
+      // The OUTERMOST link of the chain only: an inner one would report the
+      // same fallback a second time under a different line.
+      !(
+        ts.isBinaryExpression(node.parent) &&
+        isFallbackOperator(node.parent.operatorToken.kind) &&
+        node.parent.left === node
+      )
+    ) {
+      const fields = chainOperands(node).map(fieldRead);
+      const name = fields.indexOf("full_name");
+      if (name >= 0 && fields.indexOf("email", name) > name) {
+        found.push(
+          `${fileName}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`,
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory()
+      ? sourceFiles(path)
+      : /\.tsx?$/.test(entry.name)
+        ? [path]
+        : [];
+  });
+}
+
+// The files that OWN the rule, named one by one rather than by directory: a
+// second helper added beside `leadname.ts` would otherwise pass the census this
+// test exists to keep at zero.
+const LEAD_NAME_OWNERS = [
+  "format/leadname.ts",
+  "format/leadname.test.ts",
+  "format/leadname-coverage.test.ts",
+];
+
+function fallbacks(): string[] {
+  const files = sourceFiles(srcRoot)
+    .map((file) => [relative(srcRoot, file), file] as const)
+    .filter(([name]) => !LEAD_NAME_OWNERS.includes(name));
+  // A sweep that found no files and a tree with no fallbacks look identical.
+  expect(files.length).toBeGreaterThan(0);
+  return files
+    .flatMap(([name, file]) => fallbacksIn(name, readFileSync(file, "utf8")))
+    .sort();
+}
+
+const PARSE_MS = 60_000;
+
+describe("what a lead is called", () => {
+  it(
+    "is worked out in exactly one place",
+    () => {
+      const found = fallbacks();
+      expect(found, `\n${found.join("\n")}\n`).toEqual([]);
+    },
+    PARSE_MS,
+  );
+
+  const planted: ReadonlyArray<readonly [string, string, number]> = [
+    [
+      "the spelling eight screens carried",
+      'const name = lead.full_name ?? lead.email ?? "";',
+      1,
+    ],
+    [
+      "the same fallback ending at the id",
+      "const name = lead.full_name ?? lead.email ?? lead.id;",
+      1,
+    ],
+    [
+      "an organization-first label, which still names the lead at its second term",
+      'const label = lead.company_name ?? lead.full_name ?? lead.email ?? "";',
+      1,
+    ],
+    [
+      "the rule inside JSX, where it is read rather than assigned",
+      "const row = <strong>{lead.full_name ?? lead.email}</strong>;",
+      1,
+    ],
+    [
+      // The coat the gate would otherwise miss: correct today, and a second
+      // author of the rule the moment either half moves.
+      "the same rule spelled with ||",
+      'const name = lead.full_name || lead.email || "";',
+      1,
+    ],
+    [
+      "a bracketed read, which a property-access-only rule would miss",
+      'const name = lead["full_name"] ?? lead["email"];',
+      1,
+    ],
+    [
+      "a form field seeded from the stored name, where empty is the right answer",
+      'const value = lead.full_name ?? "";',
+      0,
+    ],
+    [
+      "a person, who is not a lead and has no address to fall back to",
+      "const name = data.full_name ?? null;",
+      0,
+    ],
+    [
+      "an address-first label, which is a different rule and means it",
+      "const name = lead.email ?? lead.full_name;",
+      0,
+    ],
+  ];
+
+  for (const [what, code, count] of planted) {
+    it(`sees ${what}`, () => {
+      expect(fallbacksIn("planted.tsx", code)).toHaveLength(count);
+    });
+  }
+});

--- a/frontend/src/format/leadname-coverage.test.ts
+++ b/frontend/src/format/leadname-coverage.test.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { filesUnder, scriptKindFor } from "../../scripts/lib/source-tree";
 
 // Fitness function for a screen that works out for itself what a lead is
 // called.
@@ -63,17 +64,24 @@ function chainOperands(node: ts.BinaryExpression): ts.Expression[] {
   return [...head, node.right];
 }
 
-/** The property a term reads, or null for a term that reads none. */
-function fieldRead(expression: ts.Expression): string | null {
+/** One term of a chain: WHOSE field it reads, and which. The receiver is half
+ *  the finding — `person.full_name ?? lead.email` reads two records and is not
+ *  this rule, so a gate comparing property names alone would send somebody to
+ *  "fix" a fallback that means what it says. */
+type FieldRead = Readonly<{ receiver: string; field: string }>;
+
+function fieldRead(expression: ts.Expression): FieldRead | null {
   const inner = ts.isParenthesizedExpression(expression)
     ? expression.expression
     : expression;
   if (ts.isPropertyAccessExpression(inner)) {
-    return inner.name.text;
+    return { receiver: inner.expression.getText(), field: inner.name.text };
   }
   if (ts.isElementAccessExpression(inner)) {
     const argument = inner.argumentExpression;
-    return ts.isStringLiteral(argument) ? argument.text : null;
+    return ts.isStringLiteral(argument)
+      ? { receiver: inner.expression.getText(), field: argument.text }
+      : null;
   }
   return null;
 }
@@ -85,7 +93,13 @@ function fallbacksIn(fileName: string, text: string): string[] {
     text,
     ts.ScriptTarget.Latest,
     true,
-    ts.ScriptKind.TSX,
+    // The file's OWN kind, from the one place this tree decides that. Under
+    // `TSX` a plain `.ts` generic arrow — `<T>(value: T) => value` — parses as
+    // an unclosed JSX element, and everything after it is parse recovery
+    // rather than the tree this scan means to walk. A census that reads a
+    // smaller tree reports PASS and nothing fails, which is the one way a gate
+    // must not break.
+    scriptKindFor(fileName),
   );
   const found: string[] = [];
   const visit = (node: ts.Node) => {
@@ -100,9 +114,15 @@ function fallbacksIn(fileName: string, text: string): string[] {
         node.parent.left === node
       )
     ) {
-      const fields = chainOperands(node).map(fieldRead);
-      const name = fields.indexOf("full_name");
-      if (name >= 0 && fields.indexOf("email", name) > name) {
+      const terms = chainOperands(node).map(fieldRead);
+      const name = terms.findIndex((term) => term?.field === "full_name");
+      const address = terms.findIndex(
+        (term, at) =>
+          at > name &&
+          term?.field === "email" &&
+          term.receiver === terms[name]?.receiver,
+      );
+      if (name >= 0 && address > name) {
         found.push(
           `${fileName}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`,
         );
@@ -114,15 +134,11 @@ function fallbacksIn(fileName: string, text: string): string[] {
   return found;
 }
 
+/** Every TypeScript source under `src/`, through the shared walk — which
+ *  descends a symlinked directory a bundler would ship and this scan would
+ *  otherwise read straight past. */
 function sourceFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(dir, entry.name);
-    return entry.isDirectory()
-      ? sourceFiles(path)
-      : /\.tsx?$/.test(entry.name)
-        ? [path]
-        : [];
-  });
+  return filesUnder(dir).filter((path) => /\.tsx?$/.test(path));
 }
 
 // The files that OWN the rule, named one by one rather than by directory: a
@@ -136,7 +152,7 @@ const LEAD_NAME_OWNERS = [
 
 function fallbacks(): string[] {
   const files = sourceFiles(srcRoot)
-    .map((file) => [relative(srcRoot, file), file] as const)
+    .map((file): readonly [string, string] => [relative(srcRoot, file), file])
     .filter(([name]) => !LEAD_NAME_OWNERS.includes(name));
   // A sweep that found no files and a tree with no fallbacks look identical.
   expect(files.length).toBeGreaterThan(0);
@@ -205,6 +221,14 @@ describe("what a lead is called", () => {
       "const name = lead.email ?? lead.full_name;",
       0,
     ],
+    [
+      // Two records, one chain: a person's name with a lead's address behind
+      // it is a fallback somebody meant, and calling it this rule would send
+      // the next author to break it.
+      "two different receivers, which is not one record being named",
+      "const name = person.full_name ?? lead.email;",
+      0,
+    ],
   ];
 
   for (const [what, code, count] of planted) {
@@ -212,4 +236,15 @@ describe("what a lead is called", () => {
       expect(fallbacksIn("planted.tsx", code)).toHaveLength(count);
     });
   }
+
+  // The shape a census goes blind to rather than the shape it reports: parsed
+  // as TSX, a `.ts` generic arrow opens a JSX element that never closes, and
+  // the fallback after it is inside parse recovery rather than the tree. The
+  // same source under both extensions is the only assertion that can tell.
+  const genericArrowThenFallback =
+    "const id = <T>(value: T) => value;\nconst name = lead.full_name ?? lead.email;";
+
+  it("reads a .ts generic arrow as TypeScript, so what follows it is still scanned", () => {
+    expect(fallbacksIn("planted.ts", genericArrowThenFallback)).toHaveLength(1);
+  });
 });

--- a/frontend/src/format/leadname-coverage.test.ts
+++ b/frontend/src/format/leadname-coverage.test.ts
@@ -51,17 +51,47 @@ function isFallbackOperator(kind: ts.SyntaxKind): boolean {
   );
 }
 
+/** An expression with its parentheses taken off. A reader's brackets are not a
+ *  different rule, and a scan that stopped at one would read
+ *  `lead.full_name ?? (lead.email || "")` as a chain of two terms whose second
+ *  is nothing it recognises. */
+function unwrap(expression: ts.Expression): ts.Expression {
+  return ts.isParenthesizedExpression(expression)
+    ? unwrap(expression.expression)
+    : expression;
+}
+
 /** The operands of one fallback chain, left to right. `a ?? b ?? c` parses as
  *  `(a ?? b) ?? c`, so the chain has to be flattened before the ORDER of the
- *  two fields can be read — and the order is the whole distinction between this
- *  rule and the address-first one. */
+ *  fields can be read — and the order is the whole distinction between this
+ *  rule and the address-first one. BOTH sides are flattened: `??` groups to the
+ *  left on its own, but nothing stops an author from writing the nesting out. */
 function chainOperands(node: ts.BinaryExpression): ts.Expression[] {
-  const left = node.left;
-  const head =
-    ts.isBinaryExpression(left) && isFallbackOperator(left.operatorToken.kind)
-      ? chainOperands(left)
-      : [left];
-  return [...head, node.right];
+  return [node.left, node.right].flatMap((side) => {
+    const inner = unwrap(side);
+    return ts.isBinaryExpression(inner) &&
+      isFallbackOperator(inner.operatorToken.kind)
+      ? chainOperands(inner)
+      : [inner];
+  });
+}
+
+/** Whether this chain is the whole of its own expression. An inner link is
+ *  already one of the outer chain's operands, so reporting it again would name
+ *  one fallback twice — and the parentheses have to be climbed through, or a
+ *  bracketed inner chain reads as its own. */
+function isOutermostChain(node: ts.BinaryExpression): boolean {
+  let child: ts.Node = node;
+  let parent: ts.Node = node.parent;
+  while (ts.isParenthesizedExpression(parent)) {
+    child = parent;
+    parent = parent.parent;
+  }
+  return !(
+    ts.isBinaryExpression(parent) &&
+    isFallbackOperator(parent.operatorToken.kind) &&
+    (parent.left === child || parent.right === child)
+  );
 }
 
 /** One term of a chain: WHOSE field it reads, and which. The receiver is half
@@ -106,23 +136,24 @@ function fallbacksIn(fileName: string, text: string): string[] {
     if (
       ts.isBinaryExpression(node) &&
       isFallbackOperator(node.operatorToken.kind) &&
-      // The OUTERMOST link of the chain only: an inner one would report the
-      // same fallback a second time under a different line.
-      !(
-        ts.isBinaryExpression(node.parent) &&
-        isFallbackOperator(node.parent.operatorToken.kind) &&
-        node.parent.left === node
-      )
+      isOutermostChain(node)
     ) {
       const terms = chainOperands(node).map(fieldRead);
-      const name = terms.findIndex((term) => term?.field === "full_name");
-      const address = terms.findIndex(
+      // EVERY name in the chain is asked, not the first one: an
+      // organization-first label puts somebody else's `full_name` ahead of the
+      // lead's, and a scan that stopped at the first would look for the
+      // address under the wrong receiver and find nothing.
+      const named = terms.some(
         (term, at) =>
-          at > name &&
-          term?.field === "email" &&
-          term.receiver === terms[name]?.receiver,
+          term?.field === "full_name" &&
+          terms
+            .slice(at + 1)
+            .some(
+              (later) =>
+                later?.field === "email" && later.receiver === term.receiver,
+            ),
       );
-      if (name >= 0 && address > name) {
+      if (named) {
         found.push(
           `${fileName}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`,
         );
@@ -228,6 +259,19 @@ describe("what a lead is called", () => {
       "two different receivers, which is not one record being named",
       "const name = person.full_name ?? lead.email;",
       0,
+    ],
+    [
+      // The reader's own brackets, which change nothing about the rule.
+      "a bracketed tail, where the address sits inside its own chain",
+      'const name = lead.full_name ?? (lead.email || "");',
+      1,
+    ],
+    [
+      // Somebody else's name first. A scan reading only the first `full_name`
+      // looks for the address under THAT receiver and reports nothing.
+      "another record's name ahead of the lead's own",
+      "const name = person.full_name ?? lead.full_name ?? lead.email;",
+      1,
     ],
   ];
 

--- a/frontend/src/format/leadname.test.ts
+++ b/frontend/src/format/leadname.test.ts
@@ -57,4 +57,17 @@ describe("what a lead is called", () => {
   it("answers nothing for an empty full_name with no address behind it", () => {
     expect(leadIdentityName({ full_name: "" })).toBe("");
   });
+
+  it("carries no padding out of an address either", () => {
+    expect(leadIdentityName({ email: "  vera@nordwind.example  " })).toBe(
+      "vera@nordwind.example",
+    );
+  });
+
+  // A padded name over a padded address names nobody. Answering the padding
+  // would hand back a TRUTHY blank, and every caller's own last resort — the
+  // id, the word for a lead — is reached with `||` and would never fire.
+  it("answers nothing when both fields are nothing but padding", () => {
+    expect(leadIdentityName({ full_name: " ", email: "   " })).toBe("");
+  });
 });

--- a/frontend/src/format/leadname.test.ts
+++ b/frontend/src/format/leadname.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { leadIdentityName } from "./leadname";
+
+// The same cases the server's own `TestLeadIdentityName` runs, because the two
+// answer one question and a browser that disagreed would draw a blank name
+// beside a promotion that names the lead by its address.
+describe("what a lead is called", () => {
+  it("is its own name when it has one", () => {
+    expect(leadIdentityName({ full_name: "Vera Lindqvist" })).toBe(
+      "Vera Lindqvist",
+    );
+  });
+
+  it("is the email address of a lead with no name of its own", () => {
+    expect(leadIdentityName({ email: "vera@nordwind.example" })).toBe(
+      "vera@nordwind.example",
+    );
+  });
+
+  it("prefers the name over the address", () => {
+    expect(
+      leadIdentityName({
+        full_name: "Vera Lindqvist",
+        email: "vera@nordwind.example",
+      }),
+    ).toBe("Vera Lindqvist");
+  });
+
+  // The defect this helper exists for: `??` fires on null alone, so a stored
+  // empty string reads as a name and the lead renders blank.
+  it("does not count a present-but-empty full_name as a name", () => {
+    expect(
+      leadIdentityName({ full_name: "", email: "vera@nordwind.example" }),
+    ).toBe("vera@nordwind.example");
+  });
+
+  it("does not count padding as a name either", () => {
+    expect(
+      leadIdentityName({ full_name: "   ", email: "vera@nordwind.example" }),
+    ).toBe("vera@nordwind.example");
+  });
+
+  it("carries no padding out of a name it does keep", () => {
+    expect(leadIdentityName({ full_name: "  Vera Lindqvist  " })).toBe(
+      "Vera Lindqvist",
+    );
+  });
+
+  it("answers nothing for a lead with neither", () => {
+    expect(leadIdentityName({})).toBe("");
+    expect(leadIdentityName({ full_name: null, email: null })).toBe("");
+  });
+
+  it("answers nothing for an empty full_name with no address behind it", () => {
+    expect(leadIdentityName({ full_name: "" })).toBe("");
+  });
+});

--- a/frontend/src/format/leadname.ts
+++ b/frontend/src/format/leadname.ts
@@ -17,8 +17,13 @@ type NameableLead = Readonly<{
  * `??` is not this rule. A `full_name` that is PRESENT and EMPTY is not a name,
  * and nothing between a `CreateLead` body and the stored row refuses one — so a
  * screen falling back on null alone renders such a lead blank, while the server
- * promotes the very same lead into a person named by its address. The trim is
- * the same half of the rule: padding is not identity.
+ * promotes the very same lead into a person named by its address.
+ *
+ * Both fields are trimmed, and for one reason: padding is not identity. The
+ * server's address arrives through `values.ParseEmail`, which trims it there —
+ * so trimming here is what keeps the two agreeing rather than a rule of our
+ * own. A field that is nothing but padding names nobody, and answering it would
+ * hand a caller a truthy string their own `|| fallback` then never reaches.
  *
  * This mirrors `leadIdentityName` in the people module, which is where the
  * server and its SQL answer the question. Return `""` and let the caller pick
@@ -31,5 +36,5 @@ export function leadIdentityName(lead: NameableLead): string {
   if (name) {
     return name;
   }
-  return lead.email ?? "";
+  return lead.email?.trim() ?? "";
 }

--- a/frontend/src/format/leadname.ts
+++ b/frontend/src/format/leadname.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** The two fields that can name a lead. Structural rather than the contract's
+ *  `Lead`, because the record-reference reader answers with the same pair from
+ *  a different read and is naming the same lead. */
+type NameableLead = Readonly<{
+  full_name?: string | null;
+  email?: string | null;
+}>;
+
+/**
+ * What a lead is called: its own name if it has one, otherwise the email
+ * address that is the only other thing naming it, and the empty string when it
+ * has neither.
+ *
+ * `??` is not this rule. A `full_name` that is PRESENT and EMPTY is not a name,
+ * and nothing between a `CreateLead` body and the stored row refuses one — so a
+ * screen falling back on null alone renders such a lead blank, while the server
+ * promotes the very same lead into a person named by its address. The trim is
+ * the same half of the rule: padding is not identity.
+ *
+ * This mirrors `leadIdentityName` in the people module, which is where the
+ * server and its SQL answer the question. Return `""` and let the caller pick
+ * its own last resort — a list row falls back to the id, a page heading to the
+ * word "Leads" — because what to say about a lead nothing names is the
+ * caller's to know.
+ */
+export function leadIdentityName(lead: NameableLead): string {
+  const name = lead.full_name?.trim();
+  if (name) {
+    return name;
+  }
+  return lead.email ?? "";
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1639,6 +1639,7 @@ export const de = {
   "lead.bulkFailed": "{count} nicht übernommen –",
   "lead.bulkFailedRow": "konnte nicht gespeichert werden",
   "lead.bulkSelectRow": "{name} auswählen",
+  "lead.unnamed": "Lead ohne Namen",
   "lead.sla.breached": "Überfällig",
   "lead.sla.atRisk": "Bald fällig",
   "lead.sla.withinTarget": "Im Rahmen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1677,6 +1677,7 @@ export const en = {
   "lead.bulkFailed": "{count} not applied —",
   "lead.bulkFailedRow": "could not be saved",
   "lead.bulkSelectRow": "Select {name}",
+  "lead.unnamed": "Unnamed lead",
   "lead.sla.breached": "Overdue",
   "lead.sla.atRisk": "Due soon",
   "lead.sla.withinTarget": "On time",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1633,6 +1633,7 @@ export const vi = {
   "lead.bulkFailed": "{count} không áp dụng được —",
   "lead.bulkFailedRow": "không lưu được",
   "lead.bulkSelectRow": "Chọn {name}",
+  "lead.unnamed": "Khách hàng tiềm năng chưa có tên",
   "lead.sla.breached": "Quá hạn",
   "lead.sla.atRisk": "Sắp đến hạn",
   "lead.sla.withinTarget": "Đúng hạn",

--- a/frontend/src/screens/entityref.tsx
+++ b/frontend/src/screens/entityref.tsx
@@ -6,6 +6,7 @@ import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
 import { ENTITY, type EntityKind } from "../app/entity";
 import { navigate } from "../app/router";
+import { leadIdentityName } from "../format/leadname";
 import { useT } from "../i18n";
 import { throwProblem } from "./common";
 
@@ -80,7 +81,7 @@ const NAME_READERS: Record<EntityKind, (id: string) => Promise<string | null>> =
         params: { path: { id } },
       });
       if (error) return unnamedOrThrow(error, response);
-      return data.full_name ?? data.email ?? null;
+      return leadIdentityName(data) || null;
     },
     project: async (id) => {
       const { data, error, response } = await api.GET("/projects/{id}", {

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -3,7 +3,8 @@
 
 import { ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
-import { formatNumber, hourInZone } from "../format/format";
+import { type CappedCount, cappedCountLabel } from "../format/cappedcount";
+import { hourInZone } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, usePlural, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -89,7 +90,8 @@ export type GlanceFacts = Readonly<{
   brief: GlanceBrief | null;
   overnight: GlanceOvernight | null;
   /** Open deals that have gone quiet. */
-  stalled: number | null;
+  /** Open deals gone quiet, as a floor: Home reads one page of deals. */
+  stalled: CappedCount | null;
 }>;
 
 export type GlanceProps = GlanceFacts &
@@ -115,9 +117,17 @@ export type GlanceProps = GlanceFacts &
  */
 function CountMark({
   count,
+  more,
   onClick,
   label,
-}: Readonly<{ count: number; onClick?: () => void; label?: string }>) {
+}: Readonly<{
+  count: number;
+  /** Whether the figure is a floor rather than a total — the reading came off
+   *  one page and there was another behind it. */
+  more?: boolean;
+  onClick?: () => void;
+  label?: string;
+}>) {
   const { locale } = useLocale();
   // A figure with nowhere to go is a figure, not a control. The overnight
   // capture count is the case: Home has no destination that lists the messages
@@ -127,7 +137,7 @@ function CountMark({
   if (!onClick) {
     return (
       <span className="glance-count glance-count-flat t-mono">
-        {formatNumber(count, locale)}
+        {cappedCountLabel({ seen: count, more: more ?? false }, locale)}
       </span>
     );
   }
@@ -137,7 +147,7 @@ function CountMark({
   // at two places would announce the same name.
   return (
     <button type="button" className="glance-count t-mono" onClick={onClick}>
-      {formatNumber(count, locale)}
+      {cappedCountLabel({ seen: count, more: more ?? false }, locale)}
       {label ? <span className="sr-only"> {label}</span> : null}
       <ArrowRight size={13} aria-hidden="true" />
     </button>
@@ -147,12 +157,15 @@ function CountMark({
 /** One line of the briefing: a numeral that goes somewhere, then the clause. */
 function GlanceLine({
   count,
+  more,
   onClick,
   goLabel,
   children,
   testId,
 }: Readonly<{
   count: number;
+  /** Whether the figure is a floor — forwarded to `CountMark`. */
+  more?: boolean;
   /** Omitted where the figure has no destination — see `CountMark`. */
   onClick?: () => void;
   goLabel?: string;
@@ -161,7 +174,7 @@ function GlanceLine({
 }>) {
   return (
     <p className="glance-line" data-testid={testId}>
-      <CountMark count={count} onClick={onClick} label={goLabel} />
+      <CountMark count={count} more={more} onClick={onClick} label={goLabel} />
       <span className="glance-clause">{children}</span>
     </p>
   );
@@ -254,14 +267,15 @@ export function HomeGlance({
             {plural("home.glance.duplicates", overnight.duplicates)}
           </GlanceLine>
         )}
-        {stalled !== null && stalled > 0 && (
+        {stalled !== null && stalled.seen > 0 && (
           <GlanceLine
             testId="glance-quiet"
-            count={stalled}
+            count={stalled.seen}
+            more={stalled.more}
             onClick={onGoToWatch}
             goLabel={t("home.glance.goWatch")}
           >
-            {plural("home.glance.quiet", stalled)}
+            {plural("home.glance.quiet", stalled.seen)}
           </GlanceLine>
         )}
       </div>

--- a/frontend/src/screens/home.parts.stories.tsx
+++ b/frontend/src/screens/home.parts.stories.tsx
@@ -106,7 +106,7 @@ export const Glance: Story = {
         topAmount: "€48,000.00",
       }}
       overnight={{ captured: 42, duplicates: 3 }}
-      stalled={2}
+      stalled={{ seen: 2, more: false }}
       {...GLANCE_GO}
     />,
   ),
@@ -122,7 +122,27 @@ export const GlanceCalm: Story = {
       decisions={{ pending: 0, expiringToday: 0 }}
       brief={{ ranked: 0, topDeal: null, topAmount: null }}
       overnight={{ captured: 0, duplicates: 0 }}
-      stalled={0}
+      stalled={{ seen: 0, more: false }}
+      {...GLANCE_GO}
+    />,
+  ),
+};
+
+// The quiet count came off one page with another behind it, so the numeral in
+// the briefing line is a floor and reads as one.
+export const GlanceCapped: Story = {
+  render: part(
+    <HomeGlance
+      firstName="Lena"
+      now={NOW_DATE}
+      decisions={{ pending: 6, expiringToday: 2 }}
+      brief={{
+        ranked: 3,
+        topDeal: "Fleet retrofit",
+        topAmount: "\u20ac48,000.00",
+      }}
+      overnight={{ captured: 42, duplicates: 3 }}
+      stalled={{ seen: 100, more: true }}
       {...GLANCE_GO}
     />,
   ),
@@ -139,7 +159,7 @@ export const GlanceUnread: Story = {
       decisions={{ pending: 4, expiringToday: 0 }}
       brief={null}
       overnight={null}
-      stalled={2}
+      stalled={{ seen: 2, more: false }}
       {...GLANCE_GO}
     />,
   ),
@@ -154,9 +174,23 @@ export const Readings: Story = {
   render: part(
     <HomeReadingsStrip
       decisions={{ pending: 6, expiringToday: 2 }}
-      open={{ deals: 5, currencies: 2 }}
+      open={{ deals: { seen: 5, more: false }, currencies: 2 }}
       ranked={{ count: 3, topPct: 74 }}
-      quiet={2}
+      quiet={{ seen: 2, more: false }}
+    />,
+  ),
+};
+
+// The page ended short of the list, so every reading taken from it is a FLOOR.
+// The figure carries the "+" rather than the caption, because a reader who takes
+// a bounded number for a total does it while looking at the number.
+export const ReadingsCapped: Story = {
+  render: part(
+    <HomeReadingsStrip
+      decisions={{ pending: 6, expiringToday: 2 }}
+      open={{ deals: { seen: 100, more: true }, currencies: 3 }}
+      ranked={{ count: 3, topPct: 74 }}
+      quiet={{ seen: 12, more: true }}
     />,
   ),
 };
@@ -272,13 +306,30 @@ export const Position: Story = {
 // carries no edge stripe saying the same thing a second time.
 export const Watch: Story = {
   render: part(
-    <WatchPanel deals={deals.filter((deal) => deal.stalled)} state="ready" />,
+    <WatchPanel
+      deals={deals.filter((deal) => deal.stalled)}
+      more={false}
+      state="ready"
+    />,
+  ),
+};
+
+// The deals read stopped at one page. What is on the panel is some of the quiet
+// deals and not all of them, so it says so under the rows — "nothing has gone
+// quiet" is a claim this read cannot make.
+export const WatchPartial: Story = {
+  render: part(
+    <WatchPanel
+      deals={deals.filter((deal) => deal.stalled)}
+      more
+      state="ready"
+    />,
   ),
 };
 
 // Nothing has gone quiet, which is news worth drawing rather than an empty rail.
 export const WatchClear: Story = {
-  render: part(<WatchPanel deals={[]} state="ready" />),
+  render: part(<WatchPanel deals={[]} more={false} state="ready" />),
 };
 
 // The deals read failed. "Nothing has gone quiet" is a claim about the deals, so
@@ -286,5 +337,5 @@ export const WatchClear: Story = {
 // sentence told a reader their pipeline was healthy on the strength of a request
 // that never answered.
 export const WatchRefused: Story = {
-  render: part(<WatchPanel deals={[]} state="failed" />),
+  render: part(<WatchPanel deals={[]} more={false} state="failed" />),
 };

--- a/frontend/src/screens/home.queries.ts
+++ b/frontend/src/screens/home.queries.ts
@@ -152,24 +152,37 @@ export function usePipelineValue(): UseQueryResult<PipelineReading> {
   });
 }
 
+/** One page of deals, and whether the list ended there. */
+export type HomeDeals = Readonly<{ rows: Deal[]; more: boolean }>;
+
+/** How many deals Home reads in one go. */
+const HOME_DEALS_PAGE = 100;
+
 /**
  * The deals page Home reads twice over: the quiet ones it lists, and the count
  * of open ones its readings strip reports.
  *
  * One query rather than two because there is no server-side "stalled" filter to
  * ask for — the flag arrives on the row and the filtering is ours.
+ *
+ * ONE page, and the page's own `has_more` travels with it. Following the cursor
+ * would cost an unbounded fan-out on the one screen that opens every morning,
+ * so the honest answer is the other one: every reading taken from these rows is
+ * a FLOOR past the page, and says so where it is drawn. A count that quietly
+ * stopped rising is the failure this repo cares about most — the same words, a
+ * smaller number, and nothing failing.
  */
-export function useHomeDeals(): UseQueryResult<Deal[]> {
+export function useHomeDeals(): UseQueryResult<HomeDeals> {
   return useQuery({
     queryKey: ["deals"],
-    queryFn: async (): Promise<Deal[]> => {
+    queryFn: async (): Promise<HomeDeals> => {
       const { data, error } = await api.GET("/deals", {
-        params: { query: { limit: 100 } },
+        params: { query: { limit: HOME_DEALS_PAGE } },
       });
       if (error) {
         throwProblem(error);
       }
-      return data.data;
+      return { rows: data.data, more: data.page?.has_more ?? false };
     },
   });
 }

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -340,8 +340,16 @@ export function PositionPanel() {
  */
 export function WatchPanel({
   deals,
+  more,
   state,
-}: Readonly<{ deals: readonly Deal[]; state: SectionState }>) {
+}: Readonly<{
+  deals: readonly Deal[];
+  /** Whether Home's one page of deals ended short of the list. A quiet deal
+   *  past that page is not on this panel, and `partial` is the state that says
+   *  so — "nothing has gone quiet" would be a claim this read cannot make. */
+  more: boolean;
+  state: SectionState;
+}>) {
   const t = useT();
   // No page of organizations to draw on here — this is a short list, and every
   // company it names is resolved by id and cached.
@@ -353,8 +361,17 @@ export function WatchPanel({
   // once they have been read. A failed read used to reach the same sentence,
   // which told a reader their pipeline was healthy on the strength of a request
   // that never answered.
-  const resolved: SectionState =
-    state === "ready" && deals.length === 0 ? "empty" : state;
+  // Only a settled read may say anything about the deals, and WHICH thing it
+  // says turns on whether the page ended the list: past it, an empty panel is
+  // not "nothing has gone quiet", it is "nothing on the page we read".
+  const settled = state === "ready";
+  const resolved: SectionState = !settled
+    ? state
+    : more
+      ? "partial"
+      : deals.length === 0
+        ? "empty"
+        : state;
   return (
     <Panel title={t("home.panel.watch")} className="rail-panel">
       <PanelBody className={deals.length > 0 ? "rail-watch-list" : undefined}>

--- a/frontend/src/screens/home.readings.tsx
+++ b/frontend/src/screens/home.readings.tsx
@@ -103,9 +103,17 @@ export function HomeReadingsStrip({
           numeric
           label={t("home.readings.quiet")}
           value={cappedCountLabel(quiet, locale)}
-          tone={quiet.seen > 0 ? "warn" : "good"}
+          // "None have gone quiet" is a claim, and only a reading that saw the
+          // whole list may make it. A count of zero off a page with another
+          // behind it is neither bad news nor an all-clear: it is a floor, and
+          // the tile says the figure and nothing more.
+          tone={quiet.seen > 0 ? "warn" : quiet.more ? undefined : "good"}
           dot={quiet.seen > 0}
-          detail={quiet.seen === 0 ? t("home.readings.quietNone") : undefined}
+          detail={
+            quiet.seen === 0 && !quiet.more
+              ? t("home.readings.quietNone")
+              : undefined
+          }
         />
       )}
     </StatStrip>

--- a/frontend/src/screens/home.readings.tsx
+++ b/frontend/src/screens/home.readings.tsx
@@ -3,6 +3,7 @@
 
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
+import { type CappedCount, cappedCountLabel } from "../format/cappedcount";
 import { formatNumber } from "../format/format";
 import { useLocale, usePlural, useT } from "../i18n";
 
@@ -23,12 +24,13 @@ import { useLocale, usePlural, useT } from "../i18n";
 export type HomeReadings = Readonly<{
   /** Decisions waiting, and how many stop waiting today. Null when unread. */
   decisions: { pending: number; expiringToday: number } | null;
-  /** Open deals and the currencies they are priced in. Null when unread. */
-  open: { deals: number; currencies: number } | null;
+  /** Open deals and the currencies they are priced in. Null when unread. The
+   *  deal count is a floor: Home reads one page. */
+  open: { deals: CappedCount; currencies: number } | null;
   /** The ranked queue: how many, and the top composite. Null when no run. */
   ranked: { count: number; topPct: number | null } | null;
-  /** Open deals that have gone quiet. Null when unread. */
-  quiet: number | null;
+  /** Open deals that have gone quiet, as a floor. Null when unread. */
+  quiet: CappedCount | null;
 }>;
 
 export function HomeReadingsStrip({
@@ -76,7 +78,7 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.openDeals")}
-          value={formatNumber(open.deals, locale)}
+          value={cappedCountLabel(open.deals, locale)}
           detail={plural("home.readings.currencies", open.currencies, {
             count: formatNumber(open.currencies, locale),
           })}
@@ -100,10 +102,10 @@ export function HomeReadingsStrip({
         <StatCard
           numeric
           label={t("home.readings.quiet")}
-          value={formatNumber(quiet, locale)}
-          tone={quiet > 0 ? "warn" : "good"}
-          dot={quiet > 0}
-          detail={quiet === 0 ? t("home.readings.quietNone") : undefined}
+          value={cappedCountLabel(quiet, locale)}
+          tone={quiet.seen > 0 ? "warn" : "good"}
+          dot={quiet.seen > 0}
+          detail={quiet.seen === 0 ? t("home.readings.quietNone") : undefined}
         />
       )}
     </StatStrip>

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -642,6 +642,32 @@ describe("HomeScreen — a reading in flight is absent, not zero", () => {
     expect(screen.getByText("2 evidence rows")).toBeTruthy();
   });
 
+  // Home reads ONE page of deals. Past it every reading taken from those rows is
+  // a floor, and the failure this guards is the quiet one: the same words, a
+  // smaller number, and nothing failing.
+  it("reports a deal reading off a full page as a floor rather than a total", async () => {
+    stubApi({
+      "GET /deals": () =>
+        jsonResponse({
+          data: [fleetDeal, { ...fleetDeal, id: "d-2", stalled: true }],
+          page: { has_more: true },
+        }),
+    });
+    render(<HomeScreen />);
+
+    const strip = await screen.findByTestId("home-readings");
+    await waitFor(() =>
+      expect(within(strip).getByText("Open deals")).toBeTruthy(),
+    );
+    // Two open deals on the page and another page behind them: both the open
+    // count and the quiet count say so where the figure is read.
+    expect(within(strip).getByText("2+")).toBeTruthy();
+    expect(within(strip).getByText("1+")).toBeTruthy();
+    // And the panel that LISTS them says the list is part of one, rather than
+    // making the "nothing has gone quiet" claim it has no grounds for.
+    expect(screen.getByText("Showing part of the list")).toBeTruthy();
+  });
+
   // What "today" means is the reader's own calendar day, so this is the one case
   // that pins the clock rather than reading it.
   it("counts what stops waiting today in the reader's own day", async () => {

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -287,8 +287,15 @@ export function HomeScreen() {
 
   const approvals = approvalsQuery.data?.data ?? [];
   const items = useMemo(() => deckItems(approvals), [approvals]);
-  const deals = dealsQuery.data ?? [];
+  const deals = dealsQuery.data?.rows ?? [];
+  // Every count taken from this page is a floor: the read stops at one page,
+  // and `more` is what keeps the strip from reporting a bounded number as a
+  // total.
+  const beyondPage = dealsQuery.data?.more ?? false;
   const quiet = quietDeals(deals);
+  const quietReading = dealsQuery.isSuccess
+    ? { seen: quiet.length, more: beyondPage }
+    : null;
   const brief = briefQuery.data ?? null;
   const digest = digestQuery.data ?? null;
   const leader = topDeal(brief, deals);
@@ -318,7 +325,7 @@ export function HomeScreen() {
   const openReading =
     dealsQuery.isSuccess && pipelineQuery.isSuccess
       ? {
-          deals: openDeals(deals).length,
+          deals: { seen: openDeals(deals).length, more: beyondPage },
           currencies: pipelineQuery.data.rows.length,
         }
       : null;
@@ -334,7 +341,7 @@ export function HomeScreen() {
         decisions={decisionReadings}
         brief={briefGlance(briefQuery.isSuccess, brief, leader, locale)}
         overnight={overnightGlance(digestQuery.isSuccess, digest)}
-        stalled={dealsQuery.isSuccess ? quiet.length : null}
+        stalled={quietReading}
         onGoToDecisions={() => goToSection("home-decisions")}
         onGoToToday={() => goToSection("home-today")}
         onGoToDuplicates={() => navigate({ screen: "today" })}
@@ -344,7 +351,7 @@ export function HomeScreen() {
         decisions={decisionReadings}
         open={openReading}
         ranked={rankedReading}
-        quiet={dealsQuery.isSuccess ? quiet.length : null}
+        quiet={quietReading}
       />
       {/* Screen-level so it survives the deck re-rendering under it. */}
       {decidedNote}
@@ -369,7 +376,11 @@ export function HomeScreen() {
             <OvernightPanel />
             <PositionPanel />
             <section id="home-watch">
-              <WatchPanel deals={quiet} state={readState(dealsQuery)} />
+              <WatchPanel
+                deals={quiet}
+                more={beyondPage}
+                state={readState(dealsQuery)}
+              />
             </section>
           </>
         }

--- a/frontend/src/screens/leadbulk.tsx
+++ b/frontend/src/screens/leadbulk.tsx
@@ -6,6 +6,7 @@ import { ifMatch, requireVersion } from "../api/version";
 import { Button } from "../design-system/atoms";
 import { Select } from "../design-system/select";
 import { formatNumber } from "../format/format";
+import { leadIdentityName } from "../format/leadname";
 import { useLocale, useT } from "../i18n";
 import { ProblemError, problemMessageOf, throwProblem } from "./common";
 import { useRoster } from "./entityref";
@@ -100,7 +101,7 @@ export function LeadBulkBar({
       // rep's own leads buys nothing but contention.
       leads.reduce<Promise<BulkOutcome[]>>(async (acc, lead) => {
         const done = await acc;
-        const name = lead.full_name ?? lead.email ?? lead.id;
+        const name = leadIdentityName(lead) || lead.id;
         try {
           await apply(lead, action);
           done.push({ id: lead.id, name });

--- a/frontend/src/screens/leadbulk.tsx
+++ b/frontend/src/screens/leadbulk.tsx
@@ -101,6 +101,9 @@ export function LeadBulkBar({
       // rep's own leads buys nothing but contention.
       leads.reduce<Promise<BulkOutcome[]>>(async (acc, lead) => {
         const done = await acc;
+        // The id, not the word: this name goes into a per-row outcome the
+        // reader reads back afterwards, and two unnamed leads must be tellable
+        // apart there.
         const name = leadIdentityName(lead) || lead.id;
         try {
           await apply(lead, action);

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -11,6 +11,7 @@ import {
   PipelineBoard,
 } from "../design-system/composed";
 import { formatDateTime, formatNumber } from "../format/format";
+import { leadIdentityName } from "../format/leadname";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -135,7 +136,7 @@ function LeadCard({
       {...dragHandlers}
     >
       <span className="deal-name">
-        {lead.full_name ?? lead.email ?? t("nav.leads")}
+        {leadIdentityName(lead) || t("nav.leads")}
       </span>
       {lead.company_name && (
         <span className="deal-org">

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -136,7 +136,7 @@ function LeadCard({
       {...dragHandlers}
     >
       <span className="deal-name">
-        {leadIdentityName(lead) || t("nav.leads")}
+        {leadIdentityName(lead) || t("lead.unnamed")}
       </span>
       {lead.company_name && (
         <span className="deal-org">

--- a/frontend/src/screens/leads.disqualify.stories.tsx
+++ b/frontend/src/screens/leads.disqualify.stories.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { DisqualifyDialog } from "./leads.disqualify";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// Closing a lead asks WHY, from the administered list. The dialog names the
+// lead in its heading, which is where the naming rule shows: a lead the product
+// stored with an empty name is named by its address here, exactly as the server
+// names it when the same lead is promoted.
+
+const meta: Meta = {
+  title: "Records/Leads/Disqualify",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj;
+
+type Lead = components["schemas"]["Lead"];
+
+const lead: Lead = {
+  id: "l-1",
+  full_name: "Jonas Petersen",
+  email: "jonas@nordwind.example",
+  company_name: "Nordwind Logistik",
+  status: "contacted",
+  score: 72,
+  source: "manual",
+  captured_by: "human:u1",
+  version: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const reasons = [
+  { id: "r-1", label: "No budget", position: 1, active: true },
+  { id: "r-2", label: "Wrong fit", position: 2, active: true },
+  { id: "r-3", label: "Retired reason", position: 3, active: false },
+];
+
+function withRoutes(subject: Lead) {
+  installFetchStub({
+    "GET /me": meRoute({ lead: ["read", "update"] }),
+    "GET /lead-disqualify-reasons": () => jsonResponse({ data: reasons }),
+  });
+  return (
+    <StoryProviders>
+      <DisqualifyDialog
+        lead={subject}
+        open
+        onClose={() => {}}
+        onDisqualified={() => {}}
+      />
+    </StoryProviders>
+  );
+}
+
+export const Named: Story = {
+  render: () => withRoutes(lead),
+};
+
+// A `full_name` that is present and EMPTY is not a name — nothing between a
+// `CreateLead` body and the stored row refuses one. The dialog names the lead by
+// the address rather than heading a destructive confirmation with a blank.
+export const NamedByItsAddress: Story = {
+  render: () => withRoutes({ ...lead, full_name: "" }),
+};

--- a/frontend/src/screens/leads.disqualify.tsx
+++ b/frontend/src/screens/leads.disqualify.tsx
@@ -5,6 +5,7 @@ import type { components } from "../api/schema";
 import { Button, Field, Modal, Textarea } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Select } from "../design-system/select";
+import { leadIdentityName } from "../format/leadname";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { leadWriteKeys } from "./leadkeys";
@@ -64,7 +65,7 @@ export function DisqualifyDialog({
     disqualify.reset();
     onClose();
   };
-  const name = lead.full_name ?? lead.email ?? "";
+  const name = leadIdentityName(lead);
 
   return (
     <Modal open={open} onClose={close} labelledBy={headingId}>

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -371,7 +371,7 @@ function LeadsWorkbench({
               const terminal = terminalBadge(lead.status);
               return (
                 <span>
-                  <strong>{leadIdentityName(lead)}</strong>
+                  <strong>{leadIdentityName(lead) || t("lead.unnamed")}</strong>
                   {lead.company_name && (
                     <span className="t-caption"> · {lead.company_name}</span>
                   )}
@@ -469,6 +469,8 @@ function LeadsWorkbench({
             }),
           label: (lead) =>
             t("lead.bulkSelectRow", {
+              // The id, not the word: this is an accessible NAME, and every
+              // unnamed row would otherwise announce as the same control.
               name: leadIdentityName(lead) || lead.id,
             }),
           bar: (

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -10,6 +10,7 @@ import { Badge, Button, SegmentedControl } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { ToastRegion, useToast } from "../design-system/toast";
 import { formatDateAbbrev, formatNumber } from "../format/format";
+import { leadIdentityName } from "../format/leadname";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -370,7 +371,7 @@ function LeadsWorkbench({
               const terminal = terminalBadge(lead.status);
               return (
                 <span>
-                  <strong>{lead.full_name ?? lead.email ?? ""}</strong>
+                  <strong>{leadIdentityName(lead)}</strong>
                   {lead.company_name && (
                     <span className="t-caption"> · {lead.company_name}</span>
                   )}
@@ -468,7 +469,7 @@ function LeadsWorkbench({
             }),
           label: (lead) =>
             t("lead.bulkSelectRow", {
-              name: lead.full_name ?? lead.email ?? lead.id,
+              name: leadIdentityName(lead) || lead.id,
             }),
           bar: (
             <LeadBulkBar

--- a/frontend/src/screens/leads.qualify.stories.tsx
+++ b/frontend/src/screens/leads.qualify.stories.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { QualifyDialog } from "./leads.qualify";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// Promoting a lead: what it will land on, and the deal it may open alongside.
+// The dialog names the lead twice — in its heading, and in the deal name it
+// suggests — and both go through the one naming rule, so a lead stored with an
+// empty name is named by its address rather than leaving a blank in a deal name
+// somebody is about to save.
+
+const meta: Meta = {
+  title: "Records/Leads/Qualify",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj;
+
+type Lead = components["schemas"]["Lead"];
+
+const lead: Lead = {
+  id: "l-1",
+  full_name: "Jonas Petersen",
+  email: "jonas@nordwind.example",
+  status: "engaged",
+  score: 72,
+  source: "manual",
+  captured_by: "human:u1",
+  version: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const pipeline = {
+  id: "pl-1",
+  name: "New business",
+  is_default: true,
+  position: 0,
+  stages: [
+    {
+      id: "s-1",
+      pipeline_id: "pl-1",
+      name: "Discovery",
+      position: 1,
+      semantic: "open" as const,
+      win_probability: 20,
+    },
+    {
+      id: "s-2",
+      pipeline_id: "pl-1",
+      name: "Proposal",
+      position: 2,
+      semantic: "open" as const,
+      win_probability: 60,
+    },
+  ],
+};
+
+function withRoutes(subject: Lead) {
+  installFetchStub({
+    "GET /me": meRoute({ lead: ["read", "update"], deal: ["read", "create"] }),
+    "GET /installation/settings": () =>
+      jsonResponse({ base_currency: "EUR", max_upload_bytes: 10_000_000 }),
+    "GET /pipelines": () => jsonResponse({ data: [pipeline] }),
+    [`GET /leads/${subject.id}/promote-preview`]: () =>
+      jsonResponse({ outcome: "create", person_withheld: false }),
+  });
+  return (
+    <StoryProviders>
+      <QualifyDialog
+        lead={subject}
+        open
+        onClose={() => {}}
+        onQualified={() => {}}
+      />
+    </StoryProviders>
+  );
+}
+
+export const Named: Story = {
+  render: () => withRoutes(lead),
+};
+
+// The suggested deal name is the lead's own naming with the stage after it. A
+// lead whose `full_name` is present and empty would otherwise seed that field
+// with " — Discovery", which is a deal name somebody saves without noticing.
+export const NamedByItsAddress: Story = {
+  render: () => withRoutes({ ...lead, full_name: "" }),
+};

--- a/frontend/src/screens/leads.qualify.tsx
+++ b/frontend/src/screens/leads.qualify.tsx
@@ -14,6 +14,7 @@ import {
 import { Callout } from "../design-system/callout";
 import { Select } from "../design-system/select";
 import { formatDate } from "../format/format";
+import { leadIdentityName } from "../format/leadname";
 import { toMinorUnits } from "../format/minorunits";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -179,8 +180,8 @@ export function QualifyDialog({
   const stages = openStagesOf(chosenPipeline);
   const chosenStage = stages.find((s) => s.id === stageId) ?? stages[0];
   const suggestedName = chosenStage
-    ? `${lead.company_name ?? lead.full_name ?? lead.email ?? ""} — ${chosenStage.name}`
-    : (lead.company_name ?? lead.full_name ?? "");
+    ? `${lead.company_name ?? leadIdentityName(lead)} — ${chosenStage.name}`
+    : (lead.company_name ?? leadIdentityName(lead));
 
   const qualify = useMutation({
     mutationFn: async (body: PromoteLeadRequest) => {
@@ -240,7 +241,7 @@ export function QualifyDialog({
     amount,
     currency,
   );
-  const name = lead.full_name ?? lead.email ?? "";
+  const name = leadIdentityName(lead);
 
   return (
     <Modal open={open} onClose={close} labelledBy={headingId}>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -30,6 +30,7 @@ import {
   formatDecimal,
   formatNumber,
 } from "../format/format";
+import { leadIdentityName } from "../format/leadname";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -1504,7 +1505,7 @@ function LeadDialogs({
           onQualified(
             <span>
               {t("lead.qualify.done", {
-                name: lead.full_name ?? lead.email ?? "",
+                name: leadIdentityName(lead),
               })}{" "}
               <EntityRef kind="person" id={result.person.id} />
               {result.deal_id && (
@@ -1598,7 +1599,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
       <QueryGate query={leadQuery}>
         {(lead) => (
           <RecordView
-            name={lead.full_name ?? lead.email ?? t("nav.leads")}
+            name={leadIdentityName(lead) || t("nav.leads")}
             avatarSrc={null}
             // The "Lead" marker rides the identity, not a badge among badges:
             // a reader has to know this is a prospect and not a contact

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1599,7 +1599,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
       <QueryGate query={leadQuery}>
         {(lead) => (
           <RecordView
-            name={leadIdentityName(lead) || t("nav.leads")}
+            name={leadIdentityName(lead) || t("lead.unnamed")}
             avatarSrc={null}
             // The "Lead" marker rides the identity, not a badge among badges:
             // a reader has to know this is a prospect and not a contact

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -251,3 +251,45 @@ describe("two providers connected", () => {
     expect(posted[0]).toEqual({ provider: "acmedata" });
   });
 });
+
+// A lookup spends the installation's credits on a NAMED contact, and a run
+// charged to the wrong one succeeds — so nothing on screen reports it. Which
+// contact the request is about therefore travels with the click, as a mutation
+// variable, rather than being read out of whichever render armed the mutation.
+describe("which contact a lookup is charged to", () => {
+  it("posts for the contact the panel is showing, not the one it opened on", async () => {
+    const user = userEvent.setup();
+    const paths: string[] = [];
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "POST /people/p-1/enrichment-runs": () => {
+        paths.push("p-1");
+        return queuedRun();
+      },
+      "POST /people/p-2/enrichment-runs": () => {
+        paths.push("p-2");
+        return queuedRun();
+      },
+    });
+    const { rerender } = render(
+      <StoryProviders>
+        <PersonProviderSection personId="p-1" profiles={[neverRun()]} />
+      </StoryProviders>,
+    );
+    await screen.findByRole("button", { name: /Look this contact up/ });
+
+    // The panel stays mounted across the change of subject: the record page
+    // keys its subtree by contact today, and this is the case that breaks the
+    // moment it stops.
+    rerender(
+      <StoryProviders>
+        <PersonProviderSection personId="p-2" profiles={[neverRun()]} />
+      </StoryProviders>,
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /Look this contact up/ }),
+    );
+
+    await expect.poll(() => paths).toEqual(["p-2"]);
+  });
+});

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -34,6 +34,9 @@ import {
 type Profile = components["schemas"]["PersonProviderProfile"];
 type Provider = components["schemas"]["Provider"];
 
+/** Which contact to look up, and at which provider. */
+type EnrichRun = { personId: string; provider: Provider };
+
 /** The mark every value in this section carries: bought from a named third
  *  party, on a date. `connector` rather than `agent` — nothing inferred this,
  *  somebody sold it to us. */
@@ -105,7 +108,7 @@ function ProviderPanel({
   profile,
 }: Readonly<{ personId: string; profile: Profile }>) {
   const t = useT();
-  const enrich = useEnrichRun(personId);
+  const enrich = useEnrichRun();
   // Nobody has looked this contact up yet, so the panel has no values to show
   // and the small header button is the only way to change that. An empty plate
   // that names the action instead: the reader came here to buy data, and a
@@ -146,7 +149,12 @@ function ProviderPanel({
       }
       actions={
         firstRun ? undefined : (
-          <EnrichNow profile={profile} enrich={enrich} small />
+          <EnrichNow
+            personId={personId}
+            profile={profile}
+            enrich={enrich}
+            small
+          />
         )
       }
     >
@@ -162,7 +170,13 @@ function ProviderPanel({
         {firstRun ? (
           <EmptyState
             title={t("provider.profile.emptyTitle")}
-            action={<EnrichNow profile={profile} enrich={enrich} />}
+            action={
+              <EnrichNow
+                personId={personId}
+                profile={profile}
+                enrich={enrich}
+              />
+            }
           >
             {t("provider.profile.emptyBody", { provider: name })}
           </EmptyState>
@@ -315,14 +329,17 @@ function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
  *  pending and error state, and the reader would see a failure on whichever
  *  control they did not press.
  *
- *  The provider arrives as a mutation VARIABLE rather than a captured value.
- *  React Query re-arms a mutation's options in a passive effect, so a function
- *  closing over render state can run against the previous render's copy. */
-function useEnrichRun(personId: string) {
+ *  WHO is looked up and WHERE the answer lands both arrive as mutation
+ *  VARIABLES rather than as captured values. React Query re-arms a mutation's
+ *  options in a passive effect, so between the commit that renders a control
+ *  for one contact and that effect, the observer still holds the previous
+ *  render's closure: a captured id would spend a credit on the contact the
+ *  reader just left and refresh that page instead of this one. A variable
+ *  cannot be older than the control that carried it. */
+function useEnrichRun() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationKey: ["enrich", personId],
-    mutationFn: async ({ provider }: { provider: Provider }) => {
+    mutationFn: async ({ personId, provider }: EnrichRun) => {
       const { data, error } = await api.POST("/people/{id}/enrichment-runs", {
         params: { path: { id: personId } },
         body: { provider },
@@ -332,19 +349,23 @@ function useEnrichRun(personId: string) {
       }
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, { personId }) => {
       // The run is durable and the provider has not been called yet, so the
-      // page re-reads and RunWatch picks the run up from there.
+      // page re-reads and RunWatch picks the run up from there. Keyed off the
+      // variables the run was started with, so the page that refreshes is the
+      // one the request was sent for.
       void queryClient.invalidateQueries({ queryKey: ["person360", personId] });
     },
   });
 }
 
 function EnrichNow({
+  personId,
   profile,
   enrich,
   small = false,
 }: Readonly<{
+  personId: string;
   profile: Profile;
   enrich: ReturnType<typeof useEnrichRun>;
   small?: boolean;
@@ -361,7 +382,9 @@ function EnrichNow({
       busyLabel={t("provider.profile.lookingUp")}
       // A profile carries no provider name until a run exists, so the first
       // lookup on a contact names the one the contract has.
-      onClick={() => enrich.mutate({ provider: profile.provider ?? "surfe" })}
+      onClick={() =>
+        enrich.mutate({ personId, provider: profile.provider ?? "surfe" })
+      }
     >
       <Search size={15} aria-hidden="true" /> {t("provider.profile.enrichNow")}
     </Button>

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -34,7 +34,6 @@ import {
 type Profile = components["schemas"]["PersonProviderProfile"];
 type Provider = components["schemas"]["Provider"];
 
-/** Which contact to look up, and at which provider. */
 type EnrichRun = { personId: string; provider: Provider };
 
 /** The mark every value in this section carries: bought from a named third

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -538,7 +538,7 @@ function MorningCards({
           <BriefQueueItem
             key={item.id}
             item={item}
-            deals={deals.data ?? []}
+            deals={deals.data?.rows ?? []}
             nowMs={nowMs}
             mark={mark}
           />


### PR DESCRIPTION
A sweep of open `area: frontend` issues, one branch. Rebased onto current `main`.

## What changed

### #2824 — an enrichment run is charged to the contact whose control was pressed
`useEnrichRun` took the provider as a mutation variable but still read `personId` out of the enclosing render, in both the request path and the `["person360", id]` invalidation. Both now travel with the click.

Honest note on the test: `personprovider.test.tsx` pins the behaviour (the panel posts for the contact it is showing, not the one it opened on) but does **not** reproduce the stale-closure window. I tried, including a `flushSync` commit followed by a synchronous `.click()`; React flushes pending passive effects at the start of a discrete event, so the window closes before the handler runs and the pre-fix code passes that test too. The fix stands on the invariant `frontend/AGENTS.md` states, not on a red test.

### #2807 — what a lead is called is worked out in one place
New `frontend/src/format/leadname.ts` mirroring `leadIdentityName` in the people module, with a unit test over the same cases the Go test runs. The eight sites the issue censuses are routed through it, plus two the issue left for a per-site ruling:

- `entityref.tsx` — the record-reference reader's `lead` arm. It names a lead from a different read and carries the identical defect, so it adopts the helper.
- `leads.qualify.tsx:182-183` — the organization-first label. Organization-first stays organization-first; only the lead half adopts the rule, which is what removes the blank-name case without changing the label's priority.

Left alone, deliberately: `leads.tsx:712,1427` (`full_name ?? ""` seeding a form field — empty is the right answer there) and the person reader in `entityref.tsx:69`.

`frontend/src/format/leadname-coverage.test.ts` is the census the issue asks for. It parses every `??` and `||` chain under `src/` and fails on one falling back from a `full_name` to an `email` outside the helper. `||` is included because it is the same rule in a coat that only happens to answer correctly today. Nine planted cases pin what it sees and what it deliberately does not. Verified against the pre-fix tree: it reports exactly the ten sites above.

**Verified in the browser.** `POST /leads` with `full_name: ""` is accepted (201), so the state is one the product makes. The lead page for it now reads `nameless@repro.example` where it would have rendered a blank name.

### #2577 — Home's deal readings say they are floors, not totals
`useHomeDeals` fetched one page of `/deals` and dropped the page's own `has_more`. Four readings were computed from those rows and every one of them was silently short past the page.

Following the cursor would cost an unbounded fan-out on the screen that opens every morning, so the other honest answer is taken: keep the page and say the count is a floor. A capped figure carries "+", and the panel that LISTS quiet deals draws `SurfaceState`'s `partial` rather than claiming nothing has gone quiet.

`format/cappedcount.ts` is where "a count read off one page" now lives. The agent rail had already worked this out for its duplicates count and kept the type and the label in a screen file; a second copy in Home would have been the second author this tree keeps growing. The shared spelling also puts the digits through `formatNumber`, which the rail's own copy did not.

### Stories the sweep owed
`fe-uat` fails a changed component with no story, and neither lead dialog had one. Both now have their own, in the named case and in the case the naming rule exists for.

## Three issues that no longer reproduce on `main`

Checked before writing anything, and left unfixed because there is nothing to fix:

- **#2823 — the agent rail's approvals count caps at one page.** It does not. `usePendingApprovals` reads through `fetchAllApprovals`, which walks every page via `next_cursor` before counting, so `waiting` is a true total. Only the duplicates count is bounded, and it already carries `more` and says so. The issue's suggested "real total for both" is a contract question, unchanged by this.
- **#1250 — fresh org triggers a Shell-wide render-loop crash.** Not reproducible. On a fresh `DEV_SLUG` stack with an empty database, bootstrapped admin, first-login password change and onboarding run to completion, all twelve routes (Home, Contacts, Companies, Leads, Filters, Worklist, Pipeline, Projects, Reports, Ask, Settings, Settings → Maintenance) render, a reload of `#/home` renders, and the console carries no "Maximum update depth exceeded". The two `EmbedReindexStatus` 501s named in the issue are still there and still leak an error string — that is #1230's framing, and it no longer crashes the shell.
- **#1592 — the contact page's primary action is labelled Email on contacts with no address.** Already fixed. `PersonActions` reads `useTransports(view)` and names the button through `primaryTransportAction`, and `writeRefusal` refuses it with `person.action.noTransport` when `transportsFor` returns nothing — which is the sub-decision the issue said was worth doing whichever label option won.

## Left out, and why

**#2741 — the Worklist advertises an `open` action no lane can perform.** The frontend half alone changes nothing a user can see: on current `main` only `receiptItem` still sends `open`, and it carries no `subject`, so wiring navigation keyed off `AttentionItem.subject` would render no control for any item the server actually sends. The real fix is one change across both sides — give `receiptItem` a subject (a new read through the Receipts port), wire the navigation, and restore `open` on the lanes that should offer it — and that is wider than a frontend PR. Raised rather than half-done.

## Gates

| Gate | Result |
|---|---|
| `make check` | pass (exit 0, after rebasing onto current `main`) |
| `make frontend-check` | pass |
| `make fe-uat` | pass — 92 stories captured, `.tmp/fe-uat/manifest.json` |
| `make native-controls` | pass — 35 tests |
| `make frontend-e2e` | pass — 139 passed, 14 skipped, axe sweep included |
| `make fe-clock-drift` | pass — 400 files, 5005 tests at +200 days |

Browser pass on the seeded stack: Home, Leads, and the lead record page at 390px and desktop, light and dark, console clean, no horizontal scroll on any of the three.

One pre-existing failure worth naming: at my original base commit (`296372f52`) `TestEveryHandWrittenDocsPageFitsItsBudget` failed — `docs/explanation/data-enrichment-position.md` was 499 lines against a 450 budget. It is 402 on current `main`, and the rebase cleared it. Nothing in this branch touches `docs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Counts now indicate when additional results exist, using labels such as `2+`.
  - Home screens identify partially displayed lists and show when more deals are available.
  - Count formatting respects the selected locale, including digit grouping.
  - Added localized labels for leads without names.

- **Bug Fixes**
  - Lead names consistently fall back to email when unavailable.
  - Provider enrichment requests use the currently selected contact.
  - Home and daily views correctly handle paginated deal results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->