### PR TITLE
fix(integrations): the enrichment fixture selects something an automatic run may buy

### DIFF
--- a/backend/internal/compose/integration/persondataenrich_integration_test.go
+++ b/backend/internal/compose/integration/persondataenrich_integration_test.go
@@ -44,17 +44,37 @@ type providerConsumerEnv struct {
 // mode, and wires the consumer over the REAL cross-module binding.
 func setupProviderConsumer(t *testing.T, mode string) *providerConsumerEnv {
 	t.Helper()
+	// Before the database: this is a contradiction between the fixture and the
+	// provider's own cost table, and neither a schema nor a seeded row can
+	// change the answer.
+	seeded := []string{"professional_email", "linkedin_profile"}
+	requireAnAutomaticRunCanBuy(t, seeded)
+
 	e := Setup(t)
 	c := &providerConsumerEnv{env: e, enqueued: new(int), personID: seedSubject(t, e)}
 
+	// One PRICED category and one FREE one, and both halves are load-bearing.
+	// An automatic run may take only what the provider gives away, so a
+	// connection selecting nothing free never queues anything — and the two
+	// cases here that assert a run EXISTS are the only ones that reach that
+	// code, every other case in this file being refused earlier by the actor
+	// or the toggle. Those two are this file's positive control: without them
+	// the toggle could be wired to a constant false and every assertion here
+	// would still be green. The priced category stays because narrowing to the
+	// free set is the behaviour under test, and a connection carrying only free
+	// categories cannot tell narrowing from taking everything.
+	//
+	// Named once above and passed to both the INSERT and the guard, so the
+	// check reads the selection this connection actually carries rather than a
+	// second copy of it that can drift from it silently.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO provider_connection
 			       (id, provider, status, mode, preset, categories, automatic_individual_create)
-			VALUES (gen_random_uuid(), 'surfe', 'connected', $1, 'full',
-			        ARRAY['professional_email'], true)
+			VALUES (gen_random_uuid(), 'surfe', 'connected', $1, 'full', $2, true)
 			ON CONFLICT (provider) DO UPDATE
-			   SET status = 'connected', mode = $1, automatic_individual_create = true`, mode)
+			   SET status = 'connected', mode = $1, categories = $2,
+			       automatic_individual_create = true`, mode, seeded)
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -77,6 +97,33 @@ func setupProviderConsumer(t *testing.T, mode string) *providerConsumerEnv {
 		})
 	c.consumer = compose.NewPersonDataEnrich(e.Pool, bound, slog.New(slog.NewTextHandler(os.Stderr, nil)))
 	return c
+}
+
+// requireAnAutomaticRunCanBuy fails the fixture, not the case, when the seeded
+// connection has nothing an automatic run may take.
+//
+// What it protects is this file's positive control. The refusal is silent — a
+// skipped run, no error — so a fixture that drifts out of the provider's free
+// set presents as "the toggle bought nothing", which is indistinguishable from
+// the toggle being wired to a constant false. Free() is DERIVED from the cost
+// table, so a provider that starts charging for this category fails HERE,
+// naming the fixture, rather than in two cases that read as though a policy
+// broke.
+func requireAnAutomaticRunCanBuy(t *testing.T, selected []string) {
+	t.Helper()
+	free := map[provider.Category]bool{}
+	for _, c := range integrations.NewOfflineProvider(0, time.Now).Descriptor().Free() {
+		free[c] = true
+	}
+	for _, c := range selected {
+		if free[provider.Category(c)] {
+			return
+		}
+	}
+	t.Fatalf("the fixture connection selects %v, and this provider charges for all of "+
+		"them — an automatic run takes only free categories, so it would queue nothing "+
+		"and the two cases asserting a run exists would fail as though a toggle broke",
+		selected)
 }
 
 // humanCreated is what the relay delivers for a person a HUMAN typed — the


### PR DESCRIPTION
## main is red on the integration lane, and every branch inherits it

`main-health` run `33065390617`, tip `6709b22b1`:

```
FAILED: integration / integration shard (1/6)
FAILED: integration / integration (RLS + erasure + HTTP e2e)
```

```
persondataenrich_integration_test.go:198: 0 runs exist for a captured counterparty
  with automatic_import on, want 1 — the customer switched capture enrichment on
  and got nothing
persondataenrich_integration_test.go:201: 0 submit jobs were committed, want 1
```

It presents as each author's own red, because CI builds the merge rather than
the head — three unrelated branches hit it inside one hour, each looking local.
The census that settles it is across branches at a point in time, and `main`'s
own run above confirms it.

## Cause

#2923 introduced `runCategories`: an automatic run may take only the categories
the provider gives away, because nobody weighed the purchase. The fixture
connection selects `professional_email` alone, and that costs one email credit.
Measured rather than reasoned — `Free()` is derived from the cost table:

```
Free()                        = [linkedin_profile current_employment job_history]
fixture connection categories = [professional_email]
intersection                  = ∅  →  ErrNothingFreeToBuy  →  skipped run
```

**The rule is right and stays.** The fixture is what has to move.

## The fix

The connection now selects one **priced** category and one **free** one. Both
halves carry weight: the free one is what lets an automatic run exist at all,
and the priced one keeps the narrowing observable — a connection carrying only
free categories cannot tell a run that narrowed to the free set from one that
took everything.

## Why this is a positive control rather than a broken assertion

Those two cases are the only ones in the file that reach `runCategories`. Every
other case is refused earlier — the agent by `triggerFor` in the consumer, the
toggle by connection admission before `queueOne`. I checked that before writing
it: my first draft of this claim said the negatives had been made vacuous, and
that was wrong.

What is true is narrower and worse. The refusal is silent — a skipped run, no
error — so a fixture that drifts out of the free set presents as *"the toggle
bought nothing"*, which is indistinguishable from the toggle being wired to a
constant false. The file's own comment on the second case already names that
risk:

> Without this case the refusal below passes against a gate that admits nobody —
> the toggle could be wired to a constant false and every assertion in this file
> would still be green.

So the guard reads the seeded selection rather than restating it, and runs
**before** `Setup(t)`: this is a contradiction between the fixture and the
provider's cost table, and no schema or seeded row changes the answer.

## Verification

Mutation-verified. Reverting the selection to `professional_email` alone — which
is exactly `main` today — fails on the fixture in 0.00s with no database:

```
--- FAIL: TestPersonCreatedQueuesAnEnrichmentRun (0.00s)
    the fixture connection selects [professional_email], and this provider charges
    for all of them — an automatic run takes only free categories, so it would queue
    nothing and the two cases asserting a run exists would fail as though a toggle broke
```

`make check-backend` green.

**What I could not run:** the integration lane itself. An unrelated Docker
project has held `:15432`/`:16379` on this machine for 27 hours, so `make db-up`
cannot bind and no local run of these two cases is possible. The lane on this PR
is the verification, and it is the same lane that is red on `main`.

## Note on how this landed

#2923 was merged at `10:27:21Z` past a red `ci` **and** past these two exact
integration jobs — they were failing on the PR before the merge. That is the
sixth such merge today; #2785 has the pattern. It also retires a bound I gave
earlier on that issue: I had said the bypasses cost DCO debt and nothing else a
health run can see. This one cost the integration lane.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the integration lane on main by making the enrichment fixture select a category an automatic run can buy. The fixture previously selected only `professional_email` (priced), so automatic runs found nothing free, skipped, and failed two tests. Now it selects one free category (`linkedin_profile`) and one priced one, so runs proceed while still exercising the expected narrowing. A new guard fails the fixture early if the provider starts charging for all selected categories, so a future cost change surfaces as a fixture error rather than a phantom toggle break.

<sup>Written for commit 50e89afab8894daeebc24849a6d3aa294257c986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration-test reliability by selecting multiple enrichment categories.
  * Added validation to skip or fail fast when selected categories require payment, preventing misleading test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->