### PR TITLE
fix(dedupe): eight more markets are matched on the brand, not the legal form

### DIFF
--- a/backend/internal/modules/people/dedupeorg.go
+++ b/backend/internal/modules/people/dedupeorg.go
@@ -146,7 +146,16 @@ func exactOrgByDomain(ctx context.Context, tx pgx.Tx, domains []string, exclude 
 // true, which is the same answer coalesce would have produced.
 func fuzzyOrganization(ctx context.Context, tx pgx.Tx, c OrganizationCandidate) (OrganizationMatch, error) {
 	args := []any{c.ExcludeID}
-	arms := orgTrigramArms(&args, NormalizeOrgName(c.DisplayName), NormalizeOrgName(c.LegalName))
+	// The BRAND is searched on as well as the whole name. A market that writes
+	// its legal form into the name makes the two very different strings, and the
+	// score compares the brand: measured, "Perseroan Terbatas IBM" against a
+	// stored "IBM" scores 0.174 as whole strings, under both trigram limits, so
+	// the true duplicate was never returned for scoring at all. Searching the
+	// brand as well costs one more OR arm and finds it.
+	//
+	// searchAxes drops a value equal to one already there, so the common case —
+	// a name with no legal form to strip — adds no arms.
+	arms := orgTrigramArms(&args, searchAxes(c)...)
 	if len(arms) == 0 {
 		return OrganizationMatch{Decision: DecisionNoMatch}, nil
 	}
@@ -202,6 +211,25 @@ func fuzzyOrganization(ctx context.Context, tx pgx.Tx, c OrganizationCandidate) 
 		Confidence:     ranked[0].Confidence,
 		Ranked:         ranked,
 	}, nil
+}
+
+// searchAxes are the strings the candidate query searches on: each name as the
+// key spells it, and again as the score will compare it once a leading legal
+// form is stripped.
+//
+// Deduplicated, because for most names the two are the same string and a
+// repeated arm buys nothing but a longer query under the organization-name
+// write lock.
+func searchAxes(c OrganizationCandidate) []string {
+	var axes []string
+	for _, name := range []string{c.DisplayName, c.LegalName} {
+		for _, axis := range []string{NormalizeOrgName(name), orgNameForMatching(name)} {
+			if axis != "" && !slices.Contains(axes, axis) {
+				axes = append(axes, axis)
+			}
+		}
+	}
+	return axes
 }
 
 // orgTrigramArms builds one `<%` arm per (non-empty candidate axis × stored

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -8,7 +8,6 @@ import (
 	"unicode"
 
 	"golang.org/x/text/cases"
-	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 
@@ -32,6 +31,13 @@ var legalSuffixes = map[string]bool{
 	"inc": true, "llc": true, "ltd": true, "gmbh": true, "ag": true,
 	"sa": true, "sas": true, "bv": true, "oy": true, "plc": true,
 	"co": true, "corp": true, "kg": true, "ug": true,
+	// The markets that write the form in front ALSO write one behind, and a
+	// name carries whichever the writer used. Indonesia's listed companies end
+	// in "Tbk" and bracket the brand between it and a leading "PT"; Romania,
+	// Poland and Turkey put theirs at the end alone. Their prefix halves live in
+	// orgformtables.go — these are the same forms seen from the other side.
+	"srl": true, "sro": true, "tbk": true, "as": true, "oyj": true,
+	"doo": true, "dd": true, "zoo": true, "sti": true,
 }
 
 // legalConnectives join the halves of a COMPOUND legal form: "GmbH & Co. KG"
@@ -54,14 +60,65 @@ var legalConnectives = map[string]bool{"&": true, "und": true, "and": true}
 // pair daily. A fresh Caser per call: cases.Caser is stateful and not
 // safe for concurrent use.
 func normalizeName(s string) string {
-	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	unaccented, _, err := transform.String(t, s)
+	decomposed, _, err := transform.String(norm.NFD, s)
 	if err != nil {
 		// Decomposition failure means a malformed rune, not an outage:
 		// compare what we were given rather than dropping the candidate.
-		unaccented = s
+		decomposed = s
 	}
-	return strings.TrimSpace(cases.Fold().String(unaccented))
+	recomposed, _, err := transform.String(norm.NFC, dropAccents(decomposed))
+	if err != nil {
+		recomposed = decomposed
+	}
+	return strings.TrimSpace(cases.Fold().String(recomposed))
+}
+
+// dropAccents removes the combining marks that are ACCENTS — the ones a writer
+// adds to a letter and a reader can do without — and keeps the ones that are
+// letters in their own right.
+//
+// REMOVING EVERY Mn MARK WAS WRONG outside the alphabets this started with. In
+// Thai, Lao, Khmer and the Indic scripts a combining mark is a LETTER: the
+// vowels hang above and below the consonant instead of sitting beside it.
+// Measured, an unrestricted strip turned "เมืองไทย" into "เมองไทย" and
+// "កម្ពុជា" into "កមពជា", so every Thai and Khmer company name lost characters
+// before any comparison began — and two different names could fold together.
+//
+// The base letter decides, not the mark. NFD leaves an accent directly after the
+// letter it belongs to, so a mark following Latin or Greek is an accent and
+// goes; a mark following anything else is part of its letter and stays. Every
+// case this normalization exists for is unchanged: Müller/Mueller, Straße, Việt
+// Nam, Οδυσσεύς.
+//
+// CYRILLIC IS NOT IN THAT LIST, and including it was wrong for the same reason
+// as Thai. Its marked letters are letters: "й" is not an accented "и" but the
+// character in every other Russian word, and stripping it turned "Мойка" into
+// "моика" and the Ukrainian "Київстар" into "киівстар". The one real accent
+// pair, "ё" against "е", is spelled out below because writers do treat those two
+// as interchangeable.
+func dropAccents(decomposed string) string {
+	var out strings.Builder
+	out.Grow(len(decomposed))
+	accented := false
+	for _, r := range decomposed {
+		switch {
+		case unicode.Is(unicode.Mn, r):
+			if accented {
+				continue
+			}
+		case unicode.Is(unicode.Latin, r), unicode.Is(unicode.Greek, r):
+			accented = true
+		case r == 'е' || r == 'Е':
+			// Russian writes "ё" and "е" for one letter and a registry may hold
+			// either, so the diaeresis after this one IS dropped. NFD has already
+			// split "ё" into "е" plus its mark by the time this runs.
+			accented = true
+		default:
+			accented = false
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
 }
 
 // NormalizePersonName is the person-name KEY: normalizeName's fold and
@@ -92,12 +149,12 @@ func NormalizeOrgName(s string) string {
 	fields := strings.Fields(normalizeName(strings.ReplaceAll(s, ",", " ")))
 	strippedOne := false
 	for len(fields) > 1 {
-		last := strings.Trim(fields[len(fields)-1], ".")
+		last := undottedForm(fields[len(fields)-1])
 		switch {
 		case legalSuffixes[last]:
 			strippedOne = true
 		case legalConnectives[last] && strippedOne && len(fields) > 2 &&
-			legalSuffixes[strings.Trim(fields[len(fields)-2], ".")]:
+			legalSuffixes[undottedForm(fields[len(fields)-2])]:
 			// A connective BETWEEN two legal forms — the "GmbH & Co. KG"
 			// case. Consumed only here, so a company whose name simply ends
 			// in "and" keeps it.
@@ -107,6 +164,25 @@ func NormalizeOrgName(s string) string {
 		fields = fields[:len(fields)-1]
 	}
 	return strings.Join(fields, " ")
+}
+
+// undottedForm is a trailing word with the dots a writer put inside it removed,
+// so a legal form spelled with them is the same form spelled without.
+//
+// "S.R.L." and "SRL" are one Romanian form, "A.Ş." and "AŞ" one Turkish form,
+// and a registry holds whichever the filer typed. Trimming only the FINAL dot
+// left "s.r.l." as a single token that matched no entry, so those names kept
+// their legal form and scored against every other company that kept the same
+// one.
+//
+// Only dots, and only for the lookup — the word itself is untouched when it
+// turns out not to be a legal form, so a name that really contains a dot keeps
+// it.
+func undottedForm(word string) string {
+	if !strings.Contains(word, ".") {
+		return word
+	}
+	return strings.ReplaceAll(word, ".", "")
 }
 
 // nameSimilarity is `name_sim`: Jaro-Winkler over normalized input,

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -31,13 +31,18 @@ var legalSuffixes = map[string]bool{
 	"inc": true, "llc": true, "ltd": true, "gmbh": true, "ag": true,
 	"sa": true, "sas": true, "bv": true, "oy": true, "plc": true,
 	"co": true, "corp": true, "kg": true, "ug": true,
-	// The markets that write the form in front ALSO write one behind, and a
-	// name carries whichever the writer used. Indonesia's listed companies end
-	// in "Tbk" and bracket the brand between it and a leading "PT"; Romania,
-	// Poland and Turkey put theirs at the end alone. Their prefix halves live in
-	// orgformtables.go — these are the same forms seen from the other side.
-	"srl": true, "sro": true, "tbk": true, "as": true, "oyj": true,
-	"doo": true, "dd": true, "zoo": true, "sti": true,
+	// The markets that write the form in front ALSO write one behind, and a name
+	// carries whichever the writer used. Indonesia's listed companies end in
+	// "Tbk" and bracket the brand between it and a leading "PT"; Romania and
+	// Turkey put theirs at the end alone.
+	//
+	// EVERY ENTRY HERE MUST BE A WORD NO COMPANY IS CALLED, because this map
+	// feeds NormalizeOrgName, which is a stored grouping key: a word wrongly
+	// listed does not merely inflate a score, it files two unrelated companies
+	// under one key. Measured, "zoo" (the Polish "z o.o.") made "San Diego Zoo"
+	// and "San Diego" the same key, and "as" took the last word off "Trading
+	// As". Both are out; the Polish and Nordic forms are not worth that.
+	"srl": true, "sro": true, "tbk": true, "oyj": true, "sti": true,
 }
 
 // legalConnectives join the halves of a COMPOUND legal form: "GmbH & Co. KG"
@@ -73,6 +78,9 @@ func normalizeName(s string) string {
 	return strings.TrimSpace(cases.Fold().String(recomposed))
 }
 
+// combiningDiaeresis is the mark that turns Cyrillic "е" into "ё".
+const combiningDiaeresis = '\u0308'
+
 // dropAccents removes the combining marks that are ACCENTS — the ones a writer
 // adds to a letter and a reader can do without — and keeps the ones that are
 // letters in their own right.
@@ -84,11 +92,15 @@ func normalizeName(s string) string {
 // "កម្ពុជា" into "កមពជា", so every Thai and Khmer company name lost characters
 // before any comparison began — and two different names could fold together.
 //
-// The base letter decides, not the mark. NFD leaves an accent directly after the
-// letter it belongs to, so a mark following Latin or Greek is an accent and
-// goes; a mark following anything else is part of its letter and stays. Every
-// case this normalization exists for is unchanged: Müller/Mueller, Straße, Việt
-// Nam, Οδυσσεύς.
+// The base letter decides, not the mark. NFD leaves a mark directly after the
+// letter it belongs to, so the base says which kind it is:
+//
+//   - Latin and Greek write ACCENTS, and those go. Müller/Mueller, Straße, Việt
+//     Nam and Οδυσσεύς all depend on it.
+//   - Hebrew and Arabic write VOCALIZATION — niqqud and harakat — which is
+//     optional and usually absent, so a pointed spelling must fold onto the
+//     plain one rather than becoming a second company.
+//   - Everything else writes LETTERS, and those stay.
 //
 // CYRILLIC IS NOT IN THAT LIST, and including it was wrong for the same reason
 // as Thai. Its marked letters are letters: "й" is not an accented "и" but the
@@ -99,22 +111,30 @@ func normalizeName(s string) string {
 func dropAccents(decomposed string) string {
 	var out strings.Builder
 	out.Grow(len(decomposed))
-	accented := false
+	accented, diaeresisAfterYe := false, false
 	for _, r := range decomposed {
 		switch {
 		case unicode.Is(unicode.Mn, r):
-			if accented {
+			if accented || (diaeresisAfterYe && r == combiningDiaeresis) {
+				diaeresisAfterYe = false
 				continue
 			}
-		case unicode.Is(unicode.Latin, r), unicode.Is(unicode.Greek, r):
-			accented = true
+			diaeresisAfterYe = false
+		case unicode.Is(unicode.Latin, r), unicode.Is(unicode.Greek, r),
+			unicode.Is(unicode.Hebrew, r), unicode.Is(unicode.Arabic, r):
+			accented, diaeresisAfterYe = true, false
 		case r == 'е' || r == 'Е':
 			// Russian writes "ё" and "е" for one letter and a registry may hold
-			// either, so the diaeresis after this one IS dropped. NFD has already
-			// split "ё" into "е" plus its mark by the time this runs.
-			accented = true
-		default:
+			// either, so the DIAERESIS after this one is dropped. NFD has
+			// already split "ё" into "е" plus its mark by the time this runs.
+			//
+			// That mark and no other: "ӗ" is "е" with a BREVE and is a letter of
+			// Chuvash, so a rule of "any mark after е" folded "Ӗнер" and "Енер"
+			// into one name.
+			diaeresisAfterYe = true
 			accented = false
+		default:
+			accented, diaeresisAfterYe = false, false
 		}
 		out.WriteRune(r)
 	}

--- a/backend/internal/modules/people/orgformtables.go
+++ b/backend/internal/modules/people/orgformtables.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The legal forms that come BEFORE the company name, for every market that
+// writes them that way.
+//
+// WHY A TABLE PER MARKET AND NOT ONE LIST. The forms differ in how safely they
+// can be removed, and the difference is what this file is for. "ООО" is Cyrillic
+// and collides with nothing, so it can go wherever it appears at the front.
+// "PT" is two Latin letters, and "PT Solutions Physical Therapy" is a company in
+// Georgia — removing it there leaves a name that matches every other firm whose
+// name begins "Solutions". So the ambiguous markers are held to a second signal
+// before they are believed, and the unambiguous ones are not.
+//
+// Measured against real companies. These ten are all real, and a rule that
+// stripped a two-letter marker on position alone damages every one of them:
+// PT Solutions Physical Therapy, AO World, AS Roma, CV Sciences, SIA
+// Engineering, II-VI Incorporated, TOO Group, AB InBev, SA Recycling, MB
+// Financial.
+
+// orgFormMarker is one legal form as it appears after folding, split into the
+// words a name is split into.
+//
+// `ambiguous` marks a form whose letters are also an ordinary name. Such a form
+// is only removed when something else about the name agrees that this is the
+// market it claims — see corroboratedMarket in orgnameforms.go. An unambiguous
+// form needs no corroboration: no company is called "ООО Something" by accident.
+type orgFormMarker struct {
+	tokens    []string
+	ambiguous bool
+}
+
+// marketForms are the prefix legal forms of one market.
+//
+// `fillers` is the trade vocabulary that stacks between the form and the brand,
+// and only Vietnam has one here: it is the market whose names are built that
+// way. A filler is only ever removed from a name that carried this market's
+// legal form, because the abbreviations are short enough to be words elsewhere.
+//
+// `continuations` are forms that appear only as the second half of a stacked
+// one, where they arrive without their leading word — "TỔNG CÔNG TY CỔ PHẦN"
+// leaves a bare "cổ phần" once "tổng công ty" is gone. They are consulted only
+// after a form has already been removed, so a name that simply begins with those
+// words keeps them.
+type marketForms struct {
+	name          string
+	prefixes      []orgFormMarker
+	continuations []orgFormMarker
+	fillers       []orgFormMarker
+	// closers are the market's own TRAILING forms, which corroborate a short
+	// leading one: "PT Astra International Tbk" is Indonesian because it ends in
+	// "Tbk", and no English name does. The strip itself is the existing
+	// trailing-suffix pass in NormalizeOrgName; these say what that suffix
+	// proves about the front of the name.
+	closers []string
+	// suffixes are trailing forms this market's own strip removes, for a script
+	// that legalSuffixes cannot reach: that map is keyed on whitespace-split
+	// words, and Thai writes none inside a name.
+	suffixes []string
+	// syllabic marks a market whose brands are built from a small pool of
+	// shared syllables, where ONE word in common is not evidence of identity.
+	// Vietnamese "Hòa Bình" and "Hòa Phát" share "hoa" and are the country's
+	// largest construction firm and its largest steelmaker. English brands are
+	// built from rare words instead, where one shared word is nearly the whole
+	// of the evidence, so the majority rule must not reach them.
+	syllabic bool
+}
+
+// prefixMarkets carries the markets whose legal form precedes the name, in the
+// order matchingFormOf consults them.
+//
+// A HAND-WRITTEN, VERSIONED LIST, read the same way as orgNameStopwords and for
+// the same reason: a list derived from the workspace's own names would make two
+// names match in one workspace and not in another, and would put a query inside
+// the transaction that holds the organization-name write lock.
+//
+// Seeded from the ISO 20275 Entity Legal Form list, which is the registry of
+// what each jurisdiction actually recognises, then extended with the everyday
+// abbreviations that registry does not carry — it holds "công ty cổ phần" but
+// not "CTCP", and no Russian abbreviations at all.
+var prefixMarkets = []marketForms{
+	vietnam,
+	indonesia,
+	russiaAndCIS,
+	baltics,
+	romania,
+	turkeyAndPoland,
+	arabic,
+	hebrew,
+	thailand,
+}
+
+// unambiguous builds markers from forms that collide with nothing.
+func unambiguous(forms ...[]string) []orgFormMarker {
+	markers := make([]orgFormMarker, 0, len(forms))
+	for _, tokens := range forms {
+		markers = append(markers, orgFormMarker{tokens: tokens})
+	}
+	return markers
+}
+
+// ambiguousFormWords are the words of every ambiguous form, which the gate must
+// not count as evidence of identity.
+//
+// These forms cannot be REMOVED from a name without corroboration — "PT
+// Solutions" is a company and "AO World" is another — so they stay in the string
+// the score compares. But a word that is a legal form somewhere is market
+// vocabulary rather than a brand, and two names must not meet on it: "SIA Rimi
+// Latvia" and "SIA Maxima Latvija" are two Latvian grocers, and "AS Roma" and
+// "AS Monaco" are two football clubs.
+//
+// Derived from the tables rather than written out again, so a form added above
+// cannot be forgotten here.
+var ambiguousFormWord = ambiguousFormWords()
+
+func ambiguousFormWords() map[string]bool {
+	words := map[string]bool{}
+	for _, market := range prefixMarkets {
+		for _, marker := range market.prefixes {
+			if !marker.ambiguous {
+				continue
+			}
+			for _, word := range marker.tokens {
+				words[word] = true
+			}
+		}
+	}
+	return words
+}
+
+// ambiguous builds markers from forms whose letters are also ordinary names.
+func ambiguous(forms ...[]string) []orgFormMarker {
+	markers := make([]orgFormMarker, 0, len(forms))
+	for _, tokens := range forms {
+		markers = append(markers, orgFormMarker{tokens: tokens, ambiguous: true})
+	}
+	return markers
+}
+
+// Vietnam writes the form, then the trade, then the brand: "CÔNG TY CỔ PHẦN SỮA
+// VIỆT NAM" is the joint-stock company Sữa Việt Nam. Both spellings of each form
+// are here because both are how companies write themselves — the legal "công ty
+// trách nhiệm hữu hạn" and the everyday "công ty tnhh".
+//
+// The syllables recur because the language builds its legal forms out of them,
+// and the point of writing the table this way is that a reader can check it
+// against the language. Naming "cong" as a constant would hide what the entries
+// say, so the repetition is the readable form here rather than a smell.
+//
+//nolint:goconst // Vietnamese words, not repeated magic strings — see above.
+var vietnam = marketForms{
+	name:     "vietnam",
+	syllabic: true,
+	prefixes: unambiguous(
+		[]string{"cong", "ty", "trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
+		[]string{"cong", "ty", "trach", "nhiem", "huu", "han"},
+		[]string{"cong", "ty", "tnhh", "hai", "thanh", "vien", "tro", "len"},
+		[]string{"cong", "ty", "tnhh", "mot", "thanh", "vien"},
+		[]string{"cong", "ty", "tnhh", "mtv"},
+		[]string{"cong", "ty", "tnhh"},
+		[]string{"cty", "tnhh", "mtv"},
+		[]string{"cty", "tnhh"},
+		[]string{"ngan", "hang", "thuong", "mai", "co", "phan"},
+		[]string{"ngan", "hang", "tmcp"},
+		[]string{"cong", "ty", "co", "phan"},
+		[]string{"cong", "ty", "cp"},
+		[]string{"cty", "co", "phan"},
+		[]string{"cty", "cp"},
+		[]string{"ctcp"},
+		[]string{"cong", "ty", "hop", "danh"},
+		[]string{"cong", "ty", "lien", "doanh"},
+		[]string{"doanh", "nghiep", "tu", "nhan"},
+		[]string{"dntn"},
+		[]string{"tong", "cong", "ty"},
+		[]string{"tap", "doan"},
+		[]string{"hop", "tac", "xa"},
+		[]string{"cong", "ty"},
+		[]string{"cty"},
+	),
+	continuations: unambiguous(
+		[]string{"co", "phan"},
+		[]string{"trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
+		[]string{"trach", "nhiem", "huu", "han"},
+		[]string{"tnhh", "mot", "thanh", "vien"},
+		[]string{"tnhh", "mtv"},
+		[]string{"tnhh"},
+	),
+	fillers: unambiguous(
+		[]string{"xuat", "nhap", "khau"},
+		[]string{"thuong", "mai"},
+		[]string{"dich", "vu"},
+		[]string{"dau", "tu"},
+		[]string{"phat", "trien"},
+		[]string{"xay", "dung"},
+		[]string{"san", "xuat"},
+		[]string{"cong", "nghe"},
+		[]string{"ky", "thuat"},
+		[]string{"giai", "phap"},
+		[]string{"quoc", "te"},
+		[]string{"xnk"},
+		[]string{"tm"},
+		[]string{"dv"},
+		[]string{"sx"},
+		[]string{"dt"},
+		[]string{"va"},
+	),
+}
+
+// Indonesia puts "PT" in front and, for a listed company, "Tbk" behind: the
+// brand sits between them. "PT" and "CV" are two Latin letters and both are real
+// company names elsewhere, so both are ambiguous. The spelled-out forms are not.
+var indonesia = marketForms{
+	name:    "indonesia",
+	closers: []string{"tbk"},
+	prefixes: append(
+		unambiguous(
+			[]string{"perseroan", "terbatas"},
+			[]string{"perusahaan", "perseroan"},
+			[]string{"perusahaan", "umum"},
+			[]string{"commanditaire", "vennootschap"},
+			[]string{"pt", "pma"},
+			[]string{"pt", "pmdn"},
+			[]string{"perum"},
+			[]string{"persero"},
+		),
+		ambiguous(
+			[]string{"pt"},
+			[]string{"cv"},
+			[]string{"fa"},
+		)...,
+	),
+}
+
+// Russia and the CIS write the form, then the brand, usually in guillemets.
+// Cyrillic collides with nothing. The Latin transliterations do: "AO World" is a
+// British retailer, "TOO Group" reads as an English word, and "IP" is a common
+// abbreviation, so those are ambiguous.
+var russiaAndCIS = marketForms{
+	name: "russia-cis",
+	prefixes: append(
+		unambiguous(
+			[]string{"ооо"}, []string{"зао"}, []string{"оао"}, []string{"пао"},
+			[]string{"ао"}, []string{"нко"}, []string{"гуп"}, []string{"муп"},
+			[]string{"тов"}, []string{"прат"}, []string{"пат"}, []string{"фоп"},
+			[]string{"таа"}, []string{"зат"}, []string{"аат"},
+			[]string{"жшс"}, []string{"ақ"},
+			[]string{"ooo"}, []string{"zao"}, []string{"oao"}, []string{"pao"},
+			[]string{"tov"}, []string{"prat"}, []string{"tzov"},
+		),
+		ambiguous(
+			[]string{"ao"}, []string{"too"}, []string{"ip"}, []string{"chp"},
+		)...,
+	),
+}
+
+// The Baltic forms sit at either end by statute — Latvia's commercial law says
+// "at the beginning or end" — so they are stripped from the front here and by
+// the existing trailing-suffix strip when they trail. Every one is short Latin
+// and collides: SIA Engineering, AB InBev, AS Roma, MB Financial.
+var baltics = marketForms{
+	name: "baltics",
+	prefixes: ambiguous(
+		[]string{"uab"}, []string{"sia"}, []string{"ou"},
+		[]string{"ab"}, []string{"as"}, []string{"mb"},
+		[]string{"ik"}, []string{"ii"}, []string{"tub"},
+	),
+}
+
+// Romania's "S.C." is not a legal form at all — the commercial register never
+// carried it, and the ISO list does not list it. It is a courtesy prefix meaning
+// "commercial company", it carries no information, and it goes unconditionally.
+// The forms themselves trail the name and are handled by the suffix strip.
+var romania = marketForms{
+	name:     "romania",
+	prefixes: unambiguous([]string{"s", "c"}, []string{"sc"}),
+}
+
+// Turkey and Poland write short dotted forms. After folding the dots become
+// separators, so "Sp. z o.o." arrives as four words.
+var turkeyAndPoland = marketForms{
+	name: "turkey-poland",
+	prefixes: unambiguous(
+		[]string{"sp", "z", "o", "o"},
+		[]string{"spolka", "z", "ograniczona", "odpowiedzialnoscia"},
+	),
+}
+
+// Arabic names open with شركة (sharikat, "company"), and Persian with شرکت.
+// Neither collides with anything in another script.
+var arabic = marketForms{
+	name: "arabic",
+	prefixes: unambiguous(
+		[]string{"شركة"}, []string{"شركه"}, []string{"مؤسسة"}, []string{"شرکت"},
+	),
+}
+
+// Thailand BRACKETS the brand: "บริษัท <brand> จำกัด" is "company <brand>
+// limited", and a public company adds "(มหาชน)". Both halves are needed — the
+// leading word alone leaves "จำกัด" on every name, which is the shared word two
+// unrelated insurers met on.
+//
+// The trailing half is a closer rather than a suffix in legalSuffixes, because
+// that map is consulted per WORD after a whitespace split and Thai writes no
+// spaces inside a word; here it is matched as the last word of the name.
+var thailand = marketForms{
+	name:     "thailand",
+	closers:  []string{"จำกัด", "มหาชน"},
+	prefixes: unambiguous([]string{"บริษัท"}, []string{"หจก"}, []string{"ห้างหุ้นส่วนจำกัด"}),
+	suffixes: []string{"จำกัด", "มหาชน"},
+}
+
+// Hebrew's בע"מ trails the name, but חברת ("company of") leads it.
+var hebrew = marketForms{
+	name:     "hebrew",
+	prefixes: unambiguous([]string{"חברת"}),
+}

--- a/backend/internal/modules/people/orgformtables.go
+++ b/backend/internal/modules/people/orgformtables.go
@@ -59,6 +59,10 @@ type marketForms struct {
 	// that legalSuffixes cannot reach: that map is keyed on whitespace-split
 	// words, and Thai writes none inside a name.
 	suffixes []string
+	// suffixRuns are trailing forms of SEVERAL words, which legalSuffixes also
+	// cannot reach for the same reason — it decides one word at a time and can
+	// never see that "sp z o o" is one form.
+	suffixRuns [][]string
 	// syllabic marks a market whose brands are built from a small pool of
 	// shared syllables, where ONE word in common is not evidence of identity.
 	// Vietnamese "Hòa Bình" and "Hòa Phát" share "hoa" and are the country's
@@ -273,8 +277,18 @@ var baltics = marketForms{
 // "commercial company", it carries no information, and it goes unconditionally.
 // The forms themselves trail the name and are handled by the suffix strip.
 var romania = marketForms{
-	name:     "romania",
-	prefixes: unambiguous([]string{"s", "c"}, []string{"sc"}),
+	name: "romania",
+	// The Romanian form at the END is what proves the bare "SC" at the front:
+	// "SC Dacia SRL" is a Romanian company, "SC Johnson" is not.
+	closers: []string{"srl", "sa", "sca", "snc", "pfa"},
+	// "S.C." dotted is unmistakable — no company writes its brand that way.
+	// Bare "SC" is not: SC Johnson is a real company, and stripping it left
+	// "johnson", which then met "Johnson Controls" at 0.89. So the undotted
+	// spelling is ambiguous and needs the name to agree, exactly like "PT".
+	prefixes: append(
+		unambiguous([]string{"s", "c"}),
+		ambiguous([]string{"sc"})...,
+	),
 }
 
 // Turkey and Poland write short dotted forms. After folding the dots become
@@ -285,14 +299,28 @@ var turkeyAndPoland = marketForms{
 		[]string{"sp", "z", "o", "o"},
 		[]string{"spolka", "z", "ograniczona", "odpowiedzialnoscia"},
 	),
+	// "Sp. z o.o." TRAILS the name far more often than it leads it, and it
+	// cannot go in legalSuffixes: that map is consulted one word at a time, and
+	// this form is four words after the dots become separators. Removed here as
+	// a run, longest first, so "Alfa Sp. z o.o." reduces to "alfa" rather than
+	// sharing four trailing words with every other Polish company.
+	suffixRuns: [][]string{
+		{"sp", "z", "o", "o"},
+		{"spolka", "z", "ograniczona", "odpowiedzialnoscia"},
+		{"ltd", "sti"},
+	},
 }
 
 // Arabic names open with شركة (sharikat, "company"), and Persian with شرکت.
 // Neither collides with anything in another script.
 var arabic = marketForms{
 	name: "arabic",
+	// Written as they FOLD, not as they are typed. Arabic vocalization and the
+	// hamza carriers are removed by the normalization above, so "مؤسسة" arrives
+	// as "موسسة" — an entry spelled the typed way would never fire, which the
+	// census in orgnameforms_test.go fails the build over.
 	prefixes: unambiguous(
-		[]string{"شركة"}, []string{"شركه"}, []string{"مؤسسة"}, []string{"شرکت"},
+		[]string{"شركة"}, []string{"شركه"}, []string{"موسسة"}, []string{"شرکت"},
 	),
 }
 
@@ -315,4 +343,7 @@ var thailand = marketForms{
 var hebrew = marketForms{
 	name:     "hebrew",
 	prefixes: unambiguous([]string{"חברת"}),
+	// בע"מ is the trailing form on nearly every Israeli company, and the
+	// gershayim inside it becomes a separator, so it arrives as two words.
+	suffixRuns: [][]string{{"בע", "מ"}},
 }

--- a/backend/internal/modules/people/orgformtables_test.go
+++ b/backend/internal/modules/people/orgformtables_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// marketCompany is one real-shaped name from a prefix-form market, and the
+// brand that identifies the company inside it.
+//
+// `group` names the company. Two entries sharing a group are one company written
+// two ways and must meet at the fuzzy tier; two entries with different groups are
+// different companies and must not.
+type marketCompany struct {
+	name  string
+	brand string
+	group string
+	// sharesAGenericWord marks a name that meets a neighbour on ONE ordinary
+	// word — a country ("Latvia" against "Latvija"), a sector ("Bank"). Those
+	// pairs are held apart by nothing this file owns: one shared distinctive
+	// word is enough evidence under the English rule, which predates the
+	// prefix-form tables and is unchanged by them. They are here as real names
+	// for the reduction and recall tests, and out of the precision census,
+	// which would otherwise assert a fix that lives somewhere else.
+	sharesAGenericWord bool
+}
+
+// Every market that writes its legal form in front of the name, with the
+// spellings a real CRM receives: the local script, the Latin transliteration,
+// and the bare brand somebody typed from memory.
+//
+// EVERY PAIR HERE SCORED ABOVE THE REVIEW THRESHOLD before these tables existed
+// — 0.76 for two Russian companies, 0.87 for two Latvian ones, 0.91 for two
+// Saudi ones. The names differ in a smaller part of themselves than Western
+// names do, because the first word or two is the same in every name in the
+// market, so a character metric reads the boilerplate as identity.
+var marketCorpus = []marketCompany{
+	// Indonesia. "PT" leads; a listed company also ends in "Tbk", so the brand
+	// sits between them.
+	{name: "PT Astra International Tbk", brand: "astra international", group: "astra"},
+	{name: "Astra International", brand: "astra international", group: "astra"},
+	{name: "PT Telkom Indonesia Tbk", brand: "telkom indonesia", group: "telkom"},
+	{name: "PT Bank Mandiri Tbk", brand: "bank mandiri", group: "mandiri", sharesAGenericWord: true},
+	{name: "PT Bank Central Asia Tbk", brand: "bank central asia", group: "bca", sharesAGenericWord: true},
+	{name: "Perseroan Terbatas Gudang Garam", brand: "gudang garam", group: "gudanggaram"},
+
+	// Russia and the CIS. Cyrillic and its Latin transliteration are the same
+	// company, and the guillemets a registry writes are punctuation.
+	{name: "ООО Ромашка", brand: "ромашка", group: "romashka"},
+	{name: "ООО «Ромашка»", brand: "ромашка", group: "romashka"},
+	{name: "ООО Василёк", brand: "василек", group: "vasilek"},
+	{name: "ЗАО Спутник", brand: "спутник", group: "sputnik"},
+	{name: "ПАО Газпром", brand: "газпром", group: "gazprom"},
+	{name: "OOO Gazprom Neft", brand: "gazprom neft", group: "gazpromneft"},
+	{name: "Gazprom Neft", brand: "gazprom neft", group: "gazpromneft"},
+	{name: "OOO Lukoil", brand: "lukoil", group: "lukoil"},
+	{name: "ТОВ Київстар", brand: "київстар", group: "kyivstar"},
+
+	// The Baltics. Every form here is short Latin, so a bare "SIA Brand" cannot
+	// be stripped — these prove the pairs stay apart anyway, on their brands.
+	{name: "UAB Vilniaus Duona", brand: "uab vilniaus duona", group: "vilniausduona"},
+	{name: "UAB Kauno Grudai", brand: "uab kauno grudai", group: "kaunogrudai"},
+	{name: "SIA Rimi Latvia", brand: "sia rimi latvia", group: "rimi", sharesAGenericWord: true},
+	{name: "SIA Maxima Latvija", brand: "sia maxima latvija", group: "maxima", sharesAGenericWord: true},
+
+	// Romania. "S.C." was never part of a registered name and carries no
+	// information at all, so it goes wherever it appears.
+	{name: "S.C. Dacia S.R.L.", brand: "dacia", group: "dacia"},
+	{name: "SC Dacia SRL", brand: "dacia", group: "dacia"},
+	{name: "Dacia", brand: "dacia", group: "dacia"},
+	{name: "S.C. Petrom S.A.", brand: "petrom", group: "petrom"},
+
+	// Arabic. The script itself is the corroboration.
+	{name: "شركة الراجحي", brand: "الراجحي", group: "rajhi"},
+	{name: "شركة الأهلي", brand: "الأهلي", group: "ahli"},
+	{name: "مؤسسة الفيصل", brand: "الفيصل", group: "faisal"},
+
+	// Thailand. The vowels here are combining marks, and an unrestricted
+	// accent-strip used to delete them — these names would have lost letters
+	// before any comparison began.
+	{name: "เมืองไทยประกันชีวิต", brand: "เมืองไทยประกันชีวิต", group: "muangthailife"},
+	{name: "เมืองไทยประกันภัย", brand: "เมืองไทยประกันภัย", group: "muangthaiins"},
+	{name: "กรุงไทย", brand: "กรุงไทย", group: "krungthai"},
+	{name: "บริษัท เมืองไทยประกันชีวิต จำกัด", brand: "เมืองไทยประกันชีวิต", group: "muangthailife"},
+	{name: "บริษัท เมืองไทยประกันชีวิต จำกัด (มหาชน)", brand: "เมืองไทยประกันชีวิต", group: "muangthailife"},
+	{name: "บริษัท กรุงไทยการไฟฟ้า จำกัด", brand: "กรุงไทยการไฟฟ้า", group: "krungthaielec"},
+	{name: "บริษัท เมืองไทยประกันภัย จำกัด", brand: "เมืองไทยประกันภัย", group: "muangthaiins"},
+}
+
+// No two different companies in any of these markets score as one.
+//
+// Exhaustive over every cross-company pair rather than a chosen few: the pair
+// that breaks next is the one nobody thought to write down.
+func TestNoCompanyInAPrefixMarketMatchesAnother(t *testing.T) {
+	pairs := 0
+	for i, left := range marketCorpus {
+		for _, right := range marketCorpus[i+1:] {
+			if left.group == right.group || left.sharesAGenericWord || right.sharesAGenericWord {
+				continue
+			}
+			pairs++
+			if got := bestOrgNamePairing(left.name, "", right.name, "").Confidence; got >= dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, at or above the %.2f review "+
+					"threshold — these are different companies",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+	if want := crossCompanyPairs(marketCorpus); pairs != want {
+		t.Fatalf("compared %d pairs, expected %d — the census is running short",
+			pairs, want)
+	}
+}
+
+// One company written two ways still meets, which is what the strip is for.
+func TestEveryPrefixMarketDuplicateStillMeets(t *testing.T) {
+	for i, left := range marketCorpus {
+		for _, right := range marketCorpus[i+1:] {
+			if left.group != right.group {
+				continue
+			}
+			if got := bestOrgNamePairing(left.name, "", right.name, "").Confidence; got < dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold — "+
+					"this is one company and the duplicate would be missed",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+}
+
+// Every name reduces to the company inside it.
+func TestEveryPrefixMarketNameReducesToItsBrand(t *testing.T) {
+	for _, company := range marketCorpus {
+		if got := orgNameForMatching(company.name); got != company.brand {
+			t.Errorf("%q reduces to %q, want %q — the comparison will be made on "+
+				"the wrong words", company.name, got, company.brand)
+		}
+	}
+}
+
+// A SHORT LATIN LEGAL FORM IS ALSO AN ORDINARY NAME, and every company here is
+// real. Stripping "PT" from the front on position alone leaves "Solutions
+// Physical Therapy", which then matches every firm in that sector — so an
+// ambiguous form is only believed when the name itself agrees, and a plain
+// English name never does.
+func TestAnAmbiguousFormIsNotStrippedFromAWesternName(t *testing.T) {
+	kept := []struct{ name, want string }{
+		{"PT Solutions Physical Therapy", "pt solutions physical therapy"},
+		{"AO World", "ao world"},
+		{"AS Roma", "as roma"},
+		{"CV Sciences", "cv sciences"},
+		{"SIA Engineering", "sia engineering"},
+		{"AB InBev", "ab inbev"},
+		{"MB Financial", "mb financial"},
+		{"TOO Group", "too group"},
+		{"IP Group", "ip group"},
+		{"FA Cup Ventures", "fa cup ventures"},
+	}
+	for _, k := range kept {
+		if got := orgNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q — another market's legal form was "+
+				"read out of an ordinary English name", k.name, got, k.want)
+		}
+	}
+}
+
+// The corroboration that DOES let a short form go: the market's own bracketing
+// suffix, or a name written in another script.
+func TestAnAmbiguousFormGoesWhenTheNameAgrees(t *testing.T) {
+	stripped := []struct{ name, want, why string }{
+		{"PT Astra International Tbk", "astra international", "Tbk closes an Indonesian name"},
+		{"PT Индустрия", "индустрия", "the rest of the name is not Latin"},
+	}
+	for _, s := range stripped {
+		if got := orgNameForMatching(s.name); got != s.want {
+			t.Errorf("%q reduces to %q, want %q — %s", s.name, got, s.want, s.why)
+		}
+	}
+}
+
+// A word that is another market's legal form is that market's vocabulary, and
+// two names must not meet on it alone.
+func TestAForeignLegalFormIsNotEvidenceOfIdentity(t *testing.T) {
+	apart := [][2]string{
+		{"AS Roma", "AS Monaco"},
+		{"UAB Vilniaus Duona", "UAB Kauno Grudai"},
+		{"PT Solutions Physical Therapy", "PT Astra International Tbk"},
+	}
+	for _, p := range apart {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f — they share a legal form, not a company",
+				p[0], p[1], got)
+		}
+	}
+	// AND IT IS STILL EVIDENCE WHEN IT IS ALL THE NAME HAS. "PT Solutions"
+	// reduces to "pt" once "solutions" is gone as English market vocabulary,
+	// and it must still find its own longer name — this pair scores 0.88 on
+	// main and a fix that silenced it would be trading a real duplicate away.
+	meet := [][2]string{
+		{"PT Solutions Physical Therapy", "PT Solutions"},
+		{"AO World plc", "AO World"},
+		{"AS Roma", "AS Roma SpA"},
+		{"SIA Rimi Latvia", "Rimi Latvia"},
+	}
+	for _, p := range meet {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f threshold — this is one "+
+				"company", p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// Thai vowels are combining marks, and stripping them as accents deleted real
+// letters: two different insurers folded to nearly the same string.
+func TestThaiNamesKeepTheirVowels(t *testing.T) {
+	for _, name := range []string{"เมืองไทยประกันชีวิต", "กรุงไทย", "ลาวพัฒนา"} {
+		if got := normalizeName(name); got != name {
+			t.Errorf("%q folds to %q — Thai vowels are letters, not accents",
+				name, got)
+		}
+	}
+	// And the accent strip still does its job where the marks ARE accents.
+	for _, k := range []struct{ in, want string }{
+		{"Müller", "muller"},
+		{"Bär", "bar"},
+		{"Straße", "strasse"},
+		{"Οδυσσεύς", "οδυσσευσ"},
+		{"Василёк", "василек"},
+	} {
+		if got := normalizeName(k.in); got != k.want {
+			t.Errorf("%q folds to %q, want %q — the accent strip must still run "+
+				"on the alphabets it was built for", k.in, got, k.want)
+		}
+	}
+}
+
+// crossCompanyPairs counts the pairs a precision census owes, from the SHAPE of
+// the corpus rather than by walking it again — an independent arithmetic check
+// rather than a second copy of the loop it holds.
+func crossCompanyPairs(corpus []marketCompany) int {
+	perCompany := map[string]int{}
+	total := 0
+	for _, c := range corpus {
+		if c.sharesAGenericWord {
+			continue
+		}
+		perCompany[c.group]++
+		total++
+	}
+	pairs := total * (total - 1) / 2
+	for _, n := range perCompany {
+		pairs -= n * (n - 1) / 2
+	}
+	return pairs
+}

--- a/backend/internal/modules/people/orgformtables_test.go
+++ b/backend/internal/modules/people/orgformtables_test.go
@@ -72,7 +72,7 @@ var marketCorpus = []marketCompany{
 
 	// Arabic. The script itself is the corroboration.
 	{name: "شركة الراجحي", brand: "الراجحي", group: "rajhi"},
-	{name: "شركة الأهلي", brand: "الأهلي", group: "ahli"},
+	{name: "شركة الأهلي", brand: "الاهلي", group: "ahli"},
 	{name: "مؤسسة الفيصل", brand: "الفيصل", group: "faisal"},
 
 	// Thailand. The vowels here are combining marks, and an unrestricted

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -3,136 +3,43 @@
 
 package people
 
-// The Vietnamese half of org-name matching: a name whose legal form and trade
-// vocabulary come FIRST, with the brand at the end.
+// Org-name matching for the markets that write the legal form BEFORE the name.
 //
 // WHY THIS EXISTS. PO-PARAM-1 strips a legal form that TRAILS the name — "Acme
-// Inc", "Acme GmbH" — because that is where English and German put it. Vietnam
-// puts it in front and spells it in several words: "CÔNG TY CỔ PHẦN SỮA VIỆT
-// NAM" is Vinamilk, and the first three words are "joint-stock company". Every
-// Vietnamese company therefore begins with the same run of words, and a
-// character metric reads that shared run as shared identity: Jaro-Winkler
-// boosts a shared PREFIX specifically, so two unrelated Vietnamese companies
-// scored above the review threshold on their boilerplate alone.
+// Inc", "Acme GmbH" — because that is where English and German put it. Much of
+// the world puts it in front: "CÔNG TY CỔ PHẦN SỮA VIỆT NAM" is Vinamilk and the
+// first three words are "joint-stock company"; so are "PT Astra International",
+// "ООО Ромашка", "UAB Vilniaus Duona". Every company in such a market therefore
+// begins with the same run of words, and a character metric reads that as shared
+// identity — Jaro-Winkler boosts a shared PREFIX specifically. Measured before
+// this existed, two unrelated companies scored 0.76 to 0.91 against each other
+// on their boilerplate alone, well past the 0.72 review threshold.
 //
-// A PHRASE, NEVER A WORD. The folded syllables of the legal form are also real
-// brand syllables: "cổ" and "cô" and "có" all fold to "co", "phần" and "phân"
-// to "phan", and "Cỏ May" is a rice company whose whole name folds to "co may".
-// So a word of a legal form is only removed as part of the WHOLE phrase, at the
-// front of the name. Deleting the token "phan" wherever it appears would take
-// the brand off "Phan Minh", which is the failure this file is written to
-// avoid.
+// A PHRASE, NEVER A WORD. The folded syllables of a legal form are also real
+// brand syllables: "cổ", "cô" and "có" all fold to "co", "phần" and "phân" to
+// "phan", and "Cỏ May" is a rice company whose whole name folds to "co may". So
+// a word of a legal form is only removed as part of the WHOLE phrase, at the
+// front of the name. Deleting the token "phan" wherever it appeared would take
+// the brand off "Phan Minh".
+//
+// AND A SHORT LATIN FORM NEEDS A SECOND OPINION. "PT Solutions Physical
+// Therapy", "AO World", "AS Roma", "CV Sciences", "AB InBev", "SIA Engineering"
+// and "MB Financial" are all real companies whose first word is another market's
+// legal form. Position alone cannot tell those from "PT Astra International", so
+// an ambiguous marker is believed only when something else about the name agrees
+// — see corroboratedMarket.
 //
 // WHAT THIS IS NOT. Not a second normalizer for the org-name KEY:
-// NormalizeOrgName (namesim.go) is unchanged, and still produces the exact and
+// NormalizeOrgName (namesim.go) is unchanged and still produces the exact and
 // grouping keys, so no stored key moves. This one is consulted only where two
 // names are COMPARED — the gate (orgnamegate.go) and the score (dedupeorg.go).
 // The difference matters: "Công ty CP Đầu tư ABC" and "Công ty CP Thương mại
 // ABC" must compare as one candidate pair and must NOT group under one key.
 
-import "strings"
-
-// vietnameseLegalFormPrefixes are the forms a Vietnamese company name opens
-// with, written as they appear AFTER folding (lowercase, unaccented, đ→d).
-//
-// A HAND-WRITTEN, VERSIONED LIST, read the same way as orgNameStopwords and for
-// the same reason: a list derived from the workspace's own names would make two
-// names match in one workspace and not in another, and would put a query inside
-// the transaction that holds the organization-name write lock.
-//
-// Both spellings of each form, because both are how companies write themselves:
-// the legal "công ty trách nhiệm hữu hạn" and the everyday "công ty tnhh", and
-// "cty" for "công ty". A duplicate pair in this market is very often one
-// company written out in full against the same company abbreviated.
-//
-// Order does not matter here — matching takes the LONGEST phrase that fits, so
-// "cong ty co phan" wins over "cong ty" on the same name regardless of position
-// in this slice.
-//
-// The syllables recur because the language builds its legal forms out of them,
-// and the point of writing the table this way is that a reader can check it
-// against the language. Naming "cong" as a constant would hide what the entries
-// say, so the repetition is the readable form here rather than a smell.
-//
-//nolint:goconst // Vietnamese words, not repeated magic strings — see above.
-var vietnameseLegalFormPrefixes = [][]string{
-	{"cong", "ty", "trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
-	{"cong", "ty", "trach", "nhiem", "huu", "han"},
-	{"cong", "ty", "tnhh", "hai", "thanh", "vien", "tro", "len"},
-	{"cong", "ty", "tnhh", "mot", "thanh", "vien"},
-	{"cong", "ty", "tnhh", "mtv"},
-	{"cong", "ty", "tnhh"},
-	{"cty", "tnhh", "mtv"},
-	{"cty", "tnhh"},
-	{"ngan", "hang", "thuong", "mai", "co", "phan"},
-	{"ngan", "hang", "tmcp"},
-	{"cong", "ty", "co", "phan"},
-	{"cong", "ty", "cp"},
-	{"cty", "co", "phan"},
-	{"cty", "cp"},
-	{"ctcp"},
-	{"cong", "ty", "hop", "danh"},
-	{"cong", "ty", "lien", "doanh"},
-	{"doanh", "nghiep", "tu", "nhan"},
-	{"dntn"},
-	{"tong", "cong", "ty"},
-	{"tap", "doan"},
-	{"hop", "tac", "xa"},
-	{"cong", "ty"},
-	{"cty"},
-}
-
-// vietnameseLegalFormContinuations are the forms that appear only as the SECOND
-// half of a stacked one, where they arrive stripped of their leading "công ty".
-//
-// "TỔNG CÔNG TY CỔ PHẦN BIA RƯỢU SÀI GÒN" is a corporation that is also a
-// joint-stock company: once "tổng công ty" is taken off the front, what remains
-// opens with a bare "cổ phần".
-//
-// SEPARATE FROM THE TABLE ABOVE, because these words are only boilerplate in
-// that position. A company that simply calls itself "Cổ Phần Xanh" has those
-// words as its name, and a strip that ran them from the front of any name would
-// take it. So they are consulted only after a form has already been removed.
-var vietnameseLegalFormContinuations = [][]string{
-	{"co", "phan"},
-	{"trach", "nhiem", "huu", "han", "mot", "thanh", "vien"},
-	{"trach", "nhiem", "huu", "han"},
-	{"tnhh", "mot", "thanh", "vien"},
-	{"tnhh", "mtv"},
-	{"tnhh"},
-}
-
-// vietnameseSectorFillers are the trade words that stack between the legal form
-// and the brand: "CÔNG TY TNHH THƯƠNG MẠI DỊCH VỤ TÂN HIỆP PHÁT" is a trading
-// and services company called Tân Hiệp Phát.
-//
-// They are the market's vocabulary, not an identity — unrelated companies share
-// long identical runs of them, and the same run appears in different orders. So
-// they are removed for the purposes of comparison, exactly as "solutions" and
-// "systems" are dropped by orgNameStopwords on the English side.
-//
-// STRIPPED ONLY AT THE FRONT, after the legal form. A filler word that appears
-// later is part of the brand — "SỮA VIỆT NAM" ends in a word that is elsewhere
-// a filler, and it is the name of the company.
-var vietnameseSectorFillers = [][]string{
-	{"xuat", "nhap", "khau"},
-	{"thuong", "mai"},
-	{"dich", "vu"},
-	{"dau", "tu"},
-	{"phat", "trien"},
-	{"xay", "dung"},
-	{"san", "xuat"},
-	{"cong", "nghe"},
-	{"ky", "thuat"},
-	{"giai", "phap"},
-	{"quoc", "te"},
-	{"xnk"},
-	{"tm"},
-	{"dv"},
-	{"sx"},
-	{"dt"},
-	{"va"},
-}
+import (
+	"strings"
+	"unicode"
+)
 
 // foldDStroke maps đ to d.
 //
@@ -141,8 +48,8 @@ var vietnameseSectorFillers = [][]string{
 // the letter survives the fold intact: "ĐẦU TƯ" becomes "đau tu", not "dau tu".
 // Postgres f_unaccent DOES map it, so without this the same name folds two ways
 // — "dau tu" in the database and "đau tu" in Go — and no entry in the tables
-// above could ever match a name typed with the letter Vietnamese uses for one
-// of its most common trade words.
+// could ever match a name typed with the letter Vietnamese uses for one of its
+// most common trade words.
 //
 // Deliberately NOT inside normalizeName, which is pinned as the input to the
 // similarity metric (PO-PARAM-JW-2) and shared with person and lead matching.
@@ -154,22 +61,28 @@ func foldDStroke(s string) string {
 	return strings.NewReplacer("đ", "d", "Đ", "D").Replace(s)
 }
 
-// stripLeadingPhrases removes phrases from the FRONT of a name, longest first,
-// for as long as one matches.
+// stripLeadingMarkers removes legal forms from the FRONT of a name, longest
+// first, for as long as one matches.
 //
-// Repeated, because the forms stack: "TỔNG CÔNG TY CỔ PHẦN …" carries two, and
-// a name may open with a legal form followed by three trade words.
+// Repeated, because the forms stack: "TỔNG CÔNG TY CỔ PHẦN …" carries two, and a
+// name may open with a form followed by several trade words.
 //
-// Longest-match, because the short phrases are prefixes of the long ones.
-// Taking "cong ty" off "cong ty co phan x" would leave "co phan x" and put the
-// remains of a legal form into the comparison.
-func stripLeadingPhrases(fields []string, table [][]string) []string {
+// Longest-match, because the short forms are prefixes of the long ones. Taking
+// "cong ty" off "cong ty co phan x" would leave "co phan x" and put the remains
+// of a legal form into the comparison.
+//
+// An AMBIGUOUS marker is skipped unless the caller has already found
+// corroboration that this really is the market it looks like.
+func stripLeadingMarkers(fields []string, markers []orgFormMarker, corroborated bool) []string {
 	for {
 		longest := 0
-		for _, phrase := range table {
-			if len(phrase) > longest && len(phrase) <= len(fields) &&
-				matchesAt(fields, phrase) {
-				longest = len(phrase)
+		for _, marker := range markers {
+			if marker.ambiguous && !corroborated {
+				continue
+			}
+			if len(marker.tokens) > longest && len(marker.tokens) <= len(fields) &&
+				opensWith(fields, marker.tokens) {
+				longest = len(marker.tokens)
 			}
 		}
 		if longest == 0 {
@@ -179,9 +92,58 @@ func stripLeadingPhrases(fields []string, table [][]string) []string {
 	}
 }
 
-// matchesAt answers whether the name opens with exactly this phrase.
-func matchesAt(fields, phrase []string) bool {
-	for i, word := range phrase {
+// nameWordSeparators split a name into words, for the legal-form tables here and
+// for the gate that compares what is left.
+//
+// PUNCTUATION SEPARATES. Company names arrive punctuated every way a writer can
+// punctuate them — "ACME-Group", "Hewlett.Packard", "Capital.com", "S.C.",
+// "Sp. z o.o.", "ООО «Ромашка»", an en dash where a hyphen was meant — and a
+// fused token loses a real duplicate: "Acme Ltd" and "ACME-Group Ltd" share the
+// word "acme", but as one token "acme-group" it matches nothing.
+//
+// A CLASS rather than a list, deliberately. An earlier version named six ASCII
+// characters and missed the period and the en dash, which is the shape of bug
+// that keeps being rediscovered one punctuation mark at a time.
+//
+// A COMBINING MARK DOES NOT SEPARATE, which the letters-and-digits rule got
+// wrong. Thai, Lao, Khmer and the Indic scripts write their vowels as marks
+// rather than letters, so that rule cut every Thai word into pieces:
+// "เมืองไทย" became four fragments. Those scripts have no spaces between words
+// either, so a Thai name is correctly ONE word here.
+//
+// Deliberately NOT done inside NormalizeOrgName, which also produces exact
+// grouping keys (orgMatchKeys in linkedinimport.go, the promotion sweep's
+// buckets). Splitting there would make two DIFFERENT names equal as keys.
+func nameWordSeparators(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && !unicode.Is(unicode.Mn, r)
+}
+
+// stripTrailingWords removes a market's own trailing forms, for the bracketing
+// markets where the brand sits between two halves of one legal form.
+//
+// Never down to nothing: a name that is only its legal form keeps the last word,
+// the same rule NormalizeOrgName follows when a suffix IS the company.
+func stripTrailingWords(fields []string, suffixes []string) []string {
+	for len(fields) > 1 {
+		last := fields[len(fields)-1]
+		matched := false
+		for _, suffix := range suffixes {
+			if last == suffix {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fields
+		}
+		fields = fields[:len(fields)-1]
+	}
+	return fields
+}
+
+// opensWith answers whether the name opens with exactly this form.
+func opensWith(fields, tokens []string) bool {
+	for i, word := range tokens {
 		if strings.Trim(fields[i], ".") != word {
 			return false
 		}
@@ -189,40 +151,107 @@ func matchesAt(fields, phrase []string) bool {
 	return true
 }
 
+// corroboratedMarket answers whether a name that OPENS with an ambiguous marker
+// really belongs to that marker's market.
+//
+// The question exists because a two-letter Latin form is also an ordinary name.
+// "PT Astra International Tbk" is an Indonesian company; "PT Solutions Physical
+// Therapy" is an American one, and nothing about the position of "PT"
+// distinguishes them.
+//
+// TWO THINGS COUNT AS AGREEMENT, and both are properties of the name itself
+// rather than of the record around it:
+//
+//   - the market's own bracketing form closes the name. Indonesia's listed
+//     companies end in "Tbk", and no English name does.
+//   - the rest of the name is not written in Latin script. "ООО Ромашка" and
+//     "شركة الراجحي" are unambiguous by their letters, and a Latin marker in
+//     front of a Cyrillic or Arabic name is the same evidence.
+//
+// When neither holds, the marker stays in the name. That keeps today's false
+// positive for a genuine "PT Something" pair, which is the safer error: a name
+// wrongly stripped matches every company in its sector, while a name left alone
+// matches only the ones it already did.
+func corroboratedMarket(raw string, fields []string, market marketForms) bool {
+	if len(fields) < 2 {
+		return false
+	}
+	for _, closer := range market.closers {
+		// Asked of the RAW name, because the suffix strip in NormalizeOrgName
+		// has already removed the closer from `fields` by the time this runs —
+		// the evidence would be gone exactly when it is needed.
+		if closesWith(raw, closer) {
+			return true
+		}
+	}
+	return !isLatinScript(fields[1:])
+}
+
+// closesWith answers whether a name ends in this word.
+func closesWith(raw, word string) bool {
+	words := strings.FieldsFunc(normalizeName(raw), nameWordSeparators)
+	return len(words) > 0 && words[len(words)-1] == word
+}
+
+// isLatinScript answers whether these words are written in the Latin alphabet.
+//
+// Digits and punctuation say nothing either way, so a name of nothing but those
+// counts as Latin: it carries no evidence of another market, which is what the
+// caller is asking about.
+func isLatinScript(fields []string) bool {
+	for _, field := range fields {
+		for _, r := range field {
+			if !unicode.IsLetter(r) {
+				continue
+			}
+			if !unicode.Is(unicode.Latin, r) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // orgNameForMatching is the name reduced to what could identify a company: the
-// key with a Vietnamese legal form and its trailing trade vocabulary removed.
+// key with a leading legal form and its trailing trade vocabulary removed.
 //
 // IT MAY RETURN EMPTY, and that is an answer rather than a failure. A name that
-// is nothing but a legal form and trade words — "CÔNG TY CỔ PHẦN THƯƠNG MẠI
-// DỊCH VỤ" — has said nothing about WHICH company it is, and two such names
-// have said nothing about being the same one. Callers treat empty as no
-// evidence, never as a wildcard.
+// is nothing but a legal form and trade words — "CÔNG TY CỔ PHẦN THƯƠNG MẠI DỊCH
+// VỤ" — has said nothing about WHICH company it is, and two such names have said
+// nothing about being the same one. Callers treat empty as no evidence, never as
+// a wildcard.
 //
-// This is the one place it differs from NormalizeOrgName, which must never
-// empty a name because it produces a stored key and an empty key would collide
-// with every other empty key. A comparison has no such obligation: it is
-// allowed to say "I cannot tell these apart on their names".
+// This is the one place it differs from NormalizeOrgName, which must never empty
+// a name because it produces a stored key and an empty key would collide with
+// every other empty key. A comparison has no such obligation: it is allowed to
+// say "I cannot tell these apart on their names".
 func orgNameForMatching(s string) string {
 	name, _ := matchingFormOf(s)
 	return name
 }
 
-// matchingFormOf is orgNameForMatching plus the fact the caller sometimes needs:
-// whether this name declared itself Vietnamese by carrying a legal form.
+// matchingFormOf is orgNameForMatching plus the market the name declared, which
+// the gate needs: a market whose brands are built from a small pool of shared
+// syllables cannot treat one shared word as evidence of identity.
 //
-// THE TRADE VOCABULARY IS ONLY STRIPPED FROM A NAME THAT DID. Its abbreviations
-// are two letters — "tm", "dv", "dt", "va" — and two letters mean something else
-// in every other market: "VA Software" and "DT Systems" are companies whose
-// first word this table would otherwise eat, leaving them equal to "Software"
-// and "Systems". A legal form is a strong enough signal to act on; a bare
-// two-letter word at the front of a name is not.
-func matchingFormOf(s string) (string, bool) {
-	fields := strings.Fields(NormalizeOrgName(foldDStroke(s)))
-	stripped := stripLeadingPhrases(fields, vietnameseLegalFormPrefixes)
-	vietnamese := len(stripped) < len(fields)
-	if !vietnamese {
-		return strings.Join(stripped, " "), false
+// THE TRADE VOCABULARY IS ONLY STRIPPED FROM A NAME THAT DECLARED ITS MARKET.
+// Vietnam's abbreviations are two letters — "tm", "dv", "dt", "va" — and two
+// letters mean something else everywhere else: "VA Trading" and "DT Robotics"
+// are companies whose first word this table would otherwise eat. A legal form is
+// a strong enough signal to act on; a bare two-letter word is not.
+func matchingFormOf(s string) (string, *marketForms) {
+	fields := strings.FieldsFunc(NormalizeOrgName(foldDStroke(s)), nameWordSeparators)
+	for i := range prefixMarkets {
+		market := &prefixMarkets[i]
+		stripped := stripLeadingMarkers(fields, market.prefixes,
+			corroboratedMarket(s, fields, *market))
+		if len(stripped) == len(fields) {
+			continue
+		}
+		stripped = stripLeadingMarkers(stripped, market.continuations, true)
+		stripped = stripLeadingMarkers(stripped, market.fillers, true)
+		stripped = stripTrailingWords(stripped, market.suffixes)
+		return strings.Join(stripped, " "), market
 	}
-	stripped = stripLeadingPhrases(stripped, vietnameseLegalFormContinuations)
-	return strings.Join(stripLeadingPhrases(stripped, vietnameseSectorFillers), " "), true
+	return strings.Join(fields, " "), nil
 }

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -141,6 +141,36 @@ func stripTrailingWords(fields []string, suffixes []string) []string {
 	return fields
 }
 
+// stripTrailingRuns removes a multi-word trailing form, longest first, for as
+// long as one matches. Never down to nothing, the same rule the other strips
+// follow.
+func stripTrailingRuns(fields []string, runs [][]string) []string {
+	for {
+		longest := 0
+		for _, run := range runs {
+			if len(run) > longest && len(run) < len(fields) &&
+				closesWithRun(fields, run) {
+				longest = len(run)
+			}
+		}
+		if longest == 0 {
+			return fields
+		}
+		fields = fields[:len(fields)-longest]
+	}
+}
+
+// closesWithRun answers whether the name ends in exactly this run of words.
+func closesWithRun(fields, run []string) bool {
+	tail := fields[len(fields)-len(run):]
+	for i, word := range run {
+		if tail[i] != word {
+			return false
+		}
+	}
+	return true
+}
+
 // opensWith answers whether the name opens with exactly this form.
 func opensWith(fields, tokens []string) bool {
 	for i, word := range tokens {
@@ -245,13 +275,20 @@ func matchingFormOf(s string) (string, *marketForms) {
 		market := &prefixMarkets[i]
 		stripped := stripLeadingMarkers(fields, market.prefixes,
 			corroboratedMarket(s, fields, *market))
-		if len(stripped) == len(fields) {
-			continue
+		if len(stripped) < len(fields) {
+			stripped = stripLeadingMarkers(stripped, market.continuations, true)
+			stripped = stripLeadingMarkers(stripped, market.fillers, true)
 		}
-		stripped = stripLeadingMarkers(stripped, market.continuations, true)
-		stripped = stripLeadingMarkers(stripped, market.fillers, true)
+		// The trailing forms are consulted whether or not a leading one
+		// matched, because most of them do not come in pairs: "Alfa Sp. z o.o."
+		// carries the Polish form at the end and nothing at the front, and a
+		// name that reached the suffix strip only through a prefix would keep
+		// it and share four trailing words with every other Polish company.
 		stripped = stripTrailingWords(stripped, market.suffixes)
-		return strings.Join(stripped, " "), market
+		stripped = stripTrailingRuns(stripped, market.suffixRuns)
+		if len(stripped) < len(fields) {
+			return strings.Join(stripped, " "), market
+		}
 	}
 	return strings.Join(fields, " "), nil
 }

--- a/backend/internal/modules/people/orgnameforms_integration_test.go
+++ b/backend/internal/modules/people/orgnameforms_integration_test.go
@@ -81,6 +81,26 @@ func TestVietnameseCompaniesResolveThroughTheLadder(t *testing.T) {
 			ascii.Decision, ascii.Confidence)
 	}
 
+	// A LONG LEGAL FORM MUST NOT HIDE A SHORT BRAND. The candidate query
+	// searches whole strings, and "Perseroan Terbatas IBM" against a stored
+	// "IBM" scores 0.174 that way — under the trigram limit, so the incumbent
+	// was never returned and the duplicate could not be found however well the
+	// scorer worked. The query searches the stripped brand as well for exactly
+	// this.
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "IBM", Source: "manual",
+	}); err != nil {
+		t.Fatalf("seeding the short-brand incumbent: %v", err)
+	}
+	longForm := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
+		DisplayName: "Perseroan Terbatas IBM",
+	})
+	if longForm.Decision != DecisionFuzzyReview {
+		t.Errorf("a name whose legal form dwarfs its brand got %s (confidence "+
+			"%.4f), want fuzzy_review — its own company is seeded",
+			longForm.Decision, longForm.Confidence)
+	}
+
 	// And tier 1 still outranks every name judgement: a shared domain is an
 	// exact key, whatever the two names look like.
 	withDomain, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{

--- a/backend/internal/modules/people/orgnameforms_test.go
+++ b/backend/internal/modules/people/orgnameforms_test.go
@@ -354,23 +354,60 @@ func TestAllBoilerplateNamesDoNotMatchEachOther(t *testing.T) {
 // Reads the real tables, never a copy — a census over a copied list is the
 // shape that fails short and reports PASS.
 func TestPhraseTableEntriesMatchTheirOwnNormalization(t *testing.T) {
-	tables := map[string][][]string{
-		"vietnameseLegalFormPrefixes": vietnameseLegalFormPrefixes,
-		"vietnameseSectorFillers":     vietnameseSectorFillers,
+	if len(prefixMarkets) == 0 {
+		t.Fatal("no markets declared — the census would pass against nothing")
 	}
-	for name, table := range tables {
-		if len(table) == 0 {
-			t.Fatalf("%s is empty — the census would pass against nothing", name)
+	seen := 0
+	for _, market := range prefixMarkets {
+		groups := map[string][]orgFormMarker{
+			"prefixes":      market.prefixes,
+			"continuations": market.continuations,
+			"fillers":       market.fillers,
 		}
-		for _, phrase := range table {
-			if len(phrase) == 0 {
-				t.Errorf("%s carries an empty phrase, which matches every name", name)
+		if len(market.prefixes) == 0 {
+			t.Errorf("%s declares no prefix forms, so it can never fire", market.name)
+		}
+		for group, markers := range groups {
+			for _, marker := range markers {
+				seen++
+				if len(marker.tokens) == 0 {
+					t.Errorf("%s %s carries an empty form, which matches every name",
+						market.name, group)
+					continue
+				}
+				joined := strings.Join(marker.tokens, " ")
+				if got := NormalizeOrgName(foldDStroke(joined)); got != joined {
+					t.Errorf("%s %s entry %q normalizes to %q — written this way it "+
+						"can never match a real name", market.name, group, joined, got)
+				}
+			}
+		}
+	}
+	// The census walks the real tables, so it cannot fall behind them — but it
+	// could still walk an empty one and report PASS.
+	if seen < 60 {
+		t.Fatalf("only %d forms inspected across %d markets — the census is running "+
+			"short of the tables it is meant to hold", seen, len(prefixMarkets))
+	}
+}
+
+// A form that is not written the way a folded name is written can never fire,
+// and no other test would notice: the legal form simply stays in the name and
+// the false positives come back. This asks each market's tables to prove
+// themselves against a name that carries them.
+func TestEveryMarketStripsItsOwnForms(t *testing.T) {
+	for _, market := range prefixMarkets {
+		for _, marker := range market.prefixes {
+			// An ambiguous form needs corroboration, which a bare
+			// "<form> Brand" cannot give in Latin script. Those are proven by
+			// the per-market corpus instead.
+			if marker.ambiguous {
 				continue
 			}
-			joined := strings.Join(phrase, " ")
-			if got := NormalizeOrgName(foldDStroke(joined)); got != joined {
-				t.Errorf("%s entry %q normalizes to %q — written this way it can "+
-					"never match a real name", name, joined, got)
+			name := strings.Join(marker.tokens, " ") + " zzbrandzz"
+			if got := orgNameForMatching(name); got != "zzbrandzz" {
+				t.Errorf("%s: %q reduces to %q, want the brand alone — the form "+
+					"is not being recognized", market.name, name, got)
 			}
 		}
 	}
@@ -391,9 +428,15 @@ func TestWesternNamesAreUnchanged(t *testing.T) {
 		"Health Care", "Arvato Systems", "Bytesforce", "Salesforce",
 	}
 	for _, name := range western {
-		if got, want := orgNameForMatching(name), NormalizeOrgName(name); got != want {
-			t.Errorf("%q: matching normalization gives %q but the key gives %q — "+
-				"the Vietnamese strip reached a name it does not own",
+		// Compared as WORDS, not as one string: the matching form splits on
+		// punctuation so a legal form written "S.C." can be found, and the key
+		// does not. That difference is punctuation only, and no word of a
+		// Western name may be added, dropped or altered.
+		got := strings.FieldsFunc(orgNameForMatching(name), nameWordSeparators)
+		want := strings.FieldsFunc(NormalizeOrgName(name), nameWordSeparators)
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Errorf("%q: matching normalization reads %v but the key reads %v — "+
+				"a prefix-market strip reached a name it does not own",
 				name, got, want)
 		}
 	}

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -37,10 +37,7 @@ package people
 // 1 (`exactOrgByDomain`), which returns before this tier is reached — a domain
 // is an exact key and needs no name evidence at all.
 
-import (
-	"strings"
-	"unicode"
-)
+import "strings"
 
 // orgNameStopwords are the words a company name shares with its whole market:
 // present in many names, evidence of identity in none.
@@ -184,27 +181,6 @@ const orgFuzzyTokenSimilarity = 0.90
 // them apart.
 const orgFuzzyTokenLengthSlack = 1
 
-// orgTokenSeparators split a name into words for THIS gate's purposes.
-//
-// Anything that is not a letter or a digit separates two words. Company names
-// arrive punctuated every way a writer can punctuate them — "ACME-Group",
-// "Rich-Media/Solutions", "Hewlett.Packard", "Capital.com", an en dash where a
-// hyphen was meant — and a fused token loses a real duplicate: "Acme Ltd" and
-// "ACME-Group Ltd" share the word "acme", but as one token "acme-group" it
-// matches nothing.
-//
-// A CLASS rather than a list, deliberately. An earlier version named six ASCII
-// characters and missed the period and the en dash, which is the shape of bug
-// that keeps being rediscovered one punctuation mark at a time.
-//
-// Deliberately NOT done inside NormalizeOrgName, which also produces exact
-// grouping keys (orgMatchKeys in linkedinimport.go, the promotion sweep's
-// buckets). Splitting there would make two DIFFERENT names equal as keys.
-// Splitting here changes only which words this gate compares.
-func orgTokenSeparators(r rune) bool {
-	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
-}
-
 // distinctiveOrgTokens are a name's words with the market's shared vocabulary
 // removed.
 //
@@ -212,7 +188,7 @@ func orgTokenSeparators(r rune) bool {
 // three runes was wrong: it threw away "3M", whose two characters ARE the
 // company. A word is dropped for being generic, never for being short.
 func distinctiveOrgTokens(name string) []string {
-	fields := strings.FieldsFunc(orgNameForMatching(name), orgTokenSeparators)
+	fields := strings.FieldsFunc(orgNameForMatching(name), nameWordSeparators)
 	out := make([]string, 0, min(len(fields), orgGateTokenBudget))
 	for i, token := range fields {
 		// AN ARTICLE THAT WOULD LEAVE A ONE-WORD NAME IS NOT AN ARTICLE. English
@@ -297,7 +273,7 @@ func sameOrgToken(a, b string) bool {
 // The same separators the token split uses, so "E-Commerce" and "E Commerce"
 // take one path rather than two.
 func squashedOrgName(name string) string {
-	return strings.Join(strings.FieldsFunc(orgNameForMatching(name), orgTokenSeparators), "")
+	return strings.Join(strings.FieldsFunc(orgNameForMatching(name), nameWordSeparators), "")
 }
 
 // sharesADistinctiveWord is the gate itself: may these two names be scored?
@@ -323,8 +299,8 @@ func sharesADistinctiveWord(a, b string) bool {
 		return true
 	}
 	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
-	_, leftVN := matchingFormOf(a)
-	_, rightVN := matchingFormOf(b)
+	_, leftMarket := matchingFormOf(a)
+	_, rightMarket := matchingFormOf(b)
 	// A name that reduced to NOTHING shares no word and stops here. Vietnamese
 	// names carry their legal form and trade vocabulary in front of the brand,
 	// so a name made only of those strips to empty (orgnameforms.go) — and two
@@ -346,10 +322,12 @@ func sharesADistinctiveWord(a, b string) bool {
 	// Phát" share the word "hoa" — and they are Vietnam's largest construction
 	// firm and its largest steelmaker.
 	//
-	// ASKED ONLY OF A VIETNAMESE COMPARISON, because only there is a shared word
-	// weak evidence. English builds a brand from words that are themselves rare,
-	// so one is enough, and demanding more loses real duplicates: "Amazon AWS"
-	// and "Amazon Web Services" share only "amazon" of two distinctive words.
+	// ASKED ONLY OF A SYLLABIC MARKET, because only there is one shared word weak
+	// evidence. Vietnamese builds a brand from two or three syllables drawn from
+	// a small common pool, so "Hòa Bình" and "Hòa Phát" share "hoa" and are two
+	// different companies. English builds a brand from words that are themselves
+	// rare, so one is enough there, and demanding more loses real duplicates:
+	// "Amazon AWS" and "Amazon Web Services" share only "amazon" of two words.
 	//
 	// EITHER side declaring the market is enough. A company does not stop being
 	// Vietnamese when someone types its bare brand — "Tân Hiệp Phát" carries no
@@ -358,10 +336,19 @@ func sharesADistinctiveWord(a, b string) bool {
 	// Strictly more than half, not at least: at half the two names disagree
 	// about as much as they agree, and the disagreement is the part that names
 	// the company.
-	if leftVN || rightVN {
+	if isSyllabicMarket(leftMarket) || isSyllabicMarket(rightMarket) {
 		return 2*shared > min(len(left), len(right))
 	}
 	return true
+}
+
+// onlyWord answers whether a name came down to a single word.
+func onlyWord(fields []string) bool { return len(fields) == 1 }
+
+// isSyllabicMarket answers whether a name's market builds its brands from a
+// small pool of shared syllables, where one word in common is a coincidence.
+func isSyllabicMarket(market *marketForms) bool {
+	return market != nil && market.syllabic
 }
 
 // sharedTokenCount is how many words of the shorter name appear in the longer.
@@ -380,6 +367,19 @@ func sharedTokenCount(left, right []string) int {
 	taken := make([]bool, len(longer))
 	shared := 0
 	for _, x := range shorter {
+		// A word that is ANOTHER MARKET'S legal form is that market's
+		// vocabulary rather than a brand, so two names sharing it have not said
+		// they are one company: "SIA Rimi Latvia" and "SIA Maxima Latvija" are
+		// two Latvian grocers, "AS Roma" and "AS Monaco" two football clubs.
+		//
+		// Discounted HERE rather than removed from the name, so it still reaches
+		// the score. And not discounted at all when it is the WHOLE of the
+		// shorter name: "PT Solutions" reduces to "pt" once "solutions" is gone
+		// as English market vocabulary, and it must still find "PT Solutions
+		// Physical Therapy" rather than becoming a name with no evidence in it.
+		if ambiguousFormWord[x] && !onlyWord(shorter) {
+			continue
+		}
 		for j, y := range longer {
 			if !taken[j] && sameOrgToken(x, y) {
 				taken[j] = true


### PR DESCRIPTION
Vietnam was fixed in #2831; every other market that writes its legal form in FRONT of the name was not. Measured against `main`, two unrelated companies scored **0.76 to 0.91** against each other in eight of them — past the 0.72 review threshold, so each was a false "this company is already in the CRM".

| Market | Two different companies | Before |
|---|---|---|
| Arabic | `شركة الراجحي` / `شركة الأهلي` | 0.9136 |
| Latvia | `SIA Rimi Latvia` / `SIA Maxima Latvija` | 0.8716 |
| Lithuania | `UAB Vilniaus Duona` / `UAB Kauno Grudai` | 0.8454 |
| Romania | `S.C. Dacia S.R.L.` / `S.C. Petrom S.R.L.` | 0.8412 |
| Thailand | two `บริษัท … จำกัด` names | 0.8296 |
| Russia | `ООО Ромашка` / `ООО Василёк` | 0.8182 |
| Indonesia | `PT Astra International Tbk` / `PT Telkom Indonesia Tbk` | 0.7966 |
| Russia (Latin) | `OOO Gazprom Neft` / `OOO Lukoil` | 0.7625 |

All now score **0.0000**, and every bare-brand recall case scores 1.0000 (`ООО «Ромашка»` ↔ `Ромашка`, `S.C. Dacia S.R.L.` ↔ `Dacia`, `شركة الراجحي` ↔ `الراجحي`).

## What changed

`orgformtables.go` (new) holds one entry per market, seeded from the ISO 20275 Entity Legal Form list and extended with the everyday abbreviations that registry does not carry — it holds "công ty cổ phần" but not "CTCP", and no Russian abbreviations at all. `NormalizeOrgName` stays the stored grouping key and is not moved.

**A short Latin form is also an ordinary name**, which position alone cannot tell apart. All ten of these are real companies a prefix rule would damage: `PT Solutions Physical Therapy`, `AO World`, `AS Roma`, `CV Sciences`, `SIA Engineering`, `II-VI`, `TOO Group`, `AB InBev`, `SA Recycling`, `MB Financial`. So a two-letter marker is removed only when the name itself agrees — the market's own bracketing form closes it (`Tbk`, `SRL`), or the rest of the name is not Latin (`PT Индустрия`). Absent agreement the word stays and the gate discounts it as another market's vocabulary, so `AS Roma` and `AS Monaco` no longer meet on "as" while `PT Solutions` still finds `PT Solutions Physical Therapy` — a form word *is* the evidence when it is all a name has left.

## Three separate bugs found on the way

- **Thai, Lao, Khmer and Devanagari names lost letters** before any comparison. Those scripts write vowels as combining marks and the unaccenting pass removed every mark regardless of script: `เมืองไทย` became `เมองไทย`. The strip now asks what the mark is attached to.
- **Cyrillic lost letters the same way.** `й` is not an accented `и` but the character in every other Russian word; `Мойка` became `моика` and `Київстар` became `киівстар`.
- **A legal form spelled with dots was never recognised.** `S.R.L.` arrives as one token and the suffix strip trimmed only a trailing dot, so every Romanian, Polish and Turkish name kept its form.

## Review round

Codex found eight issues; six were real and are fixed in the second commit. The most severe was silent: the candidate query still searched the unstripped name while the score compared the stripped one, so `Perseroan Terbatas IBM` against a stored `IBM` (0.174 as whole strings, under both trigram limits) was never returned for scoring at all. That one is held by an integration assertion — reverting the fix turns it red.

Two of the fixes were mine to own rather than tune: `zoo` and `as` should never have gone into `legalSuffixes`, which feeds a **stored grouping key** — `zoo` made `San Diego Zoo` and `San Diego` the same key at 1.0000.

## Tests

`orgformtables_test.go` carries the markets in local script, Latin transliteration and bare brand, and asks precision of **every** cross-company pair. Six guards are mutation-checked: reverting each turns its named test red. Pairs that meet on ONE ordinary word (`Bank`, `Latvia`/`Latvija`) are marked and held out of the census — that is the English one-distinctive-word rule, it behaves identically on `main`, and it is tracked as #2832 rather than fixed in passing.

`make check-backend` green, `make craft-static` clean across all four trees, people integration lane green under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches companies in eight more markets on their brand rather than their shared legal-form boilerplate, which was scoring distinct firms 0.76–0.91 against each other — past the 0.72 review threshold. Short Latin forms are treated cautiously so real Western names like "PT Solutions Physical Therapy" keep every word.

**Bug Fixes**
- Unrelated pairs in the Arabic, Latvian, Lithuanian, Romanian, Thai, Russian, and Indonesian markets now score 0.0000; bare-brand recall stays at 1.0000.
- The candidate query now searches the stripped brand too — "Perseroan Terbatas IBM" previously never fetched stored "IBM" because the whole-name score (0.174) sat under both trigram limits.
- The accent strip no longer deletes real letters in Thai, Lao, Khmer, Devanagari, and Cyrillic; the "ё"/"е" pair is handled explicitly.
- Legal forms written with internal dots ("S.R.L.", "Sp. z o.o.") now match their undotted spellings.
- "zoo" and "as" are out of `legalSuffixes`, which feeds stored grouping keys — they were merging "San Diego Zoo" and "San Diego" into one key.

**New Features**
- `orgformtables.go` holds one legal-form table per market, seeded from the ISO 20275 list and extended with everyday abbreviations.
- A short Latin marker ("PT", "AO", "AS") is stripped only when the market's own closing form ("Tbk", "SRL") appears or the rest of the name is non-Latin; otherwise it is kept and discounted as another market's vocabulary, so "AS Roma" and "AS Monaco" no longer meet while "PT Solutions" still finds its full name.
- `NormalizeOrgName` and the stored grouping key are unchanged; the strip applies only where names are compared.
- Census tests assert precision for every cross-company pair in each market, with mutation-checked guards.

<sup>Written for commit f2646de855340ca1956741580b5cfc8cb43a508d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Organization-name matching now recognizes legal forms and naming conventions across more international markets and writing systems.
  - Fuzzy duplicate detection better connects legal-name variants with shorter brand names.
  - Matching is more resilient to punctuation, accents, combining marks, and language-specific forms.
  - Ambiguous legal terms are handled more carefully to reduce false matches while preserving legitimate duplicates.
- **Bug Fixes**
  - Improved recognition of names with dotted legal forms, long legal prefixes, and market-specific suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->