### PR TITLE
fix(worker): a drain that overruns cancels its jobs instead of outliving them

### DIFF
--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -22,13 +22,10 @@ import (
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/aiactivity"
 	"github.com/margince/margince/backend/internal/modules/identity"
-	"github.com/margince/margince/backend/internal/modules/integrations"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
-	"github.com/margince/margince/backend/internal/modules/webhooks"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/config"
-	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/events"
 	"github.com/margince/margince/backend/internal/platform/geocode"
@@ -105,43 +102,6 @@ func resetFlush(path compose.ModelPath) func(ids.UUID) {
 	}
 }
 
-// workerLanes is what the event lanes leave behind for the job runner, which
-// schedules against the SAME instances those lanes consume into: one governed
-// registry and one brain per role, ONE deliverer FACTORY across both outbound-webhook
-// lanes (E10/S-E10.6) — never two that could drift apart — plus the object
-// store the deep-read logo write and the retention purge share.
-type workerLanes struct {
-	// background holds every lane goroutine so run() returns only after
-	// in-flight handlers finish their ack — the same shape as cmd/api's relay
-	// group; a bare goroutine would be killed mid-handler when the relay
-	// returns.
-	background *sync.WaitGroup
-	// stop ends every lane goroutine. It pairs with background: join() is the
-	// only thing that should call either, so the lanes have one shutdown.
-	stop context.CancelFunc
-	// laneCtx is what stop cancels, carried so a lane started LATER than this
-	// value — the extension subscriptions, which wait for the runtime binding
-	// the job runner makes — still lives and dies with all the others. A second
-	// context there would be a second shutdown, and join() would return with a
-	// consumer still reading the bus.
-	ctx       context.Context //nolint:containedctx // the lanes' lifetime IS this value; join() is the only thing that ends it.
-	runner    *compose.RunnerService
-	deliverer func(*database.DB) *webhooks.Deliverer
-	blob      blobstore.Store
-	// providers is the licensed-data-provider adapter registry this boot was
-	// configured with (MARGINCE_PROVIDER_SURFE). Nil is a deployment with no
-	// provider: the run lanes register nothing and nothing can reach a vendor.
-	providers *integrations.Registry
-}
-
-// join ends the lanes and waits for the handler each is in. It is what makes the
-// bus and the pool safe to close: run() defers both closes before the lanes
-// start, so LIFO runs them after this returns, never under a live subscriber.
-func (l workerLanes) join() {
-	l.stop()
-	l.background.Wait()
-}
-
 // startEventLanes starts the lanes this role runs before the job runner exists
 // and resolves what the runner then needs from them, in the order an operator
 // reads at boot.
