### PR TITLE
docs(explanation): A4 says plainly what it does

### DIFF
--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -261,11 +261,13 @@ Legally this is the cleanest item on the page. All of it describes the company, 
 
 **A4. First-party person capture.** Built.[^44]
 
-The contact sent you the details. Margince's capture works from that fact. Connected mailboxes are processed automatically. A nightly pass extracts only stated fields from email signatures: name, title and phone number, with nothing inferred. Workspace exclusion lists keep entire addresses and domains outside capture.
+When a contact sends you their details, Margince uses them. An email arrives with a signature: we read name, title and phone number out of it and enrich the person's record automatically. Someone sends a vCard: we import it into the record the same way. Only what the contact actually wrote, nothing guessed, nothing inferred.
 
-vCard import and a per-mailbox switch for the signature pass complete the channel, so an organisation can turn the granularity all the way down.
+The legal basis could not be simpler: the contact sent this data to you themselves.
 
-First-party collection is the only person-data channel that scales cleanly.[^39]
+Two controls sit on top. Exclusion lists keep chosen addresses and whole domains out of capture entirely, and every mailbox has its own switch for the signature pass, so an organisation can turn the granularity all the way down.
+
+Data the contact hands you is the only person-data channel that scales cleanly.[^39]
 
 **A5. LinkedIn as a link, plus the member's own export.** We store the LinkedIn profile URL as a clickable link. Margince never fetches the page server-side.
 


### PR DESCRIPTION
Author feedback: A4 talked around the feature. It now says it straight: an email arrives with a signature, we read name/title/phone out of it and enrich the record automatically; a vCard imports the same way; only what the contact wrote, nothing inferred; exclusion lists and the per-mailbox switch as the two controls. Same facts, human words. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the A4 section in `docs/explanation/data-enrichment-position.md` so it states plainly what the feature does: Margince reads name, title, and phone number from email signatures and imports vCards to enrich contact records automatically, with nothing inferred.

- Removes vague framing and states the legal basis directly: the contact sent the data themselves.
- Keeps the two controls—exclusion lists and the per-mailbox switch for signature capture—and moves them to their own paragraph.
- Makes the closing claim about first-party collection the only person-data channel that scales cleanly.

<sup>Written for commit 5e35a3ddbe57c927487c39c8f0a312df46ed941e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that person details can be extracted from email signatures and vCard imports.
  * Documented mailbox-level signature controls and exclusions for specific addresses or domains.
  * Reaffirmed that only contact-stated information is captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->