### PR TITLE
feat(approvals): an approved change says how to put it back

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2106,6 +2106,8 @@ export const de = {
   "decision.detailTechnical": "Technische Details",
   "decision.detailAsked": "Gefragt am",
   "decision.detailDecided": "Entschieden am",
+  "decision.applied": "Erledigt.",
+  "decision.undoOnRecord": "Am Datensatz rückgängig machen",
   "decision.status.approved": "Genehmigt",
   "decision.status.rejected": "Abgelehnt",
   "decision.status.expired": "Abgelaufen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2137,6 +2137,11 @@ export const en = {
   "decision.detailTechnical": "Technical details",
   "decision.detailAsked": "Asked",
   "decision.detailDecided": "Decided",
+  // The confirmation after an approval, and the way back to the change it
+  // made. The undo lives on the RECORD — the history panel reverses the
+  // update this approval wrote — so the verb says where it is going.
+  "decision.applied": "Done.",
+  "decision.undoOnRecord": "Undo on the record",
   "decision.status.approved": "Approved",
   "decision.status.rejected": "Rejected",
   "decision.status.expired": "Expired",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2088,6 +2088,8 @@ export const vi = {
   "decision.detailTechnical": "Chi tiết kỹ thuật",
   "decision.detailAsked": "Đã hỏi",
   "decision.detailDecided": "Đã quyết định",
+  "decision.applied": "Xong.",
+  "decision.undoOnRecord": "Hoàn tác trên bản ghi",
   "decision.status.approved": "Đã duyệt",
   "decision.status.rejected": "Đã từ chối",
   "decision.status.expired": "Đã hết hạn",

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -1,0 +1,130 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ApprovalRow } from "./approvalrow";
+import type { Approval } from "./approvals.queries";
+
+// What a reader sees after approving, and where the button goes.
+//
+// The toast is the only signpost to a reversal that already exists, so what
+// matters is that it APPEARS and that pressing it lands on the record whose
+// history holds the change. useToast is local state paired with its own
+// ToastRegion — a row showing a toast without rendering the region shows
+// nothing at all, and only a render proves it does.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function closeDateApproval(overrides: Partial<Approval> = {}): Approval {
+  return {
+    id: "ap1",
+    kind: "close_date_correction",
+    status: "pending",
+    summary: "Confirm the real close date",
+    proposed_by: "system:close-date",
+    proposed_change: {
+      deal_id: "d1",
+      expected_close_date: "2026-11-15",
+      basis: "Nobody has answered since 5 August.",
+    },
+    created_at: "2026-08-20T09:00:00Z",
+    target_entity_type: "deal",
+    target_entity_id: "d1",
+    ...overrides,
+  } as Approval;
+}
+
+beforeEach(() => {
+  localStorage.setItem("margince.workspaceSlug", "acme");
+  globalThis.location.hash = "";
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the offer to put an approved change back", () => {
+  it("appears after approving, and lands on the record that changed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ id: "ap1", status: "approved" })),
+    );
+    render(<ApprovalRow approval={closeDateApproval()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    const undo = await screen.findByRole("button", {
+      name: "Undo on the record",
+    });
+    await userEvent.click(undo);
+    expect(globalThis.location.hash).toBe("#/deals/d1");
+  });
+
+  // A rejection changed nothing, so there is nothing to put back and no offer.
+  it("stays silent after a rejection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ id: "ap1", status: "rejected" })),
+    );
+    render(<ApprovalRow approval={closeDateApproval()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Reject" }));
+    const confirm = await screen.findAllByRole("button", { name: "Reject" });
+    await userEvent.click(confirm[confirm.length - 1]);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Undo on the record" }),
+      ).toBeNull(),
+    );
+  });
+
+  // A step-up names no record, so there is no history to send anyone to.
+  it("stays silent when the approval names no record", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ id: "ap1", status: "approved" })),
+    );
+    render(
+      <ApprovalRow
+        approval={closeDateApproval({
+          kind: "quota_release",
+          target_entity_type: null,
+          target_entity_id: null,
+        })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Undo on the record" }),
+      ).toBeNull(),
+    );
+  });
+});

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -40,6 +40,23 @@ function render(ui: ReactNode) {
   );
 }
 
