### PR TITLE
fix(httpserver): one posture for a refused write, in the writer rather than in each section

### DIFF
--- a/backend/internal/platform/httpserver/exposition.go
+++ b/backend/internal/platform/httpserver/exposition.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httpserver
+
+import (
+	"fmt"
+	"io"
+)
+
+// exposition is the one thing every /readyz and /metrics section writes
+// through, and the reason none of them handles a write error.
+//
+// Two postures used to sit in this file with nothing saying which was which.
+// The job section returned its write error and the handler stopped, because a
+// truncated job section PARSES as a smaller fleet and an alert acts on it.
+// Every other section discarded its errors, on the equally sound reasoning that
+// a refused write means the scraper hung up and there is nothing left to report
+// to. The distinction was invisible, so a section added later inherited
+// whichever its author copied — the runtime section inherited the silent one,
+// and nothing said it should not have.
+//
+// There is one posture now, and it belongs to the writer rather than to each
+// section: the FIRST refused write is remembered and every write after it is a
+// no-op. A section cannot half-write, nothing downstream is pushed into a
+// socket that is gone, and the handler asks once, at the end, whether the
+// exposition it just assembled actually left.
+//
+// It is an io.Writer, which is what makes it reach the sections this package
+// does not own — the injected `extra` families and the job section — without
+// changing what they are handed. Their own discarded errors become sound here:
+// the first failure is recorded whether or not the caller looked.
+type exposition struct {
+	w   io.Writer
+	err error
+}
+
+// Write records the first failure and refuses everything after it.
+//
+// The short-circuit returns the REMEMBERED error, not nil: a writer that
+// claimed success after failing would let a section that does check its errors
+// carry on assembling into nothing.
+func (e *exposition) Write(p []byte) (int, error) {
+	if e.err != nil {
+		return 0, e.err
+	}
+	n, err := e.w.Write(p)
+	e.err = err
+	return n, err
+}
+
+// gone reports that a write was already refused, so this scrape is not going to
+// be delivered. The pure-rendering sections need no such check — printf is
+// already a no-op by then — but a section that MEASURES does: a database read
+// for a socket that is not there is work nobody will see the result of.
+func (e *exposition) gone() bool { return e.err != nil }
+
+// printf is how the sections in THIS file write. The error is not dropped — it
+// is held on the exposition, which is the only place any section's write error
+// was ever going to be actionable.
+func (e *exposition) printf(format string, a ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, a...)
+}

--- a/backend/internal/platform/httpserver/exposition_test.go
+++ b/backend/internal/platform/httpserver/exposition_test.go
@@ -86,6 +86,34 @@ func TestTheExpositionKeepsRefusingAfterTheFirstFailure(t *testing.T) {
 	}
 }
 
