### PR TITLE
docs(explanation): the whitepaper reads clean and cites at the end

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -7,7 +7,7 @@
 | **Author** | Lars Jankowfsky |
 | **Date** | 27 August 2026 |
 | **Scope** | European Union law (with German specifics) and Vietnamese law. Other jurisdictions can be added later; nothing here covers them yet. |
-| **Status** | Position paper, adversarially fact-checked. This is research to brief counsel with, not legal advice. Every load-bearing claim carries a named source. |
+| **Status** | Position paper, adversarially fact-checked. This is research to brief counsel with, not legal advice. Every load-bearing claim carries a named source in the footnotes at the end. |
 
 ---
 
@@ -33,31 +33,31 @@ I started with LinkedIn's contract because, frankly, it already kills the standa
 
 Apollo, Kaspr, Lusha and Waalaxy all sell some version of the same mechanism. A Chrome extension runs inside a salesperson's logged-in LinkedIn session. It reads each profile the person visits, parses the fields and posts them to the vendor's backend. That is the entire magic trick.
 
-Now read Section 8.2 of LinkedIn's [User Agreement](https://www.linkedin.com/legal/user-agreement). It prohibits users from developing, supporting or using software, devices, scripts, robots or any other means or processes, explicitly including crawlers, **browser plugins** and add-ons, to scrape or copy the Services, including profiles.
+Now read Section 8.2 of LinkedIn's User Agreement.[^1] It prohibits users from developing, supporting or using software, devices, scripts, robots or any other means or processes, explicitly including crawlers, **browser plugins** and add-ons, to scrape or copy the Services, including profiles.
 
 Those three verbs matter: develop, support and use. They bind everyone who accepted the agreement. In practice, that reaches both sides of the plugin economy. The user is bound by definition. The vendor is bound through the accounts it holds to build and test the product. The hiQ court later held hiQ's own corporate account against it.
 
 Another clause prohibits using LinkedIn data obtained through third parties, including search tools, **data aggregators or brokers**, without the content owner's consent. A CRM that stores purchased LinkedIn profile data sits directly inside that clause's reach.
 
