### PR TITLE
feat(person): automatic enrichment buys only what the provider gives away

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18407,6 +18407,23 @@ components:
           type: array
           items: { $ref: '#/components/schemas/ProviderMonthlySpend' }
 
+    ProviderCategoryCost:
+      type: object
+      required: [category, free, cost]
+      description: >-
+        What one category costs, per credit pool. `free` is the whole worst case being
+        nothing — a category free to REQUEST but carrying a charged fallback is not free,
+        and calling it so would put a spend behind a control that promises none.
+      properties:
+        category: { type: string }
+        free:
+          type: boolean
+          description: Automatic enrichment buys exactly these; everything else waits for a human to press a button.
+        cost:
+          type: object
+          description: Credits charged per pool, worst case, the fallback included. Empty when free.
+          additionalProperties: { type: integer, minimum: 0 }
+
     ProviderConnection:
       type: object
       required: [provider, status, credential_present, configuration, credits, version, created_at, updated_at]
@@ -18417,6 +18434,15 @@ components:
           type: boolean
           description: The only credential fact ever returned; no key prefix/suffix or vault reference.
         configuration: { $ref: '#/components/schemas/ProviderConfiguration' }
+        catalog:
+          type: array
+          description: >-
+            Every category this provider sells, with what each costs. Derived from the
+            adapter's own cost table rather than listed anywhere, so a provider that starts
+            charging for something it gave away stops reading as free the moment its
+            descriptor says so. The settings card names the free ones as safe to enable, and
+            a buy button states a price before anybody presses it.
+          items: { $ref: '#/components/schemas/ProviderCategoryCost' }
         effective_constraints:
           type: array
           description: Named deployment/provider ceilings that make behavior stricter than the saved policy.
@@ -18458,6 +18484,19 @@ components:
       required: [provider]
       properties:
         provider: { $ref: '#/components/schemas/Provider' }
+        categories:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          description: >-
+            Narrow this ONE run to a subset of what the connection buys — how a reader
+            purchases a single priced detail for one person without changing the setting for
+            every future run. Omit for the connection's own selection.
+            It can only narrow: a category the connection does not carry is refused with 422
+            rather than trimmed, because buying less than was asked for while answering as
+            though nothing was wrong is a failure the caller cannot see, and an admin's
+            selection is a ceiling a rep must not be able to raise.
+          items: { type: string }
 
     ProviderRun:
       type: object

--- a/backend/internal/compose/handlers_integrations.go
+++ b/backend/internal/compose/handlers_integrations.go
@@ -164,6 +164,10 @@ func (h integrationsHandlers) CreatePersonEnrichmentRun(w http.ResponseWriter, r
 	run, err := h.runs.QueueRun(r.Context(), provider.QueueInput{
 		PersonID: id.String(),
 		Provider: string(body.Provider),
+		// What this ONE press buys. Absent means the connection's selection;
+		// named, it is how a reader purchases a single priced detail without
+		// changing what every future run spends.
+		Categories: requestedCategories(body.Categories),
 		// A person asking explicitly. Never fenced by the duplicate or
 		// freshness checks — they know something the timestamps do not.
 		Trigger: provider.TriggerManual,
@@ -189,12 +193,32 @@ func (h integrationsHandlers) GetPersonEnrichmentRun(w http.ResponseWriter, r *h
 	httperr.WriteJSON(w, http.StatusOK, toProviderRun(run))
 }
 
+// requestedCategories converts the wire's optional list into the port's.
+func requestedCategories(in *[]string) []provider.Category {
+	if in == nil {
+		return nil
+	}
+	out := make([]provider.Category, 0, len(*in))
+	for _, c := range *in {
+		out = append(out, provider.Category(c))
+	}
+	return out
+}
+
 // writeRunError maps the port's not-connected state onto a 404. It is a
 // supported configuration rather than a fault: asking for an enrichment when
 // no provider is connected is answered honestly, not with a 500.
 func writeRunError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, provider.ErrNotConnected) {
 		httperr.Write(w, r, apperrors.ErrNotFound)
+		return
+	}
+	if errors.Is(err, integrations.ErrCategoryNotPermitted) {
+		// The caller's mistake, not a provider condition: retrying it
+		// unchanged buys nothing, so it is a 422 rather than a retryable
+		// failure.
+		httperr.Write(w, r, httperr.Validation("categories", "not_permitted",
+			"this connection does not buy that category"))
 		return
 	}
 	httperr.Write(w, r, err)

--- a/backend/internal/compose/integrationsmapping.go
+++ b/backend/internal/compose/integrationsmapping.go
@@ -65,6 +65,7 @@ func toProviderConnection(c integrations.Connection) crmcontracts.ProviderConnec
 		Spend: toProviderSpend(c.Spend),
 		// The ONLY credential fact that ever leaves: whether one is set.
 		CredentialPresent: c.CredentialPresent,
+		Catalog:           catalogWire(c.Catalog),
 		ConnectedAt:       c.ConnectedAt,
 		LastVerifiedAt:    c.LastVerifiedAt,
 		LastUsedAt:        c.LastUsedAt,
@@ -260,4 +261,23 @@ func mustUUID(s string) openapi_types.UUID {
 		return openapi_types.UUID{}
 	}
 	return openapi_types.UUID(parsed)
+}
+
+// catalogWire renders the category price list. Present on every connection,
+// including a disconnected one: an admin deciding whether to connect at all is
+// exactly who needs to know what it would cost.
+func catalogWire(catalog []integrations.CategoryCost) *[]crmcontracts.ProviderCategoryCost {
+	out := make([]crmcontracts.ProviderCategoryCost, 0, len(catalog))
+	for _, entry := range catalog {
+		cost := map[string]int{}
+		for pool, n := range entry.Cost {
+			cost[pool] = n
+		}
+		out = append(out, crmcontracts.ProviderCategoryCost{
+			Category: entry.Category,
+			Free:     entry.Free,
+			Cost:     cost,
+		})
+	}
+	return &out
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15709,6 +15709,9 @@ type CreateOrganizationRequestSizeBand string
 
 // CreatePersonEnrichmentRunRequest defines model for CreatePersonEnrichmentRunRequest.
 type CreatePersonEnrichmentRunRequest struct {
+	// Categories Narrow this ONE run to a subset of what the connection buys — how a reader purchases a single priced detail for one person without changing the setting for every future run. Omit for the connection's own selection. It can only narrow: a category the connection does not carry is refused with 422 rather than trimmed, because buying less than was asked for while answering as though nothing was wrong is a failure the caller cannot see, and an admin's selection is a ceiling a rep must not be able to raise.
+	Categories *[]string `json:"categories,omitempty"`
+
 	// Provider A licensed data provider registered in THIS installation; the domain/run contract
 	// remains provider-neutral. Deliberately a pattern-constrained string rather than an
 	// enum, for the reason `ProviderRef` gives for messaging transports: which providers
@@ -22369,6 +22372,17 @@ type PromoteLeadResponse struct {
 // live set.
 type Provider = string
 
+// ProviderCategoryCost What one category costs, per credit pool. `free` is the whole worst case being nothing — a category free to REQUEST but carrying a charged fallback is not free, and calling it so would put a spend behind a control that promises none.
+type ProviderCategoryCost struct {
+	Category string `json:"category"`
+
+	// Cost Credits charged per pool, worst case, the fallback included. Empty when free.
+	Cost map[string]int `json:"cost"`
+
+	// Free Automatic enrichment buys exactly these; everything else waits for a human to press a button.
+	Free bool `json:"free"`
+}
+
 // ProviderCategorySelection Resolved per-category choices, keyed by the connected provider's declared category
 // vocabulary (its descriptor — for Surfe, PI-PARAM-7). A key the provider does not offer is
 // rejected; at least one selected category is required. Keys are not enumerated here because
@@ -22424,9 +22438,11 @@ type ProviderConfigurationPatch struct {
 
 // ProviderConnection defines model for ProviderConnection.
 type ProviderConnection struct {
-	Configuration ProviderConfiguration `json:"configuration"`
-	ConnectedAt   *time.Time            `json:"connected_at,omitempty"`
-	CreatedAt     time.Time             `json:"created_at"`
+	// Catalog Every category this provider sells, with what each costs. Derived from the adapter's own cost table rather than listed anywhere, so a provider that starts charging for something it gave away stops reading as free the moment its descriptor says so. The settings card names the free ones as safe to enable, and a buy button states a price before anybody presses it.
+	Catalog       *[]ProviderCategoryCost `json:"catalog,omitempty"`
+	Configuration ProviderConfiguration   `json:"configuration"`
+	ConnectedAt   *time.Time              `json:"connected_at,omitempty"`
+	CreatedAt     time.Time               `json:"created_at"`
 
 	// CredentialPresent The only credential fact ever returned; no key prefix/suffix or vault reference.
 	CredentialPresent bool `json:"credential_present"`

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -69,3 +69,35 @@ func TestACatalogEntryAgreesWithTheCostTableItComesFrom(t *testing.T) {
 		t.Errorf("professional_email costs %v, want 1 email credit", byName["professional_email"].Cost)
 	}
 }
+
+func TestAFallbackIsPricedWithTheCategoryThatTriggersIt(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories: []provider.Category{"professional_email", "personal_email"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"professional_email": {"email": 1},
+			// Free to request on its own, which is the trap.
+			"personal_email": {},
+		},
+		Cascades: []provider.Cascade{{
+			Category: "personal_email",
+			After:    "professional_email",
+			Cost:     map[provider.Pool]int{"email": 2},
+		}},
+	}
+
+	byName := map[string]CategoryCost{}
+	for _, entry := range catalogOf(desc) {
+		byName[entry.Category] = entry
+	}
+
+	// A cascade bills only when its trigger was requested too, so pricing the
+	// fallback alone reads as free — the understatement a buy button must
+	// never make about what pressing it can spend.
+	fallback := byName["personal_email"]
+	if fallback.Free {
+		t.Error("personal_email reads free, and issuing it costs two email credits")
+	}
+	if fallback.Cost["email"] != 3 {
+		t.Errorf("personal_email costs %v, want the trigger's 1 plus the fallback's 2", fallback.Cost)
+	}
+}

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// The price list a settings card and a buy button both read.
+//
+// It is derived from the descriptor rather than listed, so the two questions
+// it answers — what does this cost, and is it free — cannot disagree with the
+// cost table they are computed from.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+func TestTheCatalogPricesEveryCategoryTheProviderDeclares(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories: []provider.Category{"linkedin_profile", "professional_email", "mobile"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"linkedin_profile":   {},
+			"professional_email": {"email": 1},
+			"mobile":             {"mobile": 1},
+		},
+	}
+
+	catalog := catalogOf(desc)
+
+	// One entry per declared category. A provider that adds a category and
+	// finds it missing here would show a settings card that cannot say what
+	// the new thing costs.
+	if len(catalog) != len(desc.Categories) {
+		t.Fatalf("catalog has %d entries, want one per declared category (%d)",
+			len(catalog), len(desc.Categories))
+	}
+	for i, category := range desc.Categories {
+		if catalog[i].Category != string(category) {
+			t.Errorf("entry %d is %q, want %q — the descriptor's own order", i, catalog[i].Category, category)
+		}
+	}
+}
+
+func TestACatalogEntryAgreesWithTheCostTableItComesFrom(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories: []provider.Category{"linkedin_profile", "professional_email"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"linkedin_profile":   {},
+			"professional_email": {"email": 1},
+		},
+	}
+
+	catalog := catalogOf(desc)
+
+	byName := map[string]CategoryCost{}
+	for _, entry := range catalog {
+		byName[entry.Category] = entry
+	}
+	// Free means no pool is charged, and the price is the pools that are. A
+	// button quoting a figure the reservation does not take would be asking
+	// somebody to agree to the wrong number.
+	if !byName["linkedin_profile"].Free || len(byName["linkedin_profile"].Cost) != 0 {
+		t.Errorf("linkedin_profile = %+v, want free with no cost", byName["linkedin_profile"])
+	}
+	if byName["professional_email"].Free {
+		t.Error("professional_email reads free, and the cost table charges an email credit for it")
+	}
+	if byName["professional_email"].Cost["email"] != 1 {
+		t.Errorf("professional_email costs %v, want 1 email credit", byName["professional_email"].Cost)
+	}
+}

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -11,6 +11,7 @@ package integrations
 
 import (
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
@@ -99,5 +100,50 @@ func TestAFallbackIsPricedWithTheCategoryThatTriggersIt(t *testing.T) {
 	}
 	if fallback.Cost["email"] != 3 {
 		t.Errorf("personal_email costs %v, want the trigger's 1 plus the fallback's 2", fallback.Cost)
+	}
+}
+
+func TestAProviderThatGivesNothingAwayStillConnects(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories:    []provider.Category{"premium_only"},
+		DefaultPreset: "full",
+		Presets: map[string][]provider.Category{
+			"full": {"premium_only"},
+		},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"premium_only": {"credits": 5},
+		},
+	}
+
+	cfg, err := resolveConfig(desc, nil)
+	if err != nil {
+		t.Fatalf("resolving the default config: %v", err)
+	}
+
+	// The column requires at least one category. An empty selection would be
+	// refused by the database with a constraint error rather than a sentence
+	// anybody can act on, and a connection nobody can make is worse than one
+	// whose first run costs a credit.
+	if len(cfg.Categories) == 0 {
+		t.Error("a provider with no free categories resolved to an empty selection, which the connection column refuses")
+	}
+}
+
+func TestEveryRegisteredAdapterPricesWhatItDeclares(t *testing.T) {
+	// The real adapters this build can register, not a stand-in: a stub would
+	// prove the check runs, and this proves the shipped descriptors pass it.
+	for _, adapter := range []provider.Adapter{NewOfflineProvider(0, time.Now)} {
+		desc := adapter.Descriptor()
+		t.Run(desc.Name, func(t *testing.T) {
+			for _, category := range desc.Categories {
+				if _, priced := desc.CostTable[category]; !priced {
+					// A missing entry reads as free everywhere the platform
+					// asks what something costs, so it would be bought
+					// automatically and reserved at nothing. An empty map says
+					// "free" deliberately; an omission says nothing at all.
+					t.Errorf("category %q has no cost entry: price it, or declare it free with an empty one", category)
+				}
+			}
+		})
 	}
 }