+// Every supplier, not only the expensive ones. printf goes quiet after a
+// refusal, but Go evaluates its arguments first, so a counter read still
+// happens unless the section that would print it is guarded. Cheap here — the
+// suppliers are atomic loads — and the point is the rule rather than the cost:
+// "nothing is measured for a scrape that has gone" is either true of all of
+// them or it is a claim a reader has to check one section at a time.
+func TestNoCounterIsReadForAScrapeThatHasAlreadyGone(t *testing.T) {
+	read := map[string]bool{}
+	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+
+	Metrics(nil, nil,
+		func() uint64 { read["published"] = true; return 0 },
+		nil, nil,
+		&OverlayMetrics{
+			SourceLag:     func(context.Context) (map[string]time.Duration, error) { return map[string]time.Duration{}, nil },
+			SyncedTotal:   func() uint64 { read["synced"] = true; return 0 },
+			ConflictTotal: func() uint64 { read["conflict"] = true; return 0 },
+			DeletedTotal:  func() uint64 { read["deleted"] = true; return 0 },
+		},
+	)(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	for _, supplier := range []string{"published", "synced", "conflict", "deleted"} {
+		if read[supplier] {
+			t.Errorf("the %s counter was read after the scrape's writer was already gone", supplier)
+		}
+	}
+}
+
 // A probe body is not an exposition, and it takes the same posture for a
 // smaller reason: there is nothing to log, but a half-written answer is still
 // not worth assembling.

--- a/backend/internal/platform/httpserver/exposition_test.go
+++ b/backend/internal/platform/httpserver/exposition_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httpserver
+
+// One posture for a refused write, held from both ends.
+//
+// The job section already stopped the handler; every other section discarded
+// its write errors, so a scrape whose reader hung up during the FIRST section
+// went on to query the outbox, the job table and the mirror for a socket that
+// was not there — and answered 200 with a body nobody received. The distinction
+// was invisible in the source, which is how the runtime section inherited the
+// silent half without anybody choosing it.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// hangUp is a ResponseWriter whose body refuses after the first write, which is
+// what a scraper that closed its connection looks like from in here.
+type hangUp struct {
+	http.ResponseWriter
+	writes int
+}
+
+var errClientGone = errors.New("connection reset by peer")
+
+func (h *hangUp) Write(p []byte) (int, error) {
+	h.writes++
+	if h.writes > 1 {
+		return 0, errClientGone
+	}
+	return len(p), nil
+}
+
+func TestNothingIsMeasuredForAScrapeThatHasAlreadyGone(t *testing.T) {
+	measured := map[string]bool{}
+	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+
+	Metrics(nil,
+		func(context.Context) (int64, error) { measured["backlog"] = true; return 0, nil },
+		func() uint64 { return 0 },
+		func(io.Writer) { measured["extra"] = true },
+		func(context.Context, io.Writer) error { measured["jobs"] = true; return nil },
+		&OverlayMetrics{
+			SourceLag: func(context.Context) (map[string]time.Duration, error) {
+				measured["overlay"] = true
+				return map[string]time.Duration{}, nil
+			},
+			SyncedTotal:   func() uint64 { return 0 },
+			ConflictTotal: func() uint64 { return 0 },
+			DeletedTotal:  func() uint64 { return 0 },
+		},
+	)(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	// The runtime section is first and does the refusing, so everything after
+	// it is work for a body that cannot be delivered.
+	for _, section := range []string{"backlog", "extra", "jobs", "overlay"} {
+		if measured[section] {
+			t.Errorf("the %s section was measured after the scrape's writer was already gone — "+
+				"a database read nobody will see the result of, on a socket that is not there", section)
+		}
+	}
+}
+
+// The remembered error, not nil. A section that DOES check its writes would
+// otherwise be told each one succeeded and carry on assembling into nothing.
+func TestTheExpositionKeepsRefusingAfterTheFirstFailure(t *testing.T) {
+	out := &exposition{w: &hangUp{ResponseWriter: httptest.NewRecorder()}}
+
+	out.printf("first\n")
+	out.printf("second\n")
+
+	if !out.gone() {
+		t.Fatal("the exposition reported nothing wrong after its writer refused")
+	}
+	if _, err := out.Write([]byte("third")); !errors.Is(err, errClientGone) {
+		t.Errorf("a write after the refusal answered %v, want the remembered %v — "+
+			"claiming success after failing lets a caller that checks keep writing into nothing", err, errClientGone)
+	}
+}
+
+// A probe body is not an exposition, and it takes the same posture for a
+// smaller reason: there is nothing to log, but a half-written answer is still
+// not worth assembling.
+func TestReadyzStopsWritingWhenItsReaderHangsUp(t *testing.T) {
+	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+
+	Readyz("declared", func(context.Context) string { return "ready" })(
+		w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	// "ready" lands, the ai line is refused, and the embed line must not add a
+	// second attempt on a writer that already said no.
+	if w.writes != 2 {
+		t.Errorf("the probe body attempted %d writes, want 2 — the first is the answer, the second "+
+			"is what discovers the reader is gone, and nothing after it should be tried", w.writes)
+	}
+}

--- a/backend/internal/platform/httpserver/exposition_test.go
+++ b/backend/internal/platform/httpserver/exposition_test.go
@@ -119,9 +119,15 @@ func TestNoCounterIsReadForAScrapeThatHasAlreadyGone(t *testing.T) {
 // not worth assembling.
 func TestReadyzStopsWritingWhenItsReaderHangsUp(t *testing.T) {
 	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+	resolved := false
 
-	Readyz("declared", func(context.Context) string { return "ready" })(
+	Readyz("declared", func(context.Context) string { resolved = true; return "ready" })(
 		w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if resolved {
+		t.Error("the embed marker was resolved after the probe's reader was gone — a read for a " +
+			"body that cannot be delivered")
+	}
 
 	// "ready" lands, the ai line is refused, and the embed line must not add a
 	// second attempt on a writer that already said no.

--- a/backend/internal/platform/httpserver/exposition_test.go
+++ b/backend/internal/platform/httpserver/exposition_test.go
@@ -27,13 +27,17 @@ import (
 type hangUp struct {
 	http.ResponseWriter
 	writes int
+	// accepts is how many writes land before the reader is gone. One by
+	// default; the runtime section's own probe needs two, because its first
+	// two writes are the header it sends before measuring anything.
+	accepts int
 }
 
 var errClientGone = errors.New("connection reset by peer")
 
 func (h *hangUp) Write(p []byte) (int, error) {
 	h.writes++
-	if h.writes > 1 {
+	if h.writes > h.accepts {
 		return 0, errClientGone
 	}
 	return len(p), nil
@@ -41,7 +45,12 @@ func (h *hangUp) Write(p []byte) (int, error) {
 
 func TestNothingIsMeasuredForAScrapeThatHasAlreadyGone(t *testing.T) {
 	measured := map[string]bool{}
-	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+	// One write lands, so the runtime section's own header probe is what
+	// discovers the writer is gone — before it stops the world to read memory
+	// statistics nobody will receive. That saving is not observable from out
+	// here, so it is not asserted; what is asserted is that no section after
+	// it measures anything.
+	w := &hangUp{ResponseWriter: httptest.NewRecorder(), accepts: 1}
 
 	Metrics(nil,
 		func(context.Context) (int64, error) { measured["backlog"] = true; return 0, nil },
@@ -72,7 +81,7 @@ func TestNothingIsMeasuredForAScrapeThatHasAlreadyGone(t *testing.T) {
 // The remembered error, not nil. A section that DOES check its writes would
 // otherwise be told each one succeeded and carry on assembling into nothing.
 func TestTheExpositionKeepsRefusingAfterTheFirstFailure(t *testing.T) {
-	out := &exposition{w: &hangUp{ResponseWriter: httptest.NewRecorder()}}
+	out := &exposition{w: &hangUp{ResponseWriter: httptest.NewRecorder(), accepts: 1}}
 
 	out.printf("first\n")
 	out.printf("second\n")
@@ -94,7 +103,7 @@ func TestTheExpositionKeepsRefusingAfterTheFirstFailure(t *testing.T) {
 // them or it is a claim a reader has to check one section at a time.
 func TestNoCounterIsReadForAScrapeThatHasAlreadyGone(t *testing.T) {
 	read := map[string]bool{}
-	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+	w := &hangUp{ResponseWriter: httptest.NewRecorder(), accepts: 1}
 
 	Metrics(nil, nil,
 		func() uint64 { read["published"] = true; return 0 },
@@ -118,7 +127,7 @@ func TestNoCounterIsReadForAScrapeThatHasAlreadyGone(t *testing.T) {
 // smaller reason: there is nothing to log, but a half-written answer is still
 // not worth assembling.
 func TestReadyzStopsWritingWhenItsReaderHangsUp(t *testing.T) {
-	w := &hangUp{ResponseWriter: httptest.NewRecorder()}
+	w := &hangUp{ResponseWriter: httptest.NewRecorder(), accepts: 1}
 	resolved := false
 
 	Readyz("declared", func(context.Context) string { resolved = true; return "ready" })(

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -404,11 +404,22 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 // its own go_* collector, and two definitions of one series name is a worse
 // outcome than a prefix that says who wrote it.
 func writeRuntimeMetrics(out *exposition) {
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-
+	// The first family's header goes out BEFORE anything is measured, and it
+	// is the only probe available to this section: it is the exposition's
+	// first section, so nothing earlier can have discovered a dead writer.
+	//
+	// It buys the section's one expensive reading. ReadMemStats stops the
+	// world briefly, and a scrape whose reader hung up between the request and
+	// this line should not be charged for it — nor should the process, which
+	// pays that pause for every replica while nobody is reading.
 	out.printf("# HELP margince_process_goroutines Goroutines running in the scraped process.\n")
 	out.printf("# TYPE margince_process_goroutines gauge\n")
+	if out.gone() {
+		return
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
 	out.printf("margince_process_goroutines %d\n", runtime.NumGoroutine())
 
 	out.printf("# HELP margince_process_heap_bytes Heap bytes allocated and in use by the scraped process.\n")

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -219,24 +219,30 @@ func Readyz(aiState string, embedState func(context.Context) string, checks ...R
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
+		// The probe body goes through the same writer the exposition does, for
+		// the same reason: the first refused write stops the rest. There is
+		// nothing to LOG here — a probe whose reader hung up has no channel
+		// left to report on, and the orchestrator's own timeout is what says
+		// so — but a half-written answer is still worth not assembling.
+		body := &exposition{w: w}
 		for _, c := range checks {
 			if err := c.Check(ctx); err != nil {
 				// The dependency name is enough for the orchestrator; the
 				// error text is for the server log, not the probe body.
 				slog.ErrorContext(r.Context(), "readiness check failed", "dependency", c.Name, "err", err)
 				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = fmt.Fprintf(w, "unready: %s\n", c.Name)
+				body.printf("unready: %s\n", c.Name)
 				return
 			}
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintln(w, "ready")
+		body.printf("ready\n")
 		// Each visibility line is written only by a role that wires the thing
 		// it reports. The worker wires neither, and an empty "ai: " line is
 		// noise an operator has to learn to ignore — worse than silence,
 		// because it reads as a role whose AI state could not be determined.
 		if aiState != "" {
-			_, _ = fmt.Fprintf(w, "ai: %s\n", aiState)
+			body.printf("ai: %s\n", aiState)
 		}
 		// The embed line is written unconditionally, unlike the AI one: a nil
 		// embedState and a marker-read that already failed into "unknown" are
@@ -246,7 +252,7 @@ func Readyz(aiState string, embedState func(context.Context) string, checks ...R
 		if embedState != nil {
 			embed = embedState(ctx)
 		}
-		_, _ = fmt.Fprintf(w, "embed: %s\n", embed)
+		body.printf("embed: %s\n", embed)
 	}
 }
 
@@ -298,57 +304,69 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		out := &exposition{w: w}
 
 		// Always first, and never injected: this section measures the
 		// PROCESS answering the scrape, so it is the one part of the
 		// exposition that means something different on every target and
 		// cannot be assembled anywhere but here.
-		writeRuntimeMetrics(w)
+		writeRuntimeMetrics(out)
 
 		// The backlog is a fleet-wide reading of a shared table, so a role
 		// that would only duplicate another target's copy of it passes nil
 		// rather than querying — the same "declared or absent" posture the
 		// sections below take, and the reason a FAILED read writes nothing:
 		// a gauge reporting rows it did not count reads as a drained outbox.
-		if backlog != nil {
+		if backlog != nil && !out.gone() {
 			if n, err := backlog(ctx); err == nil {
-				_, _ = fmt.Fprintf(w, "# HELP margince_outbox_unpublished Committed outbox rows the relay has not shipped yet.\n")
-				_, _ = fmt.Fprintf(w, "# TYPE margince_outbox_unpublished gauge\n")
-				_, _ = fmt.Fprintf(w, "margince_outbox_unpublished %d\n", n)
+				out.printf("# HELP margince_outbox_unpublished Committed outbox rows the relay has not shipped yet.\n")
+				out.printf("# TYPE margince_outbox_unpublished gauge\n")
+				out.printf("margince_outbox_unpublished %d\n", n)
 			} else {
 				slog.ErrorContext(r.Context(), "metrics: outbox backlog query failed", "err", err)
 			}
 		}
 
-		_, _ = fmt.Fprintf(w, "# HELP margince_relay_published_total Outbox rows shipped to the bus since process start.\n")
-		_, _ = fmt.Fprintf(w, "# TYPE margince_relay_published_total counter\n")
-		_, _ = fmt.Fprintf(w, "margince_relay_published_total %d\n", published())
+		out.printf("# HELP margince_relay_published_total Outbox rows shipped to the bus since process start.\n")
+		out.printf("# TYPE margince_relay_published_total counter\n")
+		out.printf("margince_relay_published_total %d\n", published())
 
 		// Omitted rather than zeroed when no pool was injected — the same
 		// "declared or absent" posture every other section here takes, and
 		// the reason a failed backlog read above writes nothing: a gauge
 		// reporting connections it did not measure reads as an idle pool.
-		if pool != nil {
+		if pool != nil && !out.gone() {
 			stat := pool.Stat()
-			_, _ = fmt.Fprintf(w, "# HELP margince_pgxpool_conns Connection pool state by class.\n")
-			_, _ = fmt.Fprintf(w, "# TYPE margince_pgxpool_conns gauge\n")
-			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"acquired\"} %d\n", stat.AcquiredConns())
-			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"idle\"} %d\n", stat.IdleConns())
-			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"total\"} %d\n", stat.TotalConns())
-			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"max\"} %d\n", stat.MaxConns())
+			out.printf("# HELP margince_pgxpool_conns Connection pool state by class.\n")
+			out.printf("# TYPE margince_pgxpool_conns gauge\n")
+			out.printf("margince_pgxpool_conns{state=\"acquired\"} %d\n", stat.AcquiredConns())
+			out.printf("margince_pgxpool_conns{state=\"idle\"} %d\n", stat.IdleConns())
+			out.printf("margince_pgxpool_conns{state=\"total\"} %d\n", stat.TotalConns())
+			out.printf("margince_pgxpool_conns{state=\"max\"} %d\n", stat.MaxConns())
 		}
 
-		if extra != nil {
-			extra(w)
+		if extra != nil && !out.gone() {
+			extra(out)
 		}
-		if jobStats != nil {
-			if err := jobStats(ctx, w); err != nil {
-				slog.ErrorContext(r.Context(), "metrics: writing the job section failed", "err", err)
-				return
+		if jobStats != nil && !out.gone() {
+			// Its error is a refused write, by the same contract every section
+			// here follows — a section that could not MEASURE writes nothing
+			// and returns nil. Recorded on the exposition rather than acted on
+			// here, so one place decides what a refused write means.
+			if err := jobStats(ctx, out); err != nil && out.err == nil {
+				out.err = err
 			}
 		}
-		if overlay != nil {
-			writeOverlayMetrics(r.Context(), w, overlay)
+		if overlay != nil && !out.gone() {
+			writeOverlayMetrics(r.Context(), out, overlay)
+		}
+		// Asked ONCE, about the whole exposition. A refused write means the
+		// scraper is already gone, so this cannot be answered to the caller —
+		// it is logged because a target that keeps failing to deliver its
+		// scrape looks, from Prometheus' side, exactly like a target that is
+		// down, and this line is the difference.
+		if out.err != nil {
+			slog.ErrorContext(r.Context(), "metrics: the exposition was not written in full; the scrape it belongs to is incomplete", "err", out.err)
 		}
 	}
 }
@@ -370,52 +388,52 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 // this exposition is hand-rolled: if client_golang is ever adopted it brings
 // its own go_* collector, and two definitions of one series name is a worse
 // outcome than a prefix that says who wrote it.
-func writeRuntimeMetrics(w io.Writer) {
+func writeRuntimeMetrics(out *exposition) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_process_goroutines Goroutines running in the scraped process.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_process_goroutines gauge\n")
-	_, _ = fmt.Fprintf(w, "margince_process_goroutines %d\n", runtime.NumGoroutine())
+	out.printf("# HELP margince_process_goroutines Goroutines running in the scraped process.\n")
+	out.printf("# TYPE margince_process_goroutines gauge\n")
+	out.printf("margince_process_goroutines %d\n", runtime.NumGoroutine())
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_process_heap_bytes Heap bytes allocated and in use by the scraped process.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_process_heap_bytes gauge\n")
-	_, _ = fmt.Fprintf(w, "margince_process_heap_bytes %d\n", mem.HeapAlloc)
+	out.printf("# HELP margince_process_heap_bytes Heap bytes allocated and in use by the scraped process.\n")
+	out.printf("# TYPE margince_process_heap_bytes gauge\n")
+	out.printf("margince_process_heap_bytes %d\n", mem.HeapAlloc)
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_process_heap_sys_bytes Heap bytes obtained from the OS by the scraped process -- with heap_bytes, whether memory is in use or merely held.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_process_heap_sys_bytes gauge\n")
-	_, _ = fmt.Fprintf(w, "margince_process_heap_sys_bytes %d\n", mem.HeapSys)
+	out.printf("# HELP margince_process_heap_sys_bytes Heap bytes obtained from the OS by the scraped process -- with heap_bytes, whether memory is in use or merely held.\n")
+	out.printf("# TYPE margince_process_heap_sys_bytes gauge\n")
+	out.printf("margince_process_heap_sys_bytes %d\n", mem.HeapSys)
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_process_gc_cycles_total Completed GC cycles since the scraped process started.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_process_gc_cycles_total counter\n")
-	_, _ = fmt.Fprintf(w, "margince_process_gc_cycles_total %d\n", mem.NumGC)
+	out.printf("# HELP margince_process_gc_cycles_total Completed GC cycles since the scraped process started.\n")
+	out.printf("# TYPE margince_process_gc_cycles_total counter\n")
+	out.printf("margince_process_gc_cycles_total %d\n", mem.NumGC)
 }
 
 // writeOverlayMetrics renders the overlay sync-health section — split
 // out of Metrics so that function's own top-to-bottom read stays one
 // section per line, not buried behind a nested nil-check.
-func writeOverlayMetrics(ctx context.Context, w http.ResponseWriter, overlay *OverlayMetrics) {
+func writeOverlayMetrics(ctx context.Context, out *exposition, overlay *OverlayMetrics) {
 	if lag, err := overlay.SourceLag(ctx); err == nil {
-		_, _ = fmt.Fprintf(w, "# HELP margince_overlay_source_lag_seconds Seconds since the mirror's oldest last sync per object class (worst case across the fleet).\n")
-		_, _ = fmt.Fprintf(w, "# TYPE margince_overlay_source_lag_seconds gauge\n")
+		out.printf("# HELP margince_overlay_source_lag_seconds Seconds since the mirror's oldest last sync per object class (worst case across the fleet).\n")
+		out.printf("# TYPE margince_overlay_source_lag_seconds gauge\n")
 		for _, objectClass := range sortedKeys(lag) {
-			_, _ = fmt.Fprintf(w, "margince_overlay_source_lag_seconds{object_class=%q} %.0f\n", objectClass, lag[objectClass].Seconds())
+			out.printf("margince_overlay_source_lag_seconds{object_class=%q} %.0f\n", objectClass, lag[objectClass].Seconds())
 		}
 	} else {
 		slog.Error("metrics: overlay source-lag query failed", "err", err)
 	}
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_overlay_mirror_synced_total Mirror rows ingested (push+pull) since process start.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_overlay_mirror_synced_total counter\n")
-	_, _ = fmt.Fprintf(w, "margince_overlay_mirror_synced_total %d\n", overlay.SyncedTotal())
+	out.printf("# HELP margince_overlay_mirror_synced_total Mirror rows ingested (push+pull) since process start.\n")
+	out.printf("# TYPE margince_overlay_mirror_synced_total counter\n")
+	out.printf("margince_overlay_mirror_synced_total %d\n", overlay.SyncedTotal())
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_overlay_mirror_conflict_total mirror.conflict events emitted (incumbent-wins divergence) since process start.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_overlay_mirror_conflict_total counter\n")
-	_, _ = fmt.Fprintf(w, "margince_overlay_mirror_conflict_total %d\n", overlay.ConflictTotal())
+	out.printf("# HELP margince_overlay_mirror_conflict_total mirror.conflict events emitted (incumbent-wins divergence) since process start.\n")
+	out.printf("# TYPE margince_overlay_mirror_conflict_total counter\n")
+	out.printf("margince_overlay_mirror_conflict_total %d\n", overlay.ConflictTotal())
 
-	_, _ = fmt.Fprintf(w, "# HELP margince_overlay_mirror_deleted_total mirror.deleted events emitted (incumbent-deleted records purged from the mirror) since process start.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE margince_overlay_mirror_deleted_total counter\n")
-	_, _ = fmt.Fprintf(w, "margince_overlay_mirror_deleted_total %d\n", overlay.DeletedTotal())
+	out.printf("# HELP margince_overlay_mirror_deleted_total mirror.deleted events emitted (incumbent-deleted records purged from the mirror) since process start.\n")
+	out.printf("# TYPE margince_overlay_mirror_deleted_total counter\n")
+	out.printf("margince_overlay_mirror_deleted_total %d\n", overlay.DeletedTotal())
 }
 
 // sortedKeys answers lag's object-class keys in a stable order — a

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -327,9 +327,18 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 			}
 		}
 
-		out.printf("# HELP margince_relay_published_total Outbox rows shipped to the bus since process start.\n")
-		out.printf("# TYPE margince_relay_published_total counter\n")
-		out.printf("margince_relay_published_total %d\n", published())
+		// Guarded like the sections around it, and for the same rule rather
+		// than for its cost: printf goes quiet after a refusal, but Go
+		// evaluates the argument first, so the supplier still runs. This one is
+		// an atomic load and the reads below it are too — the point is that
+		// "nothing is measured for a scrape that has gone" is either true of
+		// every supplier here or it is a claim a reader has to check one
+		// section at a time, which is the shape this file was in.
+		if !out.gone() {
+			out.printf("# HELP margince_relay_published_total Outbox rows shipped to the bus since process start.\n")
+			out.printf("# TYPE margince_relay_published_total counter\n")
+			out.printf("margince_relay_published_total %d\n", published())
+		}
 
 		// Omitted rather than zeroed when no pool was injected — the same
 		// "declared or absent" posture every other section here takes, and
@@ -421,6 +430,12 @@ func writeOverlayMetrics(ctx context.Context, out *exposition, overlay *OverlayM
 		}
 	} else {
 		slog.Error("metrics: overlay source-lag query failed", "err", err)
+	}
+	// The lag section may be what discovers the writer is gone. printf goes
+	// quiet from here, but the three counter suppliers below would still be
+	// called to build arguments for writes that go nowhere.
+	if out.gone() {
+		return
 	}
 
 	out.printf("# HELP margince_overlay_mirror_synced_total Mirror rows ingested (push+pull) since process start.\n")

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -244,6 +244,12 @@ func Readyz(aiState string, embedState func(context.Context) string, checks ...R
 		if aiState != "" {
 			body.printf("ai: %s\n", aiState)
 		}
+		// Nothing is READ for a probe whose reader is gone, the same rule the
+		// exposition takes: embedState resolves a marker, and resolving one
+		// for a body that cannot be delivered is work with no reader.
+		if body.gone() {
+			return
+		}
 		// The embed line is written unconditionally, unlike the AI one: a nil
 		// embedState and a marker-read that already failed into "unknown" are
 		// deliberately indistinguishable here, so omitting it would turn one

--- a/backend/internal/platform/httpserver/observe_test.go
+++ b/backend/internal/platform/httpserver/observe_test.go
@@ -50,7 +50,7 @@ func TestBearerTokenReadsOneSchemeForEveryTransport(t *testing.T) {
 // operators, so each family's line is asserted explicitly.
 func TestWriteOverlayMetricsRendersEveryCounter(t *testing.T) {
 	rec := httptest.NewRecorder()
-	writeOverlayMetrics(context.Background(), rec, &OverlayMetrics{
+	writeOverlayMetrics(context.Background(), &exposition{w: rec}, &OverlayMetrics{
 		SourceLag: func(context.Context) (map[string]time.Duration, error) {
 			return map[string]time.Duration{"person": 90 * time.Second}, nil
 		},


### PR DESCRIPTION
Closes #461.

Two postures sat in `observe.go` with nothing saying which was which:

- the **job section** returned its write error and the handler stopped — a truncated job section *parses as a smaller fleet* and an alert acts on it
- **every other section** discarded its errors — a refused write means the scraper hung up and there is no channel left to report to

Both readings are defensible. What was not is that the distinction was **invisible**: a section added later inherited whichever its author copied. The runtime section from #457 inherited the silent one, and nothing said it should.

## The posture belongs to the writer now

`exposition` remembers the first refused write and makes every write after it a no-op. No section can half-write, nothing downstream is pushed into a socket that is gone, and the handler asks **once**, at the end, whether what it assembled actually left.

It is an `io.Writer`, which is what lets it reach the sections this package does not own — the injected `extra` families and the job section — without changing what they are handed. Their own discarded errors become sound here: the first failure is recorded whether or not the caller looked.

The short-circuit returns the **remembered** error, not nil: a writer that claimed success after failing would let a section that *does* check its writes carry on assembling into nothing.

## Measuring stops too

`gone()` is separate from `printf`'s silence, because they answer different questions. On a scrape whose reader hung up during the first section, the old handler went on to query the outbox, the job table and the mirror for a body nobody would receive. Rendering that into a no-op writer is free; the database reads are not.

## /readyz

Same writer, smaller reason. Nothing is logged there — a probe whose reader is gone has nowhere to report, and the orchestrator's own timeout says so — but a half-written answer is still not worth assembling.

## Not a new contract

`Metrics`' doc comment already said it: *"the error return is reserved for a refused WRITE… The handler logs it and stops rather than writing further sections into a socket that is not there."* One section kept it. Now the writer does, for all of them.

## Held

- nothing is measured for a scrape that is already gone (fails by name if the `gone()` guards are removed — verified)
- the exposition keeps refusing after the first failure, with the remembered error
- `/readyz` stops writing when its reader hangs up
- the existing `TestMetricsStopsWritingWhenTheJobSectionRefusesAWrite` still passes unchanged

`exposition` lives in its own file — `observe.go` passed the 500-line cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of disconnected clients during metrics and readiness responses.
  - Stopped writing and collecting additional metrics when a connection is unavailable.
  - Preserved the original connection error across subsequent write attempts.
  - Added logging for incomplete metrics scrapes caused by client disconnects.

- **Tests**
  - Added coverage for disconnected metrics and readiness requests, including verification that unnecessary metric collection stops promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->