### PR TITLE
feat(brief): a deal you dismissed comes back saying so

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28626,6 +28626,8 @@ components:
         state: { type: string, enum: [new, acted, dismissed, snoozed], description: The acting rep's queue state for this item. }
         state_at: { type: [string, 'null'], format: date-time, description: When the rep acted/dismissed/snoozed; null while new. }
         snoozed_until: { type: [string, 'null'], format: date-time, description: 'When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.' }
+        lineage:
+          $ref: '#/components/schemas/MorningBriefItemLineage'
         finding:
           type: [string, 'null']
           description: |
@@ -28633,6 +28635,35 @@ components:
             and the one next move. Null when no pass has annotated this run. It is agent-authored
             prose and the surface marks it as such; the rank beside it stays the deterministic
             engine's, which no annotation can change.
+
+    MorningBriefItemLineage:
+      type: [object, 'null']
+      additionalProperties: false
+      description: |
+        Why this deal is back after the rep dismissed it. Absent on an item that was never
+        dismissed, which is the ordinary case.
+
+        The suppression rule holds a dismissed deal out of every later queue until a linked
+        activity occurs after the mark — so a deal that reappears is always one the rep waved
+        away and that has since moved. That is what makes the pair honest rather than a guess:
+        it is the rule that put the deal back, stated.
+      required: [dismissed_on, returned_with_activity_at]
+      properties:
+        dismissed_on:
+          type: string
+          format: date
+          description: |
+            The local day the rep dismissed this deal, in the installation reporting timezone —
+            the same zone `local_day` is stamped in, so "you dismissed it Tuesday" and "this is
+            Thursday's brief" are measured the same way. A date, not an instant: the sentence
+            names a day.
+        returned_with_activity_at:
+          type: string
+          format: date-time
+          description: |
+            When the activity that re-qualified the deal occurred. An instant, because it names a
+            specific event. It is the EARLIEST activity after the dismissal: a later one did not
+            bring the deal back, it arrived once the deal was already coming.
 
     AnnotateBriefRequest:
       type: object

--- a/backend/internal/compose/briefs/briefhandlers.go
+++ b/backend/internal/compose/briefs/briefhandlers.go
@@ -178,6 +178,18 @@ func nullableText(text string) *string {
 	return &text
 }
 
+// lineageToWire renders why a dismissed deal came back, absent when it never
+// was dismissed.
+func lineageToWire(lineage *ItemLineage) *crmcontracts.MorningBriefItemLineage {
+	if lineage == nil {
+		return nil
+	}
+	return &crmcontracts.MorningBriefItemLineage{
+		DismissedOn:            openapi_types.Date{Time: lineage.DismissedOn},
+		ReturnedWithActivityAt: lineage.ReturnedWith,
+	}
+}
+
 func briefItemToWire(item BriefRunItem) crmcontracts.MorningBriefItem {
 	evidence := make([]openapi_types.UUID, 0, len(item.EvidenceIDs))
 	for _, id := range item.EvidenceIDs {
@@ -200,5 +212,6 @@ func briefItemToWire(item BriefRunItem) crmcontracts.MorningBriefItem {
 		StateAt:      item.StateAt,
 		SnoozedUntil: item.SnoozedUntil,
 		Finding:      nullableText(item.Finding),
+		Lineage:      lineageToWire(item.Lineage),
 	}
 }

--- a/backend/internal/compose/briefs/brieflineage.go
+++ b/backend/internal/compose/briefs/brieflineage.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// A deal the rep dismissed, come back.
+//
+// WHAT THE SUPPRESSION RULE MAKES TRUE. briefCandidates holds a dismissed deal
+// out of every later queue until a linked activity occurs after the mark. So a
+// deal that reappears is always a deal the rep waved away and that has since
+// moved — never one the ranker simply changed its mind about. That is what
+// makes the sentence honest: "you dismissed this, and here is the thing that
+// happened since" is not a guess, it is the rule that put the deal back.
+//
+// It also bounds what the sentence may claim. Only an ACTIVITY can return a
+// dismissed deal, so a line naming anything else — an offer expiring, a stage
+// moving — would describe a reason that cannot be why the deal is here. Those
+// are real facts and a richer "since then" is worth building, but it is a
+// change to the suppression rule first and a change to this sentence second.
+// Shipping the sentence alone would produce a line that can never fire.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// dealLineage is why one candidate is back: the day the rep dismissed it, and
+// the activity that re-qualified it.
+type dealLineage struct {
+	dismissedOn  time.Time
+	returnedWith time.Time
+}
+
+// briefLineage reads, for every candidate, whether it is a returning dismissal.
+//
+// ONE query for the whole rank rather than one per deal. The candidate loop
+// already runs up to three statements per deal; a fourth would make an N-query
+// loop a 4N one for an answer the whole set can be asked for at once.
+//
+// A deal with no dismissal, or one dismissed and never re-qualified, simply has
+// no row here — the map is the answer, and its absence is the ordinary case.
+func briefLineage(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, order []ids.UUID, now time.Time,
+) (map[ids.UUID]dealLineage, error) {
+	out := make(map[ids.UUID]dealLineage)
+	if len(order) == 0 {
+		return out, nil
+	}
+	// The day is derived from the DISMISSAL's own instant, in the same zone the
+	// run's local_day is stamped in. Not br.local_day: that is the day the
+	// brief was FOR, and a rep who opens Tuesday's brief on Wednesday and waves
+	// a deal away is told "flagged Tuesday, you dismissed it" about a Wednesday
+	// act. The sentence says what they did, so it is dated when they did it.
+	zone, err := identity.TimezoneOf(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		return nil, fmt.Errorf("brief: the installation timezone %q does not resolve: %w", zone, err)
+	}
+
+	// The most recent mark per deal, whatever it is — then lineage only when
+	// that mark is a dismissal.
+	//
+	// Filtering to dismissals BEFORE picking the latest would cite an obsolete
+	// one: a deal dismissed, returned, then acted on has a dismissal in its
+	// history, but the act is what the rep last said about it and the card must
+	// not reopen an argument they already closed.
+	//
+	// `bi.state <> 'new'` is kept deliberately: it is what idx_brief_item_deal
+	// is partial on, so dropping it for readability would fall off the index
+	// this query is shaped around.
+	rows, err := tx.Query(ctx, `
+		WITH last_mark AS (
+			SELECT DISTINCT ON (bi.deal_id)
+			       bi.deal_id, bi.state, bi.state_at
+			  FROM brief_item bi
+			  JOIN brief_run br ON br.id = bi.brief_run_id
+			 WHERE bi.deal_id = ANY($1)
+			   AND br.user_id = $2
+			   AND bi.state <> 'new'
+			 ORDER BY bi.deal_id, bi.state_at DESC
+		)
+		SELECT m.deal_id, m.state_at, MIN(a.occurred_at)
+		  FROM last_mark m
+		  JOIN activity_link l ON l.deal_id = m.deal_id
+		  JOIN activity a ON a.id = l.activity_id
+		 WHERE m.state = 'dismissed'
+		   AND a.archived_at IS NULL
+		   AND a.occurred_at > m.state_at
+		   -- Not after the run's own instant. A future-dated activity has not
+		   -- happened yet, and the candidate query bounds itself the same way,
+		   -- so the two agree about which deals are returning — disagreement
+		   -- would put a deal back with no line explaining it.
+		   AND a.occurred_at <= $3
+		 GROUP BY m.deal_id, m.state_at`,
+		order, userID, now.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var dealID ids.UUID
+		var dismissedAt, returnedWith time.Time
+		if err := rows.Scan(&dealID, &dismissedAt, &returnedWith); err != nil {
+			return nil, err
+		}
+		local := dismissedAt.In(loc)
+		out[dealID] = dealLineage{
+			dismissedOn:  time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, time.UTC),
+			returnedWith: returnedWith,
+		}
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/compose/briefs/briefmarks.go
+++ b/backend/internal/compose/briefs/briefmarks.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// What the rep does with a queue item: acted, dismissed, snoozed.
+//
+// Split from the store's assembly and read paths because it is a different
+// concept — those build and serve a run, these record a person's answer to one
+// — and because one file holding both crossed the length ceiling once lineage
+// gave the read something more to carry.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The field names an audit image of a brief item carries. Named because three
+// writers spell them and a typo in one produces an audit row whose before and
+// after describe different fields — which reads as a change nobody made.
+const (
+	auditFieldState        = "state"
+	auditFieldStateAt      = "state_at"
+	auditFieldSnoozedUntil = "snoozed_until"
+)
+
+// MarkActed records that the rep acted on a queue item; the next run's
+// candidate filter drops the deal until it materially changes.
+func (e *BriefEngine) MarkActed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
+	return e.markItem(ctx, itemID, briefStateActed, nil, now)
+}
+
+// MarkDismissed records that the rep dismissed a queue item; the deal
+// does not reappear unless a new linked activity arrives after the mark.
+func (e *BriefEngine) MarkDismissed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
+	return e.markItem(ctx, itemID, briefStateDismissed, nil, now)
+}
+
+// MarkSnoozed hides a queue item until the given instant (A77/AC-home-6),
+// after which it re-surfaces as actionable. The transport validates that
+// `until` lies in the future; this transition only records it.
+func (e *BriefEngine) MarkSnoozed(ctx context.Context, itemID ids.UUID, until, now time.Time) (BriefRunItem, error) {
+	untilUTC := until.UTC()
+	return e.markItem(ctx, itemID, briefStateSnoozed, &untilUTC, now)
+}
+
+// markItem is the one acted/dismissed/snoozed transition: only the run's
+// owner may mark, only an actionable item transitions (a second mark is a
+// conflict, not a silent overwrite), and the write is audited in the
+// same transaction. An expired snooze counts as actionable — a rep who
+// marks straight from a stale screen must not read differently from one
+// who re-opened the brief and had the item re-surfaced first. The brief
+// is per-rep personal queue state — the object gate is the deal-read
+// grant the brief itself rides on, and the real authority is run
+// ownership.
+func (e *BriefEngine) markItem(ctx context.Context, itemID ids.UUID, state string, snoozedUntil *time.Time, now time.Time) (BriefRunItem, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return BriefRunItem{}, err
+	}
+	userID, err := briefUser(ctx)
+	if err != nil {
+		return BriefRunItem{}, err
+	}
+
+	var item BriefRunItem
+	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var owner ids.UUID
+		row := tx.QueryRow(ctx, `
+			SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, ''),
+			       bi.returned_after_dismissal_on, bi.returned_with_activity_at, br.user_id
+			FROM brief_item bi
+			JOIN brief_run br ON br.id = bi.brief_run_id
+			WHERE bi.id = $1
+			FOR UPDATE OF bi`, itemID)
+		var featuresRaw []byte
+		// Read back with the mark, because the client replaces its cached item
+		// with this response wholesale: dropping the lineage here makes the
+		// "you dismissed it" line vanish the moment the rep acts on the very
+		// item it was explaining.
+		var dismissedOn, returnedWith *time.Time
+		err := row.Scan(&item.ID, &item.DealID, &item.Rank, &item.Composite, &featuresRaw,
+			&item.EvidenceIDs, &item.State, &item.StateAt, &item.SnoozedUntil, &item.Finding,
+			&dismissedOn, &returnedWith, &owner)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		// The CHECK keeps the pair whole, so one non-null half means both are.
+		if dismissedOn != nil && returnedWith != nil {
+			item.Lineage = &ItemLineage{DismissedOn: *dismissedOn, ReturnedWith: *returnedWith}
+		}
+		if err := json.Unmarshal(featuresRaw, &item.Features); err != nil {
+			return fmt.Errorf("brief: item %s carries an unreadable feature vector: %w", item.ID, err)
+		}
+		if owner != userID {
+			// Another rep's brief: existence-hiding, like every row-scope miss.
+			return apperrors.ErrNotFound
+		}
+		// The mark's twin of the join in readRunItems: the item names a deal
+		// that may have moved since the run was assembled, and a mark is a
+		// read-back as much as a write. Checked BEFORE actionability, so a
+		// deal the rep can no longer read answers not-found rather than
+		// disclosing the item's state through a conflict.
+		if err := auth.EnsureVisible(ctx, tx, "deal", item.DealID); err != nil {
+			return err
+		}
+		if !briefItemActionable(item, now) {
+			return apperrors.ErrConflict
+		}
+
+		markedAt := now.UTC()
+		if _, err := tx.Exec(ctx, `
+			UPDATE brief_item SET state = $2, state_at = $3, snoozed_until = $4 WHERE id = $1`,
+			itemID, state, markedAt, snoozedUntil); err != nil {
+			return err
+		}
+		before := map[string]any{
+			auditFieldState: item.State, auditFieldStateAt: item.StateAt,
+			auditFieldSnoozedUntil: item.SnoozedUntil,
+		}
+		after := map[string]any{
+			auditFieldState: state, auditFieldStateAt: markedAt,
+			auditFieldSnoozedUntil: snoozedUntil,
+		}
+		if _, err := storekit.Audit(ctx, tx, "update", "brief_item", itemID, before, after); err != nil {
+			return err
+		}
+		item.State = state
+		item.StateAt = &markedAt
+		item.SnoozedUntil = snoozedUntil
+		return nil
+	})
+	if err != nil {
+		return BriefRunItem{}, err
+	}
+	return item, nil
+}
+
+// Unanswered says whether this item is still waiting on the rep, as a run READ
+// hands it back.
+//
+// It takes no instant, unlike briefItemActionable below, and the difference is
+// which question is being asked. That one guards a MARK against a stale screen,
+// so it must admit a snooze whose window has passed but whose row a read has
+// not yet flipped. This one describes an item LatestRun has already returned,
+// and that read resurfaces expired snoozes inside its own transaction — so a
+// still-snoozed item here is genuinely still set aside, and re-deciding that
+// against a second clock could only disagree with the read that produced it.
+//
+// Exported because the worklist lane asks it. What a brief state means belongs
+// to this package; a lane spelling `state == "new"` for itself would be a
+// second copy of that vocabulary.
+func Unanswered(item BriefRunItem) bool {
+	return item.State == briefStateNew
+}
+
+// briefItemActionable says whether a rep may still mark this item: fresh,
+// or snoozed past its snoozed_until (the re-surface may not have been
+// materialized by a read yet, but the item is already actionable again).
+func briefItemActionable(item BriefRunItem, now time.Time) bool {
+	if item.State == briefStateNew {
+		return true
+	}
+	return item.State == briefStateSnoozed && item.SnoozedUntil != nil && !now.UTC().Before(*item.SnoozedUntil)
+}

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -112,6 +112,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 	facts := map[ids.UUID]briefDealFacts{}
 	var order []ids.UUID
 	stakeholders := map[ids.UUID][]ids.UUID{}
