### PR TITLE
test(frontend): the onboarding gate's route claim stops racing the list's own dials

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 import { meFixture } from "./app/mefixture";
+import { parseHash, routeHash } from "./app/router";
 import { pickOption } from "./design-system/select-testing";
 import { LocaleProvider } from "./i18n";
 import { memoryStorage, sessionOnlyFetch } from "./testing/appharness";
@@ -31,6 +32,11 @@ beforeEach(() => {
   // fall to their QueryGate error state (the rail still renders — that is what
   // this test asserts). Routing by URL keeps the stub honest per endpoint.
   vi.stubGlobal("fetch", vi.fn(sessionOnlyFetch()));
+  // Every test here mounts at an address, so every test states the one it
+  // mounts at. Inheriting whatever the last one left is a dependency on which
+  // files a worker happened to reuse, and it holds only while the pool keeps
+  // handing each file a fresh jsdom.
+  window.location.hash = "";
 });
 
 afterEach(() => {
@@ -675,7 +681,12 @@ describe("onboarding gate", () => {
     // The company resolves before this settles, so a gate that redirected
     // would have replaced the hash by now.
     await screen.findByRole("navigation", { name: "Primary navigation" });
-    expect(window.location.hash).toBe("#/contacts");
+    // The SCREEN, not the whole address. A list spells its own opening dials
+    // into the hash on arrival, so contacts settles at `#/contacts?sort=…` a
+    // moment after the shell renders; an equality against the bare address
+    // holds only while that write is still pending. Where the gate left the
+    // reader is this test's claim — how the list is sorted is people.tsx's.
+    expect(routeHash(parseHash(window.location.hash))).toBe("#/contacts");
   });
 
   // A pending /oauth/authorize request lives entirely in the hash (the


### PR DESCRIPTION
Closes #2866.

## The issue's diagnosis was wrong, and the suggested fix would not have worked

#2866 reads the failure as cross-file leakage — `?sort=-created_at` "arrives from another file that ran earlier in the same worker" — and proposes a `beforeEach` that pins `window.location.hash`.

It is not another file. The test writes the hash itself (`window.location.hash = "#/contacts"`), and the query string is appended during its own render. Probe on `main`, `forks` pool, the file run alone:

```
PROBE-immediate: #/contacts
PROBE-settled:   #/contacts?sort=-created_at
```

`src/screens/people.tsx:339` opens the contacts list on `initialSort: "-created_at"`, and `useListQuery` (`src/screens/listquery.tsx:570-590`) spells a list's opening dials into the address in a mount effect, once, on arrival. The contacts screen mounts a moment after the shell's navigation lands, so the assertion at `src/App.test.tsx:678` ran in the gap before that effect flushed. Reordering the suite moves the gap. `--pool=threads --sequence.shuffle` moved it; so would anything else that changes when the list gets to mount.

So the pin alone would have left the failure exactly where it was.

## What changed

- `src/App.test.tsx` — the test asserts the SCREEN the address names, via the router's own codec (`routeHash(parseHash(hash))`), instead of the whole address. Its claim is where the onboarding gate left the reader; how the list is sorted belongs to `people.tsx`. A gate redirect still reds it, because a redirect changes the screen.
- `src/App.test.tsx` — the top-level `beforeEach` pins `window.location.hash = ""`. Not the cause, but it is the isolation claim the issue is titled on and it costs one line: every test in the file mounts at an address, and now every test states the one it mounts at rather than inheriting a worker's.

No production code changed.

## Sweep for the same shape

The defect is: assert an exact hash on a route whose screen seeds list dials, while that screen is mounted. Six screens seed (`initialSort` / `initialFilters`): `people`, `organizations`, `projects`, `leads.list`, `products`, `offertemplates`. Every exact-hash assertion in `frontend/src` was checked against that list:

- `src/screens/people.test.tsx:468` (`#/contacts`) and `src/screens/organizations.test.tsx:938` (`#/companies`) assert a bare seeding-list address, but render only `PersonScreen` / `CompanyScreen`. The list never mounts, so nothing seeds. Not hits.
- Everything else asserts a detail address (`#/contacts/p-1`, `#/deals/d-42`), a non-seeding screen (`#/home`, `#/today`, `#/reports`, `#/deals` — `deals.tsx` passes no `initialSort`), or does not mount `<App />`.

`src/App.test.tsx:678` was the only genuine hit.

## Verification

Repro from the issue, plus two fresh seeds — all on this branch:

```
pnpm exec vitest run --pool=threads --sequence.shuffle --sequence.seed=1787810984859
  Test Files  409 passed (409)   Tests  5085 passed (5085)
pnpm exec vitest run --pool=threads --sequence.shuffle --sequence.seed=424242
  Test Files  409 passed (409)   Tests  5085 passed (5085)
pnpm exec vitest run --pool=threads --sequence.shuffle --sequence.seed=987654321
  Test Files  409 passed (409)   Tests  5085 passed (5085)
```

That the assertion now lands AFTER the seeding write rather than before it was checked directly: a copy of the file with a 500 ms settle inserted at the sync point fails on `main` (`expected '#/contacts?sort=-created_at' to be '#/contacts'`) and passes here.

Gates, all exit 0:

| Gate | Result |
|---|---|
| `make frontend-check` | pass |
| `make native-controls` | 1 file, 35 tests passed |
| `make fe-uat` | `fe-uat OK — diff touches no component/story (empty scope)` |
| `make frontend-e2e` | 143 passed, 14 skipped (includes the axe sweep) |
| `make fe-clock-drift` | 409 files, 5085 tests passed at +200 days |
| `make check` | pass (5m48s) |

`fe-uat` has an empty scope and there are no before/after screenshots, because the diff is one test file and nothing a user can see changed.

Checked in a real browser against the seeded stack (API `:18080`, app `:8080`, signed in as `admin@demo.test`), because the claim above is about production behaviour and not a jsdom artefact. Setting `location.hash = "#/contacts"` reads back:

```
immediate: #/contacts
settled:   #/contacts?sort=-created_at
```

and the list draws "1–25 of 200 contacts loaded so far, sorted by Created" — the `-created_at` default, in the address, exactly as the unit test sees it.

Console on that route carries four pre-existing messages, none touched by this change and none from the contacts surface: a `401` from the auth probe before sign-in, `501 … operation EmbedReindexStatus is specified but not yet implemented` from `app/embedreindexbanner.tsx`, WebGL `GPU stall due to ReadPixels` performance warnings from the Core scene, and the `[ui-preview] VITE_UI_PREVIEW_TASKBAR is on` notice. Raising them is outside this issue; say the word and I will open one.

### Environment notes, both pre-existing and neither caused by this branch

- `make seed-dev` fails with `ERROR: relation "workspace" does not exist`. Its psql path is `docker compose -f infra/docker-compose.dev.yml exec -T postgres`, which resolves to compose project `margince` — on this machine that name is held by ANOTHER worktree's stack, whose postgres is empty. This worktree's own postgres is published on `:15432`, which is what `scripts/dev.sh`'s DSN uses, so `make dev` is unaffected. The failed run wrote nothing.
- `make verify-demo`, and `make seed-demo` after it, both end `verify: 2 rule(s) broken` — `3 employed nowhere (Carol Wagner, Bob Schmidt, Alice Müller)` and `1 still unknown (Demo GmbH)`. Those are dev-seed fixtures already in the shared `margince` database from an earlier session; clearing them means `make dev-fresh`, which drops a shared database, so I left it alone.

## Left out, and why

No pool change: #2866 measured `forks` at 73 s against `threads` at 99 s and proposed none.

No new gate. A fitness function for "an exact-hash assertion on a seeding list route" would have to know which screen a test mounts, which means walking the render calls — a real piece of work for a `priority: low` issue with one instance in the tree. Worth proposing separately if a second instance shows up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky onboarding gate test (`frontend/src/App.test.tsx`) that compared the full hash against `#/contacts`, landing in the gap before the contacts list wrote its own `?sort=-created_at`. The test now asserts the screen the address names via the router's codec, and the file's `beforeEach` pins the starting hash.

- The original issue (#2866) blamed cross-file leakage; the write is the test's own screen seeding its list dials, so the suggested `beforeEach` pin alone wouldn't have fixed it.
- No production code changed.

<sup>Written for commit cca8da43f9c164d85ad3246314f3d6484b379a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated onboarding route tests to handle query parameters reliably.
  * Added test setup to reset the URL hash before each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->