### PR TITLE
test(storekit): the refusals decided before a query leave the integration lane

### DIFF
--- a/backend/internal/compose/integration/customfields_vocab_coverage_integration_test.go
+++ b/backend/internal/compose/integration/customfields_vocab_coverage_integration_test.go
@@ -9,43 +9,28 @@ package integration
 // task 4): customfields_vocab_integration_test.go proves the cf_
 // vocabulary's day-one behavior; this file reaches the storekit
 // listquery.go branches only a less common shape exercises — the
-// default-sort cursor continuation, a genuinely malformed (non-decoding)
-// token, a cursor reused under a DIFFERENT custom sort (not just the
-// default), the NULL-tail-to-NULL-tail continuation, a descending
-// custom sort's own cursor walk, and the two core vocabulary kinds the
-// day-one suite never sorts or filters by (owner_id's uuid, created_at's
-// timestamptz) plus the currency/date/boolean filter-value refusals.
+// default-sort cursor continuation, the NULL-tail-to-NULL-tail
+// continuation, a descending custom sort's own cursor walk, the two core
+// vocabulary kinds the day-one suite never sorts by (owner_id's uuid,
+// created_at's timestamptz), and the currency/date equality matches.
+//
+// Every one of those WALKS REAL ROWS, and that is now the whole membership
+// rule for this file. The refusals that used to sit here — an error message's
+// wording, an undecodable token, a cursor reused under the opposite
+// direction, three filter values that do not parse — are decided before any
+// query runs, and they are asserted in storekit's own suite where the
+// functions deciding them live. Reaching them through a composed app and a
+// migrated Postgres proved nothing about them that a unit test does not, and
+// it made a branch sweep on a platform package read as compose's work.
 
 import (
-	"errors"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/margince/margince/backend/internal/modules/customfields"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
-	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
-
-// TestCustomFieldVocab_SortErrorMessageIsActionable: SortError.Error()
-// names both the offending field and the machine code, not just the
-// bare code — the message a log line or a debugging session actually
-// reads.
-func TestCustomFieldVocab_SortErrorMessageIsActionable(t *testing.T) {
-	f := setupCFV(t)
-	bogus := "not_a_real_field"
-	_, _, err := f.store.ListPeople(f.ctx, people.ListPeopleInput{Sort: &bogus})
-	var sortErr *storekit.SortError
-	if !errors.As(err, &sortErr) {
-		t.Fatalf("err = %v, want SortError", err)
-	}
-	msg := sortErr.Error()
-	if !strings.Contains(msg, bogus) || !strings.Contains(msg, storekit.CodeSortFieldNotAllowed) {
-		t.Fatalf("Error() = %q, want it to name the field and the code", msg)
-	}
-}
 
 // TestCustomFieldVocab_DefaultSortPaginatesWithCursor: the DEFAULT sort
 // (-created_at,id, no explicit Sort) also keyset-paginates through its
@@ -77,46 +62,6 @@ func TestCustomFieldVocab_DefaultSortPaginatesWithCursor(t *testing.T) {
 	}
 	if len(page2) != 1 || page2[0].Id != first.Id || info2.HasMore {
 		t.Fatalf("page 2 = %+v (more=%v), want [first] with no more", page2, info2.HasMore)
-	}
-}
-
-// TestCustomFieldVocab_MalformedTokenAnswersDecodeError: a cursor string
-// that does not even base64url-decode is the same client fault as one
-// whose sort key mismatches its column's type — refused before the query
-// ever runs, never a 500.
-func TestCustomFieldVocab_MalformedTokenAnswersDecodeError(t *testing.T) {
-	f := setupCFV(t)
-	garbage := "not-a-valid-base64url-token!!"
-	_, _, err := f.store.ListPeople(f.ctx, people.ListPeopleInput{Cursor: &garbage})
-	var malformed *storekit.MalformedCursorError
-	if !errors.As(err, &malformed) {
-		t.Fatalf("err = %v, want MalformedCursorError", err)
-	}
-}
-
-// TestCustomFieldVocab_CursorMintedUnderOneCustomSortRefusedUnderAnother:
-// a token minted under a cf_-sorted list is refused not only when reused
-// on the default list (already covered), but also when reused under a
-// DIFFERENT custom sort — same field, opposite direction — since the
-// keyset tuple it carries cannot continue that ordering either.
-func TestCustomFieldVocab_CursorMintedUnderOneCustomSortRefusedUnderAnother(t *testing.T) {
-	f := setupDealCFV(t)
-	score := f.defineDealField(t, customfields.FieldSpec{Object: "deal", Label: "Score", Type: customfields.TypeNumber, Source: "ui"})
-	f.seedScoredDeal(t, "A", map[string]any{score: float64(1)})
-	f.seedScoredDeal(t, "B", map[string]any{score: float64(2)})
-
-	one := 1
-	asc := score
-	_, page := f.listDealIDs(t, deals.ListDealsInput{Sort: &asc, Limit: &one})
-	if !page.HasMore || page.NextCursor == "" {
-		t.Fatalf("expected a sorted next-page cursor, got %+v", page)
-	}
-
-	desc := "-" + score
-	_, _, err := f.store.ListDeals(f.ctx, deals.ListDealsInput{Sort: &desc, Cursor: &page.NextCursor})
-	var mismatch *storekit.CursorSortMismatchError
-	if !errors.As(err, &mismatch) {
-		t.Fatalf("cursor reused under the opposite direction err = %v, want CursorSortMismatchError", err)
 	}
 }
 
