### PR TITLE
docs(explanation): section 5 says what we will build, and each A-item states its real shipped status

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -217,11 +217,11 @@ The Betriebsvereinbarung then fixes the purpose in writing: account coverage yes
 
 That negotiation is winnable because the product gives the works council something concrete to hold. A scraping plugin gives it something to veto.
 
-## 5. What we build, what we gate, what we refuse
+## 5. What we build, what we will build, and what we refuse
 
 The product policy now becomes very simple.
 
-We build A1 to A6 today. We gate B1 to B3 until the named controls exist and counsel signs off. We refuse all five Tier C models.
+We will build A1 to A6 once there is demand. No worries, we release quickly; you won't have to wait months for this. It might be built already if you read this much later than August 2026. We refuse all five Tier C models.
 
 Each item below is rated on four axes: GDPR posture, Vietnam compatibility, platform-contract exposure and works-council temperature.
 
@@ -242,7 +242,7 @@ The line must stay sharp. The moment a natural person appears in the source, per
 
 The identifier spine is EUID, LEI, VAT ID and the Vietnamese MST.
 
-**A2. The counterparty's own website, read deeper.** Build. The chassis already ships.
+**A2. The counterparty's own website, read deeper.** Built already, and it needs to be enhanced.
 
 Margince already reads company websites, as described in [company-context.md](company-context.md). The deeper read handles people named on those sites in exactly the shape this paper argues for. A stranger found on a team page is staged as a lead and remains staged until a human accepts. The system never auto-creates a new person.
 
@@ -252,13 +252,13 @@ The clean extensions are straightforward: parse the Impressum, whose publication
 
 Crawling stays polite and respects robots.txt. The existing rule also remains: a human click can write directly; an automatic read stages the suggestion.
 
-**A3. Technical enrichment.** Build.
+**A3. Technical enrichment.** Not built yet: none of this is in the tree today.
 
 MX and DNS records, TLS certificate-transparency logs, and technology-stack fingerprints from the company's public pages are company-level signals. They work the same way in Hamburg and Da Nang.
 
 The A1 caveat still applies. A personal name inside a certificate or domain record is personal data, so Margince keeps the stored signal at company level.
 
-**A4. First-party person capture.** Build. Most of it already ships.
+**A4. First-party person capture.** Half built.
 
 The contact sent you the details. Margince's capture works from that fact. Connected mailboxes are processed automatically. A nightly pass extracts only stated fields from email signatures: name, title and phone number, with nothing inferred. Workspace exclusion lists keep entire addresses and domains outside capture.
 


### PR DESCRIPTION
Author-requested edits to the enrichment whitepaper's section 5: the heading and intro now promise A1 to A6 on demand ("we release quickly; you won't have to wait months") and drop the Tier B sentence from the intro; A2 states it is built and needs enhancement, A3 admits none of it is in the tree (verified: no MX/DNS/CT/tech-stack code exists), A4 states it is half built. The build work is tracked in #2855 (A2), #2856 (A4), #2857 (A5) and #2858 (A6, needs-decision), all assigned to Lars. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates section 5 of the enrichment whitepaper to reflect the actual shipped status of A1–A6. The heading and intro now promise on-demand delivery, drop the Tier B sentence, and each A-item states whether it is built, half built, or not built yet. Build work for the missing items is tracked in #2855, #2856, #2857, and #2858. Docs-only change.

<sup>Written for commit a92648990f4f556599569d0f20d60108f39d30bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product-policy status descriptions for A1–A6 data-enrichment capabilities.
  * Clarified which capabilities are already built, partially built, planned based on demand, or not yet available.
  * Confirmed that Tier C models remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->