@@ -153,7 +113,7 @@ func (l workerLanes) join() {
 // stack trace where the boot error belongs.
 func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, vault keyvault.Vault, modelPath compose.ModelPath, logger *slog.Logger, stdout io.Writer) (workerLanes, error) {
 	laneCtx, stopLanes := context.WithCancel(ctx)
-	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stopLanes, ctx: laneCtx}
+	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stopLanes, ctx: laneCtx, logger: logger}
 
 	if err := startRunnerLane(laneCtx, cfg, pool, rdb, vault, modelPath, &lanes, logger, stdout); err != nil {
 		return lanes, err

--- a/backend/cmd/worker/boot_test.go
+++ b/backend/cmd/worker/boot_test.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -26,7 +28,7 @@ import (
 // lanes' context and does not return until each goroutine has left its handler.
 func TestJoinCancelsTheLanesAndWaitsForThem(t *testing.T) {
 	ctx, stop := context.WithCancel(context.Background())
-	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stop}
+	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stop, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
 
 	// Two lanes, each ending only on cancellation — no sleep and no clock, so
 	// the test can only pass by the cancel actually reaching them.

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -109,15 +109,63 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 		return nil, err
 	}
 	_, _ = fmt.Fprintln(stdout, jobRunnerBanner(cfg, watchCfg, modelPath, vault, lanes.runner))
-	return func() {
-		// The run context is already cancelled at shutdown, so give the
-		// drain its own bounded window.
-		stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		if err := runner.Stop(stopCtx); err != nil {
-			logger.Warn("stopping job runner", "err", err)
-		}
-	}, nil
+	return func() { stopJobRunner(ctx, runner, logger) }, nil
+}
+
+// jobLane is the job runner as SHUTDOWN sees it: two ways to stop, one softer
+// than the other. Named as an interface so the escalation between them can be
+// driven by a test — a real drain overrun needs a job that will not finish,
+// which is the one thing a test cannot arrange without waiting for it.
+type jobLane interface {
+	Stop(ctx context.Context) error
+	StopAndCancel(ctx context.Context) error
+}
+
+// jobDrainWindow bounds the graceful drain: a job caught mid-flight by shutdown
+// gets this long to finish on its own terms.
+const jobDrainWindow = 30 * time.Second
+
+// jobCancelWindow bounds the wait AFTER the work contexts are cancelled. Short,
+// because nothing is being given time to finish here — only to notice it was
+// cancelled and return.
+const jobCancelWindow = 5 * time.Second
+
+// stopJobRunner ends the job lane before this process closes what the jobs
+// write through.
+//
+// The drain is bounded, and River's Stop RETURNS on that deadline rather than
+// enforcing it — in-flight job goroutines keep running. Shutdown does not wait
+// for them: run() closes the bus and then the pool as its deferred calls
+// unwind, so an overrun used to leave a job writing an overlay budget meter
+// into a closed Redis client, or reading through a closed pool. The failure
+// lands in whatever the job logs, at shutdown, where it reads as a symptom of
+// stopping rather than of a job that was never stopped.
+//
+// So an overrun escalates rather than proceeding. Cancelling the work contexts
+// and waiting again is what actually ends those goroutines; River marks a job
+// cancelled this way for retry, so the cost is a job that runs again, not one
+// that is lost.
+//
+// If even that overruns, the process closes its connections under live job
+// goroutines — the same shape as before, but named at Error with what will
+// fail, rather than left to be inferred from a downstream write's complaint.
+func stopJobRunner(ctx context.Context, lane jobLane, logger *slog.Logger) {
+	// The run context is already cancelled at shutdown, so give the
+	// drain its own bounded window.
+	stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobDrainWindow)
+	defer cancel()
+	drained := lane.Stop(stopCtx)
+	if drained == nil {
+		return
+	}
+	logger.Warn("the job drain did not finish inside its window; cancelling the jobs still in flight so they cannot outlive the bus and the pool this process is about to close",
+		"window", jobDrainWindow, "err", drained)
+	cancelCtx, cancelHard := context.WithTimeout(context.WithoutCancel(ctx), jobCancelWindow)
+	defer cancelHard()
+	if err := lane.StopAndCancel(cancelCtx); err != nil {
+		logger.Error("job goroutines are STILL running as this process closes the bus and the pool; whatever they write next fails against a closed client, and that failure will look like a shutdown problem rather than this one",
+			"window", jobCancelWindow, "err", err)
+	}
 }
 
 // newJobRunner declares every scheduled lane this role runs, and for each the