@@ -183,13 +128,17 @@ func TestCustomFieldVocab_DescendingSortPaginatesStably(t *testing.T) {
 	assertIDOrder(t, walked, want, "descending paginated walk")
 }
 
-// TestCustomFieldVocab_FilterByCurrencyDateAndBooleanInvalidValues:
-// FilterEqualityPerType already proves text/number/boolean equality;
-// this proves the currency and date equality matches, plus the
-// invalid-value 422 for currency, date, and boolean — each exercises a
-// vocabulary kind branch FilterEqualityPerType and
-// MalformedFilterValueRefused (number-only) never reach.
-func TestCustomFieldVocab_FilterByCurrencyDateAndBooleanInvalidValues(t *testing.T) {
+// TestCustomFieldVocab_FilterByCurrencyDateEquality: FilterEqualityPerType
+// already proves text/number/boolean equality; this proves the currency and
+// date matches, each a vocabulary kind branch it never reaches.
+//
+// The three invalid-value refusals that used to sit beside these are in
+// storekit's own suite (TestCustomFilterClauses_MalformedValueRefused, which
+// covers all four kinds). They never reached a row: CustomFilterClauses
+// refuses the value while assembling the clause, so asserting it here proved
+// the refusal happens somewhere upstream of a query — which was already known
+// and did not need a migrated Postgres to say.
+func TestCustomFieldVocab_FilterByCurrencyDateEquality(t *testing.T) {
 	f := setupDealCFV(t)
 	eur := "EUR"
 	budget := f.defineDealField(t, customfields.FieldSpec{Object: "deal", Label: "Budget", Type: customfields.TypeCurrency, Currency: &eur, Source: "ui"})
@@ -208,20 +157,6 @@ func TestCustomFieldVocab_FilterByCurrencyDateAndBooleanInvalidValues(t *testing
 		assertIDOrder(t, got, []ids.UUID{match}, "date equality")
 	})
 
-	invalid := map[string]map[string]string{
-		"currency invalid value": {budget: "not-a-number"},
-		"date invalid value":     {renewal: "not-a-date"},
-		"boolean invalid value":  {strategic: "yes"},
-	}
-	for name, filters := range invalid {
-		t.Run(name, func(t *testing.T) {
-			_, _, err := f.store.ListDeals(f.ctx, deals.ListDealsInput{CustomFilters: filters})
-			var pred *storekit.PredicateError
-			if !errors.As(err, &pred) || pred.Code != storekit.CodeFilterValueInvalid {
-				t.Fatalf("err = %v, want PredicateError %s", err, storekit.CodeFilterValueInvalid)
-			}
-		})
-	}
 }
 
 // TestCustomFieldVocab_SortByOwnerIDWithCursor: owner_id is the one core
@@ -294,25 +229,5 @@ func TestCustomFieldVocab_SortByCreatedAtWithCursor(t *testing.T) {
 	}
 	if len(page2) != 1 || page2[0].Id != second.Id || info2.HasMore {
 		t.Fatalf("page 2 = %+v (more=%v), want [second] with no more", page2, info2.HasMore)
-	}
-}
-
-// TestCustomFieldVocab_MalformedTimestampCursorKeyIsClientFault: a
-// crafted cursor sorted by a timestamptz core field whose key does not
-// parse under ANY of parsesAsTimestamptz's layouts is a malformed
-// cursor at the store — proving the timestamp branch's failure path
-// (parsesAsKind's other branches already prove theirs via the number
-// suite's CraftedCursorKeyIsClientFault).
-func TestCustomFieldVocab_MalformedTimestampCursorKeyIsClientFault(t *testing.T) {
-	f := setupCFV(t)
-	badKey := "not-a-timestamp"
-	crafted := CraftCursor(t, storekit.Cursor{
-		CreatedAt: time.Now().UTC(), ID: ids.NewV7(), SortField: "created_at", SortKey: &badKey,
-	})
-	sortField := "created_at"
-	_, _, err := f.store.ListPeople(f.ctx, people.ListPeopleInput{Sort: &sortField, Cursor: &crafted})
-	var malformed *storekit.MalformedCursorError
-	if !errors.As(err, &malformed) {
-		t.Fatalf("crafted timestamp sort key err = %v, want MalformedCursorError", err)
 	}
 }

