### PR TITLE
docs(explanation): A6 in the enrichment whitepaper is a design, and now says so

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -274,11 +274,11 @@ The imported connections become private graph substrate, "ghosts", used only for
 
 I do not claim that LinkedIn's terms permit anything beyond this private graph use. Margince therefore stops there. It does not create contacts and provides no parser for pasted profile text. Once software copies the page on the user's behalf, the scraping clause is back in play. We draw the line on the safe side.
 
-**A6. The "confirm your details" flow.** Build.
+**A6. The "confirm your details" flow.** Build. Nothing of this ships yet; it is the first Tier A item on the roadmap.
 
-Margince sends the contact a link through which they can view and correct their own card. The same flow delivers the Article 14 transparency notice and gives the contact an Article 16 accuracy mechanism. Because the consent is verifiable, it also meets the standard in Vietnam's Law 91.
+The design: Margince sends the contact a link through which they can view and correct their own card. The same flow delivers the Article 14 transparency notice and gives the contact an Article 16 accuracy mechanism. Because the consent is verifiable, it also meets the standard in Vietnam's Law 91.
 
-This flow actively reduces the risk of everything else on this page.
+Once built, this flow actively reduces the risk of everything else on this page.
 
 ### Tier B: build with controls, counsel signs off first
 


### PR DESCRIPTION
Codex stop-gate catch on the author's final pass (#2839): the A6 confirm-your-details flow was described in present tense as if shipped, but no such flow exists in the tree. A6 now states it is unshipped and first on the Tier A roadmap; the design content and its three legal jobs are unchanged. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies in the enrichment whitepaper that the A6 confirm-your-details flow is an unshipped design, not a live feature. The section now reads as the first Tier A roadmap item while keeping the design description and its three legal requirements unchanged. Markdown-only, no behavior changes.

<sup>Written for commit b68ad30ea3d8be093e11db7a89872a79bfa90e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to clarify that A6 has not yet shipped and is the first planned item.
  * Documented the proposed data review and correction flow, including transparency, correction rights, and consent support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->