### PR TITLE
fix(metrics): a gauge does not carry the suffix that means counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ numbers appear here when releases start.
 
 ### Changed
 
+- **BREAKING (metrics): the sweep gauges no longer carry a `_total` suffix.**
+  `margince_sweep_workspaces_total` is now `margince_sweep_workspaces`, and
+  `margince_sweep_units_total` is now `margince_sweep_units`. The two `_failed`
+  halves are unchanged. Any dashboard or alert reading the old names has to be
+  updated; nothing is aliased, because a series published under two names is a
+  worse surface than a rename with a note.
+
+  All four are levels — how many workspaces or units a fleet pass currently
+  covers, read out of `river_job` at scrape time, numbers that go DOWN — and
+  Prometheus reserves `_total` for monotonic counters. The `# TYPE` line always
+  said `gauge`; the NAME is what a dashboard author reads, and this one invited
+  `rate()` and `increase()` over a level, which render as plausible noise rather
+  than as an error.
+
+  Both pairs move together. Renaming one half would have left an operator
+  reading `margince_sweep_workspaces_total` beside `margince_sweep_units`,
+  which is a worse surface than the convention it satisfies.
+
+  A gate now holds the rule in both directions, over what the exposition writers
+  actually emit rather than over a list of names: a gauge may not carry the
+  suffix, and a counter must.
+
 - **The schema describes margince.yaml, not just the routing block.**
   `config/ai-routing.schema.json` is gone; `config/margince.schema.json` takes
   its place and covers the whole file — all fifteen sections — with the model

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -154,8 +154,8 @@ func TestTheWorkerMetricsAreProcessLocalAndReServeNoFleetGauge(t *testing.T) {
 	for _, family := range []string{
 		"margince_job_queue_depth",
 		"margince_job_declared_info",
-		"margince_sweep_workspaces_total",
-		"margince_sweep_units_total",
+		"margince_sweep_workspaces",
+		"margince_sweep_units",
 		"margince_outbox_unpublished",
 	} {
 		if strings.Contains(body, family) {

--- a/backend/gates/metricsuffix_test.go
+++ b/backend/gates/metricsuffix_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A `_total` suffix means COUNTER, in both directions.
+//
+// Prometheus reserves the suffix for monotonically increasing counters, and a
+// dashboard author reads the name long before the `# TYPE` line. Four sweep
+// gauges carried it — levels read out of river_job at scrape time, numbers that
+// go DOWN — which invited rate() and increase() over them. Neither is
+// meaningless-looking on a graph: both render as plausible noise, so the
+// mistake is silent at exactly the moment somebody is deciding whether tenants
+// are being missed.
+//
+// The reverse matters as much. A counter WITHOUT the suffix is a series nobody
+// thinks to rate, read as a level and alerted on as one, which is the same
+// error with the roles swapped.
+//
+// The census is over what this tree EMITS, not over a list of family names: it
+// reads the `# TYPE` lines out of the exposition writers themselves, so a
+// family added tomorrow is judged the day it is written and one that is deleted
+// takes its row with it.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// typeLine matches an emitted `# TYPE <family> <type>` however the writer
+// spells it — a Fprintf format string or a WriteString literal — because the
+// exposition is assembled both ways in this tree.
+var typeLine = regexp.MustCompile(`# TYPE (margince_[a-z0-9_]+) (counter|gauge|histogram|summary|untyped)`)
+
+// familyHeader matches the compose helper that renders a header from a NAME
+// PARAMETER. Its type is not in the format string it fills, so the regex above
+// cannot see it: writeFamilyHeader emits `gauge` for every caller, which is
+// what makes the call site's literal name judgeable here.
+var familyHeader = regexp.MustCompile(`writeFamilyHeader\((?:[a-zA-Z0-9_.]+), "(margince_[a-z0-9_]+)"`)
+
+// minFamilies is a floor, not a count. A census that finds nothing passes while
+// checking nothing, and these regexes are exactly the kind that stop matching
+// when a writer is refactored into a helper. Set well below what the tree
+// carries so ordinary deletions do not trip it.
+const minFamilies = 20
+
+func TestOnlyACounterCarriesTheTotalSuffix(t *testing.T) {
+	t.Parallel()
+	families := map[string]string{}
+	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range typeLine.FindAllStringSubmatch(string(body), -1) {
+			families[m[1]] = m[2]
+		}
+		for _, m := range familyHeader.FindAllStringSubmatch(string(body), -1) {
+			families[m[1]] = "gauge"
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+	if len(families) < minFamilies {
+		t.Fatalf("only %d metric families found and the tree carries far more — the patterns have gone "+
+			"blind, and a census that matches nothing reports PASS", len(families))
+	}
+
+	for name, kind := range families {
+		total := strings.HasSuffix(name, "_total")
+		switch {
+		case total && kind != "counter":
+			t.Errorf("%s is a %s and carries the _total suffix Prometheus reserves for counters.\n"+
+				"Drop the suffix. The # TYPE line is right, and it is not what a dashboard author reads: "+
+				"the name is, and this one invites rate() and increase() over a number that goes down — "+
+				"which render as plausible noise rather than as an error.", name, kind)
+		case !total && kind == "counter":
+			t.Errorf("%s is a counter and does not end in _total.\n"+
+				"Add the suffix. Without it the series reads as a level, and gets alerted on as one.", name)
+		}
+	}
+}

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -276,12 +276,12 @@ func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 		return cmp.Compare(a.Kind, b.Kind)
 	})
 
-	if err := writeFamilyHeader(w, "margince_sweep_workspaces_total",
+	if err := writeFamilyHeader(w, "margince_sweep_workspaces",
 		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero."); err != nil {
 		return err
 	}
 	for _, s := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_total{sweep=%s} %d\n",
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces{sweep=%s} %d\n",
 			label(s.Kind), s.Workspaces); err != nil {
 			return err
 		}
@@ -316,12 +316,12 @@ func writeSweepUnitGauges(w io.Writer, units []jobs.SweepUnit) error {
 		return cmp.Compare(a.Kind, b.Kind)
 	})
 
-	if err := writeFamilyHeader(w, "margince_sweep_units_total",
-		"Fan-out units with a surviving child of this fleet pass, for the dispatchers that fan out per connection or per build rather than per workspace. The unit label names the grain. Kinds that fan out per workspace are absent here and reported by margince_sweep_workspaces_total, which is the same measurement for them."); err != nil {
+	if err := writeFamilyHeader(w, "margince_sweep_units",
+		"Fan-out units with a surviving child of this fleet pass, for the dispatchers that fan out per connection or per build rather than per workspace. The unit label names the grain. Kinds that fan out per workspace are absent here and reported by margince_sweep_workspaces, which is the same measurement for them."); err != nil {
 		return err
 	}
 	for _, u := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_units_total{sweep=%s,unit=%s} %d\n",
+		if _, err := fmt.Fprintf(w, "margince_sweep_units{sweep=%s,unit=%s} %d\n",
 			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Units); err != nil {
 			return err
 		}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -128,7 +128,7 @@ func TestTheSweepPairIsRenderedPerFanOutKind(t *testing.T) {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
 	for _, line := range []string{
-		`margince_sweep_workspaces_total{sweep="privacy_retention_workspace"} 42`,
+		`margince_sweep_workspaces{sweep="privacy_retention_workspace"} 42`,
 		`margince_sweep_workspaces_failed{sweep="privacy_retention_workspace"} 3`,
 	} {
 		if !strings.Contains(buf.String(), line) {
@@ -150,7 +150,7 @@ func TestTheSweepUnitPairIsRenderedAtTheDeclaredGrain(t *testing.T) {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
 	for _, line := range []string{
-		`margince_sweep_units_total{sweep="capture_sync",unit="connection"} 9`,
+		`margince_sweep_units{sweep="capture_sync",unit="connection"} 9`,
 		`margince_sweep_units_failed{sweep="capture_sync",unit="connection"} 2`,
 	} {
 		if !strings.Contains(buf.String(), line) {
@@ -210,9 +210,9 @@ func TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries(t *testing.T) {
 		"margince_job_discarded",
 		"margince_job_cancelled",
 		"margince_job_oldest_queued_age_seconds",
-		"margince_sweep_workspaces_total",
+		"margince_sweep_workspaces",
 		"margince_sweep_workspaces_failed",
-		"margince_sweep_units_total",
+		"margince_sweep_units",
 		"margince_sweep_units_failed",
 	} {
 		if !strings.Contains(buf.String(), "# TYPE "+family+" gauge") {

--- a/backend/internal/platform/jobs/fanoutunit_test.go
+++ b/backend/internal/platform/jobs/fanoutunit_test.go
@@ -103,7 +103,7 @@ func TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains(t *testing.T) {
 		if unit == FanOutWorkspace {
 			workspaceGrain++
 			if slices.Contains(kinds, kind) {
-				t.Errorf("%s fans out per workspace but is read by the unit pair, where it would restate margince_sweep_workspaces_total exactly", kind)
+				t.Errorf("%s fans out per workspace but is read by the unit pair, where it would restate margince_sweep_workspaces exactly", kind)
 			}
 			continue
 		}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -110,9 +110,9 @@ not the fleet.
 | `margince_job_discarded` | `kind`, `workspace_id` | every attempt spent; will never run without intervention |
 | `margince_job_cancelled` | `kind`, `workspace_id` | stopped deliberately, attempts unspent — counted apart from discarded because the operator story differs, not because it is less dead. The sweep pair counts either as a workspace missed |
 | `margince_job_oldest_queued_age_seconds` | `queue`, `workspace_id` | how long the oldest runnable-and-unclaimed job has waited |
-| `margince_sweep_workspaces_total` | `sweep` | workspaces with a surviving child of that fleet pass |
+| `margince_sweep_workspaces` | `sweep` | workspaces with a surviving child of that fleet pass |
 | `margince_sweep_workspaces_failed` | `sweep` | those whose MOST RECENT child is discarded or cancelled |
-| `margince_sweep_units_total` | `sweep`, `unit` | the same reading one grain down, for the dispatchers that fan out per **connection** or per **build**: units with a surviving child |
+| `margince_sweep_units` | `sweep`, `unit` | the same reading one grain down, for the dispatchers that fan out per **connection** or per **build**: units with a surviving child |
 | `margince_sweep_units_failed` | `sweep`, `unit` | those whose MOST RECENT child is discarded or cancelled |
 
 The last two exist because the workspace pair counts each workspace once, and

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -54,7 +54,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (58)
+## Census (59)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -88,6 +88,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
+| `metricsuffix_test.go` | H2 | A `\_total` suffix means COUNTER, in both directions. |
 | `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |
 | `onecallerpredicatebudget_test.go` | H2 | The ceiling on a statement whose predicate the CALLER wrote is one number, declared in platform/database as CallerPredicateBudget. |
 | `oneconsentcarry_test.go` | H2 | The consent carry — what happens to a retiring record's consent when another record survives it — is spelled once inside the people module. |


### PR DESCRIPTION
Closes #460.

## The rename

| before | after |
| --- | --- |
| `margince_sweep_workspaces_total` | `margince_sweep_workspaces` |
| `margince_sweep_units_total` | `margince_sweep_units` |

The two `_failed` halves already read correctly and are unchanged.

All four are **levels** — how many workspaces or units a fleet pass currently covers, read out of `river_job` at scrape time, numbers that go *down*. Prometheus reserves `_total` for monotonic counters.

The `# TYPE` line always said `gauge`. It is not what a dashboard author reads. The **name** is, and this one invited `rate()` and `increase()` over a level — neither of which looks wrong on a graph. They render as plausible noise, at exactly the moment somebody is deciding whether tenants are being missed.

Both pairs move together, which is why this is its own change rather than a side effect of #457. Renaming one half would have left an operator reading `margince_sweep_workspaces_total` beside `margince_sweep_units`.

## Breaking

Any dashboard or alert on the old names has to be updated. Noted in the changelog. **Nothing is aliased** — one number published under two names is a worse surface than a rename with a note.

## The gate

`TestOnlyACounterCarriesTheTotalSuffix` reads the `# TYPE` lines out of the exposition writers themselves rather than judging a list of family names, so a family added tomorrow is judged the day it is written and a deleted one takes its row with it. It covers both spellings this tree assembles headers in — the `Fprintf`/`WriteString` literals and compose's `writeFamilyHeader`, whose type is not in the format string.

The reverse arm is not decoration: a counter *without* the suffix is read as a level and alerted on as one — the same error with the roles swapped.

Both arms mutation-checked: putting `_total` back on `margince_sweep_workspaces` and taking it off `margince_relay_published_total` each fail the gate by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed sweep workspace and unit gauge metrics by removing the `_total` suffix.
  * No compatibility aliases are provided; update dashboards, alerts, and integrations accordingly.

* **Documentation**
  * Updated configuration and metric references to reflect the new names.
  * Documented validation requiring `_total` for counters and excluding it from gauges.

* **Tests**
  * Added repository-wide validation to enforce Prometheus metric naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->