### PR TITLE
fix(ai): a page cannot decide how long its own prompt is

### DIFF
--- a/backend/gates/promptexcerpt_test.go
+++ b/backend/gates/promptexcerpt_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A prompt built from a crawled page is bounded by this product, not by the
+// site.
+//
+// Two lanes render a company's own website into a model call. The profile lane
+// bounded its corpus — a per-page share inside a whole-call budget — and the
+// page-facts lane did not: it indexed the page's full stripped text, up to
+// webread's 1 MiB fetch cap. Nothing said the two were the same obligation, so
+// one was fixed and the other was not noticed for months.
+//
+// The cost is not hypothetical. Prompt length there is chosen by whoever
+// published the page: on a metered provider it is their decision about our
+// tokens, and on a local one it sizes the context window the adapter has to
+// allocate, which is how the gap was found. Clamping it inside the adapter is
+// the last line of defence; the prompt is where the limit belongs.
+//
+// So the argument to newSnippetIndex — the one place every such prompt's
+// evidence space is built — must be a CALL to a function that applied a
+// budget. A page's own text cannot reach it without one, and a third lane
+// cannot be added without deciding how much of a page it reads.
+//
+// Tests are exempt by rule rather than by waiver: a unit test of the index
+// itself constructs the passages it is about, and routing those through an
+// excerpt would make every fixture describe a budget it is not testing.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// promptLanesDir holds the lanes that build model calls.
+const promptLanesDir = "internal/compose"
+
+// indexBuilder is the one constructor of a call's numbered evidence space.
+const indexBuilder = "newSnippetIndex"
+
+// excerptFuncs are the functions ratified to decide how much of a page a
+// prompt reads. Each applies a rune budget and reports what it left behind, so
+// a truncated read is not mistaken downstream for a complete one.
+//
+// Adding a name here is the decision this gate exists to make deliberate: it
+// says a new lane has a budget, and the reviewer's job is to check that it
+// does.
+var excerptFuncs = []string{"pageFactsExcerpt", "profileExcerptPages"}
+
+func TestEverySnippetIndexIsBuiltFromAnExcerpt(t *testing.T) {
+	t.Parallel()
+	var raw []string
+	built := 0
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(promptLanesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		path = filepath.ToSlash(path)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		excerpted := excerptedNames(file)
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name, ok := call.Fun.(*ast.Ident)
+			if !ok || name.Name != indexBuilder || len(call.Args) != 1 {
+				return true
+			}
+			built++
+			if !fromExcerpt(call.Args[0], excerpted) {
+				raw = append(raw, fset.Position(call.Pos()).String())
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", promptLanesDir, err)
+	}
+
+	for _, at := range raw {
+		t.Errorf("%s builds a snippet index from something no excerpt function produced.\n"+
+			"The prompt would then be as long as whoever published the page chose to make it — a "+
+			"stranger's decision about a metered provider's tokens, and about the context window a "+
+			"local one must allocate. Pass the pages through a function that applies a rune budget "+
+			"and reports what it left behind (%s), and name it in excerptFuncs.",
+			at, strings.Join(excerptFuncs, ", "))
+	}
+
+	// A gate that finds no call sites passes while checking nothing, which is
+	// exactly what it would do if the constructor were renamed.
+	if built == 0 {
+		t.Errorf("no call to %s found under %s — either the evidence space is built some other way now, "+
+			"or this gate has gone blind and reports PASS over a tree it no longer describes",
+			indexBuilder, promptLanesDir)
+	}
+}
+
+// fromExcerpt reports whether this argument is the result of an excerpt
+// function: the call written inline, or a name assigned from one in the same
+// file.
+//
+// The name form has to be admitted, because the excerpt functions return TWO
+// values — the pages and what they left behind — and a two-value call cannot be
+// written inline. Refusing it would have forced the remainder to be dropped or
+// re-measured, which is the honesty half of this obligation traded away to make
+// the other half easier to check.
+//
+// One file is where the following stops, and that is the whole extent of it: no
+// scopes, no shadowing, no assignment through a struct field. A gate that
+// followed further would be a data-flow analysis, and one that gave up quietly
+// halfway is worse than one whose limit is stated — this one refuses what it
+// cannot see, so the failure is a rewrite rather than a false pass.
+func fromExcerpt(arg ast.Expr, fromExcerptNames map[string]bool) bool {
+	switch node := arg.(type) {
+	case *ast.CallExpr:
+		name, ok := node.Fun.(*ast.Ident)
+		return ok && slices.Contains(excerptFuncs, name.Name)
+	case *ast.Ident:
+		return fromExcerptNames[node.Name]
+	}
+	return false
+}
+
+// excerptedNames collects the names this file assigns from an excerpt call.
+func excerptedNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		fn, ok := call.Fun.(*ast.Ident)
+		if !ok || !slices.Contains(excerptFuncs, fn.Name) {
+			return true
+		}
+		// The FIRST result is the pages; the second is what was left behind.
+		// Naming only the first keeps the remainder from being mistaken for an
+		// excerpt if a caller ever passes it by hand.
+		if lhs, ok := assign.Lhs[0].(*ast.Ident); ok {
+			names[lhs.Name] = true
+		}
+		return true
+	})
+	return names
+}

