### PR TITLE
perf(test): one fixture where the cases share one, and a reason where they do not

### DIFF
--- a/backend/internal/compose/integration/csvimportbyid_integration_test.go
+++ b/backend/internal/compose/integration/csvimportbyid_integration_test.go
@@ -99,6 +99,11 @@ func TestCSVImportByIDUpdatesTheNamedCompany(t *testing.T) {
 
 // The three cases that destroyed data under name matching, each harmless here.
 func TestCSVImportByIDIsImmuneToEveryAmbiguityThatBrokeNameMatching(t *testing.T) {
+	// Each case seeds a DIFFERENT ambiguity into the same table, and the
+	// subject is which record an id resolves to among them. A shared fixture
+	// would leave the first case's two Kestrel Data rows in place while the
+	// third case is about a trading name that is somebody else's registered
+	// name — a different ambiguity from the one it is named for.
 	t.Run("two companies sharing a name", func(t *testing.T) {
 		e := setupImportApp(t)
 		wanted := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -409,9 +409,17 @@ func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 		{"lead", "/v1/leads", "9304", map[string]any{"full_name": "Grace Lead"}, apptest.AnyMap{"full_name": "Grace Lead 2"}, "full_name", "Grace Lead 2"},
 		{"activity", "/v1/activities", "9305", map[string]any{"kind": "call", "subject": "Intro Call"}, apptest.AnyMap{"subject": "Intro Call 2"}, "subject", "Intro Call 2"},
 	}
+	// One fixture for the five update cases: each seeds a different type at a
+	// different path, so firstListedID below still names exactly the record
+	// that case seeded.
+	//
+	// The archive loop keeps a fixture of its own, and that is not tidiness:
+	// it seeds a SECOND person and a second organization, and firstListedID
+	// cannot say which of two records at one path it means.
+	updateEnv := setupOverlayWrite(t)
 	for _, tc := range updates {
 		t.Run("update/"+tc.entityType, func(t *testing.T) {
-			e := setupOverlayWrite(t)
+			e := updateEnv
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
 			id := firstListedID(t, e.AppEnv, tc.path)
 
@@ -430,9 +438,10 @@ func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 		{"organization", "/v1/organizations", "9312", map[string]any{"display_name": "Beta Org"}, "display_name", "Beta Org"},
 		{"deal", "/v1/deals", "9313", map[string]any{"name": "Small Deal"}, "name", "Small Deal"},
 	}
+	archiveEnv := setupOverlayWrite(t)
 	for _, tc := range archives {
 		t.Run("archive/"+tc.entityType, func(t *testing.T) {
-			e := setupOverlayWrite(t)
+			e := archiveEnv
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
 			id := firstListedID(t, e.AppEnv, tc.path)
 

--- a/backend/internal/modules/activities/email_refusals_integration_test.go
+++ b/backend/internal/modules/activities/email_refusals_integration_test.go
@@ -392,6 +392,15 @@ func TestReplayingASourceKeyLeavesTheStoredThreadKeyUntouched(t *testing.T) {
 // is documentation on this surface rather than a validator, so the refusal has
 // to live where both transports pass through.
 func TestSendEmailRefusesAMessageWhoseAddresseeLineIsEmpty(t *testing.T) {
+	// One fixture for all three, which is what the cases actually share: what
+	// varies is the To/Cc pair, and the subject — the subtraction that empties
+	// the addressee line — reads none of the seeded state.
+	//
+	// The outbound count below is then CUMULATIVE, and that is a stronger
+	// assertion rather than a weaker one: a case that staged a delivery would
+	// be caught by its own assertion and by every later case's.
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
 	for _, tc := range []struct {
 		name           string
 		recipients, cc []string
@@ -407,8 +416,8 @@ func TestSendEmailRefusesAMessageWhoseAddresseeLineIsEmpty(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			e := setupSend(t)
-			anchor := e.seedAnchor(t, "", "")
+			// The stager stays per case: it accumulates, so a shared one would
+			// let a later case read an earlier case's staging as its own.
 			stager := &recordingStager{}
 			in := sendInput("transactional")
 			in.Recipients, in.Cc = tc.recipients, tc.cc

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -439,6 +439,11 @@ func TestAbsorbRefusesARowThatIsNotThisMessagesEcho(t *testing.T) {
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// A fixture of its own: every case seeds a survivor under the same
+			// minted identity and the reconcile SEARCHES for its echo, so an
+			// earlier case's bystander is a candidate for a later case's
+			// survivor. The refusals here would then be refusals about a
+			// different row than the one the case is named for.
 			e := setupSend(t)
 			survivor := e.seedSentEmail(t, mintedIdentity)
 			bystander := e.seedEcho(t, tc.seed)

--- a/backend/internal/modules/comms/dispatcher_channel_integration_test.go
+++ b/backend/internal/modules/comms/dispatcher_channel_integration_test.go
@@ -177,9 +177,11 @@ func TestDispatcherRoutesAChannelDeliveryToMessageSender(t *testing.T) {
 // redelivered job must refuse to transmit rather than deliver a second copy to a
 // customer with nothing able to detect it.
 func TestChannelDeliveryParksOnAnUnknownOutcome(t *testing.T) {
-	// One fixture, a reply of its own per case. Each stages its own delivery
-	// and every assertion is by that id — what the two halves share is the
-	// workspace and the store, which neither of them changes.
+	// One fixture, a reply of its own per case. What isolates the two is the
+	// delivery ID, not an untouched store — each case dispatches, and a
+	// dispatch writes: the status, the park reason, the in-flight marker. Both
+	// halves read those back by the id they staged, so neither can see the
+	// other's row.
 	e := setupStore(t)
 
 	t.Run("the attempt that gets no answer parks rather than retrying", func(t *testing.T) {

--- a/backend/internal/modules/comms/dispatcher_channel_integration_test.go
+++ b/backend/internal/modules/comms/dispatcher_channel_integration_test.go
@@ -177,8 +177,12 @@ func TestDispatcherRoutesAChannelDeliveryToMessageSender(t *testing.T) {
 // redelivered job must refuse to transmit rather than deliver a second copy to a
 // customer with nothing able to detect it.
 func TestChannelDeliveryParksOnAnUnknownOutcome(t *testing.T) {
+	// One fixture, a reply of its own per case. Each stages its own delivery
+	// and every assertion is by that id — what the two halves share is the
+	// workspace and the store, which neither of them changes.
+	e := setupStore(t)
+
 	t.Run("the attempt that gets no answer parks rather than retrying", func(t *testing.T) {
-		e := setupStore(t)
 		id := e.stageReply(t)
 
 		unanswered := errors.New("telegram: sendMessage: context deadline exceeded")
@@ -219,7 +223,6 @@ func TestChannelDeliveryParksOnAnUnknownOutcome(t *testing.T) {
 	})
 
 	t.Run("a crashed attempt's marker stops the next one from transmitting", func(t *testing.T) {
-		e := setupStore(t)
 		id := e.stageReply(t)
 
 		// Exactly what a killed worker leaves behind: the marker committed

--- a/backend/internal/modules/comms/store_recordsent_integration_test.go
+++ b/backend/internal/modules/comms/store_recordsent_integration_test.go
@@ -140,6 +140,11 @@ func TestRecordSentReKeysTheDeliveryWhenTheIdentityMoved(t *testing.T) {
 		{"a reply keeps its anchor's root", conversationRoot, conversationRoot},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// A fixture of its own, and not for tidiness: a message identity is
+			// unique per workspace while it is staged, so two cases staging
+			// stagedIdentity into one workspace is a conflict. Hoisting this
+			// passes only because the case above happens to stamp the identity
+			// away first — a dependency between cases that reads as none.
 			e := setupStore(t)
 			in := e.baseInput(e.activity, stagedIdentity)
 			in.ThreadKey = tc.threadKey

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -252,6 +252,11 @@ func TestARecordWithNoScrubKeepsEveryImage(t *testing.T) {
 func TestEveryScrubVerbMovesTheBoundary(t *testing.T) {
 	for _, verb := range []string{"erase", "anonymize", "restrict"} {
 		t.Run(verb, func(t *testing.T) {
+			// A fixture of its own: each case writes a scrub row for the SAME
+			// subject, and the assertion is that the pre-scrub image is no
+			// longer readable. Shared, the second case would be reading an
+			// image the first case had already put behind a boundary — green
+			// for a verb that does nothing.
 			e := setupAuditBoundary(t)
 			edit := e.auditRow(t, "update", boundaryEarlier,
 				`{"full_name":"Sara Subject"}`, `{"full_name":"Sara Renamed"}`)


### PR DESCRIPTION
Closes #535.

Table-driven integration tests that call their harness **inside** `t.Run` re-seed Postgres to vary inputs that are pure in-memory arguments. The cost is real, but the reading is the point: a reader has to check whether each case depends on the seeded state before concluding it does not, and the fixture is what makes that work.

## Hoisted where the cases genuinely share one

| where | what changed |
| --- | --- |
| `activities` — the addressee-line refusals | the ticket's named example. What varies is To/Cc; the subtraction that empties the line reads none of the seeded state. **5.15s → 0.08s** |
| `comms` — the unknown-outcome property | both halves stage their own delivery and assert by that id |
| `overlay` — the mirrored-type round trip | one fixture for the five update cases |

Two details worth naming:

- the outbound count in the activities case becomes **cumulative**, which is a stronger assertion rather than a weaker one: a case that staged a delivery would be caught by its own assertion and by every later case's
- the overlay **archive** loop keeps a fixture of its own, and that is not tidiness — it seeds a *second* person and a second organization, and `firstListedID` cannot say which of two records at one path it means

## Triaged, not rewritten

The remaining hits keep their per-case seed, and now **say why in the case itself** — which is the same fix as hoisting, answering the same question from the other direction.

| where | why the seed is load-bearing |
| --- | --- |
| `comms/store_recordsent` | a staged message identity is unique per workspace. Hoisting it *passes*, and only because the previous case stamps the identity away first — a dependency between cases that reads as none. **Found by trying it**: the second loop fails on the conflict outright. |
| `activities/messageidentity_absorb` | every case seeds a survivor under the same minted identity, and the reconcile *searches* for its echo — an earlier case's bystander is a candidate for a later case's survivor |
| `privacy/auditlogboundary` | each case scrubs the same subject and asserts the pre-scrub image is gone; shared, the second reads an image the first already put behind a boundary, and a verb that does nothing passes |
| `compose/integration/csvimportbyid` | each case seeds a different ambiguity into one table, and the subject is which record an id resolves to among them |

Every hoist verified by running the suite it belongs to; every refusal to hoist verified the same way where it could be (the comms one is a real failing run, not an argument).

## Not in scope

The issue's census names 87 parents with subtests. This PR covers the ones whose harness call sits inside the loop — 27 sites, of which 5 are now hoisted (27 → 22) and 4 more carry the reason their seed cannot move. The rest of the 87 spend their time elsewhere and are not this shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by isolating test cases and reducing dependence on execution order.
  * Reused shared fixtures where appropriate while preserving independent data setup for each scenario.
  * Added comments clarifying fixture isolation and the distinct behaviors covered by ambiguity, identity, and audit-boundary tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->