### PR TITLE
perf(check): the frontend half says where its time goes, and the rulebook stops asking for it twice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,9 +130,9 @@ sandboxed.
 1. Branch off `main`: `git switch -c <type>/<slug> origin/main`.
 2. Sign off every commit (`git commit -s`) — the DCO gate rejects any commit
    without a `Signed-off-by` trailer.
-3. Run `make check` before pushing; add `make frontend-check` when `frontend/`
-   changed. The pre-push hook runs `craft static --strict` diff-scoped on top —
-   fix what it finds, never bypass it. Install it once with `make hooks`.
+3. Run `make check` before pushing — it is both halves, `frontend/` included,
+   with nothing to add on top. The pre-push hook runs `craft static --strict`
+   diff-scoped too — fix what it finds, never bypass it; install it via `make hooks`.
 4. Push and open a PR.
 5. CI, DCO, CodeRabbit and SonarCloud must all pass. Address review findings
    rather than dismissing them.

--- a/Makefile
+++ b/Makefile
@@ -150,19 +150,25 @@ install: fe-install tools hooks
 ##     a phase around them would be their sum counted twice. PHASE_TIMER_OWNED
 ##     tells it this target owns the ledger, so it adds its rows to this table
 ##     instead of resetting and printing one of its own — which is what it does
-##     when somebody runs it directly (`make check-go`).
+##     when somebody runs it directly (`make check-go`). This target reads the
+##     same variable for the same reason: under `make check` the frontend half
+##     still has rows to add, and a report here would print without them.
 check-backend:
-	@bash scripts/phase-timer.sh reset
+	@[ -n "$$PHASE_TIMER_OWNED" ] || bash scripts/phase-timer.sh reset
 	@bash scripts/phase-timer.sh start "root script gates (x$(words $(ROOT_SCRIPT_GATES)), -j$(GATE_JOBS))"
 	$(MAKE) -j$(GATE_JOBS) $(ROOT_SCRIPT_GATES)
 	@bash scripts/phase-timer.sh stop
 	PHASE_TIMER_OWNED=1 $(MAKE) -C backend check
-	@bash scripts/phase-timer.sh report
+	@[ -n "$$PHASE_TIMER_OWNED" ] || bash scripts/phase-timer.sh report
 
-## check — the full merge gate: backend + frontend
-## (`check = check-backend check-fe`). check-fe fails if the frontend deps are
-## missing, so run `make install` first.
-check: check-backend check-fe
+## check — the full merge gate: both halves. Spelled as recipe lines rather than
+## prerequisites because it owns the timing ledger, and a prerequisite would
+## record a phase before the reset. check-fe needs `make install` first.
+check:
+	@bash scripts/phase-timer.sh reset
+	@PHASE_TIMER_OWNED=1 $(MAKE) check-backend
+	@PHASE_TIMER_OWNED=1 $(MAKE) check-fe
+	@bash scripts/phase-timer.sh report
 
 ## check-q — quiet `make check`: the full log lands in .tmp/check.log and only an
 ## excerpt prints on failure (keeps a green run's output to one line).
@@ -254,11 +260,16 @@ build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report 
 ## run `make install`, which installs them. The CI frontend job runs this too.
 check-fe: fe-typecheck-composed
 	@[ -d frontend/node_modules ] || { echo "check-fe: frontend/node_modules missing — run 'make install' (or 'make fe-install') first" >&2; exit 1; }
+	@bash scripts/phase-timer.sh start "frontend: core suite (ds-gates, drift, lint, unit, build)"
 	$(MAKE) frontend-check
+	@bash scripts/phase-timer.sh stop
 	# The unit screens' own suites. Ordered AFTER frontend-check on purpose: it
 	# is the composed lane, so it costs a composition, and there is no point
 	# paying for it when the core suite is already red.
+	@bash scripts/phase-timer.sh start "frontend: unit screens (composed workspace)"
 	$(MAKE) fe-test-ext
