### PR TITLE
fix(platform): a lost re-claim reports what the rival left, not "in progress"

### DIFF
--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -244,6 +244,14 @@ func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, dig
 // re-claim in place. The row is read FOR UPDATE inside the caller's
 // transaction, so two concurrent attempts under one key cannot both execute.
 func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (claimOutcome, storedResponse, error) {
+	return resolveClaimRow(ctx, tx, principalID, key, endpoint, digest, true)
+}
+
+// resolveClaimRow is resolveExistingClaim's body. mayReclaim is false on the
+// second pass — the one that reads back what a rival left after this attempt
+// lost the re-claim — so a row that vanishes twice inside one transaction
+// cannot loop.
+func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string, mayReclaim bool) (claimOutcome, storedResponse, error) {
 	var storedDigest, contentType string
 	var status *int
 	var respBody *string
@@ -262,6 +270,12 @@ func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endp
 		// nothing — but simply erroring here would degrade to executing
 		// with NO claim recorded, and two concurrent retries of one key
 		// would then both execute. Claim it again instead.
+		if !mayReclaim {
+			// The row went twice inside one transaction. Nothing is left to
+			// read, and in-flight is the answer that costs least if wrong:
+			// it tells the caller to retry rather than inventing a result.
+			return claimInProgress, storedResponse{}, nil
+		}
 		claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
 		if err != nil {
 			return claimFresh, storedResponse{}, err
@@ -269,9 +283,17 @@ func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endp
 		if claimed {
 			return claimFresh, storedResponse{}, nil
 		}
-		// Someone re-created it in the same instant; the honest answer is
-		// that this attempt is still in flight elsewhere.
-		return claimInProgress, storedResponse{}, nil
+		// A rival re-created it in the same instant. What they left is not
+		// necessarily in flight — it may already carry a stored response, or a
+		// different request digest — and the four verdicts below are what
+		// decide which. Reading it is the difference between answering
+		// "already used with a different request body" and telling that caller
+		// their own retry is still running.
+		//
+		// The read blocks rather than racing: the losing INSERT waited on the
+		// rival's uncommitted row, so by the time it answered the winner had
+		// committed and FOR UPDATE sees it.
+		return resolveClaimRow(ctx, tx, principalID, key, endpoint, digest, false)
 	}
 	if err != nil {
 		return claimFresh, storedResponse{}, err

--- a/backend/internal/compose/idempotencyreclaim_integration_test.go
+++ b/backend/internal/compose/idempotencyreclaim_integration_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The claim transaction's re-claim arm, over a real Postgres: when the
+// retention sweep removes a row between this attempt's INSERT and its read,
+// the attempt claims the key again — and when a rival wins that race, what
+// the rival left decides the answer.
+//
+// It used to be hardcoded: whatever the winner had recorded, the loser was
+// told "a request with this idempotency key is still in progress". A settled
+// claim and a claim under a different request body are different things to be
+// told, and a client that branches on the two 409 details was told the wrong
+// one.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// reclaimVerdict runs the read-back pass — the one that reports what a rival
+// left after this attempt lost the re-claim — against whatever the fixture put
+// in the table.
+func reclaimVerdict(t *testing.T, e *integration.Env, principalID, key, digest string) claimOutcome {
+	t.Helper()
+	var got claimOutcome
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		outcome, _, err := resolveClaimRow(context.Background(), tx, principalID, key, "POST /v1/people", digest, false)
+		got = outcome
+		return err
+	}); err != nil {
+		t.Fatalf("reading back the rival's claim: %v", err)
+	}
+	return got
+}
+
+func TestALostReclaimReportsWhatTheRivalActuallyLeft(t *testing.T) {
+	e := integration.Setup(t)
+	principalID := "human:" + ids.NewV7().String()
+
+	// The rival settled: its response is recorded and this attempt's own
+	// digest matches, so the honest answer is a replay of that response —
+	// not "still in progress", which is what the hardcoded branch said.
+	settled := ids.NewV7().String()
+	e.WsExec(t, `
+		INSERT INTO idempotency_key
+		  (principal_id, key, endpoint, request_digest,
+		   response_status, response_body, response_content_type, created_at)
+		VALUES ($1, $2, 'POST /v1/people', 'digest',
+		        201, '{"full_name":"Ada"}', 'application/json', now())`,
+		principalID, settled)
+	if got := reclaimVerdict(t, e, principalID, settled, "digest"); got != claimReplay {
+		t.Errorf("a settled rival reports %v, want claimReplay — its response is recorded and this request is the same one", got)
+	}
+
+	// The rival holds the same key for a DIFFERENT body. "Already used with a
+	// different request body" is the answer; telling this caller their own
+	// retry is in flight sends them to retry a key that will never accept it.
+	mismatched := ids.NewV7().String()
+	e.WsExec(t, `
+		INSERT INTO idempotency_key
+		  (principal_id, key, endpoint, request_digest, created_at)
+		VALUES ($1, $2, 'POST /v1/people', 'the-rivals-digest', now())`,
+		principalID, mismatched)
+	if got := reclaimVerdict(t, e, principalID, mismatched, "our-digest"); got != claimMismatch {
+		t.Errorf("a rival holding a different body reports %v, want claimMismatch", got)
+	}
+
+	// And an unsettled rival under the SAME body genuinely is in flight —
+	// the verdict the old branch always gave, now given for a reason.
+	inFlight := ids.NewV7().String()
+	e.WsExec(t, `
+		INSERT INTO idempotency_key
+		  (principal_id, key, endpoint, request_digest, created_at)
+		VALUES ($1, $2, 'POST /v1/people', 'digest', now())`,
+		principalID, inFlight)
+	if got := reclaimVerdict(t, e, principalID, inFlight, "digest"); got != claimInProgress {
+		t.Errorf("an unsettled rival under one body reports %v, want claimInProgress", got)
+	}
+}
+
+// A row that vanishes TWICE inside one transaction has nothing left to read.
+// The pass stops rather than looping, and answers in-flight — the verdict that
+// costs least if it is wrong, because it tells the caller to retry rather than
+// inventing a result.
+func TestAClaimThatVanishesTwiceStopsRatherThanLooping(t *testing.T) {
+	e := integration.Setup(t)
+	if got := reclaimVerdict(t, e, "human:"+ids.NewV7().String(), ids.NewV7().String(), "digest"); got != claimInProgress {
+		t.Errorf("a claim with no row at all reports %v, want claimInProgress", got)
+	}
+}


