### PR TITLE
fix(capture): quick capture stores a profile address the product can link

### DIFF
--- a/backend/internal/modules/people/quickcapture.go
+++ b/backend/internal/modules/people/quickcapture.go
@@ -18,6 +18,7 @@ package people
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -164,7 +165,7 @@ func personFromQuickCapture(in QuickCaptureInput) CreatePersonInput {
 		Title:    in.Title,
 		Source:   quickCaptureSource,
 	}
-	if url := trimmedValue(in.ProfileURL); url != "" {
+	if url := profileURLWithScheme(trimmedValue(in.ProfileURL)); url != "" {
 		person.Social = map[string]any{profileURLField: url}
 	}
 	if email := trimmedValue(in.Email); email != "" {
@@ -187,6 +188,32 @@ func personFromQuickCapture(in QuickCaptureInput) CreatePersonInput {
 	}
 	return person
 }
+
+// profileURLWithScheme puts a scheme on a bare host.
+//
+// The browser hides `https://`, so what somebody copies out of the address bar
+// and types here is `linkedin.com/in/jdoe`. Stored as-is it is not an absolute
+// URL, the frontend's own `webUrl` refuses it, and the row is permanently
+// unlinkable on every surface that reads it — which is exactly what the
+// profile-as-a-link work was for. The web client normalizes before sending;
+// this is the same rule for every other caller of the endpoint.
+//
+// Only a value with NO scheme is touched. One that carries `http://` keeps it:
+// the caller typed a scheme, and quietly upgrading it would claim a
+// certificate nobody has seen.
+func profileURLWithScheme(url string) string {
+	if url == "" || bareProfileHost.MatchString(url) {
+		if url == "" {
+			return ""
+		}
+		return "https://" + url
+	}
+	return url
+}
+
+// bareProfileHost matches a value that opens with a hostname rather than a
+// scheme — `linkedin.com/in/jdoe`, `www.example.com`.
+var bareProfileHost = regexp.MustCompile(`^[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+(/|$)`)
 
 func trimmedValue(v *string) string {
 	if v == nil {

--- a/backend/internal/modules/people/quickcapture_integration_test.go
+++ b/backend/internal/modules/people/quickcapture_integration_test.go
@@ -66,6 +66,39 @@ func TestQuickCaptureWritesThePersonAndTheirEmployer(t *testing.T) {
 	}
 }
 
+// The browser hides the scheme, so what somebody copies out of the address bar
+// is `linkedin.com/in/jdoe`. Stored bare it is not an absolute URL, the
+// frontend's own webUrl refuses it, and the row is permanently unlinkable —
+// which defeats the profile-as-a-link work this path exists to feed.
+func TestQuickCaptureStoresAProfileURLTheProductCanLink(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	bare := "linkedin.com/in/danabare"
+	out, err := e.store.QuickCapture(ctx, QuickCaptureInput{
+		FullName: "Dana Bare", ProfileURL: &bare,
+	})
+	if err != nil {
+		t.Fatalf("quick capture: %v", err)
+	}
+	if got := statedProfileURL(out.Person.Social); got != "https://linkedin.com/in/danabare" {
+		t.Errorf("stored profile url = %q, want the absolute form", got)
+	}
+
+	// A scheme the caller typed is kept: quietly upgrading http to https would
+	// claim a certificate nobody has seen.
+	insecure := "http://example.com/team/sam"
+	out, err = e.store.QuickCapture(ctx, QuickCaptureInput{
+		FullName: "Sam Insecure", ProfileURL: &insecure,
+	})
+	if err != nil {
+		t.Fatalf("quick capture: %v", err)
+	}
+	if got := statedProfileURL(out.Person.Social); got != insecure {
+		t.Errorf("stored profile url = %q, want %q unchanged", got, insecure)
+	}
+}
+
 func TestQuickCaptureAttachesAnExistingEmployer(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()


### PR DESCRIPTION
Found by following the walkthrough against the merged code rather than by reading it.

A browser hides the scheme, so what somebody copies out of the address bar and types into quick capture is `linkedin.com/in/jdoe`. Stored exactly as typed it is not an absolute URL, `webUrl` refuses it, and the row is **permanently unlinkable on every surface that reads it** — which defeats the profile-as-a-link work (#2917) this path exists to feed.

The web client already normalizes before sending, so the defect was invisible through the app and waiting for anything else that calls the endpoint — a script, an integration, a future surface. The rule now lives where the value is stored.

Only a value with no scheme at all is touched. One carrying `http://` keeps it: the caller typed a scheme, and quietly upgrading it would claim a certificate nobody has seen.

## Verification

- `make check-backend` and `make craft-static` green.
- One integration test covering both halves — the bare host gains `https://`, and a typed `http://` is left alone. Mutation-checked: removing the normalization makes it fail.
- Confirmed against a running stack that the bare form was what actually landed in `social.linkedin` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quick capture now normalizes bare profile URLs to `https://` so every row it stores is linkable; previously a browser-copied bare host like `linkedin.com/in/jdoe` was stored as-is and stayed unlinkable for any caller outside the web client, which already normalized before sending. Only values with no scheme are touched — a typed `http://` keeps the caller's scheme.

<sup>Written for commit 91d71856c533a5e7341c1476d09a2d08734b7c2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quick Capture now automatically adds `https://` to profile URLs entered without a scheme.
  - Existing `http://` and `https://` URLs remain unchanged.
  - Empty profile URL values continue to be handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->