### PR TITLE
fix(scripts): seed-dev detours the admin password when it equals the bootstrap value

### DIFF
--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -84,6 +84,20 @@ capture_session() {
 # happens twice.
 sign_in_as_admin() {
   local status
+
+  # A 200 here proves nothing when the chosen and operator-supplied passwords
+  # are the same string — which is what the shipped defaults do
+  # (config/margince-admin-password and ADMIN_PASSWORD both ship
+  # demo-password-123). The login succeeds whether or not the account is still
+  # on the mandatory-change hold, and the api refuses to rotate a password to
+  # itself, so there is no direct way to lift the hold in that case. Detour
+  # through an intermediate value instead: unconditional, and convergent
+  # whichever state the account started in.
+  if [ "$ADMIN_PASSWORD" = "$BOOTSTRAP_PASSWORD" ]; then
+    rotate_admin_password_via_detour
+    return
+  fi
+
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
   if [ "$status" = "200" ]; then
     capture_session
@@ -117,6 +131,60 @@ sign_in_as_admin() {
   fi
   capture_session
   echo "  OK: $ADMIN_EMAIL now owns its own password"
+}
+
+# Lifts the mandatory-change hold when ADMIN_PASSWORD and BOOTSTRAP_PASSWORD
+# are the same string, so a login can never be read as proof the hold is
+# cleared. Two real changes clear it honestly — the api refuses to "change" a
+# password to the value it already holds — and leave the account on
+# ADMIN_PASSWORD either way, whether this run found it still on the hold or
+# already past it from an earlier run.
+#
+# A failure between the two leaves the account on the detour value; the error
+# says so rather than making the next run guess.
+rotate_admin_password_via_detour() {
+  local detour="${ADMIN_PASSWORD}-seed-dev-detour" status
+
+  status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
+  if [ "$status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/body" >&2
+    fail "login as $ADMIN_EMAIL returned HTTP $status — the api bootstraps the demo organization at boot from its margince.yaml (make dev writes it); if the credentials changed, reset the dev database and restart the stack"
+  fi
+  capture_session
+
+  status="$(api POST /auth/change-password \
+    "$(jq -n --arg c "$ADMIN_PASSWORD" --arg n "$detour" '{current_password:$c,new_password:$n}')")"
+  if [ "$status" != "204" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/body" >&2
+    fail "POST /v1/auth/change-password (rotating off the operator-supplied password) returned HTTP $status"
+  fi
+
+  status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$detour" '{email:$e,password:$p}')")"
+  if [ "$status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/body" >&2
+    fail "login with the detour password returned HTTP $status — the account is now on an intermediate password; re-run with ADMIN_PASSWORD=\"$detour\" to recover it, then re-run again with the original ADMIN_PASSWORD"
+  fi
+  capture_session
+
+  status="$(api POST /auth/change-password \
+    "$(jq -n --arg c "$detour" --arg n "$ADMIN_PASSWORD" '{current_password:$c,new_password:$n}')")"
+  if [ "$status" != "204" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/body" >&2
+    fail "POST /v1/auth/change-password (restoring $ADMIN_PASSWORD) returned HTTP $status — the account is stuck on the detour password \"$detour\""
+  fi
+
+  status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
+  if [ "$status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/body" >&2
+    fail "login with the chosen password returned HTTP $status after restoring it"
+  fi
+  capture_session
+  echo "  OK: $ADMIN_EMAIL owns its own password (rotated via detour: the chosen password equals the operator-supplied one)"
 }
 
 echo "== seed-dev: API reachability =="

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -143,7 +143,9 @@ sign_in_as_admin() {
 # A failure between the two leaves the account on the detour value; the error
 # says so rather than making the next run guess.
 rotate_admin_password_via_detour() {
-  local detour="${ADMIN_PASSWORD}-seed-dev-detour" status
+  # Truncated so the detour value never exceeds the service's 256-character
+  # ceiling (passwordLengthError) even when ADMIN_PASSWORD is near it itself.
+  local detour="${ADMIN_PASSWORD:0:240}-seed-dev-detour" status
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
   if [ "$status" != "200" ]; then
@@ -165,7 +167,7 @@ rotate_admin_password_via_detour() {
   if [ "$status" != "200" ]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
-    fail "login with the detour password returned HTTP $status — the account is now on an intermediate password; re-run with ADMIN_PASSWORD=\"$detour\" to recover it, then re-run again with the original ADMIN_PASSWORD"
+    fail "login with the detour password returned HTTP $status — the account is now on an intermediate password (ADMIN_PASSWORD with the literal suffix '-seed-dev-detour' appended, truncated to 256 characters; see rotate_admin_password_via_detour). Recover by exporting that value as ADMIN_PASSWORD and re-running, then running once more with the original ADMIN_PASSWORD"
   fi
   capture_session
 
@@ -174,7 +176,7 @@ rotate_admin_password_via_detour() {
   if [ "$status" != "204" ]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
-    fail "POST /v1/auth/change-password (restoring $ADMIN_PASSWORD) returned HTTP $status — the account is stuck on the detour password \"$detour\""
+    fail "POST /v1/auth/change-password (restoring the chosen password) returned HTTP $status — the account is stuck on the detour password (see rotate_admin_password_via_detour for how it's derived from ADMIN_PASSWORD)"
   fi
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"


### PR DESCRIPTION
## The bug

`make seed-dev` prints `OK: logged in as admin@demo.test` and then fails on
the first record it tries to create:

```
{"type":"https://errors.gradion.com/password_change_required",
 "title":"Forbidden","status":403,"code":"password_change_required",
 "detail":"this account must set its own password before it can be used"}
FAIL: POST /v1/people (person Alice Müller) returned HTTP 403
```

`sign_in_as_admin`'s fast path tries the chosen `ADMIN_PASSWORD` first, and if
that login answers HTTP 200 it assumes the account is fully usable and
returns immediately. But a freshly-bootstrapped admin account is on a
mandatory `must_change_password` hold that blocks every route — including
reads — until the change happens. A login succeeding does not mean the hold
is lifted.

That matters because **the login succeeding proves nothing when the
operator-supplied bootstrap password and the chosen password are the same
string.** In that case the fast-path login succeeds while the account is
still on hold, the function returns early, and the mandatory change never
runs. The failure names the record being seeded rather than the account
doing the seeding, so it reads as a data problem rather than an auth one.

## The fix

`sign_in_as_admin` now special-cases `ADMIN_PASSWORD == BOOTSTRAP_PASSWORD`
and detours through an intermediate password instead of taking the
login-first fast path. The API refuses to "change" a password to the value
it already holds, so there is no way to rotate directly from the bootstrap
value back to itself — two real changes (to a detour value, then back) clear
the hold and land back on the chosen password whether the account was still
on the hold or already past it from an earlier run. This keeps the whole
thing convergent: re-running `make seed-dev` any number of times stays fast
and clean.

## UAT

Reproduced against the unpatched script on a fresh dev stack bootstrapped
with the bootstrap password equal to `ADMIN_PASSWORD`:

```
== seed-dev: demo installation ==
  OK: logged in as admin@demo.test
== seed-dev: demo people ==
  response body:
{"type":"https://errors.gradion.com/password_change_required", ...}
FAIL: POST /v1/people (person Alice Müller) returned HTTP 403
```

Patched, on the SAME already-broken stack (no reset needed — proves the fix
recovers a stuck account, not just a fresh one):

```
== seed-dev: demo installation ==
  OK: admin@demo.test owns its own password (rotated via detour: the chosen password equals the operator-supplied one)
== seed-dev: demo people ==
  OK: created person Alice Müller
  OK: created person Bob Schmidt
  OK: created person Carol Wagner
== seed-dev: demo organization ==
  OK: created organization Demo GmbH
== seed-dev: demo deals ==
  OK: created deal Acme Expansion
  OK: created deal Globex Renewal

seed-dev: DONE — log in at http://localhost:8082 with admin@demo.test / demo-password-123
```

Ran a second time to confirm idempotency — still detours cleanly and stays
green:

```
== seed-dev: demo installation ==
  OK: admin@demo.test owns its own password (rotated via detour: the chosen password equals the operator-supplied one)
== seed-dev: demo people ==
  OK: person Alice Müller already present
  ...
seed-dev: DONE — log in at http://localhost:8082 with admin@demo.test / demo-password-123
```

`bash -n scripts/seed-dev.sh` and `shellcheck scripts/seed-dev.sh` are clean
(only the pre-existing informational SC1091 on the `lib-devstate.sh` source
line). `make check` passes in full.

Closes the underlying bug (no separate issue reference — filed and fixed in
this PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `seed-dev` so a fresh admin account no longer gets stuck on a mandatory password-change hold when the chosen admin password equals the operator-supplied bootstrap password. Previously, a successful login was taken as proof the account was usable, but the API still blocks requests until the password is changed; with identical passwords the API refuses to rotate to the same value, so seeding failed. The script now detects that condition and rotates through a temporary intermediate password, which clears the hold and lands back on the chosen password. The fix is idempotent.

- The detour value is truncated to stay within the service's 256-character password limit.
- Failure messages no longer log the detour password; they describe how to derive it instead.

<sup>Written for commit eaf3c8282469cc9dc23980a0b04a4cbcf8086aee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved administrator sign-in during development setup when configured passwords are identical.
  * Added more reliable password recovery handling for long passwords and service limits.
  * Enhanced recovery error messages with clearer guidance while protecting sensitive password details.
  * Improved session handling after password changes to support successful sign-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->