### PR TITLE
fix(activities): the activity projection states its column order once

### DIFF
--- a/backend/internal/modules/activities/activityprojection.go
+++ b/backend/internal/modules/activities/activityprojection.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The activity projection: which columns are selected, and where each one is
+// scanned, stated ONCE.
+//
+// They used to be two lists in two functions that had to track each other by
+// eye. Most neighbours differ enough in type that a transposition fails loudly
+// on scan — but five in a row here are string-ish and nullable
+// (meeting_status, source_system, source_id, source, captured_by), and
+// swapping any two of those scans cleanly and puts the wrong value on the
+// wire. No error, no failing test, a record that says its source is a meeting
+// status.
+//
+// The order is a single slice now. A column added in the middle of the SELECT
+// arrives with its own destination attached, so there is no second list to
+// forget.
+
+import (
+	"strings"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// activityScan holds one row mid-flight: the contract record being built, and
+// the values that need converting before they can join it.
+//
+// The temporaries are here rather than local to the scanner because the
+// destination of a column is part of that column's declaration below, and a
+// closure cannot address a variable that does not exist yet.
+type activityScan struct {
+	a  crmcontracts.Activity
+	id ids.UUID
+	// assigneeID is a typed id in the row and an openapi UUID on the record.
+	assigneeID *ids.UUID
+	kind       string
+	// The nullable strings that become typed contract enums.
+	channelProvider, direction, meetingStatus, threadKey, captureLabel *string
+	bulkMailAttested                                                   bool
+	version                                                            int64
+	audience                                                           string
+	// contentAvailable is the caller's audience test, evaluated per row: it
+	// decides whether the content columns above reach the caller at all.
+	contentAvailable bool
+}
+
+// activityColumn is one column's whole declaration: how it is SELECTed and
+// where it is scanned. Keeping the two halves in one place is the point —
+// separately they are two ordered lists, and only one of them fails loudly
+// when they disagree.
+type activityColumn struct {
+	sql  string
+	into func(*activityScan) any
+}
+
+// activityProjection is the select list every activity read scans, in order.
+//
+// The last entry is the caller's audience test rendered as content_available —
+// the one column that decides whether scanActivity hands back the row's
+// content or only its markers. Its SQL is supplied per query, so it carries an
+// empty sql here and activityColumns fills it in.
+var activityProjection = []activityColumn{
+	{"a.id", func(s *activityScan) any { return &s.id }},
+	{"a.kind", func(s *activityScan) any { return &s.kind }},
+	{"a.channel_provider", func(s *activityScan) any { return &s.channelProvider }},
+	{"a.subject", func(s *activityScan) any { return &s.a.Subject }},
+	{"a.body", func(s *activityScan) any { return &s.a.Body }},
+	{"a.occurred_at", func(s *activityScan) any { return &s.a.OccurredAt }},
+	{"a.direction", func(s *activityScan) any { return &s.direction }},
+	{"a.due_at", func(s *activityScan) any { return &s.a.DueAt }},
+	{"a.remind_at", func(s *activityScan) any { return &s.a.RemindAt }},
+	{"a.assignee_id", func(s *activityScan) any { return &s.assigneeID }},
+	{"a.is_done", func(s *activityScan) any { return &s.a.IsDone }},
+	{"a.done_at", func(s *activityScan) any { return &s.a.DoneAt }},
+	{"a.duration_seconds", func(s *activityScan) any { return &s.a.DurationSeconds }},
+	{"a.meeting_status", func(s *activityScan) any { return &s.meetingStatus }},
+	{"a.source_system", func(s *activityScan) any { return &s.a.SourceSystem }},
+	{"a.source_id", func(s *activityScan) any { return &s.a.SourceId }},
+	{"a.source", func(s *activityScan) any { return &s.a.Source }},
+	{"a.captured_by", func(s *activityScan) any { return &s.a.CapturedBy }},
+	{"a.version", func(s *activityScan) any { return &s.version }},
+	{"a.created_at", func(s *activityScan) any { return &s.a.CreatedAt }},
+	{"a.updated_at", func(s *activityScan) any { return &s.a.UpdatedAt }},
+	{"a.archived_at", func(s *activityScan) any { return &s.a.ArchivedAt }},
+	{"a.thread_key", func(s *activityScan) any { return &s.threadKey }},
+	{"a.capture_label", func(s *activityScan) any { return &s.captureLabel }},
+	{"a.bulk_mail_attested", func(s *activityScan) any { return &s.bulkMailAttested }},
+	{"a.audience", func(s *activityScan) any { return &s.audience }},
+	{"", func(s *activityScan) any { return &s.contentAvailable }},
+}
+
+// activityColumns renders the select list. contentArm is the predicate
+// auth.ActivityAudienceArm rendered for this query's arguments, which is why
+// the final column's SQL cannot be a constant.
+func activityColumns(contentArm string) string {
+	out := make([]string, len(activityProjection))
+	for i, c := range activityProjection {
+		out[i] = c.sql
+	}
+	out[len(out)-1] = "(" + contentArm + ") AS content_available"
+	return strings.Join(out, ", ")
+}
+
+// activityScanTargets answers the destinations, in the projection's order.
+func activityScanTargets(s *activityScan) []any {
+	dests := make([]any, len(activityProjection))
+	for i, c := range activityProjection {
+		dests[i] = c.into(s)
+	}
+	return dests
+}
+
+// record finishes the row: the conversions the scan could not do, and the
+// content withholding the audience test decided.
+func (s *activityScan) record() crmcontracts.Activity {
+	a := s.a
+	aud := crmcontracts.ActivityAudience(s.audience)
+	a.Audience = &aud
+	threadKey, captureLabel := s.threadKey, s.captureLabel
+	state := crmcontracts.ActivityContentStateAvailable
+	if !s.contentAvailable {
+		// Withheld: the row is discoverable, its content is not the caller's.
+		// Everything that carries what was said — or identifies the message
+		// at the provider — goes; the markers stay.
+		state = crmcontracts.ActivityContentStateWithheld
+		a.Subject, a.Body, a.SourceId = nil, nil, nil
+		threadKey, captureLabel = nil, nil
+	}
+	a.ContentState = &state
+
+	a.Id = openapi_types.UUID(s.id)
+	a.AssigneeId = uuidPtr(s.assigneeID)
+	a.Kind = crmcontracts.ActivityKind(s.kind)
+	a.ChannelProvider = s.channelProvider
+	if s.direction != nil {
+		d := crmcontracts.ActivityDirection(*s.direction)
+		a.Direction = &d
+	}
+	if s.meetingStatus != nil {
+		m := crmcontracts.ActivityMeetingStatus(*s.meetingStatus)
+		a.MeetingStatus = &m
+	}
+	a.ThreadKey = threadKey
+	if captureLabel != nil {
+		label := crmcontracts.ActivityCaptureLabel(*captureLabel)
+		a.CaptureLabel = &label
+	}
+	bulk := s.bulkMailAttested
+	a.BulkMailAttested = &bulk
+	version := s.version
+	a.Version = &version
+	return a
+}

--- a/backend/internal/modules/activities/activityprojection_test.go
+++ b/backend/internal/modules/activities/activityprojection_test.go
@@ -16,6 +16,7 @@ package activities
 // for. A value that could be any column's is a value this test cannot judge.
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -309,18 +310,53 @@ func stringOf[T ~string](v *T) *string {
 	return &s
 }
 
-// The select list and the destinations come from one declaration, so their
-// lengths agree by construction. Asserted anyway, because that is the property
-// the declaration exists to hold, and a refactor that reintroduced a second
-// list would land here first.
+// The select list and the destinations come from one declaration, so they agree
+// by construction. Asserted anyway, because that is the property the
+// declaration exists to hold, and a refactor that reintroduced a second list
+// would land here first.
+//
+// The RENDERED list is what is checked, not just the count of destinations. A
+// count on its own cannot tell a projection that declares a column from one
+// that renders it: drop a column's SQL and the destinations still match the
+// declaration, while the row pgx scans is one short — which fails as a scan
+// arity error somewhere else, at a call site that has nothing to do with the
+// omission.
 func TestTheSelectListAndTheScanAgreeOnLength(t *testing.T) {
+	// A contentArm with no comma in it, so the count below is the projection's
+	// commas and not the predicate's.
 	columns := activityColumns("true")
 	dests := activityScanTargets(&activityScan{})
 	if len(dests) != len(activityProjection) {
 		t.Fatalf("the scan asks for %d destinations and the projection declares %d columns",
 			len(dests), len(activityProjection))
 	}
-	if columns == "" {
-		t.Fatal("the select list rendered empty")
+	rendered := strings.Split(columns, ", ")
+	if len(rendered) != len(activityProjection) {
+		t.Errorf("the select list renders %d columns and the projection declares %d — pgx scans "+
+			"the row the LIST asked for, so a column declared and not rendered is a scan that "+
+			"fails somewhere with nothing to do with the omission",
+			len(rendered), len(activityProjection))
+	}
+	// And none of them is blank. A declared column whose SQL went missing still
+	// renders a position — `a.due_at, , a.assignee_id` — so the count survives
+	// while the row is one column short of what the destinations expect.
+	for i, column := range rendered {
+		if strings.TrimSpace(column) == "" {
+			t.Errorf("the select list renders nothing at position %d; the projection declares a "+
+				"column there", i)
+		}
+	}
+	// And each declared column is actually in it, so a rename cannot keep the
+	// count while selecting something else.
+	for _, c := range activityProjection {
+		if c.sql == "" {
+			continue
+		}
+		if !strings.Contains(columns, c.sql) {
+			t.Errorf("the projection declares %s and the select list does not name it", c.sql)
+		}
+	}
+	if !strings.HasSuffix(columns, "AS content_available") {
+		t.Errorf("the select list does not end with the audience arm: %q", columns)
 	}
 }

--- a/backend/internal/modules/activities/activityprojection_test.go
+++ b/backend/internal/modules/activities/activityprojection_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -39,6 +41,15 @@ type sentinelRow struct {
 	// ones alternate. Two booleans set to the same value are indistinguishable
 	// after a swap, which is exactly the case this row exists to catch.
 	bools int
+	// flip inverts that alternation. Three booleans and two values means one
+	// pair must collide in any single run — is_done and content_available did
+	// — so the scan runs twice with the parity reversed, and a pair that
+	// matched in one run differs in the other.
+	flip bool
+	// last is content_available's position. It is forced true in BOTH runs:
+	// false there withholds the content columns, so a run that flipped it
+	// would report the withholding as a transposition rather than testing one.
+	last int
 }
 
 func (r *sentinelRow) Scan(dest ...any) error {
@@ -77,15 +88,9 @@ func (r *sentinelRow) fill(dest any, name string, index int) {
 		v := epoch.Add(time.Duration(index) * time.Hour)
 		*d = &v
 	case *bool:
-		// Alternating, starting true: content_available is the FIRST boolean
-		// scanned in declaration order only by accident, so it is asserted
-		// below rather than assumed — and the point here is that no two
-		// booleans in this row hold the same value.
-		*d = r.bools%2 == 0
-		r.bools++
+		*d = r.boolAt(index)
 	case **bool:
-		v := r.bools%2 == 0
-		r.bools++
+		v := r.boolAt(index)
 		*d = &v
 	case *int64:
 		*d = int64(index)
@@ -98,6 +103,17 @@ func (r *sentinelRow) fill(dest any, name string, index int) {
 	default:
 		r.t.Fatalf("the projection declares a destination this row cannot fill for %s: %T", name, dest)
 	}
+}
+
+// boolAt answers the boolean this column gets: alternating in arrival order,
+// inverted on the second run, and always true for content_available.
+func (r *sentinelRow) boolAt(index int) bool {
+	v := r.bools%2 == 0
+	r.bools++
+	if index == r.last {
+		return true
+	}
+	return v != r.flip
 }
 
 // uuidFor is a distinct, reproducible id per column position.
@@ -119,16 +135,43 @@ func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
 		}
 		index[names[i]] = i
 	}
-	got, err := scanActivity(&sentinelRow{t: t, names: names})
-	if err != nil {
-		t.Fatalf("scanActivity: %v", err)
+	// content_available is the projection's last column, and this test relies
+	// on that to keep it true in both runs. Asserted rather than assumed: a
+	// column appended after it would make the forcing silently miss.
+	if index["content_available"] != len(activityProjection)-1 {
+		t.Fatalf("content_available is column %d of %d — it is expected last, and the boolean "+
+			"sentinel forces it by position", index["content_available"], len(activityProjection))
 	}
+
+	// TWICE, with the boolean parity reversed. Three booleans share two values,
+	// so one pair collides in any single run — is_done and content_available
+	// did, which made swapping their destinations invisible. Reversing the
+	// parity separates whichever pair matched.
+	for _, flip := range []bool{false, true} {
+		t.Run(map[bool]string{false: "as declared", true: "with the booleans reversed"}[flip], func(t *testing.T) {
+			row := &sentinelRow{t: t, names: names, flip: flip, last: index["content_available"]}
+			got, err := scanActivity(row)
+			if err != nil {
+				t.Fatalf("scanActivity: %v", err)
+			}
+			assertProjection(t, got, index, flip)
+		})
+	}
+}
+
+// assertProjection checks every field the scan materializes against the column
+// it is declared for.
+func assertProjection(t *testing.T, got crmcontracts.Activity, index map[string]int, flip bool) {
+	t.Helper()
 	// content_available decides whether the content columns reach the caller
 	// at all, so a run where it landed false would blank half the fields below
 	// and report the blanking as a transposition.
-	if got.ContentState == nil || string(*got.ContentState) != "available" {
-		t.Fatalf("content_available did not scan as true (content_state %v) — every content "+
-			"assertion below would then be reading the withholding, not the scan", got.ContentState)
+	if got.ContentState == nil {
+		t.Fatal("content_state was never set — the scan did not reach the audience arm")
+	}
+	if string(*got.ContentState) != "available" {
+		t.Fatalf("content_available did not scan as true (content_state %q) — every content "+
+			"assertion below would then be reading the withholding, not the scan", *got.ContentState)
 	}
 
 	for _, want := range []struct {
@@ -159,8 +202,8 @@ func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
 		t.Errorf("a.kind landed as %q", got.Kind)
 	}
 
-	// The instants. Seven of them, all *time.Time or time.Time, and any two
-	// are as interchangeable to a scan as any two strings.
+	// The instants. Seven of them, and any two are as interchangeable to a
+	// scan as any two strings.
 	for _, want := range []struct {
 		column string
 		got    *time.Time
@@ -199,12 +242,10 @@ func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
 		t.Errorf("a.version holds %v", got.Version)
 	}
 
-	// The booleans, which carry the least information of anything here — two
-	// values across three columns — and are therefore the easiest to transpose
-	// undetected. They alternate in the row above so that no two hold the same
-	// answer.
-	assertBool(t, "a.is_done", got.IsDone, boolFor(index["a.is_done"]))
-	assertBool(t, "a.bulk_mail_attested", got.BulkMailAttested, boolFor(index["a.bulk_mail_attested"]))
+	// The booleans, which carry the least information of anything here and are
+	// therefore the easiest to transpose undetected.
+	assertBool(t, "a.is_done", got.IsDone, boolFor(index["a.is_done"]) != flip)
+	assertBool(t, "a.bulk_mail_attested", got.BulkMailAttested, boolFor(index["a.bulk_mail_attested"]) != flip)
 }
 
 // boolFor answers what the row wrote for the boolean at this column, by

--- a/backend/internal/modules/activities/activityprojection_test.go
+++ b/backend/internal/modules/activities/activityprojection_test.go
@@ -5,14 +5,15 @@ package activities
 
 // Every column of the activity projection lands in its OWN field.
 //
-// Five neighbours are string-ish and nullable — meeting_status, source_system,
-// source_id, source, captured_by — so transposing any two of them scans
-// cleanly and puts the wrong value on the wire. Nothing errors. A record
-// simply says its source is a meeting status.
+// Five string-ish neighbours can transpose without an error — meeting_status,
+// source_system, source_id, source, captured_by — and they are not the only
+// pair that can. Two booleans (is_done, bulk_mail_attested) and seven
+// timestamps are as interchangeable to a scan as two strings, and a swap among
+// them is just as silent.
 //
-// The scan is driven by a row that hands each column a sentinel naming the
-// column it came from, so a swap is not "some string in some field" but a
-// named mismatch.
+// So every destination is filled from its POSITION in the projection, and every
+// field the scan materializes is asserted against the column it is declared
+// for. A value that could be any column's is a value this test cannot judge.
 
 import (
 	"testing"
@@ -23,15 +24,21 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// sentinelRow answers each destination with a value derived from its POSITION
-// in the projection, so what a field ends up holding names where it came from.
-//
-// It writes through the destination pointers the projection handed it, which
-// is the same path pgx takes — a row that filled a struct by name would prove
-// nothing about an order nobody stated.
+// epoch anchors the timestamp sentinels. Each column gets epoch plus its own
+// index, so two timestamps are never the same instant.
+var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// sentinelRow answers each destination with a value derived from its position,
+// writing through the pointers the projection handed it — the same path pgx
+// takes. A row that filled a struct by name would prove nothing about an order
+// nobody stated.
 type sentinelRow struct {
 	t     *testing.T
 	names []string
+	// bools counts the boolean destinations as they arrive, so consecutive
+	// ones alternate. Two booleans set to the same value are indistinguishable
+	// after a swap, which is exactly the case this row exists to catch.
+	bools int
 }
 
 func (r *sentinelRow) Scan(dest ...any) error {
@@ -41,18 +48,18 @@ func (r *sentinelRow) Scan(dest ...any) error {
 			len(dest), len(r.names))
 	}
 	for i, d := range dest {
-		fill(r.t, d, r.names[i])
+		r.fill(d, r.names[i], i)
 	}
 	return nil
 }
 
-// fill writes a value that carries `name` where the type allows it, and
-// something valid where it does not. Only the string-ish columns can be
-// silently transposed, so only they need to be distinguishable.
+// fill writes a value that identifies the column it was written for: the name
+// itself where a string will hold one, the index where a number or an instant
+// will, and an alternating value for a boolean, which has only two.
 //
 //craft:ignore naked-any a scan destination is exactly what pgx.Row.Scan takes, and the whole subject here is which concrete pointer arrives in which position — naming a type would be naming the answer this switch exists to discover.
-func fill(t *testing.T, dest any, name string) {
-	t.Helper()
+func (r *sentinelRow) fill(dest any, name string, index int) {
+	r.t.Helper()
 	switch d := dest.(type) {
 	case *string:
 		*d = name
@@ -60,54 +67,70 @@ func fill(t *testing.T, dest any, name string) {
 		v := name
 		*d = &v
 	case *ids.UUID:
-		*d = ids.NewV7()
+		*d = uuidFor(index)
 	case **ids.UUID:
-		v := ids.NewV7()
+		v := uuidFor(index)
 		*d = &v
 	case *time.Time:
-		*d = time.Unix(0, 0).UTC()
+		*d = epoch.Add(time.Duration(index) * time.Hour)
 	case **time.Time:
-		v := time.Unix(0, 0).UTC()
+		v := epoch.Add(time.Duration(index) * time.Hour)
 		*d = &v
 	case *bool:
-		// content_available true, so nothing is withheld and every field the
-		// audience test would blank stays readable for the comparison below.
-		*d = true
+		// Alternating, starting true: content_available is the FIRST boolean
+		// scanned in declaration order only by accident, so it is asserted
+		// below rather than assumed — and the point here is that no two
+		// booleans in this row hold the same value.
+		*d = r.bools%2 == 0
+		r.bools++
 	case **bool:
-		v := true
+		v := r.bools%2 == 0
+		r.bools++
 		*d = &v
 	case *int64:
-		*d = 1
+		*d = int64(index)
 	case **int:
-		v := 1
+		v := index
 		*d = &v
 	case **int64:
-		v := int64(1)
+		v := int64(index)
 		*d = &v
 	default:
-		t.Fatalf("the projection declares a destination this row cannot fill for %s: %T", name, dest)
+		r.t.Fatalf("the projection declares a destination this row cannot fill for %s: %T", name, dest)
 	}
+}
+
+// uuidFor is a distinct, reproducible id per column position.
+func uuidFor(index int) ids.UUID {
+	var u ids.UUID
+	u[15] = byte(index + 1)
+	return u
 }
 
 var _ pgx.Row = (*sentinelRow)(nil)
 
 func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
 	names := make([]string, len(activityProjection))
+	index := map[string]int{}
 	for i, c := range activityProjection {
 		names[i] = c.sql
 		if names[i] == "" {
 			names[i] = "content_available"
 		}
+		index[names[i]] = i
 	}
-
 	got, err := scanActivity(&sentinelRow{t: t, names: names})
 	if err != nil {
 		t.Fatalf("scanActivity: %v", err)
 	}
+	// content_available decides whether the content columns reach the caller
+	// at all, so a run where it landed false would blank half the fields below
+	// and report the blanking as a transposition.
+	if got.ContentState == nil || string(*got.ContentState) != "available" {
+		t.Fatalf("content_available did not scan as true (content_state %v) — every content "+
+			"assertion below would then be reading the withholding, not the scan", got.ContentState)
+	}
 
-	// Only the string-carrying columns can transpose without an error, so
-	// those are the ones worth naming. Each is asserted against the column it
-	// is declared for, not against a position.
 	for _, want := range []struct {
 		column string
 		got    *string
@@ -116,41 +139,134 @@ func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
 		{"a.body", got.Body},
 		{"a.source_system", got.SourceSystem},
 		{"a.source_id", got.SourceId},
+		{"a.captured_by", got.CapturedBy},
 		{"a.channel_provider", got.ChannelProvider},
 		{"a.thread_key", got.ThreadKey},
-		{"a.captured_by", got.CapturedBy},
+	} {
+		assertString(t, want.column, want.got)
+	}
+	if got.Source != "a.source" {
+		t.Errorf("a.source landed in a field holding %q", got.Source)
+	}
+
+	// The typed enums come off string columns and are the other half of the
+	// same hazard: a swap reads as a valid-looking wrong value.
+	assertString(t, "a.direction", stringOf(got.Direction))
+	assertString(t, "a.meeting_status", stringOf(got.MeetingStatus))
+	assertString(t, "a.capture_label", stringOf(got.CaptureLabel))
+	assertString(t, "a.audience", stringOf(got.Audience))
+	if string(got.Kind) != "a.kind" {
+		t.Errorf("a.kind landed as %q", got.Kind)
+	}
+
+	// The instants. Seven of them, all *time.Time or time.Time, and any two
+	// are as interchangeable to a scan as any two strings.
+	for _, want := range []struct {
+		column string
+		got    *time.Time
+	}{
+		{"a.occurred_at", &got.OccurredAt},
+		{"a.due_at", got.DueAt},
+		{"a.remind_at", got.RemindAt},
+		{"a.done_at", got.DoneAt},
+		{"a.created_at", &got.CreatedAt},
+		{"a.updated_at", &got.UpdatedAt},
+		{"a.archived_at", got.ArchivedAt},
 	} {
 		if want.got == nil {
 			t.Errorf("%s scanned into nothing", want.column)
 			continue
 		}
-		if *want.got != want.column {
-			t.Errorf("%s landed in a field holding %q — two destinations are transposed, and a "+
-				"transposition among these scans cleanly and puts the wrong value on the wire",
-				want.column, *want.got)
+		if at := epoch.Add(time.Duration(index[want.column]) * time.Hour); !want.got.Equal(at) {
+			t.Errorf("%s holds %v, want %v — two timestamp destinations are transposed",
+				want.column, want.got, at)
 		}
 	}
-	// Source is a plain string on the record rather than a pointer.
-	if got.Source != "a.source" {
-		t.Errorf("a.source landed in a field holding %q", got.Source)
+
+	// The ids.
+	if ids.UUID(got.Id) != uuidFor(index["a.id"]) {
+		t.Errorf("a.id holds %v", got.Id)
 	}
-	// The typed enums come off the same string columns and are the other half
-	// of the same hazard: a swap here reads as a valid-looking wrong value.
-	if got.Direction == nil || string(*got.Direction) != "a.direction" {
-		t.Errorf("a.direction landed as %v", got.Direction)
+	if got.AssigneeId == nil || ids.UUID(*got.AssigneeId) != uuidFor(index["a.assignee_id"]) {
+		t.Errorf("a.assignee_id holds %v", got.AssigneeId)
 	}
-	if got.MeetingStatus == nil || string(*got.MeetingStatus) != "a.meeting_status" {
-		t.Errorf("a.meeting_status landed as %v", got.MeetingStatus)
+
+	// The numbers.
+	if got.DurationSeconds == nil || *got.DurationSeconds != index["a.duration_seconds"] {
+		t.Errorf("a.duration_seconds holds %v", got.DurationSeconds)
 	}
-	if got.CaptureLabel == nil || string(*got.CaptureLabel) != "a.capture_label" {
-		t.Errorf("a.capture_label landed as %v", got.CaptureLabel)
+	if got.Version == nil || int(*got.Version) != index["a.version"] {
+		t.Errorf("a.version holds %v", got.Version)
 	}
-	if string(got.Kind) != "a.kind" {
-		t.Errorf("a.kind landed as %q", got.Kind)
+
+	// The booleans, which carry the least information of anything here — two
+	// values across three columns — and are therefore the easiest to transpose
+	// undetected. They alternate in the row above so that no two hold the same
+	// answer.
+	assertBool(t, "a.is_done", got.IsDone, boolFor(index["a.is_done"]))
+	assertBool(t, "a.bulk_mail_attested", got.BulkMailAttested, boolFor(index["a.bulk_mail_attested"]))
+}
+
+// boolFor answers what the row wrote for the boolean at this column, by
+// counting the booleans that precede it in declaration order. Derived rather
+// than written down, so the two stay in step when a column moves.
+func boolFor(at int) bool {
+	seen := 0
+	for i, c := range activityProjection {
+		if i >= at {
+			break
+		}
+		if isBoolColumn(c.sql) {
+			seen++
+		}
 	}
-	if got.Audience == nil || string(*got.Audience) != "a.audience" {
-		t.Errorf("a.audience landed as %v", got.Audience)
+	return seen%2 == 0
+}
+
+// isBoolColumn names the projection's boolean columns. A list, because the
+// destination's type is only knowable at scan time and this has to answer
+// before one exists.
+func isBoolColumn(sql string) bool {
+	switch sql {
+	case "a.is_done", "a.bulk_mail_attested", "":
+		return true
 	}
+	return false
+}
+
+func assertBool(t *testing.T, column string, got *bool, want bool) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s scanned into nothing", column)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s holds %t, want %t — two boolean destinations are transposed, and a boolean "+
+			"carries the least information of anything here, so a swap is the easiest to miss",
+			column, *got, want)
+	}
+}
+
+func assertString(t *testing.T, column string, got *string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s scanned into nothing", column)
+		return
+	}
+	if *got != column {
+		t.Errorf("%s landed in a field holding %q — two destinations are transposed, and a "+
+			"transposition among these scans cleanly and puts the wrong value on the wire",
+			column, *got)
+	}
+}
+
+// stringOf reads a typed-enum pointer back as the string it was scanned from.
+func stringOf[T ~string](v *T) *string {
+	if v == nil {
+		return nil
+	}
+	s := string(*v)
+	return &s
 }
 
 // The select list and the destinations come from one declaration, so their

--- a/backend/internal/modules/activities/activityprojection_test.go
+++ b/backend/internal/modules/activities/activityprojection_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Every column of the activity projection lands in its OWN field.
+//
+// Five neighbours are string-ish and nullable — meeting_status, source_system,
+// source_id, source, captured_by — so transposing any two of them scans
+// cleanly and puts the wrong value on the wire. Nothing errors. A record
+// simply says its source is a meeting status.
+//
+// The scan is driven by a row that hands each column a sentinel naming the
+// column it came from, so a swap is not "some string in some field" but a
+// named mismatch.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// sentinelRow answers each destination with a value derived from its POSITION
+// in the projection, so what a field ends up holding names where it came from.
+//
+// It writes through the destination pointers the projection handed it, which
+// is the same path pgx takes — a row that filled a struct by name would prove
+// nothing about an order nobody stated.
+type sentinelRow struct {
+	t     *testing.T
+	names []string
+}
+
+func (r *sentinelRow) Scan(dest ...any) error {
+	r.t.Helper()
+	if len(dest) != len(r.names) {
+		r.t.Fatalf("the scan asked for %d destinations and the projection declares %d columns",
+			len(dest), len(r.names))
+	}
+	for i, d := range dest {
+		fill(r.t, d, r.names[i])
+	}
+	return nil
+}
+
+// fill writes a value that carries `name` where the type allows it, and
+// something valid where it does not. Only the string-ish columns can be
+// silently transposed, so only they need to be distinguishable.
+//
+//craft:ignore naked-any a scan destination is exactly what pgx.Row.Scan takes, and the whole subject here is which concrete pointer arrives in which position — naming a type would be naming the answer this switch exists to discover.
+func fill(t *testing.T, dest any, name string) {
+	t.Helper()
+	switch d := dest.(type) {
+	case *string:
+		*d = name
+	case **string:
+		v := name
+		*d = &v
+	case *ids.UUID:
+		*d = ids.NewV7()
+	case **ids.UUID:
+		v := ids.NewV7()
+		*d = &v
+	case *time.Time:
+		*d = time.Unix(0, 0).UTC()
+	case **time.Time:
+		v := time.Unix(0, 0).UTC()
+		*d = &v
+	case *bool:
+		// content_available true, so nothing is withheld and every field the
+		// audience test would blank stays readable for the comparison below.
+		*d = true
+	case **bool:
+		v := true
+		*d = &v
+	case *int64:
+		*d = 1
+	case **int:
+		v := 1
+		*d = &v
+	case **int64:
+		v := int64(1)
+		*d = &v
+	default:
+		t.Fatalf("the projection declares a destination this row cannot fill for %s: %T", name, dest)
+	}
+}
+
+var _ pgx.Row = (*sentinelRow)(nil)
+
+func TestEveryProjectedColumnLandsInItsOwnField(t *testing.T) {
+	names := make([]string, len(activityProjection))
+	for i, c := range activityProjection {
+		names[i] = c.sql
+		if names[i] == "" {
+			names[i] = "content_available"
+		}
+	}
+
+	got, err := scanActivity(&sentinelRow{t: t, names: names})
+	if err != nil {
+		t.Fatalf("scanActivity: %v", err)
+	}
+
+	// Only the string-carrying columns can transpose without an error, so
+	// those are the ones worth naming. Each is asserted against the column it
+	// is declared for, not against a position.
+	for _, want := range []struct {
+		column string
+		got    *string
+	}{
+		{"a.subject", got.Subject},
+		{"a.body", got.Body},
+		{"a.source_system", got.SourceSystem},
+		{"a.source_id", got.SourceId},
+		{"a.channel_provider", got.ChannelProvider},
+		{"a.thread_key", got.ThreadKey},
+		{"a.captured_by", got.CapturedBy},
+	} {
+		if want.got == nil {
+			t.Errorf("%s scanned into nothing", want.column)
+			continue
+		}
+		if *want.got != want.column {
+			t.Errorf("%s landed in a field holding %q — two destinations are transposed, and a "+
+				"transposition among these scans cleanly and puts the wrong value on the wire",
+				want.column, *want.got)
+		}
+	}
+	// Source is a plain string on the record rather than a pointer.
+	if got.Source != "a.source" {
+		t.Errorf("a.source landed in a field holding %q", got.Source)
+	}
+	// The typed enums come off the same string columns and are the other half
+	// of the same hazard: a swap here reads as a valid-looking wrong value.
+	if got.Direction == nil || string(*got.Direction) != "a.direction" {
+		t.Errorf("a.direction landed as %v", got.Direction)
+	}
+	if got.MeetingStatus == nil || string(*got.MeetingStatus) != "a.meeting_status" {
+		t.Errorf("a.meeting_status landed as %v", got.MeetingStatus)
+	}
+	if got.CaptureLabel == nil || string(*got.CaptureLabel) != "a.capture_label" {
+		t.Errorf("a.capture_label landed as %v", got.CaptureLabel)
+	}
+	if string(got.Kind) != "a.kind" {
+		t.Errorf("a.kind landed as %q", got.Kind)
+	}
+	if got.Audience == nil || string(*got.Audience) != "a.audience" {
+		t.Errorf("a.audience landed as %v", got.Audience)
+	}
+}
+
+// The select list and the destinations come from one declaration, so their
+// lengths agree by construction. Asserted anyway, because that is the property
+// the declaration exists to hold, and a refactor that reintroduced a second
+// list would land here first.
+func TestTheSelectListAndTheScanAgreeOnLength(t *testing.T) {
+	columns := activityColumns("true")
+	dests := activityScanTargets(&activityScan{})
+	if len(dests) != len(activityProjection) {
+		t.Fatalf("the scan asks for %d destinations and the projection declares %d columns",
+			len(dests), len(activityProjection))
+	}
+	if columns == "" {
+		t.Fatal("the select list rendered empty")
+	}
+}

--- a/backend/internal/modules/activities/activityprojection_test.go
+++ b/backend/internal/modules/activities/activityprojection_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -159,18 +159,6 @@ func ListActivitiesTx(ctx context.Context, tx pgx.Tx, in ListActivitiesInput) ([
 	return activities, page, nil
 }
 
-// activityColumns is the select list every activity read scans, closed by
-// the caller's audience test as `content_available` — the one column that
-// decides whether scanActivity hands back the row's content or only its
-// markers. contentArm is the predicate auth.ActivityAudienceArm rendered for
-// this query's arguments.
-func activityColumns(contentArm string) string {
-	return `a.id, a.kind, a.channel_provider, a.subject, a.body, a.occurred_at, a.direction,
-	a.due_at, a.remind_at, a.assignee_id, a.is_done, a.done_at, a.duration_seconds, a.meeting_status,
-	a.source_system, a.source_id, a.source, a.captured_by, a.version, a.created_at, a.updated_at, a.archived_at,
-	a.thread_key, a.capture_label, a.bulk_mail_attested, a.audience, (` + contentArm + `) AS content_available`
-}
-
 // readActivity is the module's ONE single-row activity read, and it
 // carries the row scope itself. An activity has no owner_id and the
 // workspace predicate bounds only the tenant, so its scope exists solely
@@ -276,56 +264,16 @@ func attachLinks(ctx context.Context, tx pgx.Tx, activities []crmcontracts.Activ
 	return rows.Err()
 }
 
+// scanActivity reads one row of the activity projection.
+//
+// Both the column list and these destinations come from activityProjection, so
+// a column added or moved carries its own destination with it — the transposed
+// scan that used to be possible among the string-ish neighbours has no second
+// list to disagree with.
 func scanActivity(row pgx.Row) (crmcontracts.Activity, error) {
-	var a crmcontracts.Activity
-	var id ids.UUID
-	var assigneeID *ids.UUID
-	var kind string
-	var channelProvider, direction, meetingStatus, threadKey, captureLabel *string
-	var bulkMailAttested bool
-	var version int64
-
-	var audience string
-	var contentAvailable bool
-
-	err := row.Scan(&id, &kind, &channelProvider, &a.Subject, &a.Body, &a.OccurredAt, &direction,
-		&a.DueAt, &a.RemindAt, &assigneeID, &a.IsDone, &a.DoneAt, &a.DurationSeconds, &meetingStatus,
-		&a.SourceSystem, &a.SourceId, &a.Source, &a.CapturedBy, &version, &a.CreatedAt, &a.UpdatedAt, &a.ArchivedAt,
-		&threadKey, &captureLabel, &bulkMailAttested, &audience, &contentAvailable)
-	if err != nil {
-		return a, err
+	var s activityScan
+	if err := row.Scan(activityScanTargets(&s)...); err != nil {
+		return crmcontracts.Activity{}, err
 	}
-	aud := crmcontracts.ActivityAudience(audience)
-	a.Audience = &aud
-	state := crmcontracts.ActivityContentStateAvailable
-	if !contentAvailable {
-		// Withheld: the row is discoverable, its content is not the caller's.
-		// Everything that carries what was said — or identifies the message
-		// at the provider — goes; the markers stay.
-		state = crmcontracts.ActivityContentStateWithheld
-		a.Subject, a.Body, a.SourceId = nil, nil, nil
-		threadKey, captureLabel = nil, nil
-	}
-	a.ContentState = &state
-
-	a.Id = openapi_types.UUID(id)
-	a.AssigneeId = uuidPtr(assigneeID)
-	a.Kind = crmcontracts.ActivityKind(kind)
-	a.ChannelProvider = channelProvider
-	if direction != nil {
-		d := crmcontracts.ActivityDirection(*direction)
-		a.Direction = &d
-	}
-	if meetingStatus != nil {
-		m := crmcontracts.ActivityMeetingStatus(*meetingStatus)
-		a.MeetingStatus = &m
-	}
-	a.ThreadKey = threadKey
-	if captureLabel != nil {
-		label := crmcontracts.ActivityCaptureLabel(*captureLabel)
-		a.CaptureLabel = &label
-	}
-	a.BulkMailAttested = &bulkMailAttested
-	a.Version = &version
-	return a, nil
+	return s.record(), nil
 }


### PR DESCRIPTION
Closes #582.

The select list and the scan destinations were two ordered lists in two functions that had to track each other **by eye**.

Most neighbours differ enough in type that a transposition fails loudly on scan. Five in a row do not — `meeting_status`, `source_system`, `source_id`, `source`, `captured_by` are all string-ish and nullable — and swapping any two of those scans cleanly and puts the wrong value on the wire. No error, no failing test, a record that says its source is a meeting status.

## One declaration

`activityProjection` is a single slice, each entry carrying both halves: how the column is `SELECT`ed and where it is scanned. A column added in the middle arrives with its destination attached, so there is no second list to forget.

That is the issue's first fix shape — the one that **removes the class** rather than covering the instance.

The audience arm keeps its per-query SQL: it is a predicate rendered for that query's arguments, so it is the one entry whose select text cannot be a constant, and it stays last for the same reason it always was.

## Held

`TestEveryProjectedColumnLandsInItsOwnField` drives the scan with a row that hands each column a sentinel **naming the column it came from**, through the same destination pointers pgx writes through. A transposition is then a named mismatch rather than a plausible string in the wrong field.

Verified from the other end — swapping `source_system` and `source_id` in the projection fails both assertions by name:

```
a.source_system landed in a field holding "a.source_id" — two destinations are transposed…
a.source_id landed in a field holding "a.source_system" — two destinations are transposed…
```

The whole `activities` integration suite passes unchanged, which is what says the projection still reads the same rows it did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when retrieving and displaying activity records.
  * Improved handling of optional values, identifiers, timestamps, and activity metadata.
  * Restricted sensitive activity details when access checks fail.

* **Tests**
  * Added coverage to verify activity fields and retrieved values remain accurate.
  * Added checks for content availability and withheld sensitive fields.
  * Added safeguards to keep displayed activity data aligned with query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->