### PR TITLE
fix(worker): a role resolves its key vault once

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -134,7 +134,7 @@ func fileReleaseHandbook(ctx context.Context, pool *pgxpool.Pool, logger *slog.L
 //
 // Returns the loaded deployment config every later boot phase reads, and the
 // license watcher whose posture baseComposeOptions reports.
-func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger) (deployconfig.Config, *licensecheck.Watcher, error) {
+func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, vault keyvault.Vault, logger *slog.Logger) (deployconfig.Config, *licensecheck.Watcher, error) {
 	deployCfg, err := deployconfig.Load(cfg.configPath, cfg.posture)
 	if err != nil {
 		return deployconfig.Config{}, nil, err
@@ -161,14 +161,10 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 	// production installation accepts one, and only a non-production one also
 	// runs on a license minted for a test.
 	//
-	// The vault is built here rather than taken from the later keyvaultOptions
-	// wiring, because an installation that has sealed its token and dropped the
-	// declaration reads it out of the vault: the license question cannot be
-	// answered before the vault exists.
-	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return deployconfig.Config{}, nil, fmt.Errorf("api: keyvault: %w", err)
-	}
+	// The vault reaches this phase from the boot rather than from the later
+	// keyvaultOptions wiring, because an installation that has sealed its token
+	// and dropped the declaration reads it out of the vault: the license
+	// question cannot be answered before the vault exists.
 	license, err := compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, cfg.posture, config.FromOS)
 	if err != nil {
 		return deployconfig.Config{}, nil, err
@@ -193,7 +189,7 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 // The reset lane comes back with the options because the endpoint is only half
 // of it: the other half is a listener this process runs for its own lifetime,
 // which run() starts once the handler exists.
-func declaredSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deployconfig.Config, pool, schemaPool *pgxpool.Pool, rdb *redis.Client, logger *slog.Logger, stdout io.Writer) ([]compose.Option, *resetLane, error) {
+func declaredSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deployconfig.Config, pool, schemaPool *pgxpool.Pool, vault keyvault.Vault, rdb *redis.Client, logger *slog.Logger, stdout io.Writer) ([]compose.Option, *resetLane, error) {
 	// The non-production admin data-reset endpoint (POST /v1/admin/reset-data):
 	// absent this deployment posture, or in production, ResetData answers its
 	// closed 404 default. schemaPool may be nil (no --schema-dsn configured);
@@ -240,7 +236,7 @@ func declaredSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deploy
 		opts = append(opts, compose.WithMCPConnector())
 	}
 
