### PR TITLE
feat(signals): what a company announces about itself lands on its account

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24693,7 +24693,7 @@ components:
           type: string
           enum: [stalled_deal, champion_left, reengagement, buying_intent, risk, other,
                  contract_ended, new_opportunity, commitment_made, ghosted_thread,
-                 project_gone_quiet]
+                 project_gone_quiet, funding, leadership_change, expansion, product_launch]
           description: |
             The first six are what a human files by hand. The rest are what the producers
             raise (SIG-F-3): `contract_ended`, `new_opportunity` and `commitment_made` are read

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -243,6 +243,10 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 	// gets its face even on a read whose extraction later comes back empty or
 	// dies outright.
 	w.resolveLogo(ctx, args, claim, crawl)
+	// Beside the logo and for the same reasons: a side fetch on the same
+	// guarded egress, under its own deadline, whose failure is never the
+	// read's. A company that publishes no newsroom is the ordinary case.
+	w.readNewsroom(ctx, claim, crawl)
 
 	return w.reportRead(ctx, args, claim, crawl, extraction)
 }

--- a/backend/internal/compose/newsfeed.go
+++ b/backend/internal/compose/newsfeed.go
@@ -157,6 +157,12 @@ var feedTimeLayouts = []string{
 	time.RFC1123Z,
 	time.RFC1123,
 	time.RFC3339,
+	// Two-digit years are valid RSS 2.0 and real generators still emit them.
+	// Unparsed, such a date became "no date", which then read as today — an
+	// old announcement arriving as this week's news. Go's own RFC822 layouts
+	// carry no weekday and RSS dates do, so these are spelled out.
+	"Mon, 02 Jan 06 15:04:05 -0700",
+	"Mon, 02 Jan 06 15:04:05 MST",
 	"2006-01-02T15:04:05Z0700",
 	"2006-01-02 15:04:05",
 	"2006-01-02",

--- a/backend/internal/compose/newsfeed.go
+++ b/backend/internal/compose/newsfeed.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Reading a company's own newsroom feed.
+//
+// Three fields per item and no fourth: the headline, the address, and the date.
+// The article's TEXT is never stored — what a company published is theirs, and
+// a signal that says "they announced a funding round, here is the link" is the
+// whole product need. Caching the body would make this a copy of somebody's
+// press page sitting in a CRM, which is the thing the enrichment position
+// refuses on every other surface too.
+//
+// RSS 2.0 and Atom in one reader, because a newsroom is whichever its CMS
+// emits and no reader of ours should care which.
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// FeedItem is one published item, reduced to what a signal carries.
+type FeedItem struct {
+	Title string
+	URL   string
+	// Published is the item's own date, or the zero time when the feed states
+	// none. Zero is not "today": a signal dated by when we happened to read it
+	// would put a three-year-old press release at the top of an account.
+	Published time.Time
+}
+
+// feedMaxItems bounds one feed. A newsroom lists its recent items; a feed
+// offering thousands is an archive, and reading it would file a decade of
+// history as though it had just happened.
+const feedMaxItems = 50
+
+// feedMaxBytes bounds one fetch. Feeds are tens of kilobytes; the cap is what
+// stops a hostile host from making a crawl budget disappear into one response.
+const feedMaxBytes = 2 << 20 // 2 MiB
+
+// rssDocument and atomDocument are the two shapes, read from one buffer. The
+// field sets barely overlap, so one struct with everything optional would make
+// every reader of it ask which half it got.
+type rssDocument struct {
+	XMLName xml.Name `xml:"rss"`
+	Items   []struct {
+		Title   string `xml:"title"`
+		Link    string `xml:"link"`
+		PubDate string `xml:"pubDate"`
+		Date    string `xml:"date"` // dc:date, which some CMSes emit instead
+	} `xml:"channel>item"`
+}
+
+type atomDocument struct {
+	XMLName xml.Name    `xml:"feed"`
+	Entries []atomEntry `xml:"entry"`
+}
+
+type atomEntry struct {
+	Title     string     `xml:"title"`
+	Links     []atomLink `xml:"link"`
+	Published string     `xml:"published"`
+	Updated   string     `xml:"updated"`
+}
+
+type atomLink struct {
+	Href string `xml:"href,attr"`
+	Rel  string `xml:"rel,attr"`
+}
+
+// ParseFeed reads whichever of the two shapes the bytes carry.
+func ParseFeed(r io.Reader) ([]FeedItem, error) {
+	body, err := io.ReadAll(io.LimitReader(r, feedMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading the feed: %w", err)
+	}
+	if len(body) > feedMaxBytes {
+		return nil, fmt.Errorf("the feed exceeds %d bytes", feedMaxBytes)
+	}
+	if items, ok := parseRSS(body); ok {
+		return items, nil
+	}
+	if items, ok := parseAtom(body); ok {
+		return items, nil
+	}
+	return nil, fmt.Errorf("the response is neither an RSS nor an Atom feed")
+}
+
+func parseRSS(body []byte) ([]FeedItem, bool) {
+	var doc rssDocument
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		return nil, false
+	}
+	items := make([]FeedItem, 0, len(doc.Items))
+	for _, item := range doc.Items {
+		items = append(items, FeedItem{
+			Title:     strings.TrimSpace(item.Title),
+			URL:       strings.TrimSpace(item.Link),
+			Published: parseFeedTime(item.PubDate, item.Date),
+		})
+	}
+	return capFeedItems(items), true
+}
+
+func parseAtom(body []byte) ([]FeedItem, bool) {
+	var doc atomDocument
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		return nil, false
+	}
+	items := make([]FeedItem, 0, len(doc.Entries))
+	for _, entry := range doc.Entries {
+		items = append(items, FeedItem{
+			Title:     strings.TrimSpace(entry.Title),
+			URL:       articleLink(entry.Links),
+			Published: parseFeedTime(entry.Published, entry.Updated),
+		})
+	}
+	return capFeedItems(items), true
+}
+
+// articleLink takes the alternate link, which is the article. An entry's other
+// links point at the feed itself or at an edit endpoint, and neither is
+// somewhere a reader wants to go.
+func articleLink(links []atomLink) string {
+	for _, link := range links {
+		if link.Rel == "alternate" || link.Rel == "" {
+			return strings.TrimSpace(link.Href)
+		}
+	}
+	return ""
+}
+
+// capFeedItems drops what a feed states with no headline or no address — there
+// is nothing to file and nowhere to send a reader — and bounds the rest.
+func capFeedItems(items []FeedItem) []FeedItem {
+	kept := items[:0]
+	for _, item := range items {
+		if item.Title == "" || item.URL == "" {
+			continue
+		}
+		kept = append(kept, item)
+		if len(kept) == feedMaxItems {
+			break
+		}
+	}
+	return kept
+}
+
+// feedTimeLayouts are the spellings a feed's date arrives in. RFC 1123 with and
+// without a zone name is RSS; RFC 3339 is Atom; the rest are what real
+// generators emit anyway.
+var feedTimeLayouts = []string{
+	time.RFC1123Z,
+	time.RFC1123,
+	time.RFC3339,
+	"2006-01-02T15:04:05Z0700",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
+// parseFeedTime takes the first candidate that parses. An unparseable date is
+// the ZERO time and not the current one: dating an item by when we read it
+// would file a three-year-old press release as this week's news.
+func parseFeedTime(candidates ...string) time.Time {
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		for _, layout := range feedTimeLayouts {
+			if parsed, err := time.Parse(layout, candidate); err == nil {
+				return parsed
+			}
+		}
+	}
+	return time.Time{}
+}

