### PR TITLE
fix(test): the auto-enrich fixture selects something an automatic run may buy

### DIFF
--- a/backend/internal/compose/integration/persondataenrich_integration_test.go
+++ b/backend/internal/compose/integration/persondataenrich_integration_test.go
@@ -48,13 +48,21 @@ func setupProviderConsumer(t *testing.T, mode string) *providerConsumerEnv {
 	c := &providerConsumerEnv{env: e, enqueued: new(int), personID: seedSubject(t, e)}
 
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		// BOTH halves of the split: a priced category and a free one. An
+		// automatic run takes only what the provider gives away, so a
+		// selection of professional_email alone leaves it nothing to ask for
+		// and the consumer swallows the trigger as the configuration state it
+		// is — which every "no run exists" case here would then pass for a
+		// reason that has nothing to do with what it asserts.
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO provider_connection
 			       (id, provider, status, mode, preset, categories, automatic_individual_create)
 			VALUES (gen_random_uuid(), 'surfe', 'connected', $1, 'full',
-			        ARRAY['professional_email'], true)
+			        ARRAY['professional_email', 'linkedin_profile'], true)
 			ON CONFLICT (provider) DO UPDATE
-			   SET status = 'connected', mode = $1, automatic_individual_create = true`, mode)
+			   SET status = 'connected', mode = $1,
+			       categories = ARRAY['professional_email', 'linkedin_profile'],
+			       automatic_individual_create = true`, mode)
 		return err
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
`main` is red on the integration lane. #2923 split automatic runs from priced ones — an automatic run takes only what the provider gives away — and this fixture's connection carries `professional_email` and nothing else, which is now a **priced** category.

So an automatic trigger finds nothing free to ask for, `runCategories` returns `ErrNothingFreeToBuy`, and the consumer swallows it as the configuration state it is. No run is queued.

## Two failures, and two worse passes

Failing: `TestPersonCreatedQueuesAnEnrichmentRun`, `TestACapturedContactIsBoughtOnceTheImportToggleIsOn`.

The worse half is the two that did **not** fail. `TestPersonCreatedWithAutoEnrichOffBuysNothingAndDoesNotError` and `TestAnAgentCreatedPersonBuysNothing` assert that *no* run exists — and a fixture that buys nothing free makes both unfalsifiable. They went green for a reason with nothing to do with the gate each names.

## The fix

The selection now carries both halves of the split — a priced category and a free one — so an automatic run has something to take and each refusal is again the only thing standing between the event and a run. The `ON CONFLICT` branch sets it too, so the update path and the insert path seed the same connection.

Nothing new holds this: the two positive cases already do, and they are exactly what caught it. A fixture that loses its free category takes them red again.

Verified locally on a real clone — all four cases in the family pass:

```
--- PASS: TestPersonCreatedQueuesAnEnrichmentRun (0.10s)
--- PASS: TestPersonCreatedWithAutoEnrichOffBuysNothingAndDoesNotError (0.04s)
--- PASS: TestAnAgentCreatedPersonBuysNothing (0.04s)
--- PASS: TestACapturedContactIsBoughtOnceTheImportToggleIsOn (0.05s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic enrichment test setup to include available professional email and LinkedIn profile data categories.
  * Preserved existing connection and automatic individual creation settings during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->