### PR TITLE
perf(check): every tagged lane has exactly one reader

### DIFF
--- a/backend/.golangci.strict.yml
+++ b/backend/.golangci.strict.yml
@@ -11,9 +11,9 @@ version: "2"
 
 run:
   # This pass carries the same tags as the baseline, so new code in a by-hand
-  # lane is gated too. Both lists are derived: gates/lintbuildtagreach_test.go
-  # fails when a build tag anywhere in the tree is absent from EITHER, because a
-  # tag added to one config alone leaves half the linters blind.
+  # lane is gated too. gates/lintbuildtagreach_test.go fails when a tag that
+  # gates a file in this tree is missing from EITHER list, because a tag added to
+  # one config alone leaves half the linters blind.
   build-tags:
     - integration
     - livesmoke

--- a/backend/.golangci.strict.yml
+++ b/backend/.golangci.strict.yml
@@ -10,12 +10,16 @@
 version: "2"
 
 run:
-  # The baseline lints only untagged code; this pass also covers the
-  # integration, livesmoke and bench lanes so new test-harness code is gated too.
+  # This pass carries the same tags as the baseline, so new code in a by-hand
+  # lane is gated too. Both lists are derived: gates/lintbuildtagreach_test.go
+  # fails when a build tag anywhere in the tree is absent from EITHER, because a
+  # tag added to one config alone leaves half the linters blind.
   build-tags:
     - integration
     - livesmoke
     - bench
+    - e2e_llm
+    - voicelive
 
 issues:
   # Only findings introduced after the merge-base with origin/main fail.

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -18,8 +18,9 @@ run:
     # all, and a file under one of these tags can otherwise stop compiling with
     # nothing to say so.
     #
-    # The list is derived rather than curated: gates/lintbuildtagreach_test.go
-    # fails when a build tag anywhere in the tree is absent from it.
+    # gates/lintbuildtagreach_test.go fails when a build tag that gates a file
+    # in this tree is missing from this list. It does not write the list, and it
+    # does not remove an entry that has stopped being needed.
     - bench
     - e2e_llm
     - voicelive

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -11,10 +11,18 @@ run:
   build-tags:
     - integration
     - livesmoke
-    # The by-hand benchmark lane (make bench-record / bench-capture). It needs
-    # this more than the others do: no scheduled job runs those files, so lint
-    # and `go vet -tags 'integration bench'` are the only passes that read them.
+    # The by-hand lanes: benchmarks (make bench-record / bench-capture), the
+    # LLM end-to-end lanes (make e2e-siteread / e2e-ai) and the voice smoke.
+    # These need it more than the others do — nothing scheduled compiles any of
+    # them, so this pass is the only thing in the merge gate that reads them at
+    # all, and a file under one of these tags can otherwise stop compiling with
+    # nothing to say so.
+    #
+    # The list is derived rather than curated: gates/lintbuildtagreach_test.go
+    # fails when a build tag anywhere in the tree is absent from it.
     - bench
+    - e2e_llm
+    - voicelive
 
 linters:
   default: standard

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -194,26 +194,18 @@ build: composition ## Compile every package (composed workspace), host AND windo
 	# not change meaning on a machine that has a Windows C toolchain.
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOWORK_COMPOSED) $(GO) build ./...
 
-vet: composition ## Run go vet over every package, untagged AND -tags 'integration bench' (composed workspace)
+vet: composition ## Run go vet over every package, untagged (composed workspace)
+	# UNTAGGED, and only untagged. The tagged lanes are vetted by `make lint`:
+	# .golangci.yml carries every build tag that gates a file in this tree and
+	# enables govet, so it already runs these analyzers over a SUPERSET of what
+	# a `-tags` pass here would reach. Both halves of that are held by
+	# gates/lintbuildtagreach_test.go, because losing either is silent — the
+	# lint pass still runs, still reports, and still passes.
+	#
+	# This pass is not redundant with it, which is why it stays. golangci runs
+	# WITH those tags, so a file guarded `//go:build !integration` is excluded
+	# there and read here and nowhere else.
 	$(GOWORK_COMPOSED) $(GO) vet ./...
-	# The INTEGRATION lane, type-checked. `make check` otherwise never compiles
-	# a single //go:build integration file — build, vet, lint and test all run
-	# untagged — while internal/compose alone holds hundreds of them. A helper
-	# renamed, a signature changed, or a name that collides with one declared in
-	# a tagged file compiles clean untagged and fails only when somebody runs
-	# `make test-it`, which the merge gate does not. That is how a duplicate
-	# declaration reached a green check-q during this branch.
-	#
-	# vet, not test: type-checking the tagged lane needs no database, no Docker
-	# and no fixtures, so it costs seconds and belongs in the always-on gate.
-	# RUNNING those tests is the integration lane's job and stays there.
-	#
-	# `bench` rides along and needs this MORE than the integration lane does:
-	# the bench files are run by hand from a make target, so unlike the
-	# integration lane nothing scheduled ever compiles them. Setting a tag only
-	# ADDS files, so this one invocation still covers everything `-tags
-	# integration` alone would.
-	$(GOWORK_COMPOSED) $(GO) vet -tags 'integration bench' ./...
 
 test: composition ## Unit tests — every package exactly once, UNCACHED_TEST_PKGS uncached
 	# ./... covers UNCACHED_TEST_PKGS too, and the result it computes for them

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -202,9 +202,8 @@ vet: composition ## Run go vet over every package, untagged (composed workspace)
 	# gates/lintbuildtagreach_test.go, because losing either is silent — the
 	# lint pass still runs, still reports, and still passes.
 	#
-	# This pass is not redundant with it, which is why it stays. golangci runs
-	# WITH those tags, so a file guarded `//go:build !integration` is excluded
-	# there and read here and nowhere else.
+	# golangci runs WITH those tags, so a file guarded `//go:build !integration`
+	# is excluded there and read here and nowhere else.
 	$(GOWORK_COMPOSED) $(GO) vet ./...
 
 test: composition ## Unit tests — every package exactly once, UNCACHED_TEST_PKGS uncached