--- a/backend/internal/modules/integrations/config.go
+++ b/backend/internal/modules/integrations/config.go
@@ -32,8 +32,14 @@ type resolvedConfig struct {
 
 // resolveConfig turns an optional request body into a policy this provider
 // can honour. An omitted body is not an error: it resolves to
-// automatic-on-create with the descriptor's default preset (PI-AC-1), which
+// automatic-on-create over the categories that cost nothing (PI-AC-1), which
 // is what a customer who just connected a provider expects to happen.
+//
+// The FREE categories rather than the descriptor's default preset. A customer
+// who connects a provider has said they want its data, not that they want to
+// spend on every contact that arrives — and the automatic lane takes only the
+// free set anyway, so defaulting the selection wider would show a settings
+// card promising purchases the platform declines to make.
 func resolveConfig(desc provider.Descriptor, in *ConfigInput) (resolvedConfig, error) {
 	out := resolvedConfig{
 		Mode:            string(defaultMode),
@@ -41,7 +47,7 @@ func resolveConfig(desc provider.Descriptor, in *ConfigInput) (resolvedConfig, e
 		AutomaticCreate: true,
 		AutomaticImport: false,
 	}
-	out.Categories = categoryStrings(desc.ResolvePreset(desc.DefaultPreset, nil))
+	out.Categories = categoryStrings(desc.Free())
 
 	if in == nil {
 		return out, nil

--- a/backend/internal/modules/integrations/config.go
+++ b/backend/internal/modules/integrations/config.go
@@ -47,7 +47,15 @@ func resolveConfig(desc provider.Descriptor, in *ConfigInput) (resolvedConfig, e
 		AutomaticCreate: true,
 		AutomaticImport: false,
 	}
+	// A provider that gives nothing away falls back to its own default
+	// preset. The column requires at least one category, so an empty
+	// selection would be refused by the database with a constraint error
+	// rather than a sentence anybody can act on — and a connection nobody can
+	// make is worse than one whose first run costs a credit.
 	out.Categories = categoryStrings(desc.Free())
+	if len(out.Categories) == 0 {
+		out.Categories = categoryStrings(desc.ResolvePreset(desc.DefaultPreset, nil))
+	}
 
 	if in == nil {
 		return out, nil

--- a/backend/internal/modules/integrations/connect.go
+++ b/backend/internal/modules/integrations/connect.go
@@ -118,6 +118,10 @@ func (s *Store) Connect(ctx context.Context, in ConnectInput) (Connection, error
 			return err
 		}
 		out = conns[in.Provider]
+		// The price list rides every connection a caller sees, including the
+		// one they just made: the card that appears on connecting is exactly
+		// where somebody learns what the automatic half costs them.
+		out.Catalog = catalogOf(desc)
 		return nil
 	})
 	if err != nil {

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -44,6 +44,16 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 		if _, err := d.WorstCase(d.Categories); err != nil {
 			return nil, fmt.Errorf("integrations: provider %q cannot be registered: %w", d.Name, err)
 		}
+		for _, category := range d.Categories {
+			if _, priced := d.CostTable[category]; !priced {
+				// A missing entry reads as free everywhere the platform asks
+				// what something costs, so an omission is a category bought
+				// automatically and reserved at nothing. An empty map is how
+				// an adapter says "this one really is free" — the difference
+				// between deciding and forgetting.
+				return nil, fmt.Errorf("integrations: provider %q declares category %q with no cost entry: price it, or declare it free with an empty one", d.Name, category)
+			}
+		}
 		if d.EgressHost == "" {
 			return nil, fmt.Errorf("integrations: provider %q declared no egress host", d.Name)
 		}

--- a/backend/internal/modules/integrations/runcategories.go
+++ b/backend/internal/modules/integrations/runcategories.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// What one run asks the provider for, and the two rules that bound it.
+//
+// An automatic run spends nothing: nobody weighed the purchase, so it takes
+// only the categories the provider gives away, which is what lets enrichment
+// run on every arrival without anybody deciding it was worth the money. A
+// human pressing a button may buy a priced category for one named person, but
+// never one the connection does not carry.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// runCategories is what THIS run asks for: the connection's own selection, or
+// the narrower set the caller named.
+//
+// A caller may only narrow. The connection is the ceiling an admin set, and a
+// category outside it is refused rather than trimmed — buying less than was
+// asked for while answering as though nothing was wrong is the failure a rep
+// cannot see, and spending on a category an admin switched off is the one they
+// must not be able to cause.
+func runCategories(desc provider.Descriptor, conn admittedConnection, in provider.QueueInput) ([]provider.Category, error) {
+	permitted := categoriesFrom(conn.categories)
+	if in.Trigger.Automatic() {
+		// Nobody weighed THIS purchase. An automatic run takes only what the
+		// provider gives away, so enrichment can run on every arrival without
+		// anybody deciding it was worth the money — a priced category is
+		// bought by a human pressing a button for one named person.
+		return intersect(permitted, desc.Free()), nil
+	}
+	requested := in.Categories
+	if len(requested) == 0 {
+		return permitted, nil
+	}
+	allowed := make(map[provider.Category]bool, len(permitted))
+	for _, c := range permitted {
+		allowed[c] = true
+	}
+	out := make([]provider.Category, 0, len(requested))
+	for _, c := range requested {
+		if !allowed[c] {
+			return nil, fmt.Errorf("%w: %q is not one this connection buys", ErrCategoryNotPermitted, c)
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// intersect keeps the order of the first argument, so what a run asks for
+// reads in the connection's own order rather than the descriptor's.
+func intersect(permitted, allowed []provider.Category) []provider.Category {
+	keep := make(map[provider.Category]bool, len(allowed))
+	for _, c := range allowed {
+		keep[c] = true
+	}
+	out := []provider.Category{}
+	for _, c := range permitted {
+		if keep[c] {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ErrCategoryNotPermitted reports that a run asked for a category the
+// connection does not carry. A caller's mistake, not a provider condition: the
+// HTTP surface answers 422, because retrying it unchanged buys nothing.
+var ErrCategoryNotPermitted = errors.New("integrations: this connection does not buy that category")

--- a/backend/internal/modules/integrations/runcategories.go
+++ b/backend/internal/modules/integrations/runcategories.go
@@ -33,7 +33,16 @@ func runCategories(desc provider.Descriptor, conn admittedConnection, in provide
 		// provider gives away, so enrichment can run on every arrival without
 		// anybody deciding it was worth the money — a priced category is
 		// bought by a human pressing a button for one named person.
-		return intersect(permitted, desc.Free()), nil
+		free := intersect(permitted, desc.Free())
+		if len(free) == 0 {
+			// This connection buys nothing free, so an automatic run has
+			// nothing to ask for. Dispatching it anyway sends a request with
+			// no categories, which a provider answers with a refusal — and a
+			// refusal flips the connection's status, breaking automatic
+			// ingest for every later contact over a configuration choice.
+			return nil, ErrNothingFreeToBuy
+		}
+		return free, nil
 	}
 	requested := in.Categories
 	if len(requested) == 0 {
@@ -44,13 +53,40 @@ func runCategories(desc provider.Descriptor, conn admittedConnection, in provide
 		allowed[c] = true
 	}
 	out := make([]provider.Category, 0, len(requested))
+	asked := make(map[provider.Category]bool, len(requested))
 	for _, c := range requested {
 		if !allowed[c] {
 			return nil, fmt.Errorf("%w: %q is not one this connection buys", ErrCategoryNotPermitted, c)
 		}
+		asked[c] = true
 		out = append(out, c)
 	}
+	if err := requireCascadeTriggers(desc, asked); err != nil {
+		return nil, err
+	}
 	return out, nil
+}
+
+// requireCascadeTriggers refuses a fallback asked for without the category it
+// follows.
+//
+// A cascade fires only when its trigger comes back empty, so a request naming
+// the fallback alone never issues it — and the platform prices it at nothing
+// for exactly that reason, reserving no credits. The provider is not bound by
+// our reasoning: Surfe's request still carries the email flag and charges for
+// whatever it finds, so the run spends money against a hold of zero.
+//
+// Refused rather than silently widened. Adding the trigger would buy a
+// category the caller did not ask for, and pricing the pair while sending one
+// is the mismatch this exists to prevent.
+func requireCascadeTriggers(desc provider.Descriptor, asked map[provider.Category]bool) error {
+	for _, cascade := range desc.Cascades {
+		if asked[cascade.Category] && !asked[cascade.After] {
+			return fmt.Errorf("%w: %q is a fallback for %q and cannot be bought without it",
+				ErrCategoryNotPermitted, cascade.Category, cascade.After)
+		}
+	}
+	return nil
 }
 
 // intersect keeps the order of the first argument, so what a run asks for
@@ -68,6 +104,11 @@ func intersect(permitted, allowed []provider.Category) []provider.Category {
 	}
 	return out
 }
+
+// ErrNothingFreeToBuy reports that an automatic trigger found no category it
+// may spend on. A configuration state, not a fault: the event consumer
+// swallows it exactly as it swallows a trigger the policy does not admit.
+var ErrNothingFreeToBuy = errors.New("integrations: this connection buys nothing an automatic run may take")
 
 // ErrCategoryNotPermitted reports that a run asked for a category the
 // connection does not carry. A caller's mistake, not a provider condition: the

--- a/backend/internal/modules/integrations/runcategories_test.go
+++ b/backend/internal/modules/integrations/runcategories_test.go
@@ -111,3 +111,51 @@ func TestAManualRunNamingNothingTakesTheWholeConnection(t *testing.T) {
 		t.Errorf("got %v, want the connection's full selection", got)
 	}
 }
+
+func TestAnAutomaticRunWithNothingFreeIsRefusedRatherThanDispatched(t *testing.T) {
+	// An admin enabled automatic enrichment on a connection that buys only
+	// priced categories.
+	conn := connectionBuying("professional_email", "mobile")
+
+	_, err := runCategories(pricedDescriptor(), conn, provider.QueueInput{
+		Trigger: provider.TriggerAutomaticCreate,
+	})
+
+	// Dispatching it would send a request naming no categories, which a
+	// provider answers with a refusal — and a refusal flips the connection's
+	// status, breaking automatic ingest for every later contact over one
+	// configuration choice.
+	if !errors.Is(err, ErrNothingFreeToBuy) {
+		t.Errorf("err = %v, want ErrNothingFreeToBuy", err)
+	}
+	// And the consumer swallows it: a policy that leaves nothing to buy is
+	// working as configured, not failing.
+	if !IsTriggerNotAdmitted(err) {
+		t.Error("the refusal is not swallowed as a configuration state, so every arrival logs an error")
+	}
+}
+
+func TestAFallbackCannotBeBoughtWithoutTheCategoryItFollows(t *testing.T) {
+	desc := pricedDescriptor()
+	desc.Cascades = []provider.Cascade{{
+		Category: "personal_email",
+		After:    "professional_email",
+		Cost:     map[provider.Pool]int{"email": 2},
+	}}
+	desc.CostTable["personal_email"] = map[provider.Pool]int{}
+	desc.Categories = append(desc.Categories, "personal_email")
+	conn := connectionBuying("professional_email", "personal_email")
+
+	_, err := runCategories(desc, conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"personal_email"},
+	})
+
+	// The cascade never fires without its trigger, so the platform prices this
+	// at nothing and reserves nothing — while the provider still charges for
+	// whatever the email flag returns. A hold of zero against a real charge is
+	// the one outcome this must not allow.
+	if !errors.Is(err, ErrCategoryNotPermitted) {
+		t.Errorf("err = %v, want the fallback refused without its trigger", err)
+	}
+}

--- a/backend/internal/modules/integrations/runcategories_test.go
+++ b/backend/internal/modules/integrations/runcategories_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// What one run asks for, and the two rules that bound it.
+//
+// Automatic enrichment spends nothing: nobody weighed the purchase, so it
+// takes only what the provider gives away. A human pressing a button may buy a
+// priced category, but never one the connection does not carry — the admin's
+// selection is a ceiling a rep cannot raise.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+func pricedDescriptor() provider.Descriptor {
+	return provider.Descriptor{
+		Categories: []provider.Category{
+			"linkedin_profile", "current_employment", "job_history",
+			"professional_email", "mobile",
+		},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"linkedin_profile":   {},
+			"current_employment": {},
+			"job_history":        {},
+			"professional_email": {"email": 1},
+			"mobile":             {"mobile": 1},
+		},
+	}
+}
+
+func connectionBuying(categories ...string) admittedConnection {
+	return admittedConnection{categories: categories}
+}
+
+func TestAnAutomaticRunBuysOnlyWhatCostsNothing(t *testing.T) {
+	conn := connectionBuying("linkedin_profile", "job_history", "professional_email", "mobile")
+
+	got, err := runCategories(pricedDescriptor(), conn, provider.QueueInput{
+		Trigger: provider.TriggerAutomaticCreate,
+	})
+	if err != nil {
+		t.Fatalf("narrowing the automatic run: %v", err)
+	}
+
+	// The connection permits two priced categories and the automatic lane
+	// declines both: enrichment runs on every arrival precisely because it
+	// costs nothing to let it.
+	want := []provider.Category{"linkedin_profile", "job_history"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want only the free categories %v", got, want)
+	}
+	for i, category := range want {
+		if got[i] != category {
+			t.Errorf("position %d is %q, want %q", i, got[i], category)
+		}
+	}
+}
+
+func TestAHumanCanBuyAPricedCategoryForOnePerson(t *testing.T) {
+	conn := connectionBuying("linkedin_profile", "professional_email")
+
+	got, err := runCategories(pricedDescriptor(), conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"professional_email"},
+	})
+	if err != nil {
+		t.Fatalf("narrowing the manual run: %v", err)
+	}
+
+	// Exactly what was asked for, and nothing else — a button that said
+	// "buy the work email" must not also spend on anything else it saw.
+	if len(got) != 1 || got[0] != "professional_email" {
+		t.Errorf("got %v, want only professional_email", got)
+	}
+}
+
+func TestARunCannotBuyWhatTheConnectionDoesNotCarry(t *testing.T) {
+	// An admin switched the mobile off for this installation.
+	conn := connectionBuying("linkedin_profile", "professional_email")
+
+	_, err := runCategories(pricedDescriptor(), conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"mobile"},
+	})
+
+	// Refused, not quietly trimmed. Trimming would answer as though it had
+	// complied while buying nothing, and the rep would never learn why.
+	if !errors.Is(err, ErrCategoryNotPermitted) {
+		t.Errorf("err = %v, want ErrCategoryNotPermitted", err)
+	}
+}
+
+func TestAManualRunNamingNothingTakesTheWholeConnection(t *testing.T) {
+	conn := connectionBuying("linkedin_profile", "professional_email")
+
+	got, err := runCategories(pricedDescriptor(), conn, provider.QueueInput{
+		Trigger: provider.TriggerManual,
+	})
+	if err != nil {
+		t.Fatalf("narrowing the manual run: %v", err)
+	}
+
+	// The pre-existing behaviour, unchanged: a caller that names nothing gets
+	// the connection's own selection, priced categories included.
+	if len(got) != 2 {
+		t.Errorf("got %v, want the connection's full selection", got)
+	}
+}

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -455,10 +455,16 @@ func freezeSnapshot(c admittedConnection) provider.Snapshot {
 	}
 }
 
