### PR TITLE
refactor(extensions): the extension tier stops carrying a workspace (#2121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,11 @@ change rather than guessing from the package name.
   generalizes: [docs/how-to/apply-migrations.md](docs/how-to/apply-migrations.md).
 - **The `database.WithWorkspaceTx` contract** — every tenant query goes through
   it; there is no raw-pool path for tenant data. Held by
-  `scripts/check-rls-store-path.sh`. Core carries no row-level security; extension
-  tables still carry FORCE RLS.
+  `scripts/check-rls-store-path.sh`. **No table carries row-level security** —
+  not core, and not an extension's. A unit table declares no `workspace_id` and
+  no policy, and `backend/tools/extmigrategate` refuses one that does: an
+  installation holds a single workspace, so the predicate separated nothing.
+  Per-unit isolation is a database ROLE, not a column.
 - **`internal/shared/apperrors`** — a fixed sentinel registry. Extend it only
   alongside the error contract it implements, never for one call site.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,11 +184,8 @@ change rather than guessing from the package name.
   generalizes: [docs/how-to/apply-migrations.md](docs/how-to/apply-migrations.md).
 - **The `database.WithWorkspaceTx` contract** — every tenant query goes through
   it; there is no raw-pool path for tenant data. Held by
-  `scripts/check-rls-store-path.sh`. **No table carries row-level security** —
-  not core, and not an extension's. A unit table declares no `workspace_id` and
-  no policy, and `backend/tools/extmigrategate` refuses one that does: an
-  installation holds a single workspace, so the predicate separated nothing.
-  Per-unit isolation is a database ROLE, not a column.
+  `scripts/check-rls-store-path.sh`. No table carries row-level security: a unit
+  table declares no `workspace_id` and no policy; `extmigrategate` refuses one.
 - **`internal/shared/apperrors`** — a fixed sentinel registry. Extend it only
   alongside the error contract it implements, never for one call site.
 

--- a/backend/tools/extmigrategate/catalog.go
+++ b/backend/tools/extmigrategate/catalog.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,27 +29,10 @@ const tableDML = "arwd"
 // the allowlist here is about completeness rather than isolation.
 const sequenceUse = "rwU"
 
-// tenantColumn is the column that makes a row belong to a workspace. Every
-// extension table carries it under the same name as the core tables do,
-// because the policy predicate, the app's WithWorkspaceTx binding and this
-// gate all address it by that name.
+// tenantColumn is the name a unit table must NOT carry. It named the workspace
+// a row belonged to while the tier was multi-tenant; assertNoTenantColumn says
+// why a column of that name is now refused rather than required.
 const tenantColumn = "workspace_id"
-
-// tenantPredicate is the ONE tenant-isolation expression, as pg_get_expr
-// renders it. Comparing the rendered form rather than the source text is what
-// makes the check total: any spelling that means something else — USING (true)
-// most obviously, but equally a comparison against a different setting, a
-// different column, a missing NULLIF guard, or an OR that widens it — renders
-// differently and is refused, without this gate having to enumerate the ways to
-// get it wrong.
-//
-// IF A UNIT EVER NEEDS A NARROWER SCOPE, do not loosen this. A "the canonical
-// predicate must appear as a conjunct" rule is defeated by
-// `(canonical AND true) OR something`, which is how an exact pin becomes an
-// enumeration again. Admit ONE ADDITIONAL RESTRICTIVE POLICY instead:
-// restrictive policies AND together and can only ever narrow what this one
-// admits, so the widening case stays impossible by construction.
-const tenantPredicate = `(workspace_id = (NULLIF(current_setting('app.workspace_id'::text, true), ''::text))::uuid)`
 
 // relation is one row of the ext schema's contents.
 type relation struct {
@@ -110,208 +94,119 @@ func assertRelationAllowed(ctx context.Context, conn *pgx.Conn, rel relation, na
 
 	switch rel.kind {
 	case 'r', 'p':
-		return assertTenantTable(ctx, conn, rel, namespace)
+		return assertUnitTable(ctx, conn, rel, namespace)
 	case 'i', 'I':
 		return nil // an index carries no rows of its own, and pg_class.relacl is always null for one
 	case 'S':
-		// A sequence has no workspace_id to isolate, but it does carry an ACL,
-		// and this allowlist advertises completeness.
+		// A sequence holds no rows of its own, but it does carry an ACL, and
+		// this allowlist advertises completeness.
 		return assertGrants(ctx, conn, rel, namespace, where, sequenceUse, "")
 	case 'f':
-		return fmt.Errorf("%s is a FOREIGN TABLE — PostgreSQL cannot enforce row-level security on one, so its rows would be reachable across every workspace; extension data lives in ordinary tables in %s", where, extSchema)
+		return fmt.Errorf("%s is a FOREIGN TABLE — its rows live outside this database entirely, so nothing here bounds what a unit reads or writes through it; extension data lives in ordinary tables in %s", where, extSchema)
 	case 'm':
-		return fmt.Errorf("%s is a MATERIALIZED VIEW — PostgreSQL cannot enforce row-level security on one, so it would hold a cross-workspace copy of whatever it selected", where)
+		return fmt.Errorf("%s is a MATERIALIZED VIEW — it holds a standing copy of whatever it selected, which outlives the grants on the tables it read and is refreshed by nothing this gate can see", where)
 	case 'v':
-		return fmt.Errorf("%s is a VIEW — a view is not in the allowlist: it runs with its owner's rights over the base tables and is one more surface the policy has to be re-argued on", where)
+		return fmt.Errorf("%s is a VIEW — a view is not in the allowlist: it runs with its owner's rights over the base tables, so it reaches whatever its owner can and the grant surface below says nothing about it", where)
 	default:
 		return fmt.Errorf("%s has relkind %q, which is not in the allowlist (ordinary and partitioned tables, their indexes and sequences)", where, string(rel.kind))
 	}
 }
 
-// assertTenantTable is the positive shape every extension table must have.
-func assertTenantTable(ctx context.Context, conn *pgx.Conn, rel relation, namespace string) error {
+// assertUnitTable is the shape every extension table must have.
+//
+// It is written as a set of REFUSALS rather than requirements because that is
+// what the tier's rules now are: a unit table owns its rows, names no tenant,
+// points nowhere outside the ext schema, and carries no row-level rule. Each
+// one below is a thing PostgreSQL would happily accept and this gate will not.
+func assertUnitTable(ctx context.Context, conn *pgx.Conn, rel relation, namespace string) error {
 	where := extSchema + "." + rel.name
 	if rel.persistence != 'p' {
-		return fmt.Errorf("%s has relpersistence %q — an UNLOGGED or TEMPORARY tenant table loses its rows on a crash or at disconnect, silently", where, string(rel.persistence))
+		return fmt.Errorf("%s has relpersistence %q — an UNLOGGED or TEMPORARY table loses its rows on a crash or at disconnect, silently", where, string(rel.persistence))
 	}
-	if err := assertTenantColumn(ctx, conn, rel, where); err != nil {
+	if err := assertNoTenantColumn(ctx, conn, rel, where); err != nil {
 		return err
 	}
-	if !rel.rls || !rel.force {
-		return fmt.Errorf("%s has relrowsecurity=%t relforcerowsecurity=%t — both are required: ENABLE alone leaves the table's OWNER, which is the unit's own role, reading and writing every workspace's rows", where, rel.rls, rel.force)
-	}
-	if err := assertSinglePolicy(ctx, conn, rel, where); err != nil {
+	if err := assertNoForeignKeysOutOfExt(ctx, conn, rel, where); err != nil {
 		return err
 	}
-	if err := assertGrants(ctx, conn, rel, namespace, where, tableDML, tableDML); err != nil {
+	if err := assertNoRowLevelSecurity(ctx, conn, rel, where); err != nil {
 		return err
 	}
-	// Partitioned tables plan as an Append over their partitions, so the
-	// single-relation plan shape the probe reads does not apply to them; the
-	// catalog facts above already bind, and each partition is itself a
-	// relation this loop visits.
-	//
-	// A CONSEQUENCE a unit author will hit face-first: `CREATE TABLE … PARTITION
-	// OF` propagates neither relrowsecurity, relforcerowsecurity nor policies to
-	// the child. Because this loop visits each partition as its own relation and
-	// applies the full tenant-table rule to it, a partitioned unit table is only
-	// accepted if the author enables AND forces RLS and writes an identical
-	// policy on the parent and on every partition. That errs strict rather than
-	// lax — an unprotected partition is an unprotected table — but it is not
-	// obvious from the DDL, so it is written down here.
-	if rel.kind != 'r' {
-		return nil
-	}
-	return assertRLSBindsTheOwner(ctx, conn, rel, where)
+	return assertGrants(ctx, conn, rel, namespace, where, tableDML, tableDML)
 }
 
-// assertTenantColumn requires the column and its type, then hands off to the
-// foreign-key rule. The cascade is not cosmetic: without it, deleting a
-// workspace fails on the extension's rows, so tenant erasure stops at the first
-// installed unit.
-func assertTenantColumn(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
-	var (
-		typeName string
-		notNull  bool
-	)
-	err := conn.QueryRow(ctx, `
-		SELECT format_type(a.atttypid, a.atttypmod), a.attnotnull
-		  FROM pg_attribute a
-		 WHERE a.attrelid = $1 AND a.attname = $2 AND NOT a.attisdropped`,
-		rel.oid, tenantColumn).Scan(&typeName, &notNull)
-	if err == pgx.ErrNoRows {
-		return fmt.Errorf("%s has no %s column — a table without it belongs to no workspace, and no policy can isolate it", where, tenantColumn)
-	}
-	if err != nil {
+// assertNoTenantColumn refuses a workspace column on a unit table.
+//
+// The tier carried one until an installation became single-organization. The
+// policy that compared it then admitted every row it could see, so what looked
+// like isolation was a predicate with nothing left to separate — and it was
+// never a wall against a unit in any case, because a unit can rebind
+// app.workspace_id through the seam's own verbs (pkg/extension/runtime.go
+// records that as verified against the shipped schema).
+//
+// Refused rather than merely not required: a column re-added here would read as
+// a live tenant boundary to the next author, and the thing that would restore
+// one is a per-unit database role, not a column.
+func assertNoTenantColumn(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
+	var present bool
+	if err := conn.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_attribute a
+		                WHERE a.attrelid = $1 AND a.attname = $2
+		                  AND a.attnum > 0 AND NOT a.attisdropped)`,
+		rel.oid, tenantColumn).Scan(&present); err != nil {
 		return fmt.Errorf("reading %s's columns: %w", where, err)
 	}
-	if typeName != "uuid" || !notNull {
-		return fmt.Errorf("%s.%s is %s%s — it must be `uuid NOT NULL`, or a row can carry a null or a value the policy's comparison silently never matches", where, tenantColumn, typeName, nullability(notNull))
-	}
-
-	return assertWorkspaceForeignKeys(ctx, conn, rel, where)
-}
-
-// assertWorkspaceForeignKeys enumerates EVERY foreign key the table declares
-// onto the core workspace table and requires there to be exactly one, on
-// workspace_id, cascading.
-//
-// Enumerating all of them rather than looking the tenant one up is the whole
-// point. The role holds REFERENCES on workspace(id), so nothing stops a
-// migration declaring a SECOND key from a different column:
-//
-//	workspace_id uuid NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,  -- correct
-//	pinned_ws    uuid          REFERENCES workspace(id)                     -- NO ACTION
-//
-// A lookup of the tenant key alone passes that, and the second key reinstates
-// exactly the harm the cascade rule exists to prevent: deleting a workspace
-// fails on this unit's rows, so erasing a tenant stops at the first installed
-// extension. The rule is a property of the TABLE, not of one column, so it has
-// to be checked over the whole set.
-//
-// There is deliberately no check that the key points at workspace's `id`
-// specifically. That one is covered by PRIVILEGE rather than by assertion: the
-// role's grant is `REFERENCES (id) ON public.workspace`, column-scoped, so a
-// key onto any other unique column of workspace is refused by PostgreSQL at
-// CREATE time and never reaches this query.
-func assertWorkspaceForeignKeys(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
-	rows, err := conn.Query(ctx, `
-		SELECT co.conname, co.confdeltype,
-		       (SELECT coalesce(string_agg(att.attname, ', ' ORDER BY k.ord), '')
-		          FROM unnest(co.conkey) WITH ORDINALITY AS k(num, ord)
-		          JOIN pg_attribute att ON att.attrelid = co.conrelid AND att.attnum = k.num)
-		  FROM pg_constraint co
-		 WHERE co.conrelid = $1 AND co.contype = 'f' AND co.confrelid = $2::regclass
-		 ORDER BY co.conname`, rel.oid, coreTenantParent)
-	if err != nil {
-		return fmt.Errorf("reading %s's foreign keys: %w", where, err)
-	}
-	defer rows.Close()
-
-	type foreignKey struct{ name, delete, columns string }
-	var keys []foreignKey
-	for rows.Next() {
-		var key foreignKey
-		if err := rows.Scan(&key.name, &key.delete, &key.columns); err != nil {
-			return fmt.Errorf("reading %s's foreign keys: %w", where, err)
-		}
-		keys = append(keys, key)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("reading %s's foreign keys: %w", where, err)
-	}
-
-	if len(keys) == 0 {
-		return fmt.Errorf("%s.%s has no foreign key onto %s(id) — without it the column is an unenforced claim, and a row can name a workspace that does not exist", where, tenantColumn, coreTenantParent)
-	}
-	if len(keys) > 1 {
-		named := make([]string, 0, len(keys))
-		for _, key := range keys {
-			named = append(named, fmt.Sprintf("%s on (%s)", key.name, key.columns))
-		}
-		return fmt.Errorf("%s declares %d foreign keys onto %s — exactly one is allowed, on %s: %s. A second reference to a workspace is a second tenancy claim on the row, and it is the one nothing forces to cascade",
-			where, len(keys), coreTenantParent, tenantColumn, strings.Join(named, "; "))
-	}
-	key := keys[0]
-	if key.columns != tenantColumn {
-		return fmt.Errorf("%s references %s from (%s) rather than from %s — the tenant claim must be the column the policy compares, or the row belongs to one workspace and points at another", where, coreTenantParent, key.columns, tenantColumn)
-	}
-	if key.delete != "c" {
-		return fmt.Errorf("%s.%s references %s(id) without ON DELETE CASCADE — deleting a workspace would then fail on this unit's rows, so erasing a tenant stops at the first installed extension", where, tenantColumn, coreTenantParent)
+	if present {
+		return fmt.Errorf("%s carries a %s column — an installation holds one workspace, so the column separates nothing and a policy over it would read as a tenant boundary that is not there; per-unit isolation is a database ROLE, not a column", where, tenantColumn)
 	}
 	return nil
 }
 
-// assertSinglePolicy requires exactly one policy and pins every one of its
-// dimensions. Exactly one, because a second permissive policy is an OR: it can
-// only ever widen what the first admits, and a set of policies is not something
-// a reader can evaluate by looking at one of them.
-func assertSinglePolicy(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
-	rows, err := conn.Query(ctx, `
-		SELECT p.polname, p.polcmd, p.polpermissive, p.polroles::text,
-		       coalesce(pg_get_expr(p.polqual, p.polrelid), ''),
-		       coalesce(pg_get_expr(p.polwithcheck, p.polrelid), '')
-		  FROM pg_policy p WHERE p.polrelid = $1 ORDER BY p.polname`, rel.oid)
-	if err != nil {
-		return fmt.Errorf("reading %s's policies: %w", where, err)
-	}
-	defer rows.Close()
-
-	type policy struct {
-		name, cmd, roles, qual, withCheck string
-		permissive                        bool
-	}
-	var policies []policy
-	for rows.Next() {
-		var p policy
-		if err := rows.Scan(&p.name, &p.cmd, &p.permissive, &p.roles, &p.qual, &p.withCheck); err != nil {
-			return fmt.Errorf("reading %s's policies: %w", where, err)
-		}
-		policies = append(policies, p)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("reading %s's policies: %w", where, err)
-	}
-
-	if len(policies) != 1 {
-		names := make([]string, 0, len(policies))
-		for _, p := range policies {
-			names = append(names, p.name)
-		}
-		return fmt.Errorf("%s carries %d policies (%s) — exactly one is required: permissive policies OR together, so a second one can only widen what the first admits", where, len(policies), strings.Join(names, ", "))
-	}
-	p := policies[0]
+// assertNoForeignKeysOutOfExt refuses a foreign key from a unit table to
+// anything outside the ext schema.
+//
+// Held by PRIVILEGE first — the unit's role has no grants on public at all, so
+// PostgreSQL refuses such a key at CREATE time — and asserted here anyway,
+// because the gate's role is what makes that true and a gate that trusts its
+// own setup proves nothing about a schema built any other way. A key into core
+// takes a lock on core writes and can refuse a core delete forever after, which
+// is a unit reaching into the product's own operations.
+func assertNoForeignKeysOutOfExt(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
+	var name, parent string
+	err := conn.QueryRow(ctx, `
+		SELECT co.conname, n.nspname || '.' || parent.relname
+		  FROM pg_constraint co
+		  JOIN pg_class parent ON parent.oid = co.confrelid
+		  JOIN pg_namespace n ON n.oid = parent.relnamespace
+		 WHERE co.conrelid = $1 AND co.contype = 'f' AND n.nspname <> $2
+		 ORDER BY co.conname LIMIT 1`, rel.oid, extSchema).Scan(&name, &parent)
 	switch {
-	case !p.permissive:
-		return fmt.Errorf("policy %s on %s is RESTRICTIVE and is the only policy on the table — a restrictive policy narrows a permissive one, and with none to narrow it admits no row at all", p.name, where)
-	case p.cmd != "*":
-		return fmt.Errorf("policy %s on %s applies to %q only — the single policy must cover ALL commands, or the ones it omits are unrestricted", p.name, where, commandName(p.cmd))
-	case p.roles != "{0}":
-		return fmt.Errorf("policy %s on %s is scoped TO specific roles (polroles=%s) — a role outside that list is unrestricted by it; the policy must apply to PUBLIC", p.name, where, p.roles)
-	case p.qual != tenantPredicate:
-		return fmt.Errorf("policy %s on %s has USING %s — it must be exactly %s, which is the one predicate the app's workspace binding sets", p.name, where, p.qual, tenantPredicate)
-	case p.withCheck != tenantPredicate:
-		return fmt.Errorf("policy %s on %s has WITH CHECK %q — it must be exactly %s, or the table admits INSERTs and UPDATEs that write rows into another workspace", p.name, where, p.withCheck, tenantPredicate)
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("reading %s's foreign keys: %w", where, err)
+	}
+	return fmt.Errorf("%s declares foreign key %s onto %s — a unit's tables reference nothing outside %s, because a key into core locks core writes and can refuse a core delete", where, name, parent, extSchema)
+}
+
+// assertNoRowLevelSecurity refuses RLS and any policy on a unit table.
+//
+// Both halves, because they fail differently: relrowsecurity without a policy
+// denies every row to a non-owner and reads at a glance like a table that is
+// merely protected, and a policy without RLS enabled is dead text that the next
+// author will cite as a boundary. See assertNoTenantColumn for why the tier
+// carries neither.
+func assertNoRowLevelSecurity(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
+	if rel.rls || rel.force {
+		return fmt.Errorf("%s has relrowsecurity=%t relforcerowsecurity=%t — a unit table carries no row-level rule; the tenant it would key on is gone and a per-unit ROLE is what would make one mean something", where, rel.rls, rel.force)
+	}
+	var policies int
+	if err := conn.QueryRow(ctx,
+		`SELECT count(*) FROM pg_policy WHERE polrelid = $1`, rel.oid).Scan(&policies); err != nil {
+		return fmt.Errorf("reading %s's policies: %w", where, err)
+	}
+	if policies > 0 {
+		return fmt.Errorf("%s carries %d policy/policies with row-level security disabled — dead text the next reader would cite as a boundary", where, policies)
 	}
 	return nil
 }
@@ -375,114 +270,4 @@ func assertGrants(ctx context.Context, conn *pgx.Conn, rel relation, namespace, 
 		return fmt.Errorf("reading %s's column grants: %w", where, err)
 	}
 	return nil
-}
-
-// assertRLSBindsTheOwner is the one BEHAVIORAL check here, and it exists
-// because the catalog facts above are necessary and not sufficient: FORCE ROW
-// LEVEL SECURITY is silently ignored for a superuser or a BYPASSRLS role, so
-// relforcerowsecurity=true over such a connection means nothing. mintRole
-// already proved this role holds neither exemption; this proves the effect,
-// which is the claim that actually matters — the planner puts the policy's
-// qualifier into the plan for this role, and would not for an exempt one.
-func assertRLSBindsTheOwner(ctx context.Context, conn *pgx.Conn, rel relation, where string) error {
-	// Sanitized rather than concatenated: relname comes from pg_class and is
-	// only constrained to START WITH the unit's prefix, so ext."ext_de_x; --"
-	// reaches here. It would execute as the restricted role and grant nothing
-	// the migration did not already have, but a gate that can be made to emit a
-	// confusing error instead of a verdict is not one to leave standing.
-	target := pgx.Identifier{extSchema, rel.name}.Sanitize()
-
-	plan, err := seqScanPlan(ctx, conn, target)
-	if err != nil {
-		return fmt.Errorf("planning a read of %s as its owner: %w", where, err)
-	}
-	// The whole rendered predicate, not the bare column name: a unit table
-	// called ext_de_workspace_id_map puts "workspace_id" into the plan's
-	// `Seq Scan on …` line, and a probe that looked for that would pass
-	// vacuously on exactly the table it exists to check.
-	if !strings.Contains(plan, "Filter: "+tenantPredicate) {
-		return fmt.Errorf("a read of %s by its own owner plans without the tenant filter:\n%s— row-level security is not binding the owner, so the policy on this table isolates nothing", where, plan)
-	}
-	return nil
-}
-
-// seqScanPlan renders the plan for a bare read of target with index and bitmap
-// scans disabled, so the policy's qualifier can only appear as a `Filter:` line.
-//
-// Forcing the plan shape is what makes the probe deterministic. Left to the
-// planner, a table with an index on workspace_id — the natural thing to declare
-// under RLS, since the policy compares that column — plans the policy qualifier
-// as `Index Cond:` instead, and does so on a freshly created, empty, un-ANALYZEd
-// table, which is precisely the state this gate sees. The probe would then
-// report "row-level security is not binding the owner" about a table that is
-// correctly isolated.
-//
-// The alternative — accepting `Index Cond:` as well — was rejected. That form
-// renders the predicate differently, so matching it would mean matching loosely,
-// and loose matching is the exact vacuity the `Filter:` comparison was
-// introduced to close. Better to decide the plan shape than to widen the match.
-//
-// enable_indexonlyscan is not set: PostgreSQL requires enable_indexscan for an
-// index-only scan, so turning the former off already excludes it.
-//
-// The transaction exists only to scope the SET: SET LOCAL is a no-op outside
-// one. Nothing is written, so it is rolled back rather than committed.
-func seqScanPlan(ctx context.Context, conn *pgx.Conn, target string) (string, error) {
-	tx, err := conn.Begin(ctx)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		//craft:ignore swallowed-errors nothing was written; a rollback failure cannot change the verdict
-		_ = tx.Rollback(ctx)
-	}()
-
-	for _, setting := range []string{
-		`SET LOCAL enable_indexscan = off`,
-		`SET LOCAL enable_bitmapscan = off`,
-	} {
-		if _, err := tx.Exec(ctx, setting); err != nil {
-			return "", fmt.Errorf("%s: %w", setting, err)
-		}
-	}
-
-	rows, err := tx.Query(ctx, `EXPLAIN (COSTS OFF) SELECT * FROM `+target)
-	if err != nil {
-		return "", err
-	}
-	defer rows.Close()
-
-	var plan strings.Builder
-	for rows.Next() {
-		var line string
-		if err := rows.Scan(&line); err != nil {
-			return "", err
-		}
-		plan.WriteString(line)
-		plan.WriteString("\n")
-	}
-	return plan.String(), rows.Err()
-}
-
-func nullability(notNull bool) string {
-	if notNull {
-		return " NOT NULL"
-	}
-	return " NULL"
-}
-
-// commandName renders pg_policy.polcmd for a human.
-func commandName(cmd string) string {
-	switch cmd {
-	case "r":
-		return "SELECT"
-	case "a":
-		return "INSERT"
-	case "w":
-		return "UPDATE"
-	case "d":
-		return "DELETE"
-	default:
-		return cmd
-	}
 }

--- a/backend/tools/extmigrategate/gaps_integration_test.go
+++ b/backend/tools/extmigrategate/gaps_integration_test.go
@@ -24,8 +24,8 @@ import (
 // dollar-quoted body yet executes, so the table it creates is invisible here."
 //
 // declaredTables returns [] with no error for this fixture. The table is
-// nevertheless created, without a workspace_id, and every row in it would be
-// readable by every workspace.
+// nevertheless created, and it reaches the catalog sweep carrying none of the
+// grants the tier requires — which is what the sweep, not the parser, catches.
 func TestGateCatchesATableCreatedInsideADoBlock(t *testing.T) {
 	unit := unitName(t, "doblk")
 	ns := namespaceOf(t, unit)
@@ -38,7 +38,7 @@ END $$;
 	down := fmt.Sprintf("DROP TABLE IF EXISTS ext.%s_hidden;\n", ns)
 
 	err := runGate(t, unit, migrationDir(t, up, down))
-	requireRefusal(t, err, "ext."+ns+"_hidden", "workspace_id")
+	requireRefusal(t, err, "ext."+ns+"_hidden", "margince_app")
 }
 
 // Gap 2 — "A quote inside a double-quoted identifier (ext.\"it's\") or a
@@ -80,16 +80,11 @@ CREATE TABLE ext.stowaway (id uuid NOT NULL PRIMARY KEY);
 		up := scaffoldUp(ns) + fmt.Sprintf(`
 CREATE TABLE %[2]s (
     id           uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-    workspace_id uuid NOT NULL REFERENCES workspace(id) ON DELETE CASCADE
+    body         text NOT NULL
 );
 CREATE TABLE ext.stowaway2 (id uuid NOT NULL PRIMARY KEY);
-ALTER TABLE %[2]s ENABLE ROW LEVEL SECURITY;
-ALTER TABLE %[2]s FORCE ROW LEVEL SECURITY;
-CREATE POLICY %[1]s_quoted_isolation ON %[2]s
-    USING      %[3]s
-    WITH CHECK %[3]s;
 GRANT SELECT, INSERT, UPDATE, DELETE ON %[2]s TO margince_app;
-`, ns, quoted, predicateSQL)
+`, ns, quoted)
 		down := "DROP TABLE IF EXISTS ext.stowaway2;\nDROP TABLE IF EXISTS " + quoted + ";\n" + scaffoldDown(ns)
 
 		requireRefusal(t, runGate(t, unit, migrationDir(t, up, down)),

--- a/backend/tools/extmigrategate/gate_integration_test.go
+++ b/backend/tools/extmigrategate/gate_integration_test.go
@@ -127,10 +127,6 @@ func requireRefusal(t *testing.T, err error, mustMention ...string) {
 // the fixture for the test that proves it is now refused.
 const tenantColumnSQL = "workspace_id uuid NOT NULL"
 
-// predicateSQL is the tenant predicate the retired policies compared, kept as
-// the body for the tests that prove any policy is now refused.
-const predicateSQL = `(workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)`
-
 // noteTable builds the unit's one table. modifier carries UNLOGGED and the
 // like; extra is a caller-chosen column line, empty for the correct shape and
 // set by the tests that add one the gate must refuse.

--- a/backend/tools/extmigrategate/gate_integration_test.go
+++ b/backend/tools/extmigrategate/gate_integration_test.go
@@ -17,9 +17,9 @@ package main
 //     relation is refused by PostgreSQL inside the apply, because the ext_<name>
 //     role holds no privilege on it. Those tests assert the database's own
 //     message, not the gate's.
-//   - The rest DO apply cleanly and are caught by the positive catalog
-//     assertions afterwards. A table without workspace_id is perfectly legal
-//     SQL; only the allowlist refuses it.
+//   - The rest DO apply cleanly and are caught by the catalog assertions
+//     afterwards. A table carrying a workspace_id, or a policy, is perfectly
+//     legal SQL; only the allowlist refuses it.
 
 import (
 	"context"
@@ -123,23 +123,27 @@ func requireRefusal(t *testing.T, err error, mustMention ...string) {
 // is the worse one: a replacement that silently misses leaves a test asserting
 // a refusal it is no longer provoking.
 
-// tenantColumnSQL is the correct tenant column, and the parameter the column
-// tests vary.
-const tenantColumnSQL = "workspace_id uuid NOT NULL REFERENCES workspace(id) ON DELETE CASCADE"
+// tenantColumnSQL is the tenant column as the tier used to require it, kept as
+// the fixture for the test that proves it is now refused.
+const tenantColumnSQL = "workspace_id uuid NOT NULL"
 
-// predicateSQL is the canonical tenant predicate, as an author writes it.
+// predicateSQL is the tenant predicate the retired policies compared, kept as
+// the body for the tests that prove any policy is now refused.
 const predicateSQL = `(workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)`
 
-// noteTable builds the unit's one table with a caller-chosen tenant column.
-// modifier carries UNLOGGED and the like.
-func noteTable(ns, modifier, tenant string) string {
+// noteTable builds the unit's one table. modifier carries UNLOGGED and the
+// like; extra is a caller-chosen column line, empty for the correct shape and
+// set by the tests that add one the gate must refuse.
+func noteTable(ns, modifier, extra string) string {
+	if extra != "" {
+		extra = "    " + extra + ",\n"
+	}
 	return fmt.Sprintf(`CREATE %[2]sTABLE ext.%[1]s_note (
     id           uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-    %[3]s,
-    body         text        NOT NULL,
+%[3]s    body         text        NOT NULL,
     created_at   timestamptz NOT NULL DEFAULT now()
 );
-`, ns, modifier, tenant)
+`, ns, modifier, extra)
 }
 
 // notePolicy builds the table's single policy with a caller-chosen body, so a
@@ -149,26 +153,22 @@ func notePolicy(ns, body string) string {
 	return fmt.Sprintf("CREATE POLICY %[1]s_note_tenant_isolation ON ext.%[1]s_note %[2]s;\n", ns, body)
 }
 
-// noteRLS is ENABLE plus FORCE; the FORCE test passes force=false.
-func noteRLS(ns string, force bool) string {
-	sql := fmt.Sprintf("ALTER TABLE ext.%s_note ENABLE ROW LEVEL SECURITY;\n", ns)
-	if force {
-		sql += fmt.Sprintf("ALTER TABLE ext.%s_note FORCE ROW LEVEL SECURITY;\n", ns)
-	}
-	return sql
+// noteRLS is ENABLE plus FORCE, for the tests that prove a unit table may carry
+// neither.
+func noteRLS(ns string) string {
+	return fmt.Sprintf("ALTER TABLE ext.%[1]s_note ENABLE ROW LEVEL SECURITY;\n"+
+		"ALTER TABLE ext.%[1]s_note FORCE ROW LEVEL SECURITY;\n", ns)
 }
 
 func noteGrant(ns string) string {
 	return fmt.Sprintf("GRANT SELECT, INSERT, UPDATE, DELETE ON ext.%s_note TO margince_app;\n", ns)
 }
 
-// scaffoldUp is the shape a unit is meant to ship: one tenant table in ext,
-// namespaced, workspace-scoped, forced RLS, one policy, DML to the app role.
+// scaffoldUp is the shape a unit is meant to ship: one table in ext, namespaced,
+// owning its own rows, referencing nothing outside the schema, carrying no
+// row-level rule, DML to the app role.
 func scaffoldUp(ns string) string {
-	return noteTable(ns, "", tenantColumnSQL) +
-		noteRLS(ns, true) +
-		notePolicy(ns, "USING "+predicateSQL+" WITH CHECK "+predicateSQL) +
-		noteGrant(ns)
+	return noteTable(ns, "", "") + noteGrant(ns)
 }
 
 func scaffoldDown(ns string) string {
@@ -197,113 +197,46 @@ func TestGateAcceptsTheScaffoldedShape(t *testing.T) {
 	}
 }
 
-// Indexing workspace_id is the natural thing to do under RLS — the policy's
-// predicate is a comparison on it, so every query filters on it — and it is the
-// case the plan probe is most likely to get wrong. On a freshly created, empty,
-// un-ANALYZEd table the planner's default statistics favour the index, so the
-// predicate renders as `Index Cond:` and never as `Filter:`. That is exactly the
-// state the gate sees right after applying a migration.
-func TestGateAcceptsATenantTableIndexedOnWorkspaceID(t *testing.T) {
-	unit := unitName(t, "idx")
+// A workspace column is refused rather than ignored. It separates nothing on an
+// installation that holds one workspace, and left in place it reads to the next
+// author as a tenant boundary the tier no longer has.
+func TestGateRejectsTableWithWorkspaceID(t *testing.T) {
+	unit := unitName(t, "ws")
 	ns := namespaceOf(t, unit)
-	up := scaffoldUp(ns) + fmt.Sprintf("CREATE INDEX %[1]s_note_ws ON ext.%[1]s_note (workspace_id);\n", ns)
+	up := noteTable(ns, "", tenantColumnSQL) + noteGrant(ns)
 
-	if err := runGate(t, unit, migrationDir(t, up, scaffoldDown(ns))); err != nil {
-		t.Fatalf("a correctly isolated table that indexes %s must pass: %v", tenantColumn, err)
-	}
-}
-
-// The plan probe's whole job is to refuse a connection row-level security does
-// not bind, and the trap it guards is that such a connection reports
-// relforcerowsecurity=true just like a bound one. This drives the probe directly
-// with a SUPERUSER connection — the dev and CI owner, the exact Stage A trap —
-// over a table deliberately NAMED so that the bare string "workspace_id" appears
-// in the plan without the predicate binding anything.
-//
-// A probe that looked for the column name rather than the rendered predicate
-// passes this. That is the false-pass the exact match exists to close, and this
-// is the test that keeps it closed.
-func TestTheRLSProbeRefusesAConnectionRowLevelSecurityDoesNotBind(t *testing.T) {
-	ctx := context.Background()
-	owner := admin(t)
-
-	// Not created through the gate: the point is to hold the table's shape
-	// correct and vary only the connection the probe runs over.
-	name := fmt.Sprintf("ext_probe_%d_workspace_id_map", os.Getpid())
-	for _, statement := range []string{
-		fmt.Sprintf(`CREATE TABLE ext.%s (id uuid NOT NULL, workspace_id uuid NOT NULL)`, name),
-		fmt.Sprintf(`ALTER TABLE ext.%s ENABLE ROW LEVEL SECURITY`, name),
-		fmt.Sprintf(`ALTER TABLE ext.%s FORCE ROW LEVEL SECURITY`, name),
-		fmt.Sprintf(`CREATE POLICY %s_iso ON ext.%s USING %s WITH CHECK %s`, name, name, predicateSQL, predicateSQL),
-	} {
-		if _, err := owner.Exec(ctx, statement); err != nil {
-			t.Fatalf("building the probe fixture (%s): %v", statement, err)
-		}
-	}
-	t.Cleanup(func() {
-		if _, err := owner.Exec(context.Background(), `DROP TABLE IF EXISTS ext.`+name); err != nil {
-			t.Errorf("dropping the probe fixture: %v — every later gate run enumerates schema ext", err)
-		}
-	})
-
-	var super bool
-	if err := owner.QueryRow(ctx, `SELECT rolsuper FROM pg_roles WHERE rolname = current_user`).Scan(&super); err != nil {
-		t.Fatalf("reading the owner's attributes: %v", err)
-	}
-	if !super {
-		t.Fatalf("this cluster's owner is not a superuser, so FORCE binds it and the probe would pass — the trap being tested does not exist here")
-	}
-
-	rel := relation{name: name}
-	if err := owner.QueryRow(ctx, `
-		SELECT c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-		 WHERE n.nspname = $1 AND c.relname = $2`, extSchema, name).Scan(&rel.oid); err != nil {
-		t.Fatalf("locating the probe fixture: %v", err)
-	}
-
-	requireRefusal(t, assertRLSBindsTheOwner(ctx, owner, rel, extSchema+"."+name),
-		"row-level security is not binding the owner", name)
-}
-
-func TestGateRejectsTableWithoutWorkspaceID(t *testing.T) {
-	unit := unitName(t, "nows")
-	ns := namespaceOf(t, unit)
-	up := fmt.Sprintf(`CREATE TABLE ext.%[1]s_thing (id uuid NOT NULL PRIMARY KEY);`, ns)
-	down := fmt.Sprintf(`DROP TABLE IF EXISTS ext.%s_thing;`, ns)
-
-	err := runGate(t, unit, migrationDir(t, up, down))
-	requireRefusal(t, err, "ext."+ns+"_thing", "workspace_id")
+	err := runGate(t, unit, migrationDir(t, up, scaffoldDown(ns)))
+	requireRefusal(t, err, "ext."+ns+"_note", "workspace_id")
 }
 
 // A policy that admits every row is the failure this whole tier exists to
 // prevent, and it is invisible to every textual rule: the SQL is well-formed,
 // the table is namespaced, RLS is on and forced. Only comparing the rendered
 // predicate against the one canonical spelling catches it.
-func TestGateRejectsPermissivePolicy(t *testing.T) {
-	unit := unitName(t, "perm")
+// Any policy at all, whatever it says. The gate used to pin the predicate's
+// rendered form and enumerate the ways to get it wrong; with no tenant to key
+// on there is nothing a policy here can mean, so the rule is the simpler one.
+func TestGateRejectsAnyPolicy(t *testing.T) {
+	unit := unitName(t, "pol")
 	ns := namespaceOf(t, unit)
-	up := noteTable(ns, "", tenantColumnSQL) +
-		noteRLS(ns, true) +
+	up := noteTable(ns, "", "") +
+		noteRLS(ns) +
 		notePolicy(ns, "USING (true) WITH CHECK (true)") +
 		noteGrant(ns)
 
 	err := runGate(t, unit, migrationDir(t, up, scaffoldDown(ns)))
-	requireRefusal(t, err, ns+"_note_tenant_isolation", "USING true")
+	requireRefusal(t, err, "ext."+ns+"_note", "row-level")
 }
 
-// ENABLE without FORCE is the subtlest of the seven: the table looks protected
-// and is, for the app role — but not for its OWNER, which is the unit's own
-// ext_<name> role, and that is the role the unit's own later migrations run as.
-func TestGateRejectsMissingForceRLS(t *testing.T) {
-	unit := unitName(t, "force")
+// Row-level security with no policy at all: the shape that denies every row to
+// a non-owner while looking, at a glance, like a table someone protected.
+func TestGateRejectsRowLevelSecurity(t *testing.T) {
+	unit := unitName(t, "rls")
 	ns := namespaceOf(t, unit)
-	up := noteTable(ns, "", tenantColumnSQL) +
-		noteRLS(ns, false) +
-		notePolicy(ns, "USING "+predicateSQL+" WITH CHECK "+predicateSQL) +
-		noteGrant(ns)
+	up := noteTable(ns, "", "") + noteRLS(ns) + noteGrant(ns)
 
 	err := runGate(t, unit, migrationDir(t, up, scaffoldDown(ns)))
-	requireRefusal(t, err, "ext."+ns+"_note", "relforcerowsecurity=false")
+	requireRefusal(t, err, "ext."+ns+"_note", "relrowsecurity=true")
 }
 
 // The core relations are not the extension's to touch, and this test asserts
@@ -355,22 +288,22 @@ func TestGateRejectsForeignTable(t *testing.T) {
 	t.Run("foreign table", func(t *testing.T) {
 		unit := unitName(t, "ftab")
 		ns := namespaceOf(t, unit)
-		up := fmt.Sprintf(`CREATE FOREIGN TABLE ext.%[1]s_remote (id uuid, workspace_id uuid) SERVER %[2]s OPTIONS (table_name 'anything');`, ns, server)
+		up := fmt.Sprintf(`CREATE FOREIGN TABLE ext.%[1]s_remote (id uuid, body text) SERVER %[2]s OPTIONS (table_name 'anything');`, ns, server)
 		down := fmt.Sprintf(`DROP FOREIGN TABLE IF EXISTS ext.%s_remote;`, ns)
 
 		err := runGate(t, unit, migrationDir(t, up, down))
-		requireRefusal(t, err, "ext."+ns+"_remote", "FOREIGN TABLE", "row-level security")
+		requireRefusal(t, err, "ext."+ns+"_remote", "FOREIGN TABLE", "outside this database")
 	})
 
 	t.Run("materialized view", func(t *testing.T) {
 		unit := unitName(t, "mview")
 		ns := namespaceOf(t, unit)
 		up := scaffoldUp(ns) + fmt.Sprintf(
-			"CREATE MATERIALIZED VIEW ext.%[1]s_digest AS SELECT workspace_id, count(*) AS n FROM ext.%[1]s_note GROUP BY 1;\n", ns)
+			"CREATE MATERIALIZED VIEW ext.%[1]s_digest AS SELECT body, count(*) AS n FROM ext.%[1]s_note GROUP BY 1;\n", ns)
 		down := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS ext.%s_digest;\n", ns) + scaffoldDown(ns)
 
 		err := runGate(t, unit, migrationDir(t, up, down))
-		requireRefusal(t, err, "ext."+ns+"_digest", "MATERIALIZED VIEW", "row-level security")
+		requireRefusal(t, err, "ext."+ns+"_digest", "MATERIALIZED VIEW", "standing copy")
 	})
 }
 

--- a/backend/tools/extmigrategate/refusals_integration_test.go
+++ b/backend/tools/extmigrategate/refusals_integration_test.go
@@ -45,12 +45,13 @@ func TestGateRefusesEveryShapeOutsideTheAllowlist(t *testing.T) {
 }
 
 // valid is the shape the gate accepts; the grant and object rows below add one
-// thing to it, and the policy and column rows replace one part of it.
+// thing to it, and the policy rows build their own table instead.
 func valid(ns string) string { return scaffoldUp(ns) }
 
-// policyBody is the correct policy body, so a row that varies the command or
-// the roles is not also varying the predicate.
-var policyBody = "USING " + predicateSQL + " WITH CHECK " + predicateSQL
+// policyBody is an ordinary, correct-looking predicate over a column the table
+// actually has. The rule is that a unit table carries no policy AT ALL, so the
+// row proving it must not be refusable for anything the body itself says.
+var policyBody = "USING (created_at IS NOT NULL) WITH CHECK (created_at IS NOT NULL)"
 
 // refusalCases is split into three groups only because the craft gate caps a
 // function's length; the grouping follows what each row is about.
@@ -117,118 +118,58 @@ func grantRefusals() []refusal {
 // policy compares.
 func policyRefusals() []refusal {
 	return []refusal{{
-		tag: "twopolicies",
+		// A workspace column, the shape the tier carried until an installation
+		// became single-organization. Refused rather than tolerated: it is the
+		// column a policy would key on, and its presence is what makes the next
+		// author believe there is a tenant wall here.
+		tag: "tenantcolumn",
 		up: func(ns string) string {
-			return valid(ns) + fmt.Sprintf("CREATE POLICY %[1]s_note_extra ON ext.%[1]s_note FOR SELECT USING (true);\n", ns)
+			return noteTable(ns, "", tenantColumnSQL) + noteGrant(ns)
 		},
 		down:        dropNote,
-		mustMention: []string{"carries 2 policies", "_note_extra"},
+		mustMention: []string{"workspace_id", "one workspace"},
 	}, {
-		tag: "restrictive",
+		// RLS on with no policy: every row denied to a non-owner, and a table
+		// that reads at a glance as one somebody protected.
+		tag: "rlsnopolicy",
 		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "AS RESTRICTIVE "+policyBody) + noteGrant(ns)
+			return noteTable(ns, "", "") + noteRLS(ns) + noteGrant(ns)
 		},
 		down:        dropNote,
-		mustMention: []string{"RESTRICTIVE", "admits no row at all"},
+		mustMention: []string{"relrowsecurity=true", "no row-level rule"},
 	}, {
-		tag: "selectonly",
+		// A policy, whatever it says. The predicate below is the one the tier
+		// used to require, so this row proves the rule is "no policy" and not
+		// "no BADLY WRITTEN policy".
+		tag: "policy",
 		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "FOR SELECT USING "+predicateSQL) + noteGrant(ns)
+			return noteTable(ns, "", "") + noteRLS(ns) +
+				notePolicy(ns, policyBody) + noteGrant(ns)
 		},
 		down:        dropNote,
-		mustMention: []string{`applies to "SELECT" only`},
+		mustMention: []string{"row-level"},
 	}, {
-		// The other three single-command spellings, so the refusal names the
-		// command an author actually wrote rather than pg_policy's letter.
-		tag: "insertonly",
+		// A policy with RLS left off is dead text PostgreSQL never consults,
+		// and the reading it invites — that the table is isolated — is exactly
+		// the one a later author would carry forward.
+		tag: "deadpolicy",
 		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "FOR INSERT WITH CHECK "+predicateSQL) + noteGrant(ns)
+			// No ALTER at all: PostgreSQL accepts CREATE POLICY on a table with
+			// row-level security switched off, and never consults it.
+			return noteTable(ns, "", "") + notePolicy(ns, policyBody) + noteGrant(ns)
 		},
 		down:        dropNote,
-		mustMention: []string{`applies to "INSERT" only`},
+		mustMention: []string{"policy", "dead text"},
 	}, {
-		tag: "updateonly",
+		// A foreign key into core. The role holds nothing on public, so this is
+		// refused inside the apply rather than by a catalog assertion — which is
+		// the stronger place for it, and the reason the grant was dropped.
+		tag: "corefk",
 		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "FOR UPDATE USING "+predicateSQL) + noteGrant(ns)
+			return noteTable(ns, "", "owner_id uuid NOT NULL REFERENCES workspace(id)") + noteGrant(ns)
 		},
 		down:        dropNote,
-		mustMention: []string{`applies to "UPDATE" only`},
-	}, {
-		tag: "deleteonly",
-		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "FOR DELETE USING "+predicateSQL) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{`applies to "DELETE" only`},
-	}, {
-		tag: "rolescoped",
-		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL) + noteRLS(ns, true) +
-				notePolicy(ns, "TO margince_app "+policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"scoped TO specific roles"},
-	}, {
-		// No policy here, deliberately: with a text tenant column the canonical
-		// predicate does not even parse (text = uuid), so the fixture would be
-		// refused by the CREATE POLICY rather than by the column rule this row
-		// exists to exercise.
-		tag: "wrongtype",
-		up: func(ns string) string {
-			return noteTable(ns, "", "workspace_id text NOT NULL")
-		},
-		down:        dropNote,
-		mustMention: []string{"workspace_id is text NOT NULL", "uuid NOT NULL"},
-	}, {
-		tag: "nullable",
-		up: func(ns string) string {
-			return noteTable(ns, "", "workspace_id uuid NULL REFERENCES workspace(id) ON DELETE CASCADE") +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"uuid NULL", "uuid NOT NULL"},
-	}, {
-		tag: "nofk",
-		up: func(ns string) string {
-			return noteTable(ns, "", "workspace_id uuid NOT NULL") +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"no foreign key onto public.workspace(id)"},
-	}, {
-		// THE ONE THAT A PER-COLUMN LOOKUP MISSES. The tenant column and its key
-		// are entirely correct; a second, unexamined key from another column
-		// reinstates the harm the cascade rule exists to prevent.
-		tag: "secondfk",
-		up: func(ns string) string {
-			return noteTable(ns, "", tenantColumnSQL+",\n    pinned_ws    uuid            NULL REFERENCES workspace(id)") +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"declares 2 foreign keys onto public.workspace", "pinned_ws", "exactly one is allowed"},
-	}, {
-		// The single key is present and cascades, but hangs off the wrong column,
-		// so the row's tenancy claim and the column the policy compares disagree.
-		tag: "fkwrongcolumn",
-		up: func(ns string) string {
-			return noteTable(ns, "", "workspace_id uuid NOT NULL,\n    pinned_ws    uuid NOT NULL REFERENCES workspace(id) ON DELETE CASCADE") +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"references public.workspace from (pinned_ws)", "rather than from workspace_id"},
-	}, {
-		tag: "nocascade",
-		up: func(ns string) string {
-			return noteTable(ns, "", "workspace_id uuid NOT NULL REFERENCES workspace(id)") +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
-		},
-		down:        dropNote,
-		mustMention: []string{"without ON DELETE CASCADE", "erasing a tenant"},
+		mustMention: []string{"permission denied"},
 	}}
 }
 
@@ -239,7 +180,7 @@ func relationRefusals() []refusal {
 		tag: "unlogged",
 		up: func(ns string) string {
 			return noteTable(ns, "UNLOGGED ", tenantColumnSQL) +
-				noteRLS(ns, true) + notePolicy(ns, policyBody) + noteGrant(ns)
+				noteRLS(ns) + notePolicy(ns, policyBody) + noteGrant(ns)
 		},
 		down:        dropNote,
 		mustMention: []string{"relpersistence", "loses its rows"},
@@ -495,9 +436,9 @@ func TestGateRefusesAManualReturnRule(t *testing.T) {
 	unit := unitName(t, "retrule")
 	ns := namespaceOf(t, unit)
 	up := scaffoldUp(ns) + fmt.Sprintf(`
-CREATE TABLE ext.%[1]s_asview (id uuid, workspace_id uuid);
+CREATE TABLE ext.%[1]s_asview (id uuid, body text);
 CREATE RULE "_RETURN" AS ON SELECT TO ext.%[1]s_asview
-    DO INSTEAD SELECT id, workspace_id FROM ext.%[1]s_note;
+    DO INSTEAD SELECT id, body FROM ext.%[1]s_note;
 `, ns)
 	down := fmt.Sprintf("DROP TABLE IF EXISTS ext.%s_asview CASCADE;\n", ns) + scaffoldDown(ns)
 

--- a/backend/tools/extmigrategate/role.go
+++ b/backend/tools/extmigrategate/role.go
@@ -18,10 +18,10 @@ import (
 // core owns public (backend/migrations/core/0213_ext_schema.up.sql).
 const extSchema = "ext"
 
-// coreTenantParent is the core table every extension tenant table hangs off.
-// It is the ONLY core relation the extension role is granted anything on, and
-// the grant is REFERENCES on one column — enough to declare the foreign key
-// this gate requires and not enough to read a row of it.
+// coreTenantParent is the core table extension tables used to hang off. The
+// role is granted nothing on it, or on anything else in public; the constant
+// survives only so assertNoCorePrivileges can name the last exemption that was
+// dropped when the tier stopped carrying a tenant column.
 const coreTenantParent = "public.workspace"
 
 // extRole is the restricted role a unit's migrations are applied as: the
@@ -51,13 +51,14 @@ type extRole struct {
 //     gen-composition's textual rule makes when it accepts a bare
 //     `CREATE TABLE ext_<name>_thing`.
 //
-//   - REFERENCES on workspace(id) alone. The tenant-table rule requires
-//     `workspace_id uuid NOT NULL REFERENCES workspace(id) ON DELETE CASCADE`,
-//     and declaring that foreign key needs the REFERENCES privilege on the
-//     parent, so "no grants on public at all" is not achievable alongside the
-//     rule. Column-scoped and privilege-scoped is the minimum that works: the
-//     role can point at workspace, and cannot select, insert or alter a byte of
-//     it. It also cannot point at any OTHER unique column of workspace, which
+//   - NOTHING ON PUBLIC AT ALL, which became reachable when the tier stopped
+//     carrying a tenant column. The role held REFERENCES (id) on workspace for
+//     exactly as long as a unit table was required to declare a foreign key
+//     onto it; with no such key to declare there is no core object a unit's
+//     migration may name, and PostgreSQL refuses the rest. The older shape,
+//     kept here because the reasoning still binds anything that would restore
+//     it: a key onto core is not an inert declaration — it takes a lock on core
+//     writes and can refuse a core delete forever after, which
 //     is what lets assertWorkspaceForeignKeys skip checking confkey.
 //
 //     Accepted residue: a foreign key is an existence oracle. A role holding it
@@ -109,7 +110,6 @@ func mintRole(ctx context.Context, admin *pgx.Conn, namespace, dsn string) (mint
 	}()
 	for _, statement := range []string{
 		`GRANT CREATE, USAGE ON SCHEMA ` + extSchema + ` TO ` + role.name,
-		`GRANT REFERENCES (id) ON TABLE ` + coreTenantParent + ` TO ` + role.name,
 	} {
 		if _, err := admin.Exec(ctx, statement); err != nil {
 			return nil, fmt.Errorf("preparing the %s role (%s): %w", role.name, statement, err)
@@ -257,14 +257,11 @@ func (r *extRole) assertRestricted(ctx context.Context) error {
 // function of its own on a core table, and from then on every core write runs
 // that function. Nothing else in this gate would notice.
 //
-// REFERENCES is probed separately rather than excluded, because the gate grants
-// exactly `REFERENCES (id) ON public.workspace` itself and the required tenant
-// foreign key cannot be declared without it. Excluding the verb outright was the
-// earlier posture and it was too broad: a cluster that had widened REFERENCES to
-// some other core table would let a unit's migration hang a foreign key off it,
-// which is not an inert declaration — it takes a lock on core writes and can
-// refuse a core delete forever after. So the exemption is narrowed to the exact
-// column the gate itself grants.
+// REFERENCES is still probed separately, and now with no exemption at all: the
+// gate grants none, so any column a unit's role can reference is a widening the
+// cluster brought, not one this gate made. A foreign key onto core is not an
+// inert declaration — it takes a lock on core writes and can refuse a core
+// delete forever after.
 func (r *extRole) assertNoCorePrivileges(ctx context.Context) error {
 	var reachable string
 	err := r.conn.QueryRow(ctx, `
@@ -285,13 +282,11 @@ func (r *extRole) assertNoCorePrivileges(ctx context.Context) error {
 	return r.assertNoWiderReferences(ctx)
 }
 
-// assertNoWiderReferences proves the one core grant the gate makes is the only
-// core grant the role holds: REFERENCES on public.workspace(id), nothing else on
-// that table and nothing at all on any other.
+// assertNoWiderReferences proves the role can reference nothing in public.
 //
 // The probe is column-scoped, not table-scoped: has_table_privilege answers for
-// the whole relation and so returns false for the very grant this gate makes,
-// which would make a table-level probe blind to a widening on any column.
+// the whole relation and returns false for a single-column grant, which would
+// make a table-level probe blind to a widening on any one column.
 func (r *extRole) assertNoWiderReferences(ctx context.Context) error {
 	var reachable string
 	err := r.conn.QueryRow(ctx, `
@@ -301,21 +296,20 @@ func (r *extRole) assertNoWiderReferences(ctx context.Context) error {
 		  JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
 		 WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
 		   AND has_column_privilege(c.oid, a.attnum, 'REFERENCES')
-		   AND NOT (n.nspname || '.' || c.relname = $1 AND a.attname = 'id')
-		 ORDER BY 1 LIMIT 1`, coreTenantParent).Scan(&reachable)
+		 ORDER BY 1 LIMIT 1`).Scan(&reachable)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
 		return fmt.Errorf("checking what %s can reference in public: %w", r.name, err)
 	}
-	return fmt.Errorf("role %s can declare a foreign key against %s — the only core dependency a unit may take is %s(id), and a key on anything else makes core deletes wait on, or refuse for, a unit's table", r.name, reachable, coreTenantParent)
+	return fmt.Errorf("role %s can declare a foreign key against %s — a unit takes no core dependency at all since %s(id) stopped being one, and a key onto core makes core deletes wait on, or refuse for, a unit's table", r.name, reachable, coreTenantParent)
 }
 
 // drop removes the role and everything it owns. A failure is returned rather
 // than logged away: a login role left on the cluster owns the tables it just
-// created and can drop their tenant-isolation policies, which is a standing
-// credential, not a tidiness issue.
+// created and can rewrite or drop them, which is a standing credential, not a
+// tidiness issue.
 func (r *extRole) drop(ctx context.Context, admin *pgx.Conn) error {
 	for _, statement := range []string{
 		`DROP OWNED BY ` + r.name + ` CASCADE`,

--- a/backend/tools/extmigrategate/role.go
+++ b/backend/tools/extmigrategate/role.go
@@ -227,10 +227,16 @@ func (r *extRole) assertRestricted(ctx context.Context) error {
 	case createPublic:
 		return fmt.Errorf("role %s holds CREATE on schema public — the namespace wall is that it does not, and with it a migration can create a core-schema table that this gate would then have to detect rather than have refused", r.name)
 	case !usagePublic:
-		// Not a violation of the role's own shape, but the tenant foreign key
-		// cannot be declared without it, so say so here rather than let every
-		// unit fail inside its own CREATE TABLE.
-		return fmt.Errorf("role %s cannot USE schema public, so it cannot name %s in a foreign key — grant USAGE on public to PUBLIC on this cluster (CREATE stays revoked)", r.name, coreTenantParent)
+		// Not a violation of the role's own shape, and no longer about a key a
+		// unit declares — none may, and assertNoForeignKeysOutOfExt refuses one.
+		// It is what makes the probes below MEAN anything: without USAGE the
+		// role cannot name a core object at all, so "this role cannot reference
+		// public.workspace" would be true of a cluster's schema permissions
+		// rather than of the grant surface this gate exists to police, and the
+		// gate would report a wall it never tested.
+		return fmt.Errorf("role %s cannot USE schema public, so this gate cannot tell a role that "+
+			"may not reach %s from a cluster where nobody may — grant USAGE on public to PUBLIC "+
+			"here (CREATE stays revoked)", r.name, coreTenantParent)
 	case !createExt || !usageExt:
 		return fmt.Errorf("role %s lacks CREATE/USAGE on schema %s — migration 0206 creates that schema; is this database migrated to head?", r.name, extSchema)
 	}

--- a/extensions/notes/filing.go
+++ b/extensions/notes/filing.go
@@ -76,8 +76,8 @@ func fileNote(ctx context.Context, rt extension.Runtime, in json.RawMessage) (js
 		}
 		var scanErr error
 		n, scanErr = scanNote(tx.QueryRow(ctx,
-			`INSERT INTO `+noteTable+` (workspace_id, kind, body, author_user_id, author_is_agent, filed_activity_id)
-			 VALUES (`+callerWorkspace+`, $1, $2, $3::uuid, $4::boolean, $5::uuid)
+			`INSERT INTO `+noteTable+` (kind, body, author_user_id, author_is_agent, filed_activity_id)
+			 VALUES ($1, $2, $3::uuid, $4::boolean, $5::uuid)
 			 RETURNING `+noteColumns, string(kindNote), body, authorID, authorIsAgent, filed.Id).Scan)
 		if scanErr != nil {
 			return scanErr

--- a/extensions/notes/heartbeat.go
+++ b/extensions/notes/heartbeat.go
@@ -77,7 +77,8 @@ func heartbeat(ctx context.Context, rt extension.Runtime) error {
 		// matched on the body's leading glyph, which meant a note a person
 		// typed starting with the same characters was counted as a tick and
 		// then DELETED by the prune below. Neither statement carries a tenant
-		// predicate; the policy is what makes both of them this workspace's.
+		// predicate, and neither needs one: the table holds one installation's
+		// rows and nothing else.
 		//
 		// The author columns are LEFT OUT rather than written as anything, and
 		// that is the whole handling of the no-author case on this side: a tick
@@ -87,8 +88,8 @@ func heartbeat(ctx context.Context, rt extension.Runtime) error {
 		// does not exist. Omitting them satisfies the both-or-neither CHECK by
 		// taking the "neither" branch, and the read renders no `author` at all.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO `+noteTable+` (workspace_id, kind, body)
-			 VALUES (`+callerWorkspace+`, $1, $2 || `+callerWorkspace+`::text)`,
+			`INSERT INTO `+noteTable+` (kind, body)
+			 VALUES ($1, $2)`,
 			string(kindHeartbeat), heartbeatPrefix); err != nil {
 			return err
 		}
@@ -107,9 +108,10 @@ func heartbeat(ctx context.Context, rt extension.Runtime) error {
 }
 
 // heartbeatPrefix is the display text a tick's row carries, and it is display
-// text only — no query matches on it any more. The workspace id is appended by
-// the insert above.
-const heartbeatPrefix = "⟳ heartbeat — workspace "
+// text only — no query matches on it any more. It named the workspace until the
+// tier stopped carrying one; an installation holds a single workspace, so the
+// id it printed told a reader nothing the row's presence did not.
+const heartbeatPrefix = "⟳ heartbeat"
 
 // keptHeartbeats bounds the tick history. Ten is enough to see a sequence
 // arrive on screen and small enough that the notes read (LIMIT 200) stays

--- a/extensions/notes/heartbeat_test.go
+++ b/extensions/notes/heartbeat_test.go
@@ -24,12 +24,12 @@ func TestHeartbeatWritesOneRowNamingItsWorkspace(t *testing.T) {
 	if !strings.Contains(insert, "INSERT INTO "+noteTable) {
 		t.Errorf("the tick does not write the unit's own table:\n%s", insert)
 	}
-	// The fan-out made visible. The dispatcher enqueues one child per live
-	// workspace; on a single-workspace dev install that is one child, so a row
-	// naming no tenant would demonstrate the single-tenant case and leave the
-	// multi-tenant guarantee untested.
-	if strings.Count(insert, callerWorkspace) != 2 {
-		t.Errorf("the tick does not both scope and NAME its workspace:\n%s", insert)
+	// It names NO workspace, and that is an assertion rather than the absence
+	// of one. A unit table carries no tenant column and no policy keyed on one,
+	// so a statement reaching for app.workspace_id would be reading a GUC that
+	// fences nothing and writing a column that is not there.
+	if strings.Contains(insert, "workspace") {
+		t.Errorf("the tick still names a workspace:\n%s", insert)
 	}
 	if rt.tx.args[0][0] != string(kindHeartbeat) {
 		t.Errorf("the tick writes kind %v, want %q — the column is what marks the row as the job's", rt.tx.args[0][0], kindHeartbeat)

--- a/extensions/notes/migrations/0001_note.up.sql
+++ b/extensions/notes/migrations/0001_note.up.sql
@@ -6,17 +6,18 @@
 --
 -- IN THE PRE-MERGE GATE (backend/tools/extmigrategate, `make
 -- check-ext-migrations`) it is applied as a restricted ext_notes role minted
--- against a throwaway database, holding CREATE on the ext schema and nothing on
--- public beyond REFERENCES (id) on workspace. That is what keeps every line
+-- against a throwaway database, holding CREATE on the ext schema and nothing at
+-- all on public. That is what keeps every line
 -- below to the narrowest shape such a role can produce, and the gate re-reads
 -- the resulting catalog to prove it.
 --
 -- AT RUNTIME there is NO ext_notes role. cmd/migrate opens ONE
 -- margince_owner connection and issues no SET ROLE, so this table is created
 -- and owned by margince_owner exactly as every core table is. Do not read the
--- gate's restriction as a production DDL boundary: what isolates this table in
--- production is the FORCE row level security and the workspace-bound policy
--- declared below, not its ownership. backend/migrations/core/0213_ext_schema
+-- gate's restriction as a production DDL boundary: what bounds this table in
+-- production is the grant surface extmigrategate polices and the ext schema the
+-- unit owns — not its ownership, and not a row-level policy (see below).
+-- backend/migrations/core/0213_ext_schema
 -- states the same thing at the schema, and issue #628 tracks minting the
 -- per-unit runtime role that would make ownership mean something here.
 --
@@ -37,11 +38,6 @@
 
 CREATE TABLE ext.ext_notes_note (
     id              uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-    -- The tenant claim, and the column the policy below compares. The cascade
-    -- is load-bearing rather than tidy: without it, deleting a workspace fails
-    -- on this unit's rows, so erasing a tenant would stop at the first
-    -- installed extension.
-    workspace_id    uuid        NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
     body            text        NOT NULL,
     -- WHO wrote it. Stamped by the handler from the invocation's Caller and
     -- never from the request body, because an author a client supplies is an
@@ -50,7 +46,7 @@ CREATE TABLE ext.ext_notes_note (
     --
     -- NO FOREIGN KEY TO THE USER TABLE, and its absence is a property of the
     -- gate rather than an oversight. The ext_notes role this file is applied as
-    -- holds REFERENCES (id) on workspace and NOTHING else on public, so a
+    -- holds NOTHING on public at all, so a
     -- reference to a core user table here does not fail at review — it fails
     -- when the pre-merge gate applies the file, for every unit that copies this
     -- template. The id is therefore a plain uuid and the join, when a reader
@@ -78,29 +74,28 @@ CREATE TABLE ext.ext_notes_note (
         CHECK ((author_user_id IS NULL) = (author_is_agent IS NULL))
 );
 
--- ENABLE and FORCE, both, and FORCE is the load-bearing one HERE rather than a
--- belt-and-braces habit: the owner at runtime is margince_owner (see the header),
--- and ENABLE alone exempts a table's owner from its own policies. Without FORCE
--- the isolation would hold for margince_app and not for the role that owns the
--- table — which is also the role every migration and every operator psql session
--- arrives as.
-ALTER TABLE ext.ext_notes_note ENABLE ROW LEVEL SECURITY;
-ALTER TABLE ext.ext_notes_note FORCE ROW LEVEL SECURITY;
+-- NO ROW-LEVEL SECURITY, and for a unit table that is the rule rather than an
+-- omission — state it, because this file is the template.
+--
+-- The policy this table used to carry compared a workspace_id column against
+-- app.workspace_id. An installation holds exactly one active workspace
+-- (identity.InstallationWorkspace refuses a second), so that predicate admitted
+-- every row it could see: it named an isolation there was nothing left to
+-- isolate. It was never a wall against a UNIT either — a unit can rebind the
+-- GUC through the seam's own verbs, which pkg/extension/runtime.go records as
+-- verified against the shipped schema rather than assumed.
+--
+-- What bounds a unit is the grant below and the schema it owns. A row-level
+-- rule can mean something here again once it keys on something a unit cannot
+-- set, which is the per-unit role issue #628 tracks.
 
--- Exactly one policy, permissive, ALL commands, to PUBLIC. A second
--- permissive policy ORs with this one and can only widen it, and USING
--- without WITH CHECK would admit writes into another workspace.
-CREATE POLICY ext_notes_note_tenant_isolation ON ext.ext_notes_note
-    USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
-    WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
-
--- The app role runs the unit's handlers, under the policy above. TRUNCATE is
--- deliberately absent: it empties every tenant's rows without consulting the
--- policy's USING clause.
+-- The app role runs the unit's handlers. TRUNCATE is deliberately absent: no
+-- unit verb issues one, and a privilege nothing reaches for is one more thing
+-- a compromised unit could.
 --
 -- Note what this grant is NOT, since every unit issues one: margince_app is the
 -- SHARED runtime role, so this line gives it to every unit's handlers, not only
--- to notes's. Within one workspace, another installed unit's SQL can read and
+-- to notes's. Another installed unit's SQL can read and
 -- write this table. That is inside the tier's trusted-unit threat model (see
 -- backend/pkg/extension/runtime.go) and it is what #628's per-unit role would
 -- close; it is stated here because this file is the template.

--- a/extensions/notes/migrations/0003_note_workspace_index.down.sql
+++ b/extensions/notes/migrations/0003_note_workspace_index.down.sql
@@ -1,2 +1,2 @@
 -- Reverses 0003. The index goes; the table and its rows are 0001's.
-DROP INDEX IF EXISTS ext.ext_notes_note_workspace_created;
+DROP INDEX IF EXISTS ext.ext_notes_note_created;

--- a/extensions/notes/migrations/0003_note_workspace_index.down.sql
+++ b/extensions/notes/migrations/0003_note_workspace_index.down.sql
@@ -1,2 +1,6 @@
 -- Reverses 0003. The index goes; the table and its rows are 0001's.
+-- Bounded for the same reason the build is: dropping the index takes a lock that
+-- blocks writers on the table.
+SET LOCAL lock_timeout = '3s';
+
 DROP INDEX IF EXISTS ext.ext_notes_note_created;

--- a/extensions/notes/migrations/0003_note_workspace_index.up.sql
+++ b/extensions/notes/migrations/0003_note_workspace_index.up.sql
@@ -6,12 +6,9 @@
 -- exactly the installations that did not need it — a fresh one — and never on
 -- the ones that do. An upgrade is a new number.
 --
--- The index earns its place twice. The table is cross-tenant, so every read the
--- policy admits still has to FIND this workspace's rows among every other
--- workspace's; leading on workspace_id turns the list into a range scan, and
--- trailing on created_at DESC is the order listNotes asks for, so the sort
--- comes free. The leading column is also what the workspace cascade needs:
--- without an index beginning with the referencing column, deleting one
--- workspace sequentially scans this whole table once per row it removes.
-CREATE INDEX ext_notes_note_workspace_created
-    ON ext.ext_notes_note (workspace_id, created_at DESC);
+-- The index serves listNotes, which reads the table newest-first and bounds the
+-- page. Without it that read is a sequential scan plus a sort of every note the
+-- installation has ever taken, which is fine at the size a unit starts at and
+-- is not the size it stays at.
+CREATE INDEX ext_notes_note_created
+    ON ext.ext_notes_note (created_at DESC);

--- a/extensions/notes/migrations/0003_note_workspace_index.up.sql
+++ b/extensions/notes/migrations/0003_note_workspace_index.up.sql
@@ -10,5 +10,18 @@
 -- page. Without it that read is a sequential scan plus a sort of every note the
 -- installation has ever taken, which is fine at the size a unit starts at and
 -- is not the size it stays at.
+--
+-- Not CONCURRENTLY: a migration runs in one transaction and CONCURRENTLY
+-- forbids that, so this holds a write-blocking SHARE lock on the table for the
+-- length of the build. Recorded rather than avoided, because avoiding it means
+-- a second, non-transactional migration path, and that path would exist for one
+-- index on one extension table.
+--
+-- Bounded, because the table is 0001's rather than this migration's: a
+-- lock_timeout caps how long this waits to acquire the lock, so an open
+-- transaction holding a conflicting one fails the migration instead of stalling
+-- every note write behind it indefinitely.
+SET LOCAL lock_timeout = '3s';
+
 CREATE INDEX ext_notes_note_created
     ON ext.ext_notes_note (created_at DESC);

--- a/extensions/notes/migrations/0004_note_filing.up.sql
+++ b/extensions/notes/migrations/0004_note_filing.up.sql
@@ -6,9 +6,9 @@
 -- still only the unit's.
 --
 -- A plain uuid and NOT a foreign key onto activity, which is the one thing
--- worth stating about this column. A unit's tables may reference workspace(id)
--- and nothing else in public (the migration gate mints a role that CAN point
--- nowhere else): a foreign key onto a core table takes a lock on core writes
+-- worth stating about this column. A unit's tables may reference nothing at all
+-- in public (the migration gate mints a role that CAN point nowhere else): a
+-- foreign key onto a core table takes a lock on core writes
 -- and can refuse a core delete forever after, which is a unit reaching into the
 -- product's own operations. What this column holds is a RECEIPT — the id the
 -- port answered with — and a receipt for a record that later went away is

--- a/extensions/notes/note.go
+++ b/extensions/notes/note.go
@@ -261,8 +261,8 @@ func addNote(ctx context.Context, rt extension.Runtime, in json.RawMessage) (jso
 		// reader of this insert needs, and a default states it somewhere else.
 		var scanErr error
 		n, scanErr = scanNote(tx.QueryRow(ctx,
-			`INSERT INTO `+noteTable+` (workspace_id, kind, body, author_user_id, author_is_agent)
-			 VALUES (`+callerWorkspace+`, $1, $2, $3::uuid, $4::boolean)
+			`INSERT INTO `+noteTable+` (kind, body, author_user_id, author_is_agent)
+			 VALUES ($1, $2, $3::uuid, $4::boolean)
 			 RETURNING `+noteColumns, string(kindNote), body, authorID, authorIsAgent).Scan)
 		if scanErr != nil {
 			return scanErr

--- a/extensions/notes/note_test.go
+++ b/extensions/notes/note_test.go
@@ -140,8 +140,10 @@ func TestAddNoteStoresTheBodyAndReturnsTheStoredRow(t *testing.T) {
 		t.Errorf("the insert writes kind %v, want %q", rt.tx.args[0][0], kindNote)
 	}
 	sql := rt.tx.only(t)
-	if !strings.Contains(sql, callerWorkspace) {
-		t.Errorf("the insert does not name the invocation's workspace, so the policy's WITH CHECK would refuse it:\n%s", sql)
+	// No workspace, asserted rather than merely absent — see the tick's own
+	// version of this in heartbeat_test.go.
+	if strings.Contains(sql, "workspace") {
+		t.Errorf("the insert still names a workspace:\n%s", sql)
 	}
 	if !strings.Contains(sql, "RETURNING") {
 		t.Errorf("the insert reads its own row back in a second statement:\n%s", sql)

--- a/extensions/notes/notes.go
+++ b/extensions/notes/notes.go
@@ -97,12 +97,3 @@ func New() extension.Extension {
 // audit_log.entity_type names a kind of record rather than a path to one. One
 // is derived from the other so the two spellings cannot drift into two tables.
 const noteTable = "ext." + noteEntity
-
-// callerWorkspace is the tenant the invocation is pinned to, as SQL sees it.
-//
-// The Runtime binds app.workspace_id before any statement runs and the table's
-// RLS policy compares this exact expression, so reading it back is how a
-// handler learns which workspace it is in WITHOUT the surface growing a method
-// that hands one out — and an INSERT spelling it names the only workspace the
-// policy's WITH CHECK would accept anyway.
-const callerWorkspace = `NULLIF(current_setting('app.workspace_id', true), '')::uuid`

--- a/extensions/notes/notes_test.go
+++ b/extensions/notes/notes_test.go
@@ -140,9 +140,6 @@ func TestMigrationsAreEmbedded(t *testing.T) {
 	}
 	for _, must := range []string{
 		"ext.ext_notes_note",
-		"FORCE ROW LEVEL SECURITY",
-		"ENABLE ROW LEVEL SECURITY",
-		"REFERENCES workspace(id) ON DELETE CASCADE",
 		// The author pair, and the constraint that keeps it coherent. Both
 		// columns are nullable so the tick's authorless rows can exist, which
 		// means the CHECK is the ONLY thing standing between the schema and a
@@ -158,13 +155,24 @@ func TestMigrationsAreEmbedded(t *testing.T) {
 		}
 	}
 
-	// And it carries NO foreign key from the author to a core table. The
-	// ext_notes role the pre-merge gate applies this file as holds REFERENCES
-	// (id) on `workspace` and nothing else on public, so `REFERENCES app_user`
-	// here does not fail in review — it fails when the gate applies the file,
-	// for this unit and for every unit that copies it as a template.
-	if strings.Contains(string(up), "REFERENCES app_user") {
-		t.Error("the author references a core table — the restricted role the migration gate applies this as cannot create that constraint")
+	// And it carries NO reference into public and no row-level rule. The
+	// ext_notes role the pre-merge gate applies this file as holds nothing on
+	// public at all, so `REFERENCES app_user` here does not fail in review — it
+	// fails when the gate applies the file, for this unit and for every unit
+	// that copies it as a template.
+	//
+	// The RLS pair is asserted absent for the opposite reason: it was present
+	// until the tier stopped carrying a workspace, and a policy re-added here
+	// would key on a column that is gone and read a GUC that fences nothing.
+	for _, absent := range []string{
+		"REFERENCES app_user",
+		"REFERENCES workspace",
+		"ROW LEVEL SECURITY",
+		"CREATE POLICY",
+	} {
+		if strings.Contains(string(up), absent) {
+			t.Errorf("the embedded migration carries %q — the restricted role the gate applies it as would refuse it", absent)
+		}
 	}
 
 	// The SECOND pair, by its own bytes. 0002 adds the `kind` column the

--- a/extensions/relay-probe/api/crm.yaml
+++ b/extensions/relay-probe/api/crm.yaml
@@ -26,8 +26,8 @@ actions:
   - target: $.paths['/ext/relay-probe/connect']
     update:
       # PUT, because connecting the same account twice is the same connection:
-      # the row is upserted on (workspace, member) and the token replaced. A
-      # POST would publish "create another one" for an operation that cannot.
+      # the row is upserted on the member and the token replaced. A POST would
+      # publish "create another one" for an operation that cannot.
       put:
         operationId: relayProbeConnect
         summary: Connect this member's Relay account and deposit their token.

--- a/extensions/relay-probe/connection.go
+++ b/extensions/relay-probe/connection.go
@@ -162,9 +162,9 @@ func connect(ctx context.Context, rt extension.Runtime, in json.RawMessage) (jso
 			return err
 		}
 		stored, err = scanConnection(tx.QueryRow(ctx,
-			`INSERT INTO `+connectionTable+` (workspace_id, user_id, base_url)
-			 VALUES (`+callerWorkspace+`, $1::uuid, $2)
-			 ON CONFLICT (workspace_id, user_id) DO UPDATE
+			`INSERT INTO `+connectionTable+` (user_id, base_url)
+			 VALUES ($1::uuid, $2)
+			 ON CONFLICT (user_id) DO UPDATE
 			    SET base_url = EXCLUDED.base_url,
 			        status = '`+statusConnected+`',
 			        last_error_class = NULL,

--- a/extensions/relay-probe/migrations/0001_connection.up.sql
+++ b/extensions/relay-probe/migrations/0001_connection.up.sql
@@ -4,9 +4,9 @@
 -- One row per connected member: where their Relay is, how far the poll has
 -- read, and whether the connection still works. It is applied by the pre-merge
 -- gate as a restricted ext_relay_probe role and at runtime by
--- margince_owner; what isolates it in production is the FORCE row level
--- security and the workspace-bound policy below, not its ownership
--- (extensions/notes/migrations/0001 carries the long form of that note).
+-- margince_owner; what bounds it in production is the grant surface the gate
+-- polices and the ext schema the unit owns, not its ownership and not a
+-- row-level policy (extensions/notes/migrations/0001 carries the long form).
 --
 -- THE TOKEN IS NOT HERE. A member's personal access token lives in the unit's
 -- user-scoped secret namespace, sealed by the installation's custodian. This
@@ -15,11 +15,6 @@
 
 CREATE TABLE ext.ext_relay_probe_connection (
     id              uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-    -- The tenant claim, and the column the policy below compares. The cascade
-    -- is load-bearing: without it, deleting a workspace fails on this unit's
-    -- rows, so erasing a tenant would stop at the first installed extension.
-    workspace_id    uuid        NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
-
     -- WHOSE connection this is: the member whose token produced the records,
     -- and the authority every ingest from this row runs under. Stamped by the
     -- handler from the invocation's Caller and never from the request body —
@@ -27,7 +22,7 @@ CREATE TABLE ext.ext_relay_probe_connection (
     -- would forge the consent the ingress port checks.
     --
     -- NO FOREIGN KEY to the core user table: the role this file is applied as
-    -- holds REFERENCES (id) on workspace and nothing else on public. The cost
+    -- holds nothing on public at all. The cost
     -- is real and worth stating — nothing deletes this row when the account is
     -- deleted, so a reader must treat the id as one that may no longer
     -- resolve. The poll does: identity refuses a member who is gone, and the
@@ -98,31 +93,19 @@ CREATE TABLE ext.ext_relay_probe_connection (
     created_at      timestamptz NOT NULL DEFAULT now(),
     updated_at      timestamptz NOT NULL DEFAULT now(),
 
-    -- One connection per member per workspace. Without it a member could
+    -- One connection per member. Without it a member could
     -- connect twice and have both rows poll the same inbox, which is not a
     -- duplicate-record problem — the capture key makes the second landing a
     -- no-op — but two cursors advancing over one account, each hiding the
     -- other's gaps.
     CONSTRAINT ext_relay_probe_connection_one_per_member
-        UNIQUE (workspace_id, user_id)
+        UNIQUE (user_id)
 );
 
--- ENABLE and FORCE, both. The owner at runtime is margince_owner, and ENABLE
--- alone exempts a table's owner from its own policies — so without FORCE the
--- isolation would hold for margince_app and not for the role every migration
--- and every operator psql session arrives as.
-ALTER TABLE ext.ext_relay_probe_connection ENABLE ROW LEVEL SECURITY;
-ALTER TABLE ext.ext_relay_probe_connection FORCE ROW LEVEL SECURITY;
+-- NO ROW-LEVEL SECURITY: a unit table carries none, for the reasons
+-- extensions/notes/migrations/0001 states in full.
 
--- Exactly one policy, permissive, ALL commands, to PUBLIC. A second permissive
--- policy ORs with this one and can only widen it, and USING without WITH CHECK
--- would admit writes into another workspace.
-CREATE POLICY ext_relay_probe_connection_tenant_isolation
-    ON ext.ext_relay_probe_connection
-    USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
-    WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
-
--- The app role runs the unit's handlers, under the policy above. TRUNCATE is
--- deliberately absent: it empties every tenant's rows without consulting the
--- policy's USING clause.
+-- The app role runs the unit's handlers. TRUNCATE is deliberately absent: no
+-- unit verb issues one, and a privilege nothing reaches for is one more thing a
+-- compromised unit could.
 GRANT SELECT, INSERT, UPDATE, DELETE ON ext.ext_relay_probe_connection TO margince_app;

--- a/extensions/relay-probe/relayprobe.go
+++ b/extensions/relay-probe/relayprobe.go
@@ -141,9 +141,3 @@ const tokenKey = "api-token"
 // because audit_log.entity_type names a kind of record rather than a path to
 // one. One is derived from the other so the two cannot drift into two tables.
 const connectionTable = "ext." + connectionEntity
-
-// callerWorkspace is the tenant the invocation is pinned to, as SQL sees it.
-// The Runtime binds app.workspace_id before any statement runs and the table's
-// policy compares this exact expression, so an INSERT spelling it names the
-// only workspace the policy's WITH CHECK would accept anyway.
-const callerWorkspace = `NULLIF(current_setting('app.workspace_id', true), '')::uuid`


### PR DESCRIPTION
Answers #2121, which asked whether the extension tier's FORCE RLS carve-out is
intentional and permanent. It is neither: the isolation it names stopped existing
when the installation became single-organization.

## Why the carve-out no longer holds

`identity.InstallationWorkspace` returns `ErrMultipleWorkspaces` if it finds more
than one active workspace, so `workspace_id = current_setting('app.workspace_id')`
matched every row it could see. Its one live effect was to deny rows on a
connection that forgot to bind the GUC — and `compose/extruntimetx.go` binds it
through `WithWorkspaceTx` before any unit statement runs, so that never fired.

It was never a wall against a unit either. `pkg/extension/runtime.go` records — as
verified against the shipped schema rather than assumed — that a unit can rebind
`app.workspace_id` through the seam's own verbs, after which the policies read the
new value. That file already calls the tenant wall "defence in depth, not a
boundary", and names the per-unit database role (#628) as the real answer.

**#2121's evidence had also gone stale**: it tabulates nine tables across five
units, but `dispact-connector`, `zalo-oa` and `zalo-personal` are no longer in the
tree. What exists is two tables.

## What changes

Both unit tables drop `workspace_id`, its foreign key, `ENABLE`/`FORCE ROW LEVEL
SECURITY` and their policies. `notes`'s index and `relay-probe`'s one-per-member
constraint lose their leading tenant column.

The gate now **refuses** the shape it used to require — a workspace column, RLS,
any policy, a foreign key out of `ext` — rather than merely not requiring it. A
column re-added here would read to the next author as a live tenant boundary.

## What it buys

The minted `ext_<name>` role held `REFERENCES (id) ON public.workspace` for exactly
as long as a unit table was required to declare that key. With no key to declare,
**the role now holds nothing on public at all** — which `role.go`'s own comment
recorded as unreachable while the rule stood. `assertNoWiderReferences` loses its
one exemption and probes for any reference at all.

## Amended in place, deliberately

`dbmigrate` keys on the version, so a later migration would leave the column
standing on every database that already applied `0001`, while the role that can no
longer reference `workspace` would fail to apply `0001` from scratch — the gate and
a deployed database would disagree permanently. Both units are pre-installation,
which is the condition `notes/0001`'s header already states for this exception.

## Verification

- `make check-ext-migrations` — both units apply as their `ext_<name>` role, the
  catalog holds, the revert is clean
- `make test-integration` — 46 packages, 0 skips, 0 failures
- `make check-fe`, `make -C backend test-extensions`, `craft static --strict` (14 files, 0 findings)
- `make check` is green apart from `TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim`,
  which walks the filesystem for Go modules and finds sibling git worktrees under
  `.claude/worktrees/`. It fails identically on `origin/main` and CI never sees it.

## Not in this change

`compose/datasweep.go` still reads the GUC to scope a reset, but only for tables
that carry the column — it scans `public` only, where none do, so the predicate is
already unreachable. It goes with the §5 collapse of `WithWorkspaceTx`, which this
unblocks: `app.workspace_id` now has no reader left in the tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension records are now managed without workspace-specific fields or row-level security policies.
  * Relay probe connections are tracked once per member.
  * Notes and heartbeat records no longer require workspace identifiers.
  * Note listing now uses a streamlined newest-first index.

* **Bug Fixes**
  * Migration validation now rejects unsupported workspace references, policies, row-level security, and cross-schema dependencies.
  * Updated grants and connection handling improve extension data access consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->