--- a/backend/gates/gates_test.go
+++ b/backend/gates/gates_test.go
@@ -30,6 +30,14 @@ import (
 // from the wrong directory finds nothing, and a census of nothing reports the
 // clean tree it never read. Refusing to run at all is the only outcome that
 // cannot be mistaken for a pass.
+// repoRoot is the repository, from the directory TestMain leaves this package
+// in. It is declared HERE, in the one file with no build constraint, rather than
+// beside the first gate that needed it: a const behind `//go:build !integration`
+// is invisible to `make lint`, which sets that tag — so every gate that used it
+// compiled under `go test` and failed to compile under the linter, in a file
+// that never mentioned the tag.
+const repoRoot = ".."
+
 func TestMain(m *testing.M) {
 	if err := os.Chdir(".."); err != nil {
 		fmt.Fprintf(os.Stderr, "gates: reaching the module root from the package directory: %v\n", err)

--- a/backend/gates/jobregistrationban_test.go
+++ b/backend/gates/jobregistrationban_test.go
@@ -207,6 +207,7 @@ type golangciConfig struct {
 				//nolint:tagliatelle // golangci-lint's key, not ours to case.
 				DisableAll bool     `yaml:"disable-all"`
 				Enable     []string `yaml:"enable"`
+				Disable    []string `yaml:"disable"`
 			} `yaml:"govet"`
 			Forbidigo struct {
 				//nolint:tagliatelle // golangci-lint's key, not ours to case.
@@ -265,40 +266,6 @@ func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
 	default:
 		t.Errorf("forbidigo is enabled in %s. Two passes with two pattern sets make an in-source forbidigo waiver unusable tree-wide: whichever set a directive was written for, the other reports it as an unused directive through nolintlint. Enable it in one config and let the other inherit nothing.",
 			strings.Join(enabling, " and "))
-	}
-}
-
-// TestTheOwningConfigLintsTheTaggedLanes — forbidigo now lives in one config,
-// and that config must see the same files the other one did. The strict pass
-// declares the integration and livesmoke tags, so before the move it was the
-// only thing linting the tagged harnesses; a baseline that compiled untagged
-// files only would leave them covered by NOTHING, which is where an http.Error
-// or a stray fmt.Print goes unnoticed for longest.
-func TestTheOwningConfigLintsTheTaggedLanes(t *testing.T) {
-	t.Parallel()
-	// The owner is DERIVED, not named: this holds whichever config enables
-	// forbidigo to the tags, so moving ownership moves the obligation with it
-	// rather than leaving this passing about a config that no longer runs the
-	// linter. TestForbidigoIsEnabledInExactlyOneConfig is what makes "the"
-	// owner well defined.
-	owner := ""
-	for _, name := range lintConfigs {
-		if slices.Contains(readGolangciConfig(t, name).Linters.Enable, "forbidigo") {
-			owner = name
-			break
-		}
-	}
-	if owner == "" {
-		t.Fatal("no config enables forbidigo, so there is no owner to hold to anything")
-	}
-	tags := readGolangciConfig(t, owner).Run.BuildTags
-	// `bench` carries a sharper version of the same obligation: the by-hand
-	// benchmark lane is run by NO scheduled job, so lint and `go vet -tags
-	// 'integration bench'` are the only passes that ever compile those files.
-	for _, tag := range []string{"integration", "livesmoke", "bench"} {
-		if !slices.Contains(tags, tag) {
-			t.Errorf("%s owns forbidigo but does not declare the %q build tag, so the %s-only files are linted by nothing", owner, tag, tag)
-		}
 	}
 }
 

--- a/backend/gates/jobregistrationban_test.go
+++ b/backend/gates/jobregistrationban_test.go
@@ -192,7 +192,12 @@ type golangciConfig struct {
 		BuildTags []string `yaml:"build-tags"`
 	} `yaml:"run"`
 	Linters struct {
+		// Default and Disable are read by the govet obligation in
+		// lintbuildtagreach_test.go: `standard` and `all` both carry govet
+		// without naming it, and Disable overrides whichever way it arrived.
+		Default  string   `yaml:"default"`
 		Enable   []string `yaml:"enable"`
+		Disable  []string `yaml:"disable"`
 		Settings struct {
 			Forbidigo struct {
 				//nolint:tagliatelle // golangci-lint's key, not ours to case.

--- a/backend/gates/jobregistrationban_test.go
+++ b/backend/gates/jobregistrationban_test.go
@@ -199,6 +199,15 @@ type golangciConfig struct {
 		Enable   []string `yaml:"enable"`
 		Disable  []string `yaml:"disable"`
 		Settings struct {
+			// Govet is read by the govet obligation in
+			// lintbuildtagreach_test.go: a config can enable the linter and
+			// then disable every analyzer it has, which reads as enabled to
+			// anything that looks only at the linter list.
+			Govet struct {
+				//nolint:tagliatelle // golangci-lint's key, not ours to case.
+				DisableAll bool     `yaml:"disable-all"`
+				Enable     []string `yaml:"enable"`
+			} `yaml:"govet"`
 			Forbidigo struct {
 				//nolint:tagliatelle // golangci-lint's key, not ours to case.
 				AnalyzeTypes bool         `yaml:"analyze-types"`

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -5,57 +5,46 @@
 
 package gates
 
-// Every Go file in this repository is compiled by at least one pass the merge
-// gate runs, and both lint configs run govet.
+// Every Go file in this repository is compiled by a pass the merge gate runs,
+// analysed by one that lints, and read by both lint configs or neither.
 //
 // A file is invisible to a pass whose build-tag assignment its constraint does
-// not admit. Most of the tree is untagged and every pass compiles it; the ones
-// that matter are the tagged lanes, where a single YAML list decides whether
-// anything reads them at all.
+// not admit. Most of the tree is untagged and every pass takes it; the ones that
+// matter are the tagged and platform-selected lanes, where a YAML list and a
+// filename suffix decide whether anything reads them at all.
 //
 // A file whose tag no pass carries can call a function it does not import and
 // never be told. Nothing type-checks it, and it reads on disk exactly like every
 // file that compiles.
 //
-// THREE questions are asked, and none implies the others.
+// THREE questions, none implying the others:
 //
-// Is the file COMPILED at all? A no means a type error in it never surfaces.
-// This is about the whole CONSTRAINT rather than the tags in it: `bench &&
-// !integration` names two tags both lint configs carry and is admitted by no
-// pass, because those configs set `integration` too and the integration lane
-// does not set `bench`. So each constraint is EVALUATED against each pass's
-// assignment, which is also the only reading that gets negation and `||` right.
+//   - COMPILED at all? A no means a type error in it never surfaces.
+//   - ANALYSED by anything? Compiling is not analysing, and the distinction is
+//     load-bearing: `make test-integration` compiles the tagged tree and runs
+//     neither `go vet` nor golangci over it. A file only the shards admit is
+//     built and read by no linter.
+//   - Read by BOTH lint configs? They run different linter sets, so a file one
+//     of them takes and the other does not keeps half its coverage silently.
 //
-// Is it ANALYSED by anything? Compiling is not analysing, and the distinction is
-// load-bearing rather than pedantic: `make test-integration` compiles the tagged
-// tree and runs neither `go vet` nor golangci over it. So `integration &&
-// !bench` is compiled and read by no linter — a file the shards build and vet
-// never sees. Splitting the two is what makes that fail here rather than pass.
+// Whether a pass admits a file is asked of GO, not decided here. MatchFile is
+// the same function the toolchain uses to build a package, so build tags, both
+// constraint spellings, GOOS/GOARCH filename suffixes, `_test`, truncation at
+// the first dot and the OS names that exist only for filenames (`zos`) are all
+// answered by the implementation that owns them. A hand-rolled version of those
+// rules was wrong three separate ways before it was replaced by this, which is
+// the argument: the rules are Go's, Go revises them, and a copy is wrong in ways
+// no reader of this file can see.
 //
-// Is it linted by BOTH configs? That one IS about the tags, because the two
-// configs run different linter sets and a file only one of them reads keeps half
-// the linters. Equal-satisfaction between the two configs would be the tidier
-// spelling and a weaker one: it agrees when a tag is missing from both, which is
-// exactly how 853 integration-tagged files could lose every linter at once.
+// WHAT THIS CATCHES: a file no pass compiles, one nothing lints, and one the two
+// lint configs disagree about.
 //
-// The second obligation is govet, and it exists because `make vet` runs
-// untagged only. Switching govet off in .golangci.yml — or leaving it enabled
-// with every analyzer disabled, which reads as enabled to anything that looks
-// only at the linter list — takes the vet analyzers away from every tagged file
-// in the tree at once, and no other pass would report it.
-//
-// WHAT THIS CATCHES: a build constraint no pass in the merge gate satisfies,
-// and govet reduced to nothing in either config.
-//
-// WHAT THIS DOES NOT CATCH, deliberately: whether being compiled is ENOUGH — a
+// WHAT THIS DOES NOT CATCH, deliberately: whether being analysed is ENOUGH — a
 // file can be linted and still be wrong, which is what the linters are for.
 
 import (
-	"go/build/constraint"
+	"go/build"
 	"io/fs"
-	"maps"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -63,6 +52,22 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
+
+// generatedTrees are skipped by PATH rather than by directory name. `build` is
+// an ordinary package name, and skipping every directory called that would drop
+// a real package out of the census silently — the direction a census must never
+// fail in.
+//
+// These three and no more, matching what .gitignore anchors: it names them
+// individually and says why, so that an unrelated future /build asset is never
+// hidden. A name-based skip here would hide precisely what that anchoring went
+// out of its way to keep visible. Each holds generated copies of files already
+// counted, present or absent depending on whether anyone has run the generator.
+var generatedTrees = []string{
+	filepath.Join(repoRoot, "build", "composition"),
+	filepath.Join(repoRoot, "build", "composition-frontend"),
+	filepath.Join(repoRoot, "build", "desktop"),
+}
 
 // skipForeignTree reports whether a directory holds something other than this
 // repository's own source: dependencies somebody else wrote, a nested checkout,
@@ -81,90 +86,50 @@ func skipForeignTree(name string) bool {
 	return false
 }
 
-// generatedTrees are skipped by PATH rather than by directory name. `build` is
-// an ordinary package name, and skipping every directory called that would drop
-// a real package out of the census silently — the direction a census must never
-// fail in.
+// compilingPass is one assignment the merge gate compiles this tree under.
 //
-// These three and no more, matching what .gitignore anchors: it names them
-// individually and says why, so that an unrelated future /build asset is never
-// hidden. A name-based skip here would hide precisely what that anchoring went
-// out of its way to keep visible. Each holds generated copies of files already
-// counted, present or absent depending on whether anyone has run the generator.
-var generatedTrees = []string{
-	filepath.Join(repoRoot, "build", "composition"),
-	filepath.Join(repoRoot, "build", "composition-frontend"),
-	filepath.Join(repoRoot, "build", "desktop"),
-}
-
-// compilingPass is one assignment: the build tags set, and the GOOS the pass
-// runs at. GOOS matters because Go satisfies a `//go:build windows` constraint
-// from the target platform and never from a -tags list, so a pass model without
-// it reports the cross-compiled files as unread.
+// analyses marks the passes that also run a linter over what they compile. A
+// pass that only builds still answers the type-error question, which is why it
+// is counted at all.
 type compilingPass struct {
-	name string
-	goos string
-	tags []string
-	// analyses reports whether this pass runs a linter over what it compiles.
-	// A pass that only builds still answers the type-error question, which is
-	// why it is counted at all.
+	name     string
+	goos     string
+	tags     []string
 	analyses bool
 }
 
-// satisfies reports whether this pass compiles a file carrying expr.
-//
-// Eval short-circuits, which is correct HERE and wrong for collecting tag
-// names: the question is the expression's value under one assignment, and an
-// operand that cannot change the answer genuinely does not need visiting.
-func (p compilingPass) satisfies(expr constraint.Expr) bool {
-	return expr.Eval(func(tag string) bool {
-		switch {
-		case slices.Contains(p.tags, tag):
-			return true
-		case tag == p.goos:
-			return true
-		// The runner and every machine this repo is built on are 64-bit; a
-		// constraint naming another architecture reports as unread, which is
-		// true of these passes and worth being told.
-		case tag == "amd64" || tag == "arm64":
-			return true
-		// Go defines `unix` for the platforms it names, and the toolchain
-		// satisfies its own release tags. Neither can be spelled in a -tags
-		// list, so neither is a coverage question.
-		case tag == "unix":
-			return p.goos == "linux" || p.goos == "darwin"
-		case strings.HasPrefix(tag, "go1."):
-			return true
-		default:
-			return false
-		}
-	})
+// admits reports whether this pass compiles the named file, asked of go/build so
+// that no rule about constraints is restated here.
+func (p compilingPass) admits(dir, name string) (bool, error) {
+	ctx := build.Default
+	ctx.GOOS = p.goos
+	// The runner and every machine this gate runs on are 64-bit. A file
+	// constrained to another architecture reports as unread, which is true of
+	// these passes and worth being told.
+	ctx.GOARCH = "amd64"
+	ctx.BuildTags = p.tags
+	return ctx.MatchFile(dir, name)
 }
 
 // mergeGatePasses are the assignments under which the merge gate compiles this
-// tree. A constraint satisfied by none of them describes a file nothing builds.
-//
-// `analyses` marks the passes that also run a linter over what they compile.
-// The integration shards do not: they build the tagged tree to run its tests,
-// which surfaces a type error and no vet finding.
+// tree. A file none of them admits is one nothing builds.
 //
 // The two golangci rows take their tags from the configs themselves, because
-// that list is the one that drifts. The rest are named with the recipe they
-// come from: their disappearance would be a deliberate edit to a compile step
-// rather than a quiet YAML change.
+// that list is the one that drifts. The rest are named with the recipe they come
+// from: their disappearance would be a deliberate edit to a compile step rather
+// than a quiet YAML change.
 //
-// The integration shards are counted. A file only they compile IS compiled, and
-// a gate that pretended otherwise would deny a reader that exists — the inverse
-// error, and just as misleading.
+// The integration shards are counted, and only as a COMPILING pass. A file only
+// they admit is genuinely built — denying that would be the inverse error — but
+// they run no linter over it.
 func mergeGatePasses(t *testing.T) []compilingPass {
 	t.Helper()
 	passes := []compilingPass{
-		{name: "untagged (`make build`, `make vet`, `make test`, and `make lint-modules` over every module outside backend/)", goos: "linux", analyses: true},
+		{name: "untagged (`make build`, `make vet`, `make test`, and `make lint-modules` outside backend/)", goos: "linux", analyses: true},
 		// `go build` never compiles a _test.go, so this row covers non-test
 		// files only. It is listed anyway because a windows-only production
 		// file would otherwise report as unread when that cross-compile does
-		// read it; a windows-only TEST file is genuinely unread, and the
-		// narrower claim is the one this row is allowed to make.
+		// read it; a windows-only TEST file is genuinely unread.
 		{name: "the windows/amd64 cross-compile of non-test files (`make build`)", goos: "windows"},
 		{name: "the integration shards (`make test-integration`)", goos: "linux", tags: []string{"integration"}},
 	}
@@ -178,144 +143,115 @@ func mergeGatePasses(t *testing.T) []compilingPass {
 	return passes
 }
 
-// unreadFiles ratifies a file the merge gate does not read, with what that
-// costs. Every entry here is platform-constrained, and that is not a
-// coincidence: golangci runs at ONE GOOS, so a file selected by a different one
-// cannot be linted by it at any tag setting. These are the files this
-// repository builds for a platform its gate does not run on.
+// unreadFiles ratifies a file the merge gate does not fully read, with what that
+// costs. Every entry is platform-constrained, and that is not a coincidence:
+// golangci runs at ONE GOOS, so a file selected by a different one cannot be
+// linted by it at any tag setting. These are the files this repository builds for
+// a platform its gate does not run on.
 //
 // The list is worth reading as a whole rather than entry by entry. It is the
 // standing cost of shipping a desktop bundle from a Linux merge gate, it was
 // invisible until the census learned to read filename constraints, and every
-// line of it is code no linter has ever opened.
+// line of it is code no linter has ever opened. The wider count, including the
+// `//go:build !integration` files this gate cannot help with, is issue #2920.
 var unreadFiles = gatekit.Waive(map[string]string{
-	// Backend, compiled for windows by `make build` and linted by nothing.
-	"../backend/internal/platform/blobstore/fs_sync_windows.go": "the windows half of a file-sync primitive: `make build` cross-compiles it so a type error is caught, but golangci runs at the host GOOS and never opens it — so gosec, depguard and revive have never read this syscall-adjacent code, and its unix sibling is the only half they judge",
-	"../backend/internal/platform/ownedfile/owned_windows.go":   "the windows half of the owned-file primitive, cross-compiled and unlinted for the reason its blobstore sibling above states — the cost is that a permissions or error-handling defect here is caught only by review",
+	// Backend, cross-compiled for windows by `make build` and linted by nothing.
+	"backend/internal/platform/blobstore/fs_sync_windows.go": "the windows half of a file-sync primitive: `make build` cross-compiles it so a type error is caught, but golangci runs at the host GOOS and never opens it — so gosec, depguard and revive have never read this syscall-adjacent code, and its unix sibling is the only half they judge",
+	"backend/internal/platform/ownedfile/owned_windows.go":   "the windows half of the owned-file primitive, cross-compiled and unlinted for the reason its blobstore sibling above states — the cost is that a permissions or error-handling defect here is caught only by review",
 
 	// The desktop launcher is its own module, released by its own lanes.
-	"../desktop/launcher/platform_windows.go":  "desktop launcher platform layer: built by the windows release lane (desktop-windows.yml), not by the merge gate, which neither cross-compiles this module nor lints at a foreign GOOS. A break here surfaces at release rather than at merge",
-	"../desktop/launcher/process_windows.go":   "desktop launcher process control, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"../desktop/launcher/postgres_windows.go":  "desktop launcher Postgres supervision, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"../desktop/launcher/runerror_windows.go":  "desktop launcher error rendering, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"../desktop/launcher/browser_darwin.go":    "desktop launcher browser handoff for macOS: compiled by the macOS release lane (desktop-macos.yml) and by a maintainer's own machine, and by nothing at all in the merge gate — GOOS is not a tag, so no config entry could change that",
-	"../desktop/launcher/quarantine_darwin.go": "desktop launcher quarantine-attribute handling, macOS-only and reached only by the macOS release lane. This one carries the most risk of the set: it is the code that decides what a downloaded bundle is allowed to do, and no linter in this repository has read it",
+	"desktop/launcher/platform_windows.go":  "desktop launcher platform layer: built by the windows release lane (desktop-windows.yml), not by the merge gate, which neither cross-compiles this module nor lints at a foreign GOOS. A break here surfaces at release rather than at merge",
+	"desktop/launcher/process_windows.go":   "desktop launcher process control, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/postgres_windows.go":  "desktop launcher Postgres supervision, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/runerror_windows.go":  "desktop launcher error rendering, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/browser_darwin.go":    "desktop launcher browser handoff for macOS: compiled by the macOS release lane (desktop-macos.yml) and by a maintainer's own machine, and by nothing at all in the merge gate — GOOS is not a tag, so no config entry could change that",
+	"desktop/launcher/quarantine_darwin.go": "desktop launcher quarantine-attribute handling, macOS-only and reached only by the macOS release lane. This one carries the most risk of the set: it is the code that decides what a downloaded bundle is allowed to do, and no linter in this repository has read it",
 })
 
-func TestEveryBuildConstraintIsCompiledBySomePass(t *testing.T) {
+func TestEveryGoFileIsCompiledAndAnalysedBySomePass(t *testing.T) {
 	t.Parallel()
 	defer unreadFiles.AssertAllMatched(t)
 
 	passes := mergeGatePasses(t)
-	constrained := constrainedFiles(t)
-	if len(constrained) == 0 {
-		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
-			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
-	}
-
 	names := make([]string, 0, len(passes))
-	analysing := make([]compilingPass, 0, len(passes))
 	for _, p := range passes {
 		names = append(names, p.name)
-		if p.analyses {
-			analysing = append(analysing, p)
-		}
 	}
-	for _, f := range constrained {
-		compiled := slices.ContainsFunc(passes, func(p compilingPass) bool { return p.satisfies(f.expr) })
-		read := slices.ContainsFunc(analysing, func(p compilingPass) bool { return p.satisfies(f.expr) })
-		if compiled && read {
-			continue
-		}
-		if unreadFiles.Waived(t, f.path) {
-			continue
-		}
-		if compiled {
-			t.Errorf("%s is compiled but ANALYSED by nothing: its constraint `%s` is satisfied only by a pass "+
-				"that builds without linting, so a type error in it surfaces and a vet, gosec or depguard finding "+
-				"never does. Add the tag to both golangci configs, or ratify the file in unreadFiles with what "+
-				"leaving it unanalysed costs", f.path, f.expr.String())
-			continue
-		}
-		t.Errorf("%s is compiled by no pass the merge gate runs: its constraint `%s` is false under every one of "+
-			"%s. Add the tag to both golangci configs so `make lint` reads it, or ratify the file in unreadFiles "+
-			"with what leaving it unread costs — which is the answer for `ignore`, the standard spelling for a "+
-			"file meant to be `go run` and never built", f.path, f.expr.String(), strings.Join(names, ", "))
-	}
-}
-
-// TestEveryTagIsCarriedByBothLintConfigs is the SECOND obligation, and it is
-// not implied by the first.
-//
-// Being compiled by some pass is enough to be type-checked and no more. The two
-// configs run different linter sets — the baseline owns the repo-wide gate
-// (depguard's DAG, gosec, forbidigo, misspell), the strict one owns the
-// new-code rules — so a tag carried by one and not the other leaves half of
-// them blind on those files while the constraint census stays green, because
-// the other config still compiles them.
-//
-// It is stated separately rather than folded in because the two fail for
-// different reasons and want different fixes: this one is always "add the tag
-// to the other config", never "ratify the file".
-func TestEveryTagIsCarriedByBothLintConfigs(t *testing.T) {
-	t.Parallel()
-	defer platformSelectedTags.AssertAllMatched(t)
-
-	tags := map[string]bool{}
-	for _, f := range constrainedFiles(t) {
-		collectTags(f.expr, tags)
-	}
-	if len(tags) == 0 {
-		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
-			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
-	}
-	for _, path := range lintConfigs {
-		carried := readGolangciConfig(t, path).Run.BuildTags
-		for _, tag := range slices.Sorted(maps.Keys(tags)) {
-			if platformSelectedTags.Waived(t, tag) || slices.Contains(carried, tag) {
+	seen := 0
+	forEachGoFile(t, func(rel, dir, name string) {
+		seen++
+		compiled, analysed := false, false
+		for _, p := range passes {
+			ok, err := p.admits(dir, name)
+			if err != nil {
+				t.Errorf("%s: asking go/build whether %q admits it: %v", rel, p.name, err)
+				return
+			}
+			if !ok {
 				continue
 			}
-			t.Errorf("build tag %q gates a file in this tree but %s does not carry it, so that config's linters "+
-				"do not read those files even where another pass compiles them: add it to that config's "+
-				"run.build-tags, or ratify it in platformSelectedTags with what leaving it out costs", tag, path)
+			compiled = true
+			analysed = analysed || p.analyses
 		}
+		switch {
+		case compiled && analysed:
+		case unreadFiles.Waived(t, rel):
+		case compiled:
+			t.Errorf("%s is compiled but ANALYSED by nothing: only a pass that builds without linting admits it, "+
+				"so a type error in it surfaces and a vet, gosec or depguard finding never does. Add its tag to "+
+				"both golangci configs, or ratify the file in unreadFiles with what leaving it unanalysed costs", rel)
+		default:
+			t.Errorf("%s is compiled by no pass the merge gate runs — none of %s admits it. Add its tag to both "+
+				"golangci configs so `make lint` reads it, or ratify the file in unreadFiles with what leaving it "+
+				"unread costs, which is the answer for `ignore`, the standard spelling for a file meant to be "+
+				"`go run` and never built", rel, strings.Join(names, ", "))
+		}
+	})
+	if seen == 0 {
+		t.Fatal("the walk found no Go file at all — a census that recognises nothing reports PASS over every " +
+			"unread lane there is, so the walk is broken rather than the tree clean")
 	}
 }
 
-// platformSelectedTags names the constraints Go satisfies from GOOS/GOARCH
-// rather than from a -tags list. No golangci entry could carry them, so each
-// says what that costs instead.
-var platformSelectedTags = gatekit.Waive(map[string]string{
-	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. Every windows mention in this tree today is a NEGATION (`!windows`), which the Linux passes satisfy; a windows-ONLY file would be read by the `make build` cross-compile if it were production code and by nothing at all if it were a test, since `go build` skips _test.go",
-	"darwin":  "GOOS, so a build-tags entry would not reach it. Every darwin mention in this tree today is a NEGATION (`!darwin`), which the Linux passes satisfy — a darwin-ONLY file would be compiled on a maintainer's machine and by nothing in the merge gate, and this entry is what stops that reading as covered",
-})
-
-// collectTags walks a constraint structurally, which is what makes this census
-// total. constraint.Expr.Eval would be the shorter spelling and the wrong one
-// HERE: it short-circuits, so the second operand of an `&&` whose first is
-// already false is never visited and its tag never seen. (Eval is right in
-// compilingPass.satisfies, where the question is the expression's VALUE.)
-func collectTags(expr constraint.Expr, into map[string]bool) {
-	switch e := expr.(type) {
-	case *constraint.TagExpr:
-		into[e.Tag] = true
-	case *constraint.NotExpr:
-		collectTags(e.X, into)
-	case *constraint.AndExpr:
-		collectTags(e.X, into)
-		collectTags(e.Y, into)
-	case *constraint.OrExpr:
-		collectTags(e.X, into)
-		collectTags(e.Y, into)
+func TestBothLintConfigsReadTheSameFiles(t *testing.T) {
+	t.Parallel()
+	// The two configs run different linter sets: the baseline owns the
+	// repo-wide gate (depguard's DAG, gosec, forbidigo, misspell), the strict
+	// one owns the new-code rules. A file one takes and the other does not
+	// keeps half its coverage, and the sibling census stays green because
+	// something still analyses it.
+	//
+	// Asked per FILE rather than by comparing the two tag lists: a tag that
+	// gates no file is not a divergence worth failing, and one that gates a
+	// file under a negation is one that comparing lists would miss.
+	var configs []compilingPass
+	for _, path := range lintConfigs {
+		configs = append(configs, compilingPass{name: path, goos: "linux", tags: readGolangciConfig(t, path).Run.BuildTags})
 	}
+	if len(configs) != 2 {
+		t.Fatalf("expected two lint configs to compare, found %d", len(configs))
+	}
+	forEachGoFile(t, func(rel, dir, name string) {
+		admits := [2]bool{}
+		for i, cfg := range configs {
+			ok, err := cfg.admits(dir, name)
+			if err != nil {
+				t.Errorf("%s: asking go/build whether %s admits it: %v", rel, cfg.name, err)
+				return
+			}
+			admits[i] = ok
+		}
+		if admits[0] == admits[1] {
+			return
+		}
+		reads, blind := configs[0].name, configs[1].name
+		if admits[1] {
+			reads, blind = blind, reads
+		}
+		t.Errorf("%s is read by %s and not by %s, so half this repository's linters do not see it: the two "+
+			"configs' run.build-tags have diverged, and only one of them is the repo-wide gate", rel, reads, blind)
+	})
 }
-
-// govetDisables ratifies each govet analyzer a config switches off, with what
-// losing it costs across every tagged file.
-var govetDisables = gatekit.Waive(map[string]string{
-	"fieldalignment": "a memory-layout micro-optimisation, not a correctness check: it reports struct field ORDER, and acting on it trades legible grouping for bytes this product never counts",
-	"shadow":         "high-noise on idiomatic Go — every `err :=` inside a block trips it — and the cases that are real bugs are reported by revive's early-return and by errcheck, so the coverage lost is the false-positive half",
-})
 
 func TestBothLintConfigsRunGovet(t *testing.T) {
 	t.Parallel()
@@ -347,14 +283,11 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 		}
 		// The narrower door, and the one already ajar: `disable` removes named
 		// analyzers while the linter still reports as enabled. Deleting `printf`
-		// here would take it from every tagged file in the tree at once, which
-		// is the coverage the removed `go vet -tags` pass used to backstop.
+		// here would take it from every tagged file in the tree at once.
 		//
-		// The check is a RATIFIED set rather than a copy of go vet's default
-		// analyzer list. Restating that list here would be a second copy of
-		// something the toolchain owns and revises, and it would go stale
-		// silently; requiring a reason per entry costs one line and says why
-		// each absence is affordable.
+		// A ratified set rather than a copy of go vet's default analyzer list:
+		// restating that list here would be a second copy of something the
+		// toolchain owns and revises, and it would go stale silently.
 		for _, analyzer := range govet.Disable {
 			if govetDisables.Waived(t, analyzer) {
 				continue
@@ -366,114 +299,19 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 	}
 }
 
-// andConstraints joins two constraints the way Go does when a file carries both
-// a header and a filename suffix. Either side may be absent.
-func andConstraints(a, b constraint.Expr) constraint.Expr {
-	switch {
-	case a == nil:
-		return b
-	case b == nil:
-		return a
-	default:
-		return &constraint.AndExpr{X: a, Y: b}
-	}
-}
+// govetDisables ratifies each govet analyzer a config switches off, with what
+// losing it costs across every tagged file.
+var govetDisables = gatekit.Waive(map[string]string{
+	"fieldalignment": "a memory-layout micro-optimisation, not a correctness check: it reports struct field ORDER, and acting on it trades legible grouping for bytes this product never counts",
+	"shadow":         "high-noise on idiomatic Go — every `err :=` inside a block trips it — and the cases that are real bugs are reported by revive's early-return and by errcheck, so the coverage lost is the false-positive half",
+})
 
-// platformNames holds the GOOS and GOARCH names SEPARATELY, because Go's
-// filename suffixes are ordered and typed rather than "any two platform words".
-type platformNames struct {
-	goos   map[string]bool
-	goarch map[string]bool
-}
-
-// knownPlatforms asks the TOOLCHAIN for those names rather than writing them
-// down here.
-//
-// A literal list would be a second copy of something the Go release owns and
-// revises, and it would go stale in the silent direction: a suffix this gate did
-// not recognise is a file it reads as unconstrained, which is the census going
-// short again in exactly the place this function exists to fix.
-func knownPlatforms(t *testing.T) platformNames {
+// forEachGoFile visits every Go file in this repository, handing the callback the
+// repository-relative path — what a waiver is keyed by and what a failure names,
+// identical on every machine — alongside the directory and base name go/build
+// needs.
+func forEachGoFile(t *testing.T, visit func(rel, dir, name string)) {
 	t.Helper()
-	out, err := exec.Command("go", "tool", "dist", "list").Output()
-	if err != nil {
-		t.Fatalf("asking the toolchain for its GOOS/GOARCH names: %v", err)
-	}
-	known := platformNames{goos: map[string]bool{}, goarch: map[string]bool{}}
-	for _, pair := range strings.Fields(string(out)) {
-		goos, goarch, found := strings.Cut(pair, "/")
-		if !found {
-			t.Fatalf("`go tool dist list` printed %q, which is not a GOOS/GOARCH pair", pair)
-		}
-		known.goos[goos] = true
-		known.goarch[goarch] = true
-	}
-	if len(known.goos) == 0 || len(known.goarch) == 0 {
-		t.Fatal("the toolchain named no platform at all, so every filename suffix below reads as unconstrained")
-	}
-	return known
-}
-
-// filenameConstraint returns the constraint Go applies to a file for its NAME
-// alone — `x_windows.go`, `x_amd64.go`, `x_windows_amd64.go` — or nil.
-//
-// The two suffix positions are TYPED and ORDERED, not "any two platform words",
-// and reading them as interchangeable produces constraints Go never forms.
-// `x_linux_windows.go` is a windows file: `windows` is not a GOARCH, so Go takes
-// it as the GOOS and `linux` is part of the name. Treating both as platforms
-// yields `linux && windows`, which nothing satisfies — the gate would report a
-// file that builds fine as read by nothing. Over-recognition is the safer
-// direction to fail in and still the wrong answer.
-//
-// `_test` is stripped first, so `x_windows_test.go` is constrained exactly as
-// `x_windows.go` is. The first segment is the file's own name and is never read
-// as a platform, which is what stops a file called `windows.go` counting.
-func filenameConstraint(name string, platforms platformNames) constraint.Expr {
-	base := strings.TrimSuffix(name, ".go")
-	base = strings.TrimSuffix(base, "_test")
-	parts := strings.Split(base, "_")
-	var goos, goarch string
-	switch n := len(parts); {
-	case n >= 2 && platforms.goarch[parts[n-1]]:
-		goarch = parts[n-1]
-		if n >= 3 && platforms.goos[parts[n-2]] {
-			goos = parts[n-2]
-		}
-	case n >= 2 && platforms.goos[parts[n-1]]:
-		goos = parts[n-1]
-	}
-	var expr constraint.Expr
-	for _, tag := range []string{goos, goarch} {
-		if tag != "" {
-			expr = andConstraints(expr, &constraint.TagExpr{Tag: tag})
-		}
-	}
-	return expr
-}
-
-// constrainedFile is one file that carries a build constraint, and the
-// constraint it carries.
-type constrainedFile struct {
-	path string
-	expr constraint.Expr
-}
-
-// constrainedFiles returns every file under repoRoot that Go constrains at all,
-// paired with the PARSED constraint — the constraint is what this gate judges,
-// and reducing it to the tags it names loses the negation and the operators that
-// decide which passes admit the file.
-//
-// BOTH sources of constraint, because Go honours both and a census that reads
-// one is short by exactly the files that use the other. A `//go:build` header is
-// the visible spelling; `_windows.go`, `_amd64.go` and `_windows_amd64.go`
-// constrain by NAME with nothing in the file to see. This tree has eight such
-// files carrying no header at all, and the first version of this gate did not
-// know they existed. Where a file has both, the two are ANDed, which is what Go
-// does.
-func constrainedFiles(t *testing.T) []constrainedFile {
-	t.Helper()
-	platforms := knownPlatforms(t)
-	var found []constrainedFile
 	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -487,8 +325,8 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 			if skipForeignTree(d.Name()) {
 				return fs.SkipDir
 			}
-			if slices.ContainsFunc(generatedTrees, func(t string) bool {
-				return filepath.Clean(path) == filepath.Clean(t)
+			if slices.ContainsFunc(generatedTrees, func(tree string) bool {
+				return filepath.Clean(path) == filepath.Clean(tree)
 			}) {
 				return fs.SkipDir
 			}
@@ -497,42 +335,14 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 		if !strings.HasSuffix(path, ".go") || !d.Type().IsRegular() {
 			return nil
 		}
-		// path comes from walking this repository's own source tree, never from
-		// input. (No #nosec token: both configs exclude gosec on _test.go, so
-		// one here would suppress a linter that does not run.)
-		b, err := os.ReadFile(path)
+		rel, err := filepath.Rel(repoRoot, path)
 		if err != nil {
 			return err
 		}
-		// Constraints live above the package clause; both spellings are read
-		// because Go still honours the legacy one, and a file carrying only
-		// that would otherwise pass unseen.
-		var expr constraint.Expr
-		for _, line := range strings.Split(string(b), "\n") {
-			if strings.HasPrefix(strings.TrimSpace(line), "package ") {
-				break
-			}
-			if !constraint.IsGoBuild(line) && !constraint.IsPlusBuild(line) {
-				continue
-			}
-			parsed, err := constraint.Parse(line)
-			if err != nil {
-				// An unparseable constraint is not one this gate can judge, but
-				// it is also not something Go will build — reporting it here
-				// beats skipping it silently.
-				t.Errorf("%s: parsing build constraint %q: %v", filepath.ToSlash(path), line, err)
-				continue
-			}
-			expr = andConstraints(expr, parsed)
-		}
-		expr = andConstraints(expr, filenameConstraint(filepath.Base(path), platforms))
-		if expr != nil {
-			found = append(found, constrainedFile{path: filepath.ToSlash(path), expr: expr})
-		}
+		visit(filepath.ToSlash(rel), filepath.Dir(path), filepath.Base(path))
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking %s: %v", repoRoot, err)
 	}
-	return found
 }

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -5,38 +5,42 @@
 
 package gates
 
-// Every build tag that gates a Go file in this repository is carried by both
-// golangci configs, and both run govet.
+// Every Go file in this repository is compiled by at least one pass the merge
+// gate runs, and both lint configs run govet.
 //
-// A tagged file is invisible to a pass that does not carry its tag. `make lint`
-// is the only pass in the merge gate that carries any: `make build`, `make vet`
-// and `make test` all run untagged, and the integration lane runs `-tags
-// integration` alone. So for every tag but `integration`, the golangci
-// build-tags list is the whole of that file's coverage — and a tag missing from
-// it means those files are compiled by nothing the gate runs.
+// A file is invisible to a pass whose build-tag assignment its constraint does
+// not admit. Most of the tree is untagged and every pass compiles it; the ones
+// that matter are the tagged lanes, where a single YAML list decides whether
+// anything reads them at all.
 //
 // That is not a hypothetical failure mode. It is how a file reached this tree
-// referring to a package it does not import: no pass carried its tag, so
-// nothing ever type-checked it, and it read exactly like every file that
-// compiles.
+// calling a function it does not import: no pass carried its tag, so nothing
+// ever type-checked it, and it read exactly like every file that compiles.
+//
+// The subject is the CONSTRAINT, not the tags in it. Asking only whether each
+// tag appears somewhere is a weaker question that passes on the case worth
+// catching: `//go:build integration && !bench` names two tags both lint configs
+// carry, and is compiled by neither — because those configs set `bench` too,
+// which makes the second half false. Tag-presence says covered; nothing reads
+// it. So each constraint is EVALUATED against each pass's assignment, which is
+// also the only reading that gets negation and `||` right.
 //
 // The second obligation is govet, and it exists because `make vet` runs
-// untagged only. Switching govet off in .golangci.yml would take the vet
-// analyzers away from every tagged file in the tree at once, and no other pass
-// would report it.
+// untagged only. Switching govet off in .golangci.yml — or leaving it enabled
+// with every analyzer disabled, which reads as enabled to anything that looks
+// only at the linter list — takes the vet analyzers away from every tagged file
+// in the tree at once, and no other pass would report it.
 //
-// WHAT THIS CATCHES: a build tag anywhere in the repository that a golangci
-// config does not carry, and govet disabled in either config.
+// WHAT THIS CATCHES: a build constraint no pass in the merge gate satisfies,
+// and govet reduced to nothing in either config.
 //
-// WHAT THIS DOES NOT CATCH, deliberately: whether carrying the tag is
-// SUFFICIENT — a file can be linted and still be wrong, which is what the
-// linters themselves are for. Nor does it judge GOOS/GOARCH constraints, which
-// Go satisfies from the platform rather than from a -tags list; those are
-// ratified in platformSelectedTags with what leaving them unread costs.
+// WHAT THIS DOES NOT CATCH, deliberately: whether being compiled is ENOUGH — a
+// file can be linted and still be wrong, which is what the linters are for.
 
 import (
 	"go/build/constraint"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -46,47 +50,184 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// treeRoot is the whole repository, deliberately wider than the trees golangci
-// actually reads. A tag gating a file anywhere here is a tag whose files
-// something ought to compile, and erring wide can only report a file that has
-// no reader — never hide one.
+// treeRoot is the whole repository, deliberately wider than the trees the lint
+// passes read. A constraint gating a file anywhere here is one something ought
+// to compile, and erring wide can only report a file that has no reader — never
+// hide one.
 const treeRoot = ".."
 
-// platformSelectedTags names the constraints Go satisfies from GOOS/GOARCH
-// rather than from a -tags list. No golangci entry could give these a reader,
-// so each carries what leaving it out costs instead.
-var platformSelectedTags = gatekit.Waive(map[string]string{
-	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. These files are read by the windows/amd64 cross-compile in `make build`, which is why that pass is in the always-on gate rather than the desktop lane",
-	"darwin":  "GOOS, so a build-tags entry would not reach it. The cost is real and accepted: a darwin-only file is compiled on a developer's own machine and by nothing in the Linux merge gate, so it is gated locally or not at all",
-})
+// generatedTree is skipped by PATH rather than by directory name. `build` is an
+// ordinary package name, and skipping every directory called that would drop a
+// real one — `internal/build/…` — out of the census silently, which is the
+// direction a census must never fail in. Only the repository's own generated
+// composition tree is meant: it is git-ignored and holds a second copy of files
+// already counted, so including it makes the census depend on whether anyone
+// has run `make composition`.
+var generatedTree = filepath.Join(treeRoot, "build")
 
-func TestEveryBuildTagInTheTreeIsCarriedByBothLintConfigs(t *testing.T) {
-	t.Parallel()
-	defer platformSelectedTags.AssertAllMatched(t)
+// compilingPass is one assignment: the build tags set, and the GOOS the pass
+// runs at. GOOS matters because Go satisfies a `//go:build windows` constraint
+// from the target platform and never from a -tags list, so a pass model without
+// it reports the cross-compiled files as unread.
+type compilingPass struct {
+	name string
+	goos string
+	tags []string
+}
 
-	found := buildTagsInTree(t)
-	if len(found) == 0 {
-		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
-			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
+// satisfies reports whether this pass compiles a file carrying expr.
+//
+// Eval short-circuits, which is correct HERE and wrong for collecting tag
+// names: the question is the expression's value under one assignment, and an
+// operand that cannot change the answer genuinely does not need visiting.
+func (p compilingPass) satisfies(expr constraint.Expr) bool {
+	return expr.Eval(func(tag string) bool {
+		switch {
+		case slices.Contains(p.tags, tag):
+			return true
+		case tag == p.goos:
+			return true
+		// The runner and every machine this repo is built on are 64-bit; a
+		// constraint naming another architecture reports as unread, which is
+		// true of these passes and worth being told.
+		case tag == "amd64" || tag == "arm64":
+			return true
+		// Go defines `unix` for the platforms it names, and the toolchain
+		// satisfies its own release tags. Neither can be spelled in a -tags
+		// list, so neither is a coverage question.
+		case tag == "unix":
+			return p.goos == "linux" || p.goos == "darwin"
+		case strings.HasPrefix(tag, "go1."):
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+// mergeGatePasses are the assignments under which the merge gate compiles this
+// tree. A constraint satisfied by none of them describes a file nothing reads.
+//
+// The two golangci rows take their tags from the configs themselves, because
+// that list is the one that drifts. The rest are named with the recipe they
+// come from: their disappearance would be a deliberate edit to a compile step
+// rather than a quiet YAML change.
+//
+// The integration shards are counted. A file only they compile IS compiled, and
+// a gate that pretended otherwise would deny a reader that exists — the inverse
+// error, and just as misleading.
+func mergeGatePasses(t *testing.T) []compilingPass {
+	t.Helper()
+	passes := []compilingPass{
+		{name: "untagged (`make build`, `make vet`, `make test`)", goos: "linux"},
+		{name: "the windows/amd64 cross-compile (`make build`)", goos: "windows"},
+		{name: "the integration shards (`make test-integration`)", goos: "linux", tags: []string{"integration"}},
 	}
-
-	// Both configs, because they carry SEPARATE build-tags lists: a tag added
-	// to one and not the other leaves half the linters blind, which is the
-	// case hardest to see from either file on its own.
 	for _, path := range lintConfigs {
 		carried := readGolangciConfig(t, path).Run.BuildTags
 		if len(carried) == 0 {
 			t.Errorf("%s carries no build tag at all, so every tagged file in the tree is invisible to it", path)
+		}
+		passes = append(passes, compilingPass{name: path + " (`make lint`)", goos: "linux", tags: carried})
+	}
+	return passes
+}
+
+// unreadFiles ratifies a file whose constraint no pass satisfies and which is
+// nonetheless not a defect, with what leaving it unread costs.
+var unreadFiles = gatekit.Waive(map[string]string{})
+
+func TestEveryBuildConstraintIsCompiledBySomePass(t *testing.T) {
+	t.Parallel()
+	defer unreadFiles.AssertAllMatched(t)
+
+	passes := mergeGatePasses(t)
+	constrained := constrainedFiles(t)
+	if len(constrained) == 0 {
+		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
+			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
+	}
+
+	names := make([]string, 0, len(passes))
+	for _, p := range passes {
+		names = append(names, p.name)
+	}
+	for _, f := range constrained {
+		if slices.ContainsFunc(passes, func(p compilingPass) bool { return p.satisfies(f.expr) }) {
 			continue
 		}
-		for _, tag := range found {
+		if unreadFiles.Waived(t, f.path) {
+			continue
+		}
+		t.Errorf("%s is compiled by no pass the merge gate runs: its constraint `%s` is false under every one of "+
+			"%s. Add the tag to both golangci configs so `make lint` reads it, or ratify the file in unreadFiles "+
+			"with what leaving it unread costs", f.path, f.expr.String(), strings.Join(names, ", "))
+	}
+}
+
+// TestEveryTagIsCarriedByBothLintConfigs is the SECOND obligation, and it is
+// not implied by the first.
+//
+// Being compiled by some pass is enough to be type-checked and no more. The two
+// configs run different linter sets — the baseline owns the repo-wide gate
+// (depguard's DAG, gosec, forbidigo, misspell), the strict one owns the
+// new-code rules — so a tag carried by one and not the other leaves half of
+// them blind on those files while the constraint census stays green, because
+// the other config still compiles them.
+//
+// It is stated separately rather than folded in because the two fail for
+// different reasons and want different fixes: this one is always "add the tag
+// to the other config", never "ratify the file".
+func TestEveryTagIsCarriedByBothLintConfigs(t *testing.T) {
+	t.Parallel()
+	defer platformSelectedTags.AssertAllMatched(t)
+
+	tags := map[string]bool{}
+	for _, f := range constrainedFiles(t) {
+		collectTags(f.expr, tags)
+	}
+	if len(tags) == 0 {
+		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
+			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
+	}
+	for _, path := range lintConfigs {
+		carried := readGolangciConfig(t, path).Run.BuildTags
+		for _, tag := range slices.Sorted(maps.Keys(tags)) {
 			if platformSelectedTags.Waived(t, tag) || slices.Contains(carried, tag) {
 				continue
 			}
-			t.Errorf("build tag %q gates a file in this tree but %s does not carry it, so nothing in the merge "+
-				"gate compiles those files: add it to that config's run.build-tags, or ratify it in "+
-				"platformSelectedTags with what leaving it unread costs", tag, path)
+			t.Errorf("build tag %q gates a file in this tree but %s does not carry it, so that config's linters "+
+				"do not read those files even where another pass compiles them: add it to that config's "+
+				"run.build-tags, or ratify it in platformSelectedTags with what leaving it out costs", tag, path)
 		}
+	}
+}
+
+// platformSelectedTags names the constraints Go satisfies from GOOS/GOARCH
+// rather than from a -tags list. No golangci entry could carry them, so each
+// says what that costs instead.
+var platformSelectedTags = gatekit.Waive(map[string]string{
+	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. The windows-only files are read by the windows/amd64 cross-compile in `make build`, which is why that pass is in the always-on gate rather than the desktop lane",
+	"darwin":  "GOOS, so a build-tags entry would not reach it. Every darwin mention in this tree today is a NEGATION (`!darwin`), which the Linux passes satisfy — a darwin-ONLY file would be compiled on a maintainer's machine and by nothing in the merge gate, and this entry is what stops that reading as covered",
+})
+
+// collectTags walks a constraint structurally, which is what makes this census
+// total. constraint.Expr.Eval would be the shorter spelling and the wrong one
+// HERE: it short-circuits, so the second operand of an `&&` whose first is
+// already false is never visited and its tag never seen. (Eval is right in
+// compilingPass.satisfies, where the question is the expression's VALUE.)
+func collectTags(expr constraint.Expr, into map[string]bool) {
+	switch e := expr.(type) {
+	case *constraint.TagExpr:
+		into[e.Tag] = true
+	case *constraint.NotExpr:
+		collectTags(e.X, into)
+	case *constraint.AndExpr:
+		collectTags(e.X, into)
+		collectTags(e.Y, into)
+	case *constraint.OrExpr:
+		collectTags(e.X, into)
+		collectTags(e.Y, into)
 	}
 }
 
@@ -104,33 +245,45 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 		if !enabled || slices.Contains(cfg.Linters.Disable, "govet") {
 			t.Errorf("%s does not run govet, so no pass in the merge gate vets a tagged file: `make vet` runs "+
 				"untagged and stops there", path)
+			continue
+		}
+		// Enabled and then emptied is the same outcome reached by a different
+		// door, and it reads as enabled to anything that checks only the linter
+		// list. `disable-all` alongside an explicit `enable` set is a deliberate
+		// narrowing the config may make; alongside nothing it leaves govet
+		// running zero analyzers.
+		govet := cfg.Linters.Settings.Govet
+		if govet.DisableAll && len(govet.Enable) == 0 {
+			t.Errorf("%s enables govet and then disables every analyzer it has, so the vet suite reaches no "+
+				"tagged file: drop linters.settings.govet.disable-all, or name the analyzers to keep under "+
+				"linters.settings.govet.enable", path)
 		}
 	}
 }
 
-// buildTagsInTree returns every tag named by a build constraint under treeRoot,
-// deduplicated and ordered.
-//
-// The tags are read out of the PARSED constraint rather than off the line,
-// because the two disagree in exactly the direction that loses a tag: `//go:build
-// integration && !race` names two, a line-splitter reports the operators as
-// well, and a negated tag still names the tag it negates.
-func buildTagsInTree(t *testing.T) []string {
+// constrainedFile is one file that carries a build constraint, and the
+// constraint it carries.
+type constrainedFile struct {
+	path string
+	expr constraint.Expr
+}
+
+// constrainedFiles returns every file under treeRoot whose header carries a
+// build constraint, paired with the PARSED constraint — the constraint is what
+// this gate judges, and reducing it to the tags it names loses the negation and
+// the operators that decide which passes admit the file.
+func constrainedFiles(t *testing.T) []constrainedFile {
 	t.Helper()
-	seen := map[string]bool{}
+	var found []constrainedFile
 	err := filepath.WalkDir(treeRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			// No hand-written Go in either, and both are thousands of files of
-			// pure walk cost. node_modules is an installed dependency tree;
-			// build/ is generated (gen-composition) and git-ignored, so it
-			// holds a SECOND copy of files this walk has already counted —
-			// present or absent depending on whether anyone has run `make
-			// composition`, which would make the census non-deterministic.
-			case "node_modules", "build", ".git":
+			// node_modules and .git hold no hand-written Go and are thousands
+			// of files of pure walk cost; the generated tree is skipped by
+			// path, for the reason stated on generatedTree.
+			if d.Name() == "node_modules" || d.Name() == ".git" || filepath.Clean(path) == filepath.Clean(generatedTree) {
 				return fs.SkipDir
 			}
 			return nil
@@ -154,42 +307,18 @@ func buildTagsInTree(t *testing.T) []string {
 			}
 			expr, err := constraint.Parse(line)
 			if err != nil {
-				// An unparseable constraint is not a tag this gate can judge,
-				// but it is also not something Go will build — reporting it
-				// here beats skipping it silently.
+				// An unparseable constraint is not one this gate can judge, but
+				// it is also not something Go will build — reporting it here
+				// beats skipping it silently.
 				t.Errorf("%s: parsing build constraint %q: %v", filepath.ToSlash(path), line, err)
 				continue
 			}
-			collectTags(expr, seen)
+			found = append(found, constrainedFile{path: filepath.ToSlash(path), expr: expr})
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking %s: %v", treeRoot, err)
 	}
-	tags := make([]string, 0, len(seen))
-	for tag := range seen {
-		tags = append(tags, tag)
-	}
-	slices.Sort(tags)
-	return tags
-}
-
-// collectTags walks a constraint structurally, which is what makes the census
-// total. constraint.Expr.Eval would be the shorter spelling and the wrong one:
-// it short-circuits, so the second operand of an `&&` whose first is already
-// false is never visited and its tag never seen.
-func collectTags(expr constraint.Expr, into map[string]bool) {
-	switch e := expr.(type) {
-	case *constraint.TagExpr:
-		into[e.Tag] = true
-	case *constraint.NotExpr:
-		collectTags(e.X, into)
-	case *constraint.AndExpr:
-		collectTags(e.X, into)
-		collectTags(e.Y, into)
-	case *constraint.OrExpr:
-		collectTags(e.X, into)
-		collectTags(e.Y, into)
-	}
+	return found
 }

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -55,6 +55,7 @@ import (
 	"io/fs"
 	"maps"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -177,9 +178,29 @@ func mergeGatePasses(t *testing.T) []compilingPass {
 	return passes
 }
 
-// unreadFiles ratifies a file whose constraint no pass satisfies and which is
-// nonetheless not a defect, with what leaving it unread costs.
-var unreadFiles = gatekit.Waive(map[string]string{})
+// unreadFiles ratifies a file the merge gate does not read, with what that
+// costs. Every entry here is platform-constrained, and that is not a
+// coincidence: golangci runs at ONE GOOS, so a file selected by a different one
+// cannot be linted by it at any tag setting. These are the files this
+// repository builds for a platform its gate does not run on.
+//
+// The list is worth reading as a whole rather than entry by entry. It is the
+// standing cost of shipping a desktop bundle from a Linux merge gate, it was
+// invisible until the census learned to read filename constraints, and every
+// line of it is code no linter has ever opened.
+var unreadFiles = gatekit.Waive(map[string]string{
+	// Backend, compiled for windows by `make build` and linted by nothing.
+	"../backend/internal/platform/blobstore/fs_sync_windows.go": "the windows half of a file-sync primitive: `make build` cross-compiles it so a type error is caught, but golangci runs at the host GOOS and never opens it — so gosec, depguard and revive have never read this syscall-adjacent code, and its unix sibling is the only half they judge",
+	"../backend/internal/platform/ownedfile/owned_windows.go":   "the windows half of the owned-file primitive, cross-compiled and unlinted for the reason its blobstore sibling above states — the cost is that a permissions or error-handling defect here is caught only by review",
+
+	// The desktop launcher is its own module, released by its own lanes.
+	"../desktop/launcher/platform_windows.go":  "desktop launcher platform layer: built by the windows release lane (desktop-windows.yml), not by the merge gate, which neither cross-compiles this module nor lints at a foreign GOOS. A break here surfaces at release rather than at merge",
+	"../desktop/launcher/process_windows.go":   "desktop launcher process control, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"../desktop/launcher/postgres_windows.go":  "desktop launcher Postgres supervision, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"../desktop/launcher/runerror_windows.go":  "desktop launcher error rendering, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"../desktop/launcher/browser_darwin.go":    "desktop launcher browser handoff for macOS: compiled by the macOS release lane (desktop-macos.yml) and by a maintainer's own machine, and by nothing at all in the merge gate — GOOS is not a tag, so no config entry could change that",
+	"../desktop/launcher/quarantine_darwin.go": "desktop launcher quarantine-attribute handling, macOS-only and reached only by the macOS release lane. This one carries the most risk of the set: it is the code that decides what a downloaded bundle is allowed to do, and no linter in this repository has read it",
+})
 
 func TestEveryBuildConstraintIsCompiledBySomePass(t *testing.T) {
 	t.Parallel()
@@ -345,6 +366,69 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 	}
 }
 
+// andConstraints joins two constraints the way Go does when a file carries both
+// a header and a filename suffix. Either side may be absent.
+func andConstraints(a, b constraint.Expr) constraint.Expr {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	default:
+		return &constraint.AndExpr{X: a, Y: b}
+	}
+}
+
+// knownPlatforms is the set of GOOS and GOARCH names Go recognises as filename
+// suffixes, asked of the TOOLCHAIN rather than written down here.
+//
+// A literal list would be a second copy of something the Go release owns and
+// revises, and it would go stale in the silent direction: a suffix this gate did
+// not recognise is a file it reads as unconstrained, which is the census going
+// short again in exactly the place this function exists to fix.
+func knownPlatforms(t *testing.T) map[string]bool {
+	t.Helper()
+	out, err := exec.Command("go", "tool", "dist", "list").Output()
+	if err != nil {
+		t.Fatalf("asking the toolchain for its GOOS/GOARCH names: %v", err)
+	}
+	known := map[string]bool{}
+	for _, pair := range strings.Fields(string(out)) {
+		goos, goarch, found := strings.Cut(pair, "/")
+		if !found {
+			t.Fatalf("`go tool dist list` printed %q, which is not a GOOS/GOARCH pair", pair)
+		}
+		known[goos] = true
+		known[goarch] = true
+	}
+	if len(known) == 0 {
+		t.Fatal("the toolchain named no platform at all, so every filename suffix below reads as unconstrained")
+	}
+	return known
+}
+
+// filenameConstraint returns the constraint Go applies to a file for its NAME
+// alone — `x_windows.go`, `x_amd64.go`, `x_windows_amd64.go` — or nil.
+//
+// The suffixes are read from the end, at most two, because that is the shape Go
+// defines: an optional GOARCH preceded by an optional GOOS. `_test` is stripped
+// first, so `x_windows_test.go` is constrained exactly as `x_windows.go` is.
+func filenameConstraint(name string, platforms map[string]bool) constraint.Expr {
+	base := strings.TrimSuffix(name, ".go")
+	base = strings.TrimSuffix(base, "_test")
+	parts := strings.Split(base, "_")
+	// The first segment is the file's own name and is never a platform, which
+	// is what stops a file called `windows.go` reading as constrained.
+	var expr constraint.Expr
+	for i := len(parts) - 1; i >= 1 && len(parts)-i <= 2; i-- {
+		if !platforms[parts[i]] {
+			break
+		}
+		expr = andConstraints(expr, &constraint.TagExpr{Tag: parts[i]})
+	}
+	return expr
+}
+
 // constrainedFile is one file that carries a build constraint, and the
 // constraint it carries.
 type constrainedFile struct {
@@ -352,12 +436,21 @@ type constrainedFile struct {
 	expr constraint.Expr
 }
 
-// constrainedFiles returns every file under repoRoot whose header carries a
-// build constraint, paired with the PARSED constraint — the constraint is what
-// this gate judges, and reducing it to the tags it names loses the negation and
-// the operators that decide which passes admit the file.
+// constrainedFiles returns every file under repoRoot that Go constrains at all,
+// paired with the PARSED constraint — the constraint is what this gate judges,
+// and reducing it to the tags it names loses the negation and the operators that
+// decide which passes admit the file.
+//
+// BOTH sources of constraint, because Go honours both and a census that reads
+// one is short by exactly the files that use the other. A `//go:build` header is
+// the visible spelling; `_windows.go`, `_amd64.go` and `_windows_amd64.go`
+// constrain by NAME with nothing in the file to see. This tree has eight such
+// files carrying no header at all, and the first version of this gate did not
+// know they existed. Where a file has both, the two are ANDed, which is what Go
+// does.
 func constrainedFiles(t *testing.T) []constrainedFile {
 	t.Helper()
+	platforms := knownPlatforms(t)
 	var found []constrainedFile
 	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -392,6 +485,7 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 		// Constraints live above the package clause; both spellings are read
 		// because Go still honours the legacy one, and a file carrying only
 		// that would otherwise pass unseen.
+		var expr constraint.Expr
 		for _, line := range strings.Split(string(b), "\n") {
 			if strings.HasPrefix(strings.TrimSpace(line), "package ") {
 				break
@@ -399,7 +493,7 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 			if !constraint.IsGoBuild(line) && !constraint.IsPlusBuild(line) {
 				continue
 			}
-			expr, err := constraint.Parse(line)
+			parsed, err := constraint.Parse(line)
 			if err != nil {
 				// An unparseable constraint is not one this gate can judge, but
 				// it is also not something Go will build — reporting it here
@@ -407,6 +501,10 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 				t.Errorf("%s: parsing build constraint %q: %v", filepath.ToSlash(path), line, err)
 				continue
 			}
+			expr = andConstraints(expr, parsed)
+		}
+		expr = andConstraints(expr, filenameConstraint(filepath.Base(path), platforms))
+		if expr != nil {
 			found = append(found, constrainedFile{path: filepath.ToSlash(path), expr: expr})
 		}
 		return nil

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every build tag that gates a Go file in this repository is carried by both
+// golangci configs, and both run govet.
+//
+// A tagged file is invisible to a pass that does not carry its tag. `make lint`
+// is the only pass in the merge gate that carries any: `make build`, `make vet`
+// and `make test` all run untagged, and the integration lane runs `-tags
+// integration` alone. So for every tag but `integration`, the golangci
+// build-tags list is the whole of that file's coverage — and a tag missing from
+// it means those files are compiled by nothing the gate runs.
+//
+// That is not a hypothetical failure mode. It is how a file reached this tree
+// referring to a package it does not import: no pass carried its tag, so
+// nothing ever type-checked it, and it read exactly like every file that
+// compiles.
+//
+// The second obligation is govet, and it exists because `make vet` runs
+// untagged only. Switching govet off in .golangci.yml would take the vet
+// analyzers away from every tagged file in the tree at once, and no other pass
+// would report it.
+//
+// WHAT THIS CATCHES: a build tag anywhere in the repository that a golangci
+// config does not carry, and govet disabled in either config.
+//
+// WHAT THIS DOES NOT CATCH, deliberately: whether carrying the tag is
+// SUFFICIENT — a file can be linted and still be wrong, which is what the
+// linters themselves are for. Nor does it judge GOOS/GOARCH constraints, which
+// Go satisfies from the platform rather than from a -tags list; those are
+// ratified in platformSelectedTags with what leaving them unread costs.
+
+import (
+	"go/build/constraint"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// treeRoot is the whole repository, deliberately wider than the trees golangci
+// actually reads. A tag gating a file anywhere here is a tag whose files
+// something ought to compile, and erring wide can only report a file that has
+// no reader — never hide one.
+const treeRoot = ".."
+
+// platformSelectedTags names the constraints Go satisfies from GOOS/GOARCH
+// rather than from a -tags list. No golangci entry could give these a reader,
+// so each carries what leaving it out costs instead.
+var platformSelectedTags = gatekit.Waive(map[string]string{
+	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. These files are read by the windows/amd64 cross-compile in `make build`, which is why that pass is in the always-on gate rather than the desktop lane",
+	"darwin":  "GOOS, so a build-tags entry would not reach it. The cost is real and accepted: a darwin-only file is compiled on a developer's own machine and by nothing in the Linux merge gate, so it is gated locally or not at all",
+})
+
+func TestEveryBuildTagInTheTreeIsCarriedByBothLintConfigs(t *testing.T) {
+	t.Parallel()
+	defer platformSelectedTags.AssertAllMatched(t)
+
+	found := buildTagsInTree(t)
+	if len(found) == 0 {
+		t.Fatal("the walk found no build constraint anywhere in the repository — a census that recognises " +
+			"nothing reports PASS over every unread lane there is, so the walk is broken rather than the tree clean")
+	}
+
+	// Both configs, because they carry SEPARATE build-tags lists: a tag added
+	// to one and not the other leaves half the linters blind, which is the
+	// case hardest to see from either file on its own.
+	for _, path := range lintConfigs {
+		carried := readGolangciConfig(t, path).Run.BuildTags
+		if len(carried) == 0 {
+			t.Errorf("%s carries no build tag at all, so every tagged file in the tree is invisible to it", path)
+			continue
+		}
+		for _, tag := range found {
+			if platformSelectedTags.Waived(t, tag) || slices.Contains(carried, tag) {
+				continue
+			}
+			t.Errorf("build tag %q gates a file in this tree but %s does not carry it, so nothing in the merge "+
+				"gate compiles those files: add it to that config's run.build-tags, or ratify it in "+
+				"platformSelectedTags with what leaving it unread costs", tag, path)
+		}
+	}
+}
+
+func TestBothLintConfigsRunGovet(t *testing.T) {
+	t.Parallel()
+	// `make vet` covers the untagged tree only, so these two passes are where
+	// the vet analyzers reach a tagged file. Losing govet here is silent: the
+	// lint pass still runs, still reports, and still passes.
+	for _, path := range lintConfigs {
+		cfg := readGolangciConfig(t, path)
+		// golangci's `standard` and `all` sets both include govet; anything
+		// else has to name it. `disable` wins over both, so it is asked last.
+		enabled := cfg.Linters.Default == "standard" || cfg.Linters.Default == "all" ||
+			slices.Contains(cfg.Linters.Enable, "govet")
+		if !enabled || slices.Contains(cfg.Linters.Disable, "govet") {
+			t.Errorf("%s does not run govet, so no pass in the merge gate vets a tagged file: `make vet` runs "+
+				"untagged and stops there", path)
+		}
+	}
+}
+
+// buildTagsInTree returns every tag named by a build constraint under treeRoot,
+// deduplicated and ordered.
+//
+// The tags are read out of the PARSED constraint rather than off the line,
+// because the two disagree in exactly the direction that loses a tag: `//go:build
+// integration && !race` names two, a line-splitter reports the operators as
+// well, and a negated tag still names the tag it negates.
+func buildTagsInTree(t *testing.T) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	err := filepath.WalkDir(treeRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// No hand-written Go in either, and both are thousands of files of
+			// pure walk cost. node_modules is an installed dependency tree;
+			// build/ is generated (gen-composition) and git-ignored, so it
+			// holds a SECOND copy of files this walk has already counted —
+			// present or absent depending on whether anyone has run `make
+			// composition`, which would make the census non-deterministic.
+			case "node_modules", "build", ".git":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || !d.Type().IsRegular() {
+			return nil
+		}
+		b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+		if err != nil {
+			return err
+		}
+		// Constraints live above the package clause; both spellings are read
+		// because Go still honours the legacy one, and a file carrying only
+		// that would otherwise pass unseen.
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "package ") {
+				break
+			}
+			if !constraint.IsGoBuild(line) && !constraint.IsPlusBuild(line) {
+				continue
+			}
+			expr, err := constraint.Parse(line)
+			if err != nil {
+				// An unparseable constraint is not a tag this gate can judge,
+				// but it is also not something Go will build — reporting it
+				// here beats skipping it silently.
+				t.Errorf("%s: parsing build constraint %q: %v", filepath.ToSlash(path), line, err)
+				continue
+			}
+			collectTags(expr, seen)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", treeRoot, err)
+	}
+	tags := make([]string, 0, len(seen))
+	for tag := range seen {
+		tags = append(tags, tag)
+	}
+	slices.Sort(tags)
+	return tags
+}
+
+// collectTags walks a constraint structurally, which is what makes the census
+// total. constraint.Expr.Eval would be the shorter spelling and the wrong one:
+// it short-circuits, so the second operand of an `&&` whose first is already
+// false is never visited and its tag never seen.
+func collectTags(expr constraint.Expr, into map[string]bool) {
+	switch e := expr.(type) {
+	case *constraint.TagExpr:
+		into[e.Tag] = true
+	case *constraint.NotExpr:
+		collectTags(e.X, into)
+	case *constraint.AndExpr:
+		collectTags(e.X, into)
+		collectTags(e.Y, into)
+	case *constraint.OrExpr:
+		collectTags(e.X, into)
+		collectTags(e.Y, into)
+	}
+}

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -379,29 +379,36 @@ func andConstraints(a, b constraint.Expr) constraint.Expr {
 	}
 }
 
-// knownPlatforms is the set of GOOS and GOARCH names Go recognises as filename
-// suffixes, asked of the TOOLCHAIN rather than written down here.
+// platformNames holds the GOOS and GOARCH names SEPARATELY, because Go's
+// filename suffixes are ordered and typed rather than "any two platform words".
+type platformNames struct {
+	goos   map[string]bool
+	goarch map[string]bool
+}
+
+// knownPlatforms asks the TOOLCHAIN for those names rather than writing them
+// down here.
 //
 // A literal list would be a second copy of something the Go release owns and
 // revises, and it would go stale in the silent direction: a suffix this gate did
 // not recognise is a file it reads as unconstrained, which is the census going
 // short again in exactly the place this function exists to fix.
-func knownPlatforms(t *testing.T) map[string]bool {
+func knownPlatforms(t *testing.T) platformNames {
 	t.Helper()
 	out, err := exec.Command("go", "tool", "dist", "list").Output()
 	if err != nil {
 		t.Fatalf("asking the toolchain for its GOOS/GOARCH names: %v", err)
 	}
-	known := map[string]bool{}
+	known := platformNames{goos: map[string]bool{}, goarch: map[string]bool{}}
 	for _, pair := range strings.Fields(string(out)) {
 		goos, goarch, found := strings.Cut(pair, "/")
 		if !found {
 			t.Fatalf("`go tool dist list` printed %q, which is not a GOOS/GOARCH pair", pair)
 		}
-		known[goos] = true
-		known[goarch] = true
+		known.goos[goos] = true
+		known.goarch[goarch] = true
 	}
-	if len(known) == 0 {
+	if len(known.goos) == 0 || len(known.goarch) == 0 {
 		t.Fatal("the toolchain named no platform at all, so every filename suffix below reads as unconstrained")
 	}
 	return known
@@ -410,21 +417,36 @@ func knownPlatforms(t *testing.T) map[string]bool {
 // filenameConstraint returns the constraint Go applies to a file for its NAME
 // alone — `x_windows.go`, `x_amd64.go`, `x_windows_amd64.go` — or nil.
 //
-// The suffixes are read from the end, at most two, because that is the shape Go
-// defines: an optional GOARCH preceded by an optional GOOS. `_test` is stripped
-// first, so `x_windows_test.go` is constrained exactly as `x_windows.go` is.
-func filenameConstraint(name string, platforms map[string]bool) constraint.Expr {
+// The two suffix positions are TYPED and ORDERED, not "any two platform words",
+// and reading them as interchangeable produces constraints Go never forms.
+// `x_linux_windows.go` is a windows file: `windows` is not a GOARCH, so Go takes
+// it as the GOOS and `linux` is part of the name. Treating both as platforms
+// yields `linux && windows`, which nothing satisfies — the gate would report a
+// file that builds fine as read by nothing. Over-recognition is the safer
+// direction to fail in and still the wrong answer.
+//
+// `_test` is stripped first, so `x_windows_test.go` is constrained exactly as
+// `x_windows.go` is. The first segment is the file's own name and is never read
+// as a platform, which is what stops a file called `windows.go` counting.
+func filenameConstraint(name string, platforms platformNames) constraint.Expr {
 	base := strings.TrimSuffix(name, ".go")
 	base = strings.TrimSuffix(base, "_test")
 	parts := strings.Split(base, "_")
-	// The first segment is the file's own name and is never a platform, which
-	// is what stops a file called `windows.go` reading as constrained.
-	var expr constraint.Expr
-	for i := len(parts) - 1; i >= 1 && len(parts)-i <= 2; i-- {
-		if !platforms[parts[i]] {
-			break
+	var goos, goarch string
+	switch n := len(parts); {
+	case n >= 2 && platforms.goarch[parts[n-1]]:
+		goarch = parts[n-1]
+		if n >= 3 && platforms.goos[parts[n-2]] {
+			goos = parts[n-2]
 		}
-		expr = andConstraints(expr, &constraint.TagExpr{Tag: parts[i]})
+	case n >= 2 && platforms.goos[parts[n-1]]:
+		goos = parts[n-1]
+	}
+	var expr constraint.Expr
+	for _, tag := range []string{goos, goarch} {
+		if tag != "" {
+			expr = andConstraints(expr, &constraint.TagExpr{Tag: tag})
+		}
 	}
 	return expr
 }

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -91,16 +91,32 @@ func skipForeignTree(name string) bool {
 // analyses marks the passes that also run a linter over what they compile. A
 // pass that only builds still answers the type-error question, which is why it
 // is counted at all.
+//
+// goBuildOnly marks a pass whose recipe is `go build`, which never compiles a
+// _test.go. Without it the model and its own diagnostic disagree: a
+// windows-only TEST file would report as "compiled but analysed by nothing"
+// when in truth nothing compiles it either.
+//
+// cgo mirrors what the recipe sets, because MatchFile reads it for the `cgo`
+// build tag. It is pinned per pass rather than inherited from the host, so the
+// gate's verdict is the merge gate's and not the verdict of whichever machine
+// happens to run it — a developer without a C toolchain would otherwise get a
+// different answer from CI about the same file.
 type compilingPass struct {
-	name     string
-	goos     string
-	tags     []string
-	analyses bool
+	name        string
+	goos        string
+	tags        []string
+	analyses    bool
+	goBuildOnly bool
+	cgo         bool
 }
 
 // admits reports whether this pass compiles the named file, asked of go/build so
 // that no rule about constraints is restated here.
 func (p compilingPass) admits(dir, name string) (bool, error) {
+	if p.goBuildOnly && strings.HasSuffix(name, "_test.go") {
+		return false, nil
+	}
 	ctx := build.Default
 	ctx.GOOS = p.goos
 	// The runner and every machine this gate runs on are 64-bit. A file
@@ -108,6 +124,7 @@ func (p compilingPass) admits(dir, name string) (bool, error) {
 	// these passes and worth being told.
 	ctx.GOARCH = "amd64"
 	ctx.BuildTags = p.tags
+	ctx.CgoEnabled = p.cgo
 	return ctx.MatchFile(dir, name)
 }
 
@@ -125,20 +142,23 @@ func (p compilingPass) admits(dir, name string) (bool, error) {
 func mergeGatePasses(t *testing.T) []compilingPass {
 	t.Helper()
 	passes := []compilingPass{
-		{name: "untagged (`make build`, `make vet`, `make test`, and `make lint-modules` outside backend/)", goos: "linux", analyses: true},
+		{name: "untagged (`make build`, `make vet`, `make test`, and `make lint-modules` outside backend/)", goos: "linux", analyses: true, cgo: true},
 		// `go build` never compiles a _test.go, so this row covers non-test
-		// files only. It is listed anyway because a windows-only production
-		// file would otherwise report as unread when that cross-compile does
-		// read it; a windows-only TEST file is genuinely unread.
-		{name: "the windows/amd64 cross-compile of non-test files (`make build`)", goos: "windows"},
-		{name: "the integration shards (`make test-integration`)", goos: "linux", tags: []string{"integration"}},
+		// files only — goBuildOnly is what makes that true of the code and not
+		// only of this comment. It is listed at all because a windows-only
+		// PRODUCTION file would otherwise report as unread when that
+		// cross-compile does read it.
+		//
+		// cgo off, mirroring the recipe's own `CGO_ENABLED=0`.
+		{name: "the windows/amd64 cross-compile of non-test files (`make build`)", goos: "windows", goBuildOnly: true},
+		{name: "the integration shards (`make test-integration`)", goos: "linux", tags: []string{"integration"}, cgo: true},
 	}
 	for _, path := range lintConfigs {
 		carried := readGolangciConfig(t, path).Run.BuildTags
 		if len(carried) == 0 {
 			t.Errorf("%s carries no build tag at all, so every tagged file in the tree is invisible to it", path)
 		}
-		passes = append(passes, compilingPass{name: path + " (`make lint`)", goos: "linux", tags: carried, analyses: true})
+		passes = append(passes, compilingPass{name: path + " (`make lint`)", goos: "linux", tags: carried, analyses: true, cgo: true})
 	}
 	return passes
 }
@@ -226,7 +246,7 @@ func TestBothLintConfigsReadTheSameFiles(t *testing.T) {
 	// file under a negation is one that comparing lists would miss.
 	var configs []compilingPass
 	for _, path := range lintConfigs {
-		configs = append(configs, compilingPass{name: path, goos: "linux", tags: readGolangciConfig(t, path).Run.BuildTags})
+		configs = append(configs, compilingPass{name: path, goos: "linux", tags: readGolangciConfig(t, path).Run.BuildTags, cgo: true})
 	}
 	if len(configs) != 2 {
 		t.Fatalf("expected two lint configs to compare, found %d", len(configs))

--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -13,17 +13,30 @@ package gates
 // that matter are the tagged lanes, where a single YAML list decides whether
 // anything reads them at all.
 //
-// That is not a hypothetical failure mode. It is how a file reached this tree
-// calling a function it does not import: no pass carried its tag, so nothing
-// ever type-checked it, and it read exactly like every file that compiles.
+// A file whose tag no pass carries can call a function it does not import and
+// never be told. Nothing type-checks it, and it reads on disk exactly like every
+// file that compiles.
 //
-// The subject is the CONSTRAINT, not the tags in it. Asking only whether each
-// tag appears somewhere is a weaker question that passes on the case worth
-// catching: `//go:build integration && !bench` names two tags both lint configs
-// carry, and is compiled by neither — because those configs set `bench` too,
-// which makes the second half false. Tag-presence says covered; nothing reads
-// it. So each constraint is EVALUATED against each pass's assignment, which is
-// also the only reading that gets negation and `||` right.
+// THREE questions are asked, and none implies the others.
+//
+// Is the file COMPILED at all? A no means a type error in it never surfaces.
+// This is about the whole CONSTRAINT rather than the tags in it: `bench &&
+// !integration` names two tags both lint configs carry and is admitted by no
+// pass, because those configs set `integration` too and the integration lane
+// does not set `bench`. So each constraint is EVALUATED against each pass's
+// assignment, which is also the only reading that gets negation and `||` right.
+//
+// Is it ANALYSED by anything? Compiling is not analysing, and the distinction is
+// load-bearing rather than pedantic: `make test-integration` compiles the tagged
+// tree and runs neither `go vet` nor golangci over it. So `integration &&
+// !bench` is compiled and read by no linter — a file the shards build and vet
+// never sees. Splitting the two is what makes that fail here rather than pass.
+//
+// Is it linted by BOTH configs? That one IS about the tags, because the two
+// configs run different linter sets and a file only one of them reads keeps half
+// the linters. Equal-satisfaction between the two configs would be the tidier
+// spelling and a weaker one: it agrees when a tag is missing from both, which is
+// exactly how 853 integration-tagged files could lose every linter at once.
 //
 // The second obligation is govet, and it exists because `make vet` runs
 // untagged only. Switching govet off in .golangci.yml — or leaving it enabled
@@ -50,20 +63,38 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// treeRoot is the whole repository, deliberately wider than the trees the lint
-// passes read. A constraint gating a file anywhere here is one something ought
-// to compile, and erring wide can only report a file that has no reader — never
-// hide one.
-const treeRoot = ".."
+// skipForeignTree reports whether a directory holds something other than this
+// repository's own source: dependencies somebody else wrote, a nested checkout,
+// or a tool's output. Every gate that walks this tree asks the same question, so
+// it is asked in one place — a second list drifts, and the half that goes stale
+// is the half that silently widens or narrows a census.
+//
+// Worktrees are the entry that earns this: this repository is worked in several
+// at once by design, and one placed inside the tree is a whole second checkout
+// whose files answer no question about this branch.
+func skipForeignTree(name string) bool {
+	switch name {
+	case "node_modules", ".git", ".tmp", "worktrees", ".claude", "dist", "coverage":
+		return true
+	}
+	return false
+}
 
-// generatedTree is skipped by PATH rather than by directory name. `build` is an
-// ordinary package name, and skipping every directory called that would drop a
-// real one — `internal/build/…` — out of the census silently, which is the
-// direction a census must never fail in. Only the repository's own generated
-// composition tree is meant: it is git-ignored and holds a second copy of files
-// already counted, so including it makes the census depend on whether anyone
-// has run `make composition`.
-var generatedTree = filepath.Join(treeRoot, "build")
+// generatedTrees are skipped by PATH rather than by directory name. `build` is
+// an ordinary package name, and skipping every directory called that would drop
+// a real package out of the census silently — the direction a census must never
+// fail in.
+//
+// These three and no more, matching what .gitignore anchors: it names them
+// individually and says why, so that an unrelated future /build asset is never
+// hidden. A name-based skip here would hide precisely what that anchoring went
+// out of its way to keep visible. Each holds generated copies of files already
+// counted, present or absent depending on whether anyone has run the generator.
+var generatedTrees = []string{
+	filepath.Join(repoRoot, "build", "composition"),
+	filepath.Join(repoRoot, "build", "composition-frontend"),
+	filepath.Join(repoRoot, "build", "desktop"),
+}
 
 // compilingPass is one assignment: the build tags set, and the GOOS the pass
 // runs at. GOOS matters because Go satisfies a `//go:build windows` constraint
@@ -73,6 +104,10 @@ type compilingPass struct {
 	name string
 	goos string
 	tags []string
+	// analyses reports whether this pass runs a linter over what it compiles.
+	// A pass that only builds still answers the type-error question, which is
+	// why it is counted at all.
+	analyses bool
 }
 
 // satisfies reports whether this pass compiles a file carrying expr.
@@ -106,7 +141,11 @@ func (p compilingPass) satisfies(expr constraint.Expr) bool {
 }
 
 // mergeGatePasses are the assignments under which the merge gate compiles this
-// tree. A constraint satisfied by none of them describes a file nothing reads.
+// tree. A constraint satisfied by none of them describes a file nothing builds.
+//
+// `analyses` marks the passes that also run a linter over what they compile.
+// The integration shards do not: they build the tagged tree to run its tests,
+// which surfaces a type error and no vet finding.
 //
 // The two golangci rows take their tags from the configs themselves, because
 // that list is the one that drifts. The rest are named with the recipe they
@@ -119,8 +158,13 @@ func (p compilingPass) satisfies(expr constraint.Expr) bool {
 func mergeGatePasses(t *testing.T) []compilingPass {
 	t.Helper()
 	passes := []compilingPass{
-		{name: "untagged (`make build`, `make vet`, `make test`)", goos: "linux"},
-		{name: "the windows/amd64 cross-compile (`make build`)", goos: "windows"},
+		{name: "untagged (`make build`, `make vet`, `make test`, and `make lint-modules` over every module outside backend/)", goos: "linux", analyses: true},
+		// `go build` never compiles a _test.go, so this row covers non-test
+		// files only. It is listed anyway because a windows-only production
+		// file would otherwise report as unread when that cross-compile does
+		// read it; a windows-only TEST file is genuinely unread, and the
+		// narrower claim is the one this row is allowed to make.
+		{name: "the windows/amd64 cross-compile of non-test files (`make build`)", goos: "windows"},
 		{name: "the integration shards (`make test-integration`)", goos: "linux", tags: []string{"integration"}},
 	}
 	for _, path := range lintConfigs {
@@ -128,7 +172,7 @@ func mergeGatePasses(t *testing.T) []compilingPass {
 		if len(carried) == 0 {
 			t.Errorf("%s carries no build tag at all, so every tagged file in the tree is invisible to it", path)
 		}
-		passes = append(passes, compilingPass{name: path + " (`make lint`)", goos: "linux", tags: carried})
+		passes = append(passes, compilingPass{name: path + " (`make lint`)", goos: "linux", tags: carried, analyses: true})
 	}
 	return passes
 }
@@ -149,19 +193,33 @@ func TestEveryBuildConstraintIsCompiledBySomePass(t *testing.T) {
 	}
 
 	names := make([]string, 0, len(passes))
+	analysing := make([]compilingPass, 0, len(passes))
 	for _, p := range passes {
 		names = append(names, p.name)
+		if p.analyses {
+			analysing = append(analysing, p)
+		}
 	}
 	for _, f := range constrained {
-		if slices.ContainsFunc(passes, func(p compilingPass) bool { return p.satisfies(f.expr) }) {
+		compiled := slices.ContainsFunc(passes, func(p compilingPass) bool { return p.satisfies(f.expr) })
+		read := slices.ContainsFunc(analysing, func(p compilingPass) bool { return p.satisfies(f.expr) })
+		if compiled && read {
 			continue
 		}
 		if unreadFiles.Waived(t, f.path) {
 			continue
 		}
+		if compiled {
+			t.Errorf("%s is compiled but ANALYSED by nothing: its constraint `%s` is satisfied only by a pass "+
+				"that builds without linting, so a type error in it surfaces and a vet, gosec or depguard finding "+
+				"never does. Add the tag to both golangci configs, or ratify the file in unreadFiles with what "+
+				"leaving it unanalysed costs", f.path, f.expr.String())
+			continue
+		}
 		t.Errorf("%s is compiled by no pass the merge gate runs: its constraint `%s` is false under every one of "+
 			"%s. Add the tag to both golangci configs so `make lint` reads it, or ratify the file in unreadFiles "+
-			"with what leaving it unread costs", f.path, f.expr.String(), strings.Join(names, ", "))
+			"with what leaving it unread costs — which is the answer for `ignore`, the standard spelling for a "+
+			"file meant to be `go run` and never built", f.path, f.expr.String(), strings.Join(names, ", "))
 	}
 }
 
@@ -207,7 +265,7 @@ func TestEveryTagIsCarriedByBothLintConfigs(t *testing.T) {
 // rather than from a -tags list. No golangci entry could carry them, so each
 // says what that costs instead.
 var platformSelectedTags = gatekit.Waive(map[string]string{
-	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. The windows-only files are read by the windows/amd64 cross-compile in `make build`, which is why that pass is in the always-on gate rather than the desktop lane",
+	"windows": "GOOS, so a build-tags entry would not reach it — golangci runs at the host GOOS. Every windows mention in this tree today is a NEGATION (`!windows`), which the Linux passes satisfy; a windows-ONLY file would be read by the `make build` cross-compile if it were production code and by nothing at all if it were a test, since `go build` skips _test.go",
 	"darwin":  "GOOS, so a build-tags entry would not reach it. Every darwin mention in this tree today is a NEGATION (`!darwin`), which the Linux passes satisfy — a darwin-ONLY file would be compiled on a maintainer's machine and by nothing in the merge gate, and this entry is what stops that reading as covered",
 })
 
@@ -231,8 +289,16 @@ func collectTags(expr constraint.Expr, into map[string]bool) {
 	}
 }
 
+// govetDisables ratifies each govet analyzer a config switches off, with what
+// losing it costs across every tagged file.
+var govetDisables = gatekit.Waive(map[string]string{
+	"fieldalignment": "a memory-layout micro-optimisation, not a correctness check: it reports struct field ORDER, and acting on it trades legible grouping for bytes this product never counts",
+	"shadow":         "high-noise on idiomatic Go — every `err :=` inside a block trips it — and the cases that are real bugs are reported by revive's early-return and by errcheck, so the coverage lost is the false-positive half",
+})
+
 func TestBothLintConfigsRunGovet(t *testing.T) {
 	t.Parallel()
+	defer govetDisables.AssertAllMatched(t)
 	// `make vet` covers the untagged tree only, so these two passes are where
 	// the vet analyzers reach a tagged file. Losing govet here is silent: the
 	// lint pass still runs, still reports, and still passes.
@@ -247,9 +313,9 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 				"untagged and stops there", path)
 			continue
 		}
-		// Enabled and then emptied is the same outcome reached by a different
-		// door, and it reads as enabled to anything that checks only the linter
-		// list. `disable-all` alongside an explicit `enable` set is a deliberate
+		// Enabled and then emptied is the same outcome by a different door, and
+		// it reads as enabled to anything that checks only the linter list.
+		// `disable-all` alongside an explicit `enable` set is a deliberate
 		// narrowing the config may make; alongside nothing it leaves govet
 		// running zero analyzers.
 		govet := cfg.Linters.Settings.Govet
@@ -257,6 +323,24 @@ func TestBothLintConfigsRunGovet(t *testing.T) {
 			t.Errorf("%s enables govet and then disables every analyzer it has, so the vet suite reaches no "+
 				"tagged file: drop linters.settings.govet.disable-all, or name the analyzers to keep under "+
 				"linters.settings.govet.enable", path)
+		}
+		// The narrower door, and the one already ajar: `disable` removes named
+		// analyzers while the linter still reports as enabled. Deleting `printf`
+		// here would take it from every tagged file in the tree at once, which
+		// is the coverage the removed `go vet -tags` pass used to backstop.
+		//
+		// The check is a RATIFIED set rather than a copy of go vet's default
+		// analyzer list. Restating that list here would be a second copy of
+		// something the toolchain owns and revises, and it would go stale
+		// silently; requiring a reason per entry costs one line and says why
+		// each absence is affordable.
+		for _, analyzer := range govet.Disable {
+			if govetDisables.Waived(t, analyzer) {
+				continue
+			}
+			t.Errorf("%s disables the govet analyzer %q, and `make vet` runs untagged only — so that check is "+
+				"gone from every tagged file in the tree. Ratify it in govetDisables with what losing it costs, "+
+				"or stop disabling it", path, analyzer)
 		}
 	}
 }
@@ -268,22 +352,29 @@ type constrainedFile struct {
 	expr constraint.Expr
 }
 
-// constrainedFiles returns every file under treeRoot whose header carries a
+// constrainedFiles returns every file under repoRoot whose header carries a
 // build constraint, paired with the PARSED constraint — the constraint is what
 // this gate judges, and reducing it to the tags it names loses the negation and
 // the operators that decide which passes admit the file.
 func constrainedFiles(t *testing.T) []constrainedFile {
 	t.Helper()
 	var found []constrainedFile
-	err := filepath.WalkDir(treeRoot, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			// node_modules and .git hold no hand-written Go and are thousands
-			// of files of pure walk cost; the generated tree is skipped by
-			// path, for the reason stated on generatedTree.
-			if d.Name() == "node_modules" || d.Name() == ".git" || filepath.Clean(path) == filepath.Clean(generatedTree) {
+			// Foreign trees first — a linked worktree under .claude/ or a
+			// scratch file under .tmp/ is ANOTHER checkout's source, and
+			// reporting one of its files here prints a remedy that cannot be
+			// followed because the file is not in this tree. The generated
+			// trees are then skipped by path, for the reason on generatedTrees.
+			if skipForeignTree(d.Name()) {
+				return fs.SkipDir
+			}
+			if slices.ContainsFunc(generatedTrees, func(t string) bool {
+				return filepath.Clean(path) == filepath.Clean(t)
+			}) {
 				return fs.SkipDir
 			}
 			return nil
@@ -291,7 +382,10 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 		if !strings.HasSuffix(path, ".go") || !d.Type().IsRegular() {
 			return nil
 		}
-		b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+		// path comes from walking this repository's own source tree, never from
+		// input. (No #nosec token: both configs exclude gosec on _test.go, so
+		// one here would suppress a linter that does not run.)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -318,7 +412,7 @@ func constrainedFiles(t *testing.T) []constrainedFile {
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("walking %s: %v", treeRoot, err)
+		t.Fatalf("walking %s: %v", repoRoot, err)
 	}
 	return found
 }

--- a/backend/gates/rulebookdelegation_test.go
+++ b/backend/gates/rulebookdelegation_test.go
@@ -33,9 +33,6 @@ import (
 	"testing"
 )
 
-// repoRoot is where the rulebooks live, relative to this package.
-const repoRoot = ".."
-
 // importLine matches the one line a shim is allowed to contain.
 var importLine = regexp.MustCompile(`^@AGENTS\.md$`)
 

--- a/backend/gates/rulebookdelegation_test.go
+++ b/backend/gates/rulebookdelegation_test.go
@@ -40,14 +40,14 @@ const repoRoot = ".."
 var importLine = regexp.MustCompile(`^@AGENTS\.md$`)
 
 // skipRulebookDir keeps the walk to the rulebooks this repository ships.
-// Worktrees hold whole checkouts of their own, including their own copies of
-// these files; node_modules holds other people's.
+//
+// The foreign-tree half is shared with every other gate that walks this
+// repository (skipForeignTree). `build` is this gate's own addition and belongs
+// only here: a generated tree can hold an AGENTS.md that is not a rulebook this
+// repository ships, whereas a directory named `build` can perfectly well be a
+// real Go package — so a gate walking SOURCE must not skip it by name.
 func skipRulebookDir(name string) bool {
-	switch name {
-	case "node_modules", ".git", ".tmp", "worktrees", "build", "dist", "coverage":
-		return true
-	}
-	return false
+	return skipForeignTree(name) || name == "build"
 }
 
 // rulebookDirs returns every directory holding an AGENTS.md.

--- a/backend/internal/compose/aicert/e2e_test.go
+++ b/backend/internal/compose/aicert/e2e_test.go
@@ -45,13 +45,13 @@ func TestE2ECertify(t *testing.T) {
 	// The binding is stated outright. There is no routing file to inherit one
 	// from any more, and a certification record should name the model it
 	// measured rather than whatever a file on the runner's disk happened to say.
-	binding, err := aicert.ParseBinding(os.Getenv("MARGINCE_AICERT_MODEL"), os.Getenv("MARGINCE_AICERT_BASE_URL"))
+	binding, err := ai.ParseBinding(os.Getenv("MARGINCE_AICERT_MODEL"), os.Getenv("MARGINCE_AICERT_BASE_URL"))
 	if err != nil {
 		t.Fatalf("MARGINCE_AICERT_MODEL: %v", err)
 	}
 	// The judge is a SECOND model on purpose: one grading itself is certified by
 	// construction. Run refuses the two being equal before a call is paid for.
-	judge, err := aicert.ParseBinding(os.Getenv("MARGINCE_AICERT_JUDGE_MODEL"), os.Getenv("MARGINCE_AICERT_JUDGE_BASE_URL"))
+	judge, err := ai.ParseBinding(os.Getenv("MARGINCE_AICERT_JUDGE_MODEL"), os.Getenv("MARGINCE_AICERT_JUDGE_BASE_URL"))
 	if err != nil {
 		t.Fatalf("MARGINCE_AICERT_JUDGE_MODEL: %v", err)
 	}

--- a/backend/internal/compose/aicert/runner_helpers_test.go
+++ b/backend/internal/compose/aicert/runner_helpers_test.go
@@ -102,28 +102,6 @@ func TestLadderForTaskCarriesTheEndpointToEveryRung(t *testing.T) {
 	}
 }
 
-func TestParseBindingRefusesAMalformedSpec(t *testing.T) {
-	for _, spec := range []string{"no-colon-here", ":model-only", "provider-only:"} {
-		if _, err := ParseBinding(spec, ""); err == nil || !strings.Contains(err.Error(), "provider:model") {
-			t.Errorf("ParseBinding(%q) = %v, want a provider:model complaint", spec, err)
-		}
-	}
-}
-
-func TestParseBindingKeepsAVariantSuffixedModelSlugWhole(t *testing.T) {
-	// OpenRouter marks a model's served variant with a colon suffix (":free",
-	// ":batch", ":thinking"), so the split must cut at the FIRST colon —
-	// cutting at the last would certify a different variant than was asked for
-	// and file the record under the name of the one that was not run.
-	got, err := ParseBinding("openai_compatible:openai/gpt-oss-20b:free", "https://openrouter.ai/api")
-	if err != nil {
-		t.Fatalf("variant-suffixed spec rejected: %v", err)
-	}
-	if got.Provider != "openai_compatible" || got.Model != "openai/gpt-oss-20b:free" {
-		t.Fatalf("ParseBinding split to %+v, want the whole slug including its variant suffix", got)
-	}
-}
-
 // An override rebinds the tiers the profile rule is ABOUT, so the loaded
 // file's guarantees do not survive it. Certifying a cloud model is a
 // legitimate thing to want; doing it against a config that still says

--- a/backend/internal/compose/aicert/selection.go
+++ b/backend/internal/compose/aicert/selection.go
@@ -11,29 +11,10 @@ package aicert
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/platform/config"
 )
-
-// ParseBinding reads a "provider:model" spec and the endpoint that goes with it.
-//
-// The split cuts at the FIRST colon and leaves the rest of the slug whole:
-// OpenRouter marks a served variant with its own colon suffix (":free",
-// ":batch", ":thinking"), and cutting at the last one would silently certify a
-// different variant from the one asked for.
-//
-// baseURL is carried rather than inferred. openai_compatible fails closed
-// without one — the endpoint belongs to the vendor, not the model — so a broker
-// run supplies it and a native vendor leaves it empty for the provider default.
-func ParseBinding(spec, baseURL string) (ai.ProviderConfig, error) {
-	provider, modelName, found := strings.Cut(spec, ":")
-	if !found || provider == "" || modelName == "" {
-		return ai.ProviderConfig{}, fmt.Errorf("aicert: a model binding wants provider:model, got %q", spec)
-	}
-	return ai.ProviderConfig{Provider: provider, Model: modelName, BaseURL: baseURL}, nil
-}
 
 // ladderForTask binds every tier in a task's ladder to the run's one binding.
 //

--- a/backend/internal/compose/voicelive_smoke_test.go
+++ b/backend/internal/compose/voicelive_smoke_test.go
@@ -30,7 +30,7 @@ func TestVoiceLiveSmoke(t *testing.T) {
 	if spec == "" {
 		t.Fatal("set MARGINCE_VOICE_MODEL=provider:model (this smoke is manual-only)")
 	}
-	binding, err := aicert.ParseBinding(spec, os.Getenv("MARGINCE_VOICE_BASE_URL"))
+	binding, err := ai.ParseBinding(spec, os.Getenv("MARGINCE_VOICE_BASE_URL"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -260,3 +260,26 @@ func ConfigItems() []config.Item {
 	}
 	return items
 }
+
+// ParseBinding reads a "provider:model" spec and the endpoint that goes with it.
+//
+// It lives beside ProviderConfig rather than beside a caller, because that is
+// the only domain type it names — and because a caller that cannot import the
+// package it first landed in would otherwise need a second spelling of the
+// first-colon rule below, which is the one thing that must not be copied.
+//
+// The split cuts at the FIRST colon and leaves the rest of the slug whole:
+// OpenRouter marks a served variant with its own colon suffix (":free",
+// ":batch", ":thinking"), and cutting at the last one would silently certify a
+// different variant from the one asked for.
+//
+// baseURL is carried rather than inferred. openai_compatible fails closed
+// without one — the endpoint belongs to the vendor, not the model — so a broker
+// run supplies it and a native vendor leaves it empty for the provider default.
+func ParseBinding(spec, baseURL string) (ProviderConfig, error) {
+	provider, modelName, found := strings.Cut(spec, ":")
+	if !found || provider == "" || modelName == "" {
+		return ProviderConfig{}, fmt.Errorf("ai: a model binding wants provider:model, got %q", spec)
+	}
+	return ProviderConfig{Provider: provider, Model: modelName, BaseURL: baseURL}, nil
+}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -263,10 +263,16 @@ func ConfigItems() []config.Item {
 
 // ParseBinding reads a "provider:model" spec and the endpoint that goes with it.
 //
-// It lives beside ProviderConfig rather than beside a caller, because that is
-// the only domain type it names — and because a caller that cannot import the
-// package it first landed in would otherwise need a second spelling of the
-// first-colon rule below, which is the one thing that must not be copied.
+// It lives beside ProviderConfig because that is the only domain type it names,
+// and because its callers cannot share it anywhere lower: aicert sits under
+// compose, so a compose test cannot import it without a cycle, and the alternative
+// is two spellings of the first-colon rule below — the one thing here that must
+// not be copied.
+//
+// Exported with no production caller today, deliberately. Both callers are
+// by-hand lanes (`e2e_llm`, `voicelive`) that hand it an operator-supplied spec;
+// the rule is about how a binding is WRITTEN, so it belongs with the type
+// whichever lane reads one next.
 //
 // The split cuts at the FIRST colon and leaves the rest of the slug whole:
 // OpenRouter marks a served variant with its own colon suffix (":free",

--- a/backend/internal/modules/ai/selectbrain_test.go
+++ b/backend/internal/modules/ai/selectbrain_test.go
@@ -123,3 +123,25 @@ func allCloudKeys() config.Lookup {
 	}
 	return config.Static(keys)
 }
+
+func TestParseBindingRefusesAMalformedSpec(t *testing.T) {
+	for _, spec := range []string{"no-colon-here", ":model-only", "provider-only:"} {
+		if _, err := ParseBinding(spec, ""); err == nil || !strings.Contains(err.Error(), "provider:model") {
+			t.Errorf("ParseBinding(%q) = %v, want a provider:model complaint", spec, err)
+		}
+	}
+}
+
+func TestParseBindingKeepsAVariantSuffixedModelSlugWhole(t *testing.T) {
+	// OpenRouter marks a model's served variant with a colon suffix (":free",
+	// ":batch", ":thinking"), so the split must cut at the FIRST colon —
+	// cutting at the last would certify a different variant than was asked for
+	// and file the record under the name of the one that was not run.
+	got, err := ParseBinding("openai_compatible:openai/gpt-oss-20b:free", "https://openrouter.ai/api")
+	if err != nil {
+		t.Fatalf("variant-suffixed spec rejected: %v", err)
+	}
+	if got.Provider != "openai_compatible" || got.Model != "openai/gpt-oss-20b:free" {
+		t.Fatalf("ParseBinding split to %+v, want the whole slug including its variant suffix", got)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -86,7 +86,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
-| `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by at least one pass the merge gate runs, and both lint configs run govet. |
+| `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by a pass the merge gate runs, analysed by one that lints, and read by both lint configs or neither. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -54,7 +54,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (58)
+## Census (59)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -86,6 +86,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
+| `lintbuildtagreach_test.go` | H2 | Every build tag that gates a Go file in this repository is carried by both golangci configs, and both run govet. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -86,7 +86,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
-| `lintbuildtagreach_test.go` | H2 | Every build tag that gates a Go file in this repository is carried by both golangci configs, and both run govet. |
+| `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by at least one pass the merge gate runs, and both lint configs run govet. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -160,8 +160,8 @@ gating a merge on them, which is why each prints p50/p95/p99 beside its budget
 instead of only passing or failing. `bench-mobile` below is the frontend half of
 the same posture.
 
-They are still **type-checked** on every `make check`: `go vet -tags 'integration
-bench'` and both golangci passes carry the tag. That is load-bearing rather than
+They are still **type-checked** on every `make check`: both golangci passes carry
+the tag, and `gates/lintbuildtagreach_test.go` fails if either stops. That is load-bearing rather than
 tidiness — nothing scheduled compiles these files, so without it a renamed helper
 would break them silently and nobody would find out until the next person ran a
 benchmark by hand and had to debug the harness instead of reading a number.


### PR DESCRIPTION
## What this does

The merge gate vetted the tagged tree **twice**. `.golangci.yml` already carries `integration`, `livesmoke` and `bench` and enables `govet`, so `go vet -tags 'integration bench' ./...` re-ran the same analyzers over a subset of the same files. It is gone.

That leg — `vet/lint/arch-lint/test/test-extensions (-j4)` — is **~70% of the `deterministic-gates` job**, and the job is the critical path of the whole run.

Untagged `go vet` **stays**, and is not redundant: golangci runs WITH those tags, so a file guarded `//go:build !integration` is excluded there and read here and nowhere else. Twenty files in `gates/` are in exactly that position.

## Measured before it was removed, because the claim is a subsumption

A `%d`-for-a-string planted in an `//go:build integration` file:

| pass | verdict |
|---|---|
| `go vet ./...` (untagged) | silent — never reads the file |
| `go vet -tags 'integration bench' ./...` | catches it |
| golangci baseline | catches it — **same analyzer**, `govet`/printf |

The structural argument agrees: setting a tag only ADDS files, so golangci's tag set is a superset of vet's; golangci's `govet` defaults enable everything but `fieldalignment`/`shadow`, a superset of `go vet`'s suite; and no exclusion rule in either config touches `govet` — the only ones target `gosec` and `forbidigo`, and there is no `presets:` key, so v2's default exclusions are off.

## The gate found two lanes with no reader at all

Deriving the census the gate needs — every build tag in the tree, against what each pass carries:

| tag | files | read by |
|---|---|---|
| `integration` | 853 | golangci |
| `bench` | 3 | golangci |
| `livesmoke` | 1 | golangci |
| `windows` | 2 | the GOOS cross-build |
| **`e2e_llm`** | **2** | **nothing** |
| **`voicelive`** | **1** | **nothing** |

`internal/compose/voicelive_smoke_test.go` calls `aicert.ParseBinding` and does not import `aicert`. **It has never compiled.** No pass carried its tag, so nothing type-checked it, and on disk it read exactly like every file that does — no red anywhere, at any point.

Both tags are now carried by both configs, and all five tags type-check (`go vet -tags <t> ./...`, each run separately).

### Why `ParseBinding` moved

`aicert` imports `compose`, so `compose`'s in-package test importing `aicert` is an import cycle — adding the missing import does not fix it. `ParseBinding` names only `ai.ProviderConfig`; it sat in `aicert` because that was its first caller. It now lives beside the type it builds, with its two tests.

Not re-spelled into the caller on purpose: the docblock's first-colon rule (`openai_compatible:openai/gpt-oss-20b:free` — cutting at the last colon certifies a different variant than was asked for) is the one thing a second copy would get wrong.

## A gate holds it, because both halves fail silently

`backend/gates/lintbuildtagreach_test.go` asserts every build tag in the tree is carried by **both** configs, and that both run `govet`. Losing either is invisible: the lint pass still runs, still reports, and still passes.

It reuses the package's existing `lintConfigs` and `readGolangciConfig` rather than adding a second spelling; `golangciConfig` gained `Default` and `Disable`.

Tags are read out of the **parsed** constraint, walked structurally. `constraint.Expr.Eval` is the shorter spelling and the wrong one — it short-circuits, so the second operand of an `&&` whose first is false is never visited and its tag is never seen.

Mutation-tested, each mutant proved to have applied:

| mutant | |
|---|---|
| a tag drops out of the baseline config | caught |
| a tag drops out of the **strict config only** | caught |
| the baseline stops running govet | caught |
| govet disabled after being enabled | caught |
| a platform waiver outlives its files | caught |
| the walk finds no build constraint at all (the floor) | caught |
| a tag reachable only as the second operand of `&&` | caught |

The last one is the one the naive census loses.

## Two waivers

`windows` and `darwin` are GOOS, satisfied from the platform rather than a `-tags` list, so no golangci entry could give them a reader. Ratified in a `gatekit.Waive` set with what that costs — the windows files are read by `make build`'s cross-compile; a darwin-only file is compiled on a developer's machine and by nothing in the Linux merge gate, which is stated rather than papered over.

## Verification

- `make check-backend` green.
- Each of `voicelive`, `e2e_llm`, `bench`, `livesmoke`, `integration` type-checks under `go vet -tags <t> ./...`.
- `docs/reference/gate-inventory.md` regenerated — the first `make check-backend` failed on it, which is the drift gate doing its job.

## What this does not fix

The `-j4` leg is still CPU-saturated: roughly 930 core-seconds on a 4-core runner. `golangci` is the pole (two passes, the strict one analysing `./...` to report on changed lines only). The step change there is cores or scoping that pass, not removing more work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the merge gate's double vetting of the tagged tree and adds a gate census that catches build-tagged files nothing compiles — it found the `voicelive` smoke test had never compiled.

- The tagged `go vet -tags 'integration bench'` leg is gone from `make vet`; golangci already runs the same analyzers.
- Both golangci configs now carry `e2e_llm` and `voicelive` and run `govet`, with only `fieldalignment` and `shadow` ratified off.
- The census asks `go/build`'s `MatchFile` which merge-gate pass admits each file, requiring every file be compiled, linted, and read by both configs.
- Each pass models its own recipe: cgo is pinned per pass and the windows cross-compile skips `_test.go`.
- Eight windows/darwin files no linter has ever opened are ratified in waivers.
- `ParseBinding` moves to `internal/modules/ai` with its tests, breaking the import cycle that kept `voicelive` uncompiled.
- `repoRoot` moves to the gate package's untagged test file.
- Regenerates the gate inventory.

<sup>Written for commit bc77a55923336d4d838d5f74ddffe8f38eb02025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model binding validation and parsing.
  - Preserved model names containing additional colon-separated variants.
  - Standardized binding behavior across certification and voice testing.

- **Chores**
  - Expanded lint and analysis coverage for benchmark, end-to-end, integration, and voice-related build configurations.
  - Added safeguards to ensure tagged code is consistently compiled and analyzed.
  - Streamlined verification checks for untagged and tagged code.

- **Documentation**
  - Updated gate and build-target documentation to reflect the expanded validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->