--- a/backend/internal/compose/certcase_sitepagefacts.go
+++ b/backend/internal/compose/certcase_sitepagefacts.go
@@ -108,7 +108,10 @@ func (sitePageFactsCases) Prepare(fixture, expected json.RawMessage) (aitasks.Pr
 				"none — and a scenario over one would certify a request the product never issues", f.Kind)
 	}
 	page := crawlPage{URL: f.URL, Kind: f.Kind, Text: f.Text}
-	idx := newSnippetIndex([]crawlPage{page})
+	// The SAME excerpt the lane applies. A certification that indexed the
+	// whole page would certify a prompt this product never sends.
+	excerpt, _ := pageFactsExcerpt(page)
+	idx := newSnippetIndex(excerpt)
 	if len(idx.refs) == 0 {
 		return nil, errors.New(
 			"site_fact_extract/page_facts: the fixture's page yields no passage, and the lane calls no model without one")

--- a/backend/internal/compose/certcase_sitepagefacts_test.go
+++ b/backend/internal/compose/certcase_sitepagefacts_test.go
@@ -66,7 +66,8 @@ func sitePageFactsClaim(field, value, snippetID string) string {
 // page splits, so a citation is computed rather than written down.
 func sitePageFactsSnippetID(t *testing.T, kind crmcontracts.SiteReadPageKind, text, contains string) string {
 	t.Helper()
-	idx := newSnippetIndex([]crawlPage{{URL: sitePageFactsURL, Kind: kind, Text: text}})
+	excerpt, _ := pageFactsExcerpt(crawlPage{URL: sitePageFactsURL, Kind: kind, Text: text})
+	idx := newSnippetIndex(excerpt)
 	for i, ref := range idx.refs {
 		if strings.Contains(ref.passage, contains) {
 			return fmt.Sprintf("s%d", i)

--- a/backend/internal/compose/pageexcerpt_test.go
+++ b/backend/internal/compose/pageexcerpt_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// How much of a crawled page one fact call reads, and what it says about the
+// rest.
+//
+// The lane used to index the page's whole stripped text, so the prompt was as
+// long as whoever published the page chose to make it — up to webread's 1 MiB
+// fetch cap. On a metered provider that is a stranger's decision about our
+// tokens; on a local one it sizes the context window the adapter must
+// allocate.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAPageIsReadOnlyAsFarAsItsBudget(t *testing.T) {
+	long := strings.Repeat("ä", pageFactsExcerptRunes*3)
+
+	excerpt, unread := pageFactsExcerpt(crawlPage{URL: "https://example.test/x", Text: long})
+
+	if len(excerpt) != 1 {
+		t.Fatalf("the excerpt holds %d pages, want the one it was given", len(excerpt))
+	}
+	// Runes, not bytes. The text is multi-byte on purpose: a byte slice would
+	// cut mid-character here and the budget would mean something different for
+	// a German page than for an English one.
+	if got := len([]rune(excerpt[0].Text)); got != pageFactsExcerptRunes {
+		t.Errorf("the excerpt kept %d runes, want %d", got, pageFactsExcerptRunes)
+	}
+	if want := pageFactsExcerptRunes * 2; unread != want {
+		t.Errorf("it reported %d runes unread, want %d — the cap alone cannot say what was lost, "+
+			"because a page one rune over and one a hundred times over are read identically", unread, want)
+	}
+}
+
+// A page inside the budget must not be reported as truncated: a warning that
+// fires on every ordinary page is one an operator learns to ignore, and then
+// the real one is invisible too.
+func TestAPageInsideTheBudgetIsReadWholeAndSaysSo(t *testing.T) {
+	whole := strings.Repeat("a", pageFactsExcerptRunes)
+
+	excerpt, unread := pageFactsExcerpt(crawlPage{URL: "https://example.test/x", Text: whole})
+
+	if excerpt[0].Text != whole {
+		t.Errorf("a page exactly at the budget was altered: kept %d of %d runes",
+			len([]rune(excerpt[0].Text)), len([]rune(whole)))
+	}
+	if unread != 0 {
+		t.Errorf("a page read in full reported %d runes unread", unread)
+	}
+}

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -18,6 +18,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -72,6 +73,14 @@ type threadMessage struct {
 	Subject   string
 	Body      string
 	At        time.Time
+	// UnreadRunes is how much of this body extractBodyLimit left behind.
+	//
+	// Carried rather than inferred, because it cannot be inferred: a body cut
+	// at the limit and a body that was exactly that long reach the prompt
+	// identically, and the reading is drawn from the head either way. The
+	// remainder is the half that says which happened, and how far the model's
+	// view of the exchange falls short of it.
+	UnreadRunes int
 }
 
 // settledThread is one conversation due for a read, with the account it
@@ -273,9 +282,14 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 // threadMessages reads the tail of one conversation, oldest first, so the
 // prompt reads in the order the exchange happened.
 func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage, error) {
+	// The remainder is measured in the same statement that cuts the body:
+	// asked for afterwards it would be a second read of a row that may have
+	// changed, and the number would then describe a different message from the
+	// one in the prompt.
 	rows, err := tx.Query(ctx, `
 		SELECT id, coalesce(direction, ''), coalesce(subject, ''),
-		       coalesce(left(body, $1), ''), occurred_at
+		       coalesce(left(body, $1), ''),
+		       greatest(coalesce(char_length(body), 0) - $1, 0), occurred_at
 		  FROM (SELECT id, direction, subject, body, occurred_at
 		          FROM activity
 		         WHERE thread_key = $2 AND kind = 'email' AND archived_at IS NULL
@@ -287,15 +301,32 @@ func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage
 	}
 	defer rows.Close()
 	var out []threadMessage
+	unread, cut := 0, 0
 	for rows.Next() {
 		var message threadMessage
 		if err := rows.Scan(&message.ID, &message.Direction, &message.Subject,
-			&message.Body, &message.At); err != nil {
+			&message.Body, &message.UnreadRunes, &message.At); err != nil {
 			return nil, err
+		}
+		if message.UnreadRunes > 0 {
+			unread += message.UnreadRunes
+			cut++
 		}
 		out = append(out, message)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if cut > 0 {
+		// Said once per conversation rather than once per message: what a
+		// reader needs is how much of THIS exchange the reading was drawn
+		// from, and a line per body would bury that under the long threads it
+		// is most true of.
+		slog.WarnContext(ctx, "part of this conversation was not read; the events extracted from it are drawn from the head of each mail and anything stated below the cut is absent rather than judged",
+			"thread_key", key, "messages_cut", cut, "messages_read", len(out),
+			"body_limit", extractBodyLimit, "unread_runes", unread)
+	}
+	return out, nil
 }
 
 // recordThreadRefusal counts one refused reading of this exact conversation

--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"unicode"
 
@@ -273,6 +274,39 @@ type pageFactsResult struct {
 	entities []corpusLegalEntity
 }
 
+// pageFactsExcerptRunes bounds what ONE page contributes to its own fact call.
+//
+// Derived from the profile lane's WHOLE-CALL budget, not from its per-page
+// share, because that is the matching quantity: the profile lane spends
+// profileExcerptBudgetRunes across a corpus in one call, and this lane issues
+// one call per page, so a page here may cost what a corpus costs there.
+//
+// It has to be bounded by something. Without this the prompt was as long as
+// whoever published the page chose to make it — up to webread's 1 MiB fetch
+// cap, most of which survives StripTags on a text-heavy page. That spends a
+// metered provider's tokens on a stranger's decision, and on a local provider
+// it sizes the context window the adapter must allocate, which is how this was
+// found.
+const pageFactsExcerptRunes = profileExcerptBudgetRunes
+
+// pageFactsExcerpt bounds one page for its own fact call, and answers how many
+// runes it left behind.
+//
+// The count leaves with the page because the cap alone cannot say what was
+// lost: a page one rune over the budget and one a hundred times over are read
+// identically, and only the remainder tells them apart. Same reasoning the
+// embed adapter's window report carries, for the same reason — a truncation
+// nobody is told about is indistinguishable downstream from a complete read.
+func pageFactsExcerpt(page crawlPage) (excerptPages, int) {
+	runes := []rune(page.Text)
+	if len(runes) <= pageFactsExcerptRunes {
+		return excerptPages{page}, 0
+	}
+	unread := len(runes) - pageFactsExcerptRunes
+	page.Text = string(runes[:pageFactsExcerptRunes])
+	return excerptPages{page}, unread
+}
+
 // extractPageFacts runs one page's call on the fact lane and gates the
 // reply. Pages whose kind has no menu return empty without a call.
 func (x evidenceExtractor) extractPageFacts(ctx context.Context, page crawlPage) (pageFactsResult, error) {
@@ -280,7 +314,16 @@ func (x evidenceExtractor) extractPageFacts(ctx context.Context, page crawlPage)
 	if !ok {
 		return pageFactsResult{url: page.URL, kind: page.Kind}, nil
 	}
-	idx := newSnippetIndex([]crawlPage{page})
+	excerpt, unread := pageFactsExcerpt(page)
+	if unread > 0 {
+		// Both numbers, because the ratio is the finding: a page that
+		// overruns by a paragraph and one whose facts are mostly past the cap
+		// produce the same result and the same absent facts, and only the
+		// remainder says which happened.
+		slog.WarnContext(ctx, "a page is longer than this lane reads; its facts are extracted from the head of the page and anything stated below the cut is absent rather than refused",
+			"url", page.URL, "kind", page.Kind, "read_runes", pageFactsExcerptRunes, "unread_runes", unread)
+	}
+	idx := newSnippetIndex(excerpt)
 	if len(idx.refs) == 0 {
 		return pageFactsResult{url: page.URL, kind: page.Kind}, nil
 	}

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -25,7 +25,8 @@ func pageFixture(kind crmcontracts.SiteReadPageKind, url, text string) (crawlPag
 	if !ok {
 		panic("fixture kind has no menu")
 	}
-	return page, menu, newSnippetIndex([]crawlPage{page})
+	excerpt, _ := pageFactsExcerpt(page)
+	return page, menu, newSnippetIndex(excerpt)
 }
 
 func dropReasons(dropped []droppedFinding) map[string]string {
@@ -244,7 +245,8 @@ func TestGatePageFactsEntitiesOnlyFromShallowLegalPages(t *testing.T) {
 		URL: seedURL + "/customers/other/legal", Kind: crmcontracts.SiteReadPageKindImpressum,
 		Text: "Other Co AG imprint for a customer project hosted under a deep path with plenty of text.",
 	}
-	deepIdx := newSnippetIndex([]crawlPage{deepPage})
+	deepExcerpt, _ := pageFactsExcerpt(deepPage)
+	deepIdx := newSnippetIndex(deepExcerpt)
 	res, dropped = gatePageFacts(`{"facts":[],"entities":[{"n":"Other Co AG","e":"s0"}]}`, deepPage, menu, deepIdx)
 	if len(res.entities) != 0 {
 		t.Fatalf("a deep legal page testified: %+v", res.entities)

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -125,14 +125,14 @@ func profileSchema(snippetIDs []string) json.RawMessage {
 // total budget. The legal census is a separate page-fact lane, so the
 // profile prompt represents at most one legal page and reserves room for
 // About, services, products, home, contact, and team evidence.
-func profileExcerptPages(pages []crawlPage) []crawlPage {
+func profileExcerptPages(pages []crawlPage) excerptPages {
 	// Drop the navigation chrome first, so the per-page cap below is spent
 	// on the company's own words rather than on the mega-menu every page
 	// opens with. See siteboilerplate.go for why this is measured from the
 	// corpus rather than guessed at.
 	ranked := stripSharedPrefix(pages)
 	sortPagesByCorpusRank(ranked)
-	var out []crawlPage
+	var out excerptPages
 	used := 0
 	legalPages := 0
 	legalRunes := 0

--- a/backend/internal/compose/sitesnippet.go
+++ b/backend/internal/compose/sitesnippet.go
@@ -136,9 +136,26 @@ type snippetIndex struct {
 	refs []snippetRef
 }
 
+// excerptPages is text a lane has already decided how much of to read.
+//
+// A prompt built from a crawled page is as long as whoever published the page
+// chose to make it, which spends a metered provider's tokens and sizes the
+// context window a local one must allocate. The profile lane bounded its
+// corpus; the page-facts lane did not, and nothing said the two were the same
+// obligation — so one of them was fixed and the other was not noticed.
+//
+// The type names the obligation at the one place every such prompt is built,
+// and it does NOT enforce it: a named slice type is assignable from its
+// unnamed underlying type, and everything here is one package anyway, so no
+// declaration in Go stops a caller writing the raw pages in. What holds it is
+// TestEverySnippetIndexIsBuiltFromAnExcerpt, which requires the argument to be
+// a call to a function that applied a budget — so a third lane cannot index a
+// page's full text without first deciding how much of it to read.
+type excerptPages []crawlPage
+
 // newSnippetIndex numbers the pages' passages in page order. Ids are
 // index-derived ("s12"), so rendering and resolution can never disagree.
-func newSnippetIndex(pages []crawlPage) snippetIndex {
+func newSnippetIndex(pages excerptPages) snippetIndex {
 	var idx snippetIndex
 	for _, page := range pages {
 		for _, passage := range segmentPassages(page.Text) {

--- a/backend/internal/compose/threadexcerpt_integration_test.go
+++ b/backend/internal/compose/threadexcerpt_integration_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// How much of a conversation the extraction lane reads, and what it says about
+// the rest.
+//
+// The cut is made in SQL, so a body of exactly extractBodyLimit characters and
+// one truncated to that length arrive identically — the reading is drawn from
+// the head either way, and downstream nothing can tell them apart. The
+// remainder is what tells them apart, and it is measured in the same statement
+// that cuts, because asked for afterwards it would describe a row that may have
+// changed.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedThreadMail plants one email on a thread with a body of the given length.
+func seedThreadMail(t *testing.T, e *integration.Env, threadKey string, bodyRunes, minutesAgo int) {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, thread_key, occurred_at,
+			                      source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'a subject', $2, 'inbound', $3,
+			        now() - make_interval(mins => $4),
+			        'gmail', $5, 'gmail:seed', 'connector:gmail')`,
+			id, strings.Repeat("x", bodyRunes), threadKey, minutesAgo, id.String())
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAThreadReportsHowMuchOfItselfWasNotRead(t *testing.T) {
+	e := integration.Setup(t)
+	key := "thread-" + ids.NewV7().String()
+
+	// One mail the limit holds whole, and one past it by a known amount. Both,
+	// because the finding is the DIFFERENCE: a fixture of only-long mails would
+	// pass against an implementation that reported every body as truncated.
+	over := 400
+	seedThreadMail(t, e, key, extractBodyLimit, 2)
+	seedThreadMail(t, e, key, extractBodyLimit+over, 1)
+
+	var messages []threadMessage
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		var err error
+		messages, err = threadMessages(context.Background(), tx, key)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(messages) != 2 {
+		t.Fatalf("the thread read %d messages, want 2", len(messages))
+	}
+	for _, message := range messages {
+		if got := len([]rune(message.Body)); got > extractBodyLimit {
+			t.Errorf("a body reached the prompt at %d runes, past the %d limit", got, extractBodyLimit)
+		}
+	}
+	// Oldest first, so the whole one comes back first.
+	if messages[0].UnreadRunes != 0 {
+		t.Errorf("a mail the limit holds whole reported %d runes unread — a warning that fires on "+
+			"every ordinary mail is one an operator learns to ignore", messages[0].UnreadRunes)
+	}
+	if messages[1].UnreadRunes != over {
+		t.Errorf("the truncated mail reported %d runes unread, want %d — the limit alone cannot say "+
+			"what was lost, because a body one rune over and one far over arrive identically",
+			messages[1].UnreadRunes, over)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -183,6 +183,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `keyvaultonceperrole_test.go` | H2 | A role resolves its key vault ONCE. |
 | `logsecrets_test.go` | H2 | A credential reaches a log field only on the failure of the channel that was supposed to carry it. |
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
+| `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |
 | `publicreferences_test.go` | H1 | This repository is public. |
 | `retentionscope_test.go` | H2 | retentionScopeBuilder is the fixture whose reach these gates bound, retentionScopeSink is the one call it may feed, and retentionScopeSinkOwner is the package that call must live in. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -165,7 +165,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (22)
+## Prohibition (23)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #509.

## The cap

Two lanes render a company's own website into a model call. The profile lane bounded its corpus — a per-page share inside a whole-call budget — and the page-facts lane did not: it indexed the page's **full** stripped text, up to webread's 1 MiB fetch cap, most of which survives `StripTags` on a text-heavy page. Nothing said the two were the same obligation, so one was fixed and the other was not noticed.

Prompt length there is chosen by whoever published the page. On a metered provider that is a stranger's decision about our tokens; on a local one it sizes the context window the adapter must allocate, which is how this was found. Clamping it inside the adapter (#506) is the last line of defence — the prompt is where the limit belongs.

`pageFactsExcerptRunes` is **derived** from `profileExcerptBudgetRunes` rather than invented, and from that figure rather than its per-page share, because that is the matching quantity: the profile lane spends it across a corpus in one call, and this lane issues one call *per page*.

## The visibility half

Both truncations now say so, in the shape the ollama embed adapter's window report already established (#508 / PR #874): **the remainder leaves with the text.**

- the cap alone cannot say what was lost — a page one rune over the budget and one a hundred times over are read identically
- a body cut at `extractBodyLimit` is otherwise indistinguishable from a body that was exactly that long

The signal-extract lane measures its remainder **in the same statement that cuts the body**; asked for afterwards it would be a second read of a row that may have changed, and the number would describe a different message from the one in the prompt. It reports once per conversation rather than once per body, so the "how much of this exchange did we read" answer is not buried under the long threads it is most true of.

## Held, not described

`newSnippetIndex` is the one place every such prompt's evidence space is built, and `TestEverySnippetIndexIsBuiltFromAnExcerpt` requires its argument to come from a function that applied a budget. A third lane cannot index a page's full text without first deciding how much of it to read.

The `excerptPages` type in the signature *names* the rule and does not enforce it — a named slice type is assignable from its unnamed underlying type, and this is all one package — and its comment says which does. The gate admits a name assigned from an excerpt call in the same file, because the excerpt functions return two values and a two-value call cannot be written inline; refusing that would have traded the honesty half away to make the other half easier to check. One file is where the following stops, and the gate refuses what it cannot see rather than passing it.

Mutation-checked: replacing either production call site with a raw page fails the gate by position. The certification lane applies the same excerpt — a certification that indexed the whole page would certify a prompt this product never sends.

## Not in scope

The issue's wider suggestion — *every compose lane that renders third-party text into a prompt declares a budget* — needs a verdict per lane about whether its text is third-party at all, across ~25 lanes that build a `model.Request`. That is its own change with its own research; this one closes the two named defects and holds the class they were in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Page and message processing now uses bounded excerpts for lengthy content.
  - Multibyte text is truncated safely without splitting characters.
  - Fact extraction focuses on permitted page content for more consistent results.
  - Processing reports how much content remains unread when truncation occurs.

- **Quality**
  - Added automated checks to ensure excerpt limits are applied consistently.
  - Expanded coverage for oversized content and unread-text reporting.
  - Updated gate inventory documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->