### PR TITLE
fix(ai): a voice-source weight has to be a number

### DIFF
--- a/backend/internal/modules/ai/voice_source_mutations.go
+++ b/backend/internal/modules/ai/voice_source_mutations.go
@@ -66,8 +66,8 @@ func (s *VoiceStore) UpdateSource(ctx context.Context, profileID, sourceID ids.U
 }
 
 func validateSourceUpdate(in UpdateSourceInput) (*bool, error) {
-	if in.Weight != nil && (*in.Weight < 0 || *in.Weight > 2.0) {
-		return nil, &CorpusIngestError{Field: voiceKeyWeight, Reason: "must be between 0 and 2"}
+	if in.Weight != nil && voiceWeightRefused(*in.Weight) {
+		return nil, &CorpusIngestError{Field: voiceKeyWeight, Reason: voiceWeightRange}
 	}
 	excluded := in.Excluded
 	if in.Included != nil {

--- a/backend/internal/modules/ai/voicesources.go
+++ b/backend/internal/modules/ai/voicesources.go
@@ -10,6 +10,7 @@ package ai
 // visibleProfile gate.
 
 import (
+	"math"
 	"strings"
 	"time"
 
@@ -134,8 +135,8 @@ func validateDeclaredSource(in IngestSourceInput) (register string, weight float
 	if weight == 0 {
 		weight = 1.0
 	}
-	if weight < 0 || weight > 2.0 {
-		return "", 0, &CorpusIngestError{Field: voiceKeyWeight, Reason: "must be between 0 and 2"}
+	if voiceWeightRefused(weight) {
+		return "", 0, &CorpusIngestError{Field: voiceKeyWeight, Reason: voiceWeightRange}
 	}
 	if strings.TrimSpace(in.SourceLabel) == "" {
 		return "", 0, &CorpusIngestError{Field: voiceKeySourceLabel, Reason: voiceValidationNotEmpty}
@@ -225,4 +226,25 @@ func transcriptCorpusFormat(content string) string {
 	default:
 		return corpusFormatSRT
 	}
+}
+
+// voiceWeightRange is the refusal both write paths answer with, so a caller
+// hears the same sentence from the ingest and from the manifest patch.
+const voiceWeightRange = "must be a number between 0 and 2"
+
+// voiceWeightRefused reports a weight the corpus cannot use.
+//
+// The finiteness test is the point of this function existing. A weight is a
+// MULTIPLIER in voice-corpus scoring, and every comparison against NaN is
+// false — so `w < 0 || w > 2` admitted NaN, and the JSON decoders on this path
+// take NaN and Infinity as numbers, which is what made it reachable from the
+// wire. One NaN weight then propagates through every sum and average it takes
+// part in and turns the whole computed profile into NaN: a silent failure
+// nobody can attribute, rather than a rejected request.
+//
+// Both infinities were already refused by the bounds (+Inf fails the upper,
+// -Inf the lower). They are named anyway, so the check says what it means
+// instead of catching them by accident.
+func voiceWeightRefused(weight float64) bool {
+	return math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 || weight > 2.0
 }

--- a/backend/internal/modules/ai/voiceweight_test.go
+++ b/backend/internal/modules/ai/voiceweight_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// A voice-source weight is a multiplier in corpus scoring, so a value that is
+// not a number does not fail loudly - it propagates through every sum and
+// average it takes part in and turns the computed profile into NaN. The range
+// check alone could not refuse one, because every comparison against NaN is
+// false.
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestAVoiceWeightMustBeANumberInRange(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		weight  float64
+		refused bool
+	}{
+		{"the default", 1.0, false},
+		{"the lower bound", 0, false},
+		{"the upper bound", 2.0, false},
+		{"below the range", -0.5, true},
+		{"above the range", 2.5, true},
+		// The one the range check admitted: NaN compares false against both
+		// bounds, so it passed and was stored.
+		{"not a number", math.NaN(), true},
+		{"positive infinity", math.Inf(1), true},
+		{"negative infinity", math.Inf(-1), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := voiceWeightRefused(tc.weight); got != tc.refused {
+				t.Errorf("voiceWeightRefused(%v) = %t, want %t", tc.weight, got, tc.refused)
+			}
+		})
+	}
+}
+
+// Both write paths validate separately, so fixing one would have left the
+// other open. They answer through the same check and say the same sentence.
+func TestBothVoiceWritePathsRefuseANaNWeight(t *testing.T) {
+	_, _, err := validateDeclaredSource(IngestSourceInput{
+		Kind: voiceSourceKindEmail, Register: voiceRegisterEmail,
+		SourceLabel: "a label", Content: "some text", Weight: math.NaN(),
+	})
+	var refusal *CorpusIngestError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("the ingest accepted a NaN weight (err %v)", err)
+	}
+	if refusal.Field != voiceKeyWeight || refusal.Reason != voiceWeightRange {
+		t.Errorf("the ingest refused a NaN weight as %s/%q, want %s/%q",
+			refusal.Field, refusal.Reason, voiceKeyWeight, voiceWeightRange)
+	}
+}


### PR DESCRIPTION
A weight is a **multiplier** in voice-corpus scoring, and the range check could not refuse one that is not a number: every comparison against NaN is false, so `weight < 0 || weight > 2.0` admitted it and stored it. The JSON decoders on this path take `NaN` and `Infinity` as numbers, so the value is reachable from the wire.

The cost is not a rejected request, it is a silent one. A single NaN weight propagates through every sum and average it takes part in and turns the whole computed profile into NaN — an obviously-wrong number would at least be attributable.

**Both write paths validated separately**, so fixing one would have left the other open: the ingest's declared-field check and the manifest patch each carried their own copy of the bounds. Both now answer through one function and say one sentence, so a caller cannot be told two different things about one rule.

Both infinities were already refused by the bounds — `+Inf` fails the upper, `-Inf` the lower. They are named in the check anyway so it says what it means rather than catching them by accident, and the table pins that they stay refused.

Against the range check alone, exactly the NaN case fails:

```
--- FAIL: TestAVoiceWeightMustBeANumberInRange/not_a_number
--- FAIL: TestBothVoiceWritePathsRefuseANaNWeight
```

`make check-backend` green.

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for voice-source weights during updates and corpus ingestion.
  * Invalid values, including values outside the 0–2 range, NaN, and infinities, are now rejected with a consistent error message.

* **Tests**
  * Added coverage for valid, out-of-range, and non-finite voice-source weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->