-	passwordOpts, err := passwordResetOptions(ctx, deployCfg, pool, cfg.publicBaseURL, logger, stdout)
+	passwordOpts, err := passwordResetOptions(ctx, deployCfg, pool, vault, cfg.publicBaseURL, logger, stdout)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/cmd/api/keyvault.go
+++ b/backend/cmd/api/keyvault.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -24,22 +23,18 @@ import (
 // configured. Without one the vault stays absent: every connector's connect
 // path (gmail, gcal, graph, imap all seal to the vault) refuses loudly rather
 // than nil-deref if ever invoked; the vault is required for any standing
-// connection. A key that is set but malformed is a boot error
-// (keyvault.FromEnv), never a silent fallback to something weaker.
-func keyvaultOptions(ctx context.Context, pool *pgxpool.Pool, stdout io.Writer, overlayBackfillLimit int) ([]compose.Option, error) {
-	vault, configured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return nil, fmt.Errorf("api: keyvault: %w", err)
-	}
-	// Bound BEFORE the unconfigured return, and with whatever FromEnv gave:
-	// the extension tier's per-call Runtime needs the POOL for its
+// connection. A key that is set but malformed already failed the boot, never a
+// silent fallback to something weaker.
+func keyvaultOptions(pool *pgxpool.Pool, vault keyvault.Vault, stdout io.Writer, overlayBackfillLimit int) ([]compose.Option, error) {
+	// Bound BEFORE the unconfigured return, and with whatever the boot
+	// resolved: the extension tier's per-call Runtime needs the POOL for its
 	// workspace-pinned transactions whether or not a custodian exists, and a
 	// deployment with no keyvault should have its extension secrets refuse by
 	// name rather than have its extension database access silently disabled
-	// too. FromEnv returns a nil vault when unconfigured, which is the
-	// ErrNoCustodian posture the store already documents.
+	// too. A nil vault here is the ErrNoCustodian posture the store already
+	// documents.
 	compose.BindExtensionRuntime(pool, vault)
-	if !configured {
+	if vault == nil {
 		return nil, nil
 	}
 	_, _ = fmt.Fprintln(stdout, "api connector-credential vault enabled (keyvault configured)")

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -82,15 +82,13 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	config.WarnUndeclared(logger, cfg.unknownVars)
 
-	// Already proven to connect as a role row-level security binds — boot.go
-	// carries why that check belongs with the pool's own construction.
-	pool, err := boundPool(ctx, cfg.dsn)
+	pool, vault, err := openInstallation(ctx, cfg.dsn)
 	if err != nil {
 		return err
 	}
 	defer pool.Close()
 
-	deployCfg, license, err := bindInstallation(ctx, cfg, pool, logger)
+	deployCfg, license, err := bindInstallation(ctx, cfg, pool, vault, logger)
 	if err != nil {
 		return err
 	}
@@ -103,7 +101,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	opts, schemaPool, closeSchemaPool, err := baseComposeOptions(ctx, cfg, compose.CaptureConfigFromDeploy(deployCfg.Capture, logger), pool, logger, stdout, license)
+	opts, schemaPool, closeSchemaPool, err := baseComposeOptions(ctx, cfg, compose.CaptureConfigFromDeploy(deployCfg.Capture, logger), pool, vault, logger, stdout, license)
 	if err != nil {
 		return err
 	}
@@ -112,7 +110,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	rdb, closeRedis := sharedRedisClient(cfg, logger)
 	defer closeRedis()
 
-	surfaceOpts, resetLane, err := declaredSurfaceOptions(ctx, cfg, deployCfg, pool, schemaPool, rdb, logger, stdout)
+	surfaceOpts, resetLane, err := declaredSurfaceOptions(ctx, cfg, deployCfg, pool, schemaPool, vault, rdb, logger, stdout)
 	if err != nil {
 		return err
 	}
@@ -164,6 +162,37 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// neither serves a binding the installation has replaced (compose/routingwatcher).
 	go compose.NewRoutingWatcher(pool, modelPath, config.FromOS, logger).Run(ctx)
 	return serveUntilSignal(ctx, cfg, apiHandler, stdout)
+}
+
+// openInstallation opens what this role reaches the installation THROUGH: the
+// database pool, and the one key vault every phase below reads secrets from.
+//
+// Together because the vault is a table in that pool, and apart from every
+// phase that uses them because both are settled before any phase runs. The pool
+// is already proven to connect as the role it must — boot.go carries why that
+// check belongs with the pool's own construction.
+//
+// The vault is resolved ONCE, here, and handed down — the license this
+// installation may have sealed, the connector-credential surface, the outbound
+// relay password each used to resolve their own, so one deployment fact was
+// read three times. A nil vault IS an unconfigured deployment; keyvault.ForRole
+// carries why nothing downstream is handed a flag beside it.
+//
+// The caller owns closing the pool it gets back. A vault that refuses the boot
+// closes it here instead, because there is no pool to return alongside an error.
+//
+//nolint:ireturn // the vault seam has two providers behind one Vault; returning the interface is the design, and this only carries what ForRole handed back.
+func openInstallation(ctx context.Context, dsn string) (*pgxpool.Pool, keyvault.Vault, error) {
+	pool, err := boundPool(ctx, dsn)
+	if err != nil {
+		return nil, nil, err
+	}
+	vault, err := keyvault.ForRole(ctx, "api", pool, config.FromOS)
+	if err != nil {
+		pool.Close()
+		return nil, nil, err
+	}
+	return pool, vault, nil
 }
 
 // validatePublicBaseURL refuses a base URL the connector cannot be reached at.
@@ -232,7 +261,7 @@ func validateBareOrigin(flagName, raw string) error {
 // uses. The returned close func releases whatever this stage opened
 // (currently only the schema pool) and is always safe to call, even when
 // nothing was opened.
-func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.CaptureConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer, license *licensecheck.Watcher) ([]compose.Option, *pgxpool.Pool, func(), error) {
+func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.CaptureConfig, pool *pgxpool.Pool, vault keyvault.Vault, logger *slog.Logger, stdout io.Writer, license *licensecheck.Watcher) ([]compose.Option, *pgxpool.Pool, func(), error) {
 	var opts []compose.Option
 	// The posture bindInstallation resolved, read at scrape time rather than
 	// copied in: a license lapses on a calendar, and the watcher behind this
@@ -283,7 +312,7 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.Captu
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("api: %w", err)
 	}
-	kvOpts, err := keyvaultOptions(ctx, pool, stdout, overlayBackfillLimit)
+	kvOpts, err := keyvaultOptions(pool, vault, stdout, overlayBackfillLimit)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -318,16 +347,12 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.Captu
 // canonical external base — with email enabled, a missing
 // --public-base-url is a boot error, never a link derived from a
 // request Host.
-func passwordResetOptions(ctx context.Context, deployCfg deployconfig.Config, pool *pgxpool.Pool, publicBaseURL string, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
+func passwordResetOptions(ctx context.Context, deployCfg deployconfig.Config, pool *pgxpool.Pool, vault keyvault.Vault, publicBaseURL string, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
 	if !deployCfg.Email.Enabled {
 		return nil, nil
 	}
 	if publicBaseURL == "" {
 		return nil, errors.New("api: email.enabled requires --public-base-url/MARGINCE_PUBLIC_BASE_URL (the reset link's canonical base)")
-	}
-	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return nil, fmt.Errorf("api: keyvault: %w", err)
 	}
 	// The relay password is sealed into the vault on the boot that first sees
 	// it, and read back from there once the deployment stops declaring it.

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -151,11 +151,11 @@ func (l workerLanes) join() {
 // lanes started are already reading the bus and the pool, and a zero value would
 // make join() a nil dereference in a deferred call during a failing boot — a
 // stack trace where the boot error belongs.
-func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, modelPath compose.ModelPath, logger *slog.Logger, stdout io.Writer) (workerLanes, error) {
+func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, vault keyvault.Vault, modelPath compose.ModelPath, logger *slog.Logger, stdout io.Writer) (workerLanes, error) {
 	laneCtx, stopLanes := context.WithCancel(ctx)
 	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stopLanes, ctx: laneCtx}
 
-	if err := startRunnerLane(laneCtx, cfg, pool, rdb, modelPath, &lanes, logger, stdout); err != nil {
+	if err := startRunnerLane(laneCtx, cfg, pool, rdb, vault, modelPath, &lanes, logger, stdout); err != nil {
 		return lanes, err
 	}
 	startProjectionLanes(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
@@ -184,21 +184,10 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		_, _ = fmt.Fprintf(stdout, "worker executing provider enrichment runs (%s)\n", strings.Join(providers.Names(), ", "))
 	}
 	lanes.providers = providers
-	if err := backfillConnectorCredentials(ctx, pool, stdout, logger); err != nil {
-		return lanes, err
-	}
+	backfillConnectorCredentials(ctx, pool, vault, stdout, logger)
 	// Automatic enrichment on create, which needs BOTH halves the run lanes
 	// need: an adapter to call and the vault that unseals its credential.
-	// keyvault.FromEnv is resolved here rather than passed down because this
-	// is the first lane in this role that needs it.
-	providerVault, vaultConfigured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return lanes, fmt.Errorf("worker: keyvault: %w", err)
-	}
-	if !vaultConfigured {
-		providerVault = nil
-	}
-	if err := startPersonDataEnrich(laneCtx, pool, rdb, providers, providerVault, lanes.background, logger, stdout); err != nil {
+	if err := startPersonDataEnrich(laneCtx, pool, rdb, providers, vault, lanes.background, logger, stdout); err != nil {
 		return lanes, err
 	}
 
@@ -341,7 +330,7 @@ func startResetLane(ctx context.Context, allowed bool, rdb *redis.Client, modelP
 // startRunnerLane builds the Surface-B runner and starts the subscriber that
 // resumes its approved runs. Without a declared brain there is no runner and
 // lanes.runner stays nil, which is what leaves the scheduler unregistered.
-func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, modelPath compose.ModelPath, lanes *workerLanes, logger *slog.Logger, stdout io.Writer) error {
+func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, vault keyvault.Vault, modelPath compose.ModelPath, lanes *workerLanes, logger *slog.Logger, stdout io.Writer) error {
 	// The Surface-B runner is this role's sending lane, and it stages through
 	// the SAME delivery machinery the api does — built before the lane so it
 	// cannot be composed without one. Insert-only, like the api's: the staged
@@ -357,14 +346,12 @@ func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return nil
 	}
 	grounding := search.NewRetriever(search.NewStore(compose.InstallationDB(pool)), modelPath.Embedder)
-	// The Surface-B runner's agent tools reach overlay write-back through
-	// the workspace's own vaulted incumbent token; wire the FromEnv
-	// vault-backed resolver so an autonomous run can write back (nil vault
-	// → clean errNoWriteIncumbent, never a crash).
-	runnerVault, _, rverr := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if rverr != nil {
-		return rverr
-	}
+	// The Surface-B runner's agent tools reach overlay write-back through the
+	// workspace's own vaulted incumbent token; wire the vault-backed resolver so
+	// an autonomous run can write back. A deployment with none configured has a
+	// nil vault here, and the resolver answers "no incumbent" from it — the same
+	// unsupported that the job lane's equivalent surface reports, because it is
+	// now the same value rather than a second reading of one.
 	// The same pool and custodian back the extension tier's per-call Runtime:
 	// a Surface-B run invokes governed extension tools through the runner's
 	// registry, so this role serves them and must bind what they reach the
@@ -379,10 +366,10 @@ func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 	// window for a Surface-B run that arrives before the runner is wired.
 	//
 	// Both pass the SAME two values, so the calls are idempotent whichever
-	// order the boot reaches them in: one pool, and keyvault.FromEnv's vault,
+	// order the boot reaches them in: one pool, and the boot's one vault,
 	// which is already nil on a deployment that configured none.
-	compose.BindExtensionRuntime(pool, runnerVault)
-	runnerSvc := compose.NewRunnerService(pool, modelPath.AgentLoop, modelPath.DraftReply, grounding, logger, compose.OverlayIncumbentResolver(pool, runnerVault), send)
+	compose.BindExtensionRuntime(pool, vault)
+	runnerSvc := compose.NewRunnerService(pool, modelPath.AgentLoop, modelPath.DraftReply, grounding, logger, compose.OverlayIncumbentResolver(pool, vault), send)
 	_, _ = fmt.Fprintln(stdout, "worker resuming approved Surface-B runs (cg:overnight-agent)")
 	lanes.runner = runnerSvc
 	lanes.background.Go(func() { runResumeSubscriber(ctx, rdb, runnerSvc, logger) })
@@ -478,22 +465,21 @@ func relayUntilSignal(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool,
 // idempotent — a row already carrying a credential_ref is skipped — so
 // re-running every boot is safe and a no-op once every row is migrated.
 // Without a vault it is skipped: the legacy auth column still resolves
-// credentials until one is provisioned. A malformed root key fails the boot
-// (keyvault.FromEnv); a mid-backfill failure is logged and non-fatal — capture
-// keeps resolving from the auth column and the next boot retries.
-func backfillConnectorCredentials(ctx context.Context, pool *pgxpool.Pool, stdout io.Writer, logger *slog.Logger) error {
-	vault, configured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return fmt.Errorf("worker: keyvault: %w", err)
-	}
-	if !configured {
-		return nil
+// credentials until one is provisioned.
+//
+// It cannot fail the boot, and now says so by returning nothing. A malformed
+// root key was the only failure it ever passed up, and that is the boot's own
+// vault resolution to refuse, before any lane starts. What is left is a
+// mid-backfill failure, which is logged and non-fatal — capture keeps resolving
+// from the auth column and the next boot retries.
+func backfillConnectorCredentials(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, stdout io.Writer, logger *slog.Logger) {
+	if vault == nil {
+		return
 	}
 	migrated, err := compose.NewCaptureRegistry(pool, vault, compose.CaptureConfig{}).BackfillCredentials(ctx)
 	if err != nil {
 		logger.Error("connector-credential backfill did not complete; capture continues from the legacy column and the next boot retries", "err", err)
-		return nil
+		return
 	}
 	_, _ = fmt.Fprintf(stdout, "worker keyvault configured; migrated %d legacy connector credential(s) onto the vault\n", migrated)
-	return nil
 }

--- a/backend/cmd/worker/boot_integration_test.go
+++ b/backend/cmd/worker/boot_integration_test.go
@@ -50,7 +50,7 @@ func TestABootFailureAfterALaneStartedStillJoinsIt(t *testing.T) {
 	// is the only interesting shape — a failure before any lane starts is
 	// trivially safe to return from.
 	lanes, err := startEventLanes(t.Context(), workerConfig{webhookKey: "not-a-valid-signing-key"},
-		pool, rdb, compose.ModelPath{}, laneLog, &announced)
+		pool, rdb, nil, compose.ModelPath{}, laneLog, &announced)
 	if err == nil {
 		t.Fatal("startEventLanes accepted a malformed webhook signing key — this test needs it to fail AFTER a lane was launched")
 	}

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/capture"
-	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/platform/geocode"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
@@ -47,22 +46,18 @@ func gmailWatchConfig(cfg workerConfig, gmailWired bool) compose.GmailWatchConfi
 // drain — what the bare tickers lacked. The domain logic (Sweep/Reconcile)
 // is unchanged; only the scheduler is River now. The returned stop function
 // drains in-flight jobs on shutdown.
-func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, overlayBudget overlaybudget.Config, logger *slog.Logger, cfg workerConfig, modelPath compose.ModelPath, boundModels map[string]map[string]bool, lanes workerLanes, weeklyMail compose.WeeklyMailConfig, stdout io.Writer) (func(), error) {
+func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, vault keyvault.Vault, overlayBudget overlaybudget.Config, logger *slog.Logger, cfg workerConfig, modelPath compose.ModelPath, boundModels map[string]map[string]bool, lanes workerLanes, weeklyMail compose.WeeklyMailConfig, stdout io.Writer) (func(), error) {
 	// The sweep registry is always live — the standing IMAP connector needs
 	// no deployment config; gmail joins it when the OAuth app is configured.
 	// The vault holds every connection's sealed credential (the standing
-	// flavors resolve through it), so it initializes here regardless. The
-	// SAME vault is the credential custodian of the two pollers this role
-	// runs — the overlay reconcile (the only one that can resolve a connected
-	// workspace's sealed HubSpot token, overlay.DueOverlayConnections'
-	// CredentialRef) and the Telegram getUpdates poll (a bot's sealed token) —
-	// resolved once, shared; when it is not configured, configuredVault is nil
+	// flavors resolve through it), so it is wired here regardless. The SAME
+	// vault is the credential custodian of the two pollers this role runs — the
+	// overlay reconcile (the only one that can resolve a connected workspace's
+	// sealed HubSpot token, overlay.DueOverlayConnections' CredentialRef) and
+	// the Telegram getUpdates poll (a bot's sealed token) — and it is the
+	// boot's, not a second resolution of it; when none is configured it is nil,
 	// so an unconfigured deployment never fails worker boot over pollers it has
 	// no connected workspace to run anyway.
-	vault, vaultConfigured, verr := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if verr != nil {
-		return nil, fmt.Errorf("worker: keyvault: %w", verr)
-	}
 	// THIS is the role that pulls mailboxes, so the object store a captured
 	// file is written to has to reach the config the sync registry and the job
 	// lanes are built from. Wired in the api role alone, every inbound
@@ -78,10 +73,6 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 		Tenant:       cfg.graphTenant,
 	}, cfg.captureConfig, logger).WithSyncInterval(cfg.gmailSyncInterval)
 	watchCfg := gmailWatchConfig(cfg, cfg.gmailAppWired())
-	configuredVault := vault
-	if !vaultConfigured {
-		configuredVault = nil
-	}
 
 	// The extension tier's per-call Runtime, bound before the runner exists
 	// rather than beside the Surface-B lane that also binds it. This is the
@@ -93,9 +84,9 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 	// ever refuse is not a working job.
 	//
 	// Unconditional, and that is the point: a guard here would reintroduce
-	// exactly the shape that left the job lane unbound. `vault` is
-	// keyvault.FromEnv's, already nil where none is configured, and it is the
-	// same value startRunnerLane passes — so the two bindings are idempotent.
+	// exactly the shape that left the job lane unbound. `vault` is the boot's,
+	// already nil where none is configured, and it is the same value
+	// startRunnerLane passes — so the two bindings are idempotent.
 	compose.BindExtensionRuntime(pool, vault)
 	// The capture pipeline a unit's ingress lands through, bound in the same
 	// breath and on the same terms. THIS role is the one that matters: a record
@@ -110,14 +101,14 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 	// attachment store rather than two that drift.
 	compose.BindExtensionCapture(pool, cfg.captureConfig)
 
-	runner, err := newJobRunner(pool, logger, cfg, captureReg, watchCfg, configuredVault, lanes, rdb, overlayBudget, modelPath, boundModels, weeklyMail)
+	runner, err := newJobRunner(pool, logger, cfg, captureReg, watchCfg, vault, lanes, rdb, overlayBudget, modelPath, boundModels, weeklyMail)
 	if err != nil {
 		return nil, err
 	}
 	if err := runner.Start(ctx); err != nil {
 		return nil, err
 	}
-	_, _ = fmt.Fprintln(stdout, jobRunnerBanner(cfg, watchCfg, modelPath, configuredVault, lanes.runner))
+	_, _ = fmt.Fprintln(stdout, jobRunnerBanner(cfg, watchCfg, modelPath, vault, lanes.runner))
 	return func() {
 		// The run context is already cancelled at shutdown, so give the
 		// drain its own bounded window.
@@ -133,7 +124,7 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 // deployment condition that turns it on — or the omission that honestly leaves
 // it off. One declaration, so no lane can be enabled by one boot phase and
 // starved by another.
-func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, captureReg *capture.Registry, watchCfg compose.GmailWatchConfig, configuredVault keyvault.Vault, lanes workerLanes, rdb *redis.Client, overlayBudget overlaybudget.Config, modelPath compose.ModelPath, boundModels map[string]map[string]bool, weeklyMail compose.WeeklyMailConfig) (*jobs.Runner, error) {
+func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, captureReg *capture.Registry, watchCfg compose.GmailWatchConfig, vault keyvault.Vault, lanes workerLanes, rdb *redis.Client, overlayBudget overlaybudget.Config, modelPath compose.ModelPath, boundModels map[string]map[string]bool, weeklyMail compose.WeeklyMailConfig) (*jobs.Runner, error) {
 	// Firing a scheduled message stages its delivery and enqueues the dispatch
 	// job, through the SAME machinery an immediate send uses. Insert-only, like
 	// the api's: this role works what it inserts, and a stager built on the
@@ -175,7 +166,7 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// with no provider configured — nothing can reach a vendor at all
 		// (PI-AC-9). lanes.providers is nil unless MARGINCE_PROVIDER_SURFE
 		// named a mode.
-		ProviderRuns:  compose.ProviderRunsConfig{Registry: lanes.providers, Vault: configuredVault},
+		ProviderRuns:  compose.ProviderRunsConfig{Registry: lanes.providers, Vault: vault},
 		GmailRegistry: captureReg,
 		GmailWatch:    watchCfg,
 		// The Telegram ingest worker builds its Sink from this — the same
@@ -186,7 +177,7 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// sealed token. Without a configured vault there is no token to unseal
 		// and the poller stays off by omission, the same posture the overlay
 		// poller takes one field below.
-		ChannelVault: configuredVault,
+		ChannelVault: vault,
 		// The classify + enrich passes run only where a model is
 		// configured; without one both are absent by omission.
 		ClassifyBrain:      modelPath.CaptureClassify,
@@ -199,7 +190,7 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		WeeklyMail:             weeklyMail,
 		TranscriptProposeBrain: modelPath.TranscriptPropose,
 		DocumentExtractBrain:   modelPath.DocumentExtract,
-		OverlayVault:           configuredVault,
+		OverlayVault:           vault,
 		OverlayInterval:        cfg.overlayInterval,
 		OverlayBackfillLimit:   cfg.overlayBackfillLimit,
 		// The poller's OVB meter records against the SAME Redis the relay

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -104,7 +104,21 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// release assertion above, which exists to stop a role that must not run
 	// from writing. AssertRuntimeRole comes earlier still, so a pool connecting
 	// as the wrong role fails as that rather than as a license nobody can read.
-	if err := ensureLicense(ctx, logger, pool, deployCfg, cfg.posture); err != nil {
+	// THE key vault for this process, resolved once and handed to every lane
+	// that needs one. Three lanes used to resolve their own and each read the
+	// answer in its own way; one value cannot drift from itself.
+	//
+	// Here because this is the first thing that needs it, and no earlier: the
+	// question it may have to answer — does this installation hold sealed
+	// secrets it can no longer open — is asked of a table, so it belongs after
+	// the pool and after the release assertion, for the same reasons the license
+	// does. A nil vault IS an unconfigured deployment; keyvault.ForRole carries
+	// why nothing downstream is handed a flag beside it.
+	vault, err := keyvault.ForRole(ctx, "worker", pool, config.FromOS)
+	if err != nil {
+		return err
+	}
+	if err := ensureLicense(ctx, logger, pool, vault, deployCfg, cfg.posture); err != nil {
 		return err
 	}
 
@@ -152,7 +166,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// Deferred BEFORE the error is checked: a failure here still leaves earlier
 	// lanes running on the bus and the pool whose closes are deferred above, and
 	// LIFO is what puts this join ahead of them.
-	lanes, err := startEventLanes(ctx, cfg, pool, rdb, modelPath, logger, stdout)
+	lanes, err := startEventLanes(ctx, cfg, pool, rdb, vault, modelPath, logger, stdout)
 	defer lanes.join()
 	if err != nil {
 		return err
@@ -160,10 +174,10 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 
 	// The operator relay, resolved in THIS role. Unattended work runs here, so
 	// the weekly retrospective's mail has no request to arrive on.
-	weeklyMail := weeklyMailConfig(ctx, cfg, deployCfg, pool, logger)
+	weeklyMail := weeklyMailConfig(ctx, cfg, deployCfg, pool, vault, logger)
 	_, _ = fmt.Fprintln(stdout, weeklyMailBanner(weeklyMail))
 
-	stopJobs, err := startJobRunner(ctx, pool, rdb, compose.OverlayBudgetConfig(deployCfg.EffectiveOverlayBudget()),
+	stopJobs, err := startJobRunner(ctx, pool, rdb, vault, compose.OverlayBudgetConfig(deployCfg.EffectiveOverlayBudget()),
 		logger, cfg, modelPath, boundModels, lanes, weeklyMail, stdout)
 	if err != nil {
 		return err
@@ -307,18 +321,14 @@ func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Gr
 	}
 }
 
-// ensureLicense resolves this worker's entitlement, building the key vault it
-// may have to read the token out of.
+// ensureLicense resolves this worker's entitlement, reading the token out of
+// the boot's key vault when the installation has sealed it there.
 //
-// A vault that is configured but malformed is a boot error here rather than a
-// silent fallback, the same posture every other keyvault.FromEnv site takes: an
-// installation whose root key no longer opens its own secrets has a problem
-// that outlives the license question.
-func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
-	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		return fmt.Errorf("worker: keyvault: %w", err)
-	}
-	_, err = compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, posture, config.FromOS)
+// A vault that is configured but malformed already failed the boot before this
+// is reached, which is the posture every role takes: an installation whose root
+// key no longer opens its own secrets has a problem that outlives the license
+// question.
+func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, vault keyvault.Vault, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
+	_, err := compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, posture, config.FromOS)
 	return err
 }

--- a/backend/cmd/worker/weeklymail.go
+++ b/backend/cmd/worker/weeklymail.go
@@ -40,17 +40,15 @@ import (
 //
 // A zero value mails nothing, which is what an installation that configured no
 // operator mail asked for.
+// The vault is the boot's, not one resolved here: a role has ONE, and a vault
+// this could not build would have refused the boot long before the weekly mail
+// was considered. What is left for this function to degrade over is the relay
+// credential inside it.
 func weeklyMailConfig(
 	ctx context.Context, cfg workerConfig, deployCfg deployconfig.Config,
-	pool *pgxpool.Pool, logger *slog.Logger,
+	pool *pgxpool.Pool, vault keyvault.Vault, logger *slog.Logger,
 ) compose.WeeklyMailConfig {
 	if !deployCfg.Email.Enabled {
-		return compose.WeeklyMailConfig{}
-	}
-	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
-	if err != nil {
-		logger.WarnContext(ctx, "no weekly mail: the key vault the relay credential is sealed in is unavailable",
-			"cause", err)
 		return compose.WeeklyMailConfig{}
 	}
 	password, err := compose.SealedSMTPPassword(ctx, pool, vault, deployCfg, config.FromOS, logger)

--- a/backend/gates/keyvaultonceperrole_test.go
+++ b/backend/gates/keyvaultonceperrole_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A role resolves its key vault ONCE.
+//
+// cmd/worker used to resolve it three times — the Surface-B runner lane, the
+// connector-credential backfill, the job runner — and each read the answer in
+// its own way: two nil-ed the vault on the `configured` flag, one passed
+// through whatever FromEnv returned. cmd/api had the same shape in three
+// phases. Nothing diverged in practice, because the flag and the nil say the
+// same thing, but "does this deployment have a vault?" had three answers in one
+// process and only a coincidence kept them equal. That is the kind of
+// divergence an operator reports as unreproducible.
+//
+// So the roles cannot ask. keyvault.FromEnv is unreachable from cmd/, and
+// keyvault.ForRole — which resolves once, hands back a vault or nil, and lets
+// no flag out — may be called once per role. A fourth lane needing a vault now
+// takes the one its boot already holds.
+//
+// The FromEnv census is module-wide rather than cmd-only, because a gate that
+// judges one subtree also claims that the subtree is where the obligated code
+// lives, and that second claim is the one nothing checks: boot wiring that
+// moved into internal/ would walk straight out of reach with the gate still
+// green. Detection is over the syntax tree rather than the text, through
+// gatekit.References, so an aliased import is caught the same as a plain one.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// keyvaultPath is the vault's package, matched by import path rather than by
+// the identifier a file happens to bind it to.
+const keyvaultPath = "github.com/margince/margince/backend/internal/platform/keyvault"
+
+// ownResolvers are the non-test files outside the keyvault package ratified to
+// resolve a vault of their own, each bound to why a boot-owned one will not do.
+var ownResolvers = gatekit.Waive(map[string]string{
+	"internal/compose/routingsource.go": "resolves per WORKSPACE and per routing change, not per boot: it " +
+		"upgrades a caller-supplied env lookup — not necessarily the process environment — into one that " +
+		"unseals that workspace's BYOK keys, and the routing watcher re-runs it while the role serves. It " +
+		"also treats an unbuildable vault as a warning rather than a boot refusal, deliberately, because " +
+		"the serving roles have already had their say on that by the time it runs. A boot vault threaded " +
+		"in would answer a different question under the same name.",
+})
+
+func TestTheKeyVaultIsResolvedOncePerRole(t *testing.T) {
+	t.Parallel()
+	var resolvers, roleCalls []string
+	callsPerRole := map[string]int{}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return err
+		}
+		p = filepath.ToSlash(p)
+		// The vault's own package is where FromEnv is SUPPOSED to be reached:
+		// ForRole is built on it. Excluded by rule rather than waived, because a
+		// waiver would read as "this one is allowed to misbehave" when it is the
+		// definition of behaving.
+		if strings.HasPrefix(p, keyvaultDir+"/") {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, p, nil, 0)
+		if err != nil {
+			return err
+		}
+		if gatekit.References(file, keyvaultPath, "FromEnv") && !ownResolvers.Waived(t, p) {
+			resolvers = append(resolvers, p)
+		}
+		if n := countsForRole(file); n > 0 && strings.HasPrefix(p, "cmd/") {
+			role := path.Dir(p)
+			callsPerRole[role] += n
+			roleCalls = append(roleCalls, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+
+	for _, p := range resolvers {
+		if strings.HasPrefix(p, "cmd/") {
+			t.Errorf("%s resolves its own key vault. A role's boot resolves ONE, at a single ownership "+
+				"boundary, and hands it to every lane that needs it — take the vault your boot already "+
+				"holds, or call keyvault.ForRole where that boot is.", p)
+			continue
+		}
+		t.Errorf("%s calls keyvault.FromEnv and is not ratified to. Boot code takes the vault its role "+
+			"resolved (keyvault.ForRole); a path that genuinely needs its own — a different lookup, a "+
+			"different lifetime, a different verdict on failure — says which, in ownResolvers.", p)
+	}
+
+	for role, n := range callsPerRole {
+		if n > 1 {
+			t.Errorf("%s calls keyvault.ForRole %d times. ForRole is the role's ONE resolution; a second "+
+				"is a second answer to a question that has one.", role, n)
+		}
+	}
+
+	// Both halves must stay live. If nothing calls ForRole any more the count
+	// check passes while checking nothing, and if the walk stops finding Go
+	// files the census reports PASS over an empty tree.
+	if len(roleCalls) == 0 {
+		t.Error("no role calls keyvault.ForRole — either the roles stopped resolving a vault at boot, " +
+			"or this gate has gone blind and its count check now passes vacuously")
+	}
+	ownResolvers.AssertAllMatched(t)
+}
+
+// keyvaultDir is the vault package's directory, derived from the import path
+// above rather than written out a second time.
+var keyvaultDir = strings.TrimPrefix(keyvaultPath, "github.com/margince/margince/backend/")
+
+// countsForRole counts the CALL SITES of keyvault.ForRole in one file. A count
+// rather than gatekit.References's boolean, because the thing being prohibited
+// is a second resolution and one file can hold both.
+//
+// Syntactic call sites, which is what a static gate can honestly say: a single
+// call inside a function the boot invokes twice is out of reach here, and so is
+// one behind a stored func value. Neither is a shape this boot code has, and a
+// gate that pretended otherwise would be claiming a guarantee it does not hold.
+func countsForRole(file *ast.File) int {
+	qualifier, dotImported := gatekit.ImportedAs(file, keyvaultPath)
+	if qualifier == "" && !dotImported {
+		return 0
+	}
+	calls := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkg, ok := fn.X.(*ast.Ident)
+			if ok && pkg.Name == qualifier && qualifier != "" && fn.Sel.Name == "ForRole" {
+				calls++
+			}
+		case *ast.Ident:
+			if dotImported && fn.Name == "ForRole" {
+				calls++
+			}
+		}
+		return true
+	})
+	return calls
+}

--- a/backend/internal/platform/keyvault/fromenv_integration_test.go
+++ b/backend/internal/platform/keyvault/fromenv_integration_test.go
@@ -16,6 +16,7 @@ package keyvault_test
 // treating a nil vault as "nothing was ever sealed".
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -66,5 +67,48 @@ func TestSealedSecretsWithNoRootKeyRefuseTheBoot(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("the refusal %q does not name %q", err, want)
 		}
+	}
+}
+
+// Every role now reads "this deployment has no vault" off the vault value
+// alone — ForRole hands back nil and the boolean stops there. That rests on
+// FromEnv's two answers agreeing, so the equivalence is asserted rather than
+// assumed, in both directions: a nil vault reported configured
+// wires a lane onto nothing, and a real vault reported unconfigured leaves
+// every sealed credential unreachable on a deployment that has one.
+//
+// Here rather than beside the unit tests because the configured direction needs
+// a pool — the local provider refuses to build without one.
+func TestForRoleHandsBackNilForExactlyAnUnconfiguredVault(t *testing.T) {
+	pool := singleConnPool(t)
+	configured := config.Static(map[string]string{
+		keyvault.EnvRootKey: base64.StdEncoding.EncodeToString(rootKey(t)),
+	})
+
+	for _, tc := range []struct {
+		name       string
+		env        config.Lookup
+		wantAVault bool
+	}{
+		{"no root key", config.Static(nil), false},
+		{"a root key", configured, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vault, flag, err := keyvault.FromEnv(t.Context(), pool, tc.env)
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if flag != tc.wantAVault || (vault != nil) != tc.wantAVault {
+				t.Fatalf("FromEnv reported configured=%v vault!=nil=%v, want both %v",
+					flag, vault != nil, tc.wantAVault)
+			}
+			forRole, err := keyvault.ForRole(t.Context(), "role", pool, tc.env)
+			if err != nil {
+				t.Fatalf("ForRole: %v", err)
+			}
+			if (forRole != nil) != tc.wantAVault {
+				t.Fatalf("ForRole handed back vault!=nil=%v, want %v", forRole != nil, tc.wantAVault)
+			}
+		})
 	}
 }

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -300,3 +300,34 @@ func refuseIfAnythingIsSealed(ctx context.Context, pool *pgxpool.Pool) error {
 		"key, outbound-mail password and license token. Restore the root key this installation "+
 		"sealed with; it is not recoverable from anywhere else", EnvRootKey)
 }
