### PR TITLE
fix(capture): an account's last touch counts the mail its contacts got

### DIFF
--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -334,3 +334,86 @@ func seedLeadInStatus(t *testing.T, owner *pgx.Conn, status string) ids.UUID {
 	}
 	return id
 }
+
+// recentlyWorked is INSIDE the cutoff: a touch at this instant means somebody
+// is working the relationship right now.
+var recentlyWorked = eligibilityScanNow.AddDate(0, 0, -1)
+
+// seedTouchAt is seedQuietTouch with the instant named, so a suite can put one
+// touch either side of the cutoff and assert which one decided the outcome.
+func seedTouchAt(t *testing.T, owner *pgx.Conn, at time.Time) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'email', 'Genuine engagement', $2, 'manual', 'human:x')`,
+		id, at); err != nil {
+		t.Fatalf("seeding a touch at %s: %v", at, err)
+	}
+	return id
+}
+
+// An account is reached by mail filed against its CONTACT, which is how
+// capture files it — the message names the person it was with, never the
+// company. Counting only the account's own links, this account looks untouched
+// since the old direct mail and earns a reminder about a relationship a rep
+// worked yesterday.
+func TestAnAccountWorkedThroughItsContactIsNotRemindedAbout(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open, _ := DealFixture(t, e)
+
+	org := e.SeedOrg(t, "Worked Through Its People", nil)
+	deal := e.SeedDeal(t, "Renewal", pipeline, open, nil)
+	attachDealToOrg(t, owner, deal, org)
+	backdateCreatedAt(t, owner, "organization", org, longEstablished)
+	backdateCreatedAt(t, owner, "deal", deal, longEstablished)
+
+	// The account's own last direct mail is old.
+	linkTouch(t, owner, e.WS, seedTouchAt(t, owner, quietSince), "organization", org)
+
+	// Yesterday a rep mailed the contact. Capture files that against the
+	// PERSON, so it carries no organization link of its own.
+	contact := e.SeedPerson(t, "Ingrid Sattler", nil)
+	seedEmployment(t, owner, contact, org)
+	linkTouch(t, owner, e.WS, seedTouchAt(t, owner, recentlyWorked), "person", contact)
+
+	seedNoActivityReminder(t, owner, e.WS)
+	runEligibilityScan(t, e)
+
+	if got := taskCountOn(t, e, "organization", org); got != 0 {
+		t.Fatalf("reminder tasks on an account mailed through its contact yesterday = %d, want 0 — "+
+			"the account is being worked, and the mail reaches it through the person it was with", got)
+	}
+}
+
+// The mirror case, and the reason this is not just a false-positive fix: an
+// account whose correspondence NEVER carried a direct link was not merely
+// mis-dated, it was invisible. Counting only its own links it has no last
+// touch at all, so it never entered the draw and could never be reminded about
+// however long it went quiet.
+func TestAnAccountWhoseOnlyMailIsItsContactsIsStillDrawnWhenItGoesQuiet(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open, _ := DealFixture(t, e)
+
+	org := e.SeedOrg(t, "Quiet Through Its People", nil)
+	deal := e.SeedDeal(t, "Renewal", pipeline, open, nil)
+	attachDealToOrg(t, owner, deal, org)
+	backdateCreatedAt(t, owner, "organization", org, longEstablished)
+	backdateCreatedAt(t, owner, "deal", deal, longEstablished)
+
+	// Every message this account ever had is filed against its contact, and
+	// the last of them is long past the cutoff. No direct link, ever.
+	contact := e.SeedPerson(t, "Ingrid Sattler", nil)
+	seedEmployment(t, owner, contact, org)
+	linkTouch(t, owner, e.WS, seedTouchAt(t, owner, quietSince), "person", contact)
+
+	seedNoActivityReminder(t, owner, e.WS)
+	runEligibilityScan(t, e)
+
+	if got := taskCountOn(t, e, "organization", org); got != 1 {
+		t.Fatalf("reminder tasks on a quiet account reached only through its contact = %d, want 1 — "+
+			"an account with no direct link is still an account somebody stopped talking to", got)
+	}
+}

--- a/backend/internal/modules/activities/lasttouch.go
+++ b/backend/internal/modules/activities/lasttouch.go
@@ -49,6 +49,78 @@ type LastTouchCandidate struct {
 	LastTouch  time.Time
 }
 
+// lastTouchCandidateQuery is LastTouchBefore's read: every linked entity's most
+// recent genuine engagement, narrowed to the ones carrying live work. It is a
+// function rather than a constant because two of its fragments are built —
+// the link-id coalesce, and the organization walk — and it sits apart from the
+// scan so the scan reads as what it does with the rows.
+//
+// $1 is the source the automation engine stamps, $2 the cutoff, $3 the cap.
+func lastTouchCandidateQuery() string {
+	return storekit.SQLf(`
+			WITH genuine AS (
+				SELECT a.id, a.occurred_at
+				FROM activity a
+				WHERE a.archived_at IS NULL
+				  AND a.source <> $1
+			), direct AS (
+				SELECT al.entity_type AS entity_type,
+				       %[1]s AS entity_id,
+				       max(g.occurred_at) AS last_touch
+				FROM activity_link al
+				JOIN genuine g ON g.id = al.activity_id
+				WHERE al.entity_type <> '%[3]s'
+				GROUP BY al.entity_type, %[1]s
+			), accounts AS (
+				SELECT '%[3]s' AS entity_type,
+				       reach.organization_id AS entity_id,
+				       max(g.occurred_at) AS last_touch
+				FROM (%[6]s) reach
+				JOIN genuine g ON g.id = reach.activity_id
+				GROUP BY reach.organization_id
+			), quiet AS (
+				SELECT entity_type, entity_id, last_touch FROM direct
+				UNION ALL
+				SELECT entity_type, entity_id, last_touch FROM accounts
+			)
+			SELECT q.entity_type, q.entity_id, q.last_touch
+			FROM quiet q
+			WHERE q.last_touch < $2
+			  AND ((q.entity_type = '%[2]s' AND EXISTS (
+			         SELECT 1 FROM deal d
+			         WHERE d.id = q.entity_id
+			           AND d.status = 'open' AND d.archived_at IS NULL
+			           AND d.created_at < $2))
+			   OR (q.entity_type = '%[3]s' AND EXISTS (
+			         SELECT 1 FROM organization o
+			         JOIN deal d ON d.organization_id = o.id
+			                    AND d.status = 'open' AND d.archived_at IS NULL
+			         WHERE o.id = q.entity_id
+			           AND o.archived_at IS NULL
+			           AND o.created_at < $2))
+			   OR (q.entity_type = '%[4]s' AND EXISTS (
+			         SELECT 1 FROM person p
+			         JOIN relationship r ON r.person_id = p.id
+			                    AND r.kind = 'deal_stakeholder'
+			                    AND r.ended_at IS NULL AND r.archived_at IS NULL
+			         JOIN deal d ON d.id = r.deal_id
+			                    AND d.status = 'open' AND d.archived_at IS NULL
+			         WHERE p.id = q.entity_id
+			           AND p.archived_at IS NULL
+			           AND p.created_at < $2))
+			   OR (q.entity_type = '%[5]s' AND EXISTS (
+			         SELECT 1 FROM lead l
+			         WHERE l.id = q.entity_id
+			           AND l.status IN ('new','contacted','engaged') AND l.archived_at IS NULL
+			           AND l.created_at < $2)))
+			ORDER BY q.last_touch, q.entity_id
+			LIMIT $3`,
+		linkIDCoalesceQualified("al"),
+		datasource.RecordDeal, datasource.RecordOrganization,
+		datasource.RecordPerson, datasource.RecordLead,
+		OrgReachSet())
+}
+
 // LastTouchBefore returns the entities that are BOTH quiet and worth
 // reminding about: linked through activity_link, most recent
 // GENUINE-engagement activity.occurred_at before cutoff, and carrying
@@ -81,6 +153,22 @@ type LastTouchCandidate struct {
 //   - organization — it has at least one open, unarchived deal. The
 //     account is what the rep works, so the reminder belongs on the
 //     account, once.
+//
+// An account's last touch is read through the three-arm walk (OrgReachSet)
+// rather than off its own links, and that is the difference between this
+// trigger working and not. Capture files mail against the PERSON it was with,
+// so on a real workspace an account's correspondence carries no direct
+// organization link at all: counting only direct links, an account whose reps
+// mailed a contact yesterday looked untouched and earned a reminder about a
+// relationship somebody is actively working, while an account that never got a
+// direct link was never drawn at all. The other three types keep their own
+// links, because each is the thing the activity names.
+//
+// It widens the draw in both directions and that is the point: accounts
+// previously invisible become candidates, and accounts previously drawn while
+// being worked stop being. Eligibility is unchanged — an account still needs an
+// open unarchived deal — so the batch is spent on accounts somebody is working
+// rather than on ones nobody is.
 //   - person — they hold a live deal_stakeholder seat on an open deal.
 //     Deliberately NOT "their employer has an open deal": that would mint
 //     one reminder per employee of every busy account, each one a
@@ -110,53 +198,7 @@ func (s *Store) LastTouchBefore(ctx context.Context, cutoff time.Time, limit int
 		// vocabulary (linktarget.go), the same source the coalesce
 		// expression is built from, so a renamed record type cannot leave a
 		// stale string behind in this query.
-		rows, err := tx.Query(ctx, storekit.SQLf(`
-			WITH quiet AS (
-				SELECT al.entity_type AS entity_type,
-				       %[1]s AS entity_id,
-				       max(a.occurred_at) AS last_touch
-				FROM activity_link al
-				JOIN activity a ON a.id = al.activity_id
-				WHERE a.archived_at IS NULL
-				  AND a.source <> $1
-				GROUP BY al.entity_type, %[1]s
-				HAVING max(a.occurred_at) < $2
-			)
-			SELECT q.entity_type, q.entity_id, q.last_touch
-			FROM quiet q
-			WHERE (q.entity_type = '%[2]s' AND EXISTS (
-			         SELECT 1 FROM deal d
-			         WHERE d.id = q.entity_id
-			           AND d.status = 'open' AND d.archived_at IS NULL
-			           AND d.created_at < $2))
-			   OR (q.entity_type = '%[3]s' AND EXISTS (
-			         SELECT 1 FROM organization o
-			         JOIN deal d ON d.organization_id = o.id
-			                    AND d.status = 'open' AND d.archived_at IS NULL
-			         WHERE o.id = q.entity_id
-			           AND o.archived_at IS NULL
-			           AND o.created_at < $2))
-			   OR (q.entity_type = '%[4]s' AND EXISTS (
-			         SELECT 1 FROM person p
-			         JOIN relationship r ON r.person_id = p.id
-			                    AND r.kind = 'deal_stakeholder'
-			                    AND r.ended_at IS NULL AND r.archived_at IS NULL
-			         JOIN deal d ON d.id = r.deal_id
-			                    AND d.status = 'open' AND d.archived_at IS NULL
-			         WHERE p.id = q.entity_id
-			           AND p.archived_at IS NULL
-			           AND p.created_at < $2))
-			   OR (q.entity_type = '%[5]s' AND EXISTS (
-			         SELECT 1 FROM lead l
-			         WHERE l.id = q.entity_id
-			           AND l.status IN ('new','contacted','engaged') AND l.archived_at IS NULL
-			           AND l.created_at < $2))
-			ORDER BY q.last_touch, q.entity_id
-			LIMIT $3`,
-			linkIDCoalesceQualified("al"),
-			datasource.RecordDeal, datasource.RecordOrganization,
-			datasource.RecordPerson, datasource.RecordLead),
-			automationSource, cutoff, limit)
+		rows, err := tx.Query(ctx, lastTouchCandidateQuery(), automationSource, cutoff, limit)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`LastTouchBefore` grouped `activity_link` by entity type and entity id, so an organization candidate's last touch counted only activities linked **directly** to the account. Capture files mail against the PERSON it was with, so on a real workspace an account's correspondence carries no organization link at all — and the trigger read two things wrong at once:

- an account whose reps mailed a contact **yesterday** looked untouched, and `no_activity_reminder` fired on a relationship somebody is actively working;
- an account that never got a direct link had no last touch to be quiet *since*, so it never entered the draw and could not be reminded about however long it went silent.

The organization arm now reads through `OrgReachSet` — the same three-arm walk the timeline, the hierarchy roll-up and the signal producers already use: the activity's own link, its deal's account, and the employer of the contact it is about. The other three types keep their own links, because each is the thing the activity names.

## Volume, which is why this was deferred rather than folded into the signal fix

Eligibility is untouched — an account still needs an open, unarchived deal — so the 200-candidate batch is not widened by records nobody is working. What changes is *which* accounts fill it, in both directions: previously invisible accounts can be drawn, and accounts being worked through their people stop being. That is the correction, not a side effect of it.

## Both directions have a case

Both fail against the old arm:

```
--- FAIL: TestAnAccountWorkedThroughItsContactIsNotRemindedAbout
--- FAIL: TestAnAccountWhoseOnlyMailIsItsContactsIsStillDrawnWhenItGoesQuiet
```

The six existing eligibility cases still pass unchanged.

The read moved into a named `lastTouchCandidateQuery()` on the way past the function-length gate, which also gives the SQL a name — the scan now reads as what it does with the rows.

`make check-backend` green.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved activity tracking when determining whether an organization needs a reminder.
  - Recent activity through related contacts or deals now correctly prevents unnecessary reminders.
  - Organizations with only outdated related activity can still receive reminders when appropriate.
- **Tests**
  - Added coverage for reminder eligibility based on recent and stale related activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->