### PR TITLE
fix(capture): relinking an activity merges its displaced participants

### DIFF
--- a/backend/internal/compose/integration/relinkparticipants_integration_test.go
+++ b/backend/internal/compose/integration/relinkparticipants_integration_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Relink repoints the activity's PARTICIPANTS along with its link, so the two
+// keep telling one story: a human saying "this conversation was not with her,
+// it was with him" must not leave her named on it. activity_participant is
+// registered PII and is what the interaction-edge projection derives its
+// (user, person) pairs from, so a row left behind keeps feeding a
+// relationship-strength signal for somebody the human just ruled out.
+//
+// Both shapes below used to break that, in opposite directions.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func seedRelinkActivity(t *testing.T, e *Env, subject string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', $2, now(), 'manual', 'human:x')`, id, subject)
+	return id
+}
+
+func namedOn(t *testing.T, e *Env, activity, person ids.UUID) int {
+	t.Helper()
+	return e.WsCount(t, `SELECT count(*) FROM activity_participant
+		 WHERE activity_id = $1 AND person_id = $2`, activity, person)
+}
+
+// The target is ALREADY a participant. The repoint's skip left the displaced
+// row standing, so the activity's link named him and its participants still
+// named her.
+func TestRelinkRemovesTheDisplacedParticipantWhenTheTargetIsAlreadyOne(t *testing.T) {
+	e := Setup(t)
+	admin := e.As(e.Rep1, nil, AdminPerms)
+	her, him := e.SeedPerson(t, "Ingrid Sattler", nil), e.SeedPerson(t, "Tomas Berg", nil)
+	act := seedRelinkActivity(t, e, "Quote follow-up")
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, act, her)
+	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'to', $2)`, act, her)
+	// He was on it too, in another role — which is a different row under
+	// uq_activity_participant, and used to be enough to skip the repoint.
+	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'cc', $2)`, act, him)
+
+	if _, err := e.Activities.RelinkActivity(admin, ids.From[ids.ActivityKind](act), activities.RelinkActivityInput{
+		EntityType: "person", EntityID: him, ReplaceExistingOfType: true,
+	}); err != nil {
+		t.Fatalf("relink: %v", err)
+	}
+
+	if n := namedOn(t, e, act, her); n != 0 {
+		t.Errorf("the displaced contact is still named on the activity (%d row(s)) — "+
+			"its link says one thing and its participants another", n)
+	}
+	if n := namedOn(t, e, act, him); n == 0 {
+		t.Error("the target is named on no participant row; the relink dropped the conversation's only party")
+	}
+}
+
+// SEVERAL displaced participants and no target row. Every one of them
+// qualified for the rewrite, and the second collided with the first on
+// uq_activity_participant.
+func TestRelinkMergesSeveralDisplacedParticipantsWithoutColliding(t *testing.T) {
+	e := Setup(t)
+	admin := e.As(e.Rep1, nil, AdminPerms)
+	her, other := e.SeedPerson(t, "Ingrid Sattler", nil), e.SeedPerson(t, "Petra Lang", nil)
+	him := e.SeedPerson(t, "Tomas Berg", nil)
+	act := seedRelinkActivity(t, e, "Renewal thread")
+	for _, p := range []ids.UUID{her, other} {
+		e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, act, p)
+		// The SAME role, which is what makes the two collide once both are
+		// rewritten to one person.
+		e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'to', $2)`, act, p)
+	}
+
+	if _, err := e.Activities.RelinkActivity(admin, ids.From[ids.ActivityKind](act), activities.RelinkActivityInput{
+		EntityType: "person", EntityID: him, ReplaceExistingOfType: true,
+	}); err != nil {
+		t.Fatalf("relink with two displaced participants: %v", err)
+	}
+
+	if n := namedOn(t, e, act, him); n != 1 {
+		t.Errorf("the target is named on %d participant row(s), want exactly 1 — "+
+			"two displaced rows merge onto one person, they do not each become one", n)
+	}
+	for name, p := range map[string]ids.UUID{"Ingrid": her, "Petra": other} {
+		if n := namedOn(t, e, act, p); n != 0 {
+			t.Errorf("%s is still named on the activity (%d row(s)) after being relinked away", name, n)
+		}
+	}
+}

--- a/backend/internal/compose/integration/relinkparticipants_integration_test.go
+++ b/backend/internal/compose/integration/relinkparticipants_integration_test.go
@@ -45,8 +45,11 @@ func TestRelinkRemovesTheDisplacedParticipantWhenTheTargetIsAlreadyOne(t *testin
 	act := seedRelinkActivity(t, e, "Quote follow-up")
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, act, her)
 	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'to', $2)`, act, her)