--- a/backend/internal/compose/newsfeed_test.go
+++ b/backend/internal/compose/newsfeed_test.go
@@ -93,6 +93,25 @@ func TestParseFeedLeavesAnUnreadableDateBlankRatherThanGuessing(t *testing.T) {
 	}
 }
 
+func TestParseFeedReadsATwoDigitYear(t *testing.T) {
+	// Valid RSS 2.0, and real generators still emit it. Unparsed it became "no
+	// date", which then read as today — an old press release arriving as this
+	// week's news.
+	feed := `<rss version="2.0"><channel><item>
+	  <title>An older announcement</title>
+	  <link>https://acme.example/news/older</link>
+	  <pubDate>Tue, 12 Aug 08 09:00:00 +0000</pubDate>
+	</item></channel></rss>`
+
+	items, err := ParseFeed(strings.NewReader(feed))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	if items[0].Published.Year() != 2008 {
+		t.Errorf("published = %v, want 2008", items[0].Published)
+	}
+}
+
 func TestParseFeedDropsAnItemWithNothingToFile(t *testing.T) {
 	feed := `<rss version="2.0"><channel>
 	  <item><title>No link here</title></item>

--- a/backend/internal/compose/newsfeed_test.go
+++ b/backend/internal/compose/newsfeed_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a company's newsroom actually serves, in both shapes.
+//
+// The load-bearing case is the one that looks like a detail: an item whose date
+// will not parse gets the ZERO time rather than today's. Dating a press release
+// by when we happened to read it would put three-year-old news at the top of an
+// account, which is worse than having no date at all — a reader can see a blank
+// and cannot see a wrong one.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseFeedReadsRSS(t *testing.T) {
+	feed := `<?xml version="1.0"?>
+	<rss version="2.0"><channel>
+	  <title>Acme Newsroom</title>
+	  <item>
+	    <title>Acme raises a Series B</title>
+	    <link>https://acme.example/news/series-b</link>
+	    <pubDate>Tue, 12 Aug 2026 09:00:00 +0000</pubDate>
+	  </item>
+	  <item>
+	    <title>Acme opens in Lisbon</title>
+	    <link>https://acme.example/news/lisbon</link>
+	    <pubDate>Mon, 04 Aug 2026 10:30:00 +0000</pubDate>
+	  </item>
+	</channel></rss>`
+
+	items, err := ParseFeed(strings.NewReader(feed))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].Title != "Acme raises a Series B" {
+		t.Errorf("title = %q", items[0].Title)
+	}
+	if items[0].URL != "https://acme.example/news/series-b" {
+		t.Errorf("url = %q", items[0].URL)
+	}
+	if got := items[0].Published.UTC(); got != time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC) {
+		t.Errorf("published = %v", got)
+	}
+}
+
+func TestParseFeedReadsAtom(t *testing.T) {
+	feed := `<?xml version="1.0"?>
+	<feed xmlns="http://www.w3.org/2005/Atom">
+	  <title>Globex Press</title>
+	  <entry>
+	    <title>Globex names a new CFO</title>
+	    <link rel="alternate" href="https://globex.example/press/cfo"/>
+	    <link rel="edit" href="https://globex.example/admin/press/cfo"/>
+	    <published>2026-07-01T12:00:00Z</published>
+	  </entry>
+	</feed>`
+
+	items, err := ParseFeed(strings.NewReader(feed))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	// The ALTERNATE link is the article; the edit link is somewhere no reader
+	// of ours should be sent.
+	if items[0].URL != "https://globex.example/press/cfo" {
+		t.Errorf("url = %q, want the alternate link", items[0].URL)
+	}
+}
+
+func TestParseFeedLeavesAnUnreadableDateBlankRatherThanGuessing(t *testing.T) {
+	feed := `<rss version="2.0"><channel><item>
+	  <title>Undated announcement</title>
+	  <link>https://acme.example/news/undated</link>
+	  <pubDate>whenever</pubDate>
+	</item></channel></rss>`
+
+	items, err := ParseFeed(strings.NewReader(feed))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	if !items[0].Published.IsZero() {
+		t.Errorf("published = %v, want the zero time — an item dated by when we read it reads as news", items[0].Published)
+	}
+}
+
+func TestParseFeedDropsAnItemWithNothingToFile(t *testing.T) {
+	feed := `<rss version="2.0"><channel>
+	  <item><title>No link here</title></item>
+	  <item><link>https://acme.example/news/no-title</link></item>
+	  <item><title>Complete</title><link>https://acme.example/news/complete</link></item>
+	</channel></rss>`
+
+	items, err := ParseFeed(strings.NewReader(feed))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	// An item with no headline has nothing to say and one with no address has
+	// nowhere to send a reader. Neither is a signal.
+	if len(items) != 1 || items[0].Title != "Complete" {
+		t.Fatalf("items = %+v, want only the complete one", items)
+	}
+}
+
+func TestParseFeedCapsHowMuchOfAnArchiveItReads(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`<rss version="2.0"><channel>`)
+	for i := 0; i < feedMaxItems*3; i++ {
+		b.WriteString(`<item><title>Item</title><link>https://acme.example/n</link></item>`)
+	}
+	b.WriteString(`</channel></rss>`)
+
+	items, err := ParseFeed(strings.NewReader(b.String()))
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	// A feed offering its whole archive is not a newsroom, and filing a decade
+	// of history as though it had just happened is the failure being bounded.
+	if len(items) != feedMaxItems {
+		t.Errorf("items = %d, want the %d cap", len(items), feedMaxItems)
+	}
+}
+
+func TestParseFeedRefusesWhatIsNotAFeed(t *testing.T) {
+	for _, body := range []string{
+		"<html><body>a newsroom PAGE, not its feed</body></html>",
+		"not xml at all",
+		"",
+	} {
+		if _, err := ParseFeed(strings.NewReader(body)); err == nil {
+			t.Errorf("%q parsed as a feed, want a refusal", body)
+		}
+	}
+}