+	lineage := map[ids.UUID]dealLineage{}
 	revenueNorm := int64(briefRevenueNormFallbackMinor)
 
 	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
@@ -138,7 +139,14 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		if err := briefCandidates(ctx, tx, userID, now, base, facts, &order); err != nil {
 			return err
 		}
-		return briefEvidenceRows(ctx, tx, lastView, facts, order, stakeholders)
+		if err := briefEvidenceRows(ctx, tx, lastView, facts, order, stakeholders); err != nil {
+			return err
+		}
+		// Why each returning deal is back, for the whole candidate set at once.
+		// It reads AFTER the candidates because it is asked about them: a deal
+		// the suppression rule is still holding out has no lineage to tell.
+		lineage, err = briefLineage(ctx, tx, userID, order, now)
+		return err
 	})
 	if err != nil {
 		return BriefRanking{}, err
@@ -150,7 +158,18 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 
 	scored := make([]BriefQueueItem, 0, len(order))
 	for _, dealID := range order {
-		scored = append(scored, briefScore(facts[dealID], revenueNorm, now))
+		item := briefScore(facts[dealID], revenueNorm, now)
+		// Attached AFTER scoring, never inside it. briefScore is a pure
+		// function of the ranking facts and is tested as one; lineage explains
+		// why a deal is in the queue and must not be able to change where it
+		// sits, or "you dismissed this" would become a reason to rank it.
+		if back, returning := lineage[dealID]; returning {
+			item.Lineage = &ItemLineage{
+				DismissedOn:  back.dismissedOn,
+				ReturnedWith: back.returnedWith,
+			}
+		}
+		scored = append(scored, item)
 	}
 
 	// The deterministic floor first: the full §10.1 candidate set, ordered
@@ -274,8 +293,14 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 			      ELSE NOT EXISTS (
 				SELECT 1 FROM activity a
 				JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
-				WHERE a.archived_at IS NULL AND a.occurred_at > bi.state_at) END)`,
-		briefBaseValueSQL(asOfPos, basePos), userPos, asOfPos)
+				WHERE a.archived_at IS NULL AND a.occurred_at > bi.state_at
+				  -- Not after this instant. A future-dated activity has not
+				  -- happened, so treating it as "the deal moved" brings a
+				  -- dismissed deal back for something still to come — and the
+				  -- lineage read bounds itself the same way, so an unbounded
+				  -- one here would return deals whose card can say nothing.
+				  AND a.occurred_at <= $%d) END)`,
+		briefBaseValueSQL(asOfPos, basePos), userPos, asOfPos, asOfPos)
 	if scope != "" {
 		q += " AND " + scope
 	}

