### PR TITLE
fix(dedupe): two companies sharing one ordinary word are not one company

### DIFF
--- a/backend/internal/modules/people/orgcommonwords.go
+++ b/backend/internal/modules/people/orgcommonwords.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Which shared words count as evidence that two company names are one company.
+//
+// The gate next door (orgnamegate.go) decides whether two names may be scored at
+// all, and it does that by looking for a word they share. That is right when the
+// word is a brand and wrong when it is the vocabulary of a whole market: "Bank of
+// the West" and "Bank of the East" share "bank", "Union Pacific" and "Union
+// Carbide" share "union", and each pair is two different businesses.
+
+// orgCommonNameWords are ordinary words that many unrelated companies put in
+// their names, so two names meeting on one have said nothing about being one
+// company.
+//
+// DIFFERENT FROM orgNameStopwords, which is why this is a second map rather than
+// more entries in that one. A stopword is REMOVED from the name: it is market
+// vocabulary and never a brand, so "Digital Solutions" and "Digital Ocean" must
+// not meet on either word. These words CAN be a brand — Bank of America is a
+// bank, Central Group is a real company, Star Alliance is named Star — so they
+// stay in the name and reach the score, and only stop being counted as the
+// evidence that two names are one company.
+//
+// Measured on the pairs that reached review wrongly: "Bank of the West" against
+// "Bank of the East" scored 0.9750, "Union Pacific" against "Union Carbide"
+// 0.8547, "Central Park Media" against "Central Valley Media" 0.8967. Each
+// shares exactly one ordinary word and nothing else.
+//
+// SMALL ON PURPOSE. This is not a frequency list and must not grow into one: a
+// long list starts refusing real brands their only evidence. What keeps a
+// company actually called "Bank" findable is the escape in sharedTokenCount —
+// two names that agree entirely are one company however ordinary their words —
+// and a market whose common words are missing keeps today's false positives
+// rather than gaining new ones.
+//
+// The countries are here for the same reason as the rest: a country says where a
+// company works, not which company it is, and a subsidiary carries its parent's
+// country the way a rival carries the same one.
+var orgCommonNameWords = map[string]bool{
+	// Sector nouns that name a whole industry rather than a company in it.
+	"bank": true, "insurance": true, "energy": true, "motors": true, "airlines": true,
+	"telecom": true, "pharma": true, "foods": true, "realty": true, "properties": true,
+	// Qualifiers a company adds to say it is large, old or first.
+	"first": true, "premier": true, "prime": true, "standard": true, "general": true,
+	"united": true, "allied": true, "associated": true, "union": true, "central": true,
+	"metro": true, "regional": true, "continental": true, "universal": true,
+	// Direction and place words that qualify a name rather than being one.
+	"north": true, "south": true, "east": true, "west": true, "northern": true,
+	"southern": true, "eastern": true, "western": true, "pacific": true, "atlantic": true,
+	"american": true, "european": true, "asia": true, "asian": true,
+	// Ornaments.
+	"royal": true, "crown": true, "star": true, "sun": true, "summit": true, "apex": true,
+	// The country a company works in, which a subsidiary carries and a rival
+	// carries too: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers,
+	// and two unrelated firms both add "Deutschland" to their German arm.
+	//
+	// The MARKETS THIS TREE HOLDS, in the spellings those markets use — the same
+	// rule as the rest of this map, and the same rule as the legal-form tables
+	// next door. A country is added when a name from it arrives, not in advance:
+	// a list of every country would refuse evidence to companies nobody here has.
+	"latvia": true, "latvija": true, "deutschland": true, "france": true,
+	"ireland": true, "indonesia": true,
+}
+
+// weakEvidenceWord answers whether a shared word says nothing about two names
+// being one company.
+func weakEvidenceWord(word string) bool {
+	return ambiguousFormWord[word] || orgCommonNameWords[word]
+}
+
+// agreeEntirely answers whether the shorter name appears whole in the longer,
+// and whatever the longer adds is a word that names something rather than one
+// every company shares.
+//
+// A MULTISET TEST, not a subsequence one — word order is not consulted, because
+// a registry and a letterhead disagree about it more often than two companies
+// do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree.
+//
+// The condition on the LEFTOVER is what separates a qualified brand from two
+// unrelated names: "Sun Microsystems" adds a brand to "Sun", while "Bank of the
+// West" adds only "west" to "Bank", and a pair whose every word is market
+// vocabulary has nothing left to be identified by.
+//
+// A MULTISET TEST, not a subsequence one — word order is not consulted, because
+// a registry and a letterhead disagree about it more often than two companies
+// do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree entirely,
+// which is the answer a human would give.
+func agreeEntirely(shorter, longer []string) bool {
+	if len(shorter) == 0 {
+		return false
+	}
+	taken := make([]bool, len(longer))
+	for _, x := range shorter {
+		found := false
+		for j, y := range longer {
+			if !taken[j] && sameOrgToken(x, y) {
+				taken[j], found = true, true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	for j, y := range longer {
+		if !taken[j] && weakEvidenceWord(y) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/modules/people/orgcommonwords_test.go
+++ b/backend/internal/modules/people/orgcommonwords_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// TWO COMPANIES THAT SHARE ONE ORDINARY WORD ARE NOT ONE COMPANY.
+//
+// The gate counts a shared word as evidence of identity, which is right when the
+// word is a brand and wrong when it is the vocabulary of a whole market. Every
+// pair here shares exactly one such word and scored above the review threshold
+// on it: "Bank of the West" against "Bank of the East" at 0.9750, "Union
+// Pacific" against "Union Carbide" at 0.8547.
+func TestTwoCompaniesSharingOneOrdinaryWordStayApart(t *testing.T) {
+	for _, p := range [][2]string{
+		{"Bank of the West", "Bank of the East"},
+		{"Union Pacific", "Union Carbide"},
+		{"Central Park Media", "Central Valley Media"},
+		{"Pacific Gas", "Pacific Life"},
+		{"Royal Bank", "Royal Mail"},
+		{"North Star", "South Star"},
+		{"Standard Bank", "Standard Life"},
+		{"Premier Foods", "Premier Energy"},
+		// A country is the same kind of word: it says where a company works,
+		// not which company it is.
+		{"SIA Rimi Latvia", "SIA Maxima Latvija"},
+		{"Acme Deutschland", "Beta Deutschland"},
+		{"Foo France", "Bar France"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, at or above the %.2f review threshold "+
+				"— they share market vocabulary, not a company",
+				p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// AND A COMMON WORD IS STILL EVIDENCE WHEN IT IS THE WHOLE NAME.
+//
+// Discounting a word must not stop a company finding itself. "Bank of Ireland"
+// is ordinary words end to end, and "Bank" is a real company name; refusing them
+// their only evidence would leave each matching nothing.
+//
+// The escape is that the shorter name appears WHOLE inside the longer one. "Bank
+// of Ireland" and "Bank of Ireland Group" agree on every word they have, while
+// "Bank of the West" and "Bank of the East" agree on one and disagree on the
+// word that names them.
+func TestACommonWordIsEvidenceWhenItIsTheWholeName(t *testing.T) {
+	for _, p := range [][2]string{
+		{"Bank of Ireland", "Bank of Ireland Group"},
+		{"Air France", "Air France KLM"},
+		{"Bank", "Bank Ltd"},
+		{"Star", "Star GmbH"},
+		{"Central", "Central Inc"},
+		{"France", "France SA"},
+		{"Bank of America", "Bank of America Corp"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold — one "+
+				"of these names is the whole of the other",
+				p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// The discount must not reach a name built from rare words, which is where one
+// shared word really is nearly the whole of the evidence.
+func TestARareSharedWordIsStillEvidence(t *testing.T) {
+	for _, p := range [][2]string{
+		{"Arvato", "Arvato Systems"},
+		{"Amazon AWS", "Amazon Web Services"},
+		{"Siemens", "Siemens Energy"},
+		{"Bosch", "Bosch Rexroth"},
+		{"Deloitte", "Deloitte Consulting"},
+		{"Fenwick Software", "Fenwick Software Pty Ltd"},
+		{"TLC Healthcare", "TLC Health Care"},
+		{"PT Solutions Physical Therapy", "PT Solutions"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f review threshold — this "+
+				"is one company and the word they share is its name",
+				p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
+// Every entry must be written the way a folded name is written, or it can never
+// fire and no other test would notice.
+func TestCommonNameWordsMatchTheirOwnNormalization(t *testing.T) {
+	if len(orgCommonNameWords) == 0 {
+		t.Fatal("no common words declared — the census would pass against nothing")
+	}
+	for word := range orgCommonNameWords {
+		if got := NormalizeOrgName(word); got != word {
+			t.Errorf("%q normalizes to %q — written this way it can never match a "+
+				"word in a real name", word, got)
+		}
+		// A word here must not ALSO be a stopword: the two lists mean different
+		// things, and a word in both is deleted before this one is consulted,
+		// which makes its entry here dead.
+		if orgNameStopwords[word] {
+			t.Errorf("%q is both a stopword and a common word — the stopword "+
+				"deletes it first, so the entry here never fires", word)
+		}
+	}
+}

--- a/backend/internal/modules/people/orgcommonwords_test.go
+++ b/backend/internal/modules/people/orgcommonwords_test.go
@@ -7,11 +7,9 @@ import "testing"
 
 // TWO COMPANIES THAT SHARE ONE ORDINARY WORD ARE NOT ONE COMPANY.
 //
-// The gate counts a shared word as evidence of identity, which is right when the
-// word is a brand and wrong when it is the vocabulary of a whole market. Every
-// pair here shares exactly one such word and scored above the review threshold
-// on it: "Bank of the West" against "Bank of the East" at 0.9750, "Union
-// Pacific" against "Union Carbide" at 0.8547.
+// A shared word is evidence of identity when it is a brand and not when it is
+// the vocabulary of a whole market. Every pair here shares exactly one such word
+// and nothing else.
 func TestTwoCompaniesSharingOneOrdinaryWordStayApart(t *testing.T) {
 	for _, p := range [][2]string{
 		{"Bank of the West", "Bank of the East"},
@@ -61,6 +59,40 @@ func TestACommonWordIsEvidenceWhenItIsTheWholeName(t *testing.T) {
 				"of these names is the whole of the other",
 				p[0], p[1], got, dedupeReviewThreshold)
 		}
+	}
+	// AND THE ESCAPE REACHES NO FURTHER. A bare common word must not meet every
+	// longer name that begins with it: what the longer name ADDS has to name
+	// something. "Sun Microsystems" adds a brand to "Sun" and meets it; "Bank of
+	// the West" adds only "west" to "Bank" and does not.
+	for _, p := range [][2]string{
+		{"Bank", "Bank of the West"},
+		{"United", "United Airlines"},
+		{"Metro", "Metro Bank"},
+		{"Star", "North Star"},
+		{"Prime", "Prime Standard"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f — a company named after one ordinary "+
+				"word must not meet every longer name carrying it",
+				p[0], p[1], got)
+		}
+	}
+	// A distinctive addition IS a qualified version of the same brand.
+	for _, p := range [][2]string{
+		{"Sun", "Sun Microsystems"},
+		{"Star", "Star Alliance"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f threshold — the longer "+
+				"name adds a brand, which makes this one company said twice",
+				p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+	// Finding: order is not consulted, which a reader must not have to guess.
+	if got := bestOrgNamePairing("Union Pacific Bank", "", "Pacific Union Bank", "").Confidence; got < dedupeReviewThreshold {
+		t.Errorf("two names of the same words in a different order score %.4f — "+
+			"a registry and a letterhead disagree about order more often than "+
+			"two companies do", got)
 	}
 }
 

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -94,6 +94,55 @@ var orgNameStopwords = map[string]bool{
 	"or": true, "ne": true, "ac": true, "gov": true, "edu": true,
 }
 
+// orgCommonNameWords are ordinary words that many unrelated companies put in
+// their names, so two names meeting on one have said nothing about being one
+// company.
+//
+// DIFFERENT FROM orgNameStopwords, which is why this is a second map rather than
+// more entries in that one. A stopword is REMOVED from the name: it is market
+// vocabulary and never a brand, so "Digital Solutions" and "Digital Ocean" must
+// not meet on either word. These words CAN be a brand — Bank of America is a
+// bank, Central Group is a real company, Star Alliance is named Star — so they
+// stay in the name and reach the score, and only stop being counted as the
+// evidence that two names are one company.
+//
+// Measured on the pairs that reached review wrongly: "Bank of the West" against
+// "Bank of the East" scored 0.9750, "Union Pacific" against "Union Carbide"
+// 0.8547, "Central Park Media" against "Central Valley Media" 0.8967. Each
+// shares exactly one ordinary word and nothing else.
+//
+// SMALL AND ENGLISH-SHAPED on purpose. This is not a frequency list and must not
+// grow into one: a long list starts deleting real brands, and the escape below
+// (a word IS evidence when it is all a name has) is what keeps a company
+// actually called "Bank" or "Star" findable. A market whose common words are
+// missing keeps today's false positives rather than gaining new ones.
+var orgCommonNameWords = map[string]bool{
+	// Sector nouns that name a whole industry rather than a company in it.
+	"bank": true, "insurance": true, "energy": true, "motors": true, "airlines": true,
+	"telecom": true, "pharma": true, "foods": true, "realty": true, "properties": true,
+	// Qualifiers a company adds to say it is large, old or first.
+	"first": true, "premier": true, "prime": true, "standard": true, "general": true,
+	"united": true, "allied": true, "associated": true, "union": true, "central": true,
+	"metro": true, "regional": true, "continental": true, "universal": true,
+	// Direction and place words that qualify a name rather than being one.
+	"north": true, "south": true, "east": true, "west": true, "northern": true,
+	"southern": true, "eastern": true, "western": true, "pacific": true, "atlantic": true,
+	"american": true, "european": true, "asia": true, "asian": true,
+	// Ornaments.
+	"royal": true, "crown": true, "star": true, "sun": true, "summit": true, "apex": true,
+	// The country a company operates in, which subsidiaries carry and rivals
+	// share: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers, and
+	// two unrelated firms both add "Deutschland" to their German arm. The
+	// escape below still finds "Air France" and "Bank of Ireland", which share
+	// a second word, and a company whose whole name is a country keeps it.
+	"latvia": true, "latvija": true, "lietuva": true, "eesti": true,
+	"deutschland": true, "france": true, "espana": true, "italia": true,
+	"nederland": true, "polska": true, "suomi": true, "sverige": true, "norge": true,
+	"danmark": true, "osterreich": true, "schweiz": true, "belgique": true,
+	"ireland": true, "britain": true, "indonesia": true, "malaysia": true,
+	"singapore": true, "australia": true, "canada": true, "mexico": true, "brasil": true,
+}
+
 // orgNameArticles are the words that can never be the whole of a name.
 //
 // Every other stopword can: "Capital", "Health" and "Digital" are all real
@@ -342,8 +391,33 @@ func sharesADistinctiveWord(a, b string) bool {
 	return true
 }
 
-// onlyWord answers whether a name came down to a single word.
-func onlyWord(fields []string) bool { return len(fields) == 1 }
+// weakEvidenceWord answers whether a shared word says nothing about two names
+// being one company.
+func weakEvidenceWord(word string) bool {
+	return ambiguousFormWord[word] || orgCommonNameWords[word]
+}
+
+// coversEveryWord answers whether the shorter name appears whole inside the
+// longer one — every word of it matched, none left over.
+func coversEveryWord(shorter, longer []string) bool {
+	if len(shorter) == 0 {
+		return false
+	}
+	taken := make([]bool, len(longer))
+	for _, x := range shorter {
+		found := false
+		for j, y := range longer {
+			if !taken[j] && sameOrgToken(x, y) {
+				taken[j], found = true, true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
 
 // isSyllabicMarket answers whether a name's market builds its brands from a
 // small pool of shared syllables, where one word in common is a coincidence.
@@ -364,20 +438,34 @@ func sharedTokenCount(left, right []string) int {
 	// One word of the longer name answers for at most one word of the shorter.
 	// Without that, "Acme Acme" drew two matches from the single "acme" in
 	// "Acme Beta" and counted a repetition as a second piece of evidence.
+	// A name of nothing but common words is still a name, and must find itself.
+	// "Bank of Ireland" and "Bank of Ireland Group" are ordinary words end to
+	// end, so discounting all of them would leave the company matching nothing.
+	//
+	// The escape is EVERY word, not merely a weak one: those two agree on all of
+	// "bank" and "ireland", while "Bank of the West" and "Bank of the East"
+	// agree on "bank" and disagree on the word that names them. Sharing the
+	// whole of a common-word name is evidence; sharing part of one is the
+	// coincidence this discount exists to reject.
+	if coversEveryWord(shorter, longer) {
+		return len(shorter)
+	}
 	taken := make([]bool, len(longer))
 	shared := 0
 	for _, x := range shorter {
-		// A word that is ANOTHER MARKET'S legal form is that market's
-		// vocabulary rather than a brand, so two names sharing it have not said
-		// they are one company: "SIA Rimi Latvia" and "SIA Maxima Latvija" are
-		// two Latvian grocers, "AS Roma" and "AS Monaco" two football clubs.
+		// A word that many companies share is not evidence that two of them are
+		// one company. Two kinds qualify: another market's legal form ("SIA Rimi
+		// Latvia" and "SIA Maxima Latvija" are two Latvian grocers, "AS Roma"
+		// and "AS Monaco" two football clubs), and the ordinary words that
+		// recur across unrelated names in a market ("Bank of the West" against
+		// "Bank of the East", "Union Pacific" against "Union Carbide").
 		//
 		// Discounted HERE rather than removed from the name, so it still reaches
 		// the score. And not discounted at all when it is the WHOLE of the
 		// shorter name: "PT Solutions" reduces to "pt" once "solutions" is gone
 		// as English market vocabulary, and it must still find "PT Solutions
 		// Physical Therapy" rather than becoming a name with no evidence in it.
-		if ambiguousFormWord[x] && !onlyWord(shorter) {
+		if weakEvidenceWord(x) {
 			continue
 		}
 		for j, y := range longer {

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -94,55 +94,6 @@ var orgNameStopwords = map[string]bool{
 	"or": true, "ne": true, "ac": true, "gov": true, "edu": true,
 }
 
-// orgCommonNameWords are ordinary words that many unrelated companies put in
-// their names, so two names meeting on one have said nothing about being one
-// company.
-//
-// DIFFERENT FROM orgNameStopwords, which is why this is a second map rather than
-// more entries in that one. A stopword is REMOVED from the name: it is market
-// vocabulary and never a brand, so "Digital Solutions" and "Digital Ocean" must
-// not meet on either word. These words CAN be a brand — Bank of America is a
-// bank, Central Group is a real company, Star Alliance is named Star — so they
-// stay in the name and reach the score, and only stop being counted as the
-// evidence that two names are one company.
-//
-// Measured on the pairs that reached review wrongly: "Bank of the West" against
-// "Bank of the East" scored 0.9750, "Union Pacific" against "Union Carbide"
-// 0.8547, "Central Park Media" against "Central Valley Media" 0.8967. Each
-// shares exactly one ordinary word and nothing else.
-//
-// SMALL AND ENGLISH-SHAPED on purpose. This is not a frequency list and must not
-// grow into one: a long list starts deleting real brands, and the escape below
-// (a word IS evidence when it is all a name has) is what keeps a company
-// actually called "Bank" or "Star" findable. A market whose common words are
-// missing keeps today's false positives rather than gaining new ones.
-var orgCommonNameWords = map[string]bool{
-	// Sector nouns that name a whole industry rather than a company in it.
-	"bank": true, "insurance": true, "energy": true, "motors": true, "airlines": true,
-	"telecom": true, "pharma": true, "foods": true, "realty": true, "properties": true,
-	// Qualifiers a company adds to say it is large, old or first.
-	"first": true, "premier": true, "prime": true, "standard": true, "general": true,
-	"united": true, "allied": true, "associated": true, "union": true, "central": true,
-	"metro": true, "regional": true, "continental": true, "universal": true,
-	// Direction and place words that qualify a name rather than being one.
-	"north": true, "south": true, "east": true, "west": true, "northern": true,
-	"southern": true, "eastern": true, "western": true, "pacific": true, "atlantic": true,
-	"american": true, "european": true, "asia": true, "asian": true,
-	// Ornaments.
-	"royal": true, "crown": true, "star": true, "sun": true, "summit": true, "apex": true,
-	// The country a company operates in, which subsidiaries carry and rivals
-	// share: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers, and
-	// two unrelated firms both add "Deutschland" to their German arm. The
-	// escape below still finds "Air France" and "Bank of Ireland", which share
-	// a second word, and a company whose whole name is a country keeps it.
-	"latvia": true, "latvija": true, "lietuva": true, "eesti": true,
-	"deutschland": true, "france": true, "espana": true, "italia": true,
-	"nederland": true, "polska": true, "suomi": true, "sverige": true, "norge": true,
-	"danmark": true, "osterreich": true, "schweiz": true, "belgique": true,
-	"ireland": true, "britain": true, "indonesia": true, "malaysia": true,
-	"singapore": true, "australia": true, "canada": true, "mexico": true, "brasil": true,
-}
-
 // orgNameArticles are the words that can never be the whole of a name.
 //
 // Every other stopword can: "Capital", "Health" and "Digital" are all real
@@ -391,34 +342,6 @@ func sharesADistinctiveWord(a, b string) bool {
 	return true
 }
 
-// weakEvidenceWord answers whether a shared word says nothing about two names
-// being one company.
-func weakEvidenceWord(word string) bool {
-	return ambiguousFormWord[word] || orgCommonNameWords[word]
-}
-
-// coversEveryWord answers whether the shorter name appears whole inside the
-// longer one — every word of it matched, none left over.
-func coversEveryWord(shorter, longer []string) bool {
-	if len(shorter) == 0 {
-		return false
-	}
-	taken := make([]bool, len(longer))
-	for _, x := range shorter {
-		found := false
-		for j, y := range longer {
-			if !taken[j] && sameOrgToken(x, y) {
-				taken[j], found = true, true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
-}
-
 // isSyllabicMarket answers whether a name's market builds its brands from a
 // small pool of shared syllables, where one word in common is a coincidence.
 func isSyllabicMarket(market *marketForms) bool {
@@ -442,12 +365,14 @@ func sharedTokenCount(left, right []string) int {
 	// "Bank of Ireland" and "Bank of Ireland Group" are ordinary words end to
 	// end, so discounting all of them would leave the company matching nothing.
 	//
-	// The escape is EVERY word, not merely a weak one: those two agree on all of
-	// "bank" and "ireland", while "Bank of the West" and "Bank of the East"
-	// agree on "bank" and disagree on the word that names them. Sharing the
-	// whole of a common-word name is evidence; sharing part of one is the
-	// coincidence this discount exists to reject.
-	if coversEveryWord(shorter, longer) {
+	// The escape asks that the shorter name appear whole in the longer AND that
+	// what the longer adds be a word that names something. "Sun" and "Sun
+	// Microsystems" pass: the addition is a brand, so this is one company said
+	// twice. "Bank" and "Bank of the West" do not: the addition is "west", and
+	// two names built entirely from words every company shares have not said
+	// they are one company — a company called Bank must not meet every bank in
+	// the estate.
+	if agreeEntirely(shorter, longer) {
 		return len(shorter)
 	}
 	taken := make([]bool, len(longer))
@@ -460,11 +385,9 @@ func sharedTokenCount(left, right []string) int {
 		// recur across unrelated names in a market ("Bank of the West" against
 		// "Bank of the East", "Union Pacific" against "Union Carbide").
 		//
-		// Discounted HERE rather than removed from the name, so it still reaches
-		// the score. And not discounted at all when it is the WHOLE of the
-		// shorter name: "PT Solutions" reduces to "pt" once "solutions" is gone
-		// as English market vocabulary, and it must still find "PT Solutions
-		// Physical Therapy" rather than becoming a name with no evidence in it.
+		// Discounted HERE rather than removed from the name, so the word still
+		// reaches the score. The case where such a word IS the evidence is
+		// answered above, before this loop runs.
 		if weakEvidenceWord(x) {
 			continue
 		}


### PR DESCRIPTION
The gate counts a shared word as evidence that two names are the same company. That is right when the word is a brand and wrong when it is the vocabulary of a whole market.

| Two different companies | Before | After |
|---|---|---|
| `Bank of the West` / `Bank of the East` | 0.9750 | 0.0000 |
| `Central Park Media` / `Central Valley Media` | 0.8967 | 0.0000 |
| `Royal Bank` / `Royal Mail` | 0.8800 | 0.0000 |
| `Union Pacific` / `Union Carbide` | 0.8547 | 0.0000 |
| `SIA Rimi Latvia` / `SIA Maxima Latvija` | 0.8716 | 0.0000 |
| `North Star` / `South Star` | 0.8667 | 0.0000 |
| `Standard Bank` / `Standard Life` | 0.8769 | 0.0000 |

Each shares exactly one ordinary word and nothing else. This closes #2832.

## A second list, not more stopwords

`orgNameStopwords` **removes** a word from the name: it is market vocabulary and never a brand. These words **can** be a brand — Bank of America is a bank, Star Alliance is named Star — so they stay in the name, reach the score, and only stop counting as the evidence that two names are one company. A test fails a word listed in both, because the stopword would delete it first and leave the entry here dead.

Country names are the same kind of word: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers.

## The escape

Discounting a word must not stop a company finding itself, and some names are ordinary words end to end. So the discount is suspended when the shorter name appears **whole** in the longer **and** what the longer adds names something:

- `Sun` ↔ `Sun Microsystems` — the addition is a brand, so this is one company said twice. **Meets.**
- `Bank` ↔ `Bank of the West` — the addition is only "west", and two names built entirely from shared vocabulary have not said they are one company. **Refuses.**

Recall is unchanged: Arvato/Arvato Systems, Amazon AWS/Amazon Web Services, Siemens/Siemens Energy, Deloitte/Deloitte Consulting, Fenwick Software/Fenwick Software Pty Ltd, Bank of Ireland/Bank of Ireland Group, Air France/Air France KLM and PT Solutions/PT Solutions Physical Therapy all still meet. So do the ten real companies whose only distinctive word is now a common one — Continental AG, Metro AG, Star Alliance, Sun Microsystems, Apex Tool Group, Summit Materials, Standard Chartered, United Airlines, Allied Irish Banks, Prime Video.

## Review round

A craft review found six defects, all real, fixed in the second commit. The serious one: **the escape reached far past what its tests asserted.** Any single common word counted as "wholly contained" in every longer name carrying it, so a company called "Bank" met "Bank of the West" at 0.8500 — the exact false-positive shape this gate exists to remove. The test table only covered `Bank` against `Bank Ltd`, where the suffix strip leaves the two identical, so it never saw the reach. Both directions are now asserted.

Three comments claimed things the code did not do, including one describing a guard the same commit had moved. The country list was cut from 26 speculative entries to the 6 with a measured pair behind them — the declaration had contradicted its own "must not grow into a frequency list" rule.

## One case deliberately unfixed

`First National Bank` against `First Republic Bank` still meets. `national` is deleted upstream as a stopword, leaving `[first bank]` genuinely contained in `[first republic bank]`. That is the stopword deletion, not this rule, and fixing it belongs with whoever revisits that list.

## Tests

Three guards mutation-checked: emptying the word list produces 11 failures, and both directions of the escape fail when broken. `make check-backend` green, `make craft-static` clean across all four trees, people integration lane green under a private template. `orgnamegate.go` crossed the 500-line ceiling, so the words and the two rules that read them moved to `orgcommonwords.go` — a different question from the one the gate asks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes company-name dedupe so two different companies sharing only an ordinary word no longer match. Previously a shared "bank", "union", or "west" gave near-perfect confidence; now those words are discounted as weak evidence, while still contributing to the score.

**Key changes**
- Adds a curated list of common market words and country names that do not count as proof of identity.
- Adds an escape: the discount is suspended when the shorter name appears whole in the longer and the extra word is distinctive, so real brands still match.
- Fixes `#2832`; recall for tested single-company pairs is unchanged.

<sup>Written for commit dc4ce58566599577a4ea3dca0891cea6702127b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization-name matching to reduce false duplicate matches caused by generic industry, geographic, country, and legal-form terms.
  * Improved recognition of genuine matches when names contain the same distinctive words, regardless of word order.
  * Improved handling of longer names that include meaningful brand additions.

* **Tests**
  * Added comprehensive coverage for common-word filtering and organization-name deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->