### PR TITLE
fix(ci-tests): the conformance sweep invokes the brief tool that writes

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -101,6 +101,19 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 	calls := []struct{ tool, args string }{
 		{"list_pipelines", `{}`},
 		{"read_brief", `{}`},
+		// The write half of the brief pair, annotating the run read_brief just
+		// read. EMPTY on purpose: the schema requires nothing at the top level,
+		// and `AnnotateBriefArgs` says so — "Empty is a real answer: a quiet
+		// night has no sentence". So this proves the answer shape and the
+		// envelope without the sweep leaving prose on a rep's morning as a side
+		// effect of checking a schema, which is the same posture the approval
+		// call below takes by rejecting rather than releasing.
+		//
+		// It reaches a handler rather than a refusal only because the fixture
+		// assembles a run for TODAY: annotate writes onto what the deterministic
+		// engine ranked, and answers not-found when there is nothing to write
+		// onto. Both halves of the pair rest on `snapshotBriefRun` above.
+		{"annotate_brief", `{}`},
 		// Who the caller is, and who else they can hand work to. Both answer
 		// about the acting human rather than about a record, so the empty
 		// object is the whole input; list_colleagues also runs narrowed,


### PR DESCRIPTION
**main is red on `integration shard (4/6)`**, and it takes the `integration` fan-in with it. Confirmed at `origin/main` by main-health run 33038608724 on `d600a6f64`:

```
toolschema_conformance_integration_test.go:222:
annotate_brief is registered but never invoked here, so nothing holds its
result to the schema or the envelope.
```

`annotate_brief` shipped with the overnight brief and the lane never called it. **The gate is right** — a registered tool nothing exercises is a schema nobody has read.

## A call, not a waiver

`unreachableInThisLane` is for handlers needing a provider this lane has no business composing: a live calendar, an outbound mailbox, a crawl runner. This one needs nothing the lane lacks. Listing it there would spend the census's one exception on precisely the case it exists to catch — same call `describe_query_vocabulary` got a few commits ago.

## Empty on purpose

The top level of `annotateBriefSchema` requires nothing, and `AnnotateBriefArgs` says why:

> *Empty is a real answer: a quiet night has no sentence, and saying so is better than inventing one.*

So `{}` is a valid call, not a degenerate one. It proves the answer shape and the envelope **without the sweep leaving prose on a rep's morning as a side effect of checking a schema** — the same posture the approval call already takes by rejecting rather than releasing.

Traced end to end rather than assumed:

| step | result |
|---|---|
| top-level schema `required` | absent — `{}` validates |
| `Annotation.validate()` | `boundProse` only bounds length; the item loop is empty |
| `AnnotateCurrentRun` | needs today's `brief_run`, or answers not-found |
| the fixture | `snapshotBriefRun` assembles one for today |

That last row is the interesting one: **both halves of the brief pair rest on the same fixture.** `annotate_brief` writes onto what the deterministic engine ranked, so it reaches a handler rather than a refusal only because `snapshotBriefRun` stamps a run with the day the reader asks for.

## Verification

`go vet -tags integration` clean, `gofmt` clean. The lane needs a real Postgres, so CI is the proof here — the failing test is in this PR's own shard.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the conformance sweep failing on the `integration` shard by invoking `annotate_brief` with an empty object, so the registered tool is exercised and its schema is validated.

- `annotate_brief` is now part of the sweep, matching the other brief-pair tool `read_brief`.
- Empty input is intentional: the schema requires nothing, and the fixture provides a run for today, so the call reaches a handler and proves the envelope without side effects.
- The waiver list stays unused for this tool because it needs nothing the lane lacks.

<sup>Written for commit 177478ae796e3bb45e81ce9c455d61f33c5c41ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for calling `annotate_brief` with no arguments.
  * Verified that the handler response matches its declared schema and response envelope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->