+// How many times the row posted a decision, by verb. The negative tests wait
+// on these: an absence asserted before the request went out is an absence that
+// survives the interaction being deleted.
+function decisionCalls(fetched: ReturnType<typeof vi.fn>, verb: string) {
+  // The client hands fetch a Request, not a url string, so the path is read
+  // off the object rather than by stringifying the argument.
+  return fetched.mock.calls.filter(([input]) =>
+    input instanceof Request
+      ? new URL(input.url).pathname.endsWith(verb)
+      : String(input).endsWith(verb),
+  ).length;
+}
+const approveCalls = (f: ReturnType<typeof vi.fn>) =>
+  decisionCalls(f, "/approve");
+const rejectCalls = (f: ReturnType<typeof vi.fn>) =>
+  decisionCalls(f, "/reject");
+
 function closeDateApproval(overrides: Partial<Approval> = {}): Approval {
   return {
     id: "ap1",
@@ -86,30 +103,36 @@ describe("the offer to put an approved change back", () => {
   });
 
   // A rejection changed nothing, so there is nothing to put back and no offer.
+  //
+  // The absence is asserted only AFTER the reject call has actually gone out.
+  // Before it, the button is absent for the uninteresting reason that nothing
+  // has happened yet — an assertion that would survive the interaction being
+  // removed entirely, and therefore proves nothing about rejecting.
   it("stays silent after a rejection", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => jsonResponse({ id: "ap1", status: "rejected" })),
+    const fetched = vi.fn(async () =>
+      jsonResponse({ id: "ap1", status: "rejected" }),
     );
+    vi.stubGlobal("fetch", fetched);
     render(<ApprovalRow approval={closeDateApproval()} />);
 
     await userEvent.click(screen.getByRole("button", { name: "Reject" }));
     const confirm = await screen.findAllByRole("button", { name: "Reject" });
     await userEvent.click(confirm[confirm.length - 1]);
 
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Undo on the record" }),
-      ).toBeNull(),
-    );
+    await waitFor(() => expect(rejectCalls(fetched)).toBe(1));
+    expect(
+      screen.queryByRole("button", { name: "Undo on the record" }),
+    ).toBeNull();
   });
 
-  // A step-up names no record, so there is no history to send anyone to.
+  // A step-up names no record, so there is no history to send anyone to. Same
+  // rule as above: the approve call must have gone out before the absence means
+  // anything.
   it("stays silent when the approval names no record", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => jsonResponse({ id: "ap1", status: "approved" })),
+    const fetched = vi.fn(async () =>
+      jsonResponse({ id: "ap1", status: "approved" }),
     );