-	// He was on it too, in another role — which is a different row under
-	// uq_activity_participant, and used to be enough to skip the repoint.
+	// He was on it too, in ANOTHER role — a different row under
+	// uq_activity_participant, and no obstacle to the repoint, but enough to
+	// make the old guard skip it because that guard asked only about the
+	// person. The displaced row is promoted here; the same-role case below is
+	// the one that has to delete instead.
 	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'cc', $2)`, act, him)
 
 	if _, err := e.Activities.RelinkActivity(admin, ids.From[ids.ActivityKind](act), activities.RelinkActivityInput{
@@ -94,5 +97,33 @@ func TestRelinkMergesSeveralDisplacedParticipantsWithoutColliding(t *testing.T) 
 		if n := namedOn(t, e, act, p); n != 0 {
 			t.Errorf("%s is still named on the activity (%d row(s)) after being relinked away", name, n)
 		}
+	}
+}
+
+// The target already holds a row of the SAME shape, so there is nothing to
+// promote the displaced row into — it has to be deleted. This is the branch
+// the different-role case above cannot reach, and the one that decides whether
+// "merge" means merge or means duplicate.
+func TestRelinkDeletesTheDisplacedParticipantWhenTheTargetHoldsItsShape(t *testing.T) {
+	e := Setup(t)
+	admin := e.As(e.Rep1, nil, AdminPerms)
+	her, him := e.SeedPerson(t, "Ingrid Sattler", nil), e.SeedPerson(t, "Tomas Berg", nil)
+	act := seedRelinkActivity(t, e, "Quote follow-up")
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, act, her)
+	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'to', $2)`, act, her)
+	e.WsExec(t, `INSERT INTO activity_participant (activity_id, role, person_id) VALUES ($1, 'to', $2)`, act, him)
+
+	if _, err := e.Activities.RelinkActivity(admin, ids.From[ids.ActivityKind](act), activities.RelinkActivityInput{
+		EntityType: "person", EntityID: him, ReplaceExistingOfType: true,
+	}); err != nil {
+		t.Fatalf("relink: %v", err)
+	}
+
+	if n := namedOn(t, e, act, her); n != 0 {
+		t.Errorf("the displaced contact is still named on the activity (%d row(s))", n)
+	}
+	if n := namedOn(t, e, act, him); n != 1 {
+		t.Errorf("the target is named on %d row(s), want exactly 1 — its own row was already there, "+
+			"so the displaced one is removed rather than renamed onto it", n)
 	}
 }

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -368,21 +368,58 @@ func repointDisplacedParticipants(ctx context.Context, tx pgx.Tx, id ids.Activit
 		// An unbounded caller narrows nothing.
 		visible = "true"
 	}
