### PR TITLE
perf(gates): the fitness gates run in parallel

### DIFF
--- a/backend/gates/agentgrantscopes_test.go
+++ b/backend/gates/agentgrantscopes_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestEveryGrantFundsTheToolsItsAgentDeclares(t *testing.T) {
+	t.Parallel()
 	granted := grantedScopes(t)
 	required := toolScopes(t)
 	declared := agentToolLists(t)

--- a/backend/gates/aggregategatereach_test.go
+++ b/backend/gates/aggregategatereach_test.go
@@ -68,6 +68,7 @@ type aggregateJobs struct {
 }
 
 func TestEveryAggregatedJobCanRunOnTheMergeQueue(t *testing.T) {
+	t.Parallel()
 	raw, err := os.ReadFile(aggregateWorkflow) // #nosec G304 -- a fixed repo-relative path
 	if err != nil {
 		t.Fatalf("reading %s: %v", aggregateWorkflow, err)
@@ -162,6 +163,7 @@ var callerConcerns = []string{
 // the fan-ins need `always()` precisely so a failed sibling cannot skip them into
 // a green.
 func TestNoLaneWorkflowDecidesItsOwnScope(t *testing.T) {
+	t.Parallel()
 	lanes, err := filepath.Glob(filepath.Join(workflowDir, "_lane-*.yml"))
 	if err != nil {
 		t.Fatalf("listing lane workflows: %v", err)

--- a/backend/gates/aiactivitycatalogparity_test.go
+++ b/backend/gates/aiactivitycatalogparity_test.go
@@ -42,6 +42,7 @@ import (
 const documentReadingKind = activities.ExtractionAITask
 
 func TestEveryKindSomethingProducesIsOneTheContractCanExpress(t *testing.T) {
+	t.Parallel()
 	declared := crmYAMLNamedEnum(t, "AiActivityKind")
 	if len(declared) == 0 {
 		t.Fatal("AiActivityKind declares no enum; this gate would pass vacuously")
@@ -110,6 +111,7 @@ func producedKinds() []string {
 // The reverse: a kind nothing can produce is copy three locales carry, a line
 // no reader will see, and a promise the server cannot keep.
 func TestEveryContractKindHasSomethingThatProducesIt(t *testing.T) {
+	t.Parallel()
 	produced := producedKinds()
 	for _, kind := range crmYAMLNamedEnum(t, "AiActivityKind") {
 		if !slices.Contains(produced, kind) {
@@ -125,6 +127,7 @@ func TestEveryContractKindHasSomethingThatProducesIt(t *testing.T) {
 // a string a strict client rejects; a smaller one truncates below what the
 // contract promised a reader would get.
 func TestTheReadsTextCapsAreTheOnesTheContractPublishes(t *testing.T) {
+	t.Parallel()
 	for _, b := range []struct {
 		property string
 		cap      int
@@ -171,6 +174,7 @@ func crmYAMLMaxLength(t *testing.T, schema, property string) int {
 // A spec name that is not a legal message-key segment cannot have copy keyed on
 // it, which is the other half of "the rail renders nothing".
 func TestEverySpecNameCanBeAMessageKeySegment(t *testing.T) {
+	t.Parallel()
 	for _, spec := range runner.Catalog() {
 		if strings.ContainsAny(spec.Name, " .") || spec.Name == "" {
 			t.Errorf("spec name %q cannot key a locale message", spec.Name)

--- a/backend/gates/aitaskcensus_test.go
+++ b/backend/gates/aitaskcensus_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestTaskCensusMatchesTheContract(t *testing.T) {
+	t.Parallel()
 	registry, err := compose.NewTaskCensus()
 	if err != nil {
 		t.Fatalf("building the task census: %v", err)
@@ -32,6 +33,7 @@ func TestTaskCensusMatchesTheContract(t *testing.T) {
 // about the request this build sends. Validate names the gap; this test is
 // where the composition is held to it.
 func TestTaskCensusBindsACaseToEverySite(t *testing.T) {
+	t.Parallel()
 	registry, err := compose.NewTaskCensus()
 	if err != nil {
 		t.Fatalf("building the task census: %v", err)

--- a/backend/gates/aitaskparity_test.go
+++ b/backend/gates/aitaskparity_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestEveryEmittedAITaskIsDeclaredInTheContract(t *testing.T) {
+	t.Parallel()
 	declared := make([]string, 0, len(ai.AllTasks()))
 	for _, task := range ai.AllTasks() {
 		declared = append(declared, string(task))

--- a/backend/gates/aitaskrailcensus_test.go
+++ b/backend/gates/aitaskrailcensus_test.go
@@ -50,6 +50,7 @@ var carrierSources = map[string]string{
 }
 
 func TestEveryAITaskNamesTheSourceThatReportsIt(t *testing.T) {
+	t.Parallel()
 	tasks := everyRoutableTask(t)
 	if len(tasks) == 0 {
 		t.Fatal("derived no tasks at all; this gate would pass vacuously")
@@ -164,6 +165,7 @@ func taskConstantValues(file *ast.File) []string {
 // nobody can act on, and it would keep the router quiet about a name that no
 // longer routes anywhere.
 func TestTheRailRegistryNamesNoTaskTheContractDropped(t *testing.T) {
+	t.Parallel()
 	declared := map[string]bool{}
 	for _, task := range everyRoutableTask(t) {
 		declared[string(task)] = true
@@ -181,6 +183,7 @@ func TestTheRailRegistryNamesNoTaskTheContractDropped(t *testing.T) {
 // is one no module writes, the task is reported by NOBODY — which reads exactly
 // like a task that is wired.
 func TestEveryCarrierOverrideNamesASourceThatIsReallyEmitted(t *testing.T) {
+	t.Parallel()
 	for task, source := range ai.RailOwners() {
 		if source == ai.SourceRouter || source == ai.SourceNoOccurrence {
 			continue

--- a/backend/gates/aitaskrunenum_test.go
+++ b/backend/gates/aitaskrunenum_test.go
@@ -44,6 +44,7 @@ import (
 // contract is a state the server can emit and the client cannot name; one added
 // to the contract and not to the CHECK is a promise no writer can keep.
 func TestTheWireStateEnumIsTheProjectionsPlusTheDerivedOne(t *testing.T) {
+	t.Parallel()
 	stored := aiTaskRunCheckValues(t, "state")
 	wire := crmYAMLEnum(t, "AiActivityItem", "state")
 
@@ -110,6 +111,7 @@ func crmYAMLSchemas(t *testing.T) map[string]crmYAMLSchema {
 }
 
 func TestTheAiTaskPayloadEnumsMatchTheProjectionsChecks(t *testing.T) {
+	t.Parallel()
 	for _, b := range []struct{ property, column string }{
 		{"state", "state"},
 		{"quantity_unit", "quantity_unit"},

--- a/backend/gates/aitaskwiring_test.go
+++ b/backend/gates/aitaskwiring_test.go
@@ -65,6 +65,7 @@ var laneWiringExemptions = gatekit.Waive(map[string]string{
 })
 
 func TestEveryCensusedSiteRidesALaneAProcessRoleWires(t *testing.T) {
+	t.Parallel()
 	defer laneWiringExemptions.AssertAllMatched(t)
 	census, err := compose.NewTaskCensus()
 	if err != nil {

--- a/backend/gates/arch_test.go
+++ b/backend/gates/arch_test.go
@@ -80,6 +80,7 @@ func projectImports(t *testing.T, dir string) []string {
 // (ADR-0054 §5) — it may import shared and other platform packages, but
 // never a domain module, the composition layer, or a process role.
 func TestPlatformOwnsNoDomain(t *testing.T) {
+	t.Parallel()
 	forbidden := []string{
 		modulePath + "/internal/modules/",
 		modulePath + "/internal/compose",
@@ -102,6 +103,7 @@ func TestPlatformOwnsNoDomain(t *testing.T) {
 // module list is derived from the tree, so a new module is enrolled the
 // moment its directory exists.
 func TestNoSiblingModuleImports(t *testing.T) {
+	t.Parallel()
 	modules, err := filepath.Glob("internal/modules/*")
 	if err != nil {
 		t.Fatal(err)
@@ -128,6 +130,7 @@ func TestNoSiblingModuleImports(t *testing.T) {
 // and an extension register the same type, ADR-0069 §3). Anything else
 // is an architecture defect.
 func TestSharedIsPure(t *testing.T) {
+	t.Parallel()
 	for _, dir := range packagesUnder(t, "internal/shared") {
 		for _, imp := range projectImports(t, dir) {
 			if strings.HasPrefix(imp, modulePath+"/internal/shared/") {
@@ -146,6 +149,7 @@ func TestSharedIsPure(t *testing.T) {
 // nothing else. Any other import would become transitively-frozen
 // published API the moment an extension binds it.
 func TestPublishedSurfaceIsPure(t *testing.T) {
+	t.Parallel()
 	for _, dir := range packagesUnder(t, "pkg") {
 		for _, imp := range projectImports(t, dir) {
 			if strings.HasPrefix(imp, modulePath+"/pkg/") {
@@ -183,6 +187,7 @@ var modelPathAssemblySeam = map[string]bool{
 // assembly is DB-less by design (siteread debug, tests); a production
 // role has a pool and belongs on the metered compose.NewModelPath.
 func TestNoModelClientOutsideTheGate(t *testing.T) {
+	t.Parallel()
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -284,6 +289,7 @@ func funcsCallingSelector(t *testing.T, dir, pkgIdent, funcName string) []string
 // intended to grow. The role list is derived from the tree, so a new
 // cmd/<role> is enrolled the moment its directory exists.
 func TestOneModelPathPerRole(t *testing.T) {
+	t.Parallel()
 	roles, err := filepath.Glob("cmd/*")
 	if err != nil {
 		t.Fatal(err)

--- a/backend/gates/attestationproducer_test.go
+++ b/backend/gates/attestationproducer_test.go
@@ -54,6 +54,7 @@ const (
 )
 
 func TestOnlyTheMailMapperMintsTheOutboundAttestation(t *testing.T) {
+	t.Parallel()
 	var offenders []string
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/backend/gates/auditbeforeimage_test.go
+++ b/backend/gates/auditbeforeimage_test.go
@@ -183,6 +183,7 @@ var directAuditLogWriters = gatekit.Waive(map[string]string{
 })
 
 func TestEveryAuditedUpdateRecordsWhatItChangedFrom(t *testing.T) {
+	t.Parallel()
 	defer eventShapedUpdates.AssertAllMatched(t)
 	defer unresolvableAuditActions.AssertAllMatched(t)
 	defer directAuditLogWriters.AssertAllMatched(t)

--- a/backend/gates/auditcoherence_test.go
+++ b/backend/gates/auditcoherence_test.go
@@ -47,6 +47,7 @@ import (
 var auditActionDBOnly = gatekit.Waive(map[string]string{})
 
 func TestAuditLogEnumCoherence(t *testing.T) {
+	t.Parallel()
 	defer auditActionDBOnly.AssertAllMatched(t)
 	contractAction, contractActorType := auditLogContractEnums(t)
 	ddl := tableCheckSets(t) // reused from enumsync_test.go (last-wins over migrations)
@@ -112,6 +113,7 @@ func TestAuditLogEnumCoherence(t *testing.T) {
 //
 // So this reads the tree the way the other direction reads the migrations.
 func TestEveryAuditVerbTheCodeWritesIsLegal(t *testing.T) {
+	t.Parallel()
 	ddl := tableCheckSets(t)
 	allowed, ok := ddl["audit_log.action"]
 	if !ok {

--- a/backend/gates/backfillwindow_test.go
+++ b/backend/gates/backfillwindow_test.go
@@ -57,6 +57,7 @@ var backfillWindowSchemas = []string{
 }
 
 func TestTheBackfillWindowSetIsOneSet(t *testing.T) {
+	t.Parallel()
 	contract := contractWindowSets(t)
 	months := contract[backfillWindowSchemas[0]]
 	for _, schema := range backfillWindowSchemas {

--- a/backend/gates/basecurrencyguard_test.go
+++ b/backend/gates/basecurrencyguard_test.go
@@ -34,6 +34,7 @@ import (
 const dealsDir = "internal/modules/deals"
 
 func TestTheBaseCurrencyGuardCountsEveryFrozenRate(t *testing.T) {
+	t.Parallel()
 	schema := tablesWithFrozenRateColumn(t)
 	if len(schema) == 0 {
 		t.Fatal("no table carries fx_rate_to_base — this test has stopped reading the migrations it derives from")
@@ -138,6 +139,7 @@ func contains(haystack []string, needle string) bool {
 // path refuses. The claim is checkable against the schema, so it is checked
 // rather than trusted to the constant's name.
 func TestNoArchiveColumnIsOnlyPassedForTablesWithoutOne(t *testing.T) {
+	t.Parallel()
 	archivable := tablesWithArchivedAt(t)
 	// Both halves are derived, so both can go silently empty and leave the
 	// comparison vacuously true. `organization` is the archivable table this

--- a/backend/gates/bootcomposition_test.go
+++ b/backend/gates/bootcomposition_test.go
@@ -33,6 +33,7 @@ const (
 )
 
 func TestEveryRoleThatComposesExtensionsRecordsWhatItComposed(t *testing.T) {
+	t.Parallel()
 	roles, err := os.ReadDir("cmd")
 	if err != nil {
 		t.Fatalf("reading the process roles under cmd/: %v", err)

--- a/backend/gates/buildtag_default_test.go
+++ b/backend/gates/buildtag_default_test.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package gates
+
+// builtWithIntegrationTag is false here; see buildtag_integration_test.go for
+// why the package has to be able to answer this at all.
+const builtWithIntegrationTag = false

--- a/backend/gates/buildtag_integration_test.go
+++ b/backend/gates/buildtag_integration_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package gates
+
+// builtWithIntegrationTag is how this package answers "which files did the
+// compiler take?" — Go offers no way to read a binary's own build tags, and the
+// parallel census has to ask, because thirteen gates here are `!integration`
+// and a census that judged files the build excluded would report tests Go never
+// runs. Two four-line files are the whole mechanism.
+const builtWithIntegrationTag = true

--- a/backend/gates/capturedbytyping_test.go
+++ b/backend/gates/capturedbytyping_test.go
@@ -51,6 +51,7 @@ func tableOfMigration(body string) string {
 }
 
 func TestCapturedByIsAlwaysTextAndNeverAUserForeignKey(t *testing.T) {
+	t.Parallel()
 	migrations, err := filepath.Glob(filepath.Join("migrations", "core", "*.up.sql"))
 	if err != nil {
 		t.Fatalf("listing core migrations: %v", err)

--- a/backend/gates/catalogoptionsreaders_test.go
+++ b/backend/gates/catalogoptionsreaders_test.go
@@ -67,6 +67,7 @@ var catalogOptionsReaders = map[string]string{
 }
 
 func TestOnlyTheDeclaredPackagesReadACustomFieldsOptions(t *testing.T) {
+	t.Parallel()
 	found := map[string]bool{}
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/backend/gates/claimedspelling_test.go
+++ b/backend/gates/claimedspelling_test.go
@@ -80,6 +80,7 @@ type claimedConst struct {
 }
 
 func TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed(t *testing.T) {
+	t.Parallel()
 	if claimShapes[driftShape] == nil {
 		t.Fatalf("the detector no longer declares the %q shape, so this gate's corpus is empty and "+
 			"every claim it used to judge is unjudged", driftShape)

--- a/backend/gates/clearablefields_test.go
+++ b/backend/gates/clearablefields_test.go
@@ -132,6 +132,7 @@ func collectClearableMaps(file *ast.File, into map[string][]string, unreadable m
 }
 
 func TestTheFieldsARestoreClearsAreTheFieldsTheStoresClear(t *testing.T) {
+	t.Parallel()
 	fromStores := storeClearableFields(t)
 	if len(fromStores) == 0 {
 		t.Fatal("no clearable-column map found in any module; the walk is broken, not the tree — " +

--- a/backend/gates/commsreconciler_test.go
+++ b/backend/gates/commsreconciler_test.go
@@ -51,6 +51,7 @@ func isCommsNewStore(fun ast.Expr) bool {
 }
 
 func TestEveryComposedDeliveryStoreCarriesAMessageIdentityReconciler(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	found := 0
 	for _, root := range []string{"internal", "cmd"} {

--- a/backend/gates/composerowscope_test.go
+++ b/backend/gates/composerowscope_test.go
@@ -146,6 +146,7 @@ type referenceSite struct {
 }
 
 func TestEveryComposeReadOfARecordReferenceAppliesItsRowScope(t *testing.T) {
+	t.Parallel()
 	defer unscopedReferenceReads.AssertAllMatched(t)
 
 	tables := rowScopedTables(t)

--- a/backend/gates/configschema_test.go
+++ b/backend/gates/configschema_test.go
@@ -54,6 +54,7 @@ func compiledConfigSchema(t *testing.T) *jsonschema.Schema {
 // ships. They are the files an operator copies, so a schema that rejects one is
 // telling them their starting point is wrong.
 func TestEveryShippedConfigValidatesAgainstTheSchema(t *testing.T) {
+	t.Parallel()
 	schema := compiledConfigSchema(t)
 	paths, err := filepath.Glob("../config/margince*.yaml")
 	if err != nil {
@@ -111,6 +112,7 @@ func asJSONValue(t *testing.T, path string) any {
 // the struct together, so it derives its list from the struct rather than
 // restating one.
 func TestTheSchemaAcceptsEveryFieldTheConfigDeclares(t *testing.T) {
+	t.Parallel()
 	raw, err := os.ReadFile(configSchemaPath)
 	if err != nil {
 		t.Fatalf("read schema: %v", err)
@@ -174,6 +176,7 @@ func schemaFieldName(f reflect.StructField) (string, bool) {
 // section out without deleting it. A schema that flagged that would be wrong
 // about the file in the direction that teaches people to ignore the squiggle.
 func TestTheSchemaAcceptsAnExplicitNullWhereTheLoaderDoes(t *testing.T) {
+	t.Parallel()
 	const withNulls = `version: 1
 bootstrap_admin: null
 uploads:

--- a/backend/gates/consentproof_test.go
+++ b/backend/gates/consentproof_test.go
@@ -45,6 +45,7 @@ var consentProofInsert = regexp.MustCompile(`(?is)INSERT\s+INTO\s+consent_event\
 var unprovenConsentWrites = gatekit.Waive(map[string]string{})
 
 func TestEveryConsentStateWriteAppendsProof(t *testing.T) {
+	t.Parallel()
 	defer unprovenConsentWrites.AssertAllMatched(t)
 	fset := token.NewFileSet()
 	for _, root := range []string{"internal/modules", "internal/compose"} {

--- a/backend/gates/consumerlanes_test.go
+++ b/backend/gates/consumerlanes_test.go
@@ -50,6 +50,7 @@ var reservedGroups = gatekit.Waive(map[string]string{
 })
 
 func TestEveryDeclaredConsumerGroupIsSubscribedSomewhere(t *testing.T) {
+	t.Parallel()
 	subscribed := groupNamesTheRolesName(t)
 	// A walk that found no group at all reports exactly like a tree where every
 	// group has a lane, which is the failure this gate is closing elsewhere.
@@ -119,6 +120,7 @@ func collectGroupLiterals(file *ast.File, fset *token.FileSet, path string, out 
 // vacuously if Groups() ever answers a set this file cannot see, and a gate
 // whose subject list has collapsed reports exactly like a tree with no gap.
 func TestTheLaneCensusReadsTheWholeCatalog(t *testing.T) {
+	t.Parallel()
 	names := make([]string, 0, len(kevents.Groups()))
 	for _, g := range kevents.Groups() {
 		names = append(names, g.Name)

--- a/backend/gates/consumermailonelist_test.go
+++ b/backend/gates/consumermailonelist_test.go
@@ -115,6 +115,7 @@ func looksLikeADomain(value string) bool {
 const consumerMailOwner = "internal/platform/freemail/"
 
 func TestOnlyOnePackageDeclaresConsumerMailProviders(t *testing.T) {
+	t.Parallel()
 	found := consumerMailListsIn(t, "internal")
 	if len(found) > 0 {
 		t.Fatalf("a second consumer-mail list — ask platform/freemail instead:\n%s",
@@ -126,6 +127,7 @@ func TestOnlyOnePackageDeclaresConsumerMailProviders(t *testing.T) {
 // blind detector, and this one was written over a literal that had been sitting
 // in the tree for months.
 func TestConsumerMailCensusSeesTheShapesThatShipped(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		code string

--- a/backend/gates/contentionprobe_test.go
+++ b/backend/gates/contentionprobe_test.go
@@ -91,6 +91,7 @@ type sqlCall struct {
 // TestEveryContentionProbeClearsTheStatsSnapshot fails on a function that asks
 // pg_blocking_pids without a snapshot clear that can actually reach it.
 func TestEveryContentionProbeClearsTheStatsSnapshot(t *testing.T) {
+	t.Parallel()
 	var offenders []string
 	fset := token.NewFileSet()
 

--- a/backend/gates/contextanchorenum_test.go
+++ b/backend/gates/contextanchorenum_test.go
@@ -35,6 +35,7 @@ const searchBranchFile = "internal/modules/search/store.go"
 const contextPath = "/records/{entity_type}/{id}/context"
 
 func TestContextAnchorEnumMatchesTheSearchableEntities(t *testing.T) {
+	t.Parallel()
 	contract := contextAnchorEnum(t)
 	searchable := searchableEntitiesFromSource(t)
 	slices.Sort(contract)
@@ -51,6 +52,7 @@ func TestContextAnchorEnumMatchesTheSearchableEntities(t *testing.T) {
 // type must be an admissible ref type. A missing member makes the endpoint's
 // own answer fail validation against the contract that describes it.
 func TestEveryContextAnchorIsAnAdmissibleRefType(t *testing.T) {
+	t.Parallel()
 	refTypes := contractSchema(t, "ContextEntityRef").Properties["type"]
 	var typeSchema contractSchemaFields
 	if err := refTypes.Decode(&typeSchema); err != nil {

--- a/backend/gates/contractfrontendlane_test.go
+++ b/backend/gates/contractfrontendlane_test.go
@@ -53,6 +53,7 @@ const theFrontendFilter = "frontend"
 // TestTheContractReachesTheFrontendLane fails when a contract change would no
 // longer run the CI job that regenerates and diffs the frontend schema.
 func TestTheContractReachesTheFrontendLane(t *testing.T) {
+	t.Parallel()
 	raw, err := os.ReadFile(ciWorkflowForContractLane)
 	if err != nil {
 		t.Fatalf("reading %s: %v", ciWorkflowForContractLane, err)

--- a/backend/gates/contractproducers_test.go
+++ b/backend/gates/contractproducers_test.go
@@ -43,6 +43,7 @@ var producedSchemas = []string{
 var genField = regexp.MustCompile("^\t([A-Z][A-Za-z0-9]*)\\s+\\S")
 
 func TestEveryContractPropertyOnAPageCompositeHasAProducer(t *testing.T) {
+	t.Parallel()
 	fields := map[string][]string{}
 	for _, schema := range producedSchemas {
 		found := generatedFieldsOf(t, schema)

--- a/backend/gates/contractrefs_test.go
+++ b/backend/gates/contractrefs_test.go
@@ -33,6 +33,7 @@ var (
 )
 
 func TestContractRefsResolve(t *testing.T) {
+	t.Parallel()
 	const path = "api/crm.yaml"
 	raw, err := os.ReadFile(path)
 	if err != nil {

--- a/backend/gates/contractvocabulary_test.go
+++ b/backend/gates/contractvocabulary_test.go
@@ -126,6 +126,7 @@ type vocabularySet struct {
 }
 
 func TestEveryClosedVocabularyOverAContractEnumHoldsAllOfIt(t *testing.T) {
+	t.Parallel()
 	byName, byEnum := contractEnumIndex(t)
 	scope := gatekit.Scope{
 		Roots:   []string{"internal/compose", "internal/modules"},

--- a/backend/gates/corepicklistcontract_test.go
+++ b/backend/gates/corepicklistcontract_test.go
@@ -73,6 +73,7 @@ var picklistInContract = map[string]struct{ schema, property string }{
 }
 
 func TestEveryOfferedPicklistMatchesTheContractsValues(t *testing.T) {
+	t.Parallel()
 	doc := loadContractDocument(t)
 	compared := 0
 	for _, resource := range vocabularyResources(t, doc) {

--- a/backend/gates/cursorrefusal_test.go
+++ b/backend/gates/cursorrefusal_test.go
@@ -228,6 +228,7 @@ func literalTypeName(lit *ast.CompositeLit) string {
 // TestARefusalAboutACursorIsTheContractsRefusal is the first arm: nothing but
 // storekit's type may name a cursor as the field it refuses.
 func TestARefusalAboutACursorIsTheContractsRefusal(t *testing.T) {
+	t.Parallel()
 	files := refusalFiles(t)
 	if len(files) < 300 {
 		t.Fatalf("the census read only %d files, so it covered almost nothing", len(files))
@@ -278,6 +279,7 @@ func TestARefusalAboutACursorIsTheContractsRefusal(t *testing.T) {
 // Keyed on the decode rather than on the error's shape, because a refusal that
 // names no field is invisible to the first arm.
 func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is one for a function that has moved or
 	// been folded in, and leaving it quietly re-exempts whatever takes its name.
 	defer connectorCursors.AssertAllMatched(t)

--- a/backend/gates/dealtargettype_test.go
+++ b/backend/gates/dealtargettype_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestEveryStagingNamesItsDealTargetThroughOneConstant(t *testing.T) {
+	t.Parallel()
 	root := filepath.Join("internal", "compose")
 	fset := token.NewFileSet()
 	var offenders []string

--- a/backend/gates/declaredfilters_test.go
+++ b/backend/gates/declaredfilters_test.go
@@ -118,6 +118,7 @@ var overlayDialsTheMirrorAnswersTheSameWayEitherWay = gatekit.Waive(map[string]s
 
 // TestEveryDeclaredNarrowingParameterIsReadByItsHandler is the native obligation.
 func TestEveryDeclaredNarrowingParameterIsReadByItsHandler(t *testing.T) {
+	t.Parallel()
 	declared := narrowingParametersByType(t)
 	if len(declared) < wantMinimumNarrowedOperations {
 		t.Fatalf("only %d operations declare a narrowing query parameter in %s, want at least %d — "+
@@ -145,6 +146,7 @@ func TestEveryDeclaredNarrowingParameterIsReadByItsHandler(t *testing.T) {
 // TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow is
 // the second obligation — #579's fitness function.
 func TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow(t *testing.T) {
+	t.Parallel()
 	declared := narrowingParametersByType(t)
 	shadows := 0
 	for _, file := range overlayShadowScope().Files(t) {
@@ -208,6 +210,7 @@ func callsOverlayModeDispatch(file *ast.File) bool {
 // the walk must tell apart is put to it here, against source written for the
 // purpose rather than against the tree it judges.
 func TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse(t *testing.T) {
+	t.Parallel()
 	declared := map[string][]declaredFilter{"ListThingsParams": {{field: "Tag", wire: "tag"}}}
 	for _, probe := range []struct {
 		name   string
@@ -269,6 +272,7 @@ func TestTheDeclaredFilterWalkReportsADroppedParameterAndNothingElse(t *testing.
 // silent failure: a census that mistook the paging components for filters, or
 // missed a form tag, would judge the wrong set without ever reporting it.
 func TestTheDeclaredFilterCensusReadsTheGeneratedShape(t *testing.T) {
+	t.Parallel()
 	declared := narrowingParametersByType(t)
 	people, listed := declared["ListPeopleParams"]
 	if !listed {

--- a/backend/gates/dedupeevidencefields_test.go
+++ b/backend/gates/dedupeevidencefields_test.go
@@ -25,6 +25,7 @@ import (
 // `full_name` and `org` on screen. A field the contract publishes and nothing
 // writes is a word three translations carry for a row that never arrives.
 func TestEveryDedupeEvidenceFieldIsNameableOnTheWire(t *testing.T) {
+	t.Parallel()
 	written := people.DedupeEvidenceFields()
 	published := publishedEvidenceEnum(t, "field")
 
@@ -49,6 +50,7 @@ func TestEveryDedupeEvidenceFieldIsNameableOnTheWire(t *testing.T) {
 // every identity-conflict card on screen shows an empty comparison. That is
 // exactly what it did.
 func TestEveryDedupeEvidenceSignalIsNameableOnTheWire(t *testing.T) {
+	t.Parallel()
 	written := people.DedupeEvidenceSignals()
 	published := publishedEvidenceEnum(t, "signal")
 

--- a/backend/gates/dedupespine_test.go
+++ b/backend/gates/dedupespine_test.go
@@ -66,6 +66,7 @@ var sanctionedMintSites = gatekit.Waive(map[string]string{
 })
 
 func TestEveryIdentityInsertGoesThroughTheChokepoint(t *testing.T) {
+	t.Parallel()
 	defer sanctionedMintSites.AssertAllMatched(t)
 	for _, path := range goSourceFiles(t, ".") {
 		if strings.HasSuffix(path, "_test.go") {
@@ -107,6 +108,7 @@ var leadClaimCheckSQL = regexp.MustCompile(`(?is)SELECT\s+id\s+FROM\s+lead\s+WHE
 // ever called, so two imports of one person under different addresses both
 // landed.
 func TestLeadIdentityProbesAreSingleSourced(t *testing.T) {
+	t.Parallel()
 	const home = "internal/platform/database/storekit/leadidentity.go"
 	for _, path := range goSourceFiles(t, ".") {
 		if strings.HasSuffix(path, "_test.go") {
@@ -148,6 +150,7 @@ var sanctionedMergeWriters = gatekit.Waive(map[string]string{
 // else; only a human's disposition, executed by the merge path, may point one
 // record at another.
 func TestOnlyTheMergePathRetiresARecord(t *testing.T) {
+	t.Parallel()
 	defer sanctionedMergeWriters.AssertAllMatched(t)
 	for _, path := range goSourceFiles(t, ".") {
 		if strings.HasSuffix(path, "_test.go") {

--- a/backend/gates/docslinktargets_test.go
+++ b/backend/gates/docslinktargets_test.go
@@ -49,6 +49,7 @@ var (
 )
 
 func TestEveryRelativeLinkUnderDocsResolves(t *testing.T) {
+	t.Parallel()
 	const docsRoot = "../docs"
 
 	scanned := 0

--- a/backend/gates/docspagelength_test.go
+++ b/backend/gates/docspagelength_test.go
@@ -252,6 +252,7 @@ func docsPageLineCount(t *testing.T, rel string) int {
 }
 
 func TestEveryHandWrittenDocsPageFitsItsBudget(t *testing.T) {
+	t.Parallel()
 	pages := handWrittenDocsPages(t)
 	if len(pages) == 0 {
 		t.Fatal("found no hand-written page in any documented tree — this gate would pass by " +
@@ -310,6 +311,7 @@ func TestEveryHandWrittenDocsPageFitsItsBudget(t *testing.T) {
 // is about, so the exemption cannot quietly widen into "any page with a comment
 // near the top".
 func TestTheDocsBudgetGateSeesAGeneratedPageAsGenerated(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	cases := map[string]struct {
 		body string

--- a/backend/gates/domainclaimprobe_test.go
+++ b/backend/gates/domainclaimprobe_test.go
@@ -75,6 +75,7 @@ var domainResolvers = gatekit.Waive(map[string]string{
 })
 
 func TestEveryDomainClaimAnswersThroughOneProbe(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is a ratification for a site that has
 	// moved or been fixed, and leaving it in place quietly re-exempts whatever
 	// takes its name next.
@@ -152,6 +153,7 @@ func TestEveryDomainClaimAnswersThroughOneProbe(t *testing.T) {
 // A gate asserting a shape is ABSENT passes identically over a clean tree and
 // over a detector that has stopped detecting.
 func TestTheDomainClaimCensusSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	caught := []string{
 		"SELECT organization_id FROM organization_domain WHERE domain = lower($1)",
 		// Wrapped across lines, which is how it is actually written.

--- a/backend/gates/edgereaders_test.go
+++ b/backend/gates/edgereaders_test.go
@@ -218,6 +218,7 @@ func readsRelationshipTable(filePath string, file *ast.File) bool {
 }
 
 func TestEveryReaderOfTheRelationshipTableCarriesTheEdgeGateOrAVerdict(t *testing.T) {
+	t.Parallel()
 	files := edgeReaderScope.Files(t)
 	gated := gatedFunctionsByPackage(t, files)
 

--- a/backend/gates/elapsedonespelling_test.go
+++ b/backend/gates/elapsedonespelling_test.go
@@ -71,6 +71,7 @@ var governedSurfaces = []string{
 }
 
 func TestOnlyElapsedCountsDaysOfSilence(t *testing.T) {
+	t.Parallel()
 	found := offenders(t)
 	for _, where := range found {
 		t.Errorf("%s divides a duration by 24 to count days. That is the second spelling of a rule "+
@@ -87,6 +88,7 @@ func TestOnlyElapsedCountsDaysOfSilence(t *testing.T) {
 // still recognises the shape it was written for — the exact line the coverage
 // rule used to carry — rather than only that today's tree is clean.
 func TestTheGateCanStillSeeItsOwnSubject(t *testing.T) {
+	t.Parallel()
 	wasReal := `	days := int(now.Sub(c.LastTouchAt).Hours() / hoursPerDay)`
 	if !durationOverADay.MatchString(wasReal) {
 		t.Error("the pattern no longer matches the line this gate was written to catch, so it is guarding nothing")

--- a/backend/gates/employmentcurrency_test.go
+++ b/backend/gates/employmentcurrency_test.go
@@ -102,6 +102,7 @@ var endedAtCurrency = regexp.MustCompile(`ended_at\s+IS\s+(NOT\s+)?NULL|ended_at
 const employmentCurrencyOwner = "internal/modules/people/employmentcurrency.go"
 
 func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is a ratification for a site that has
 	// moved or been fixed, and leaving it in place quietly re-exempts whatever
 	// takes its name next.
@@ -309,6 +310,7 @@ func read() string {
 }
 
 func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	for _, tc := range employmentProbes {
 		t.Run(tc.name, func(t *testing.T) {
@@ -480,6 +482,7 @@ const slotProbeFile = gateDir + "/employmentcurrency_test.go"
 var slotColumn = regexp.MustCompile(`(?i)is_current_primary`)
 
 func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching describes a site that has moved or
 	// been fixed, and leaving it quietly re-exempts whatever takes its name.
 	defer slotBlockedByTheModuleDAG.AssertAllMatched(t)
@@ -621,6 +624,7 @@ var slotProbes = []struct {
 }
 
 func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	for _, tc := range slotProbes {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/gates/enumsync_test.go
+++ b/backend/gates/enumsync_test.go
@@ -204,6 +204,7 @@ func goConstSet(t *testing.T, pkgDir, typeName string) []string {
 }
 
 func TestEveryDomainEnumMatchesItsSchemaCheck(t *testing.T) {
+	t.Parallel()
 	checks := tableCheckSets(t)
 	for col, binding := range enumBindings {
 		want, ok := checks[col]

--- a/backend/gates/envcontract_test.go
+++ b/backend/gates/envcontract_test.go
@@ -218,6 +218,7 @@ func namesIn(t *testing.T, path string) map[string]bool {
 // of leaves an operator guessing, and a secret nobody wrote down cannot be
 // provisioned at all.
 func TestEveryEnvVarIsDocumented(t *testing.T) {
+	t.Parallel()
 	documented := namesIn(t, configurationDoc)
 	sites := envVarsReadByGoCode(t)
 
@@ -237,6 +238,7 @@ func TestEveryEnvVarIsDocumented(t *testing.T) {
 // worse than no entry at all, because it invites an operator to supply a value
 // that cannot take effect.
 func TestEnvExampleNamesOnlyLiveVars(t *testing.T) {
+	t.Parallel()
 	assertNamesOnlyLiveVars(t, envExample)
 }
 
@@ -244,6 +246,7 @@ func TestEnvExampleNamesOnlyLiveVars(t *testing.T) {
 // bar as the template it now absorbs. Without it the more authoritative file is
 // the one free to keep a row for a var that no longer exists.
 func TestConfigurationDocNamesOnlyLiveVars(t *testing.T) {
+	t.Parallel()
 	assertNamesOnlyLiveVars(t, configurationDoc)
 }
 
@@ -266,6 +269,7 @@ var entrypointRequired = regexp.MustCompile(`\$\{(MARGINCE_[A-Z0-9_]+):?\?`)
 // script that rejects them. docs/deployment.md names .env.example as that
 // file, which is what makes this an obligation rather than a nicety.
 func TestEntrypointRequiredVarsAreInTheEnvExample(t *testing.T) {
+	t.Parallel()
 	offered := namesIn(t, envExample)
 
 	required := map[string]string{}
@@ -349,6 +353,7 @@ var docDefaultTable = regexp.MustCompile(`(?mi)^\|\s*Env\s*\|\s*Default\s*\|`)
 var docDefaultLiteral = regexp.MustCompile("^`([^`]*)`$")
 
 func TestEveryDeclaredDefaultMatchesTheDocumentedOne(t *testing.T) {
+	t.Parallel()
 	declared := declaredConfigDefaults(t)
 	documented := documentedDefaults(t)
 	if len(declared) == 0 {

--- a/backend/gates/errmatch_test.go
+++ b/backend/gates/errmatch_test.go
@@ -79,6 +79,7 @@ func matchesErrorText(n ast.Node) (verb string, found bool) {
 }
 
 func TestNoErrorMessageStringMatching(t *testing.T) {
+	t.Parallel()
 	defer errTextMatchWaivers.AssertAllMatched(t)
 	fset := token.NewFileSet()
 	err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {

--- a/backend/gates/errtaxonomy_test.go
+++ b/backend/gates/errtaxonomy_test.go
@@ -125,6 +125,7 @@ func mappedSentinels(t *testing.T) map[string]bool {
 }
 
 func TestEverySentinelHasAWireVerdict(t *testing.T) {
+	t.Parallel()
 	declared := declaredSentinels(t)
 	mapped := mappedSentinels(t)
 

--- a/backend/gates/eventtypeownership_test.go
+++ b/backend/gates/eventtypeownership_test.go
@@ -355,6 +355,7 @@ var sharedEventTypes = gatekit.Waive(map[string]string{
 })
 
 func TestEveryEventTypeHasOneEmittingModule(t *testing.T) {
+	t.Parallel()
 	sites := collectEmitSites(t)
 	// A walk that found no emit at all reports exactly like a tree where every
 	// type has one owner, which is the failure mode this gate is closing in a
@@ -413,6 +414,7 @@ var unemittedEventTypes = gatekit.Waive(map[string]string{
 // schemas. What this refuses is a type that quietly stops being emitted — the
 // contract keeps promising it, subscribers keep waiting, and nothing fails.
 func TestEveryUnemittedEventTypeSaysWhyNothingEmitsIt(t *testing.T) {
+	t.Parallel()
 	sites := collectEmitSites(t)
 	// Armed after the walk, which can fatal. Deferred above it, the sweep runs on
 	// the way out and buries the one true line under an entry per waiver, each

--- a/backend/gates/extensions_arch_test.go
+++ b/backend/gates/extensions_arch_test.go
@@ -143,6 +143,7 @@ func allowlistedSurface(t *testing.T) map[string]bool {
 // module, or a sibling extension (EXT-P2/P7). Third-party imports are
 // the extension's own business (its go.mod carries them).
 func TestExtensionsImportOnlyTheAllowlistedSurface(t *testing.T) {
+	t.Parallel()
 	trees := extensionTrees(t)
 	modPaths := extensionModulePaths(t, trees)
 	surface := allowlistedSurface(t)
@@ -177,6 +178,7 @@ func TestExtensionsImportOnlyTheAllowlistedSurface(t *testing.T) {
 // else in the backend tree. Test files are exempt: the allowlist
 // derivation never reads them (this file's own constant included).
 func TestSurfaceMarkerLivesOnlyUnderPkg(t *testing.T) {
+	t.Parallel()
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
@@ -220,6 +222,7 @@ var compositionWiringFiles = map[string]bool{
 // directly (extensions reach the backend only through the generated
 // compose file, ADR-0069 §3).
 func TestCompositionWiredOnlyFromCmd(t *testing.T) {
+	t.Parallel()
 	extMods := extensionModulePaths(t, extensionTrees(t))
 	wired := map[string]bool{}
 	for file, imports := range goImports(t, ".") {

--- a/backend/gates/extensionsignored_test.go
+++ b/backend/gates/extensionsignored_test.go
@@ -47,6 +47,7 @@ import (
 // extensions/ to exercise the tier, so a fixture git does not have is the same
 // defect one lane further out.
 func TestEveryEnabledExtensionIsTracked(t *testing.T) {
+	t.Parallel()
 	for _, root := range []string{"../extensions", "../fixtures/extensions"} {
 		entries, err := os.ReadDir(root)
 		if os.IsNotExist(err) {

--- a/backend/gates/extensionsqlscope_test.go
+++ b/backend/gates/extensionsqlscope_test.go
@@ -96,6 +96,7 @@ const computedFragment = "?"
 // TestExtensionSQLNamesOnlyTheUnitsOwnTables reads every unit's SQL and refuses
 // a table outside the unit's namespace.
 func TestExtensionSQLNamesOnlyTheUnitsOwnTables(t *testing.T) {
+	t.Parallel()
 	trees := extensionTrees(t)
 	if len(trees) == 0 {
 		t.Fatal("no extension tree was found: this gate judges extensions/* and fixtures/extensions/*, and a run that enrols none certifies nothing")

--- a/backend/gates/extensionsqlscopecases_test.go
+++ b/backend/gates/extensionsqlscopecases_test.go
@@ -318,6 +318,7 @@ const source = "FROM person LIMIT 1"`,
 // TestExtensionSQLScopeRefusesWhatItMust drives the gate with sources the real
 // tree does not contain.
 func TestExtensionSQLScopeRefusesWhatItMust(t *testing.T) {
+	t.Parallel()
 	for _, probe := range extSQLGateCases {
 		t.Run(probe.name, func(t *testing.T) {
 			scan := scanUnitSQL(t, probeUnit, map[string]string{"probe.go": probeSource(probe.body, probe.decls)})

--- a/backend/gates/fieldnames_test.go
+++ b/backend/gates/fieldnames_test.go
@@ -159,6 +159,7 @@ func typesPublishingAFieldName(files []parsedFile) map[string]bool {
 }
 
 func TestAPublishedFieldNameIsAFieldNameNotProse(t *testing.T) {
+	t.Parallel()
 	files := parseInternalTree(t)
 	policed := typesPublishingAFieldName(files)
 	if len(policed) == 0 {
@@ -377,6 +378,7 @@ var validationFieldsOutsideTheContract = gatekit.Waive(map[string]string{
 // certifying nothing is asserted rather than counted — a walk that judged no literal at all
 // fails below, as does a vocabulary too small to be the contract's.
 func TestEveryValidationFieldLiteralNamesAContractField(t *testing.T) {
+	t.Parallel()
 	vocabulary := contractFieldNames(t)
 	checked := 0
 	for _, pf := range parseInternalTree(t) {

--- a/backend/gates/filtervocabularyparity_test.go
+++ b/backend/gates/filtervocabularyparity_test.go
@@ -166,6 +166,7 @@ func operatorConstant(name string) string {
 }
 
 func TestBothFilterSurfacesOfferTheSameOperators(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is one for a difference already closed.
 	defer declaredDifferences.AssertAllMatched(t)
 
@@ -240,6 +241,7 @@ var filterCompilers = []string{
 }
 
 func TestNeitherFilterCompilerDropsAnUnsetRowFromNeq(t *testing.T) {
+	t.Parallel()
 	nullSafe := 0
 	var findings []string
 	for _, path := range filterCompilers {

--- a/backend/gates/flagdefault_test.go
+++ b/backend/gates/flagdefault_test.go
@@ -45,6 +45,7 @@ var directEnvFlagDefault = []*regexp.Regexp{
 }
 
 func TestNoStringFlagDefaultsToAnEnvironmentValue(t *testing.T) {
+	t.Parallel()
 	roots := []string{"cmd", "internal/compose"}
 	checked := 0
 

--- a/backend/gates/formulafieldscope_test.go
+++ b/backend/gates/formulafieldscope_test.go
@@ -122,6 +122,7 @@ func schemaWritesFormulaSQL(doc map[string]any, schema map[string]any, seen map[
 // property, derived from the live contract rather than a point check on
 // today's operation list — an operation added tomorrow is covered for free.
 func TestContract_noOperationWritesFormulaSQL(t *testing.T) {
+	t.Parallel()
 	doc := loadContract(t)
 	paths, ok := doc["paths"].(map[string]any)
 	if !ok {
@@ -186,6 +187,7 @@ func TestContract_noOperationWritesFormulaSQL(t *testing.T) {
 // fires the moment such an operation is added, not just that today's
 // contract happens to lack one.
 func TestSchemaWritesFormulaSQL_detectsAWritableProperty(t *testing.T) {
+	t.Parallel()
 	doc := map[string]any{
 		"components": map[string]any{
 			"schemas": map[string]any{

--- a/backend/gates/frontendapprovalkinds_test.go
+++ b/backend/gates/frontendapprovalkinds_test.go
@@ -74,6 +74,7 @@ func labelledKinds(t *testing.T, source string) []string {
 }
 
 func TestEveryStageableKindHasAFrontendLabel(t *testing.T) {
+	t.Parallel()
 	source, err := os.ReadFile(frontendApprovalKinds)
 	if err != nil {
 		t.Fatalf("reading the frontend approval-kind map: %v", err)

--- a/backend/gates/frontendfiscalyear_test.go
+++ b/backend/gates/frontendfiscalyear_test.go
@@ -166,6 +166,7 @@ func blankComments(source string) string {
 
 // TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire holds the mirror.
 func TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire(t *testing.T) {
+	t.Parallel()
 	frontend := readFiscalSource(t, frontendFiscalYear)
 	backend := readFiscalSource(t, backendFiscalYear)
 
@@ -221,6 +222,7 @@ func TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire(t *testing.T) {
 // would keep passing. So the two directions are both planted here: a fragment
 // in a comment must NOT be seen, and the same fragment in code must be.
 func TestTheGateReadsCodeRatherThanComments(t *testing.T) {
+	t.Parallel()
 	source := "package p\n" +
 		"// was: reportFiscalStartMonthToken + \" = 1\"\n" +
 		"/* also: reportFiscalStartMonthToken + \" = 1\" */\n" +

--- a/backend/gates/frontendidlebase_test.go
+++ b/backend/gates/frontendidlebase_test.go
@@ -49,6 +49,7 @@ var tsIdleFallback = regexp.MustCompile(`\.\s*([a-z_]+)\s*\?\?\s*[A-Za-z_$]+\s*\
 var tsIdleComment = regexp.MustCompile(`(?s)//[^\n]*|/\*.*?\*/`)
 
 func TestTheDealBoardMeasuresIdleTheWayTheServerDoes(t *testing.T) {
+	t.Parallel()
 	source, err := os.ReadFile(frontendIdleBase)
 	if err != nil {
 		t.Fatalf("reading the frontend idle-base helper: %v", err)

--- a/backend/gates/frontendlaneparity_test.go
+++ b/backend/gates/frontendlaneparity_test.go
@@ -338,6 +338,7 @@ func ciGateTargets(t *testing.T, path string) []string {
 }
 
 func TestEveryLocalFrontendGateLegRunsInCI(t *testing.T) {
+	t.Parallel()
 	targets := parseMakefile(t, "../Makefile")
 	local := reachable(targets, localGateRoot)
 	if len(local) < 2 {
@@ -367,6 +368,7 @@ func TestEveryLocalFrontendGateLegRunsInCI(t *testing.T) {
 // each arm below states what the reading must be, including the two that must
 // still refuse.
 func TestASubMakeBehindAVariableIsStillReadAsLegs(t *testing.T) {
+	t.Parallel()
 	vars := readLiteralVars("LEGS := fe-lint fe-test\nWIDTH := 4\n" +
 		"DERIVED := $(LEGS) fe-build\nCONTINUED := fe-a \\\n  fe-b\n")
 
@@ -420,6 +422,7 @@ func TestASubMakeBehindAVariableIsStillReadAsLegs(t *testing.T) {
 // a lane to a fraction of what CI runs. Each case below is what `make` itself
 // would expand the name to.
 func TestTheThreeAssignmentsAreReadAsMakeReadsThem(t *testing.T) {
+	t.Parallel()
 	for _, c := range []struct {
 		name, makefile, want string
 	}{
@@ -451,6 +454,7 @@ func TestTheThreeAssignmentsAreReadAsMakeReadsThem(t *testing.T) {
 // an empty ROOT_SCRIPT_GATES would otherwise make the loop below assert nothing
 // and pass, which is indistinguishable from a fan-out that reaches everything.
 func TestTheFanOutsOwnLegsAreVisibleToThisGate(t *testing.T) {
+	t.Parallel()
 	const fanOutFloor = 20
 
 	body, err := os.ReadFile("../Makefile")

--- a/backend/gates/frontendminorunits_test.go
+++ b/backend/gates/frontendminorunits_test.go
@@ -50,6 +50,7 @@ var tsMinorUnitEntry = regexp.MustCompile(`["']?\b([A-Z]{3})\b["']?:\s*(\d+)\b`)
 var tsComment = regexp.MustCompile(`(?s)//[^\n]*|/\*.*?\*/`)
 
 func TestTheFrontendMinorUnitTableMatchesTheGoOne(t *testing.T) {
+	t.Parallel()
 	source, err := os.ReadFile(frontendMinorUnits)
 	if err != nil {
 		t.Fatalf("reading the frontend minor-unit table: %v", err)

--- a/backend/gates/frontendsetupproviders_test.go
+++ b/backend/gates/frontendsetupproviders_test.go
@@ -71,6 +71,7 @@ func readSetupOffers(t *testing.T) []setupOffer {
 }
 
 func TestOnboardingOffersOnlyModelsTheServerPrices(t *testing.T) {
+	t.Parallel()
 	priced := map[string]bool{}
 	for _, r := range ai.SeedModelRates(time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)) {
 		priced[r.Provider+"/"+r.ModelID] = true
@@ -87,6 +88,7 @@ func TestOnboardingOffersOnlyModelsTheServerPrices(t *testing.T) {
 }
 
 func TestOnboardingOffersOnlyProvidersTheServerServes(t *testing.T) {
+	t.Parallel()
 	known := map[string]bool{}
 	for _, p := range ai.KnownProviders() {
 		known[p] = true

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -75,6 +75,7 @@ type censusDecl struct {
 // is not "no map" — some of these maps ARE the assertion — but saying which,
 // once, at the declaration.
 func TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture(t *testing.T) {
+	t.Parallel()
 	files, fset := censusFiles(t, "test source", isTestSource)
 	declared, annotated, written := 0, 0, 0
 	for _, pf := range files {
@@ -134,6 +135,7 @@ func TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture(t *testing.T) {
 // constructed: a set a helper assembles grants exactly what an inline literal
 // grants, so reading the entries would decide the obligation on a spelling.
 func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
+	t.Parallel()
 	files, fset := censusFiles(t, "Go source", func(string) bool { return true })
 
 	// A package, not a directory: a waiver set is unexported, so only the
@@ -190,6 +192,7 @@ func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
 // so the toolchain's internal-package rule refuses them the import before this
 // walk would have to.
 func TestGatekitServesTestsOnly(t *testing.T) {
+	t.Parallel()
 	files, _ := censusFiles(t, "product source", func(p string) bool { return !isTestSource(p) })
 	for _, pf := range files {
 		for _, imported := range pf.file.Imports {
@@ -324,6 +327,7 @@ func reasonMapOrWaiverSet(spec *ast.ValueSpec, gatekitLocal string) (mapped, wai
 // this most — nothing in the tree declares a waiver that way today, so only a
 // probe can prove the arm still classifies it.
 func TestTheCensusClassifiesEveryWaiverAndReasonMapSpelling(t *testing.T) {
+	t.Parallel()
 	for _, probe := range []struct {
 		name        string
 		declaration string

--- a/backend/gates/gateinventory_test.go
+++ b/backend/gates/gateinventory_test.go
@@ -103,6 +103,7 @@ type gate struct {
 // Neither fails anything. That is the point: the hole would be made entirely of
 // green, so it takes an assertion rather than a gate noticing.
 func TestNoGoSourceHidesWhereThisCensusCannotSeeIt(t *testing.T) {
+	t.Parallel()
 	atRoot, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("listing the module root: %v", err)
@@ -133,6 +134,7 @@ func TestNoGoSourceHidesWhereThisCensusCannotSeeIt(t *testing.T) {
 }
 
 func TestEveryGateDeclaresItsShape(t *testing.T) {
+	t.Parallel()
 	gates, untagged := readGateDeclarations(t)
 	if len(untagged) > 0 {
 		t.Errorf("%d gate file(s) carry no //gate:kind declaration:\n\t%s\n\n"+
@@ -151,6 +153,7 @@ func TestEveryGateDeclaresItsShape(t *testing.T) {
 }
 
 func TestTheGateInventoryPageIsCurrent(t *testing.T) {
+	t.Parallel()
 	gates, _ := readGateDeclarations(t)
 	if len(gates) < gateFloor {
 		t.Fatalf("refusing to judge the page against %d gate(s); see TestEveryGateDeclaresItsShape",
@@ -429,6 +432,7 @@ The eight shapes, what each is for, and how each one silently passes:
 // unmerged branch — and nothing said so: a citation is prose, and prose is
 // where a doc rots. Review caught it, which is the thing a gate is for.
 func TestGatePatternsCitesGatesThatExist(t *testing.T) {
+	t.Parallel()
 	page, err := os.ReadFile(gatePatternsPage)
 	if err != nil {
 		t.Fatalf("reading %s: %v", gatePatternsPage, err)
@@ -465,6 +469,7 @@ var citedTestFiles = regexp.MustCompile("`([a-z_0-9]+_test\\.go)`")
 const gateCitationFloor = 20
 
 func TestFirstSentenceKeepsACitationWhoseDotIsPartOfAWord(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct{ name, prose, want string }{
 		{
 			"legal citation", "The Art. 7(1) invariant holds. The rest does not.",

--- a/backend/gates/gateinventory_test.go
+++ b/backend/gates/gateinventory_test.go
@@ -152,8 +152,12 @@ func TestEveryGateDeclaresItsShape(t *testing.T) {
 	}
 }
 
+// Deliberately NOT parallel, and named in parallelExempt for the reason: under
+// -update-gate-inventory this REWRITES gateInventoryPage, which the gates that
+// walk ../docs read. os.WriteFile truncates, so a concurrent reader can see
+// half a page and report a broken link or a wrong length. Sequential orders the
+// write after every such read, including ones not written yet.
 func TestTheGateInventoryPageIsCurrent(t *testing.T) {
-	t.Parallel()
 	gates, _ := readGateDeclarations(t)
 	if len(gates) < gateFloor {
 		t.Fatalf("refusing to judge the page against %d gate(s); see TestEveryGateDeclaresItsShape",
@@ -249,18 +253,13 @@ func parseGateFile(t *testing.T, path string, source []byte) *ast.File {
 // of one is not a gate.
 func declaresATest(file *ast.File) bool {
 	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") {
-			continue
+		// isGateTest (parallelgates_test.go) is the one spelling of "this
+		// declaration is one of the package's gates", TestMain carve-out
+		// included — a file holding only TestMain judges nothing, so it owes no
+		// //gate:kind declaration and belongs on no row of the page.
+		if fn, ok := decl.(*ast.FuncDecl); ok && isGateTest(fn) {
+			return true
 		}
-		// TestMain is the package's entry point and not one of its tests — Go
-		// itself runs it INSTEAD of the tests and hands them to it. A file that
-		// holds only TestMain judges nothing, so it owes no //gate:kind
-		// declaration and belongs on no row of the page.
-		if fn.Name.Name == "TestMain" {
-			continue
-		}
-		return true
 	}
 	return false
 }

--- a/backend/gates/geocodestaleness_test.go
+++ b/backend/gates/geocodestaleness_test.go
@@ -94,6 +94,7 @@ var addressColumns = []string{
 }
 
 func TestTheSchemaMarksCoordinatesStaleWhenAnAddressMoves(t *testing.T) {
+	t.Parallel()
 	// Missing entirely is lastStatement's own failure: without the trigger every
 	// address writer has to remember to invalidate, and the one that forgets
 	// produces a company answering radius queries from an address it no longer
@@ -120,6 +121,7 @@ func TestTheSchemaMarksCoordinatesStaleWhenAnAddressMoves(t *testing.T) {
 // own would answer from the previous address however diligently the trigger
 // fired.
 func TestOnlyResolvedCoordinatesAreQueryable(t *testing.T) {
+	t.Parallel()
 	// A missing index is lastStatement's own failure: a radius query would then
 	// have nothing to select through.
 	index := lastStatement(t, `CREATE INDEX idx_organization_geocoded\b.*?;`)
@@ -132,6 +134,7 @@ func TestOnlyResolvedCoordinatesAreQueryable(t *testing.T) {
 // Every organization address writer is still accounted for, so the trigger's
 // coverage can be checked against something rather than assumed.
 func TestTheAddressWritersAreStillTheOnesTheTriggerCovers(t *testing.T) {
+	t.Parallel()
 	root := filepath.Join("internal", "modules", "people")
 	entries, err := os.ReadDir(root)
 	if err != nil {

--- a/backend/gates/goversionpins_test.go
+++ b/backend/gates/goversionpins_test.go
@@ -29,6 +29,7 @@ import (
 var goDirective = regexp.MustCompile(`(?m)^go (\d+\.\d+(?:\.\d+)?)$`)
 
 func TestEveryGoVersionPinMatchesTheProductModule(t *testing.T) {
+	t.Parallel()
 	want := goVersionOf(t, "go.mod")
 	if strings.Count(want, ".") != 2 {
 		t.Fatalf("backend/go.mod pins %q; a patch version is what the other pins have to match", want)

--- a/backend/gates/idempotencymap_test.go
+++ b/backend/gates/idempotencymap_test.go
@@ -148,6 +148,7 @@ func mappedIdempotentOperations(t *testing.T) map[string]bool {
 }
 
 func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
+	t.Parallel()
 	declared := idempotencyKeyDeclarations(t)
 	mapped := mappedIdempotentOperations(t)
 	// Vacuous-pass guards: both sides carry dozens of operations; finding

--- a/backend/gates/integrationmigrateonce_test.go
+++ b/backend/gates/integrationmigrateonce_test.go
@@ -72,6 +72,7 @@ var inlineMigrators = gatekit.Waive(map[string]string{
 })
 
 func TestIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
+	t.Parallel()
 	var offenders, inMigrations []string
 	fset := token.NewFileSet()
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {

--- a/backend/gates/jobargscontent_test.go
+++ b/backend/gates/jobargscontent_test.go
@@ -55,6 +55,7 @@ var contentWords = []string{
 }
 
 func TestEveryJobArgsFieldIsAnIdOrAnArguedForScalar(t *testing.T) {
+	t.Parallel()
 	census, err := compose.NewJobCensus()
 	if err != nil {
 		t.Fatalf("building the job census: %v", err)

--- a/backend/gates/jobbinding_test.go
+++ b/backend/gates/jobbinding_test.go
@@ -35,6 +35,7 @@ const workspaceBindFloor = 15
 // and bind another, or bind a zero UUID, with the role gate in jobrole_test.go
 // still green. That is the drift this prevents.
 func TestOnlyTheSharedHelperBindsAWorkspace(t *testing.T) {
+	t.Parallel()
 	fset, files := parseGoFilesUnder(t, filepath.Join("internal", "compose"))
 	guarded := 0
 	for _, file := range files {

--- a/backend/gates/jobcensus_test.go
+++ b/backend/gates/jobcensus_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestJobCensusMatchesTheContract(t *testing.T) {
+	t.Parallel()
 	census, err := compose.NewJobCensus()
 	if err != nil {
 		t.Fatalf("building the job census: %v", err)

--- a/backend/gates/jobfault_test.go
+++ b/backend/gates/jobfault_test.go
@@ -28,6 +28,7 @@ import (
 const workerFloor = 20
 
 func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
+	t.Parallel()
 	// The ratified log-and-return-nil workers, each bound to the durable retry
 	// policy that makes its green River row honest. They are DECLARED per kind
 	// in api/jobs.yaml (fault: nil_after_logging) and joined to the receiver

--- a/backend/gates/jobfleetscan_test.go
+++ b/backend/gates/jobfleetscan_test.go
@@ -171,6 +171,7 @@ func isAlphanumeric(c byte) bool {
 }
 
 func TestFleetEnumerationOnlyAtRatifiedSites(t *testing.T) {
+	t.Parallel()
 	found := map[string]int{}
 	paths, err := goFilesUnder("internal")
 	if err != nil {

--- a/backend/gates/jobfleetwide_test.go
+++ b/backend/gates/jobfleetwide_test.go
@@ -389,5 +389,6 @@ func checkFleetWideDispatchers(t *testing.T, dir string) {
 // TestEveryFleetWideJobOnlyDispatches is the gate. See the file comment for the
 // allowlist and what it deliberately does not prove.
 func TestEveryFleetWideJobOnlyDispatches(t *testing.T) {
+	t.Parallel()
 	checkFleetWideDispatchers(t, filepath.Join("internal", "compose"))
 }

--- a/backend/gates/jobfleetwideshapes_test.go
+++ b/backend/gates/jobfleetwideshapes_test.go
@@ -36,6 +36,7 @@ func parseFleetWideSource(t *testing.T, src string) (*token.FileSet, []*ast.File
 // be fixed by weakening it, and the weakening is what the next sweep loop walks
 // back in through — so every shape the tree actually uses is a test.
 func TestTheFleetWideGateAcceptsEveryDispatchShapeInTheTree(t *testing.T) {
+	t.Parallel()
 	eachShape(t, fleetWideShapesInTheTree(), fleetWideShapeFloor, func(t *testing.T, d fleetWideDispatcher) {
 		if !d.fansOut {
 			t.Errorf("the gate does not recognize this dispatch shape as a fan-out; it is in the tree and must be in the allowlist")
@@ -89,6 +90,7 @@ func eachShape(t *testing.T, shapes map[string]string, floor int, assert func(*t
 // the gate exists for: both plants declare FleetWide, both would keep a null
 // `args->>'workspace_id'`, and both do a tenant's work inside one row.
 func TestTheFleetWideGateRejectsADispatcherThatDoesTenantWork(t *testing.T) {
+	t.Parallel()
 	plants := map[string]string{
 		"a write in the dispatcher's own body": `
 			func (w *sweepWorker) Work(ctx context.Context, _ *river.Job[SweepArgs]) error {
@@ -127,6 +129,7 @@ func TestTheFleetWideGateRejectsADispatcherThatDoesTenantWork(t *testing.T) {
 // whatever attempt cap the author typed instead of the one the child declares.
 // A dispatcher shaped like this is the defect that shipped once already.
 func TestTheFleetWideGateRejectsAFanOutThatGoesAroundTheChokepoints(t *testing.T) {
+	t.Parallel()
 	plants := map[string]string{
 		"a due-scan fanning out one client.Insert per due row": `
 			func (w *sweepWorker) Work(ctx context.Context, _ *river.Job[SweepArgs]) error {

--- a/backend/gates/jobkindgate_test.go
+++ b/backend/gates/jobkindgate_test.go
@@ -96,6 +96,7 @@ func main() {
 `
 
 func TestTheGateAcceptsADeclaredKind(t *testing.T) {
+	t.Parallel()
 	out, ok := compileScratch(t, scratchPreamble+"\taddDeclaredWorker[AArgs](aWorker{})\n}\n")
 	if !ok {
 		t.Fatalf("a declared kind must register cleanly; the gate would block a legitimate author:\n%s", out)
@@ -103,6 +104,7 @@ func TestTheGateAcceptsADeclaredKind(t *testing.T) {
 }
 
 func TestTheGateRejectsAnUndeclaredKind(t *testing.T) {
+	t.Parallel()
 	out, ok := compileScratch(t, scratchPreamble+"\taddDeclaredWorker[CArgs](cWorker{})\n}\n")
 	if ok {
 		t.Fatal("an undeclared kind compiled — the closed type set is not closed")
@@ -116,6 +118,7 @@ func TestTheGateRejectsAnUndeclaredKind(t *testing.T) {
 }
 
 func TestTheGateRejectsAWorkerRegisteredUnderTheWrongKind(t *testing.T) {
+	t.Parallel()
 	out, ok := compileScratch(t, scratchPreamble+"\taddDeclaredWorker[BArgs](aWorker{})\n}\n")
 	if ok {
 		t.Fatal("worker A registered under kind B compiled — the type parameter is not binding the worker")
@@ -207,6 +210,7 @@ func buildComposeWith(t *testing.T, body string) (string, bool) {
 // stale import, a renamed helper — would otherwise read exactly like a union
 // doing its job.
 func TestTheRealGeneratedUnionRefusesAnUndeclaredKind(t *testing.T) {
+	t.Parallel()
 	if out, unmodified := buildComposeWith(t, ""); !unmodified {
 		t.Fatalf("internal/compose does not build as it stands, so nothing below could be attributed to the union:\n%s", out)
 	}

--- a/backend/gates/jobregistrationban_test.go
+++ b/backend/gates/jobregistrationban_test.go
@@ -237,6 +237,7 @@ var lintConfigs = []string{".golangci.yml", ".golangci.strict.yml"}
 // forbidigo. Keeping the two sets identical by hand would restore the waiver
 // and reintroduce the duplicate nobody maintains.
 func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
+	t.Parallel()
 	var enabling []string
 	for _, name := range lintConfigs {
 		if slices.Contains(readGolangciConfig(t, name).Linters.Enable, "forbidigo") {
@@ -260,6 +261,7 @@ func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
 // files only would leave them covered by NOTHING, which is where an http.Error
 // or a stray fmt.Print goes unnoticed for longest.
 func TestTheOwningConfigLintsTheTaggedLanes(t *testing.T) {
+	t.Parallel()
 	// The owner is DERIVED, not named: this holds whichever config enables
 	// forbidigo to the tags, so moving ownership moves the obligation with it
 	// rather than leaving this passing about a config that no longer runs the
@@ -343,6 +345,7 @@ func banCovers(t *testing.T, rules []forbidRule, expr string) bool {
 // fourth way to register fails here, at the line of the upgrade, rather than
 // on the first pull request that quietly uses it.
 func TestTheRegistrationBanCoversEveryRiverEntryPoint(t *testing.T) {
+	t.Parallel()
 	entryPoints := riverRegistrationEntryPoints(t)
 	rules := riverForbidRules(t)
 
@@ -362,6 +365,7 @@ func TestTheRegistrationBanCoversEveryRiverEntryPoint(t *testing.T) {
 // the file never declared and the census cannot see — so every exported method
 // on it has to be forbidden, not just the ones that exist today.
 func TestTheScheduleBanCoversEveryPeriodicBundleMutator(t *testing.T) {
+	t.Parallel()
 	mutators := riverPeriodicBundleMutators(t)
 	rules := riverForbidRules(t)
 

--- a/backend/gates/jobrole_test.go
+++ b/backend/gates/jobrole_test.go
@@ -184,6 +184,7 @@ var composedJobArgsTypes = map[string]bool{
 // river.JobArgs, and cmd/api holds seven inserter handles — would be invisible
 // to them. This walks the tree instead, so the type existing at all is enough.
 func TestEveryJobArgsTypeIsDeclaredInTheContract(t *testing.T) {
+	t.Parallel()
 	byType := methodsByType(t, filepath.Join("internal", "compose"))
 	declared := declaredKindTypes(t)
 
@@ -210,6 +211,7 @@ func TestEveryJobArgsTypeIsDeclaredInTheContract(t *testing.T) {
 // just as happily by a type that ALSO implements WorkspaceID. Only a walker
 // sees both at once.
 func TestNoJobArgsDeclaresBothRoles(t *testing.T) {
+	t.Parallel()
 	byType := methodsByType(t, filepath.Join("internal", "compose"))
 	roled := 0
 	for typeName, methods := range byType {

--- a/backend/gates/jobtestonly_test.go
+++ b/backend/gates/jobtestonly_test.go
@@ -52,6 +52,7 @@ const testOnlySetterFloor = 1
 // TestJobRunnerConfigIsNeverSetInProduction is the whole obligation: TestOnly may
 // be set from a test file, and from nowhere else.
 func TestJobRunnerConfigIsNeverSetInProduction(t *testing.T) {
+	t.Parallel()
 	var offenders, permitted []string
 	fset := token.NewFileSet()
 

--- a/backend/gates/jobwirekey_test.go
+++ b/backend/gates/jobwirekey_test.go
@@ -52,6 +52,7 @@ const (
 )
 
 func TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join("internal", "compose")
 	byType := methodsByType(t, dir)
 	fset, files := parseGoFilesUnder(t, dir)

--- a/backend/gates/laneconnbudget_test.go
+++ b/backend/gates/laneconnbudget_test.go
@@ -174,6 +174,7 @@ func laneConnectionDemand(t *testing.T, jobs int) int {
 func fits(demand, maxConns int) bool { return demand <= maxConns }
 
 func TestTheLaneFitsInsideTheClusterItRunsAgainst(t *testing.T) {
+	t.Parallel()
 	script := readRepoFile(t, laneScriptPath)
 	jobs := ciIntegrationJobs(t, gateWorkflows(t))
 	perPool := laneTerm(t, script, "LANE_POOL_MAX_CONNS")
@@ -224,6 +225,7 @@ different package set every run (#1109).`,
 // configuration and accepts every broken one while reading green here. So both
 // directions of `fits` are exercised by name.
 func TestTheBudgetGateRefusesTheConfigurationThatShipped(t *testing.T) {
+	t.Parallel()
 	const (
 		jobsInCI      = 16  // .github/workflows/ci.yml, at the time of #1109
 		stockMaxConns = 100 // what a Postgres with no max_connections serves
@@ -250,6 +252,7 @@ func TestTheBudgetGateRefusesTheConfigurationThatShipped(t *testing.T) {
 // budgeting for a limit nothing applies. Both ends of that seam are asserted,
 // because either one alone can be present while the pin does nothing.
 func TestTheLanePinsThePoolCeilingItBudgetsFor(t *testing.T) {
+	t.Parallel()
 	script := readRepoFile(t, laneScriptPath)
 	// The lane's end: the ceiling is EXPORTED, since the workers re-exec and a
 	// variable that is set but not exported expands to empty in them.

--- a/backend/gates/languageset_test.go
+++ b/backend/gates/languageset_test.go
@@ -40,6 +40,7 @@ var languageEnumSchemas = []string{
 }
 
 func TestEveryLanguageEnumInTheContractListsTheShippedLanguages(t *testing.T) {
+	t.Parallel()
 	contract, err := os.ReadFile("api/crm.yaml")
 	if err != nil {
 		t.Fatalf("reading the contract: %v", err)

--- a/backend/gates/legacyadvisorylock_test.go
+++ b/backend/gates/legacyadvisorylock_test.go
@@ -76,6 +76,7 @@ var legacyAdvisoryLockKeys = []string{
 }
 
 func TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease(t *testing.T) {
+	t.Parallel()
 	var found []string
 	// The same hand-written Go corpus the licence notice covers, for the same
 	// reason: extensions/ and fixtures/ are separate modules that a `./...`

--- a/backend/gates/license_test.go
+++ b/backend/gates/license_test.go
@@ -57,6 +57,7 @@ func isGenerated(path, text string) bool {
 // happens to name a directory the same way — an inherited exemption is a file
 // shipping with no notice and a gate reporting it clean.
 func TestTheContractsExemptionIsAnchoredToTheBackendTree(t *testing.T) {
+	t.Parallel()
 	const unlicensed = "package contracts\n"
 	if !isGenerated("internal/contracts/doc.go", unlicensed) {
 		t.Error("the backend's frozen contracts package lost its exemption")
@@ -90,6 +91,7 @@ var licensedTrees = []licensedTree{
 }
 
 func TestEveryHandWrittenGoFileCarriesTheLicenseHeader(t *testing.T) {
+	t.Parallel()
 	var missing []string
 	walk := func(root string) (int, error) {
 		checked := 0

--- a/backend/gates/listenvelope_test.go
+++ b/backend/gates/listenvelope_test.go
@@ -30,6 +30,7 @@ import (
 const contractGen = "internal/contracts/api_gen.go"
 
 func TestEveryListResponseCarriesADataSlice(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, contractGen, nil, 0)
 	if err != nil {

--- a/backend/gates/livemember_test.go
+++ b/backend/gates/livemember_test.go
@@ -148,6 +148,7 @@ var appUserAlias = regexp.MustCompile(`(?i)\bapp_user\b(?:\s+AS)?\s+([a-z]\w*)`)
 var readsAppUser = regexp.MustCompile(`(?i)\bapp_user\b`)
 
 func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching covers a site that has moved or been
 	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
 	defer cannotReachIdentity.AssertAllMatched(t)
@@ -231,6 +232,7 @@ func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
 // not bound as a parameter, so a caller that passed request input would inject.
 // Every call site names a table alias it wrote itself, and this says so.
 func TestEveryLiveMemberAliasIsALiteral(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	var findings []string
 	calls := 0
@@ -706,6 +708,7 @@ func read() string {
 }
 
 func TestTheLiveMemberDetectorSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	for _, tc := range liveMemberProbes {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/gates/logsecrets_test.go
+++ b/backend/gates/logsecrets_test.go
@@ -113,6 +113,7 @@ const attrGroup = "Group"
 // attribute key without standing in the failure branch of the channel that
 // should have carried it.
 func TestACredentialIsLoggedOnlyWhenItsOwnChannelFailed(t *testing.T) {
+	t.Parallel()
 	defer spreadTailWaivers.AssertAllMatched(t)
 	if len(credentialLogKeys) != wantCredentialLogKeys {
 		t.Fatalf("credentialLogKeys holds %d keys, wantCredentialLogKeys is %d — a key was removed; "+

--- a/backend/gates/makefilepaths_test.go
+++ b/backend/gates/makefilepaths_test.go
@@ -53,6 +53,7 @@ func gitIgnored(t *testing.T, path string) bool {
 var configPath = regexp.MustCompile(`(?:\.\./)?config/[A-Za-z0-9._*-]+\.(?:ya?ml|json)`)
 
 func TestEveryConfigPathAMakefileNamesExists(t *testing.T) {
+	t.Parallel()
 	makefiles := []string{"Makefile", "../Makefile"}
 	checked := 0
 	for _, mk := range makefiles {

--- a/backend/gates/manifestdigest_test.go
+++ b/backend/gates/manifestdigest_test.go
@@ -59,6 +59,7 @@ var manifestTrees = []struct {
 }
 
 func TestEveryGeneratedManifestHashNamesItsAlgorithm(t *testing.T) {
+	t.Parallel()
 	for _, tree := range manifestTrees {
 		var tiered int
 		for _, path := range committedManifests(t, tree.root) {

--- a/backend/gates/mcpfaultcoverage_test.go
+++ b/backend/gates/mcpfaultcoverage_test.go
@@ -429,6 +429,7 @@ func isUnprocessableEntity(expr ast.Expr) bool {
 }
 
 func TestSeamReachableModulesCarryTheirOwnFieldVerdict(t *testing.T) {
+	t.Parallel()
 	defer seamOutsideRoots.AssertAllMatched(t)
 
 	reachable := seamReachableUnits(t)

--- a/backend/gates/migrationcitations_test.go
+++ b/backend/gates/migrationcitations_test.go
@@ -245,8 +245,13 @@ func TestTheCitationDetectorSeesWhatItClaims(t *testing.T) {
 // Nothing else holds it: a hand-added entry lands wherever the author typed it,
 // and the next prune rewrites the whole file sorted — so an unsorted register
 // produces a diff full of moves that hides the one line that matters.
+// Deliberately NOT parallel, and named in parallelExempt for the reason: under
+// -update-citations, TestEveryCitedMigrationExists REWRITES the very file this
+// test reads. Go resumes parallel tests only after every sequential one has
+// finished, so staying sequential orders this read strictly before any prune —
+// which a skip would not do, and which keeps the register judged in that mode
+// rather than merely unexamined.
 func TestTheCitationRegisterIsSortedAndUnique(t *testing.T) {
-	t.Parallel()
 	entries := registerEntries(t, citationRegisterPath)
 	seen := map[string]bool{}
 	for i, e := range entries {

--- a/backend/gates/migrationcitations_test.go
+++ b/backend/gates/migrationcitations_test.go
@@ -135,8 +135,13 @@ const (
 var updateCitationRegister = flag.Bool("update-citations", false,
 	"prune danglingcitations.txt of entries the tree no longer has")
 
+// Deliberately NOT parallel, and named in parallelExempt for the reason: under
+// -update-citations this REWRITES danglingcitations.txt, which
+// TestTheCitationRegisterIsSortedAndUnique reads. Go resumes parallel tests
+// only once every sequential one has finished, so staying sequential orders
+// this write after every read — including reads nobody has added yet, which
+// holding the reader back instead would not cover.
 func TestEveryCitedMigrationExists(t *testing.T) {
-	t.Parallel()
 	known := knownMigrationVersions(t)
 	found, unread, scanned, skipped := scanTreeForCitations(t, known)
 	// A census that read a fraction of the tree must not report the same word
@@ -245,13 +250,8 @@ func TestTheCitationDetectorSeesWhatItClaims(t *testing.T) {
 // Nothing else holds it: a hand-added entry lands wherever the author typed it,
 // and the next prune rewrites the whole file sorted — so an unsorted register
 // produces a diff full of moves that hides the one line that matters.
-// Deliberately NOT parallel, and named in parallelExempt for the reason: under
-// -update-citations, TestEveryCitedMigrationExists REWRITES the very file this
-// test reads. Go resumes parallel tests only after every sequential one has
-// finished, so staying sequential orders this read strictly before any prune —
-// which a skip would not do, and which keeps the register judged in that mode
-// rather than merely unexamined.
 func TestTheCitationRegisterIsSortedAndUnique(t *testing.T) {
+	t.Parallel()
 	entries := registerEntries(t, citationRegisterPath)
 	seen := map[string]bool{}
 	for i, e := range entries {

--- a/backend/gates/migrationcitations_test.go
+++ b/backend/gates/migrationcitations_test.go
@@ -136,6 +136,7 @@ var updateCitationRegister = flag.Bool("update-citations", false,
 	"prune danglingcitations.txt of entries the tree no longer has")
 
 func TestEveryCitedMigrationExists(t *testing.T) {
+	t.Parallel()
 	known := knownMigrationVersions(t)
 	found, unread, scanned, skipped := scanTreeForCitations(t, known)
 	// A census that read a fraction of the tree must not report the same word
@@ -193,6 +194,7 @@ func TestEveryCitedMigrationExists(t *testing.T) {
 // the honest half — each is a real shape this gate cannot see, and flipping one
 // is how a future widening announces itself.
 func TestTheCitationDetectorSeesWhatItClaims(t *testing.T) {
+	t.Parallel()
 	known := map[string]map[string]bool{
 		"core":   {"0001": true, "1787320004": true},
 		"custom": {"20260716120000": true},
@@ -244,6 +246,7 @@ func TestTheCitationDetectorSeesWhatItClaims(t *testing.T) {
 // and the next prune rewrites the whole file sorted — so an unsorted register
 // produces a diff full of moves that hides the one line that matters.
 func TestTheCitationRegisterIsSortedAndUnique(t *testing.T) {
+	t.Parallel()
 	entries := registerEntries(t, citationRegisterPath)
 	seen := map[string]bool{}
 	for i, e := range entries {

--- a/backend/gates/minorunitscale_test.go
+++ b/backend/gates/minorunitscale_test.go
@@ -364,6 +364,7 @@ func handWrittenGoFiles(t *testing.T) []string {
 }
 
 func TestNobodyBuildsAMinorUnitScaleByHand(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	var findings []string
 	for _, path := range handWrittenGoFiles(t) {
@@ -589,6 +590,7 @@ func decimate(n int64) int64 {
 }
 
 func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	for _, tc := range handScaledProbes {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/gates/moduleaudits_test.go
+++ b/backend/gates/moduleaudits_test.go
@@ -208,6 +208,7 @@ func moduleWritesAuditRow(module string, subjects map[string]bool) (bool, error)
 }
 
 func TestEveryTableOwningModuleWritesAnAuditRow(t *testing.T) {
+	t.Parallel()
 	modules := modulesOwningTables()
 	// A census that examined nothing reports exactly like a tree where every
 	// module audits, which is the shape of the hole this gate closes.

--- a/backend/gates/modulepoolsharing_test.go
+++ b/backend/gates/modulepoolsharing_test.go
@@ -95,6 +95,7 @@ var ownPools = gatekit.Waive(map[string]string{
 // TestModuleSuitesTakeTheProcessSharedPool fails when a module integration test
 // builds its own pool instead of taking testdb's.
 func TestModuleSuitesTakeTheProcessSharedPool(t *testing.T) {
+	t.Parallel()
 	var offenders, sharing, unguarded []string
 	fset := token.NewFileSet()
 	err := filepath.WalkDir(modulesTree, func(path string, d fs.DirEntry, err error) error {

--- a/backend/gates/netguardparity_test.go
+++ b/backend/gates/netguardparity_test.go
@@ -35,6 +35,7 @@ import (
 // it could, and that drift was the way around the guard for a member-supplied
 // host.
 func TestPublishedReservedNetsMatchTheGuard(t *testing.T) {
+	t.Parallel()
 	published := extension.ReservedNets()
 	internal := netguard.ReservedNetsForTest()
 	if len(published) != len(internal) {
@@ -51,6 +52,7 @@ func TestPublishedReservedNetsMatchTheGuard(t *testing.T) {
 // across a module boundary to callers the core does not control, and a caller
 // that reslices or overwrites an element would be editing the guard itself.
 func TestReservedNetsDoesNotHandOutTheGuardsOwnSlice(t *testing.T) {
+	t.Parallel()
 	first := extension.ReservedNets()
 	if len(first) == 0 {
 		t.Fatal("ReservedNets returned nothing — the denylist is the guard")

--- a/backend/gates/onecallerpredicatebudget_test.go
+++ b/backend/gates/onecallerpredicatebudget_test.go
@@ -62,6 +62,7 @@ var callerPredicateBudgetScope = gatekit.Scope{
 }
 
 func TestTheCallerPredicateBudgetIsDeclaredOnce(t *testing.T) {
+	t.Parallel()
 	// EXACTLY one DECLARATION, not one file. A file is the wrong unit twice
 	// over: two declarations in one file are two numbers and would report as
 	// one, and zero of them reads the same as a clean tree — the direction a
@@ -92,6 +93,7 @@ func TestTheCallerPredicateBudgetIsDeclaredOnce(t *testing.T) {
 // gate holding its own copy of the number it protects has become the second
 // copy it exists to forbid.
 func TestTheGateAgreesWithTheConstantItGuards(t *testing.T) {
+	t.Parallel()
 	if callerPredicateBudget != database.CallerPredicateBudget {
 		t.Errorf("this gate measures %s and platform/database declares %s; the gate is guarding a number "+
 			"the tree no longer uses", callerPredicateBudget, database.CallerPredicateBudget)
@@ -197,6 +199,7 @@ func durationUnit(expr ast.Expr) (time.Duration, bool) {
 // has stopped matching passes by finding nothing, which is the same word it
 // prints over a clean tree.
 func TestTheBudgetCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	subjects := map[string]string{
 		"the ceiling as the tree spells it": "" +
 			"package p\nimport \"time\"\nconst previewStatementBudget = 5 * time.Second\n",

--- a/backend/gates/oneconsentcarry_test.go
+++ b/backend/gates/oneconsentcarry_test.go
@@ -80,6 +80,7 @@ func writesConsentState(_ string, file *ast.File) bool {
 const theCarryFile = "internal/modules/people/consentcarry.go"
 
 func TestTheConsentCarryIsSpelledOnceInPeople(t *testing.T) {
+	t.Parallel()
 	scope := gatekit.Scope{
 		Roots:   []string{"internal/modules/people"},
 		Subject: writesConsentState,
@@ -112,6 +113,7 @@ func TestTheConsentCarryIsSpelledOnceInPeople(t *testing.T) {
 // count at one and is a second answer to "what happens to a withdrawal when the
 // record holding it retires".
 func TestEveryConsentWriteInTheCarryFileBelongsToTheCarry(t *testing.T) {
+	t.Parallel()
 	source, err := os.ReadFile(theCarryFile)
 	if err != nil {
 		t.Fatalf("reading the carry: %v", err)
@@ -153,6 +155,7 @@ var reKeyedConsent = regexp.MustCompile(`(?is)UPDATE\s+(person_consent|consent_e
 // only thing it could see — and a re-key added to the consent module, which the
 // scope above waives wholesale, is exactly the copy this is here to catch.
 func TestOnlyTheCarryReKeysAConsentRow(t *testing.T) {
+	t.Parallel()
 	scope := gatekit.Scope{
 		Roots:   []string{"internal/modules"},
 		Subject: func(_ string, file *ast.File) bool { return holdsMatchingLiteral(file, reKeyedConsent) },

--- a/backend/gates/onecursorenvelope_test.go
+++ b/backend/gates/onecursorenvelope_test.go
@@ -47,6 +47,7 @@ var cursorEnvelopeScope = gatekit.Scope{
 }
 
 func TestTheCursorEnvelopeIsSpelledOnce(t *testing.T) {
+	t.Parallel()
 	inside := cursorEnvelopeScope.Files(t)
 	if len(inside) > 1 {
 		var where []string
@@ -128,6 +129,7 @@ func raisesMalformedCursor(body *ast.BlockStmt) bool {
 // that has stopped matching passes by finding nothing, which is the same word
 // it prints over a clean tree.
 func TestTheCursorEnvelopeCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	subjects := map[string]string{
 		"a hand-rolled envelope, as all four were written": "" +
 			"package p\nfunc f(token string) error {\n\traw, err := base64.RawURLEncoding.DecodeString(token)\n" +

--- a/backend/gates/onedownloadheader_test.go
+++ b/backend/gates/onedownloadheader_test.go
@@ -59,6 +59,7 @@ var downloadHeaderScope = gatekit.Scope{
 }
 
 func TestADownloadsHeadersAreSpelledOnce(t *testing.T) {
+	t.Parallel()
 	// EXACTLY one WRITE, not one file. A file is the wrong unit twice over:
 	// two writes in one file are two spellings reported as one, and zero of
 	// them reads the same as a clean tree.
@@ -188,6 +189,7 @@ func isResponseHeaderSet(n ast.Node, name string, hoisted map[string]bool) bool 
 // census that has stopped matching passes by finding nothing, which is the same
 // word it prints over a clean tree.
 func TestTheDownloadHeaderCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	subjects := map[string]string{
 		"a disposition written straight onto the response": "" +
 			"func f(w http.ResponseWriter) { w.Header().Set(\"Content-Disposition\", `attachment; filename=\"x\"`) }",

--- a/backend/gates/oneidlebase_test.go
+++ b/backend/gates/oneidlebase_test.go
@@ -202,6 +202,7 @@ var idleBaseScope = gatekit.Scope{
 }
 
 func TestTheIdleBaseIsSpelledOnce(t *testing.T) {
+	t.Parallel()
 	inside := idleBaseScope.Files(t)
 	if len(inside) > 1 {
 		var where []string
@@ -415,6 +416,7 @@ func isNilIdent(expr ast.Expr) bool {
 // on the column is not a second copy of the rule, and neither is a coalesce
 // onto something that is not the creation instant.
 func TestTheGateRecognisesEverySpellingOfTheIdleBase(t *testing.T) {
+	t.Parallel()
 	spellings := map[string]string{
 		"an ORDER BY over the base": "" +
 			"func f() { q(`ORDER BY coalesce(d.last_activity_at, d.created_at), d.id`) }",

--- a/backend/gates/onejitteredbackoff_test.go
+++ b/backend/gates/onejitteredbackoff_test.go
@@ -54,6 +54,7 @@ var jitteredBackoffScope = gatekit.Scope{
 }
 
 func TestTheJitteredLadderIsSpelledOnce(t *testing.T) {
+	t.Parallel()
 	inside := jitteredBackoffScope.Files(t)
 	if len(inside) > 1 {
 		var where []string
@@ -130,6 +131,7 @@ func localNameForMathRand(file *ast.File) (string, bool) {
 // has stopped matching passes by finding nothing, which is the same word it
 // prints over a clean tree.
 func TestTheJitterCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	subjects := map[string]string{
 		"a jitter multiplier drawn the way this tree draws one": "" +
 			"package p\nimport \"math/rand/v2\"\nfunc f() float64 { return 0.8 + 0.4*rand.Float64() }",

--- a/backend/gates/oneretryafter_test.go
+++ b/backend/gates/oneretryafter_test.go
@@ -48,6 +48,7 @@ var retryAfterScope = gatekit.Scope{
 }
 
 func TestTheRetryAfterReadingIsSpelledOnce(t *testing.T) {
+	t.Parallel()
 	inside := retryAfterScope.Files(t)
 	if len(inside) > 1 {
 		var where []string
@@ -94,6 +95,7 @@ func readsTheRetryAfterHeader(_ string, file *ast.File) bool {
 // that has stopped matching passes by finding nothing, which is the same word
 // it prints over a clean tree.
 func TestTheRetryAfterCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	subjects := map[string]string{
 		"a read off a response's headers": "" +
 			"package p\nfunc f(resp *http.Response) string { return resp.Header.Get(\"Retry-After\") }",

--- a/backend/gates/onevoiceversionwriter_test.go
+++ b/backend/gates/onevoiceversionwriter_test.go
@@ -46,6 +46,7 @@ import (
 var voiceWriteTables = []string{"voice_profile_version", "voice_profile_delta"}
 
 func TestVoiceVersionsHaveOneWriter(t *testing.T) {
+	t.Parallel()
 	for _, table := range voiceWriteTables {
 		t.Run(table, func(t *testing.T) {
 			scope := gatekit.Scope{
@@ -174,6 +175,7 @@ func holdsWholeMatch(expr ast.Expr, pattern *regexp.Regexp) bool {
 // stops matching passes by finding nothing, which is the same word it prints
 // over a clean tree.
 func TestTheWriterCensusStillSeesItsSubject(t *testing.T) {
+	t.Parallel()
 	for _, table := range voiceWriteTables {
 		subject := insertsInto(table)
 		written := parseGateFixture(t, "package p\nfunc f() { q(`\n\t\tINSERT INTO "+table+

--- a/backend/gates/orgrenamerecheck_test.go
+++ b/backend/gates/orgrenamerecheck_test.go
@@ -197,6 +197,7 @@ func endOfBlockComment(statement string, i int) int {
 var remembersTheRecheckItself = gatekit.Waive(map[string]string{})
 
 func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching covers a writer that has moved or been
 	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
 	defer remembersTheRecheckItself.AssertAllMatched(t)
@@ -282,6 +283,7 @@ func firstRenameStatement(statements []string) (string, bool) {
 // the tree is clean: it reads the same over a clean tree and over a detector
 // that has stopped detecting.
 func TestTheRenameDetectorReadsSQLAndNotProse(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name   string
 		sql    string

--- a/backend/gates/outboundidentity_test.go
+++ b/backend/gates/outboundidentity_test.go
@@ -39,6 +39,7 @@ var identitySurfaceRoots = []string{
 }
 
 func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
+	t.Parallel()
 	var findings []string
 	headerWrites := 0
 	// Gathered per PACKAGE, not per file. A constant is package-scoped, so

--- a/backend/gates/overdueboundary_test.go
+++ b/backend/gates/overdueboundary_test.go
@@ -87,6 +87,7 @@ var asksIfLateInSQL = []*regexp.Regexp{
 // A census asserting a shape is ABSENT passes identically over a clean tree and
 // over a pattern that has stopped matching.
 func TestTheSQLPatternsSeeWhatTheyClaimTo(t *testing.T) {
+	t.Parallel()
 	caught := []string{
 		"WHERE a.due_at <= now()",
 		"WHERE a.due_at <= $2",
@@ -129,6 +130,7 @@ func anyAsksIfLate(statement string) bool {
 }
 
 func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is one for a statement that has moved
 	// or been fixed, and leaving it re-exempts whatever takes its place.
 	defer schedulerClaims.AssertAllMatched(t)

--- a/backend/gates/parallelgates_test.go
+++ b/backend/gates/parallelgates_test.go
@@ -8,10 +8,9 @@ package gates
 // Every gate here runs in parallel with the others, and this is what keeps that
 // true as gates are added.
 //
-// These tests are readers: each walks the tree, parses what it finds and judges
-// it. Serially that was 102 s and the longest single test was 5.4 s — a flat
-// tail of ~100 independent walks, not a hot spot — which is exactly the shape
-// parallelism answers. With t.Parallel() it is 18 s.
+// These gates are readers, and the tail is flat: a hundred independent walks of
+// the same tree, no single one of them hot. That is the shape parallelism
+// answers — the suite costs its slowest walk instead of the sum of all of them.
 //
 // The reason this needs a gate rather than a convention: a gate added without
 // the call still PASSES. It just runs alone while the others share the machine,
@@ -19,86 +18,119 @@ package gates
 // tells anybody — the cost arrives as a number in a CI log that nobody is
 // comparing against last month's.
 //
-// WHAT MAKES IT SAFE, since a package of parallel tests sharing state is a fair
-// thing to worry about: the state they share is each gatekit.Waivers set, whose
-// `matched` map is mutex-guarded, and whose AssertAllMatched must be called
-// from exactly one place per declaration — held by
-// TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce. Getting that wrong
-// under parallelism reports staleness that is not there, which is a LOUD
-// failure rather than a gate quietly passing.
+// WHAT THE PARALLEL GATES SHARE, since a package of concurrent tests is a fair
+// thing to worry about. Both halves matter, and the second is why
+// parallelExempt is not only about t.Setenv:
+//
+//   - Each gatekit.Waivers set. Its `matched` map is mutex-guarded, and
+//     AssertAllMatched must be called from exactly one place per declaration —
+//     held by TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce.
+//     Getting that wrong reports staleness that is not there, which fails
+//     loudly rather than passing quietly.
+//   - The tree itself, which is read-only EXCEPT under the `-update-*` flags.
+//     A gate holding one of those rewrites a file other gates read, and
+//     os.WriteFile truncates, so a concurrent reader can see half a file.
 
 import (
 	"go/ast"
-	"go/parser"
-	"go/token"
+	"go/build"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// parallelExempt names the gates that cannot take t.Parallel(), with the reason.
+// parallelExempt names the gates that must NOT take t.Parallel(), with the
+// reason. Keyed by test name rather than by file: the obligation is a property
+// of the function, and a file-keyed exemption would silently cover every gate
+// that later joins that file.
 //
-// Keyed by test name rather than by file: the obligation is a property of the
-// function, and a file-keyed exemption would silently cover every gate that
-// later joins that file.
+// The file-rewriting entries name the WRITER, never a reader. Go resumes
+// parallel tests only once every sequential one has finished, so a sequential
+// writer is ordered before every parallel reader there is OR WILL BE. Exempting
+// a reader instead fixes one call site and leaves the next reader somebody adds
+// racing the same write.
 //
 // A gatekit.Waivers rather than a bare map, so the reasons are held to the same
-// standard as every other waiver in this tree and a stale entry is reported by
-// the mechanism that already does that, instead of by a second copy of it here.
+// standard as every other waiver here and a stale entry is reported by the
+// mechanism that already does that.
 var parallelExempt = gatekit.Waive(map[string]string{
 	// t.Setenv panics outright in a parallel test — the environment is
 	// process-wide, so Go refuses the combination rather than letting one
 	// test's variable leak into another's.
 	"TestTheSchemaAndTheParserAgreeOnEveryInputDeclaration": "calls t.Setenv, which Go forbids in a parallel test",
-	// Under -update-citations another gate REWRITES the file this one reads.
-	// Go resumes parallel tests only once every sequential one has finished, so
-	// staying sequential is what orders the read before the rewrite.
-	"TestTheCitationRegisterIsSortedAndUnique": "reads danglingcitations.txt, which -update-citations rewrites from another gate",
+	// Rewrites ../docs/reference/gate-inventory.md under -update-gate-inventory.
+	// The gates that walk ../docs — link targets, rulebook direction, page
+	// length — read that file.
+	"TestTheGateInventoryPageIsCurrent": "rewrites the inventory page under -update-gate-inventory, which the docs gates read",
+	// Rewrites danglingcitations.txt under -update-citations, which
+	// TestTheCitationRegisterIsSortedAndUnique reads.
+	"TestEveryCitedMigrationExists": "rewrites the citation register under -update-citations, which the register gate reads",
 })
+
+// parallelCensusFloor sits below the real number of gate tests, so a walk that
+// stopped finding them fails rather than reporting that all nought are parallel.
+const parallelCensusFloor = 250
 
 func TestEveryGateRunsInParallelWithTheOthers(t *testing.T) {
 	t.Parallel()
 	// The sole sweep of this declaration, as gatekit requires: matched
 	// accumulates across the package, so a second caller would report staleness
 	// that is not there.
-	defer parallelExempt.AssertAllMatched(t)
-
-	// Below the real count, so a walk that stopped finding gates fails here
-	// rather than reporting that all nought of them are parallel.
-	const gateFloor = 250
-
-	paths, err := filepath.Glob(filepath.Join(gateDir, "*_test.go"))
-	if err != nil {
-		t.Fatalf("listing the gate sources: %v", err)
+	//
+	// Only under the default build, and that is not a skip: two of the three
+	// exempt gates live in `!integration` files, so with the tag set they are
+	// not in the package at all. Their entries would then match no subject —
+	// which means "excluded by a build tag" and not "ratifies code that is
+	// gone". The default build contains every gate, so staleness is judged
+	// there, on the whole set, every run.
+	if !builtWithIntegrationTag {
+		defer parallelExempt.AssertAllMatched(t)
 	}
 
-	fset := token.NewFileSet()
-	serial, seen := []string{}, 0
-	for _, path := range paths {
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			t.Fatalf("parsing %s: %v", path, parseErr)
+	var serial, exemptButParallel []string
+	seen := 0
+	for _, path := range activeGateSources(t) {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
 		}
-		for _, decl := range file.Decls {
+		for _, decl := range parseGateFile(t, path, source).Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") || fn.Name.Name == "TestMain" {
+			if !ok || !isGateTest(fn) {
 				continue
 			}
 			seen++
+			named := filepath.Base(path) + ":" + fn.Name.Name
+			if callsParallelFirst(fn) {
+				// A gate that complies needs no exemption, and one that has
+				// both has lost whatever the exemption was for. Subjects()
+				// rather than Waived(): asking must not MARK the entry, or a
+				// waiver stays green by being consulted while the reason it
+				// ratifies is gone — which is the failure AssertAllMatched
+				// exists to report.
+				//
+				// Both then fire, deliberately: the sweep reports it as a key
+				// that matched nothing, which is true but reads as a rename,
+				// and this says what actually happened.
+				if slices.Contains(parallelExempt.Subjects(), fn.Name.Name) {
+					exemptButParallel = append(exemptButParallel, named)
+				}
+				continue
+			}
 			if parallelExempt.Waived(t, fn.Name.Name) {
 				continue
 			}
-			if !callsParallelFirst(fn) {
-				serial = append(serial, filepath.Base(path)+":"+fn.Name.Name)
-			}
+			serial = append(serial, named)
 		}
 	}
 
-	if seen < gateFloor {
-		t.Fatalf("found %d gate(s) and expected at least %d — this census stopped seeing the "+
-			"package rather than the package having shrunk", seen, gateFloor)
+	if seen < parallelCensusFloor {
+		t.Fatalf("found %d gate test(s) and expected at least %d — this census stopped seeing the "+
+			"package rather than the package having shrunk", seen, parallelCensusFloor)
 	}
 	for _, name := range serial {
 		t.Errorf("%s does not open with t.Parallel(). These gates are readers and run "+
@@ -106,15 +138,61 @@ func TestEveryGateRunsInParallelWithTheOthers(t *testing.T) {
 			"nothing fails to say so. Add the call, or name it in parallelExempt with the reason "+
 			"it cannot take one", name)
 	}
+	for _, name := range exemptButParallel {
+		t.Errorf("%s is named in parallelExempt but opens with t.Parallel(). Something about that "+
+			"gate needs it sequential and the call has taken that away, while the entry still "+
+			"reads as ratifying it: remove one or the other", name)
+	}
+}
+
+// activeGateSources is the gate files THIS BUILD compiles, not every file on
+// disk whose name ends in _test.go.
+//
+// Thirteen gates carry `//go:build !integration`, so a glob and the compiler
+// disagree by that many whenever the integration tag is set — and this census
+// would then judge functions the build does not contain, reporting a serial
+// test that Go never runs. go/build answers the question the compiler answered.
+func activeGateSources(t *testing.T) []string {
+	t.Helper()
+	ctx := build.Default
+	if builtWithIntegrationTag {
+		ctx.BuildTags = append(ctx.BuildTags, "integration")
+	}
+	pkg, err := ctx.ImportDir(gateDir, 0)
+	if err != nil {
+		t.Fatalf("asking go/build which sources %s compiles: %v", gateDir, err)
+	}
+	paths := make([]string, 0, len(pkg.TestGoFiles))
+	for _, name := range pkg.TestGoFiles {
+		paths = append(paths, filepath.Join(gateDir, name))
+	}
+	return paths
+}
+
+// isGateTest reports whether a declaration is one of this package's gates.
+//
+// Shared with the inventory census rather than spelled twice: two gates
+// deciding "is this a gate?" independently answer differently the day either is
+// corrected.
+func isGateTest(fn *ast.FuncDecl) bool {
+	if fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+		return false
+	}
+	// TestMain is the package's entry point and not one of its tests — Go runs
+	// it INSTEAD of the tests and hands them to it.
+	return fn.Name.Name != "TestMain"
 }
 
 // callsParallelFirst reports whether the function's FIRST statement is
-// t.Parallel().
+// t.Parallel() on its own *testing.T.
 //
 // First, not merely present: Go runs a parallel test's body up to the call
 // synchronously, so work above it is serial work that reads as parallel. A gate
 // that walked the tree and then called t.Parallel() would look annotated and
 // buy nothing.
+//
+// The receiver is read from the signature rather than assumed to be `t`, so a
+// gate is judged on what it does and not on what it named its parameter.
 func callsParallelFirst(fn *ast.FuncDecl) bool {
 	if fn.Body == nil || len(fn.Body.List) == 0 {
 		return false
@@ -132,5 +210,18 @@ func callsParallelFirst(fn *ast.FuncDecl) bool {
 		return false
 	}
 	receiver, ok := selector.X.(*ast.Ident)
-	return ok && receiver.Name == "t"
+	return ok && receiver.Name == testingParamName(fn)
+}
+
+// testingParamName is what a test calls its *testing.T, or "" for a signature
+// that names nothing — which matches no identifier, so such a function is
+// reported rather than silently accepted.
+func testingParamName(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return ""
+	}
+	if names := fn.Type.Params.List[0].Names; len(names) > 0 {
+		return names[0].Name
+	}
+	return ""
 }

--- a/backend/gates/parallelgates_test.go
+++ b/backend/gates/parallelgates_test.go
@@ -52,6 +52,10 @@ var parallelExempt = gatekit.Waive(map[string]string{
 	// process-wide, so Go refuses the combination rather than letting one
 	// test's variable leak into another's.
 	"TestTheSchemaAndTheParserAgreeOnEveryInputDeclaration": "calls t.Setenv, which Go forbids in a parallel test",
+	// Under -update-citations another gate REWRITES the file this one reads.
+	// Go resumes parallel tests only once every sequential one has finished, so
+	// staying sequential is what orders the read before the rewrite.
+	"TestTheCitationRegisterIsSortedAndUnique": "reads danglingcitations.txt, which -update-citations rewrites from another gate",
 })
 
 func TestEveryGateRunsInParallelWithTheOthers(t *testing.T) {

--- a/backend/gates/parallelgates_test.go
+++ b/backend/gates/parallelgates_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H3
+
+package gates
+
+// Every gate here runs in parallel with the others, and this is what keeps that
+// true as gates are added.
+//
+// These tests are readers: each walks the tree, parses what it finds and judges
+// it. Serially that was 102 s and the longest single test was 5.4 s — a flat
+// tail of ~100 independent walks, not a hot spot — which is exactly the shape
+// parallelism answers. With t.Parallel() it is 18 s.
+//
+// The reason this needs a gate rather than a convention: a gate added without
+// the call still PASSES. It just runs alone while the others share the machine,
+// and the suite gets a little slower every time. Nothing fails, so nothing
+// tells anybody — the cost arrives as a number in a CI log that nobody is
+// comparing against last month's.
+//
+// WHAT MAKES IT SAFE, since a package of parallel tests sharing state is a fair
+// thing to worry about: the state they share is each gatekit.Waivers set, whose
+// `matched` map is mutex-guarded, and whose AssertAllMatched must be called
+// from exactly one place per declaration — held by
+// TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce. Getting that wrong
+// under parallelism reports staleness that is not there, which is a LOUD
+// failure rather than a gate quietly passing.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// parallelExempt names the gates that cannot take t.Parallel(), with the reason.
+//
+// Keyed by test name rather than by file: the obligation is a property of the
+// function, and a file-keyed exemption would silently cover every gate that
+// later joins that file.
+//
+// A gatekit.Waivers rather than a bare map, so the reasons are held to the same
+// standard as every other waiver in this tree and a stale entry is reported by
+// the mechanism that already does that, instead of by a second copy of it here.
+var parallelExempt = gatekit.Waive(map[string]string{
+	// t.Setenv panics outright in a parallel test — the environment is
+	// process-wide, so Go refuses the combination rather than letting one
+	// test's variable leak into another's.
+	"TestTheSchemaAndTheParserAgreeOnEveryInputDeclaration": "calls t.Setenv, which Go forbids in a parallel test",
+})
+
+func TestEveryGateRunsInParallelWithTheOthers(t *testing.T) {
+	t.Parallel()
+	// The sole sweep of this declaration, as gatekit requires: matched
+	// accumulates across the package, so a second caller would report staleness
+	// that is not there.
+	defer parallelExempt.AssertAllMatched(t)
+
+	// Below the real count, so a walk that stopped finding gates fails here
+	// rather than reporting that all nought of them are parallel.
+	const gateFloor = 250
+
+	paths, err := filepath.Glob(filepath.Join(gateDir, "*_test.go"))
+	if err != nil {
+		t.Fatalf("listing the gate sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	serial, seen := []string{}, 0
+	for _, path := range paths {
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", path, parseErr)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") || fn.Name.Name == "TestMain" {
+				continue
+			}
+			seen++
+			if parallelExempt.Waived(t, fn.Name.Name) {
+				continue
+			}
+			if !callsParallelFirst(fn) {
+				serial = append(serial, filepath.Base(path)+":"+fn.Name.Name)
+			}
+		}
+	}
+
+	if seen < gateFloor {
+		t.Fatalf("found %d gate(s) and expected at least %d — this census stopped seeing the "+
+			"package rather than the package having shrunk", seen, gateFloor)
+	}
+	for _, name := range serial {
+		t.Errorf("%s does not open with t.Parallel(). These gates are readers and run "+
+			"concurrently; one that does not costs the suite its own runtime on every run, and "+
+			"nothing fails to say so. Add the call, or name it in parallelExempt with the reason "+
+			"it cannot take one", name)
+	}
+}
+
+// callsParallelFirst reports whether the function's FIRST statement is
+// t.Parallel().
+//
+// First, not merely present: Go runs a parallel test's body up to the call
+// synchronously, so work above it is serial work that reads as parallel. A gate
+// that walked the tree and then called t.Parallel() would look annotated and
+// buy nothing.
+func callsParallelFirst(fn *ast.FuncDecl) bool {
+	if fn.Body == nil || len(fn.Body.List) == 0 {
+		return false
+	}
+	expr, ok := fn.Body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := expr.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Parallel" {
+		return false
+	}
+	receiver, ok := selector.X.(*ast.Ident)
+	return ok && receiver.Name == "t"
+}

--- a/backend/gates/passportmint_test.go
+++ b/backend/gates/passportmint_test.go
@@ -46,6 +46,7 @@ const passportOwner = "internal/modules/identity"
 // So every call site must pass an identity it READ from the request context,
 // never one it built. identityFrom is the only way to obtain one honestly.
 func TestEveryPassportMintTakesItsUserFromTheSession(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	calls := 0
 	roots := []string{"internal", "cmd"}
@@ -94,6 +95,7 @@ func TestEveryPassportMintTakesItsUserFromTheSession(t *testing.T) {
 }
 
 func TestOnlyIdentityMintsAPassportAndOnlyForTheSessionUser(t *testing.T) {
+	t.Parallel()
 	var inserts []string
 	roots := []string{"internal", "cmd"}
 	for _, root := range roots {

--- a/backend/gates/personprofilefieldwriter_test.go
+++ b/backend/gates/personprofilefieldwriter_test.go
@@ -72,6 +72,7 @@ func isCarryOver(sql string) bool { return carryOverSource.MatchString(sql) }
 var carryOverSource = regexp.MustCompile(`(?is)INSERT\s+INTO\s+person_profile_field.*\bFROM\s+person_profile_field\b`)
 
 func TestEveryProfileFieldWriteUsesTheOneWriter(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching describes a write that has moved or
 	// been folded in, and leaving it quietly re-exempts whatever takes its name.
 	defer bulkRelinkIsNotAFill.AssertAllMatched(t)
@@ -197,6 +198,7 @@ var personProfileFieldProbes = []struct {
 // The waiver's second half, read directly: a file key alone would ratify the
 // topic, and this is what makes it ratify the instance.
 func TestOnlyACarryOverIsRatifiedInTheMergeRelink(t *testing.T) {
+	t.Parallel()
 	carryOver := "INSERT INTO person_profile_field\n  (person_id, field, value)\n  SELECT $2, field, value\n    FROM person_profile_field WHERE person_id = $1\n  ON CONFLICT (person_id, field) DO NOTHING"
 	if !isCarryOver(carryOver) {
 		t.Error("the merge relink's own statement is not recognised as a carry-over, so its waiver ratifies nothing")
@@ -210,6 +212,7 @@ func TestOnlyACarryOverIsRatifiedInTheMergeRelink(t *testing.T) {
 }
 
 func TestTheProfileFieldWriteDetectorSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	for _, tc := range personProfileFieldProbes {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/gates/personscrub_test.go
+++ b/backend/gates/personscrub_test.go
@@ -84,6 +84,7 @@ var clearedOnlyByTheEraser = gatekit.Waive(map[string]string{
 var clearedOnlyByTheAnonymize = gatekit.Waive(map[string]string{})
 
 func TestErasingAndAnonymizingClearTheSameTables(t *testing.T) {
+	t.Parallel()
 	defer clearedOnlyByTheEraser.AssertAllMatched(t)
 	defer clearedOnlyByTheAnonymize.AssertAllMatched(t)
 

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -527,6 +527,7 @@ func statementDestroying(statements []string, table, column string) string {
 }
 
 func TestErasureAndSARReachEveryPIITable(t *testing.T) {
+	t.Parallel()
 	writes := map[string]bool{}
 	for _, path := range erasureCascadeFiles {
 		for _, lit := range sqlLiterals(t, path) {

--- a/backend/gates/pollcadenceparity_test.go
+++ b/backend/gates/pollcadenceparity_test.go
@@ -70,6 +70,7 @@ var (
 const faultSource = "internal/platform/jobs/fault.go"
 
 func TestEveryPostponingConnectorPostponesByItsOwnDeclaredCadence(t *testing.T) {
+	t.Parallel()
 	ceiling, hasCeiling := durationIn(t, faultSource, rescheduleCeiling, "the postponement ceiling")
 	if !hasCeiling {
 		t.Fatalf("%s declares no maxRescheduleDelay — either the seam stopped clamping a postponement, in which case delete this half of the gate, or this expression no longer finds the bound", faultSource)

--- a/backend/gates/positionalrowscan_test.go
+++ b/backend/gates/positionalrowscan_test.go
@@ -38,6 +38,7 @@ import (
 var positionalScanTrees = []string{".", "../extensions", "../fixtures"}
 
 func TestAPositionalRowScanTargetsItsOwnPackagesStruct(t *testing.T) {
+	t.Parallel()
 	calls := 0
 	for _, root := range positionalScanTrees {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/backend/gates/precheckwiring_test.go
+++ b/backend/gates/precheckwiring_test.go
@@ -76,6 +76,7 @@ func parseComposeFiles(t *testing.T, root string) []composeFile {
 }
 
 func TestEveryPrecheckInComposeIsWired(t *testing.T) {
+	t.Parallel()
 	files := parseComposeFiles(t, filepath.Join("internal", "compose"))
 
 	// Keyed by package AND name: two compose subpackages may each declare a

--- a/backend/gates/profilefieldreaders_test.go
+++ b/backend/gates/profilefieldreaders_test.go
@@ -143,6 +143,7 @@ func unoverlaidValueReaders(file *ast.File) []string {
 }
 
 func TestEveryReaderServingProfileFieldValuesConsultsTheVerdictLedger(t *testing.T) {
+	t.Parallel()
 	defer profileFieldValueReaders.AssertAllMatched(t)
 	files := profileFieldReaderScope.Files(t)
 	if len(files) == 0 {
@@ -174,6 +175,7 @@ func TestEveryReaderServingProfileFieldValuesConsultsTheVerdictLedger(t *testing
 // Each was found by a person or a bot, not by the gate, which is the argument
 // for this test.
 func TestTheProfileFieldCensusSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	for name, tc := range map[string]struct {
 		source string
 		want   []string

--- a/backend/gates/promptfence_test.go
+++ b/backend/gates/promptfence_test.go
@@ -104,6 +104,7 @@ func goFilesUnderTree(t *testing.T, visit func(path, code string)) {
 }
 
 func TestNoPromptDeclaresAFixedDataBoundary(t *testing.T) {
+	t.Parallel()
 	var offenders []string
 	goFilesUnderTree(t, func(path, body string) {
 		if strings.HasPrefix(path, promptfencePackage) {
@@ -132,6 +133,7 @@ func TestNoPromptDeclaresAFixedDataBoundary(t *testing.T) {
 // lane — making the promise with no nonce behind it anywhere, which is the shape
 // every instance found so far has taken.
 func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
+	t.Parallel()
 	var offenders []string
 	claimants := 0
 	goFilesUnderTree(t, func(path, body string) {
@@ -167,6 +169,7 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 // still names a claim, not that the claim still needs waiving — a file that now
 // mints its fence as well still matches, and stays matched.
 func TestEveryBoundaryClaimWaiverIsStillReachable(t *testing.T) {
+	t.Parallel()
 	defer claimWithoutFence.AssertAllMatched(t)
 	goFilesUnderTree(t, func(path, body string) {
 		if boundaryClaim.MatchString(body) {

--- a/backend/gates/promptlanguage_test.go
+++ b/backend/gates/promptlanguage_test.go
@@ -63,6 +63,7 @@ var promptTrees = []string{
 }
 
 func TestEveryPromptSaysWhatLanguageToAnswerIn(t *testing.T) {
+	t.Parallel()
 	// The two rule spellings must stay recognisable to one gate. A block that
 	// stopped opening with the heading would leave every drafting surface
 	// looking unguarded, and the gate would fail loudly rather than quietly
@@ -87,6 +88,7 @@ func TestEveryPromptSaysWhatLanguageToAnswerIn(t *testing.T) {
 }
 
 func TestEveryPromptLanguageWaiverGivesAReason(t *testing.T) {
+	t.Parallel()
 	for _, site := range everyModelRequest(t) {
 		if site.waived && site.waiverReason == "" {
 			t.Errorf("%s waives the language rule without saying why. A waiver nobody can check is one nobody will revisit: "+
@@ -347,6 +349,7 @@ func readSource(t *testing.T, path string) string {
 // second block — correspondence follows the correspondence's language, not the
 // installation's, and it says so where it is declared.
 func TestOnlyPromptlangSpellsTheLanguageRule(t *testing.T) {
+	t.Parallel()
 	const (
 		owner     = "internal/compose/promptlang/promptlang.go"
 		sanctionA = "internal/compose/draftrules"
@@ -402,6 +405,7 @@ func TestOnlyPromptlangSpellsTheLanguageRule(t *testing.T) {
 // reaches a model exactly like a literal does, and would carry no rule while
 // the gate stayed green.
 func TestAModelRequestIsBuiltAsALiteral(t *testing.T) {
+	t.Parallel()
 	for _, tree := range promptTrees {
 		err := filepath.WalkDir(tree, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {

--- a/backend/gates/promptversionderived_test.go
+++ b/backend/gates/promptversionderived_test.go
@@ -357,6 +357,7 @@ func collectIdents(node ast.Node, into map[string]bool) {
 }
 
 func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
+	t.Parallel()
 	packages := promptSurfacePackages(t)
 	var findings, unreadable []string
 	declaring := 0
@@ -401,6 +402,7 @@ func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
 }
 
 func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
+	t.Parallel()
 	// A ratification that stops matching is one for a prompt that has moved or
 	// been folded in, and leaving it quietly re-exempts whatever takes its name.
 	defer uncachedPrompts.AssertAllMatched(t)
@@ -451,6 +453,7 @@ func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
 // A census asserting a shape is ABSENT passes identically over a clean tree and
 // over a detector that has stopped detecting.
 func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"briefSystem", "askSystem", "dossierSystem", "growthFitSystem", "judgeSystemPrompt"} {
 		if !promptConstantName.MatchString(name) {
 			t.Errorf("the census does not recognise %q as a prompt constant", name)

--- a/backend/gates/promptvoice_test.go
+++ b/backend/gates/promptvoice_test.go
@@ -63,6 +63,7 @@ var voiceRuleHeading = promptvoice.Heading
 const voiceWaiverPrefix = "//promptvoice:exempt"
 
 func TestEveryPromptEitherSpeaksInTheOneVoiceOrSaysWhyNot(t *testing.T) {
+	t.Parallel()
 	sites := everyModelRequest(t)
 	if len(sites) == 0 {
 		t.Fatal("found no model.Request literals at all; this gate would pass vacuously")
@@ -79,6 +80,7 @@ func TestEveryPromptEitherSpeaksInTheOneVoiceOrSaysWhyNot(t *testing.T) {
 }
 
 func TestEveryVoiceWaiverGivesAReason(t *testing.T) {
+	t.Parallel()
 	for _, site := range everyModelRequest(t) {
 		if site.voiceWaived && site.voiceWaiverReason == "" {
 			t.Errorf("%s waives the voice without saying why. A waiver nobody can check is one nobody will "+
@@ -97,6 +99,7 @@ func TestEveryVoiceWaiverGivesAReason(t *testing.T) {
 // a file waiving one and not the other is the case that proves they are read
 // separately.
 func TestTheVoiceWaiverIsItsOwnAnswer(t *testing.T) {
+	t.Parallel()
 	languageOnly := 0
 	for _, site := range everyModelRequest(t) {
 		if site.waived && !site.voiceWaived {

--- a/backend/gates/publicevents_test.go
+++ b/backend/gates/publicevents_test.go
@@ -78,6 +78,7 @@ func subscribableTypes() []string {
 }
 
 func TestEverySubscribableEventHasAPayloadSchema(t *testing.T) {
+	t.Parallel()
 	var uncovered []string
 	for _, tp := range subscribableTypes() {
 		if _, ok := crmcontracts.PublicEventVersions[tp]; !ok {
@@ -91,6 +92,7 @@ func TestEverySubscribableEventHasAPayloadSchema(t *testing.T) {
 }
 
 func TestNoOrphanPayloadSchema(t *testing.T) {
+	t.Parallel()
 	catalog := map[string]bool{}
 	for _, tp := range events.Types() {
 		catalog[tp] = true
@@ -103,6 +105,7 @@ func TestNoOrphanPayloadSchema(t *testing.T) {
 }
 
 func TestPayloadVersionsMatchCatalog(t *testing.T) {
+	t.Parallel()
 	for tp, wantVersion := range crmcontracts.PublicEventVersions {
 		if got := events.VersionOf(tp); got != wantVersion {
 			t.Errorf("version drift for %q: events.VersionOf = %d, PublicEventVersions = %d (contract x-version and catalog.go disagree)", tp, got, wantVersion)
@@ -176,6 +179,7 @@ func parseSubscribableEventTypeEnum(t *testing.T) []string {
 // PublicEvent<Event> schema but is never appended to the enum drifts
 // silently, and the picker quietly under-offers it forever.
 func TestSubscribableEventTypeEnumMatchesPayloadCatalog(t *testing.T) {
+	t.Parallel()
 	enum := map[string]bool{}
 	for _, tp := range parseSubscribableEventTypeEnum(t) {
 		if enum[tp] {
@@ -231,6 +235,7 @@ var dynamicProbeResolved = gatekit.Waive(map[string]string{
 })
 
 func TestEverySubscribableEventIsDeliveryResolvable(t *testing.T) {
+	t.Parallel()
 	defer dynamicProbeResolved.AssertAllMatched(t)
 	entityByEvent := parseContractEntityTypes(t)
 	c := parseDeliveryClassification(t)
@@ -458,6 +463,7 @@ func stringLit(t *testing.T, expr ast.Expr) string {
 // events (capture.* via EmitPipeline, a distinct function) are exempt by
 // construction: they carry no PublicEvent schema and use a different call.
 func TestNoRawEmitForSubscribableEvent(t *testing.T) {
+	t.Parallel()
 	subscribable := map[string]bool{}
 	for tp := range crmcontracts.PublicEventVersions {
 		subscribable[tp] = true

--- a/backend/gates/publicreferences_test.go
+++ b/backend/gates/publicreferences_test.go
@@ -66,6 +66,7 @@ var scanned = map[string]bool{
 }
 
 func TestPublicTreeCitesNothingPrivate(t *testing.T) {
+	t.Parallel()
 	out, err := exec.Command("git", "-C", "..", "ls-files", "-z").Output()
 	if err != nil {
 		t.Fatalf("listing tracked files: %v (this test must run inside the git worktree)", err)

--- a/backend/gates/rbacbaselineerafixture_test.go
+++ b/backend/gates/rbacbaselineerafixture_test.go
@@ -65,6 +65,7 @@ const (
 )
 
 func TestBaselineEraFixtureIsTheMatrixTheBaselineSeeded(t *testing.T) {
+	t.Parallel()
 	assertCommitIsTheUpgradeFloor(t)
 	derived := baselineEraFromHistory(t)
 	committed := readJSONFixture(t, baselineEraFixture)
@@ -96,6 +97,7 @@ func TestBaselineEraFixtureIsTheMatrixTheBaselineSeeded(t *testing.T) {
 // integration arm refuses that too, but only later, in the database lane; here it
 // is cheap, and this is the lane that runs on every push.
 func TestBaselineEraFixtureStillDiffersFromTheSeededMatrix(t *testing.T) {
+	t.Parallel()
 	before := readJSONFixture(t, baselineEraFixture)
 	after := readJSONFixture(t, seededDefaultsPath)
 

--- a/backend/gates/rbacgate_test.go
+++ b/backend/gates/rbacgate_test.go
@@ -632,6 +632,7 @@ func reachesAuthGate(fns map[string]*gateFnInfo, name string, seen map[string]bo
 }
 
 func TestEveryStoreEntryPointIsAuthGated(t *testing.T) {
+	t.Parallel()
 	defer ungatedEntryPoints.AssertAllMatched(t)
 	defer entryPointsOutsideModules.AssertAllMatched(t)
 

--- a/backend/gates/rbacvocabulary_test.go
+++ b/backend/gates/rbacvocabulary_test.go
@@ -45,6 +45,7 @@ const (
 )
 
 func TestContractObjectEnumMatchesPolicyVocabulary(t *testing.T) {
+	t.Parallel()
 	contract := contractSchema(t, "RbacObject").Enum
 	if len(contract) == 0 {
 		t.Fatal("api/crm.yaml declares no RbacObject enum; the vocabulary the web client " +
@@ -87,6 +88,7 @@ func TestContractObjectEnumMatchesPolicyVocabulary(t *testing.T) {
 // fifth action cannot exist without a fifth field, which is what makes this
 // derivation total rather than a spot check.
 func TestContractActionEnumMatchesObjectGrant(t *testing.T) {
+	t.Parallel()
 	fields := objectGrantActions(t)
 	if len(fields) == 0 {
 		t.Fatal("parsed no fields from principal.ObjectGrant; the struct this gate derives from has moved")

--- a/backend/gates/registrarparity_test.go
+++ b/backend/gates/registrarparity_test.go
@@ -74,6 +74,7 @@ var fullToolRegistries = []struct{ path, builder, claim string }{
 type toolRegistrar struct{ name, at string }
 
 func TestEveryToolRegistrarIsInvokedByEveryFullRegistry(t *testing.T) {
+	t.Parallel()
 	registrars, methods := toolRegistrars(t)
 	if len(registrars) < toolRegistrarFloor {
 		t.Fatalf("discovered only %d tool registrars in %s, expected at least %d: the AST derivation broke, not the subject — a registrar is a package-level func taking *%s, and this gate is currently certifying every builder against an empty list",

--- a/backend/gates/replayscope_test.go
+++ b/backend/gates/replayscope_test.go
@@ -106,6 +106,7 @@ type expectedTarget struct {
 const replayScopeSource = "internal/compose/replayscope.go"
 
 func TestReplayScopeCoversEveryIdempotentOperation(t *testing.T) {
+	t.Parallel()
 	governance := mappedReplayScope(t)
 	responses := successResponseSchemas(t)
 

--- a/backend/gates/requiredbodyids_test.go
+++ b/backend/gates/requiredbodyids_test.go
@@ -94,6 +94,7 @@ var unguardedRequiredIDBodies = gatekit.Waive(map[string]string{
 })
 
 func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {
+	t.Parallel()
 	bodies := contractBodiesWithARequiredID(t)
 	if len(bodies) == 0 {
 		t.Fatalf("no request body in %s declares a required non-pointer UUID — the walk is reading "+

--- a/backend/gates/resetflushscope_test.go
+++ b/backend/gates/resetflushscope_test.go
@@ -42,6 +42,7 @@ const (
 )
 
 func TestOnlyTheGatedResetFlushClearsTheAuthLockouts(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, resetFlushFile, nil, 0)
 	if err != nil {

--- a/backend/gates/resetwireshape_test.go
+++ b/backend/gates/resetwireshape_test.go
@@ -42,6 +42,7 @@ const (
 var requiredList = regexp.MustCompile(`^\s*required:\s*\[([^\]]*)\]`)
 
 func TestResetDataResponseMatchesTheContract(t *testing.T) {
+	t.Parallel()
 	contract := resetDataRequiredFields(t)
 	if len(contract) == 0 {
 		t.Fatalf("no required field list found for the resetData 200 response in %s — "+

--- a/backend/gates/restrictedreaders_test.go
+++ b/backend/gates/restrictedreaders_test.go
@@ -139,6 +139,7 @@ func unguardedActivityReaders(file *ast.File) []string {
 }
 
 func TestEveryReaderOfTheActivityTableExcludesRestrictedRows(t *testing.T) {
+	t.Parallel()
 	defer restrictedReadersAdmitted.AssertAllMatched(t)
 	for _, src := range activityReaderScope.Files(t) {
 		if restrictedReadersAdmitted.Waived(t, src.Path) {

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -19,6 +19,7 @@ package gates
 import "testing"
 
 func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
+	t.Parallel()
 	const table, column = "activity", "counterparty_email"
 
 	for _, tc := range []struct {
@@ -94,6 +95,7 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 // statement, so an unrelated statement — or a helper nothing calls — cannot
 // answer for an erasure that no longer happens.
 func TestDeclaredErasuresMustArriveInOneStatement(t *testing.T) {
+	t.Parallel()
 	declared := []string{"body = NULL", "raw = NULL"}
 
 	together := []string{`update activity set body = null, raw = null, subject = $2 where id = $1`}

--- a/backend/gates/retentionscope_test.go
+++ b/backend/gates/retentionscope_test.go
@@ -47,6 +47,7 @@ const (
 // own entry point the same way and for the same reason.
 
 func TestRetentionPassCtxOnlyDrivesTheRetentionPass(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	references := 0
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
@@ -120,6 +121,7 @@ func TestRetentionPassCtxOnlyDrivesTheRetentionPass(t *testing.T) {
 // instead of by luck: exactly one declaration, in the package that owns the
 // retention engine.
 func TestTheRetentionScopeSinkIsTheOneTheGateMeans(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	var found []string
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {

--- a/backend/gates/rlsclaims_test.go
+++ b/backend/gates/rlsclaims_test.go
@@ -53,6 +53,7 @@ var rlsClaim = regexp.MustCompile(`(?i)\bRLS[ -](?:scope|bound|confine|restrict|
 // three that must survive it. A gate whose pattern silently stopped matching
 // would read exactly like a clean tree.
 func TestTheRLSClaimPatternCatchesTheSpellingsThisTreeGrew(t *testing.T) {
+	t.Parallel()
 	mustMatch := []string{
 		"// EmailSuppressed reports whether an address belongs to an erased subject in the current workspace (RLS scopes the read).",
 		"// members (row-scoped by RLS), optionally filtered by in.Q.",
@@ -85,6 +86,7 @@ func TestTheRLSClaimPatternCatchesTheSpellingsThisTreeGrew(t *testing.T) {
 // license notice covers — derived from the tree, so a new file is enrolled the
 // moment it exists.
 func TestNoGoSourceClaimsRLSStillScopesARead(t *testing.T) {
+	t.Parallel()
 	var claims []string
 	checked := 0
 	for _, tree := range licensedTrees {

--- a/backend/gates/rowgatespelling_test.go
+++ b/backend/gates/rowgatespelling_test.go
@@ -70,6 +70,7 @@ type rowGateFn struct {
 }
 
 func TestNoWriteResolvesItsRowThroughAPackagesReadSpelling(t *testing.T) {
+	t.Parallel()
 	byDir := rowGateIndex(t)
 	pairs := 0
 	for _, fns := range byDir {

--- a/backend/gates/rulebookdelegation_test.go
+++ b/backend/gates/rulebookdelegation_test.go
@@ -83,6 +83,7 @@ func rulebookDirs(t *testing.T) []string {
 // opens, so a Claude session in that directory works without those rules and
 // nothing says so.
 func TestEveryRulebookHasAClaudeShim(t *testing.T) {
+	t.Parallel()
 	for _, dir := range rulebookDirs(t) {
 		shim := filepath.Join(dir, "CLAUDE.md")
 		if _, err := os.Stat(shim); err != nil {
@@ -105,6 +106,7 @@ func TestEveryRulebookHasAClaudeShim(t *testing.T) {
 // only that line cannot hold a fence to hide it in, which is the second reason
 // this shape is the one to gate.
 func TestEveryClaudeShimIsNothingButTheImport(t *testing.T) {
+	t.Parallel()
 	for _, dir := range rulebookDirs(t) {
 		path := filepath.Join(dir, "CLAUDE.md")
 		raw, err := os.ReadFile(path)

--- a/backend/gates/rulebookdirection_test.go
+++ b/backend/gates/rulebookdirection_test.go
@@ -50,6 +50,7 @@ import (
 var upwardLink = regexp.MustCompile(`]\(\s*[^)\s]*(?:AGENTS|CLAUDE)\.md(?:#[^)\s]*)?\s*\)`)
 
 func TestNothingUnderDocsLinksUpToARulebook(t *testing.T) {
+	t.Parallel()
 	const docsRoot = "../docs"
 
 	scanned := 0
@@ -96,6 +97,7 @@ func TestNothingUnderDocsLinksUpToARulebook(t *testing.T) {
 // the pattern stopped naming a path spelling: every `want: true` row below except
 // the first is a link the `(?:\.\./)+` spelling reported as clean.
 func TestTheUpwardLinkPatternSeesEverySpellingOfTheDefect(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		line string

--- a/backend/gates/rulebooklength_test.go
+++ b/backend/gates/rulebooklength_test.go
@@ -60,6 +60,7 @@ var ceilings = map[string]int{
 }
 
 func TestNoRulebookGrowsPastItsCeiling(t *testing.T) {
+	t.Parallel()
 	dirs := rulebookDirs(t)
 	if len(dirs) == 0 {
 		t.Fatal("rulebookDirs found no AGENTS.md at all — this gate would pass by " +

--- a/backend/gates/rulebooktally_test.go
+++ b/backend/gates/rulebooktally_test.go
@@ -106,6 +106,7 @@ func tallyParagraphs(path string) ([]prosePara, error) {
 }
 
 func TestNoRulebookSpellsOutACountableTally(t *testing.T) {
+	t.Parallel()
 	for _, path := range rulebookProse(t) {
 		// Every path here comes from the walk or is the catalog the rulebook
 		// sends a reader to, so all of them exist. An unreadable one is a
@@ -230,6 +231,7 @@ func indented(line string) bool {
 // tally (the gate agrees with a stale number) or a false one (the gate refuses
 // correct prose, which is how a gate gets switched off).
 func TestTheTallyGateReadsMarkdownCorrectly(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		md      string

--- a/backend/gates/runneractivityparity_test.go
+++ b/backend/gates/runneractivityparity_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestEveryAgentRunStatusHasAProjectionState(t *testing.T) {
+	t.Parallel()
 	statuses := checkValues(t, "agent_run_status_check")
 	if len(statuses) == 0 {
 		t.Fatal("derived no agent_run statuses; this gate would pass vacuously")

--- a/backend/gates/satellite_lifecycle_test.go
+++ b/backend/gates/satellite_lifecycle_test.go
@@ -197,6 +197,7 @@ func pathWrites(t *testing.T, file string) map[string]bool {
 }
 
 func TestEveryPersonSatelliteJoinsEveryLifecyclePathThatApplies(t *testing.T) {
+	t.Parallel()
 	satellites := personSatellites(t)
 	var missing []string
 	for _, path := range satelliteLifecyclePaths {

--- a/backend/gates/scrubverbs_test.go
+++ b/backend/gates/scrubverbs_test.go
@@ -73,6 +73,7 @@ var privacyNonScrubVerbs = gatekit.Waive(map[string]string{
 })
 
 func TestEveryPrivacyAuditVerbIsJudgedAScrubOrNot(t *testing.T) {
+	t.Parallel()
 	defer privacyNonScrubVerbs.AssertAllMatched(t)
 
 	consts := privacyPackageConstants(t)

--- a/backend/gates/seatfanout_test.go
+++ b/backend/gates/seatfanout_test.go
@@ -57,6 +57,7 @@ var triggerKeyedConstraints = []string{
 // passed" while seeding one identical ref for every seat, which is the bug
 // this exists to prevent.
 func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
+	t.Parallel()
 	calls := triggerRefCalls(t)
 	if len(calls) == 0 {
 		t.Fatal("no production call to TriggerRef was found: this gate proves nothing " +
@@ -87,6 +88,7 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 // segment redundant rather than load-bearing, and a later author reading only
 // the gate above would be told to preserve a rule that no longer holds.
 func TestTheTriggerRefStillCarriesTheWholeUniquenessKey(t *testing.T) {
+	t.Parallel()
 	sql := readMigrations(t)
 	for _, name := range triggerKeyedConstraints {
 		// The LAST mention, not the first: the baseline defines these

--- a/backend/gates/seeddemoargonparity_test.go
+++ b/backend/gates/seeddemoargonparity_test.go
@@ -65,6 +65,7 @@ var argonParityPairs = map[string]string{
 }
 
 func TestSeedDemoHashesAtTheParametersTheProductShips(t *testing.T) {
+	t.Parallel()
 	product := map[string]int64{}
 	for _, f := range argonParityFiles {
 		for k, v := range intConstants(t, f) {

--- a/backend/gates/sendattachmentcap_test.go
+++ b/backend/gates/sendattachmentcap_test.go
@@ -57,6 +57,7 @@ var goAttachmentCaps = map[string]struct {
 // TestTheSendAttachmentCapMatchesTheContract holds every Go statement of the cap
 // to the contract's own maxItems.
 func TestTheSendAttachmentCapMatchesTheContract(t *testing.T) {
+	t.Parallel()
 	want := contractAttachmentCap(t)
 	for name, site := range goAttachmentCaps {
 		src, err := os.ReadFile(site.file)

--- a/backend/gates/settingscatalog_test.go
+++ b/backend/gates/settingscatalog_test.go
@@ -40,6 +40,7 @@ import (
 var keyShape = regexp.MustCompile(`^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$`)
 
 func TestEverySettingIsUniqueWellFormedAndGoverned(t *testing.T) {
+	t.Parallel()
 	defs := compose.SettingsCatalogForTest()
 	if len(defs) == 0 {
 		t.Fatal("the settings catalog is empty; this gate would pass vacuously")
@@ -88,6 +89,7 @@ func TestEverySettingIsUniqueWellFormedAndGoverned(t *testing.T) {
 }
 
 func TestEverySettingKeyIsPrefixedByItsOwningModule(t *testing.T) {
+	t.Parallel()
 	modules, err := os.ReadDir(filepath.Join("internal", "modules"))
 	if err != nil {
 		t.Fatalf("listing modules: %v", err)
@@ -117,6 +119,7 @@ func TestEverySettingKeyIsPrefixedByItsOwningModule(t *testing.T) {
 }
 
 func TestNoSettingKeyIsAlsoADeploymentConfigKey(t *testing.T) {
+	t.Parallel()
 	// Derived from the config STRUCT, not from the example file: the template
 	// is illustrative and omits whole sections (there is no `capture:` block
 	// in it today), so comparing against it would pass vacuously for exactly
@@ -147,6 +150,7 @@ var settingsWithInjectedFreeze = map[string]string{
 }
 
 func TestEverySettingWithAnInjectedFreezeActuallyHasOne(t *testing.T) {
+	t.Parallel()
 	seen := map[string]bool{}
 	for _, d := range compose.SettingsCatalogForTest() {
 		why, wants := settingsWithInjectedFreeze[d.Key]

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -748,6 +748,7 @@ func unratifiedCrossStoreWrites(t testing.TB, waivers *gatekit.Waivers[string], 
 }
 
 func TestEveryPackageOnlyWritesTablesItOwns(t *testing.T) {
+	t.Parallel()
 	defer crossStoreWrites.AssertAllMatched(t)
 	defer indirectTableArg.AssertAllMatched(t)
 
@@ -769,6 +770,7 @@ func TestEveryPackageOnlyWritesTablesItOwns(t *testing.T) {
 // one marks its entries matched for the whole package, which would quietly
 // satisfy the staleness sweep for whichever entry this case names.
 func TestASecondCopyOfARatifiedWriteIsNotCoveredByTheFirst(t *testing.T) {
+	t.Parallel()
 	const (
 		owner = "internal/modules/people"
 		table = "activity_link"

--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -73,6 +73,7 @@ var connectionAcquirers = map[string]string{
 }
 
 func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
+	t.Parallel()
 	exempt := gatekit.Waive(map[string]string{
 		// The seeding tool, which is not a seam: it opens the transaction it
 		// then passes down, so there is no caller whose transaction could be
@@ -245,6 +246,7 @@ func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
 // gate. Each case below runs it over source holding one defect it exists for,
 // and over the repair that must read clean.
 func TestTheGateSeesASeamThatReachesForTheCatalogInsideTheCallersTransaction(t *testing.T) {
+	t.Parallel()
 	const seam = fixtureImports + `
 func (s *Store) GetPersonTx(ctx context.Context, tx pgx.Tx, id ids.PersonID) (Person, error) {
 	active, err := s.activeColumns(ctx, "person")
@@ -273,6 +275,7 @@ func (s *Store) GetPersonTx(ctx context.Context, tx pgx.Tx, id ids.PersonID, act
 // The shape the gate exists to catch most: not a named seam at all, but the
 // callback a transaction opener is handed.
 func TestTheGateSeesAnAcquireInsideATransactionCallback(t *testing.T) {
+	t.Parallel()
 	const assembler = fixtureImports + `
 func (s *Service) Assemble(ctx context.Context, id ids.PersonID) (Person, error) {
 	var out Person
@@ -311,6 +314,7 @@ func (s *Service) Assemble(ctx context.Context, id ids.PersonID) (Person, error)
 
 // A file that spells the import under another name is judged, not skipped.
 func TestTheGateFollowsAnAliasedPgxImport(t *testing.T) {
+	t.Parallel()
 	const aliased = `package people
 
 import pg "github.com/jackc/pgx/v5"
@@ -362,6 +366,7 @@ func assertGateReads(t *testing.T, src, body string, want ...string) {
 // out, not a transaction it borrows: whoever supplies the literal is judged
 // where they wrote it.
 func TestTheGateReadsAFuncTypedParameterAsItsSuppliersBusiness(t *testing.T) {
+	t.Parallel()
 	const callbackTaker = fixtureImports + `
 func (s *Store) ClaimAndEnqueue(ctx context.Context, enqueue func(tx pgx.Tx) error) error {
 	return s.claim(ctx, enqueue)

--- a/backend/gates/undoreasoncensus_test.go
+++ b/backend/gates/undoreasoncensus_test.go
@@ -89,6 +89,7 @@ func declaredReasons() []string {
 // as a raw identifier under a disabled button — and no gate here would notice,
 // because all three of the others read the list rather than the branches.
 func TestEveryReasonABranchReturnsIsListed(t *testing.T) {
+	t.Parallel()
 	body, err := parser.ParseFile(token.NewFileSet(),
 		filepath.Join("internal", "compose", "undoability.go"), nil, 0)
 	if err != nil {
@@ -112,6 +113,7 @@ func TestEveryReasonABranchReturnsIsListed(t *testing.T) {
 }
 
 func TestTheContractAdmitsExactlyTheReasonsTheEvaluatorCanReturn(t *testing.T) {
+	t.Parallel()
 	declared, published := declaredReasons(), contractReasonEnum(t)
 	if len(declared) == 0 {
 		t.Fatal("compose.Reasons is empty; the census would report agreement between two " +
@@ -129,6 +131,7 @@ func TestTheContractAdmitsExactlyTheReasonsTheEvaluatorCanReturn(t *testing.T) {
 // is the greyed button with no explanation this feature exists to remove —
 // and it fails silently, because the button still renders.
 func TestTheFrontendHasWordsForEveryReason(t *testing.T) {
+	t.Parallel()
 	copyText := readFrontendReasonCopy(t)
 	for _, reason := range declaredReasons() {
 		if !strings.Contains(copyText, reason) {
@@ -181,6 +184,7 @@ func readFrontendReasonCopy(t *testing.T) string {
 // not that the read can return a word the write cannot, or the reverse. Both
 // modes run the same branches, and this is the assertion that they do.
 func TestBothEvaluationModesCanReturnTheSameReasons(t *testing.T) {
+	t.Parallel()
 	body, err := parser.ParseFile(token.NewFileSet(),
 		filepath.Join("internal", "compose", "undoability.go"), nil, 0)
 	if err != nil {

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -201,6 +201,7 @@ func testFunctions(t *testing.T) map[string][]string {
 }
 
 func TestEveryUniquenessClaimNamesItsGateOrIsRegisteredDebt(t *testing.T) {
+	t.Parallel()
 	claims := allClaims(t)
 	registered := map[string]bool{}
 	for _, key := range readRegister(t) {
@@ -226,6 +227,7 @@ func TestEveryUniquenessClaimNamesItsGateOrIsRegisteredDebt(t *testing.T) {
 }
 
 func TestANamedGateExistsAndLivesWhereTheClaimSaysItDoes(t *testing.T) {
+	t.Parallel()
 	claims := allClaims(t)
 	tests := testFunctions(t)
 	held := 0
@@ -309,6 +311,7 @@ func namesTheFile(paths []string, want string) bool {
 // green while the collision returns. A guard the tree happens not to reach is a
 // guard with no test.
 func TestADeclarationsKeyIsUniqueWithinItsFile(t *testing.T) {
+	t.Parallel()
 	const source = `package probe
 
 type Reader interface{ Read() }
@@ -389,6 +392,7 @@ const (
 }
 
 func TestABindingDoesNotOpenTheDocCommentItSitsIn(t *testing.T) {
+	t.Parallel()
 	// Go's convention — and revive's `exported` rule — is that a doc comment
 	// opens with the identifier it documents. A binding written above that
 	// sentence turns the claim's own documentation into a footnote and fails
@@ -409,6 +413,7 @@ func TestABindingDoesNotOpenTheDocCommentItSitsIn(t *testing.T) {
 }
 
 func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
+	t.Parallel()
 	claims := allClaims(t)
 	live := map[string]bool{}
 	for _, c := range claims {
@@ -490,6 +495,7 @@ func registeredDebt() int {
 }
 
 func TestTheRegisterHoldsExactlyTheDebtItPins(t *testing.T) {
+	t.Parallel()
 	keys := readRegister(t)
 	debt := registeredDebt()
 	if len(keys) > debt {
@@ -516,6 +522,7 @@ func TestTheRegisterHoldsExactlyTheDebtItPins(t *testing.T) {
 // stops reaching claims — is paid for by editing the very row that was supposed
 // to notice.
 func TestEveryShapeAttributesTheClaimsItsCensusPins(t *testing.T) {
+	t.Parallel()
 	attributed := map[string]int{}
 	for _, c := range allClaims(t) {
 		if c.held == "" {
@@ -570,6 +577,7 @@ func TestEveryShapeAttributesTheClaimsItsCensusPins(t *testing.T) {
 }
 
 func TestTheRegisterIsSortedAndFreeOfDuplicates(t *testing.T) {
+	t.Parallel()
 	keys := readRegister(t)
 	if len(keys) == 0 {
 		t.Fatal("the register is empty — either every claim in the tree is held (in which case " +
@@ -601,6 +609,7 @@ func TestTheRegisterIsSortedAndFreeOfDuplicates(t *testing.T) {
 // matching nothing in the real tree fails, and there is nothing to fabricate:
 // the evidence is whatever the walk found.
 func TestEveryShapeEarnsItsPlaceInTheRealTree(t *testing.T) {
+	t.Parallel()
 	claims := allClaims(t)
 	perShape := map[string]string{}
 	for _, c := range claims {
@@ -653,6 +662,7 @@ func TestEveryShapeEarnsItsPlaceInTheRealTree(t *testing.T) {
 // arbitrarily and this arm stays green — a negative corpus with holes permits
 // exactly the widening it exists to refuse.
 func TestNoShapeReadsOrdinaryProseAsAClaim(t *testing.T) {
+	t.Parallel()
 	// One sentence per shape, each written to graze the shape it is paired
 	// with — the pairing is asserted below, so a case cannot quietly stop
 	// being a near-miss of anything.
@@ -701,6 +711,7 @@ func TestNoShapeReadsOrdinaryProseAsAClaim(t *testing.T) {
 // one, or every claim that happens to follow a hyphenated word goes quiet and
 // the register falls with nothing to say why.
 func TestAHyphenatedModifierIsNotAClaimAndDoesNotHideTheClaimBesideIt(t *testing.T) {
+	t.Parallel()
 	onlyNoun := claimShapes["only-noun"]
 	if onlyNoun == nil {
 		t.Fatal("the only-noun shape is gone, so the cases below prove nothing about it")
@@ -779,6 +790,7 @@ func TestAHyphenatedModifierIsNotAClaimAndDoesNotHideTheClaimBesideIt(t *testing
 // next sentence would be invisible to every arm — the two readings of one text
 // have to agree about which match is the claim.
 func TestAnIdiomDoesNotHideTheDerivedShapesRealClaim(t *testing.T) {
+	t.Parallel()
 	named := namedExhaustiveness("func Read")
 	if named == nil {
 		t.Fatal("the derived shape built nothing for a plain function, so this case proves nothing")
@@ -805,6 +817,7 @@ func TestAnIdiomDoesNotHideTheDerivedShapesRealClaim(t *testing.T) {
 // parser on the shapes an author will actually write, including the ones that
 // must NOT bind.
 func TestTheBindingIsReadOffTheCommentRatherThanGuessedAt(t *testing.T) {
+	t.Parallel()
 	binds := []struct {
 		comment, test, file string
 	}{

--- a/backend/gates/uniquenessclaimscorpus_test.go
+++ b/backend/gates/uniquenessclaimscorpus_test.go
@@ -53,6 +53,7 @@ var gateIdentifiers = []string{
 const exemptGateFiles = 3
 
 func TestOnlyTheGatesOwnSourcesAreExemptFromTheSweep(t *testing.T) {
+	t.Parallel()
 	if len(gateFiles) != exemptGateFiles {
 		t.Fatalf("%d file(s) are exempt from the sweep against a pin of %d.\n\n"+
 			"An exemption removes a file's claims from the register without holding or "+
@@ -117,6 +118,7 @@ func gateNamesDeclaredIn(file *ast.File) []string {
 // from the same rule the sweep itself uses — a module of generated files is
 // legitimately unswept and needs no exemption anybody has to remember.
 func TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim(t *testing.T) {
+	t.Parallel()
 	const repoRoot = ".."
 	rootOf := func(tree claimedTree) string {
 		return filepath.Clean(filepath.Join("backend", tree.root))
@@ -266,6 +268,7 @@ func declaresItsOwnModule(dir string) (bool, error) {
 // so both refusals would go unexercised by the sweep — and a guard the tree
 // happens not to reach is a guard with no test.
 func TestTheTwoDoorsAreJudgedRatherThanTrusted(t *testing.T) {
+	t.Parallel()
 	for _, c := range []struct {
 		name  string
 		paths []string

--- a/backend/gates/updateguard_test.go
+++ b/backend/gates/updateguard_test.go
@@ -691,6 +691,7 @@ func lockedTable(call *ast.CallExpr, consts map[string]string) string {
 }
 
 func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
+	t.Parallel()
 	defer unguardedByIDUpdates.AssertAllMatched(t)
 	versioned := versionedTables(t)
 	fset := token.NewFileSet()

--- a/backend/gates/updateguardcases_test.go
+++ b/backend/gates/updateguardcases_test.go
@@ -261,6 +261,7 @@ const HeldRename = ` + "`" + marker + "`",
 }
 
 func TestTheGuardCensusJudgesEveryStatementAFunctionAnswersFor(t *testing.T) {
+	t.Parallel()
 	for _, tc := range statementReadingCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fset := token.NewFileSet()

--- a/backend/gates/userrecordviewwriter_test.go
+++ b/backend/gates/userrecordviewwriter_test.go
@@ -80,6 +80,7 @@ var writesViewBaseline = regexp.MustCompile(
 // TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
 // comment names.
 func TestUserRecordViewHasOneWriter(t *testing.T) {
+	t.Parallel()
 	var findings []string
 	judged := 0
 	for _, root := range []string{".", "../extensions", "../fixtures"} {
@@ -142,6 +143,7 @@ func TestUserRecordViewHasOneWriter(t *testing.T) {
 // over a detector that has stopped detecting, so the detector needs its own
 // evidence.
 func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
 	caught := []string{
 		"INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)",
 		// The worst second writer: no GREATEST at all, so it rewinds.

--- a/backend/gates/vaultwriters_test.go
+++ b/backend/gates/vaultwriters_test.go
@@ -75,6 +75,7 @@ var vaultWriters = map[string]string{
 }
 
 func TestEveryKeyVaultWriterHasAVerdict(t *testing.T) {
+	t.Parallel()
 	found := map[string]bool{}
 	root := "internal"
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {

--- a/backend/gates/versionguard_test.go
+++ b/backend/gates/versionguard_test.go
@@ -98,6 +98,7 @@ type triggerBody struct {
 }
 
 func TestEveryVersionPinnedTableBumpsItsVersion(t *testing.T) {
+	t.Parallel()
 	pinned := versionPinnedTables(t)
 	if len(pinned) < versionPinnedTableFloor {
 		t.Fatalf("resolved only %d keys of approvals.versionTables, expected at least %d: the AST derivation broke, not the subject — every key is a constant identifier declared elsewhere in package %s, so this gate is currently certifying nothing",

--- a/backend/gates/workflowhandler_test.go
+++ b/backend/gates/workflowhandler_test.go
@@ -72,6 +72,7 @@ var expectedHandlerTypes = []string{
 }
 
 func TestWorkflowHandlerMatchAndPlanAreReadOnly(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	methodsByType := map[string]map[string]bool{}      // "dir.Type" -> method-name set
 	matchPlanDecls := map[string][]handlerMethodDecl{} // "dir.Type" -> its Match/Plan decls

--- a/backend/gates/workflowtimeouts_test.go
+++ b/backend/gates/workflowtimeouts_test.go
@@ -50,6 +50,7 @@ type workflowJobs struct {
 }
 
 func TestEveryWorkflowJobCarriesATimeoutCeiling(t *testing.T) {
+	t.Parallel()
 	// Both extensions, because GitHub Actions honours both. Globbing one would
 	// leave the gate blind to a whole class of workflow — the precise hole a
 	// derived check exists to not have.

--- a/backend/gates/writeauthority_test.go
+++ b/backend/gates/writeauthority_test.go
@@ -248,6 +248,7 @@ func (f *writeAuthorityFn) noteWrite(table string) {
 }
 
 func TestEveryMutationOfAShareableRecordProbesForWriteAuthority(t *testing.T) {
+	t.Parallel()
 	defer readAuthorityOnAWritePath.AssertAllMatched(t)
 
 	tables := shareableTables(t)

--- a/backend/gates/writeauthorityreach_test.go
+++ b/backend/gates/writeauthorityreach_test.go
@@ -160,6 +160,7 @@ func reachesWriteAuthorityCore(fns map[string]*writeAuthorityFn, name string, se
 }
 
 func TestEveryWriteToAShareableRecordReachesAWriteAuthorityProbe(t *testing.T) {
+	t.Parallel()
 	defer writesWithoutARowProbe.AssertAllMatched(t)
 
 	tables := shareableTables(t)
@@ -235,6 +236,7 @@ func TestEveryWriteToAShareableRecordReachesAWriteAuthorityProbe(t *testing.T) {
 // assembled at run time would fall out of the census silently, and silence is
 // indistinguishable from safety.
 func TestNoMutationOfAShareableRecordHidesItsTableFromThisGate(t *testing.T) {
+	t.Parallel()
 	for dir, byReceiver := range writeAuthorityIndex(t, shareableTables(t)) {
 		for _, fns := range byReceiver {
 			for name, info := range fns {

--- a/backend/gates/writeshape_test.go
+++ b/backend/gates/writeshape_test.go
@@ -193,6 +193,7 @@ var auditOnlyWrites = gatekit.Waive(map[string]string{
 })
 
 func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {
+	t.Parallel()
 	defer auditOnlyWrites.AssertAllMatched(t)
 	emissionPathsByDir := map[string]map[string]bool{}
 	fset := token.NewFileSet()

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -53,7 +53,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (57)
+## Census (56)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -67,7 +67,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
-| `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
@@ -96,6 +95,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `onejitteredbackoff_test.go` | H2 | The jittered retry ladder is spelled once, in shared/kernel/backoff. |
 | `oneretryafter_test.go` | H2 | The Retry-After header is read in one place, shared/kernel/retryafter. |
 | `onevoiceversionwriter_test.go` | H2 | voice\_profile\_version and voice\_profile\_delta each have ONE writer. |
+| `parallelgates_test.go` | H3 | Every gate here runs in parallel with the others, and this is what keeps that true as gates are added. |
 | `passportmint_test.go` | H1 | A passport is minted for the session user, and for nobody else. |
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
@@ -111,7 +111,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
-| `undoreasoncensus_test.go` | H2 | One refusal set, three spellings. |
 | `uniquenessclaimscorpus_test.go` | H2 | WHERE the claim sweep looks, as against what it looks for. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -53,7 +53,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (56)
+## Census (58)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -67,6 +67,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
+| `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
@@ -111,6 +112,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
+| `undoreasoncensus_test.go` | H2 | One refusal set, three spellings. |
 | `uniquenessclaimscorpus_test.go` | H2 | WHERE the claim sweep looks, as against what it looks for. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |
 


### PR DESCRIPTION
## What this does

The fitness gates run in parallel. The package goes **102 s → 18 s**, and it was the pole of the `-j4` fan-out that was **71% of `check-backend`** in CI.

Locally, `check-backend` goes **2m31s → 1m38s**:

| phase | before | after |
|---|---|---|
| `-j4` vet/lint/arch-lint/test/test-extensions | 86 s (57%) | **31 s (32%)** |
| root script gates (x30, -j4) | 53 s (35%) | 53 s (54%) |
| build, drift, composition | 12 s | 14 s |

## Measured first, because the fix depended on the shape

Each leg timed **alone and warm** — in the real run they contend, so the longest pole is invisible there:

| leg | cost |
|---|---|
| **test** | **91 s** |
| lint | 45 s |
| vet | 18 s |
| arch-lint | 2 s |
| test-extensions | 2 s |

Inside `test`, the gates package was a *flat tail*: 287 tests, 102 s, slowest single test 5.4 s. No hot spot to fix — the cost is ~100 independent tree walks (**78 `filepath.WalkDir`** and **106 `parser.ParseFile`** sites) at about 600 ms each.

Caching the parse inside `gatekit.Scope` was the other candidate. It would have returned **~13 s of the 102**, because only 22 of those walks go through `Scope`. Parallelism returns the wall time across all of them without editing one.

## Why it is safe, checked rather than assumed

These gates are readers. The state they share is each `gatekit.Waivers` set, and:

- its `matched` map is **already mutex-guarded**, with a comment naming `t.Parallel()` as the reason;
- `AssertAllMatched` **already** has to be called from exactly one place per declaration, held by `TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce`;
- getting that wrong under parallelism reports staleness that is not there — a **loud failure**, not a gate quietly passing.

Verified across three runs, two of them shuffled: **296 tests, identical set, identical verdicts, zero failures.**

## A gate holds it, because the regression is silent

A gate added without `t.Parallel()` still **passes**. It just runs alone while the others share the machine, and the suite gets a little slower with nothing failing to say so.

`TestEveryGateRunsInParallelWithTheOthers` requires the call to be **first** — Go runs a parallel test's body up to the call synchronously, so work above it is serial work that reads as annotated.

Mutation-tested, each mutant proved to have landed:

| mutant | |
|---|---|
| a gate loses `t.Parallel()` | caught |
| the call is present but not first | caught |
| an exemption names a gate that is gone | caught |
| the staleness sweep is dropped | caught (by the existing exactly-once gate) |
| the census sees no gates at all | caught (floor) |

## One exemption

`TestTheSchemaAndTheParserAgreeOnEveryInputDeclaration` calls `t.Setenv`, which Go forbids in a parallel test — the environment is process-wide. It is ratified in a `gatekit.Waive` set rather than a bare map, so its reason meets the same bar as every other waiver here and a stale entry is reported by the mechanism that already does that. (The tree's own `TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture` caught my first version, which was a hand-rolled map with a hand-rolled staleness check — a second copy of machinery that already exists.)

## What this does not fix

The script gates are now the pole at 54%, and they are near their own floor: at `-j4` the wall cannot drop below the slowest single gate. Timed cleanly, with nothing else of mine running:

| gate | |
|---|---|
| `test-money-scale` | 34 s |
| `money-scale` | 32 s |
| `test-one-spelling` | 20 s |
| `one-spelling` | 18 s |

So ~34 s is the floor against a 53 s fan-out. (A first reading put `test-money-scale` at 75 s; that was taken while other jobs of mine were running and disagreed with a clean baseline, so it is not the number — worth saying, because the contended figure would have argued for a much bigger prize than is actually there.)

Going further means making those scans faster — `money-scale` awks every Go and TS file through a comment stripper — which is a change to a gate whose failure mode is *going blind*. That wants its own PR and its own care rather than riding this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enabled parallel execution across the gate test suite to reduce validation time.
  - Added checks that verify parallel-test coverage across supported build configurations.
  - Improved handling of build-specific and sequential tests.
  - Preserved existing assertions and validation behavior.

- **Documentation**
  - Updated the gate inventory to reflect expanded parallel-execution coverage and revised census totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->