+    vi.stubGlobal("fetch", fetched);
     render(
       <ApprovalRow
         approval={closeDateApproval({
@@ -121,10 +144,9 @@ describe("the offer to put an approved change back", () => {
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Accept" }));
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Undo on the record" }),
-      ).toBeNull(),
-    );
+    await waitFor(() => expect(approveCalls(fetched)).toBe(1));
+    expect(
+      screen.queryByRole("button", { name: "Undo on the record" }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/screens/approvalrow.test.ts
+++ b/frontend/src/screens/approvalrow.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { recordRoute } from "./approvalrow";
+
+// Where the product offers to put an approved change back.
+//
+// The undo is the RECORD's: an effect that changes a field writes an ordinary
+// update audit row, and the record's history panel reverses one of those. So
+// the offer is only honest for an approval naming a record with a page — and
+// this function is the whole of that rule.
+describe("recordRoute", () => {
+  it("routes each record kind to the screen that holds its history", () => {
+    expect(recordRoute("deal", "d1")).toEqual({ screen: "deals", id: "d1" });
+    expect(recordRoute("organization", "o1")).toEqual({
+      screen: "companies",
+      id: "o1",
+    });
+    expect(recordRoute("person", "p1")).toEqual({
+      screen: "contacts",
+      id: "p1",
+    });
+    expect(recordRoute("lead", "l1")).toEqual({ screen: "leads", id: "l1" });
+    expect(recordRoute("project", "pr1")).toEqual({
+      screen: "projects",
+      id: "pr1",
+    });
+  });
+
+  // An approval that names no record — a step-up, a held scheduled send —
+  // changed nothing a history panel can show, so there is nothing to offer.
+  it("offers nothing when the approval names no target", () => {
+    expect(recordRoute(null, null)).toBeUndefined();
+    expect(recordRoute(undefined, undefined)).toBeUndefined();
+    expect(recordRoute("deal", null)).toBeUndefined();
+    expect(recordRoute(null, "d1")).toBeUndefined();
+  });
+
+  // activity is served by the history engine and has no record page. Offering
+  // it would send a reader to a screen that cannot answer, which is worse than
+  // not offering: the button would promise a reversal the product cannot reach.
+  it("offers nothing for a kind with no record page", () => {
+    expect(recordRoute("activity", "a1")).toBeUndefined();
+    expect(recordRoute("approval", "ap1")).toBeUndefined();
+    expect(recordRoute("", "x1")).toBeUndefined();
+  });
+});

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -10,6 +10,8 @@ import {
   KIND_TO_VERB,
   useAgentTierMap,
 } from "../app/autonomy";
+import { ENTITY, isEntityKind } from "../app/entity";
+import { navigate, type Route } from "../app/router";
 import { Button, Card, Field, Textarea } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import {
@@ -19,6 +21,7 @@ import {
   type DecisionStatusLabels,
   DecisionToolChip,
 } from "../design-system/decisioncard";
+import { useToast } from "../design-system/toast";
 import { AutonomyDot, confidenceLevel } from "../design-system/trust";
 import { formatCountdown, useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
@@ -142,6 +145,24 @@ function statusLabels(t: Translator, locale: Locale): DecisionStatusLabels {
   };
 }
 
+// The record page an approved change can be put back on, or undefined when
+// there is none.
+//
+// isEntityKind is the same question the breadcrumb asks before it links, and it
+// narrows the wire's free-form string to the five kinds with a record page. The
+// history panel serves one more — `activity` — which has no page to route to,
+// so a target of that kind is honestly not offered rather than linked into
+// nothing.
+export function recordRoute(
+  entityType: string | null | undefined,
+  entityID: string | null | undefined,
+): Route | undefined {
+  if (!entityID || !entityType || !isEntityKind(entityType)) {
+    return undefined;
+  }
+  return ENTITY[entityType].route(entityID);
+}
+
 export function ApprovalRow({
   approval,
   decided,
@@ -164,6 +185,7 @@ export function ApprovalRow({
   const viewerId = useViewerId();
   const queryClient = useQueryClient();
   const tierMap = useAgentTierMap();
+  const toast = useToast();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [rejecting, setRejecting] = useState(false);
@@ -175,6 +197,47 @@ export function ApprovalRow({
   // Decided lists (interval 0 ⇒ useNow does not tick).
   const needsCountdown = !decided && approval.expires_at != null;
   const now = useNow(needsCountdown ? 1000 : 0);
+
+  // Where an approved change can be put back, and where it cannot.
+  //
+  // The undo is the RECORD's, not the approval's: an effect that changes a
+  // field writes an ordinary `update` audit row on the record it changed, and
+  // the history panel already reverses one of those (compose/undoability.go
+  // judges it, and refuses with a named reason where it cannot). So this offers
+  // the way there rather than a second reversal engine.
+  //
+  // Only for an approval naming a record type that panel serves — recordRoute
+  // above decides which. A kind that sends mail, creates a record, or names no
+  // target at all has nothing to put back, and a button leading to a page with
+  // no entry for it would be an offer the product cannot keep.
+  const undoTarget = recordRoute(
+    approval.target_entity_type,
+    approval.target_entity_id,
+  );
+
+  // Sticky, because this confirmation carries a verb and a reader reaching for
+  // it must not lose it mid-reach. Only on approve: a rejection changed
+  // nothing, so there is nothing to put back.
+  const showUndoOffer = (verdict: "approve" | "reject") => {
+    if (verdict !== "approve" || !undoTarget) {
+      return;
+    }
+    toast.show(
+      <span>
+        {t("decision.applied")}{" "}
+        <Button
+          small
+          onClick={() => {
+            toast.dismiss();
+            navigate(undoTarget);
+          }}
+        >
+          {t("decision.undoOnRecord")}
+        </Button>
+      </span>,
+      { sticky: true },
+    );
+  };
 
   const decide = useMutation({
     mutationFn: async (input: {
@@ -200,11 +263,12 @@ export function ApprovalRow({
       }
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, input) => {
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
       for (const queryKey of extraInvalidateKeys ?? []) {
         queryClient.invalidateQueries({ queryKey });
       }
+      showUndoOffer(input.verdict);
     },
     onError: (error) => {
       const problem = error instanceof ProblemError ? error.problem : null;

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -21,7 +21,7 @@ import {
   type DecisionStatusLabels,
   DecisionToolChip,
 } from "../design-system/decisioncard";
-import { useToast } from "../design-system/toast";
+import { ToastRegion, useToast } from "../design-system/toast";
 import { AutonomyDot, confidenceLevel } from "../design-system/trust";
 import { formatCountdown, useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
@@ -403,6 +403,10 @@ export function ApprovalRow({
         />
       }
     >
+      {/* The row owns the region as well as the toast: useToast is local state,
+          so a caller that shows one without rendering a region shows nothing.
+          Every other consumer in the tree pairs the two the same way. */}
+      <ToastRegion toast={toast} />
       <ConfirmModal
         open={rejecting}
         onClose={() => setRejecting(false)}

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -21,7 +21,7 @@ import {
   type DecisionStatusLabels,
   DecisionToolChip,
 } from "../design-system/decisioncard";
-import { ToastRegion, useToast } from "../design-system/toast";
+import { type Toast, ToastRegion, useToast } from "../design-system/toast";
 import { AutonomyDot, confidenceLevel } from "../design-system/trust";
 import { formatCountdown, useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
@@ -168,9 +168,20 @@ export function ApprovalRow({
   decided,
   onAlreadyDecided,
   extraInvalidateKeys,
+  toast: hostToast,
 }: Readonly<{
   approval: Approval;
   decided?: boolean;
+  // The surface's own toast, where it has one. The undo offer is sticky and
+  // outlives this row: approving invalidates ["approvals"], which unmounts the
+  // row it was shown from, and a toast owned HERE would go with it. A screen
+  // that shows a queue therefore owns the toast and its region, and hands the
+  // controller down.
+  //
+  // Optional, because a surface may render one row and nothing else (the
+  // stories do). Then the row falls back to its own, which is correct for a
+  // row nothing is going to unmount.
+  toast?: Toast;
   // Lift the already-decided signal to a surface that survives this row's
   // unmount (the pending invalidation drops it). Optional so a surface can
   // reuse the row without a screen-level surface.
@@ -185,7 +196,8 @@ export function ApprovalRow({
   const viewerId = useViewerId();
   const queryClient = useQueryClient();
   const tierMap = useAgentTierMap();
-  const toast = useToast();
+  const ownToast = useToast();
+  const toast = hostToast ?? ownToast;
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [rejecting, setRejecting] = useState(false);
@@ -403,10 +415,9 @@ export function ApprovalRow({
         />
       }
     >
-      {/* The row owns the region as well as the toast: useToast is local state,
-          so a caller that shows one without rendering a region shows nothing.
-          Every other consumer in the tree pairs the two the same way. */}
-      <ToastRegion toast={toast} />
+      {/* Only where the row owns the toast. A region for somebody else's
+          controller would be a second place the same message renders. */}
+      {!hostToast && <ToastRegion toast={ownToast} />}
       <ConfirmModal
         open={rejecting}
         onClose={() => setRejecting(false)}

--- a/frontend/src/screens/companyapprovals.tsx
+++ b/frontend/src/screens/companyapprovals.tsx
@@ -2,6 +2,7 @@ import { useId } from "react";
 import type { components } from "../api/schema";
 import { Button, EmptyState, Modal, Skeleton } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
+import { ToastRegion, useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { approvalKindLabel } from "./approvalkind";
@@ -92,6 +93,9 @@ export function CompanyApprovalsPanel({
   // A decision changes what the page says is waiting, so the composite read
   // behind the chip is re-read alongside the approvals list.
   const extraInvalidateKeys = [["organization360", orgId]];
+  // The modal owns the toast: a decision drops its row from the list, and a
+  // sticky offer owned by that row would leave with it.
+  const toast = useToast();
   return (
     <Modal open onClose={onClose} labelledBy={titleId} size="wide">
       <h2 id={titleId} className="t-h2 modal-title">
@@ -125,10 +129,12 @@ export function CompanyApprovalsPanel({
               approval={approval}
               onAlreadyDecided={sink.onAlreadyDecided}
               extraInvalidateKeys={extraInvalidateKeys}
+              toast={toast}
             />
           ))}
         </section>
       ))}
+      <ToastRegion toast={toast} />
     </Modal>
   );
 }

--- a/frontend/src/screens/today.focus.tsx
+++ b/frontend/src/screens/today.focus.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2 } from "lucide-react";
 import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
+import { type Toast, ToastRegion, useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
@@ -81,7 +82,8 @@ function AllClear({ decided }: Readonly<{ decided: number }>) {
 function FocusBody({
   item,
   onDone,
-}: Readonly<{ item: AttentionItem; onDone: () => void }>) {
+  toast,
+}: Readonly<{ item: AttentionItem; onDone: () => void; toast: Toast }>) {
   const t = useT();
   const dispose = useDisposeDuplicate();
   const pending = dispose.isPending;
@@ -126,14 +128,15 @@ function FocusBody({
   // evidence stands behind it. So the card fetches the one approval it is
   // showing. One card is on screen, so this is one read, and it is the same
   // read the record page makes.
-  return <StagedDecision id={item.id} onDone={onDone} />;
+  return <StagedDecision id={item.id} onDone={onDone} toast={toast} />;
 }
 
 // One staged proposal, fetched whole because it is the one being decided.
 function StagedDecision({
   id,
   onDone,
-}: Readonly<{ id: string; onDone: () => void }>) {
+  toast,
+}: Readonly<{ id: string; onDone: () => void; toast: Toast }>) {
   const t = useT();
   const approval = useApproval(id);
   // A body that carries no `kind` is not a proposal this card can draw: the
@@ -171,6 +174,7 @@ function StagedDecision({
           // every proposal the reader answers normally.
           onAlreadyDecided={onDone}
           extraInvalidateKeys={[attentionKey]}
+          toast={toast}
         />
       )}
     </SurfaceState>
@@ -198,6 +202,11 @@ export function FocusLane({
   const t = useT();
   const { locale } = useLocale();
   const current = items[0];
+  // The lane owns the toast, not the card. Answering a proposal replaces the
+  // card — that is how the queue advances — and a sticky offer owned by the
+  // card would leave with it, which is the one message that must survive the
+  // card it was shown from.
+  const toast = useToast();
   return (
     <Panel
       title={
@@ -214,7 +223,7 @@ export function FocusLane({
         ) : current ? (
           <div className="focus">
             <Progress done={decided} total={total} />
-            <FocusBody item={current} onDone={onDecided} />
+            <FocusBody item={current} onDone={onDecided} toast={toast} />
             {/* Later, not never. A queue whose only exits are terminal is one
                 a reader stops opening the moment it holds something they
                 cannot answer yet. */}
@@ -228,6 +237,7 @@ export function FocusLane({
           <AllClear decided={decided} />
         )}
       </PanelBody>
+      <ToastRegion toast={toast} />
     </Panel>
   );
 }


### PR DESCRIPTION
Approving a proposal changes a record and, until now, said nothing about undoing it.

**The reversal already existed.** The record's history panel replays an audited update, and `compose/undoability.go` judges whether it can — refusing with one of ten named reasons where it cannot. Nothing pointed a reader at it.

So this points. It builds no second reversal engine.

## What it does

A sticky toast after an approval, carrying the verb. That is what `sticky` is for, in the design system's own words: *"a reader reaching for Undo must not lose it mid-reach."* The button navigates to the record whose history holds the change.

## Offered only where it can be kept

`recordRoute` narrows the wire's free-form `target_entity_type` through `isEntityKind` — the same question the breadcrumb asks before it links. A kind that sends mail, creates a record, or names no target at all gets no button.

The history engine serves one type the app cannot route to (`activity`, which has no record page). That one is deliberately **not** offered rather than linked into a screen that cannot answer it.

Only on approve. A rejection changed nothing.

## Why this and not `POST /approvals/{id}/undo`

Checked against the live database before writing anything. An applied `close_date_correction` writes an ordinary `update` audit row on the **deal**, with both before and after images; `deal` is one of the six types the restore path serves; `update` is a replayable verb. The reversal works today through a route that shipped in #2798.

A dedicated approval-undo endpoint would be a second door onto one engine.

One thing I had flagged as a blocker turned out not to be: `close_date_provisional` is `readOnly` in the contract, so a restore never sends it and the update path re-derives it. The flag cannot be left inconsistent.

## The first commit was broken, and CI caught it

Worth stating plainly. `useToast` is local state paired with its own `<ToastRegion>` — every other consumer in the tree renders both. The row showed a toast while rendering no region, so **the confirmation never appeared**. `make check-fe` passed because nothing rendered it.

SonarCloud failed the quality gate on new-code coverage: 52.4% against 80. The uncovered half was `showUndoOffer` — exactly where the bug was. A coverage number naming the one function nobody had exercised was right, and the second commit fixes both.

## Verification

- `make check-fe` green — design-system gates, 5071 unit tests.
- Three render tests hold what a reader actually sees: the offer appears after an approval and lands on `#/deals/d1`, stays silent after a rejection, stays silent for an approval naming no record.
- The routing rule has its own unit test: five kinds route, a missing target does not, a kind without a page does not.
- **Mutation-checked twice**: removing the `<ToastRegion>` fails the render test; dropping the `isEntityKind` guard fails two routing cases.

Strings added in all three locales. No existing string changed, and no e2e spec asserts on approval toasts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation messaging when an approval is applied.
  * Added an option to undo an approval directly from the confirmation message and navigate to the related record when supported.
  * Notifications now persist as approval queues advance.
  * Added German, English, and Vietnamese translations for the new messages.

* **Tests**
  * Added coverage for routing to supported record types and handling missing or unsupported targets.
  * Added coverage confirming undo actions appear only for supported approved records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->