### PR TITLE
fix(e2e-llm): make the LLM lane actually run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,8 @@ workspace/
 /backend/tools/contract-overlay/contract-overlay
 /backend/tools/contract-overlay/contract-overlay.exe
 /seed-demo
+
+# e2e-llm run artifacts. The lane writes a transcript per run (hundreds of KB
+# each) plus a small verdict file. They are evidence for the run that produced
+# them, not repository content — read them locally, do not carry them in git.
+e2e/llm/records/

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -30,15 +30,32 @@ may_call:
   - search_records
 
 # Criterion 3: the record wins. September is what the email says.
+#
+# "Sep" is in the alternation because a real answer writes the date the way a
+# person does — every run of 2026-08-27 said "18 Sep 2025" and the pattern,
+# which demanded the month spelled out or a numeric 09, called all three a
+# failure. That was a bug in this file, not in the answer.
 must_mention:
-  - "September|09/|09-|-09-"
+  - "September|Sept|Sep 2025|09/|09-|-09-"
 # Criterion 1 needs it to find the accounts without being told which.
   - "Reply|valantic|Körber"
 
-# The note says "im Oktober" and it is wrong. Saying October means the prose
-# was preferred over the record, which is the defect this case exists to catch.
+# The note says "im Oktober" and it is wrong.
+#
+# A bare /Oktober|October/ cannot express the thing being tested. An answer
+# SHOULD quote the note — it is a real record and hiding it would be its own
+# defect. What must not happen is the model adopting the note's month as its
+# own finding, which is what all three runs of 2026-08-27 did: each cited the
+# email as 18 Sep 2025, quoted the note correctly, and then wrote "the customer
+# raised it clearly in October" in its own voice, with no mention that the two
+# disagree.
+#
+# So the forbidden shape is October asserted OUTSIDE a quotation: "raised it in
+# October", "flagged it in October", "told us in September/October". The
+# quotation itself is allowed through.
 must_not_mention:
-  - "Oktober|October"
+  - "raised (it|this) (clearly )?in Okt|flagged (it|this) (clearly )?in Okt|told us (clearly )?in (September/)?Okt|complained in Okt"
+  - "raised (it|this) (clearly )?in Octo|flagged (it|this) (clearly )?in Octo|told us (clearly )?in (September/)?Octo|complained in Octo"
 
 runs: 3
 pass_at: 2

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -45,19 +45,133 @@ try:
 except Exception:
     print("")'; }
 