+	@bash scripts/phase-timer.sh stop
+	@[ -n "$$PHASE_TIMER_OWNED" ] || bash scripts/phase-timer.sh report
 ## fitness-jurisdiction — no country strings in core (alias for no-jurisdiction).
 fitness-jurisdiction: no-jurisdiction
 ## gen-types — regenerate the contract types (alias for gen).
@@ -567,6 +578,12 @@ fe-typecheck:
 ## "gate that quietly checks nothing" the CI workflow's own comments warn
 ## about. Part of `make check-fe`, so the merge gate covers both lanes.
 fe-typecheck-composed: composition
+	@# The frontend half's ledger is reset HERE rather than in check-fe, because
+	@# this is check-fe's prerequisite: it records its phase before check-fe's
+	@# recipe runs at all, so a reset there deleted the seconds just measured and
+	@# printed a table one row short.
+	@[ -n "$$PHASE_TIMER_OWNED" ] || bash scripts/phase-timer.sh reset
+	@bash scripts/phase-timer.sh start "frontend: composed typecheck"
 	@[ -f build/composition/frontend/extensions.gen.ts ] || { echo "fe-typecheck-composed: build/composition/frontend/extensions.gen.ts is missing after 'make composition' — the composed frontend lane has nothing to typecheck against" >&2; exit 1; }
 	@# The ROOT install first, and the order is load-bearing: the composed
 	@# workspace links react, react-dom, @tanstack/react-query and @types/react
@@ -597,6 +614,7 @@ fe-typecheck-composed: composition
 	# screen's test fixtures are checked by nothing, since vitest transpiles
 	# without typechecking.
 	cd frontend && pnpm exec tsc -p tsconfig.composed-tests.json
+	@bash scripts/phase-timer.sh stop
 
 ## frontend-e2e — the screen-acceptance harness (AC-<screen>-N + axe WCAG AA
 ## + PERF-1's held-read claim) against the built app over the seed mock.

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -41,7 +41,7 @@ UAT guides call by name (`docs/target-minimum-setup.md §3`). `check-q`,
 | Target | What it does |
 |---|---|
 | `check` | **The merge gate.** Backend `make check` = build + vet + lint + arch-lint + test + drift. Root `make check` runs that **plus** the craft-doc floor, image pins, contract breaking-change (`oasdiff`), test-lane hygiene, and the file-length ratchet |