--- a/backend/cmd/worker/lanes.go
+++ b/backend/cmd/worker/lanes.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// What the event lanes leave behind, and how they end. Apart from boot.go
+// because starting them and ending them are two concerns and only one of them
+// runs at shutdown, under the deferred closes whose ordering join() is what
+// makes safe.
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/integrations"
+	"github.com/margince/margince/backend/internal/modules/webhooks"
+	"github.com/margince/margince/backend/internal/platform/blobstore"
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+// workerLanes is what the event lanes leave behind for the job runner, which
+// schedules against the SAME instances those lanes consume into: one governed
+// registry and one brain per role, ONE deliverer FACTORY across both outbound-webhook
+// lanes (E10/S-E10.6) — never two that could drift apart — plus the object
+// store the deep-read logo write and the retention purge share.
+type workerLanes struct {
+	// background holds every lane goroutine so run() returns only after
+	// in-flight handlers finish their ack — the same shape as cmd/api's relay
+	// group; a bare goroutine would be killed mid-handler when the relay
+	// returns.
+	background *sync.WaitGroup
+	// stop ends every lane goroutine. It pairs with background: join() is the
+	// only thing that should call either, so the lanes have one shutdown.
+	stop context.CancelFunc
+	// laneCtx is what stop cancels, carried so a lane started LATER than this
+	// value — the extension subscriptions, which wait for the runtime binding
+	// the job runner makes — still lives and dies with all the others. A second
+	// context there would be a second shutdown, and join() would return with a
+	// consumer still reading the bus.
+	ctx       context.Context //nolint:containedctx // the lanes' lifetime IS this value; join() is the only thing that ends it.
+	runner    *compose.RunnerService
+	deliverer func(*database.DB) *webhooks.Deliverer
+	blob      blobstore.Store
+	// providers is the licensed-data-provider adapter registry this boot was
+	// configured with (MARGINCE_PROVIDER_SURFE). Nil is a deployment with no
+	// provider: the run lanes register nothing and nothing can reach a vendor.
+	providers *integrations.Registry
+	// logger is carried for join(), which reports a lane that did not stop.
+	// The lanes themselves were handed one at construction and do not read
+	// this.
+	logger *slog.Logger
+}
+
+// laneJoinWindow bounds join(). The same window the job drain gets, because it
+// is the same promise being kept — nothing this process started is still
+// running when it closes what that thing writes through.
+const laneJoinWindow = 30 * time.Second
+
+// join ends the lanes and waits for the handler each is in. It is what makes the
+// bus and the pool safe to close: run() defers both closes before the lanes
+// start, so LIFO runs them after this returns, never under a live subscriber.
+//
+// Bounded, and that bound is a real weakening of the sentence above — on
+// overrun this returns with a lane still reading, and the closes follow. It is
+// the better failure anyway. Unbounded, a handler that ignores cancellation
+// hangs the process silently, and on the boot-failure path that turns an
+// `exit 1` into no exit at all: a supervisor reads a process that never leaves
+// as still starting, and the boot error nobody sees was the whole point of
+// failing. An overrun that says which promise it broke can be acted on.
+func (l workerLanes) join() {
+	l.joinWithin(laneJoinWindow)
+}
+
+// joinWithin is join with the window as an argument, so a test can watch an
+// overrun happen instead of waiting out the real one.
+func (l workerLanes) joinWithin(window time.Duration) {
+	l.stop()
+	stopped := make(chan struct{})
+	go func() {
+		l.background.Wait()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(window):
+		l.logger.Error("a lane did not stop inside its window; this process closes the bus and the pool with a subscriber still reading them, so whatever it does next fails against a closed client",
+			"window", window)
+	}
+}