+# url_encode makes a display name safe in a query string. "Körber Digital" and
+# "valantic AG Betreuerwechsel" both need it.
+url_encode() { python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"; }
+
+# days_ago prints an RFC3339 instant N days back, on BSD date (macOS) or GNU.
+days_ago() {
+  date -u -v-"$1"d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || date -u -d "$1 days ago" '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+# person_id_by_email finds a seeded person, or prints nothing.
+#
+# It searches by NAME and matches the email from the rows that come back.
+# `/people?q=` matches display names, not addresses — querying it with an email
+# returns zero rows, which read as "not seeded yet" and made the second run try
+# to create Mai Nguyen again and die on 409 duplicate_email.
+person_id_by_email() {
+  local name="$1" email="$2"
+  api GET "/people?q=$(url_encode "$name")&limit=50" | python3 -c 'import json,sys
+want = sys.argv[1].lower()
+for row in json.load(sys.stdin).get("data", []):
+    for e in row.get("emails", []):
+        if (e.get("email") or "").lower() == want:
+            print(row["id"]); sys.exit(0)
+print("")' "$email"
+}
+
+# create_or_die POSTs and returns the new id, or STOPS.
+#
+# The old code ended every create with `|| true` and read the id with a helper
+# that answered "" on any failure. A 422 therefore looked exactly like a
+# success with nothing to return: the seed printed "LLM fixtures seeded" having
+# written nothing, and the first evidence was an assistant finding an empty CRM.
+# A fixture that fails must fail loudly — the run is worthless either way, and
+# only one of the two says why.
+create_or_die() {
+  local path="$1" body="$2" what="$3" response id
+  response="$(api POST "$path" "$body")"
+  id="$(printf '%s' "$response" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("id",""))
+except Exception: print("")')"
+  if [ -z "$id" ]; then
+    echo "could not create $what:" >&2
+    printf '  %s\n' "$response" >&2
+    exit 1
+  fi
+  printf '%s' "$id"
+}
+
 echo "seeding LLM fixtures into $API_BASE"
 
-api POST /auth/login "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" >/dev/null
+# status_of runs a request for its HTTP CODE alone, so a step that must be
+# allowed to fail can be told apart from one that must not.
+status_of() {
+  local method="$1" path="$2" body="${3:-}"
+  # -d is passed as its own argument rather than through ${body:+...}: an
+  # unquoted expansion splits the JSON on its spaces and curl receives
+  # fragments, which surfaced as "[: too many arguments" from the caller.
+  if [ -n "$body" ]; then
+    curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIES" -c "$COOKIES" \
+      -X "$method" -H 'Content-Type: application/json' -d "$body" "$API_BASE/v1$path"
+  else
+    curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIES" -c "$COOKIES" \
+      -X "$method" -H 'Content-Type: application/json' "$API_BASE/v1$path"
+  fi
+}
+
+login_as() {
+  # The body is built into a variable first. Inlining it in the command
+  # substitution let the shell split it on the comma-space, so status_of ran
+  # twice with half a document each and the caller compared "422 422" to "200".
+  local body code
+  body="$(printf '{"email":"%s","password":"%s"}' "$ADMIN_EMAIL" "$1")"
+  code="$(status_of POST /auth/login "$body")"
+  [ "$code" = "200" ]
+}
+
+# THE FIRST-LOGIN HOLD. A bootstrapped installation sets must_change_password
+# and refuses every write with 403 password_change_required until the operator
+# credential has been REPLACED — signing in successfully is not enough.
+#
+# `make dev` writes demo-password-123 as the bootstrap password AND sets the
+# hold, so the account is held on the very value it should end up with, and the
+# product refuses rotating a password to itself. Two changes clear it honestly:
+# out to a detour value and back. This is the same dance
+# backend/tools/seed-demo/apiclient.go does, and for the same reason.
+DETOUR_PASSWORD="${DETOUR_PASSWORD:-demo-password-123-first-change}"
+
+login_as "$ADMIN_PASSWORD" || {
+  echo "could not sign in as $ADMIN_EMAIL" >&2; exit 1; }
+
+# A write the admin is always allowed to attempt. 403 here means the hold, not
+# a permission problem — this account is an admin.
+if [ "$(status_of GET /users)" = "403" ]; then
+  echo "  admin is on the first-login hold; replacing the bootstrap password"
+  rotate_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
+    "$ADMIN_PASSWORD" "$DETOUR_PASSWORD")"
+  if [ "$(status_of POST /auth/change-password "$rotate_body")" != "204" ]; then
+    echo "could not rotate the bootstrap password to the detour value" >&2; exit 1
+  fi
+  login_as "$DETOUR_PASSWORD" || {
+    echo "could not sign in with the detour password" >&2; exit 1; }
+  rotate_back_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
+    "$DETOUR_PASSWORD" "$ADMIN_PASSWORD")"
+  if [ "$(status_of POST /auth/change-password "$rotate_back_body")" != "204" ]; then
+    echo "the admin is stranded on $DETOUR_PASSWORD — rotate it back by hand" >&2; exit 1
+  fi
+  login_as "$ADMIN_PASSWORD" || {
+    echo "could not sign in after replacing the password" >&2; exit 1; }
+  echo "  admin now owns its own password"
+fi
 
 # The colleague who owns the accounts. Criterion 6 of case 4 is about telling
 # the rep an account is somebody ELSE'S, so a workspace where the admin owns
 # everything cannot exercise it.
