### PR TITLE
fix(frontend): the catalog gate reads a title whichever way it is written

### DIFF
--- a/frontend/src/design-system/catalog.test.ts
+++ b/frontend/src/design-system/catalog.test.ts
@@ -230,14 +230,23 @@ function storyTitle(path: string, text: string): string | null {
     : named;
   if (!meta || !ts.isObjectLiteralExpression(meta)) return null;
   for (const property of meta.properties) {
-    if (
-      ts.isPropertyAssignment(property) &&
-      property.name.getText(source) === "title" &&
-      ts.isStringLiteralLike(property.initializer)
-    ) {
-      return property.initializer.text;
-    }
+    if (!ts.isPropertyAssignment(property)) continue;
+    if (propertyKey(property.name) !== "title") continue;
+    const value = unwrap(property.initializer);
+    if (ts.isStringLiteralLike(value)) return value.text;
   }
+  return null;
+}
+
+// The key, whichever way it is written. `{ title: … }` and `{ "title": … }` are
+// the same property, but reading the name's SOURCE TEXT compares the quotes
+// too, so the quoted spelling matched nothing and the story fell out of the
+// root check — skipped rather than reported, the one direction this gate must
+// not be wrong in. A computed key is deliberately not resolved: what it
+// evaluates to is not a question the parser can answer, and guessing would be
+// worse than the honest null.
+function propertyKey(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
   return null;
 }
 
@@ -452,6 +461,30 @@ describe("the detectors report what they are for", () => {
         'export default { title: "Shell/Top bar" } satisfies Meta<typeof Bar>;',
       ),
     ).toBe("Shell/Top bar");
+  });
+
+  it("reads a title whichever way the key and value are written", () => {
+    for (const meta of [
+      'const meta = { "title": "Shell/Top bar" };',
+      'const meta = { title: "Shell/Top bar" as const };',
+      'const meta = { title: ("Shell/Top bar") };',
+      'const meta = { "title": "Shell/Top bar" as const };',
+    ]) {
+      expect(storyTitle(probe, `${meta}\nexport default meta;`)).toBe(
+        "Shell/Top bar",
+      );
+    }
+  });
+
+  it("reports no title rather than resolving a computed key", () => {
+    // What a computed key evaluates to is not a question the parser can answer,
+    // and a guess would be worse than the honest null.
+    expect(
+      storyTitle(
+        probe,
+        'const k = "title";\nconst meta = { [k]: "Shell/Top bar" };\nexport default meta;',
+      ),
+    ).toBe(null);
   });
 
   it("reports no title rather than guessing when there is no default export", () => {


### PR DESCRIPTION
Follow-up to #2860. The third CodeRabbit finding on that PR was fixed and reviewed but landed after the squash merge had already fired, so it is not on `main`. Same commit, unchanged.

The third shape of the same defect the other two were: a form the detector could not read returned `null`, and a `null` title is **skipped** by the documented-root check rather than reported — so a story written that way walks past the gate entirely. Under-recognition, the one direction `AGENTS.md` §8 says a census must not be wrong in.

- `{ "title": … }` is the same property as `{ title: … }`, but the key was compared as **source text**, which carries the quotes, so the quoted spelling matched nothing. The key is now read off `Identifier` / `StringLiteral` alike.
- The value had to be a bare string literal, so `title: "…" as const` and a parenthesized one read as no title. Both go through the same `unwrap` the metadata object already used.

A computed key stays unread on purpose — what it evaluates to is not a question the parser can answer, and a guess would be worse than the honest `null`. That case is planted as a probe too, so the line is stated rather than assumed.

Gates: `catalog.test.ts` 18 pass, `tsc -b` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the catalog gate so story titles are read however the key and value are written, preventing stories from slipping past the gate when the detector can't parse the syntax.

- Quoted keys like `"title"` are now read from the identifier instead of the source text, which included the quotes.
- Values wrapped in `as const` or parentheses are unwrapped before checking for a string literal.
- Computed keys deliberately return `null`, since resolving them would require guessing runtime values.

<sup>Written for commit 7a21c4f699c835d14a0d3d66e156569ed7de2250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title recognition for quoted property keys and type-only or parenthesized values.
  * Computed property keys now correctly remain unresolved when a title cannot be determined.
* **Tests**
  * Added coverage for supported key and value formats, including computed-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->