### PR TITLE
docs(explanation): A6's risk-reduction claim waits for the ship date

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -278,7 +278,8 @@ I do not claim that LinkedIn's terms permit anything beyond this private graph u
 
 The design: Margince sends the contact a link through which they can view and correct their own card. The same flow delivers the Article 14 transparency notice and gives the contact an Article 16 accuracy mechanism. Because the consent is verifiable, it also meets the standard in Vietnam's Law 91. And the same email asks the contact to grant or decline marketing consent, with the answer landing on the consent proof log and the send itself logged in the record's history.
 
-This flow actively reduces the risk of everything else on this page.
+Once it ships, this flow actively reduces the risk of everything else on this
+page.
 
 ### Tier B: build with controls, counsel signs off first
 


### PR DESCRIPTION
Stop-gate catch on #2869: A6's closing line claimed the unshipped confirm-details flow already reduces risk. It now reads "Once it ships, this flow actively reduces the risk of everything else on this page." Markdown-only, one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes A6's closing claim in the data-enrichment explanation so it no longer presents the unshipped confirm-details flow as already reducing risk; it now reads "Once it ships, this flow actively reduces the risk of everything else on this page."

<sup>Written for commit 104df6ebadf40f8f5905281082422029a1757af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the A6 “Confirm your details” flow documentation to clarify its risk-reduction impact across the paper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->