### PR TITLE
refactor(gates): one walk over the licensed trees, not two

### DIFF
--- a/backend/gates/envcontract_test.go
+++ b/backend/gates/envcontract_test.go
@@ -53,7 +53,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -92,42 +91,6 @@ const (
 // operator.
 var deploySurfaceRoots = []string{"../scripts", "../infra", "../.github/workflows"}
 
-// walkTextFiles reads every file under root and hands each to visit. The trees
-// swept here are small and text-only; a read error fails the test rather than
-// narrowing the sweep in silence.
-func walkTextFiles(t *testing.T, root string, visit func(path, text string)) {
-	t.Helper()
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		// A unit's frontend layer is a pnpm workspace package, so extensions/
-		// now contains an installed dependency tree — thousands of files this
-		// sweep has no business reading, and symlinked DIRECTORIES that are not
-		// IsDir() and so reach the ReadFile below as "is a directory".
-		if d.IsDir() && d.Name() == "node_modules" {
-			return fs.SkipDir
-		}
-		if d.IsDir() {
-			return nil
-		}
-		// Belt and braces for the same reason: a symlink is not a regular file,
-		// and this sweep reads text a human wrote.
-		if !d.Type().IsRegular() {
-			return nil
-		}
-		b, err := os.ReadFile(path) // #nosec G304 G122 -- path comes from walking a fixed root inside the trusted source tree
-		if err != nil {
-			return err
-		}
-		visit(filepath.ToSlash(path), string(b))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking %s: %v", root, err)
-	}
-}
-
 // envVarsReadByGoCode maps each MARGINCE_* name a Go string literal spells to
 // the first file spelling it. The trees are the ones the license sweep covers
 // (licensedTrees, license_test.go): extensions/ and fixtures/ are separate
