### PR TITLE
feat(onboarding): the conversation speaks every language the product ships

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7401,9 +7401,9 @@ paths:
           description: Language for the open questions' copy; option values are locale-invariant.
           schema:
             type: string
-            enum: [en, de]
+            enum: [en, de, vi]
             default: en
-            x-enum-varnames: [OnboardingProposalLocaleEN, OnboardingProposalLocaleDE]
+            x-enum-varnames: [OnboardingProposalLocaleEN, OnboardingProposalLocaleDE, OnboardingProposalLocaleVI]
       responses:
         '200':
           description: The current deterministic proposal snapshot.
@@ -27157,8 +27157,8 @@ components:
         message: { type: string, minLength: 1, maxLength: 2000 }
         locale:
           type: string
-          enum: [en, de]
-          x-enum-varnames: [OnboardingCompanyLocaleEN, OnboardingCompanyLocaleDE]
+          enum: [en, de, vi]
+          x-enum-varnames: [OnboardingCompanyLocaleEN, OnboardingCompanyLocaleDE, OnboardingCompanyLocaleVI]
         act:
           $ref: '#/components/schemas/OnboardingAct'
           default: company

--- a/backend/gates/onboardinglocales_test.go
+++ b/backend/gates/onboardinglocales_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The onboarding conversation speaks every language the product does.
+//
+// It used to speak two, in a shape that could not say so: each line of copy was
+// an `if locale == "de"` with English underneath, so a third shipped language
+// took the English branch silently. A Vietnamese reader was onboarded in
+// English inside an otherwise Vietnamese product, and the only way to find that
+// out was to run it.
+//
+// Three declarations of one set have to agree — textlang.Shipped, the
+// contract's two onboarding locale enums, and the copy table the conversation
+// reads. The frontend's own map is the fourth and holds itself: it is
+// `satisfies Record<OnboardingLocale, true>`, so widening the enum stops the
+// build until the map follows. This gate is the same obligation for the three
+// that cannot state it in their own types.
+//
+// textlang.Shipped is the SUBJECT, not a party to the comparison: it is where
+// the product says which languages it speaks, and the other two answer to it.
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// onboardingLocaleEnums finds the onboarding locale enums in the contract by
+// the varname prefix each declares, rather than by line number or by the
+// enum's own text: a contract edit that moved either would otherwise take this
+// gate's subject with it and leave the assertion passing over nothing.
+var onboardingLocaleEnums = regexp.MustCompile(
+	`enum: \[([^\]]*)\]\n[^\n]*\n?[^\n]*x-enum-varnames: \[(Onboarding(?:Company|Proposal)Locale[^\]]*)\]`)
+
+func TestTheOnboardingConversationSpeaksEveryShippedLanguage(t *testing.T) {
+	t.Parallel()
+
+	contract, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	found := onboardingLocaleEnums.FindAllStringSubmatch(string(contract), -1)
+	// Two: the message request's and the proposal parameter's. Pinned, because
+	// a regex that stopped matching one of them would leave this gate green
+	// over an enum nobody is checking.
+	const declared = 2
+	if len(found) != declared {
+		t.Fatalf("found %d onboarding locale enum(s) in the contract, want %d — the pattern has gone "+
+			"blind, and an enum this gate cannot see is one it cannot hold", len(found), declared)
+	}
+
+	want := make([]string, 0, len(textlang.Shipped))
+	for _, lang := range textlang.Shipped {
+		want = append(want, string(lang))
+	}
+	for _, match := range found {
+		got := splitEnum(match[1])
+		if !slices.Equal(got, want) {
+			t.Errorf("the contract's %s enum admits %v, and the product ships %v.\n"+
+				"A language in the shipped set that the enum refuses is one the frontend maps away "+
+				"to English rather than 422s on — so the reader is onboarded in the wrong language "+
+				"and nothing reports it. Widen the enum, its x-enum-varnames and the copy table "+
+				"together.", strings.Split(match[2], ",")[0], got, want)
+		}
+	}
+
+	// And the copy the conversation reads. Held here rather than in compose
+	// because it is the same obligation: a language in the shipped set with no
+	// copy behind it falls back to English, which is exactly the failure the
+	// enum half exists to prevent, one layer in.
+	for _, lang := range textlang.Shipped {
+		if !onboardingCopyDeclares(t, string(lang)) {
+			t.Errorf("the onboarding copy table has no entry for %q, which the product ships.\n"+
+				"copyFor falls back to English, so this reader is onboarded in a language they did "+
+				"not choose — silently. Add the entry in internal/compose/onboardingcopy.go.", lang)
+		}
+	}
+}
+
+// splitEnum reads a YAML flow sequence's members.
+func splitEnum(raw string) []string {
+	out := []string{}
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// onboardingCopyDeclares reports whether the copy table names this language.
+//
+// Read out of the source rather than by importing compose, which is what every
+// gate in this package does with an unexported declaration: the table is
+// package-private, and exporting it to be tested would widen an API for the
+// benefit of the thing checking it.
+func onboardingCopyDeclares(t *testing.T, code string) bool {
+	t.Helper()
+	body, err := os.ReadFile("internal/compose/onboardingcopy.go")
+	if err != nil {
+		t.Fatalf("reading the onboarding copy table: %v", err)
+	}
+	name := map[string]string{"en": "English", "de": "German", "vi": "Vietnamese"}[code]
+	if name == "" {
+		t.Fatalf("the product ships %q and this gate does not know its textlang constant — "+
+			"teach it here rather than letting the copy check pass vacuously", code)
+	}
+	return strings.Contains(string(body), "textlang."+name+": {")
+}

--- a/backend/internal/compose/onboardingclarify.go
+++ b/backend/internal/compose/onboardingclarify.go
@@ -30,8 +30,6 @@ import (
 // than this presents the first six as printed.
 const onboardingClarifyOptionLimit = 6
 
-const localeDE = "de"
-
 // withSelectedOption records the clarify option the administrator
 // clicked — the strongest explicit instruction there is. It grants
 // exactly the named field with the chosen value (post-trim exact match)
@@ -319,50 +317,29 @@ func conflictOption(value, label, detail string) crmcontracts.OnboardingClarifyO
 }
 
 func clarifyEntityQuestion(locale string) string {
-	if locale == localeDE {
-		return "Die rechtlichen Angaben der Website nennen mehrere juristische Personen. Welche ist Ihr Unternehmen?"
-	}
-	return "The legal notice names more than one legal entity. Which one is your company?"
+	return copyFor(locale).entityQuestion
 }
 
 func clarifyAddressQuestion(locale string) string {
-	if locale == localeDE {
-		return "Die Website nennt mehrere Geschäftsanschriften. Welche gehört zu Ihrem Unternehmen?"
-	}
-	return "The website states more than one registered address. Which one belongs to your company?"
+	return copyFor(locale).addressQuestion
 }
 
 func clarifyConflictQuestion(locale, key string) string {
-	if locale == localeDE {
-		return fmt.Sprintf("Ihr gespeicherter Wert für %s unterscheidet sich von der Website. Welchen Wert soll ich verwenden?", key)
-	}
-	return fmt.Sprintf("Your saved value for %s differs from what the website states. Which value should I use?", key)
+	return fmt.Sprintf(copyFor(locale).conflictQuestion, key)
 }
 
 func clarifyKeepLabel(locale string) string {
-	if locale == localeDE {
-		return "Meinen Wert behalten"
-	}
-	return "Keep my value"
+	return copyFor(locale).keepLabel
 }
 
 func clarifyKeepDetail(locale string) string {
-	if locale == localeDE {
-		return "Von einem Menschen eingetragen; bleibt bei der Bestätigung unverändert (keep_current)."
-	}
-	return "Entered by a human; confirming keeps it unchanged (keep_current)."
+	return copyFor(locale).keepDetail
 }
 
 func clarifyTakeLabel(locale string) string {
-	if locale == localeDE {
-		return "Wert der Website übernehmen"
-	}
-	return "Use the website's value"
+	return copyFor(locale).takeLabel
 }
 
 func clarifyTakeDetail(locale string) string {
-	if locale == localeDE {
-		return "Von der Website gelesen; die Bestätigung übernimmt diesen Wert (accept_proposal)."
-	}
-	return "Read from the website; confirming takes this value (accept_proposal)."
+	return copyFor(locale).takeDetail
 }

--- a/backend/internal/compose/onboardingcompanymessage.go
+++ b/backend/internal/compose/onboardingcompanymessage.go
@@ -195,7 +195,7 @@ func decodeOnboardingCompanyMessage(w http.ResponseWriter, r *http.Request) (crm
 		return req, "", false
 	}
 	if !req.Locale.Valid() {
-		httperr.Write(w, r, httperr.Validation("locale", "invalid", "locale must be en or de"))
+		httperr.Write(w, r, httperr.Validation("locale", "invalid", onboardingLocaleRefusal()))
 		return req, "", false
 	}
 	message := strings.TrimSpace(req.Message)
@@ -350,28 +350,17 @@ func isCompanyStatusQuestion(message string) bool {
 }
 
 func onboardingStatusMessage(locale string, research onboardingResearchState, missing int) string {
-	if locale == "de" {
-		if research.confirmed {
-			return "Ja. Ich habe das bestätigte Unternehmensprofil gespeichert."
-		}
-		if research.status == siteReadWireStatusFailed {
-			return fmt.Sprintf("Meine Web-Recherche ist beendet, konnte aber nicht abgeschlossen werden. Wir können die %d fehlenden Pflichtangaben hier gemeinsam manuell ergänzen; gespeichert ist noch nichts.", missing)
-		}
-		if !research.ready {
-			return "Ja. Ich recherchiere noch und zeige neue belegte Funde im Unternehmensentwurf. Gespeichert ist noch nichts."
-		}
-		return fmt.Sprintf("Ja. Meine Recherche funktioniert. Es fehlen noch %d Pflichtangaben; gespeichert ist noch nichts.", missing)
+	said := copyFor(locale)
+	switch {
+	case research.confirmed:
+		return said.statusConfirmed
+	case research.status == siteReadWireStatusFailed:
+		return fmt.Sprintf(said.statusFailed, missing)
+	case !research.ready:
+		return said.statusResearching
+	default:
+		return fmt.Sprintf(said.statusMissing, missing)
 	}
-	if research.confirmed {
-		return "Yes. I saved the confirmed company profile."
-	}
-	if research.status == siteReadWireStatusFailed {
-		return fmt.Sprintf("My website research has stopped without completing. We can fill the %d missing required details together here; nothing is saved yet.", missing)
-	}
-	if !research.ready {
-		return "Yes. I'm still researching and will add grounded findings to the company draft as they arrive. Nothing is saved yet."
-	}
-	return fmt.Sprintf("Yes. The company workspace is working. %d required details remain; nothing is saved yet.", missing)
 }
 
 func onboardingCompanyReply(act string, answer companyReadModelReply, evidence []companyReadEvidence, remaining []string, research onboardingResearchState, runtime ai.RunSummary) crmcontracts.OnboardingCompanyMessageReply {

--- a/backend/internal/compose/onboardingcopy.go
+++ b/backend/internal/compose/onboardingcopy.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The onboarding conversation's hand-written copy, per language.
+//
+// Every line here used to be an `if locale == "de"` with English underneath,
+// which is a shape that reads as a choice and behaves as a floor: a third
+// shipped language took the English branch, silently, and nothing anywhere
+// failed. A Vietnamese reader was onboarded in English inside an otherwise
+// Vietnamese product, and the only way to find out was to run it.
+//
+// A table instead, keyed by the language, with the shipped set as the census.
+// TestEveryShippedLanguageHasOnboardingCopy fails when the product gains a
+// language this file has not learned — before a reader does.
+//
+// The model-written half of the conversation needs none of this: it is
+// instructed through promptlang.Rule, which already answers for every shipped
+// language. What lives here is the copy this product wrote itself.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// onboardingCopy is one language's set. Every field is required — a partial
+// set is the same silent English fallback in miniature, and the census below
+// refuses one.
+type onboardingCopy struct {
+	// entityQuestion asks which of several legal entities on the site is the
+	// reader's own company.
+	entityQuestion string
+	// addressQuestion asks the same about several registered addresses.
+	addressQuestion string
+	// conflictQuestion asks which value to keep where the saved one and the
+	// site's disagree. %s is the field's key, which is NOT translated: it
+	// names a field the reader can see on their own screen.
+	conflictQuestion string
+	// keepLabel / keepDetail present the saved value as the choice.
+	keepLabel  string
+	keepDetail string
+	// takeLabel / takeDetail present the site's value as the choice.
+	takeLabel  string
+	takeDetail string
+	// statusConfirmed answers "is it working" once the profile is saved.
+	statusConfirmed string
+	// statusFailed answers it when the research stopped without completing.
+	// %d is how many required details are still missing.
+	statusFailed string
+	// statusResearching answers it while the research is still running.
+	statusResearching string
+	// statusMissing answers it when the research works and details remain.
+	// %d is how many.
+	statusMissing string
+}
+
+// onboardingCopyByLang is the census. Keyed by textlang.Lang rather than by a
+// string, so the gate can walk textlang.Shipped and ask this map directly.
+var onboardingCopyByLang = map[textlang.Lang]onboardingCopy{
+	textlang.English: {
+		entityQuestion:    "The legal notice names more than one legal entity. Which one is your company?",
+		addressQuestion:   "The website states more than one registered address. Which one belongs to your company?",
+		conflictQuestion:  "Your saved value for %s differs from what the website states. Which value should I use?",
+		keepLabel:         "Keep my value",
+		keepDetail:        "Entered by a human; confirming keeps it unchanged (keep_current).",
+		takeLabel:         "Use the website's value",
+		takeDetail:        "Read from the website; confirming takes this value (accept_proposal).",
+		statusConfirmed:   "Yes. I saved the confirmed company profile.",
+		statusFailed:      "My website research has stopped without completing. We can fill the %d missing required details together here; nothing is saved yet.",
+		statusResearching: "Yes. I'm still researching and will add grounded findings to the company draft as they arrive. Nothing is saved yet.",
+		statusMissing:     "Yes. The company workspace is working. %d required details remain; nothing is saved yet.",
+	},
+	textlang.German: {
+		entityQuestion:    "Die rechtlichen Angaben der Website nennen mehrere juristische Personen. Welche ist Ihr Unternehmen?",
+		addressQuestion:   "Die Website nennt mehrere Geschäftsanschriften. Welche gehört zu Ihrem Unternehmen?",
+		conflictQuestion:  "Ihr gespeicherter Wert für %s unterscheidet sich von der Website. Welchen Wert soll ich verwenden?",
+		keepLabel:         "Meinen Wert behalten",
+		keepDetail:        "Von einem Menschen eingetragen; bleibt bei der Bestätigung unverändert (keep_current).",
+		takeLabel:         "Wert der Website übernehmen",
+		takeDetail:        "Von der Website gelesen; die Bestätigung übernimmt diesen Wert (accept_proposal).",
+		statusConfirmed:   "Ja. Ich habe das bestätigte Unternehmensprofil gespeichert.",
+		statusFailed:      "Meine Web-Recherche ist beendet, konnte aber nicht abgeschlossen werden. Wir können die %d fehlenden Pflichtangaben hier gemeinsam manuell ergänzen; gespeichert ist noch nichts.",
+		statusResearching: "Ja. Ich recherchiere noch und zeige neue belegte Funde im Unternehmensentwurf. Gespeichert ist noch nichts.",
+		statusMissing:     "Ja. Meine Recherche funktioniert. Es fehlen noch %d Pflichtangaben; gespeichert ist noch nichts.",
+	},
+	// Addressed as "bạn", the neutral second person this product's Vietnamese
+	// UI already uses. The parenthesised keep_current / accept_proposal stay in
+	// English: they are the wire values behind the two buttons, and a reader
+	// comparing what they clicked with what the record says needs the same
+	// word in both places.
+	textlang.Vietnamese: {
+		entityQuestion:    "Trang thông tin pháp lý của website nêu nhiều pháp nhân. Pháp nhân nào là công ty của bạn?",
+		addressQuestion:   "Website nêu nhiều địa chỉ đăng ký. Địa chỉ nào là của công ty bạn?",
+		conflictQuestion:  "Giá trị đã lưu của bạn cho %s khác với thông tin trên website. Tôi nên dùng giá trị nào?",
+		keepLabel:         "Giữ giá trị của tôi",
+		keepDetail:        "Do một người nhập vào; xác nhận sẽ giữ nguyên giá trị này (keep_current).",
+		takeLabel:         "Dùng giá trị của website",
+		takeDetail:        "Đọc được từ website; xác nhận sẽ lấy giá trị này (accept_proposal).",
+		statusConfirmed:   "Vâng. Tôi đã lưu hồ sơ công ty đã được xác nhận.",
+		statusFailed:      "Phần tìm hiểu website của tôi đã dừng mà chưa hoàn tất. Chúng ta có thể cùng điền %d thông tin bắt buộc còn thiếu ngay tại đây; hiện chưa có gì được lưu.",
+		statusResearching: "Vâng. Tôi vẫn đang tìm hiểu và sẽ bổ sung vào bản nháp công ty những thông tin có căn cứ khi tìm được. Hiện chưa có gì được lưu.",
+		statusMissing:     "Vâng. Không gian làm việc của công ty đang hoạt động. Còn thiếu %d thông tin bắt buộc; hiện chưa có gì được lưu.",
+	},
+}
+
+// copyFor answers the reader's language, and English for anything else.
+//
+// The fallback is unreachable for a language the product ships — the census
+// holds that — and it is still here because this takes a string off the wire.
+// A caller that reached it with a locale the contract admits would be a bug
+// this function cannot fix; what it can do is answer in a language rather than
+// in nothing.
+func copyFor(locale string) onboardingCopy {
+	if said, ok := onboardingCopyByLang[textlang.Lang(locale)]; ok {
+		return said
+	}
+	return onboardingCopyByLang[textlang.English]
+}
+
+// onboardingLocaleRefusal names the languages the onboarding conversation
+// speaks, derived from the shipped set rather than spelled out — the refusal a
+// caller reads must not be able to name a different set from the one the
+// contract admits.
+func onboardingLocaleRefusal() string {
+	codes := make([]string, 0, len(textlang.Shipped))
+	for _, lang := range textlang.Shipped {
+		codes = append(codes, string(lang))
+	}
+	return fmt.Sprintf("locale must be one of %v", codes)
+}

--- a/backend/internal/compose/onboardingcopy_test.go
+++ b/backend/internal/compose/onboardingcopy_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every shipped language answers in ITS OWN words.
+//
+// A census that only checked for an entry would pass against a set copied from
+// English and never translated — which is the same reader in the same wrong
+// language, with a row in a table saying otherwise. Difference is the thing
+// worth asserting, because sameness is what the bug looked like.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+func TestNoShippedLanguageAnswersInEnglishByAccident(t *testing.T) {
+	english := onboardingCopyByLang[textlang.English]
+	for _, lang := range textlang.Shipped {
+		if lang == textlang.English {
+			continue
+		}
+		t.Run(string(lang), func(t *testing.T) {
+			said := onboardingCopyByLang[lang]
+			for _, field := range []struct{ name, got, en string }{
+				{"entityQuestion", said.entityQuestion, english.entityQuestion},
+				{"addressQuestion", said.addressQuestion, english.addressQuestion},
+				{"conflictQuestion", said.conflictQuestion, english.conflictQuestion},
+				{"keepLabel", said.keepLabel, english.keepLabel},
+				{"keepDetail", said.keepDetail, english.keepDetail},
+				{"takeLabel", said.takeLabel, english.takeLabel},
+				{"takeDetail", said.takeDetail, english.takeDetail},
+				{"statusConfirmed", said.statusConfirmed, english.statusConfirmed},
+				{"statusFailed", said.statusFailed, english.statusFailed},
+				{"statusResearching", said.statusResearching, english.statusResearching},
+				{"statusMissing", said.statusMissing, english.statusMissing},
+			} {
+				if field.got == "" {
+					t.Errorf("%s is empty — a blank line of copy reaches the reader as nothing at all", field.name)
+					continue
+				}
+				if field.got == field.en {
+					t.Errorf("%s is the English string verbatim; the entry exists and the reader still "+
+						"gets English", field.name)
+				}
+			}
+		})
+	}
+}
+
+// The verbs behind the two buttons are wire values, not prose. A reader
+// comparing what they clicked with what the record says needs the same word in
+// both places, so these stay in English in every language.
+func TestTheChoiceVerbsAreNotTranslated(t *testing.T) {
+	for _, lang := range textlang.Shipped {
+		said := onboardingCopyByLang[lang]
+		for _, want := range []struct{ verb, in string }{
+			{"keep_current", said.keepDetail},
+			{"accept_proposal", said.takeDetail},
+		} {
+			if !strings.Contains(want.in, want.verb) {
+				t.Errorf("%s's copy does not carry %q: %q", lang, want.verb, want.in)
+			}
+		}
+	}
+}
+
+// The formatting holes have to survive translation. A %d dropped from one
+// language's string prints the sentence without the number the sentence is
+// about; a %s dropped from the conflict question stops naming the field.
+func TestEveryLanguageKeepsItsFormattingHoles(t *testing.T) {
+	for _, lang := range textlang.Shipped {
+		said := onboardingCopyByLang[lang]
+		for _, field := range []struct{ name, got, verb string }{
+			{"conflictQuestion", said.conflictQuestion, "%s"},
+			{"statusFailed", said.statusFailed, "%d"},
+			{"statusMissing", said.statusMissing, "%d"},
+		} {
+			if strings.Count(field.got, field.verb) != 1 {
+				t.Errorf("%s's %s carries %d %s verbs, want exactly 1: %q",
+					lang, field.name, strings.Count(field.got, field.verb), field.verb, field.got)
+			}
+		}
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -5876,6 +5876,7 @@ func (e OnboardingCompanyMessageReplyRemainingRequiredFields) Valid() bool {
 const (
 	OnboardingCompanyLocaleDE OnboardingCompanyMessageRequestLocale = "de"
 	OnboardingCompanyLocaleEN OnboardingCompanyMessageRequestLocale = "en"
+	OnboardingCompanyLocaleVI OnboardingCompanyMessageRequestLocale = "vi"
 )
 
 // Valid indicates whether the value is a known member of the OnboardingCompanyMessageRequestLocale enum.
@@ -5884,6 +5885,8 @@ func (e OnboardingCompanyMessageRequestLocale) Valid() bool {
 	case OnboardingCompanyLocaleDE:
 		return true
 	case OnboardingCompanyLocaleEN:
+		return true
+	case OnboardingCompanyLocaleVI:
 		return true
 	default:
 		return false
@@ -11567,6 +11570,7 @@ func (e ListListsParamsEntityType) Valid() bool {
 const (
 	OnboardingProposalLocaleDE GetOnboardingCompanyProposalParamsLocale = "de"
 	OnboardingProposalLocaleEN GetOnboardingCompanyProposalParamsLocale = "en"
+	OnboardingProposalLocaleVI GetOnboardingCompanyProposalParamsLocale = "vi"
 )
 
 // Valid indicates whether the value is a known member of the GetOnboardingCompanyProposalParamsLocale enum.
@@ -11575,6 +11579,8 @@ func (e GetOnboardingCompanyProposalParamsLocale) Valid() bool {
 	case OnboardingProposalLocaleDE:
 		return true
 	case OnboardingProposalLocaleEN:
+		return true
+	case OnboardingProposalLocaleVI:
 		return true
 	default:
 		return false

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (34)
+## Parity (35)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -45,6 +45,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `minorunitscale_test.go` | H3 | A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one fact, and the table that holds it lives in shared/kernel/values. |
 | `netguardparity_test.go` | H3 | The egress SSRF denylist exists twice, and this is where the two are held equal. |
+| `onboardinglocales_test.go` | H2 | The onboarding conversation speaks every language the product does. |
 | `outboundidentity_test.go` | H1 | A remote operator sees one name for this product and decides about it: blocks it, rate-limits it, allow-lists it, or writes a robots.txt group naming it. |
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -19861,7 +19861,7 @@ export interface components {
         OnboardingCompanyMessageRequest: {
             message: string;
             /** @enum {string} */
-            locale: "en" | "de";
+            locale: "en" | "de" | "vi";
             /**
              * @description Which onboarding act the conversation is in; omitted means company.
              * @default company
@@ -31613,7 +31613,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description Language for the open questions' copy; option values are locale-invariant. */
-                locale?: "en" | "de";
+                locale?: "en" | "de" | "vi";
             };
             header?: never;
             path?: never;

--- a/frontend/src/screens/onboarding-conversation/onboarding-locale.test.ts
+++ b/frontend/src/screens/onboarding-conversation/onboarding-locale.test.ts
@@ -1,25 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { LOCALES } from "../../i18n";
-import { onboardingLocale } from "./onboarding-locale";
+import { onboardingLocale, PROMPTED_LOCALES } from "./onboarding-locale";
 
 describe("onboarding conversation locale", () => {
   it("passes a prompted locale through untouched", () => {
-    expect(onboardingLocale("en")).toBe("en");
-    expect(onboardingLocale("de")).toBe("de");
+    for (const locale of PROMPTED_LOCALES) {
+      expect(onboardingLocale(locale)).toBe(locale);
+    }
   });
 
   it("falls back to the contract default for a locale the prompts do not cover", () => {
-    // A UI catalog can ship before the prompt library follows. Sending the
-    // catalog's code anyway would 422 the reader out of onboarding.
-    expect(onboardingLocale("vi")).toBe("en");
+    // No SHIPPED locale needs this today — the prompt library covers all three
+    // — and the case stays because that is a fact about today, not a property.
+    // A UI catalog ships as soon as its strings are translated; the prompt
+    // library follows separately, and in the window between them sending the
+    // catalog's code would 422 the reader out of onboarding.
+    //
+    // Cast, because the only codes left that reach this branch are ones the
+    // Locale type does not admit — which is exactly the shape a fourth
+    // language arrives in.
+    expect(onboardingLocale("fr" as never)).toBe("en");
   });
 
-  // Derived from LOCALES, so a locale added to the registry is covered here
-  // without editing this test — the point being that NO shipped locale can
-  // put an unenumerated value on the wire.
+  // Derived from LOCALES on one side and PROMPTED_LOCALES on the other, so a
+  // locale added to either registry is covered here without editing this test.
+  // The point is that NO shipped locale can put an unenumerated value on the
+  // wire.
   it("maps every shipped locale to a value the contract enumerates", () => {
     for (const locale of LOCALES) {
-      expect(["en", "de"], locale).toContain(onboardingLocale(locale));
+      expect(PROMPTED_LOCALES, locale).toContain(onboardingLocale(locale));
     }
   });
 });

--- a/frontend/src/screens/onboarding-conversation/onboarding-locale.ts
+++ b/frontend/src/screens/onboarding-conversation/onboarding-locale.ts
@@ -19,7 +19,7 @@ export type OnboardingLocale =
 // follows. A `readonly OnboardingLocale[]` list cannot say that — a subset
 // satisfies it happily, and the new language would keep falling back to
 // English forever with nothing failing.
-const PROMPTED = { en: true, de: true } satisfies Record<
+const PROMPTED = { en: true, de: true, vi: true } satisfies Record<
   OnboardingLocale,
   true
 >;

--- a/frontend/src/screens/onboarding-conversation/onboarding-locale.ts
+++ b/frontend/src/screens/onboarding-conversation/onboarding-locale.ts
@@ -24,6 +24,12 @@ const PROMPTED = { en: true, de: true, vi: true } satisfies Record<
   true
 >;
 
+// The prompted set as a runtime value, for a test that has to name it without
+// restating it. Reading these keys is not circular: what ties PROMPTED to the
+// CONTRACT is the `satisfies` above, which the compiler checks, so a test that
+// ties this function's output to these keys is tying it to the enum by proxy.
+export const PROMPTED_LOCALES = Object.keys(PROMPTED) as OnboardingLocale[];
+
 function isPrompted(locale: Locale): locale is Locale & OnboardingLocale {
   return Object.hasOwn(PROMPTED, locale);
 }


### PR DESCRIPTION
Closes #532.

A Vietnamese reader was onboarded in **English** inside an otherwise Vietnamese product. The contract's locale enum admitted `en` and `de`; the frontend mapped anything else to the default so nobody was 422'd mid-onboarding; and the conversation answered in a language the reader had not chosen — quietly, which is the part that matters.

## The copy

Vietnamese for all eleven hand-written lines: the two entity/address clarify questions, the conflict question and its four option labels and details, and the four status answers.

The branching that hid the gap goes with it. Every line used to be an `if locale == "de"` with English underneath — a shape that reads as a choice and behaves as a floor, so a third shipped language took the English branch and nothing failed. It is a table now, keyed by `textlang.Lang`, with the shipped set as the census.

**The model-written half needed nothing.** It is instructed through `promptlang.Rule`, which has answered for every shipped language all along — which is why the gap was only in the copy this product writes itself.

## Two things stay in English inside the Vietnamese set

- `keep_current` / `accept_proposal` are the wire values behind the two buttons: a reader comparing what they clicked with what the record says needs the same word in both places
- the conflict question names a field by its key, because that is what the reader sees on their own screen

The refusal a bad locale gets is now derived from the shipped set rather than spelled out — a message naming a different set from the one the contract admits is a lie the next language would make true.

## Held

Three declarations of one set have to agree: `textlang.Shipped`, the contract's two onboarding enums, and the copy table. The frontend's map is the fourth and already held itself (`satisfies Record<OnboardingLocale, true>` stops the build until it follows), so the gate covers the three that cannot state it in their own types. `Shipped` is the **subject**, not a party to the comparison — it is where the product says which languages it speaks.

Both arms mutation-checked: narrowing either contract enum, or renaming the Vietnamese entry out of the table, fails the gate by name.

Sameness gets its own tests, because sameness is what the bug looked like — a set copied from English and never translated would satisfy a census that only asked whether an entry exists. The format verbs are pinned too: a `%d` dropped in translation prints the sentence without the number it is about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Vietnamese as a supported onboarding language.
  - Added Vietnamese translations for onboarding prompts, company messages, status updates, and clarification questions.
  - Onboarding locale selection now supports Vietnamese.
  - Added support for recording in-person qualifying events with a required note and timestamp.

- **Bug Fixes**
  - Improved localization fallback and invalid-locale messaging.
  - Preserved required formatting and consistent response options in translated content.

- **Documentation**
  - Updated onboarding language coverage and validation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->