+	// One merge, not a conditional rewrite. The repoint used to UPDATE each
+	// displaced row to the target and skip when the target was already a
+	// participant, which was wrong in both directions:
+	//
+	//   - the skip left the displaced row naming the OLD contact, so the
+	//     activity's links said one thing and its participants another —
+	//     exactly what the repoint exists to prevent — and that row kept
+	//     feeding a relationship-strength signal for somebody the human had
+	//     just said the conversation was not with;
+	//   - with several displaced participants and no target row, every one of
+	//     them qualified and each was rewritten to the target, colliding on
+	//     uq_activity_participant.
+	//
+	// The uniqueness is per (activity, role, user, person, address), not per
+	// person, so both the skip test and the collision are decided by the whole
+	// tuple. Within each such group exactly one displaced row is promoted to
+	// the target — and only when the target holds no row of that shape
+	// already — and the rest are deleted. Either way the target is named once
+	// and no displaced row survives.
+	const nilUUID = `'00000000-0000-0000-0000-000000000000'::uuid`
 	if _, err := tx.Exec(ctx, storekit.SQLf(`
-		UPDATE activity_participant ap
-		   SET person_id = $%d
-		 WHERE ap.activity_id = $%d
-		   -- Exactly the people the link delete removed, and no
-		   -- others. A participant can name somebody who was never
-		   -- linked at all, and inferring the displaced set from "no
-		   -- longer linked" would rewrite them too.
-		   AND ap.person_id = ANY($%d::uuid[])
-		   AND ap.person_id <> $%d
-		   AND EXISTS (SELECT 1 FROM person op WHERE op.id = ap.person_id AND (`+visible+`))
-		   AND NOT EXISTS (
-		       SELECT 1 FROM activity_participant other
-		        WHERE other.activity_id = ap.activity_id AND other.person_id = $%d)`,
-		targetPos, idPos, displacedPos, targetPos, targetPos), pargs...); err != nil {
+		WITH scoped AS (
+			SELECT ap.id, ap.role, ap.user_id, ap.address,
+			       row_number() OVER (
+			           PARTITION BY ap.role, coalesce(ap.user_id, `+nilUUID+`), coalesce(ap.address, '')
+			           ORDER BY ap.id) AS rank
+			  FROM activity_participant ap
+			 WHERE ap.activity_id = $%d
+			   -- Exactly the people the link delete removed, and no
+			   -- others. A participant can name somebody who was never
+			   -- linked at all, and inferring the displaced set from "no
+			   -- longer linked" would rewrite them too.
+			   AND ap.person_id = ANY($%d::uuid[])
+			   AND ap.person_id <> $%d
+			   AND EXISTS (SELECT 1 FROM person op WHERE op.id = ap.person_id AND (`+visible+`))
+		), promoted AS (
+			UPDATE activity_participant ap SET person_id = $%d
+			  FROM scoped s
+			 WHERE ap.id = s.id AND s.rank = 1
+			   AND NOT EXISTS (
+			       SELECT 1 FROM activity_participant other
+			        WHERE other.activity_id = ap.activity_id
+			          AND other.role = s.role
+			          AND other.person_id = $%d
+			          AND coalesce(other.user_id, `+nilUUID+`) = coalesce(s.user_id, `+nilUUID+`)
+			          AND coalesce(other.address, '') = coalesce(s.address, ''))
+			RETURNING ap.id
+		)
+		DELETE FROM activity_participant
+		 WHERE id IN (SELECT id FROM scoped)
+		   AND id NOT IN (SELECT id FROM promoted)`,
+		idPos, displacedPos, targetPos, targetPos, targetPos), pargs...); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
`RelinkActivity` repoints the activity's participants along with its link, so the two keep telling one story: a human saying *"this conversation was not with her, it was with him"* must not leave her named on it. The repoint was a conditional rewrite with a `NOT EXISTS` guard, and it was wrong in **both** directions.

**Skipped.** When the target already had a participant row, the guard fired and the displaced row was neither rewritten nor deleted — so the activity's link named him and its participants still named her. `activity_participant` is registered PII and is what the interaction-edge projection derives its `(user, person)` pairs from, so that row kept feeding a relationship-strength signal for somebody the human had just ruled out.

**Collided.** With several displaced participants and no target row, every one of them qualified and each was rewritten to the target, violating `uq_activity_participant`.

**The guard also asked the wrong question.** Uniqueness is per `(activity, role, user, person, address)`, not per person — so a target already on the activity in a *different role* was enough to skip a rewrite that would not have collided, and two displaced rows in the *same* role collided where the guard saw nothing.

One set-based merge replaces it, keyed on the tuple the index actually uses: within each group exactly one displaced row is promoted to the target — and only where the target holds no row of that shape already — and the rest are deleted. Either way the target is named once and no displaced row survives.

Both shapes have a case, and both fail against the old statement:

```
the displaced contact is still named on the activity (1 row(s)) — its link says one thing and its participants another
relink with two displaced participants: ERROR: duplicate key value violates unique constraint "uq_activity_participant" (SQLSTATE 23505)
```

Out of scope, and unchanged: the stale interaction-edge gap documented in-source at the same call site is a public-event contract change and stays its own slice.

`make check-backend` green.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity relinking when participants are reassigned.
  * Prevented duplicate participant records and uniqueness conflicts during relinking.
  * Removed stale participant entries left behind after multiple participants are merged.
  * Ensured displaced participants are correctly removed when the destination already contains a matching participant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->