### PR TITLE
fix(dedupe): Chinese, Japanese and Korean names are matched on their brand

### DIFF
--- a/backend/internal/modules/people/orgformtables.go
+++ b/backend/internal/modules/people/orgformtables.go
@@ -96,6 +96,12 @@ var prefixMarkets = []marketForms{
 	thailand,
 }
 
+// cjkMarket names the scripts whose forms are matched by substring rather than
+// by word (orgnamecjk.go). It carries no tables of its own — the forms live
+// there, because they are matched a different way — and exists so a caller can
+// tell that a name declared one of these markets.
+var cjkMarket = marketForms{name: "cjk"}
+
 // unambiguous builds markers from forms that collide with nothing.
 func unambiguous(forms ...[]string) []orgFormMarker {
 	markers := make([]orgFormMarker, 0, len(forms))

--- a/backend/internal/modules/people/orgnamecjk.go
+++ b/backend/internal/modules/people/orgnamecjk.go
@@ -38,7 +38,6 @@ package people
 
 import (
 	"strings"
-	"unicode"
 
 	"golang.org/x/text/unicode/norm"
 )
@@ -105,6 +104,22 @@ var cjkFormAliases = map[string]string{
 // needs a lookup: the forms above simply do not contain them.
 var cjkBrandTierWords = []string{"集团", "集團", "控股", "控股集团"}
 
+// cjkMaxFormsStripped bounds how many legal forms one name may shed.
+//
+// The strip is a loop over a shrinking string, so its cost is quadratic in the
+// number of forms — measured, a name of 10 000 concatenated forms takes 370ms,
+// and `display_name` is `text` with no maxLength in the contract. That work
+// happens inside DedupeOrganizationForCreate, which holds the workspace-wide
+// organization-name write lock, so an unbounded name pins every other
+// organization-name writer behind it. The same reasoning as nameScoringMaxRunes
+// (namesim.go), which bounds the metric for the same lock.
+//
+// FOUR is far past any real name: a company carries a form at one end, or at
+// both, and "株式会社ガナ株式会社" is already the strange case. Past the bound the
+// name keeps whatever forms are left, which for a name this shape is the same
+// answer any comparison would give.
+const cjkMaxFormsStripped = 4
+
 // cjkMinimumBrandRunes is the shortest name a strip may leave behind.
 //
 // A name that is nothing but its legal form — a bare "株式会社" or "㈜" in a CRM
@@ -113,16 +128,21 @@ var cjkBrandTierWords = []string{"集团", "集團", "控股", "控股集团"}
 // Japan and Korea have no such floor and dirty data has no floor at all.
 const cjkMinimumBrandRunes = 1
 
-// hasCJKScript answers whether a name is written in one of these scripts, and so
-// whether the character-level path applies to it at all.
+// carriesCJKForm answers whether this path owns the name: does it end or begin
+// with one of the legal forms above?
 //
-// Any Han, Hiragana, Katakana or Hangul character is enough. A name mixing Latin
-// with Han — common for a Japanese company writing its own name — still needs
-// the form stripped off the Han half.
-func hasCJKScript(s string) bool {
-	for _, r := range s {
-		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+// THE FORM, NOT THE SCRIPT. An earlier version claimed any name containing a
+// single Han, Kana or Hangul character, which is far too much — "CÔNG TY TNHH
+// 東京 Việt" is a Vietnamese company with a Han word in its name, and routing it
+// here left its Vietnamese legal form in place and squashed its spaces. The same
+// for "Acme 漢 GmbH", which needs the Latin suffix strip.
+//
+// A name that carries one of these forms is one of these markets, whatever else
+// it is written in: "Toyota株式会社" and "ABC有限公司" are how those companies
+// write themselves.
+func carriesCJKForm(name string) bool {
+	for _, form := range cjkLegalForms {
+		if strings.HasPrefix(name, form) || strings.HasSuffix(name, form) {
 			return true
 		}
 	}
@@ -146,12 +166,16 @@ func normalizeCJKName(s string) string {
 	var out strings.Builder
 	out.Grow(len(folded))
 	for _, r := range folded {
-		if isVariationSelector(r) || unicode.IsSpace(r) {
+		if isVariationSelector(r) {
 			continue
 		}
 		out.WriteRune(r)
 	}
-	return strings.ToLower(out.String())
+	// The SAME fold the rest of the package uses, not strings.ToLower: full
+	// Unicode folding is what makes Greek final sigma and ß behave, and a second
+	// spelling of "lowercase" here would make this path disagree with every
+	// other one about the same Latin name.
+	return normalizeName(strings.Join(strings.Fields(out.String()), " "))
 }
 
 // isVariationSelector reports the two ranges that pick a glyph shape.
@@ -180,10 +204,10 @@ func cjkNameForMatching(s string) (string, bool) {
 	// of its own: "㈱" is one compatibility character, and the script only
 	// appears once NFKC and the alias map have rewritten it as "株式会社".
 	name := normalizeCJKName(s)
-	if !hasCJKScript(name) {
+	if !carriesCJKForm(name) {
 		return "", false
 	}
-	for {
+	for stripped := 0; stripped < cjkMaxFormsStripped; stripped++ {
 		longest := ""
 		for _, form := range cjkLegalForms {
 			if len(form) <= len(longest) {
@@ -203,9 +227,11 @@ func cjkNameForMatching(s string) (string, bool) {
 		// A name that IS its legal form keeps it: an empty string would match
 		// every other empty string, and a bare "株式会社" in an export names no
 		// company at all.
+		trimmed = strings.TrimSpace(trimmed)
 		if len([]rune(trimmed)) < cjkMinimumBrandRunes {
 			return name, true
 		}
 		name = trimmed
 	}
+	return name, true
 }

--- a/backend/internal/modules/people/orgnamecjk.go
+++ b/backend/internal/modules/people/orgnamecjk.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Org-name matching for Chinese, Japanese and Korean, where a name has no word
+// boundaries to split on.
+//
+// WHY A SECOND PATH. Everything else in this package finds a legal form by
+// splitting a name into words and comparing them. These scripts write no spaces:
+// "北京字节跳动科技有限公司" is one token, so the gate had nothing to compare and
+// answered no-match to every pair — including a company against ITSELF written
+// without its legal form. Measured before this existed, all six of these scored
+// 0.0000: 株式会社トヨタ自動車 against トヨタ自動車, 주식회사 삼성전자 against
+// 삼성전자, 阿里巴巴集团控股有限公司 against 阿里巴巴. Missed duplicates, silently.
+// Meanwhile 주식회사 삼성전자 and 주식회사 현대자동차 — Samsung and Hyundai —
+// scored 0.8533 on the shared "주식회사".
+//
+// So the form is matched as a SUBSTRING anchored at each end, longest first.
+// Unicode's own word segmentation (UAX #29) does not help: it breaks Han between
+// every character and keeps a whole Hangul run as one word, and the standard
+// says so itself. The alternative is a dictionary, which this package will not
+// carry.
+//
+// A MATCH HERE IS A QUESTION, NOT A MERGE. Japanese registration treats
+// 株式会社ガナ and ガナ株式会社 as two registrable names at one address, so the
+// two really can be different companies. This tier answers "worth a human
+// look", never "these are one record" — and against the alternative, which is
+// the silence measured above, asking is the right error to make.
+//
+// THE KOREAN REGISTRY DOES EXACTLY THIS. Its rule for deciding whether two
+// company names are the same removes the company-type string first and compares
+// what is left, which is the algorithm below. It also settles a question this
+// file would otherwise have to guess at: 가나주식회사 and 주식회사가나 are the
+// same name, because once the type string is gone neither has a position left to
+// differ in. Japan is the same — company law requires "株式会社" to appear in the
+// name and says nothing about where.
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// cjkLegalForms are the company-type strings of the three scripts, matched
+// against the ends of a name.
+//
+// Longest first, and the loop repeats. "有限公司" is a suffix of "有限责任公司"
+// and of "股份有限公司", so a short match taken alone would leave "有限责任" on the
+// brand — though either the ordering or the repetition covers that by itself.
+// What needs BOTH is a name carrying a form at each end: strip once and
+// "株式会社ガナ株式会社" keeps one of them.
+//
+// Simplified and Traditional are separate entries because Unicode does not
+// bridge them — "责" and "責" are distinct characters and NFKC leaves both alone,
+// so a table with only one spelling is blind to half the market.
+var cjkLegalForms = []string{
+	// Chinese, mainland and traditional.
+	"有限责任公司", "有限責任公司",
+	"股份有限公司",
+	"个体工商户", "個體工商戶",
+	"有限合伙", "有限夥",
+	"合伙企业", "合夥企業",
+	"有限公司",
+	"股份公司",
+	// Japanese.
+	"一般社団法人", "一般財団法人",
+	"株式会社", "株式會社",
+	"有限会社", "有限會社",
+	"合同会社", "合資会社", "合名会社",
+	"医療法人",
+	// Korean.
+	"유한책임회사",
+	"주식회사", "유한회사", "합자회사", "합명회사",
+	"재단법인", "사단법인",
+}
+
+// cjkFormAliases are the squared and parenthesised spellings of a legal form,
+// mapped onto the form itself.
+//
+// NFKC DOES NOT DO THIS, which is the trap. It rewrites ㈱ to "(株)" and ㈜ to
+// "(주)" — the parentheses, not the words — so a name written "㈱ガナ" still
+// shares no substring with "株式会社ガナ" after normalization. Verified against
+// the Go normalizer rather than assumed.
+var cjkFormAliases = map[string]string{
+	"(株)": "株式会社",
+	"(有)": "有限会社",
+	"(资)": "合資会社",
+	"(名)": "合名会社",
+	"(주)": "주식회사",
+	"(유)": "유한회사",
+}
+
+// cjkBrandTierWords are words that LOOK like a legal form and are not.
+//
+// 集团 (group) and 控股 (holding) name a different legal person from the company
+// they sit beside: 中国中车集团有限公司 is the state-owned parent and
+// 中国中车股份有限公司 is its listed subsidiary, and the parent holds 54% of it.
+// Stripping the word would file those two as one company — a parent merged with
+// its own subsidiary, which is the opposite of deduplication, and this is the
+// standard shape of the largest Chinese groups rather than an edge case.
+//
+// Listed here so the intent is written down and testable, not because the code
+// needs a lookup: the forms above simply do not contain them.
+var cjkBrandTierWords = []string{"集团", "集團", "控股", "控股集团"}
+
+// cjkMinimumBrandRunes is the shortest name a strip may leave behind.
+//
+// A name that is nothing but its legal form — a bare "株式会社" or "㈜" in a CRM
+// export — must not become the empty string, which would match every other empty
+// string. Mainland registration requires a brand of at least two characters, but
+// Japan and Korea have no such floor and dirty data has no floor at all.
+const cjkMinimumBrandRunes = 1
+
+// hasCJKScript answers whether a name is written in one of these scripts, and so
+// whether the character-level path applies to it at all.
+//
+// Any Han, Hiragana, Katakana or Hangul character is enough. A name mixing Latin
+// with Han — common for a Japanese company writing its own name — still needs
+// the form stripped off the Han half.
+func hasCJKScript(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeCJKName folds a name to the form the tables are written in.
+//
+// NFKC rather than the NFD pass the rest of this package uses: it is what maps
+// the full-width Latin and half-width katakana a Japanese registry emits onto
+// their ordinary spellings, and the ideographic space onto a plain one.
+//
+// Variation selectors are removed by hand because normalization keeps them.
+// They are a rendering instruction — which shape of 葛 to draw — and two records
+// of one company differ by them for no reason a reader could see.
+func normalizeCJKName(s string) string {
+	folded := norm.NFKC.String(s)
+	for alias, form := range cjkFormAliases {
+		folded = strings.ReplaceAll(folded, alias, form)
+	}
+	var out strings.Builder
+	out.Grow(len(folded))
+	for _, r := range folded {
+		if isVariationSelector(r) || unicode.IsSpace(r) {
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return strings.ToLower(out.String())
+}
+
+// isVariationSelector reports the two ranges that pick a glyph shape.
+func isVariationSelector(r rune) bool {
+	return (r >= 0xFE00 && r <= 0xFE0F) || (r >= 0xE0100 && r <= 0xE01EF)
+}
+
+// cjkNameForMatching is the name with its legal form removed from either end.
+//
+// EITHER END, because both are correct and the difference is a style choice.
+// Japanese writers put "株式会社" in front (前株) or behind (後株) with no legal
+// distinction, and the Korean registry's own comparison rule removes the type
+// string wherever it sits before deciding whether two names are the same.
+//
+// Repeated, because a name can carry a form at both ends, and a Chinese name can
+// carry "集团有限公司" — where "有限公司" goes and "集团" stays.
+//
+// Returns false only when the name is written in some OTHER script, so the
+// caller can hand it to the word-level path. A name that IS one of these scripts
+// belongs here whether or not a form was found: the word-level path would split
+// it into a single token and then strip Latin forms out of it, and "㈱" — which
+// normalizes to a bare "株式会社" and has no brand to keep — came back empty from
+// there.
+func cjkNameForMatching(s string) (string, bool) {
+	// Normalized BEFORE the script test, because a squared form carries no Han
+	// of its own: "㈱" is one compatibility character, and the script only
+	// appears once NFKC and the alias map have rewritten it as "株式会社".
+	name := normalizeCJKName(s)
+	if !hasCJKScript(name) {
+		return "", false
+	}
+	for {
+		longest := ""
+		for _, form := range cjkLegalForms {
+			if len(form) <= len(longest) {
+				continue
+			}
+			if strings.HasPrefix(name, form) || strings.HasSuffix(name, form) {
+				longest = form
+			}
+		}
+		if longest == "" {
+			return name, true
+		}
+		trimmed := strings.TrimPrefix(name, longest)
+		if trimmed == name {
+			trimmed = strings.TrimSuffix(name, longest)
+		}
+		// A name that IS its legal form keeps it: an empty string would match
+		// every other empty string, and a bare "株式会社" in an export names no
+		// company at all.
+		if len([]rune(trimmed)) < cjkMinimumBrandRunes {
+			return name, true
+		}
+		name = trimmed
+	}
+}

--- a/backend/internal/modules/people/orgnamecjk_test.go
+++ b/backend/internal/modules/people/orgnamecjk_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"strings"
+	"testing"
+)
+
+// cjkCompany is one real-shaped CJK name and the brand it must reduce to.
+type cjkCompany struct {
+	name  string
+	brand string
+	group string
+}
+
+// The corpus: the three scripts, each written the ways a real CRM receives them
+// — with the legal form in front, behind, abbreviated to its squared character,
+// and left off entirely.
+//
+// EVERY SAME-COMPANY PAIR HERE SCORED 0.0000 before this path existed, because
+// these scripts write no spaces and the whole name arrived as a single token
+// with nothing to compare. Toyota did not match itself. Meanwhile Samsung and
+// Hyundai matched each other at 0.8533 on the shared "주식회사".
+var cjkCorpus = []cjkCompany{
+	// Chinese. The region and the industry stay: both are legally part of the
+	// name, and either can BE the brand — 北京银行 is the Bank of Beijing.
+	{name: "北京字节跳动科技有限公司", brand: "北京字节跳动科技", group: "bytedance"},
+	{name: "北京字节跳动科技", brand: "北京字节跳动科技", group: "bytedance"},
+	{name: "北京百度网讯科技有限公司", brand: "北京百度网讯科技", group: "baidu"},
+	{name: "上海贸易有限公司", brand: "上海贸易", group: "shtrade"},
+	{name: "深圳市腾讯计算机系统有限公司", brand: "深圳市腾讯计算机系统", group: "tencent"},
+	{name: "台湾积体电路制造股份有限公司", brand: "台湾积体电路制造", group: "tsmc"},
+
+	// Japanese. 前株 and 後株 are one company written two ways, and the squared
+	// ㈱ is a third.
+	{name: "株式会社トヨタ自動車", brand: "トヨタ自動車", group: "toyota"},
+	{name: "トヨタ自動車株式会社", brand: "トヨタ自動車", group: "toyota"},
+	{name: "㈱トヨタ自動車", brand: "トヨタ自動車", group: "toyota"},
+	{name: "トヨタ自動車", brand: "トヨタ自動車", group: "toyota"},
+	{name: "株式会社ホンダ技研", brand: "ホンダ技研", group: "honda"},
+	{name: "有限会社山田製作所", brand: "山田製作所", group: "yamada"},
+	{name: "㍿ホンダ技研", brand: "ホンダ技研", group: "honda"},
+	{name: "ＡＢＣ株式会社", brand: "abc", group: "abc"},
+	{name: "ABC株式会社", brand: "abc", group: "abc"},
+
+	// Korean. The registry's own rule removes the type string before comparing,
+	// so a spaced and an unspaced spelling are one name.
+	{name: "주식회사 삼성전자", brand: "삼성전자", group: "samsung"},
+	{name: "삼성전자주식회사", brand: "삼성전자", group: "samsung"},
+	{name: "삼성전자", brand: "삼성전자", group: "samsung"},
+	{name: "주식회사 현대자동차", brand: "현대자동차", group: "hyundai"},
+	{name: "(주)카카오", brand: "카카오", group: "kakao"},
+	{name: "카카오", brand: "카카오", group: "kakao"},
+}
+
+// Every CJK name reduces to the company inside it.
+func TestEveryCJKNameReducesToItsBrand(t *testing.T) {
+	for _, company := range cjkCorpus {
+		if got := orgNameForMatching(company.name); got != company.brand {
+			t.Errorf("%q reduces to %q, want %q — the comparison will be made on "+
+				"the wrong characters", company.name, got, company.brand)
+		}
+	}
+}
+
+// No two different CJK companies score as one. Exhaustive over every
+// cross-company pair.
+func TestNoCJKCompanyMatchesAnother(t *testing.T) {
+	pairs := 0
+	for i, left := range cjkCorpus {
+		for _, right := range cjkCorpus[i+1:] {
+			if left.group == right.group {
+				continue
+			}
+			pairs++
+			if got := bestOrgNamePairing(left.name, "", right.name, "").Confidence; got >= dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, at or above the %.2f review "+
+					"threshold — these are different companies",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+	if want := cjkCrossCompanyPairs(); pairs != want {
+		t.Fatalf("compared %d pairs, expected %d — the census is running short",
+			pairs, want)
+	}
+}
+
+// THE MISSED DUPLICATES. Every pairing within a company must meet, and this is
+// the half of the defect that was silent: a company that does not match itself
+// produces no warning, no queue entry and nothing for anyone to notice.
+func TestEveryCJKDuplicateStillMeets(t *testing.T) {
+	for i, left := range cjkCorpus {
+		for _, right := range cjkCorpus[i+1:] {
+			if left.group != right.group {
+				continue
+			}
+			if got := bestOrgNamePairing(left.name, "", right.name, "").Confidence; got < dedupeReviewThreshold {
+				t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold — "+
+					"this is one company written two ways",
+					left.name, right.name, got, dedupeReviewThreshold)
+			}
+		}
+	}
+}
+
+// A PARENT IS NOT ITS OWN SUBSIDIARY.
+//
+// 集团 (group) and 控股 (holding) name a different legal person from the company
+// beside them: 中国中车集团有限公司 is the state-owned parent and
+// 中国中车股份有限公司 its listed subsidiary, and the parent holds 54% of it.
+// Stripping the word would file the two as one company, and this is the standard
+// shape of the largest Chinese groups rather than an edge case.
+func TestAChineseGroupIsNotItsListedCompany(t *testing.T) {
+	parent, subsidiary := "中国中车集团有限公司", "中国中车股份有限公司"
+	if got := bestOrgNamePairing(parent, "", subsidiary, "").Confidence; got >= dedupeReviewThreshold {
+		t.Errorf("%q vs %q scores %.4f — a group and its listed company are two "+
+			"legal persons", parent, subsidiary, got)
+	}
+	// And the word survives the strip, which is what keeps them apart.
+	for _, word := range cjkBrandTierWords {
+		name := "中国中车" + word + "有限公司"
+		if got := orgNameForMatching(name); !strings.Contains(got, word) {
+			t.Errorf("%q reduces to %q, which has lost %q — that word names the "+
+				"company, not its legal form", name, got, word)
+		}
+	}
+}
+
+// A NAME THAT IS ONLY ITS LEGAL FORM STILL NAMES SOMETHING.
+//
+// A bare "株式会社" or "㈜" arrives in real exports. Reducing it to the empty
+// string would make it match every other empty string, so the strip stops.
+func TestABareCJKFormIsNotEmptied(t *testing.T) {
+	for _, bare := range []string{"株式会社", "㈱", "주식회사", "有限公司", "株式会社株式会社"} {
+		if got := orgNameForMatching(bare); got == "" {
+			t.Errorf("%q reduces to the empty string, which matches every other "+
+				"empty name", bare)
+		}
+	}
+}
+
+// The table must be written the way a folded name is written, or an entry can
+// never fire and no other test would notice.
+func TestCJKFormsMatchTheirOwnNormalization(t *testing.T) {
+	if len(cjkLegalForms) == 0 {
+		t.Fatal("no CJK forms declared — the census would pass against nothing")
+	}
+	for _, form := range cjkLegalForms {
+		if got := normalizeCJKName(form); got != form {
+			t.Errorf("form %q normalizes to %q — written this way it can never "+
+				"match a real name", form, got)
+		}
+	}
+	// Longest-match is what keeps a shorter form from leaving the remains of a
+	// longer one, so every form that CONTAINS another must be reachable.
+	for _, long := range cjkLegalForms {
+		for _, short := range cjkLegalForms {
+			if long == short || !strings.HasSuffix(long, short) {
+				continue
+			}
+			name := "ゼット" + long
+			if got, _ := cjkNameForMatching(name); got != "ゼット" {
+				t.Errorf("%q reduces to %q — the shorter form %q won over %q and "+
+					"left part of a legal form behind", name, got, short, long)
+			}
+		}
+	}
+	// A form at EACH END needs the loop: stripping once leaves the other.
+	for _, k := range []struct{ name, want string }{
+		{"小米科技有限责任公司", "小米科技"},
+		{"台湾积体电路制造股份有限公司", "台湾积体电路制造"},
+		{"株式会社ガナ株式会社", "ガナ"},
+		{"有限公司北京科技有限公司", "北京科技"},
+	} {
+		if got, _ := cjkNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q — a shorter form matched first and "+
+				"left the rest of a longer one behind", k.name, got, k.want)
+		}
+	}
+}
+
+// A LEGAL FORM INSIDE A BRAND IS PART OF THE BRAND.
+//
+// The strip matches only at the ends of a name, never in the middle. 公司宝 is a
+// Chinese company whose name opens with the word for "company"; 会社四季報 is a
+// Japanese periodical whose name opens with the word for "company". A rule that
+// removed the form wherever it appeared would take the brand off both.
+func TestACJKFormInsideABrandIsKept(t *testing.T) {
+	for _, k := range []struct{ name, want string }{
+		{"公司宝科技有限公司", "公司宝科技"},
+		{"会社四季報株式会社", "会社四季報"},
+		{"株式会社会社設立freee", "会社設立freee"},
+	} {
+		if got, _ := cjkNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q — the form was taken from inside "+
+				"the brand", k.name, got, k.want)
+		}
+	}
+	// Every alias must resolve to a form the table actually carries.
+	for alias, form := range cjkFormAliases {
+		if !strings.Contains(normalizeCJKName("ゼット"+alias), form) {
+			t.Errorf("alias %q does not resolve to %q", alias, form)
+		}
+	}
+}
+
+// The CJK path must not reach a name written in another script.
+func TestTheCJKPathLeavesOtherScriptsAlone(t *testing.T) {
+	for _, name := range []string{
+		"Acme Inc", "ООО Ромашка", "شركة الراجحي", "CÔNG TY CỔ PHẦN SỮA VIỆT NAM",
+		"บริษัท เมืองไทยประกันชีวิต จำกัด", "SIA Rimi Latvia",
+	} {
+		if _, stripped := cjkNameForMatching(name); stripped {
+			t.Errorf("%q was handled by the CJK path, which owns no script in it", name)
+		}
+	}
+}
+
+// cjkCrossCompanyPairs counts what the precision census owes, from the shape of
+// the corpus rather than by walking it again.
+func cjkCrossCompanyPairs() int {
+	perCompany := map[string]int{}
+	for _, c := range cjkCorpus {
+		perCompany[c.group]++
+	}
+	pairs := len(cjkCorpus) * (len(cjkCorpus) - 1) / 2
+	for _, n := range perCompany {
+		pairs -= n * (n - 1) / 2
+	}
+	return pairs
+}

--- a/backend/internal/modules/people/orgnamecjk_test.go
+++ b/backend/internal/modules/people/orgnamecjk_test.go
@@ -6,6 +6,7 @@ package people
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // cjkCompany is one real-shaped CJK name and the brand it must reduce to.
@@ -203,6 +204,57 @@ func TestACJKFormInsideABrandIsKept(t *testing.T) {
 	for alias, form := range cjkFormAliases {
 		if !strings.Contains(normalizeCJKName("ゼット"+alias), form) {
 			t.Errorf("alias %q does not resolve to %q", alias, form)
+		}
+	}
+}
+
+// THE STRIP IS BOUNDED, because the work happens while the workspace-wide
+// organization-name write lock is held and `display_name` has no length cap in
+// the contract. Measured before the bound, a name of 10 000 concatenated forms
+// took 370ms; every other organization-name writer waits behind that.
+func TestTheCJKStripIsBounded(t *testing.T) {
+	name := strings.Repeat("株式会社", 20000) + "ガナ"
+	start := time.Now()
+	got, isCJK := cjkNameForMatching(name)
+	elapsed := time.Since(start)
+	if !isCJK {
+		t.Fatal("a name of nothing but legal forms is still this path's to answer")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("stripping took %v — the bound is not holding, and this runs "+
+			"under the organization-name write lock", elapsed)
+	}
+	// Bounded, not wrong: the brand is still found at the end of what remains.
+	if !strings.HasSuffix(got, "ガナ") {
+		t.Errorf("the bounded strip lost the brand: %q", got[max(0, len(got)-24):])
+	}
+}
+
+// A name this path claims must actually CARRY one of its forms. A stray Han or
+// Kana character in a Vietnamese, Latin or Russian name is not this path's
+// business — routing it here left the other market's legal form in place.
+func TestOnlyANameCarryingACJKFormIsClaimed(t *testing.T) {
+	for _, k := range []struct{ name, want string }{
+		{"CÔNG TY TNHH 東京 Việt", "東京 viet"},
+		{"Acme 漢 GmbH", "acme 漢"},
+		{"ООО Ромашка 中", "ромашка 中"},
+	} {
+		if _, isCJK := cjkNameForMatching(k.name); isCJK {
+			t.Errorf("%q was claimed by the CJK path, which owns no form in it", k.name)
+		}
+		if got := orgNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q — its own market's handling was "+
+				"skipped", k.name, got, k.want)
+		}
+	}
+	// And a name that DOES carry one is claimed, whatever else it is written in.
+	for _, k := range []struct{ name, want string }{
+		{"Toyota株式会社", "toyota"},
+		{"ABC有限公司", "abc"},
+		{"Toyota Motor 株式会社", "toyota motor"},
+	} {
+		if got := orgNameForMatching(k.name); got != k.want {
+			t.Errorf("%q reduces to %q, want %q", k.name, got, k.want)
 		}
 	}
 }

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -270,6 +270,13 @@ func orgNameForMatching(s string) string {
 // are companies whose first word this table would otherwise eat. A legal form is
 // a strong enough signal to act on; a bare two-letter word is not.
 func matchingFormOf(s string) (string, *marketForms) {
+	// The scripts with no word boundaries are answered first, by substring
+	// (orgnamecjk.go). Splitting them into words yields the whole name as one
+	// token, so every path below would find nothing to strip and nothing to
+	// compare.
+	if name, isCJK := cjkNameForMatching(s); isCJK {
+		return name, &cjkMarket
+	}
 	fields := strings.FieldsFunc(NormalizeOrgName(foldDStroke(s)), nameWordSeparators)
 	for i := range prefixMarkets {
 		market := &prefixMarkets[i]

--- a/backend/internal/modules/people/orgnameforms_integration_test.go
+++ b/backend/internal/modules/people/orgnameforms_integration_test.go
@@ -120,6 +120,22 @@ func TestVietnameseCompaniesResolveThroughTheLadder(t *testing.T) {
 				name, m.Decision, m.Confidence)
 		}
 	}
+	// A TWO-CHARACTER CHINESE BRAND is the shortest thing this tier has to
+	// retrieve, and whole-string similarity cannot: measured, "小米" against its
+	// own registered name scores 0.167, under the trigram limit. The containment
+	// arm is what finds it.
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "小米科技有限责任公司", Source: "manual",
+	}); err != nil {
+		t.Fatalf("seeding the short Chinese brand: %v", err)
+	}
+	short := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{DisplayName: "小米科技"})
+	if short.Decision != DecisionFuzzyReview {
+		t.Errorf("a two-character Chinese brand got %s (confidence %.4f), want "+
+			"fuzzy_review — its own company is seeded",
+			short.Decision, short.Confidence)
+	}
+
 	unrelated := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
 		DisplayName: "주식회사 현대자동차",
 	})

--- a/backend/internal/modules/people/orgnameforms_integration_test.go
+++ b/backend/internal/modules/people/orgnameforms_integration_test.go
@@ -101,6 +101,34 @@ func TestVietnameseCompaniesResolveThroughTheLadder(t *testing.T) {
 			longForm.Decision, longForm.Confidence)
 	}
 
+	// A SCRIPT WITH NO SPACES, through the real ladder. These names arrive as one
+	// token, so before the character-level path existed the candidate query and
+	// the gate had nothing to work with and every pair — including a company
+	// against itself — came back no_match.
+	for _, name := range []string{"株式会社トヨタ自動車", "주식회사 삼성전자"} {
+		if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+			DisplayName: name, Source: "manual",
+		}); err != nil {
+			t.Fatalf("seeding %q: %v", name, err)
+		}
+	}
+	for _, name := range []string{"トヨタ自動車", "삼성전자"} {
+		m := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{DisplayName: name})
+		if m.Decision != DecisionFuzzyReview {
+			t.Errorf("%q got %s (confidence %.4f), want fuzzy_review — its own "+
+				"company is seeded under its registered name",
+				name, m.Decision, m.Confidence)
+		}
+	}
+	unrelated := e.dedupeOrgInTx(ctx, t, OrganizationCandidate{
+		DisplayName: "주식회사 현대자동차",
+	})
+	if unrelated.Decision != DecisionNoMatch {
+		t.Errorf("Hyundai collided with Samsung (decision %s, confidence %.4f) — "+
+			"they share only the words for \"joint-stock company\"",
+			unrelated.Decision, unrelated.Confidence)
+	}
+
 	// And tier 1 still outranks every name judgement: a shared domain is an
 	// exact key, whatever the two names look like.
 	withDomain, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{


### PR DESCRIPTION
These scripts write no spaces, so every path in this package saw a whole name as **one token** and had nothing to compare. The result was silent: measured against `main`, a company did not match **itself**.

| Pair | Before | After |
|---|---|---|
| `株式会社トヨタ自動車` ↔ `トヨタ自動車` | **0.0000** missed | 1.0000 |
| `トヨタ自動車株式会社` ↔ `トヨタ自動車` | **0.0000** missed | 1.0000 |
| `㈱トヨタ自動車` ↔ `株式会社トヨタ自動車` | **0.0000** missed | 1.0000 |
| `주식회사 삼성전자` ↔ `삼성전자` | **0.0000** missed | 1.0000 |
| `(주)카카오` ↔ `카카오` | 0.5111 missed | 1.0000 |
| `阿里巴巴集团控股有限公司` ↔ `阿里巴巴集团控股` | **0.0000** missed | 1.0000 |
| `주식회사 삼성전자` ↔ `주식회사 현대자동차` (Samsung/Hyundai) | 0.8533 **false** | 0.0000 |

Six missed duplicates with no warning, no queue entry and nothing for anyone to notice — plus one false match on the shared words for "joint-stock company".

## Why a second path

The form is matched as a **substring anchored at each end**, longest first, in the new `orgnamecjk.go`. Unicode's own word segmentation does not help and says so: it breaks Han between every character and keeps a whole Hangul run as one word. The only alternative is a dictionary, which this package will not carry.

The Korean company registry decides whether two names are the same by removing the company-type string first and comparing the remainder — which is exactly this algorithm, and settles the position question: once the type string is gone, `가나주식회사` and `주식회사가나` have no position left to differ in. Japanese registration *does* treat 前株 and 後株 as two registrable names at one address, so the two really can be different companies — but this tier asks a human and never merges, and against the silence it replaces, asking is the right error.

## What is deliberately NOT stripped

- **`集团` / `控股`.** `中国中车集团有限公司` is a state-owned parent and `中国中车股份有限公司` its listed subsidiary, and the parent holds 54% of it. Removing the word would file a parent and its own subsidiary as one company, and that shape is the standard structure of the largest Chinese groups.
- **The region and the industry.** Chinese naming law lets either be the brand — `北京银行` is the Bank of Beijing, and stripping `北京` leaves "Bank Co Ltd".

## NFKC needs help

It rewrites `㈱` to `(株)` — the parentheses, not the words — so an alias map turns it into `株式会社`; verified against the normalizer rather than assumed. It also leaves variation selectors alone, which are a rendering instruction. `㍿` is the one character it expands correctly on its own.

## Review round

Codex found five issues, all real, fixed in the second commit. The worst: claiming a name by **script** was far too broad — one Han character in `CÔNG TY TNHH 東京 Việt` suppressed the Vietnamese handling entirely. The path now claims a name only when one of its own forms opens or closes it. Also fixed: two folds that disagreed with the rest of the package (`Toyota Motor 株式会社` reduced to `toyotamotor` while `Toyota Motor` kept its space), and unbounded quadratic work under the workspace-wide write lock (10 000 concatenated forms took 370ms; now flat).

Two findings needed the database rather than an argument. A two-character Chinese brand **is** retrievable: `小米` scores 0.167 against its own registered name as whole strings — under the trigram limit — but produces three trigrams and passes the containment arm. There is now an integration assertion for it.

## Tests

`orgnamecjk_test.go` carries the three scripts written the ways a real CRM receives them: form in front, form behind, squared abbreviation, full-width Latin, and bare brand. Precision is asked of every cross-company pair. Six guards are mutation-checked — reverting each turns its named test red, including the loop bound, which fails at 1.89s when removed.

`make check-backend` green, `make craft-static` clean across all four trees, people integration lane green under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes organization deduplication for Chinese, Japanese, and Korean names, which previously never matched themselves: these scripts write no spaces, so a whole name arrived as one token, silently hiding six duplicate pairs and also matching Samsung to Hyundai on their shared word for "joint-stock company". The new CJK path strips the legal form from either end of a name — longest form first, with an alias map for squared and parenthesized spellings (`㈱` → `株式会社`) after NFKC normalization.

**Behavior to know**
- A match only queues a human review; it never merges, because Japanese 前株 and 後株 can be two registrable companies.
- `集团` and `控股` stay in the name, so a state-owned parent and its listed subsidiary are not filed as one.
- The region and industry stay too — either can be the brand (`北京银行` is the Bank of Beijing).
- A name is claimed only when one of its own forms starts or ends it; a Han character inside an otherwise Vietnamese or Latin name no longer routes it here.
- The strip stops at four forms so a pathological name cannot pin the workspace-wide organization-name write lock.

<sup>Written for commit 1b301d9abf6cce6a17089c7dda50cca51b39e8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added organization-name matching and normalization for Chinese, Japanese, and Korean names.
  - Recognizes regional legal-form variations, including names without spaces and compatibility characters.
  - Improves duplicate detection, brand extraction, and separation of unrelated companies across CJK markets.

- **Bug Fixes**
  - Prevents companies sharing only a legal-form phrase from being incorrectly matched.
  - Preserves short brands, parent/subsidiary distinctions, and standalone legal forms during matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->