### PR TITLE
fix(capture): raw_capture keeps the provider's bytes

### DIFF
--- a/backend/internal/compose/participantreplay.go
+++ b/backend/internal/compose/participantreplay.go
@@ -26,6 +26,7 @@ package compose
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -213,13 +214,28 @@ func replayOne(ctx context.Context, tx pgx.Tx, c replayCandidate) (string, error
 
 // decodeStoredOriginal unwraps what the sink put in raw_capture.payload.
 //
-// The column is jsonb and a provider's original need not be JSON: capture
-// stores a non-JSON payload (an RFC822 message) as a JSON *string*, and a JSON
-// one (a calendar event resource) as itself. Both spellings arrive here, so
-// the string case is unwrapped and anything else is handed on as it stands.
+// The column is jsonb and a provider's original need not be JSON, so three
+// spellings arrive here: a JSON payload (a calendar event resource) as itself,
+// text (an RFC822 message) as a JSON *string*, and bytes jsonb cannot hold as
+// text — invalid UTF-8, or a NUL — in a base64 envelope that names its own
+// encoding. The envelope is checked before the string case because it IS a
+// JSON object, and it is checked by its declared encoding rather than by shape
+// so a provider payload that happens to carry those two keys cannot be
+// mistaken for one.
 func decodeStoredOriginal(payload []byte) ([]byte, error) {
 	if len(payload) == 0 {
 		return nil, errors.New("compose: the stored original is empty")
+	}
+	var envelope struct {
+		Encoding string `json:"encoding"`
+		Data     string `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err == nil && envelope.Encoding == capture.RawCaptureBase64Encoding {
+		raw, err := base64.StdEncoding.DecodeString(envelope.Data)
+		if err != nil {
+			return nil, fmt.Errorf("compose: decoding the stored original: %w", err)
+		}
+		return raw, nil
 	}
 	if !strings.HasPrefix(strings.TrimSpace(string(payload)), `"`) {
 		return payload, nil

--- a/backend/internal/modules/capture/rawcapturepayload_test.go
+++ b/backend/internal/modules/capture/rawcapturepayload_test.go
@@ -49,6 +49,11 @@ func TestARawCapturePayloadComesBackByteIdentical(t *testing.T) {
 		{"a body that is not valid UTF-8", []byte("Subject: Gr\xfc\xdfe\r\n\r\nlatin-1 \xff\xfe bytes")},
 		{"a body carrying a NUL", []byte("Subject: quarterly update\r\n\r\nHello\x00World")},
 		{"JSON whose own string escapes a NUL", []byte(`{"body":"Hello\u0000World"}`)},
+		// The lookalike: an escaped BACKSLASH followed by the text u0000. It
+		// decodes to a backslash and five characters, carries no NUL, and jsonb
+		// takes it — so it must stay stored as itself rather than be sent down
+		// the base64 path by a search that cannot tell the two apart.
+		{"JSON carrying the TEXT of a NUL escape", []byte(`{"body":"Hello\\u0000World"}`)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stored, err := rawCapturePayload(tc.raw)
@@ -117,4 +122,21 @@ func carriesNUL(v any) bool {
 		}
 	}
 	return false
+}
+
+// The lookalike above decides between two spellings, so it gets its own
+// assertion rather than only riding the round-trip.
+func TestTheTextOfANULEscapeIsStoredAsJSON(t *testing.T) {
+	lookalike := []byte(`{"body":"Hello\\u0000World"}`)
+	stored, err := rawCapturePayload(lookalike)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stored) != string(lookalike) {
+		t.Errorf("stored as %q, want the document unchanged — it carries the TEXT of an escape, not a NUL", stored)
+	}
+	escaped := []byte(`{"body":"Hello\u0000World"}`)
+	if stored, err := rawCapturePayload(escaped); err != nil || string(stored) == string(escaped) {
+		t.Errorf("a real NUL escape stored as %q (err %v), want it off the as-itself path", stored, err)
+	}
 }

--- a/backend/internal/modules/capture/rawcapturepayload_test.go
+++ b/backend/internal/modules/capture/rawcapturepayload_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// raw_capture is the copy a re-parse or a dispute reads, so what it holds has
+// to be what the provider sent. These pin that: every shape a provider can
+// send comes back byte-identical, and the two the old spelling lost are named.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// roundTrip is what a reader does with a stored payload, in the order
+// compose's decodeStoredOriginal does it.
+func roundTrip(t *testing.T, stored []byte) []byte {
+	t.Helper()
+	var envelope rawCaptureEnvelope
+	if err := json.Unmarshal(stored, &envelope); err == nil && envelope.Encoding == RawCaptureBase64Encoding {
+		raw, err := base64.StdEncoding.DecodeString(envelope.Data)
+		if err != nil {
+			t.Fatalf("decoding the envelope: %v", err)
+		}
+		return raw
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(stored)), `"`) {
+		return stored
+	}
+	var text string
+	if err := json.Unmarshal(stored, &text); err != nil {
+		t.Fatalf("unwrapping the stored string: %v", err)
+	}
+	return []byte(text)
+}
+
+func TestARawCapturePayloadComesBackByteIdentical(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+	}{
+		{"a JSON resource, stored as itself", []byte(`{"id":"evt_1","summary":"Kickoff"}`)},
+		{"an RFC822 message, stored as a JSON string", []byte("From: a@b.test\r\nSubject: Hallo\r\n\r\nGruesse")},
+		// The two the old spelling lost. A body in a non-UTF-8 charset came
+		// back with U+FFFD where its bytes had been; a NUL never came back at
+		// all, because jsonb refused the row and took the whole capture with it.
+		{"a body that is not valid UTF-8", []byte("Subject: Gr\xfc\xdfe\r\n\r\nlatin-1 \xff\xfe bytes")},
+		{"a body carrying a NUL", []byte("Subject: quarterly update\r\n\r\nHello\x00World")},
+		{"JSON whose own string escapes a NUL", []byte(`{"body":"Hello\u0000World"}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stored, err := rawCapturePayload(tc.raw)
+			if err != nil {
+				t.Fatalf("storing: %v", err)
+			}
+			// Whatever shape it took, jsonb has to accept it: a payload
+			// carrying a NUL escape is refused by the column, and the
+			// connectors treat that refusal as fatal to the whole pull.
+			if !json.Valid(stored) {
+				t.Fatalf("the stored payload is not JSON at all: %q", stored)
+			}
+			// What jsonb refuses is a NUL in a decoded string, not the
+			// characters that spell one — a payload that escapes its own
+			// backslash carries the text and no NUL, and is accepted.
+			var decoded any
+			if err := json.Unmarshal(stored, &decoded); err != nil {
+				t.Fatalf("the stored payload does not decode: %q", stored)
+			}
+			if carriesNUL(decoded) {
+				t.Errorf("the stored payload decodes to a string carrying a NUL, which jsonb refuses: %q", stored)
+			}
+			if got := roundTrip(t, stored); string(got) != string(tc.raw) {
+				t.Errorf("read back %q, want the provider's own %q", got, tc.raw)
+			}
+		})
+	}
+}
+
+// The common shapes keep the spelling every existing row uses, so this is a fix
+// for the broken case rather than a rewrite of the table.
+func TestTheUnbrokenShapesKeepTheirOldSpelling(t *testing.T) {
+	resource := []byte(`{"id":"evt_1"}`)
+	if stored, err := rawCapturePayload(resource); err != nil || string(stored) != string(resource) {
+		t.Errorf("a JSON resource stored as %q (err %v), want it unchanged", stored, err)
+	}
+	text := []byte("From: a@b.test\r\n\r\nHallo")
+	stored, err := rawCapturePayload(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(stored), `"`) {
+		t.Errorf("text stored as %q, want the JSON-string spelling", stored)
+	}
+}
+
+// carriesNUL walks a decoded payload for the one thing jsonb will not store:
+// a NUL inside a string.
+//
+//craft:ignore naked-any a decoded JSON document has no shape to name - this walks whatever the provider sent, which is the point
+func carriesNUL(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.ContainsRune(t, 0)
+	case map[string]any:
+		for _, e := range t {
+			if carriesNUL(e) {
+				return true
+			}
+		}
+	case []any:
+		for _, e := range t {
+			if carriesNUL(e) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/modules/capture/sinkraw.go
+++ b/backend/internal/modules/capture/sinkraw.go
@@ -75,9 +75,7 @@ type rawCaptureEnvelope struct {
 // anything else travels base64 in a self-describing envelope. Only the third
 // case is new, and it is exactly the case that was being lost.
 func rawCapturePayload(raw []byte) ([]byte, error) {
-	// \u0000 is legal JSON and illegal jsonb, so a provider's own escaped NUL
-	// has to leave the JSON path too.
-	if json.Valid(raw) && !bytes.Contains(bytes.ToLower(raw), []byte(`\u0000`)) {
+	if json.Valid(raw) && !jsonEscapesNUL(raw) {
 		return raw, nil
 	}
 	if utf8.Valid(raw) && !bytes.ContainsRune(raw, 0) {
@@ -87,4 +85,32 @@ func rawCapturePayload(raw []byte) ([]byte, error) {
 		Encoding: RawCaptureBase64Encoding,
 		Data:     base64.StdEncoding.EncodeToString(raw),
 	})
+}
+
+// jsonEscapesNUL reports whether a JSON document decodes to a string carrying a
+// NUL. That escape is legal JSON and illegal jsonb, so such a document has to
+// leave the as-itself path even though it parses.
+//
+// Parity, not substring. The bytes `\\u0000` are a valid JSON document that
+// decodes to a BACKSLASH followed by the text u0000 — no NUL anywhere — and a
+// plain search would send it down the base64 path for nothing. Only a `u0000`
+// preceded by an ODD run of backslashes is an escape rather than the text of
+// one, because the run's last backslash is what escapes the u.
+func jsonEscapesNUL(raw []byte) bool {
+	lower := bytes.ToLower(raw)
+	for at := 0; ; {
+		found := bytes.Index(lower[at:], []byte("u0000"))
+		if found < 0 {
+			return false
+		}
+		found += at
+		slashes := 0
+		for k := found - 1; k >= 0 && lower[k] == '\\'; k-- {
+			slashes++
+		}
+		if slashes%2 == 1 {
+			return true
+		}
+		at = found + len("u0000")
+	}
 }

--- a/backend/internal/modules/capture/sinkraw.go
+++ b/backend/internal/modules/capture/sinkraw.go
@@ -4,9 +4,12 @@
 package capture
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -22,15 +25,9 @@ func storeRawCapture(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRec
 	if len(rec.Raw) == 0 {
 		return nil
 	}
-	payload := rec.Raw
-	if !json.Valid(payload) {
-		// Non-JSON originals are stored as a JSON string so the
-		// column type never rejects a provider's format.
-		encoded, err := json.Marshal(string(rec.Raw))
-		if err != nil {
-			return err
-		}
-		payload = encoded
+	payload, err := rawCapturePayload(rec.Raw)
+	if err != nil {
+		return err
 	}
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO raw_capture (source_system, source_id, payload)
@@ -40,4 +37,54 @@ func storeRawCapture(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRec
 		return fmt.Errorf("capture: raw store: %w", err)
 	}
 	return nil
+}
+
+// RawCaptureBase64Encoding names the envelope rawCapturePayload uses for a
+// provider original that jsonb cannot hold as text. It is exported so the one
+// reader that unwraps a stored original reads the name rather than repeating
+// the string.
+const RawCaptureBase64Encoding = "base64"
+
+// rawCaptureEnvelope carries bytes jsonb will not take, and says so. The
+// encoding travels WITH the payload rather than being inferred, because a
+// reader guessing at a blob is how a re-parse silently reads the wrong bytes.
+type rawCaptureEnvelope struct {
+	Encoding string `json:"encoding"`
+	Data     string `json:"data"`
+}
+
+// rawCapturePayload turns a provider's original into something the jsonb
+// column can hold without ALTERING a byte of it. raw_capture is the copy a
+// re-parse or a dispute reads, so what it holds has to be what the provider
+// sent — the one thing this table exists for.
+//
+// The old spelling was json.Marshal(string(raw)) for anything non-JSON, and it
+// broke on the two shapes mail actually produces:
+//
+//   - Go's encoder replaces every invalid UTF-8 byte with U+FFFD, so a body in
+//     a non-UTF-8 charset, or a malformed header, was stored ALTERED. The
+//     insert succeeded and the row looked fine; only a byte comparison against
+//     the provider would have shown it.
+//   - A NUL becomes the escape \u0000, which jsonb refuses outright
+//     (22P05). That one does not corrupt quietly — it fails the capture
+//     transaction, and the connectors treat a non-skip error as fatal to the
+//     whole pull.
+//
+// So: JSON that jsonb will take is stored as itself; text that is valid UTF-8
+// and NUL-free keeps the JSON-string spelling every existing row uses; and
+// anything else travels base64 in a self-describing envelope. Only the third
+// case is new, and it is exactly the case that was being lost.
+func rawCapturePayload(raw []byte) ([]byte, error) {
+	// \u0000 is legal JSON and illegal jsonb, so a provider's own escaped NUL
+	// has to leave the JSON path too.
+	if json.Valid(raw) && !bytes.Contains(bytes.ToLower(raw), []byte(`\u0000`)) {
+		return raw, nil
+	}
+	if utf8.Valid(raw) && !bytes.ContainsRune(raw, 0) {
+		return json.Marshal(string(raw))
+	}
+	return json.Marshal(rawCaptureEnvelope{
+		Encoding: RawCaptureBase64Encoding,
+		Data:     base64.StdEncoding.EncodeToString(raw),
+	})
 }


### PR DESCRIPTION
The raw-evidence insert stored a non-JSON original as `json.Marshal(string(rec.Raw))`. Go's encoder replaces every invalid UTF-8 byte with U+FFFD, so a payload that is not valid UTF-8 was stored **altered** — and `raw_capture` then no longer held what the provider sent, which is the one thing that table exists to hold.

Mail is the realistic trigger: a body in a non-UTF-8 charset, or a malformed header, is not exotic. The corruption is silent — the insert succeeds, the row looks fine, and only a byte-level comparison against the provider would reveal it. The raw copy is what a re-parse or a dispute reads, so a silent substitution is the worst shape this could take.

The same encode has a second edge with a sharper end: a NUL becomes the six-character escape that jsonb refuses outright (`22P05`). That one does not corrupt quietly — it fails the capture transaction.

## Three shapes, only the third is new

- JSON the column will take is stored **as itself**, unchanged;
- text that is valid UTF-8 and NUL-free keeps the **JSON-string spelling** every existing row already uses;
- anything else travels **base64 in an envelope that names its own encoding**.

The encoding travels *with* the payload rather than being inferred, because a reader guessing at a blob is how a re-parse silently reads the wrong bytes. The one reader that unwraps a stored original — `decodeStoredOriginal` — recognises the envelope by its declared encoding rather than by shape, so a provider payload that happens to carry those two keys cannot be mistaken for one.

**No migration.** Every existing row keeps its spelling, and the two shapes that already worked take the same path they took before.

## Coverage

The cases walk every shape a provider can send and require it back byte for byte. Against the old spelling, exactly the two the issue names fail:

```
--- FAIL: .../a_body_that_is_not_valid_UTF-8
--- FAIL: .../a_body_carrying_a_NUL
```

## Relationship to #2548

This removes the mechanism behind that report's poison pill **at its source** — the NUL no longer reaches the column as an escape, so the insert no longer fails and the sync watermark no longer sticks. It does **not** close #2548: that asks additionally for the Sink to classify a data-shape rejection (SQLSTATE class 22) as `connector.ErrSkip`, so that *any* future unstorable message can never hold a mailbox's cursor back. That defence-in-depth half is still worth having and is left open.

`make check-backend` green.

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raw capture now preserves non-UTF-8 data and content containing NUL characters without altering the original bytes.
  * Base64-encoded raw captures are supported when storing and reading captured payloads.
  * Existing JSON and text payload formats remain compatible and unchanged where applicable.
  * JSON containing literal escaped text continues to be preserved correctly.

* **Bug Fixes**
  * Invalid base64-encoded captures are now rejected with an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->