### PR TITLE
refactor(dedupe): the org-name comments say the rule, not the history

### DIFF
--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -81,33 +81,22 @@ func normalizeName(s string) string {
 // combiningDiaeresis is the mark that turns Cyrillic "е" into "ё".
 const combiningDiaeresis = '\u0308'
 
-// dropAccents removes the combining marks that are ACCENTS — the ones a writer
-// adds to a letter and a reader can do without — and keeps the ones that are
-// letters in their own right.
+// dropAccents removes the combining marks that are ACCENTS and keeps the ones
+// that are letters in their own right.
 //
-// REMOVING EVERY Mn MARK WAS WRONG outside the alphabets this started with. In
-// Thai, Lao, Khmer and the Indic scripts a combining mark is a LETTER: the
-// vowels hang above and below the consonant instead of sitting beside it.
-// Measured, an unrestricted strip turned "เมืองไทย" into "เมองไทย" and
-// "កម្ពុជា" into "កមពជា", so every Thai and Khmer company name lost characters
-// before any comparison began — and two different names could fold together.
+// The BASE LETTER decides, because NFD leaves a mark directly after the letter it
+// belongs to:
 //
-// The base letter decides, not the mark. NFD leaves a mark directly after the
-// letter it belongs to, so the base says which kind it is:
+//   - Latin and Greek write accents, and those go — Müller/Mueller, Straße,
+//     Việt Nam, Οδυσσεύς all depend on it.
+//   - Hebrew and Arabic write vocalization, optional and usually absent, so a
+//     pointed spelling folds onto the plain one.
+//   - Everything else writes letters, and those stay.
 //
-//   - Latin and Greek write ACCENTS, and those go. Müller/Mueller, Straße, Việt
-//     Nam and Οδυσσεύς all depend on it.
-//   - Hebrew and Arabic write VOCALIZATION — niqqud and harakat — which is
-//     optional and usually absent, so a pointed spelling must fold onto the
-//     plain one rather than becoming a second company.
-//   - Everything else writes LETTERS, and those stay.
-//
-// CYRILLIC IS NOT IN THAT LIST, and including it was wrong for the same reason
-// as Thai. Its marked letters are letters: "й" is not an accented "и" but the
-// character in every other Russian word, and stripping it turned "Мойка" into
-// "моика" and the Ukrainian "Київстар" into "киівстар". The one real accent
-// pair, "ё" against "е", is spelled out below because writers do treat those two
-// as interchangeable.
+// Removing every Mn mark instead was wrong wherever a mark IS a letter: it
+// turned "เมืองไทย" into "เมองไทย" and the Russian "Мойка" into "моика", so
+// those names lost characters before any comparison began. Cyrillic's one real
+// accent pair, "ё" against "е", is spelled out below.
 func dropAccents(decomposed string) string {
 	var out strings.Builder
 	out.Grow(len(decomposed))
@@ -186,18 +175,12 @@ func NormalizeOrgName(s string) string {
 	return strings.Join(fields, " ")
 }
 
-// undottedForm is a trailing word with the dots a writer put inside it removed,
-// so a legal form spelled with them is the same form spelled without.
+// undottedForm is a trailing word with its internal dots removed, so "S.R.L."
+// and "SRL" are one Romanian form. Trimming only the final dot left "s.r.l." as
+// one token matching no entry.
 //
-// "S.R.L." and "SRL" are one Romanian form, "A.Ş." and "AŞ" one Turkish form,
-// and a registry holds whichever the filer typed. Trimming only the FINAL dot
-// left "s.r.l." as a single token that matched no entry, so those names kept
-// their legal form and scored against every other company that kept the same
-// one.
-//
-// Only dots, and only for the lookup — the word itself is untouched when it
-// turns out not to be a legal form, so a name that really contains a dot keeps
-// it.
+// Only for the lookup: a word that turns out not to be a legal form keeps its
+// dots.
 func undottedForm(word string) string {
 	if !strings.Contains(word, ".") {
 		return word

--- a/backend/internal/modules/people/orgcommonwords.go
+++ b/backend/internal/modules/people/orgcommonwords.go
@@ -78,11 +78,8 @@ func agreeEntirely(shorter, longer []string) bool {
 		return false
 	}
 	// A name of nothing but common words may only agree with a name of exactly
-	// the same words. "Bank of Ireland" and "Bank of Ireland Group" are one
-	// company — "group" is deleted upstream, so both arrive as the same two
-	// words. "First National Bank" arrives as "first bank" and "First Republic
-	// Bank" as "first republic bank": one is a strict subset of the other, both
-	// are vocabulary end to end, and there is no company between them to find.
+	// the same words. Where one is a strict SUBSET of the other and both are
+	// vocabulary end to end, there is no company between them to find.
 	//
 	// A one-word name is exempt: a company called "Sun" has said all it has to
 	// say, and "Sun Microsystems" is that name qualified.

--- a/backend/internal/modules/people/orgcommonwords.go
+++ b/backend/internal/modules/people/orgcommonwords.go
@@ -5,39 +5,23 @@ package people
 
 // Which shared words count as evidence that two company names are one company.
 //
-// The gate next door (orgnamegate.go) decides whether two names may be scored at
-// all, and it does that by looking for a word they share. That is right when the
-// word is a brand and wrong when it is the vocabulary of a whole market: "Bank of
-// the West" and "Bank of the East" share "bank", "Union Pacific" and "Union
-// Carbide" share "union", and each pair is two different businesses.
+// The gate next door looks for a word two names share. That is right when the
+// word is a brand and wrong when it is the vocabulary of a whole market: "Bank
+// of the West" and "Bank of the East" share "bank", and they are two banks.
 
 // orgCommonNameWords are ordinary words that many unrelated companies put in
-// their names, so two names meeting on one have said nothing about being one
-// company.
+// their names.
 //
-// DIFFERENT FROM orgNameStopwords, which is why this is a second map rather than
-// more entries in that one. A stopword is REMOVED from the name: it is market
-// vocabulary and never a brand, so "Digital Solutions" and "Digital Ocean" must
-// not meet on either word. These words CAN be a brand — Bank of America is a
-// bank, Central Group is a real company, Star Alliance is named Star — so they
-// stay in the name and reach the score, and only stop being counted as the
-// evidence that two names are one company.
+// DISCOUNTED, NOT DELETED, which is why this is not more entries in
+// orgNameStopwords. A stopword is removed from the name because it is never a
+// brand; these words CAN be one — Bank of America is a bank, Star Alliance is
+// named Star — so they stay in the name and reach the score, and only stop
+// counting as the evidence that two names are one company.
 //
-// Measured on the pairs that reached review wrongly: "Bank of the West" against
-// "Bank of the East" scored 0.9750, "Union Pacific" against "Union Carbide"
-// 0.8547, "Central Park Media" against "Central Valley Media" 0.8967. Each
-// shares exactly one ordinary word and nothing else.
-//
-// SMALL ON PURPOSE. This is not a frequency list and must not grow into one: a
-// long list starts refusing real brands their only evidence. What keeps a
-// company actually called "Bank" findable is the escape in sharedTokenCount —
-// two names that agree entirely are one company however ordinary their words —
-// and a market whose common words are missing keeps today's false positives
-// rather than gaining new ones.
-//
-// The countries are here for the same reason as the rest: a country says where a
-// company works, not which company it is, and a subsidiary carries its parent's
-// country the way a rival carries the same one.
+// SMALL ON PURPOSE, and not a frequency list: a long one starts refusing real
+// brands their only evidence. What keeps a company actually called "Bank"
+// findable is agreeEntirely below. A market whose common words are missing keeps
+// today's false positives rather than gaining new ones.
 var orgCommonNameWords = map[string]bool{
 	// Sector nouns that name a whole industry rather than a company in it.
 	"bank": true, "insurance": true, "energy": true, "motors": true, "airlines": true,
@@ -53,13 +37,8 @@ var orgCommonNameWords = map[string]bool{
 	// Ornaments.
 	"royal": true, "crown": true, "star": true, "sun": true, "summit": true, "apex": true,
 	// The country a company works in, which a subsidiary carries and a rival
-	// carries too: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers,
-	// and two unrelated firms both add "Deutschland" to their German arm.
-	//
-	// The MARKETS THIS TREE HOLDS, in the spellings those markets use — the same
-	// rule as the rest of this map, and the same rule as the legal-form tables
-	// next door. A country is added when a name from it arrives, not in advance:
-	// a list of every country would refuse evidence to companies nobody here has.
+	// carries too: "Rimi Latvia" and "Maxima Latvija" are two Latvian grocers.
+	// Added when a name from that market arrives, not in advance.
 	"latvia": true, "latvija": true, "deutschland": true, "france": true,
 	"ireland": true, "indonesia": true,
 }
@@ -105,12 +84,11 @@ func agreeEntirely(shorter, longer []string) bool {
 	// Bank" as "first republic bank": one is a strict subset of the other, both
 	// are vocabulary end to end, and there is no company between them to find.
 	//
-	// A one-word name is exempt, because a company called "Sun" has said all it
-	// has to say and "Sun Microsystems" is that name qualified.
+	// A one-word name is exempt: a company called "Sun" has said all it has to
+	// say, and "Sun Microsystems" is that name qualified.
 	//
-	// Comparing LENGTHS is enough to mean "a subset rather than the same words":
-	// two names of equal length that differ in a word are rejected by the
-	// containment loop below, which needs every word of the shorter to be found.
+	// Comparing LENGTHS is enough to mean "a subset rather than the same words",
+	// because the containment loop below rejects equal-length names that differ.
 	if len(shorter) > 1 && !anyStrongWord(shorter) && len(shorter) != len(longer) {
 		return false
 	}

--- a/backend/internal/modules/people/orgformtables.go
+++ b/backend/internal/modules/people/orgformtables.go
@@ -7,11 +7,9 @@ package people
 //
 // A TABLE PER MARKET because the forms differ in how safely they can be removed.
 // "ООО" is Cyrillic and collides with nothing. "PT" is two Latin letters, and
-// "PT Solutions Physical Therapy" is a company in Georgia — removing it there
-// leaves a name matching every firm whose name begins "Solutions". These ten are
-// all real companies a position-only rule would damage: PT Solutions Physical
-// Therapy, AO World, AS Roma, CV Sciences, SIA Engineering, II-VI, TOO Group,
-// AB InBev, SA Recycling, MB Financial.
+// "PT Solutions Physical Therapy" is a company — removing it there leaves a name
+// matching every firm whose name begins "Solutions". So is "AO World", and so is
+// "AS Roma"; orgformtables_test.go holds the rest.
 
 // orgFormMarker is one legal form as it appears after folding, split into the
 // words a name is split into.

--- a/backend/internal/modules/people/orgformtables.go
+++ b/backend/internal/modules/people/orgformtables.go
@@ -3,22 +3,15 @@
 
 package people
 
-// The legal forms that come BEFORE the company name, for every market that
-// writes them that way.
+// The legal forms that come BEFORE the company name, per market.
 //
-// WHY A TABLE PER MARKET AND NOT ONE LIST. The forms differ in how safely they
-// can be removed, and the difference is what this file is for. "ООО" is Cyrillic
-// and collides with nothing, so it can go wherever it appears at the front.
-// "PT" is two Latin letters, and "PT Solutions Physical Therapy" is a company in
-// Georgia — removing it there leaves a name that matches every other firm whose
-// name begins "Solutions". So the ambiguous markers are held to a second signal
-// before they are believed, and the unambiguous ones are not.
-//
-// Measured against real companies. These ten are all real, and a rule that
-// stripped a two-letter marker on position alone damages every one of them:
-// PT Solutions Physical Therapy, AO World, AS Roma, CV Sciences, SIA
-// Engineering, II-VI Incorporated, TOO Group, AB InBev, SA Recycling, MB
-// Financial.
+// A TABLE PER MARKET because the forms differ in how safely they can be removed.
+// "ООО" is Cyrillic and collides with nothing. "PT" is two Latin letters, and
+// "PT Solutions Physical Therapy" is a company in Georgia — removing it there
+// leaves a name matching every firm whose name begins "Solutions". These ten are
+// all real companies a position-only rule would damage: PT Solutions Physical
+// Therapy, AO World, AS Roma, CV Sciences, SIA Engineering, II-VI, TOO Group,
+// AB InBev, SA Recycling, MB Financial.
 
 // orgFormMarker is one legal form as it appears after folding, split into the
 // words a name is split into.
@@ -34,16 +27,12 @@ type orgFormMarker struct {
 
 // marketForms are the prefix legal forms of one market.
 //
-// `fillers` is the trade vocabulary that stacks between the form and the brand,
-// and only Vietnam has one here: it is the market whose names are built that
-// way. A filler is only ever removed from a name that carried this market's
-// legal form, because the abbreviations are short enough to be words elsewhere.
+// `fillers` is the trade vocabulary stacking between the form and the brand,
+// removed only from a name that carried this market's legal form — the
+// abbreviations are short enough to be words elsewhere.
 //
-// `continuations` are forms that appear only as the second half of a stacked
-// one, where they arrive without their leading word — "TỔNG CÔNG TY CỔ PHẦN"
-// leaves a bare "cổ phần" once "tổng công ty" is gone. They are consulted only
-// after a form has already been removed, so a name that simply begins with those
-// words keeps them.
+// `continuations` appear only as the second half of a stacked form, arriving
+// without their leading word: "TỔNG CÔNG TY CỔ PHẦN" leaves a bare "cổ phần".
 type marketForms struct {
 	name          string
 	prefixes      []orgFormMarker
@@ -75,15 +64,10 @@ type marketForms struct {
 // prefixMarkets carries the markets whose legal form precedes the name, in the
 // order matchingFormOf consults them.
 //
-// A HAND-WRITTEN, VERSIONED LIST, read the same way as orgNameStopwords and for
-// the same reason: a list derived from the workspace's own names would make two
-// names match in one workspace and not in another, and would put a query inside
-// the transaction that holds the organization-name write lock.
-//
-// Seeded from the ISO 20275 Entity Legal Form list, which is the registry of
-// what each jurisdiction actually recognises, then extended with the everyday
-// abbreviations that registry does not carry — it holds "công ty cổ phần" but
-// not "CTCP", and no Russian abbreviations at all.
+// Hand-written and versioned, for the reason orgNameStopwords is. Seeded from
+// the ISO 20275 Entity Legal Form list and extended with the everyday
+// abbreviations it does not carry: it holds "công ty cổ phần" but not "CTCP",
+// and no Russian abbreviations at all.
 var prefixMarkets = []marketForms{
 	vietnam,
 	indonesia,
@@ -96,12 +80,6 @@ var prefixMarkets = []marketForms{
 	thailand,
 }
 
-// cjkMarket names the scripts whose forms are matched by substring rather than
-// by word (orgnamecjk.go). It carries no tables of its own — the forms live
-// there, because they are matched a different way — and exists so a caller can
-// tell that a name declared one of these markets.
-var cjkMarket = marketForms{name: "cjk"}
-
 // unambiguous builds markers from forms that collide with nothing.
 func unambiguous(forms ...[]string) []orgFormMarker {
 	markers := make([]orgFormMarker, 0, len(forms))
@@ -112,17 +90,11 @@ func unambiguous(forms ...[]string) []orgFormMarker {
 }
 
 // ambiguousFormWords are the words of every ambiguous form, which the gate must
-// not count as evidence of identity.
+// not count as evidence: "SIA Rimi Latvia" and "SIA Maxima Latvija" are two
+// Latvian grocers. They cannot be REMOVED without corroboration, so they stay in
+// the string the score compares.
 //
-// These forms cannot be REMOVED from a name without corroboration — "PT
-// Solutions" is a company and "AO World" is another — so they stay in the string
-// the score compares. But a word that is a legal form somewhere is market
-// vocabulary rather than a brand, and two names must not meet on it: "SIA Rimi
-// Latvia" and "SIA Maxima Latvija" are two Latvian grocers, and "AS Roma" and
-// "AS Monaco" are two football clubs.
-//
-// Derived from the tables rather than written out again, so a form added above
-// cannot be forgotten here.
+// Derived from the tables rather than written out again.
 var ambiguousFormWord = ambiguousFormWords()
 
 func ambiguousFormWords() map[string]bool {
@@ -151,13 +123,10 @@ func ambiguous(forms ...[]string) []orgFormMarker {
 
 // Vietnam writes the form, then the trade, then the brand: "CÔNG TY CỔ PHẦN SỮA
 // VIỆT NAM" is the joint-stock company Sữa Việt Nam. Both spellings of each form
-// are here because both are how companies write themselves — the legal "công ty
-// trách nhiệm hữu hạn" and the everyday "công ty tnhh".
+// are here because companies write themselves both ways.
 //
-// The syllables recur because the language builds its legal forms out of them,
-// and the point of writing the table this way is that a reader can check it
-// against the language. Naming "cong" as a constant would hide what the entries
-// say, so the repetition is the readable form here rather than a smell.
+// The syllables recur because the language builds its forms out of them, and a
+// reader must be able to check the table against the language.
 //
 //nolint:goconst // Vietnamese words, not repeated magic strings — see above.
 var vietnam = marketForms{

--- a/backend/internal/modules/people/orgnamecjk.go
+++ b/backend/internal/modules/people/orgnamecjk.go
@@ -28,9 +28,9 @@ import (
 )
 
 // cjkLegalForms are the company-type strings, matched against the ends of a name
-// longest-first. "有限公司" is a suffix of "有限责任公司", so a short match taken
-// alone would leave "有限责任" on the brand; the loop repeats because a name can
-// carry a form at each end.
+// longest-first, in a loop. "有限公司" is a suffix of "有限责任公司", so a short
+// match alone would leave "有限责任" on the brand — either the ordering or the
+// repetition covers that. What needs BOTH is a form at each end.
 //
 // Simplified and Traditional are separate entries: NFKC does not bridge them, so
 // a table with one spelling is blind to half the market.
@@ -67,11 +67,9 @@ var cjkFormAliases = map[string]string{
 	"(유)": "유한회사",
 }
 
-// cjkBrandTierWords LOOK like a legal form and are not. 中国中车集团有限公司 is a
-// state-owned parent and 中国中车股份有限公司 its listed subsidiary, so stripping
-// 集团 would file a parent as its own subsidiary — the standard shape of the
-// largest Chinese groups. Named here so a test can hold the intent; the forms
-// above simply do not contain them.
+// cjkBrandTierWords LOOK like a legal form and are not: 集团 and 控股 name a
+// different legal person from the company beside them, so the tables above must
+// never contain them. Named here so a test can hold that intent.
 var cjkBrandTierWords = []string{"集团", "集團", "控股", "控股集团"}
 
 // cjkMaxFormsStripped bounds how many forms one name may shed. The strip is a
@@ -83,6 +81,9 @@ const cjkMaxFormsStripped = 4
 // cjkMinimumBrandRunes is the shortest name a strip may leave behind. A bare
 // "株式会社" arrives in real exports and must not become the empty string, which
 // would match every other empty string.
+//
+// One and not two: Japan and Korea set no floor on a brand's length, and dirty
+// data sets none at all.
 const cjkMinimumBrandRunes = 1
 
 // carriesCJKForm answers whether this path owns the name: does it begin or end
@@ -134,8 +135,11 @@ func isVariationSelector(r rune) bool {
 }
 
 // cjkNameForMatching is the name with its legal form removed from either end.
-// Returns false for a name carrying none of them, so the caller can hand it to
-// the word-level path.
+//
+// Returns false for a name carrying none of these forms, so the caller can hand
+// it to the word-level path. A name that DOES carry one belongs here whatever
+// else it is written in: the word-level path would see it as a single token and
+// then strip Latin forms out of it.
 func cjkNameForMatching(s string) (string, bool) {
 	// Normalized BEFORE the script test, because a squared form carries no Han
 	// of its own: "㈱" is one compatibility character, and the script only

--- a/backend/internal/modules/people/orgnamecjk.go
+++ b/backend/internal/modules/people/orgnamecjk.go
@@ -6,35 +6,20 @@ package people
 // Org-name matching for Chinese, Japanese and Korean, where a name has no word
 // boundaries to split on.
 //
-// WHY A SECOND PATH. Everything else in this package finds a legal form by
-// splitting a name into words and comparing them. These scripts write no spaces:
-// "北京字节跳动科技有限公司" is one token, so the gate had nothing to compare and
-// answered no-match to every pair — including a company against ITSELF written
-// without its legal form. Measured before this existed, all six of these scored
-// 0.0000: 株式会社トヨタ自動車 against トヨタ自動車, 주식회사 삼성전자 against
-// 삼성전자, 阿里巴巴集团控股有限公司 against 阿里巴巴. Missed duplicates, silently.
-// Meanwhile 주식회사 삼성전자 and 주식회사 현대자동차 — Samsung and Hyundai —
-// scored 0.8533 on the shared "주식회사".
+// Everything else in this package finds a legal form by splitting a name into
+// words. These scripts write no spaces, so "北京字节跳动科技有限公司" is one token
+// and the gate had nothing to compare: a company did not match ITSELF, while
+// Samsung and Hyundai met on the shared "주식회사". So the form is matched as a
+// SUBSTRING anchored at each end. Unicode's own word segmentation does not help
+// and says so — it breaks Han between every character and keeps a whole Hangul
+// run as one word.
 //
-// So the form is matched as a SUBSTRING anchored at each end, longest first.
-// Unicode's own word segmentation (UAX #29) does not help: it breaks Han between
-// every character and keeps a whole Hangul run as one word, and the standard
-// says so itself. The alternative is a dictionary, which this package will not
-// carry.
-//
-// A MATCH HERE IS A QUESTION, NOT A MERGE. Japanese registration treats
-// 株式会社ガナ and ガナ株式会社 as two registrable names at one address, so the
-// two really can be different companies. This tier answers "worth a human
-// look", never "these are one record" — and against the alternative, which is
-// the silence measured above, asking is the right error to make.
-//
-// THE KOREAN REGISTRY DOES EXACTLY THIS. Its rule for deciding whether two
-// company names are the same removes the company-type string first and compares
-// what is left, which is the algorithm below. It also settles a question this
-// file would otherwise have to guess at: 가나주식회사 and 주식회사가나 are the
-// same name, because once the type string is gone neither has a position left to
-// differ in. Japan is the same — company law requires "株式会社" to appear in the
-// name and says nothing about where.
+// EITHER END, because both are correct. The Korean registry's rule for deciding
+// whether two names are the same removes the company-type string first and
+// compares the remainder, which is this algorithm; Japanese company law requires
+// "株式会社" to appear and says nothing about where. Japanese registration does
+// treat the two orders as two registrable names, so this tier asks a human
+// rather than merging.
 
 import (
 	"strings"
@@ -42,18 +27,13 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// cjkLegalForms are the company-type strings of the three scripts, matched
-// against the ends of a name.
+// cjkLegalForms are the company-type strings, matched against the ends of a name
+// longest-first. "有限公司" is a suffix of "有限责任公司", so a short match taken
+// alone would leave "有限责任" on the brand; the loop repeats because a name can
+// carry a form at each end.
 //
-// Longest first, and the loop repeats. "有限公司" is a suffix of "有限责任公司"
-// and of "股份有限公司", so a short match taken alone would leave "有限责任" on the
-// brand — though either the ordering or the repetition covers that by itself.
-// What needs BOTH is a name carrying a form at each end: strip once and
-// "株式会社ガナ株式会社" keeps one of them.
-//
-// Simplified and Traditional are separate entries because Unicode does not
-// bridge them — "责" and "責" are distinct characters and NFKC leaves both alone,
-// so a table with only one spelling is blind to half the market.
+// Simplified and Traditional are separate entries: NFKC does not bridge them, so
+// a table with one spelling is blind to half the market.
 var cjkLegalForms = []string{
 	// Chinese, mainland and traditional.
 	"有限责任公司", "有限責任公司",
@@ -75,13 +55,9 @@ var cjkLegalForms = []string{
 	"재단법인", "사단법인",
 }
 
-// cjkFormAliases are the squared and parenthesised spellings of a legal form,
-// mapped onto the form itself.
-//
-// NFKC DOES NOT DO THIS, which is the trap. It rewrites ㈱ to "(株)" and ㈜ to
-// "(주)" — the parentheses, not the words — so a name written "㈱ガナ" still
-// shares no substring with "株式会社ガナ" after normalization. Verified against
-// the Go normalizer rather than assumed.
+// cjkFormAliases map the squared and parenthesised spellings onto the form
+// itself. NFKC does not: it rewrites ㈱ to "(株)" — the parentheses, not the
+// words — so "㈱ガナ" would still share no substring with "株式会社ガナ".
 var cjkFormAliases = map[string]string{
 	"(株)": "株式会社",
 	"(有)": "有限会社",
@@ -91,55 +67,31 @@ var cjkFormAliases = map[string]string{
 	"(유)": "유한회사",
 }
 
-// cjkBrandTierWords are words that LOOK like a legal form and are not.
-//
-// 集团 (group) and 控股 (holding) name a different legal person from the company
-// they sit beside: 中国中车集团有限公司 is the state-owned parent and
-// 中国中车股份有限公司 is its listed subsidiary, and the parent holds 54% of it.
-// Stripping the word would file those two as one company — a parent merged with
-// its own subsidiary, which is the opposite of deduplication, and this is the
-// standard shape of the largest Chinese groups rather than an edge case.
-//
-// Listed here so the intent is written down and testable, not because the code
-// needs a lookup: the forms above simply do not contain them.
+// cjkBrandTierWords LOOK like a legal form and are not. 中国中车集团有限公司 is a
+// state-owned parent and 中国中车股份有限公司 its listed subsidiary, so stripping
+// 集团 would file a parent as its own subsidiary — the standard shape of the
+// largest Chinese groups. Named here so a test can hold the intent; the forms
+// above simply do not contain them.
 var cjkBrandTierWords = []string{"集团", "集團", "控股", "控股集团"}
 
-// cjkMaxFormsStripped bounds how many legal forms one name may shed.
-//
-// The strip is a loop over a shrinking string, so its cost is quadratic in the
-// number of forms — measured, a name of 10 000 concatenated forms takes 370ms,
-// and `display_name` is `text` with no maxLength in the contract. That work
-// happens inside DedupeOrganizationForCreate, which holds the workspace-wide
-// organization-name write lock, so an unbounded name pins every other
-// organization-name writer behind it. The same reasoning as nameScoringMaxRunes
-// (namesim.go), which bounds the metric for the same lock.
-//
-// FOUR is far past any real name: a company carries a form at one end, or at
-// both, and "株式会社ガナ株式会社" is already the strange case. Past the bound the
-// name keeps whatever forms are left, which for a name this shape is the same
-// answer any comparison would give.
+// cjkMaxFormsStripped bounds how many forms one name may shed. The strip is a
+// loop over a shrinking string, so its cost is quadratic — measured, 10 000
+// concatenated forms took 370ms — and it runs while the workspace-wide
+// organization-name write lock is held. Four is past any real name.
 const cjkMaxFormsStripped = 4
 
-// cjkMinimumBrandRunes is the shortest name a strip may leave behind.
-//
-// A name that is nothing but its legal form — a bare "株式会社" or "㈜" in a CRM
-// export — must not become the empty string, which would match every other empty
-// string. Mainland registration requires a brand of at least two characters, but
-// Japan and Korea have no such floor and dirty data has no floor at all.
+// cjkMinimumBrandRunes is the shortest name a strip may leave behind. A bare
+// "株式会社" arrives in real exports and must not become the empty string, which
+// would match every other empty string.
 const cjkMinimumBrandRunes = 1
 
-// carriesCJKForm answers whether this path owns the name: does it end or begin
-// with one of the legal forms above?
+// carriesCJKForm answers whether this path owns the name: does it begin or end
+// with one of the forms above?
 //
-// THE FORM, NOT THE SCRIPT. An earlier version claimed any name containing a
-// single Han, Kana or Hangul character, which is far too much — "CÔNG TY TNHH
-// 東京 Việt" is a Vietnamese company with a Han word in its name, and routing it
-// here left its Vietnamese legal form in place and squashed its spaces. The same
-// for "Acme 漢 GmbH", which needs the Latin suffix strip.
-//
-// A name that carries one of these forms is one of these markets, whatever else
-// it is written in: "Toyota株式会社" and "ABC有限公司" are how those companies
-// write themselves.
+// THE FORM, NOT THE SCRIPT. Claiming any name containing a single Han or Kana
+// character is far too much — "CÔNG TY TNHH 東京 Việt" needs its Vietnamese
+// handling and "Acme 漢 GmbH" its Latin suffix strip. A name that carries one of
+// these forms is one of these markets whatever else it is written in.
 func carriesCJKForm(name string) bool {
 	for _, form := range cjkLegalForms {
 		if strings.HasPrefix(name, form) || strings.HasSuffix(name, form) {
@@ -149,15 +101,13 @@ func carriesCJKForm(name string) bool {
 	return false
 }
 
-// normalizeCJKName folds a name to the form the tables are written in.
+// normalizeCJKName folds a name to the form the tables are written in. NFKC
+// rather than the NFD pass used elsewhere: it maps the full-width Latin and
+// half-width katakana a Japanese registry emits onto their ordinary spellings.
 //
-// NFKC rather than the NFD pass the rest of this package uses: it is what maps
-// the full-width Latin and half-width katakana a Japanese registry emits onto
-// their ordinary spellings, and the ideographic space onto a plain one.
-//
-// Variation selectors are removed by hand because normalization keeps them.
-// They are a rendering instruction — which shape of 葛 to draw — and two records
-// of one company differ by them for no reason a reader could see.
+// Variation selectors are removed by hand because normalization keeps them; they
+// choose which shape of 葛 to draw, and two records of one company should not
+// differ by one.
 func normalizeCJKName(s string) string {
 	folded := norm.NFKC.String(s)
 	for alias, form := range cjkFormAliases {
@@ -184,21 +134,8 @@ func isVariationSelector(r rune) bool {
 }
 
 // cjkNameForMatching is the name with its legal form removed from either end.
-//
-// EITHER END, because both are correct and the difference is a style choice.
-// Japanese writers put "株式会社" in front (前株) or behind (後株) with no legal
-// distinction, and the Korean registry's own comparison rule removes the type
-// string wherever it sits before deciding whether two names are the same.
-//
-// Repeated, because a name can carry a form at both ends, and a Chinese name can
-// carry "集团有限公司" — where "有限公司" goes and "集团" stays.
-//
-// Returns false only when the name is written in some OTHER script, so the
-// caller can hand it to the word-level path. A name that IS one of these scripts
-// belongs here whether or not a form was found: the word-level path would split
-// it into a single token and then strip Latin forms out of it, and "㈱" — which
-// normalizes to a bare "株式会社" and has no brand to keep — came back empty from
-// there.
+// Returns false for a name carrying none of them, so the caller can hand it to
+// the word-level path.
 func cjkNameForMatching(s string) (string, bool) {
 	// Normalized BEFORE the script test, because a squared form carries no Han
 	// of its own: "㈱" is one compatibility character, and the script only

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -201,8 +201,8 @@ func isLatinScript(fields []string) bool {
 //
 // IT MAY RETURN EMPTY, which is an answer: a name of nothing but a legal form and
 // trade words has not said WHICH company it is. Callers treat empty as no
-// evidence, never as a wildcard. NormalizeOrgName may not do this, because it
-// produces a stored key and an empty key collides with every other.
+// evidence, never as a wildcard — which is the one thing NormalizeOrgName may
+// not do (namesim.go).
 func orgNameForMatching(s string) string {
 	name, _ := matchingFormOf(s)
 	return name

--- a/backend/internal/modules/people/orgnameforms.go
+++ b/backend/internal/modules/people/orgnameforms.go
@@ -5,55 +5,36 @@ package people
 
 // Org-name matching for the markets that write the legal form BEFORE the name.
 //
-// WHY THIS EXISTS. PO-PARAM-1 strips a legal form that TRAILS the name — "Acme
-// Inc", "Acme GmbH" — because that is where English and German put it. Much of
-// the world puts it in front: "CÔNG TY CỔ PHẦN SỮA VIỆT NAM" is Vinamilk and the
-// first three words are "joint-stock company"; so are "PT Astra International",
-// "ООО Ромашка", "UAB Vilniaus Duona". Every company in such a market therefore
-// begins with the same run of words, and a character metric reads that as shared
-// identity — Jaro-Winkler boosts a shared PREFIX specifically. Measured before
-// this existed, two unrelated companies scored 0.76 to 0.91 against each other
-// on their boilerplate alone, well past the 0.72 review threshold.
+// PO-PARAM-1 strips a form that TRAILS the name, because that is where English
+// and German put it. Much of the world puts it in front — "CÔNG TY CỔ PHẦN SỮA
+// VIỆT NAM" is Vinamilk and the first three words are "joint-stock company" — so
+// every company in such a market begins with the same run of words, and
+// Jaro-Winkler's prefix boost read that as shared identity. Measured before this
+// existed, two unrelated companies scored 0.76 to 0.91 against each other.
 //
-// A PHRASE, NEVER A WORD. The folded syllables of a legal form are also real
-// brand syllables: "cổ", "cô" and "có" all fold to "co", "phần" and "phân" to
-// "phan", and "Cỏ May" is a rice company whose whole name folds to "co may". So
-// a word of a legal form is only removed as part of the WHOLE phrase, at the
-// front of the name. Deleting the token "phan" wherever it appeared would take
-// the brand off "Phan Minh".
+// A PHRASE, NEVER A WORD. The folded syllables of a legal form are also brand
+// syllables: "cổ" and "cỏ" both fold to "co", and "Cỏ May" is a rice company. So
+// a word is only removed as part of the whole phrase, at the front of the name.
 //
 // AND A SHORT LATIN FORM NEEDS A SECOND OPINION. "PT Solutions Physical
-// Therapy", "AO World", "AS Roma", "CV Sciences", "AB InBev", "SIA Engineering"
-// and "MB Financial" are all real companies whose first word is another market's
-// legal form. Position alone cannot tell those from "PT Astra International", so
-// an ambiguous marker is believed only when something else about the name agrees
-// — see corroboratedMarket.
+// Therapy", "AO World" and "AS Roma" are real companies whose first word is
+// another market's legal form — see corroboratedMarket.
 //
-// WHAT THIS IS NOT. Not a second normalizer for the org-name KEY:
-// NormalizeOrgName (namesim.go) is unchanged and still produces the exact and
-// grouping keys, so no stored key moves. This one is consulted only where two
-// names are COMPARED — the gate (orgnamegate.go) and the score (dedupeorg.go).
-// The difference matters: "Công ty CP Đầu tư ABC" and "Công ty CP Thương mại
-// ABC" must compare as one candidate pair and must NOT group under one key.
+// NOT a second normalizer for the org-name KEY: NormalizeOrgName is unchanged
+// and still produces the exact and grouping keys, so no stored key moves. This
+// one is consulted only where two names are COMPARED.
 
 import (
 	"strings"
 	"unicode"
 )
 
-// foldDStroke maps đ to d.
+// foldDStroke maps đ to d. U+0111 has no canonical decomposition, so the NFD
+// pass in normalizeName leaves it while Postgres f_unaccent maps it — without
+// this, "ĐẦU TƯ" folds to "đau tu" in Go and "dau tu" in the database.
 //
-// U+0111 LATIN SMALL LETTER D WITH STROKE has no canonical decomposition, so
-// the NFD pass in normalizeName cannot separate a combining mark from it and
-// the letter survives the fold intact: "ĐẦU TƯ" becomes "đau tu", not "dau tu".
-// Postgres f_unaccent DOES map it, so without this the same name folds two ways
-// — "dau tu" in the database and "đau tu" in Go — and no entry in the tables
-// could ever match a name typed with the letter Vietnamese uses for one of its
-// most common trade words.
-//
-// Deliberately NOT inside normalizeName, which is pinned as the input to the
-// similarity metric (PO-PARAM-JW-2) and shared with person and lead matching.
-// This is an org-name concern and stays on the org-name path.
+// Not inside normalizeName, which is pinned as the similarity metric's input
+// (PO-PARAM-JW-2) and shared with person and lead matching.
 func foldDStroke(s string) string {
 	if !strings.ContainsAny(s, "đĐ") {
 		return s
@@ -62,17 +43,11 @@ func foldDStroke(s string) string {
 }
 
 // stripLeadingMarkers removes legal forms from the FRONT of a name, longest
-// first, for as long as one matches.
+// first, for as long as one matches — the forms stack ("TỔNG CÔNG TY CỔ PHẦN"
+// carries two), and taking "cong ty" off "cong ty co phan x" first would leave
+// the remains of a longer form behind.
 //
-// Repeated, because the forms stack: "TỔNG CÔNG TY CỔ PHẦN …" carries two, and a
-// name may open with a form followed by several trade words.
-//
-// Longest-match, because the short forms are prefixes of the long ones. Taking
-// "cong ty" off "cong ty co phan x" would leave "co phan x" and put the remains
-// of a legal form into the comparison.
-//
-// An AMBIGUOUS marker is skipped unless the caller has already found
-// corroboration that this really is the market it looks like.
+// An AMBIGUOUS marker is skipped unless the caller found corroboration.
 func stripLeadingMarkers(fields []string, markers []orgFormMarker, corroborated bool) []string {
 	for {
 		longest := 0
@@ -92,28 +67,20 @@ func stripLeadingMarkers(fields []string, markers []orgFormMarker, corroborated 
 	}
 }
 
-// nameWordSeparators split a name into words, for the legal-form tables here and
-// for the gate that compares what is left.
+// nameWordSeparators split a name into words, for the tables here and the gate
+// that compares what is left.
 //
-// PUNCTUATION SEPARATES. Company names arrive punctuated every way a writer can
-// punctuate them — "ACME-Group", "Hewlett.Packard", "Capital.com", "S.C.",
-// "Sp. z o.o.", "ООО «Ромашка»", an en dash where a hyphen was meant — and a
-// fused token loses a real duplicate: "Acme Ltd" and "ACME-Group Ltd" share the
-// word "acme", but as one token "acme-group" it matches nothing.
+// PUNCTUATION SEPARATES, as a class rather than a list: names arrive punctuated
+// every way a writer can manage, and a fused "acme-group" matches nothing. An
+// earlier version named six ASCII characters and missed the period and the en
+// dash.
 //
-// A CLASS rather than a list, deliberately. An earlier version named six ASCII
-// characters and missed the period and the en dash, which is the shape of bug
-// that keeps being rediscovered one punctuation mark at a time.
+// A COMBINING MARK DOES NOT. Thai, Lao, Khmer and the Indic scripts write vowels
+// as marks, so a letters-and-digits rule cut "เมืองไทย" into four fragments.
+// Those scripts have no spaces either, so a Thai name is correctly one word.
 //
-// A COMBINING MARK DOES NOT SEPARATE, which the letters-and-digits rule got
-// wrong. Thai, Lao, Khmer and the Indic scripts write their vowels as marks
-// rather than letters, so that rule cut every Thai word into pieces:
-// "เมืองไทย" became four fragments. Those scripts have no spaces between words
-// either, so a Thai name is correctly ONE word here.
-//
-// Deliberately NOT done inside NormalizeOrgName, which also produces exact
-// grouping keys (orgMatchKeys in linkedinimport.go, the promotion sweep's
-// buckets). Splitting there would make two DIFFERENT names equal as keys.
+// NOT done inside NormalizeOrgName, which also produces exact grouping keys —
+// splitting there would make two DIFFERENT names equal as keys.
 func nameWordSeparators(r rune) bool {
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && !unicode.Is(unicode.Mn, r)
 }
@@ -182,26 +149,14 @@ func opensWith(fields, tokens []string) bool {
 }
 
 // corroboratedMarket answers whether a name that OPENS with an ambiguous marker
-// really belongs to that marker's market.
+// really belongs to that market. "PT Astra International Tbk" is Indonesian and
+// "PT Solutions Physical Therapy" is American, and the position of "PT" does not
+// distinguish them.
 //
-// The question exists because a two-letter Latin form is also an ordinary name.
-// "PT Astra International Tbk" is an Indonesian company; "PT Solutions Physical
-// Therapy" is an American one, and nothing about the position of "PT"
-// distinguishes them.
-//
-// TWO THINGS COUNT AS AGREEMENT, and both are properties of the name itself
-// rather than of the record around it:
-//
-//   - the market's own bracketing form closes the name. Indonesia's listed
-//     companies end in "Tbk", and no English name does.
-//   - the rest of the name is not written in Latin script. "ООО Ромашка" and
-//     "شركة الراجحي" are unambiguous by their letters, and a Latin marker in
-//     front of a Cyrillic or Arabic name is the same evidence.
-//
-// When neither holds, the marker stays in the name. That keeps today's false
-// positive for a genuine "PT Something" pair, which is the safer error: a name
-// wrongly stripped matches every company in its sector, while a name left alone
-// matches only the ones it already did.
+// Two things count, both properties of the name itself: the market's own
+// bracketing form closes it ("Tbk"), or the rest is not Latin script. When
+// neither holds the marker stays, which is the safer error — a name wrongly
+// stripped matches every company in its sector.
 func corroboratedMarket(raw string, fields []string, market marketForms) bool {
 	if len(fields) < 2 {
 		return false
@@ -242,40 +197,31 @@ func isLatinScript(fields []string) bool {
 	return true
 }
 
-// orgNameForMatching is the name reduced to what could identify a company: the
-// key with a leading legal form and its trailing trade vocabulary removed.
+// orgNameForMatching is the name reduced to what could identify a company.
 //
-// IT MAY RETURN EMPTY, and that is an answer rather than a failure. A name that
-// is nothing but a legal form and trade words — "CÔNG TY CỔ PHẦN THƯƠNG MẠI DỊCH
-// VỤ" — has said nothing about WHICH company it is, and two such names have said
-// nothing about being the same one. Callers treat empty as no evidence, never as
-// a wildcard.
-//
-// This is the one place it differs from NormalizeOrgName, which must never empty
-// a name because it produces a stored key and an empty key would collide with
-// every other empty key. A comparison has no such obligation: it is allowed to
-// say "I cannot tell these apart on their names".
+// IT MAY RETURN EMPTY, which is an answer: a name of nothing but a legal form and
+// trade words has not said WHICH company it is. Callers treat empty as no
+// evidence, never as a wildcard. NormalizeOrgName may not do this, because it
+// produces a stored key and an empty key collides with every other.
 func orgNameForMatching(s string) string {
 	name, _ := matchingFormOf(s)
 	return name
 }
 
 // matchingFormOf is orgNameForMatching plus the market the name declared, which
-// the gate needs: a market whose brands are built from a small pool of shared
-// syllables cannot treat one shared word as evidence of identity.
+// the gate needs to know whether one shared word is evidence.
 //
 // THE TRADE VOCABULARY IS ONLY STRIPPED FROM A NAME THAT DECLARED ITS MARKET.
-// Vietnam's abbreviations are two letters — "tm", "dv", "dt", "va" — and two
-// letters mean something else everywhere else: "VA Trading" and "DT Robotics"
-// are companies whose first word this table would otherwise eat. A legal form is
-// a strong enough signal to act on; a bare two-letter word is not.
+// Vietnam's abbreviations are two letters — "tm", "dv", "dt" — and two letters
+// mean something else elsewhere: "VA Trading" and "DT Robotics" are companies
+// whose first word this table would otherwise eat.
 func matchingFormOf(s string) (string, *marketForms) {
 	// The scripts with no word boundaries are answered first, by substring
 	// (orgnamecjk.go). Splitting them into words yields the whole name as one
 	// token, so every path below would find nothing to strip and nothing to
 	// compare.
 	if name, isCJK := cjkNameForMatching(s); isCJK {
-		return name, &cjkMarket
+		return name, nil
 	}
 	fields := strings.FieldsFunc(NormalizeOrgName(foldDStroke(s)), nameWordSeparators)
 	for i := range prefixMarkets {

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -6,59 +6,32 @@ package people
 // The precondition on the PO-F-2 fuzzy tier: two company names may only be
 // SCORED against each other when they share a distinctive word.
 //
-// WHY THIS EXISTS. `nameSimilarity` is Jaro-Winkler, a character metric with no
-// concept of a word. On person names that is right — people have no legal forms
-// and no industry vocabulary, so shared letters really are evidence. On company
-// names it is not: every company in a market ends in the same handful of nouns,
-// and a metric that cannot see a word boundary reads that shared vocabulary as
-// shared identity.
+// `nameSimilarity` is Jaro-Winkler, a character metric with no concept of a
+// word. That is right for person names and wrong for company names, where every
+// name in a market ends in the same handful of nouns: measured over one
+// workspace's 296 names, 180 pairs reached the review threshold and one was a
+// real duplicate. A genuine duplicate shares a whole word — "Arvato Systems"
+// contains "arvato" — while the noise shares only letters.
 //
-// MEASURED, on the 296 company names in one real workspace. Of 43,660 pairs,
-// 180 scored at or above the 0.72 review threshold. Exactly ONE was a genuine
-// duplicate ("Arvato" / "Arvato Systems"). The other 179 were pairs like
-// Stripe/Strix (0.89), ACY Capital/Soda Capital (0.82), Fenwick
-// Software/Centric Software (0.82), HPS/KPS (0.72). A 99.4% false-positive
-// rate, firing on every organization create.
-//
-// It was not theoretical. A CSV import of 107 contacts refused to create nine
-// companies, reporting "a company of this name is already in the CRM" when no
-// such company existed — the operator went looking through the UI for records
-// that were never there.
-//
-// THE RULE. A genuine duplicate shares a whole distinctive word; the noise
-// shares only letters. "Arvato Systems" contains "arvato"; "Strix" contains no
-// word of "Stripe". So the score is only consulted once a shared distinctive
-// word is found. The same 180 pairs reduce to 3.
-//
-// WHAT THIS DOES NOT CHANGE. Not `nameSimilarity`, which stays exactly the
-// pinned Jaro-Winkler (PO-PARAM-JW-1) and stays shared with person dedupe
-// (dedupe.go), lead dedupe (leaddedupe.go) and site-person matching
-// (sitepersonfields.go), where the character metric is the right one. Not tier
-// 1 (`exactOrgByDomain`), which returns before this tier is reached — a domain
-// is an exact key and needs no name evidence at all.
+// `nameSimilarity` itself is unchanged: it stays the pinned Jaro-Winkler
+// (PO-PARAM-JW-1) shared with person and lead dedupe, where the character metric
+// is the right one.
 
 import "strings"
 
 // orgNameStopwords are the words a company name shares with its whole market:
-// present in many names, evidence of identity in none.
+// present in many names, evidence of identity in none. They are REMOVED from a
+// name before comparison, so a word that could be a brand belongs in
+// orgCommonNameWords instead, which only discounts.
 //
-// A HAND-WRITTEN, VERSIONED LIST, and deliberately not one derived from the
-// workspace's own names at run time. A derived list would make the same two
-// names match in one workspace and not in another, drift as each workspace
-// grew, and put a second query inside `DedupeOrganizationForCreate`, which
-// holds the organization-name write lock while the ladder runs. Every other
-// dedupe parameter in this package is an auditable constant (dedupe.go), and
-// this one is read the same way.
+// Hand-written and versioned rather than derived from the workspace at run time:
+// a derived list would make the same two names match in one workspace and not in
+// another, and would put a query inside the transaction holding the
+// organization-name write lock.
 //
-// English and German, the markets whose names this list was measured against.
-// A NEW market needs its own generics added here — the list is a precision
-// policy, not a language model, and a market whose generics are missing simply
-// keeps today's false positives rather than gaining new ones.
-//
-// A market only belongs here if its generic words are generic AS WORDS. Where a
-// name is built by stacking a legal form and trade vocabulary in front of the
-// brand, the phrase is what is generic and the words are not, and it is removed
-// in position instead — see orgnameforms.go for the Vietnamese case.
+// English and German, the markets measured. A market that stacks a legal form
+// and trade vocabulary in FRONT of the brand belongs in orgformtables.go
+// instead — there the phrase is generic and its words are not.
 var orgNameStopwords = map[string]bool{
 	// Corporate form that survives NormalizeOrgName's legal-suffix strip.
 	"group": true, "holding": true, "holdings": true, "company": true,
@@ -96,14 +69,11 @@ var orgNameStopwords = map[string]bool{
 
 // orgNameArticles are the words that can never be the whole of a name.
 //
-// Every other stopword can: "Capital", "Health" and "Digital" are all real
-// businesses, so when a strip would empty a name the first word is restored and
-// the comparison proceeds. An article is different — "The Group" and "The
-// Holding" would both restore to "the" and meet on it, which is two companies
-// matching on an English article.
+// Every other stopword can — "Capital" and "Health" are real businesses — so an
+// emptied name restores its first word. An article must not be restored: "The
+// Group" and "The Holding" would both come back as "the".
 //
-// They are stopwords too, folded into orgNameStopwords by init below rather
-// than written out twice. One list, one place to add a language.
+// Stopwords too, folded in by init below rather than written out twice.
 var orgNameArticles = map[string]bool{
 	"the": true, "a": true, "an": true, "and": true, "of": true, "for": true,
 	"le": true, "la": true, "les": true, "der": true, "die": true, "das": true,
@@ -116,87 +86,47 @@ func init() {
 }
 
 // orgFuzzyTokenFloor is the shortest token a NEAR-identical (rather than equal)
-// match is trusted on.
+// match is trusted on. A 0.90 score on two three-letter tokens is one letter in
+// three, which is how "SORA" met "Suraksha"; on seven letters it is a spelling
+// variant. Equality is honoured at every length, so "3M" still matches itself.
 //
-// A 0.90 Jaro-Winkler score means something different at each length. On two
-// seven-letter tokens it is a spelling variant; on two three-letter tokens it is
-// one letter in three, which is how "SORA" met "Suraksha" in the corpus.
-// Equality is still honoured at every length — this floor bounds only the fuzzy
-// comparison, so "3M" and "HP" match themselves exactly while never matching a
-// neighbour.
-//
-// THREE, and the length was measured rather than guessed. German transliterates
-// an umlaut into a second vowel, which makes a short surname pair one rune
-// apart: "Bär" folds to "bar" (3) and "Baer" to "baer" (4); "Röhm" to "rohm"
-// and "Roehm" to "roehm"; likewise Götz/Goetz and Köhlm/Koehlm. A floor of five
-// refused every one of them, and those names are on companies.
-//
-// Three is safe because the SIMILARITY bar is what separates these, not the
-// length. Measured on every three-letter pair that must stay apart —
-// hps/kps 0.78, acy/ace 0.82, ibm/ibn 0.82, sora/sura 0.85 — against the
-// transliterations that must meet: bar/baer 0.93, rohm/roehm 0.95. The gap is
-// clean, and 0.90 sits inside it.
-//
-// Two is where it stops: a two-letter pair one letter apart has nothing left to
-// distinguish it, and equality already covers "3M" and "HP" matching themselves.
+// Three rather than five because German transliterates an umlaut into a second
+// vowel, and "Bär"/"Baer" and "Röhm"/"Roehm" are company names.
 const orgFuzzyTokenFloor = 3
 
-// orgGateTokenBudget bounds how many words this gate will compare on one side.
+// orgGateTokenBudget bounds how many words this gate compares on one side.
 //
-// The comparison is a nested loop, so the work is the PRODUCT of the two token
-// counts — and `display_name` is `text` with no maxLength in the contract, so
-// one create can hand it a megabyte. That would be a slow function anywhere
-// else; here it runs inside `DedupeOrganizationForCreate`, which holds the
-// workspace-wide organization-name write lock, so an unbounded name would pin
-// every organization-name writer in the workspace behind it.
-//
-// The same reasoning as nameScoringMaxRunes (namesim.go), which bounds the
-// length of one comparison. That bound does not help here: it caps each call
-// and this is about the NUMBER of calls.
-//
-// 32 words is far past any real company name — the longest in the measured
-// corpus was 6. Past the bound the gate compares the first 32 words of each
-// side, which for names this long is the same answer any comparison would give.
+// The comparison is a nested loop, so the work is the PRODUCT of the two counts,
+// and `display_name` is `text` with no maxLength in the contract. It runs inside
+// DedupeOrganizationForCreate, which holds the workspace-wide organization-name
+// write lock, so an unbounded name pins every other writer behind it. The same
+// reasoning as nameScoringMaxRunes (namesim.go), which bounds one comparison
+// rather than their number.
 const orgGateTokenBudget = 32
 
-// orgFuzzyTokenSimilarity is the bar a token PAIR must clear to count as the
-// same word.
-//
-// Set above the pair scores this is meant to reject and below the
-// transliterations it must keep: "Müller"/"Mueller" scores 0.93 and
-// "Straße"/"Strasse" 1.00 after the fold, both of which the DACH market
-// produces daily.
+// orgFuzzyTokenSimilarity is the bar a token PAIR clears to count as the same
+// word: above the pairs that must stay apart, below the transliterations the
+// DACH market produces daily ("Müller"/"Mueller" scores 0.93).
 const orgFuzzyTokenSimilarity = 0.90
 
-// orgFuzzyTokenLengthSlack is how much longer one word may be than the other
-// and still be called the same word.
+// orgFuzzyTokenLengthSlack is how much longer one word may be than the other and
+// still be the same word. ONE RUNE, which is what a transliteration costs.
 //
-// ONE RUNE, which is what a transliteration costs: "bar" becomes "baer", "rohm"
-// becomes "roehm", "gotz" becomes "goetz". Every one adds a single vowel.
-//
-// Without it, Jaro-Winkler's prefix boost makes a short word match any longer
-// word that starts with it — "base" against "baseplan" scores exactly 0.90, and
-// Base.com and Baseplan are two companies in one real workspace. A shared
-// prefix is not a spelling variant, and the similarity bar alone cannot tell
-// them apart.
+// Without it Jaro-Winkler's prefix boost makes a short word match any longer one
+// starting with it: "base" and "baseplan" score exactly 0.90, and they are two
+// companies. A shared prefix is not a spelling variant.
 const orgFuzzyTokenLengthSlack = 1
 
 // distinctiveOrgTokens are a name's words with the market's shared vocabulary
-// removed.
-//
-// LENGTH IS NOT A FILTER HERE, and an earlier version that dropped tokens under
-// three runes was wrong: it threw away "3M", whose two characters ARE the
-// company. A word is dropped for being generic, never for being short.
+// removed. A word is dropped for being generic, never for being short: a filter
+// on length threw away "3M", whose two characters ARE the company.
 func distinctiveOrgTokens(name string) []string {
 	fields := strings.FieldsFunc(orgNameForMatching(name), nameWordSeparators)
 	out := make([]string, 0, min(len(fields), orgGateTokenBudget))
 	for i, token := range fields {
-		// AN ARTICLE THAT WOULD LEAVE A ONE-WORD NAME IS NOT AN ARTICLE. English
-		// puts a real one beside other real words — "Bank of the West" keeps
-		// "bank" and "west" without it — so dropping it there costs nothing.
-		// A two-word name whose second word is "an" is a different thing: "Việt
-		// An", "Long An" and "Hòa An" are companies, and dropping the syllable
-		// left each of them a single word that matched half the market.
+		// An article that would leave a ONE-WORD name is not an article: "Việt
+		// An" and "Long An" are companies whose second syllable is the English
+		// word, and dropping it left each matching half the market.
 		if i > 0 && orgNameArticles[token] && len(fields) == 2 {
 			out = append(out, token)
 			continue
@@ -209,20 +139,11 @@ func distinctiveOrgTokens(name string) []string {
 		}
 		out = append(out, token)
 	}
-	// THE STRIP MUST NEVER REMOVE THE WHOLE NAME, the same rule
-	// NormalizeOrgName follows when a legal suffix IS the company. A name of
-	// nothing but generic words still has to be comparable to itself:
-	// "Capital" is a real business, "Capital.com" is how it writes itself, and
-	// a gate that empties both has nothing left to match them on.
+	// The strip must never remove the whole name: "Capital" is a real business
+	// and a gate that empties it has nothing left to match it on.
 	//
-	// The FIRST non-article word, not all of them. Keeping every word would
-	// readmit what this gate exists to remove — "Health Care" and "Medical
-	// Care" would meet on the shared "care", which is the market's vocabulary
-	// and not an identity. Keeping the head of the name is where a brand sits:
-	// "Capital" in "Capital.com", "Health" in "Health Care".
-	//
-	// An article is skipped rather than restored, because it can never be a
-	// name: restoring it made "The Group" and "The Holding" meet on "the".
+	// The FIRST non-article word, not all of them — keeping every word would
+	// readmit "Health Care" against "Medical Care" on the shared "care".
 	if len(out) == 0 {
 		for _, token := range fields {
 			if !orgNameArticles[token] {
@@ -233,18 +154,13 @@ func distinctiveOrgTokens(name string) []string {
 	return out
 }
 
-// sameOrgToken answers whether two words are the same word.
+// sameOrgToken answers whether two words are the same word: equal at any length,
+// or near-identical when both are long enough for that to mean a spelling
+// variant.
 //
-// Equal at any length, or near-identical when both are long enough for
-// near-identity to mean a spelling variant rather than a different word.
-//
-// A WORD IS NOT A PREFIX OF ANOTHER WORD. Jaro-Winkler boosts a shared start,
-// so a short word scores high against any longer word beginning with it —
-// "base" and "baseplan" reach exactly 0.90, and they are two companies. A
-// spelling variant changes the letters inside a word, not its length: "rohm"
-// and "roehm" differ by one rune, "bar" and "baer" by one. So the two words
-// must be within one rune of each other in length before their similarity is
-// consulted at all.
+// A WORD IS NOT A PREFIX OF ANOTHER WORD. Jaro-Winkler boosts a shared start, so
+// the length test comes first — a spelling variant changes the letters inside a
+// word, not its length.
 func sameOrgToken(a, b string) bool {
 	if a == b {
 		return true
@@ -259,83 +175,51 @@ func sameOrgToken(a, b string) bool {
 	return jaroWinkler(a, b) >= orgFuzzyTokenSimilarity
 }
 
-// squashedOrgName is the name with its word separators removed.
+// squashedOrgName is the name with its word separators removed, so that where a
+// writer put the space does not decide identity: "Health Care" and "Healthcare"
+// are one company, and so are "Digital Ocean" and "DigitalOcean".
 //
-// Two things need this, and both are the same difference: where the writer put
-// the space. "Health Care" and "Healthcare" are one company; so are "Digital
-// Ocean" and "DigitalOcean", "Media Markt" and "MediaMarkt". Compounding is how
-// brands are written half the time and it must not decide identity.
-//
-// It merges exactly that difference and nothing else. "Health Care" and
-// "Medical Care" stay apart, because removing spaces does not make different
-// words equal.
-//
-// The same separators the token split uses, so "E-Commerce" and "E Commerce"
-// take one path rather than two.
+// It merges that difference and nothing else — "Health Care" and "Medical Care"
+// stay apart, because removing spaces does not make different words equal.
 func squashedOrgName(name string) string {
 	return strings.Join(strings.FieldsFunc(orgNameForMatching(name), nameWordSeparators), "")
 }
 
 // sharesADistinctiveWord is the gate itself: may these two names be scored?
 //
-// Two ways to answer yes, and the second is not a fallback for the first.
-//
-// THE SQUASHED NAME is asked first, because compounding hides a shared word
-// rather than removing it: "DigitalOcean" is one token, so it shares no word
-// with "Digital Ocean" even though they are plainly one company. The same
-// comparison is also the whole answer for a name of nothing but market
-// vocabulary ("Health Care", "The Group"), which has no distinctive word for
-// the token pass to find.
-//
-// THE TOKEN PASS then asks whether the two names share a word that means
-// something — one that is not the vocabulary every company in the market uses.
+// The SQUASHED NAME is asked first, because compounding hides a shared word
+// rather than removing it — "DigitalOcean" is one token and shares no word with
+// "Digital Ocean". The TOKEN PASS then asks whether they share a word that means
+// something.
 func sharesADistinctiveWord(a, b string) bool {
-	// Where the writer put the space is not evidence of a different company.
-	//
 	// An EMPTY squashed name is not a match with another empty one: two names
-	// made entirely of punctuation have said nothing about being one company,
-	// the same way two blank legal names do in bestOrgNamePairing.
+	// made entirely of punctuation have said nothing about being one company.
 	if squashed := squashedOrgName(a); squashed != "" && squashed == squashedOrgName(b) {
 		return true
 	}
 	left, right := distinctiveOrgTokens(a), distinctiveOrgTokens(b)
 	_, leftMarket := matchingFormOf(a)
 	_, rightMarket := matchingFormOf(b)
-	// A name that reduced to NOTHING shares no word and stops here. Vietnamese
-	// names carry their legal form and trade vocabulary in front of the brand,
-	// so a name made only of those strips to empty (orgnameforms.go) — and two
-	// such names have said nothing about being one company, any more than two
-	// blank legal names have.
+	// A name that reduced to NOTHING shares no word and stops here: a Vietnamese
+	// name of only its legal form and trade vocabulary strips to empty
+	// (orgnameforms.go), and two such names have said nothing.
 	shared := sharedTokenCount(left, right)
 	if shared == 0 {
 		return false
 	}
-	// ONE SHARED WORD IS NOT ALWAYS ENOUGH, and how much it is worth depends on
-	// how much of the name it is.
+	// ONE SHARED WORD IS NOT ALWAYS ENOUGH, and this is asked only of a syllabic
+	// market. Vietnamese builds a brand from two or three syllables drawn from a
+	// small pool — measured over 30 brands, "nam" and "viet" appear in 6 each —
+	// so "Hòa Bình" and "Hòa Phát" share "hoa" and are two different companies.
+	// English brands are built from rare words, where one is nearly the whole of
+	// the evidence and demanding more loses "Amazon AWS" against "Amazon Web
+	// Services".
 	//
-	// In English a distinctive word is nearly the whole of the evidence:
-	// "Arvato" appears in "Arvato Systems" and the two are one company. In
-	// Vietnamese it is not, because a brand is built from two or three syllables
-	// drawn from a small common pool. Measured on the corpus in
-	// orgnameforms_test.go: across 30 distinct brands, "nam" and "viet" each
-	// appear in 6 of them and "hoa" and "minh" in 3. So "Hòa Bình" and "Hòa
-	// Phát" share the word "hoa" — and they are Vietnam's largest construction
-	// firm and its largest steelmaker.
+	// EITHER side declaring the market is enough: a company does not stop being
+	// Vietnamese when someone types its bare brand.
 	//
-	// ASKED ONLY OF A SYLLABIC MARKET, because only there is one shared word weak
-	// evidence. Vietnamese builds a brand from two or three syllables drawn from
-	// a small common pool, so "Hòa Bình" and "Hòa Phát" share "hoa" and are two
-	// different companies. English builds a brand from words that are themselves
-	// rare, so one is enough there, and demanding more loses real duplicates:
-	// "Amazon AWS" and "Amazon Web Services" share only "amazon" of two words.
-	//
-	// EITHER side declaring the market is enough. A company does not stop being
-	// Vietnamese when someone types its bare brand — "Tân Hiệp Phát" carries no
-	// legal form, and it still must not meet "Hòa Phát" on the shared syllable.
-	//
-	// Strictly more than half, not at least: at half the two names disagree
-	// about as much as they agree, and the disagreement is the part that names
-	// the company.
+	// Strictly more than half, because at half the two names disagree about as
+	// much as they agree.
 	if isSyllabicMarket(leftMarket) || isSyllabicMarket(rightMarket) {
 		return 2*shared > min(len(left), len(right))
 	}
@@ -358,36 +242,18 @@ func sharedTokenCount(left, right []string) int {
 	if len(longer) < len(shorter) {
 		shorter, longer = longer, shorter
 	}
-	// One word of the longer name answers for at most one word of the shorter.
-	// Without that, "Acme Acme" drew two matches from the single "acme" in
-	// "Acme Beta" and counted a repetition as a second piece of evidence.
-	// A name of nothing but common words is still a name, and must find itself.
-	// "Bank of Ireland" and "Bank of Ireland Group" are ordinary words end to
-	// end, so discounting all of them would leave the company matching nothing.
-	//
-	// The escape asks that the shorter name appear whole in the longer AND that
-	// what the longer adds be a word that names something. "Sun" and "Sun
-	// Microsystems" pass: the addition is a brand, so this is one company said
-	// twice. "Bank" and "Bank of the West" do not: the addition is "west", and
-	// two names built entirely from words every company shares have not said
-	// they are one company — a company called Bank must not meet every bank in
-	// the estate.
+	// A name of nothing but common words must still find itself: "Bank of
+	// Ireland" is ordinary words end to end, and discounting all of them would
+	// leave the company matching nothing. See agreeEntirely for what it takes.
 	if agreeEntirely(shorter, longer) {
 		return len(shorter)
 	}
+	// One word of the longer name answers for at most one word of the shorter,
+	// so a name that repeats a word does not accumulate evidence from it.
 	taken := make([]bool, len(longer))
 	shared := 0
 	for _, x := range shorter {
-		// A word that many companies share is not evidence that two of them are
-		// one company. Two kinds qualify: another market's legal form ("SIA Rimi
-		// Latvia" and "SIA Maxima Latvija" are two Latvian grocers, "AS Roma"
-		// and "AS Monaco" two football clubs), and the ordinary words that
-		// recur across unrelated names in a market ("Bank of the West" against
-		// "Bank of the East", "Union Pacific" against "Union Carbide").
-		//
-		// Discounted HERE rather than removed from the name, so the word still
-		// reaches the score. The case where such a word IS the evidence is
-		// answered above, before this loop runs.
+		// Discounted rather than removed, so the word still reaches the score.
 		if weakEvidenceWord(x) {
 			continue
 		}

--- a/backend/internal/modules/people/orgnamegate.go
+++ b/backend/internal/modules/people/orgnamegate.go
@@ -13,9 +13,8 @@ package people
 // real duplicate. A genuine duplicate shares a whole word — "Arvato Systems"
 // contains "arvato" — while the noise shares only letters.
 //
-// `nameSimilarity` itself is unchanged: it stays the pinned Jaro-Winkler
-// (PO-PARAM-JW-1) shared with person and lead dedupe, where the character metric
-// is the right one.
+// This gate never touches `nameSimilarity`, which is pinned by PO-PARAM-JW-1 and
+// shared with person and lead dedupe, where the character metric is right.
 
 import "strings"
 
@@ -105,8 +104,8 @@ const orgFuzzyTokenFloor = 3
 const orgGateTokenBudget = 32
 
 // orgFuzzyTokenSimilarity is the bar a token PAIR clears to count as the same
-// word: above the pairs that must stay apart, below the transliterations the
-// DACH market produces daily ("Müller"/"Mueller" scores 0.93).
+// word. It sits in a measured gap: the pairs that must stay apart score 0.78 to
+// 0.85, the transliterations the DACH market produces daily score 0.93 and up.
 const orgFuzzyTokenSimilarity = 0.90
 
 // orgFuzzyTokenLengthSlack is how much longer one word may be than the other and
@@ -217,9 +216,6 @@ func sharesADistinctiveWord(a, b string) bool {
 	//
 	// EITHER side declaring the market is enough: a company does not stop being
 	// Vietnamese when someone types its bare brand.
-	//
-	// Strictly more than half, because at half the two names disagree about as
-	// much as they agree.
 	if isSyllabicMarket(leftMarket) || isSyllabicMarket(rightMarket) {
 		return 2*shared > min(len(left), len(right))
 	}


### PR DESCRIPTION
Comments were **51% of these six files** and 67% of `orgnamegate.go`. Five changes landed in sequence, each explaining itself in full, so the same measurement is retold in a production comment and again in the test that proves it — the Amazon/AWS case, the CJK scores, the list of companies a position-only rule would damage.

| | Before | After |
|---|---|---|
| Source lines | 1,772 | 1,446 |
| Comment lines | 936 (52%) | 612 (42%) |
| `orgnamegate.go` | 67% comment | 50% |

## What stays and what goes

**Stays** — the reasons a reader cannot derive from the code: why the matching normalization must not touch the stored grouping key, why NFKC rather than NFD for CJK, why the work under the organization-name write lock is bounded, why the trigram arms name the column bare, and the measured intervals behind each constant.

**Goes** — the narrative around them and the case lists the tests already carry. The CSV-import incident is history and git has it; the 99.4% false-positive rate was decoration on a ratio already stated.

## Two defects fixed on the way

- `cjkMarket` existed only to be returned as a pointer nobody read.
- A comment in `orgnamecjk.go` still described the routing rule that was **replaced during review**: it claimed any name in these scripts is claimed by that path, while the code requires one of its legal forms — which is what makes `CÔNG TY TNHH 東京 Việt` keep its Vietnamese handling.

## Behaviour is unchanged, and checked rather than assumed

28 scored pairs and 10 normalizations across every market produce **byte-identical output** before and after. Re-verified after the review round.

## Review round

A craft review found the diet had cut too close in four places, fixed in the second commit: a table comment shortened into a false account of which mechanism covers which case, two constants left looking arbitrary (`cjkMinimumBrandRunes` no longer said why one and not two; `orgFuzzyTokenSimilarity` gave the ceiling of its interval but not the floor), and one doc comment reduced to saying *what* rather than *why*. It also found three places still duplicating a test, now cut.

`make check-backend` green, `make craft-static` clean across all four trees, people integration lane green under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims the comments in the org-name matching files — comments were 51% of six files and 67% of `orgnamegate.go`, now 42% and 50% — keeping the reasoning the code can't show and cutting the narrative and case lists the tests already carry.

- Fixes two defects on the way: drops `cjkMarket`, a pointer nobody read, and corrects a comment in `orgnamecjk.go` that still described the old routing rule — the code requires one of the legal forms, not any CJK script character, which is what keeps `CÔNG TY TNHH 東京 Việt` on the Vietnamese path.
- Behavior is unchanged and re-verified: 28 scored pairs and 10 normalizations produce byte-identical output.

<sup>Written for commit 6a4133f945d7933a0a66ac4b903cc8a46ef9729a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified organization-name matching behavior, including accent handling, legal-form recognition, CJK naming, stopwords, and market-specific rules.
  * Documented how shared company-name words, country terms, weak evidence, and deduplication affect matching.
  * Removed outdated references and an unused market declaration.
* **Refactor**
  * No executable logic or end-user behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->