### PR TITLE
fix(overlay): the webhook's halt cache keeps the yes and re-reads the no

### DIFF
--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -169,9 +169,17 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 // webhookCaches are the lookup caches the events of ONE delivery share: portal
-// bindings resolved once per portal, and the mirror-halt flag read once per
-// workspace (a mid-batch collision flips it so the rest of the batch is skipped
-// without re-querying).
+// bindings resolved once per portal, and the workspaces this delivery has seen
+// halted.
+//
+// halted records only the YES. A halt is global state and HubSpot delivers
+// batches concurrently, so a negative cached for the length of a batch is a
+// promise this request cannot keep: another delivery classifying a collision
+// halts the mirror in the database, and the events still to come in THIS batch
+// would read their own stale "not halted" and re-fetch into a mirror whose
+// state is no longer trusted — the fail-safe the halt exists to be. A yes is
+// safe to keep, because nothing but a disconnect clears it, so a mid-batch
+// collision still skips the rest of the batch without re-querying.
 type webhookCaches struct {
 	portals map[string]portalResolution
 	halted  map[string]bool
@@ -257,15 +265,17 @@ func (h *hubspotWebhookHandler) mirrorHalted(ctx context.Context, caches webhook
 	if h.halted == nil {
 		return false, nil
 	}
-	if halted, cached := caches.halted[ws.String()]; cached {
-		return halted, nil
+	if caches.halted[ws.String()] {
+		return true, nil
 	}
 	halted, err := h.halted(ctx)
 	if err != nil {
 		h.log.ErrorContext(ctx, "overlay webhook: reading the mirror-halt flag", "err", err)
 		return false, err
 	}
-	caches.halted[ws.String()] = halted
+	if halted {
+		caches.halted[ws.String()] = true
+	}
 	return halted, nil
 }
 

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -437,3 +437,63 @@ func TestWithOverlayWebhookAbsentWithoutSecretOrInserter(t *testing.T) {
 		t.Error("a nil inserter must leave the webhook route unmounted")
 	}
 }
+
+// A halt is global state and HubSpot delivers batches CONCURRENTLY, so a
+// "not halted" answer is only true of the instant it was read. Caching it for
+// the length of a batch let a rival delivery halt the mirror mid-batch while
+// this one carried on re-fetching into it on its own stale negative — which is
+// exactly the fail-safe the halt exists to be.
+//
+// The rival is stood in for by a checker that answers false once and true
+// afterwards: nothing in THIS batch halts anything, so a cached negative would
+// enqueue both events.
+func TestWebhookReceiverRereadsTheHaltFlagAfterANegative(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	reads := 0
+	h.halted = func(context.Context) (bool, error) {
+		reads++
+		return reads > 1, nil // another delivery halts the mirror between the two events
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t,
+		`[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange","propertyName":"firstname","propertyValue":"Ada"},`+
+			`{"portalId":777,"objectId":43,"subscriptionType":"contact.propertyChange","propertyName":"lastname","propertyValue":"Lovelace"}]`))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if reads != 2 {
+		t.Fatalf("the halt flag was read %d time(s), want one per event — a negative answer is not the batch's to keep", reads)
+	}
+	if len(enq.jobs) != 1 {
+		t.Fatalf("re-fetches enqueued = %d, want 1 — the second event arrives after the mirror was halted elsewhere", len(enq.jobs))
+	}
+}
+
+// The yes, however, IS the batch's to keep: nothing but a disconnect clears a
+// halt, so once this delivery has seen one the rest of its events are skipped
+// without asking again.
+func TestWebhookReceiverKeepsAConfirmedHaltForTheRestOfTheBatch(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	reads := 0
+	h.halted = func(context.Context) (bool, error) {
+		reads++
+		return true, nil
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t,
+		`[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange","propertyName":"firstname","propertyValue":"Ada"},`+
+			`{"portalId":777,"objectId":43,"subscriptionType":"contact.propertyChange","propertyName":"lastname","propertyValue":"Lovelace"}]`))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if reads != 1 {
+		t.Fatalf("the halt flag was read %d time(s), want 1 — a confirmed halt is not re-queried per event", reads)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a halted mirror must ingest nothing, got %d jobs", len(enq.jobs))
+	}
+}


### PR DESCRIPTION
`hubspotWebhookHandler` cached the mirror-halt flag per workspace **per request**, storing both answers. A halt is *global* state and HubSpot delivers batches concurrently, so a cached negative is a promise one request cannot keep:

1. delivery A reads the flag, gets `false`, caches it;
2. delivery B classifies an event as a collision, which halts the mirror in the database;
3. a later event in **A's** batch consults A's own cache, still reads `false`, and reaches `enqueueRefetch` — re-fetching into a halted mirror.

That is exactly what the OVA-AC-3 fail-safe exists to prevent: the halt means the write ledger saw a value-hash collision and the mirror's state is no longer trusted. Bounded by one batch's remaining events, but reachable in ordinary operation rather than only under synthetic load.

**Option 1 from the issue**, which is the smallest change that closes it: the cache now records only the confirmed halt. A negative is re-read per event — one workspace-scoped query on the healthy path — and a yes stays sticky for the rest of the batch, because nothing but a disconnect clears one. So the mid-batch collision the cache was written for still skips the rest of the batch without re-querying.

Both halves have a case, and the re-read one fails against the old cache — a checker that answers `false` once and `true` afterwards (a rival delivery halting the mirror between two events) was asked once and enqueued both:

```
--- FAIL: TestWebhookReceiverRereadsTheHaltFlagAfterANegative
    the halt flag was read 1 time(s), want one per event
```

`make check-backend` green.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook processing when a workspace is halted during batch delivery.
  * Newly detected halts now prevent subsequent events from being queued.
  * Confirmed halted states remain respected throughout the current delivery batch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->