+# role is the WIRE KEY, not the label. The UI shows `rep` as "Member" (ADR-0110),
+# and sending "Member" answers 404 unknown_role — which surfaced here as the
+# misleading "could not resolve the colleague seat".
 colleague="$(id_of "$(api POST /users '{
-  "email":"sofia.meier@demo.test","display_name":"Sofia Meier","role":"Member"}')")"
+  "email":"sofia.meier@demo.test","display_name":"Sofia Meier","role":"rep"}')")"
 if [ -z "$colleague" ]; then
+  # The list envelope is {"data": [...], "page": {...}} — reading "items" here
+  # always found nothing, so a re-run (create answers 409 email_taken) resolved
+  # an EMPTY colleague and every fixture below it was skipped in silence.
   colleague="$(api GET '/users?q=sofia.meier@demo.test' | python3 -c 'import json,sys
-items = json.load(sys.stdin).get("items", [])
-print(items[0]["id"] if items else "")')"
+rows = json.load(sys.stdin).get("data", [])
+print(rows[0]["id"] if rows else "")')"
 fi
 [ -n "$colleague" ] || { echo "could not resolve the colleague seat" >&2; exit 1; }
 
@@ -67,41 +181,61 @@ fi
 # name (people/geocodecity.go), so these coordinates ARE the centre. No
 # geocoder is called. Filing one of them under a different city would stretch
 # the average past the one-degree spread cap and the resolver would refuse.
+#
+# Every body below is built into a VARIABLE first. Writing the JSON inline
+# inside `"$(id_of "$(api ... "{...}")")"` nests double quotes three deep: bash
+# closes the inner quote at `"{`, the document escapes its own quoting and
+# splits on its newlines, and the server answers 422 malformed_json. The `|| true`
+# on these calls then hid it, so the seed printed success having created
+# nothing. Keep the bodies in variables.
+org_id_by_name() {
+  api GET "/organizations?q=$(url_encode "$1")&limit=50" | python3 -c 'import json,sys
+want = sys.argv[1]
+for row in json.load(sys.stdin).get("data", []):
+    if row.get("display_name") == want:
+        print(row["id"]); break
+else:
+    print("")' "$1"
+}
+
 seed_cologne() {
-  local name="$1" lat="$2" lon="$3"
-  api POST /organizations "{
-    \"display_name\":\"$name\",\"owner_id\":\"$colleague\",
-    \"address\":{\"line1\":\"Domkloster 4\",\"city\":\"Köln\",\"country\":\"DE\"},
-    \"geocode\":{\"lat\":$lat,\"lon\":$lon}}" >/dev/null || true
+  local name="$1" lat="$2" lon="$3" body existing
+  existing="$(org_id_by_name "$name")"
+  if [ -n "$existing" ]; then
+    echo "  $name already present"
+    return 0
+  fi
+  body="$(printf '{"display_name":"%s","owner_id":"%s",' "$name" "$colleague")"
+  body="$body$(printf '"address":{"line1":"Domkloster 4","city":"Köln","country":"DE"},')"
+  body="$body$(printf '"geocode":{"lat":%s,"lon":%s}}' "$lat" "$lon")"
+  create_or_die "/organizations" "$body" "$name" >/dev/null
 }
 seed_cologne "Dom Digital GmbH"    50.9375 6.9603
 seed_cologne "Rheinufer AG"        50.9475 6.9603
 seed_cologne "Vorort Systeme KG"   51.0175 6.9603
 
 # --- CASE 5: the Vietnam partner, with a promise nobody kept -----------------