--- a/backend/internal/platform/database/storekit/listquery_test.go
+++ b/backend/internal/platform/database/storekit/listquery_test.go
@@ -367,3 +367,50 @@ func TestCustomFilterClauses_EmptyFilterIsNoClause(t *testing.T) {
 		t.Fatalf("empty filters: got %v, %v", clauses, err)
 	}
 }
+
+// The refusal a log line and a debugging session actually read. A SortError
+// that printed only its machine code would name what went wrong without
+// naming what it went wrong ON, which is the whole of the remedy: the field
+// came off the caller's own query string.
+//
+// Here rather than through a store, which is where it used to be asserted: the
+// formatting is a pure function of two strings, and reaching it through a
+// booted app and a migrated Postgres proved nothing about it that this does
+// not.
+func TestSortError_NamesTheFieldAndTheCode(t *testing.T) {
+	err := &SortError{Message: "not_a_real_field is not sortable", Code: CodeSortFieldNotAllowed}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "not_a_real_field") {
+		t.Errorf("Error() = %q and does not name the field — the remedy is to change that field", msg)
+	}
+	if !strings.Contains(msg, CodeSortFieldNotAllowed) {
+		t.Errorf("Error() = %q and does not carry %q, which is what a caller matches on",
+			msg, CodeSortFieldNotAllowed)
+	}
+}
+
+// A token that does not decode at all, as against one that decodes to a
+// position the sort cannot continue. Both are the client's fault and both must
+// be refused before the query, but they fail at different steps and only one
+// of them was covered: DecodeCursor rejects this one before KeysetClause has a
+// sort to compare against, so a nil ListSort reaches it too.
+func TestKeysetClause_UndecodableTokenIsMalformed(t *testing.T) {
+	sorted, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var def *ListSort
+
+	for name, s := range map[string]*ListSort{"default list": def, "sorted list": sorted} {
+		t.Run(name, func(t *testing.T) {
+			arg, _ := keysetArgs()
+			_, err := s.KeysetClause("not-a-valid-base64url-token!!", arg)
+			var malformed *MalformedCursorError
+			if !errors.As(err, &malformed) {
+				t.Fatalf("err = %v, want MalformedCursorError — an undecodable token must not reach "+
+					"the query, where Postgres would answer a 500 for a caller's typo", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #536.

A branch-coverage sweep on a **platform** package was written at the compose-integration layer, so four assertions about pure functions reached their subject through a composed app and a migrated Postgres.

## Three of them were already proven one layer down

That is the part worth saying. `storekit`'s own suite already covers:

| integration test | already covered by |
| --- | --- |
| `MalformedTimestampCursorKeyIsClientFault` | `TestKeysetClause_UnparseableSortKeyIsMalformed` — its `created_at: "yesterday"` case |
| `CursorMintedUnderOneCustomSortRefusedUnderAnother` | `TestKeysetClause_SortMismatchIsTypedMismatch` — its "ascending cursor on a descending sort" case |
| the three invalid-value subtests of `FilterByCurrencyDateAndBooleanInvalidValues` | `TestCustomFilterClauses_MalformedValueRefused` — all four kinds |

These were not a layer above their unit counterparts. They were **the same assertions again, with a database in the way.**

## Two were genuinely uncovered, and move

- `SortError.Error()` must name the **field** as well as the code — the field is the whole of the remedy, since it came off the caller's own query string
- a token that does not decode at all fails at a different step from one that decodes to a position the sort cannot continue, so it is now asserted against both a default and a sorted list

## What stays

Everything that walks real rows, and that is the file's membership rule now — stated in its header, so the next test added there has a rule to answer to: the default-sort continuation, the NULL-tail-to-NULL-tail continuation, the descending walk, the two core vocabulary kinds, and the currency/date equality matches.

The `FilterByCurrencyDateAndBooleanInvalidValues` test keeps its two equality subtests and is renamed to what it now is.

## The rail is not in this PR, and here is why

The issue proposes extending `check-test-lanes.sh` with the mirror rule: *an integration-tagged file whose tests never reach infrastructure fails the gate.*

**That rule would have been green on the file that prompted it.** `TestCustomFieldVocab_SortErrorMessageIsActionable` called `setupCFV(t)`, which dials Postgres, boots the app and seeds a workspace. It *did* reach infrastructure — it just did not need to. Every honest resolution of "reaches infrastructure", including the transitive one the issue asks for, answers yes here.

A gate that passes its own worked example is worse than none: it reads as coverage of a class it cannot see. What the rule would actually need is "does the assertion depend on anything the harness created", which is not a question a build-tag scan can answer.

Filing that as its own problem rather than shipping a gate that gives false assurance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for cursor pagination, including malformed cursor handling across default and sorted lists.
  - Verified sorting errors include the invalid field and a machine-readable error code.
  - Confirmed successful currency and date equality filtering.
  - Consolidated related integration coverage to reduce duplication while preserving validation of key behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->