--- a/backend/internal/compose/briefs/briefrank_integration_test.go
+++ b/backend/internal/compose/briefs/briefrank_integration_test.go
@@ -414,3 +414,220 @@ func queueHasDeal(queue []BriefQueueItem, dealID ids.UUID) bool {
 	}
 	return false
 }
+
+// A deal that comes back says so, and says why.
+//
+// The suppression rule is what makes the sentence honest: a dismissed deal is
+// held out of every later queue until a linked activity occurs after the mark,
+// so a deal that reappears is ALWAYS one the rep waved away and that has since
+// moved. The lineage states that rule rather than guessing at it — which is
+// also why it can only ever name an activity: nothing else brings a dismissed
+// deal back, so a line naming an offer or a stage move would describe a reason
+// that cannot be why the deal is here.
+func TestADismissedDealComesBackCarryingWhyItReturned(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markAt := briefClock.Add(2 * time.Hour)
+	dismissed := run.Items[1]
+	if _, err := b.engine.MarkDismissed(b.repCtx, dismissed.ID, markAt); err != nil {
+		t.Fatal(err)
+	}
+
+	returnedAt := "2026-06-04T10:00:00Z"
+	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they came back', '`+returnedAt+`', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, fresh, "deal", dismissed.DealID)
+
+	nextClock := briefClock.Add(24 * time.Hour)
+	reranked, err := b.engine.Rank(b.repCtx, nextClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back *BriefQueueItem
+	for i := range reranked.Queue {
+		if reranked.Queue[i].DealID == dismissed.DealID {
+			back = &reranked.Queue[i]
+		}
+	}
+	if back == nil {
+		t.Fatalf("the re-qualified deal is not in the queue: %v", queueDeals(reranked.Queue))
+	}
+	if back.Lineage == nil {
+		t.Fatal("the returning deal carries no lineage — the rep sees a deal they dismissed " +
+			"sitting in today's queue with no explanation, which reads as the product having forgotten")
+	}
+	// The DAY they dismissed it, in the installation's reporting zone — the
+	// same zone the run's own local_day is stamped in.
+	if got := back.Lineage.DismissedOn.Format(time.DateOnly); got != markAt.Format(time.DateOnly) {
+		t.Errorf("lineage says dismissed on %s, want %s", got, markAt.Format(time.DateOnly))
+	}
+	// And the activity that actually brought it back.
+	if got := back.Lineage.ReturnedWith.UTC().Format(time.RFC3339); got != returnedAt {
+		t.Errorf("lineage cites an activity at %s, want the one that re-qualified it (%s)", got, returnedAt)
+	}
+}
+
+// An item nobody dismissed carries no lineage. Without this the test above
+// passes against an engine that attaches the same sentence to everything.
+func TestAnItemNobodyDismissedCarriesNoLineage(t *testing.T) {
+	b := setupBrief(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.Items) == 0 {
+		t.Fatal("the seeded run ranked nothing, so this test proves nothing")
+	}
+	for _, item := range run.Items {
+		if item.Lineage != nil {
+			t.Errorf("deal %s was never dismissed but carries lineage %+v — "+
+				"the rep is told they waved away something they never saw", item.DealID, item.Lineage)
+		}
+	}
+}
+
+// The lineage survives the round trip through the row, because that is where it
+// is read from every morning after the one it was computed on.
+func TestTheLineageIsPersistedNotRecomputedOnEveryRead(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dismissed := run.Items[1]
+	if _, err := b.engine.MarkDismissed(b.repCtx, dismissed.ID, briefClock.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they came back', '2026-06-04T10:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, fresh, "deal", dismissed.DealID)
+
+	// A fresh run on a later day persists the returning item...
+	nextClock := briefClock.Add(24 * time.Hour)
+	if _, err := b.engine.SnapshotRun(b.repCtx, nextClock); err != nil {
+		t.Fatal(err)
+	}
+	// ...and the on-open read serves it back from the row.
+	read, err := b.engine.LatestRun(b.repCtx, nextClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, item := range read.Items {
+		if item.DealID == dismissed.DealID {
+			found = true
+			if item.Lineage == nil {
+				t.Error("the persisted returning item read back with no lineage — " +
+					"the sentence would appear the morning it was computed and vanish the next")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("the returning deal is not in the persisted run: %v", read.Items)
+	}
+}
+
+// The lineage names the day the rep DISMISSED it, not the day the brief was
+// for. A rep who opens Tuesday's brief on Wednesday and waves a deal away did
+// that on Wednesday, and a card telling them otherwise is describing an act
+// they did not perform on a day they did not perform it.
+func TestTheLineageIsDatedWhenTheRepActedNotWhenTheBriefWasFor(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dismissed := run.Items[1]
+	// The brief is for briefClock's day; the rep gets to it the NEXT day.
+	dismissedNextDay := briefClock.Add(26 * time.Hour)
+	if _, err := b.engine.MarkDismissed(b.repCtx, dismissed.ID, dismissedNextDay); err != nil {
+		t.Fatal(err)
+	}
+	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they came back', '2026-06-05T10:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, fresh, "deal", dismissed.DealID)
+
+	reranked, err := b.engine.Rank(b.repCtx, briefClock.Add(72*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range reranked.Queue {
+		if item.DealID != dismissed.DealID {
+			continue
+		}
+		if item.Lineage == nil {
+			t.Fatal("the returning deal carries no lineage")
+		}
+		want := dismissedNextDay.Format(time.DateOnly)
+		if got := item.Lineage.DismissedOn.Format(time.DateOnly); got != want {
+			t.Errorf("lineage says dismissed on %s, want %s — the day the rep acted, "+
+				"not the day the brief was assembled for", got, want)
+		}
+		return
+	}
+	t.Fatalf("the returning deal is not in the queue: %v", queueDeals(reranked.Queue))
+}
+
+// A deal dismissed, returned, and then ACTED on carries no lineage: the act is
+// the last thing the rep said about it, and reopening the dismissal would
+// reargue a point they have already closed.
+func TestALaterActRetiresTheDismissalLineage(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal := run.Items[1]
+	if _, err := b.engine.MarkDismissed(b.repCtx, deal.ID, briefClock.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	first := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they came back', '2026-06-04T10:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, first, "deal", deal.DealID)
+
+	// It returns, and this time the rep acts on it.
+	second, err := b.engine.SnapshotRun(b.repCtx, briefClock.Add(24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var returned ids.UUID
+	for _, item := range second.Items {
+		if item.DealID == deal.DealID {
+			returned = item.ID
+		}
+	}
+	if returned.IsZero() {
+		t.Fatalf("the deal did not return on day two: %v", second.Items)
+	}
+	if _, err := b.engine.MarkActed(b.repCtx, returned, briefClock.Add(26*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	// A third activity brings it back again — but the last thing the rep said
+	// was "acted", not "dismissed".
+	third := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'and again', '2026-06-06T10:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, third, "deal", deal.DealID)
+
+	final, err := b.engine.Rank(b.repCtx, briefClock.Add(72*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range final.Queue {
+		if item.DealID == deal.DealID && item.Lineage != nil {
+			t.Errorf("the deal carries a dismissal line after the rep ACTED on it (%+v) — "+
+				"the card reopens an argument they already closed", item.Lineage)
+		}
+	}
+}

--- a/backend/internal/compose/briefs/briefscore.go
+++ b/backend/internal/compose/briefs/briefscore.go
@@ -76,6 +76,23 @@ type BriefQueueItem struct {
 	Composite   float64
 	Features    BriefFeatureVector
 	EvidenceIDs []ids.UUID
+	// Lineage is set when this deal is back after the rep dismissed it. Nil is
+	// the ordinary case — most items were never dismissed — and it does not
+	// affect the ranking: the sentence explains why the deal is here, it does
+	// not decide whether it is.
+	Lineage *ItemLineage
+}
+
+// ItemLineage is why a dismissed deal came back: the day the rep waved it away,
+// and the activity that re-qualified it.
+type ItemLineage struct {
+	// DismissedOn is a calendar day in the installation's reporting zone, the
+	// same zone brief_run.local_day is stamped in — so "you dismissed it
+	// Tuesday" and "this is Thursday's brief" are measured the same way.
+	DismissedOn time.Time
+	// ReturnedWith is when the activity that brought it back occurred. An
+	// instant, because it names a specific event.
+	ReturnedWith time.Time
 }
 
 // briefDealFacts are the raw per-deal facts the candidate query gathers;

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -73,6 +73,9 @@ type BriefRunItem struct {
 	// Finding is what the overnight agent found about this deal, empty when no
 	// pass has annotated the run it belongs to.
 	Finding string
+	// Lineage is set when this deal is back after the rep dismissed it. Nil is
+	// the ordinary case.
+	Lineage *ItemLineage
 }
 
 // SnapshotRun ranks and persists one brief run for the acting rep at the
@@ -203,12 +206,22 @@ func insertRunItems(ctx context.Context, tx pgx.Tx, runID ids.UUID, queue []Brie
 			Features:    item.Features,
 			EvidenceIDs: item.EvidenceIDs,
 			State:       briefStateNew,
+			Lineage:     item.Lineage,
+		}
+		// Both halves or neither — brief_item_lineage_whole says so, and a
+		// sentence with one half is one the screen cannot finish.
+		var dismissedOn, returnedWith *time.Time
+		if item.Lineage != nil {
+			dismissedOn = &item.Lineage.DismissedOn
+			returnedWith = &item.Lineage.ReturnedWith
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO brief_item (id, brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			INSERT INTO brief_item (id, brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state,
+			                        returned_after_dismissal_on, returned_with_activity_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 			persisted.ID, runID, persisted.DealID, persisted.Rank,
-			persisted.Composite, features, persisted.EvidenceIDs, briefStateNew); err != nil {
+			persisted.Composite, features, persisted.EvidenceIDs, briefStateNew,
+			dismissedOn, returnedWith); err != nil {
 			return nil, err
 		}
 		items = append(items, persisted)
@@ -298,7 +311,8 @@ func readRunItems(ctx context.Context, tx pgx.Tx, runID ids.UUID) ([]BriefRunIte
 		return nil, err
 	}
 	q := fmt.Sprintf(`
-		SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, '')
+		SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, ''),
+		       bi.returned_after_dismissal_on, bi.returned_with_activity_at
 		FROM brief_item bi
 		JOIN deal d ON d.id = bi.deal_id
 		WHERE bi.brief_run_id = $%d AND bi.state <> 'snoozed'`, runPos)
@@ -338,8 +352,11 @@ func resurfaceExpiredSnoozes(ctx context.Context, tx pgx.Tx, runID ids.UUID, now
 		return err
 	}
 	for _, itemID := range resurfaced {
-		before := map[string]any{"state": briefStateSnoozed}
-		after := map[string]any{"state": briefStateNew, "state_at": nil, "snoozed_until": nil}
+		before := map[string]any{auditFieldState: briefStateSnoozed}
+		after := map[string]any{
+			auditFieldState: briefStateNew, auditFieldStateAt: nil,
+			auditFieldSnoozedUntil: nil,
+		}
 		if _, err := storekit.Audit(ctx, tx, "update", "brief_item", itemID, before, after); err != nil {
 			return err
 		}
@@ -347,142 +364,23 @@ func resurfaceExpiredSnoozes(ctx context.Context, tx pgx.Tx, runID ids.UUID, now
 	return nil
 }
 
-// MarkActed records that the rep acted on a queue item; the next run's
-// candidate filter drops the deal until it materially changes.
-func (e *BriefEngine) MarkActed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
-	return e.markItem(ctx, itemID, briefStateActed, nil, now)
-}
-
-// MarkDismissed records that the rep dismissed a queue item; the deal
-// does not reappear unless a new linked activity arrives after the mark.
-func (e *BriefEngine) MarkDismissed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
-	return e.markItem(ctx, itemID, briefStateDismissed, nil, now)
-}
-
-// MarkSnoozed hides a queue item until the given instant (A77/AC-home-6),
-// after which it re-surfaces as actionable. The transport validates that
-// `until` lies in the future; this transition only records it.
-func (e *BriefEngine) MarkSnoozed(ctx context.Context, itemID ids.UUID, until, now time.Time) (BriefRunItem, error) {
-	untilUTC := until.UTC()
-	return e.markItem(ctx, itemID, briefStateSnoozed, &untilUTC, now)
-}
-
-// markItem is the one acted/dismissed/snoozed transition: only the run's
-// owner may mark, only an actionable item transitions (a second mark is a
-// conflict, not a silent overwrite), and the write is audited in the
-// same transaction. An expired snooze counts as actionable — a rep who
-// marks straight from a stale screen must not read differently from one
-// who re-opened the brief and had the item re-surfaced first. The brief
-// is per-rep personal queue state — the object gate is the deal-read
-// grant the brief itself rides on, and the real authority is run
-// ownership.
-func (e *BriefEngine) markItem(ctx context.Context, itemID ids.UUID, state string, snoozedUntil *time.Time, now time.Time) (BriefRunItem, error) {
-	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
-		return BriefRunItem{}, err
-	}
-	userID, err := briefUser(ctx)
-	if err != nil {
-		return BriefRunItem{}, err
-	}
-
-	var item BriefRunItem
-	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
-		var owner ids.UUID
-		row := tx.QueryRow(ctx, `
-			SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, ''), br.user_id
-			FROM brief_item bi
-			JOIN brief_run br ON br.id = bi.brief_run_id
-			WHERE bi.id = $1
-			FOR UPDATE OF bi`, itemID)
-		var featuresRaw []byte
-		err := row.Scan(&item.ID, &item.DealID, &item.Rank, &item.Composite, &featuresRaw,
-			&item.EvidenceIDs, &item.State, &item.StateAt, &item.SnoozedUntil, &item.Finding, &owner)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(featuresRaw, &item.Features); err != nil {
-			return fmt.Errorf("brief: item %s carries an unreadable feature vector: %w", item.ID, err)
-		}
-		if owner != userID {
-			// Another rep's brief: existence-hiding, like every row-scope miss.
-			return apperrors.ErrNotFound
-		}
-		// The mark's twin of the join in readRunItems: the item names a deal
-		// that may have moved since the run was assembled, and a mark is a
-		// read-back as much as a write. Checked BEFORE actionability, so a
-		// deal the rep can no longer read answers not-found rather than
-		// disclosing the item's state through a conflict.
-		if err := auth.EnsureVisible(ctx, tx, "deal", item.DealID); err != nil {
-			return err
-		}
-		if !briefItemActionable(item, now) {
-			return apperrors.ErrConflict
-		}
-
-		markedAt := now.UTC()
-		if _, err := tx.Exec(ctx, `
-			UPDATE brief_item SET state = $2, state_at = $3, snoozed_until = $4 WHERE id = $1`,
-			itemID, state, markedAt, snoozedUntil); err != nil {
-			return err
-		}
-		before := map[string]any{"state": item.State, "state_at": item.StateAt, "snoozed_until": item.SnoozedUntil}
-		after := map[string]any{"state": state, "state_at": markedAt, "snoozed_until": snoozedUntil}
-		if _, err := storekit.Audit(ctx, tx, "update", "brief_item", itemID, before, after); err != nil {
-			return err
-		}
-		item.State = state
-		item.StateAt = &markedAt
-		item.SnoozedUntil = snoozedUntil
-		return nil
-	})
-	if err != nil {
-		return BriefRunItem{}, err
-	}
-	return item, nil
-}
-
-// Unanswered says whether this item is still waiting on the rep, as a run READ
-// hands it back.
-//
-// It takes no instant, unlike briefItemActionable below, and the difference is
-// which question is being asked. That one guards a MARK against a stale screen,
-// so it must admit a snooze whose window has passed but whose row a read has
-// not yet flipped. This one describes an item LatestRun has already returned,
-// and that read resurfaces expired snoozes inside its own transaction — so a
-// still-snoozed item here is genuinely still set aside, and re-deciding that
-// against a second clock could only disagree with the read that produced it.
-//
-// Exported because the worklist lane asks it. What a brief state means belongs
-// to this package; a lane spelling `state == "new"` for itself would be a
-// second copy of that vocabulary.
-func Unanswered(item BriefRunItem) bool {
-	return item.State == briefStateNew
-}
-
-// briefItemActionable says whether a rep may still mark this item: fresh,
-// or snoozed past its snoozed_until (the re-surface may not have been
-// materialized by a read yet, but the item is already actionable again).
-func briefItemActionable(item BriefRunItem, now time.Time) bool {
-	if item.State == briefStateNew {
-		return true
-	}
-	return item.State == briefStateSnoozed && item.SnoozedUntil != nil && !now.UTC().Before(*item.SnoozedUntil)
-}
-
 // scanBriefItem reads one brief_item row in the LatestRun column order.
 func scanBriefItem(rows pgx.Rows) (BriefRunItem, error) {
 	var item BriefRunItem
 	var featuresRaw []byte
+	var dismissedOn *time.Time
+	var returnedWith *time.Time
 	if err := rows.Scan(&item.ID, &item.DealID, &item.Rank, &item.Composite,
 		&featuresRaw, &item.EvidenceIDs, &item.State, &item.StateAt, &item.SnoozedUntil,
-		&item.Finding); err != nil {
+		&item.Finding, &dismissedOn, &returnedWith); err != nil {
 		return BriefRunItem{}, err
 	}
 	if err := json.Unmarshal(featuresRaw, &item.Features); err != nil {
 		return BriefRunItem{}, fmt.Errorf("brief: item %s carries an unreadable feature vector: %w", item.ID, err)
+	}
+	// The CHECK keeps the pair whole, so one non-null half means both are.
+	if dismissedOn != nil && returnedWith != nil {
+		item.Lineage = &ItemLineage{DismissedOn: *dismissedOn, ReturnedWith: *returnedWith}
 	}
 	return item, nil
 }

--- a/backend/internal/compose/briefseam.go
+++ b/backend/internal/compose/briefseam.go
@@ -71,6 +71,7 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 	for _, item := range run.Items {
 		items = append(items, agents.BriefItem{
 			ItemID: item.ID, DealID: item.DealID, Rank: item.Rank,
+			Lineage:   lineageForTool(item.Lineage),
 			Composite: item.Composite, Factors: agents.BriefFactors{
 				Winnability: item.Features.Winnability, Revenue: item.Features.Revenue,
 				Timing: item.Features.Timing, Momentum: item.Features.Momentum,
@@ -89,5 +90,17 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 		BriefID: run.ID, GeneratedAt: run.GeneratedAt, AsOf: run.AsOf,
 		LocalDay:       run.LocalDay.Format(time.DateOnly),
 		CandidateCount: run.CandidateCount, Items: items,
+	}
+}
+
+// lineageForTool serves why a dismissed deal came back, absent when it never
+// was dismissed.
+func lineageForTool(lineage *briefs.ItemLineage) *agents.BriefItemLineage {
+	if lineage == nil {
+		return nil
+	}
+	return &agents.BriefItemLineage{
+		DismissedOn:  lineage.DismissedOn.Format(time.DateOnly),
+		ReturnedWith: lineage.ReturnedWith,
 	}
 }

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -68,6 +68,10 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 			EvidenceIDs: []ids.UUID{evidence}, State: "snoozed",
 			StateAt: &stateAt, SnoozedUntil: &snoozedUntil,
 			Finding: "He asked about the delivery date yesterday.",
+			Lineage: &briefs.ItemLineage{
+				DismissedOn:  time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+				ReturnedWith: time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC),
+			},
 		}},
 	}
 
@@ -101,6 +105,7 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		"EvidenceIDs": `"evidence_ids":["` + evidence.String(), "State": `"state":"snoozed"`,
 		"StateAt": `"state_at":"2026-08-08T07:33:00Z"`, "SnoozedUntil": `"snoozed_until":"2026-08-09T08:44:00Z"`,
 		"Finding": "He asked about the delivery date yesterday.",
+		"Lineage": `"dismissed_on":"2026-08-05"`,
 	}, string(served))
 	// An entry no field reached names something that is gone, which reads as a
 	// deliberate omission while certifying nothing.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -18504,6 +18504,15 @@ type MorningBriefItem struct {
 	Finding *string            `json:"finding,omitempty"`
 	Id      openapi_types.UUID `json:"id"`
 
+	// Lineage Why this deal is back after the rep dismissed it. Absent on an item that was never
+	// dismissed, which is the ordinary case.
+	//
+	// The suppression rule holds a dismissed deal out of every later queue until a linked
+	// activity occurs after the mark — so a deal that reappears is always one the rep waved
+	// away and that has since moved. That is what makes the pair honest rather than a guess:
+	// it is the rule that put the deal back, stated.
+	Lineage *MorningBriefItemLineage `json:"lineage,omitempty"`
+
 	// Rank Position in the queue (1 = top), after the L2 re-order.
 	Rank int `json:"rank"`
 
@@ -18519,6 +18528,26 @@ type MorningBriefItem struct {
 
 // MorningBriefItemState The acting rep's queue state for this item.
 type MorningBriefItemState string
+
+// MorningBriefItemLineage Why this deal is back after the rep dismissed it. Absent on an item that was never
+// dismissed, which is the ordinary case.
+//
+// The suppression rule holds a dismissed deal out of every later queue until a linked
+// activity occurs after the mark — so a deal that reappears is always one the rep waved
+// away and that has since moved. That is what makes the pair honest rather than a guess:
+// it is the rule that put the deal back, stated.
+type MorningBriefItemLineage struct {
+	// DismissedOn The local day the rep dismissed this deal, in the installation reporting timezone —
+	// the same zone `local_day` is stamped in, so "you dismissed it Tuesday" and "this is
+	// Thursday's brief" are measured the same way. A date, not an instant: the sentence
+	// names a day.
+	DismissedOn openapi_types.Date `json:"dismissed_on"`
+
+	// ReturnedWithActivityAt When the activity that re-qualified the deal occurred. An instant, because it names a
+	// specific event. It is the EARLIEST activity after the dismissal: a later one did not
+	// bring the deal back, it arrived once the deal was already coming.
+	ReturnedWithActivityAt time.Time `json:"returned_with_activity_at"`
+}
 
 // MorningDigest The CAP-DDL-6 payload: what capture did overnight and what awaits the human (CAP-WIRE-6).
 type MorningDigest struct {

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -5176,6 +5176,21 @@
                   "type": "string",
                   "format": "uuid"
                 },
+                "lineage": {
+                  "type": "object",
+                  "properties": {
+                    "dismissed_on": {
+                      "type": "string"
+                    },
+                    "returned_with_activity_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dismissed_on",
+                    "returned_with_activity_at"
+                  ]
+                },
                 "rank": {
                   "type": "integer"
                 },

--- a/backend/internal/modules/agents/tools_brief.go
+++ b/backend/internal/modules/agents/tools_brief.go
@@ -121,6 +121,23 @@ type BriefItem struct {
 	// SnoozedUntil is when a snoozed item re-surfaces, and is absent unless the
 	// item is snoozed.
 	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+	// Lineage is set when this deal is back after the person dismissed it, and
+	// it is SERVED rather than withheld: it is a deterministic fact about what
+	// they did, not something an agent wrote, so reading it is not a loop
+	// reading its own output. It is also the context an agent most needs — a
+	// finding that ignores "you already waved this away once" is a finding that
+	// repeats an argument the reader has already rejected.
+	Lineage *BriefItemLineage `json:"lineage,omitempty"`
+}
+
+// BriefItemLineage is why a dismissed deal came back.
+type BriefItemLineage struct {
+	// DismissedOn is the local day the person dismissed it, as a calendar date
+	// in the installation's reporting zone.
+	DismissedOn string `json:"dismissed_on"`
+	// ReturnedWith is when the activity that re-qualified it occurred — the
+	// EARLIEST one after the dismissal, which is the one that brought it back.
+	ReturnedWith time.Time `json:"returned_with_activity_at"`
 }
 
 // BriefFactors is the §10.1 factor decomposition, each normalized 0..1.

--- a/backend/migrations/core/1787803200_a_returning_brief_item_remembers_it_was_dismissed.down.sql
+++ b/backend/migrations/core/1787803200_a_returning_brief_item_remembers_it_was_dismissed.down.sql
@@ -1,0 +1,7 @@
+-- Same bound as the up: dropping a column takes an ACCESS EXCLUSIVE lock on a
+-- table the live product writes every morning.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_item DROP CONSTRAINT IF EXISTS brief_item_lineage_whole;
+ALTER TABLE brief_item DROP COLUMN IF EXISTS returned_with_activity_at;
+ALTER TABLE brief_item DROP COLUMN IF EXISTS returned_after_dismissal_on;

--- a/backend/migrations/core/1787803200_a_returning_brief_item_remembers_it_was_dismissed.up.sql
+++ b/backend/migrations/core/1787803200_a_returning_brief_item_remembers_it_was_dismissed.up.sql
@@ -1,0 +1,43 @@
+-- A deal the rep dismissed and that has come back says so.
+--
+-- The suppression rule (briefrank.go's candidate query) holds a dismissed deal
+-- out of every later queue until a linked activity occurs after the mark. So a
+-- deal that reappears is ALWAYS a deal the rep waved away and that has since
+-- moved — and until now the card said nothing about it. The rep sees the same
+-- deal they dismissed on Tuesday sitting at rank 2 on Thursday with no
+-- explanation, which reads as the product having forgotten.
+--
+-- WHY NOT REUSE state_at. brief_item_state_stamped enforces
+-- (state = 'new') = (state_at IS NULL), so a returning item — which IS new in
+-- its own run — cannot carry the previous mark's timestamp in that column.
+-- These are a different fact anyway: state_at is what the rep did to THIS row,
+-- and these say what they did to an earlier one.
+--
+-- WHY ON THE ROW rather than derived at read time. The derivation would be a
+-- cross-run query per item on the read path, and the answer never changes once
+-- the run is assembled: the dismissal it names has already happened. Stamping
+-- it when the run is built is one write instead of a read every morning.
+--
+-- Bounded, because both statements block writers on a table this migration did
+-- not create.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_item ADD COLUMN returned_after_dismissal_on date;
+
+-- The local day the rep dismissed this deal on, in the installation's
+-- reporting zone — the same zone brief_run.local_day is stamped in, so "you
+-- dismissed it Tuesday" and "this is Thursday's brief" are measured the same
+-- way. A DATE and not an instant: the sentence names a day, and storing an
+-- instant would invite a reader to render a time nobody promised was accurate.
+
+ALTER TABLE brief_item ADD COLUMN returned_with_activity_at timestamptz;
+
+-- When the activity that brought it back occurred. THIS one is an instant,
+-- because it is a specific event and the card may say how long ago it was.
+--
+-- The pair is all-or-nothing: an item either carries both halves of the
+-- lineage or neither. Half of it — a dismissal day with no reason it returned,
+-- or a reason with no dismissal — is a sentence the screen cannot finish.
+ALTER TABLE brief_item
+    ADD CONSTRAINT brief_item_lineage_whole
+    CHECK ((returned_after_dismissal_on IS NULL) = (returned_with_activity_at IS NULL));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -710,6 +710,7 @@ public.brief_item acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/ma
 public.brief_item.brief_item_composite_check CHECK (((composite >= (0)::double precision) AND (composite <= (1)::double precision)))
 public.brief_item.brief_item_deal_fkey FOREIGN KEY (deal_id) REFERENCES deal(id) ON DELETE CASCADE
 public.brief_item.brief_item_finding_length CHECK (((finding IS NULL) OR (char_length(finding) <= 600)))
+public.brief_item.brief_item_lineage_whole CHECK (((returned_after_dismissal_on IS NULL) = (returned_with_activity_at IS NULL)))
 public.brief_item.brief_item_pkey PRIMARY KEY (id)
 public.brief_item.brief_item_rank_check CHECK ((rank >= 1))
 public.brief_item.brief_item_run_fkey FOREIGN KEY (brief_run_id) REFERENCES brief_run(id) ON DELETE CASCADE
@@ -724,6 +725,8 @@ public.brief_item.feature_vector jsonb NOT NULL gen=- def=-
 public.brief_item.finding text gen=- def=-
 public.brief_item.id uuid NOT NULL gen=- def=uuidv7()
 public.brief_item.rank integer NOT NULL gen=- def=-
+public.brief_item.returned_after_dismissal_on date gen=- def=-
+public.brief_item.returned_with_activity_at timestamp with time zone gen=- def=-
 public.brief_item.snoozed_until timestamp with time zone gen=- def=-
 public.brief_item.state text NOT NULL gen=- def='new'::text
 public.brief_item.state_at timestamp with time zone gen=- def=-

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 167270,
+    "tool_catalog_bytes": 167448,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 42695,
+    "approx_wire_tokens_total": 42740,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 39998,
       "input_schema_bytes": 36664,
-      "output_schema_bytes": 77783,
+      "output_schema_bytes": 77961,
       "description_plus_input_schema_bytes": 76662
     }
   },
@@ -6759,6 +6759,21 @@
                       "item_id": {
                         "format": "uuid",
                         "type": "string"
+                      },
+                      "lineage": {
+                        "properties": {
+                          "dismissed_on": {
+                            "type": "string"
+                          },
+                          "returned_with_activity_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "dismissed_on",
+                          "returned_with_activity_at"
+                        ],
+                        "type": "object"
                       },
                       "rank": {
                         "type": "integer"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 163.3 KB |
+| Tool catalog | 163.5 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 42695 |
+| Approx. wire tokens | 42740 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 76.0 KB | 46% | **No** — a result's shape, never listed to a model |
+| Output schemas | 76.1 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 39.1 KB | 23% | Yes, every step |
 | Input schemas | 35.8 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
@@ -99,7 +99,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 4.0 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
-| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
+| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.0 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.2 KB |
@@ -7406,6 +7406,21 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
               "item_id": {
                 "format": "uuid",
                 "type": "string"
+              },
+              "lineage": {
+                "properties": {
+                  "dismissed_on": {
+                    "type": "string"
+                  },
+                  "returned_with_activity_at": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "dismissed_on",
+                  "returned_with_activity_at"
+                ],
+                "type": "object"
               },
               "rank": {
                 "type": "integer"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21588,6 +21588,7 @@ export interface components {
              * @description When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.
              */
             snoozed_until?: string | null;
+            lineage?: components["schemas"]["MorningBriefItemLineage"];
             /**
              * @description What the overnight agent found about this deal — why it is on the list, what changed,
              *     and the one next move. Null when no pass has annotated this run. It is agent-authored
@@ -21596,6 +21597,32 @@ export interface components {
              */
             finding?: string | null;
         };
+        /**
+         * @description Why this deal is back after the rep dismissed it. Absent on an item that was never
+         *     dismissed, which is the ordinary case.
+         *
+         *     The suppression rule holds a dismissed deal out of every later queue until a linked
+         *     activity occurs after the mark — so a deal that reappears is always one the rep waved
+         *     away and that has since moved. That is what makes the pair honest rather than a guess:
+         *     it is the rule that put the deal back, stated.
+         */
+        MorningBriefItemLineage: {
+            /**
+             * Format: date
+             * @description The local day the rep dismissed this deal, in the installation reporting timezone —
+             *     the same zone `local_day` is stamped in, so "you dismissed it Tuesday" and "this is
+             *     Thursday's brief" are measured the same way. A date, not an instant: the sentence
+             *     names a day.
+             */
+            dismissed_on: string;
+            /**
+             * Format: date-time
+             * @description When the activity that re-qualified the deal occurred. An instant, because it names a
+             *     specific event. It is the EARLIEST activity after the dismissal: a later one did not
+             *     bring the deal back, it arrived once the deal was already coming.
+             */
+            returned_with_activity_at: string;
+        } | null;
         /**
          * @description One overnight pass's findings for the acting rep's own current run.
          *

--- a/frontend/src/design-system/briefitem.css
+++ b/frontend/src/design-system/briefitem.css
@@ -333,3 +333,22 @@
   color: var(--textContent);
   line-height: 1.5;
 }
+
+/* Why a dismissed deal is back, above the finding. It reads as a caption
+   because it is context for the answer rather than the answer — and quieter
+   than the finding, which is the sentence the reader came for. */
+.brief-item-lineage {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin: 0 0 var(--space-2);
+  color: var(--textMeta);
+}
+
+.brief-item-lineage > svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  align-self: center;
+}

--- a/frontend/src/design-system/briefitem.stories.tsx
+++ b/frontend/src/design-system/briefitem.stories.tsx
@@ -43,6 +43,8 @@ const LABELS: BriefItemLabels = {
   dismissed: "Dismissed",
   snoozed: "Snoozed",
   resurfaces: "Back",
+  previouslyDismissed: "Flagged 03.06.2026 — you dismissed it.",
+  returnedWith: "It came back with activity on",
 };
 
 // Fixed instants, formatted without touching a clock or a locale database, so
@@ -143,6 +145,22 @@ export const Dismissed: Story = {
 // A write in flight. The pressed button keeps its label, its ink and the
 // reader's focus and turns a mark; the other two are refused, because a queue
 // entry takes one decision at a time.
+/** A deal the rep dismissed, come back. The line above the meters says when
+ *  they waved it away and what brought it back — deterministic, from the row,
+ *  which is why it carries no agent provenance the way a finding does. */
+export const Returning: Story = {
+  args: {
+    ...base,
+    item: {
+      ...base.item,
+      lineage: {
+        dismissed_on: "2026-06-03",
+        returned_with_activity_at: "2026-06-04T10:00:00Z",
+      },
+    },
+  },
+};
+
 export const Acting: Story = { args: { ...base, pending: "act" } };
 
 // The server refused the write — the item was already settled in another tab.

--- a/frontend/src/design-system/briefitem.test.tsx
+++ b/frontend/src/design-system/briefitem.test.tsx
@@ -52,6 +52,8 @@ const LABELS: BriefItemLabels = {
   dismissed: "Dismissed",
   snoozed: "Snoozed",
   resurfaces: "Back",
+  previouslyDismissed: "Flagged 03.06.2026 — you dismissed it.",
+  returnedWith: "It came back with activity on",
 };
 
 const ITEM: BriefItem = {
@@ -344,4 +346,39 @@ describe("BriefItemCardPending", () => {
     expect(region.getAttribute("aria-busy")).toBe("true");
     expect(region.textContent).toContain("Reading this morning's brief");
   });
+});
+
+// A deal the rep dismissed and that has come back says so.
+//
+// The suppression rule holds a dismissed deal out of every later queue until a
+// linked activity arrives after the mark, so the line states that rule rather
+// than guessing — and it is a deterministic fact from brief_item rows, never a
+// model's sentence, which is why it carries no agent provenance.
+it("says why a dismissed deal is back, without claiming an agent wrote it", () => {
+  render(
+    <BriefItemCard
+      {...cardProps({
+        item: {
+          ...ITEM,
+          lineage: {
+            dismissed_on: "2026-06-03",
+            returned_with_activity_at: "2026-06-04T10:00:00Z",
+          },
+        },
+      })}
+    />,
+  );
+
+  expect(
+    screen.getByText("Flagged 03.06.2026 — you dismissed it."),
+  ).toBeTruthy();
+  // Indigo is a claim that a model wrote something. Tagging a row-derived fact
+  // that way would be false in the one place the product asks a reader to
+  // trust the marking.
+  expect(document.querySelector(".provenance-agent")).toBeNull();
+});
+
+it("says nothing about a dismissal for an item that never had one", () => {
+  render(<BriefItemCard {...cardProps()} />);
+  expect(screen.queryByText(/you dismissed it/)).toBeNull();
 });

--- a/frontend/src/design-system/briefitem.tsx
+++ b/frontend/src/design-system/briefitem.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { AlarmClock, ArrowRight, Check, X } from "lucide-react";
+import { AlarmClock, ArrowRight, Check, History, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import type { components } from "../api/schema";
 import { ordinalNumber } from "../format/format";
@@ -74,6 +74,12 @@ export type BriefItemLabels = Readonly<{
   evidenceNone: string;
   /** The deal link's text before the caller knows the deal's name. */
   openDeal: string;
+  /** The lineage line, already composed by the caller with the day the rep
+   *  dismissed it — "Flagged Tuesday, you dismissed it". The card knows no
+   *  language and no calendar, so the weekday cannot be assembled here. */
+  previouslyDismissed: string;
+  /** What brought it back, before the instant ("came back with"). */
+  returnedWith: string;
   act: string;
   dismiss: string;
   snooze: string;
@@ -195,6 +201,11 @@ export function BriefItemCard({
           <span className="brief-item-amount t-mono">{amount}</span>
         )}
       </div>
+      <BriefItemLineage
+        item={item}
+        labels={labels}
+        formatInstant={formatInstant}
+      />
       <BriefItemFinding item={item} />
       <BriefFactorVector
         item={item}
@@ -360,6 +371,43 @@ function BriefBar({
         {formatPercent(clamped)}
       </span>
     </div>
+  );
+}
+
+// Why this deal is back after the rep dismissed it.
+//
+// ABOVE the finding, because it is context for the answer rather than the
+// answer: the card reads "this deal → you saw it before → here is what the
+// night found → here is the working".
+//
+// It carries NO ProvenanceTag. Indigo is a claim that a model wrote something,
+// and this is a deterministic fact assembled from brief_item rows — tagging it
+// agent-authored would be false in the one place the product asks the reader to
+// trust that marking.
+function BriefItemLineage({
+  item,
+  labels,
+  formatInstant,
+}: Readonly<{
+  item: BriefItem;
+  labels: BriefItemLabels;
+  formatInstant: (utcIso: string) => string;
+}>) {
+  const lineage = item.lineage;
+  if (!lineage) {
+    return null;
+  }
+  return (
+    <p className="brief-item-lineage t-caption">
+      <History aria-hidden="true" />
+      <span>{labels.previouslyDismissed}</span>{" "}
+      <span>
+        {labels.returnedWith}{" "}
+        <time dateTime={lineage.returned_with_activity_at}>
+          {formatInstant(lineage.returned_with_activity_at)}
+        </time>
+      </span>
+    </p>
   );
 }
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2154,6 +2154,9 @@ export const de = {
   "home.deck.bundleMembers": "Die {count} Vorgänge anzeigen",
   "home.brief.rank": "Rang",
   "home.brief.composite": "Bewertung",
+  "home.brief.previouslyDismissed":
+    "Am {day} markiert — du hast es weggeklickt.",
+  "home.brief.returnedWith": "Zurück durch Aktivität am",
   "home.brief.resurfaces": "Zurück",
   "home.evidenceNone": "keine Belege erfasst",
   "home.snooze": "Zurückstellen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2188,6 +2188,11 @@ export const en = {
   "home.deck.bundleMembers": "Show the {count} items",
   "home.brief.rank": "Rank",
   "home.brief.composite": "Score",
+  // A deal the rep dismissed, come back. The suppression rule holds a dismissed
+  // deal out until a linked activity arrives after the mark, so the sentence
+  // states that rule rather than guessing: it can only ever name an activity.
+  "home.brief.previouslyDismissed": "Flagged {day} — you dismissed it.",
+  "home.brief.returnedWith": "It came back with activity on",
   "home.brief.resurfaces": "Back",
   "home.evidenceNone": "no evidence recorded",
   "home.snooze": "Snooze",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2138,6 +2138,8 @@ export const vi = {
   "home.deck.bundleMembers": "Xem {count} mục",
   "home.brief.rank": "Hạng",
   "home.brief.composite": "Điểm",
+  "home.brief.previouslyDismissed": "Đã đánh dấu {day} — bạn đã bỏ qua.",
+  "home.brief.returnedWith": "Quay lại do hoạt động ngày",
   "home.brief.resurfaces": "Trở lại",
   "home.evidenceNone": "chưa ghi nhận bằng chứng",
   "home.snooze": "Tạm hoãn",

--- a/frontend/src/screens/briefqueue.tsx
+++ b/frontend/src/screens/briefqueue.tsx
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import type { BriefItemLabels } from "../design-system/briefitem";
 import { BriefItemCard } from "../design-system/briefitem";
 import {
+  formatDate,
   formatDateTime,
   formatMoneyOrAbsent,
   formatNumber,
@@ -45,6 +47,15 @@ export function briefLabels(
   t: (key: MessageKey, params?: Record<string, string>) => string,
   evidenceCount: number,
   locale: Parameters<typeof formatNumber>[1],
+  // The day the rep dismissed this deal, when it is one that came back. The
+  // CARD cannot compose this: it knows no language and no calendar, and the
+  // sentence names a day.
+  dismissedOn?: string,
+  // The zone that date is read in. The INSTALLATION's, not the reader's: a
+  // `format: date` wire value holds no instant to localize, and reading
+  // 2026-08-21 in a zone behind UTC prints the day before — so a rep in
+  // Vancouver would be told they dismissed it a day earlier than they did.
+  recordZone?: string,
 ): BriefItemLabels {
   return {
     rank: t("home.brief.rank"),
@@ -68,6 +79,13 @@ export function briefLabels(
     dismissed: t("home.dismissedState"),
     snoozed: t("home.snoozedState"),
     resurfaces: t("home.brief.resurfaces"),
+    previouslyDismissed:
+      dismissedOn === undefined || recordZone === undefined
+        ? ""
+        : t("home.brief.previouslyDismissed", {
+            day: formatDate(dismissedOn, locale, recordZone),
+          }),
+    returnedWith: t("home.brief.returnedWith"),
   };
 }
 
@@ -91,10 +109,17 @@ export function BriefQueueItem({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   return (
     <BriefItemCard
       item={item}
-      labels={briefLabels(t, item.evidence_ids.length, locale)}
+      labels={briefLabels(
+        t,
+        item.evidence_ids.length,
+        locale,
+        item.lineage?.dismissed_on,
+        recordZone,
+      )}
       // `revenueBasisNote` is deliberately not passed. The run carries
       // `revenue_norm_minor` but not the currency it is in, and the base
       // currency lives on a settings read neither screen makes — a bare figure


### PR DESCRIPTION
## What was wrong

The suppression rule holds a dismissed deal out of every later queue until a linked activity occurs after the mark. So a deal that reappears is **always** one the rep waved away and that has since moved — and the card said nothing about it. The rep saw a deal they dismissed on Tuesday sitting at rank 2 on Thursday with no explanation, which reads as the product having forgotten.

## What this adds

`brief_item` gains `returned_after_dismissal_on` + `returned_with_activity_at`, both-or-neither by CHECK. The card says when they dismissed it and what brought it back.

**What the sentence may claim is bounded by the same rule that puts the deal back.** Only an activity can return a dismissed deal, so a line naming an offer expiry or a stage move would describe a reason that cannot be why the deal is here. Those are real facts and a richer "since then" is worth building — but it is a change to the *suppression rule* first and to this sentence second. Shipping the sentence alone produces a line that can never fire.

**Attached after scoring, never inside it.** Lineage explains why a deal is in the queue; it must not change where it sits, or "you dismissed this" becomes a reason to rank it.

**No agent provenance on the line.** Indigo claims a model wrote something; this is assembled from `brief_item` rows. Tagging it that way would be false in the one place the product asks a reader to trust the marking.

**Served to the agent too** — unlike the agent's own findings, which stay withheld. A finding that ignores "you already waved this away once" repeats an argument the reader has rejected.

## Review round

Codex raised eight findings. **One was a false positive**, five were real:

- **Not a defect:** it flagged restricted activities leaking a timestamp. The `activity_restricted_is_archived` CHECK makes `restricted_at IS NOT NULL → archived_at IS NOT NULL`, so the existing `archived_at IS NULL` filter already excludes them. Verified in the baseline migration before dismissing it.
- **The date was wrong.** I returned `br.local_day` — the day the brief was *for* — but the sentence says "you dismissed it". A rep who opens Tuesday's brief on Wednesday was told they acted Tuesday. Now derived from `state_at` in the installation zone.
- **An obsolete dismissal could be cited.** Filtering to dismissals *before* picking the latest mark meant a deal dismissed → returned → **acted on** still showed the old dismissal. Now takes the most recent mark and attaches lineage only when that mark is a dismissal.
- **The two predicates disagreed on future-dated activity.** The candidate query had no upper bound, so a future activity returned the deal while lineage — correctly bounded at `now` — had nothing to say. Both are bounded now.
- **Marking an item dropped its lineage.** `markItem` did not read the columns back, and the client replaces its cached item wholesale — so the line vanished the moment the rep acted on the very item it explained.
- **The date rendered a day early west of UTC.** A `format: date` value has no instant to localize; the tree's own timezone contract says so. Switched from `viewerZone()` to `useRecordZone()`.

Also split `briefstore.go` (508 lines) into `briefmarks.go` at the concept seam rather than waiving the length cap, and named the three audit field strings the split revealed as triplicated.

## Verification

- `make check-backend`, `make check-fe`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` — all green.
- Integration lanes green: migrations (down-then-up), briefs, compose/integration.
- 5 new integration tests, each paired against a negative: an item nobody dismissed carries no lineage; a later *act* retires it; the date follows the rep's action, not the brief's day.
- Mutation-checked: reverting the date fix fails with "dismissed on 2026-06-04, want 2026-06-05"; removing the attach fails both the rank and the persistence tests; removing the card render fails the component test.

Per the plan, the public hit rate and per-kind damping are **deliberately not shipped**: `brief_item` records whether the rep clicked, not whether the ranking was right, so a number built on it would measure engagement and call it accuracy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains returning dismissed deals in the morning brief: the card now says when the rep dismissed a deal and which activity brought it back, instead of showing a revisited deal with no comment.

**New Features**
- `brief_item` gains `returned_after_dismissal_on` and `returned_with_activity_at`, held both-or-neither by a CHECK constraint and stamped when the run is built.
- The suppression rule bounds the sentence: only an activity can re-qualify a dismissed deal, so the card can cite only that.
- Lineage is attached after scoring and never affects rank.
- The line is row-derived, so it carries no agent provenance, and it is served to the agent tool while agent findings stay withheld.
- The planned hit-rate metrics are not shipped: clicks measure engagement, not ranking accuracy.

**Bug Fixes**
- The dismissal date now comes from the mark's instant in the installation zone, not the brief's `local_day`.
- Only the most recent mark is used, so acting on a returned deal retires the old dismissal line.
- Both the candidate query and the lineage query now exclude future-dated activities.
- `markItem` reads the lineage columns back, so the line survives the rep marking the item it explains.
- The frontend renders the date in the record zone, not the viewer zone.
- Split `briefstore.go` into `briefmarks.go` at the concept seam.

<sup>Written for commit c763d90853c8d93943baf6e319caf3c5fc1ed403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brief items now explain when a previously dismissed deal returns due to new activity.
  * Added dismissal date and returning activity timestamp to brief item details.
  * Added actions to mark items as acted, dismissed, or snoozed.
  * Added localized display support in English, German, and Vietnamese.

* **UI Improvements**
  * Added contextual history indicators and return details to brief item cards.
  * Dates are formatted using the record’s timezone.

* **Documentation**
  * Updated the brief item output schema and reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->