### PR TITLE
fix(seed): an account's work is keyed by the account, not by one of its domains

### DIFF
--- a/backend/tools/seed-demo/activityproject_test.go
+++ b/backend/tools/seed-demo/activityproject_test.go
@@ -14,8 +14,12 @@ import (
 // oldest-first order loadProjects guarantees.
 func refsWithProjects(projects ...seededProject) pipelineRefs {
 	return pipelineRefs{
-		now:               time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
-		projectsByCompany: map[string][]seededProject{"acme.test": projects},
+		now: time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
+		// Two domains onto one account, because that is the shape the
+		// by-domain keying used to lose: whichever alias the reversal
+		// happened to keep was the only one that resolved.
+		orgsByDom:     map[string]string{"acme.test": "org-acme", "acme.example": "org-acme"},
+		projectsByOrg: map[string][]seededProject{"org-acme": projects},
 	}
 }
 
@@ -264,5 +268,27 @@ func TestTheIndexReadsBothLinksItActsOn(t *testing.T) {
 	}
 	if got.OccurredAt == "" {
 		t.Error("occurred_at was dropped; the reconciliation dates against it")
+	}
+}
+
+// TestEitherDomainOfOneAccountFindsTheSameWork — the defect the organization
+// keying exists for.
+//
+// The projects map was keyed by domain and built by reversing orgsByDom, so an
+// account with two domains kept exactly one of them and which one was Go map
+// iteration order. An activity naming the other found no projects at all, and
+// found them again on the next run. Both of an account's domains name the same
+// account, so both must reach the same delivery work.
+func TestEitherDomainOfOneAccountFindsTheSameWork(t *testing.T) {
+	refs := refsWithProjects(seededProject{ID: "migration", StartedAt: "2026-01-15"})
+
+	named := projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 30})
+	alias := projectForActivity(refs, demoActivity{Company: "acme.example", DaysAgo: 30})
+
+	if named != "migration" {
+		t.Fatalf("the account's own domain reaches %q, want the migration", named)
+	}
+	if alias != named {
+		t.Errorf("the alias reaches %q and the domain reaches %q; one account, one answer", alias, named)
 	}
 }