### PR DESCRIPTION
The claim transaction has an arm for the retention sweep removing a row between this attempt's INSERT and its `FOR UPDATE` read. The row was past the replay window so it protected nothing, and erroring there would execute with **no claim recorded**, letting two concurrent retries of one key both run — so the attempt claims the key again.

When that re-claim **lost** — a rival re-created the key in the same instant — the outcome was hardcoded to `claimInProgress`. But the row the rival left may already be **settled** (the honest answer is a replay of its recorded response) or may carry a **different request digest** ("already used with a different request body"). Both were reported as *"a request with this idempotency key is still in progress"*.

Nothing executes twice either way and the 409 tells the client to retry, so this was never unsafe — it was **untrue**, and the two 409s carry different detail text precisely so a client can tell them apart.

The arm now reads the row back and lets the same four verdicts decide, which is what the surrounding function already implements. The read blocks rather than racing: the losing INSERT waited on the rival's uncommitted row, so by the time it answered the winner had committed and `FOR UPDATE` sees it. A second pass cannot re-claim, so a row that vanishes twice inside one transaction stops rather than looping and answers in-flight — the verdict that costs least if it is wrong.

## On coverage, stated plainly

The read-back pass is covered where it can be driven deterministically: replay for a settled rival, mismatch for one holding a different body, in-flight for an unsettled one under the same body.

Driving the sweep-then-recreate **interleaving** end to end is not covered. It needs an injection point between the read and the INSERT, which the issue itself names as the open question (*"awkward to test without a deliberate injection point for the sweep-then-recreate interleaving — worth deciding how to express that before implementing"*). The wiring that reaches the covered pass is one line and visible in review; I would rather say that than imply the race is pinned.

`make check-backend` green.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved idempotency reclaim handling when competing claims are recreated or removed.
  - Accurate outcomes are now reported for matching completed requests, mismatched requests, and requests still in progress.
  - Prevented repeated reclaim attempts from looping indefinitely when a claim disappears multiple times.
- **Tests**
  - Added integration coverage for reclaim conflicts, missing claims, replay behavior, mismatches, and in-progress requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->