@@ -138,10 +101,7 @@ func envVarsReadByGoCode(t *testing.T) map[string]string {
 	t.Helper()
 	sites := map[string]string{}
 	for _, tree := range licensedTrees {
-		walkTextFiles(t, tree.root, func(path, text string) {
-			if !strings.HasSuffix(path, ".go") || isGenerated(path, text) {
-				return
-			}
+		walkHandWrittenGoFiles(t, tree.root, func(path, text string) {
 			for _, m := range quotedEnvVarName.FindAllStringSubmatch(text, -1) {
 				if _, seen := sites[m[1]]; !seen {
 					sites[m[1]] = path
@@ -388,8 +348,10 @@ func declaredConfigDefaults(t *testing.T) []configItemDefault {
 	var out []configItemDefault
 	fset := token.NewFileSet()
 	for _, tree := range licensedTrees {
-		walkTextFiles(t, tree.root, func(path, text string) {
-			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") || isGenerated(path, text) {
+		walkHandWrittenGoFiles(t, tree.root, func(path, text string) {
+			// Non-test only here: a config-item default declared in a suite is
+			// a fixture, not something an operator can set.
+			if strings.HasSuffix(path, "_test.go") {
 				return
 			}
 			file, err := parser.ParseFile(fset, path, text, 0)
@@ -507,10 +469,7 @@ func envNameConstants(t *testing.T) map[string]string {
 	consts := map[string]string{}
 	fset := token.NewFileSet()
 	for _, tree := range licensedTrees {
-		walkTextFiles(t, tree.root, func(path, text string) {
-			if !strings.HasSuffix(path, ".go") || isGenerated(path, text) {
-				return
-			}
+		walkHandWrittenGoFiles(t, tree.root, func(path, text string) {
 			file, err := parser.ParseFile(fset, path, text, 0)
 			if err != nil {
 				t.Fatalf("parsing %s: %v", path, err)

--- a/backend/gates/license_test.go
+++ b/backend/gates/license_test.go
@@ -13,8 +13,6 @@ package gates
 // generator (and the drift gate), not by hand.
 
 import (
-	"io/fs"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -94,42 +92,12 @@ var licensedTrees = []licensedTree{
 func TestEveryHandWrittenGoFileCarriesTheLicenseHeader(t *testing.T) {
 	t.Parallel()
 	var missing []string
-	walk := func(root string) (int, error) {
-		checked := 0
-		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			// extensions/ now holds installed dependency trees (a unit's
-			// frontend layer is a workspace package). Nothing in one is
-			// hand-written, and walking it is thousands of files of pure cost.
-			if d.IsDir() && d.Name() == "node_modules" {
-				return fs.SkipDir
-			}
-			if d.IsDir() || !strings.HasSuffix(path, ".go") || !d.Type().IsRegular() {
-				return nil
-			}
-			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
-			if err != nil {
-				return err
-			}
-			text := string(b)
-			if isGenerated(path, text) {
-				return nil
-			}
-			checked++
-			if !strings.HasPrefix(text, spdxHeader) {
-				missing = append(missing, filepath.ToSlash(path))
-			}
-			return nil
-		})
-		return checked, err
-	}
 	for _, tree := range licensedTrees {
-		checked, err := walk(tree.root)
-		if err != nil {
-			t.Fatalf("walking %s: %v", tree.root, err)
-		}
+		checked := walkHandWrittenGoFiles(t, tree.root, func(path, text string) {
+			if !strings.HasPrefix(text, spdxHeader) {
+				missing = append(missing, path)
+			}
+		})
 		if tree.mustHaveFiles && checked == 0 {
 			t.Fatalf("%s yielded no hand-written Go file — a root that scans nothing passes exactly like a clean one", tree.root)
 		}

--- a/backend/gates/treewalk_test.go
+++ b/backend/gates/treewalk_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gates
+
+// The one walk over this repository's hand-written trees.
+//
+// Two gates used to carry their own: the license header sweep and the env-var
+// contract, over the same roots, with the same node_modules skip, the same
+// regular-file guard and the same generated-file filter. Nothing was wrong
+// with either, and that is the hazard — a duplicated walk drifts one skip at a
+// time, and the gate that keeps the older copy quietly covers less than the
+// one that got the fix.
+//
+// What was already shared is the ROOTS (licensedTrees, license_test.go), so a
+// new Go tree enrols in every gate at once. This is the loop around that list.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// walkTextFiles reads every file under root and hands each to visit. The trees
+// swept here are small and text-only; a read error fails the test rather than
+// narrowing the sweep in silence.
+func walkTextFiles(t *testing.T, root string, visit func(path, text string)) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// A unit's frontend layer is a pnpm workspace package, so extensions/
+		// now contains an installed dependency tree — thousands of files this
+		// sweep has no business reading, and symlinked DIRECTORIES that are not
+		// IsDir() and so reach the ReadFile below as "is a directory".
+		if d.IsDir() && d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Belt and braces for the same reason: a symlink is not a regular file,
+		// and this sweep reads text a human wrote.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		b, err := os.ReadFile(path) // #nosec G304 G122 -- path comes from walking a fixed root inside the trusted source tree
+		if err != nil {
+			return err
+		}
+		visit(filepath.ToSlash(path), string(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}
+
+// walkHandWrittenGoFiles visits the Go files a human wrote under one root, and
+// answers how many it found.
+//
+// The COUNT is the reason this is a wrapper rather than a filter each caller
+// repeats: a gate whose root yields nothing passes exactly like a clean one,
+// and only the caller knows whether an empty root is legitimate (extensions/
+// is; backend/ is not). Handing back the number lets each decide, without
+// either of them re-deriving what "hand-written Go file" means.
+func walkHandWrittenGoFiles(t *testing.T, root string, visit func(path, text string)) int {
+	t.Helper()
+	found := 0
+	walkTextFiles(t, root, func(path, text string) {
+		if !strings.HasSuffix(path, ".go") || isGenerated(path, text) {
+			return
+		}
+		found++
+		visit(path, text)
+	})
+	return found
+}


### PR DESCRIPTION
Closes #573.

The license-header sweep and the env-var contract each carried their own `WalkDir` over the same roots, with the same `node_modules` skip, the same regular-file guard and the same generated-file filter.

Nothing was wrong with either, and that is the hazard: a duplicated walk drifts one skip at a time, and the gate keeping the older copy quietly covers *less* than the one that got the fix. Both already shared the **roots** (`licensedTrees`), so a new Go tree enrols in every gate at once — what was duplicated was the loop around that list, not the obligation.

## The shared form returns the count

`walkHandWrittenGoFiles` visits the Go files a human wrote under one root **and answers how many it found**. That is why it is a wrapper rather than a filter each caller repeats: a gate whose root yields nothing passes exactly like a clean one, and only the caller knows whether an empty root is legitimate — `extensions/` is (presence under it *is* enablement), `backend/` is not.

## Four sweeps route through it

The header check, plus three in the env contract that were repeating the same two-line `.go` + `isGenerated` filter. The one that also wants non-test files keeps that condition inline, because it is that gate's own reason — a config-item default declared in a suite is a fixture, not something an operator can set — and not the shared walk's.

`walkTextFiles` moves out of `envcontract_test.go` into a file named for what it is, so one gate's helper is no longer owned by another gate's file. `licensedTrees` stays with the license gate, where its comment explains the enrolment coupling.

## Verified

Both safeguards survive the move, checked by mutation:

- a root that does not exist still fails on the walk error
- a count that stops incrementing still fails `mustHaveFiles` (`. yielded no hand-written Go file`)

`io/fs` and `os` are now unused in `license_test.go`, as the issue predicted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved source-file scanning consistency across environment-variable, configuration, and license checks.
  * Added shared traversal for handwritten Go files while excluding generated files and dependency directories.
  * Enhanced handling of filesystem errors and irregular file entries during test scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->