-| `check-backend` / `check-fe` | The two halves of the root gate, runnable alone: `check-backend` = backend `check` + the root script gates below (what CI's deterministic-gates job runs; it needs no frontend toolchain — `contract-frontend-drift` skips loudly without pnpm); `check-fe` = `frontend-check` with a loud fail if `frontend/node_modules` is missing |
+| `check-backend` / `check-fe` | The two halves of the root gate, runnable alone: `check-backend` = backend `check` + the root script gates below (what CI's deterministic-gates job runs; it needs no frontend toolchain — `contract-frontend-drift` skips loudly without pnpm); `check-fe` = the composed typecheck, `frontend-check`, and the unit screens' own suites (`fe-test-ext`), with a loud fail if `frontend/node_modules` is missing |
 | `build` | `go build ./...` |
 | `vet` | `go vet ./...` |
 | `test` | Unit tests; the fitness gates in `backend/gates/` (license header, write shape, architecture, enum sync, `audit_log` enum coherence, contract `$ref` resolution) run uncached |
@@ -88,6 +88,44 @@ root script gates (each is a small script; all merge-blocking, and `check-backen
 | `test-money-scale` | Points that gate at a throwaway tree and asserts its verdict on the unmodified repo plus twenty-nine planted cases: divide, multiply and remainder fire in **both** languages and at every power the detector accepts (10, 100, 1000, 10000), including an expression the formatter wrapped across lines and an upper-case identifier; a percentage and a progress-bar width do not; the waiver silences its own line and only that line, a marker inside a string literal waives nothing, a template interpolation is judged as the code it is while the string around it is not, and a grouped literal past any minor unit does not fire; and a `fires` case must see an actual scale finding, so the gate exiting non-zero for an unrelated reason cannot pass for a detection |
 | `test-migration-versions` | Points that gate at throwaway git repositories and asserts its verdict on ten planted cases: each of the four defects it names fires (collision, sorts-below, duplicate-in-tree, undeclared consolidation), and every branch of the baseline-reset declaration is exercised — admitted for a real consolidation, refused for a survivor at the base's version AND name, refused for a one-for-one rename that does not collapse, and refused for a real collision. Each case also asserts a string the gate's own output must contain, so a gate broken such that it exits non-zero for an unrelated reason cannot pass for a detection; setup and mutation failures fail the case rather than leaving a clean tree that passes; and the harness unsets the gate's own switch and git's environment, because CI sets the reset declaration on the same step this target runs on |
 | `pkg-freeze` | Published-surface freeze (EXT-P3): apidiff on every `backend/pkg` package vs the merge target (`origin/$GITHUB_BASE_REF` in CI; locally the extensions integration branch, else `origin/main`). **Advisory before the first v1+ release tag** — incompatible changes print, never block (the surface is design-fluid). **Enforcing from v1.0.0** — incompatible changes and removed packages fail; a ratified change is its exact apidiff finding line in `scripts/pkg-freeze-allowlist.txt`, bound to the merge-base sha it was ratified against (superseded entries license nothing and warn); removals are never allowlistable. Overrides: `PKG_FREEZE_MODE=advisory\|enforce`, `PKG_FREEZE_BASE=<ref>` |
+
+### Where the gate spends its time
+
+Every green `make check` ends with a table of its own phases, so the next person
+to optimize it starts from a reading of their machine rather than from a number
+in a comment. Both halves report: the backend's four phases and the gate
+fan-out, and the frontend's composed typecheck, core suite and unit screens.
+
+The distribution is lopsided, and it is worth knowing which end to pull. On a
+quiet laptop the frontend's five core legs measure ds-gates 12s, drift 3s, lint
+2s, **unit 75s**, build 3s — so `fe-unit` alone is about 79% of those 95s and
+everything else together is 20s. An optimization that does not touch the
+vitest suite is arguing over the remainder.
+
+### What has already been tried, and rejected
+
+Each of these looks obviously right and is not. They are recorded because the
+measurement is the expensive part, and re-deriving a "no" costs the same as
+deriving it the first time.
+
+- **`pool: threads` for vitest.** Reads as a large win under load and is a loss
+  on an idle machine: forks 73s vs threads 99s measured quiet, the sign opposite
+  to the contended reading that suggested it. It also shares one jsdom across a
+  worker's files, which two suites here depend on not happening (#2866). vitest
+  4's `forks` default is correct for this tree.
+- **Fanning `frontend-check`'s five legs out under `-j`.** Four of them begin
+  with `pnpm install --frozen-lockfile` into one `frontend/node_modules`;
+  concurrently they race the `.bin` symlink farm and leave the tree broken
+  (`ENOENT ... chmod`, exit 2). That CI runs these five as parallel *jobs* is not
+  evidence for it: a CI job has its own checkout, so the isolation the local run
+  needs is the one thing CI's green never tested. A working fan-out was worth
+  about 20s.
+- **Running `check-backend` and `check-fe` concurrently.** The backend's last two
+  phases (`drift`, `check-composition`) REWRITE `build/composition/` and
+  `*_gen.go` in place, and both frontend legs read `build/composition/`. This is
+  the write-under-reader race the backend `check` recipe already keeps its own
+  phases serial to avoid — running the halves together reintroduces it across a
+  wider surface.
 
 ## Occasional
 


### PR DESCRIPTION
## The defect

The shipping step said:

> Run `make check` before pushing; add `make frontend-check` when `frontend/` changed.

`make check` runs `check-fe`, and `check-fe` runs `frontend-check`. So anyone
following the rulebook literally ran the frontend suite a **second** time for
nothing — 95 seconds on this machine. It survived because a duplicated step is
invisible for the same reason a borrowed green is: it produces the right answer,
so nothing complains.

Step 3 now says the gate is both halves with nothing to add on top.

## Why nobody could have measured it

The timing table shipped with the gate fan-out covered `check-backend` only, and
`check-fe` is about 47% of the run. Every claim about the frontend half — several
of mine included — was a guess.

Both halves report now, into ONE table:

```
  where the time went (5m03s total)
     59s   19.5%  root script gates (x30, -j4)
     15s    5.0%  backend: build (host + windows)
     88s   29.0%  backend: vet/lint/arch-lint/test/test-extensions (-j4)
      7s    2.3%  backend: contract drift
      1s    0.3%  backend: composition reproducibility
     14s    4.6%  frontend: composed typecheck
    112s   37.0%  frontend: core suite (ds-gates, drift, lint, unit, build)
      7s    2.3%  frontend: unit screens (composed workspace)
```

An external clock read 304s against the table's 303s, so the rows account for
the run rather than sampling it.

Two ordering details, both load-bearing:

- `check` is spelled as recipe lines rather than prerequisites, because it owns
  the ledger and the reset has to happen before either half runs — a prerequisite
  runs before the recipe that would have held it.
- The frontend's reset sits in `fe-typecheck-composed`, not `check-fe`. It is
  `check-fe`'s prerequisite, so it records its phase first; a reset in `check-fe`
  **deleted the 13 seconds it had just measured** and printed a table one row
  short. Caught by running a standalone `make check-fe` and counting the rows.

## Where the time actually is

The frontend's five core legs, measured quiet: ds-gates 12s, drift 3s, lint 2s,
**unit 75s**, build 3s. `fe-unit` alone is ~79% of those 95s; everything else
together is 20s. An optimization that does not touch the vitest suite is
arguing over the remainder.

## Three optimizations measured and rejected

Recorded in `docs/reference/make-targets.md`, because re-deriving a "no" costs
what deriving it did.

- **`pool: threads` for vitest** — reads as a 43% win under load, is a 26% *loss*
  measured quiet (forks 73s vs threads 99s). The sign reverses with contention.
  It also shares one jsdom across a worker's files, which two suites here depend
  on not happening (#2866).
- **Fanning `frontend-check`'s legs out under `-j`** — four of the five begin with
  `pnpm install --frozen-lockfile` into one `node_modules`; run together they race
  the `.bin` symlink farm and leave the tree broken (`ENOENT … chmod`, exit 2).
  That CI runs these five as parallel *jobs* is not evidence for it: a CI job has
  its own checkout, so the isolation the local run needs is the one property CI's
  green never tested. A working fan-out was worth ~20s.
- **Running the two halves concurrently** — `drift` and `check-composition`
  rewrite `build/composition/` and `*_gen.go` in place, and both frontend legs
  read `build/composition/`. That is the write-under-reader race the backend
  recipe already keeps its own phases serial to avoid.

## Verification

- `make check` green on the merged tree, rc=0 — twice: 5m03s on cold caches
  (the table above) and 3m37s warm. The phase shares move with the caches, which
  is the point of measuring rather than quoting a number: the frontend core suite
  is 37% cold and 43% warm, because the Go caches absorb more of the backend's.
- The two gates that parse the Makefile (`TestEveryLocalFrontendGateLegRunsInCI`,
  `TestASubMakeBehindAVariableIsStillReadAsLegs`) pass. The fan-out line stays a
  bare `$(MAKE)` line so the parity gate still sees all thirty legs, and
  `frontend-check` stays a pure delegator — a timer line there would have flipped
  it to "does work" and demanded a CI job that reaches it.
- AGENTS.md is line-neutral at its 330 ceiling.
- A standalone `make check-fe` prints all three frontend rows, and a standalone
  `make fe-typecheck-composed` records its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the standard check command includes frontend validation.
  * Updated pre-push guidance, including installation instructions and strict change-scoped checks.
  * Expanded build-check documentation to cover composed typechecking, frontend unit tests, and phase timing.
  * Documented evaluated performance optimizations that were not adopted.

* **Chores**
  * Improved validation reporting by tracking backend and frontend check phases separately while preserving the full check workflow.
  * Consolidated frontend validation into the standard check process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->