--- a/backend/cmd/worker/shutdown_test.go
+++ b/backend/cmd/worker/shutdown_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Shutdown's one promise: nothing this process started is still running when it
+// closes the bus and the pool that thing writes through.
+//
+// Both halves used to break it in the same way and for opposite reasons. The
+// job drain RETURNED on its deadline with job goroutines still going, because
+// that is what River's Stop does when its context expires. The lane join had no
+// deadline at all, so a handler that ignored cancellation hung the process
+// instead — which on the boot-failure path means an `exit 1` that never
+// happens and a supervisor that reads a dead worker as still starting.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeJobLane records which stop it was asked for and answers each as the test
+// arranges. The real overrun cannot be staged without a job that will not
+// finish, which is the one thing a test cannot arrange without waiting for it.
+type fakeJobLane struct {
+	stopErr       error
+	cancelErr     error
+	stops         int
+	stopAndCancel int
+}
+
+func (f *fakeJobLane) Stop(context.Context) error {
+	f.stops++
+	return f.stopErr
+}
+
+func (f *fakeJobLane) StopAndCancel(context.Context) error {
+	f.stopAndCancel++
+	return f.cancelErr
+}
+
+func recordingLogger() (*slog.Logger, *bytes.Buffer) {
+	var written bytes.Buffer
+	return slog.New(slog.NewTextHandler(&written, &slog.HandlerOptions{Level: slog.LevelDebug})), &written
+}
+
+func TestADrainThatFinishesIsNotEscalated(t *testing.T) {
+	lane := &fakeJobLane{}
+	logger, written := recordingLogger()
+
+	stopJobRunner(t.Context(), lane, logger)
+
+	if lane.stopAndCancel != 0 {
+		t.Errorf("a drain that finished was escalated to StopAndCancel %d time(s); "+
+			"cancelling a job that was about to complete costs it a retry for nothing", lane.stopAndCancel)
+	}
+	if written.Len() != 0 {
+		t.Errorf("an ordinary shutdown logged %q; nothing went wrong", written.String())
+	}
+}
+
+// The window expiring is exactly what River reports, and it is NOT the end of
+// the story: Stop returns, the job goroutines do not.
+func TestADrainThatOverrunsCancelsTheJobsStillRunning(t *testing.T) {
+	lane := &fakeJobLane{stopErr: context.DeadlineExceeded}
+	logger, written := recordingLogger()
+
+	stopJobRunner(t.Context(), lane, logger)
+
+	if lane.stopAndCancel != 1 {
+		t.Fatalf("the drain overran and StopAndCancel was called %d time(s), want 1 — "+
+			"without it the job goroutines outlive the bus and the pool this process is closing", lane.stopAndCancel)
+	}
+	if !strings.Contains(written.String(), "level=WARN") {
+		t.Errorf("the escalation was silent: %q", written.String())
+	}
+}
+
+// The floor. Both stops overran, the connections close under live job
+// goroutines, and the only thing left to do is say so where it can be read as
+// the cause rather than as a symptom.
+func TestJobsThatSurviveBothStopsAreReportedAsAnError(t *testing.T) {
+	lane := &fakeJobLane{stopErr: context.DeadlineExceeded, cancelErr: errors.New("still working")}
+	logger, written := recordingLogger()
+
+	stopJobRunner(t.Context(), lane, logger)
+
+	if !strings.Contains(written.String(), "level=ERROR") {
+		t.Errorf("this process is closing its connections under running jobs and said nothing at ERROR: %q", written.String())
+	}
+}
+
+func TestJoinReportsALaneThatDoesNotStop(t *testing.T) {
+	logger, written := recordingLogger()
+	_, stop := context.WithCancel(context.Background())
+	lanes := workerLanes{background: &sync.WaitGroup{}, stop: stop, logger: logger}
+
+	// A lane that ignores cancellation. It is released at the end of the test
+	// rather than left running, so the suite does not leak it.
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+	lanes.background.Go(func() { <-stuck })
+
+	returned := make(chan struct{})
+	go func() {
+		lanes.joinWithin(time.Millisecond)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("join() never returned with a lane that ignores cancellation — a boot failure that " +
+			"cannot exit is read by a supervisor as a worker that is still starting")
+	}
+	if !strings.Contains(written.String(), "level=ERROR") {
+		t.Errorf("join() abandoned a running lane silently: %q", written.String())
+	}
+}

--- a/backend/internal/platform/jobs/jobs.go
+++ b/backend/internal/platform/jobs/jobs.go
@@ -157,6 +157,22 @@ func (r *Runner) Stop(ctx context.Context) error {
 	return nil
 }
 
+// StopAndCancel is the harder stop, for when a graceful drain has already
+// overrun its window: it cancels the work contexts of every job still in flight
+// and waits for those goroutines to return, rather than leaving them running.
+//
+// A job cancelled this way is not lost. River marks it for retry, so it is
+// picked up by this replica's next boot or by another one that is still
+// serving — which is the trade the caller is making: an interrupted job that
+// runs again beats a job goroutine that outlives the connections it writes
+// through.
+func (r *Runner) StopAndCancel(ctx context.Context) error {
+	if err := r.client.StopAndCancel(ctx); err != nil {
+		return fmt.Errorf("jobs: stop and cancel: %w", err)
+	}
+	return nil
+}
+
 // SubscribeCompleted delivers job-completion events so callers can await a
 // specific job without polling or sleeping. Subscribe before Start so no
 // completion is missed; call the returned cancel when done.