-// fingerprintOf hashes exactly what will be SENT plus what was asked for. Two
-// runs share a fingerprint when they would produce the same purchase, which is
-// what makes the live-run index a duplicate-spend guard rather than a
-// coincidence.
+// fingerprintOf hashes exactly what will be SENT plus what was asked for, so a
+// repeat of the SAME request finds the run already in flight rather than
+// buying the same answer twice.
+//
+// It does not catch two runs whose category sets overlap without matching:
+// they hash differently, both pass the live-run index, and both buy the
+// category they share. Guarding that needs a per-category claim rather than a
+// whole-set hash, which is a schema change — tracked as its own work, and said
+// here rather than left for the next reader to discover from a duplicate
+// charge.
 func fingerprintOf(id provider.PersonIdentifiers, cats []provider.Category) string {
 	names := make([]string, 0, len(cats))
 	for _, c := range cats {

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -243,6 +243,62 @@ func (s *Store) admit(ctx context.Context, tx pgx.Tx, name string, trigger provi
 	return c, nil
 }
 
+// runCategories is what THIS run asks for: the connection's own selection, or
+// the narrower set the caller named.
+//
+// A caller may only narrow. The connection is the ceiling an admin set, and a
+// category outside it is refused rather than trimmed — buying less than was
+// asked for while answering as though nothing was wrong is the failure a rep
+// cannot see, and spending on a category an admin switched off is the one they
+// must not be able to cause.
+func runCategories(desc provider.Descriptor, conn admittedConnection, in provider.QueueInput) ([]provider.Category, error) {
+	permitted := categoriesFrom(conn.categories)
+	if in.Trigger.Automatic() {
+		// Nobody weighed THIS purchase. An automatic run takes only what the
+		// provider gives away, so enrichment can run on every arrival without
+		// anybody deciding it was worth the money — a priced category is
+		// bought by a human pressing a button for one named person.
+		return intersect(permitted, desc.Free()), nil
+	}
+	requested := in.Categories
+	if len(requested) == 0 {
+		return permitted, nil
+	}
+	allowed := make(map[provider.Category]bool, len(permitted))
+	for _, c := range permitted {
+		allowed[c] = true
+	}
+	out := make([]provider.Category, 0, len(requested))
+	for _, c := range requested {
+		if !allowed[c] {
+			return nil, fmt.Errorf("%w: %q is not one this connection buys", ErrCategoryNotPermitted, c)
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// intersect keeps the order of the first argument, so what a run asks for
+// reads in the connection's own order rather than the descriptor's.
+func intersect(permitted, allowed []provider.Category) []provider.Category {
+	keep := make(map[provider.Category]bool, len(allowed))
+	for _, c := range allowed {
+		keep[c] = true
+	}
+	out := []provider.Category{}
+	for _, c := range permitted {
+		if keep[c] {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ErrCategoryNotPermitted reports that a run asked for a category the
+// connection does not carry. A caller's mistake, not a provider condition: the
+// HTTP surface answers 422, because retrying it unchanged buys nothing.
+var ErrCategoryNotPermitted = errors.New("integrations: this connection does not buy that category")
+
 // errTriggerNotAdmitted reports that the saved policy does not run this
 // trigger. It is not an error the caller shows anybody: the person.created
 // consumer swallows it, because "auto-enrich is off" is the configuration
@@ -264,7 +320,10 @@ func IsTriggerNotAdmitted(err error) bool { return errors.Is(err, errTriggerNotA
 // person not enriched" deserves a row that answers, and a silent no-op cannot.
 func (s *Store) queueOne(ctx context.Context, tx pgx.Tx, desc provider.Descriptor, conn admittedConnection, in provider.QueueInput) (provider.Run, error) {
 	snapshot := freezeSnapshot(conn)
-	cats := categoriesFrom(conn.categories)
+	cats, err := runCategories(desc, conn, in)
+	if err != nil {
+		return provider.Run{}, err
+	}
 
 	// 1. Consent, suppression, objection, erasure. Before anything else,
 	//    because a subject we may not contact must not even be looked up.

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -243,62 +243,6 @@ func (s *Store) admit(ctx context.Context, tx pgx.Tx, name string, trigger provi
 	return c, nil
 }
 
-// runCategories is what THIS run asks for: the connection's own selection, or
-// the narrower set the caller named.
-//
-// A caller may only narrow. The connection is the ceiling an admin set, and a
-// category outside it is refused rather than trimmed — buying less than was
-// asked for while answering as though nothing was wrong is the failure a rep
-// cannot see, and spending on a category an admin switched off is the one they
-// must not be able to cause.
-func runCategories(desc provider.Descriptor, conn admittedConnection, in provider.QueueInput) ([]provider.Category, error) {
-	permitted := categoriesFrom(conn.categories)
-	if in.Trigger.Automatic() {
-		// Nobody weighed THIS purchase. An automatic run takes only what the
-		// provider gives away, so enrichment can run on every arrival without
-		// anybody deciding it was worth the money — a priced category is
-		// bought by a human pressing a button for one named person.
-		return intersect(permitted, desc.Free()), nil
-	}
-	requested := in.Categories
-	if len(requested) == 0 {
-		return permitted, nil
-	}
-	allowed := make(map[provider.Category]bool, len(permitted))
-	for _, c := range permitted {
-		allowed[c] = true
-	}
-	out := make([]provider.Category, 0, len(requested))
-	for _, c := range requested {
-		if !allowed[c] {
-			return nil, fmt.Errorf("%w: %q is not one this connection buys", ErrCategoryNotPermitted, c)
-		}
-		out = append(out, c)
-	}
-	return out, nil
-}
-
-// intersect keeps the order of the first argument, so what a run asks for
-// reads in the connection's own order rather than the descriptor's.
-func intersect(permitted, allowed []provider.Category) []provider.Category {
-	keep := make(map[provider.Category]bool, len(allowed))
-	for _, c := range allowed {
-		keep[c] = true
-	}
-	out := []provider.Category{}
-	for _, c := range permitted {
-		if keep[c] {
-			out = append(out, c)
-		}
-	}
-	return out
-}
-
-// ErrCategoryNotPermitted reports that a run asked for a category the
-// connection does not carry. A caller's mistake, not a provider condition: the
-// HTTP surface answers 422, because retrying it unchanged buys nothing.
-var ErrCategoryNotPermitted = errors.New("integrations: this connection does not buy that category")
-
 // errTriggerNotAdmitted reports that the saved policy does not run this
 // trigger. It is not an error the caller shows anybody: the person.created
 // consumer swallows it, because "auto-enrich is off" is the configuration

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -257,7 +257,12 @@ var errTriggerNotAdmitted = errors.New("integrations: this trigger is not admitt
 // refusal apart from a failure, and the alternative is comparing error text:
 // a predicate here means the sentinel can be reworded without silently
 // turning a swallowed configuration state into a logged error.
-func IsTriggerNotAdmitted(err error) bool { return errors.Is(err, errTriggerNotAdmitted) }
+func IsTriggerNotAdmitted(err error) bool {
+	// ErrNothingFreeToBuy is the same kind of answer: the saved policy leaves
+	// an automatic run nothing it may spend on, which is a configuration
+	// working rather than a failure to log.
+	return errors.Is(err, errTriggerNotAdmitted) || errors.Is(err, ErrNothingFreeToBuy)
+}
 
 // queueOne is the admission pipeline for one subject. Each refusal writes a
 // skipped run rather than nothing at all: a customer asking "why was this
@@ -433,6 +438,12 @@ func (s *Store) duplicateAlreadyBought(ctx context.Context, tx pgx.Tx, in provid
 
 // freezeSnapshot captures what this run is allowed to do, so a later settings
 // change cannot widen it (PI-AC-2).
+// The snapshot records the POLICY that admitted this run, not what the run
+// went on to ask for. The two differ now that a run can narrow: an automatic
+// run takes only the free categories and a button buys one, while the policy
+// says what the connection permitted at that moment. requested_categories on
+// the run row is the second question, and a reader reconciling a charge needs
+// both — what was allowed, and what was actually bought.
 func freezeSnapshot(c admittedConnection) provider.Snapshot {
 	return provider.Snapshot{
 		Mode:             c.mode,

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -321,6 +321,11 @@ func catalogOf(d provider.Descriptor) []CategoryCost {
 // pricedWith is the category set whose worst case is the true price of asking
 // for one category: itself, plus the trigger of any cascade it is the fallback
 // for.
+//
+// ONE hop. No adapter declares a cascade whose trigger is itself a fallback,
+// and a chain would need this to walk it — said here rather than built for,
+// because the descriptor that needed it would also be the one to prove what
+// walking should cost.
 func pricedWith(d provider.Descriptor, category provider.Category) []provider.Category {
 	out := []provider.Category{category}
 	for _, cascade := range d.Cascades {

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -95,8 +95,18 @@ func NewStore(db *database.DB, vault keyvault.Vault, reg *Registry, now func() t
 // Connection is one provider's connection as the surfaces read it. It carries
 // no credential material and no vault reference — only whether a key is
 // present at all.
+// CategoryCost is one category's price, as the settings card and a buy button
+// read it.
+type CategoryCost struct {
+	Category string
+	Free     bool
+	Cost     map[string]int
+}
+
 type Connection struct {
-	Provider          string
+	Provider string
+	// Catalog is every category this provider sells with what each costs.
+	Catalog           []CategoryCost
 	Status            string
 	CredentialPresent bool
 	Mode              string
@@ -143,6 +153,10 @@ func (s *Store) List(ctx context.Context) ([]Connection, error) {
 			return err
 		}
 		for _, name := range s.registry.Names() {
+			d, err := s.registry.Descriptor(name)
+			if err != nil {
+				return err
+			}
 			if c, ok := rows[name]; ok {
 				// The card shows what the provider says is LEFT and what this
 				// installation SPENT side by side, so both arrive in one read
@@ -153,21 +167,22 @@ func (s *Store) List(ctx context.Context) ([]Connection, error) {
 					return err
 				}
 				c.Spend = spend
+				c.Catalog = catalogOf(d)
 				out = append(out, c)
 				continue
 			}
 			// Never connected: report the honest zero state rather than
 			// omitting the provider entirely.
-			d, err := s.registry.Descriptor(name)
-			if err != nil {
-				return err
-			}
 			out = append(out, Connection{
-				Provider:   name,
-				Status:     "disconnected",
-				Mode:       string(defaultMode),
-				Preset:     d.DefaultPreset,
-				Categories: categoryStrings(d.ResolvePreset(d.DefaultPreset, nil)),
+				Provider: name,
+				Status:   "disconnected",
+				Mode:     string(defaultMode),
+				Preset:   d.DefaultPreset,
+				// The free categories, not the descriptor's default preset:
+				// what an admin is first offered should be the set that costs
+				// them nothing, and the priced ones an explicit choice.
+				Categories: categoryStrings(d.Free()),
+				Catalog:    catalogOf(d),
 			})
 		}
 		return nil
@@ -260,6 +275,38 @@ func categoryStrings(cats []provider.Category) []string {
 	out := make([]string, 0, len(cats))
 	for _, c := range cats {
 		out = append(out, string(c))
+	}
+	return out
+}
+
+// catalogOf is what each category costs, derived from the descriptor so a
+// price and the fact of being free can never disagree.
+func catalogOf(d provider.Descriptor) []CategoryCost {
+	free := map[provider.Category]bool{}
+	for _, c := range d.Free() {
+		free[c] = true
+	}
+	out := make([]CategoryCost, 0, len(d.Categories))
+	for _, category := range d.Categories {
+		// The WORST case, the fallback included: a price quoted before a
+		// cascade fires would understate what pressing the button can spend.
+		cost, err := d.WorstCase([]provider.Category{category})
+		if err != nil {
+			// An unmetered or subscription provider prices nothing per
+			// category; the whole catalog reads free, which it is.
+			cost = map[provider.Pool]int{}
+		}
+		priced := map[string]int{}
+		for pool, n := range cost {
+			if n > 0 {
+				priced[string(pool)] = n
+			}
+		}
+		out = append(out, CategoryCost{
+			Category: string(category),
+			Free:     free[category],
+			Cost:     priced,
+		})
 	}
 	return out
 }

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -293,9 +293,11 @@ func catalogOf(d provider.Descriptor) []CategoryCost {
 	}
 	out := make([]CategoryCost, 0, len(d.Categories))
 	for _, category := range d.Categories {
-		// The WORST case, the fallback included: a price quoted before a
-		// cascade fires would understate what pressing the button can spend.
-		cost, err := d.WorstCase([]provider.Category{category})
+		// Priced WITH its trigger where it has one. A cascade bills only when
+		// both its own category and the category it follows were requested,
+		// so pricing the fallback alone reads as free — which is exactly the
+		// understatement a button must not make about what it can spend.
+		cost, err := d.WorstCase(pricedWith(d, category))
 		if err != nil {
 			// An unmetered or subscription provider prices nothing per
 			// category; the whole catalog reads free, which it is.
@@ -312,6 +314,19 @@ func catalogOf(d provider.Descriptor) []CategoryCost {
 			Free:     free[category],
 			Cost:     priced,
 		})
+	}
+	return out
+}
+
+// pricedWith is the category set whose worst case is the true price of asking
+// for one category: itself, plus the trigger of any cascade it is the fallback
+// for.
+func pricedWith(d provider.Descriptor, category provider.Category) []provider.Category {
+	out := []provider.Category{category}
+	for _, cascade := range d.Cascades {
+		if cascade.Category == category {
+			out = append(out, cascade.After)
+		}
 	}
 	return out
 }

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -105,7 +105,12 @@ type CategoryCost struct {
 
 type Connection struct {
 	Provider string
-	// Catalog is every category this provider sells with what each costs.
+	// Catalog is what this provider sells, with what each entry costs.
+	//
+	// Held by: TestTheCatalogPricesEveryCategoryTheProviderDeclares
+	// (backend/internal/modules/integrations/catalog_test.go) — the entries are
+	// derived from the descriptor's own category list, so a provider that adds
+	// one cannot leave it unpriced on the settings card.
 	Catalog           []CategoryCost
 	Status            string
 	CredentialPresent bool

--- a/backend/internal/shared/ports/provider/provider.go
+++ b/backend/internal/shared/ports/provider/provider.go
@@ -436,6 +436,21 @@ type QueueInput struct {
 	Provider    string
 	Trigger     Trigger
 	RequestedBy string
+	// Categories narrows this ONE run to a subset of what the connection
+	// permits. Empty means the connection's own selection, which is what every
+	// automatic trigger uses.
+	//
+	// It can only ever narrow. The connection is the ceiling an admin set, and
+	// a request naming a category outside it is refused rather than trimmed —
+	// a rep must not spend on something an admin switched off, and silently
+	// dropping it would buy less than the caller asked for while answering as
+	// though it had complied.
+	//
+	// What it is FOR: automatic enrichment takes the free categories on
+	// everybody, and a human presses a button to buy a priced one for a named
+	// person. Without a per-run set, that button could only change the setting
+	// for every future run too.
+	Categories []Category
 }
 
 // RunService is what a domain module sees. modules/integrations implements it.

--- a/backend/internal/shared/ports/provider/worstcase.go
+++ b/backend/internal/shared/ports/provider/worstcase.go
@@ -113,3 +113,44 @@ func PoolsInLockOrder(cost map[Pool]int) []Pool {
 	sort.Slice(pools, func(i, j int) bool { return pools[i] < pools[j] })
 	return pools
 }
+
+// Free reports the categories this provider charges nothing for, in the
+// descriptor's own declared order.
+//
+// DERIVED from the cost table rather than listed, so a provider that starts
+// charging for something it used to give away stops being advertised as free
+// the moment its descriptor says so. A second list would be a second answer to
+// "what does this cost", and the two would drift.
+//
+// What it buys: the free set is what automatic enrichment may spend on nobody's
+// explicit say-so. Everything a run can take without touching a credit pool can
+// be bought for every new contact and nobody has to weigh it, while the priced
+// categories stay behind a human pressing a button for one named person.
+//
+// A cascade's cost counts. A category that is free to request but triggers a
+// charged fallback is not free, and calling it so would put a spend behind a
+// switch labelled "costs nothing".
+func (d Descriptor) Free() []Category {
+	charged := map[Category]bool{}
+	for category, pools := range d.CostTable {
+		for _, n := range pools {
+			if n > 0 {
+				charged[category] = true
+			}
+		}
+	}
+	for _, cascade := range d.Cascades {
+		for _, n := range cascade.Cost {
+			if n > 0 {
+				charged[cascade.Category] = true
+			}
+		}
+	}
+	free := []Category{}
+	for _, category := range d.Categories {
+		if !charged[category] {
+			free = append(free, category)
+		}
+	}
+	return free
+}

--- a/backend/internal/shared/ports/provider/worstcase_test.go
+++ b/backend/internal/shared/ports/provider/worstcase_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package provider_test
+
+// What a provider gives away, and what it only appears to.
+//
+// The free set decides what automatic enrichment may buy on nobody's say-so,
+// so a category wrongly counted free is a spend behind a switch that promises
+// none.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+func TestFreeExcludesACategoryWhoseCascadeCharges(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories: []provider.Category{"linkedin_profile", "professional_email", "personal_email"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"linkedin_profile":   {},
+			"professional_email": {"email": 1},
+			// Free to REQUEST, and that is the trap: asking for it costs
+			// nothing until the fallback fires.
+			"personal_email": {},
+		},
+		Cascades: []provider.Cascade{{
+			Category: "personal_email",
+			After:    "professional_email",
+			Cost:     map[provider.Pool]int{"email": 2},
+		}},
+	}
+
+	free := desc.Free()
+
+	// Only the genuinely free one. Advertising personal_email as free would put
+	// a two-credit spend behind a switch labelled "costs nothing".
+	if len(free) != 1 || free[0] != "linkedin_profile" {
+		t.Errorf("Free() = %v, want only linkedin_profile", free)
+	}
+}
+
+func TestFreeKeepsTheDescriptorsOwnOrder(t *testing.T) {
+	desc := provider.Descriptor{
+		Categories: []provider.Category{"zebra", "apple", "mango"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"zebra": {}, "apple": {}, "mango": {},
+		},
+	}
+
+	free := desc.Free()
+
+	// The declared order, not a map's. A settings card listing the free
+	// categories must not reshuffle them between two reads.
+	want := []provider.Category{"zebra", "apple", "mango"}
+	for i, category := range want {
+		if free[i] != category {
+			t.Errorf("position %d is %q, want %q", i, free[i], category)
+		}
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12479,12 +12479,24 @@ export interface components {
         ProviderSpend: {
             months: components["schemas"]["ProviderMonthlySpend"][];
         };
+        /** @description What one category costs, per credit pool. `free` is the whole worst case being nothing — a category free to REQUEST but carrying a charged fallback is not free, and calling it so would put a spend behind a control that promises none. */
+        ProviderCategoryCost: {
+            category: string;
+            /** @description Automatic enrichment buys exactly these; everything else waits for a human to press a button. */
+            free: boolean;
+            /** @description Credits charged per pool, worst case, the fallback included. Empty when free. */
+            cost: {
+                [key: string]: number;
+            };
+        };
         ProviderConnection: {
             provider: components["schemas"]["Provider"];
             status: components["schemas"]["ProviderConnectionStatus"];
             /** @description The only credential fact ever returned; no key prefix/suffix or vault reference. */
             credential_present: boolean;
             configuration: components["schemas"]["ProviderConfiguration"];
+            /** @description Every category this provider sells, with what each costs. Derived from the adapter's own cost table rather than listed anywhere, so a provider that starts charging for something it gave away stops reading as free the moment its descriptor says so. The settings card names the free ones as safe to enable, and a buy button states a price before anybody presses it. */
+            catalog?: components["schemas"]["ProviderCategoryCost"][];
             /** @description Named deployment/provider ceilings that make behavior stricter than the saved policy. */
             effective_constraints?: string[];
             credits: components["schemas"]["ProviderCredits"];
@@ -12513,6 +12525,8 @@ export interface components {
         };
         CreatePersonEnrichmentRunRequest: {
             provider: components["schemas"]["Provider"];
+            /** @description Narrow this ONE run to a subset of what the connection buys — how a reader purchases a single priced detail for one person without changing the setting for every future run. Omit for the connection's own selection. It can only narrow: a category the connection does not carry is refused with 422 rather than trimmed, because buying less than was asked for while answering as though nothing was wrong is a failure the caller cannot see, and an admin's selection is a ceiling a rep must not be able to raise. */
+            categories?: string[];
         };
         ProviderRun: {
             /** Format: uuid */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6396,10 +6396,8 @@ export const de = {
   "provider.profile.notRequested":
     "Nicht angefragt: {categories}. Eine Lücke heißt hier, dass niemand danach gekauft hat — nicht, dass der Anbieter nichts hatte.",
   "provider.profile.buy": "{category} kaufen · {credits} Credit",
-  "provider.freeTier.label": "Kostenlose Angaben automatisch holen",
   "provider.freeTier.hint":
     "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
-  "provider.pricedTier.label": "Angaben, die Credits kosten",
   "provider.pricedTier.hint":
     "Werden nie automatisch gekauft. Jemand drückt bei einem einzelnen Kontakt auf den Knopf, und der Preis steht darauf.",
   "provider.profile.receiptAt": "Abgefragt am {at}.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6395,6 +6395,13 @@ export const de = {
   "provider.profile.seniorities": "Ebene",
   "provider.profile.notRequested":
     "Nicht angefragt: {categories}. Eine Lücke heißt hier, dass niemand danach gekauft hat — nicht, dass der Anbieter nichts hatte.",
+  "provider.profile.buy": "{category} kaufen · {credits} Credit",
+  "provider.freeTier.label": "Kostenlose Angaben automatisch holen",
+  "provider.freeTier.hint":
+    "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
+  "provider.pricedTier.label": "Angaben, die Credits kosten",
+  "provider.pricedTier.hint":
+    "Werden nie automatisch gekauft. Jemand drückt bei einem einzelnen Kontakt auf den Knopf, und der Preis steht darauf.",
   "provider.profile.receiptAt": "Abgefragt am {at}.",
   "provider.profile.receipt":
     "Abgefragt am {at} · {asked} Angaben angefragt, {answered} zurückbekommen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6450,6 +6450,14 @@ export const en = {
   // The receipt. Without it a lookup that returned one detail out of six read
   // exactly like one that returned all six, and nothing on the page said when
   // the answer arrived.
+  // The price rides the button because the decision IS the spend.
+  "provider.profile.buy": "Buy {category} · {credits} credit",
+  "provider.freeTier.label": "Buy the free details automatically",
+  "provider.freeTier.hint":
+    "LinkedIn profile, current role and work history cost no credits. Leave this on: every new contact gets them without anybody deciding.",
+  "provider.pricedTier.label": "Details that cost credits",
+  "provider.pricedTier.hint":
+    "Never bought automatically. Somebody presses a button on one contact, and the price is on the button.",
   "provider.profile.receiptAt": "Looked up {at}.",
   "provider.profile.receipt":
     "Looked up {at} · asked for {asked} details, got {answered} back.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6452,10 +6452,8 @@ export const en = {
   // the answer arrived.
   // The price rides the button because the decision IS the spend.
   "provider.profile.buy": "Buy {category} · {credits} credit",
-  "provider.freeTier.label": "Buy the free details automatically",
   "provider.freeTier.hint":
     "LinkedIn profile, current role and work history cost no credits. Leave this on: every new contact gets them without anybody deciding.",
-  "provider.pricedTier.label": "Details that cost credits",
   "provider.pricedTier.hint":
     "Never bought automatically. Somebody presses a button on one contact, and the price is on the button.",
   "provider.profile.receiptAt": "Looked up {at}.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6332,10 +6332,8 @@ export const vi = {
   "provider.profile.notRequested":
     "Không hỏi tới: {categories}. Chỗ trống ở đây nghĩa là không ai mua, chứ không phải nhà cung cấp không có.",
   "provider.profile.buy": "Mua {category} · {credits} tín dụng",
-  "provider.freeTier.label": "Tự động lấy các thông tin miễn phí",
   "provider.freeTier.hint":
     "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
-  "provider.pricedTier.label": "Thông tin tốn tín dụng",
   "provider.pricedTier.hint":
     "Không bao giờ mua tự động. Ai đó bấm nút trên một liên hệ cụ thể, và giá hiện ngay trên nút.",
   "provider.profile.receiptAt": "Tra cứu ngày {at}.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6331,6 +6331,13 @@ export const vi = {
   "provider.profile.seniorities": "Cấp bậc",
   "provider.profile.notRequested":
     "Không hỏi tới: {categories}. Chỗ trống ở đây nghĩa là không ai mua, chứ không phải nhà cung cấp không có.",
+  "provider.profile.buy": "Mua {category} · {credits} tín dụng",
+  "provider.freeTier.label": "Tự động lấy các thông tin miễn phí",
+  "provider.freeTier.hint":
+    "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
+  "provider.pricedTier.label": "Thông tin tốn tín dụng",
+  "provider.pricedTier.hint":
+    "Không bao giờ mua tự động. Ai đó bấm nút trên một liên hệ cụ thể, và giá hiện ngay trên nút.",
   "provider.profile.receiptAt": "Tra cứu ngày {at}.",
   "provider.profile.receipt":
     "Tra cứu ngày {at} · đã hỏi {asked} thông tin, nhận về {answered}.",

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import "./integrations-provider.css";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plug, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
@@ -27,14 +27,13 @@ import { SettingList, SettingRow } from "../design-system/settingrow";
 import { Switch } from "../design-system/switch";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
+import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import {
-  problemCode,
-  problemMessageOf,
-  QueryGate,
-  throwProblem,
-  useMe,
-} from "./common";
-import { connectionLabel, connectionTone } from "./provider-status";
+  type ConnectionsResult,
+  connectionLabel,
+  connectionTone,
+  useProviderConnections,
+} from "./provider-status";
 
 // The licensed-data-provider card (ADR-0101, PI-WIRE-1..5): connect a key,
 // decide whether new contacts are enriched automatically, and read what the
@@ -56,32 +55,6 @@ import { connectionLabel, connectionTone } from "./provider-status";
 // contact data, made a misclick the same size as a decision.
 
 type ProviderConnection = components["schemas"]["ProviderConnection"];
-
-type ConnectionsResult = {
-  /** True when this build carries no adapter at all. Not an error: it is the
-   *  supported "no provider" configuration, and the card says so plainly
-   *  rather than showing a broken control (PI-AC-9). */
-  notConfigured: boolean;
-  connections: ProviderConnection[];
-};
-
-function useProviderConnections() {
-  return useQuery({
-    queryKey: ["provider-connections"],
-    queryFn: async (): Promise<ConnectionsResult> => {
-      const { data, error, response } = await api.GET("/provider-connections");
-      // 501 is a deployment fact, not a failure — the same shape connectors.tsx
-      // uses for a connector nobody configured.
-      if (response.status === 501 && problemCode(error) === "not_implemented") {
-        return { notConfigured: true, connections: [] };
-      }
-      if (error || !response.ok) {
-        throwProblem(error);
-      }
-      return { notConfigured: false, connections: data?.data ?? [] };
-    },
-  });
-}
 
 export function ProviderCard() {
   const t = useT();
@@ -395,6 +368,7 @@ function PolicyRow({
   const disconnected = connection.status !== "connected";
   return (
     <>
+      <FreeTierNote catalog={connection.catalog ?? []} />
       <SettingRow
         label={t("provider.autoEnrich")}
         description={t("provider.autoEnrichHint")}
@@ -741,5 +715,31 @@ function CredentialRow({
         </Field>
       </ConfirmModal>
     </>
+  );
+}
+
+/** What automatic enrichment actually buys, said where an admin decides
+ *  whether to switch it on.
+ *
+ *  The two toggles below spend nothing: an automatic run takes only the
+ *  categories this provider gives away, and every priced one waits for a
+ *  human to press a button on one named contact. An admin who does not know
+ *  that reads "enrich automatically" as "spend automatically" and leaves the
+ *  switch off, which costs them the free half of the product.
+ */
+function FreeTierNote({
+  catalog,
+}: Readonly<{ catalog: components["schemas"]["ProviderCategoryCost"][] }>) {
+  const t = useT();
+  const free = catalog.filter((entry) => entry.free);
+  const priced = catalog.filter((entry) => !entry.free);
+  if (free.length === 0) {
+    return null;
+  }
+  return (
+    <Callout tone="info">
+      <p>{t("provider.freeTier.hint")}</p>
+      {priced.length > 0 && <p>{t("provider.pricedTier.hint")}</p>}
+    </Callout>
   );
 }

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -837,3 +837,12 @@
   align-items: center;
   gap: var(--space-2);
 }
+
+/* The buy row: one button per priced detail, wrapping rather than truncating
+   so a price is never cut off. */
+.pe-buy-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -467,6 +467,27 @@ describe("the details that cost credits", () => {
     });
   });
 
+  it("names the free categories when the plain lookup button is pressed", async () => {
+    const user = userEvent.setup();
+    const posted = mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Look this contact up/ }),
+    );
+
+    // The FREE set, named. Sending no categories asks for the connection's
+    // whole selection, priced ones included — a button that spends without
+    // saying so, which is what the split exists to prevent.
+    await expect.poll(() => posted.length).toBe(1);
+    expect(posted[0]).toEqual({
+      provider: "surfe",
+      categories: ["linkedin_profile"],
+    });
+  });
+
   it("does not offer to buy what the section already shows", async () => {
     mountWithCatalog(providerCompletedProfile, queuedRun);
 

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -381,3 +381,99 @@ describe("a lookup that came back mostly empty", () => {
     expect(screen.queryByText(/asked for/)).toBeNull();
   });
 });
+
+describe("the details that cost credits", () => {
+  const catalog = [
+    { category: "linkedin_profile", free: true, cost: {} },
+    { category: "professional_email", free: false, cost: { email: 1 } },
+    { category: "mobile", free: false, cost: { mobile: 1 } },
+  ];
+
+  function mountWithCatalog(profile: Profile, run: () => Response) {
+    const posted: unknown[] = [];
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /provider-connections": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "surfe",
+              status: "connected",
+              credential_present: true,
+              catalog,
+              configuration: {
+                categories: {
+                  linkedin_profile: true,
+                  professional_email: true,
+                  mobile: true,
+                },
+              },
+              credits: { pools: {} },
+              version: 1,
+              created_at: "2026-08-20T09:00:00Z",
+              updated_at: "2026-08-20T09:00:00Z",
+            },
+          ],
+        }),
+      "POST /people/p-1/enrichment-runs": (body) => {
+        posted.push(body);
+        return run();
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection personId="p-1" profiles={[profile]} />
+      </StoryProviders>,
+    );
+    return posted;
+  }
+
+  it("offers each priced detail with its price on the button", async () => {
+    mountWithCatalog({ ...neverRun(), state: "completed" }, queuedRun);
+
+    // The price is ON the button: the decision is what to spend, and a button
+    // that hid its cost would ask somebody to agree to a number they cannot see.
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+    expect(
+      await screen.findByRole("button", {
+        name: /Buy mobile number · 1 credit/,
+      }),
+    ).toBeDefined();
+
+    // No button for a free category: it arrives without anybody pressing
+    // anything, which is the whole point of the split.
+    expect(screen.queryByRole("button", { name: /Buy LinkedIn/ })).toBeNull();
+  });
+
+  it("buys only the detail whose button was pressed", async () => {
+    const user = userEvent.setup();
+    const posted = mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Buy work email/ }),
+    );
+
+    // One category, named. A press that sent the connection's whole selection
+    // would spend on the mobile too, which nobody asked for.
+    await expect.poll(() => posted.length).toBe(1);
+    expect(posted[0]).toEqual({
+      provider: "surfe",
+      categories: ["professional_email"],
+    });
+  });
+
+  it("does not offer to buy what the section already shows", async () => {
+    mountWithCatalog(providerCompletedProfile, queuedRun);
+
+    // The completed fixture already carries an address and a mobile. Offering
+    // to buy them again would spend credits on what is on screen.
+    await screen.findByText(providerCompletedProfile.emails[0].value);
+    expect(screen.queryByRole("button", { name: /Buy work email/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Buy mobile/ })).toBeNull();
+  });
+});

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -36,6 +36,7 @@ import {
 
 type Profile = components["schemas"]["PersonProviderProfile"];
 type Provider = components["schemas"]["Provider"];
+type ProviderConnection = components["schemas"]["ProviderConnection"];
 
 type EnrichRun = {
   personId: string;
@@ -118,6 +119,11 @@ function ProviderPanel({
 }: Readonly<{ personId: string; profile: Profile }>) {
   const t = useT();
   const enrich = useEnrichRun();
+  const connections = useProviderConnections();
+  // What costs nothing on this connection, as the server itself derives it: a
+  // button that guessed the free set could ask for a priced category and
+  // spend without saying so.
+  const free = freeCategories(connections.data?.connections, profile.provider);
   // Nobody has looked this contact up yet, so the panel has no values to show
   // and the small header button is the only way to change that. An empty plate
   // that names the action instead: the reader came here to buy data, and a
@@ -162,6 +168,7 @@ function ProviderPanel({
             personId={personId}
             profile={profile}
             enrich={enrich}
+            free={free}
             small
           />
         )
@@ -184,6 +191,7 @@ function ProviderPanel({
                 personId={personId}
                 profile={profile}
                 enrich={enrich}
+                free={free}
               />
             }
           >
@@ -547,8 +555,10 @@ function EnrichNow({
   personId,
   profile,
   enrich,
+  free,
   small = false,
 }: Readonly<{
+  free: string[];
   personId: string;
   profile: Profile;
   enrich: ReturnType<typeof useEnrichRun>;
@@ -566,8 +576,20 @@ function EnrichNow({
       busyLabel={t("provider.profile.lookingUp")}
       // A profile carries no provider name until a run exists, so the first
       // lookup on a contact names the one the contract has.
+      // The FREE categories, named. Sending none asks for the connection's
+      // whole selection, priced ones included — a button that spends without
+      // saying so, which is the thing the split exists to prevent. Every
+      // purchase now states its price, and this one states that there is none.
       onClick={() =>
-        enrich.mutate({ personId, provider: profile.provider ?? "surfe" })
+        enrich.mutate({
+          personId,
+          provider: profile.provider ?? "surfe",
+          // Omitted rather than empty while the catalog is still loading: an
+          // empty list asks for nothing at all, and the contract's minItems
+          // refuses it. Omitting falls back to the connection's own selection,
+          // which is what this button did before the free set existed.
+          categories: free.length > 0 ? free : undefined,
+        })
       }
     >
       <Search size={15} aria-hidden="true" /> {t("provider.profile.enrichNow")}
@@ -620,3 +642,16 @@ function useRunWatch(personId: string, profile: Profile) {
 const RUNNING_RUN_STATES = new Set<
   components["schemas"]["ProviderRun"]["state"]
 >(["queued", "submitting", "in_progress"]);
+
+/** The categories this connection buys for nothing, from the server's own
+ *  catalog. Empty while the connections are still loading, which keeps a
+ *  button from asking for a set nobody has confirmed. */
+function freeCategories(
+  connections: ProviderConnection[] | undefined,
+  name: string,
+): string[] {
+  const connection = connections?.find((c) => c.provider === name);
+  return (connection?.catalog ?? [])
+    .filter((entry) => entry.free)
+    .map((entry) => entry.category);
+}

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -24,6 +24,7 @@ import {
   isRunning,
   profileLabel,
   profileTone,
+  useProviderConnections,
 } from "./provider-status";
 
 // What a licensed data provider was PAID to tell us about this person
@@ -36,7 +37,14 @@ import {
 type Profile = components["schemas"]["PersonProviderProfile"];
 type Provider = components["schemas"]["Provider"];
 
-type EnrichRun = { personId: string; provider: Provider };
+type EnrichRun = {
+  personId: string;
+  provider: Provider;
+  // What this press buys. Absent asks for the connection's whole selection;
+  // named, it purchases one priced detail without changing what every future
+  // run spends.
+  categories?: string[];
+};
 
 /** The mark every value in this section carries: bought from a named third
  *  party, on a date. `connector` rather than `agent` — nothing inferred this,
@@ -184,10 +192,95 @@ function ProviderPanel({
         ) : (
           <ProviderValues profile={profile} />
         )}
+        <BuyPriced personId={personId} profile={profile} enrich={enrich} />
         <RunWatch personId={personId} profile={profile} />
       </PanelBody>
     </Panel>
   );
+}
+
+/** The priced details, each behind its own button with its own price.
+ *
+ *  Automatic enrichment takes only what the provider gives away, so these are
+ *  the ones nobody has bought yet and nobody will until a reader decides this
+ *  particular contact is worth it. The price is on the button because the
+ *  decision is what to spend, and a button that hid its cost would be asking
+ *  somebody to agree to a number they cannot see.
+ */
+function BuyPriced({
+  personId,
+  profile,
+  enrich,
+}: Readonly<{
+  personId: string;
+  profile: Profile;
+  enrich: ReturnType<typeof useEnrichRun>;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const connections = useProviderConnections();
+  const connection = connections.data?.connections.find(
+    (c) => c.provider === profile.provider,
+  );
+  // Only what this connection actually carries: a category an admin switched
+  // off is not one to offer, and the server would refuse it anyway.
+  const buyable = (connection?.catalog ?? []).filter(
+    (entry) =>
+      !entry.free &&
+      (connection?.configuration.categories?.[entry.category] ?? false) &&
+      !alreadyHeld(profile, entry.category),
+  );
+  if (buyable.length === 0 || !canEnrichNow(profile.state)) {
+    return null;
+  }
+  return (
+    <div className="pe-buy-row">
+      {buyable.map((entry) => (
+        <Button
+          key={entry.category}
+          small
+          type="button"
+          pending={enrich.isPending}
+          busyLabel={t("provider.profile.lookingUp")}
+          onClick={() =>
+            enrich.mutate({
+              personId,
+              provider: profile.provider,
+              categories: [entry.category],
+            })
+          }
+        >
+          {t("provider.profile.buy", {
+            category: categoryNames([entry.category], t),
+            credits: formatNumber(creditsOf(entry), locale),
+          })}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+/** The credits one category costs, summed across pools. A category priced in
+ *  two pools is one purchase, and two figures on one button would read as a
+ *  choice between them. */
+function creditsOf(
+  entry: components["schemas"]["ProviderCategoryCost"],
+): number {
+  return Object.values(entry.cost).reduce((total, n) => total + n, 0);
+}
+
+/** Whether the section already shows what this category buys, so a button does
+ *  not offer to buy again what is on screen. */
+function alreadyHeld(profile: Profile, category: string): boolean {
+  switch (category) {
+    case "professional_email":
+    case "personal_email":
+      return profile.emails.length > 0;
+    case "mobile":
+      return profile.mobile_phones.length > 0;
+    default:
+      return false;
+  }
 }
 
 // A component rather than a hook call in the section, so the watch mounts
@@ -430,10 +523,10 @@ function categoryNames(
 function useEnrichRun() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ personId, provider }: EnrichRun) => {
+    mutationFn: async ({ personId, provider, categories }: EnrichRun) => {
       const { data, error } = await api.POST("/people/{id}/enrichment-runs", {
         params: { path: { id: personId } },
-        body: { provider },
+        body: categories ? { provider, categories } : { provider },
       });
       if (error) {
         throwProblem(error);

--- a/frontend/src/screens/provider-status.ts
+++ b/frontend/src/screens/provider-status.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
 import type { components } from "../api/schema";
 import type { MessageKey } from "../i18n/en";
+import { problemCode, throwProblem } from "./common";
 
 // The licensed-data-provider status vocabulary, in one place because two
 // surfaces render it: the Settings card says whether the connection works,
@@ -156,4 +159,47 @@ export function canEnrichNow(state: ProviderProfileState): boolean {
     state !== "stale" &&
     !isRunning(state)
   );
+}
+
+/** What a provider connection costs, per category, as both surfaces read it:
+ *  the settings card naming the free ones as safe to switch on, and a buy
+ *  button on the person page stating a price before anybody presses it. */
+export type ConnectionsResult = {
+  /** True when this build carries no adapter at all. Not an error: it is the
+   *  supported "no provider" configuration, and the card says so plainly
+   *  rather than showing a broken control (PI-AC-9). */
+  notConfigured: boolean;
+  connections: ProviderConnection[];
+};
+
+/** The connections, shared by the settings card and the person page.
+ *
+ *  HERE rather than in either screen: the person page needs the price catalog
+ *  to label a buy button, and a second copy of this read would be a second
+ *  answer to "what does this provider charge". */
+export function useProviderConnections() {
+  return useQuery({
+    queryKey: ["provider-connections"],
+    queryFn: async (): Promise<ConnectionsResult> => {
+      const { data, error, response } = await api.GET("/provider-connections");
+      // 501 is a deployment fact, not a failure — the same shape connectors.tsx
+      // uses for a connector nobody configured.
+      if (response.status === 501 && problemCode(error) === "not_implemented") {
+        return { notConfigured: true, connections: [] };
+      }
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return { notConfigured: false, connections: data?.data ?? [] };
+    },
+  });
+}
+
+/** What one category costs on this connection, or undefined when the provider
+ *  never declared it. */
+export function categoryCost(
+  connection: ProviderConnection | undefined,
+  category: string,
+): components["schemas"]["ProviderCategoryCost"] | undefined {
+  return connection?.catalog?.find((entry) => entry.category === category);
 }


### PR DESCRIPTION
Surfe charges for exactly two things — the work email (1 credit) and the mobile
(1 credit) — and gives away the LinkedIn profile, the current role and the whole
work history. Automatic enrichment bought whatever the connection was configured
for, so "enrich automatically" meant "spend automatically", and an admin who
wanted the free half had no way to take it without authorising the paid half for
every contact that ever arrives.

The split is now the product's own:

- **An automatic run takes the free categories and nothing else.** Nobody
  weighed that purchase, so it may not cost anything — and because it costs
  nothing it can run on every arrival without a decision.
- **A priced category is bought by a human pressing a button on one named
  person.** The run names what it buys, so a press purchases one detail without
  changing what every future run spends.

Verified end to end: a contact created with the connection on automatic queued a
run asking for `{linkedin_profile, current_employment, job_history}` and neither
priced category.

## Free is derived, never listed

`Descriptor.Free()` reads the adapter's own cost table, so a provider that starts
charging for something stops reading as free the moment its descriptor says so.
A category free to *request* but carrying a charged fallback is not free —
Surfe's personal-email pass costs two credits, so it is priced at three (its
trigger's one plus its own two).

The connection reports that price list, so the settings card can tell an admin
the automatic half costs nothing and a buy button can state a price before
anybody presses it.

## Money defects found in review and fixed here

This is money-handling code and the review found real leaks. Each has a test.

- **A fallback bought without its trigger charged against a hold of zero.** The
  cascade never fires, so the platform prices it at nothing — but Surfe's request
  still carries the email flag and charges for what it finds. Refused now, rather
  than silently widened to include the trigger, which would buy a category the
  caller never asked for.
- **The plain lookup button sent no categories**, which the server reads as the
  connection's *whole* selection, priced ones included — a button that spends
  without saying so, in the middle of a change whose point is that every purchase
  states its price.
- **An automatic trigger on a connection with nothing free** would have dispatched
  a run asking for no categories. A provider answers that with a refusal, and a
  refusal flips the connection's status — one configuration choice breaking
  automatic ingest for every later contact.
- **A category an adapter forgets to price read as free** everywhere the platform
  asks what something costs: bought automatically, reserved at nothing. The
  registry refuses such an adapter now, and an empty cost map is how one says
  "free" deliberately. A fitness test holds it over the real descriptors.
- **A provider with no free categories at all** would have produced an empty
  selection, which the connection column refuses — a connection nobody can make.

## Deferred, filed

**#2921** — two concurrent runs whose category sets *overlap without matching*
hash to different fingerprints, so both pass the live-run index and both buy the
category they share. Reachable by pressing the plain lookup and a buy button
before the page refetches. The guard needs to be per category rather than per
set, which is a migration; `fingerprintOf`'s comment now states the gap rather
than overstating the guarantee.

## Gates

`make check-backend`, `make check-fe` (5121 tests), `make craft-static` all
green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatic enrichment now buys only the free categories a provider gives away, instead of whatever the connection was configured for. Priced categories are bought by a human pressing a button on one named person, with the price stated on the button.

**New Features**
- The connection now returns a per-category price catalog derived from the adapter's own cost table, so settings and buy buttons always quote the same numbers; a category free to request but carrying a charged fallback is priced with its trigger.
- A manual run may name a subset of the connection's categories; it buys exactly that without changing future runs, and anything outside the connection's selection is refused with 422.
- New connections default to the free categories, falling back to the provider's default preset only when nothing is free.

**Bug Fixes**
- Refuses a fallback category bought without the category it follows, which previously charged against a hold of zero.
- The plain lookup button now names the free set instead of sending no categories, which the server read as the connection's whole selection.
- An automatic trigger on a connection with nothing free is refused up front, so it cannot dispatch an empty run that would flip the connection's status.
- The registry now rejects an adapter that declares a category with no cost entry, since an omission previously read as free.
- Two runs with overlapping category sets can still both buy a shared category; guarding that needs a migration (#2921).

<sup>Written for commit 22a554f96b82b79b90d52ddb75ab0d914e510b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider connections now show available enrichment categories and estimated credit costs.
  * Enrichment runs can select specific categories, with free categories handled automatically.
  * Added purchase controls for paid contact-data categories, including category-specific costs.
  * Prevented repurchasing contact data already available.
  * Added German, English, and Vietnamese translations for tier and purchase guidance.

* **Bug Fixes**
  * Unsupported category selections now return a clear validation error.
  * Paid cascade options are no longer treated as free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->