### PR TITLE
docs(core): the workspace columns are gone, and the comments stop warning about them

### DIFF
--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -192,8 +192,8 @@ func (h dataResetHandlers) runQuiesced(ctx context.Context, wsID ids.UUID, clear
 // organization's name.
 func confirmResetOrgName(ctx context.Context, tx pgx.Tx, confirmation string) error {
 	// The SETTING, because that is the name the operator is reading off the
-	// screen when they type it. Demanding the column's copy would, the moment
-	// the two drifted, refuse the only spelling they can see (issue #521).
+	// screen when they type it — and, since the workspace row's copy was
+	// dropped, the only name there is.
 	orgName, err := identity.NameOf(ctx, tx)
 	if err != nil {
 		return err

--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -218,7 +218,7 @@ func TestForecastSpecShape(t *testing.T) {
 	// One join, a to-one lookup for win_probability, never a row multiplier.
 	// The workspace join went with the §11 reporting-zone "today": that zone
 	// is an installation SETTING now, bound as a parameter, so the join had
-	// nothing left to carry (issue #521).
+	// nothing left to carry.
 	if got := spec.fromClause(); got != "deal t JOIN stage s ON s.id = t.stage_id" {
 		t.Errorf("fromClause = %q", got)
 	}

--- a/backend/internal/compose/integration/harnessinstallation.go
+++ b/backend/internal/compose/integration/harnessinstallation.go
@@ -19,17 +19,18 @@ import (
 // seedInstallationIdentity writes the installation's own settings rows.
 func seedInstallationIdentity(ctx context.Context, t *testing.T, owner *pgx.Conn) {
 	t.Helper()
-	// The installation's identity as settings rows (ADR-0090/A135) — the other
-	// half of the same fact. This harness builds the installation by raw SQL,
-	// so bootstrap never seeded them and 0191's backfill ran before the
-	// workspace existed, while the readers resolve the SETTINGS, not the
-	// columns (issue #521). All of them, because bootstrap writes all of them:
-	// name, currency, language and zone are one act, and a fixture holding some
-	// of them is a state no installation is ever in.
+	// The installation's identity (ADR-0090/A135). This harness builds the
+	// installation by raw SQL, so bootstrap never seeded these and 0191's
+	// backfill ran before the workspace existed.
 	//
-	// They must match the columns above. A suite whose two copies disagree
-	// measures the drift rather than the behaviour under test — except where
-	// the disagreement IS the test, which is what basecurrencyseam does.
+	// All of them, because bootstrap writes all of them: name, currency,
+	// language and zone are one act, and a fixture holding some of them is a
+	// state no installation is ever in.
+	//
+	// These rows are the whole of it now. They used to have to match a copy on
+	// the workspace row, and a suite whose two copies disagreed measured the
+	// drift rather than the behaviour under test; the columns are gone, so
+	// there is one place to seed and one place to read.
 	if _, err := owner.Exec(ctx,
 		`INSERT INTO setting (key, value) VALUES
 			('installation.name', '"Authz"'::jsonb),

--- a/backend/internal/compose/integration/harnessperms.go
+++ b/backend/internal/compose/integration/harnessperms.go
@@ -57,7 +57,7 @@ const (
 	// objInstallSettings gates the read of the installation's own values —
 	// name, base currency, timezone. Every fixture that reads deals or
 	// accounts carries it, because those reads resolve the basis they are
-	// reported in (issue #521), and 0191 grants it to all five seeded roles.
+	// reported in, and 0191 grants it to all five seeded roles.
 	objInstallSettings = "installation_settings"
 )
 

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -80,8 +80,7 @@ func setupForecast(t *testing.T) *forecastEnv {
 	}
 	// The installation's identity as settings rows: the forecast's
 	// slipped-category dimension resolves its zone from the SETTING now, and
-	// this env builds its workspace by raw SQL, so bootstrap never seeded them
-	// (issue #521).
+	// this env builds its workspace by raw SQL, so bootstrap never seeded them.
 	if _, err := owner.Exec(ctx, `INSERT INTO setting (key, value) VALUES
 			('installation.name', '"Forecast"'::jsonb),
 			('installation.base_currency', '"EUR"'::jsonb),
@@ -161,7 +160,7 @@ func (e *forecastEnv) dealReadCtx(userID ids.UUID, teams []ids.UUID, scope princ
 			Objects: map[string]principal.ObjectGrant{
 				"deal": {Read: true},
 				// The forecast buckets "today" in the installation's zone, and
-				// that zone is read behind this object now (issue #521). 0191
+				// that zone is read behind this object now. 0191
 				// grants it to all five seeded roles, so no real caller of a
 				// report is without it.
 				"installation_settings": {Read: true},

--- a/backend/internal/modules/deals/offer_render.go
+++ b/backend/internal/modules/deals/offer_render.go
@@ -143,9 +143,9 @@ func resolveRenderBuyerBlock(ctx context.Context, tx pgx.Tx, offer crmcontracts.
 // once sent, else the installation's current live name.
 //
 // The live half reads the SAME source the frozen half was written from
-// (sendSnapshots). Reading it from the retiring column here would make a draft
-// and a sent offer disagree about who issued them the moment the two copies
-// drift — one fact, one source (issue #521).
+// (sendSnapshots), which is what stops a draft and a sent offer disagreeing
+// about who issued them. One fact, one source — and since the workspace row's
+// copy was dropped there is no second source left to read it from.
 func (s *Store) resolveRenderIssuerName(ctx context.Context, tx pgx.Tx, offer crmcontracts.Offer) (string, error) {
 	if offer.IssuerSnapshot != nil {
 		if name, ok := (*offer.IssuerSnapshot)["workspace_name"].(string); ok && name != "" {

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -153,7 +153,7 @@ func (s *Store) SetRawTx(ctx context.Context, tx pgx.Tx, key string, next json.R
 		// succeeded, while every reader that refuses an absent row
 		// (RequireTx) kept refusing — with no way to repair it through the
 		// product. Reachable wherever 0191's conditional backfill wrote
-		// nothing (issue #521).
+		// nothing.
 		unchanged := string(canonical) == string(next)
 		if stored && unchanged {
 			return nil


### PR DESCRIPTION
Closes #521.

## The columns are already dropped

| column | dropped by |
| --- | --- |
| `slug` | `1787572000_workspace_slug_retired` |
| `x_sor_mode` | `20260825120000_overlay_mode_leaves_the_workspace_row` |
| `x_incumbent` | same |
| `capture_auto_enrich` | went the same way |

Verified against a fully migrated schema — `workspace` carries `id`, `created_at`, `updated_at`, `archived_at` and nothing else.

## What was left

Prose that still describes them, and two comments that were actively **false**:

- `datareset.go` warned that demanding "the column's copy" would refuse the only spelling an operator can see — about a column that no longer exists
- `offer_render.go` warned against reading the issuer name "from the retiring column" — same
- `harnessinstallation.go` told a reader its settings rows "must match the columns above", where there are no columns above

That is the same hazard the issue itself was about, one level up: something live-looking that governs nothing. A warning against a mistake nobody can make reads as a live constraint, and the next author writes around it.

The remaining five were citations of a ticket that is answered, so they go with it — which is also this issue's own third to-do.

No behaviour changes; comments only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation and test descriptions around installation identity, organization names, forecast specifications, issuer names, and settings-backed data.
  * Removed obsolete issue references and updated notes to reflect current data sources.

* **Bug Fixes**
  * No user-facing behavior changes were introduced in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->