+
+// ForRole resolves the key vault ONCE, at a role's boot, for every lane in
+// that role to share.
+//
+// A process that resolves the vault in three places has three chances to
+// interpret one answer differently, and cmd/worker took them: the job lane
+// nil-ed its vault on the configured flag, the Surface-B runner lane passed
+// whatever FromEnv returned, and the credential backfill read the flag on its
+// own. Nothing diverged in practice — the flag and the nil say the same thing —
+// but "is a vault available?" had three answers in one process, and only the
+// coincidence that they agreed kept it from mattering.
+//
+// So the boolean does not leave this function. A caller holds a vault or holds
+// nil, and nil IS an unconfigured deployment: one value, one meaning, nothing
+// to keep in step. The equivalence FromEnv already guarantees is asserted here
+// rather than assumed, because a role that reads the nil is relying on it.
+//
+// role names the binary in the boot error, which is the only place it appears.
+//
+//nolint:ireturn // the seam has two providers behind one Vault; returning the interface is the design.
+func ForRole(ctx context.Context, role string, pool *pgxpool.Pool, env config.Lookup) (Vault, error) {
+	vault, configured, err := FromEnv(ctx, pool, env)
+	if err != nil {
+		return nil, fmt.Errorf("%s: keyvault: %w", role, err)
+	}
+	if !configured {
+		//nolint:nilnil // an absent vault IS the answer for a deployment that configured none, not a missing one. Reading it off the value is the whole point: the alternative is the flag beside it that three lanes kept interpreting separately.
+		return nil, nil
+	}
+	return vault, nil
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -163,7 +163,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (21)
+## Prohibition (22)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -178,6 +178,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobfleetscan_test.go` | H2 | The fleet enumeration lives at ratified sites only. |
 | `jobregistrationban_test.go` | H2 | The forbidigo rule that bans a direct River registration, held to River's own API rather than to a remembered list of its spellings. |
 | `jobtestonly_test.go` | H2 | jobs.Config.TestOnly and compose.JobRunnerConfig.TestOnly carry River's flag of the same name, which disables machinery that is "useful in production, but which may be harmful to tests" — in the pinned river@v0.43.0, the maintenance services' staggered startup. |
+| `keyvaultonceperrole_test.go` | H2 | A role resolves its key vault ONCE. |
 | `logsecrets_test.go` | H2 | A credential reaches a log field only on the failure of the channel that was supposed to carry it. |
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |


### PR DESCRIPTION
Closes #440.

## What was there

`cmd/worker` resolved the key vault in three places — the Surface-B runner lane, the connector-credential backfill, the job runner — and each read the answer in its own way: two nil-ed the vault on the `configured` flag, the runner lane passed through whatever `FromEnv` returned. `cmd/api` had the same shape across three phases: the license binding, the connector-credential surface, the outbound relay password.

## Nothing actually diverged

`keyvault.FromEnv` already returns a **nil** vault when nothing is configured, so the flag and the nil say the same thing. The runner lane's `OverlayIncumbentResolver` therefore reported the same clean "no incumbent" the job lane's wired-off surface does.

That also answers the ticket's open question: on an unconfigured deployment overlay write-back is **already declared unsupported**, not failing per call.

## What was wrong

"Does this deployment have a vault?" had three answers in one process, and only their agreeing kept it from mattering. That is the shape a fourth lane gets wrong, and the symptom is an operator report nobody can reproduce.

## The fix

`keyvault.ForRole` resolves once, hands back a vault or nil, and lets no flag out. Each role calls it at boot and passes the value down: one deployment fact, read once, nothing to keep in step.

- the redundant `if !configured { vault = nil }` blocks go with it
- `backfillConnectorCredentials` returns nothing now — the vault resolution was the only error it ever passed up, and that is the boot's to refuse before any lane starts
- api's `run` gained `openInstallation`, which opens the pool and the vault together (both settled before any phase runs) and keeps the function under the length gate

## Held, not described

- `keyvault.FromEnv` is unreachable outside the vault package except from ratified sites that say why. One entry: compose's per-workspace BYOK lookup, which resolves per routing change rather than per boot, over a caller-supplied lookup, and deliberately warns rather than refusing.
- each role may call `ForRole` once — a second call fails the gate.
- the equivalence the roles now rely on (nil vault exactly when unconfigured) is asserted in both directions rather than assumed, since reading "unconfigured" off the value is what removing the flag rests on.

The census is module-wide rather than `cmd/`-only: boot wiring that moved into `internal/` would otherwise walk out of reach with the gate still green.

Both gate arms mutation-checked — adding a second `ForRole` call and a stray `FromEnv` to `cmd/worker/boot.go` fails each of them by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Streamlined application and worker startup by initializing secure configuration once and reusing it consistently.
  - Improved handling when secure configuration is unavailable, allowing optional features such as email delivery to remain disabled without unnecessary startup failures.
  - Reduced disruption from credential backfill issues by treating individual failures as non-blocking.
  - Improved error context when secure configuration cannot be initialized.

- **Tests**
  - Added coverage to verify consistent secure-configuration behavior across application roles and deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->