### PR TITLE
fix(overlay): a mirrored record's archive flag is unmappable, not deferred

### DIFF
--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -165,7 +165,10 @@ var personBindings = EntityBinding{
 		{WireSlot: "updated_at", CanonicalKey: "last_synced_at", Incumbent: []string{"lastmodifieddate"}, Disposition: DispositionMapped},
 
 		{WireSlot: "social", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/985"},
-		{WireSlot: "archived_at", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/986"},
+		{
+			WireSlot: "archived_at", Disposition: DispositionUnmappable,
+			Reason: "An archived record is never IN the mirror to carry the flag. The deletion sweep purges an incumbent-archived record outright rather than tombstoning it, and a local archive purges through the same path after the incumbent accepts it — so the only value the sync feed could ever read for a record the mirror still holds is absent.",
+		},
 
 		{
 			WireSlot: "consent", Disposition: DispositionUnmappable,
@@ -186,12 +189,12 @@ var personBindings = EntityBinding{
 // organizationBindings disposition every contract Organization field. Armed,
 // on the same terms personBindings is.
 //
-// Six fields the incumbent could fill are deferred rather than mapped, and
+// Five fields the incumbent could fill are deferred rather than mapped, and
 // each names the reason it is not a one-line addition: one needs a projection
-// that does not exist yet (an association sweep for the parent), four need a
-// decision the mapping cannot make on its own (a length rule, a URL
+// that does not exist yet (an association sweep for the parent), and four need
+// a decision the mapping cannot make on its own (a length rule, a URL
 // normalization, two remaps onto vocabularies this product defines on its own
-// axes), and one needs a read the adapter does not perform (the archive flag).
+// axes).
 //
 //nolint:goconst // the rows are read as data, and each column is its own vocabulary: a wire slot, the mirror's jsonb key and an incumbent property spell "address" and "industry" alike here by coincidence, so hiding any of them behind one shared name would assert a correspondence the table exists to keep separate
 var organizationBindings = EntityBinding{
@@ -213,7 +216,10 @@ var organizationBindings = EntityBinding{
 		{WireSlot: "website_url", Disposition: DispositionDerived, DerivedFrom: []string{"domains"}},
 
 		{WireSlot: "parent_org_id", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/1023"},
-		{WireSlot: "archived_at", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/1024"},
+		{
+			WireSlot: "archived_at", Disposition: DispositionUnmappable,
+			Reason: "An archived record is never IN the mirror to carry the flag. The deletion sweep purges an incumbent-archived record outright rather than tombstoning it, and a local archive purges through the same path after the incumbent accepts it — so the only value the sync feed could ever read for a record the mirror still holds is absent.",
+		},
 		{WireSlot: "description", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/1026"},
 		{WireSlot: "linkedin_url", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/1027"},
 		{WireSlot: "lifecycle", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/1028"},


### PR DESCRIPTION
`person.archived_at` and `organization.archived_at` were both deferred against an issue each, on the reading that HubSpot publishes the flag on an object read and the adapter simply does not fetch it. The first half is true; the second does not lead anywhere, because no mapping could ever read a value.

**An archived record is never in the mirror to carry the flag.**

- The deletion sweep **purges** an incumbent-archived record outright. `mirrordeletion.go` says so and says why: a deletion is not an erasure hold, and a record HubSpot later restores must be free to re-mirror, so no tombstone is left behind.
- The local archive path ends in that same purge once the incumbent accepts the write (`provider_archive.go`).
- The sync feed lists only unarchived records, so for every record the mirror still holds the flag reads `false`.

So the slot is `unmappable` rather than pending a read, and the registry now says that with the reason instead of pointing at two issues a mapping cannot close. The `organizationBindings` summary counted this among its deferrals and now counts five.

Both issues are the same binding in two entities with one shared reason, so they land as one change rather than two CI runs.

`make check-backend` green.

Closes #986
Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected field mapping behavior for person and organization archive timestamps.
  * These fields are now clearly identified as unavailable for mapping, with explanations provided.
  * Updated organization field documentation to accurately reflect the number of deferred fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->