### PR TITLE
fix(records): a site read's findings are recorded by the attempt that holds it

### DIFF
--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -353,8 +353,9 @@ func terminalCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 }
 
-func (w *siteDeepReadWorker) finish(ctx context.Context, readID ids.UUID, status string, readPages []crawlPage, crawl siteCrawl, factCount int, proposalIDs []ids.UUID, fields []people.DeepReadField, facts []people.DeepReadFact, found []people.SiteReadPerson, entities []people.SiteReadLegalEntity, warnings []string, proposalHash string) error {
+func (w *siteDeepReadWorker) finish(ctx context.Context, readID ids.UUID, claim people.SiteReadClaim, status string, readPages []crawlPage, crawl siteCrawl, factCount int, proposalIDs []ids.UUID, fields []people.DeepReadField, facts []people.DeepReadFact, found []people.SiteReadPerson, entities []people.SiteReadLegalEntity, warnings []string, proposalHash string) error {
 	in := people.FinishSiteReadInput{
+		ClaimedAt:     &claim.ClaimedAt,
 		Status:        status,
 		Pages:         make([]people.SiteReadPage, 0, len(readPages)),
 		Skipped:       make([]people.SiteReadSkip, 0, len(crawl.Skipped)),

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -556,12 +556,13 @@ func TestDeepReadFinishSurvivesACancelledWorkContext(t *testing.T) {
 	// The dossier is picked up (queued → running), then the work context dies
 	// — exactly the shape the live incident hit mid-extraction.
 	workCtx, cancel := context.WithCancel(deepReadWorkerCtx(context.Background(), args))
-	if _, err := worker.people.BeginSiteRead(workCtx, read.ID, worker.reclaimAfter()); err != nil {
+	claim, err := worker.people.BeginSiteRead(workCtx, read.ID, worker.reclaimAfter())
+	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	cancel()
 
-	if err := worker.finish(workCtx, read.ID, "partial", nil, siteCrawl{}, 0, nil, nil, nil, nil, nil, nil, ""); err != nil {
+	if err := worker.finish(workCtx, read.ID, claim, "partial", nil, siteCrawl{}, 0, nil, nil, nil, nil, nil, nil, ""); err != nil {
 		t.Fatalf("finish under a cancelled work context: %v", err)
 	}
 

--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -47,7 +47,7 @@ func (w *siteDeepReadWorker) reportRead(ctx context.Context, args SiteDeepReadAr
 	}
 	// Zero surviving findings is an honest empty read — done, fact_count 0,
 	// no proposal — not an error: the site simply evidenced nothing.
-	return w.finish(ctx, args.SiteReadID, status, readPages, crawl, factCount, proposalIDs,
+	return w.finish(ctx, args.SiteReadID, claim, status, readPages, crawl, factCount, proposalIDs,
 		draftFields, extraction.merged.facts, draftPeople, draftEntities,
 		warnings, proposalHash)
 }

--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -58,7 +58,7 @@ func (w *siteDeepReadWorker) runTriage(ctx context.Context, args SiteDeepReadArg
 		// company with a broken site, so the decision falls to the sender's name.
 		w.log.WarnContext(ctx, "domain triage: the seed page could not be read",
 			"read", args.SiteReadID.String(), "domain", domain, "err", err)
-		return w.resolveUnreachable(ctx, args, domain, siteReadWireStatusFailed, triageWarningNothingRead)
+		return w.resolveUnreachable(ctx, args, claim, domain, siteReadWireStatusFailed, triageWarningNothingRead)
 	}
 
 	verdict, err := w.classifySeed(ctx, seed)
@@ -75,7 +75,7 @@ func (w *siteDeepReadWorker) runTriage(ctx context.Context, args SiteDeepReadArg
 	if verdict.Aborts() {
 		// The whole point of classifying first: one page read, no crawl, no
 		// extraction, no company invented.
-		return w.settleTriage(ctx, args, domain, triageStatusFor(verdict.Kind),
+		return w.settleTriage(ctx, args, claim, domain, triageStatusFor(verdict.Kind),
 			people.DomainSourceSiteRead, triageEvidence(verdict), siteReadWireStatusCancelled, triageWarningNotACompany, nil)
 	}
 
@@ -93,7 +93,7 @@ func (w *siteDeepReadWorker) triageWithoutLooking(ctx context.Context, args Site
 		return w.fail(ctx, args.SiteReadID,
 			fmt.Errorf("site deep read %s: %q is not a triageable seed", args.SiteReadID, claim.SeedURL))
 	}
-	return w.resolveUnreachable(ctx, args, domain, siteReadWireStatusCancelled, triageWarningNotAllowed)
+	return w.resolveUnreachable(ctx, args, claim, domain, siteReadWireStatusCancelled, triageWarningNotAllowed)
 }
 
 // readAndResolveTriage runs the full read for a domain the seed page did not
@@ -111,7 +111,7 @@ func (w *siteDeepReadWorker) readAndResolveTriage(ctx context.Context, args Site
 		}
 		w.log.WarnContext(ctx, "domain triage: the crawl failed",
 			"read", args.SiteReadID.String(), "domain", domain, "err", err)
-		return w.resolveUnreachable(ctx, args, domain, siteReadWireStatusFailed, triageWarningNothingRead)
+		return w.resolveUnreachable(ctx, args, claim, domain, siteReadWireStatusFailed, triageWarningNothingRead)
 	}
 	if deferred, deferErr := w.deferForBudget(ctx, args.SiteReadID, extraction.err); deferred {
 		return deferErr
@@ -136,14 +136,14 @@ func (w *siteDeepReadWorker) readAndResolveTriage(ctx context.Context, args Site
 	if stated == "" && len(extraction.merged.entities) == 0 {
 		// The site read fine and identified nobody. Nothing went wrong, so this
 		// is not a failure — it is an answer the crawl could not supply.
-		return w.resolveUnreachable(ctx, args, domain, siteReadWireStatusCancelled, triageWarningNoCompany)
+		return w.resolveUnreachable(ctx, args, claim, domain, siteReadWireStatusCancelled, triageWarningNoCompany)
 	}
 
 	status := siteReadWireStatusDone
 	if crawl.Stopped != nil || extraction.err != nil {
 		status = siteReadWireStatusPartial
 	}
-	return w.settleTriage(ctx, args, domain, people.DomainCompany, people.DomainSourceSiteRead,
+	return w.settleTriage(ctx, args, claim, domain, people.DomainCompany, people.DomainSourceSiteRead,
 		triageCompanyEvidence(stated, len(extraction.merged.entities)), status, "",
 		&triagePayload{
 			DossierName: stated,
@@ -165,7 +165,7 @@ func (w *siteDeepReadWorker) readAndResolveTriage(ctx context.Context, args Site
 // operator — recording either as `failed` would send somebody investigating a
 // read that did what it was told. Each caller therefore names its own terminal
 // status and the sentence that goes on the dossier.
-func (w *siteDeepReadWorker) resolveUnreachable(ctx context.Context, args SiteDeepReadArgs, domain, status, warning string) error {
+func (w *siteDeepReadWorker) resolveUnreachable(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, domain, status, warning string) error {
 	res, err := w.people.ResolveUnreadableDomainTriage(ctx, people.ResolveDomainTriageInput{
 		Domain: domain, Evidence: warning, ReadID: args.SiteReadID,
 		SeedURL: people.TriageSeedURL(domain),
@@ -176,7 +176,7 @@ func (w *siteDeepReadWorker) resolveUnreachable(ctx context.Context, args SiteDe
 	}
 	w.log.InfoContext(ctx, "domain triage settled without a site", "domain", domain,
 		"organization_created", res.OrgCreated, "employment_edges", res.EdgesPlanted, "why", warning)
-	return w.finishTriageRead(ctx, args, status, warning, nil)
+	return w.finishTriageRead(ctx, args, claim, status, warning, nil)
 }
 
 // triagePayload is what a company verdict has to hand to the resolve: the name
@@ -198,7 +198,7 @@ type triagePayload struct {
 // first because it is what the ensure ladder reads: a dossier marked done
 // beside an unanswered question would leave every later message from the domain
 // re-asking it.
-func (w *siteDeepReadWorker) settleTriage(ctx context.Context, args SiteDeepReadArgs, domain, status, source, evidence, readStatus, warning string, payload *triagePayload) error {
+func (w *siteDeepReadWorker) settleTriage(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, domain, status, source, evidence, readStatus, warning string, payload *triagePayload) error {
 	in := people.ResolveDomainTriageInput{
 		Domain: domain, Status: status, Source: source, Evidence: evidence, ReadID: args.SiteReadID,
 	}
@@ -215,33 +215,35 @@ func (w *siteDeepReadWorker) settleTriage(ctx context.Context, args SiteDeepRead
 	if payload == nil || res.OrganizationID == nil {
 		// Nothing was created, so there is nothing to stage people onto and no
 		// dossier to report against a company.
-		return w.finishTriageRead(ctx, args, readStatus, warning, payload)
+		return w.finishTriageRead(ctx, args, claim, readStatus, warning, payload)
 	}
 	// Site people stage as leads onto the organization the verdict just made —
 	// strangers stay staged (NEVER-8), exactly as on the auto-enrich lane.
-	claim := people.SiteReadClaim{OrganizationID: &res.OrganizationID.UUID, SeedURL: payload.SeedURL}
+	// A claim shaped for the logo lane, naming the company the verdict just
+	// made — not this read's own claim, which the terminal write is reserved to.
+	logoClaim := people.SiteReadClaim{OrganizationID: &res.OrganizationID.UUID, SeedURL: payload.SeedURL}
 	// The logo, on the same terms as every other company (A55): a 🟢 display
 	// asset read off the seed page's own markup. Nothing else would ever give
 	// these organizations one — the auto-enrich sweep only offers rows with no
 	// finished read, and a triage company already has one — so skipping it here
 	// means faceless forever.
-	w.resolveLogo(ctx, args, claim, payload.Crawl)
+	w.resolveLogo(ctx, args, logoClaim, payload.Crawl)
 	// One verdict, one bundle, one transaction: the people this triage published
 	// were all asked about by the same act, and reach the inbox as one question.
 	if _, err := w.stageSiteLeads(ctx, args.SiteReadID, claim, payload.People, ids.NewV7()); err != nil {
 		w.log.WarnContext(ctx, "domain triage: staging the site's people failed",
 			"read", args.SiteReadID.String(), "err", err)
 	}
-	return w.finishTriageRead(ctx, args, readStatus, warning, payload)
+	return w.finishTriageRead(ctx, args, claim, readStatus, warning, payload)
 }
 
 // finishTriageRead records the dossier's terminal state and the sentence that
 // explains it, so a human reading the row learns why it ended without going to
 // the logs.
-func (w *siteDeepReadWorker) finishTriageRead(ctx context.Context, args SiteDeepReadArgs, status, warning string, payload *triagePayload) error {
+func (w *siteDeepReadWorker) finishTriageRead(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, status, warning string, payload *triagePayload) error {
 	tctx, cancel := terminalCtx(ctx)
 	defer cancel()
-	in := people.FinishSiteReadInput{Status: status}
+	in := people.FinishSiteReadInput{Status: status, ClaimedAt: &claim.ClaimedAt}
 	if warning != "" {
 		in.Warnings = []string{warning}
 	}

--- a/backend/internal/compose/sitereadstore_integration_test.go
+++ b/backend/internal/compose/sitereadstore_integration_test.go
@@ -414,3 +414,67 @@ func TestASucceededReadCarriesNoDiagnosis(t *testing.T) {
 		t.Fatal("a failure was accepted with no sentence a human can act on")
 	}
 }
+
+// A reclaim hands the read to a new attempt, and the abandoned one may still
+// be running. Its terminal write must not land: the pages, facts and legal
+// entities it carries are the ones IT crawled, and the dossier now belongs to
+// somebody else. Running alone never told the two apart, because a reclaim
+// puts a running row back into running.
+func TestAReclaimedReadRefusesTheAbandonedAttemptsTerminalWrite(t *testing.T) {
+	e := integration.Setup(t)
+	store := people.NewStore(e.DB())
+	human := e.As(e.Rep1, nil, integration.AdminPerms)
+	worker := siteReadWorkerCtx(e)
+	org := siteReadOrg(e.SeedOrg(t, "Acme", &e.Rep1))
+	read, _, err := store.StartSiteRead(human, org, "https://acme.example", "human:"+e.Rep1.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := store.BeginSiteRead(worker, read.ID, 20*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Age the lease past its own interval so the next Begin reclaims it.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `UPDATE site_read
+			SET started_at = now() - interval '21 minutes' WHERE id = $1`, read.ID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	live, err := store.BeginSiteRead(worker, read.ID, 20*time.Minute)
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if live.ClaimedAt.Equal(stale.ClaimedAt) {
+		t.Fatalf("the reclaim stamped the same lease %v, so the two attempts are indistinguishable", live.ClaimedAt)
+	}
+
+	// The abandoned attempt comes back with a full report. It is refused.
+	if err := store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status: "done", FactCount: 99, ClaimedAt: &stale.ClaimedAt,
+	}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("the abandoned attempt finished the read → %v, want ErrNotFound", err)
+	}
+	running, err := store.GetSiteRead(human, org, read.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running.Status != "running" || running.FactCount == 99 {
+		t.Fatalf("after the refused write the read is %+v, want still running with none of the abandoned attempt's findings", running)
+	}
+
+	// The attempt that holds it still finishes.
+	if err := store.FinishSiteRead(worker, read.ID, people.FinishSiteReadInput{
+		Status: "done", FactCount: 3, ClaimedAt: &live.ClaimedAt,
+	}); err != nil {
+		t.Fatalf("the holding attempt finished → %v, want it recorded", err)
+	}
+	done, err := store.GetSiteRead(human, org, read.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.Status != "done" || done.FactCount != 3 {
+		t.Fatalf("finished read = %+v, want done with the holding attempt's three facts", done)
+	}
+}

--- a/backend/internal/modules/people/sitereadfinish.go
+++ b/backend/internal/modules/people/sitereadfinish.go
@@ -40,6 +40,23 @@ type SiteReadClaim struct {
 // FinishSiteReadInput is the worker's completed crawl report.
 type FinishSiteReadInput struct {
 	Status string // done | partial | failed | cancelled
+	// ClaimedAt reserves this terminal write for the attempt that HOLDS the
+	// read: the lease BeginSiteRead handed it (SiteReadClaim.ClaimedAt). Set
+	// it and the CAS matches started_at as well as running, so a worker whose
+	// job was reclaimed after its deadline cannot record ITS pages, facts and
+	// legal entities over the attempt that now owns the dossier. Running alone
+	// never distinguished the two, because a reclaim puts a running row back
+	// into running under a new attempt.
+	//
+	// Nil closes whatever attempt holds the read, and the paths that record no
+	// FINDINGS pass nil deliberately: a failure and a cancellation say only
+	// that this read is over, and both must be able to close a dossier however
+	// it was claimed — a panic recovered at the job boundary may not have
+	// claimed at all, and a read nobody wants any more should not survive
+	// because the worker that abandoned it lost a race. What they must not do
+	// is stand in for a report, which is why the finding-carrying writes
+	// present the lease and these do not.
+	ClaimedAt *time.Time
 	// StatusCode and StatusDetail diagnose a FAILED read: the closed code an
 	// operator groups by, and the one sentence they read. Both are required
 	// when Status is "failed" and forbidden otherwise — a read that worked has
@@ -191,10 +208,11 @@ func (s *Store) FinishSiteRead(ctx context.Context, readID ids.UUID, in FinishSi
 			    draft_version = draft_version + 1, pages_read = $13, phase = NULL,
 			    first_grounded_at = CASE WHEN $14 THEN COALESCE(first_grounded_at, now()) ELSE first_grounded_at END,
 			    finished_at = now(), updated_at = now()
-			WHERE id = $1 AND status = 'running'`,
+			WHERE id = $1 AND status = 'running'
+			  AND ($19::timestamptz IS NULL OR started_at = $19)`,
 			readID, in.Status, pages, skipped, in.StoppedReason, in.FactCount, proposals,
 			profileFields, facts, people, warnings, in.ProposalHash, len(in.Pages), grounded, entities,
-			in.StatusCode, in.StatusDetail, in.NextAttemptAt)
+			in.StatusCode, in.StatusDetail, in.NextAttemptAt, in.ClaimedAt)
 		if err != nil {
 			return fmt.Errorf("finish site read: %w", err)
 		}


### PR DESCRIPTION
#162 recorded three findings deferred from #156. This closes it: one is fixed here, one was already fixed, and one is split out because it needs a ruling rather than a patch.

## 1. The finding-carrying writes are reserved for the attempt that holds the read

`FinishSiteRead`'s CAS guarded on `status = 'running'` alone. **A reclaim puts a running row back into running under a new attempt**, so that predicate never told the two apart: a worker whose job was reclaimed after its deadline could still record its pages, facts and legal entities over the attempt that now owns the dossier.

The lease already existed and was already documented — `BeginSiteRead` RETURNs `started_at` as `SiteReadClaim.ClaimedAt`, and its own comment says *"a write that only the current holder may make presents it again to prove it is still the current holder"*. `RecordSiteReadLogo` does exactly that. The terminal write did not, so the comment described a guarantee one writer kept.

The two writes that carry **findings** — the dossier's own report and the triage verdict — now present the claim, which both had in hand already.

The failure and cancellation paths deliberately do not. They record no findings (they say only that this read is over) and both must be able to close a dossier however it was claimed: a panic recovered at the job boundary may not have claimed at all, and a read nobody wants any more should not survive because the worker that abandoned it lost a race. What they must not do is stand in for a report, which is the line this draws — and it is stated at the field.

Regression test reclaims a read, has the abandoned attempt return with a full report, requires it refused with the dossier untouched, then lets the holding attempt finish. Mutation-checked — without the predicate:

```
--- FAIL: TestAReclaimedReadRefusesTheAbandonedAttemptsTerminalWrite
```

## 2. The legal-only partial read was already fixed

`reportRead`'s survivor check counts `extraction.merged.entities` alongside facts and people, so a read whose only surviving output is the legal census is no longer recorded as a failure. Nothing to do.

## 3. The VAT-group fold is split out — #2882

`register_number` is documented in `crm.yaml` as holding a *"registration, VAT, UID or tax number"*: four identifier kinds, one string, no marker. The fold cannot ask what it is looking at, and each obvious repair gives something up — including the shape test, which reads `HRB 12345` as a Croatian VAT id because `HR` is a valid country code. That is a decision about what the field carries, so it is filed with `status: needs-decision` rather than guessed at here.

`make check-backend` green; the site-read integration tests pass against a real database.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)