--- a/backend/internal/compose/newsroomlane.go
+++ b/backend/internal/compose/newsroomlane.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The newsroom lane of a deep read: find the company's own feed, read it, and
+// file what it announced as signals on the account.
+//
+// It runs beside the logo lane and for the same reasons — a side fetch the
+// crawl itself does not make, on the SAME guarded egress, under its own
+// deadline. Nothing it does is allowed to hold the dossier open: a company that
+// publishes no feed, a feed that will not parse, a host that stopped answering
+// are all the ordinary case, and every one of them leaves the read exactly as
+// it would have been.
+//
+// What it stores is in newsroomsignals.go and is deliberately small: a
+// headline, a date, a link. The article's text never lands.
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+// newsroomLaneBudget is the whole lane's deadline — discovery, fetch and the
+// row writes together. A newsroom is worth a few seconds and never worth the
+// time the job budget reserves for CLOSING the dossier: a read cancelled before
+// its outcome is recorded stays running forever, squatting the organization's
+// one in-flight slot.
+const newsroomLaneBudget = 20 * time.Second
+
+// newsroomPaths are the addresses a feed sits at when a page did not declare
+// one. Ordered by how often they answer, and short on purpose: each is a
+// request against a host that may not want them, and a company with no feed
+// should cost four 404s rather than forty.
+var newsroomPaths = []string{"/feed", "/rss", "/news/feed", "/blog/feed", "/feed.xml"}
+
+// readNewsroom files what the company announced about itself, if it says.
+//
+// Errors are logged and dropped rather than returned: this lane is additive to
+// a read that has already succeeded, and a feed nobody could reach is not a
+// failed enrichment.
+func (w *siteDeepReadWorker) readNewsroom(ctx context.Context, claim people.SiteReadClaim, crawl siteCrawl) {
+	if w.fetch == nil || claim.OrganizationID == nil {
+		return
+	}
+	laneCtx, cancel := context.WithTimeout(ctx, newsroomLaneBudget)
+	defer cancel()
+
+	items := w.fetchNewsroomItems(laneCtx, crawl)
+	if len(items) == 0 {
+		return
+	}
+	orgID := *claim.OrganizationID
+	events := make([]NewsroomItem, 0, len(items))
+	for _, item := range items {
+		events = append(events, NewsroomItem{
+			Kind:      classifyHeadline(item.Title),
+			Headline:  item.Title,
+			URL:       item.URL,
+			Published: item.Published,
+		})
+	}
+
+	if err := database.WithWorkspaceTx(laneCtx, w.pool, func(tx pgx.Tx) error {
+		raised, err := WriteNewsroomSignals(laneCtx, tx, orgID, events, time.Now())
+		if err != nil {
+			return err
+		}
+		if raised > 0 {
+			w.log.InfoContext(laneCtx, "newsroom signals filed",
+				"organization", orgID.String(), "raised", raised, "read", len(events))
+		}
+		return nil
+	}); err != nil {
+		w.log.WarnContext(laneCtx, "the newsroom lane could not file its signals",
+			"organization", orgID.String(), "err", err)
+	}
+}
+
+// fetchNewsroomItems tries the well-known addresses. The FIRST one that parses
+// wins: a site offering several is
+// offering the same newsroom twice, and reading both would file every
+// announcement under two addresses.
+func (w *siteDeepReadWorker) fetchNewsroomItems(ctx context.Context, crawl siteCrawl) []FeedItem {
+	for _, candidate := range newsroomCandidates(crawl) {
+		body, _, err := w.fetch.FetchAsset(ctx, candidate)
+		if err != nil {
+			// A 404 for a company with no feed is the ordinary case, and so is
+			// a robots refusal. Neither is worth a warning on every crawl.
+			w.log.DebugContext(ctx, "no newsroom feed here", "url", candidate, "err", err)
+			continue
+		}
+		items, err := ParseFeed(strings.NewReader(string(body)))
+		if err != nil {
+			w.log.DebugContext(ctx, "the response was not a feed", "url", candidate, "err", err)
+			continue
+		}
+		if len(items) > 0 {
+			return items
+		}
+	}
+	return nil
+}
+
+// newsroomCandidates is where to look: the conventional paths off the site's
+// own origin.
+//
+// A `<link rel="alternate" type="application/rss+xml">` in the seed page's head
+// would be the better first answer, and it is not read here because the crawl
+// hands this lane extracted TEXT rather than markup. Reaching for the head
+// would mean a second fetch of a page already read, which is a cost this lane
+// does not get to impose on a host — so it asks the four addresses a CMS
+// actually uses and stops.
+func newsroomCandidates(crawl siteCrawl) []string {
+	origin := originOf(crawl.SeedURL)
+	if origin == "" {
+		return nil
+	}
+	candidates := make([]string, 0, len(newsroomPaths))
+	for _, path := range newsroomPaths {
+		candidates = append(candidates, origin+path)
+	}
+	return candidates
+}
+
+// originOf reduces an address to its scheme and host, which is what a
+// well-known path hangs off.
+func originOf(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}