-vietnam="$(id_of "$(api POST /organizations "{
-  \"display_name\":\"Vietnam Partner JSC\",\"owner_id\":\"$colleague\"}")")"
-if [ -n "$vietnam" ]; then
-  mai="$(id_of "$(api POST /people "{
-    \"full_name\":\"Mai Nguyen\",\"owner_id\":\"$colleague\",
-    \"emails\":[{\"email\":\"mai.nguyen@vietnampartner.test\",\"is_primary\":true}]}")")"
-  api POST /relationships "{
-    \"kind\":\"employment\",\"person_id\":\"$mai\",\"organization_id\":\"$vietnam\"}" >/dev/null || true
+vietnam="$(org_id_by_name "Vietnam Partner JSC")"
+if [ -z "$vietnam" ]; then
+  body="$(printf '{"display_name":"Vietnam Partner JSC","owner_id":"%s"}' "$colleague")"
+  vietnam="$(create_or_die "/organizations" "$body" "Vietnam Partner JSC")"
+fi
+
+mai="$(person_id_by_email "Mai Nguyen" "mai.nguyen@vietnampartner.test")"
+if [ -z "$mai" ]; then
+  body="$(printf '{"full_name":"Mai Nguyen","owner_id":"%s","emails":[{"email":"mai.nguyen@vietnampartner.test","is_primary":true}]}' "$colleague")"
+  mai="$(create_or_die "/people" "$body" "Mai Nguyen")"
+  body="$(printf '{"kind":"employment","person_id":"%s","organization_id":"%s"}' "$mai" "$vietnam")"
+  api POST /relationships "$body" >/dev/null
 
   # THE PROMISE. An outbound message saying the list will be sent, and nothing
   # after it. Criterion 5 is whether a model notices the silence.