--- a/backend/tools/seed-demo/activityprojects.go
+++ b/backend/tools/seed-demo/activityprojects.go
@@ -129,7 +129,7 @@ func projectForActivity(refs pipelineRefs, act demoActivity) string {
 // decide an unchanged activity now belongs to a different project. It would
 // then relink it, which stamps six-year retention that cannot be lifted.
 func projectForActivityOn(refs pipelineRefs, company, when string) string {
-	projects := refs.projectsByCompany[strings.ToLower(company)]
+	projects := refs.projectsByOrg[refs.orgForDomain(company)]
 	if len(projects) == 0 {
 		return ""
 	}

--- a/backend/tools/seed-demo/pipeline.go
+++ b/backend/tools/seed-demo/pipeline.go
@@ -29,13 +29,19 @@ type pipelineRefs struct {
 	// contractsByRef lets the renewal read its successor's terms: a renewal
 	// inherits nothing, so every field is restated from the dataset.
 	contractsByRef []demoContract
-	// dealsByCompany is filled after the deals are seeded, so an activity can
+	// dealsByOrg is filled after the deals are seeded, so an activity can
 	// link to the deal it moved.
-	dealsByCompany map[string][]string
-	// projectsByCompany holds the seeded projects, keyed by company domain and
+	//
+	// Keyed by ORGANIZATION, not by domain, because that is whose work it is.
+	// Both of these were keyed by domain and built by reversing orgsByDom,
+	// which silently dropped every domain but one for an account that has
+	// several — and which one survived was Go map iteration order, so an
+	// activity naming a valid alias found nothing, differently on each run.
+	dealsByOrg map[string][]string
+	// projectsByOrg holds the seeded projects, keyed by organization and
 	// ordered oldest first, so an activity can link to the delivery work it
 	// was about.
-	projectsByCompany map[string][]seededProject
+	projectsByOrg map[string][]seededProject
 	// anchorName and orgNameByID name the parties a document prints.
 	anchorName  string
 	orgNameByID map[string]string
@@ -48,6 +54,14 @@ type pipelineRefs struct {
 	ownerRefByDomain map[string]string
 	pipelineID       string
 	now              time.Time
+}
+
+// orgForDomain answers which account a company domain names. Phases hold a
+// domain because that is what the dataset writes down; the work belongs to the
+// organization, and an account reached by any of its domains must find the
+// same deals and the same projects.
+func (r pipelineRefs) orgForDomain(domain string) string {
+	return r.orgsByDom[strings.ToLower(domain)]
 }
 
 // dayOffset turns a dataset offset into a date. Negative is the past.
@@ -67,17 +81,17 @@ func (r pipelineRefs) timestamp(days int) string {
 // once, so each phase is a straight write rather than a search.
 func loadPipelineRefs(c *client, cfg demoConfig, now time.Time) (pipelineRefs, error) {
 	refs := pipelineRefs{
-		contractsByRef:    cfg.Contracts,
-		dealsByCompany:    map[string][]string{},
-		projectsByCompany: map[string][]seededProject{},
-		ownerRefByDomain:  map[string]string{},
-		orgNameByID:       map[string]string{},
-		domainByOrgID:     map[string]string{},
-		anchorName:        cfg.Anchor.LegalName,
-		usersByRef:        map[string]string{},
-		orgsByDom:         map[string]string{},
-		stagesByNm:        map[string]string{},
-		now:               now,
+		contractsByRef:   cfg.Contracts,
+		dealsByOrg:       map[string][]string{},
+		projectsByOrg:    map[string][]seededProject{},
+		ownerRefByDomain: map[string]string{},
+		orgNameByID:      map[string]string{},
+		domainByOrgID:    map[string]string{},
+		anchorName:       cfg.Anchor.LegalName,
+		usersByRef:       map[string]string{},
+		orgsByDom:        map[string]string{},
+		stagesByNm:       map[string]string{},
+		now:              now,
 	}
 
 	var users struct {
@@ -374,10 +388,6 @@ func (r *pipelineRefs) loadOrganizations(c *client) error {
 // dataset's own left every generated deal without a buying committee, and
 // left activities unable to link to one.
 func (r *pipelineRefs) loadDeals(c *client, _ demoConfig) error {
-	domainByOrg := map[string]string{}
-	for domain, orgID := range r.orgsByDom {
-		domainByOrg[orgID] = domain
-	}
 	return c.getAll("/v1/deals", nil, func(raw json.RawMessage) error {
 		var rows []struct {
 			ID             string `json:"id"`
@@ -387,11 +397,12 @@ func (r *pipelineRefs) loadDeals(c *client, _ demoConfig) error {
 			return err
 		}
 		for _, row := range rows {
-			domain, ok := domainByOrg[row.OrganizationID]
-			if !ok {
+			// An account nobody can name by domain is one no phase reaches,
+			// so recording its deals would only grow a map nothing reads.
+			if _, named := r.domainByOrgID[row.OrganizationID]; !named {
 				continue
 			}
-			r.dealsByCompany[domain] = append(r.dealsByCompany[domain], row.ID)
+			r.dealsByOrg[row.OrganizationID] = append(r.dealsByOrg[row.OrganizationID], row.ID)
 		}
 		return nil
 	})

--- a/backend/tools/seed-demo/projects.go
+++ b/backend/tools/seed-demo/projects.go
@@ -253,12 +253,8 @@ func projectIndex(c *client, mode runMode) (map[string]bool, error) {
 // dataset does not name still has delivery work, and its correspondence
 // should reach it.
 func (r *pipelineRefs) loadProjects(c *client) error {
-	domainByOrg := map[string]string{}
-	for domain, orgID := range r.orgsByDom {
-		domainByOrg[orgID] = domain
-	}
-	r.projectsByCompany = map[string][]seededProject{}
-	byDomain := map[string][]seededProject{}
+	r.projectsByOrg = map[string][]seededProject{}
+	byOrg := map[string][]seededProject{}
 	if err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
 		var rows []struct {
 			ID             string `json:"id"`
@@ -269,11 +265,12 @@ func (r *pipelineRefs) loadProjects(c *client) error {
 			return err
 		}
 		for _, row := range rows {
-			domain, ok := domainByOrg[row.OrganizationID]
-			if !ok {
+			// Same reason loadDeals gives: an account no domain names is an
+			// account no phase looks up.
+			if _, named := r.domainByOrgID[row.OrganizationID]; !named {
 				continue
 			}
-			byDomain[domain] = append(byDomain[domain], seededProject{ID: row.ID, StartedAt: row.StartedAt})
+			byOrg[row.OrganizationID] = append(byOrg[row.OrganizationID], seededProject{ID: row.ID, StartedAt: row.StartedAt})
 		}
 		return nil
 	}); err != nil {
@@ -291,7 +288,7 @@ func (r *pipelineRefs) loadProjects(c *client) error {
 	//
 	// A project with no start date sorts last: it is the one an activity has
 	// the weakest claim to belong to.
-	for domain, projects := range byDomain {
+	for orgID, projects := range byOrg {
 		sort.Slice(projects, func(i, j int) bool {
 			a, b := projects[i].StartedAt, projects[j].StartedAt
 			if (a == "") != (b == "") {
@@ -302,7 +299,7 @@ func (r *pipelineRefs) loadProjects(c *client) error {
 			}
 			return projects[i].ID < projects[j].ID
 		})
-		r.projectsByCompany[domain] = projects
+		r.projectsByOrg[orgID] = projects
 	}
 	return nil
 }

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -163,7 +163,7 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 		}
 	}
 
-	for _, deal := range refs.dealsByCompany[strings.ToLower(act.Company)] {
+	for _, deal := range refs.dealsByOrg[refs.orgForDomain(act.Company)] {
 		links = append(links, jsonBody{"entity_type": "deal", "entity_id": deal})
 		break // one deal: an account with two is ambiguous, and guessing wrong is worse than not guessing
 	}

--- a/backend/tools/seed-demo/stakeholders.go
+++ b/backend/tools/seed-demo/stakeholders.go
@@ -65,11 +65,7 @@ func containsAnyOf(haystack string, needles ...string) bool {
 // same reason, and the verify pass fails on it either way.
 func seedStakeholders(c *client, _ demoConfig, refs pipelineRefs, mode runMode) (int, error) {
 	created := 0
-	for _, domain := range sortedCompanyDomains(refs.dealsByCompany) {
-		orgID, ok := refs.orgsByDom[domain]
-		if !ok {
-			continue
-		}
+	for _, orgID := range sortedAccountIDs(refs.dealsByOrg) {
 		// One read per company rather than per deal: a company with three
 		// deals has one staff list, and it is the same list each time.
 		staff, err := staffBySeniority(c, orgID)
@@ -82,7 +78,7 @@ func seedStakeholders(c *client, _ demoConfig, refs pipelineRefs, mode runMode) 
 			// exempts on purpose.
 			continue
 		}
-		for _, dealID := range refs.dealsByCompany[domain] {
+		for _, dealID := range refs.dealsByOrg[orgID] {
 			for i, personID := range staff {
 				if i >= len(buyingRoles) {
 					break
@@ -93,7 +89,9 @@ func seedStakeholders(c *client, _ demoConfig, refs pipelineRefs, mode runMode) 
 				}
 				added, err := ensureStakeholder(c, dealID, personID, buyingRoles[i])
 				if err != nil {
-					return created, fmt.Errorf("deal at %s: %w", domain, err)
+					// The account's settled domain, which is what a reader
+					// recognises an account by — the loop now walks ids.
+					return created, fmt.Errorf("deal at %s: %w", refs.domainByOrgID[orgID], err)
 				}
 				if added {
 					created++
@@ -173,12 +171,12 @@ func seedProjectStakeholders(c *client, mode runMode) (int, error) {
 	return created, nil
 }
 
-// sortedCompanyDomains keeps the write order stable across runs, so the same
+// sortedAccountIDs keeps the write order stable across runs, so the same
 // input produces the same audit trail.
-func sortedCompanyDomains(byCompany map[string][]string) []string {
-	out := make([]string, 0, len(byCompany))
-	for domain := range byCompany {
-		out = append(out, domain)
+func sortedAccountIDs(byAccount map[string][]string) []string {
+	out := make([]string, 0, len(byAccount))
+	for orgID := range byAccount {
+		out = append(out, orgID)
 	}
 	sort.Strings(out)
 	return out

--- a/backend/tools/seed-demo/standing.go
+++ b/backend/tools/seed-demo/standing.go
@@ -44,7 +44,7 @@ func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string
 		stage := plan[domain].Lifecycle
 		if stage == "" {
 			stage = "target"
-			if len(refs.dealsByCompany[domain]) > 0 {
+			if len(refs.dealsByOrg[refs.orgForDomain(domain)]) > 0 {
 				stage = "opportunity"
 			}
 		}


### PR DESCRIPTION
`loadProjects` and `loadDeals` both built their by-company map by **reversing** `orgsByDom` — a domain→organization map — into an organization→domain one. That reversal cannot be faithful: an account with several domains has several keys collapsing onto one value, so all but one domain were dropped, and **which one survived was Go map iteration order**.

An activity naming any other valid domain of that account then found no entry, and got no deal link and no project link. Nondeterministic between runs, so one dataset could seed two different timelines.

**The fix removes the reversal rather than making it pick better.** Both maps are keyed by the organization — whose work it actually is — and the phases that hold a domain resolve it through `orgsByDom`, the map's own direction, where many domains legitimately name one account. A third caller cannot reintroduce the class.

Deliberately unchanged:

- **The seeded population.** Both loaders skip an organization no domain names, because that is an account no phase looks up. This stays a fix for the defect, not a change to what gets seeded.
- **`domainByOrgID`.** Not the same shape: it reverses a per-organization *slice* of domains, in order, and takes the first — settled and deterministic. It answers which language an account's paper is written in, and is left alone.

The regression test names one account by two domains and requires both to reach the same project. Mutation-checked — against the defect the alias reaches `""`:

```
--- FAIL: TestEitherDomainOfOneAccountFindsTheSameWork
    the alias reaches "" and the domain reaches "migration"; one account, one answer
```

`make check-backend` green.

Closes #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved demo data seeding for organizations with multiple domains.
  - Ensured related activities, projects, deals, stakeholders, and lifecycle data resolve consistently across domain aliases.
  - Prevented records from being lost or assigned incorrectly when organizations have multiple known domains.
  - Preserved chronological project ordering and improved handling of organizations without recognized domains.

- **Tests**
  - Added regression coverage confirming multiple domains for the same account resolve to one project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->