### PR TITLE
fix(e2e-llm): seed through the first-login hold on a fresh checkout

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -441,7 +441,11 @@ jobs:
           name: e2e-llm-transcripts
           path: e2e/llm/records/
           retention-days: 30
-          if-no-files-found: warn
+          # ERROR, not warn. An empty records/ means the lane never drove a
+          # scenario, and the first CI run passed this step while uploading
+          # nothing — a green step on top of a job that had already failed 30
+          # seconds in. The absence of transcripts is itself the finding.
+          if-no-files-found: error
 
   # The suite's verdict must not depend on the calendar.
   #

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -24,6 +24,29 @@ API_BASE="${API_BASE:-$(dev_app_base_url)}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
 
+# The BOOTSTRAP password, which is not the one anybody signs in with.
+#
+# `make dev` writes config/margince-admin-password and leaves it alone, so a
+# checkout where `make seed-dev` has already run holds demo-password-123 there
+# and a plain login works. A FRESH checkout does not: dev.sh writes
+# `operator-supplied-first-password` and the admin is on the first-login hold,
+# so signing in with the documented password fails outright.
+#
+# That is exactly what happened the first time this lane ran on GitHub — "could
+# not sign in as admin@demo.test", 30 seconds in, having driven no scenario.
+# Locally it had never been seen, because every local checkout had been seeded
+# by hand at some point.
+#
+# Read the FILE rather than keeping a copy of the default in step with dev.sh,
+# which is what scripts/seed-dev.sh does and for the same reason. A lane that
+# keeps the file elsewhere passes BOOTSTRAP_PASSWORD; the literal is the last
+# resort for a stack booted by hand.
+BOOTSTRAP_PASSWORD_FILE="${BOOTSTRAP_PASSWORD_FILE:-config/margince-admin-password}"
+if [ -z "${BOOTSTRAP_PASSWORD:-}" ] && [ -r "$BOOTSTRAP_PASSWORD_FILE" ]; then
+  BOOTSTRAP_PASSWORD="$(cat "$BOOTSTRAP_PASSWORD_FILE")"
+fi
+BOOTSTRAP_PASSWORD="${BOOTSTRAP_PASSWORD:-operator-supplied-first-password}"
+
 COOKIES="$(mktemp)"
 trap 'rm -f "$COOKIES"' EXIT
 
@@ -133,8 +156,26 @@ login_as() {
 # backend/tools/seed-demo/apiclient.go does, and for the same reason.
 DETOUR_PASSWORD="${DETOUR_PASSWORD:-demo-password-123-first-change}"
 
-login_as "$ADMIN_PASSWORD" || {
-  echo "could not sign in as $ADMIN_EMAIL" >&2; exit 1; }
+# Sign in with the chosen password, or fall back to the bootstrap one and
+# replace it. Both paths end with the admin owning ADMIN_PASSWORD.
+if ! login_as "$ADMIN_PASSWORD"; then
+  if ! login_as "$BOOTSTRAP_PASSWORD"; then
+    echo "could not sign in as $ADMIN_EMAIL with either the chosen password or" >&2
+    echo "the bootstrap one ($BOOTSTRAP_PASSWORD_FILE). The api bootstraps the demo" >&2
+    echo "organization at boot from config/margince.yaml; if those credentials" >&2
+    echo "changed, reset the dev database and restart the stack." >&2
+    exit 1
+  fi
+  echo "  signed in with the operator-supplied password; replacing it"
+  first_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
+    "$BOOTSTRAP_PASSWORD" "$ADMIN_PASSWORD")"
+  if [ "$(status_of POST /auth/change-password "$first_body")" != "204" ]; then
+    echo "could not replace the operator-supplied password" >&2; exit 1
+  fi
+  login_as "$ADMIN_PASSWORD" || {
+    echo "could not sign in with the newly chosen password" >&2; exit 1; }
+  echo "  $ADMIN_EMAIL now owns its own password"
+fi
 
 # A write the admin is always allowed to attempt. 403 here means the hold, not
 # a permission problem — this account is an admin.


### PR DESCRIPTION
## What happened

The weekly lane ran on GitHub for the first time (dispatch of #2872) and **failed 30 seconds in**, having driven no scenario:

```
==> booting the ci stack (never :8080)
==> app at http://localhost:8081
could not sign in as admin@demo.test
```

Filed automatically as #2891, correctly as **"the weekly model-driven use cases could not run"** rather than as a use case failing. That split is what made this five minutes of diagnosis instead of an afternoon reading transcripts for a defect that was not there.

## Why it only failed in CI

`make dev` writes `config/margince-admin-password` **once and then leaves it alone**. Every local checkout had been through `make seed-dev` at some point, so that file held `demo-password-123` and a plain login worked.

A fresh checkout has no such file. `dev.sh` writes `operator-supplied-first-password`, the admin sits on the first-login hold, and signing in with the documented password fails outright.

CI is the only place that is ever true. This could not have surfaced locally without deliberately reproducing it.

## The fix

Read the password **file** and fall back to the bootstrap value, replacing it on the way — the same three steps `scripts/seed-dev.sh` already takes, and its comment gives the reason directly: follow whatever the installation was actually bootstrapped with rather than keeping a copy of the default in step with `dev.sh`.

The seed already handled the *other* half of this: the detour rotation for when the bootstrap password is already `demo-password-123`. What it did not handle was that password being a different string entirely.

## Verification

Reproduced CI's condition locally by moving `config/margince-admin-password` aside and booting `dev-fresh`, which then writes the operator password exactly as a fresh runner does. The boot log confirms it: `login admin@demo.test / operator-supplied-first-password (bootstrap admin — cold start, no other data)`.

- **Before the fix:** the same `could not sign in as admin@demo.test`.
- **After:** seeds clean, and the admin ends up owning `demo-password-123` as the README documents.
- All seven fixtures land, including the September email and the "im Oktober" note case 6 rests on. (The workspace also holds `Demo GmbH` and three demo people — the api's own bootstrap data written at boot, not leftovers.)

## Also in here

The transcript upload moves from `if-no-files-found: warn` to **`error`**.

The first CI run uploaded **nothing** and reported that step **green**, sitting on top of a job that had already failed. An empty `records/` means no scenario was ever driven, and that absence is itself a finding — it must not pass quietly.

## What this does not fix

Nothing about the model. The lane has still never completed a sweep on a GitHub runner, so the CI-side answer to "can an assistant drive this surface" remains unknown. This gets it past the door.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the e2e LLM CI lane so it can sign in on a fresh checkout, where the admin is on the first-login hold and the documented password fails.

**Seed script**
- Reads the bootstrap password from `config/margince-admin-password` and falls back to `operator-supplied-first-password`.
- Signs in with the bootstrap password, replaces it, and confirms the documented password works.

**Workflow**
- Transcript upload now fails when no files are found instead of warning, since an empty `records/` means no scenario ran.

<sup>Written for commit b076b8efb5be6beee897a4681283a3b8619e0f58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled transcript artifact uploads now fail when no transcript records are produced, making missing output visible instead of silently passing.
  - End-to-end fixture setup now supports configurable bootstrap passwords and automatically updates them to the configured administrator password.
  - Improved authentication fallback handling and error messages during fixture seeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->