--- a/backend/internal/compose/newsroomsignals.go
+++ b/backend/internal/compose/newsroomsignals.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A company's own newsroom, as signals on its account.
+//
+// The whole of what is stored is the headline, the date and the address. The
+// article's text is never cached: what a company published is theirs, and a CRM
+// holding a copy of somebody's press page is the shape this product refuses
+// everywhere else. A reader who wants the article follows the link.
+//
+// The classification reads the HEADLINE alone — no body, no page — and is
+// deterministic rather than a model call. The four kinds are announcement
+// genres with stable vocabulary in both languages this reads, so a word list
+// answers the question, and a model would spend a round trip per item of every
+// crawl to answer it less predictably. A headline that matches nothing is filed
+// as `other`, because a funding round that was actually a hiring announcement
+// is worse on an account page than an unclassified line.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/signals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// severityInfo is what a company's own announcement is: news about the
+// account, never a problem with it. `warn` and `urgent` are what a reader
+// triages by, and a press release competing there for attention would make
+// that column mean less.
+const severityInfo = "info"
+
+// The four kinds a newsroom item can be, plus the one it is when the reader
+// cannot tell. Spelled here because this file is what produces them.
+const (
+	kindFunding          = "funding"
+	kindLeadershipChange = "leadership_change"
+	kindExpansion        = "expansion"
+	kindProductLaunch    = "product_launch"
+	kindOtherEvent       = "other"
+)
+
+// newsroomChannel and newsroomSource say where these rows came from, in the
+// signal table's own vocabulary and in the audit trail's.
+const (
+	newsroomChannel = "web"
+	newsroomSource  = "site-newsroom"
+)
+
+// newsroomMaxAge bounds how far back a first read files. A newsroom lists its
+// archive, and a company's whole press history arriving at once would bury the
+// account's real work under announcements nobody is acting on.
+const newsroomMaxAge = 365 * 24 * time.Hour
+
+// NewsroomItem is one classified item, ready to file.
+type NewsroomItem struct {
+	Kind      string
+	Headline  string
+	URL       string
+	Published time.Time
+}
+
+// WriteNewsroomSignals files what a company announced about itself.
+//
+// Returns how many were raised; an item already on file raises nothing, which
+// is the normal case for a feed read twice and not a failure. The fingerprint
+// is the item's own address, so a headline the CMS later rewords does not
+// arrive as a second event.
+func WriteNewsroomSignals(
+	ctx context.Context,
+	tx pgx.Tx,
+	orgID ids.UUID,
+	items []NewsroomItem,
+	now time.Time,
+) (int, error) {
+	raised := 0
+	for _, item := range items {
+		if stale(item, now) {
+			continue
+		}
+		filed, err := signals.RecordDerived(ctx, tx, signals.DerivedSignal{
+			Kind:           item.Kind,
+			OrganizationID: orgID,
+			Summary:        item.Headline,
+			// Never `warn` or `urgent`: a company announcing something is news
+			// about the account, not a problem with it, and the severity
+			// vocabulary is what a reader triages by.
+			Severity:    severityInfo,
+			Channel:     newsroomChannel,
+			Source:      newsroomSource,
+			Fingerprint: fingerprintOf(item.Kind, orgID.String(), item.URL),
+			// The article is CITED, never copied: the snippet is the headline
+			// the company itself published, and the source is where to read the
+			// rest.
+			Evidence: []signals.DerivedEvidence{{
+				Snippet:   item.Headline,
+				SourceURL: item.URL,
+			}},
+			Audit: map[string]any{
+				paramKind:      item.Kind,
+				"source_url":   item.URL,
+				"published_at": publishedForAudit(item.Published),
+			},
+		}, detectedAt(item, now))
+		if err != nil {
+			return raised, fmt.Errorf("filing a newsroom signal: %w", err)
+		}
+		if filed {
+			raised++
+		}
+	}
+	return raised, nil
+}
+
+// stale drops what is too old to be news. An item with no date at all is kept:
+// the feed stated no date, which is not the same as stating an old one, and
+// dropping it would silently lose a company's whole newsroom when its CMS
+// omits the field.
+func stale(item NewsroomItem, now time.Time) bool {
+	if item.Published.IsZero() {
+		return false
+	}
+	return now.Sub(item.Published) > newsroomMaxAge
+}
+
+// detectedAt dates the signal by the item's own publication, falling back to
+// the read. A signal is triaged by when it happened, and the fallback is only
+// for a feed that stated nothing.
+func detectedAt(item NewsroomItem, now time.Time) time.Time {
+	if item.Published.IsZero() {
+		return now
+	}
+	return item.Published
+}
+
+// publishedForAudit renders the item's date for the audit row, or nil when the
+// feed stated none.
+//
+// A *string rather than a bare any: nil marshals to JSON null either way, and
+// the pointer says in the signature that absence is one of the two answers.
+// Spelled as null rather than omitted, because "the feed gave no date" is a
+// fact about the source and an absent key would read as a field the write
+// forgot.
+func publishedForAudit(published time.Time) *string {
+	if published.IsZero() {
+		return nil
+	}
+	stamped := published.UTC().Format(time.RFC3339)
+	return &stamped
+}
+
+// classifyHeadline places one headline in the four-kind vocabulary.
+//
+// Deterministic and local: the kinds are announcement genres with stable
+// vocabulary, and a model call per headline would cost a round trip for each
+// item of every crawl to answer a question a word list answers. A headline that
+// matches nothing is `other`, which is an honest verdict rather than a guess.
+func classifyHeadline(headline string) string {
+	lowered := strings.ToLower(headline)
+	for _, rule := range headlineRules {
+		for _, word := range rule.words {
+			if strings.Contains(lowered, word) {
+				return rule.kind
+			}
+		}
+	}
+	return kindOtherEvent
+}
+
+// headlineRules is read in order, so an earlier rule wins a headline both would
+// claim. Funding leads because a funding announcement routinely names the
+// growth it will pay for, and the money is the event.
+var headlineRules = []struct {
+	kind  string
+	words []string
+}{
+	{kindFunding, []string{
+		"series a", "series b", "series c", "series d", "seed round",
+		"funding", "raises", "raised", "investment round", "finanzierung",
+		"finanzierungsrunde", "kapitalerhöhung",
+	}},
+	{kindLeadershipChange, []string{
+		"appoints", "appointed", "names new", "joins as", "steps down",
+		"new ceo", "new cfo", "new cto", "new coo", "chief executive",
+		"managing director", "ernennt", "neuer geschäftsführer", "vorstand",
+	}},
+	{kindExpansion, []string{
+		"opens", "expands", "expansion", "new office", "acquires",
+		"acquisition", "merger", "enters the", "eröffnet", "übernimmt",
+		"expandiert", "neuer standort",
+	}},
+	{kindProductLaunch, []string{
+		"launches", "launch of", "introduces", "unveils", "now available",
+		"announces the release", "general availability", "startet",
+		"stellt vor", "veröffentlicht",
+	}},
+}

