### PR TITLE
fix(dedupe): a name of nothing but common words agrees only with the same words

### DIFF
--- a/backend/internal/modules/people/orgcommonwords.go
+++ b/backend/internal/modules/people/orgcommonwords.go
@@ -70,23 +70,6 @@ func weakEvidenceWord(word string) bool {
 	return ambiguousFormWord[word] || orgCommonNameWords[word]
 }
 
-// agreeEntirely answers whether the shorter name appears whole in the longer,
-// and whatever the longer adds is a word that names something rather than one
-// every company shares.
-//
-// A MULTISET TEST, not a subsequence one — word order is not consulted, because
-// a registry and a letterhead disagree about it more often than two companies
-// do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree.
-//
-// The condition on the LEFTOVER is what separates a qualified brand from two
-// unrelated names: "Sun Microsystems" adds a brand to "Sun", while "Bank of the
-// West" adds only "west" to "Bank", and a pair whose every word is market
-// vocabulary has nothing left to be identified by.
-//
-// A MULTISET TEST, not a subsequence one — word order is not consulted, because
-// a registry and a letterhead disagree about it more often than two companies
-// do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree entirely,
-// which is the answer a human would give.
 // anyStrongWord answers whether a name has a word of its own — one that is not
 // vocabulary every company shares.
 func anyStrongWord(fields []string) bool {
@@ -98,6 +81,19 @@ func anyStrongWord(fields []string) bool {
 	return false
 }
 
+// agreeEntirely answers whether the shorter name appears whole in the longer,
+// and whatever the longer adds is a word that names something rather than one
+// every company shares.
+//
+// A MULTISET TEST, not a subsequence one — word order is not consulted, because
+// a registry and a letterhead disagree about it more often than two companies
+// do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree, which is
+// the answer a human would give.
+//
+// The condition on the LEFTOVER is what separates a qualified brand from two
+// unrelated names: "Sun Microsystems" adds a brand to "Sun", while "Bank of the
+// West" adds only "west" to "Bank", and a pair whose every word is market
+// vocabulary has nothing left to be identified by.
 func agreeEntirely(shorter, longer []string) bool {
 	if len(shorter) == 0 {
 		return false
@@ -111,6 +107,10 @@ func agreeEntirely(shorter, longer []string) bool {
 	//
 	// A one-word name is exempt, because a company called "Sun" has said all it
 	// has to say and "Sun Microsystems" is that name qualified.
+	//
+	// Comparing LENGTHS is enough to mean "a subset rather than the same words":
+	// two names of equal length that differ in a word are rejected by the
+	// containment loop below, which needs every word of the shorter to be found.
 	if len(shorter) > 1 && !anyStrongWord(shorter) && len(shorter) != len(longer) {
 		return false
 	}

--- a/backend/internal/modules/people/orgcommonwords.go
+++ b/backend/internal/modules/people/orgcommonwords.go
@@ -87,8 +87,31 @@ func weakEvidenceWord(word string) bool {
 // a registry and a letterhead disagree about it more often than two companies
 // do. "Union Pacific Bank" and "Pacific Union Bank" therefore agree entirely,
 // which is the answer a human would give.
+// anyStrongWord answers whether a name has a word of its own — one that is not
+// vocabulary every company shares.
+func anyStrongWord(fields []string) bool {
+	for _, word := range fields {
+		if !weakEvidenceWord(word) {
+			return true
+		}
+	}
+	return false
+}
+
 func agreeEntirely(shorter, longer []string) bool {
 	if len(shorter) == 0 {
+		return false
+	}
+	// A name of nothing but common words may only agree with a name of exactly
+	// the same words. "Bank of Ireland" and "Bank of Ireland Group" are one
+	// company — "group" is deleted upstream, so both arrive as the same two
+	// words. "First National Bank" arrives as "first bank" and "First Republic
+	// Bank" as "first republic bank": one is a strict subset of the other, both
+	// are vocabulary end to end, and there is no company between them to find.
+	//
+	// A one-word name is exempt, because a company called "Sun" has said all it
+	// has to say and "Sun Microsystems" is that name qualified.
+	if len(shorter) > 1 && !anyStrongWord(shorter) && len(shorter) != len(longer) {
 		return false
 	}
 	taken := make([]bool, len(longer))

--- a/backend/internal/modules/people/orgcommonwords_test.go
+++ b/backend/internal/modules/people/orgcommonwords_test.go
@@ -96,6 +96,40 @@ func TestACommonWordIsEvidenceWhenItIsTheWholeName(t *testing.T) {
 	}
 }
 
+// A NAME OF NOTHING BUT COMMON WORDS AGREES ONLY WITH THE SAME WORDS.
+//
+// "First National Bank" reduces to "first bank" — market vocabulary end to end,
+// because "national" is deleted upstream as a stopword — and that is a strict
+// subset of "first republic bank". The addition reads as distinctive and is not:
+// there is no company between the two names, only words half the market uses.
+//
+// "Bank of Ireland" is the shape this must not catch: it reduces to the SAME two
+// words as "Bank of Ireland Group", not to a subset of them.
+func TestAnAllCommonNameAgreesOnlyWithTheSameWords(t *testing.T) {
+	for _, p := range [][2]string{
+		{"First National Bank", "First Republic Bank"},
+		{"United Pacific Group", "United Atlantic Group"},
+		{"Central National Bank", "Central Regional Bank"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got >= dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f — one name is a subset of the other and "+
+				"every word of both is vocabulary, so there is no company between them",
+				p[0], p[1], got)
+		}
+	}
+	// Same words, one of them qualified away: still one company.
+	for _, p := range [][2]string{
+		{"Bank of Ireland", "Bank of Ireland Group"},
+		{"Air France", "Air France KLM"},
+		{"Union Pacific Bank", "Pacific Union Bank"},
+	} {
+		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
+			t.Errorf("%q vs %q scores %.4f, below the %.2f threshold — these are "+
+				"the same words", p[0], p[1], got, dedupeReviewThreshold)
+		}
+	}
+}
+
 // The discount must not reach a name built from rare words, which is where one
 // shared word really is nearly the whole of the evidence.
 func TestARareSharedWordIsStillEvidence(t *testing.T) {

--- a/backend/internal/modules/people/orgcommonwords_test.go
+++ b/backend/internal/modules/people/orgcommonwords_test.go
@@ -108,7 +108,6 @@ func TestACommonWordIsEvidenceWhenItIsTheWholeName(t *testing.T) {
 func TestAnAllCommonNameAgreesOnlyWithTheSameWords(t *testing.T) {
 	for _, p := range [][2]string{
 		{"First National Bank", "First Republic Bank"},
-		{"United Pacific Group", "United Atlantic Group"},
 		{"Central National Bank", "Central Regional Bank"},
 	} {
 		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got >= dedupeReviewThreshold {
@@ -118,10 +117,17 @@ func TestAnAllCommonNameAgreesOnlyWithTheSameWords(t *testing.T) {
 		}
 	}
 	// Same words, one of them qualified away: still one company.
+	//
+	// "Acme Digital Group" and "Acme Digital Ventures" are here because they LOOK
+	// like the pairs above and are not: both reduce to the one word "acme", and a
+	// one-word name is exempt. Two arms of one brand are worth a human's glance,
+	// and the tree already decided that shape when it accepted "Acme Inc" against
+	// "Acme GmbH".
 	for _, p := range [][2]string{
 		{"Bank of Ireland", "Bank of Ireland Group"},
 		{"Air France", "Air France KLM"},
 		{"Union Pacific Bank", "Pacific Union Bank"},
+		{"Acme Digital Group", "Acme Digital Ventures"},
 	} {
 		if got := bestOrgNamePairing(p[0], "", p[1], "").Confidence; got < dedupeReviewThreshold {
 			t.Errorf("%q vs %q scores %.4f, below the %.2f threshold — these are "+


### PR DESCRIPTION
`First National Bank` and `First Republic Bank` met at **0.8275**. The cause is not the words they share but what happens before: `national` is deleted upstream as a stopword, so the first name arrives as `first bank` — market vocabulary end to end — and that is a **strict subset** of `first republic bank`. The escape then read `republic` as a distinctive addition and handed back full evidence, as though a brand were being qualified. There is no brand, and no company between those two names — only words half the market uses.

| Pair | Before | After |
|---|---|---|
| `First National Bank` / `First Republic Bank` | 0.8275 | 0.0000 |
| `Central National Bank` / `Central Regional Bank` | 0.8380 | 0.0000 |

## The rule

A name with no word of its own may only agree with a name of **exactly** the same words. A one-word name is exempt, because a company called "Sun" has said everything it has to say and `Sun Microsystems` is that name qualified.

Recall is unchanged. `Bank of Ireland` still meets `Bank of Ireland Group` — `group` is deleted upstream, so both arrive as the same two words rather than one being a subset. `Air France` / `Air France KLM`, `Union Pacific Bank` / `Pacific Union Bank`, `Sun` / `Sun Microsystems`, `Arvato` / `Arvato Systems` and `Acme Inc` / `Acme GmbH` all still meet.

## What this deliberately does not change

`Acme Digital Group` and `Acme Digital Ventures` both reduce to `acme` and still meet. That looked like the same defect and is not: they reduce to the **same** name, not a subset of one, and the tree already decided that shape is one company when it accepted `Acme Inc` against `Acme GmbH`. Two arms of one brand are worth a human's glance, and the fuzzy tier asks rather than merges. It is now pinned in the must-meet table so the decision cannot rot.

## Review round

A craft review found four defects, all real, fixed in the second commit:

- **A blocker in the comment structure.** The insertion split a doc block so `agreeEntirely` carried no comment at all while `anyStrongWord` inherited the whole thing, including a paragraph duplicated verbatim. The duplication predates this branch; the insertion made it visible.
- **A test passing for the wrong reason.** One of three pairs I asserted as newly caught — `United Pacific Group` / `United Atlantic Group` — reduces to two names of *equal length*, so the new clause never runs and the pair was already rejected. Green either way. Removed.
- **An untested claim**, and true for a different reason than my commit message gave: the `Acme Digital` pair is answered by the one-word exemption, not by the guard.
- **An unexplained proxy.** The length comparison now says why it is enough to mean "subset": equal-length names that differ in a word are rejected by the containment loop below.

The guard's three clauses were each mutation-checked and all are load-bearing.

`make check-backend` green, `make craft-static` clean across all four trees, people integration lane green under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deduplication matching two all-common-word names when one is a strict subset of the other, so `First National Bank` and `First Republic Bank` no longer score 0.8275.

- A name with no distinctive words now agrees only with a name of exactly the same words; one-word names are exempt.
- `Bank of Ireland` still meets `Bank of Ireland Group` because both reduce to the same two words after stopword deletion.
- `Acme Digital Group` and `Acme Digital Ventures` deliberately still match — both reduce to `acme` — and that case is now pinned in the tests.

<sup>Written for commit 38c5687a439ae6358dc35f842e5b2bf3636bab2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization-name matching for names made entirely of common words.
  * Prevents subset matches from being treated as identical unless word counts align.
  * Preserves matching for reordered words, qualified names, identical names, and single-word brand names.

* **Tests**
  * Added coverage for common-word organization-name matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->