-Buying a Sales Navigator seat changes nothing. The [subscription agreement](https://www.linkedin.com/legal/l/lsa) calls unauthorized scraping an "Incurable Breach". There is no CSV export. The only sanctioned route from Sales Navigator into a CRM is CRM Sync on the Advanced Plus tier, and LinkedIn limits it to a short list of large incumbents: Salesforce, Microsoft Dynamics 365, HubSpot and Oracle Sales. LinkedIn publishes the list in its [CRM matrix](https://www.linkedin.com/help/linkedin/answer/a106005/?lang=en).
+Buying a Sales Navigator seat changes nothing. The subscription agreement calls unauthorized scraping an "Incurable Breach".[^2] There is no CSV export. The only sanctioned route from Sales Navigator into a CRM is CRM Sync on the Advanced Plus tier, and LinkedIn limits it to a short list of large incumbents: Salesforce, Microsoft Dynamics 365, HubSpot and Oracle Sales.[^3]
 
 Then somebody always says: "But hiQ won. Scraping public profiles is legal."
 
 That sentence may be the most expensive misreading in our industry.
 
-The 9th Circuit said something much narrower in 2019 and reaffirmed it in [April 2022](https://cdn.ca9.uscourts.gov/datastore/opinions/2022/04/18/17-16783.pdf): scraping publicly available pages was likely not a federal *hacking crime* under the Computer Fraud and Abuse Act.
+The 9th Circuit said something much narrower in 2019 and reaffirmed it in April 2022: scraping publicly available pages was likely not a federal *hacking crime* under the Computer Fraud and Abuse Act.[^4]
 
 That ruling did not bless scraping as a business model.
 
-On remand, in [November 2022](https://caselaw.findlaw.com/court/us-dis-crt-n-d-cal/2182242.html), the district court held LinkedIn's anti-scraping terms enforceable and granted LinkedIn summary judgment over hiQ's use of fake "turker" accounts. Liability for the scraping itself remained open because of waiver and estoppel questions.
+On remand, in November 2022, the district court held LinkedIn's anti-scraping terms enforceable and granted LinkedIn summary judgment over hiQ's use of fake "turker" accounts.[^5] Liability for the scraping itself remained open because of waiver and estoppel questions.
 
-The court never answered those questions. hiQ folded and [settled](https://www.zwillgen.com/alternative-data/hiq-v-linkedin-wrapped-up-web-scraping-lessons-learned/) instead: a negotiated consent judgment of USD 500,000, a permanent injunction with no distinction between public and private pages, and deletion of all scraped data and code.
+The court never answered those questions. hiQ folded and settled instead: a negotiated consent judgment of USD 500,000, a permanent injunction with no distinction between public and private pages, and deletion of all scraped data and code.[^6]
 
 No precedent was set. Something more practical was. The company celebrated for "making scraping legal" ended the fight enjoined and gone.
 
-LinkedIn has kept going. It sued [Mantheos](https://news.linkedin.com/2022/february/taking-legal-action-to-protect-members-against-scraping), which settled, and [ProAPIs](https://securityaffairs.com/183001/security/linkedin-sues-proapis-for-15k-month-linkedin-data-scraping-scheme.html), filed in 2025.
+LinkedIn has kept going. It sued Mantheos, which settled,[^7] and ProAPIs, filed in 2025.[^8]
 
-The official route is closed as well. LinkedIn's [partner documentation](https://learn.microsoft.com/en-us/linkedin/sales/) says it is "not currently accepting new partners" for the Sales Navigator API. The self-service API returns only the name, email address and photo of the single member who gave consent through OpenID Connect.
+The official route is closed as well. LinkedIn's partner documentation says it is "not currently accepting new partners" for the Sales Navigator API.[^9] The self-service API returns only the name, email address and photo of the single member who gave consent through OpenID Connect.
 
 Now look at who carries the risk in the plugin economy.
 
@@ -71,9 +71,9 @@ That is the second layer.
 
 The GDPR does not ban B2B enrichment. That is important because a lot of bad legal analysis begins by pretending the answer is simply no.
 
-In 2024, the Court of Justice confirmed that a purely commercial interest can qualify as a legitimate interest under Article 6(1)(f) ([*KNLTB*, C-621/22](https://privacymatters.dlapiper.com/2024/10/eu-cjeu-confirms-that-legitimate-interests-can-cover-purely-commercial-interests/)). Recital 47 expressly names direct marketing as a possible legitimate interest. France's CNIL and the UK's ICO both accept B2B prospecting on that basis when the data relates to the person's professional capacity and the person can opt out.
+In 2024, the Court of Justice confirmed that a purely commercial interest can qualify as a legitimate interest under Article 6(1)(f) (*KNLTB*, C-621/22).[^10] Recital 47 expressly names direct marketing as a possible legitimate interest. France's CNIL and the UK's ICO both accept B2B prospecting on that basis when the data relates to the person's professional capacity and the person can opt out.
 
-Retention still needs a reason. CNIL works with a benchmark of roughly three years after the last contact. The ICO [sets no fixed period](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/plan-direct-marketing/) and expects the controller to justify whatever period it chooses.
+Retention still needs a reason. CNIL works with a benchmark of roughly three years after the last contact. The ICO sets no fixed period and expects the controller to justify whatever period it chooses.[^11]
 
 The part that surprised me was Article 14.
 
@@ -87,7 +87,7 @@ Three cases tell the story. The source changed each time. The missing duty did n
 
 Between 2019 and 2023, Bisnode fought over a database containing 7.5 million sole traders and company directors, all collected from *public government registers*. It emailed the 682,000 people for whom it held an email address and placed a notice on its website for everyone else. Bisnode argued that sending postal notices would require disproportionate effort.
 
-The Polish DPA [fined it](https://uodo.gov.pl/en/553/1572) roughly EUR 220,000 and ordered individual notification.
+The Polish DPA fined it roughly EUR 220,000 and ordered individual notification.[^12]
 
 The Supreme Administrative Court dismissed the final appeal on 19 September 2023. Transparency was the rule. Exceptions had to be read restrictively. On these facts, cost alone did not carry the exception, and the public-register origin changed nothing.
 
@@ -95,7 +95,7 @@ The duty follows the data.
 
 ### Kaspr: LinkedIn visibility choices mattered
 
-On 5 December 2024, [CNIL fined Kaspr](https://www.cnil.fr/en/data-scraping-kaspr-fined-eu240000) EUR 240,000. Kaspr's browser extension fed a database of 160 million contacts from LinkedIn.
+On 5 December 2024, CNIL fined Kaspr EUR 240,000.[^13] Kaspr's browser extension fed a database of 160 million contacts from LinkedIn.
 
 CNIL found four problems that matter here:
 
@@ -104,27 +104,27 @@ CNIL found four problems that matter here:
 - It delivered no Article 14 notice at all until 2022.
 - In access-request responses, it named only "publicly available sources", although CNIL held that Kaspr had to provide all source information it actually possessed.
 
-CNIL later [closed the injunction](https://www.cnil.fr/en/closure-order-issued-against-kaspr). Read that closure carefully before describing it as regulatory approval. Kaspr complied by deleting the offending data and stopping the LinkedIn collection. The regulator approved the exit from the model.
+CNIL later closed the injunction.[^14] Read that closure carefully before describing it as regulatory approval. Kaspr complied by deleting the offending data and stopping the LinkedIn collection. The regulator approved the exit from the model.
 
 ### Lusha: a compliance seal did not save the database
 
-In July 2026, Italy's Garante [fined Lusha](https://www.garanteprivacy.it/home/docweb/-/docweb-display/docweb/10275230) EUR 2 million and ordered deletion of ALL Italian contact data within 60 days.
+In July 2026, Italy's Garante fined Lusha EUR 2 million and ordered deletion of ALL Italian contact data within 60 days.[^15]
 
 Lusha's US domicile did not change the result. Neither did its TrustArc compliance seal. The Garante took the certification into account when calculating the fine, and the answer was still two million euros.
 
 Around those three enrichment cases sit the harder scraping precedents.
 
-Clearview AI scraped public photographs and has accumulated roughly EUR 100 million in fines across five European authorities: EUR 20 million each in Italy, Greece and France, EUR 30.5 million in the Netherlands, plus the UK's GBP 7.5 million penalty, which is [still in litigation](https://ico.org.uk/about-the-ico/media-centre/news-and-blogs/2025/10/uk-upper-tribunal-hands-down-judgment-on-clearview-ai-inc/). France later added a EUR 5.2 million non-compliance penalty.
+Clearview AI scraped public photographs and has accumulated roughly EUR 100 million in fines across five European authorities: EUR 20 million each in Italy, Greece and France, EUR 30.5 million in the Netherlands, plus the UK's GBP 7.5 million penalty, which is still in litigation.[^16] France later added a EUR 5.2 million non-compliance penalty.
 
-The customer carries its own liability. Sweden's IMY [fined the police](https://www.imy.se/en/about-us/arkiv/nyhetsarkiv/police-unlawfully-used-facial-recognition-app/) EUR 250,000 merely for *using* Clearview. In August 2023, twelve DPAs signed a [joint statement on data scraping](https://ico.org.uk/media2/migrated/4026232/joint-statement-data-scraping-202308.pdf). Buying or using unlawfully scraped data does not move the liability somewhere else.
+The customer carries its own liability. Sweden's IMY fined the police EUR 250,000 merely for *using* Clearview.[^17] In August 2023, twelve DPAs signed a joint statement on data scraping.[^18] Buying or using unlawfully scraped data does not move the liability somewhere else.
 
-Even the platforms get pulled in. The Irish DPC fined Meta [EUR 265 million](https://www.dataprotection.ie/en/news-media/press-releases/data-protection-commission-announces-decision-in-facebook-data-scraping-inquiry) for its data-protection-by-design failures after a scraped dataset of 533 million users surfaced. That decision binds Meta, not every online platform. But the direction is uncomfortable for the plugin industry: the host platform's design duty runs against scraping.
+Even the platforms get pulled in. The Irish DPC fined Meta EUR 265 million for its data-protection-by-design failures after a scraped dataset of 533 million users surfaced.[^19] That decision binds Meta, not every online platform. But the direction is uncomfortable for the plugin industry: the host platform's design duty runs against scraping.
 
 For anyone holding enriched data, two product consequences follow.
 
 First, Article 15(1)(g) gives the person a right to "any available information" about the source. Kaspr shows that a regulator will reject "public sources" when the company knows more. Margince therefore stores per-field provenance. That goes beyond the literal wording and makes the eventual data-subject access answer easy.
 
-Second, erasure has to stick. The law does not [literally mandate a suppression list](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/respect-peoples-preferences/), but the next synchronization will otherwise resurrect the deleted contact. Then you are back in the same lawful-basis analysis with worse facts. The ICO recommends a suppression list. We ship one. The design is documented in [privacy-and-consent.md](privacy-and-consent.md).
+Second, erasure has to stick. The law does not literally mandate a suppression list,[^20] but the next synchronization will otherwise resurrect the deleted contact. Then you are back in the same lawful-basis analysis with worse facts. The ICO recommends a suppression list. We ship one. The design is documented in [privacy-and-consent.md](privacy-and-consent.md).
 
 I understood the product line only after reading all three enrichment decisions: scale changes the facts.
 
@@ -134,7 +134,7 @@ Trigger and scale separate a defensible lookup from the Bisnode pattern.
 
 One more line matters, especially in Germany. *Storing* a business email address is a GDPR question. *Sending marketing to it* is governed separately.
 
-Germany's [Section 7 UWG](https://www.gesetze-im-internet.de/englisch_uwg/englisch_uwg.pdf) requires prior express consent for email marketing, including B2B email. Section 7(3) contains one narrow exception for existing customers, the same-product context and an opt-out at every step.
+Germany's Section 7 UWG requires prior express consent for email marketing, including B2B email.[^21] Section 7(3) contains one narrow exception for existing customers, the same-product context and an opt-out at every step.
 
 Your CRM may lawfully hold an address that you still may not cold-email from Frankfurt.
 
@@ -144,17 +144,17 @@ I live in Vietnam. We build Margince for companies here as well as in Germany. V
 
 It is also the strictest law in this paper, and most Western vendors appear not to have noticed that it exists.
 
-The timeline matters. Vietnam operated under [Decree 13/2023/ND-CP](https://thuvienphapluat.vn/van-ban/EN/Cong-nghe-thong-tin/Decree-No-13-2023-ND-CP-dated-April-17-2023-on-protection-of-personal-data/564343/tieng-anh.aspx) until the end of 2025. Since 1 January 2026, the Personal Data Protection Law has applied. [Law 91/2025/QH15](https://english.luatvietnam.vn/dan-su/law-on-personal-data-protection-law-no-91-2025-qh15-405135-d1.html) was passed on 26 June 2025, and implementing Decree 356/2025 entered into force on the same day as the law.
+The timeline matters. Vietnam operated under Decree 13/2023/ND-CP until the end of 2025.[^22] Since 1 January 2026, the Personal Data Protection Law has applied. Law 91/2025/QH15 was passed on 26 June 2025,[^23] and implementing Decree 356/2025 entered into force on the same day as the law.
 
 The Vietnamese model is harder than the GDPR. Processing rests on consent plus a short, closed list of exceptions. Its "legitimate interest" basis is defensive only. It covers protecting rights against an act of infringement, which means use cases such as fraud prevention and legal claims.
 
-Every law-firm analysis I checked reaches the same conclusion: [Tilleke & Gibbins](https://www.tilleke.com/insights/vietnams-new-personal-data-protection-law-a-closer-look/), [Baker McKenzie](https://connectontech.bakermckenzie.com/vietnam-decoding-vietnams-pdp-law-gdpr-inspired-rules-with-local-twists/), [DLA Piper](https://www.dlapiperdataprotection.com/?t=law&c=VN) and [Rouse](https://rouse.com/insights/news/2025/vietnam-s-new-personal-data-protection-law-what-businesses-need-to-know). That basis cannot carry prospecting or enrichment.
+Every law-firm analysis I checked reaches the same conclusion: Tilleke & Gibbins,[^24] Baker McKenzie,[^25] DLA Piper[^26] and Rouse.[^27] That basis cannot carry prospecting or enrichment.
 
 There is no separate basis for publicly available data. Publishing personal data waives nothing. Marketing requires consent, with no soft opt-in, on top of the Decree 91/2020 anti-spam regime and its do-not-call register.
 
 Article 7(6) prohibits buying and selling personal data unless the law itself provides otherwise. The statute could hardly be clearer: "Personal data is not a commodity."
 
-The penalty rules in Article 8 and the sanctions regime reach ten times the revenue gained from illegal data trading. Violations of the cross-border transfer rules can reach 5% of prior-year revenue. The [official text is available through the Ministry of Public Security](https://bocongan.gov.vn/media/bca-media/photo-library/20250728100402_a4c3955c-ea1d-48a0-9998-c262b14864af-Lu%E1%BA%ADt-B%E1%BA%A3o-v%E1%BB%87-d%E1%BB%AF-li%E1%BB%87u-c%C3%A1-nh%C3%A2n.pdf).
+The penalty rules in Article 8 and the sanctions regime reach ten times the revenue gained from illegal data trading. Violations of the cross-border transfer rules can reach 5% of prior-year revenue.[^28]
 
 Buying broker data about Vietnamese contacts is the highest-risk act in this entire area.
 
@@ -172,15 +172,15 @@ A business card can begin a business relationship. It does not prove consent to 
 
 American CRM vendors regularly forget the person who reviews software in Germany: the works council.
 
-Germany's Federal Labour Court gave us the doctrine in one perfect image in 2024. A retail headset system required works-council co-determination even though it stored no data at all ([1 ABR 16/23](https://www.bundesarbeitsgericht.de/wp-content/uploads/2024/11/1-ABR-16-23.pdf)).
+Germany's Federal Labour Court gave us the doctrine in one perfect image in 2024. A retail headset system required works-council co-determination even though it stored no data at all (1 ABR 16/23).[^29]
 
-Under [Section 87(1)(6) BetrVG](https://www.gesetze-im-internet.de/betrvg/__87.html), any technical system *capable* of monitoring employee performance or behaviour is co-determined. The employer's intent is irrelevant. There is no de-minimis threshold.
+Under Section 87(1)(6) BetrVG, any technical system *capable* of monitoring employee performance or behaviour is co-determined.[^30] The employer's intent is irrelevant. There is no de-minimis threshold.
 
-The court has applied the rule to an Excel attendance list ([1 ABN 36/18](https://www.bundesarbeitsgericht.de/entscheidung/1-abn-36-18/)), SAP (1 ABR 45/11) and Office 365 ([1 ABR 20/21](https://www.hensche.de/bag-beschluss-vom-08.03.2022-1-abr-20-21-zustaendigkeit-des-gesamtbetriebsrats-bei-unternehmenseinheitlicher-nutzung-von-microsoft-office-365.html)).
+The court has applied the rule to an Excel attendance list (1 ABN 36/18),[^31] SAP (1 ABR 45/11) and Office 365 (1 ABR 20/21).[^32]
 
 A CRM containing an audit trail and pipeline numbers per sales rep is co-determined. Period.
 
-That part is routine. A German enterprise CRM rollout normally includes a Betriebsvereinbarung. A well-drafted agreement can itself provide the GDPR basis for employee-side processing when it meets Article 88(2) GDPR and [Section 26(4) BDSG](https://www.gesetze-im-internet.de/englisch_bdsg/englisch_bdsg.html).
+That part is routine. A German enterprise CRM rollout normally includes a Betriebsvereinbarung. A well-drafted agreement can itself provide the GDPR basis for employee-side processing when it meets Article 88(2) GDPR and Section 26(4) BDSG.[^33]
 
 The feature list decides whether that negotiation takes six weeks or eighteen months.
 
@@ -194,7 +194,7 @@ The Kaspr decision gives any works council a ready-made argument that the tool i
 
 Since 2021, an AI layer has sat on top. Section 90 BetrVG requires the employer to inform the works council during the *planning* stage of AI use. The EU AI Act classifies systems that monitor and evaluate worker performance as high-risk under Annex III 4(b).
 
-The 2026 AI omnibus moved the compliance deadline for Annex III systems from 2 August 2026 to 2 December 2027 ([Regulation (EU) 2026/1744](https://www.steptoe.com/en/news-publications/steptechtoe-blog/eu-ai-act-amendments-enter-into-force.html)). The category still exists. Only the deadline moved.
+The 2026 AI omnibus moved the compliance deadline for Annex III systems from 2 August 2026 to 2 December 2027 (Regulation (EU) 2026/1744).[^34] The category still exists. Only the deadline moved.
 
 Our rule stands regardless of the date: the AI evaluates records, deals and companies. It never evaluates the work quality of a named sales rep.
 
@@ -217,11 +217,11 @@ The Betriebsvereinbarung then fixes the purpose in writing: account coverage yes
 
 That negotiation is winnable because the product gives the works council something concrete to hold. A scraping plugin gives it something to veto.
 
-## 5. What we build, what we will build, and what we refuse
+## 5. What we build, what we are building, and what we refuse
 
 The product policy now becomes very simple.
 
-We will build A1 to A6 once there is demand. No worries, we release quickly; you won't have to wait months for this. It might be built already if you read this much later than August 2026. We refuse all five Tier C models.
+Part of Tier A ships today; the rest is in work, ticket by ticket, and each item below says which is which. We release quickly, so the gap between "in work" and "shipped" is weeks, not months, and it may already be closed by the time you read this. We refuse all five Tier C models.
 
 Each item below is rated on four axes: GDPR posture, Vietnam compatibility, platform-contract exposure and works-council temperature.
 
@@ -231,8 +231,8 @@ Each item below is rated on four axes: GDPR posture, Vietnam compatibility, plat
 
 | Source | Data | Access | Limit |
 |---|---|---|---|
-| [VIES](https://ec.europa.eu/taxation_customs/vies/) | VAT validity, registered name and address in many member states | Free API; we store the consultation number as proof | Availability varies by state |
-| [GLEIF LEI](https://www.gleif.org/en/about/open-data) | Legal entity plus ownership tree | Free API and bulk files, CC0 | Coverage thins outside finance |
+| VIES[^35] | VAT validity, registered name and address in many member states | Free API; we store the consultation number as proof | Availability varies by state |
+| GLEIF LEI[^36] | Legal entity plus ownership tree | Free API and bulk files, CC0 | Coverage thins outside finance |
 | Swiss Zefix | Commercial register, daily change feed | Free REST API | None that bites |
 | UK Companies House | Register, officers, filings | Free API and streaming | Rate limits only |
 | German Handelsregister | Register data, free since the 2022 DiRUG reform | Web, per-lookup | Portal caps queries and bans bulk |
@@ -242,7 +242,7 @@ The line must stay sharp. The moment a natural person appears in the source, per
 
 The identifier spine is EUID, LEI, VAT ID and the Vietnamese MST.
 
-**A2. The counterparty's own website, read deeper.** Built already; the enhancements are in work ([#2855](https://github.com/margince/margince/issues/2855)).
+**A2. The counterparty's own website, read deeper.** Built already; the enhancements are in work (ticket #2855).
 
 Margince already reads company websites, as described in [company-context.md](company-context.md). The deeper read handles people named on those sites in exactly the shape this paper argues for. A stranger found on a team page is staged as a lead and remains staged until a human accepts. The system never auto-creates a new person.
 
@@ -258,7 +258,7 @@ MX and DNS records, TLS certificate-transparency logs, and technology-stack fing
 
 The A1 caveat still applies. A personal name inside a certificate or domain record is personal data, so Margince keeps the stored signal at company level.
 
-**A4. First-party person capture.** Half built; the other half is in work ([#2856](https://github.com/margince/margince/issues/2856)).
+**A4. First-party person capture.** Half built; the other half is in work (ticket #2856).
 
 The contact sent you the details. Margince's capture works from that fact. Connected mailboxes are processed automatically. A nightly pass extracts only stated fields from email signatures: name, title and phone number, with nothing inferred. Workspace exclusion lists keep entire addresses and domains outside capture.
 
@@ -268,18 +268,17 @@ First-party collection is the only person-data channel that scales cleanly. See 
 
 **A5. LinkedIn as a link, plus the member's own export.** We store the LinkedIn profile URL as a clickable link. Margince never fetches the page server-side.
 
-The user reads the profile in their own browser and manually enters what they learned; a quick-capture form built for exactly that moment is in work ([#2857](https://github.com/margince/margince/issues/2857)). LinkedIn also allows every member to download their own data. The flow in [import-your-linkedin-network.md](../how-to/import-your-linkedin-network.md) imports the member's `Connections.csv` in a deliberately limited form.
+The user reads the profile in their own browser and manually enters what they learned; a quick-capture form built for exactly that moment is in work (ticket #2857). LinkedIn also allows every member to download their own data. The flow in [import-your-linkedin-network.md](../how-to/import-your-linkedin-network.md) imports the member's `Connections.csv` in a deliberately limited form.
 
 The imported connections become private graph substrate, "ghosts", used only for reach and warmth. They are visible only to the importer. They never become contact records and never create people.
 
 I do not claim that LinkedIn's terms permit anything beyond this private graph use. Margince therefore stops there. It does not create contacts and provides no parser for pasted profile text. Once software copies the page on the user's behalf, the scraping clause is back in play. We draw the line on the safe side.
 
-**A6. The "confirm your details" flow.** In work now ([#2858](https://github.com/margince/margince/issues/2858)), bundled with the marketing-consent ask.
+**A6. The "confirm your details" flow.** In work now (ticket #2858), bundled with the marketing-consent ask.
 
 The design: Margince sends the contact a link through which they can view and correct their own card. The same flow delivers the Article 14 transparency notice and gives the contact an Article 16 accuracy mechanism. Because the consent is verifiable, it also meets the standard in Vietnam's Law 91. And the same email asks the contact to grant or decline marketing consent, with the answer landing on the consent proof log and the send itself logged in the record's history.
 
-Once it ships, this flow actively reduces the risk of everything else on this
-page.
+Once it ships, this flow actively reduces the risk of everything else on this page.
 
 ### Tier B: build with controls, counsel signs off first
 
@@ -303,7 +302,7 @@ I have not found this feature at any vendor. I think I know why. Their model can
 
 The notice text does not ship until counsel has reviewed it market by market.
 
-**B3. Licensed notified-database providers.** Providers such as [Cognism](https://www.cognism.com/compliance) and Dealfront operate what they call a "notified database". They claim Article 6(1)(f) based on a documented balancing test and say they discharge Article 14 by emailing the data subjects.
+**B3. Licensed notified-database providers.** Providers such as Cognism[^37] and Dealfront operate what they call a "notified database". They claim Article 6(1)(f) based on a documented balancing test and say they discharge Article 14 by emailing the data subjects.
 
 Those are provider assertions. No regulator has certified the model. The customer remains an independent controller with duties of its own.
 
@@ -338,45 +337,7 @@ Margince creates no inferred employee traits, conduct profiles or performance sc
 
 Whether mailbox processing satisfies Section 26 BDSG must be assessed purpose by purpose. Account coverage with these controls is a purpose we can defend in writing. Rep scoring is not. It remains refused.
 
-## 6. Sources and verification status
-
-The primary decisions and rulings linked above were verified against the issuing body where available:
-
-- CJEU C-621/22 (*KNLTB*);
-- UODO v. Bisnode, including the NSA ruling of 19 September 2023;
-- CNIL v. Kaspr, EUR 240,000 on 5 December 2024, plus the closure notice;
-- Garante v. Lusha, EUR 2 million in July 2026;
-- the Clearview AI fine series in Italy, Greece, France, the Netherlands and the UK, with the UK litigation continuing;
-- IMY v. the Swedish police;
-- Irish DPC v. Meta, EUR 265 million;
-- hiQ v. LinkedIn, including the 9th Circuit ruling in 2022, the N.D. California ruling in November 2022 and the consent judgment in December 2022;
-- LinkedIn v. Mantheos and LinkedIn v. ProAPIs;
-- BAG 1 ABN 36/18, 1 ABR 45/11, 1 ABR 20/21 and 1 ABR 16/23.
-
-The statutory set is:
-
-- GDPR Articles 5, 6(1)(f), 14, 15(1)(g), 17, 21 and 88, plus Recitals 14 and 47;
-- Sections 87(1)(6), 90 and 80(3) BetrVG;
-- Section 26 BDSG;
-- Section 5 DDG;
-- Section 7 UWG;
-- EU AI Act Annex III 4(b), as amended by Regulation (EU) 2026/1744;
-- Vietnam Decree 13/2023/ND-CP, Personal Data Protection Law 91/2025/QH15 Articles 7(6), 8 and 9, Decree 356/2025 and Decree 91/2020.
-
-The Vietnamese-law analysis rests on the official texts plus concurring commentary from Tilleke & Gibbins, DLA Piper, Baker McKenzie, Rouse and DFDL.
-
-On 27 August 2026, I reconciled all 26 findings from an adversarial fact-check into this version.
-
-Counsel still needs to close four Tier B questions:
-
-- the final adoption status of the EDPB's Guidelines 1/2024 on legitimate interest, still in draft as of this writing;
-- Vietnam's administrative sanctions decree, which remains in flux through 2026;
-- the exact section numbering in LinkedIn's subscription agreement;
-- the Section 7 UWG detail for each outreach channel.
-
-None of those open questions changes a tier placement.
-
-## 7. Why this wins deals
+## 6. Why this wins deals
 
 This paper defines what Margince can sell with a straight face.
 
@@ -401,3 +362,51 @@ Who sends the Article 14 notices for the ten thousand contacts that its plugin j
 We have answers to both.
 
 They have a Chrome extension.
+
+## 7. Sources and verification status
+
+The primary decisions and rulings cited in the footnotes were verified against the issuing body where available: CJEU C-621/22 (*KNLTB*); UODO v. Bisnode including the NSA ruling of 19 September 2023; CNIL v. Kaspr plus the closure notice; Garante v. Lusha; the Clearview AI fine series in Italy, Greece, France, the Netherlands and the UK, with the UK litigation continuing; IMY v. the Swedish police; Irish DPC v. Meta; hiQ v. LinkedIn across the 9th Circuit ruling, the N.D. California ruling of November 2022 and the consent judgment of December 2022; LinkedIn v. Mantheos and LinkedIn v. ProAPIs; and BAG 1 ABN 36/18, 1 ABR 45/11, 1 ABR 20/21 and 1 ABR 16/23.
+
+The statutory set: GDPR Articles 5, 6(1)(f), 14, 15(1)(g), 17, 21 and 88 plus Recitals 14 and 47; Sections 87(1)(6), 90 and 80(3) BetrVG; Section 26 BDSG; Section 5 DDG; Section 7 UWG; EU AI Act Annex III 4(b) as amended by Regulation (EU) 2026/1744; Vietnam Decree 13/2023/ND-CP, Personal Data Protection Law 91/2025/QH15 Articles 7(6), 8 and 9, Decree 356/2025 and Decree 91/2020. The Vietnamese-law analysis rests on the official texts plus concurring commentary from Tilleke & Gibbins, DLA Piper, Baker McKenzie, Rouse and DFDL.
+
+On 27 August 2026, I reconciled all 26 findings from an adversarial fact-check into this version.
+
+Counsel still needs to close four Tier B questions: the final adoption status of the EDPB's Guidelines 1/2024 on legitimate interest, still in draft as of this writing; Vietnam's administrative sanctions decree, which remains in flux through 2026; the exact section numbering in LinkedIn's subscription agreement; and the Section 7 UWG detail for each outreach channel. None of those open questions changes a tier placement.
+
+[^1]: LinkedIn User Agreement, Section 8.2: https://www.linkedin.com/legal/user-agreement
+[^2]: LinkedIn Subscription Agreement: https://www.linkedin.com/legal/l/lsa
+[^3]: LinkedIn CRM integration matrix: https://www.linkedin.com/help/linkedin/answer/a106005/?lang=en
+[^4]: hiQ Labs v. LinkedIn, 9th Cir., opinion of 18 April 2022: https://cdn.ca9.uscourts.gov/datastore/opinions/2022/04/18/17-16783.pdf
+[^5]: hiQ Labs v. LinkedIn, N.D. Cal., November 2022: https://caselaw.findlaw.com/court/us-dis-crt-n-d-cal/2182242.html
+[^6]: ZwillGen, "hiQ v. LinkedIn Wrapped Up": https://www.zwillgen.com/alternative-data/hiq-v-linkedin-wrapped-up-web-scraping-lessons-learned/
+[^7]: LinkedIn on the Mantheos suit: https://news.linkedin.com/2022/february/taking-legal-action-to-protect-members-against-scraping
+[^8]: Coverage of LinkedIn v. ProAPIs: https://securityaffairs.com/183001/security/linkedin-sues-proapis-for-15k-month-linkedin-data-scraping-scheme.html
+[^9]: LinkedIn Sales Navigator partner documentation: https://learn.microsoft.com/en-us/linkedin/sales/
+[^10]: DLA Piper on CJEU C-621/22: https://privacymatters.dlapiper.com/2024/10/eu-cjeu-confirms-that-legitimate-interests-can-cover-purely-commercial-interests/
+[^11]: ICO direct-marketing retention guidance: https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/plan-direct-marketing/
+[^12]: UODO on the Bisnode case and the NSA ruling: https://uodo.gov.pl/en/553/1572
+[^13]: CNIL, Kaspr fine of 5 December 2024: https://www.cnil.fr/en/data-scraping-kaspr-fined-eu240000
+[^14]: CNIL, closure of the Kaspr injunction: https://www.cnil.fr/en/closure-order-issued-against-kaspr
+[^15]: Garante, Lusha decision: https://www.garanteprivacy.it/home/docweb/-/docweb-display/docweb/10275230
+[^16]: ICO on the Clearview Upper Tribunal judgment: https://ico.org.uk/about-the-ico/media-centre/news-and-blogs/2025/10/uk-upper-tribunal-hands-down-judgment-on-clearview-ai-inc/
+[^17]: IMY, fine against the Swedish police: https://www.imy.se/en/about-us/arkiv/nyhetsarkiv/police-unlawfully-used-facial-recognition-app/
+[^18]: Joint DPA statement on data scraping, August 2023: https://ico.org.uk/media2/migrated/4026232/joint-statement-data-scraping-202308.pdf
+[^19]: Irish DPC, Meta data-scraping decision: https://www.dataprotection.ie/en/news-media/press-releases/data-protection-commission-announces-decision-in-facebook-data-scraping-inquiry
+[^20]: ICO guidance on suppression: https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-guidance/respect-peoples-preferences/
+[^21]: UWG Section 7, official English translation: https://www.gesetze-im-internet.de/englisch_uwg/englisch_uwg.pdf
+[^22]: Decree 13/2023/ND-CP, English text: https://thuvienphapluat.vn/van-ban/EN/Cong-nghe-thong-tin/Decree-No-13-2023-ND-CP-dated-April-17-2023-on-protection-of-personal-data/564343/tieng-anh.aspx
+[^23]: Law 91/2025/QH15, English translation: https://english.luatvietnam.vn/dan-su/law-on-personal-data-protection-law-no-91-2025-qh15-405135-d1.html
+[^24]: Tilleke & Gibbins on the PDPL: https://www.tilleke.com/insights/vietnams-new-personal-data-protection-law-a-closer-look/
+[^25]: Baker McKenzie on the PDPL: https://connectontech.bakermckenzie.com/vietnam-decoding-vietnams-pdp-law-gdpr-inspired-rules-with-local-twists/
+[^26]: DLA Piper data protection handbook, Vietnam: https://www.dlapiperdataprotection.com/?t=law&c=VN
+[^27]: Rouse on the PDPL: https://rouse.com/insights/news/2025/vietnam-s-new-personal-data-protection-law-what-businesses-need-to-know
+[^28]: PDPL official text via the Ministry of Public Security: https://bocongan.gov.vn/media/bca-media/photo-library/20250728100402_a4c3955c-ea1d-48a0-9998-c262b14864af-Lu%E1%BA%ADt-B%E1%BA%A3o-v%E1%BB%87-d%E1%BB%AF-li%E1%BB%87u-c%C3%A1-nh%C3%A2n.pdf
+[^29]: BAG 1 ABR 16/23, decision text: https://www.bundesarbeitsgericht.de/wp-content/uploads/2024/11/1-ABR-16-23.pdf
+[^30]: BetrVG Section 87: https://www.gesetze-im-internet.de/betrvg/__87.html
+[^31]: BAG 1 ABN 36/18: https://www.bundesarbeitsgericht.de/entscheidung/1-abn-36-18/
+[^32]: Hensche on BAG 1 ABR 20/21: https://www.hensche.de/bag-beschluss-vom-08.03.2022-1-abr-20-21-zustaendigkeit-des-gesamtbetriebsrats-bei-unternehmenseinheitlicher-nutzung-von-microsoft-office-365.html
+[^33]: BDSG, official English translation: https://www.gesetze-im-internet.de/englisch_bdsg/englisch_bdsg.html
+[^34]: Steptoe on Regulation (EU) 2026/1744: https://www.steptoe.com/en/news-publications/steptechtoe-blog/eu-ai-act-amendments-enter-into-force.html
+[^35]: VIES VAT validation: https://ec.europa.eu/taxation_customs/vies/
+[^36]: GLEIF open data: https://www.gleif.org/en/about/open-data
+[^37]: Cognism compliance statements: https://www.cognism.com/compliance


### PR DESCRIPTION
Three author-requested fixes to the enrichment whitepaper:

1. The section 5 intro said "we will build A1 to A6 once there is demand" while the items below say built / half built / in work. It now reads: part of Tier A ships today, the rest is in work ticket by ticket, releases are quick.
2. All external hyperlinks moved out of the body into 37 numbered footnotes; the body cites by marker, the URLs live in the Sources section. Ticket references are plain numbers, internal doc links stay.
3. Sources and verification status is now the final section, after "Why this wins deals".

Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistencies and citation formatting in the enrichment whitepaper.

**Changes**
- Corrects the Section 5 intro so it no longer claims Tier A items are unbuilt when they are shipped or in progress.
- Moves all external hyperlinks out of the body into 37 numbered footnotes; ticket references are now plain numbers.
- Moves the Sources and verification status section to the end, after the deal-closing argument.

<sup>Written for commit 036e88d01de028e6c2d11fe583e4395a8276edbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized citations into numbered footnotes and expanded the bibliography to 37 references.
  - Added a status note identifying named sources for key claims.
  - Clarified which product-policy features are shipped versus in progress, with ticket references.
  - Reordered the sources section and preserved the existing legal and enforcement content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->