-  api POST /activities "{
-    \"kind\":\"email\",\"direction\":\"outbound\",
-    \"occurred_at\":\"$(date -u -v-18d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '18 days ago' '+%Y-%m-%dT%H:%M:%SZ')\",
-    \"body\":\"Ich schicke die Aufstellung mit.\",
-    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$mai\"},
-               {\"entity_type\":\"organization\",\"entity_id\":\"$vietnam\"}]}" >/dev/null || true
-  api POST /activities "{
-    \"kind\":\"email\",\"direction\":\"inbound\",
-    \"occurred_at\":\"$(date -u -v-20d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '20 days ago' '+%Y-%m-%dT%H:%M:%SZ')\",
-    \"body\":\"Cảm ơn — we will review the appendix this week.\",
-    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$mai\"},
-               {\"entity_type\":\"organization\",\"entity_id\":\"$vietnam\"}]}" >/dev/null || true
+  body="$(printf '{"kind":"email","direction":"outbound","occurred_at":"%s","body":"Ich schicke die Aufstellung mit.","links":[{"entity_type":"person","entity_id":"%s"},{"entity_type":"organization","entity_id":"%s"}]}' \
+    "$(days_ago 18)" "$mai" "$vietnam")"
+  create_or_die "/activities" "$body" "the unkept promise" >/dev/null
+  body="$(printf '{"kind":"email","direction":"inbound","occurred_at":"%s","body":"Cảm ơn — we will review the appendix this week.","links":[{"entity_type":"person","entity_id":"%s"},{"entity_type":"organization","entity_id":"%s"}]}' \
+    "$(days_ago 20)" "$mai" "$vietnam")"
+  create_or_die "/activities" "$body" "the inbound reply" >/dev/null
 fi
 
 # --- CASE 6: the contradiction ----------------------------------------------
@@ -109,41 +243,39 @@ fi
 # An email dated in September, and a note written later whose prose says the
 # complaint was raised "im Oktober". The record is right; the prose is wrong.
 # This is the fixture the sharpest assertion in the lane rests on.
-reply="$(id_of "$(api POST /organizations "{
-  \"display_name\":\"Reply Deutschland Betreuerwechsel\",\"owner_id\":\"$colleague\",
-  \"industry\":\"Managed Services\"}")")"
-if [ -n "$reply" ]; then
-  katrin="$(id_of "$(api POST /people "{
-    \"full_name\":\"Katrin Sommer\",\"owner_id\":\"$colleague\",
-    \"emails\":[{\"email\":\"katrin.sommer@reply.test\",\"is_primary\":true}]}")")"
-  api POST /relationships "{
-    \"kind\":\"employment\",\"person_id\":\"$katrin\",\"organization_id\":\"$reply\"}" >/dev/null || true
+reply="$(org_id_by_name "Reply Deutschland Betreuerwechsel")"
+if [ -z "$reply" ]; then
+  body="$(printf '{"display_name":"Reply Deutschland Betreuerwechsel","owner_id":"%s","industry":"Managed Services"}' "$colleague")"
+  reply="$(create_or_die "/organizations" "$body" "Reply Deutschland")"
+fi
 
-  # The record. September.
-  api POST /activities "{
-    \"kind\":\"email\",\"direction\":\"inbound\",\"occurred_at\":\"2025-09-18T09:12:00Z\",
-    \"subject\":\"Wechsel der Ansprechpartner\",
-    \"body\":\"Der ständige Wechsel der Ansprechpartner ist für uns ein echtes Problem.\",
-    \"links\":[{\"entity_type\":\"person\",\"entity_id\":\"$katrin\"},
-               {\"entity_type\":\"organization\",\"entity_id\":\"$reply\"}]}" >/dev/null || true
+katrin="$(person_id_by_email "Katrin Sommer" "katrin.sommer@reply.test")"
+if [ -z "$katrin" ]; then
+  body="$(printf '{"full_name":"Katrin Sommer","owner_id":"%s","emails":[{"email":"katrin.sommer@reply.test","is_primary":true}]}' "$colleague")"
+  katrin="$(create_or_die "/people" "$body" "Katrin Sommer")"
+  body="$(printf '{"kind":"employment","person_id":"%s","organization_id":"%s"}' "$katrin" "$reply")"
+  api POST /relationships "$body" >/dev/null
+
+  # The record. September. This date is the assertion case 6 rests on.
+  body="$(printf '{"kind":"email","direction":"inbound","occurred_at":"2025-09-18T09:12:00Z","subject":"Wechsel der Ansprechpartner","body":"Der ständige Wechsel der Ansprechpartner ist für uns ein echtes Problem.","links":[{"entity_type":"person","entity_id":"%s"},{"entity_type":"organization","entity_id":"%s"}]}' \
+    "$katrin" "$reply")"
+  create_or_die "/activities" "$body" "the September complaint" >/dev/null
+
   # The prose. Wrong about the month, exactly as a real post-mortem was.
-  api POST /activities "{
-    \"kind\":\"note\",\"occurred_at\":\"2025-12-03T10:00:00Z\",
-    \"subject\":\"Post-mortem Betreuerwechsel\",
-    \"body\":\"Der Kunde hat das im Oktober klar angesprochen; wir haben zu spät reagiert.\",
-    \"links\":[{\"entity_type\":\"organization\",\"entity_id\":\"$reply\"}]}" >/dev/null || true
+  body="$(printf '{"kind":"note","occurred_at":"2025-12-03T10:00:00Z","subject":"Post-mortem Betreuerwechsel","body":"Der Kunde hat das im Oktober klar angesprochen; wir haben zu spät reagiert.","links":[{"entity_type":"organization","entity_id":"%s"}]}' \
+    "$reply")"
+  create_or_die "/activities" "$body" "the Oktober post-mortem" >/dev/null
 fi
 
 # Two more accounts that lived through the same thing, so "did we have this in
 # the past" has a pattern to find rather than a single case.
 for company in "valantic AG Betreuerwechsel" "Körber Digital Betreuerwechsel"; do
-  org="$(id_of "$(api POST /organizations "{
-    \"display_name\":\"$company\",\"owner_id\":\"$colleague\",\"industry\":\"Managed Services\"}")")"
-  [ -n "$org" ] || continue
-  api POST /activities "{
-    \"kind\":\"email\",\"direction\":\"inbound\",\"occurred_at\":\"2025-11-04T08:00:00Z\",
-    \"body\":\"Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort.\",
-    \"links\":[{\"entity_type\":\"organization\",\"entity_id\":\"$org\"}]}" >/dev/null || true
+  org="$(org_id_by_name "$company")"
+  [ -n "$org" ] && continue
+  body="$(printf '{"display_name":"%s","owner_id":"%s","industry":"Managed Services"}' "$company" "$colleague")"
+  org="$(create_or_die "/organizations" "$body" "$company")"
+  body="$(printf '{"kind":"email","direction":"inbound","occurred_at":"2025-11-04T08:00:00Z","body":"Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort.","links":[{"entity_type":"organization","entity_id":"%s"}]}' "$org")"
+  create_or_die "/activities" "$body" "$company's silence" >/dev/null
 done
 
 echo "LLM fixtures seeded"

--- a/scripts/e2e-llm.sh
+++ b/scripts/e2e-llm.sh
@@ -70,6 +70,10 @@ trap cleanup EXIT
 # database between their own runs — they are the only ones whose second run
 # would see the first one's records.
 echo "==> booting the $SLUG stack (never :8080)"
+# A previous run that was interrupted leaves its api holding :18081, and
+# dev-fresh refuses rather than attaching to the wrong stack. Stopping this
+# slug first is safe whether or not anything is up, and it never touches :8080.
+(cd "$ROOT" && make dev-stop DEV_SLUG="$SLUG" >/dev/null 2>&1) || true
 (cd "$ROOT" && make dev-fresh DEV_SLUG="$SLUG" >/dev/null)
 
 # shellcheck source=scripts/lib-devstate.sh
@@ -162,6 +166,11 @@ for scenario in "$SCENARIO_DIR"/*.yaml; do
     case "$name" in
       case1_*|case2_*|case3_*)
         if [ "$i" -gt 1 ]; then
+          # dev-stop FIRST. dev-fresh refuses to boot over a port its own
+          # stack is already holding — "port :18081 already in use" — so
+          # calling it on the running stack killed the lane after case 1
+          # run 1 on the first real outing of this script.
+          (cd "$ROOT" && make dev-stop DEV_SLUG="$SLUG" >/dev/null 2>&1) || true
           (cd "$ROOT" && make dev-fresh DEV_SLUG="$SLUG" >/dev/null)
           seed_everything
         fi

--- a/scripts/e2e-llm.sh
+++ b/scripts/e2e-llm.sh
@@ -92,20 +92,51 @@ seed_everything
 # what makes this lane runnable without a tunnel: the assistant is a local
 # process talking to a local stack.
 COOKIES="$WORK/cookies"
-curl -sS -c "$COOKIES" -X POST -H 'Content-Type: application/json' \
-  -d '{"email":"admin@demo.test","password":"demo-password-123"}' \
-  "$APP_BASE/v1/auth/login" >/dev/null
-
-PASSPORT="$(curl -sS -b "$COOKIES" -X POST -H 'Content-Type: application/json' \
-  -d '{"label":"e2e-llm","scopes":["read","write"]}' \
-  "$APP_BASE/v1/passports" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
-[ -n "$PASSPORT" ] || { echo "could not mint a passport" >&2; exit 1; }
-
 MCP_CONFIG="$WORK/mcp.json"
-cat > "$MCP_CONFIG" <<JSON
-{"mcpServers":{"margince":{"type":"http","url":"$APP_BASE/mcp",
- "headers":{"Authorization":"Bearer $PASSPORT"}}}}
-JSON
+
+# mint_passport signs in and writes the MCP config.
+#
+# It is a FUNCTION and not a one-time step because dev-fresh drops and
+# recreates the database, which destroys the passport row with everything
+# else. Minting once at startup left every run after the first re-seed
+# presenting a token that no longer existed: the CLI reported
+# {"name":"margince","status":"failed"}, the assistant saw no tools at all,
+# and the checker read that as "the answer was not drawn from Margince" —
+# six scenarios failing for one expired credential.
+#
+# It also runs AFTER seeding, because the seed lifts the admin's first-login
+# hold, and a passport cannot be minted by an account that is still held.
+mint_passport() {
+  curl -sS -c "$COOKIES" -X POST -H 'Content-Type: application/json' \
+    -d '{"email":"admin@demo.test","password":"demo-password-123"}' \
+    "$APP_BASE/v1/auth/login" >/dev/null
+
+  PASSPORT="$(curl -sS -b "$COOKIES" -X POST -H 'Content-Type: application/json' \
+    -d '{"label":"e2e-llm","scopes":["read","write"]}' \
+    "$APP_BASE/v1/passports" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("token",""))
+except Exception: print("")')"
+  [ -n "$PASSPORT" ] || { echo "could not mint a passport" >&2; exit 1; }
+
+  python3 -c 'import json,sys
+cfg = {"mcpServers": {"margince": {"type": "http", "url": sys.argv[1] + "/mcp",
+       "headers": {"Authorization": "Bearer " + sys.argv[2]}}}}
+open(sys.argv[3], "w").write(json.dumps(cfg))' "$APP_BASE" "$PASSPORT" "$MCP_CONFIG"
+
+  # A config the CLI cannot connect with produces an assistant with no tools,
+  # which reads downstream as a model that chose not to call anything. Fail
+  # here instead, where the cause is still visible.
+  local probe
+  probe="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$APP_BASE/mcp" \
+    -H "Authorization: Bearer $PASSPORT" -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"e2e-llm","version":"1"}}}')"
+  [ "$probe" = "200" ] || {
+    echo "the freshly minted passport cannot reach $APP_BASE/mcp (HTTP $probe)" >&2
+    exit 1
+  }
+}
+mint_passport
 
 # --- run one scenario once ---------------------------------------------------
 #
@@ -173,6 +204,8 @@ for scenario in "$SCENARIO_DIR"/*.yaml; do
           (cd "$ROOT" && make dev-stop DEV_SLUG="$SLUG" >/dev/null 2>&1) || true
           (cd "$ROOT" && make dev-fresh DEV_SLUG="$SLUG" >/dev/null)
           seed_everything
+          # The rebuild took the passport row with the old database.
+          mint_passport
         fi
         ;;
     esac


### PR DESCRIPTION
## What this is

The LLM lane merged in #2837 had never been executed. This is what running it revealed: four harness bugs, one scenario whose assertions were wrong in both directions, and — once those were out of the way — **one real product finding**.

## The result after the fixes

Six scenarios, three runs each, `claude -p` against a dedicated `e2ellm` stack. **Five of six pass.**

| scenario | result |
|---|---|
| case1_log_it | PASS 3/3 |
| case2_business_card | PASS 3/3 |
| case3_spreadsheet | PASS 3/3 |
| case4_use_the_moment | PASS 2/3 |
| case5_before_the_meeting | PASS 2/3 |
| case6_ask_the_company | **FAIL 1/3** |

## The product finding (case 6)

Asked about past account-manager changes, the assistant:

1. Cites the record correctly — *"18 Sep 2025, inbound email from Katrin Sommer"*
2. Quotes the December post-mortem correctly, as a quotation
3. Then asserts **in its own voice**: *"the customer raised it clearly in October"*

October is the note's wrong month. Two of three runs repeated it as fact. Run 3 passed only because it stopped after the quotation — it did not notice the contradiction either. **No run flagged that the two records disagree.**

**The server is not at fault.** Every activity in the tool result carried its `occurred_at`: the email at `2025-09-18`, the note at `2025-12-03`. The model had both dates and preferred the prose. This is the half of todo 33 no deterministic test can reach, and the reason this lane exists.

## The four harness bugs

**1. The seed wrote almost nothing** (`e2e/llm/seed-llm-fixtures.sh`). Four stacked defects:

- **The first-login hold.** A bootstrapped installation refuses every write with 403 `password_change_required` until the operator credential is *replaced*. `make dev` writes `demo-password-123` as the bootstrap password **and** sets the hold, so the account is held on the very value it should end up with — and the product refuses rotating a password to itself. Fixed by rotating out to a detour value and back, the same dance `backend/tools/seed-demo/apiclient.go` documents.
- **The role key.** `role: "Member"` answers 404 `unknown_role`. "Member" is the UI label; `rep` is the wire key (ADR-0110).
- **Nested quotes ate the JSON.** Bodies written inline inside `"$(id_of "$(api ... "{...}")")"` nest double quotes three deep; bash closes the inner quote at the opening brace and the document splits on its newlines. Server answered 422 `malformed_json`.
- **The list envelope.** Fallback lookups read `items`; the API returns `data`. They always found nothing, so a re-run resolved an *empty* colleague id and skipped every fixture below it.

Every one of these was hidden by `|| true` on the creates. They now go through `create_or_die`, which prints the server's response and stops.

**2. `dev-fresh` on a running stack.** The lane died after case 1 run 1 with "port :18081 already in use". `dev-fresh` refuses rather than attaching to the wrong stack — correct behaviour, and what made it legible. Both call sites now `dev-stop` first.

**3. The passport died with the database.** This is the instructive one. The passport was minted once at startup, but `dev-fresh` between the write scenarios' runs **drops and recreates the database**, taking the passport row with it. Every run after the first rebuild presented a dead token, the CLI reported `{"name":"margince","status":"failed"}`, the assistant had **no tools at all**, and the checker recorded "the answer was not drawn from Margince" — six scenarios failing for one expired credential, disguised as unhelpful model behaviour.

`mint_passport` is now a function called after every rebuild (and after seeding, since a held account cannot mint). It ends by initializing `/mcp` with the new token and **stops if that is not 200**. A credential the CLI cannot connect with must fail where the cause is visible.

**4. Case 6's assertions were wrong in both directions.** `must_mention` demanded `September` spelled out or a numeric `09` — every run wrote "18 Sep 2025", the correct date spelled the way a person spells it, and none matched. And `must_not_mention` was a bare `/Oktober|October/`, which forbids *quoting* the note; the note is a real record and hiding it would be its own defect. The assertion now forbids October asserted outside a quotation and lets the quotation through.

## Verification

- Seed run against a genuinely fresh stack: 7 organizations, 2 people, 6 activities, all correctly linked, including the September email and the "im Oktober" note. A second run adds nothing and exits clean.
- All 18 runs of the final sweep show `status: connected` and call real tools.
- `--tools ""` confirmed working: case 5 attempted `Bash` to read a calendar and the CLI refused it — `No such tool available: Bash`. Nothing outside MCP was reachable.
- `make craft-static` — PASS, 0 findings on these four files.
- Run transcripts (1.8MB per sweep) are gitignored; they are evidence for the run that produced them.

## Still open

Case 6's finding is unfixed and deliberately so — this PR makes the lane able to *report* it. Whether the product should teach the model to prefer the record, or surface the contradiction itself, is a separate decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the e2e LLM lane actually run. The lane merged earlier had never been executed; running it revealed four harness bugs that made it silently do nothing. After the fixes, five of six scenarios pass (case 4 and 5 at 2/3), and case 6 fails 1/3, surfacing a real product finding.

**Bug Fixes**
- The seed was writing almost nothing: the first-login hold rejected every write with 403, `"Member"` is the UI label not the `rep` wire key, nested double quotes mangled the JSON bodies into 422s, and fallback lookups read `items` instead of the `data` envelope.
- All creates ended in `|| true`, which hid every one of those failures as a silent success; they now go through `create_or_die`, which prints the server response and stops.
- `dev-fresh` was called on a running stack and refused over its own port; both call sites now `dev-stop` first.
- The passport was minted once, but `dev-fresh` drops and recreates the database (and the passport row with it), so every run after the first rebuild presented a dead token and the assistant had no tools; it is now re-minted after every rebuild and after seeding, and probes `/mcp` so a bad credential fails where the cause is visible.
- Case 6's assertions were wrong in both directions: the patch demanded a month format no answer used, and the October ban forbade quoting the note itself, which is correct behavior; it now accepts "Sep" and forbids October only asserted outside a quotation.
- Run transcripts, ~1.8MB per sweep, are gitignored.

**What the lane found**
- The model cites the September email correctly, quotes the December note's wrong month correctly, then states "the customer raised it clearly in October" in its own voice, never flagging that the two records disagree. Both `occurred_at` dates reached the model; it preferred the prose. Whether the product should teach the model to prefer the record, or surface the contradiction itself, is a separate decision and deliberately unfixed here.

<sup>Written for commit 47c95e5127f0a89bb536aff842ef31f96b68100d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test setup with more reliable fixture creation, account initialization, and environment validation.
  - Added support for additional date formats and more precise handling of quoted versus unquoted findings in automated evaluation scenarios.
  - Improved recovery when rebuilding test environments, including refreshed authentication and connectivity checks.

- **Chores**
  - Excluded generated test transcripts and evaluation artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->