### PR TITLE
fix(gates): the gate inventory counts the declarations the tree carries

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -54,7 +54,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (59)
+## Census (60)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
## What is red

`main-health` run `33071401786`, tip `b9855881f` — four jobs, one cause:

```
--- FAIL: TestTheGateInventoryPageIsCurrent (0.17s)
    gateinventory_test.go:181: ../docs/reference/gate-inventory.md no longer
    matches the //gate:kind declarations in the tree.
```

| job | why |
|---|---|
| `backend gate (main)` | the failure |
| `integration / integration unit coverage` | runs the same `./gates` package |
| `integration / integration (RLS + erasure + HTTP e2e)` | fan-in over the shards |
| `dco (main)` | unrelated, `188598a90` — #2785 |

## The fix

`go test ./gates -run GateInventory -update-gate-inventory`. The entire diff:

```diff
-## Census (59)
+## Census (60)
```

No table row moved — the census number is derived from the `//gate:kind`
declarations, and the tree carries one the page had not counted.

## Nobody's PR is wrong, and that is the point

The census counts the **whole tree**, so it is a committed derived artifact with
no merge queue behind it. A PR touching any gate declaration regenerates the page
against a tree containing its own change and none of the others in flight. Four
landed inside one window:

| PR | what it added |
|---|---|
| #2896 | `lintbuildtagreach_test.go` |
| #2922 | `keyvaultonceperrole_test.go` |
| #2926 | `metricsuffix_test.go` |
| #2933 | declarations in `writeauthority_test.go` + `writeauthorityreach_test.go` |

Each was green on its own base, and I checked rather than assumed: #2896, #2922
and #2926 were merged with no red check at all. **The count they collided on is
the one thing none of them could have got right alone** — two PRs that share no
file still collide here.

This is #2714, and the fix recorded there is a merge queue or a count that is not
committed. Not a rule about remembering to regenerate: the last four authors all
did regenerate.

## Verification

`make check-backend` green, including the gate that was failing. The diff is one
character of content, so the risk is in the diagnosis rather than the change —
which is why the census above names the four PRs rather than a culprit.

## Note on how the tip got here

#2939 was merged past a red `extension-reference` and a red
`integration / integration unit coverage` — the latter being this exact failure,
visible on the PR before it landed. Its own CI run was **still in progress** at
merge time, so unlike the earlier bypasses today this one merged past no verdict
rather than past a red one. #2933 was merged past a red `SonarCloud Code
Analysis`. That is the seventh and eighth today; #2785 carries the pattern.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `TestTheGateInventoryPageIsCurrent` by regenerating the gate inventory census to count the tree's 60 `//gate:kind` declarations (previously 59).

**Why the count drifted**
- The census is a committed derived artifact that counts the whole tree, so concurrent gate-declaring PRs each regenerated against their own base and couldn't see the others' additions.
- The diff is the census number only; no table rows changed.

<sup>Written for commit f843bdab32be25269f662722e261d62a097c9cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Census gate inventory count from 59 to 60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->