### PR TITLE
fix(docs): re-measure the explanation page budget

### DIFF
--- a/backend/gates/docspagelength_test.go
+++ b/backend/gates/docspagelength_test.go
@@ -60,8 +60,21 @@ func docsPageCeiling(rel string) int {
 	switch {
 	case strings.HasPrefix(rel, "docs/how-to/"), strings.HasPrefix(rel, "docs/tutorials/"):
 		return 350
+	// EXPLANATION is the section that carries a mechanism, and it was measured
+	// again in August 2026 because the number had stopped describing it. The
+	// section holds 28 pages. Their 75th percentile is 404 by nearest rank and
+	// 412 interpolated, so 1.5x is 606 to 618 — while the constant said 450,
+	// which is about 1.1x. Four pages were over, all four waived, and a new
+	// mechanism page was arriving over budget on its first commit.
+	//
+	// 620 is the top of that band, rounded. Deliberately NOT a number chosen to
+	// clear the four waived pages: the longest is 519, so the band would have
+	// freed them at any point in it. Picking the top rather than the middle is
+	// the one judgement here, and it is made because 606 and 618 are the same
+	// measurement read two defensible ways — a budget should not sit between
+	// them and depend on which.
 	case strings.HasPrefix(rel, "docs/explanation/"):
-		return 450
+		return 620
 	// A user guide is a narrative followed once, so it runs longer than a how-to
 	// that is consulted a field at a time — the same reason an explanation does.
 	case strings.HasPrefix(rel, "user-guide/"):
@@ -87,7 +100,13 @@ func docsPageCeiling(rel string) int {
 // that needs a baseline of the list, and the list IS the baseline — the only place
 // the addition is visible is the diff, which is where a reviewer reads it. Named
 // here so the pin is not mistaken for a complete guard.
-const waivedPageBudget = 10
+// 10 → 6 when the explanation budget was re-measured in August 2026: four
+// waived pages were already inside the new number and left the list without a
+// word of their prose changing. Lowering the pin in the same change is what
+// keeps that a ratchet tooth rather than four spare slots — the swap above is
+// still open, and a re-measure that freed pages without lowering the pin would
+// widen it.
+const waivedPageBudget = 6
 
 const (
 	docsWaiverFile = "../scripts/docs-page-length-waivers.txt"

--- a/scripts/docs-page-length-waivers.txt
+++ b/scripts/docs-page-length-waivers.txt
@@ -8,10 +8,6 @@
 # budget and stayed listed, and when a line names a page that no longer exists —
 # so this file cannot rot into "pages allowed to be long".
 docs/evidence/extension-tier/DESIGN.md
-docs/explanation/extensibility.md
-docs/explanation/job-fleet.md
-docs/explanation/outbound-messaging.md
-docs/explanation/outbound-webhooks.md
 docs/how-to/add-an-extension.md
 docs/how-to/flip-an-overlay-to-native.md
 docs/principles/one-source-of-truth.md


### PR DESCRIPTION
## What is wrong

The `docs/explanation/` page-length budget said **450 lines**, while the comment directly above it claimed the number was "roughly 1.5x its section's 75th percentile". Those two statements stopped agreeing some time ago.

Measured against the current tree: the section holds **28 pages**, whose 75th percentile is **404** by nearest rank and **412** interpolated. 1.5x that is **606 to 618**. The constant sat at about 1.1x.

The visible symptom: a new explanation page arrived over budget on its first commit, and four pages were parked in the waiver file to land at all.

## What this changes

`docs/explanation/` budget **450 → 620**.

620 is the top of the measured band, rounded. The top rather than the middle because 606 and 618 are one measurement read two defensible ways, and a budget should not sit between them and depend on which reading a later author picks.

## What falls out

Four waivers leave the list with no prose changed:

| page | lines |
|---|---|
| `outbound-messaging.md` | 474 |
| `outbound-webhooks.md` | 510 |
| `job-fleet.md` | 516 |
| `extensibility.md` | 519 |

**This is not a number picked to clear them.** The longest is 519, so anywhere in the 606–618 band would have freed all four.

`waivedPageBudget` moves **10 → 6** in the same change, so the four freed slots do not stay available for a future page. To be precise about what that pin does and does not do: it is not an append-only guard. A swap — drop one waived page, add a different over-budget one in the same change — leaves the count unchanged and passes, which the comment above the constant has always said. Lowering the pin alongside a re-measure is what stops the re-measure from quietly widening the list.

## Why a re-measure and not an exemption

The alternative considered was exempting the section outright. That would remove the gate from the one part of the docs tree where page length is most likely to go wrong — a mechanism page that has grown to 900 lines usually needs splitting, and nothing else would say so. The budget was not wrong to exist; it was wrong about its own section.

## Verification

- `make check-backend` — green.
- `make craft-static` — PASS, 0 findings.
- **Mutation-checked both directions.** At a budget of 500 the gate names `extensibility.md` (519) and `job-fleet.md` (516). At a pin of 9 it demands the pin be lowered. The numbers are load-bearing, not merely passing.
- Reviewed by Codex, which independently replicated the gate's own discovery and counting logic and reached the same 28 / 404 / 412 figures. It also confirmed by blob hash that all four dropped waivers are byte-identical to their merge-base versions — no prose was edited down to fit under the new number.

## Deliberately not done here

Codex flags `extensibility.md` (519) and `outbound-webhooks.md` (510) as having clear structural seams and being good split candidates. They likely are. That is prose work on pages this PR does not otherwise touch, and folding it in would turn a two-file gate change into a docs rewrite. Worth a follow-up.

## Note on the base

Rebased onto current main after #2812, which moved this gate from `backend/docspagelength_test.go` to `backend/gates/docspagelength_test.go` and edited ten explanation pages. The measurement was re-run after that rebase and is unchanged — 28 pages, p75 404/412, nothing over 620, and the four freed pages still at 474/510/516/519.

Also rebased earlier, after #2836 and #2839 landed. Those rewrote `data-enrichment-position.md` from 519 to 402 lines, which moved the section's percentile — an earlier revision of this PR quoted a p75 of 446 and a budget of 650, measured before that landed. The figures above are measured against the post-rebase tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation standards to reflect current page-length measurements.
  - Reduced the number of documentation pages requiring length exceptions by incorporating several pages into the standard guidelines.
  - Documentation quality checks now accommodate the expanded explanation content while maintaining tighter exception limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