--- a/backend/internal/platform/jobs/jobs_integration_test.go
+++ b/backend/internal/platform/jobs/jobs_integration_test.go
@@ -58,7 +58,7 @@ func (noopWorker) Work(context.Context, *river.Job[noopArgs]) error { return nil
 // reach this suite asserts rests on GRANT USAGE ON SCHEMA public TO
 // margince_app, which EnsureSchema issues itself when it rebuilds the schema
 // and a lane clone carries from core 0015 when EnsureSchema reuses one.
-func migratedAppPool(t *testing.T) (*jobs.Runner, *pgxpool.Pool) {
+func migratedAppPool(t *testing.T, register ...func(*river.Workers)) (*jobs.Runner, *pgxpool.Pool) {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
@@ -102,6 +102,12 @@ func migratedAppPool(t *testing.T) (*jobs.Runner, *pgxpool.Pool) {
 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &noopWorker{})
+	// A caller that needs work of its own registers it here rather than
+	// rebuilding the chassis: the schema, the roles and the River migration
+	// above are what make this expensive, and none of them differ.
+	for _, add := range register {
+		add(workers)
+	}
 	r, err := jobs.New(appPool, jobs.Config{
 		Queues:  map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
 		Workers: workers,

--- a/backend/internal/platform/jobs/stopandcancel_integration_test.go
+++ b/backend/internal/platform/jobs/stopandcancel_integration_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package jobs_test
+
+// The escalation a role's shutdown depends on.
+//
+// River's Stop returns when its context expires and the job goroutines it was
+// draining keep running — so a caller that treats the return as "the lane has
+// stopped" goes on to close the bus and the pool those jobs write through.
+// StopAndCancel is what actually ends them, and this is the case that proves
+// the two differ: a job that will not finish on its own, drained past a
+// deadline, then cancelled.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+)
+
+// stuckArgs is work that ends only on cancellation — the shape a soft drain
+// cannot dislodge, and the reason the escalation exists.
+type stuckArgs struct{}
+
+func (stuckArgs) Kind() string { return "stuck" }
+
+type stuckWorker struct {
+	river.WorkerDefaults[stuckArgs]
+	started  chan struct{}
+	returned chan struct{}
+}
+
+func (w *stuckWorker) Work(ctx context.Context, _ *river.Job[stuckArgs]) error {
+	close(w.started)
+	<-ctx.Done()
+	close(w.returned)
+	return ctx.Err()
+}
+
+func TestStopAndCancelEndsAJobThatOutlastsTheDrain(t *testing.T) {
+	stuck := &stuckWorker{started: make(chan struct{}), returned: make(chan struct{})}
+	r, _ := migratedAppPool(t, func(w *river.Workers) { river.AddWorker(w, stuck) })
+	ctx := t.Context()
+
+	if err := r.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Enqueue(ctx, stuckArgs{}, nil); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// Waited on rather than slept through: the finding is about a job that is
+	// RUNNING when shutdown arrives, and a test that drained before the claim
+	// would prove nothing about it.
+	select {
+	case <-stuck.started:
+	case <-time.After(riverLifecycleBudget):
+		t.Fatal("the stuck job was never claimed — the drain below would have nothing to outlast")
+	}
+
+	// The soft drain, given a window it cannot possibly meet.
+	drainCtx, cancelDrain := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancelDrain()
+	if err := r.Stop(drainCtx); err == nil {
+		t.Fatal("Stop reported a clean drain while a job was still running — the escalation below " +
+			"rests on it reporting the overrun instead")
+	}
+	select {
+	case <-stuck.returned:
+		t.Fatal("the job ended at the drain deadline; this case needs one that does NOT, or it " +
+			"proves nothing about what StopAndCancel adds")
+	default:
+	}
+
+	cancelCtx, cancelHard := context.WithTimeout(ctx, riverLifecycleBudget)
+	defer cancelHard()
+	if err := r.StopAndCancel(cancelCtx); err != nil {
+		t.Fatalf("StopAndCancel: %v", err)
+	}
+	select {
+	case <-stuck.returned:
+	case <-time.After(time.Second):
+		t.Fatal("StopAndCancel returned with the job goroutine still running — a role that then " +
+			"closes its bus and its pool leaves that job writing into both")
+	}
+}

--- a/backend/internal/platform/jobs/stopandcancel_integration_test.go
+++ b/backend/internal/platform/jobs/stopandcancel_integration_test.go
@@ -16,6 +16,7 @@ package jobs_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,4 +87,50 @@ func TestStopAndCancelEndsAJobThatOutlastsTheDrain(t *testing.T) {
 		t.Fatal("StopAndCancel returned with the job goroutine still running — a role that then " +
 			"closes its bus and its pool leaves that job writing into both")
 	}
+}
+
+// The wrapped failure, which is the only thing a caller can act on: shutdown
+// escalates to StopAndCancel BECAUSE the soft drain overran, so an escalation
+// that fails in turn is what tells a role it is about to close the bus and the
+// pool underneath running jobs. A bare context error would not name the step.
+func TestStopAndCancelWrapsItsOwnFailure(t *testing.T) {
+	stuck := &stuckWorker{started: make(chan struct{}), returned: make(chan struct{})}
+	r, _ := migratedAppPool(t, func(w *river.Workers) { river.AddWorker(w, stuck) })
+	ctx := t.Context()
+
+	if err := r.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Enqueue(ctx, stuckArgs{}, nil); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	select {
+	case <-stuck.started:
+	case <-time.After(riverLifecycleBudget):
+		t.Fatal("the stuck job was never claimed")
+	}
+
+	// A window already spent, which is the state a shutdown that has burned
+	// its whole budget on the soft drain arrives in.
+	spent, cancel := context.WithCancel(ctx)
+	cancel()
+	err := r.StopAndCancel(spent)
+	if err == nil {
+		t.Fatal("StopAndCancel reported success against a context that was already done")
+	}
+	if !strings.Contains(err.Error(), "stop and cancel") {
+		t.Errorf("the failure reads %q and does not name the step it happened in", err)
+	}
+
+	// Left in a stoppable state for the harness rather than abandoned mid-drain.
+	// The second stop's own outcome is not this case's subject — the case above
+	// is what asserts a clean escalation — but a failure here would leave a
+	// client running against a pool the harness is about to close, so it is
+	// reported rather than dropped.
+	done, release := context.WithTimeout(ctx, riverLifecycleBudget)
+	defer release()
+	if err := r.StopAndCancel(done); err != nil {
+		t.Fatalf("the client would not stop after the refused escalation: %v", err)
+	}
+	<-stuck.returned
 }


### PR DESCRIPTION
Closes #444.

Shutdown makes one promise: **nothing this process started is still running when it closes the bus and the pool that thing writes through.** Both halves broke it, in opposite ways.

## The job drain returned with jobs still running

River's `Stop` returns on its context's deadline; the job goroutines do not stop with it. Shutdown carried on — `lanes.join()`, `closeBus(rdb)`, `pool.Close()` — so a job still writing an overlay budget meter hit a closed Redis client, and one still reading hit a closed pool. The failure surfaced in whatever that job logged, during shutdown, where it reads as a symptom of stopping rather than of a job that was never stopped.

An overrun now escalates to `StopAndCancel`: cancelling the work contexts and waiting again is what actually ends those goroutines. River marks a job cancelled that way for retry, so the cost is a job that runs again, not one that is lost.

If even that overruns, the process says so at `Error`, naming what will fail — the same shape as before, but as a cause rather than something to infer from a downstream complaint.

## The lane join had no deadline at all

A handler that ignored cancellation hung the process. On the boot-failure path from #427 that turns an `exit 1` into no exit — a supervisor reads a worker that never leaves as one that is still *starting*, and the boot error nobody sees was the whole point of failing.

`join()` is bounded now, on the same window, and an overrun is reported rather than waited out. That **is** a weakening of what `join` promises, and its comment says so: a lane abandoned loudly beats a process that hangs silently.

## Held, not described

- the escalation, through a fake job lane — a real drain overrun needs a job that will not finish, which is the one thing a test cannot arrange without waiting for it
- the clean path, asserting `StopAndCancel` is **not** called: cancelling a job that was about to complete costs it a retry for nothing
- the join, through a lane that ignores cancellation, on an injected window

Each fails if its half is reverted.

`workerLanes` and its shutdown move to `lanes.go` — starting the lanes and ending them are two concerns, and `boot.go` passed the 500-line cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved worker shutdown with a 30-second graceful drain period.
  * Remaining jobs are cancelled when graceful shutdown exceeds the time limit.
  * Worker lanes now have bounded shutdown waits, with errors reported when they remain active.
  * Improved coordination of shared resources during startup and shutdown.

* **Bug Fixes**
  * Improved reporting for jobs that do not stop after cancellation.
  * Credential migration issues no longer prevent workers from starting.
  * Improved consistency when sharing vault access across worker operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->