--- a/backend/internal/compose/newsroomsignals.go
+++ b/backend/internal/compose/newsroomsignals.go
@@ -91,10 +91,14 @@ func WriteNewsroomSignals(
 			// Never `warn` or `urgent`: a company announcing something is news
 			// about the account, not a problem with it, and the severity
 			// vocabulary is what a reader triages by.
-			Severity:    severityInfo,
-			Channel:     newsroomChannel,
-			Source:      newsroomSource,
-			Fingerprint: fingerprintOf(item.Kind, orgID.String(), item.URL),
+			Severity: severityInfo,
+			Channel:  newsroomChannel,
+			Source:   newsroomSource,
+			// The article's ADDRESS is the identity, and the kind is
+			// deliberately not in it: a headline the CMS rewords, or a rule
+			// that later places it differently, is the same announcement and
+			// must not arrive as a second event.
+			Fingerprint: fingerprintOf(newsroomSource, orgID.String(), item.URL),
 			// The article is CITED, never copied: the snippet is the headline
 			// the company itself published, and the source is where to read the
 			// rest.
@@ -164,13 +168,45 @@ func publishedForAudit(published time.Time) *string {
 func classifyHeadline(headline string) string {
 	lowered := strings.ToLower(headline)
 	for _, rule := range headlineRules {
-		for _, word := range rule.words {
-			if strings.Contains(lowered, word) {
+		for _, phrase := range rule.words {
+			if containsPhrase(lowered, phrase) {
 				return rule.kind
 			}
 		}
 	}
 	return kindOtherEvent
+}
+
+// containsPhrase matches on word boundaries rather than as a substring.
+//
+// A bare Contains claims every word the token merely sits inside: "praises"
+// would answer to "raises", and a company praising its new CEO would be filed
+// as having raised money. The phrases themselves may hold spaces ("series b"),
+// so the test is on what surrounds the match rather than on a split.
+func containsPhrase(haystack, phrase string) bool {
+	from := 0
+	for {
+		at := strings.Index(haystack[from:], phrase)
+		if at < 0 {
+			return false
+		}
+		at += from
+		before := at == 0 || !isWordByte(haystack[at-1])
+		end := at + len(phrase)
+		after := end == len(haystack) || !isWordByte(haystack[end])
+		if before && after {
+			return true
+		}
+		from = at + 1
+	}
+}
+
+// isWordByte reports whether a byte continues a word. ASCII only, deliberately:
+// what it guards against is a token sitting inside a longer ASCII word, and a
+// multi-byte rune's bytes are all >= 0x80 and answer false — the right answer
+// at a boundary like "übernimmt".
+func isWordByte(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9'
 }
 
 // headlineRules is read in order, so an earlier rule wins a headline both would

--- a/backend/internal/compose/newsroomsignals_test.go
+++ b/backend/internal/compose/newsroomsignals_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Placing a headline, and deciding what is still news.
+//
+// The classification is checked against headlines in the shape companies write
+// them, in both languages this reads. What matters as much as the hits is the
+// MISS: a headline the rules cannot place must come back `other`, because a
+// hiring announcement filed as a funding round is worse on an account page than
+// an unclassified line.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassifyHeadlinePlacesTheGenresACompanyAnnounces(t *testing.T) {
+	cases := []struct {
+		headline string
+		want     string
+	}{
+		{"Acme raises $12M Series B to expand its platform", kindFunding},
+		{"Globex schließt Finanzierungsrunde über 5 Mio. Euro ab", kindFunding},
+		{"Initech appoints Jane Doe as Chief Financial Officer", kindLeadershipChange},
+		{"Umbrella ernennt neuen Geschäftsführer", kindLeadershipChange},
+		{"Acme opens a second office in Lisbon", kindExpansion},
+		{"Globex übernimmt Wettbewerber Initech", kindExpansion},
+		{"Initech launches its next-generation analytics suite", kindProductLaunch},
+		{"Umbrella stellt vor: die neue Plattform", kindProductLaunch},
+
+		// The miss. Both of these are real newsroom genres this vocabulary
+		// deliberately does not name, and inventing a kind for them would put a
+		// guess on an account page.
+		{"Acme wins the 2026 sustainability award", kindOtherEvent},
+		{"Our engineering blog: what we learned scaling Postgres", kindOtherEvent},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.headline, func(t *testing.T) {
+			if got := classifyHeadline(tc.headline); got != tc.want {
+				t.Errorf("classified as %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyHeadlineReadsTheFirstRuleThatClaimsIt(t *testing.T) {
+	// A funding announcement routinely names the growth it will pay for, and
+	// the money is the event. The rule order is what decides it, so the case is
+	// here rather than left to whichever rule happened to be first.
+	got := classifyHeadline("Acme raises Series C and opens a new office in Porto")
+	if got != kindFunding {
+		t.Errorf("classified as %q, want %q — the money is the event", got, kindFunding)
+	}
+}
+
+func TestStaleDropsAnArchivedAnnouncementAndKeepsAnUndatedOne(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	old := NewsroomItem{Published: now.Add(-2 * newsroomMaxAge)}
+	if !stale(old, now) {
+		t.Error("a two-year-old press release is still news — a first read would file a whole archive")
+	}
+
+	recent := NewsroomItem{Published: now.Add(-24 * time.Hour)}
+	if stale(recent, now) {
+		t.Error("yesterday's announcement was dropped")
+	}
+
+	// No date is not an old date. A CMS that omits the field would otherwise
+	// lose the company its whole newsroom.
+	if stale(NewsroomItem{}, now) {
+		t.Error("an undated item was dropped as stale")
+	}
+}
+
+func TestDetectedAtDatesASignalByWhenItHappened(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	published := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+
+	if got := detectedAt(NewsroomItem{Published: published}, now); !got.Equal(published) {
+		t.Errorf("detected at %v, want the publication date %v", got, published)
+	}
+	// Only a feed that stated nothing falls back to the read.
+	if got := detectedAt(NewsroomItem{}, now); !got.Equal(now) {
+		t.Errorf("an undated item detected at %v, want the read %v", got, now)
+	}
+}

--- a/backend/internal/compose/newsroomsignals_test.go
+++ b/backend/internal/compose/newsroomsignals_test.go
@@ -56,6 +56,19 @@ func TestClassifyHeadlineReadsTheFirstRuleThatClaimsIt(t *testing.T) {
 	}
 }
 
+func TestClassifyHeadlineDoesNotClaimAWordItMerelySitsInside(t *testing.T) {
+	// "praises" contains "raises". A substring match files a company praising
+	// its new chief executive as having raised money — which is both wrong and
+	// the kind of wrong a reader believes, because funding is what they were
+	// hoping to see on the account.
+	if got := classifyHeadline("Acme praises its new CEO"); got == kindFunding {
+		t.Errorf("classified as %q — \"praises\" is not \"raises\"", got)
+	}
+	if got := classifyHeadline("Acme raises a Series A"); got != kindFunding {
+		t.Errorf("classified as %q, want %q", got, kindFunding)
+	}
+}
+
 func TestStaleDropsAnArchivedAnnouncementAndKeepsAnUndatedOne(t *testing.T) {
 	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -9037,9 +9037,13 @@ const (
 	SignalKindChampionLeft     SignalKind = "champion_left"
 	SignalKindCommitmentMade   SignalKind = "commitment_made"
 	SignalKindContractEnded    SignalKind = "contract_ended"
+	SignalKindExpansion        SignalKind = "expansion"
+	SignalKindFunding          SignalKind = "funding"
 	SignalKindGhostedThread    SignalKind = "ghosted_thread"
+	SignalKindLeadershipChange SignalKind = "leadership_change"
 	SignalKindNewOpportunity   SignalKind = "new_opportunity"
 	SignalKindOther            SignalKind = "other"
+	SignalKindProductLaunch    SignalKind = "product_launch"
 	SignalKindProjectGoneQuiet SignalKind = "project_gone_quiet"
 	SignalKindReengagement     SignalKind = "reengagement"
 	SignalKindRisk             SignalKind = "risk"
@@ -9057,11 +9061,19 @@ func (e SignalKind) Valid() bool {
 		return true
 	case SignalKindContractEnded:
 		return true
+	case SignalKindExpansion:
+		return true
+	case SignalKindFunding:
+		return true
 	case SignalKindGhostedThread:
+		return true
+	case SignalKindLeadershipChange:
 		return true
 	case SignalKindNewOpportunity:
 		return true
 	case SignalKindOther:
+		return true
+	case SignalKindProductLaunch:
 		return true
 	case SignalKindProjectGoneQuiet:
 		return true

--- a/backend/internal/modules/signals/derived.go
+++ b/backend/internal/modules/signals/derived.go
@@ -60,6 +60,14 @@ type DerivedSignal struct {
 	// Audit carries whatever the producer wants recorded about the derivation
 	// beyond the row itself.
 	Audit map[string]any
+	// Channel is WHERE the finding came from, in the signal table's own
+	// vocabulary. Empty means `derived` — a finding computed from what this
+	// workspace already holds, which is what every producer was until a
+	// company's own newsroom became one.
+	Channel string
+	// Source names the producer for the audit trail. Empty means the signal
+	// scan, for the same reason.
+	Source string
 	// PrivateTo is the one reader this finding answers to, or the zero value
 	// when the whole workspace may read it.
 	//
@@ -90,9 +98,16 @@ func nullableOwner(owner ids.UUID) *ids.UUID {
 }
 
 // DerivedEvidence is one citable record behind a derived signal.
+//
+// The two source shapes are exclusive and both are cited the same way: an
+// ACTIVITY the finding was drawn from, or a PAGE it was read on. A web finding
+// carries the second because there is no activity to open — what a reader wants
+// is the article, and storing the article's text instead of its address is the
+// thing this product does not do.
 type DerivedEvidence struct {
 	Snippet    string
 	ActivityID ids.UUID
+	SourceURL  string
 }
 
 // RecordDerived writes one derived signal inside the caller's transaction, or
@@ -115,6 +130,7 @@ func RecordDerived(ctx context.Context, tx pgx.Tx, in DerivedSignal, detectedAt 
 		return false, err
 	}
 	subjectType, subjectID := in.subject()
+	channel, source := in.channelAndSource()
 	// Every placeholder is derived from the argument slice, so a column added
 	// to this statement cannot bind to its neighbour's value.
 	var args []any
@@ -129,8 +145,8 @@ func RecordDerived(ctx context.Context, tx pgx.Tx, in DerivedSignal, detectedAt 
 		   evidence, fingerprint, source_channel, resolution_state, severity,
 		   status, detected_at, source, captured_by, visibility, owner_id)
 		VALUES (`+arg(in.Kind)+`, `+arg(subjectType)+`, `+arg(subjectID)+`, `+arg(in.OrganizationID)+`, `+arg(in.Summary)+`,
-		        `+arg(evidence)+`, `+arg(in.Fingerprint)+`, 'derived', 'resolved', `+arg(in.Severity)+`,
-		        'open', `+arg(detectedAt)+`, 'signal-scan', `+arg(by)+`, `+arg(visibility)+`, `+arg(nullableOwner(in.PrivateTo))+`)
+		        `+arg(evidence)+`, `+arg(in.Fingerprint)+`, `+arg(channel)+`, 'resolved', `+arg(in.Severity)+`,
+		        'open', `+arg(detectedAt)+`, `+arg(source)+`, `+arg(by)+`, `+arg(visibility)+`, `+arg(nullableOwner(in.PrivateTo))+`)
 		ON CONFLICT DO NOTHING
 		RETURNING id`,
 		args...).Scan(&signalID)
@@ -151,7 +167,7 @@ func RecordDerived(ctx context.Context, tx pgx.Tx, in DerivedSignal, detectedAt 
 	if err := storekit.EmitEvent(ctx, tx, auditID, signalID, crmcontracts.PublicEventSignalDetected{
 		SignalId:        openapi_types.UUID(signalID),
 		Kind:            in.Kind,
-		SourceChannel:   "derived",
+		SourceChannel:   channel,
 		ResolutionState: resolutionResolved,
 		Severity:        in.Severity,
 		// The signal's SUBJECT. The envelope's own entity is the signal.
@@ -161,6 +177,20 @@ func RecordDerived(ctx context.Context, tx pgx.Tx, in DerivedSignal, detectedAt 
 		return false, fmt.Errorf("emit signal.detected: %w", err)
 	}
 	return true, nil
+}
+
+// channelAndSource fills in what a producer left unsaid. The defaults are what
+// every producer meant before there was a second kind: a finding computed from
+// this workspace's own records, by the signal scan.
+func (in DerivedSignal) channelAndSource() (channel, source string) {
+	channel, source = in.Channel, in.Source
+	if channel == "" {
+		channel = "derived"
+	}
+	if source == "" {
+		source = "signal-scan"
+	}
+	return channel, source
 }
 
 // subject is the (entity_type, entity_id) pair the row carries: the project
@@ -177,11 +207,15 @@ func (in DerivedSignal) subject() (string, ids.UUID) {
 func derivedEvidenceRows(in []DerivedEvidence) []map[string]any {
 	out := make([]map[string]any, 0, len(in))
 	for _, cited := range in {
-		out = append(out, map[string]any{
-			"snippet":     cited.Snippet,
-			"source_type": "activity",
-			"source_id":   cited.ActivityID.String(),
-		})
+		row := map[string]any{"snippet": cited.Snippet}
+		if cited.SourceURL != "" {
+			row["source_type"] = "url"
+			row["source_id"] = cited.SourceURL
+		} else {
+			row["source_type"] = "activity"
+			row["source_id"] = cited.ActivityID.String()
+		}
+		out = append(out, row)
 	}
 	return out
 }

--- a/backend/internal/modules/signals/derived.go
+++ b/backend/internal/modules/signals/derived.go
@@ -209,7 +209,10 @@ func derivedEvidenceRows(in []DerivedEvidence) []map[string]any {
 	for _, cited := range in {
 		row := map[string]any{"snippet": cited.Snippet}
 		if cited.SourceURL != "" {
-			row["source_type"] = "url"
+			// `page` is the contract's own word for a cited web page
+			// (SignalEvidence.source_type). Inventing a second one here would
+			// write rows the published enum refuses.
+			row["source_type"] = "page"
 			row["source_id"] = cited.SourceURL
 		} else {
 			row["source_type"] = "activity"

--- a/backend/migrations/core/1787831200_a_company_event_is_a_signal.down.sql
+++ b/backend/migrations/core/1787831200_a_company_event_is_a_signal.down.sql
@@ -1,0 +1,24 @@
+-- Same bound as the up: the constraint swap takes an ACCESS EXCLUSIVE lock on a
+-- table the signal scan writes on every pass.
+--
+-- Rows carrying one of the four kinds would fail the narrowed constraint, so
+-- they are retired first. `archived_at` rather than a delete: a signal somebody
+-- has already read and acted on is history, and this direction is a schema
+-- rollback rather than a decision that the finding was wrong.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE signal
+   SET kind = 'other', archived_at = coalesce(archived_at, now())
+ WHERE kind IN ('funding', 'leadership_change', 'expansion', 'product_launch');
+
+ALTER TABLE signal ADD CONSTRAINT signal_kind_check_v1
+    CHECK (kind IN ('stalled_deal', 'champion_left', 'reengagement', 'buying_intent',
+                    'risk', 'other', 'contract_ended', 'new_opportunity',
+                    'commitment_made', 'ghosted_thread', 'project_gone_quiet'))
+    NOT VALID;
+
+ALTER TABLE signal VALIDATE CONSTRAINT signal_kind_check_v1;
+
+ALTER TABLE signal DROP CONSTRAINT signal_kind_check;
+
+ALTER TABLE signal RENAME CONSTRAINT signal_kind_check_v1 TO signal_kind_check;

--- a/backend/migrations/core/1787831200_a_company_event_is_a_signal.up.sql
+++ b/backend/migrations/core/1787831200_a_company_event_is_a_signal.up.sql
@@ -1,0 +1,36 @@
+-- Four kinds for what a company says about itself in public.
+--
+-- A newsroom item is a signal about an ACCOUNT — a funding round, a new CFO, a
+-- second office, a product — and the signal table is already the company-level
+-- substrate with the fingerprint dedupe, the triage lifecycle and the surface
+-- that lists them. What it lacked was a vocabulary for the four things a
+-- company's own press page actually announces.
+--
+-- Deliberately NOT folded onto `new_opportunity`, which is the closest existing
+-- kind and the wrong one: that kind carries workflow meaning for the warm-room
+-- and resolver paths, and a quarter's worth of press releases arriving under it
+-- would put newsroom noise into a surface built for sales intent.
+--
+-- `leadership_change` names a person in its summary and is still a COMPANY
+-- event: the resolver never creates a person from a signal, and a new CFO is a
+-- fact about the account until somebody decides otherwise.
+--
+-- ADD ... NOT VALID then VALIDATE, then swap: the runner wraps each migration
+-- in one transaction, so a failure at any statement rolls the whole file back
+-- and `signal` can never be left with no kind constraint. The two-step also
+-- shortens the ACCESS EXCLUSIVE hold — NOT VALID takes it without scanning, and
+-- VALIDATE drops to SHARE UPDATE EXCLUSIVE for the pass.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE signal ADD CONSTRAINT signal_kind_check_v2
+    CHECK (kind IN ('stalled_deal', 'champion_left', 'reengagement', 'buying_intent',
+                    'risk', 'other', 'contract_ended', 'new_opportunity',
+                    'commitment_made', 'ghosted_thread', 'project_gone_quiet',
+                    'funding', 'leadership_change', 'expansion', 'product_launch'))
+    NOT VALID;
+
+ALTER TABLE signal VALIDATE CONSTRAINT signal_kind_check_v2;
+
+ALTER TABLE signal DROP CONSTRAINT signal_kind_check;
+
+ALTER TABLE signal RENAME CONSTRAINT signal_kind_check_v2 TO signal_kind_check;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3813,7 +3813,7 @@ public.signal.resolved_person_id uuid gen=- def=-
 public.signal.severity text NOT NULL gen=- def='info'::text
 public.signal.signal_entity_pair CHECK (((entity_type IS NULL) = (entity_id IS NULL)))
 public.signal.signal_entity_type_check CHECK (((entity_type IS NULL) OR (entity_type = ANY (ARRAY['deal'::text, 'organization'::text, 'person'::text, 'project'::text]))))
-public.signal.signal_kind_check CHECK ((kind = ANY (ARRAY['stalled_deal'::text, 'champion_left'::text, 'reengagement'::text, 'buying_intent'::text, 'risk'::text, 'other'::text, 'contract_ended'::text, 'new_opportunity'::text, 'commitment_made'::text, 'ghosted_thread'::text, 'project_gone_quiet'::text])))
+public.signal.signal_kind_check CHECK ((kind = ANY (ARRAY['stalled_deal'::text, 'champion_left'::text, 'reengagement'::text, 'buying_intent'::text, 'risk'::text, 'other'::text, 'contract_ended'::text, 'new_opportunity'::text, 'commitment_made'::text, 'ghosted_thread'::text, 'project_gone_quiet'::text, 'funding'::text, 'leadership_change'::text, 'expansion'::text, 'product_launch'::text])))
 public.signal.signal_owner_fkey FOREIGN KEY (owner_id) REFERENCES app_user(id) ON DELETE SET NULL (owner_id)
 public.signal.signal_owner_private_names_its_owner CHECK (((visibility <> 'owner'::text) OR (owner_id IS NOT NULL)))
 public.signal.signal_pkey PRIMARY KEY (id)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17884,7 +17884,7 @@ export interface components {
              *     (`entity_type: project`), attributed to the project's company.
              * @enum {string}
              */
-            kind: "stalled_deal" | "champion_left" | "reengagement" | "buying_intent" | "risk" | "other" | "contract_ended" | "new_opportunity" | "commitment_made" | "ghosted_thread" | "project_gone_quiet";
+            kind: "stalled_deal" | "champion_left" | "reengagement" | "buying_intent" | "risk" | "other" | "contract_ended" | "new_opportunity" | "commitment_made" | "ghosted_thread" | "project_gone_quiet" | "funding" | "leadership_change" | "expansion" | "product_launch";
             /**
              * @description Where the raw signal came from.
              * @default derived


### PR DESCRIPTION
Half of item A2 of the enrichment position paper: newsroom events. (The Impressum field extension, the other half, is **not** in this PR — see Deferred below.)

## What changes for a user

A deep read now also looks for the company's own newsroom feed, and what it finds lands as signals on the account — a funding round, a new CFO, a second office, a product. They appear in the company rail's existing Signals section with no new surface, because a newsroom item *is* a company-level signal and the section was already built for those.

**Three fields per item and no fourth**: the headline, the address, the date. The article's text is never stored. What a company published is theirs, and a CRM holding a copy of somebody's press page is the shape this product refuses everywhere else — a reader who wants the article follows the link.

## Why four new kinds rather than an existing one

`new_opportunity` is the closest existing kind and the wrong one: it carries workflow meaning for the warm-room and resolver paths, and a quarter of press releases arriving under it would put newsroom noise into a surface built for sales intent. `leadership_change` names a person in its summary and stays a **company** event — the resolver never creates a person from a signal.

## The classification is deterministic, not a model call

The plan said an LLM lane; the code does not. The four kinds are announcement genres with stable vocabulary in both languages this reads, so a word list answers the question, and a model would spend a round trip per item of every crawl to answer it less predictably. Matching is on word boundaries — a review caught that a substring match filed "Acme **praises** its new CEO" as a funding round. A headline that matches nothing is `other`, because a hiring announcement filed as a funding round is worse on an account page than an unclassified line.

## Reuse

`signals.RecordDerived` gained a source channel and a producer name rather than growing a sibling. Its fingerprint dedupe, its audit and its event emission are what every signal producer needs, and a second insert path would have been a second answer to how a signal is written. Its evidence rows now cite a page as well as an activity.

## Two things the tests pin down

An item whose date will not parse gets the **zero** time rather than today's: dating a press release by when we happened to read it would put three-year-old news at the top of an account. And a first read is bounded to a year, so a company's whole archive does not arrive as this week's events.

## Fixed along the way

The migration preserves `project_gone_quiet`, a kind added after the baseline — rebuilding the list from the baseline alone silently dropped it, and the head catalog is what caught that.

## Deferred

**The Impressum field extension is not here.** `sitecorpuslegal.go` already extracts entity name, registered address and register number from imprint pages, so that ticket is an extension of an existing census rather than the new lane the plan assumed — and the vocabulary it extends is mirrored in four places that must move together. It is filed as its own issue rather than half-done here.

Note also that `RegisterNumber` currently maps onto the `register_vat` profile field, which is imprecise: an HRB number and a USt-IdNr are different things. That is named in the follow-up issue.

## Verification

- `make check-backend`, `make check-fe` and `make craft-static` all green.
- Sixteen unit tests: both feed shapes, the date fallbacks, the item and byte caps, the refusals, the classifier in both languages including the word-boundary case and the deliberate miss.
- Migration integration lane green; head catalog regenerated and additive.
- A review pass found two contract violations that would have made every stored signal unrepresentable to API clients, a fingerprint that would have double-filed reclassified articles, and the substring bug. All fixed here with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deep reads now fetch a company's own newsroom feed and file its announcements as signals on the account — funding, leadership changes, expansion, and product launches — surfacing in the existing Signals rail without new UI.

- Stores only headline, URL, and published date per item; article text is never saved and readers follow the link.
- Classification is deterministic word-boundary matching in English and German, not a model call; unclassifiable headlines become `other`.
- Unparseable feed dates stay zero rather than reading as today, and a first read is bounded to one year, so archives don't arrive as this week's news.
- `signals.RecordDerived` gains a source channel, producer name, and page-citing evidence rows instead of a second write path.
- Migration widens the `signal.kind` check (preserving `project_gone_quiet`) and adds the four kinds to the API and generated clients.

<sup>Written for commit 160641c4ba57dfa6a6e1d8b579c2a6a9ead34fa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic newsroom feed reading from company websites.
  - Added detection of funding, leadership changes, expansions, and product launches from recent announcements.
  - Added support for RSS and Atom feeds, including publication dates and article links.
  - Added URL-backed evidence and clearer source metadata for detected signals.

- **Bug Fixes**
  - Newsroom read or feed failures no longer prevent the main site analysis from completing.
  - Older announcements are excluded, while undated announcements remain eligible for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->