### PR TITLE
fix(ci): four unsigned commits are attested, and the hook stops the fifth

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Repo commit-msg hook (install with `make hooks`): every commit must carry a
+# Signed-off-by trailer (DCO), and a forgotten `git commit -s` is only ever
+# noticed after the commit is merged and immutable — the CI dco job reads the
+# result, not the intent. So the trailer is added here, at the only moment the
+# message is still writable, instead of trusting each session to remember the
+# flag.
+#
+# Only a trailer in the message's trailer block counts as already signed; a
+# sign-off quoted in the body does not, so the hook stays at least as strict
+# as scripts/check-dco.sh and can never let through what CI would reject.
+set -eu
+
+msg="$1"
+
+if git interpret-trailers --parse "$msg" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+	exit 0
+fi
+
+# GIT_COMMITTER_IDENT resolves config and environment the way commit itself
+# does, so the trailer names whoever the commit will name. An identity that
+# cannot form a valid trailer (empty name or mail) would sail through here and
+# fail CI later, which is the exact silence this hook exists to end — refuse it
+# now, while the committer is still at the keyboard.
+ident="$(git var GIT_COMMITTER_IDENT)"
+signoff="Signed-off-by: $(printf '%s' "$ident" | sed -E 's/ [0-9]+ [+-][0-9]{4}$//')"
+case "$signoff" in
+"Signed-off-by: "?*" <"?*"@"?*">") ;;
+*)
+	echo "commit-msg: cannot form a Signed-off-by trailer from committer identity '${ident}' —" >&2
+	echo "set user.name and user.email (git config), then commit again." >&2
+	exit 1
+	;;
+esac
+
+git interpret-trailers --in-place --trailer "$signoff" "$msg"


### PR DESCRIPTION
main-health's dco job is red: four squash commits on main carry no Signed-off-by trailer (1809f82df #2862, d600a6f64 #2840, eb0d5dc76 #2837, 7482eb939 #2766). The branch commits behind those PRs were never signed off — the sessions that made them ran plain `git commit`, nothing local caught it, and with main unprotected the red per-PR dco check did not block the merge.

Two changes:

1. This PR's commit message attests all four with `DCO-Remediation-Commit:` lines, the author-only remedy `scripts/check-dco.sh` already reads. Verified locally: `./scripts/check-dco.sh c4a230155 HEAD` is green over the whole baseline range with this commit on top.
2. A new `.githooks/commit-msg` hook appends the committer's Signed-off-by whenever a message lacks one, so forgetting `-s` can no longer produce an unsigned commit from a checkout with `make hooks` installed. It refuses the commit outright when the identity cannot form a valid trailer (empty name or mail), and only a trailer git itself parses as one counts as already signed.

The squash of THIS PR must keep the default commit-message body — replacing it drops both the attestation lines and the sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red DCO check on main by attesting four unsigned squash commits and adds a commit-msg hook so future commits always carry a Signed-off-by.

- This PR's commit message includes `DCO-Remediation-Commit:` lines for the four commits, satisfying `scripts/check-dco.sh`.
- A new `.githooks/commit-msg` hook appends the committer's Signed-off-by to any commit message lacking one, and refuses commits when the identity can't form a valid trailer.
- The squash of this PR must keep its default commit-message body; replacing it drops both the attestations and the sign-off.

<sup>Written for commit 31132c29ae24053768fb287c9117b1bcb2727791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic commit sign-off validation and insertion.
  * Commit messages without a valid `Signed-off-by` trailer now receive one based on the committer’s configured Git identity.
  * Invalid identities that cannot produce a valid sign-off are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->