### PR TITLE
refactor(test): one parameter order, and a JSON alias that is not the app fixture

### DIFF
--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -52,11 +52,11 @@ import (
 // agent's differ in the CREDENTIAL and in nothing else. The approved retry has
 // to be the identical request — the diff hash binds it — which is a second
 // reason it is built in one place.
-func accountSendBody(org, subject string) apptest.AnyMap {
-	return apptest.AnyMap{
+func accountSendBody(org, subject string) AnyMap {
+	return AnyMap{
 		"subject": subject, "body": "Good morning — introducing ourselves.",
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
-		"links": []apptest.AnyMap{{"entity_type": "organization", "entity_id": org}},
+		"links": []AnyMap{{"entity_type": "organization", "entity_id": org}},
 	}
 }
 
@@ -251,7 +251,7 @@ func TestAFlooredAccountSendStagesAndOnlyLeavesOnceApproved(t *testing.T) {
 		t.Fatal("the staged send is not in the approvals inbox; nobody could ever release it")
 	}
 	if status := a.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve",
-		apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+		AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	if n := a.deliveryCount(t); n != 0 {
@@ -390,7 +390,7 @@ func (a *accountSendEnv) mintAccountSendPassport(t *testing.T) string {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := a.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := a.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "outreach agent", "scopes": []string{"read", "send"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/activity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/activity_lifecycle_integration_test.go
@@ -24,13 +24,13 @@ func seedTaskAndTarget(t *testing.T, e *apptest.AppEnv) (personID, taskID string
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Task Target"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Task Target"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var task struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Send offer",
 	}, nil, &task); status != http.StatusCreated {
 		t.Fatalf("log task → %d", status)
@@ -48,7 +48,7 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 		IsDone bool    `json:"is_done"`
 		DoneAt *string `json:"done_at"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"is_done": true}, nil, &updated); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, AnyMap{"is_done": true}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("complete task → %d", status)
 	}
 	if !updated.IsDone || updated.DoneAt == nil {
@@ -58,7 +58,7 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"subject": "x"},
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, AnyMap{"subject": "x"},
 		map[string]string{"If-Match": "999"}, &problem); status != http.StatusConflict || problem.Code != "version_skew" {
 		t.Fatalf("stale If-Match → %d %q", status, problem.Code)
 	}
@@ -77,7 +77,7 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/activities/"+taskID, nil, nil, &archived); status != http.StatusOK || archived.ArchivedAt == nil {
 		t.Fatalf("archive did not stamp: %d %+v", status, archived)
 	}
-	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"subject": "zombie"}, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, AnyMap{"subject": "zombie"}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("mutating an archived activity → %d, want 404", status)
 	}
 }
@@ -90,7 +90,7 @@ func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *apptest.AppEnv, 
 	t.Helper()
 	// Relink: idempotent association onto a visible person.
 	for i := 0; i < 2; i++ {
-		if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", AnyMap{
 			"entity_type": "person", "entity_id": personID,
 		}, nil, nil); status != http.StatusOK {
 			t.Fatalf("relink (round %d) → %d", i, status)
@@ -114,25 +114,25 @@ func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *apptest.AppEnv, 
 		t.Fatalf("relink audits = %d, want 1 (idempotent replay is silent)", relinks)
 	}
 	// An invisible relink target reads as absent (H1).
-	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", AnyMap{
 		"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("invisible relink target → %d, want 404", status)
 	}
 	// The lead arm (0038): relinking onto a real lead lands on the lead's
 	// timeline; a guessed lead id reads as absent like any other target.
-	var lead apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
+	var lead AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", AnyMap{
 		"full_name": "Relink Lead", "email": "relink@lead.test", "source": "manual",
 	}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", AnyMap{
 		"entity_type": "lead", "entity_id": lead["id"],
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("lead relink → %d, want 200", status)
 	}
-	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", AnyMap{
 		"entity_type": "lead", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("guessed lead relink → %d, want 404", status)

--- a/backend/internal/compose/integration/activity_remindat_integration_test.go
+++ b/backend/internal/compose/integration/activity_remindat_integration_test.go
@@ -25,7 +25,7 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 		ID       string  `json:"id"`
 		RemindAt *string `json:"remind_at"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Call back", "remind_at": "2026-07-08T09:00:00Z",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create task with remind_at → %d", status)
@@ -38,7 +38,7 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var patched struct {
 		RemindAt *string `json:"remind_at"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/activities/"+created.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/activities/"+created.ID, AnyMap{
 		"remind_at": "2026-07-09T10:30:00Z",
 	}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patch remind_at → %d", status)
@@ -52,7 +52,7 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "note", "body": "no reminders on notes", "remind_at": "2026-07-08T09:00:00Z",
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
@@ -64,10 +64,10 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var note struct {
 		ID string `json:"id"`
 	}
-	if s := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{"kind": "note", "body": "plain"}, nil, &note); s != http.StatusCreated {
+	if s := e.Call(t, "POST", "/v1/activities", AnyMap{"kind": "note", "body": "plain"}, nil, &note); s != http.StatusCreated {
 		t.Fatalf("create note → %d", s)
 	}
-	if s := e.Call(t, "PATCH", "/v1/activities/"+note.ID, apptest.AnyMap{"remind_at": "2026-07-08T09:00:00Z"}, nil, nil); s != http.StatusUnprocessableEntity {
+	if s := e.Call(t, "PATCH", "/v1/activities/"+note.ID, AnyMap{"remind_at": "2026-07-08T09:00:00Z"}, nil, nil); s != http.StatusUnprocessableEntity {
 		t.Fatalf("patch remind_at onto a note → %d, want 422", s)
 	}
 }

--- a/backend/internal/compose/integration/agent_humanonly_read_integration_test.go
+++ b/backend/internal/compose/integration/agent_humanonly_read_integration_test.go
@@ -30,7 +30,7 @@ func TestAgentBearerIsRefusedOnHumanOnlyReads(t *testing.T) {
 		PassportID string `json:"passport_id"`
 		Token      string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "human-only read probe", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/agent_versionpin_integration_test.go
+++ b/backend/internal/compose/integration/agent_versionpin_integration_test.go
@@ -36,7 +36,7 @@ func TestAnAgentDraftsPricesAndArchivesAnOfferOnItsOwnPassport(t *testing.T) {
 	bearer := map[string]string{"Authorization": "Bearer " + token}
 
 	// The agent prices the terms, then archives — neither asks a human.
-	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+offer.LineItems[0].ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+offer.LineItems[0].ID, AnyMap{
 		"unit_price_minor": 100,
 	}, bearer, nil); status != http.StatusOK {
 		t.Fatalf("agent line-item rewrite → %d", status)
@@ -76,7 +76,7 @@ func seedOfferForPin(t *testing.T, e *apptest.AppEnv) (string, string, pinOffer)
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		// The version-pin race happens inside archive_record's approval, so the
 		// passport must be able to spend `write` to get there.
 		"label": "pin agent", "scopes": []string{"read", "write"},
@@ -86,9 +86,9 @@ func seedOfferForPin(t *testing.T, e *apptest.AppEnv) (string, string, pinOffer)
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
 	var offer pinOffer
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []apptest.AnyMap{
+		"line_items": []AnyMap{
 			{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0},
 		},
 	}, bearer, &offer); status != http.StatusCreated {

--- a/backend/internal/compose/integration/agentaccess/mcp_deadline_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_deadline_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
@@ -98,7 +99,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	var thread struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", integration.AnyMap{
 		"kind": "email", "subject": "Renewal terms", "body": "What would renewal look like?",
 		"direction": "inbound",
 	}, nil, &thread); status != http.StatusCreated {
@@ -107,7 +108,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": "slow caller", "scopes": []string{"read", "draft"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/agentaccess/mcp_handshake_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_handshake_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/compose/integration"
 )
 
 // TestAConnectorCompletesTheWholeHandshakeOnOneOrigin is the phase's headline
@@ -35,7 +35,7 @@ func TestAConnectorCompletesTheWholeHandshakeOnOneOrigin(t *testing.T) {
 	var registered struct {
 		ClientID string `json:"client_id"`
 	}
-	if status := e.Call(t, "POST", advertised.register, apptest.AnyMap{
+	if status := e.Call(t, "POST", advertised.register, integration.AnyMap{
 		"client_name": "one-origin connector", "redirect_uris": []string{oauthRedirect},
 	}, nil, &registered); status != http.StatusCreated || registered.ClientID == "" {
 		t.Fatalf("DCR at %s → %d %+v", advertised.register, status, registered)
@@ -61,7 +61,7 @@ func TestAConnectorCompletesTheWholeHandshakeOnOneOrigin(t *testing.T) {
 	// ADR-0092 §6 it mints no session, so every later request on this
 	// connection carries its credential and the revision and nothing more.
 	const requested = "2025-06-18"
-	initialized := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+	initialized := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 		`{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"`+requested+
 			`","clientInfo":{"name":"conformance","version":"1"}}}`,
 		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + token})
@@ -116,16 +116,16 @@ type advertisedEndpoints struct {
 // instead of much later as an unexplained client error.
 func (e *connectorEnv) discover(t *testing.T) advertisedEndpoints {
 	t.Helper()
-	unauth := listTools(e.AppEnv, t, "")
+	unauth := listTools(t, e.AppEnv, "")
 	if unauth.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("unauthenticated POST /mcp → %d, want 401", unauth.StatusCode)
 	}
-	resourceDoc := getJSON(e.AppEnv, t, e.pathOn(t, resourceMetadataParam(t, unauth.Header.Get("WWW-Authenticate"))))
+	resourceDoc := getJSON(t, e.AppEnv, e.pathOn(t, resourceMetadataParam(t, unauth.Header.Get("WWW-Authenticate"))))
 	servers, ok := resourceDoc["authorization_servers"].([]any)
 	if !ok || len(servers) != 1 || servers[0] != e.origin {
 		t.Fatalf("authorization_servers = %v, want [%s]", resourceDoc["authorization_servers"], e.origin)
 	}
-	asDoc := getJSON(e.AppEnv, t, "/.well-known/oauth-authorization-server")
+	asDoc := getJSON(t, e.AppEnv, "/.well-known/oauth-authorization-server")
 	out := advertisedEndpoints{
 		register:  e.pathOn(t, stringField(t, asDoc, "registration_endpoint")),
 		authorize: e.pathOn(t, stringField(t, asDoc, "authorization_endpoint")),

--- a/backend/internal/compose/integration/agentaccess/mcp_modernframing_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_modernframing_integration_test.go
@@ -58,7 +58,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 	bearer := apptest.PassportBearer(t, e.AppEnv, "dual-era client", "read", "write")
 
 	t.Run("a modern client needs no handshake", func(t *testing.T) {
-		discovered := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		discovered := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{`+modernMeta+`}}`,
 			modernHeaders(bearer, "server/discover", ""))
 		if discovered.StatusCode != http.StatusOK {
@@ -77,7 +77,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 
 		// The tool list is filtered by this passport's scopes, so the copy it
 		// hands back may never be shared with another caller.
-		listed := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		listed := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{`+modernMeta+`}}`,
 			modernHeaders(bearer, "tools/list", ""))
 		if listed.StatusCode != http.StatusOK {
@@ -90,7 +90,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 
 		// And the call itself, with no session ever minted: this is what lets a
 		// modern conversation land on any replica.
-		called := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		called := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{`+modernMeta+
 				`,"name":"create_record","arguments":{"record_type":"person",`+
 				`"fields":{"full_name":"Modern Framing Person"}}}}`,
@@ -107,7 +107,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 	})
 
 	t.Run("a handshake client still connects, and is handed no session", func(t *testing.T) {
-		initialized := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		initialized := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`,
 			withContentType(bearer))
 		if initialized.StatusCode != http.StatusOK {
@@ -122,7 +122,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 			t.Fatalf("negotiated %q, want the revision this client asked for", negotiated)
 		}
 
-		called := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		called := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_record",`+
 				`"arguments":{"record_type":"person","fields":{"full_name":"Handshake Era Person"}}}}`,
 			legacyHeaders(bearer, negotiated))
@@ -139,7 +139,7 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 		// credential, and the one revision the window dropped (ADR-0092 §3).
 		headers := withContentType(bearer)
 		headers["MCP-Protocol-Version"] = "2025-03-26"
-		refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		refused := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 			`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
 
 		if refused.StatusCode != http.StatusBadRequest {
@@ -200,7 +200,7 @@ func TestAModernRequestWhoseHeaderContradictsItsBodyRunsNothing(t *testing.T) {
 	e := setupConnector(t)
 	bearer := apptest.PassportBearer(t, e.AppEnv, "mismatching client", "read", "write")
 
-	refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+	refused := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{`+modernMeta+
 			`,"name":"create_record","arguments":{"record_type":"person",`+
 			`"fields":{"full_name":"Never Created"}}}}`,

--- a/backend/internal/compose/integration/agentaccess/mcp_tasks_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_tasks_integration_test.go
@@ -52,7 +52,7 @@ func TestTheExtensionIsAdvertisedAndItsMethodsRequireIt(t *testing.T) {
 	e := setupConnector(t)
 	bearer := apptest.PassportBearer(t, e.AppEnv, "task client", "read")
 
-	discovered := rpcResult(t, mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+	discovered := rpcResult(t, mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{%s}}`, tasksMeta),
 		modernHeaders(bearer, "server/discover", "")).Body)
 	capabilities, _ := discovered["capabilities"].(map[string]any)
@@ -66,7 +66,7 @@ func TestTheExtensionIsAdvertisedAndItsMethodsRequireIt(t *testing.T) {
 
 	// And a request that did not declare it is asking for a method that, for
 	// that caller, does not exist.
-	undeclared := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+	undeclared := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp",
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{%s,"taskId":"019fe000-0000-7000-8000-00000000dead"}}`, modernMeta),
 		modernHeaders(bearer, "tasks/get", "019fe000-0000-7000-8000-00000000dead"))
 	code, message := rpcErrorOf(t, undeclared.Body)

--- a/backend/internal/compose/integration/agentaccess/mcp_transport_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/mcp_transport_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -82,22 +83,22 @@ type httpResult struct {
 // admission assertion needs: whether this credential gets in at all. An empty
 // bearer sends NO Authorization header — the unauthenticated shape a client
 // starts its discovery from, which is not the same as an empty credential.
-func listTools(e *apptest.AppEnv, t *testing.T, bearer string) httpResult {
+func listTools(t *testing.T, e *apptest.AppEnv, bearer string) httpResult {
 	t.Helper()
 	headers := map[string]string{"Content-Type": "application/json"}
 	if bearer != "" {
 		headers["Authorization"] = "Bearer " + bearer
 	}
-	return mcpRaw(e, t, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
+	return mcpRaw(t, e, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
 }
 
 // getJSON dereferences a discovery document the way a client does and fails
 // on anything but a 200 with a JSON object.
 //
 //craft:ignore naked-any a discovery document is an open JSON object by RFC 8414/9728 — asserting on it means reading it untyped
-func getJSON(e *apptest.AppEnv, t *testing.T, path string) map[string]any {
+func getJSON(t *testing.T, e *apptest.AppEnv, path string) map[string]any {
 	t.Helper()
-	got := mcpRaw(e, t, http.MethodGet, path, "", nil)
+	got := mcpRaw(t, e, http.MethodGet, path, "", nil)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("GET %s → %d %s", path, got.StatusCode, got.Body)
 	}
@@ -111,7 +112,7 @@ func getJSON(e *apptest.AppEnv, t *testing.T, path string) map[string]any {
 // raw issues one request against the harness origin and returns the whole
 // outcome. It never decodes: the connector suite asserts on status codes and
 // headers as often as on bodies, and a 404 has no JSON to decode.
-func mcpRaw(e *apptest.AppEnv, t *testing.T, method, path, payload string, headers map[string]string) httpResult {
+func mcpRaw(t *testing.T, e *apptest.AppEnv, method, path, payload string, headers map[string]string) httpResult {
 	t.Helper()
 	var body io.Reader
 	if payload != "" {
@@ -141,7 +142,7 @@ func mcpRaw(e *apptest.AppEnv, t *testing.T, method, path, payload string, heade
 // that URL is served here, and it points at this same issuer.
 func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	env := setupConnector(t)
-	resp := listTools(env.AppEnv, t, "")
+	resp := listTools(t, env.AppEnv, "")
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("unauthenticated POST /mcp → %d, want 401", resp.StatusCode)
 	}
@@ -150,7 +151,7 @@ func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	if !strings.HasPrefix(metaURL, env.origin) {
 		t.Fatalf("resource_metadata = %q, want an absolute URL on %s", metaURL, env.origin)
 	}
-	doc := getJSON(env.AppEnv, t, strings.TrimPrefix(metaURL, env.origin))
+	doc := getJSON(t, env.AppEnv, strings.TrimPrefix(metaURL, env.origin))
 	if doc["resource"] != env.origin+"/mcp" {
 		t.Fatalf("resource = %v, want %s/mcp", doc["resource"], env.origin)
 	}
@@ -161,7 +162,7 @@ func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	if !ok || len(servers) != 1 || servers[0] != env.origin {
 		t.Fatalf("authorization_servers = %v, want [%s]", doc["authorization_servers"], env.origin)
 	}
-	asDoc := getJSON(env.AppEnv, t, "/.well-known/oauth-authorization-server")
+	asDoc := getJSON(t, env.AppEnv, "/.well-known/oauth-authorization-server")
 	if asDoc["issuer"] != env.origin || asDoc["token_endpoint"] != env.origin+"/oauth/token" {
 		t.Fatalf("authorization-server metadata = %v, want issuer+token endpoint on %s", asDoc, env.origin)
 	}
@@ -193,7 +194,7 @@ func TestMCPOnTheAPIServesTheAPIsOwnToolSurface(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := env.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := env.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": "connector client", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -216,7 +217,7 @@ func TestMCPOnTheAPIServesTheAPIsOwnToolSurface(t *testing.T) {
 		t.Fatal("the REST agent surface reports no tools, so there is nothing to compare the transport against")
 	}
 
-	got := listTools(env.AppEnv, t, minted.Token)
+	got := listTools(t, env.AppEnv, minted.Token)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("authenticated POST /mcp → %d %s", got.StatusCode, got.Body)
 	}
@@ -277,7 +278,7 @@ func TestConnectorGateOffRemovesEveryConnectorRoute(t *testing.T) {
 	}
 	var want, wantFrom string
 	for _, p := range probes {
-		got := mcpRaw(e, t, p.method, p.path, p.payload, nil)
+		got := mcpRaw(t, e, p.method, p.path, p.payload, nil)
 		if got.StatusCode != http.StatusNotFound {
 			t.Fatalf("%s %s → %d, want 404: the gate must remove the route, not guard it",
 				p.method, p.path, got.StatusCode)
@@ -340,7 +341,7 @@ func (e *connectorEnv) rpc(t *testing.T, bearer, protocolVersion, payload string
 	if protocolVersion != "" {
 		headers["MCP-Protocol-Version"] = protocolVersion
 	}
-	got := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp", payload, headers)
+	got := mcpRaw(t, e.AppEnv, http.MethodPost, "/mcp", payload, headers)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("POST /mcp %s → %d %s", payload, got.StatusCode, got.Body)
 	}

--- a/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
@@ -38,7 +39,7 @@ func (o *oauthEnv) mintPassport(t *testing.T, label string, scopes []string) str
 	var minted struct {
 		ID string `json:"passport_id"`
 	}
-	if status := o.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint %q → %d", label, status)
@@ -178,7 +179,7 @@ func TestSelectablePassportsExcludesAnotherUsersPassport(t *testing.T) {
 	var other struct {
 		ID string `json:"id"`
 	}
-	if status := o.Call(t, "POST", "/v1/users", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/v1/users", integration.AnyMap{
 		"email": "otherhuman@acme.test", "display_name": "Other Human", "role": "rep",
 	}, nil, &other); status != http.StatusCreated {
 		t.Fatalf("inviting a second user → %d", status)

--- a/backend/internal/compose/integration/agentaccess/oauth_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
@@ -57,7 +58,7 @@ func setupOAuthWith(t *testing.T, extra ...compose.Option) *oauthEnv {
 	var registered struct {
 		ClientID string `json:"client_id"`
 	}
-	if status := e.Call(t, "POST", "/oauth/register", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/oauth/register", integration.AnyMap{
 		"client_name": "night agent", "redirect_uris": []string{oauthRedirect},
 	}, nil, &registered); status != http.StatusCreated || registered.ClientID == "" {
 		t.Fatalf("DCR → %d %+v", status, registered)
@@ -377,7 +378,7 @@ func TestOAuthRefusesDowngradesAndPrivilegedClients(t *testing.T) {
 
 	// No confidential clients, ever.
 	var problem map[string]any
-	if status := o.Call(t, "POST", "/oauth/register", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/oauth/register", integration.AnyMap{
 		"client_name": "privileged", "redirect_uris": []string{oauthRedirect},
 		"token_endpoint_auth_method": "client_secret_basic",
 	}, nil, &problem); status != http.StatusBadRequest {

--- a/backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/compose/integration"
 )
 
 // approve is one consent decision that LENDS a named passport: the GET arms the
@@ -327,13 +327,13 @@ func TestAPendingConsentDoesNotSurviveItsHumansDeactivation(t *testing.T) {
 	// not be deactivated — the organization would lose user administration with
 	// no way back. A second admin is what the guard is protecting against, so
 	// inviting one is what lets the real endpoint run.
-	if status := o.Call(t, "POST", "/v1/users", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/v1/users", integration.AnyMap{
 		"email": "second-admin@fable.test", "display_name": "Second Admin", "role": "admin",
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("inviting a second admin → %d", status)
 	}
 	granter := o.userIDByEmail(t, "granter@fable.test")
-	if status := o.Call(t, "POST", "/v1/users/"+granter+"/deactivate", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/v1/users/"+granter+"/deactivate", integration.AnyMap{
 		"reason": "left the company",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("deactivate → %d", status)

--- a/backend/internal/compose/integration/agentaccess/oauth_revocation_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_revocation_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
@@ -50,7 +51,7 @@ func setupConnectedClient(t *testing.T) *connectedClient {
 // answer that sends a client back to the human for consent.
 func (c *connectedClient) callMCP(t *testing.T) int {
 	t.Helper()
-	return listTools(c.AppEnv, t, c.access).StatusCode
+	return listTools(t, c.AppEnv, c.access).StatusCode
 }
 
 // refreshSucceeds reports whether the client can still mint itself a fresh
@@ -289,7 +290,7 @@ func TestALocallyMintedPassportIsUnaffectedByADeadConnector(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": "local agent", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue a local passport → %d", status)
@@ -298,7 +299,7 @@ func TestALocallyMintedPassportIsUnaffectedByADeadConnector(t *testing.T) {
 	c.disableClient(t)
 	c.revokeGrant(t)
 
-	if code := listTools(c.AppEnv, t, minted.Token).StatusCode; code != http.StatusOK {
+	if code := listTools(t, c.AppEnv, minted.Token).StatusCode; code != http.StatusOK {
 		t.Fatalf("locally minted passport → %d, want 200: it answers to no grant", code)
 	}
 	if code := c.callMCP(t); code != http.StatusUnauthorized {

--- a/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
@@ -53,7 +53,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	var problem struct {
 		Detail string `json:"detail"`
 	}
-	if status := o.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := o.Call(t, "POST", "/v1/webhook-subscriptions", integration.AnyMap{
 		"target_url": "https://jws.example/hook", "event_types": []string{"organization.created"},
 	}, agentBearer, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent webhook-subscription create → %d, want staged 403", status)
@@ -63,7 +63,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	var approved struct {
 		ApprovalToken *string `json:"approval_token"`
 	}
-	if status := o.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, &approved); status != http.StatusOK {
+	if status := o.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", integration.AnyMap{}, nil, &approved); status != http.StatusOK {
 		t.Fatalf("approve → %d", status)
 	}
 	if approved.ApprovalToken == nil || strings.Count(*approved.ApprovalToken, ".") != 2 {

--- a/backend/internal/compose/integration/agentaccess/queryrefusal_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryrefusal_integration_test.go
@@ -102,7 +102,7 @@ type toolCallEnvelope struct {
 // it wanted one — and fail if the call actually ran.
 func refusedToolText(t *testing.T, env *connectorEnv, bearer, payload string) string {
 	t.Helper()
-	called := mcpRaw(env.AppEnv, t, http.MethodPost, "/mcp", payload,
+	called := mcpRaw(t, env.AppEnv, http.MethodPost, "/mcp", payload,
 		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + bearer})
 	if called.StatusCode != http.StatusOK {
 		t.Fatalf("tools/call → %d %s", called.StatusCode, called.Body)

--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -62,12 +62,12 @@ func TestTheComposedMCPMountPublishesTheQueryVocabulary(t *testing.T) {
 	bearer := readPassport(t, env.AppEnv, "query vocabulary reader")
 
 	// The catalogue advertises it, which is how a client finds it at all.
-	listed := mcpRPC(env.AppEnv, t, bearer, `{"jsonrpc":"2.0","id":1,"method":"resources/list"}`)
+	listed := mcpRPC(t, env.AppEnv, bearer, `{"jsonrpc":"2.0","id":1,"method":"resources/list"}`)
 	if !strings.Contains(listed, search.QuerySchemaURI) {
 		t.Fatalf("resources/list does not advertise %s: %s", search.QuerySchemaURI, listed)
 	}
 
-	doc := readVocabulary(env.AppEnv, t, bearer)
+	doc := readVocabulary(t, env.AppEnv, bearer)
 	if doc.Version != search.PlanVersion {
 		t.Fatalf("published vocabulary is version %q, want %q", doc.Version, search.PlanVersion)
 	}
@@ -125,7 +125,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 	env := setupConnectorWith(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	bearer := readPassport(t, env.AppEnv, "custom field reader")
 
-	before := readVocabulary(env.AppEnv, t, bearer)
+	before := readVocabulary(t, env.AppEnv, bearer)
 	if fieldNamed(dealVocabulary(t, before), "cf_renewal_risk") {
 		t.Fatal("the field under test already exists in the vocabulary")
 	}
@@ -146,7 +146,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 		Title      string `json:"title"`
 		Detail     string `json:"detail"`
 	}
-	status := env.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	status := env.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "deal", "label": "Renewal risk", "type": "text", "source": "ui",
 	}, nil, &created)
 	if status != http.StatusCreated {
@@ -156,7 +156,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 		t.Fatalf("the engine named the column %q; this test asks the vocabulary for cf_renewal_risk", created.ColumnName)
 	}
 
-	added := readVocabulary(env.AppEnv, t, bearer)
+	added := readVocabulary(t, env.AppEnv, bearer)
 	if !fieldNamed(dealVocabulary(t, added), "cf_renewal_risk") {
 		t.Fatal("a custom field active in the catalog is not in the published vocabulary")
 	}
@@ -164,7 +164,7 @@ func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
 	if status := env.Call(t, "POST", "/v1/custom-fields/"+created.ID+"/retire", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("retiring the custom field → %d", status)
 	}
-	if fieldNamed(dealVocabulary(t, readVocabulary(env.AppEnv, t, bearer)), "cf_renewal_risk") {
+	if fieldNamed(dealVocabulary(t, readVocabulary(t, env.AppEnv, bearer)), "cf_renewal_risk") {
 		t.Error("a retired custom field is still published; the vocabulary is cached rather than derived")
 	}
 }
@@ -175,7 +175,7 @@ func TestAnUnservedResourceURIIsRefusedOverTheTransport(t *testing.T) {
 	env := setupConnector(t)
 	bearer := readPassport(t, env.AppEnv, "resource prober")
 
-	out := mcpRPC(env.AppEnv, t, bearer,
+	out := mcpRPC(t, env.AppEnv, bearer,
 		`{"jsonrpc":"2.0","id":9,"method":"resources/read","params":{"uri":"margince://schema/secrets"}}`)
 	if !strings.Contains(out, `"error"`) || !strings.Contains(out, "-32002") {
 		t.Fatalf("read of an unserved URI → %s, want a resource-not-found error", out)
@@ -192,7 +192,7 @@ func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": label, "scopes": []string{"read"},
 	}, nil, &minted)
 	if status != http.StatusCreated {
@@ -209,9 +209,9 @@ func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
 // mcpRPC posts one JSON-RPC exchange to the composed /mcp mount and returns
 // the raw body — the errors this file asserts on live in the envelope, not in
 // a decoded result.
-func mcpRPC(e *apptest.AppEnv, t *testing.T, bearer, payload string) string {
+func mcpRPC(t *testing.T, e *apptest.AppEnv, bearer, payload string) string {
 	t.Helper()
-	got := mcpRaw(e, t, http.MethodPost, "/mcp", payload, map[string]string{
+	got := mcpRaw(t, e, http.MethodPost, "/mcp", payload, map[string]string{
 		"Content-Type": "application/json", "Authorization": "Bearer " + bearer,
 	})
 	if got.StatusCode != http.StatusOK {
@@ -221,9 +221,9 @@ func mcpRPC(e *apptest.AppEnv, t *testing.T, bearer, payload string) string {
 }
 
 // readVocabulary fetches and decodes the published document.
-func readVocabulary(e *apptest.AppEnv, t *testing.T, bearer string) vocabularyDoc {
+func readVocabulary(t *testing.T, e *apptest.AppEnv, bearer string) vocabularyDoc {
 	t.Helper()
-	body := mcpRPC(e, t, bearer,
+	body := mcpRPC(t, e, bearer,
 		`{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"`+search.QuerySchemaURI+`"}}`)
 
 	var envelope struct {

--- a/backend/internal/compose/integration/agentcallapproval_integration_test.go
+++ b/backend/internal/compose/integration/agentcallapproval_integration_test.go
@@ -75,7 +75,7 @@ func TestOneRefusedAgentCallCollectsExactlyOneApprovalHoweverOftenItIsRetried(t 
 	}
 	c.assertApprovalCount(t, 1, "an early retry")
 
-	if status := c.Call(t, "POST", "/v1/approvals/"+first.ApprovalID.String()+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := c.Call(t, "POST", "/v1/approvals/"+first.ApprovalID.String()+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 
@@ -166,13 +166,13 @@ func TestAnApprovedCallWhoseTargetMovedIsStagedAfreshRatherThanHandedBackDead(t 
 	args := enrichArgs(org)
 
 	staged := c.stagedApproval(t, invoke, args)
-	if status := c.Call(t, "POST", "/v1/approvals/"+staged.ApprovalID.String()+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := c.Call(t, "POST", "/v1/approvals/"+staged.ApprovalID.String()+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	// A human edits the record the approval is pinned to, which is ordinary work
 	// on the very company the enrich would rewrite.
 	if status := c.Call(t, "PATCH", "/v1/organizations/"+org,
-		apptest.AnyMap{"industry": "logistics"}, nil, nil); status != http.StatusOK {
+		AnyMap{"industry": "logistics"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human edit of the target → %d", status)
 	}
 
@@ -206,7 +206,7 @@ func TestAnApprovalStagedByOnePassportIsNeverOfferedToAnother(t *testing.T) {
 
 	first := c.enrichInvoker(t, c.mintPassport(t, []string{"read", "enrich"}))
 	mine := c.stagedApproval(t, first, args)
-	if status := c.Call(t, "POST", "/v1/approvals/"+mine.ApprovalID.String()+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := c.Call(t, "POST", "/v1/approvals/"+mine.ApprovalID.String()+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 
@@ -233,19 +233,19 @@ func TestTheRESTDoorAlsoCollectsExactlyOneApprovalPerIdenticalCall(t *testing.T)
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Greta Human"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Greta Human"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("human create → %d", status)
 	}
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "duplicate-approval agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
-	overwrite := apptest.AnyMap{"full_name": "Greta Machine"}
+	overwrite := AnyMap{"full_name": "Greta Machine"}
 
 	stage := func(what string) (id, detail string) {
 		t.Helper()
@@ -270,7 +270,7 @@ func TestTheRESTDoorAlsoCollectsExactlyOneApprovalPerIdenticalCall(t *testing.T)
 	}
 	assertPersonApprovalCount(t, e, 1, "two identical refused PATCHes")
 
-	if status := e.Call(t, "POST", "/v1/approvals/"+first+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+first+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -51,7 +51,7 @@ func TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing(t *tes
 	// An account is readable by every seat unless its capture is private:
 	// visibility='owner' narrows it to owner_id, which is the admin and not
 	// the rep below, so the miss is genuine rather than incidental.
-	orgID := createdID(t, e, "/v1/organizations", apptest.AnyMap{
+	orgID := createdID(t, e, "/v1/organizations", AnyMap{
 		"display_name": "Capture-Private Inc", "owner_id": adminID,
 	})
 
@@ -67,7 +67,7 @@ func TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing(t *tes
 		// whose capture is private to somebody else.
 		stmt(`INSERT INTO role_assignment (role_id, user_id) SELECT r.id, $1 FROM role r WHERE r.key = 'rep'`, rep),
 	)
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "rep@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rep login → %d, want 200", status)
@@ -142,7 +142,7 @@ func stageWebhookCreate(t *testing.T, e *apptest.AppEnv, bearer map[string]strin
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": url, "event_types": []string{"organization.created"},
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent subscription create %q → %d %q, want 403 approval_required", url, status, problem.Code)

--- a/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_createpatch_integration_test.go
@@ -36,7 +36,7 @@ func TestARestCreateStagesItsRecordTypeWithNoTargetID(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://example.test/hook", "event_types": []string{"organization.created"},
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent webhook-subscription create → %d %q, want 403 approval_required", status, problem.Code)
@@ -90,7 +90,7 @@ func TestARestPatchOutsideTheToolSchemaStagesTheRowWithID(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"subscription"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create subscription → %d", status)
@@ -101,7 +101,7 @@ func TestARestPatchOutsideTheToolSchemaStagesTheRowWithID(t *testing.T) {
 		Detail string `json:"detail"`
 	}
 	if status := e.Call(t, "PATCH", "/v1/webhook-subscriptions/"+created.Subscription.ID,
-		apptest.AnyMap{"state": "paused"}, bearer, &problem); status != http.StatusForbidden ||
+		AnyMap{"state": "paused"}, bearer, &problem); status != http.StatusForbidden ||
 		problem.Code != "approval_required" {
 		t.Fatalf("agent subscription patch → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -154,7 +154,7 @@ func TestARestCreateCustomFieldStagesRatherThanRefuses(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/custom-fields", AnyMap{
 		"object": "deal", "label": "Champion Score", "type": "text", "source": "ui",
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent custom field create → %d %q, want 403 approval_required — a hard refusal here is "+
@@ -202,7 +202,7 @@ func TestARestCreateWebhookSubscriptionStagesRatherThanRefuses(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent webhook subscription create → %d %q, want 403 approval_required — a hard refusal "+

--- a/backend/internal/compose/integration/agentcommandtarget_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandtarget_integration_test.go
@@ -40,7 +40,7 @@ func TestARestArchiveOutsideTheToolSchemaPerformsOnTheAgentsPassport(t *testing.
 	e.BootstrapWorkspace(t)
 	bearer := agentBearer(t, e, "outside-the-tool-schema agent")
 
-	tagID := createdID(t, e, "/v1/tags", apptest.AnyMap{"name": "Champion"})
+	tagID := createdID(t, e, "/v1/tags", AnyMap{"name": "Champion"})
 
 	if status := e.Call(t, "DELETE", "/v1/tags/"+tagID, nil, bearer, nil); status == http.StatusForbidden {
 		t.Fatalf("agent tag archive → 403 — a passport archives what its holder could archive unaided")

--- a/backend/internal/compose/integration/agentquotaladder_integration_test.go
+++ b/backend/internal/compose/integration/agentquotaladder_integration_test.go
@@ -85,11 +85,11 @@ func pendingStepUp(t *testing.T, e *apptest.AppEnv) (id ids.ApprovalID, passport
 // presented passport. It ignores the answer: every caller here is about what
 // the call left BEHIND — a staged question, or the absence of one — and a tool
 // refusal is the expected outcome in all of them.
-func callTool(t *testing.T, e *apptest.AppEnv, bearer map[string]string, tool string, args apptest.AnyMap) {
+func callTool(t *testing.T, e *apptest.AppEnv, bearer map[string]string, tool string, args AnyMap) {
 	t.Helper()
-	status := e.Call(t, "POST", "/mcp", apptest.AnyMap{
+	status := e.Call(t, "POST", "/mcp", AnyMap{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-		"params": apptest.AnyMap{"name": tool, "arguments": args},
+		"params": AnyMap{"name": tool, "arguments": args},
 	}, bearer, nil)
 	if status != http.StatusOK {
 		t.Fatalf("tools/call %s → %d, want 200 with the refusal inside the result", tool, status)
@@ -112,7 +112,7 @@ func TestAReadPastItsThresholdIsReleasedByTheHumanWhoLentThePassport(t *testing.
 	// The REST door refuses without staging (it has no tool to name), so the
 	// question is put through the MCP door — which is the door the ladder is
 	// written for.
-	callTool(t, e, bearer, "search_records", apptest.AnyMap{"query": "Metered"})
+	callTool(t, e, bearer, "search_records", AnyMap{"query": "Metered"})
 
 	id, staged, summary := pendingStepUp(t, e)
 	if staged != passport {
@@ -143,7 +143,7 @@ func TestOneReleaseIsOneMoreAllowanceAndNotAStandingPermission(t *testing.T) {
 	bearer, passport := passportWithID(t, e, "reading agent", "read")
 	seedPeople(t, e, 2)
 	spendCounter(t, e, meter, passport, agentquota.Reads, 120)
-	callTool(t, e, bearer, "search_records", apptest.AnyMap{"query": "Metered"})
+	callTool(t, e, bearer, "search_records", AnyMap{"query": "Metered"})
 	id, _, _ := pendingStepUp(t, e)
 	if status := e.Call(t, "POST", "/v1/approvals/"+id.String()+"/approve", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("approving the step-up → %d", status)
@@ -165,7 +165,7 @@ func TestASpentEgressCeilingAsksNobodyAnything(t *testing.T) {
 	bearer, passport := passportWithID(t, e, "sending agent", "read", "send")
 	spendCounter(t, e, meter, passport, agentquota.Egress, 5)
 
-	callTool(t, e, bearer, "send_email", apptest.AnyMap{
+	callTool(t, e, bearer, "send_email", AnyMap{
 		"to": "someone@example.com", "subject": "s", "body": "b",
 	})
 

--- a/backend/internal/compose/integration/agentreadbound_integration_test.go
+++ b/backend/internal/compose/integration/agentreadbound_integration_test.go
@@ -147,7 +147,7 @@ func TestARestSingleRecordReadChargesOne(t *testing.T) {
 	var created struct {
 		ID ids.UUID `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Single Read",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("seeding the person → %d", status)
@@ -207,7 +207,7 @@ func TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt(t *testing.T) {
 		}
 	})
 	onWrite := advance(func() {
-		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/people", AnyMap{
 			"full_name": "Charged By The Gate",
 		}, bearer, nil); status != http.StatusCreated {
 			t.Fatalf("the agent write → %d, want 201", status)
@@ -263,7 +263,7 @@ func passportWithID(t *testing.T, e *apptest.AppEnv, label string, scopes ...str
 		ID    ids.UUID `json:"passport_id"`
 		Token string   `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport %q → %d", label, status)
@@ -279,7 +279,7 @@ func passportWithID(t *testing.T, e *apptest.AppEnv, label string, scopes ...str
 func seedPeople(t *testing.T, e *apptest.AppEnv, n int) {
 	t.Helper()
 	for i := range n {
-		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/people", AnyMap{
 			"full_name": "Metered Person " + string(rune('A'+i)),
 		}, nil, nil); status != http.StatusCreated {
 			t.Fatalf("seeding person %d → %d", i, status)

--- a/backend/internal/compose/integration/agentscope_integration_test.go
+++ b/backend/internal/compose/integration/agentscope_integration_test.go
@@ -51,9 +51,9 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": "Acme GmbH", "source": "ui",
-		"domains": []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
+		"domains": []AnyMap{{"domain": "acme.example", "is_primary": true}},
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
@@ -124,9 +124,9 @@ func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
 	// Drafting is 🟢 under `write` and still is: send being human-only is
 	// not a blanket tightening of the offer surface.
 	var offer offerBody
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []apptest.AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
 	}, bearer, &offer); status != http.StatusCreated {
 		t.Fatalf("agent 🟢 offer draft → %d", status)
 	}

--- a/backend/internal/compose/integration/aiactivity_http_integration_test.go
+++ b/backend/internal/compose/integration/aiactivity_http_integration_test.go
@@ -62,7 +62,7 @@ func TestMyAiActivityRefusesAnAgentBearer(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "agent activity read probe", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/anymap.go
+++ b/backend/internal/compose/integration/anymap.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// AnyMap is the shape a scenario builds an ad-hoc JSON request body in, and
+// reads a response into when it asserts on one or two fields rather than a
+// typed struct. An alias, not a new type, so it interchanges freely with the
+// map literals the suites already write.
+//
+// Here rather than in apptest, whose subject is the booted application: a JSON
+// literal has nothing to do with one, and fourteen files were importing that
+// package for this alone — a dependency that said the suite needed a running
+// server when all it needed was a map.
+type AnyMap = map[string]any

--- a/backend/internal/compose/integration/approval_bundle_http_integration_test.go
+++ b/backend/internal/compose/integration/approval_bundle_http_integration_test.go
@@ -99,7 +99,7 @@ func TestABundleIsListedAndDecidedThroughTheAPI(t *testing.T) {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": "Acme GmbH", "source": "ui",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
@@ -121,7 +121,7 @@ func TestABundleIsListedAndDecidedThroughTheAPI(t *testing.T) {
 
 	var decision bundleDecisionBody
 	if status := e.Call(t, "POST", "/v1/approval-bundles/"+bundle.String()+"/approve",
-		apptest.AnyMap{"reason": "the read looks right"}, nil, &decision); status != http.StatusOK {
+		AnyMap{"reason": "the read looks right"}, nil, &decision); status != http.StatusOK {
 		t.Fatalf("approve bundle → %d", status)
 	}
 	if decision.BundleID != bundle.String() || len(decision.Data) != 3 {
@@ -179,7 +179,7 @@ func TestABundleDecisionRefusesAReadOnlyPassport(t *testing.T) {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": "Acme GmbH", "source": "ui",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)

--- a/backend/internal/compose/integration/approval_idless_target_integration_test.go
+++ b/backend/internal/compose/integration/approval_idless_target_integration_test.go
@@ -28,7 +28,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "create agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -38,7 +38,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 	// createWebhookSubscription is confirm-first, so the agent's call stages
 	// instead of writing. The identical body is the redemption key, so it is
 	// sent twice.
-	body := apptest.AnyMap{"target_url": "https://example.test/hook", "event_types": []string{"organization.created"}}
+	body := AnyMap{"target_url": "https://example.test/hook", "event_types": []string{"organization.created"}}
 	var problem struct {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
@@ -67,7 +67,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 	assertDecidableInTheInbox(t, e, approvalID, "webhook_subscription")
 
 	// And the decision releases the identical call, which lands the project.
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{

--- a/backend/internal/compose/integration/approval_targetarms_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetarms_integration_test.go
@@ -43,25 +43,25 @@ func TestConfirmFirstArchivesAreDecidableForEveryTargetArm(t *testing.T) {
 	// for an agent and performs — the half that used to be hidden behind the
 	// approval.
 	t.Run("list", func(t *testing.T) {
-		id := createdID(t, e, "/v1/lists", apptest.AnyMap{"name": "Q3 Targets", "entity_type": "person"})
+		id := createdID(t, e, "/v1/lists", AnyMap{"name": "Q3 Targets", "entity_type": "person"})
 		archivesOnItsOwnPassport(t, e, bearer, "/v1/lists/"+id)
 	})
 
 	t.Run("tag", func(t *testing.T) {
-		id := createdID(t, e, "/v1/tags", apptest.AnyMap{"name": "Champion"})
+		id := createdID(t, e, "/v1/tags", AnyMap{"name": "Champion"})
 		archivesOnItsOwnPassport(t, e, bearer, "/v1/tags/"+id)
 	})
 
 	t.Run("saved_view", func(t *testing.T) {
-		id := createdID(t, e, "/v1/views", apptest.AnyMap{
-			"resource": "people", "name": "My people", "query": apptest.AnyMap{"columns": []any{"full_name"}},
+		id := createdID(t, e, "/v1/views", AnyMap{
+			"resource": "people", "name": "My people", "query": AnyMap{"columns": []any{"full_name"}},
 		})
 		archivesOnItsOwnPassport(t, e, bearer, "/v1/views/"+id)
 	})
 
 	t.Run("offer_template", func(t *testing.T) {
-		id := createdID(t, e, "/v1/offer-templates", apptest.AnyMap{
-			"name": "Standard DE", "layout": apptest.AnyMap{"logo_url": "https://example.test/logo.png"},
+		id := createdID(t, e, "/v1/offer-templates", AnyMap{
+			"name": "Standard DE", "layout": AnyMap{"logo_url": "https://example.test/logo.png"},
 		})
 		archivesOnItsOwnPassport(t, e, bearer, "/v1/offer-templates/"+id)
 	})
@@ -72,13 +72,13 @@ func TestConfirmFirstArchivesAreDecidableForEveryTargetArm(t *testing.T) {
 				ID string `json:"id"`
 			} `json:"subscription"`
 		}
-		if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 			"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 		}, nil, &created); status != http.StatusCreated {
 			t.Fatalf("create subscription → %d", status)
 		}
 		releaseStagedCall(t, e, bearer, "PATCH", "/v1/webhook-subscriptions/"+created.Subscription.ID,
-			apptest.AnyMap{"state": "paused"}, "webhook_subscription")
+			AnyMap{"state": "paused"}, "webhook_subscription")
 	})
 }
 
@@ -106,13 +106,13 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			Version int64  `json:"version"`
 		} `json:"subscription"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create subscription → %d", status)
 	}
 	path := "/v1/webhook-subscriptions/" + created.Subscription.ID
-	staged := apptest.AnyMap{"state": "paused"}
+	staged := AnyMap{"state": "paused"}
 
 	var problem struct {
 		Code   string `json:"code"`
@@ -131,7 +131,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			Version int64 `json:"version"`
 		} `json:"subscription"`
 	}
-	if status := e.Call(t, "PATCH", path, apptest.AnyMap{"event_types": []string{"deal.updated"}}, nil, &edited); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", path, AnyMap{"event_types": []string{"deal.updated"}}, nil, &edited); status != http.StatusOK {
 		t.Fatalf("admin re-point → %d", status)
 	}
 	if edited.Subscription.Version == created.Subscription.Version {
@@ -139,7 +139,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			edited.Subscription.Version)
 	}
 
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"X-Approval-Token": approvalID}
@@ -166,7 +166,7 @@ func agentBearer(t *testing.T, e *apptest.AppEnv, label string) map[string]strin
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": label, "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -176,7 +176,7 @@ func agentBearer(t *testing.T, e *apptest.AppEnv, label string) map[string]strin
 
 // createdID creates one record as the bootstrap admin over their session and
 // returns its id — the human-owned row a later agent call stages against.
-func createdID(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
+func createdID(t *testing.T, e *apptest.AppEnv, path string, body AnyMap) string {
 	t.Helper()
 	var created struct {
 		ID string `json:"id"`
@@ -231,7 +231,7 @@ func archivesOnItsOwnPassport(t *testing.T, e *apptest.AppEnv, bearer map[string
 	}
 }
 
-func releaseStagedCall(t *testing.T, e *apptest.AppEnv, bearer map[string]string, method, path string, body apptest.AnyMap, wantTargetType string) {
+func releaseStagedCall(t *testing.T, e *apptest.AppEnv, bearer map[string]string, method, path string, body AnyMap, wantTargetType string) {
 	t.Helper()
 	var problem struct {
 		Code   string `json:"code"`
@@ -245,7 +245,7 @@ func releaseStagedCall(t *testing.T, e *apptest.AppEnv, bearer map[string]string
 
 	assertDecidableInTheInbox(t, e, approvalID, wantTargetType)
 
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d, want 200 — a row the inbox lists and cannot decide is the same dead "+
 			"end one step later", status)
 	}

--- a/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
+++ b/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
@@ -73,7 +73,7 @@ func (q *queueEnv) mintPassport(t *testing.T, label string, scopes ...string) st
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := q.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := q.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issuing passport %q → %d", label, status)
@@ -94,7 +94,7 @@ func (q *queueEnv) stageAConfirmFirstCall(t *testing.T, invoke func(tool, args s
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := q.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": name}, nil, &org); status != http.StatusCreated {
+	if status := q.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": name}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 	_, err := invoke("enrich", `{"organization_id":"`+org.ID+`"}`)
@@ -283,19 +283,19 @@ func TestAnAgentRelinksToAPersonWithoutAskingAndStillStagesAProject(t *testing.T
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := q.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Relink Subject"}, nil, &person); status != http.StatusCreated {
+	if status := q.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Relink Subject"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := q.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Relink Account"}, nil, &org); status != http.StatusCreated {
+	if status := q.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": "Relink Account"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 	var project struct {
 		ID string `json:"id"`
 	}
-	if status := q.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := q.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Relink Engagement", "organization_id": org.ID,
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("create project → %d", status)

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -242,12 +242,6 @@ func (e *AppEnv) Call(t *testing.T, method, path string, body any, headers map[s
 	return resp.StatusCode
 }
 
-// AnyMap is the shape a scenario builds an ad-hoc JSON request body in, and
-// reads a response into when it asserts on one or two fields rather than a
-// typed struct. An alias, not a new type, so it interchanges freely with the
-// map literals the suites already write.
-type AnyMap = map[string]any
-
 // BootstrapWorkspaceSession provisions the installation's organization through
 // the A107 boot path — configuration-driven, exactly what cmd/api runs at
 // startup — and signs its admin in over HTTP. The arrange step every e2e
@@ -277,7 +271,7 @@ func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminE
 	if err := compose.EnsureInstallation(context.Background(), e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg); err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
-	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", map[string]any{
 		"email": adminEmail, "password": operatorSupplied,
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("login → %d", status)
@@ -287,7 +281,7 @@ func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminE
 	// fixture does what a real first login does rather than clearing the flag
 	// in SQL — a suite arranged around a state the product cannot reach would
 	// prove nothing about the product.
-	if status := e.Call(t, "POST", "/v1/auth/change-password", AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/change-password", map[string]any{
 		"current_password": operatorSupplied, "new_password": adminPassword,
 	}, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("completing setup (change-password) → %d", status)
@@ -295,7 +289,7 @@ func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminE
 	// The change ended every session, this one included. Signing in again with
 	// the chosen password is what a real admin does next, and it leaves the
 	// suites holding the session they expect.
-	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", map[string]any{
 		"email": adminEmail, "password": adminPassword,
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("login after completing setup → %d", status)

--- a/backend/internal/compose/integration/apptest/passport.go
+++ b/backend/internal/compose/integration/apptest/passport.go
@@ -25,7 +25,7 @@ func PassportBearer(t *testing.T, e *AppEnv, label string, scopes ...string) map
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", map[string]any{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport %q → %d", label, status)

--- a/backend/internal/compose/integration/apptest/pipeline.go
+++ b/backend/internal/compose/integration/apptest/pipeline.go
@@ -73,11 +73,11 @@ func ExerciseDealToWon(t *testing.T, e *AppEnv, stages SeededStages) string {
 	t.Helper()
 	dealID := CreateOpenDeal(t, e, stages)
 
-	var deal AnyMap
+	var deal map[string]any
 	// The win gate (ADR-0109 §6): a won deal points at a signed agreement or
 	// says why it cannot, and a fixture has no contract in this database by
 	// construction — which is precisely what `imported` means.
-	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", AnyMap{
+	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", map[string]any{
 		"to_stage_id":                 stages.Won,
 		"won_without_contract_reason": "imported",
 	}, nil, &deal)
@@ -93,18 +93,18 @@ func ExerciseDealToWon(t *testing.T, e *AppEnv, stages SeededStages) string {
 // refusals around closing it, say — needs the state without the close.
 func CreateOpenDeal(t *testing.T, e *AppEnv, stages SeededStages) string {
 	t.Helper()
-	var org AnyMap
-	status := e.Call(t, "POST", "/v1/organizations", AnyMap{
+	var org map[string]any
+	status := e.Call(t, "POST", "/v1/organizations", map[string]any{
 		"display_name": "Acme GmbH",
 		"source":       "ui",
-		"domains":      []AnyMap{{"domain": "acme.example", "is_primary": true}},
+		"domains":      []map[string]any{{"domain": "acme.example", "is_primary": true}},
 	}, nil, &org)
 	if status != http.StatusCreated {
 		t.Fatalf("create org = %d %v", status, org)
 	}
 
-	var deal AnyMap
-	status = e.Call(t, "POST", "/v1/deals", AnyMap{
+	var deal map[string]any
+	status = e.Call(t, "POST", "/v1/deals", map[string]any{
 		"name":            "Acme rollout",
 		"amount_minor":    250_000_00,
 		"currency":        "EUR",

--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -55,9 +55,9 @@ func createRouteLeadAutomation(t *testing.T, e *apptest.AppEnv) string {
 		ID  string `json:"id"`
 		Key string `json:"key"`
 	}
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
 		"key": "assign_lead_owner", "name": "Router under observation",
-		"params": apptest.AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
+		"params": AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create automation → %d", status)
 	}
@@ -218,7 +218,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/leads", AnyMap{
 		"full_name": "Uma Unrouted", "source": "manual",
 	}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
@@ -242,7 +242,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 		Sample               *[]string `json:"sample"`
 		ExcludedByPermission *int      `json:"excluded_by_permission"`
 	}
-	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{}, nil, &preview); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", AnyMap{}, nil, &preview); status != http.StatusOK {
 		t.Fatalf("preview → %d", status)
 	}
 	if preview.MatchesNow != 1 || preview.WindowDays != 30 {
@@ -264,7 +264,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 		MatchesNow int `json:"matches_now"`
 		WindowDays int `json:"window_days"`
 	}
-	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", AnyMap{
 		"key": "stage_change_create_task", "window_days": 7,
 	}, nil, &draft); status != http.StatusOK {
 		t.Fatalf("draft-override preview → %d", status)
@@ -274,14 +274,14 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 	}
 
 	// The editor's preview 422s match its save 422s.
-	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{"key": "invented_type"}, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", AnyMap{"key": "invented_type"}, nil, nil); status != 422 {
 		t.Fatalf("preview with a non-catalog key → %d, want 422", status)
 	}
-	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{"window_days": 0}, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", AnyMap{"window_days": 0}, nil, nil); status != 422 {
 		t.Fatalf("preview with a zero window → %d, want 422", status)
 	}
 	unknown := ids.NewV7().String()
-	if status := e.Call(t, "POST", "/v1/automations/"+unknown+"/preview", apptest.AnyMap{}, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "POST", "/v1/automations/"+unknown+"/preview", AnyMap{}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("preview on an unknown automation → %d, want 404 (existence-hiding, like Get)", status)
 	}
 

--- a/backend/internal/compose/integration/automations_integration_test.go
+++ b/backend/internal/compose/integration/automations_integration_test.go
@@ -29,14 +29,14 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 
 	// Enable under a stale If-Match is refused; the current version wins.
 	stale := map[string]string{"If-Match": "99"}
-	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, apptest.AnyMap{"status": "enabled"}, stale, nil); status != http.StatusConflict {
+	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, AnyMap{"status": "enabled"}, stale, nil); status != http.StatusConflict {
 		t.Fatalf("stale If-Match → %d, want 409 version_skew", status)
 	}
 	var updated struct {
 		Status  string `json:"status"`
 		Version int    `json:"version"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, apptest.AnyMap{"status": "enabled"},
+	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, AnyMap{"status": "enabled"},
 		map[string]string{"If-Match": "1"}, &updated); status != http.StatusOK {
 		t.Fatalf("enable → %d", status)
 	}
@@ -54,7 +54,7 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 
 	// Config is an audited fact end to end.
 	var audit struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/audit-log?entity_type=automation", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit read → %d", status)
@@ -128,18 +128,18 @@ func assertBootstrapSeededStartersEnabled(t *testing.T, e *apptest.AppEnv) {
 func assertAutomationCreateValidatesParams(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// An unknown catalog key and out-of-schema params are 422s.
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
-		"key": "invented_type", "name": "Nope", "params": apptest.AnyMap{},
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
+		"key": "invented_type", "name": "Nope", "params": AnyMap{},
 	}, nil, nil); status != 422 {
 		t.Fatalf("unknown key → %d, want 422", status)
 	}
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
-		"key": "assign_lead_owner", "name": "Bad params", "params": apptest.AnyMap{"cap_per_owner": "soon"},
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
+		"key": "assign_lead_owner", "name": "Bad params", "params": AnyMap{"cap_per_owner": "soon"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("mistyped param → %d, want 422", status)
 	}
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
-		"key": "assign_lead_owner", "name": "Rogue knob", "params": apptest.AnyMap{"rule_body": "if x then y"},
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
+		"key": "assign_lead_owner", "name": "Rogue knob", "params": AnyMap{"rule_body": "if x then y"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("out-of-schema param → %d, want 422 (the anti-DSL guard)", status)
 	}
@@ -156,9 +156,9 @@ func createPausedAutomation(t *testing.T, e *apptest.AppEnv) string {
 		Params  map[string]any `json:"params"`
 		Version int            `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
 		"key": "assign_lead_owner", "name": "Slow-lane routing",
-		"params": apptest.AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
+		"params": AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
@@ -187,15 +187,15 @@ func TestAutomationConfigRejectsAgents(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "automation prober", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
-	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
-		"key": "assign_lead_owner", "name": "Agent-made", "params": apptest.AnyMap{},
+	if status := e.Call(t, "POST", "/v1/automations", AnyMap{
+		"key": "assign_lead_owner", "name": "Agent-made", "params": AnyMap{},
 	}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent create automation → %d, want 403", status)
 	}

--- a/backend/internal/compose/integration/booking_consent_integration_test.go
+++ b/backend/internal/compose/integration/booking_consent_integration_test.go
@@ -24,12 +24,12 @@ import (
 
 // bookingAt shapes one /v1/bookings body for a fixed Tuesday slot,
 // linked to the person; extra fields merge over the base.
-func bookingAt(start time.Time, personID string, extra apptest.AnyMap) apptest.AnyMap {
-	body := apptest.AnyMap{
+func bookingAt(start time.Time, personID string, extra AnyMap) AnyMap {
+	body := AnyMap{
 		"start":   start,
 		"end":     start.Add(30 * time.Minute),
 		"subject": "Consented discovery call",
-		"links":   []apptest.AnyMap{{"entity_type": "person", "entity_id": personID}},
+		"links":   []AnyMap{{"entity_type": "person", "entity_id": personID}},
 	}
 	for k, v := range extra {
 		body[k] = v
@@ -45,13 +45,13 @@ func TestBookingConsentPassthrough(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Carla Consenting"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Carla Consenting"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
 	// A fixed Tuesday keeps every slot inside business hours.
 	tuesday := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
-	consent := apptest.AnyMap{
+	consent := AnyMap{
 		"purpose_id":     purposeID,
 		"policy_version": "pp-2026-01",
 		"wording":        "You agree we may contact you about this meeting.",
@@ -70,25 +70,25 @@ func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *apptest.AppEnv, pe
 	slot := tuesday // 10:00 — reused by every refusal, then proven free
 
 	// An unknown purpose cannot be recorded.
-	unknownPurpose := bookingAt(slot, personID, apptest.AnyMap{
-		"consent": apptest.AnyMap{"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01"},
+	unknownPurpose := bookingAt(slot, personID, AnyMap{
+		"consent": AnyMap{"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01"},
 	})
 	if status := e.Call(t, "POST", "/v1/bookings", unknownPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with an unknown consent purpose → %d, want 422", status)
 	}
 
 	// The wording version shown to the subject is the proof's anchor.
-	noPolicy := bookingAt(slot, personID, apptest.AnyMap{
-		"consent": apptest.AnyMap{"purpose_id": purposeID},
+	noPolicy := bookingAt(slot, personID, AnyMap{
+		"consent": AnyMap{"purpose_id": purposeID},
 	})
 	if status := e.Call(t, "POST", "/v1/bookings", noPolicy, nil, nil); status != 422 {
 		t.Fatalf("booking consent without policy_version → %d, want 422", status)
 	}
 
 	// Consent is person-keyed: no linked person, nothing to attach to.
-	subjectless := bookingAt(slot, personID, apptest.AnyMap{
-		"links":   []apptest.AnyMap{},
-		"consent": apptest.AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
+	subjectless := bookingAt(slot, personID, AnyMap{
+		"links":   []AnyMap{},
+		"consent": AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
 	})
 	if status := e.Call(t, "POST", "/v1/bookings", subjectless, nil, nil); status != 422 {
 		t.Fatalf("booking consent without a linked person → %d, want 422", status)
@@ -132,10 +132,10 @@ func assertConsentlessBookingStaysPlain(t *testing.T, e *apptest.AppEnv, personI
 // assertConsentedBookingLandsGrantWithProof books with the consent block
 // and proves both facts of the seam: the meeting on the timeline AND the
 // person_consent grant carrying the passthrough proof verbatim.
-func assertConsentedBookingLandsGrantWithProof(t *testing.T, e *apptest.AppEnv, personID string, tuesday time.Time, purposeID string, consent apptest.AnyMap) {
+func assertConsentedBookingLandsGrantWithProof(t *testing.T, e *apptest.AppEnv, personID string, tuesday time.Time, purposeID string, consent AnyMap) {
 	t.Helper()
 	if status := e.Call(t, "POST", "/v1/bookings",
-		bookingAt(tuesday.Add(2*time.Hour), personID, apptest.AnyMap{"consent": consent}), nil, nil); status != http.StatusCreated {
+		bookingAt(tuesday.Add(2*time.Hour), personID, AnyMap{"consent": consent}), nil, nil); status != http.StatusCreated {
 		t.Fatalf("consented booking → %d", status)
 	}
 

--- a/backend/internal/compose/integration/brief_e2e_integration_test.go
+++ b/backend/internal/compose/integration/brief_e2e_integration_test.go
@@ -87,7 +87,7 @@ func createDealClosingThisWeek(t *testing.T, e *apptest.AppEnv, stages apptest.S
 	var created struct {
 		Id string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name":                name,
 		"pipeline_id":         stages.PipelineID,
 		"stage_id":            stages.Open,
@@ -106,14 +106,14 @@ func assertSnoozeHidesItem(t *testing.T, e *apptest.AppEnv, toSnooze briefItemRe
 	t.Helper()
 	past := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
 	if status := e.Call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
-		apptest.AnyMap{"snoozed_until": past}, nil, nil); status != http.StatusUnprocessableEntity {
+		AnyMap{"snoozed_until": past}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("snooze into the past = %d, want 422", status)
 	}
 
 	until := time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339)
 	var snoozed briefItemResponse
 	if status := e.Call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
-		apptest.AnyMap{"snoozed_until": until}, nil, &snoozed); status != http.StatusOK {
+		AnyMap{"snoozed_until": until}, nil, &snoozed); status != http.StatusOK {
 		t.Fatalf("snooze = %d, want 200", status)
 	}
 	if snoozed.State != "snoozed" || snoozed.SnoozedUntil == "" {

--- a/backend/internal/compose/integration/briefannotate_integration_test.go
+++ b/backend/internal/compose/integration/briefannotate_integration_test.go
@@ -73,9 +73,9 @@ func TestAnAnnotationWithVerifiableCitationsIsWritten(t *testing.T) {
 	run := seedRunWithItems(t, e)
 	item := run.Items[0]
 
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "Two replies overnight, one deal went quiet.",
-		"items": []apptest.AnyMap{{
+		"items": []AnyMap{{
 			"item_id":        item.ID,
 			"finding":        "He asked about the delivery date and you usually answer within a day.",
 			"cited_evidence": item.EvidenceIds[:1],
@@ -111,9 +111,9 @@ func TestAQuietNightIsStampedEvenWithNothingToSay(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	seedRunWithItems(t, e)
 
-	if status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "",
-		"items":     []apptest.AnyMap{},
+		"items":     []AnyMap{},
 	}, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("annotate with an empty narrative = %d, want 204", status)
 	}
@@ -139,9 +139,9 @@ func TestACitationOutsideTheItemsOwnEvidenceRefusesTheWholeWrite(t *testing.T) {
 	// is the shape a plausible-looking hallucination takes: it is not invented,
 	// it is simply not evidence for the claim it is attached to.
 	borrowed := second.EvidenceIds[0]
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "Something happened.",
-		"items": []apptest.AnyMap{{
+		"items": []AnyMap{{
 			"item_id":        first.ID,
 			"finding":        "This claims to rest on a row that belongs to another deal.",
 			"cited_evidence": []string{borrowed},
@@ -166,8 +166,8 @@ func TestAnItemFromAnotherRunCannotBeAnnotated(t *testing.T) {
 	seedRunWithItems(t, e)
 
 	// A well-formed uuid that names no item in this run.
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
-		"items": []apptest.AnyMap{{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
+		"items": []AnyMap{{
 			"item_id":        "01a04000-0000-7000-8000-000000000000",
 			"finding":        "A finding about a queue entry that is not in this brief.",
 			"cited_evidence": []string{"01a04000-0000-7000-8000-000000000001"},
@@ -183,9 +183,9 @@ func TestAnnotatingWithNoRunTodayIsRefused(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 	// Deliberately no POST /v1/brief: this rep has no run today.
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "A sentence about a morning that was never assembled.",
-		"items":     []apptest.AnyMap{},
+		"items":     []AnyMap{},
 	}, nil, nil)
 	// Inventing a run here would produce a brief carrying prose with no ranking
 	// behind it.
@@ -201,9 +201,9 @@ func TestASecondPassReplacesTheFirstRatherThanAppending(t *testing.T) {
 	item := run.Items[0]
 
 	for _, narrative := range []string{"First reading of the night.", "Corrected reading."} {
-		if status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+		if status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 			"narrative": narrative,
-			"items": []apptest.AnyMap{{
+			"items": []AnyMap{{
 				"item_id":        item.ID,
 				"finding":        narrative + " (finding)",
 				"cited_evidence": item.EvidenceIds[:1],
@@ -230,9 +230,9 @@ func TestProseBeyondTheCeilingIsRefusedWithSomethingActionable(t *testing.T) {
 	for i := range long {
 		long[i] = 'x'
 	}
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": string(long),
-		"items":     []apptest.AnyMap{},
+		"items":     []AnyMap{},
 	}, nil, nil)
 	// 422 rather than a driver error surfacing as a failed run: an agent can
 	// read this and shorten, which is the whole point of refusing in Go as well
@@ -251,8 +251,8 @@ func TestAFindingThatCitesNothingIsRefused(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	run := seedRunWithItems(t, e)
 
-	status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
-		"items": []apptest.AnyMap{{
+	status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
+		"items": []AnyMap{{
 			"item_id": run.Items[0].ID,
 			"finding": "He is going to sign this week.",
 		}},
@@ -277,9 +277,9 @@ func TestASecondPassClearsFindingsItDoesNotRestate(t *testing.T) {
 	first, second := run.Items[0], run.Items[1]
 
 	// Night one annotates both items.
-	if status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "Two things moved.",
-		"items": []apptest.AnyMap{
+		"items": []AnyMap{
 			{"item_id": first.ID, "finding": "First deal moved.", "cited_evidence": first.EvidenceIds[:1]},
 			{"item_id": second.ID, "finding": "Second deal moved.", "cited_evidence": second.EvidenceIds[:1]},
 		},
@@ -288,9 +288,9 @@ func TestASecondPassClearsFindingsItDoesNotRestate(t *testing.T) {
 	}
 
 	// Night two has something to say about the first deal only.
-	if status := e.Call(t, "PUT", "/v1/brief/annotations", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/brief/annotations", AnyMap{
 		"narrative": "One thing moved.",
-		"items": []apptest.AnyMap{
+		"items": []AnyMap{
 			{"item_id": first.ID, "finding": "First deal moved again.", "cited_evidence": first.EvidenceIds[:1]},
 		},
 	}, nil, nil); status != http.StatusNoContent {

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -203,9 +203,9 @@ func (c *telegramEnv) assertNothingWasMerged(t *testing.T, channelPerson, phoneP
 // a record the product itself would have produced.
 func (c *telegramEnv) seedPerson(t *testing.T, name string, phone *string) string {
 	t.Helper()
-	body := apptest.AnyMap{"full_name": name}
+	body := integration.AnyMap{"full_name": name}
 	if phone != nil {
-		body["phones"] = []apptest.AnyMap{{"phone": *phone, "phone_type": "mobile"}}
+		body["phones"] = []integration.AnyMap{{"phone": *phone, "phone_type": "mobile"}}
 	}
 	var created struct {
 		ID string `json:"id"`

--- a/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_ingress_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
@@ -120,7 +121,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 	var owned struct {
 		ID string `json:"id"`
 	}
-	if status := c.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people", integration.AnyMap{
 		"full_name": "Private To The Admin", "owner_id": c.admin,
 	}, nil, &owned); status != 201 {
 		t.Fatalf("seeding the private control person → %d", status)

--- a/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/capture/telegram"
@@ -76,7 +77,7 @@ func (c *telegramEnv) grantConsent(t *testing.T, personID, purposeKey string) {
 	if purposeID == "" {
 		t.Fatalf("the bootstrap seeded no %q consent purpose", purposeKey)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+personID+"/consent", integration.AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -120,7 +121,7 @@ func TestInboundThenReplyRoundTrip(t *testing.T) {
 		Direction       string `json:"direction"`
 		Body            string `json:"body"`
 	}
-	status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
+	status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
 		"body": reply, "consent_purpose": "transactional",
 	}, nil, &sent)
 	if status != http.StatusAccepted {
@@ -187,7 +188,7 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 	// The rep answers, which is what puts an outbound activity in this chat's
 	// thread for the customer's next message to match against.
 	c.grantConsent(t, personID, "transactional")
-	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
 		"body": repReply, "consent_purpose": "transactional",
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -256,7 +257,7 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 	var sent struct {
 		ID string `json:"id"`
 	}
-	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
 		"body": "We are — hall 4.", "consent_purpose": "transactional",
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -327,7 +328,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 
 	// A real outbound goes into the Telegram conversation.
 	c.grantConsent(t, personID, "transactional")
-	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
 		"body": "Sending it over today.", "consent_purpose": "transactional",
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -77,7 +77,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID
@@ -158,7 +158,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 	if purposeID == "" {
 		t.Fatalf("bootstrap seeded no %q purpose: %+v", key, purposes.Data)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -197,7 +197,7 @@ func (c *channelSendEnv) sendReply(t *testing.T, purpose, body string, headers m
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status = c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", apptest.AnyMap{
+	status = c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", AnyMap{
 		"body": body, "consent_purpose": purpose,
 	}, headers, &answer)
 	if errs := answer.Details.Errors; len(errs) > 0 {
@@ -212,7 +212,7 @@ func (c *channelSendEnv) mintPassport(t *testing.T, scopes []string) string {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{"label": "reply agent", "scopes": scopes}, nil, &minted); status != http.StatusCreated {
+	if status := c.Call(t, "POST", "/v1/passports", AnyMap{"label": "reply agent", "scopes": scopes}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
 	}
 	return minted.Token
@@ -460,7 +460,7 @@ func TestSentMessageLandsAsAnOutboundActivity(t *testing.T) {
 		Direction string `json:"direction"`
 		Body      string `json:"body"`
 	}
-	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", AnyMap{
 		"body": "On its way.", "consent_purpose": "transactional",
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("human reply → %d", status)

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -65,7 +65,7 @@ func (c *channelSendEnv) enrichTarget(t *testing.T) string {
 		ID string `json:"id"`
 	}
 	if status := c.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Approval Mechanism GmbH"}, nil, &org); status != http.StatusCreated {
+		AnyMap{"display_name": "Approval Mechanism GmbH"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 	return org.ID

--- a/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
@@ -59,7 +59,7 @@ func setupChannelSendNoGmail(t *testing.T) *channelSendEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID

--- a/backend/internal/compose/integration/collections/filterpreview_integration_test.go
+++ b/backend/internal/compose/integration/collections/filterpreview_integration_test.go
@@ -32,8 +32,8 @@ import (
 // the column name so a filter can name it.
 func seedPeopleWithTier(t *testing.T, e *apptest.AppEnv, gold, other int) string {
 	t.Helper()
-	var field apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	var field integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "person", "label": "Preview Tier", "type": "text", "source": "ui",
 	}, nil, &field); status != http.StatusCreated {
 		t.Fatalf("create custom field: status=%d body=%v", status, field)
@@ -47,8 +47,8 @@ func seedPeopleWithTier(t *testing.T, e *apptest.AppEnv, gold, other int) string
 		if i >= gold {
 			tier = "silver"
 		}
-		var person apptest.AnyMap
-		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+		var person integration.AnyMap
+		if status := e.Call(t, "POST", "/v1/people", integration.AnyMap{
 			"full_name": "Preview Subject", "source": "ui", column: tier,
 		}, nil, &person); status != http.StatusCreated {
 			t.Fatalf("create person %d: status=%d body=%v", i, status, person)
@@ -83,11 +83,11 @@ func ledgers(t *testing.T, e *apptest.AppEnv) ledgerCounts {
 }
 
 type previewBody struct {
-	Resource   string           `json:"resource"`
-	MatchCount int              `json:"match_count"`
-	Columns    []string         `json:"columns"`
-	Rows       []apptest.AnyMap `json:"rows"`
-	Truncated  bool             `json:"truncated"`
+	Resource   string               `json:"resource"`
+	MatchCount int                  `json:"match_count"`
+	Columns    []string             `json:"columns"`
+	Rows       []integration.AnyMap `json:"rows"`
+	Truncated  bool                 `json:"truncated"`
 }
 
 // The count counts everything and the page is bounded, which is the whole point:
@@ -99,9 +99,9 @@ func TestAFilterPreviewCountsEveryMatchAndReturnsABoundedPage(t *testing.T) {
 
 	limit := 3
 	var got previewBody
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/filters/preview", integration.AnyMap{
 		"resource": "person",
-		"filter":   apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"filter":   integration.AnyMap{"field": column, "op": "eq", "value": "gold"},
 		"limit":    limit,
 	}, nil, &got); status != http.StatusOK {
 		t.Fatalf("preview: status=%d body=%+v", status, got)
@@ -136,9 +136,9 @@ func TestAFilterPreviewThatFitsIsNotTruncated(t *testing.T) {
 	column := seedPeopleWithTier(t, e, 2, 1)
 
 	var got previewBody
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/filters/preview", integration.AnyMap{
 		"resource": "person",
-		"filter":   apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"filter":   integration.AnyMap{"field": column, "op": "eq", "value": "gold"},
 	}, nil, &got); status != http.StatusOK {
 		t.Fatalf("preview: status=%d body=%+v", status, got)
 	}
@@ -157,10 +157,10 @@ func TestAFilterPreviewDescribesTheSameSliceTheExportWrites(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 	column := seedPeopleWithTier(t, e, 3, 2)
-	filter := apptest.AnyMap{"field": column, "op": "eq", "value": "gold"}
+	filter := integration.AnyMap{"field": column, "op": "eq", "value": "gold"}
 
 	var preview previewBody
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/filters/preview", integration.AnyMap{
 		"resource": "person", "filter": filter, "limit": 100,
 	}, nil, &preview); status != http.StatusOK {
 		t.Fatalf("preview: status=%d body=%+v", status, preview)
@@ -169,10 +169,10 @@ func TestAFilterPreviewDescribesTheSameSliceTheExportWrites(t *testing.T) {
 	// The export renders JSON, so the harness decodes its envelope straight into
 	// the shape below — that envelope is the comparison's other half.
 	var exported struct {
-		Rows     []apptest.AnyMap `json:"rows"`
-		RowCount int              `json:"row_count"`
+		Rows     []integration.AnyMap `json:"rows"`
+		RowCount int                  `json:"row_count"`
 	}
-	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/exports", integration.AnyMap{
 		"object": "person", "filter": filter, "format": "json",
 	}, nil, &exported); status != http.StatusOK {
 		t.Fatalf("export: status=%d", status)
@@ -219,12 +219,12 @@ func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 	column := seedPeopleWithTier(t, e, 2, 0)
-	filter := apptest.AnyMap{"field": column, "op": "eq", "value": "gold"}
+	filter := integration.AnyMap{"field": column, "op": "eq", "value": "gold"}
 
 	before := ledgers(t, e)
 	for range 3 {
 		var got previewBody
-		if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/filters/preview", integration.AnyMap{
 			"resource": "person", "filter": filter,
 		}, nil, &got); status != http.StatusOK {
 			t.Fatalf("preview: status=%d", status)
@@ -234,8 +234,8 @@ func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
 		t.Errorf("three previews moved the ledgers %+v → %+v; a recount while somebody types must write nothing", before, after)
 	}
 
-	var exported apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
+	var exported integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/exports", integration.AnyMap{
 		"object": "person", "filter": filter, "format": "json",
 	}, nil, &exported); status != http.StatusOK {
 		t.Fatalf("export: status=%d", status)
@@ -263,23 +263,23 @@ func TestAFilterPreviewRefusalNamesTheOffendingInput(t *testing.T) {
 
 	for _, c := range []struct {
 		name  string
-		body  apptest.AnyMap
+		body  integration.AnyMap
 		field string
 	}{
-		{"a field the vocabulary does not admit", apptest.AnyMap{
+		{"a field the vocabulary does not admit", integration.AnyMap{
 			"resource": "person",
-			"filter":   apptest.AnyMap{"field": "not_a_column", "op": "eq", "value": "x"},
+			"filter":   integration.AnyMap{"field": "not_a_column", "op": "eq", "value": "x"},
 		}, "not_a_column"},
-		{"no filter at all", apptest.AnyMap{"resource": "person"}, "filter"},
-		{"a resource with no engine", apptest.AnyMap{
+		{"no filter at all", integration.AnyMap{"resource": "person"}, "filter"},
+		{"a resource with no engine", integration.AnyMap{
 			"resource": "activity",
-			"filter":   apptest.AnyMap{"field": "kind", "op": "eq", "value": "call"},
+			"filter":   integration.AnyMap{"field": "kind", "op": "eq", "value": "call"},
 		}, "resource"},
 		// The contract publishes 1..100; a value outside it is refused rather than
 		// quietly rewritten, so a caller learns their request was not honoured.
-		{"a limit past the published ceiling", apptest.AnyMap{
+		{"a limit past the published ceiling", integration.AnyMap{
 			"resource": "person",
-			"filter":   apptest.AnyMap{"field": "full_name", "op": "contains", "value": "a"},
+			"filter":   integration.AnyMap{"field": "full_name", "op": "contains", "value": "a"},
 			"limit":    limitTooLarge,
 		}, "limit"},
 	} {

--- a/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
+++ b/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
@@ -36,8 +36,8 @@ func TestADynamicListOverHTTPAcceptsAndEvaluatesACustomFieldFilter(t *testing.T)
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 
-	var field apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	var field integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "person", "label": "Loyalty Tier HTTP", "type": "text", "source": "ui",
 	}, nil, &field); status != http.StatusCreated {
 		t.Fatalf("create custom field: status=%d body=%v", status, field)
@@ -47,8 +47,8 @@ func TestADynamicListOverHTTPAcceptsAndEvaluatesACustomFieldFilter(t *testing.T)
 		t.Fatalf("created field carries no column_name: %v", field)
 	}
 
-	var matching apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var matching integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", integration.AnyMap{
 		"full_name": "Match", "source": "ui",
 	}, nil, &matching); status != http.StatusCreated {
 		t.Fatalf("create matching person: status=%d body=%v", status, matching)
@@ -58,8 +58,8 @@ func TestADynamicListOverHTTPAcceptsAndEvaluatesACustomFieldFilter(t *testing.T)
 		t.Fatalf("created matching person carries no id: %v", matching)
 	}
 
-	var other apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var other integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", integration.AnyMap{
 		"full_name": "Other", "source": "ui",
 	}, nil, &other); status != http.StatusCreated {
 		t.Fatalf("create non-matching person: status=%d body=%v", status, other)
@@ -67,17 +67,17 @@ func TestADynamicListOverHTTPAcceptsAndEvaluatesACustomFieldFilter(t *testing.T)
 
 	// Set through the update path, exactly like the store-level scenario:
 	// a value a customer fills in after the fact must filter the same way.
-	var updated apptest.AnyMap
-	if status := e.Call(t, "PATCH", "/v1/people/"+matchID, apptest.AnyMap{column: "gold"}, nil, &updated); status != http.StatusOK {
+	var updated integration.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/people/"+matchID, integration.AnyMap{column: "gold"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("set the custom field through the update path: status=%d body=%v", status, updated)
 	}
 
 	// The regression's own repro: this exact call used to answer 422 at
 	// the endpoint filtered export already accepted the same predicate on.
-	var list apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	var list integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/lists", integration.AnyMap{
 		"name": "Gold tier", "entity_type": "person", "list_type": "dynamic",
-		"definition": apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"definition": integration.AnyMap{"field": column, "op": "eq", "value": "gold"},
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("a dynamic list on a custom field was refused over HTTP: status=%d body=%v", status, list)
 	}
@@ -87,7 +87,7 @@ func TestADynamicListOverHTTPAcceptsAndEvaluatesACustomFieldFilter(t *testing.T)
 	}
 
 	var members struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/lists/"+listID+"/members", nil, nil, &members); status != http.StatusOK {
 		t.Fatalf("list members: status=%d", status)
@@ -115,8 +115,8 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 
-	var field apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	var field integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "person", "label": "Vocabulary Probe", "type": "picklist", "source": "ui",
 		"options": []string{"gold", "silver"},
 	}, nil, &field); status != http.StatusCreated {
@@ -215,24 +215,24 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 	}
 
 	// The equivalence, forwards: a listed field is one a dynamic list accepts.
-	var accepted apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	var accepted integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/lists", integration.AnyMap{
 		"name": "Reported field is accepted", "entity_type": "person", "list_type": "dynamic",
-		"definition": apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"definition": integration.AnyMap{"field": column, "op": "eq", "value": "gold"},
 	}, nil, &accepted); status != http.StatusCreated {
 		t.Fatalf("the vocabulary listed %s but a dynamic list on it was refused: status=%d body=%v", column, status, accepted)
 	}
 
 	// And backwards: a field it does not list is one the same endpoint refuses,
 	// so the omission is a real answer rather than an incomplete one.
-	var refused apptest.AnyMap
+	var refused integration.AnyMap
 	unlisted := column + "_not_in_the_catalog"
 	if reported[unlisted] {
 		t.Fatalf("%s was meant to be absent from the vocabulary", unlisted)
 	}
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists", integration.AnyMap{
 		"name": "Unreported field is refused", "entity_type": "person", "list_type": "dynamic",
-		"definition": apptest.AnyMap{"field": unlisted, "op": "eq", "value": "gold"},
+		"definition": integration.AnyMap{"field": unlisted, "op": "eq", "value": "gold"},
 	}, nil, &refused); status != http.StatusUnprocessableEntity {
 		t.Fatalf("the vocabulary omits %s but a dynamic list on it was not refused 422: status=%d body=%v", unlisted, status, refused)
 	}
@@ -241,7 +241,7 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 	// bare 404: the generated wrapper binds this as a plain string and never
 	// calls the Valid() it also generates, so the handler is the only thing that
 	// can tell a typo from a real absence.
-	var badResource apptest.AnyMap
+	var badResource integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/filters/vocabulary?resource=peron", nil, nil, &badResource); status != http.StatusUnprocessableEntity {
 		t.Fatalf("a misspelled resource: status=%d body=%v, want 422", status, badResource)
 	}
@@ -261,8 +261,8 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 
-	var field apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	var field integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "person", "label": "Retiring Tier", "type": "text", "source": "ui",
 	}, nil, &field); status != http.StatusCreated {
 		t.Fatalf("create custom field: status=%d body=%v", status, field)
@@ -274,10 +274,10 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 	}
 
 	// A segment built while the field is live — the one that has to keep working.
-	var list apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	var list integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/lists", integration.AnyMap{
 		"name": "Built before retirement", "entity_type": "person", "list_type": "dynamic",
-		"definition": apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"definition": integration.AnyMap{"field": column, "op": "eq", "value": "gold"},
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("create the list while the field is live: status=%d body=%v", status, list)
 	}
@@ -287,8 +287,8 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 		t.Fatalf("%s is active and the vocabulary does not offer it", column)
 	}
 
-	var retired apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/custom-fields/"+fieldID+"/retire", apptest.AnyMap{}, nil, &retired); status != http.StatusOK {
+	var retired integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields/"+fieldID+"/retire", integration.AnyMap{}, nil, &retired); status != http.StatusOK {
 		t.Fatalf("retire the field: status=%d body=%v", status, retired)
 	}
 
@@ -298,7 +298,7 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 
 	// And the segment written against it still evaluates rather than erroring.
 	var members struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/lists/"+listID+"/members", nil, nil, &members); status != http.StatusOK {
 		t.Errorf("the segment naming the retired %s no longer evaluates: status=%d", column, status)

--- a/backend/internal/compose/integration/collections_integration_test.go
+++ b/backend/internal/compose/integration/collections_integration_test.go
@@ -24,7 +24,7 @@ func setupCollections(t *testing.T) (*apptest.AppEnv, string) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "List Target"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "List Target"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	return e, person.ID
@@ -36,19 +36,19 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 	var list struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists", AnyMap{
 		"name": "Q3 Targets", "entity_type": "person",
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("create list → %d", status)
 	}
 	// A static list refuses a definition; a dynamic one demands it.
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists", AnyMap{
 		"name": "Broken", "entity_type": "person", "list_type": "dynamic",
 	}, nil, nil); status != 422 {
 		t.Fatalf("definition-less dynamic list → %d, want 422", status)
 	}
 
-	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("add member → %d", status)
@@ -56,19 +56,19 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, &problem); status != http.StatusConflict {
 		t.Fatalf("duplicate member → %d, want 409", status)
 	}
 	// A wrong-typed member is refused before any probe.
-	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", AnyMap{
 		"entity_type": "deal", "entity_id": personID,
 	}, nil, nil); status != 422 {
 		t.Fatalf("type-mismatched member → %d, want 422", status)
 	}
 	// A member reference outside visibility is absent (H1).
-	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", AnyMap{
 		"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("invisible member target → %d, want 404", status)
@@ -102,20 +102,20 @@ func TestTagsLifecycleAndApplication(t *testing.T) {
 	var tag struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "Champion", "color": "#ff6b00"}, nil, &tag); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/tags", AnyMap{"name": "Champion", "color": "#ff6b00"}, nil, &tag); status != http.StatusCreated {
 		t.Fatalf("create tag → %d", status)
 	}
 	// The name is unique case-insensitively.
-	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "champion"}, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/tags", AnyMap{"name": "champion"}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("duplicate tag name → %d, want 409", status)
 	}
 
-	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("apply tag → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("re-apply → %d, want 409", status)
@@ -125,7 +125,7 @@ func TestTagsLifecycleAndApplication(t *testing.T) {
 		t.Fatalf("archive tag → %d", status)
 	}
 	// An archived tag reads as absent for new applications.
-	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("apply on archived tag → %d, want 404", status)

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -95,7 +95,7 @@ func (p *preflightEnv) sendExpectingAcceptance(t *testing.T, purpose, subject, b
 	var sent struct {
 		ID string `json:"id"`
 	}
-	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", apptest.AnyMap{
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": subject, "body": body,
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": purpose,
 	}, nil, &sent)
@@ -339,12 +339,12 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	var issued struct {
 		Token string `json:"token"`
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", apptest.AnyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", AnyMap{
 		"purpose_id": marketing, "deliver": false,
 	}, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("issue the double-opt-in token → %d", status)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", apptest.AnyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", AnyMap{
 		"purpose_id": marketing, "new_state": "granted",
 		"lawful_basis": "consent", "double_opt_in_token": issued.Token,
 	}, nil, nil); status != http.StatusOK {

--- a/backend/internal/compose/integration/company_http_integration_test.go
+++ b/backend/internal/compose/integration/company_http_integration_test.go
@@ -71,8 +71,8 @@ func orAbsent(value *string) string {
 
 // wellFormedCompany is a submission every required field of which is filled —
 // the base a test perturbs one field of, so a 422 can only be about that field.
-func wellFormedCompany() apptest.AnyMap {
-	return apptest.AnyMap{
+func wellFormedCompany() AnyMap {
+	return AnyMap{
 		"display_name":  "Acme GmbH",
 		"offer_summary": "Revenue operations software",
 		"icp":           "RevOps at SaaS scale-ups",
@@ -314,7 +314,7 @@ func TestCompanyPutRefusesAnAgentPassport(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "read-back agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -36,18 +36,18 @@ func setupConsent(t *testing.T) *consentEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Consent Subject",
-		"emails":    []apptest.AnyMap{{"email": "subject@consent.test"}},
+		"emails":    []AnyMap{{"email": "subject@consent.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "subject": "Inbound question", "direction": "inbound",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -77,7 +77,7 @@ func (c *consentEnv) send(t *testing.T, purpose string) (int, string) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", apptest.AnyMap{
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
 		"to": []string{"subject@consent.test"}, "consent_purpose": purpose,
 	}, nil, &problem)
@@ -92,7 +92,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 		Subject string `json:"subject"`
 	}
 	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/draft-email",
-		apptest.AnyMap{"intent": "friendly nudge"}, nil, &draft); status != http.StatusOK {
+		AnyMap{"intent": "friendly nudge"}, nil, &draft); status != http.StatusOK {
 		t.Fatalf("draft → %d", status)
 	}
 	if draft.Subject != "Re: Inbound question" {
@@ -114,7 +114,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 	// Grant marketing through the round-trip its purpose demands; the send
 	// under THAT purpose then flows.
 	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"lawful_basis": "consent", "double_opt_in_token": token,
 	}, nil, nil); status != http.StatusOK {
@@ -126,7 +126,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 
 	// Withdrawal re-blocks, and it does so through the objection rule that
 	// overrides every other basis.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
@@ -283,7 +283,7 @@ func TestAnObjectionOverridesAQualifyingEvent(t *testing.T) {
 	if status, _ := c.send(t, "business_correspondence"); status != http.StatusAccepted {
 		t.Fatal("the fixture's inbound message should allow correspondence before the objection")
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["business_correspondence"], "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record the objection → %d", status)
@@ -300,7 +300,7 @@ func TestConsentGateIsNotAnOracleForUnauthorizedCallers(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.Call(t, "POST", "/v1/activities/00000000-0000-7000-8000-000000000001/send-email", apptest.AnyMap{
+	status := c.Call(t, "POST", "/v1/activities/00000000-0000-7000-8000-000000000001/send-email", AnyMap{
 		"subject": "probe", "body": "probe",
 		"to": []string{"subject@consent.test"}, "consent_purpose": "transactional",
 	}, nil, &problem)
@@ -316,14 +316,14 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 	}, nil, &problem)
 	if status != 422 {
 		t.Fatalf("DOI-less marketing grant → %d, want 422", status)
 	}
 	// A fabricated token proves nothing: only a server-issued one confirms.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": "doi-token-forged",
 	}, nil, nil); status != 422 {
@@ -334,7 +334,7 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	// no mint/delivery endpoint yet, so issuance rides the store seam),
 	// the confirming grant presents it, and the send flows.
 	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": token,
 	}, nil, nil); status != http.StatusOK {
@@ -346,12 +346,12 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 
 	// The token is single-use: after a withdrawal the consumed token
 	// cannot resurrect the grant.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": token,
 	}, nil, nil); status != 422 {
@@ -369,7 +369,7 @@ func (c *consentEnv) issueDOIToken(t *testing.T, purposeID string) string {
 		Token     string     `json:"token"`
 		ExpiresAt *time.Time `json:"expires_at"`
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
 		"purpose_id": purposeID, "deliver": false,
 	}, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("issue DOI token → %d", status)
@@ -388,7 +388,7 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 	c := setupConsent(t)
 
 	// transactional does not require double opt-in → 422.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
 		"purpose_id": c.purposes["transactional"],
 	}, nil, nil); status != 422 {
 		t.Fatalf("DOI issuance for a non-DOI purpose → %d, want 422", status)
@@ -398,14 +398,14 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 	second := c.issueDOIToken(t, c.purposes["marketing_email"])
 
 	// The superseded first token no longer redeems…
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": first,
 	}, nil, nil); status != 422 {
 		t.Fatalf("superseded token redeemed → %d, want 422", status)
 	}
 	// …the fresh one does.
-	if c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": second,
 	}, nil, nil) != http.StatusOK {
@@ -414,7 +414,7 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 
 	// Issuance is an audited fact.
 	var audit struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := c.Call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit read → %d", status)
@@ -427,7 +427,7 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	c := setupConsent(t)
 	grant := func() int {
-		return c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+		return c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 			"purpose_id": c.purposes["transactional"], "new_state": "granted",
 		}, nil, nil)
 	}

--- a/backend/internal/compose/integration/createtask_integration_test.go
+++ b/backend/internal/compose/integration/createtask_integration_test.go
@@ -21,11 +21,11 @@ func TestATaskCreatedThroughItsOwnDoorIsATaskOnTheTimeline(t *testing.T) {
 	stages := apptest.DiscoverSeededPipeline(t, e)
 	dealID := apptest.CreateOpenDeal(t, e, stages)
 
-	var task apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/tasks", apptest.AnyMap{
+	var task AnyMap
+	if status := e.Call(t, "POST", "/v1/tasks", AnyMap{
 		"subject": "Send the redline",
 		"due_at":  "2026-09-01T09:00:00+02:00",
-		"links":   []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links":   []AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 		"source":  "ui",
 	}, nil, &task); status != http.StatusCreated {
 		t.Fatalf("create task = %d %v", status, task)
@@ -34,7 +34,7 @@ func TestATaskCreatedThroughItsOwnDoorIsATaskOnTheTimeline(t *testing.T) {
 		t.Fatalf("task = %v", task)
 	}
 
-	var listed apptest.AnyMap
+	var listed AnyMap
 	if status := e.Call(t, "GET", "/v1/activities?kind=task&entity_type=deal&entity_id="+dealID, nil, nil, &listed); status != http.StatusOK {
 		t.Fatalf("list = %d %v", status, listed)
 	}
@@ -42,7 +42,7 @@ func TestATaskCreatedThroughItsOwnDoorIsATaskOnTheTimeline(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("timeline tasks = %v, want the one created", rows)
 	}
-	if status := e.Call(t, "POST", "/v1/tasks", apptest.AnyMap{"subject": "", "source": "ui"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/tasks", AnyMap{"subject": "", "source": "ui"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("empty subject = %d, want 422", status)
 	}
 }

--- a/backend/internal/compose/integration/csvimport_integration_test.go
+++ b/backend/internal/compose/integration/csvimport_integration_test.go
@@ -176,7 +176,7 @@ func createRunOnDuplicate(t *testing.T, e *apptest.AppEnv, object, sourceRef str
 func createRunWithMapping(t *testing.T, e *apptest.AppEnv, object, sourceRef string, mapping map[string]string) (importRunDTO, int) {
 	t.Helper()
 	var run importRunDTO
-	status := e.Call(t, http.MethodPost, "/v1/imports", apptest.AnyMap{
+	status := e.Call(t, http.MethodPost, "/v1/imports", AnyMap{
 		"connector": "csv", "object": object,
 		"source_ref": sourceRef, "mapping": mapping,
 	}, nil, &run)
@@ -195,7 +195,7 @@ func leadCount(t *testing.T, e *apptest.AppEnv) int {
 func importedPersonCount(t *testing.T, e *apptest.AppEnv) int {
 	t.Helper()
 	var people struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, http.MethodGet, "/v1/people?limit=100", nil, nil, &people); status != http.StatusOK {
 		t.Fatalf("GET /v1/people → %d, want 200", status)
@@ -397,7 +397,7 @@ func TestCSVImportRefusesAnImpossibleMapping(t *testing.T) {
 	e := setupImportApp(t)
 
 	profile, _ := uploadCSV(t, e, "lead", prospectCSV)
-	status := e.Call(t, http.MethodPost, "/v1/imports", apptest.AnyMap{
+	status := e.Call(t, http.MethodPost, "/v1/imports", AnyMap{
 		"connector": "csv", "object": "lead",
 		"source_ref": profile.SourceRef,
 		"mapping":    map[string]string{"Email": "email", "Title": "annual_revenue"},
@@ -417,7 +417,7 @@ func TestCSVImportRefusesAForeignSourceReference(t *testing.T) {
 	profile, _ := uploadCSV(t, e, "lead", prospectCSV)
 	foreign := "11111111-1111-7111-8111-111111111111/import/" + path.Base(profile.SourceRef)
 
-	status := e.Call(t, http.MethodPost, "/v1/imports", apptest.AnyMap{
+	status := e.Call(t, http.MethodPost, "/v1/imports", AnyMap{
 		"connector": "csv", "object": "lead",
 		"source_ref": foreign, "mapping": profile.SuggestedMapping,
 	}, nil, nil)
@@ -466,7 +466,7 @@ func TestCSVImportRecordsAValidationThatCouldNotFinish(t *testing.T) {
 		t.Fatalf("removing the stored upload: %v", err)
 	}
 
-	status := e.Call(t, http.MethodPost, "/v1/imports", apptest.AnyMap{
+	status := e.Call(t, http.MethodPost, "/v1/imports", AnyMap{
 		"connector": "csv", "object": "lead",
 		"source_ref": profile.SourceRef, "mapping": profile.SuggestedMapping,
 	}, nil, nil)
@@ -513,7 +513,7 @@ func TestCSVImportRunNamesWhoOpenedIt(t *testing.T) {
 		ID         string `json:"id"`
 		CapturedBy string `json:"captured_by"`
 	}
-	if status := e.Call(t, http.MethodPost, "/v1/imports", apptest.AnyMap{
+	if status := e.Call(t, http.MethodPost, "/v1/imports", AnyMap{
 		"connector": "csv", "object": "lead",
 		"source_ref": profile.SourceRef, "mapping": profile.SuggestedMapping,
 	}, nil, &run); status != http.StatusAccepted {

--- a/backend/internal/compose/integration/csvimportundo_integration_test.go
+++ b/backend/internal/compose/integration/csvimportundo_integration_test.go
@@ -86,7 +86,7 @@ func TestCSVImportUndoReversesUntouchedAndKeepsEdited(t *testing.T) {
 		FullName string `json:"full_name"`
 	}
 	if status := e.Call(t, http.MethodPatch, "/v1/leads/"+edited.ID,
-		apptest.AnyMap{"full_name": "Grace M. Hopper"}, nil, &patched); status != http.StatusOK {
+		AnyMap{"full_name": "Grace M. Hopper"}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("editing the lead as a human → %d, want 200", status)
 	}
 

--- a/backend/internal/compose/integration/cursor_integration_test.go
+++ b/backend/internal/compose/integration/cursor_integration_test.go
@@ -39,8 +39,8 @@ func TestMalformedCursorAnswersMalformedCursorEverywhere(t *testing.T) {
 	apptest.BootstrapWorkspaceSession(t, e, "Cursor Probe", "admin@cursor.test", "Admin")
 
 	// /lists/{id}/members needs a real list to point at.
-	var list apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	var list AnyMap
+	if status := e.Call(t, "POST", "/v1/lists", AnyMap{
 		"name": "Probe", "entity_type": "person",
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("create list = %d %v", status, list)

--- a/backend/internal/compose/integration/customfields/customfields_http_assertions_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_http_assertions_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -23,7 +24,7 @@ import (
 // details.errors[{field,code}], no fabricated message.
 func assertValidationDetails(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, apptest.AnyMap{
+	status, _, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Budget ceiling", "type": "currency", "source": "ui",
 	})
 	if status != http.StatusUnprocessableEntity {
@@ -42,7 +43,7 @@ func assertValidationDetails(t *testing.T, e *apptest.AppEnv) {
 // 422 example verbatim, including details.route.
 func assertStructuralChangeRefused(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, apptest.AnyMap{
+	status, _, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Renewal formula", "type": "text", "source": "ui",
 	})
 	if status != http.StatusUnprocessableEntity {
@@ -60,7 +61,7 @@ func assertStructuralChangeRefused(t *testing.T, e *apptest.AppEnv) {
 // the same (object, label) pair refused the second time.
 func assertDuplicateSlugConflict(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	body := apptest.AnyMap{"object": "deal", "label": "Renewal Window", "type": "text", "source": "ui"}
+	body := integration.AnyMap{"object": "deal", "label": "Renewal Window", "type": "text", "source": "ui"}
 	first, field, _ := createCustomField(t, e, body)
 	if first != http.StatusCreated {
 		t.Fatalf("first create status = %d, want 201: %+v", first, field)
@@ -101,7 +102,7 @@ func assertListInvalidObject(t *testing.T, e *apptest.AppEnv) {
 // generic validation_error.
 func assertNotPicklistOptionsEdit(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Not A Picklist", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -109,7 +110,7 @@ func assertNotPicklistOptionsEdit(t *testing.T, e *apptest.AppEnv) {
 	}
 	var notPicklist customFieldProblem
 	optStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		apptest.AnyMap{"options": []string{"a"}}, nil, &notPicklist)
+		integration.AnyMap{"options": []string{"a"}}, nil, &notPicklist)
 	if optStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422: %+v", optStatus, notPicklist)
 	}
@@ -124,7 +125,7 @@ func assertNotPicklistOptionsEdit(t *testing.T, e *apptest.AppEnv) {
 // ErrVersionSkew, wire-mapped to 409 like every other versioned PATCH.
 func assertRenameConcurrencyErrors(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Concurrency Subject", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -133,14 +134,14 @@ func assertRenameConcurrencyErrors(t *testing.T, e *apptest.AppEnv) {
 
 	var malformed customFieldProblem
 	malformedStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		apptest.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "not-a-number"}, &malformed)
+		integration.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "not-a-number"}, &malformed)
 	if malformedStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("malformed If-Match status = %d, want 422: %+v", malformedStatus, malformed)
 	}
 
 	var skew customFieldProblem
 	skewStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		apptest.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "999999"}, &skew)
+		integration.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "999999"}, &skew)
 	if skewStatus != http.StatusConflict {
 		t.Fatalf("stale If-Match status = %d, want 409: %+v", skewStatus, skew)
 	}
@@ -153,7 +154,7 @@ func assertRenameConcurrencyErrors(t *testing.T, e *apptest.AppEnv) {
 // type creates end to end with the shape its type requires.
 func assertSixTypesCreate(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	cases := []apptest.AnyMap{
+	cases := []integration.AnyMap{
 		{"object": "deal", "label": "Renewal Date", "type": "date", "source": "ui"},
 		{"object": "deal", "label": "Seat Count", "type": "number", "source": "ui"},
 		{"object": "deal", "label": "Deal Notes", "type": "text", "source": "ui"},
@@ -186,7 +187,7 @@ func assertSixTypesCreate(t *testing.T, e *apptest.AppEnv) {
 func assertInjectionLabel(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	hostile := `Notes'); DROP TABLE person; --`
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "person", "label": hostile, "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -200,8 +201,8 @@ func assertInjectionLabel(t *testing.T, e *apptest.AppEnv) {
 	}
 
 	// The person table survives: an ordinary person write still round-trips.
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", integration.AnyMap{
 		"full_name": "Injection Survivor", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("person table did not survive the injection attempt: create status = %d %v", status, person)
@@ -212,7 +213,7 @@ func assertInjectionLabel(t *testing.T, e *apptest.AppEnv) {
 // only, column_name never moves.
 func assertRenameStable(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Original Label", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -221,7 +222,7 @@ func assertRenameStable(t *testing.T, e *apptest.AppEnv) {
 	originalColumn := field.ColumnName
 
 	var renamed customFieldWire
-	renameStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID, apptest.AnyMap{"label": "Renamed Label"}, nil, &renamed)
+	renameStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID, integration.AnyMap{"label": "Renamed Label"}, nil, &renamed)
 	if renameStatus != http.StatusOK {
 		t.Fatalf("rename status = %d, want 200: %+v", renameStatus, renamed)
 	}
@@ -237,7 +238,7 @@ func assertRenameStable(t *testing.T, e *apptest.AppEnv) {
 // stays null — retire is a status flip, never an archive.
 func assertRetire(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "To Be Retired", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -262,7 +263,7 @@ func assertRetire(t *testing.T, e *apptest.AppEnv) {
 // conflict, while a repeat retire stays the 200 no-op.
 func assertRetiredFieldFrozen(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Frozen Route", "type": "picklist",
 		"options": []string{"direct", "reseller"}, "source": "ui",
 	})
@@ -276,14 +277,14 @@ func assertRetiredFieldFrozen(t *testing.T, e *apptest.AppEnv) {
 
 	var renameProblem customFieldProblem
 	renameStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		apptest.AnyMap{"label": "Thawed Route"}, nil, &renameProblem)
+		integration.AnyMap{"label": "Thawed Route"}, nil, &renameProblem)
 	if renameStatus != http.StatusConflict || renameProblem.Code != "conflict" {
 		t.Fatalf("rename on retired = %d/%q, want 409/conflict: %+v", renameStatus, renameProblem.Code, renameProblem)
 	}
 
 	var optionsProblem customFieldProblem
 	optionsStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		apptest.AnyMap{"options": []string{"direct"}}, nil, &optionsProblem)
+		integration.AnyMap{"options": []string{"direct"}}, nil, &optionsProblem)
 	if optionsStatus != http.StatusConflict || optionsProblem.Code != "conflict" {
 		t.Fatalf("options on retired = %d/%q, want 409/conflict: %+v", optionsStatus, optionsProblem.Code, optionsProblem)
 	}
@@ -299,7 +300,7 @@ func assertRetiredFieldFrozen(t *testing.T, e *apptest.AppEnv) {
 // request schema deliberately has no additionalProperties catch-all.
 func assertUnknownCreateKey(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, apptest.AnyMap{
+	status, _, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Typo Subject", "type": "currency",
 		"curency": "USD", "source": "ui",
 	})
@@ -317,7 +318,7 @@ func assertUnknownCreateKey(t *testing.T, e *apptest.AppEnv) {
 // refused with the contract's exact lastOption shape.
 func assertOptionsLifecycle(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, apptest.AnyMap{
+	status, field, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Deployment Region", "type": "picklist",
 		"options": []string{"us-east", "eu-west", "apac"}, "source": "ui",
 	})
@@ -327,7 +328,7 @@ func assertOptionsLifecycle(t *testing.T, e *apptest.AppEnv) {
 
 	var updated customFieldWire
 	optStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		apptest.AnyMap{"options": []string{"eu-west", "apac", "sa-east"}}, nil, &updated)
+		integration.AnyMap{"options": []string{"eu-west", "apac", "sa-east"}}, nil, &updated)
 	if optStatus != http.StatusOK {
 		t.Fatalf("options update status = %d, want 200: %+v", optStatus, updated)
 	}
@@ -337,7 +338,7 @@ func assertOptionsLifecycle(t *testing.T, e *apptest.AppEnv) {
 
 	var lastOptionProblem customFieldProblem
 	emptyStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		apptest.AnyMap{"options": []string{}}, nil, &lastOptionProblem)
+		integration.AnyMap{"options": []string{}}, nil, &lastOptionProblem)
 	if emptyStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("empty-options status = %d, want 422: %+v", emptyStatus, lastOptionProblem)
 	}
@@ -351,13 +352,13 @@ func assertOptionsLifecycle(t *testing.T, e *apptest.AppEnv) {
 // both lifecycle states, and object/status each narrow correctly.
 func assertListFiltering(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	activeStatus, active, activeProblem := createCustomField(t, e, apptest.AnyMap{
+	activeStatus, active, activeProblem := createCustomField(t, e, integration.AnyMap{
 		"object": "lead", "label": "Lead Source Detail", "type": "text", "source": "ui",
 	})
 	if activeStatus != http.StatusCreated {
 		t.Fatalf("create active field status = %d: %+v", activeStatus, activeProblem)
 	}
-	retiringStatus, retiring, retiringProblem := createCustomField(t, e, apptest.AnyMap{
+	retiringStatus, retiring, retiringProblem := createCustomField(t, e, integration.AnyMap{
 		"object": "lead", "label": "Lead Legacy Field", "type": "text", "source": "ui",
 	})
 	if retiringStatus != http.StatusCreated {
@@ -425,7 +426,7 @@ func assertUnwired501(t *testing.T) {
 	unwired.BootstrapWorkspace(t)
 
 	var createProblem customFieldProblem
-	createStatus := unwired.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	createStatus := unwired.Call(t, "POST", "/v1/custom-fields", integration.AnyMap{
 		"object": "deal", "label": "Never Lands", "type": "date", "source": "ui",
 	}, nil, &createProblem)
 	if createStatus != http.StatusNotImplemented {
@@ -434,7 +435,7 @@ func assertUnwired501(t *testing.T) {
 
 	var optionsProblem customFieldProblem
 	optionsStatus := unwired.Call(t, "PATCH", "/v1/custom-fields/"+ids.NewV7().String()+"/options",
-		apptest.AnyMap{"options": []string{"a", "b"}}, nil, &optionsProblem)
+		integration.AnyMap{"options": []string{"a", "b"}}, nil, &optionsProblem)
 	if optionsStatus != http.StatusNotImplemented {
 		t.Fatalf("options status = %d, want 501: %+v", optionsStatus, optionsProblem)
 	}

--- a/backend/internal/compose/integration/customfields/customfields_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_http_integration_test.go
@@ -108,7 +108,7 @@ func schemaWiredEnv(t *testing.T) *apptest.AppEnv {
 // number http.StatusCode, while CustomField's own `status` is the
 // lifecycle string (active/retired) — unmarshaling one body into the
 // other's struct would fail on that type mismatch, not just leave zeros.
-func createCustomField(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) (int, customFieldWire, customFieldProblem) {
+func createCustomField(t *testing.T, e *apptest.AppEnv, body integration.AnyMap) (int, customFieldWire, customFieldProblem) {
 	t.Helper()
 	var raw json.RawMessage
 	status := e.Call(t, "POST", "/v1/custom-fields", body, nil, &raw)

--- a/backend/internal/compose/integration/customfields/customfields_values_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_values_http_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
@@ -26,7 +27,7 @@ import (
 // payload.
 //
 //craft:ignore naked-any want is whichever JSON-decoded shape the wire carries for the field's type (string/bool/float64) — the assertion seam mirrors env.call's out
-func assertWireCF(t *testing.T, payload apptest.AnyMap, key string, want any) {
+func assertWireCF(t *testing.T, payload integration.AnyMap, key string, want any) {
 	t.Helper()
 	if payload[key] != want {
 		t.Fatalf("wire %s = %v (%T), want top-level %v", key, payload[key], payload[key], want)
@@ -35,9 +36,9 @@ func assertWireCF(t *testing.T, payload apptest.AnyMap, key string, want any) {
 
 // createWithCF posts one record body and returns the decoded response
 // plus its id, asserting the 201.
-func createWithCF(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) (apptest.AnyMap, string) {
+func createWithCF(t *testing.T, e *apptest.AppEnv, path string, body integration.AnyMap) (integration.AnyMap, string) {
 	t.Helper()
-	var created apptest.AnyMap
+	var created integration.AnyMap
 	if status := e.Call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST %s status = %d (%v)", path, status, created)
 	}
@@ -50,25 +51,25 @@ func createWithCF(t *testing.T, e *apptest.AppEnv, path string, body apptest.Any
 
 func assertPersonWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/people", apptest.AnyMap{
+	created, id := createWithCF(t, e, "/v1/people", integration.AnyMap{
 		"full_name": "Ada Lovelace", "source": "ui", col: "gold",
 	})
 	assertWireCF(t, created, col, "gold")
 
-	var got apptest.AnyMap
+	var got integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get person status = %d", status)
 	}
 	assertWireCF(t, got, col, "gold")
 
-	var updated apptest.AnyMap
-	if status := e.Call(t, "PATCH", "/v1/people/"+id, apptest.AnyMap{col: "silver"}, nil, &updated); status != http.StatusOK {
+	var updated integration.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/people/"+id, integration.AnyMap{col: "silver"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update person status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "silver")
 
 	var list struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/people", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list people status = %d", status)
@@ -81,12 +82,12 @@ func assertPersonWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 
 func assertOrganizationWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/organizations", apptest.AnyMap{
+	created, id := createWithCF(t, e, "/v1/organizations", integration.AnyMap{
 		"display_name": "Acme GmbH", "source": "ui", col: "emea",
 	})
 	assertWireCF(t, created, col, "emea")
 
-	var got apptest.AnyMap
+	var got integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/organizations/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get organization status = %d", status)
 	}
@@ -99,26 +100,26 @@ func assertOrganizationWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string
 func assertDealWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
 	stages := apptest.DiscoverSeededPipeline(t, e)
-	created, id := createWithCF(t, e, "/v1/deals", apptest.AnyMap{
+	created, id := createWithCF(t, e, "/v1/deals", integration.AnyMap{
 		"name": "Acme Renewal", "pipeline_id": stages.PipelineID, "stage_id": stages.Open,
 		"source": "ui", col: "enterprise",
 	})
 	assertWireCF(t, created, col, "enterprise")
 
-	var got apptest.AnyMap
+	var got integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/deals/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get deal status = %d", status)
 	}
 	assertWireCF(t, got, col, "enterprise")
 
-	var updated apptest.AnyMap
-	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{col: "mid-market"}, nil, &updated); status != http.StatusOK {
+	var updated integration.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, integration.AnyMap{col: "mid-market"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update deal status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "mid-market")
 
 	var list struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/deals", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list deals status = %d", status)
@@ -134,25 +135,25 @@ func assertDealWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 // carry the cf key top-level over the wire.
 func assertLeadWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/leads", apptest.AnyMap{
+	created, id := createWithCF(t, e, "/v1/leads", integration.AnyMap{
 		"full_name": "Grace Hopper", "source": "ui", col: "champion",
 	})
 	assertWireCF(t, created, col, "champion")
 
-	var got apptest.AnyMap
+	var got integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/leads/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get lead status = %d", status)
 	}
 	assertWireCF(t, got, col, "champion")
 
-	var updated apptest.AnyMap
-	if status := e.Call(t, "PATCH", "/v1/leads/"+id, apptest.AnyMap{col: "detractor"}, nil, &updated); status != http.StatusOK {
+	var updated integration.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/leads/"+id, integration.AnyMap{col: "detractor"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update lead status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "detractor")
 
 	var list struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/leads", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list leads status = %d", status)
@@ -168,7 +169,7 @@ func assertLeadWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 // type — the wire-level twin of TestCustomFieldValues_AllSixTypesRoundTrip.
 func sixTypeWireFields(t *testing.T, e *apptest.AppEnv) map[string]string {
 	t.Helper()
-	specs := map[string]apptest.AnyMap{
+	specs := map[string]integration.AnyMap{
 		"text":     {"object": "person", "label": "Note", "type": "text", "source": "ui"},
 		"number":   {"object": "person", "label": "Score", "type": "number", "source": "ui"},
 		"date":     {"object": "person", "label": "Renewal", "type": "date", "source": "ui"},
@@ -195,7 +196,7 @@ func sixTypeWireFields(t *testing.T, e *apptest.AppEnv) map[string]string {
 func assertSixTypesWireRoundTrip(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	cols := sixTypeWireFields(t, e)
-	want := apptest.AnyMap{
+	want := integration.AnyMap{
 		cols["text"]:     "prefers morning calls",
 		cols["number"]:   42.5,
 		cols["date"]:     "2026-07-11",
@@ -203,7 +204,7 @@ func assertSixTypesWireRoundTrip(t *testing.T, e *apptest.AppEnv) {
 		cols["picklist"]: "partner",
 		cols["boolean"]:  true,
 	}
-	body := apptest.AnyMap{"full_name": "Grace Hopper", "source": "ui"}
+	body := integration.AnyMap{"full_name": "Grace Hopper", "source": "ui"}
 	for col, v := range want {
 		body[col] = v
 	}
@@ -212,7 +213,7 @@ func assertSixTypesWireRoundTrip(t *testing.T, e *apptest.AppEnv) {
 		assertWireCF(t, created, col, v)
 	}
 
-	var got apptest.AnyMap
+	var got integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get person status = %d", status)
 	}
@@ -229,7 +230,7 @@ func assertPicklistCheckViolation422(t *testing.T, e *apptest.AppEnv, col string
 	// below could look for it — a disclosure guard reading a filtered copy of
 	// the thing it is guarding.
 	var raw json.RawMessage
-	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/people", integration.AnyMap{
 		"full_name": "Bad Option", "source": "ui", col: "bogus",
 	}, nil, &raw)
 	var problem customFieldProblem
@@ -259,26 +260,26 @@ func assertPicklistCheckViolation422(t *testing.T, e *apptest.AppEnv, col string
 func TestCustomFieldValuesHTTP(t *testing.T) {
 	e := schemaWiredEnv(t)
 
-	status, tier, problem := createCustomField(t, e, apptest.AnyMap{
+	status, tier, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "person", "label": "Tier", "type": "picklist",
 		"options": []string{"gold", "silver"}, "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create person field status = %d: %+v", status, problem)
 	}
-	status, region, problem := createCustomField(t, e, apptest.AnyMap{
+	status, region, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "organization", "label": "Region", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create organization field status = %d: %+v", status, problem)
 	}
-	status, segment, problem := createCustomField(t, e, apptest.AnyMap{
+	status, segment, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "deal", "label": "Segment", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create deal field status = %d: %+v", status, problem)
 	}
-	status, persona, problem := createCustomField(t, e, apptest.AnyMap{
+	status, persona, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "lead", "label": "Persona", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {

--- a/backend/internal/compose/integration/customfields/customfields_vocab_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields/customfields_vocab_http_integration_test.go
@@ -29,7 +29,7 @@ import (
 func listPeopleNames(t *testing.T, e *apptest.AppEnv, query string) []string {
 	t.Helper()
 	var list struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []integration.AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/people"+query, nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET /v1/people%s status = %d", query, status)
@@ -60,7 +60,7 @@ func walkCFSortedPagesOverWire(t *testing.T, e *apptest.AppEnv, col string) []st
 			t.Fatalf("pagination did not terminate after %d pages (walked %v)", page, walked)
 		}
 		var list struct {
-			Data []apptest.AnyMap `json:"data"`
+			Data []integration.AnyMap `json:"data"`
 			Page struct {
 				HasMore    bool    `json:"has_more"`
 				NextCursor *string `json:"next_cursor"`
@@ -106,7 +106,7 @@ func assert422Code(t *testing.T, e *apptest.AppEnv, path, wantCode string) {
 // under one sort reused under another.
 func assertCursorSortRefusals(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, score, problem := createCustomField(t, e, apptest.AnyMap{
+	status, score, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "person", "label": "Score", "type": "number", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -145,7 +145,7 @@ func assertCursorSortRefusals(t *testing.T, e *apptest.AppEnv) {
 func TestCustomFieldVocabHTTP(t *testing.T) {
 	e := schemaWiredEnv(t)
 
-	status, tier, problem := createCustomField(t, e, apptest.AnyMap{
+	status, tier, problem := createCustomField(t, e, integration.AnyMap{
 		"object": "person", "label": "Tier", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -153,9 +153,9 @@ func TestCustomFieldVocabHTTP(t *testing.T) {
 	}
 	col := tier.ColumnName
 
-	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person B", "source": "ui", col: "beta"})
-	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person A", "source": "ui", col: "alpha"})
-	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person N", "source": "ui"})
+	createWithCF(t, e, "/v1/people", integration.AnyMap{"full_name": "Person B", "source": "ui", col: "beta"})
+	createWithCF(t, e, "/v1/people", integration.AnyMap{"full_name": "Person A", "source": "ui", col: "alpha"})
+	createWithCF(t, e, "/v1/people", integration.AnyMap{"full_name": "Person N", "source": "ui"})
 
 	t.Run("cf_ sort orders the page, NULL last", func(t *testing.T) {
 		got := listPeopleNames(t, e, "?sort="+col)

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -54,7 +54,7 @@ func TestResetDataOverHTTP(t *testing.T) {
 	}
 
 	// Wrong confirmation is refused before anything is deleted.
-	if code := e.Call(t, "POST", "/v1/admin/reset-data", apptest.AnyMap{"confirmation": "wrong"}, nil, nil); code != 422 {
+	if code := e.Call(t, "POST", "/v1/admin/reset-data", AnyMap{"confirmation": "wrong"}, nil, nil); code != 422 {
 		t.Fatalf("reset with wrong confirmation = %d, want 422", code)
 	}
 
@@ -63,7 +63,7 @@ func TestResetDataOverHTTP(t *testing.T) {
 		Status        string `json:"status"`
 		TablesCleared int    `json:"tables_cleared"`
 	}
-	if code := e.Call(t, "POST", "/v1/admin/reset-data", apptest.AnyMap{"confirmation": "Fable E2E"}, nil, &out); code != 200 {
+	if code := e.Call(t, "POST", "/v1/admin/reset-data", AnyMap{"confirmation": "Fable E2E"}, nil, &out); code != 200 {
 		t.Fatalf("reset with the org name = %d, want 200", code)
 	}
 	if out.Status != "reset" {

--- a/backend/internal/compose/integration/dealroom_buyer_edge_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_buyer_edge_integration_test.go
@@ -40,16 +40,16 @@ func openRoomWithABuyer(t *testing.T, e *apptest.AppEnv) buyerRoom {
 	stages := apptest.DiscoverSeededPipeline(t, e)
 	dealID := apptest.CreateOpenDeal(t, e, stages)
 
-	var room apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms", apptest.AnyMap{
+	var room AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms", AnyMap{
 		"deal_id": dealID, "title": "Acme rollout", "welcome_message": "Welcome, Laura.", "source": "ui",
 	}, nil, &room); status != http.StatusCreated {
 		t.Fatalf("create room = %d %v", status, room)
 	}
 	roomID, _ := room["id"].(string)
 
-	var issued apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+roomID+"/participants", apptest.AnyMap{
+	var issued AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+roomID+"/participants", AnyMap{
 		"full_name": "Laura Buyer", "email": "laura@buyer.example", "capability": "comment", "source": "ui",
 	}, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("invite = %d %v", status, issued)
@@ -70,23 +70,23 @@ func TestABuyerEntersTheRoomReadsTheReleaseAndSpeaks(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
 
-	var peek apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/peek", apptest.AnyMap{"credential": room.credential}, nil, &peek); status != http.StatusOK || peek["exchangeable"] != true {
+	var peek AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/peek", AnyMap{"credential": room.credential}, nil, &peek); status != http.StatusOK || peek["exchangeable"] != true {
 		t.Fatalf("peek = %d %v, want 200 exchangeable", status, peek)
 	}
 
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d %v", status, session)
 	}
 	token, _ := session["session_token"].(string)
 
 	// One-time: the same credential a second time admits nobody.
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, nil); status != http.StatusNotFound {
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("second exchange = %d, want 404", status)
 	}
 
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), &me); status != http.StatusOK {
 		t.Fatalf("me = %d %v", status, me)
 	}
@@ -104,8 +104,8 @@ func TestABuyerEntersTheRoomReadsTheReleaseAndSpeaks(t *testing.T) {
 
 	// The room IS what the buyer reads: a rename reaches them on their next
 	// read, with no second act by the seller.
-	var patched apptest.AnyMap
-	if status := e.Call(t, "PATCH", "/v1/deal-rooms/"+room.roomID, apptest.AnyMap{"title": "Renamed live"}, nil, &patched); status != http.StatusOK {
+	var patched AnyMap
+	if status := e.Call(t, "PATCH", "/v1/deal-rooms/"+room.roomID, AnyMap{"title": "Renamed live"}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patch = %d %v", status, patched)
 	}
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), &me); status != http.StatusOK {
@@ -116,13 +116,13 @@ func TestABuyerEntersTheRoomReadsTheReleaseAndSpeaks(t *testing.T) {
 	}
 
 	// The buyer speaks: a room-level thread.
-	var opened apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{"body": "When does the pilot start?"}, bearer(token), &opened); status != http.StatusCreated {
+	var opened AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{"body": "When does the pilot start?"}, bearer(token), &opened); status != http.StatusCreated {
 		t.Fatalf("open thread = %d %v", status, opened)
 	}
 
 	// The seller reads the same thread, attributed to the buyer's side.
-	var sellerThreads apptest.AnyMap
+	var sellerThreads AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/threads", nil, nil, &sellerThreads); status != http.StatusOK {
 		t.Fatalf("seller threads = %d", status)
 	}
@@ -139,28 +139,28 @@ func TestABuyerEntersTheRoomReadsTheReleaseAndSpeaks(t *testing.T) {
 	}
 
 	// Pause: the session still resolves, content is withheld, the tick refuses.
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("pause = %d", status)
 	}
 	// A fresh map: decoding into the one above would keep its old "room" key.
-	var paused apptest.AnyMap
+	var paused AnyMap
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), &paused); status != http.StatusOK || paused["access"] != "paused" || paused["room"] != nil {
 		t.Fatalf("paused me = %d %v, want access paused and no room", status, paused)
 	}
-	var refused apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{"body": "still there?"}, bearer(token), &refused); status != http.StatusUnprocessableEntity || refused["code"] != "deal_room_paused" {
+	var refused AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{"body": "still there?"}, bearer(token), &refused); status != http.StatusUnprocessableEntity || refused["code"] != "deal_room_paused" {
 		t.Fatalf("comment while paused = %d %v, want 422 deal_room_paused", status, refused)
 	}
 
 	// Revoke: the next request is refused.
-	var roster apptest.AnyMap
+	var roster AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/participants", nil, nil, &roster); status != http.StatusOK {
 		t.Fatalf("roster = %d", status)
 	}
 	seats, _ := roster["data"].([]any)
 	seat, _ := seats[0].(map[string]any)
 	participantID, _ := seat["id"].(string)
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants/"+participantID+"/revoke", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants/"+participantID+"/revoke", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("revoke = %d", status)
 	}
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), nil); status != http.StatusUnauthorized {
@@ -175,27 +175,27 @@ func TestEveryDeadCredentialReadsAlikeAndARoomSessionHoldsNoCRMAuthority(t *test
 
 	// Pause BEFORE the exchange: a valid credential for a paused room still
 	// exchanges, so the anonymous edge cannot say whether a room is paused.
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("pause = %d", status)
 	}
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange into a paused room = %d, want 200", status)
 	}
 	token, _ := session["session_token"].(string)
 
 	// Unknown, consumed and a session token presented as a credential: one answer.
-	var shapes []apptest.AnyMap
+	var shapes []AnyMap
 	for _, dead := range []string{"mdr_unknown", room.credential, token} {
-		var body apptest.AnyMap
-		status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": dead}, nil, &body)
+		var body AnyMap
+		status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": dead}, nil, &body)
 		if status != http.StatusNotFound {
 			t.Fatalf("exchange %q = %d, want 404", dead, status)
 		}
 		delete(body, "instance")
 		shapes = append(shapes, body)
-		var peek apptest.AnyMap
-		if status := publicCall(t, e, "POST", "/v1/public/rooms/peek", apptest.AnyMap{"credential": dead}, nil, &peek); status != http.StatusOK || peek["exchangeable"] != false {
+		var peek AnyMap
+		if status := publicCall(t, e, "POST", "/v1/public/rooms/peek", AnyMap{"credential": dead}, nil, &peek); status != http.StatusOK || peek["exchangeable"] != false {
 			t.Fatalf("peek %q = %d %v, want 200 not exchangeable", dead, status, peek)
 		}
 	}
@@ -213,19 +213,19 @@ func TestEveryDeadCredentialReadsAlikeAndARoomSessionHoldsNoCRMAuthority(t *test
 	}
 
 	// A read-only participant reads the list but cannot work it.
-	var viewerIssued apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants", apptest.AnyMap{
+	var viewerIssued AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants", AnyMap{
 		"full_name": "Victor Viewer", "email": "victor@buyer.example", "capability": "view", "source": "ui",
 	}, nil, &viewerIssued); status != http.StatusCreated {
 		t.Fatalf("invite viewer = %d %v", status, viewerIssued)
 	}
-	var viewerSession apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": viewerIssued["credential"]}, nil, &viewerSession); status != http.StatusOK {
+	var viewerSession AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": viewerIssued["credential"]}, nil, &viewerSession); status != http.StatusOK {
 		t.Fatalf("viewer exchange = %d", status)
 	}
 	viewerToken, _ := viewerSession["session_token"].(string)
-	var viewerRefused apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{"body": "hello"}, bearer(viewerToken), &viewerRefused); status != http.StatusUnprocessableEntity || !strings.Contains(fmt.Sprint(viewerRefused["detail"]), "read-only") {
+	var viewerRefused AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{"body": "hello"}, bearer(viewerToken), &viewerRefused); status != http.StatusUnprocessableEntity || !strings.Contains(fmt.Sprint(viewerRefused["detail"]), "read-only") {
 		t.Fatalf("viewer comment = %d %v, want 422 view_only", status, viewerRefused)
 	}
 
@@ -253,7 +253,7 @@ func uploadDealFile(t *testing.T, e *apptest.AppEnv, dealID, filename string, da
 		t.Fatal(err)
 	}
 	defer apptest.CloseBody(t, resp)
-	var att apptest.AnyMap
+	var att AnyMap
 	if err := json.NewDecoder(resp.Body).Decode(&att); err != nil || resp.StatusCode != http.StatusCreated {
 		t.Fatalf("upload = %d (%v) %v", resp.StatusCode, err, att)
 	}
@@ -265,7 +265,7 @@ func TestABuyerReadsAndDownloadsOnlyWhatTheReleaseNames(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blobstore.NewMemory()))
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
 		t.Fatalf("room = %d", status)
 	}
@@ -274,27 +274,27 @@ func TestABuyerReadsAndDownloadsOnlyWhatTheReleaseNames(t *testing.T) {
 	// A file on the deal goes into the room under a fixed group; one on some
 	// other record is refused as absent.
 	attachmentID := uploadDealFile(t, e, dealID, "DPA_v7.pdf", []byte("%PDF-DPA"))
-	var doc apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	var doc AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "legal", "title": "Data processing agreement", "source": "ui",
 	}, nil, &doc); status != http.StatusCreated {
 		t.Fatalf("add document = %d %v", status, doc)
 	}
 	docID, _ := doc["id"].(string)
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "marketing", "source": "ui",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("unknown group = %d, want 422", status)
 	}
 
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d", status)
 	}
 	token, _ := session["session_token"].(string)
 
 	// A document added to the room is shared: no second act by the seller.
-	var after apptest.AnyMap
+	var after AnyMap
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents", nil, bearer(token), &after); status != http.StatusOK {
 		t.Fatalf("documents = %d", status)
 	}
@@ -335,7 +335,7 @@ func TestABuyerReadsAndDownloadsOnlyWhatTheReleaseNames(t *testing.T) {
 	if status := e.Call(t, "DELETE", "/v1/deal-rooms/"+room.roomID+"/documents/"+docID, nil, map[string]string{"If-Match": fmt.Sprint(doc["version"])}, nil); status != http.StatusOK {
 		t.Fatalf("remove = %d", status)
 	}
-	var gone apptest.AnyMap
+	var gone AnyMap
 	publicCall(t, e, "GET", "/v1/public/rooms/documents", nil, bearer(token), &gone)
 	if list, _ := gone["data"].([]any); len(list) != 0 {
 		t.Fatalf("a removed document still reaches the buyer: %v", list)
@@ -346,37 +346,37 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blobstore.NewMemory()))
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow)
 	dealID, _ := roomRow["deal_id"].(string)
 	attachmentID := uploadDealFile(t, e, dealID, "MSA_v2.pdf", []byte("%PDF-MSA"))
-	var doc apptest.AnyMap
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	var doc AnyMap
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
 	}, nil, &doc)
 	docID, _ := doc["id"].(string)
 
 	// Two buyers on the same room, both able to speak in it.
-	var session apptest.AnyMap
-	publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session)
+	var session AnyMap
+	publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session)
 	laura, _ := session["session_token"].(string)
-	var ritaIssued, ritaSession apptest.AnyMap
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants", apptest.AnyMap{
+	var ritaIssued, ritaSession AnyMap
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants", AnyMap{
 		"full_name": "Rita Buyer", "email": "rita@buyer.example", "capability": "comment", "source": "ui",
 	}, nil, &ritaIssued)
-	publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": ritaIssued["credential"]}, nil, &ritaSession)
+	publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": ritaIssued["credential"]}, nil, &ritaSession)
 	rita, _ := ritaSession["session_token"].(string)
 
 	// The seller asks on the document; the buyer answers; both names show.
-	var opened apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/threads", apptest.AnyMap{
+	var opened AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/threads", AnyMap{
 		"document_id": docID, "body": "Does clause 4 work for you?", "source": "ui",
 	}, nil, &opened); status != http.StatusCreated {
 		t.Fatalf("open thread = %d %v", status, opened)
 	}
 	threadID, _ := opened["id"].(string)
-	var replied apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads/"+threadID+"/comments", apptest.AnyMap{"body": "Thirty days would."}, bearer(laura), &replied); status != http.StatusCreated {
+	var replied AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads/"+threadID+"/comments", AnyMap{"body": "Thirty days would."}, bearer(laura), &replied); status != http.StatusCreated {
 		t.Fatalf("buyer reply = %d %v", status, replied)
 	}
 	comments, _ := replied["comments"].([]any)
@@ -390,8 +390,8 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 	}
 
 	// A required-change thread is still how a buyer says a document needs work.
-	var required apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{
+	var required AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{
 		"document_id": docID, "body": "Please shorten the cure period.", "required_change": true,
 	}, bearer(rita), &required); status != http.StatusCreated {
 		t.Fatalf("required-change thread = %d %v", status, required)
@@ -408,7 +408,7 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 		{"Laura", laura},
 	} {
 		status := publicCall(t, e, "POST", "/v1/public/rooms/documents/"+docID+"/decision",
-			apptest.AnyMap{"kind": "confirm_version"}, bearer(seat.token), nil)
+			AnyMap{"kind": "confirm_version"}, bearer(seat.token), nil)
 		if status != http.StatusNotFound {
 			t.Fatalf("%s deciding on a document = %d, want 404: the route is retired", seat.who, status)
 		}
@@ -419,7 +419,7 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 		t.Fatalf("resolve = %d", status)
 	}
 	// A resolved thread takes no more replies.
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads/"+requiredID+"/comments", apptest.AnyMap{"body": "one more"}, bearer(rita), nil); status != http.StatusUnprocessableEntity {
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads/"+requiredID+"/comments", AnyMap{"body": "one more"}, bearer(rita), nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("reply on resolved = %d, want 422", status)
 	}
 
@@ -433,12 +433,12 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 	// how a seller takes something back — and the conversation about it goes
 	// with it, rather than hanging in the buyer's list pointing at nothing.
 	withdrawn := uploadDealFile(t, e, dealID, "pricing_internal.xlsx", []byte("secret"))
-	var withdrawnDoc apptest.AnyMap
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{"attachment_id": withdrawn, "group_key": "commercial", "source": "ui"}, nil, &withdrawnDoc)
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/threads", apptest.AnyMap{"document_id": withdrawnDoc["id"], "body": "note on pricing", "source": "ui"}, nil, nil)
+	var withdrawnDoc AnyMap
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{"attachment_id": withdrawn, "group_key": "commercial", "source": "ui"}, nil, &withdrawnDoc)
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/threads", AnyMap{"document_id": withdrawnDoc["id"], "body": "note on pricing", "source": "ui"}, nil, nil)
 	e.Call(t, "DELETE", "/v1/deal-rooms/"+room.roomID+"/documents/"+withdrawnDoc["id"].(string), nil,
 		map[string]string{"If-Match": fmt.Sprint(withdrawnDoc["version"])}, nil)
-	var visible apptest.AnyMap
+	var visible AnyMap
 	publicCall(t, e, "GET", "/v1/public/rooms/threads", nil, bearer(laura), &visible)
 	for _, th := range visible["data"].([]any) {
 		if m, _ := th.(map[string]any); m["document_id"] == withdrawnDoc["id"] {
@@ -447,8 +447,8 @@ func TestTheConversationFlowsBothWaysAndADocumentIsNeverConfirmed(t *testing.T) 
 	}
 
 	// Paused: the conversation reads, but nobody on the buyer's side writes.
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", apptest.AnyMap{}, nil, nil)
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{"body": "hello?"}, bearer(laura), nil); status != http.StatusUnprocessableEntity {
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", AnyMap{}, nil, nil)
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{"body": "hello?"}, bearer(laura), nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("thread while paused = %d, want 422", status)
 	}
 }
@@ -464,22 +464,22 @@ func TestAThreadClosesToTheBuyerWhenItsDocumentLeavesTheRoom(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blobstore.NewMemory()))
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow)
 	dealID, _ := roomRow["deal_id"].(string)
 	attachmentID := uploadDealFile(t, e, dealID, "terms.pdf", []byte("%PDF-TERMS"))
-	var doc apptest.AnyMap
-	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	var doc AnyMap
+	e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
 	}, nil, &doc)
 	docID, _ := doc["id"].(string)
 
-	var session apptest.AnyMap
-	publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session)
+	var session AnyMap
+	publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session)
 	token, _ := session["session_token"].(string)
 
-	var thread apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{
+	var thread AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{
 		"document_id": docID, "body": "Is clause 4 negotiable?",
 	}, bearer(token), &thread); status != http.StatusCreated {
 		t.Fatalf("open thread = %d %v", status, thread)
@@ -493,7 +493,7 @@ func TestAThreadClosesToTheBuyerWhenItsDocumentLeavesTheRoom(t *testing.T) {
 	}
 
 	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads/"+threadID+"/comments",
-		apptest.AnyMap{"body": "still there?"}, bearer(token), nil); status != http.StatusNotFound {
+		AnyMap{"body": "still there?"}, bearer(token), nil); status != http.StatusNotFound {
 		t.Fatalf("reply after the document left = %d, want 404", status)
 	}
 }

--- a/backend/internal/compose/integration/dealroom_by_participant_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_by_participant_integration_test.go
@@ -21,7 +21,7 @@ func TestRoomsAreListedByTheAddressThatHoldsASeat(t *testing.T) {
 	room := openRoomWithABuyer(t, e)
 
 	byEmail := func(email string) int {
-		var page apptest.AnyMap
+		var page AnyMap
 		if status := e.Call(t, "GET", "/v1/deal-rooms?participant_email="+url.QueryEscape(email), nil, nil, &page); status != http.StatusOK {
 			t.Fatalf("list by %s = %d %v", email, status, page)
 		}
@@ -38,13 +38,13 @@ func TestRoomsAreListedByTheAddressThatHoldsASeat(t *testing.T) {
 		t.Fatalf("rooms for a stranger = %d, want 0", got)
 	}
 
-	var roster apptest.AnyMap
+	var roster AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/participants", nil, nil, &roster); status != http.StatusOK {
 		t.Fatalf("roster = %d", status)
 	}
 	seats, _ := roster["data"].([]any)
 	seat, _ := seats[0].(map[string]any)
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants/"+seat["id"].(string)+"/revoke", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants/"+seat["id"].(string)+"/revoke", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("revoke = %d", status)
 	}
 	if got := byEmail(room.email); got != 0 {

--- a/backend/internal/compose/integration/dealroom_files_area_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_files_area_integration_test.go
@@ -31,14 +31,14 @@ import (
 // mailbox pull takes, so the row carries exactly what capture stamps.
 func captureFileOnEmail(t *testing.T, e *apptest.AppEnv, blob blobstore.Store, dealID string) (activityID, attachmentID string) {
 	t.Helper()
-	var email apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	var email AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "subject": "Re: MSA", "direction": "inbound",
 	}, nil, &email); status != http.StatusCreated {
 		t.Fatalf("log email = %d %v", status, email)
 	}
 	activityID, _ = email["id"].(string)
-	if status := e.Call(t, "POST", "/v1/activities/"+activityID+"/relink", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+activityID+"/relink", AnyMap{
 		"entity_type": "deal", "entity_id": dealID,
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("link the email to the deal = %d", status)
@@ -86,7 +86,7 @@ func TestAnEmailedFileReachesTheBuyerThroughTheRoomUntilItIsHidden(t *testing.T)
 	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blob))
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
 		t.Fatalf("room = %d", status)
 	}
@@ -94,23 +94,23 @@ func TestAnEmailedFileReachesTheBuyerThroughTheRoomUntilItIsHidden(t *testing.T)
 	_, attachmentID := captureFileOnEmail(t, e, blob, dealID)
 
 	// The emailed file is in the deal's Files area, and so admissible to the room.
-	var area apptest.AnyMap
+	var area AnyMap
 	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/documents", nil, nil, &area); status != http.StatusOK {
 		t.Fatalf("deal files = %d %v", status, area)
 	}
 	if list, _ := area["data"].([]any); len(list) != 1 {
 		t.Fatalf("deal files = %v, want the emailed file", list)
 	}
-	var doc apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	var doc AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
 	}, nil, &doc); status != http.StatusCreated {
 		t.Fatalf("add emailed file to the room = %d %v", status, doc)
 	}
 	docID, _ := doc["id"].(string)
 
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d", status)
 	}
 	token, _ := session["session_token"].(string)
@@ -126,14 +126,14 @@ func TestAnEmailedFileReachesTheBuyerThroughTheRoomUntilItIsHidden(t *testing.T)
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents/"+docID+"/file", nil, bearer(token), nil); status != http.StatusNotFound {
 		t.Fatalf("download after hide = %d, want 404", status)
 	}
-	var sellerDocs apptest.AnyMap
+	var sellerDocs AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/documents", nil, nil, &sellerDocs); status != http.StatusOK {
 		t.Fatalf("seller documents = %d", status)
 	}
 	if list, _ := sellerDocs["data"].([]any); len(list) != 1 {
 		t.Fatalf("the seller's list dropped the hidden entry (%v); only the seller can remove it", list)
 	}
-	var buyerDocs apptest.AnyMap
+	var buyerDocs AnyMap
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents", nil, bearer(token), &buyerDocs); status != http.StatusOK {
 		t.Fatalf("buyer documents = %d", status)
 	}
@@ -147,7 +147,7 @@ func TestARepCannotShareATeammatesLimitedAudienceMailAttachment(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blob))
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
 		t.Fatalf("room = %d", status)
 	}
@@ -165,7 +165,7 @@ func TestARepCannotShareATeammatesLimitedAudienceMailAttachment(t *testing.T) {
 		`DELETE FROM activity_participant WHERE activity_id = $1`, activityID); err != nil {
 		t.Fatalf("take the rep off the mail: %v", err)
 	}
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", AnyMap{
 		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("sharing a teammate's limited-audience attachment = %d, want 404", status)

--- a/backend/internal/compose/integration/dealroom_preview_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_preview_integration_test.go
@@ -24,7 +24,7 @@ func TestASellerPreviewsTheRoomAsABuyerAndCanChangeNothing(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
 
-	var issued apptest.AnyMap
+	var issued AnyMap
 	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/preview", nil, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("preview = %d %v", status, issued)
 	}
@@ -34,7 +34,7 @@ func TestASellerPreviewsTheRoomAsABuyerAndCanChangeNothing(t *testing.T) {
 	}
 
 	// The roster never shows the preview seat.
-	var roster apptest.AnyMap
+	var roster AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/participants", nil, nil, &roster); status != http.StatusOK {
 		t.Fatalf("roster = %d", status)
 	}
@@ -44,12 +44,12 @@ func TestASellerPreviewsTheRoomAsABuyerAndCanChangeNothing(t *testing.T) {
 
 	// Through the public edge, exactly as a buyer: the release is served,
 	// the view says it is a preview, and a write is refused by name.
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d %v", status, session)
 	}
 	token, _ := session["session_token"].(string)
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), &me); status != http.StatusOK {
 		t.Fatalf("me = %d %v", status, me)
 	}
@@ -59,38 +59,38 @@ func TestASellerPreviewsTheRoomAsABuyerAndCanChangeNothing(t *testing.T) {
 	if content, _ := me["room"].(map[string]any); content["title"] != "Acme rollout" {
 		t.Fatalf("preview does not read the release: %v", me["room"])
 	}
-	var refused apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", apptest.AnyMap{"body": "hello"}, bearer(token), &refused); status != http.StatusUnprocessableEntity || !strings.Contains(fmt.Sprint(refused["details"]), "preview_session") {
+	var refused AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/threads", AnyMap{"body": "hello"}, bearer(token), &refused); status != http.StatusUnprocessableEntity || !strings.Contains(fmt.Sprint(refused["details"]), "preview_session") {
 		t.Fatalf("preview write = %d %v, want 422 naming preview_session", status, refused)
 	}
 
 	// The rep's own address never answers a public link request: the seat
 	// is not a buyer's, so nothing is mailed and nothing is stamped.
-	var seller apptest.AnyMap
+	var seller AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &seller); status != http.StatusOK {
 		t.Fatalf("me = %d", status)
 	}
 	user, _ := seller["user"].(map[string]any)
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/link-request", apptest.AnyMap{"email": user["email"]}, nil, nil); status != http.StatusAccepted {
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/link-request", AnyMap{"email": user["email"]}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("link request = %d, want the uniform 202", status)
 	}
 
 	// A second credential minted just before the pause: the pause retires it
 	// unopened, and ends the open preview — the buyer's own session survives.
-	var unopened apptest.AnyMap
+	var unopened AnyMap
 	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/preview", nil, nil, &unopened); status != http.StatusCreated {
 		t.Fatalf("preview before pause = %d %v", status, unopened)
 	}
-	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/pause", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("pause = %d", status)
 	}
 	if status := publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(token), nil); status != http.StatusUnauthorized {
 		t.Fatalf("preview after pause = %d, want 401", status)
 	}
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": unopened["credential"]}, nil, nil); status != http.StatusNotFound {
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": unopened["credential"]}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unopened preview credential after pause = %d, want 404", status)
 	}
-	var again apptest.AnyMap
+	var again AnyMap
 	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/preview", nil, nil, &again); status != http.StatusCreated {
 		t.Fatalf("second preview = %d %v, want a fresh credential for the same seat", status, again)
 	}
@@ -108,12 +108,12 @@ func TestASecondPreviewLeavesTheFirstTabWorking(t *testing.T) {
 	room := openRoomWithABuyer(t, e)
 
 	open := func(what string) string {
-		var issued apptest.AnyMap
+		var issued AnyMap
 		if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/preview", nil, nil, &issued); status != http.StatusCreated {
 			t.Fatalf("%s preview = %d %v", what, status, issued)
 		}
-		var session apptest.AnyMap
-		if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": issued["credential"]}, nil, &session); status != http.StatusOK {
+		var session AnyMap
+		if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": issued["credential"]}, nil, &session); status != http.StatusOK {
 			t.Fatalf("%s exchange = %d %v", what, status, session)
 		}
 		token, _ := session["session_token"].(string)
@@ -142,8 +142,8 @@ func TestAFreshRoomIsLiveAndCanBePreviewedAtOnce(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	stages := apptest.DiscoverSeededPipeline(t, e)
 	dealID := apptest.CreateOpenDeal(t, e, stages)
-	var room apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deal-rooms", apptest.AnyMap{
+	var room AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms", AnyMap{
 		"deal_id": dealID, "title": "Fresh", "welcome_message": "Welcome.", "source": "ui",
 	}, nil, &room); status != http.StatusCreated {
 		t.Fatalf("create room = %d %v", status, room)
@@ -152,17 +152,17 @@ func TestAFreshRoomIsLiveAndCanBePreviewedAtOnce(t *testing.T) {
 		t.Fatalf("a new room is %v, want live", room["state"])
 	}
 	roomID, _ := room["id"].(string)
-	var issued apptest.AnyMap
+	var issued AnyMap
 	if status := e.Call(t, "POST", "/v1/deal-rooms/"+roomID+"/preview", nil, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("preview of a fresh room = %d %v, want it issued", status, issued)
 	}
 	// And it shows the room, not an empty page.
 	credential, _ := issued["credential"].(string)
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": credential}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": credential}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d %v", status, session)
 	}
-	var me apptest.AnyMap
+	var me AnyMap
 	publicCall(t, e, "GET", "/v1/public/rooms/me", nil, bearer(session["session_token"].(string)), &me)
 	content, _ := me["room"].(map[string]any)
 	if content == nil || content["welcome_message"] != "Welcome." {
@@ -174,12 +174,12 @@ func TestADeactivatedSellersPreviewEndsWithTheirSeat(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var issued apptest.AnyMap
+	var issued AnyMap
 	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/preview", nil, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("preview = %d %v", status, issued)
 	}
-	var session apptest.AnyMap
-	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": issued["credential"]}, nil, &session); status != http.StatusOK {
+	var session AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", AnyMap{"credential": issued["credential"]}, nil, &session); status != http.StatusOK {
 		t.Fatalf("exchange = %d %v", status, session)
 	}
 	token, _ := session["session_token"].(string)
@@ -188,7 +188,7 @@ func TestADeactivatedSellersPreviewEndsWithTheirSeat(t *testing.T) {
 	}
 
 	// The seller's seat ends; the preview worn as a buyer ends with it.
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("me = %d", status)
 	}

--- a/backend/internal/compose/integration/dealstatus_integration_test.go
+++ b/backend/internal/compose/integration/dealstatus_integration_test.go
@@ -57,10 +57,10 @@ func TestTheDealStatusCardFollowsTheDealsOwnRecords(t *testing.T) {
 	}
 
 	// An unanswered inbound mail outranks the open task.
-	var mail apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	var mail AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "direction": "inbound", "subject": "Re: rollout", "body": "Can you send the DPA?",
-		"links":  []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links":  []AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 		"source": "ui",
 	}, nil, &mail); status != http.StatusCreated {
 		t.Fatalf("log mail = %d %v", status, mail)
@@ -82,10 +82,10 @@ func TestTheDealStatusCardFollowsTheDealsOwnRecords(t *testing.T) {
 
 	// Answering it takes the thread away again: the box goes back to offering
 	// a fresh mail, which is the whole behaviour the two labels describe.
-	var reply apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	var reply AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "direction": "outbound", "subject": "Re: rollout", "body": "DPA attached.",
-		"links":  []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links":  []AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 		"source": "ui",
 	}, nil, &reply); status != http.StatusCreated {
 		t.Fatalf("log the reply = %d %v", status, reply)
@@ -100,7 +100,7 @@ func TestTheDealStatusCardCitesItsRecordsAndHidesADealTheCallerCannotSee(t *test
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 	room := openRoomWithABuyer(t, e)
-	var roomRow apptest.AnyMap
+	var roomRow AnyMap
 	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
 		t.Fatalf("room = %d", status)
 	}
@@ -127,9 +127,9 @@ func TestTheDealStatusCardCitesItsRecordsAndHidesADealTheCallerCannotSee(t *test
 	}
 }
 
-func readStatus(t *testing.T, e *apptest.AppEnv, dealID string) apptest.AnyMap {
+func readStatus(t *testing.T, e *apptest.AppEnv, dealID string) AnyMap {
 	t.Helper()
-	var card apptest.AnyMap
+	var card AnyMap
 	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/status", nil, nil, &card); status != http.StatusOK {
 		t.Fatalf("status = %d %v", status, card)
 	}

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -64,7 +64,7 @@ func onlyRecord(t *testing.T, e *apptest.AppEnv, path, want, what string) {
 }
 
 // createdRecord posts one record and returns its id.
-func createdRecord(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
+func createdRecord(t *testing.T, e *apptest.AppEnv, path string, body AnyMap) string {
 	t.Helper()
 	var created struct {
 		ID string `json:"id"`
@@ -79,10 +79,10 @@ func TestThePersonListNarrowsByTagOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	tagged := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Tagged Person"})
-	createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Untagged Person"})
-	tag := createdRecord(t, e, "/v1/tags", apptest.AnyMap{"name": "VIP"})
-	if status := e.Call(t, "POST", "/v1/tags/"+tag+"/apply", apptest.AnyMap{
+	tagged := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Tagged Person"})
+	createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Untagged Person"})
+	tag := createdRecord(t, e, "/v1/tags", AnyMap{"name": "VIP"})
+	if status := e.Call(t, "POST", "/v1/tags/"+tag+"/apply", AnyMap{
 		"entity_type": "person", "entity_id": tagged,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("applying the tag = %d, want 201", status)
@@ -96,11 +96,11 @@ func TestTheOrganizationListNarrowsByDomainOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	held := createdRecord(t, e, "/v1/organizations", apptest.AnyMap{
-		"display_name": "Acme", "domains": []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
+	held := createdRecord(t, e, "/v1/organizations", AnyMap{
+		"display_name": "Acme", "domains": []AnyMap{{"domain": "acme.example", "is_primary": true}},
 	})
-	createdRecord(t, e, "/v1/organizations", apptest.AnyMap{
-		"display_name": "Other", "domains": []apptest.AnyMap{{"domain": "other.example", "is_primary": true}},
+	createdRecord(t, e, "/v1/organizations", AnyMap{
+		"display_name": "Other", "domains": []AnyMap{{"domain": "other.example", "is_primary": true}},
 	})
 
 	onlyRecord(t, e, "/v1/organizations?domain=acme.example", held, "the account that lists the domain")
@@ -119,11 +119,11 @@ func TestTheActivityListNarrowsByAssigneeOnTheWire(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("GET /v1/me = %d, want 200", status)
 	}
-	mine := createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+	mine := createdRecord(t, e, "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me.User.ID,
 	})
 	// An unassigned task is the row a dropped filter hands back alongside it.
-	createdRecord(t, e, "/v1/activities", apptest.AnyMap{"kind": "task", "subject": "Nobody's"})
+	createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
 
 	onlyRecord(t, e, "/v1/activities?assignee_id="+me.User.ID, mine, "the open task that person holds")
 }
@@ -132,7 +132,7 @@ func TestThePipelineListAnswersIncludeArchivedOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	retired := createdRecord(t, e, "/v1/pipelines", apptest.AnyMap{"name": "Retired"})
+	retired := createdRecord(t, e, "/v1/pipelines", AnyMap{"name": "Retired"})
 	// Aged through the database because no wire operation archives a pipeline.
 	// The parameter is about rows in this state, and the state is reachable in
 	// a deployment's data whether or not an endpoint mints it.
@@ -187,8 +187,8 @@ func TestThePersonListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	owner := callerUserID(t, e)
 
-	createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Owned Person", "owner_id": owner})
-	unowned := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Unowned Person"})
+	createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Owned Person", "owner_id": owner})
+	unowned := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Unowned Person"})
 	disownOverDB(t, e, "person", unowned)
 
 	// Unassigned is a fact with its own queue, not an absence: a list that
@@ -202,8 +202,8 @@ func TestTheLeadListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	owner := callerUserID(t, e)
 
-	createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
-	unowned := createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
+	createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
+	unowned := createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
 	disownOverDB(t, e, "lead", unowned)
 
 	// The same dial the person and company lists answer (DM-VOCAB-OWN-1): a
@@ -233,21 +233,21 @@ func TestTheActivityListNarrowsByProjectOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	org := createdRecord(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Acme"})
-	person := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Dana Buyer"})
+	org := createdRecord(t, e, "/v1/organizations", AnyMap{"display_name": "Acme"})
+	person := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Dana Buyer"})
 	project := func(name string) string {
-		return createdRecord(t, e, "/v1/projects", apptest.AnyMap{
+		return createdRecord(t, e, "/v1/projects", AnyMap{
 			"name": name, "organization_id": org, "source": "manual",
 		})
 	}
 	erp, migration := project("ERP rollout"), project("Datacentre migration")
 
 	mail := func(subject string, within string) string {
-		links := []apptest.AnyMap{{"entity_type": "person", "entity_id": person}}
+		links := []AnyMap{{"entity_type": "person", "entity_id": person}}
 		if within != "" {
-			links = append(links, apptest.AnyMap{"entity_type": "project", "entity_id": within})
+			links = append(links, AnyMap{"entity_type": "project", "entity_id": within})
 		}
-		return createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+		return createdRecord(t, e, "/v1/activities", AnyMap{
 			"kind": "email", "subject": subject, "direction": "inbound", "links": links,
 		})
 	}
@@ -280,11 +280,11 @@ func TestTheActivityListNarrowsByDateRangeOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	person := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Dana Buyer"})
+	person := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Dana Buyer"})
 	mail := func(subject, occurredAt string) string {
-		return createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+		return createdRecord(t, e, "/v1/activities", AnyMap{
 			"kind": "email", "subject": subject, "direction": "inbound", "occurred_at": occurredAt,
-			"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person}},
+			"links": []AnyMap{{"entity_type": "person", "entity_id": person}},
 		})
 	}
 	day1 := mail("Monday", "2026-03-02T10:00:00Z")
@@ -332,13 +332,13 @@ func TestThePerson360TimelineCursorContinuesIntoTheActivityList(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	person := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Dana Buyer"})
+	person := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Dana Buyer"})
 	const total = 27
 	for i := range total {
-		id := createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+		id := createdRecord(t, e, "/v1/activities", AnyMap{
 			"kind": "email", "subject": fmt.Sprintf("Mail %02d", i), "direction": "inbound",
 			"occurred_at": fmt.Sprintf("2026-03-%02dT10:00:00Z", i+1),
-			"links":       []apptest.AnyMap{{"entity_type": "person", "entity_id": person}},
+			"links":       []AnyMap{{"entity_type": "person", "entity_id": person}},
 		})
 		// The thread key is capture's to write, never the API's, so it is
 		// stamped the way capture leaves it.

--- a/backend/internal/compose/integration/dedupequeue_http_integration_test.go
+++ b/backend/internal/compose/integration/dedupequeue_http_integration_test.go
@@ -49,15 +49,15 @@ func seedOrgPairHTTP(t *testing.T, e *apptest.AppEnv, stem, incumbentDomain, dup
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": stem + " GmbH",
-		"domains":      []apptest.AnyMap{{"domain": incumbentDomain, "is_primary": true}},
+		"domains":      []AnyMap{{"domain": incumbentDomain, "is_primary": true}},
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("incumbent create → %d, want 201", status)
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": stem + " Inc",
-		"domains":      []apptest.AnyMap{{"domain": dupDomain, "is_primary": true}},
+		"domains":      []AnyMap{{"domain": dupDomain, "is_primary": true}},
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("fuzzy create must still 201, got %d", status)
 	}
@@ -97,18 +97,18 @@ func TestDedupeQueueOverHTTP(t *testing.T) {
 
 	// DH-EXT-2 refusals: an unknown verb and a merge without a winner.
 	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		apptest.AnyMap{"disposition": "merge"}, nil, nil); status != http.StatusUnprocessableEntity {
+		AnyMap{"disposition": "merge"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("merge without winner → %d, want 422", status)
 	}
 
 	// Dismiss, verify the flip, refuse the second decision, undo.
 	var decided dedupeCandidateDTO
 	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		apptest.AnyMap{"disposition": "not_a_duplicate"}, nil, &decided); status != http.StatusOK || decided.Status != "not_a_duplicate" {
+		AnyMap{"disposition": "not_a_duplicate"}, nil, &decided); status != http.StatusOK || decided.Status != "not_a_duplicate" {
 		t.Fatalf("dismiss → %d/%s, want 200/not_a_duplicate", status, decided.Status)
 	}
 	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		apptest.AnyMap{"disposition": "not_a_duplicate"}, nil, nil); status != http.StatusConflict {
+		AnyMap{"disposition": "not_a_duplicate"}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("second decision → %d, want 409", status)
 	}
 	var reopened dedupeCandidateDTO
@@ -119,7 +119,7 @@ func TestDedupeQueueOverHTTP(t *testing.T) {
 	// Merge: the winner survives, and a merged pair cannot be undone.
 	var merged dedupeCandidateDTO
 	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		apptest.AnyMap{"disposition": "merge", "winner_id": incumbentID}, nil, &merged); status != http.StatusOK || merged.Status != "merged" {
+		AnyMap{"disposition": "merge", "winner_id": incumbentID}, nil, &merged); status != http.StatusOK || merged.Status != "merged" {
 		t.Fatalf("merge → %d/%s, want 200/merged", status, merged.Status)
 	}
 	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/undo", nil, nil, nil); status != http.StatusConflict {

--- a/backend/internal/compose/integration/dsr_erasure_integration_test.go
+++ b/backend/internal/compose/integration/dsr_erasure_integration_test.go
@@ -14,8 +14,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestBootstrapSeedsDefaultRetentionPolicies(t *testing.T) {
@@ -60,12 +58,12 @@ func TestFulfillingAnErasureDSRExecutesTheErasure(t *testing.T) {
 	var dsr struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/data-subject-requests", AnyMap{
 		"kind": "erasure", "subject_ref": e.personID, "due_at": "2026-08-01T00:00:00Z",
 	}, nil, &dsr); status != http.StatusCreated {
 		t.Fatalf("create DSR → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, AnyMap{
 		"status": "fulfilled", "resolution": "erased per Art. 17",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("fulfill DSR → %d", status)

--- a/backend/internal/compose/integration/dsr_integration_test.go
+++ b/backend/internal/compose/integration/dsr_integration_test.go
@@ -13,8 +13,6 @@ import (
 	"net/http"
 	"testing"
 	"time"
-
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestDataSubjectRequestLifecycle(t *testing.T) {
@@ -25,30 +23,30 @@ func TestDataSubjectRequestLifecycle(t *testing.T) {
 		ID     string `json:"id"`
 		Status string `json:"status"`
 	}
-	if status := c.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/data-subject-requests", AnyMap{
 		"kind": "erasure", "subject_ref": c.personID, "due_at": due,
 	}, nil, &dsr); status != http.StatusCreated || dsr.Status != "open" {
 		t.Fatalf("create DSR → %d %+v", status, dsr)
 	}
 
 	// Closing without a resolution refuses.
-	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, AnyMap{
 		"status": "fulfilled",
 	}, nil, nil); status != 422 {
 		t.Fatalf("resolution-less close → %d, want 422", status)
 	}
-	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, AnyMap{
 		"status": "in_progress",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("start → %d", status)
 	}
-	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, AnyMap{
 		"status": "fulfilled", "resolution": "erased person + activities per retention policy",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("fulfill → %d", status)
 	}
 	// A closed request never reopens.
-	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, AnyMap{
 		"status": "open",
 	}, nil, nil); status != 422 {
 		t.Fatalf("reopen → %d, want 422", status)
@@ -67,13 +65,13 @@ func TestDataSubjectRequestLifecycle(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "dsr probe", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint passport → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
-	if status := c.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/data-subject-requests", AnyMap{
 		"kind": "access", "subject_ref": "x", "due_at": due,
 	}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent DSR create → %d, want 403 (human-only)", status)

--- a/backend/internal/compose/integration/e2e_agent_integration_test.go
+++ b/backend/internal/compose/integration/e2e_agent_integration_test.go
@@ -32,7 +32,7 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 		PassportID string `json:"passport_id"`
 		Token      string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "e2e agent", "scopes": []string{"read"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -83,7 +83,7 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Should not exist", "source": "mcp", "captured_by": "x",
 	}, bearer, &problem)
 	if status != 403 || problem.Code != "scope_exceeds_grantor" {
@@ -117,7 +117,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "write agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -130,7 +130,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 		ID         string `json:"id"`
 		CapturedBy string `json:"captured_by"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Governed Green Write", "source": "mcp", "captured_by": "human:forged",
 	}, bearer, &created); status != 201 {
 		t.Fatalf("write-scope 🟢 REST mutation → %d, want 201 (ADR-0055 admits governed agent writes)", status)
@@ -164,7 +164,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://example.test/hook", "event_types": []string{"organization.created"},
 	}, bearer, &problem)
 	if status != 403 || problem.Code != "approval_required" {
@@ -184,22 +184,22 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 	var denyBody struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
 		t.Fatalf("agent self-approval → %d %q, want 403 permission_denied", status, denyBody.Code)
 	}
 
 	// Human-only config surface rejects the agent whatever its scopes.
-	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{"name": "Shadow"}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
+	if status := e.Call(t, "POST", "/v1/pipelines", AnyMap{"name": "Shadow"}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
 		t.Fatalf("agent on human-only pipeline config → %d %q, want 403 permission_denied", status, denyBody.Code)
 	}
 
 	// A human approves; the agent repeats the IDENTICAL request with the
 	// approval token and the effect lands exactly once.
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + minted.Token, "X-Approval-Token": approvalID}
-	body := apptest.AnyMap{
+	body := AnyMap{
 		"target_url": "https://example.test/hook", "event_types": []string{"organization.created"},
 	}
 	// Past the gate is what the token buys. Where the create lands after that is
@@ -226,7 +226,7 @@ func TestEndToEnd_readSeatCannotMutate(t *testing.T) {
 	var created struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Full Seat Made", "source": "manual", "captured_by": "admin",
 	}, nil, &created); status != 201 {
 		t.Fatalf("full-seat create → %d", status)
@@ -244,12 +244,12 @@ func TestEndToEnd_readSeatCannotMutate(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Read Seat Blocked", "source": "manual", "captured_by": "admin",
 	}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
 		t.Fatalf("read-seat create → %d %q, want 403 seat_tier_insufficient", status, problem.Code)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "X"}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "X"}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
 		t.Fatalf("read-seat update → %d %q, want 403 seat_tier_insufficient", status, problem.Code)
 	}
 }

--- a/backend/internal/compose/integration/e2e_integration_test.go
+++ b/backend/internal/compose/integration/e2e_integration_test.go
@@ -24,11 +24,11 @@ import (
 // If-Match version skew, then the versioned update. Returns the person id.
 func exercisePersonWriteInvariants(t *testing.T, e *apptest.AppEnv, adminUserID string) string {
 	t.Helper()
-	var person apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Grace Hopper",
 		"source":    "ui",
-		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
+		"emails":    []AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
 	}, nil, &person)
 	if status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
@@ -38,28 +38,28 @@ func exercisePersonWriteInvariants(t *testing.T, e *apptest.AppEnv, adminUserID 
 		t.Errorf("captured_by = %v; the server must stamp the acting principal", person["captured_by"])
 	}
 
-	var dup apptest.AnyMap
-	status = e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var dup AnyMap
+	status = e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Grace Clone",
 		"source":    "ui",
-		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil"}},
+		"emails":    []AnyMap{{"email": "grace@navy.mil"}},
 	}, nil, &dup)
 	if status != http.StatusConflict {
 		t.Fatalf("duplicate email = %d, want 409", status)
 	}
-	if dup["details"].(apptest.AnyMap)["existing_id"] != personID {
+	if dup["details"].(AnyMap)["existing_id"] != personID {
 		t.Errorf("409 existing_id = %v, want %s", dup["details"], personID)
 	}
 
-	var conflict apptest.AnyMap
-	status = e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Rear Admiral"},
+	var conflict AnyMap
+	status = e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"title": "Rear Admiral"},
 		map[string]string{"If-Match": "42"}, &conflict)
 	if status != http.StatusConflict || conflict["code"] != "version_skew" {
 		t.Fatalf("stale If-Match = %d %v, want 409 version_skew", status, conflict)
 	}
 
-	var person2 apptest.AnyMap
-	status = e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Rear Admiral"},
+	var person2 AnyMap
+	status = e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"title": "Rear Admiral"},
 		map[string]string{"If-Match": "1"}, &person2)
 	if status != http.StatusOK || person2["version"].(float64) != 2 {
 		t.Fatalf("If-Match update = %d version %v, want 200 v2", status, person2["version"])
@@ -73,19 +73,19 @@ func exercisePersonWriteInvariants(t *testing.T, e *apptest.AppEnv, adminUserID 
 func exerciseActivityIdempotentCapture(t *testing.T, e *apptest.AppEnv, dealID string) {
 	t.Helper()
 	// --- activity: log against the deal, idempotent capture replay ---
-	var activity apptest.AnyMap
-	logReq := apptest.AnyMap{
+	var activity AnyMap
+	logReq := AnyMap{
 		"kind":          "email",
 		"subject":       "Signed!",
 		"source":        "email:msg-1",
 		"source_system": "gmail",
 		"source_id":     "msg-1",
-		"links":         []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links":         []AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 	}
 	if status := e.Call(t, "POST", "/v1/activities", logReq, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log activity = %d %v", status, activity)
 	}
-	var replay apptest.AnyMap
+	var replay AnyMap
 	if status := e.Call(t, "POST", "/v1/activities", logReq, nil, &replay); status != http.StatusOK {
 		t.Fatalf("capture replay = %d, want 200 (idempotent)", status)
 	}
@@ -99,23 +99,23 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	// The cookie authenticates /me.
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	if got := me["user"].(apptest.AnyMap)["email"]; got != "ada@example.com" {
+	if got := me["user"].(AnyMap)["email"]; got != "ada@example.com" {
 		t.Fatalf("/me email = %v", got)
 	}
 
 	stages := apptest.DiscoverSeededPipeline(t, e)
-	personID := exercisePersonWriteInvariants(t, e, me["user"].(apptest.AnyMap)["id"].(string))
+	personID := exercisePersonWriteInvariants(t, e, me["user"].(AnyMap)["id"].(string))
 	dealID := apptest.ExerciseDealToWon(t, e, stages)
 
 	exerciseActivityIdempotentCapture(t, e, dealID)
 
 	// --- lead: segregated, dedupes on email ---
-	var lead apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
+	var lead AnyMap
+	status := e.Call(t, "POST", "/v1/leads", AnyMap{
 		"full_name":    "Cold Prospect",
 		"email":        "cold@example.org",
 		"company_name": "Unknown AG",
@@ -124,7 +124,7 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 	if status != http.StatusCreated {
 		t.Fatalf("create lead = %d %v", status, lead)
 	}
-	status = e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
+	status = e.Call(t, "POST", "/v1/leads", AnyMap{
 		"email":  "cold@example.org",
 		"source": "import:batch-2",
 	}, nil, nil)
@@ -133,7 +133,7 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 	}
 
 	// --- archive cascades and stays fetchable by id ---
-	var person apptest.AnyMap
+	var person AnyMap
 	if status := e.Call(t, "DELETE", "/v1/people/"+personID, nil, nil, &person); status != http.StatusOK {
 		t.Fatalf("archive person = %d", status)
 	}
@@ -141,7 +141,7 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 		t.Error("archived person carries no archived_at")
 	}
 	var people struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/people", nil, nil, &people); status != http.StatusOK {
 		t.Fatalf("list people = %d", status)
@@ -154,8 +154,8 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 
 	// --- the governance audit view reflects the session's own trail ---
 	var audit struct {
-		Data []apptest.AnyMap `json:"data"`
-		Page apptest.AnyMap   `json:"page"`
+		Data []AnyMap `json:"data"`
+		Page AnyMap   `json:"page"`
 	}
 	if status := e.Call(t, "GET", "/v1/audit-log?entity_type=person&action=archive", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit log = %d", status)
@@ -176,8 +176,8 @@ func TestEndToEnd_authAndSurfaceBoundaries(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	// An unimplemented contract operation answers an explicit 501.
-	var problem apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/coldstart", apptest.AnyMap{"url": "https://example.com"}, nil, &problem); status != http.StatusNotImplemented {
+	var problem AnyMap
+	if status := e.Call(t, "POST", "/v1/coldstart", AnyMap{"url": "https://example.com"}, nil, &problem); status != http.StatusNotImplemented {
 		t.Fatalf("unimplemented op = %d %v, want 501", status, problem)
 	}
 
@@ -190,8 +190,8 @@ func TestEndToEnd_authAndSurfaceBoundaries(t *testing.T) {
 	}
 
 	// Login re-authenticates with fresh credentials.
-	var me apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	var me AnyMap
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email":    "ada@example.com",
 		"password": "correct-horse-battery",
 	}, nil, &me); status != http.StatusOK {
@@ -202,8 +202,8 @@ func TestEndToEnd_authAndSurfaceBoundaries(t *testing.T) {
 	}
 
 	// Wrong password is a 401 that does not say which half was wrong.
-	var authErr apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	var authErr AnyMap
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email":    "ada@example.com",
 		"password": "wrong",
 	}, nil, &authErr); status != http.StatusUnauthorized {
@@ -225,9 +225,9 @@ func TestAdvancingToLostWithoutAReasonIsRefused(t *testing.T) {
 	stages := apptest.DiscoverSeededPipeline(t, e)
 	dealID := apptest.CreateOpenDeal(t, e, stages)
 
-	var refusal apptest.AnyMap
+	var refusal AnyMap
 	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance",
-		apptest.AnyMap{"to_stage_id": stages.Lost}, nil, &refusal)
+		AnyMap{"to_stage_id": stages.Lost}, nil, &refusal)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("advance to lost with no reason = %d %v, want 422 — the deal_lost_reason CHECK must refuse it", status, refusal)
 	}

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -213,7 +213,7 @@ func embedPreview(t *testing.T, e *apptest.AppEnv) (int, embedReindexPreviewWire
 
 // embedConfirm issues the confirm call. body is nil for a bare confirm
 // (an empty request — decodeEmbedReindexStart's zero-value path) or an
-// apptest.AnyMap carrying previewed_identity/force; passed straight through as
+// AnyMap carrying previewed_identity/force; passed straight through as
 // `any` so a literal nil stays a true nil interface (never a boxed nil
 // map, which would marshal to the 4-byte literal "null" instead of an
 // empty body — harmless to the handler's own decode either way, but this
@@ -428,7 +428,7 @@ func TestEmbedReindexConfirmLifecycle(t *testing.T) {
 	// The released marker is claimable again: the run gave it back, rather
 	// than the confirm having to wait for a job row to age out of some
 	// uniqueness window.
-	if status, _, _ := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, _ := embedConfirm(t, e, AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("confirm after the run released -> %d, want 202", status)
 	}
 }
@@ -476,13 +476,13 @@ func TestEmbedReindexConfirmRefusesIdentityDrift(t *testing.T) {
 	wsID := apptest.InstallationWorkspaceID(context.Background(), t, e.Owner)
 	seedStaleEmbeddingRow(t, e, wsID)
 
-	status, _, problem := embedConfirm(t, e, apptest.AnyMap{"previewed_identity": "fake/someone-else@1024"})
+	status, _, problem := embedConfirm(t, e, AnyMap{"previewed_identity": "fake/someone-else@1024"})
 	if status != http.StatusConflict || problem.Code != "reindex_identity_drift" {
 		t.Fatalf("drifted confirm -> %d %+v, want 409 reindex_identity_drift", status, problem)
 	}
 
 	identity, _ := router.EmbedIdentity()
-	status, confirmed, _ := embedConfirm(t, e, apptest.AnyMap{"previewed_identity": identity})
+	status, confirmed, _ := embedConfirm(t, e, AnyMap{"previewed_identity": identity})
 	if status != http.StatusAccepted {
 		t.Fatalf("matching-identity confirm -> %d, want 202 (the drifted attempt must not have left a live claim)", status)
 	}
@@ -512,7 +512,7 @@ func TestEmbedReindexIdentityMismatchedJobCancels(t *testing.T) {
 	// force=true: this scenario is about the WORKER's own drift guard,
 	// not about whether the store happens to derive reindex-needed —
 	// force is the affordance that lets the enqueue happen regardless.
-	status, confirmed, _ := embedConfirm(t, e, apptest.AnyMap{"force": true})
+	status, confirmed, _ := embedConfirm(t, e, AnyMap{"force": true})
 	if status != http.StatusAccepted || confirmed.Status != "reembedding" {
 		t.Fatalf("confirm -> %d %+v, want 202/reembedding", status, confirmed)
 	}
@@ -548,7 +548,7 @@ func TestEmbedReindexIdentityMismatchedJobCancels(t *testing.T) {
 	if st.PopulatedIdentity != before {
 		t.Fatalf("populated_identity = %q, want it unmoved at %q — a cancelled run re-embedded nothing and must claim nothing", st.PopulatedIdentity, before)
 	}
-	if status, _, problem := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, problem := embedConfirm(t, e, AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("re-confirm after the drifted run cancelled -> %d %+v, want 202 — the marker is what the next run needs back", status, problem)
 	}
 }
@@ -577,7 +577,7 @@ func TestEmbedReindexForceReindexWhenNotNeeded(t *testing.T) {
 		t.Fatalf("bare confirm on a caught-up store -> %d %+v, want 409 reindex_not_needed", status, problem)
 	}
 
-	status, forced, _ := embedConfirm(t, e, apptest.AnyMap{"force": true})
+	status, forced, _ := embedConfirm(t, e, AnyMap{"force": true})
 	if status != http.StatusAccepted {
 		t.Fatalf("forced confirm -> %d, want 202 (force is the rebuild affordance)", status)
 	}

--- a/backend/internal/compose/integration/embedreindex_pass_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_pass_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose"
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/compose/integration/jobtest"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/search"
@@ -136,12 +135,12 @@ func TestEmbedReindexForceTakesTheMarkerBackFromAWedgedRun(t *testing.T) {
 	router := embedReindexRouter(t, "reindex-wedged-v1")
 	e := setupEmbedReindex(t, router)
 
-	if status, _, _ := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, _ := embedConfirm(t, e, AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("first confirm -> %d, want 202", status)
 	}
 	// A forced confirm while the run is genuinely moving must still be refused:
 	// the marker was claimed a moment ago, so nothing here is stale.
-	if status, _, problem := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusConflict || problem.Code != "reindex_running" {
+	if status, _, problem := embedConfirm(t, e, AnyMap{"force": true}); status != http.StatusConflict || problem.Code != "reindex_running" {
 		t.Fatalf("forced confirm over a live run -> %d %+v, want 409 reindex_running", status, problem)
 	}
 
@@ -156,7 +155,7 @@ func TestEmbedReindexForceTakesTheMarkerBackFromAWedgedRun(t *testing.T) {
 	if status, _, problem := embedConfirm(t, e, nil); status != http.StatusConflict || problem.Code != "reindex_running" {
 		t.Fatalf("bare confirm over a wedged marker -> %d %+v, want 409 — taking a run's marker away is something a human asks for", status, problem)
 	}
-	status, confirmed, problem := embedConfirm(t, e, apptest.AnyMap{"force": true})
+	status, confirmed, problem := embedConfirm(t, e, AnyMap{"force": true})
 	if status != http.StatusAccepted {
 		t.Fatalf("forced confirm over a wedged marker -> %d %+v, want 202 — an installation with no way back answers 409 forever", status, problem)
 	}

--- a/backend/internal/compose/integration/employment_dedupe_integration_test.go
+++ b/backend/internal/compose/integration/employment_dedupe_integration_test.go
@@ -17,14 +17,12 @@ package integration
 import (
 	"net/http"
 	"testing"
-
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
 // employment posts one edge and returns the status plus what the store made of
 // it — the created id, whether it landed primary, and the refusal detail when
 // it did not land at all.
-func (e *relEnv) employment(t *testing.T, orgID string, body apptest.AnyMap) (status int, id string, primary bool, detail string) {
+func (e *relEnv) employment(t *testing.T, orgID string, body AnyMap) (status int, id string, primary bool, detail string) {
 	t.Helper()
 	body["kind"] = "employment"
 	body["person_id"] = e.personID
@@ -45,7 +43,7 @@ func (e *relEnv) secondOrg(t *testing.T, name string) string {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": name}, nil, &org); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": name}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create %s → %d", name, status)
 	}
 	return org.ID
@@ -54,14 +52,14 @@ func (e *relEnv) secondOrg(t *testing.T, name string) string {
 func TestASecondCurrentEmploymentAtTheSameCompanyIsRefused(t *testing.T) {
 	e := setupRelationships(t)
 
-	status, first, _, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, first, _, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated {
 		t.Fatalf("first employment → %d", status)
 	}
 
 	// The same pair again. Before uq_rel_employment both rows landed, and the
 	// account then counted the person twice.
-	status, _, _, detail := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, _, _, detail := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusConflict {
 		t.Fatalf("duplicate employment → %d, want 409", status)
 	}
@@ -72,7 +70,7 @@ func TestASecondCurrentEmploymentAtTheSameCompanyIsRefused(t *testing.T) {
 
 	// The role is not part of the key: the same person cannot hold the same job
 	// twice under two titles either.
-	if status, _, _, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "ceo"}); status != http.StatusConflict {
+	if status, _, _, _ := e.employment(t, e.orgID, AnyMap{"role": "ceo"}); status != http.StatusConflict {
 		t.Errorf("duplicate under a different role → %d, want 409", status)
 	}
 
@@ -83,13 +81,13 @@ func TestASecondCurrentEmploymentAtTheSameCompanyIsRefused(t *testing.T) {
 		IsCurrentPrimary bool `json:"is_current_primary"`
 	}
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+first,
-		apptest.AnyMap{"ended_at": "2026-01-31"}, nil, &ended); status != http.StatusOK {
+		AnyMap{"ended_at": "2026-01-31"}, nil, &ended); status != http.StatusOK {
 		t.Fatalf("ending the first employment → %d", status)
 	}
 	if ended.IsCurrentPrimary {
 		t.Error("a job the person has left is still flagged as their CURRENT primary employer")
 	}
-	status, _, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, _, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated {
 		t.Errorf("re-employment after leaving → %d, want 201: a former employer may hire someone back", status)
 	}
@@ -104,7 +102,7 @@ func TestASecondCurrentEmploymentAtTheSameCompanyIsRefused(t *testing.T) {
 func TestAnEndedEmploymentCannotBeMadeTheCurrentPrimaryOne(t *testing.T) {
 	e := setupRelationships(t)
 
-	status, edge, _, _ := e.employment(t, e.orgID, apptest.AnyMap{
+	status, edge, _, _ := e.employment(t, e.orgID, AnyMap{
 		"started_at": "2019-01-01", "ended_at": "2021-06-30",
 	})
 	if status != http.StatusCreated {
@@ -114,7 +112,7 @@ func TestAnEndedEmploymentCannotBeMadeTheCurrentPrimaryOne(t *testing.T) {
 		IsCurrentPrimary bool `json:"is_current_primary"`
 	}
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
-		apptest.AnyMap{"is_current_primary": true}, nil, &patched); status != http.StatusOK {
+		AnyMap{"is_current_primary": true}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patching the flag onto an ended employment → %d", status)
 	}
 	if patched.IsCurrentPrimary {
@@ -128,7 +126,7 @@ func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
 	// Nobody asked for primary. is_current_primary defaults to false, so before
 	// this rule the person ended up employed by exactly one company and having
 	// no primary employer — a state every reader of the column has to guess at.
-	status, _, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, _, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated {
 		t.Fatalf("first employment → %d", status)
 	}
@@ -139,7 +137,7 @@ func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
 	// A SECOND concurrent job is not promoted. Which of two employers is the
 	// primary one is a fact about the person that the second insert does not
 	// carry, and guessing it would overwrite the answer the first one gave.
-	if status, _, primary, _ := e.employment(t, e.secondOrg(t, "Moonlight Ltd"), apptest.AnyMap{}); status != http.StatusCreated || primary {
+	if status, _, primary, _ := e.employment(t, e.secondOrg(t, "Moonlight Ltd"), AnyMap{}); status != http.StatusCreated || primary {
 		t.Errorf("second concurrent employment → %d primary=%t, want 201 and not primary", status, primary)
 	}
 }
@@ -150,7 +148,7 @@ func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
 func TestAnExplicitlyUnsetPrimaryFlagIsHonouredOnTheOnlyEmployment(t *testing.T) {
 	e := setupRelationships(t)
 
-	status, first, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{
+	status, first, primary, _ := e.employment(t, e.orgID, AnyMap{
 		"role": "cto", "is_current_primary": false,
 	})
 	if status != http.StatusCreated {
@@ -162,7 +160,7 @@ func TestAnExplicitlyUnsetPrimaryFlagIsHonouredOnTheOnlyEmployment(t *testing.T)
 
 	// The choice sticks. Nothing later re-derives it, so the person keeps the
 	// employer they recorded and no primary flag until somebody says otherwise.
-	if status := e.Call(t, "PATCH", "/v1/relationships/"+first, apptest.AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+first, AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("patching an unrelated field → %d", status)
 	}
 	if e.isPrimary(t, first) {
@@ -198,7 +196,7 @@ func TestANoticePeriodDoesNotEndSomebodysEmployment(t *testing.T) {
 	// notice period rather than a re-statement of what the row already said. A row
 	// that starts with the future date and is then patched to the same value never
 	// crosses the boundary this test is about.
-	status, edge, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, edge, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated {
 		t.Fatalf("employment → %d", status)
 	}
@@ -211,7 +209,7 @@ func TestANoticePeriodDoesNotEndSomebodysEmployment(t *testing.T) {
 		IsCurrentPrimary bool `json:"is_current_primary"`
 	}
 	if got := e.Call(t, "PATCH", "/v1/relationships/"+edge,
-		apptest.AnyMap{"ended_at": future}, nil, &noticed); got != http.StatusOK {
+		AnyMap{"ended_at": future}, nil, &noticed); got != http.StatusOK {
 		t.Fatalf("recording the notice → %d", got)
 	}
 	if !noticed.IsCurrentPrimary {
@@ -220,7 +218,7 @@ func TestANoticePeriodDoesNotEndSomebodysEmployment(t *testing.T) {
 
 	// And a fresh employment created ALREADY in notice keeps it too, which is the
 	// other door onto the same rule.
-	if status, _, alreadyNoticed, _ := e.employment(t, e.secondOrg(t, "Backfilled GmbH"), apptest.AnyMap{
+	if status, _, alreadyNoticed, _ := e.employment(t, e.secondOrg(t, "Backfilled GmbH"), AnyMap{
 		"ended_at": future,
 	}); status != http.StatusCreated || alreadyNoticed {
 		// Not primary: this person already holds a current employment, so the
@@ -242,12 +240,12 @@ func TestANoticePeriodDoesNotEndSomebodysEmployment(t *testing.T) {
 func TestMakingANoticePeriodEmploymentThePrimaryOneReplacesTheIncumbent(t *testing.T) {
 	e := setupRelationships(t)
 
-	status, incumbent, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, incumbent, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated || !primary {
 		t.Fatalf("the job they hold → %d primary=%t", status, primary)
 	}
 	// A second job, ending in ninety days, not primary yet.
-	status, notice, _, _ := e.employment(t, e.secondOrg(t, "Leaving Soon GmbH"), apptest.AnyMap{
+	status, notice, _, _ := e.employment(t, e.secondOrg(t, "Leaving Soon GmbH"), AnyMap{
 		"ended_at": e.dbDate(t, 90),
 	})
 	if status != http.StatusCreated {
@@ -260,7 +258,7 @@ func TestMakingANoticePeriodEmploymentThePrimaryOneReplacesTheIncumbent(t *testi
 		IsCurrentPrimary bool `json:"is_current_primary"`
 	}
 	if got := e.Call(t, "PATCH", "/v1/relationships/"+notice,
-		apptest.AnyMap{"is_current_primary": true}, nil, &patched); got != http.StatusOK {
+		AnyMap{"is_current_primary": true}, nil, &patched); got != http.StatusOK {
 		t.Fatalf("promoting the notice-period employment → %d, want 200 (a 409 here is the two-primaries bug)", got)
 	}
 	if !patched.IsCurrentPrimary {
@@ -283,7 +281,7 @@ func TestAnEmploymentPastItsLastDayStopsCountingAtTheAccount(t *testing.T) {
 	e := setupRelationships(t)
 
 	// Written as a notice period, so the flag is legitimately TRUE on the row.
-	status, edge, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{
+	status, edge, primary, _ := e.employment(t, e.orgID, AnyMap{
 		"ended_at": e.dbDate(t, 30),
 	})
 	if status != http.StatusCreated || !primary {
@@ -369,7 +367,7 @@ func TestTheBoundaryBetweenNoticeAndDepartureIsTodayItself(t *testing.T) {
 	} {
 		t.Run(day.name, func(t *testing.T) {
 			env := setupRelationships(t)
-			status, _, primary, _ := env.employment(t, env.orgID, apptest.AnyMap{
+			status, _, primary, _ := env.employment(t, env.orgID, AnyMap{
 				"ended_at": env.dbDate(t, day.offset),
 			})
 			if status != http.StatusCreated {
@@ -388,7 +386,7 @@ func TestTheBoundaryBetweenNoticeAndDepartureIsTodayItself(t *testing.T) {
 func TestAnAlreadyEndedEmploymentIsNeverPromoted(t *testing.T) {
 	e := setupRelationships(t)
 
-	status, current, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	status, current, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
 	if status != http.StatusCreated || !primary {
 		t.Fatalf("the job they actually hold → %d primary=%t, want 201 and primary", status, primary)
 	}
@@ -396,7 +394,7 @@ func TestAnAlreadyEndedEmploymentIsNeverPromoted(t *testing.T) {
 	// Backfilled WITH the flag asked for. The row does not take it, and the
 	// demotion that would have cleared the incumbent never runs — so the
 	// employer they actually have keeps the flag instead of the job they left.
-	status, _, primary, _ = e.employment(t, e.secondOrg(t, "Former Employer GmbH"), apptest.AnyMap{
+	status, _, primary, _ = e.employment(t, e.secondOrg(t, "Former Employer GmbH"), AnyMap{
 		"started_at": "2019-01-01", "ended_at": "2021-06-30", "is_current_primary": true,
 	})
 	if status != http.StatusCreated {

--- a/backend/internal/compose/integration/extractionaccept_http_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_http_integration_test.go
@@ -27,7 +27,7 @@ import (
 
 // uploadAttachmentHTTP drives the real multipart upload endpoint (e.Call
 // only speaks JSON) and returns the new attachment's id.
-func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID, filename string) string {
+func uploadAttachmentHTTP(t *testing.T, e *apptest.AppEnv, entityType, entityID, filename string) string {
 	t.Helper()
 	body, ctype := multipartAttachment(t, entityType, entityID, filename, []byte("attachment bytes"))
 	req, err := http.NewRequest(http.MethodPost, e.TS.URL+"/v1/attachments", body)
@@ -80,10 +80,10 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *apptest.AppEnv, attID, dealID, r
 			Provenance string `json:"provenance"`
 		} `json:"accepted"`
 	}
-	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", AnyMap{
 		"extraction_id": readingID,
 		"field_keys":    []string{"amount_minor", "currency"},
-		"edits":         apptest.AnyMap{"amount_minor": "200000"},
+		"edits":         AnyMap{"amount_minor": "200000"},
 	}, nil, &resp)
 	if status != http.StatusOK {
 		t.Fatalf("accept = %d %+v", status, resp)
@@ -97,7 +97,7 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *apptest.AppEnv, attID, dealID, r
 		t.Errorf("accepted = %+v, want the edited amount as human and the extracted currency as ai-extracted", resp.Accepted)
 	}
 
-	var got apptest.AnyMap
+	var got AnyMap
 	if status := e.Call(t, "GET", "/v1/deals/"+dealID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("read back deal = %d", status)
 	}
@@ -110,19 +110,19 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *apptest.AppEnv, attID, dealID, r
 // the typed unsupported_entity_type refusal.
 func assertAcceptHTTPNonDeal422(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Attachment Holder", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
 	}
-	personAtt := uploadAttachmentHTTP(e, t, "person", person["id"].(string), "cv.pdf")
+	personAtt := uploadAttachmentHTTP(t, e, "person", person["id"].(string), "cv.pdf")
 
 	// The entity-type refusal fires before the accept resolves a reading, so a
 	// person-scoped attachment needs none — and naming one it could not have is
 	// what proves the order.
 	var problem acceptProblemWire
-	status := e.Call(t, "POST", "/v1/attachments/"+personAtt+"/extraction:accept", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+personAtt+"/extraction:accept", AnyMap{
 		"extraction_id": ids.NewV7().String(), "field_keys": []string{"amount_minor"},
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "unsupported_entity_type" {
@@ -137,7 +137,7 @@ func assertAcceptHTTPValidation422(
 ) {
 	t.Helper()
 	var problem acceptProblemWire
-	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", AnyMap{
 		"extraction_id": readingID, "field_keys": fieldKeys,
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
@@ -153,15 +153,15 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	stages := apptest.DiscoverSeededPipeline(t, e)
 
-	var deal apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	var deal AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "HTTP Accept Deal", "pipeline_id": stages.PipelineID,
 		"stage_id": stages.Open, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal = %d %v", status, deal)
 	}
 	dealID := deal["id"].(string)
-	attID := uploadAttachmentHTTP(e, t, "deal", dealID, "quote.pdf")
+	attID := uploadAttachmentHTTP(t, e, "deal", dealID, "quote.pdf")
 	readingID := seedExtractionReadingHTTP(e, t, attID, []extraction.ExtractedField{
 		{Field: "amount_minor", Value: "150000", SourceQuote: "Total: EUR 1,500.00", PageOrSection: "p.2", Confidence: "high"},
 		{Field: "currency", Value: "EUR", SourceQuote: "all amounts in EUR", PageOrSection: "p.2", Confidence: "medium"},
@@ -180,7 +180,7 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 		assertAcceptHTTPValidation422(t, e, attID, readingID, []string{"probability"}, "field_keys[0]", "not_grounded")
 	})
 	t.Run("404 for a missing attachment", func(t *testing.T) {
-		status := e.Call(t, "POST", "/v1/attachments/"+ids.NewV7().String()+"/extraction:accept", apptest.AnyMap{
+		status := e.Call(t, "POST", "/v1/attachments/"+ids.NewV7().String()+"/extraction:accept", AnyMap{
 			"extraction_id": readingID, "field_keys": []string{"amount_minor"},
 		}, nil, nil)
 		if status != http.StatusNotFound {
@@ -188,7 +188,7 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 		}
 	})
 	t.Run("404 for a reading this document never had", func(t *testing.T) {
-		status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
+		status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", AnyMap{
 			"extraction_id": ids.NewV7().String(), "field_keys": []string{"amount_minor"},
 		}, nil, nil)
 		if status != http.StatusNotFound {

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -152,8 +152,8 @@ type fieldHistoryHTTPFixture struct {
 // diff rows the happy-path subtest below asserts on.
 func seedFieldHistoryHTTPFixture(t *testing.T, e *apptest.AppEnv, dbEnv *Env) fieldHistoryHTTPFixture {
 	t.Helper()
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "History Wire Subject",
 		"source":    "ui",
 	}, nil, &person); status != http.StatusCreated {

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -268,7 +268,7 @@ func lastSystemLog(t *testing.T, e *SearchEnv, action string) (gotAction string,
 func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ada@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("login → %d", status)
@@ -276,9 +276,9 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 
 	// A valid filter with no matching rows still returns a CSV (header row):
 	// the endpoint is wired and the open format is honest on an empty slice.
-	body, err := json.Marshal(apptest.AnyMap{
+	body, err := json.Marshal(AnyMap{
 		"object": "deal",
-		"filter": apptest.AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"},
+		"filter": AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"},
 		"format": "csv",
 	})
 	if err != nil {
@@ -316,9 +316,9 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/exports", AnyMap{
 		"object": "deal",
-		"filter": apptest.AnyMap{"field": "amount_minor", "op": "eq", "value": 1},
+		"filter": AnyMap{"field": "amount_minor", "op": "eq", "value": 1},
 		"format": "csv",
 	}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("out-of-vocabulary filter → %d, want 422", status)
@@ -339,20 +339,20 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ada@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("login → %d", status)
 	}
 
-	commitFilter := apptest.AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"}
+	commitFilter := AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"}
 
 	var view struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/views", AnyMap{
 		"resource": "deals", "name": "Commit deals",
-		"query": apptest.AnyMap{"filter": commitFilter},
+		"query": AnyMap{"filter": commitFilter},
 	}, nil, &view); status != http.StatusCreated {
 		t.Fatalf("create saved view → %d, want 201", status)
 	}
@@ -360,7 +360,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	var dynamic struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists", AnyMap{
 		"name": "Commit segment", "entity_type": "deal", "list_type": "dynamic",
 		"definition": commitFilter,
 	}, nil, &dynamic); status != http.StatusCreated {
@@ -370,7 +370,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	var static struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/lists", AnyMap{
 		"name": "Hand-picked deals", "entity_type": "deal", "list_type": "static",
 	}, nil, &static); status != http.StatusCreated {
 		t.Fatalf("create static list → %d, want 201", status)
@@ -379,9 +379,9 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	var viewless struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/views", AnyMap{
 		"resource": "deals", "name": "Columns only",
-		"query": apptest.AnyMap{"columns": []string{"name"}},
+		"query": AnyMap{"columns": []string{"name"}},
 	}, nil, &viewless); status != http.StatusCreated {
 		t.Fatalf("create filterless view → %d, want 201", status)
 	}
@@ -392,9 +392,9 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	var cleared struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/views", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/views", AnyMap{
 		"resource": "deals", "name": "Cleared filter",
-		"query": apptest.AnyMap{"columns": []string{"name"}, "filter": nil},
+		"query": AnyMap{"columns": []string{"name"}, "filter": nil},
 	}, nil, &cleared); status != http.StatusCreated {
 		t.Fatalf("create view with a null filter → %d, want 201 — the write surface reads null as cleared", status)
 	}
@@ -404,10 +404,10 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	// which is what "one engine" has to mean here.
 	for _, c := range []struct {
 		name string
-		body apptest.AnyMap
+		body AnyMap
 	}{
-		{"by view_id", apptest.AnyMap{"view_id": view.ID, "format": "csv"}},
-		{"by list_id", apptest.AnyMap{"list_id": dynamic.ID, "format": "csv"}},
+		{"by view_id", AnyMap{"view_id": view.ID, "format": "csv"}},
+		{"by list_id", AnyMap{"list_id": dynamic.ID, "format": "csv"}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			rows := exportCSV(t, e, c.body)
@@ -420,13 +420,13 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 	// The refusals, each naming the field the caller actually sent.
 	for _, c := range []struct {
 		name  string
-		body  apptest.AnyMap
+		body  AnyMap
 		field string
 	}{
-		{"a static list has members, not a filter", apptest.AnyMap{"list_id": static.ID, "format": "csv"}, "list_id"},
-		{"a view carrying no filter state", apptest.AnyMap{"view_id": viewless.ID, "format": "csv"}, "view_id"},
-		{"a view whose filter is explicitly null", apptest.AnyMap{"view_id": cleared.ID, "format": "csv"}, "view_id"},
-		{"a view_id that is not a uuid", apptest.AnyMap{"view_id": "not-a-uuid", "format": "csv"}, "view_id"},
+		{"a static list has members, not a filter", AnyMap{"list_id": static.ID, "format": "csv"}, "list_id"},
+		{"a view carrying no filter state", AnyMap{"view_id": viewless.ID, "format": "csv"}, "view_id"},
+		{"a view whose filter is explicitly null", AnyMap{"view_id": cleared.ID, "format": "csv"}, "view_id"},
+		{"a view_id that is not a uuid", AnyMap{"view_id": "not-a-uuid", "format": "csv"}, "view_id"},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			// The per-field breakdown rides `details.errors` (httperr's
@@ -450,7 +450,7 @@ func TestFilteredExportFromASavedViewAndFromAList(t *testing.T) {
 
 // exportCSV posts an export and parses the CSV body, failing the test on any
 // non-200 or unparseable response.
-func exportCSV(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) [][]string {
+func exportCSV(t *testing.T, e *apptest.AppEnv, body AnyMap) [][]string {
 	t.Helper()
 	raw, err := json.Marshal(body)
 	if err != nil {

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
@@ -195,7 +194,7 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 		ID string `json:"id"`
 	}
 	// Sharing with a random subject refuses (the subject must exist).
-	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/record-grants", AnyMap{
 		"record_type": "person", "record_id": e.personID,
 		"subject_type": "user", "subject_id": "00000000-0000-7000-8000-00000000dead",
 		"access": "read",
@@ -203,7 +202,7 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 		t.Fatalf("grant to missing subject → %d, want 404", status)
 	}
 	subject := meUserID(t, e)
-	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/record-grants", AnyMap{
 		"record_type": "person", "record_id": e.personID,
 		"subject_type": "user", "subject_id": subject,
 		"access": "write", "reason": "deal desk assist",
@@ -245,7 +244,7 @@ func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
 	e := setupRelationships(t)
 	subject := meUserID(t, e)
 
-	assert := func(body apptest.AnyMap) (int, grantBody) {
+	assert := func(body AnyMap) (int, grantBody) {
 		var got grantBody
 		body["record_type"], body["record_id"] = "person", e.personID
 		body["subject_type"], body["subject_id"] = "user", subject
@@ -253,7 +252,7 @@ func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
 	}
 
 	expiry := time.Now().Add(72 * time.Hour).UTC().Truncate(time.Second)
-	status, first := assert(apptest.AnyMap{
+	status, first := assert(AnyMap{
 		"access": "read", "reason": "quarter review", "expires_at": expiry.Format(time.RFC3339),
 	})
 	if status != http.StatusCreated {
@@ -267,7 +266,7 @@ func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
 	// An upgrade: same tuple, wider access, no expiry and no reason. Every
 	// field the contract names moves, and `expires_at` moving to NULL is the
 	// half a COALESCE-shaped upsert would silently refuse to do.
-	status, second := assert(apptest.AnyMap{"access": "write"})
+	status, second := assert(AnyMap{"access": "write"})
 	if status != http.StatusCreated {
 		t.Fatalf("re-assert → %d, want 201 (the contract declares no 409 for this operation)", status)
 	}
@@ -289,7 +288,7 @@ func TestReAssertingAGrantUpdatesTheSameRow(t *testing.T) {
 	}
 
 	// And back down again: the contract says upgrades AND downgrades.
-	if status, third := assert(apptest.AnyMap{"access": "read"}); status != http.StatusCreated || third.Access != "read" {
+	if status, third := assert(AnyMap{"access": "read"}); status != http.StatusCreated || third.Access != "read" {
 		t.Fatalf("downgrade → %d %q, want 201 read", status, third.Access)
 	}
 
@@ -313,7 +312,7 @@ func TestReAssertingAGrantAuditsWhatItDisplaced(t *testing.T) {
 	subject := meUserID(t, e)
 	share := func(access string) {
 		t.Helper()
-		if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/record-grants", AnyMap{
 			"record_type": "person", "record_id": e.personID,
 			"subject_type": "user", "subject_id": subject, "access": access,
 		}, nil, nil); status != http.StatusCreated {

--- a/backend/internal/compose/integration/growthfit_e2e_integration_test.go
+++ b/backend/internal/compose/integration/growthfit_e2e_integration_test.go
@@ -169,7 +169,7 @@ func createBareOrganization(t *testing.T, e *apptest.AppEnv) string {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": "Voltaq Systems GmbH", "source": "ui",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization = %d, want 201", status)

--- a/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
@@ -55,7 +55,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Acme renewal", "pipeline_id": pipelineID, "stage_id": stageID,
 		"amount_minor": 25000000, "currency": "EUR",
 		"expected_close_date": "2026-12-31", "source": "manual",
@@ -66,7 +66,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "create-time precedence agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -82,7 +82,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/deals/"+deal.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/deals/"+deal.ID, AnyMap{
 		"amount_minor": 100, "expected_close_date": "2027-06-30",
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent money patch → %d %q, want 403 approval_required — the human typed those values at create",
@@ -140,7 +140,7 @@ func TestAgentStillFillsAnEmptyFieldWithoutApproval(t *testing.T) {
 			ApprovalID string `json:"approval_id"`
 		} `json:"staged_approval"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Founder"}, bearer, &patched); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"title": "Founder"}, bearer, &patched); status != http.StatusOK {
 		t.Fatalf("agent fills an empty field → %d", status)
 	}
 	if patched.StagedApproval != nil && patched.StagedApproval.ApprovalID != "" {

--- a/backend/internal/compose/integration/humanprecedence_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_integration_test.go
@@ -37,14 +37,14 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Greta Human"}, nil, &person); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Greta Human"}, nil, &person); status != 201 {
 		t.Fatalf("human create → %d", status)
 	}
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "precedence agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -53,12 +53,12 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 
 	// A field no human ever wrote updates 🟢 — the reversible-and-logged
 	// path stays open.
-	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"title": "CTO"}, bearer, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, AnyMap{"title": "CTO"}, bearer, nil); status != 200 {
 		t.Fatalf("agent patch of a never-human field → %d, want 200 (🟢)", status)
 	}
 	// A field the AGENT last wrote stays 🟢 too — precedence protects
 	// people, not machines.
-	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"title": "VP Engineering"}, bearer, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, AnyMap{"title": "VP Engineering"}, bearer, nil); status != 200 {
 		t.Fatalf("agent re-patch of its own field → %d, want 200 (🟢)", status)
 	}
 
@@ -67,7 +67,7 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, bearer, &problem)
+	status := e.Call(t, "PATCH", "/v1/people/"+person.ID, AnyMap{"full_name": "Greta Machine"}, bearer, &problem)
 	if status != 403 || problem.Code != "approval_required" {
 		t.Fatalf("agent overwrite of a human field → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -80,11 +80,11 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 	approvalID := ExtractStagedApprovalID(t, problem.Detail)
 
 	// A human decision releases it; the identical retry lands the patch.
-	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + minted.Token, "X-Approval-Token": approvalID}
-	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, withToken, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, AnyMap{"full_name": "Greta Machine"}, withToken, nil); status != 200 {
 		t.Fatalf("approved retry → %d, want the patch to execute", status)
 	}
 	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Machine" {
@@ -94,7 +94,7 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 	// The redemption was consumed exactly once: the identical retry with
 	// the same token changes nothing further.
 	before := current.FullName
-	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, withToken, &problem); status != 403 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, AnyMap{"full_name": "Greta Machine"}, withToken, &problem); status != 403 {
 		t.Fatalf("re-redeeming a consumed approval → %d, want 403", status)
 	}
 	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != before {
@@ -120,13 +120,13 @@ func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Otto Human"}, nil, &lead); status != 201 {
+	if status := e.Call(t, "POST", "/v1/leads", AnyMap{"full_name": "Otto Human"}, nil, &lead); status != 201 {
 		t.Fatalf("human create lead → %d", status)
 	}
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "variant agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -138,7 +138,7 @@ func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
 	var patched struct {
 		FullName string `json:"full_name"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, apptest.AnyMap{"FULL_NAME": "Otto Machine"}, bearer, &patched); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, AnyMap{"FULL_NAME": "Otto Machine"}, bearer, &patched); status != 200 {
 		t.Fatalf("case-variant patch → %d, want 200 (dropped, not written)", status)
 	}
 	if patched.FullName != "Otto Human" {
@@ -161,13 +161,13 @@ func stagePersonAndAgent(t *testing.T, e *apptest.AppEnv, fullName, label string
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": fullName}, nil, &person); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": fullName}, nil, &person); status != 201 {
 		t.Fatalf("human create → %d", status)
 	}
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": label, "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -213,7 +213,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 	personID, agentToken := stagePersonAndAgent(t, e, "Petra Human", "split agent")
 	// The human TYPES the title in an update: the per-field audit image
 	// makes title human-owned alongside the created full_name.
-	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Founder"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"title": "Founder"}, nil, nil); status != 200 {
 		t.Fatalf("human title patch → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + agentToken}
@@ -230,7 +230,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 			Message    string          `json:"message"`
 		} `json:"staged_approval"`
 	}
-	status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{
+	status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{
 		"first_name": "Petra", "full_name": "Petra Machine", "title": "CEO",
 	}, bearer, &split)
 	if status != 200 {
@@ -246,7 +246,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 
 	// A human approves; the agent replays ONLY the staged fields with the
 	// token — the sub-patch is what the approval is bound to.
-	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/approve", AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + agentToken, "X-Approval-Token": split.StagedApproval.ApprovalID}
@@ -256,11 +256,11 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"full_name": "Petra Impostor", "title": "CEO"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"full_name": "Petra Impostor", "title": "CEO"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
 		t.Fatalf("tampered replay → %d %q, want 403 approval_token_invalid", status, problem.Code)
 	}
 
-	var replay apptest.AnyMap
+	var replay AnyMap
 	if err := json.Unmarshal(split.StagedApproval.Replay, &replay); err != nil {
 		t.Fatalf("staged replay body is not an object: %v", err)
 	}
@@ -292,12 +292,12 @@ func TestEndToEnd_rejectedSplitWritesNothing(t *testing.T) {
 			ApprovalID string `json:"approval_id"`
 		} `json:"staged_approval"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{
 		"first_name": "Rita", "full_name": "Rita Machine",
 	}, bearer, &split); status != 200 || split.StagedApproval.ApprovalID == "" {
 		t.Fatalf("mixed patch → %d %+v, want 200 with a staged approval", status, split)
 	}
-	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/reject", apptest.AnyMap{"reason": "keep my spelling"}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/reject", AnyMap{"reason": "keep my spelling"}, nil, nil); status != 200 {
 		t.Fatalf("human reject → %d", status)
 	}
 
@@ -305,7 +305,7 @@ func TestEndToEnd_rejectedSplitWritesNothing(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"full_name": "Rita Machine"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, AnyMap{"full_name": "Rita Machine"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
 		t.Fatalf("replaying a rejected staging → %d %q, want 403 approval_token_invalid", status, problem.Code)
 	}
 	var current struct {
@@ -418,7 +418,7 @@ func TestEndToEnd_perFieldSplitOnMCPUpdate(t *testing.T) {
 	}
 
 	// A human approves; the replay redeems and lands exactly the field.
-	if status := e.Call(t, "POST", "/v1/approvals/"+result.StagedApproval.ApprovalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+result.StagedApproval.ApprovalID+"/approve", AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	if _, err := invoke("update_record", replay); err != nil {

--- a/backend/internal/compose/integration/idempotency_integration_test.go
+++ b/backend/internal/compose/integration/idempotency_integration_test.go
@@ -28,21 +28,21 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 	apptest.BootstrapWorkspaceSession(t, e, "Idem Probe", "admin@idem.test", "Admin")
 
 	keyed := map[string]string{"Idempotency-Key": "lead-retry-1"}
-	leadReq := apptest.AnyMap{
+	leadReq := AnyMap{
 		"full_name":    "Retry Prospect",
 		"email":        "retry@example.org",
 		"company_name": "Retry AG",
 		"source":       "import:idem",
 	}
 
-	var first apptest.AnyMap
+	var first AnyMap
 	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create lead = %d %v", status, first)
 	}
 
 	// The replay is byte-identical: same status, same body — NOT the 409
 	// the natural email dedupe would answer if the request re-executed.
-	var replay apptest.AnyMap
+	var replay AnyMap
 	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &replay); status != http.StatusCreated {
 		t.Fatalf("keyed replay = %d %v, want the original 201", status, replay)
 	}
@@ -52,7 +52,7 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 
 	// Exactly one lead landed.
 	var leads struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/leads", nil, nil, &leads); status != http.StatusOK {
 		t.Fatalf("list leads = %d", status)
@@ -62,8 +62,8 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 	}
 
 	// The same key with a DIFFERENT body is a conflict, never a replay.
-	var problem apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
+	var problem AnyMap
+	status := e.Call(t, "POST", "/v1/leads", AnyMap{
 		"full_name": "Different Intent",
 		"email":     "other@example.org",
 		"source":    "import:idem",
@@ -85,14 +85,14 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 	apptest.BootstrapWorkspaceSession(t, e, "Idem Erase", "admin@idemerase.test", "Admin")
 
 	keyed := map[string]string{"Idempotency-Key": "lead-erase-1"}
-	leadReq := apptest.AnyMap{
+	leadReq := AnyMap{
 		"full_name":    "Erasable Prospect",
 		"email":        "erasable@example.org",
 		"company_name": "Erasable AG",
 		"source":       "import:idem",
 	}
 
-	var first apptest.AnyMap
+	var first AnyMap
 	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create lead = %d %v", status, first)
 	}
@@ -103,7 +103,7 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 
 	// The positive control, BEFORE the record goes: the replay works, so a
 	// later refusal is the archive doing it and not the mechanism being broken.
-	var live apptest.AnyMap
+	var live AnyMap
 	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &live); status != http.StatusCreated {
 		t.Fatalf("replay while the record is live = %d %v, want the original 201", status, live)
 	}
@@ -112,7 +112,7 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 		t.Fatalf("archiving the lead = %d, want 200", status)
 	}
 
-	var problem apptest.AnyMap
+	var problem AnyMap
 	status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &problem)
 	if status != http.StatusNotFound {
 		t.Fatalf("replay after the record was archived = %d %v, want 404 — the recorded body is a snapshot of a record that no longer exists",
@@ -130,23 +130,23 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	adminID := me["user"].(apptest.AnyMap)["id"].(string)
+	adminID := me["user"].(AnyMap)["id"].(string)
 
 	keyed := map[string]string{"Idempotency-Key": "quota-retry-1"}
-	quotaReq := apptest.AnyMap{
+	quotaReq := AnyMap{
 		"owner_id": adminID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}
 
-	var first apptest.AnyMap
+	var first AnyMap
 	if status := e.Call(t, "POST", "/v1/quotas", quotaReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create quota = %d %v", status, first)
 	}
-	var replay apptest.AnyMap
+	var replay AnyMap
 	if status := e.Call(t, "POST", "/v1/quotas", quotaReq, keyed, &replay); status != http.StatusCreated {
 		t.Fatalf("keyed replay = %d %v, want the original 201", status, replay)
 	}
@@ -155,7 +155,7 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 	}
 
 	var quotas struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/quotas", nil, nil, &quotas); status != http.StatusOK {
 		t.Fatalf("list quotas = %d", status)
@@ -165,8 +165,8 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 	}
 
 	// The same key with a DIFFERENT body is a conflict, never a replay.
-	var problem apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var problem AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": adminID, "period_start": "2026-04-01", "period_end": "2026-06-30",
 		"target_minor": 2000000, "currency": "EUR",
 	}, keyed, &problem)
@@ -180,22 +180,22 @@ func TestIdempotencyKeyReplay_logActivity(t *testing.T) {
 
 	apptest.BootstrapWorkspaceSession(t, e, "Idem Activity", "admin@idem-act.test", "Admin")
 
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Idem Person", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
 	}
 
 	keyed := map[string]string{"Idempotency-Key": "act-retry-1"}
-	logReq := apptest.AnyMap{
+	logReq := AnyMap{
 		"kind":    "note",
 		"subject": "Keyed note",
 		"source":  "ui",
-		"links":   []apptest.AnyMap{{"entity_type": "person", "entity_id": person["id"]}},
+		"links":   []AnyMap{{"entity_type": "person", "entity_id": person["id"]}},
 	}
 
-	var first, replay apptest.AnyMap
+	var first, replay AnyMap
 	if status := e.Call(t, "POST", "/v1/activities", logReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed log activity = %d %v", status, first)
 	}
@@ -207,7 +207,7 @@ func TestIdempotencyKeyReplay_logActivity(t *testing.T) {
 	}
 
 	var activities struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/activities", nil, nil, &activities); status != http.StatusOK {
 		t.Fatalf("list activities = %d", status)

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -148,7 +148,7 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 
 	// The configured currency is asserted with the other two settings below —
 	// they are one act of bootstrap and one place to read it back.
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ops@configured.test", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("configured admin login → %d", status)

--- a/backend/internal/compose/integration/jobfanout/agentgrantapi_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/agentgrantapi_integration_test.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/compose/integration"
 )
 
 // grantPath is the endpoint these tests answer on.
@@ -28,7 +28,7 @@ const grantPath = "/v1/me/agent-grants/morning_brief"
 // answerGrant puts one answer as the signed-in rep.
 func (re *runnerEnv) answerGrant(t *testing.T, granted bool) int {
 	t.Helper()
-	return re.Call(t, "PUT", grantPath, apptest.AnyMap{"granted": granted}, nil, nil)
+	return re.Call(t, "PUT", grantPath, integration.AnyMap{"granted": granted}, nil, nil)
 }
 
 func TestGrantingMintsTheRepsOwnCredentialAndNothingWider(t *testing.T) {
@@ -152,7 +152,7 @@ func TestTwoSimultaneousAnswersStillLeaveOneLiveCredential(t *testing.T) {
 		go func(slot int) {
 			defer wg.Done()
 			<-start
-			statuses[slot] = re.Call(t, "PUT", grantPath, apptest.AnyMap{"granted": true}, nil, nil)
+			statuses[slot] = re.Call(t, "PUT", grantPath, integration.AnyMap{"granted": true}, nil, nil)
 		}(i)
 	}
 	close(start)
@@ -178,7 +178,7 @@ func TestTwoSimultaneousAnswersStillLeaveOneLiveCredential(t *testing.T) {
 func TestAnUnknownAgentIsRefusedRatherThanGranted(t *testing.T) {
 	re := setupRunner(t)
 	status := re.Call(t, "PUT", "/v1/me/agent-grants/not_an_agent",
-		apptest.AnyMap{"granted": true}, nil, nil)
+		integration.AnyMap{"granted": true}, nil, nil)
 	// 422, not 200: minting a credential for an agent this build does not
 	// schedule is authority that can never be used and never be found.
 	if status != http.StatusUnprocessableEntity && status != http.StatusBadRequest {

--- a/backend/internal/compose/integration/jobfanout/runner_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runner_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/agents/runner"
 	"github.com/margince/margince/backend/internal/modules/ai"
@@ -97,7 +98,7 @@ func setupRunner(t *testing.T) *runnerEnv {
 	var minted struct {
 		PassportID string `json:"passport_id"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": "overnight runner", "scopes": []string{"read", "write", "enrich"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -256,7 +257,7 @@ func TestRunnerConfirmationRequiredSuspendApproveResume(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Unknown Co"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/organizations", integration.AnyMap{"display_name": "Unknown Co"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 
@@ -281,7 +282,7 @@ func TestRunnerConfirmationRequiredSuspendApproveResume(t *testing.T) {
 	}
 
 	// A human approves in the same inbox every surface stages into.
-	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", apptest.AnyMap{}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", integration.AnyMap{}, nil, nil); got != http.StatusOK {
 		t.Fatalf("approve → %d", got)
 	}
 
@@ -314,7 +315,7 @@ func TestRunnerConfirmationRequiredRejectionReplansWithoutEffect(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Keep Me"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/organizations", integration.AnyMap{"display_name": "Keep Me"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 
@@ -329,7 +330,7 @@ func TestRunnerConfirmationRequiredRejectionReplansWithoutEffect(t *testing.T) {
 	if approvalID == nil {
 		t.Fatal("no staged approval")
 	}
-	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/reject", apptest.AnyMap{"reason": "not a duplicate"}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/reject", integration.AnyMap{"reason": "not a duplicate"}, nil, nil); got != http.StatusOK {
 		t.Fatalf("reject → %d", got)
 	}
 	if err := re.svc.HandleEvent(context.Background(), decidedEnvelope(re.wsID, *approvalID, "rejected")); err != nil {
@@ -403,7 +404,7 @@ func TestRunnerResumeIsClaimedSoARedeliveryIsANoOp(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Resume Once"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/organizations", integration.AnyMap{"display_name": "Resume Once"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 
@@ -421,7 +422,7 @@ func TestRunnerResumeIsClaimedSoARedeliveryIsANoOp(t *testing.T) {
 	if approvalID == nil {
 		t.Fatal("no staged approval")
 	}
-	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", apptest.AnyMap{}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", integration.AnyMap{}, nil, nil); got != http.StatusOK {
 		t.Fatalf("approve → %d", got)
 	}
 
@@ -478,7 +479,7 @@ func TestTheSweepMayNotArchiveEvenWithAModelThatTriesTo(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Stale Duplicate"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/people", integration.AnyMap{"full_name": "Stale Duplicate"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
@@ -533,7 +534,7 @@ func TestASuspendedRunWhoseAuthorityDiesIsClosedRatherThanParkedForever(t *testi
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := re.Call(t, "POST", "/v1/organizations", integration.AnyMap{
 		"display_name": "Authority Dies Parked",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
@@ -551,7 +552,7 @@ func TestASuspendedRunWhoseAuthorityDiesIsClosedRatherThanParkedForever(t *testi
 	if status != "awaiting_approval" || approvalID == nil {
 		t.Fatalf("run = %s approval=%v, want a parked run", status, approvalID)
 	}
-	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", apptest.AnyMap{}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", integration.AnyMap{}, nil, nil); got != http.StatusOK {
 		t.Fatalf("approve → %d", got)
 	}
 

--- a/backend/internal/compose/integration/jobfanout/standinggrant_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/standinggrant_integration_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/modules/agents/runner"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -40,7 +40,7 @@ func (re *runnerEnv) mintPassportFor(t *testing.T) ids.PassportID {
 	var minted struct {
 		PassportID string `json:"passport_id"`
 	}
-	if status := re.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := re.Call(t, "POST", "/v1/passports", integration.AnyMap{
 		"label": "overnight brief", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -348,7 +348,7 @@ func TestJobHealthRefusesAPassportOverHTTP(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "job health probe", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)

--- a/backend/internal/compose/integration/knowledgeask_http_integration_test.go
+++ b/backend/internal/compose/integration/knowledgeask_http_integration_test.go
@@ -40,18 +40,18 @@ func (unaskableEmbedder) Embed(context.Context, model.EmbedRequest) (model.Embed
 	return model.Embeddings{}, context.Canceled
 }
 
-func askCorpusOverHTTP(t *testing.T, e *apptest.AppEnv, corpusID, question string) (int, apptest.AnyMap) {
+func askCorpusOverHTTP(t *testing.T, e *apptest.AppEnv, corpusID, question string) (int, AnyMap) {
 	t.Helper()
-	var answer apptest.AnyMap
+	var answer AnyMap
 	status := e.Call(t, "POST", "/v1/knowledge/corpora/"+corpusID+"/ask",
-		apptest.AnyMap{"question": question}, nil, &answer)
+		AnyMap{"question": question}, nil, &answer)
 	return status, answer
 }
 
 func createCorpusOverHTTP(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	var made apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/knowledge/corpora", apptest.AnyMap{
+	var made AnyMap
+	status := e.Call(t, "POST", "/v1/knowledge/corpora", AnyMap{
 		"name":            "How-to",
 		"topic_statement": "How this product is operated.",
 	}, nil, &made)

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -129,7 +129,7 @@ func TestLeadScoreOverrideRejectsMissingReasonOverHTTP(t *testing.T) {
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Otto Lead", "source": "manual"}, nil, &lead); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/leads", AnyMap{"full_name": "Otto Lead", "source": "manual"}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
 
@@ -142,7 +142,7 @@ func TestLeadScoreOverrideRejectsMissingReasonOverHTTP(t *testing.T) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, apptest.AnyMap{"score": 80}, nil, &problem); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, AnyMap{"score": 80}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("score without reason → %d, want 422", status)
 	}
 	if problem.Code != "validation_error" ||

--- a/backend/internal/compose/integration/linkedin_http_integration_test.go
+++ b/backend/internal/compose/integration/linkedin_http_integration_test.go
@@ -28,7 +28,7 @@ type importSummaryDTO struct {
 }
 
 // uploadExport posts a CSV as multipart, the way the browser does.
-func uploadExport(e *apptest.AppEnv, t *testing.T, csv string) (int, importSummaryDTO) {
+func uploadExport(t *testing.T, e *apptest.AppEnv, csv string) (int, importSummaryDTO) {
 	t.Helper()
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
@@ -80,7 +80,7 @@ func TestUploadingAnExportImportsItAndReportsWhatItDid(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	status, got := uploadExport(e, t, exportWithPreamble)
+	status, got := uploadExport(t, e, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("upload status = %d, want 200", status)
 	}
@@ -100,7 +100,7 @@ func TestUploadingAnExportImportsItAndReportsWhatItDid(t *testing.T) {
 	// Re-uploading a refreshed export updates rather than duplicating —
 	// people re-export regularly, and a doubled network makes every reach
 	// count a lie.
-	status, again := uploadExport(e, t, exportWithPreamble)
+	status, again := uploadExport(t, e, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("re-upload status = %d", status)
 	}
@@ -114,15 +114,15 @@ func TestAnExactAddressMatchConfirmsOverHTTP(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	// A contact carrying the address the export names.
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Dana Buyer",
-		"emails":    []apptest.AnyMap{{"email": "dana@acme.test", "is_primary": true}},
+		"emails":    []AnyMap{{"email": "dana@acme.test", "is_primary": true}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating the contact: %d", status)
 	}
 
-	status, got := uploadExport(e, t, exportWithPreamble)
+	status, got := uploadExport(t, e, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("upload status = %d", status)
 	}
@@ -144,7 +144,7 @@ func TestAFileThatIsNotAnExportIsRefusedWithAReadableReason(t *testing.T) {
 
 	// Picking the wrong file is a mistake a sentence can fix. Answering 500
 	// would send someone to support for something they can solve themselves.
-	status, _ := uploadExport(e, t, "id,amount\n1,20\n")
+	status, _ := uploadExport(t, e, "id,amount\n1,20\n")
 	if status != http.StatusUnprocessableEntity {
 		t.Errorf("a non-export answered %d, want 422", status)
 	}

--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -41,8 +41,8 @@ type coverageRiskDTO struct {
 
 type dealCoverageDTO struct {
 	DealID       string            `json:"deal_id"`
-	Stakeholders []apptest.AnyMap  `json:"stakeholders"`
-	OurSide      []apptest.AnyMap  `json:"our_side"`
+	Stakeholders []AnyMap          `json:"stakeholders"`
+	OurSide      []AnyMap          `json:"our_side"`
 	Risks        []coverageRiskDTO `json:"risks"`
 }
 
@@ -50,9 +50,9 @@ func TestPersonNetworkAnswersHonestlyWhenNobodyKnowsThem(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var person apptest.AnyMap
+	var person AnyMap
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Unknown Contact"}, nil, &person); status != http.StatusCreated {
+		AnyMap{"full_name": "Unknown Contact"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating the contact: %d", status)
 	}
 	id, _ := person["id"].(string)
@@ -78,7 +78,7 @@ func TestPersonNetworkHidesAContactTheCallerCannotRead(t *testing.T) {
 
 	// A person id that does not exist is indistinguishable from one this
 	// caller may not see — existence is not disclosed, here as everywhere.
-	var body apptest.AnyMap
+	var body AnyMap
 	if status := e.Call(t, "GET",
 		"/v1/people/019fb000-0000-7000-8000-00000000dead/network", nil, nil, &body); status != http.StatusNotFound {
 		t.Errorf("an unknown contact answered %d, want 404 — a network read must not "+
@@ -90,14 +90,14 @@ func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var pipelines apptest.AnyMap
+	var pipelines AnyMap
 	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("listing pipelines: %d", status)
 	}
 	pipeline, stage := firstPipelineAndStage(t, pipelines)
 
-	var deal apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	var deal AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Threadless", "pipeline_id": pipeline, "stage_id": stage, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("creating the deal: %d", status)
@@ -110,10 +110,10 @@ func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
 	// would fire on every deal somebody just created. Seeding the touch keeps
 	// this test on the case it is named for — a deal that HAS been worked and
 	// is still single-threaded — rather than on the calendar.
-	var touch apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	var touch AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "note", "body": "Kickoff call notes",
-		"links": []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links": []AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 	}, nil, &touch); status != http.StatusCreated {
 		t.Fatalf("capturing a touch on the deal: %d", status)
 	}
@@ -149,7 +149,7 @@ func TestDealCoverageHidesADealTheCallerCannotRead(t *testing.T) {
 
 	// The coverage payload names the deal's people, so a caller who cannot
 	// read the deal must not learn who sits on it.
-	var body apptest.AnyMap
+	var body AnyMap
 	if status := e.Call(t, "GET",
 		"/v1/deals/019fb000-0000-7000-8000-00000000beef/coverage", nil, nil, &body); status != http.StatusNotFound {
 		t.Errorf("an unknown deal answered %d, want 404", status)
@@ -159,21 +159,21 @@ func TestDealCoverageHidesADealTheCallerCannotRead(t *testing.T) {
 func TestDealCoverageDistinguishesADepartedChampionFromADepartedStakeholder(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	org, deal := dealAtAnAccount(e, t, "Bär Pharma", "Renewal")
+	org, deal := dealAtAnAccount(t, e, "Bär Pharma", "Renewal")
 
 	// Two people who used to work there and one who still does. The rule
 	// demands EVIDENCE of a departure — an ended employment plus no live one —
 	// so the third person proves the flag is about leaving and not about
 	// having no employment row.
-	gone := contactAt(e, t, org, "Departed Champion", "2026-01-31")
-	alsoGone := contactAt(e, t, org, "Departed Legal", "2026-02-28")
-	stayed := contactAt(e, t, org, "Still There", "")
+	gone := contactAt(t, e, org, "Departed Champion", "2026-01-31")
+	alsoGone := contactAt(t, e, org, "Departed Legal", "2026-02-28")
+	stayed := contactAt(t, e, org, "Still There", "")
 
-	stakeholder(e, t, deal, gone, "champion")
-	stakeholder(e, t, deal, alsoGone, "legal")
-	stakeholder(e, t, deal, stayed, "user")
+	stakeholder(t, e, deal, gone, "champion")
+	stakeholder(t, e, deal, alsoGone, "legal")
+	stakeholder(t, e, deal, stayed, "user")
 
-	risks := coverageRisks(e, t, deal)
+	risks := coverageRisks(t, e, deal)
 	champion := findRisk(risks, "champion_left")
 	if champion == nil {
 		t.Fatalf("the champion left the account and no champion_left risk fired: %+v", risks)
@@ -202,17 +202,17 @@ func TestDealCoverageDistinguishesADepartedChampionFromADepartedStakeholder(t *t
 func TestDealCoverageDoesNotCallARehiredStakeholderDeparted(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	org, deal := dealAtAnAccount(e, t, "Voss Systems", "Expansion")
+	org, deal := dealAtAnAccount(t, e, "Voss Systems", "Expansion")
 
 	// A role change recorded as end-then-start, which is how most CRMs record
 	// a promotion. The closed row is real and so is the live one, and only the
 	// live one decides: flagging this would announce a resignation every time
 	// somebody changed job title.
-	person := contactAt(e, t, org, "Promoted Person", "2026-01-31")
-	employ(e, t, person, org, "2026-02-01", "")
-	stakeholder(e, t, deal, person, "champion")
+	person := contactAt(t, e, org, "Promoted Person", "2026-01-31")
+	employ(t, e, person, org, "2026-02-01", "")
+	stakeholder(t, e, deal, person, "champion")
 
-	risks := coverageRisks(e, t, deal)
+	risks := coverageRisks(t, e, deal)
 	if findRisk(risks, "champion_left") != nil {
 		t.Errorf("a stakeholder with a live employment was reported as departed: %+v", risks)
 	}
@@ -221,21 +221,21 @@ func TestDealCoverageDoesNotCallARehiredStakeholderDeparted(t *testing.T) {
 func TestGoingColdFiresOnTheReportingWindowAndCarriesTheDayCount(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	_, deal := dealAtAnAccount(e, t, "Kessler GmbH", "Silent")
+	_, deal := dealAtAnAccount(t, e, "Kessler GmbH", "Silent")
 
 	// A brand-new deal has been silent since it was created, which is zero
 	// days — not cold. The flag must not fire on the day a rep writes a deal
 	// down.
-	if findRisk(coverageRisks(e, t, deal), "going_cold") != nil {
+	if findRisk(coverageRisks(t, e, deal), "going_cold") != nil {
 		t.Error("a deal created moments ago was flagged as going cold")
 	}
 
 	// Age the last touch past REPORT-PARAM-2's window. Written through the
 	// owner connection because no API sets this column — it is maintained by
 	// the capture path, and the point of the test is the read, not the write.
-	ageLastTouch(e, t, deal, 41)
+	ageLastTouch(t, e, deal, 41)
 
-	risks := coverageRisks(e, t, deal)
+	risks := coverageRisks(t, e, deal)
 	cold := findRisk(risks, "going_cold")
 	if cold == nil {
 		t.Fatalf("a deal untouched for 41 days raised no going_cold risk: %+v", risks)
@@ -259,13 +259,13 @@ func TestGoingColdFiresOnTheReportingWindowAndCarriesTheDayCount(t *testing.T) {
 func TestAWonDealIsNotGoingCold(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
-	_, deal := dealAtAnAccount(e, t, "Brandt Automotive", "Delivered")
-	ageLastTouch(e, t, deal, 400)
-	closeWon(e, t, deal)
+	_, deal := dealAtAnAccount(t, e, "Brandt Automotive", "Delivered")
+	ageLastTouch(t, e, deal, 400)
+	closeWon(t, e, deal)
 
 	// Silence after the close is delivery, not decay. Flagging it would train
 	// a rep to ignore the flag on the deals where it means something.
-	if findRisk(coverageRisks(e, t, deal), "going_cold") != nil {
+	if findRisk(coverageRisks(t, e, deal), "going_cold") != nil {
 		t.Error("a won deal silent for 400 days was flagged as going cold")
 	}
 }
@@ -273,7 +273,7 @@ func TestAWonDealIsNotGoingCold(t *testing.T) {
 // --- fixture helpers ---
 
 // coverageRisks reads one deal's findings through the real endpoint.
-func coverageRisks(e *apptest.AppEnv, t *testing.T, dealID string) []coverageRiskDTO {
+func coverageRisks(t *testing.T, e *apptest.AppEnv, dealID string) []coverageRiskDTO {
 	t.Helper()
 	var got dealCoverageDTO
 	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
@@ -294,23 +294,23 @@ func findRisk(risks []coverageRiskDTO, kind string) *coverageRiskDTO {
 // dealAtAnAccount creates an organization and an open deal owned by it — the
 // shape every departure rule needs, since a deal with no account has nobody to
 // have left.
-func dealAtAnAccount(e *apptest.AppEnv, t *testing.T, orgName, dealName string) (org, deal string) {
+func dealAtAnAccount(t *testing.T, e *apptest.AppEnv, orgName, dealName string) (org, deal string) {
 	t.Helper()
-	var created apptest.AnyMap
+	var created AnyMap
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": orgName, "source": "ui"}, nil, &created); status != http.StatusCreated {
+		AnyMap{"display_name": orgName, "source": "ui"}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("creating the account: %d", status)
 	}
 	org, _ = created["id"].(string)
 
-	var pipelines apptest.AnyMap
+	var pipelines AnyMap
 	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("listing pipelines: %d", status)
 	}
 	pipeline, stage := firstPipelineAndStage(t, pipelines)
 
-	var made apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	var made AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": dealName, "pipeline_id": pipeline, "stage_id": stage,
 		"organization_id": org, "source": "ui",
 	}, nil, &made); status != http.StatusCreated {
@@ -327,37 +327,37 @@ const hiredOn = "2020-01-01"
 
 // contactAt creates a person and their employment at the account. An empty
 // endedAt means they still work there.
-func contactAt(e *apptest.AppEnv, t *testing.T, org, name, endedAt string) string {
+func contactAt(t *testing.T, e *apptest.AppEnv, org, name, endedAt string) string {
 	t.Helper()
-	var person apptest.AnyMap
+	var person AnyMap
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": name}, nil, &person); status != http.StatusCreated {
+		AnyMap{"full_name": name}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating %s: %d", name, status)
 	}
 	id, _ := person["id"].(string)
-	employ(e, t, id, org, hiredOn, endedAt)
+	employ(t, e, id, org, hiredOn, endedAt)
 	return id
 }
 
-func employ(e *apptest.AppEnv, t *testing.T, person, org, startedAt, endedAt string) {
+func employ(t *testing.T, e *apptest.AppEnv, person, org, startedAt, endedAt string) {
 	t.Helper()
-	body := apptest.AnyMap{
+	body := AnyMap{
 		"kind": "employment", "person_id": person, "organization_id": org,
 		"started_at": startedAt, "source": "ui",
 	}
 	if endedAt != "" {
 		body["ended_at"] = endedAt
 	}
-	var out apptest.AnyMap
+	var out AnyMap
 	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &out); status != http.StatusCreated {
 		t.Fatalf("recording employment: %d (%v)", status, out)
 	}
 }
 
-func stakeholder(e *apptest.AppEnv, t *testing.T, deal, person, role string) {
+func stakeholder(t *testing.T, e *apptest.AppEnv, deal, person, role string) {
 	t.Helper()
-	var out apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	var out AnyMap
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "deal_stakeholder", "deal_id": deal, "person_id": person,
 		"role": role, "source": "ui",
 	}, nil, &out); status != http.StatusCreated {
@@ -368,7 +368,7 @@ func stakeholder(e *apptest.AppEnv, t *testing.T, deal, person, role string) {
 // ageLastTouch backdates the deal's last captured touch. Written as owner
 // because no API writes this column — capture maintains it — and the behaviour
 // under test is how the coverage read interprets it.
-func ageLastTouch(e *apptest.AppEnv, t *testing.T, deal string, days int) {
+func ageLastTouch(t *testing.T, e *apptest.AppEnv, deal string, days int) {
 	t.Helper()
 	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE deal SET last_activity_at = now() - make_interval(days => $2) WHERE id = $1`,
@@ -377,7 +377,7 @@ func ageLastTouch(e *apptest.AppEnv, t *testing.T, deal string, days int) {
 	}
 }
 
-func closeWon(e *apptest.AppEnv, t *testing.T, deal string) {
+func closeWon(t *testing.T, e *apptest.AppEnv, deal string) {
 	t.Helper()
 	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE deal SET status = 'won', closed_at = now() WHERE id = $1`, deal); err != nil {
@@ -386,7 +386,7 @@ func closeWon(e *apptest.AppEnv, t *testing.T, deal string) {
 }
 
 // firstPipelineAndStage picks the default pipeline and its first stage.
-func firstPipelineAndStage(t *testing.T, listed apptest.AnyMap) (pipeline, stage string) {
+func firstPipelineAndStage(t *testing.T, listed AnyMap) (pipeline, stage string) {
 	t.Helper()
 	data, _ := listed["data"].([]any)
 	if len(data) == 0 {

--- a/backend/internal/compose/integration/offerpdf_http_integration_test.go
+++ b/backend/internal/compose/integration/offerpdf_http_integration_test.go
@@ -31,10 +31,10 @@ func TestOfferPdfHTTP_DownloadBeforeRenderReturns404(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -62,10 +62,10 @@ func TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -75,7 +75,7 @@ func TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404(t *testing.T) {
 	}
 
 	var rendered renderedOffer
-	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 
@@ -96,10 +96,10 @@ func TestOfferPdfHTTP_DownloadAfterRenderReturnsTheRenderedBytes(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -109,7 +109,7 @@ func TestOfferPdfHTTP_DownloadAfterRenderReturnsTheRenderedBytes(t *testing.T) {
 	}
 
 	var rendered renderedOffer
-	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 

--- a/backend/internal/compose/integration/offerrender_http_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_http_integration_test.go
@@ -49,10 +49,10 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -62,7 +62,7 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 	}
 
 	var rendered renderedOffer
-	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 	if rendered.ID != offerID {
@@ -98,7 +98,7 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 	// re-render still reclaims its now-superseded PREVIOUS ref rather than
 	// accumulating orphans, and stays 200.
 	var renderedAgain renderedOffer
-	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &renderedAgain); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &renderedAgain); status != http.StatusOK {
 		t.Fatalf("second render = %d", status)
 	}
 	if renderedAgain.PdfAssetRef == rendered.PdfAssetRef {
@@ -148,8 +148,8 @@ func (r *raceLineAdder) Put(ctx context.Context, key string, body io.Reader, siz
 		return err
 	}
 	r.putKey = key
-	var line apptest.AnyMap
-	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/line-items", apptest.AnyMap{
+	var line AnyMap
+	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/line-items", AnyMap{
 		"description": "Concurrent Line", "quantity": 1.0, "unit_price_minor": 1000,
 	}, nil, &line)
 	if status != http.StatusCreated {
@@ -173,10 +173,10 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -189,7 +189,7 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &problem)
 	if race.hookErr != nil {
 		t.Fatal(race.hookErr)
 	}
@@ -208,7 +208,7 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 	}
 
 	// The rejected render must not have moved pdf_asset_ref at all.
-	var got apptest.AnyMap
+	var got AnyMap
 	if status := e.Call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get offer after rejected render = %d", status)
 	}
@@ -244,7 +244,7 @@ func (r *raceOfferArchiver) Put(ctx context.Context, key string, body io.Reader,
 		return err
 	}
 	r.putKey = key
-	var archived apptest.AnyMap
+	var archived AnyMap
 	if status := r.e.Call(r.t, "DELETE", "/v1/offers/"+r.offerID, nil, nil, &archived); status != http.StatusOK {
 		r.hookErr = fmt.Errorf("archive the offer between prepare and set = %d %v", status, archived)
 	}
@@ -264,10 +264,10 @@ func TestOfferRenderHTTP_OfferArchivedBetweenPrepareAndSetReclaimsTheBlob(t *tes
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -280,7 +280,7 @@ func TestOfferRenderHTTP_OfferArchivedBetweenPrepareAndSetReclaimsTheBlob(t *tes
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &problem)
 	if race.hookErr != nil {
 		t.Fatal(race.hookErr)
 	}
@@ -330,7 +330,7 @@ func (r *raceDoubleRenderer) Put(ctx context.Context, key string, body io.Reader
 	}
 	r.nested = true
 	var winner renderedOffer
-	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/render", apptest.AnyMap{}, nil, &winner)
+	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/render", AnyMap{}, nil, &winner)
 	if status != http.StatusOK {
 		r.hookErr = fmt.Errorf("nested concurrent render = %d %+v, want 200", status, winner)
 	}
@@ -355,10 +355,10 @@ func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *te
 	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -371,7 +371,7 @@ func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *te
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, &problem)
 	if race.hookErr != nil {
 		t.Fatal(race.hookErr)
 	}
@@ -379,7 +379,7 @@ func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *te
 		t.Fatalf("outer render racing a nested concurrent render = %d %+v, want 409 version_skew", status, problem)
 	}
 
-	var got apptest.AnyMap
+	var got AnyMap
 	if status := e.Call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get offer after the race = %d", status)
 	}

--- a/backend/internal/compose/integration/offers_integration_test.go
+++ b/backend/internal/compose/integration/offers_integration_test.go
@@ -50,7 +50,7 @@ func offerFixture(t *testing.T, e *apptest.AppEnv) (dealID string) {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Offer-bearing deal", "pipeline_id": pipelines.Data[0].ID, "stage_id": stageID, "source": "manual",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal → %d", status)
@@ -114,13 +114,13 @@ func createRateCardProduct(t *testing.T, e *apptest.AppEnv) string {
 		UnitPriceMinor int64  `json:"unit_price_minor"`
 		Version        int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/products", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/products", AnyMap{
 		"name": "Consulting day", "sku": "CONS-DAY", "unit": "day",
 		"unit_price_minor": 120000, "currency": "EUR", "default_tax_rate": 19.0, "source": "manual",
 	}, nil, &product); status != http.StatusCreated {
 		t.Fatalf("create product → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/products", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/products", AnyMap{
 		"name": "Duplicate", "sku": "CONS-DAY", "unit_price_minor": 1, "currency": "EUR", "source": "manual",
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("duplicate live sku → %d, want 409", status)
@@ -142,7 +142,7 @@ func assertOfferTotalsAreDerived(t *testing.T, e *apptest.AppEnv, dealID string)
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual", "net_minor": 999999,
 	}, nil, &problem); status != http.StatusUnprocessableEntity || problem.Details.Errors[0].Code != "totals_derived" {
 		t.Fatalf("client-supplied net_minor → %d %+v, want 422 totals_derived", status, problem)
@@ -160,9 +160,9 @@ func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
 	// 2 days × 1200.00 @19% → net 240000, tax 45600
 	// 3 × 99.99 − 10% = 269.97…→ 26997 @7% → tax 1890 (1889.79 → 1890)
 	var offer offerBody
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{
+		"line_items": []AnyMap{
 			{"product_id": productID, "quantity": 2},
 			{"description": "Licence", "quantity": 3, "unit_price_minor": 9999, "discount_pct": 10.0, "tax_rate": 7.0},
 		},
@@ -180,7 +180,7 @@ func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
 
 	// Snapshot semantics (B-E03.17): re-pricing the product must NOT
 	// mutate the existing line.
-	if status := e.Call(t, "PATCH", "/v1/products/"+productID, apptest.AnyMap{"unit_price_minor": 999999}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/products/"+productID, AnyMap{"unit_price_minor": 999999}, nil, nil); status != http.StatusOK {
 		t.Fatalf("re-price product → %d", status)
 	}
 	var after offerBody
@@ -209,7 +209,7 @@ func exerciseDraftLineWrites(t *testing.T, e *apptest.AppEnv, offer offerBody) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", AnyMap{
 		"description": "Sneaky", "quantity": 1, "unit_price_minor": 100, "line_total_minor": 1,
 	}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("client-supplied line_total_minor → %d, want 422", status)
@@ -217,7 +217,7 @@ func exerciseDraftLineWrites(t *testing.T, e *apptest.AppEnv, offer offerBody) {
 
 	// Draft line CRUD recomputes the totals every time.
 	var withLine offerBody
-	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", AnyMap{
 		"description": "Support", "quantity": 1.5, "unit_price_minor": 20000, "tax_rate": 19.0,
 	}, nil, &withLine); status != http.StatusCreated {
 		t.Fatalf("add line → %d", status)
@@ -229,7 +229,7 @@ func exerciseDraftLineWrites(t *testing.T, e *apptest.AppEnv, offer offerBody) {
 
 	lineID := withLine.LineItems[len(withLine.LineItems)-1].ID
 	var updated offerBody
-	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+lineID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+lineID, AnyMap{
 		"quantity": 2.0,
 	}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update line → %d", status)
@@ -258,7 +258,7 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 
 	// An empty draft has nothing to send.
 	var empty offerBody
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
 	}, nil, &empty); status != http.StatusCreated {
 		t.Fatalf("create empty offer → %d", status)
@@ -271,10 +271,10 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 	assertSendFreezesDailyFxRate(t, e, wsID, usd.ID)
 
 	// A sent offer is immutable: header, lines and re-send all refuse.
-	if status := e.Call(t, "PATCH", "/v1/offers/"+usd.ID, apptest.AnyMap{"intro_text": "rewrite"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "PATCH", "/v1/offers/"+usd.ID, AnyMap{"intro_text": "rewrite"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("patch sent offer → %d, want 422", status)
 	}
-	if status := e.Call(t, "POST", "/v1/offers/"+usd.ID+"/line-items", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+usd.ID+"/line-items", AnyMap{
 		"description": "Late line", "quantity": 1, "unit_price_minor": 1,
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("add line to sent offer → %d, want 422", status)
@@ -291,7 +291,7 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 		t.Fatal("send EUR offer failed")
 	}
 	var rejected offerBody
-	if status := e.Call(t, "POST", "/v1/offers/"+eur.ID+"/reject", apptest.AnyMap{"reason": "budget cut"}, nil, &rejected); status != http.StatusOK || rejected.Status != "rejected" {
+	if status := e.Call(t, "POST", "/v1/offers/"+eur.ID+"/reject", AnyMap{"reason": "budget cut"}, nil, &rejected); status != http.StatusOK || rejected.Status != "rejected" {
 		t.Fatalf("reject → %d %q", status, rejected.Status)
 	}
 
@@ -327,9 +327,9 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 func createOfferInCurrency(t *testing.T, e *apptest.AppEnv, dealID, currency string) offerBody {
 	t.Helper()
 	var o offerBody
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": currency, "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &o); status != http.StatusCreated {
 		t.Fatalf("create %s offer → %d", currency, status)
 	}
@@ -426,7 +426,7 @@ func TestOfferSendIsHumanOnlyButTheHumanPathStillWorks(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		// Even the broadest cap the contract knows for this surface does not
 		// reach a human-only verb — there is no cap that would.
 		"label": "offer agent", "scopes": []string{"read", "write", "send"},
@@ -437,9 +437,9 @@ func TestOfferSendIsHumanOnlyButTheHumanPathStillWorks(t *testing.T) {
 
 	// 🟢 create_record: the agent drafts the offer, provenance is the agent.
 	var offer offerBody
-	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []apptest.AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
 	}, bearer, &offer); status != http.StatusCreated {
 		t.Fatalf("agent 🟢 offer draft → %d", status)
 	}

--- a/backend/internal/compose/integration/offertemplate_http_integration_test.go
+++ b/backend/internal/compose/integration/offertemplate_http_integration_test.go
@@ -68,9 +68,9 @@ func TestOfferTemplatesHTTP(t *testing.T) {
 
 func assertOfferTemplateCreate201(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	var created apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
-		"name": "HTTP Standard DE", "layout": apptest.AnyMap{"logo_url": "https://example.test/logo.png"},
+	var created AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", AnyMap{
+		"name": "HTTP Standard DE", "layout": AnyMap{"logo_url": "https://example.test/logo.png"},
 	}, nil, &created)
 	if status != http.StatusCreated {
 		t.Fatalf("create = %d %v", status, created)
@@ -91,8 +91,8 @@ func assertOfferTemplateCreate201(t *testing.T, e *apptest.AppEnv) string {
 func assertOfferTemplateNameDuplicate409(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var problem offerTemplateProblem
-	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
-		"name": "HTTP Standard DE", "layout": apptest.AnyMap{},
+	status := e.Call(t, "POST", "/v1/offer-templates", AnyMap{
+		"name": "HTTP Standard DE", "layout": AnyMap{},
 	}, nil, &problem)
 	if status != http.StatusConflict || problem.Code != "offer_template_name_duplicate" {
 		t.Fatalf("duplicate name create = %d %+v, want 409 offer_template_name_duplicate", status, problem)
@@ -104,17 +104,17 @@ func assertOfferTemplateNameDuplicate409(t *testing.T, e *apptest.AppEnv) {
 
 func assertOfferTemplateDefaultConflict409(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var firstDefault apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
-		"name": "HTTP DE Default", "layout": apptest.AnyMap{}, "is_default": true,
+	var firstDefault AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", AnyMap{
+		"name": "HTTP DE Default", "layout": AnyMap{}, "is_default": true,
 	}, nil, &firstDefault)
 	if status != http.StatusCreated {
 		t.Fatalf("seed default template = %d %v", status, firstDefault)
 	}
 
 	var problem offerTemplateProblem
-	status = e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
-		"name": "HTTP DE Default Two", "layout": apptest.AnyMap{}, "is_default": true,
+	status = e.Call(t, "POST", "/v1/offer-templates", AnyMap{
+		"name": "HTTP DE Default Two", "layout": AnyMap{}, "is_default": true,
 	}, nil, &problem)
 	if status != http.StatusConflict || problem.Code != "offer_template_default_conflict" {
 		t.Fatalf("default conflict create = %d %+v, want 409 offer_template_default_conflict", status, problem)
@@ -126,7 +126,7 @@ func assertOfferTemplateDefaultConflict409(t *testing.T, e *apptest.AppEnv) {
 
 func assertOfferTemplateGet(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var got apptest.AnyMap
+	var got AnyMap
 	if status := e.Call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
 		t.Fatalf("get = %d %+v, want 200 id=%s", status, got, id)
 	}
@@ -138,7 +138,7 @@ func assertOfferTemplateGet(t *testing.T, e *apptest.AppEnv, id string) {
 func assertOfferTemplateList(t *testing.T, e *apptest.AppEnv, seededID string) {
 	t.Helper()
 	var deList struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/offer-templates?locale=de-DE", nil, nil, &deList); status != http.StatusOK {
 		t.Fatalf("list locale=de-DE = %d", status)
@@ -159,18 +159,18 @@ func assertOfferTemplateList(t *testing.T, e *apptest.AppEnv, seededID string) {
 
 func assertOfferTemplateUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var updated apptest.AnyMap
-	status := e.Call(t, "PUT", "/v1/offer-templates/"+id, apptest.AnyMap{
+	var updated AnyMap
+	status := e.Call(t, "PUT", "/v1/offer-templates/"+id, AnyMap{
 		"name": "HTTP Standard DE v2", "locale": "de-DE", "is_default": false,
-		"layout": apptest.AnyMap{"footer_text": "v2"},
+		"layout": AnyMap{"footer_text": "v2"},
 	}, map[string]string{"If-Match": "1"}, &updated)
 	if status != http.StatusOK || updated["name"] != "HTTP Standard DE v2" || updated["version"].(float64) != 2 {
 		t.Fatalf("update = %d %+v, want 200 name=... version=2", status, updated)
 	}
 
 	var stale offerTemplateProblem
-	status = e.Call(t, "PUT", "/v1/offer-templates/"+id, apptest.AnyMap{
-		"name": "HTTP Standard DE v3", "locale": "de-DE", "is_default": false, "layout": apptest.AnyMap{},
+	status = e.Call(t, "PUT", "/v1/offer-templates/"+id, AnyMap{
+		"name": "HTTP Standard DE v3", "locale": "de-DE", "is_default": false, "layout": AnyMap{},
 	}, map[string]string{"If-Match": "1"}, &stale)
 	if status != http.StatusConflict || stale.Code != "version_skew" {
 		t.Fatalf("stale If-Match = %d %+v, want 409 version_skew", status, stale)
@@ -179,9 +179,9 @@ func assertOfferTemplateUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 
 func assertOfferTemplateArchive(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var created apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
-		"name": "HTTP Archivable", "layout": apptest.AnyMap{},
+	var created AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", AnyMap{
+		"name": "HTTP Archivable", "layout": AnyMap{},
 	}, nil, &created)
 	if status != http.StatusCreated {
 		t.Fatalf("create to archive = %d %v", status, created)
@@ -191,12 +191,12 @@ func assertOfferTemplateArchive(t *testing.T, e *apptest.AppEnv) {
 		t.Fatalf("create to archive response carries no id: %v", created)
 	}
 
-	var archived apptest.AnyMap
+	var archived AnyMap
 	status = e.Call(t, "DELETE", "/v1/offer-templates/"+id, nil, nil, &archived)
 	if status != http.StatusOK || archived["archived_at"] == nil || archived["id"] != id {
 		t.Fatalf("archive = %d %+v, want 200 + the full entity with archived_at set", status, archived)
 	}
-	var stillGettable apptest.AnyMap
+	var stillGettable AnyMap
 	if status := e.Call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
 		t.Fatalf("get archived template = %d %+v, want 200 with archived_at set", status, stillGettable)
 	}
@@ -213,7 +213,7 @@ func assertOfferTemplateMissingLayout422(t *testing.T, e *apptest.AppEnv) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{"name": "No Layout"}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offer-templates", AnyMap{"name": "No Layout"}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
 		t.Fatalf("missing layout = %d %+v, want 422 validation_error", status, problem)
 	}
@@ -236,10 +236,10 @@ func assertOfferTemplateMissingLayout422(t *testing.T, e *apptest.AppEnv) {
 func assertRenderOfferNotImplementedWithoutBlobstore(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	dealID := offerFixture(t, e)
-	var offer apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
+	var offer AnyMap
+	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer)
 	if status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
@@ -248,7 +248,7 @@ func assertRenderOfferNotImplementedWithoutBlobstore(t *testing.T, e *apptest.Ap
 	if !ok {
 		t.Fatalf("create offer for render response carries no id: %v", offer)
 	}
-	status = e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, nil)
+	status = e.Call(t, "POST", "/v1/offers/"+offerID+"/render", AnyMap{}, nil, nil)
 	if status != http.StatusNotImplemented {
 		t.Fatalf("renderOffer without a wired blobstore = %d, want 501", status)
 	}

--- a/backend/internal/compose/integration/onboarding_state_http_integration_test.go
+++ b/backend/internal/compose/integration/onboarding_state_http_integration_test.go
@@ -23,12 +23,12 @@ type onboardingStateDTO struct {
 	Version          int            `json:"version"`
 }
 
-func onboardingStateBody(version int, step string) apptest.AnyMap {
-	return apptest.AnyMap{
+func onboardingStateBody(version int, step string) AnyMap {
+	return AnyMap{
 		"expected_version":   version,
 		"step":               step,
 		"source_mode":        "manual",
-		"company_draft":      apptest.AnyMap{"display_name": "Acme draft"},
+		"company_draft":      AnyMap{"display_name": "Acme draft"},
 		"selected_fact_keys": []string{},
 		"voice_skipped":      false,
 		"connect_skipped":    false,
@@ -65,7 +65,7 @@ func TestOnboardingStateResumesAndRejectsStaleTabs(t *testing.T) {
 		t.Fatalf("resumed state = %+v, want the persisted draft", resumed)
 	}
 
-	var blocked apptest.AnyMap
+	var blocked AnyMap
 	status = e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(1, "voice"), onboardingHeaders("onboarding-blocked"), &blocked)
 	if status != http.StatusConflict || blocked["code"] != "conflict" {
@@ -83,7 +83,7 @@ func TestOnboardingStateResumesAndRejectsStaleTabs(t *testing.T) {
 		t.Fatalf("advanced state = %d %+v, want creator/v2", status, advanced)
 	}
 
-	var stale apptest.AnyMap
+	var stale AnyMap
 	status = e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(1, "connect"), onboardingHeaders("onboarding-stale"), &stale)
 	if status != http.StatusConflict || stale["code"] != "version_skew" {

--- a/backend/internal/compose/integration/orgrollup_http_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_http_integration_test.go
@@ -76,11 +76,11 @@ type orgRollupFxProblem struct {
 // optionally hanging it under parentID (empty = a root).
 func createOrgRollupOrg(t *testing.T, e *apptest.AppEnv, name, parentID string) string {
 	t.Helper()
-	body := apptest.AnyMap{"display_name": name, "source": "ui"}
+	body := AnyMap{"display_name": name, "source": "ui"}
 	if parentID != "" {
 		body["parent_org_id"] = parentID
 	}
-	var org apptest.AnyMap
+	var org AnyMap
 	if status := e.Call(t, "POST", "/v1/organizations", body, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization %q = %d %v", name, status, org)
 	}
@@ -124,8 +124,8 @@ func orgRollupOpenStage(t *testing.T, e *apptest.AppEnv) (pipelineID, stageID st
 // rounding stays exact arithmetic in the caller's test, not a guess.
 func createOrgRollupOpenDeal(t *testing.T, e *apptest.AppEnv, pipelineID, stageID, orgID string, amountMinor int64, currency string) {
 	t.Helper()
-	var deal apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	var deal AnyMap
+	status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name":            "Rollup HTTP Deal",
 		"amount_minor":    amountMinor,
 		"currency":        currency,

--- a/backend/internal/compose/integration/outbox_integration_test.go
+++ b/backend/internal/compose/integration/outbox_integration_test.go
@@ -62,15 +62,15 @@ func TestWriteStagesOneCompleteEnvelope(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
 
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Grace Hopper",
-		"emails":    []apptest.AnyMap{{"email": "grace@example.com"}},
+		"emails":    []AnyMap{{"email": "grace@example.com"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person status = %d, body %v", status, person)
 	}
@@ -124,7 +124,7 @@ func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
 	e := apptest.SetupApp(t)
 	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Admin")
 
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ada@example.com", "password": "wrong-password-entirely",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("bad login status = %d, want 401", status)
@@ -155,18 +155,18 @@ func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
 	// account-existence oracle. The in-process 429 flood throttle sits in
 	// front for distinct-email sprays; on a single account the lock wins.
 	for i := 2; i <= 5; i++ {
-		if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 			"email": "ada@example.com", "password": "wrong-password-entirely",
 		}, nil, nil); status != http.StatusUnauthorized {
 			t.Fatalf("failure %d = %d, want 401", i, status)
 		}
 	}
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ada@example.com", "password": "wrong-password-entirely",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("attempt past the lock threshold = %d, want 401 (a locked account reads as bad credentials)", status)
 	}
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "ada@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("correct password on a locked account = %d, want 401 (indistinguishable from an unknown email)", status)

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -524,17 +524,17 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	var conn map[string]any
-	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", integration.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, &conn); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me apptest.AnyMap
+	var me integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(integration.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_connect_incumbent_down_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_connect_incumbent_down_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 )
@@ -32,8 +33,8 @@ func TestConnectStandsUpAnOverlayTheIncumbentWouldNotAnswer(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(keyvault.NewMemory()))
 	e.BootstrapWorkspace(t)
 
-	var conn apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+	var conn integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/overlay/connection", integration.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, &conn); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d %v — a connect must survive an incumbent that will not answer", status, conn)

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose"
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	overlaymod "github.com/margince/margince/backend/internal/modules/overlay"
@@ -75,10 +75,10 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 		t.Fatalf("writing the pre-flip export: %v", err)
 	}
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("preflight = %d ready=%v blocking=%v", code, verdict.Ready, verdict.Blocking)
 	}
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, nil); code != http.StatusAccepted {
 		t.Fatalf("execute = %d", code)

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	overlaymod "github.com/margince/margince/backend/internal/modules/overlay"
@@ -181,7 +182,7 @@ func assertOverlayOpsGatedInNativeMode(t *testing.T, e *apptest.AppEnv) {
 func connectOverlayToTheFakeIncumbent(t *testing.T, e *apptest.AppEnv) (adminID, wsID ids.UUID, wsIDStr string) {
 	t.Helper()
 	var conn map[string]any
-	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", integration.AnyMap{
 		"incumbent":       "hubspot",
 		"region":          "eu1",
 		"privateAppToken": "fake-token-never-used",
@@ -189,11 +190,11 @@ func connectOverlayToTheFakeIncumbent(t *testing.T, e *apptest.AppEnv) (adminID,
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me apptest.AnyMap
+	var me integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(integration.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -140,17 +140,17 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
 	e.BootstrapWorkspace(t)
 
-	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", integration.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d", status)
 	}
 
-	var me apptest.AnyMap
+	var me integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	user, ok := me["user"].(apptest.AnyMap)
+	user, ok := me["user"].(integration.AnyMap)
 	if !ok {
 		t.Fatalf("/me carried no user object: %v", me)
 	}
@@ -326,7 +326,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// 1. Everything green EXCEPT the pre-flip export: not ready, the
 	// export_missing reason named, nothing sealed (F1's no-op return).
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight = %d", code)
 	}
 	if verdict.Ready || !hasBlocking(verdict, "export_missing") {
@@ -340,7 +340,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// blocking reason + the emergency disclosure; the workspace stays in
 	// overlay on its last mirror and nothing is partially migrated.
 	f.setConnectionStatus(t, "revoked")
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight (revoked) = %d", code)
 	}
 	if verdict.Ready || !hasBlocking(verdict, "incumbent_unreachable") {
@@ -366,8 +366,8 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	}
 
 	// The execute op is blocked with the flip-blocked sentinel.
-	var problem apptest.AnyMap
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	var problem integration.AnyMap
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &problem); code != http.StatusConflict {
 		t.Fatalf("execute while blocked = %d %v, want 409", code, problem)
@@ -391,7 +391,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// seals the snapshot, and previews parity with ZERO rows written.
 	f.setConnectionStatus(t, "active")
 	f.writePreflipExport(t)
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight (green) = %d", code)
 	}
 	if !verdict.Ready || len(verdict.Blocking) != 0 {
@@ -420,7 +420,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	}
 
 	// 4. The typed-phrase gate: a wrong phrase never runs the flip.
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "flip to sor",
 	}, nil, &problem); code != http.StatusUnprocessableEntity {
 		t.Fatalf("wrong-phrase execute = %d, want 422", code)
@@ -442,12 +442,12 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	f.writePreflipExport(t)
 
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("green preflight = %d ready=%v", code, verdict.Ready)
 	}
 
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("execute = %d %+v", code, accepted)
@@ -542,11 +542,11 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	if code := e.Call(t, "GET", "/v1/overlay/sync-status", nil, nil, nil); code != http.StatusNotFound {
 		t.Errorf("sync-status after flip = %d, want 404 mode_not_overlay", code)
 	}
-	var me apptest.AnyMap
+	var me integration.AnyMap
 	if code := e.Call(t, "GET", "/v1/me", nil, nil, &me); code != http.StatusOK {
 		t.Fatalf("/me = %d", code)
 	}
-	if sor, ok := me["system_of_record"].(apptest.AnyMap); !ok || sor["mode"] != "native" {
+	if sor, ok := me["system_of_record"].(integration.AnyMap); !ok || sor["mode"] != "native" {
 		t.Errorf("/me system_of_record = %v, want native", me["system_of_record"])
 	}
 	var people crmcontracts.PersonListResponse
@@ -559,7 +559,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 
 	// A second execute is refused: the flip is one-way (the lifecycle op
 	// answers mode_not_overlay once native).
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, nil); code != http.StatusNotFound {
 		t.Errorf("second execute = %d, want 404 mode_not_overlay", code)
@@ -573,8 +573,8 @@ func TestOverlayFlipEmergencyCutover(t *testing.T) {
 	// Refused while the incumbent is reachable — the never-substituted
 	// guarantee holds in BOTH directions.
 	f.writePreflipExport(t)
-	var problem apptest.AnyMap
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	var problem integration.AnyMap
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"mode": "emergency", "confirmation_phrase": "FLIP TO SOR",
 	}, nil, &problem); code != http.StatusConflict {
 		t.Fatalf("emergency while reachable = %d, want 409", code)
@@ -589,7 +589,7 @@ func TestOverlayFlipEmergencyCutover(t *testing.T) {
 	f.setConnectionStatus(t, "revoked")
 
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"mode": "emergency", "confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("emergency execute = %d %+v", code, accepted)
@@ -690,7 +690,7 @@ func TestOverlayExportDownload(t *testing.T) {
 		t.Errorf("export audit rows = %d, want exactly 1", got)
 	}
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight after export = %d", code)
 	}
 	if hasBlocking(verdict, "export_missing") {
@@ -728,7 +728,7 @@ func TestAbortedExportDoesNotSatisfyTheFlipGate(t *testing.T) {
 
 	// And the preflight still blocks on it.
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight = %d", code)
 	}
 	if !hasBlocking(verdict, "export_missing") {
@@ -780,11 +780,11 @@ func TestAFlipAdoptsAHalfLandedDealAndFinishesClosingIt(t *testing.T) {
 	})
 
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("green preflight = %d ready=%v", code, verdict.Ready)
 	}
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", integration.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("execute = %d %+v", code, accepted)
@@ -839,7 +839,7 @@ func TestFlipRefusesAMirrorRowNoCurrentDeclarationProduced(t *testing.T) {
 	f.writePreflipExport(t)
 
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight = %d", code)
 	}
 	if verdict.Ready || len(verdict.Blocking) != 1 || !hasBlocking(verdict, "force_fresh_incomplete") {
@@ -856,7 +856,7 @@ func TestFlipRefusesAMirrorRowNoCurrentDeclarationProduced(t *testing.T) {
 		t.Fatalf("re-projecting the row through the current declaration: %v", err)
 	}
 	f.writePreflipExport(t)
-	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", integration.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight after the re-projection = %d", code)
 	}
 	if !verdict.Ready || len(verdict.Blocking) != 0 {

--- a/backend/internal/compose/integration/overlay/overlay_write_audit_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_audit_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
@@ -103,7 +104,7 @@ func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 	id := firstListedID(t, e.AppEnv, "/v1/deals")
 
 	var deal crmcontracts.Deal
-	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, integration.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
 		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
 	}
 

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	overlaymod "github.com/margince/margince/backend/internal/modules/overlay"
@@ -75,17 +76,17 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 	e.BootstrapWorkspace(t)
 
 	var conn map[string]any
-	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", integration.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, &conn); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me apptest.AnyMap
+	var me integration.AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(integration.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestOverlayUpdateDealWritesBackAndReturnsTheMirroredRow(t *testing.T) {
 	id := firstListedID(t, e.AppEnv, "/v1/deals")
 
 	var deal crmcontracts.Deal
-	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, integration.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
 		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
 	}
 	if deal.Name != "Acme Renewal — Q3" {
@@ -229,11 +230,11 @@ func TestOverlayUnsupportedWritesStillRefused(t *testing.T) {
 	placeholder := ids.NewV7().String()
 
 	if status := e.Call(t, "POST", "/v1/deals/"+placeholder+"/advance",
-		apptest.AnyMap{"to_stage_id": placeholder}, nil, nil); status != http.StatusUnprocessableEntity {
+		integration.AnyMap{"to_stage_id": placeholder}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("advance_deal in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Should Never Land"}, nil, nil); status != http.StatusUnprocessableEntity {
+		integration.AnyMap{"full_name": "Should Never Land"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("create person in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
 	if status := e.Call(t, "DELETE", "/v1/activities/"+placeholder, nil, nil, nil); status != http.StatusUnprocessableEntity {
@@ -269,7 +270,7 @@ func TestOverlayTagWriteStillWorks(t *testing.T) {
 	e := setupOverlayWrite(t)
 
 	var tag crmcontracts.Tag
-	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "hot-lead"}, nil, &tag); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/tags", integration.AnyMap{"name": "hot-lead"}, nil, &tag); status != http.StatusCreated {
 		t.Fatalf("POST /v1/tags in overlay mode = %d, want 201", status)
 	}
 	if tag.Name != "hot-lead" {
@@ -287,7 +288,7 @@ func TestOverlayUpdateIgnoresIfMatch(t *testing.T) {
 	id := firstListedID(t, e.AppEnv, "/v1/people")
 
 	var person crmcontracts.Person
-	status := e.Call(t, "PATCH", "/v1/people/"+id, apptest.AnyMap{"first_name": "Grace2"},
+	status := e.Call(t, "PATCH", "/v1/people/"+id, integration.AnyMap{"first_name": "Grace2"},
 		map[string]string{"If-Match": "999"}, &person)
 	if status != http.StatusOK {
 		t.Fatalf("PATCH with a stale If-Match = %d, want 200 (If-Match is not evaluated on the overlay path)", status)
@@ -344,7 +345,7 @@ func TestOverlayUpdateDropsUnmappedFields(t *testing.T) {
 
 	var person crmcontracts.Person
 	status := e.Call(t, "PATCH", "/v1/people/"+id,
-		apptest.AnyMap{"first_name": "Rosalind2", "owner_id": ids.NewV7().String()}, nil, &person)
+		integration.AnyMap{"first_name": "Rosalind2", "owner_id": ids.NewV7().String()}, nil, &person)
 	if status != http.StatusOK {
 		t.Fatalf("PATCH with an owner_id field = %d, want 200", status)
 	}
@@ -370,7 +371,7 @@ type overlayUpdateCase struct {
 	path       string
 	externalID string
 	seedFields map[string]any
-	patch      apptest.AnyMap
+	patch      integration.AnyMap
 	field      string
 	want       string
 }
@@ -403,11 +404,11 @@ type overlayArchiveCase struct {
 // uniform proof per type rather than five ad hoc ones.
 func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 	updates := []overlayUpdateCase{
-		{"person", "/v1/people", "9301", map[string]any{"first_name": "Marie"}, apptest.AnyMap{"first_name": "Marie2"}, "first_name", "Marie2"},
-		{"organization", "/v1/organizations", "9302", map[string]any{"display_name": "Acme Org"}, apptest.AnyMap{"display_name": "Acme Org 2"}, "display_name", "Acme Org 2"},
-		{"deal", "/v1/deals", "9303", map[string]any{"name": "Widget Deal"}, apptest.AnyMap{"name": "Widget Deal 2"}, "name", "Widget Deal 2"},
-		{"lead", "/v1/leads", "9304", map[string]any{"full_name": "Grace Lead"}, apptest.AnyMap{"full_name": "Grace Lead 2"}, "full_name", "Grace Lead 2"},
-		{"activity", "/v1/activities", "9305", map[string]any{"kind": "call", "subject": "Intro Call"}, apptest.AnyMap{"subject": "Intro Call 2"}, "subject", "Intro Call 2"},
+		{"person", "/v1/people", "9301", map[string]any{"first_name": "Marie"}, integration.AnyMap{"first_name": "Marie2"}, "first_name", "Marie2"},
+		{"organization", "/v1/organizations", "9302", map[string]any{"display_name": "Acme Org"}, integration.AnyMap{"display_name": "Acme Org 2"}, "display_name", "Acme Org 2"},
+		{"deal", "/v1/deals", "9303", map[string]any{"name": "Widget Deal"}, integration.AnyMap{"name": "Widget Deal 2"}, "name", "Widget Deal 2"},
+		{"lead", "/v1/leads", "9304", map[string]any{"full_name": "Grace Lead"}, integration.AnyMap{"full_name": "Grace Lead 2"}, "full_name", "Grace Lead 2"},
+		{"activity", "/v1/activities", "9305", map[string]any{"kind": "call", "subject": "Intro Call"}, integration.AnyMap{"subject": "Intro Call 2"}, "subject", "Intro Call 2"},
 	}
 	for _, tc := range updates {
 		t.Run("update/"+tc.entityType, func(t *testing.T) {
@@ -415,7 +416,7 @@ func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
 			id := firstListedID(t, e.AppEnv, tc.path)
 
-			var body apptest.AnyMap
+			var body integration.AnyMap
 			if status := e.Call(t, "PATCH", tc.path+"/"+id, tc.patch, nil, &body); status != http.StatusOK {
 				t.Fatalf("PATCH %s/%s = %d", tc.path, id, status)
 			}
@@ -436,7 +437,7 @@ func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
 			id := firstListedID(t, e.AppEnv, tc.path)
 
-			var body apptest.AnyMap
+			var body integration.AnyMap
 			if status := e.Call(t, "DELETE", tc.path+"/"+id, nil, nil, &body); status != http.StatusOK {
 				t.Fatalf("DELETE %s/%s = %d, want 200", tc.path, id, status)
 			}

--- a/backend/internal/compose/integration/partner_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/partner_lifecycle_integration_test.go
@@ -14,8 +14,6 @@ package integration
 import (
 	"net/http"
 	"testing"
-
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
 // partnerWire is the contract Partner shape as this suite reads it.
@@ -36,14 +34,14 @@ func TestPartnerLifecycleFieldsRoundTrip(t *testing.T) {
 
 	// Upsert with the full lifecycle block.
 	var upserted partnerWire
-	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", AnyMap{
 		"partner_role":       "consulting",
 		"cert_status":        "applied",
 		"relationship_stage": "in_conversation",
 		"next_step":          "Send the partnership one-pager",
 		"next_step_due_at":   "2026-08-01",
 		"served_segments":    []string{"manufacturing", "fintech"},
-		"gate_metrics":       apptest.AnyMap{"certified_staff": 4, "retention_rate": 87},
+		"gate_metrics":       AnyMap{"certified_staff": 4, "retention_rate": 87},
 	}, nil, &upserted); status != http.StatusOK {
 		t.Fatalf("upsert partner with lifecycle fields → %d", status)
 	}
@@ -77,7 +75,7 @@ func TestPartnerLifecycleFieldsRoundTrip(t *testing.T) {
 
 	// A stage outside the closed lifecycle vocabulary is refused at the
 	// seam — 422, and the stored stage stands.
-	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", AnyMap{
 		"partner_role":       "consulting",
 		"relationship_stage": "best_friends",
 	}, map[string]string{"If-Match": "1"}, nil); status != 422 {

--- a/backend/internal/compose/integration/perfrecord_bench_test.go
+++ b/backend/internal/compose/integration/perfrecord_bench_test.go
@@ -154,7 +154,7 @@ func benchRecordSave(t *testing.T, e *apptest.AppEnv, personID string) search.Qu
 	stats, err := benchRuns("record_save_person", perf4RecordSaveBudget, recordBenchSpec, func() error {
 		edit++
 		return benchExpectOK(t, e, http.MethodPatch, "/v1/people/"+personID,
-			apptest.AnyMap{"title": "Rear Admiral " + strconv.Itoa(edit)})
+			AnyMap{"title": "Rear Admiral " + strconv.Itoa(edit)})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -229,11 +229,11 @@ func recordBenchSeeds(workspace string) []struct {
 // the row the benchmark opens is one the product's own writer produced.
 func createBenchPerson(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	var person apptest.AnyMap
-	if status := e.Call(t, http.MethodPost, "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/people", AnyMap{
 		"full_name": "Grace Hopper",
 		"source":    "ui",
-		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
+		"emails":    []AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
 	}
@@ -247,18 +247,18 @@ func createBenchOrganizationAndDeal(t *testing.T, e *apptest.AppEnv) (string, st
 	t.Helper()
 	stages := apptest.DiscoverSeededPipeline(t, e)
 
-	var org apptest.AnyMap
-	if status := e.Call(t, http.MethodPost, "/v1/organizations", apptest.AnyMap{
+	var org AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/organizations", AnyMap{
 		"display_name": "Acme GmbH",
 		"source":       "ui",
-		"domains":      []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
+		"domains":      []AnyMap{{"domain": "acme.example", "is_primary": true}},
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization = %d %v", status, org)
 	}
 	orgID := benchID(t, org, "organization")
 
-	var deal apptest.AnyMap
-	if status := e.Call(t, http.MethodPost, "/v1/deals", apptest.AnyMap{
+	var deal AnyMap
+	if status := e.Call(t, http.MethodPost, "/v1/deals", AnyMap{
 		"name": "Acme rollout", "amount_minor": 250_000_00, "currency": "EUR",
 		"pipeline_id": stages.PipelineID, "stage_id": stages.Open,
 		"organization_id": orgID, "source": "ui",
@@ -270,7 +270,7 @@ func createBenchOrganizationAndDeal(t *testing.T, e *apptest.AppEnv) (string, st
 
 // benchID reads the created record's id, failing on a payload that carries none
 // rather than measuring requests against an empty path.
-func benchID(t *testing.T, record apptest.AnyMap, what string) string {
+func benchID(t *testing.T, record AnyMap, what string) string {
 	t.Helper()
 	id, ok := record["id"].(string)
 	if !ok {
@@ -286,13 +286,13 @@ func benchID(t *testing.T, record apptest.AnyMap, what string) string {
 //
 // reqBody stays a nil interface when there is no body: a typed nil map handed
 // to Call is not nil to it, and would be marshalled as a literal `null`.
-func benchExpectOK(t *testing.T, e *apptest.AppEnv, method, path string, body apptest.AnyMap) error {
+func benchExpectOK(t *testing.T, e *apptest.AppEnv, method, path string, body AnyMap) error {
 	t.Helper()
 	var reqBody any
 	if body != nil {
 		reqBody = body
 	}
-	var out apptest.AnyMap
+	var out AnyMap
 	if status := e.Call(t, method, path, reqBody, nil, &out); status != http.StatusOK {
 		return fmt.Errorf("%s %s → %d %v", method, path, status, out)
 	}

--- a/backend/internal/compose/integration/pipeline_config_integration_test.go
+++ b/backend/internal/compose/integration/pipeline_config_integration_test.go
@@ -25,14 +25,14 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 		ID        string `json:"id"`
 		IsDefault bool   `json:"is_default"`
 	}
-	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{
-		"name": "Partnerships", "stages": []apptest.AnyMap{{"name": "Scout", "position": 1}},
+	if status := e.Call(t, "POST", "/v1/pipelines", AnyMap{
+		"name": "Partnerships", "stages": []AnyMap{{"name": "Scout", "position": 1}},
 	}, nil, &second); status != http.StatusCreated {
 		t.Fatalf("create pipeline → %d", status)
 	}
 
 	// Promoting the new pipeline demotes the seeded default in one tx.
-	if status := e.Call(t, "PATCH", "/v1/pipelines/"+second.ID, apptest.AnyMap{"is_default": true}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/pipelines/"+second.ID, AnyMap{"is_default": true}, nil, nil); status != http.StatusOK {
 		t.Fatalf("promote default → %d", status)
 	}
 	var defaults int
@@ -48,13 +48,13 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 		ID             string `json:"id"`
 		WinProbability int    `json:"win_probability"`
 	}
-	if status := e.Call(t, "POST", "/v1/stages", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/stages", AnyMap{
 		"pipeline_id": second.ID, "name": "Won", "position": 2, "semantic": "won",
 	}, nil, &stage); status != http.StatusCreated {
 		t.Fatalf("create stage → %d", status)
 	}
 	// A colliding position is a 409, not a 500.
-	if status := e.Call(t, "POST", "/v1/stages", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/stages", AnyMap{
 		"pipeline_id": second.ID, "name": "Dup", "position": 2,
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("position collision → %d, want 409", status)
@@ -64,10 +64,10 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 	}
 
 	// Rename → stage.updated; reorder → ONE pipeline.updated.
-	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, apptest.AnyMap{"name": "Closed Won"}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, AnyMap{"name": "Closed Won"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rename stage → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, apptest.AnyMap{"position": 5}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, AnyMap{"position": 5}, nil, nil); status != http.StatusOK {
 		t.Fatalf("reorder stage → %d", status)
 	}
 	var stageUpdated, pipelineUpdated int
@@ -110,13 +110,13 @@ func TestDealStakeholdersView(t *testing.T) {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Stakeholder Deal", "pipeline_id": pipelines.Data[0].ID,
 		"stage_id": pipelines.Data[0].Stages[0].ID,
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "deal_stakeholder", "deal_id": deal.ID, "person_id": e.personID,
 		"role": "champion", "source": "ui",
 	}, nil, nil); status != http.StatusCreated {

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -37,7 +37,7 @@ import (
 // request origin to prove the emitted link ignores them.
 func sendMarketing(t *testing.T, e *apptest.AppEnv, activityID, purpose, host, xfProto string) (int, string) {
 	t.Helper()
-	raw, err := json.Marshal(apptest.AnyMap{
+	raw, err := json.Marshal(AnyMap{
 		"subject": "Newsletter", "body": "hello", "to": []string{"subject@consent.test"}, "consent_purpose": purpose,
 	})
 	if err != nil {
@@ -124,7 +124,7 @@ func tokenFromLink(t *testing.T, link string) string {
 
 func grantPurpose(t *testing.T, c *consentEnv, purposeID string) {
 	t.Helper()
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant %s → %d", purposeID, status)
@@ -138,7 +138,7 @@ func createNewsletterPurpose(t *testing.T, c *consentEnv) string {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
@@ -410,7 +410,7 @@ func TestPreferenceCenterRevokedTokenReadsAsAbsent(t *testing.T) {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
@@ -448,7 +448,7 @@ func TestPreferenceCenterRejectsOversizedChoiceArray(t *testing.T) {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
@@ -457,11 +457,11 @@ func TestPreferenceCenterRejectsOversizedChoiceArray(t *testing.T) {
 	sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
 	token := tokenFromLink(t, unsubscribeLinkIn(t, transmittedBody(t, c)))
 
-	choices := make([]apptest.AnyMap, 0, 100)
+	choices := make([]AnyMap, 0, 100)
 	for i := 0; i < 100; i++ {
-		choices = append(choices, apptest.AnyMap{"purpose_key": "newsletter", "state": "withdrawn"})
+		choices = append(choices, AnyMap{"purpose_key": "newsletter", "state": "withdrawn"})
 	}
-	if s := publicCall(t, c.AppEnv, "PUT", "/v1/public/preferences/"+token, apptest.AnyMap{"choices": choices}, nil, nil); s != http.StatusUnprocessableEntity {
+	if s := publicCall(t, c.AppEnv, "PUT", "/v1/public/preferences/"+token, AnyMap{"choices": choices}, nil, nil); s != http.StatusUnprocessableEntity {
 		t.Fatalf("oversized choices PUT → %d, want 422", s)
 	}
 }

--- a/backend/internal/compose/integration/project_http_integration_test.go
+++ b/backend/internal/compose/integration/project_http_integration_test.go
@@ -92,7 +92,7 @@ func anchorOrg(t *testing.T, e *apptest.AppEnv, name string) string {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": name, "source": "manual",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("POST /organizations → %d, want 201", status)
@@ -106,7 +106,7 @@ func anchorPerson(t *testing.T, e *apptest.AppEnv, full string) string {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": full, "source": "manual",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("POST /people → %d, want 201", status)
@@ -123,7 +123,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	org := anchorOrg(t, e, "Northwind")
 
 	var created projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Warehouse rollout", "organization_id": org, "source": "manual",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -154,7 +154,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var patched projectDTO
-	if status := e.Call(t, "PATCH", "/v1/projects/"+created.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+created.ID, AnyMap{
 		"description": "Two sites, one cutover.",
 	}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("PATCH /projects/{id} → %d, want 200", status)
@@ -167,7 +167,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var advanced projectDTO
-	if status := e.Call(t, "POST", "/v1/projects/"+created.ID+"/advance", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+created.ID+"/advance", AnyMap{
 		"to_phase": "pursuing",
 	}, nil, &advanced); status != http.StatusOK {
 		t.Fatalf("POST /projects/{id}/advance → %d, want 200", status)
@@ -211,7 +211,7 @@ func TestTwoProjectsWithOneStemGetDifferentMintedKeys(t *testing.T) {
 		var created struct {
 			Key *string `json:"key"`
 		}
-		body := apptest.AnyMap{"name": name, "organization_id": org, "source": "manual"}
+		body := AnyMap{"name": name, "organization_id": org, "source": "manual"}
 		if status := e.Call(t, "POST", "/v1/projects", body, nil, &created); status != http.StatusCreated {
 			t.Fatalf("POST /projects %q → %d, want 201", name, status)
 		}
@@ -240,20 +240,20 @@ func TestClosingAProjectOverHTTPRequiresAReason(t *testing.T) {
 	org := anchorOrg(t, e, "Initech")
 
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Migration", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
 
-	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", AnyMap{
 		"to_phase": "closed",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("closing with no reason → %d, want 422", status)
 	}
 
 	var closed projectDTO
-	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", AnyMap{
 		"to_phase": "closed", "reason": "delivered",
 	}, nil, &closed); status != http.StatusOK {
 		t.Fatalf("closing with a reason → %d, want 200", status)
@@ -280,17 +280,17 @@ func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
 	// no row to protect when no id was supplied. Answering 404 to an omitted id
 	// sends the caller looking for a company it never named.
 	for name, tc := range map[string]struct {
-		body apptest.AnyMap
+		body AnyMap
 		want int
 	}{
-		"no name":    {apptest.AnyMap{"organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
-		"blank name": {apptest.AnyMap{"name": "   ", "organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
+		"no name":    {AnyMap{"organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
+		"blank name": {AnyMap{"name": "   ", "organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
 		"organization_id omitted": {
-			apptest.AnyMap{"name": "Orphan", "source": "manual"},
+			AnyMap{"name": "Orphan", "source": "manual"},
 			http.StatusUnprocessableEntity,
 		},
 		"organization_id names nothing visible": {
-			apptest.AnyMap{"name": "Orphan", "organization_id": ids.NewV7().String(), "source": "manual"},
+			AnyMap{"name": "Orphan", "organization_id": ids.NewV7().String(), "source": "manual"},
 			http.StatusNotFound,
 		},
 	} {
@@ -304,12 +304,12 @@ func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
 	// A blank name is refused on the way IN and on the way through: a rule
 	// that only one verb carries is a rule the other verb erases.
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Named", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, AnyMap{
 		"name": "   ",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("PATCH to a blank name → %d, want 422", status)
@@ -326,14 +326,14 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 	person := anchorPerson(t, e, "Pepper Potts")
 
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Arc reactor", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
 
 	var edge relationshipDTO
-	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", AnyMap{
 		"person_id": person, "role": "sponsor",
 	}, nil, &edge); status != http.StatusOK {
 		t.Fatalf("PUT stakeholder → %d, want 200", status)
@@ -344,7 +344,7 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 
 	// The same person again: the role moves, the edge does not multiply.
 	var recorrected relationshipDTO
-	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", AnyMap{
 		"person_id": person, "role": "project_lead",
 	}, nil, &recorrected); status != http.StatusOK {
 		t.Fatalf("re-attaching → %d, want 200", status)
@@ -389,7 +389,7 @@ func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
 	person := anchorPerson(t, e, "Miles Dyson")
 
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Skynet", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -400,12 +400,12 @@ func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/projects/"+project.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("a read seat reading a project → %d, want 200", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, AnyMap{
 		"description": "not allowed",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat patching a project → %d, want 403", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", AnyMap{
 		"to_phase": "pursuing",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat advancing a phase → %d, want 403", status)
@@ -413,7 +413,7 @@ func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
 	// The roster is part of the project's writable state, so both stakeholder
 	// verbs sit behind the same ceiling. Detach is asserted because it is the
 	// one that used to check only the relationship grant.
-	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", AnyMap{
 		"person_id": person, "role": "sponsor",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat attaching a stakeholder → %d, want 403", status)
@@ -438,12 +438,12 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 	org := anchorOrg(t, e, "Wayne Enterprises")
 
 	var first, second projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Applied Sciences", "organization_id": org, "source": "manual",
 	}, nil, &first); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Batcave retrofit", "organization_id": org, "source": "manual",
 	}, nil, &second); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -452,9 +452,9 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "note", "source": "manual",
-		"links": []apptest.AnyMap{{"entity_type": "project", "entity_id": first.ID}},
+		"links": []AnyMap{{"entity_type": "project", "entity_id": first.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("POST /activities → %d, want 201", status)
 	}
@@ -462,7 +462,7 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 	// A second project without asking to replace: the index refuses, and the
 	// caller must be told that in terms they can act on.
 	var problem projectProblem
-	status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", AnyMap{
 		"entity_type": "project", "entity_id": second.ID, "replace_existing_of_type": false,
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
@@ -484,7 +484,7 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 
 	// Asking to replace moves it, so the refusal really was about the rule
 	// and not about the caller's authority.
-	if status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", AnyMap{
 		"entity_type": "project", "entity_id": second.ID, "replace_existing_of_type": true,
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("relink with replace → %d, want 200", status)
@@ -501,7 +501,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 	org := anchorOrg(t, e, "Refusal GmbH")
 
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Baseline", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -509,7 +509,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 
 	t.Run("an end date before the start", func(t *testing.T) {
 		var problem projectProblem
-		if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
+		if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, AnyMap{
 			"started_at": "2026-06-01", "ended_at": "2026-01-01",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
 			t.Fatalf("an inverted date range → %d, want 422", status)
@@ -524,7 +524,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 
 	t.Run("closing without a reason", func(t *testing.T) {
 		var problem projectProblem
-		if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", AnyMap{
 			"to_phase": "closed",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
 			t.Fatalf("closing with no reason → %d, want 422", status)
@@ -543,7 +543,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 		// a 422 about the rule rather than a server fault.
 		other := anchorOrg(t, e, "Elsewhere AG")
 		var elsewhere projectDTO
-		if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 			"name": "Their work", "organization_id": other, "source": "manual",
 		}, nil, &elsewhere); status != http.StatusCreated {
 			t.Fatalf("POST /projects → %d, want 201", status)
@@ -566,7 +566,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 			t.Fatal("the bootstrapped workspace has no pipeline with stages — the fixture no longer seeds one")
 		}
 		var problem projectProblem
-		status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+		status := e.Call(t, "POST", "/v1/deals", AnyMap{
 			"name": "Mismatched", "organization_id": org, "project_id": elsewhere.ID,
 			"pipeline_id": pipelines.Data[0].ID, "stage_id": pipelines.Data[0].Stages[0].ID,
 			"source": "manual",
@@ -592,7 +592,7 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	org := anchorOrg(t, e, "Skew GmbH")
 
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Contended", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -600,7 +600,7 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	stale := strconv.Itoa(project.Version)
 
 	// Someone else moves first.
-	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, AnyMap{
 		"description": "first writer",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("first PATCH → %d, want 200", status)
@@ -610,7 +610,7 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	// different 4xx would be a different promise, so accepting either would
 	// let the surface change contracts without anything noticing.
 	var problem projectProblem
-	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, AnyMap{
 		"description": "second writer",
 	}, map[string]string{"If-Match": stale}, &problem); status != http.StatusConflict {
 		t.Fatalf("a stale If-Match → %d, want 409", status)
@@ -618,13 +618,13 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	if problem.Code != "version_skew" {
 		t.Errorf("refusal code = %q, want version_skew", problem.Code)
 	}
-	if n := callDescription(e, t, project.ID); n != "first writer" {
+	if n := callDescription(t, e, project.ID); n != "first writer" {
 		t.Fatalf("description = %q — the stale write landed anyway", n)
 	}
 }
 
 // callDescription reads one project's description back over the wire.
-func callDescription(e *apptest.AppEnv, t *testing.T, id string) string {
+func callDescription(t *testing.T, e *apptest.AppEnv, id string) string {
 	t.Helper()
 	var out projectDTO
 	if status := e.Call(t, "GET", "/v1/projects/"+id, nil, nil, &out); status != http.StatusOK {
@@ -655,13 +655,13 @@ func TestProjectOwnershipTransferOverHTTP(t *testing.T) {
 	var colleague struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/users", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/users", AnyMap{
 		"email": "colleague@northwind.test", "display_name": "Colleague", "role": "rep",
 	}, nil, &colleague); status != http.StatusCreated {
 		t.Fatalf("POST /users → %d, want 201", status)
 	}
 	for _, name := range []string{"Warehouse rollout", "ERP replacement"} {
-		if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 			"name": name, "organization_id": org, "source": "manual", "owner_id": me.User.ID,
 		}, nil, nil); status != http.StatusCreated {
 			t.Fatalf("POST /projects %s → %d, want 201", name, status)
@@ -671,7 +671,7 @@ func TestProjectOwnershipTransferOverHTTP(t *testing.T) {
 	var result struct {
 		Transferred int `json:"transferred"`
 	}
-	if status := e.Call(t, "POST", "/v1/projects/transfer-ownership", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects/transfer-ownership", AnyMap{
 		"from_owner_id": me.User.ID, "to_owner_id": colleague.ID,
 	}, nil, &result); status != http.StatusOK {
 		t.Fatalf("POST /projects/transfer-ownership → %d, want 200", status)
@@ -687,11 +687,11 @@ func TestProjectOwnershipTransferOverHTTP(t *testing.T) {
 		t.Errorf("the colleague now owns %d projects, want 2", len(listed.Data))
 	}
 
-	if status := e.Call(t, "POST", "/v1/users/"+colleague.ID+"/deactivate", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/users/"+colleague.ID+"/deactivate", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("POST /users/{id}/deactivate → %d, want 200", status)
 	}
 	var problem projectProblem
-	status := e.Call(t, "POST", "/v1/projects/transfer-ownership", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/projects/transfer-ownership", AnyMap{
 		"from_owner_id": me.User.ID, "to_owner_id": colleague.ID,
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.fieldName() != "to_owner_id" || problem.fieldCode() != "owner_not_active" {

--- a/backend/internal/compose/integration/providerkeyhttp_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyhttp_integration_test.go
@@ -46,7 +46,7 @@ func TestTheKeyIsWriteOnlyOverHTTP(t *testing.T) {
 	e := setupProviderKeyApp(t)
 
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
-		apptest.AnyMap{"api_key": providerKeySecret}, nil, nil); code != 204 {
+		AnyMap{"api_key": providerKeySecret}, nil, nil); code != 204 {
 		t.Fatalf("PUT provider key = %d, want 204", code)
 	}
 
@@ -102,7 +102,7 @@ func TestTheListSaysWhichVendorsAreConfigured(t *testing.T) {
 	}
 
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/openai",
-		apptest.AnyMap{"api_key": "sk-openai"}, nil, nil); code != 204 {
+		AnyMap{"api_key": "sk-openai"}, nil, nil); code != 204 {
 		t.Fatal("PUT failed")
 	}
 	var after struct {
@@ -140,7 +140,7 @@ func TestRemovingOverHTTPIsIdempotent(t *testing.T) {
 	e := setupProviderKeyApp(t)
 
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/anthropic",
-		apptest.AnyMap{"api_key": "sk-anthropic"}, nil, nil); code != 204 {
+		AnyMap{"api_key": "sk-anthropic"}, nil, nil); code != 204 {
 		t.Fatal("PUT failed")
 	}
 	if code := e.Call(t, "DELETE", "/v1/ai/provider-keys/anthropic", nil, nil, nil); code != 204 {
@@ -156,13 +156,13 @@ func TestRemovingOverHTTPIsIdempotent(t *testing.T) {
 func TestAVendorThatTakesNoKeyIsRefusedOverHTTP(t *testing.T) {
 	e := setupProviderKeyApp(t)
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/ollama",
-		apptest.AnyMap{"api_key": "sk-local-needs-none"}, nil, nil); code != http.StatusUnprocessableEntity {
+		AnyMap{"api_key": "sk-local-needs-none"}, nil, nil); code != http.StatusUnprocessableEntity {
 		t.Errorf("PUT for a local provider = %d, want 422", code)
 	}
 	// An empty key is the caller's mistake too: removing a credential is
 	// DELETE, not a write of nothing.
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
-		apptest.AnyMap{"api_key": "   "}, nil, nil); code != http.StatusUnprocessableEntity {
+		AnyMap{"api_key": "   "}, nil, nil); code != http.StatusUnprocessableEntity {
 		t.Errorf("PUT with a blank key = %d, want 422", code)
 	}
 	// And an OMITTED key, which is a different path from a blank one. Marking
@@ -173,7 +173,7 @@ func TestAVendorThatTakesNoKeyIsRefusedOverHTTP(t *testing.T) {
 	// thing standing between an absent field and a sealed zero-length key that
 	// would read as configured and authenticate nothing.
 	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
-		apptest.AnyMap{}, nil, nil); code != http.StatusUnprocessableEntity {
+		AnyMap{}, nil, nil); code != http.StatusUnprocessableEntity {
 		t.Errorf("PUT with no api_key at all = %d, want 422", code)
 	}
 }

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -139,18 +139,18 @@ func assertAnonymousAvailability(t *testing.T, e *apptest.AppEnv, base, window s
 func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base string, monday time.Time) {
 	t.Helper()
 	// A booking without consent is refused before any write.
-	noConsent := apptest.AnyMap{
+	noConsent := AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
-		"booker": apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker": AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 	}
 	if status := publicCall(t, e, "POST", base, noConsent, nil, nil); status != 422 {
 		t.Fatalf("booking without consent → %d, want 422", status)
 	}
 	// A bogus purpose is refused before any write too.
-	badPurpose := apptest.AnyMap{
+	badPurpose := AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
-		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
-		"consent": apptest.AnyMap{"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01"},
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"consent": AnyMap{"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01"},
 	}
 	if status := publicCall(t, e, "POST", base, badPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with unknown purpose → %d, want 422", status)
@@ -168,13 +168,13 @@ func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base str
 // else disclosed) plus a second slot under a case-folded email,
 // asserting the booker lands as ONE person. Returns the first booking
 // body so the taken slot can be re-posted.
-func bookHappyPathSlot(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent apptest.AnyMap) apptest.AnyMap {
+func bookHappyPathSlot(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent AnyMap) AnyMap {
 	t.Helper()
 	// The happy path: 201 with the slot and NOTHING else.
-	booking := apptest.AnyMap{
+	booking := AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
 		"subject": "Intro call",
-		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	var confirmation map[string]any
@@ -186,9 +186,9 @@ func bookHappyPathSlot(t *testing.T, e *apptest.AppEnv, base string, monday time
 	}
 
 	// The booker exists once; a second booking re-uses the person.
-	second := apptest.AnyMap{
+	second := AnyMap{
 		"start": monday.Add(3 * time.Hour), "end": monday.Add(3*time.Hour + 30*time.Minute),
-		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "ANNA@visitor.example"},
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "ANNA@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, second, nil, nil); status != http.StatusCreated {
@@ -238,20 +238,20 @@ func assertBookingProofAndProvenance(t *testing.T, e *apptest.AppEnv) {
 // assertWithdrawalStandsAgainstBooking covers the consent-hijack guard:
 // a withdrawal on record STANDS — an anonymous booking naming the same
 // email may proceed but cannot flip the state back to granted.
-func assertWithdrawalStandsAgainstBooking(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, purposeID string, consent apptest.AnyMap) {
+func assertWithdrawalStandsAgainstBooking(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, purposeID string, consent AnyMap) {
 	t.Helper()
 	var annaID string
 	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM person`).Scan(&annaID); err != nil {
 		t.Fatal(err)
 	}
-	if status := e.Call(t, "POST", "/v1/people/"+annaID+"/consent", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+annaID+"/consent", AnyMap{
 		"purpose_id": purposeID, "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
-	fourth := apptest.AnyMap{
+	fourth := AnyMap{
 		"start": monday.Add(7 * time.Hour), "end": monday.Add(7*time.Hour + 30*time.Minute),
-		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, fourth, nil, nil); status != http.StatusCreated {
@@ -274,12 +274,12 @@ func assertWithdrawalStandsAgainstBooking(t *testing.T, e *apptest.AppEnv, base 
 // another (see idempotentOperations' exemption). A keyed retry therefore
 // re-executes and the slot's natural key refuses it — a duplicate meeting
 // never lands, but neither does a stranger's recorded response.
-func assertIdempotencyKeyNotClaimed(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent apptest.AnyMap) {
+func assertIdempotencyKeyNotClaimed(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent AnyMap) {
 	t.Helper()
 	replayKey := map[string]string{"Idempotency-Key": "public-replay-1"}
-	third := apptest.AnyMap{
+	third := AnyMap{
 		"start": monday.Add(5 * time.Hour), "end": monday.Add(5*time.Hour + 30*time.Minute),
-		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, third, replayKey, nil); status != http.StatusCreated {
@@ -314,7 +314,7 @@ func TestPublicBookingEndToEnd(t *testing.T) {
 	assertAnonymousAvailability(t, e, base, window)
 	assertBookingRequiresValidConsent(t, e, base, monday)
 
-	consent := apptest.AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01", "wording": "You agree we may contact you about this meeting."}
+	consent := AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01", "wording": "You agree we may contact you about this meeting."}
 	booking := bookHappyPathSlot(t, e, base, monday, consent)
 	assertBookingProofAndProvenance(t, e)
 	assertWithdrawalStandsAgainstBooking(t, e, base, monday, purposeID, consent)
@@ -339,7 +339,7 @@ func TestPublicBookingRateLimited(t *testing.T) {
 
 	last := 0
 	for i := 0; i < 21; i++ {
-		last = publicCall(t, e, "POST", "/v1/public/booking/"+slug, apptest.AnyMap{}, nil, nil)
+		last = publicCall(t, e, "POST", "/v1/public/booking/"+slug, AnyMap{}, nil, nil)
 	}
 	if last != http.StatusTooManyRequests {
 		t.Fatalf("21st burst booking → %d, want 429", last)

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -120,8 +120,8 @@ func demoteToRep(t *testing.T, e *apptest.AppEnv) {
 // toward an owner-quota's attainment.
 func createAndCloseQuotaDeal(t *testing.T, e *apptest.AppEnv, stages apptest.SeededStages, ownerID string, amountMinor int64, currency string) string {
 	t.Helper()
-	var deal apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	var deal AnyMap
+	status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Quota Attainment Deal", "amount_minor": amountMinor, "currency": currency,
 		"pipeline_id": stages.PipelineID, "stage_id": stages.Open, "owner_id": ownerID, "source": "ui",
 	}, nil, &deal)
@@ -131,7 +131,7 @@ func createAndCloseQuotaDeal(t *testing.T, e *apptest.AppEnv, stages apptest.See
 	dealID := deal["id"].(string)
 	// This quota fixture wins a deal to make attainment non-zero; it holds no
 	// agreement, and the win gate wants that said rather than assumed.
-	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{
+	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", AnyMap{
 		"to_stage_id":                 stages.Won,
 		"won_without_contract_reason": "imported",
 	}, nil, &deal)
@@ -145,11 +145,11 @@ func TestQuotasHTTP(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var me apptest.AnyMap
+	var me AnyMap
 	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	adminID := me["user"].(apptest.AnyMap)["id"].(string)
+	adminID := me["user"].(AnyMap)["id"].(string)
 	teamID := seedQuotaTeam(t, e, "Quota HTTP Team")
 
 	var ownerQuotaID, teamQuotaID string
@@ -205,8 +205,8 @@ func TestQuotasHTTP(t *testing.T) {
 // side and the fresh-row invariants (version 1, no archived_at).
 func assertQuotaCreate201(t *testing.T, e *apptest.AppEnv, ownerID, teamID string) (ownerQuotaID, teamQuotaID string) {
 	t.Helper()
-	var owned apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var owned AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2020-01-01", "period_end": "2030-12-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}, nil, &owned)
@@ -223,8 +223,8 @@ func assertQuotaCreate201(t *testing.T, e *apptest.AppEnv, ownerID, teamID strin
 		t.Errorf("a fresh quota carries version 1 and no archived_at, got %+v", owned)
 	}
 
-	var team apptest.AnyMap
-	status = e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var team AnyMap
+	status = e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"team_id": teamID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 5000000, "currency": "EUR",
 	}, nil, &team)
@@ -243,7 +243,7 @@ func assertQuotaCreate201(t *testing.T, e *apptest.AppEnv, ownerID, teamID strin
 // the both-set and neither-set violations.
 func assertQuotaXOR422(t *testing.T, e *apptest.AppEnv, ownerID, teamID *string) {
 	t.Helper()
-	body := apptest.AnyMap{"period_start": "2026-01-01", "period_end": "2026-03-31", "target_minor": 1000, "currency": "EUR"}
+	body := AnyMap{"period_start": "2026-01-01", "period_end": "2026-03-31", "target_minor": 1000, "currency": "EUR"}
 	if ownerID != nil {
 		body["owner_id"] = *ownerID
 	}
@@ -263,7 +263,7 @@ func assertQuotaXOR422(t *testing.T, e *apptest.AppEnv, ownerID, teamID *string)
 
 func assertQuotaGet(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var got apptest.AnyMap
+	var got AnyMap
 	if status := e.Call(t, "GET", "/v1/quotas/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
 		t.Fatalf("get quota = %d %+v, want 200 id=%s", status, got, id)
 	}
@@ -275,7 +275,7 @@ func assertQuotaGet(t *testing.T, e *apptest.AppEnv, id string) {
 func assertQuotaList(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID, ownerID, teamID string) {
 	t.Helper()
 	var byOwner struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/quotas?owner_id="+ownerID, nil, nil, &byOwner); status != http.StatusOK {
 		t.Fatalf("list by owner_id = %d", status)
@@ -284,7 +284,7 @@ func assertQuotaList(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID,
 		t.Fatalf("owner_id filter = %+v, want exactly the owner quota", byOwner.Data)
 	}
 	var byTeam struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/quotas?team_id="+teamID, nil, nil, &byTeam); status != http.StatusOK {
 		t.Fatalf("list by team_id = %d", status)
@@ -302,7 +302,7 @@ func assertQuotaList(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID,
 func assertQuotaListSort(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID string) {
 	t.Helper()
 	var asc struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/quotas?sort=period_start", nil, nil, &asc); status != http.StatusOK {
 		t.Fatalf("sort=period_start = %d", status)
@@ -311,7 +311,7 @@ func assertQuotaListSort(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuot
 		t.Fatalf("sort=period_start order = %+v, want [owner %s, team %s]", asc.Data, ownerQuotaID, teamQuotaID)
 	}
 	var desc struct {
-		Data []apptest.AnyMap `json:"data"`
+		Data []AnyMap `json:"data"`
 	}
 	if status := e.Call(t, "GET", "/v1/quotas?sort=-period_start", nil, nil, &desc); status != http.StatusOK {
 		t.Fatalf("sort=-period_start = %d", status)
@@ -336,22 +336,22 @@ func assertQuotaListSort(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuot
 // then a non-numeric If-Match (422 validation_error/malformed_if_match).
 func assertQuotaUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var updated apptest.AnyMap
-	status := e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 2000000},
+	var updated AnyMap
+	status := e.Call(t, "PATCH", "/v1/quotas/"+id, AnyMap{"target_minor": 2000000},
 		map[string]string{"If-Match": "1"}, &updated)
 	if status != http.StatusOK || updated["target_minor"].(float64) != 2000000 || updated["version"].(float64) != 2 {
 		t.Fatalf("update = %d %+v, want 200 target=2000000 version=2", status, updated)
 	}
 
 	var stale quotaProblem
-	status = e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 3000000},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+id, AnyMap{"target_minor": 3000000},
 		map[string]string{"If-Match": "1"}, &stale)
 	if status != http.StatusConflict || stale.Code != "version_skew" {
 		t.Fatalf("stale If-Match = %d %+v, want 409 version_skew", status, stale)
 	}
 
 	var malformed quotaProblem
-	status = e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 3000000},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+id, AnyMap{"target_minor": 3000000},
 		map[string]string{"If-Match": "not-a-version"}, &malformed)
 	if status != http.StatusUnprocessableEntity || malformed.Code != "validation_error" {
 		t.Fatalf("malformed If-Match = %d %+v, want 422 validation_error", status, malformed)
@@ -363,8 +363,8 @@ func assertQuotaUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 // house single-get convention: an archived quota stays fetchable by id.
 func assertQuotaArchive(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var created apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var created AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 100, "currency": "EUR",
 	}, nil, &created)
@@ -373,13 +373,13 @@ func assertQuotaArchive(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	}
 	id := created["id"].(string)
 
-	var archived apptest.AnyMap
+	var archived AnyMap
 	status = e.Call(t, "DELETE", "/v1/quotas/"+id, nil, nil, &archived)
 	if status != http.StatusOK || archived["archived_at"] == nil || archived["id"] != id {
 		t.Fatalf("archive = %d %+v, want 200 + the full entity with archived_at set", status, archived)
 	}
 
-	var stillGettable apptest.AnyMap
+	var stillGettable AnyMap
 	if status := e.Call(t, "GET", "/v1/quotas/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
 		t.Fatalf("get archived quota = %d %+v, want 200 with archived_at set", status, stillGettable)
 	}
@@ -408,21 +408,21 @@ func assertQuotaNegativeTarget(t *testing.T, e *apptest.AppEnv, ownerID string) 
 	}
 
 	var problem quotaProblem
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": -1, "currency": "EUR",
 	}, nil, &problem)
 	assertNegativeTarget422(status, problem, "create")
 
-	var created apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var created AnyMap
+	if status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2027-01-01", "period_end": "2027-03-31",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("seed quota for the patch scenario = %d %+v", status, created)
 	}
 	var patched quotaProblem
-	status = e.Call(t, "PATCH", "/v1/quotas/"+created["id"].(string), apptest.AnyMap{"target_minor": -1},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+created["id"].(string), AnyMap{"target_minor": -1},
 		map[string]string{"If-Match": "1"}, &patched)
 	assertNegativeTarget422(status, patched, "patch")
 }
@@ -430,7 +430,7 @@ func assertQuotaNegativeTarget(t *testing.T, e *apptest.AppEnv, ownerID string) 
 func assertQuotaInvalidCurrency(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	var problem quotaProblem
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "eur",
 	}, nil, &problem)
@@ -444,7 +444,7 @@ func assertQuotaInvalidCurrency(t *testing.T, e *apptest.AppEnv, ownerID string)
 func assertQuotaInvertedPeriod(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	var problem quotaProblem
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-03-31", "period_end": "2026-01-01",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &problem)
@@ -481,8 +481,8 @@ func assertCheckBreachIsAnsweredWithoutItsConstraintName(
 // the signed gap, the band, and the per-deal decomposition.
 func assertQuotaAttainmentHappy(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var quota AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2020-01-01", "period_end": "2030-12-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}, nil, &quota)
@@ -494,7 +494,7 @@ func assertQuotaAttainmentHappy(t *testing.T, e *apptest.AppEnv, ownerID string)
 	stages := apptest.DiscoverSeededPipeline(t, e)
 	dealID := createAndCloseQuotaDeal(t, e, stages, ownerID, 1_500_000, "EUR")
 
-	var att apptest.AnyMap
+	var att AnyMap
 	status = e.Call(t, "GET", "/v1/quotas/"+quotaID+"/attainment", nil, nil, &att)
 	if status != http.StatusOK {
 		t.Fatalf("attainment = %d %v", status, att)
@@ -521,7 +521,7 @@ func assertQuotaAttainmentHappy(t *testing.T, e *apptest.AppEnv, ownerID string)
 	if !ok || len(deals) != 1 {
 		t.Fatalf("contributing_deals = %v, want exactly one entry", att["contributing_deals"])
 	}
-	first, _ := deals[0].(apptest.AnyMap)
+	first, _ := deals[0].(AnyMap)
 	if first["deal_id"] != dealID || first["base_value_minor"].(float64) != 1_500_000 {
 		t.Errorf("contributing_deals[0] = %+v, want deal_id=%s base_value_minor=1500000", first, dealID)
 	}
@@ -532,8 +532,8 @@ func assertQuotaAttainmentHappy(t *testing.T, e *apptest.AppEnv, ownerID string)
 
 func assertQuotaAttainmentTargetZero(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var quota AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 0, "currency": "EUR",
 	}, nil, &quota)
@@ -553,8 +553,8 @@ func assertQuotaAttainmentTargetZero(t *testing.T, e *apptest.AppEnv, ownerID st
 // wrapped sentinel carries for the server log.
 func assertQuotaAttainmentComputationFailed(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota apptest.AnyMap
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	var quota AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "GBP",
 	}, nil, &quota)
@@ -581,7 +581,7 @@ func assertQuotaRepCannotCreate(t *testing.T, e *apptest.AppEnv, ownerID string)
 	t.Helper()
 	demoteToRep(t, e)
 	var problem quotaProblem
-	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/quotas", AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &problem)

--- a/backend/internal/compose/integration/rates_http_integration_test.go
+++ b/backend/internal/compose/integration/rates_http_integration_test.go
@@ -30,7 +30,7 @@ type fxRateListDTO struct {
 	Data []fxRateDTO `json:"data"`
 }
 
-func baseCurrency(e *apptest.AppEnv, t *testing.T) string {
+func baseCurrency(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var base string
 	if err := e.Owner.QueryRow(context.Background(),
@@ -46,7 +46,7 @@ func TestFxRatesOverHTTP(t *testing.T) {
 	today := time.Now().UTC().Format("2006-01-02")
 
 	from := "USD"
-	if baseCurrency(e, t) == "USD" {
+	if baseCurrency(t, e) == "USD" {
 		from = "GBP"
 	}
 

--- a/backend/internal/compose/integration/recordcontext_http_integration_test.go
+++ b/backend/internal/compose/integration/recordcontext_http_integration_test.go
@@ -54,14 +54,14 @@ func seedPersonWithActivity(t *testing.T, e *apptest.AppEnv) string {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Context Anchor",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "note", "body": "Discussed renewal terms",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -77,9 +77,9 @@ func seedMeetingLinkedTo(t *testing.T, e *apptest.AppEnv, personID string) strin
 	var meeting struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "meeting", "subject": "Renewal review",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": personID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": personID}},
 	}, nil, &meeting); status != http.StatusCreated {
 		t.Fatalf("log meeting → %d", status)
 	}
@@ -188,7 +188,7 @@ func TestGetRecordContextReturnsAnchorAndIsRowScoped(t *testing.T) {
 		var lead struct {
 			ID string `json:"id"`
 		}
-		if s := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Context Lead"}, nil, &lead); s != http.StatusCreated {
+		if s := e.Call(t, "POST", "/v1/leads", AnyMap{"full_name": "Context Lead"}, nil, &lead); s != http.StatusCreated {
 			t.Fatalf("create lead → %d", s)
 		}
 		var got contextResponseWire

--- a/backend/internal/compose/integration/recordhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_http_integration_test.go
@@ -72,8 +72,8 @@ const recordHistoryFixtureRows = 4
 
 func seedRecordHistoryHTTPFixture(t *testing.T, e *apptest.AppEnv, dbEnv *Env) recordHistoryHTTPFixture {
 	t.Helper()
-	var person apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	var person AnyMap
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Record History Subject",
 		"source":    "ui",
 	}, nil, &person); status != http.StatusCreated {

--- a/backend/internal/compose/integration/recordrestore_integration_test.go
+++ b/backend/internal/compose/integration/recordrestore_integration_test.go
@@ -97,11 +97,11 @@ func TestEndToEnd_anAuditedChangeGoesBack(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Original", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Original", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+		AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch person → %d", status)
 	}
 
@@ -141,11 +141,11 @@ func TestEndToEnd_anEntryAlreadyPutBackRefusesBySayingSo(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Twice", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Twice", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+		AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -173,14 +173,14 @@ func TestEndToEnd_aFieldWrittenAgainRefusesTheRestore(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Superseded", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Superseded", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("first patch → %d", status)
 	}
 	target := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "COO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "COO"}, nil, nil); status != 200 {
 		t.Fatalf("second patch → %d", status)
 	}
 
@@ -211,14 +211,14 @@ func TestEndToEnd_restoringNullIntoAColumnTheModuleCannotClearRefuses(t *testing
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Call Greta",
 	}, nil, &activity); status != 201 {
 		t.Fatalf("create activity → %d", status)
 	}
 	// due_at was empty; setting it records a before-image holding null.
 	if status := e.Call(t, "PATCH", "/v1/activities/"+activity.ID,
-		apptest.AnyMap{"due_at": "2026-09-01T10:00:00Z"}, nil, nil); status != 200 {
+		AnyMap{"due_at": "2026-09-01T10:00:00Z"}, nil, nil); status != 200 {
 		t.Fatalf("set due_at → %d", status)
 	}
 
@@ -245,10 +245,10 @@ func TestEndToEnd_undoingAnUndoReopensTheOriginalEntry(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Reundo", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Reundo", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	original := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -282,10 +282,10 @@ func TestEndToEnd_aStaleVersionRefusesTheRestoreAndWritesNothing(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Stale", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Stale", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -293,7 +293,7 @@ func TestEndToEnd_aStaleVersionRefusesTheRestoreAndWritesNothing(t *testing.T) {
 
 	// Somebody else touches the record between reading and pressing.
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"full_name": "Greta Moved"}, nil, nil); status != 200 {
+		AnyMap{"full_name": "Greta Moved"}, nil, nil); status != 200 {
 		t.Fatalf("concurrent patch → %d", status)
 	}
 	if status, _ := restore(t, e, "person", created.ID, entry.ID, stale); status != 409 {
@@ -315,13 +315,13 @@ func TestEndToEnd_anEntryFromAnotherRecordIsNotFound(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	var mine, theirs personRecord
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Greta Mine"}, nil, &mine); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Greta Mine"}, nil, &mine); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Greta Theirs", "title": "CTO"}, nil, &theirs); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Greta Theirs", "title": "CTO"}, nil, &theirs); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+theirs.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+theirs.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	other := theUpdateEntry(t, readHistory(t, e, "person", theirs.ID))
@@ -371,10 +371,10 @@ func TestEndToEnd_anArchivedRecordSaysSoRatherThanFailingLater(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Archived", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Archived", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -402,20 +402,20 @@ func TestEndToEnd_aRetiredCustomFieldRefusesByNamingIt(t *testing.T) {
 		ColumnName string `json:"column_name"`
 		Version    int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/custom-fields", AnyMap{
 		"object": "person", "label": "Budget", "type": "text", "source": "manual",
 	}, nil, &field); status != 201 {
 		t.Fatalf("create custom field → %d", status)
 	}
 
 	var created personRecord
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Greta Custom", field.ColumnName: "first",
 	}, nil, &created); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{field.ColumnName: "second"}, nil, nil); status != 200 {
+		AnyMap{field.ColumnName: "second"}, nil, nil); status != 200 {
 		t.Fatalf("patch custom field → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -462,10 +462,10 @@ func TestEndToEnd_aRestoreWithoutAUsableIfMatchIsRefused(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Precondition", "title": "CTO"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Precondition", "title": "CTO"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "CEO"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{"title": "CEO"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -498,19 +498,19 @@ func TestEndToEnd_aRetireTheVersionGuardCannotSeeIsCaughtAtWriteTime(t *testing.
 		ID         string `json:"id"`
 		ColumnName string `json:"column_name"`
 	}
-	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/custom-fields", AnyMap{
 		"object": "person", "label": "Budget", "type": "text", "source": "manual",
 	}, nil, &field); status != 201 {
 		t.Fatalf("create custom field → %d", status)
 	}
 	var created personRecord
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Greta Dropped", field.ColumnName: "first",
 	}, nil, &created); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{field.ColumnName: "second"}, nil, nil); status != 200 {
+		AnyMap{field.ColumnName: "second"}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)
 	}
 	entry := theUpdateEntry(t, readHistory(t, e, "person", created.ID))
@@ -550,11 +550,11 @@ func TestEndToEnd_aFieldFilledInGoesBackToEmpty(t *testing.T) {
 	// Created with NO title, so the change below records a before-image of null.
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Greta Cleared"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Greta Cleared"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"title": "Typed by mistake"}, nil, nil); status != 200 {
+		AnyMap{"title": "Typed by mistake"}, nil, nil); status != 200 {
 		t.Fatalf("fill the field → %d", status)
 	}
 
@@ -595,13 +595,13 @@ func TestEndToEnd_anActivityFieldFilledInRefusesBecauseItCannotBeCleared(t *test
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Call Greta",
 	}, nil, &activity); status != 201 {
 		t.Fatalf("create activity → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/activities/"+activity.ID,
-		apptest.AnyMap{"due_at": "2026-09-01T10:00:00Z"}, nil, nil); status != 200 {
+		AnyMap{"due_at": "2026-09-01T10:00:00Z"}, nil, nil); status != 200 {
 		t.Fatalf("set due_at → %d", status)
 	}
 
@@ -626,14 +626,14 @@ func TestEndToEnd_anAddressGoesBackAsOneField(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	var created personRecord
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Greta Address",
-		"address":   apptest.AnyMap{"city": "Hanoi", "line1": "1 First Street"},
+		"address":   AnyMap{"city": "Hanoi", "line1": "1 First Street"},
 	}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
-	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{
-		"address": apptest.AnyMap{"city": "Da Nang", "line1": "2 Second Street"},
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, AnyMap{
+		"address": AnyMap{"city": "Da Nang", "line1": "2 Second Street"},
 	}, nil, nil); status != 200 {
 		t.Fatalf("change the address → %d", status)
 	}
@@ -676,12 +676,12 @@ func TestEndToEnd_severalChangesGoBackOneAtATime(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Walker", "title": "A"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Walker", "title": "A"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
 	for _, value := range []string{"B", "C"} {
 		if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-			apptest.AnyMap{"title": value}, nil, nil); status != 200 {
+			AnyMap{"title": value}, nil, nil); status != 200 {
 			t.Fatalf("set title %s → %d", value, status)
 		}
 	}
@@ -745,11 +745,11 @@ func TestEndToEnd_anExplicitNullClearsTheFieldRatherThanBeingIgnored(t *testing.
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Nullable", "title": "Head of Nothing"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Nullable", "title": "Head of Nothing"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"title": nil}, nil, nil); status != 200 {
+		AnyMap{"title": nil}, nil, nil); status != 200 {
 		t.Fatalf("clear the title → %d", status)
 	}
 	if title := readPerson(t, e, created.ID).Title; title != nil && *title != "" {
@@ -760,11 +760,11 @@ func TestEndToEnd_anExplicitNullClearsTheFieldRatherThanBeingIgnored(t *testing.
 	// An absent field is still left alone — the whole point of telling the two
 	// apart. A patch of one field must not wipe the others.
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"title": "Restored By Hand"}, nil, nil); status != 200 {
+		AnyMap{"title": "Restored By Hand"}, nil, nil); status != 200 {
 		t.Fatalf("set the title again → %d", status)
 	}
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"first_name": "Nully"}, nil, nil); status != 200 {
+		AnyMap{"first_name": "Nully"}, nil, nil); status != 200 {
 		t.Fatalf("patch a different field → %d", status)
 	}
 	if title := readPerson(t, e, created.ID).Title; title == nil || *title != "Restored By Hand" {
@@ -780,13 +780,13 @@ func TestEndToEnd_aNullOnAnUnclearableFieldIsRefusedByName(t *testing.T) {
 
 	var created personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Named Forever"}, nil, &created); status != 201 {
+		AnyMap{"full_name": "Named Forever"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
 	// full_name is not nullable in the contract and a record with no name is
 	// not a record anybody can find again.
 	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID,
-		apptest.AnyMap{"full_name": nil}, nil, nil); status != 422 {
+		AnyMap{"full_name": nil}, nil, nil); status != 422 {
 		t.Errorf("clearing full_name → %d, want 422 naming the field", status)
 	}
 	if name := readPerson(t, e, created.ID).FullName; name != "Named Forever" {
@@ -810,14 +810,14 @@ func TestEndToEnd_anEntryTouchingAFieldHeldElsewhereIsStillUndoable(t *testing.T
 		Version int64  `json:"version"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Held Elsewhere Ltd"}, nil, &created); status != 201 {
+		AnyMap{"display_name": "Held Elsewhere Ltd"}, nil, &created); status != 201 {
 		t.Fatalf("create → %d", status)
 	}
 	// domains and relationship_types live in their own tables; industry is an
 	// ordinary column, so the entry mixes both kinds.
-	if status := e.Call(t, "PATCH", "/v1/organizations/"+created.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/organizations/"+created.ID, AnyMap{
 		"industry":           "Manufacturing",
-		"domains":            []apptest.AnyMap{{"domain": "held.test", "is_primary": true}},
+		"domains":            []AnyMap{{"domain": "held.test", "is_primary": true}},
 		"relationship_types": []string{"customer"},
 	}, nil, nil); status != 200 {
 		t.Fatalf("patch → %d", status)

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -41,10 +41,10 @@ func setupRelationships(t *testing.T) *relEnv {
 	var person, org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Edge Person"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{"full_name": "Edge Person"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Edge Org"}, nil, &org); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": "Edge Org"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
 	return &relEnv{AppEnv: e, personID: person.ID, orgID: org.ID}
@@ -57,7 +57,7 @@ func TestRelationshipLifecycle(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "is_current_primary": true, "source": "ui",
 	}, nil, &first); status != http.StatusCreated {
@@ -68,10 +68,10 @@ func TestRelationshipLifecycle(t *testing.T) {
 	var org2 struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Second Org"}, nil, &org2); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": "Second Org"}, nil, &org2); status != http.StatusCreated {
 		t.Fatalf("create org2 → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": org2.ID,
 		"is_current_primary": true, "source": "ui",
 	}, nil, nil); status != http.StatusCreated {
@@ -100,12 +100,12 @@ func TestRelationshipLifecycle(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, apptest.AnyMap{"role": "ceo"},
+	status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, AnyMap{"role": "ceo"},
 		map[string]string{"If-Match": "999"}, &problem)
 	if status != http.StatusConflict || problem.Code != "version_skew" {
 		t.Fatalf("stale If-Match → %d %q, want 409 version_skew", status, problem.Code)
 	}
-	if status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, apptest.AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("update → %d", status)
 	}
 
@@ -114,13 +114,13 @@ func TestRelationshipLifecycle(t *testing.T) {
 	}
 
 	// A malformed endpoint shape is a 422, not a DB error.
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "source": "ui",
 	}, nil, nil); status != 422 {
 		t.Fatalf("shape-violating edge → %d, want 422", status)
 	}
 	// An invisible endpoint reads as absent (H1).
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": "00000000-0000-7000-8000-00000000dead",
 		"organization_id": e.orgID, "source": "ui",
 	}, nil, nil); status != http.StatusNotFound {
@@ -147,7 +147,7 @@ func TestAnAgentArchivesAnEdgeOnItsOwnPassport(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "source": "ui",
 	}, nil, &edge); status != http.StatusCreated {
@@ -157,7 +157,7 @@ func TestAnAgentArchivesAnEdgeOnItsOwnPassport(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "edge agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -206,7 +206,7 @@ func TestAFlooredEdgeArchiveStagesWithItsVersionPinned(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "source": "ui",
 	}, nil, &edge); status != http.StatusCreated {
@@ -216,7 +216,7 @@ func TestAFlooredEdgeArchiveStagesWithItsVersionPinned(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "edge agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -263,7 +263,7 @@ func TestAFlooredEdgeArchiveStagesWithItsVersionPinned(t *testing.T) {
 
 	// And it can be REJECTED, which is the half a caller cannot fake: a decision
 	// runs the same visibility predicate as the list.
-	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", apptest.AnyMap{
+	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", AnyMap{
 		"reason": "probe",
 	}, nil, nil); got != http.StatusOK {
 		t.Fatalf("deciding the staged archive → %d, want 200 — a row the inbox lists and cannot decide is "+
@@ -292,7 +292,7 @@ func TestAnApprovedEdgeArchiveRefusesAfterTheEdgeMoves(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "source": "ui",
 	}, nil, &edge); status != http.StatusCreated {
@@ -302,7 +302,7 @@ func TestAnApprovedEdgeArchiveRefusesAfterTheEdgeMoves(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "skew agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -317,13 +317,13 @@ func TestAnApprovedEdgeArchiveRefusesAfterTheEdgeMoves(t *testing.T) {
 
 	// The human approves the edge they were shown.
 	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve",
-		apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+		AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 
 	// The edge is then rewritten through the auto_execute patch route, which
 	// runs unattended. Its version moves; the approval's does not.
-	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge.ID, AnyMap{
 		"role": "chief technology officer",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rewriting the edge → %d", status)
@@ -393,9 +393,9 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 	var partner struct {
 		CertStatus string `json:"cert_status"`
 	}
-	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", AnyMap{
 		"partner_role": "consulting", "cert_status": "certified",
-		"gate_metrics": apptest.AnyMap{"certified_staff": 3, "retention_rate": 90},
+		"gate_metrics": AnyMap{"certified_staff": 3, "retention_rate": 90},
 	}, nil, &partner); status != http.StatusOK || partner.CertStatus != "certified" {
 		t.Fatalf("upsert partner → %d %+v", status, partner)
 	}
@@ -476,7 +476,7 @@ func TestAnApprovalStaysDecidableAfterItsTargetIsArchived(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "archived target agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -485,7 +485,7 @@ func TestAnApprovalStaysDecidableAfterItsTargetIsArchived(t *testing.T) {
 	var problem struct {
 		Detail string `json:"detail"`
 	}
-	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", AnyMap{
 		"target_url": "https://example.test/vanishing", "event_types": []string{"organization.created"},
 	}, map[string]string{"Authorization": "Bearer " + minted.Token}, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent webhook-subscription create → %d, want 403 approval_required", status)
@@ -495,7 +495,7 @@ func TestAnApprovalStaysDecidableAfterItsTargetIsArchived(t *testing.T) {
 	// A create names no existing row, so there is nothing for the archive race
 	// to remove — which is itself the point: the row must be decidable with a
 	// NULL target, the state every staged create is in.
-	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", apptest.AnyMap{
+	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", AnyMap{
 		"reason": "no longer wanted",
 	}, nil, nil); got != http.StatusOK {
 		t.Errorf("rejecting an approval whose target does not exist → %d, want 200 — a human must be able "+

--- a/backend/internal/compose/integration/relinkbatch_http_integration_test.go
+++ b/backend/internal/compose/integration/relinkbatch_http_integration_test.go
@@ -26,7 +26,7 @@ func TestRelinkingAThreadOverHTTP(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Stark Industries")
 	var project projectDTO
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Arc reactor", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -38,7 +38,7 @@ func TestRelinkingAThreadOverHTTP(t *testing.T) {
 		var activity struct {
 			ID string `json:"id"`
 		}
-		if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 			"kind": "note", "source": "manual", "body": "part of one conversation",
 		}, nil, &activity); status != http.StatusCreated {
 			t.Fatalf("POST /activities → %d, want 201", status)
@@ -56,7 +56,7 @@ func TestRelinkingAThreadOverHTTP(t *testing.T) {
 	}
 
 	var out relinkBatchDTO
-	if status := e.Call(t, "POST", "/v1/activities/relink-thread", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/relink-thread", AnyMap{
 		"thread_key": key, "entity_type": "project", "entity_id": project.ID,
 	}, nil, &out); status != http.StatusOK {
 		t.Fatalf("POST /activities/relink-thread → %d, want 200", status)
@@ -66,14 +66,14 @@ func TestRelinkingAThreadOverHTTP(t *testing.T) {
 	}
 
 	var problem projectProblem
-	if status := e.Call(t, "POST", "/v1/activities/relink-thread", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/relink-thread", AnyMap{
 		"thread_key": key, "entity_type": "invoice", "entity_id": project.ID,
 	}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Errorf("a destination outside the link vocabulary → %d, want 422", status)
 	}
 
 	var bulk relinkBatchDTO
-	if status := e.Call(t, "POST", "/v1/activities/relink-bulk", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/relink-bulk", AnyMap{
 		"activity_ids": members[:2], "entity_type": "organization", "entity_id": org,
 	}, nil, &bulk); status != http.StatusOK {
 		t.Fatalf("POST /activities/relink-bulk → %d, want 200", status)
@@ -81,7 +81,7 @@ func TestRelinkingAThreadOverHTTP(t *testing.T) {
 	if bulk.Relinked != 2 {
 		t.Errorf("bulk relinked = %d, want 2", bulk.Relinked)
 	}
-	if status := e.Call(t, "POST", "/v1/activities/relink-bulk", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/relink-bulk", AnyMap{
 		"activity_ids": []string{ids.NewV7().String()}, "entity_type": "organization", "entity_id": org,
 	}, nil, &problem); status != http.StatusNotFound {
 		t.Errorf("a named id that does not exist → %d, want 404", status)

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -117,7 +117,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Acme"}, nil, &org); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{"display_name": "Acme"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
 	var pipelines struct {
@@ -143,7 +143,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 		t.Fatalf("no open stage in the seeded pipeline: %+v", pipelines)
 	}
 	for i := 0; i < 2; i++ {
-		if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 			"name": fmt.Sprintf("Acme Deal %d", i), "pipeline_id": pipelines.Data[0].ID,
 			"stage_id": stageID, "organization_id": org.ID,
 		}, nil, nil); status != http.StatusCreated {
@@ -171,7 +171,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 		Code string `json:"code"`
 	}
 	status := e.Call(t, "POST", "/v1/reports/open-deals-per-company",
-		apptest.AnyMap{"group_by": []string{"captured_by"}}, nil, &problem)
+		AnyMap{"group_by": []string{"captured_by"}}, nil, &problem)
 	if status != 422 || problem.Code != "report_field_not_allowed" {
 		t.Fatalf("OOV field → %d %q, want 422 report_field_not_allowed", status, problem.Code)
 	}

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -70,17 +70,17 @@ type requiredIDFixtures struct {
 func seedRequiredIDFixtures(t *testing.T, e *apptest.AppEnv) requiredIDFixtures {
 	t.Helper()
 	var out requiredIDFixtures
-	out.person = createAndID(t, e, "/v1/people", apptest.AnyMap{"full_name": "Merge Source"})
-	out.organization = createAndID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Merge Org"})
-	out.activity = createAndID(t, e, "/v1/activities", apptest.AnyMap{
+	out.person = createAndID(t, e, "/v1/people", AnyMap{"full_name": "Merge Source"})
+	out.organization = createAndID(t, e, "/v1/organizations", AnyMap{"display_name": "Merge Org"})
+	out.activity = createAndID(t, e, "/v1/activities", AnyMap{
 		"kind": "note", "body": "relink probe",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": out.person}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": out.person}},
 	})
-	out.list = createAndID(t, e, "/v1/lists", apptest.AnyMap{
+	out.list = createAndID(t, e, "/v1/lists", AnyMap{
 		"name": "Required IDs", "entity_type": "person", "list_type": "static",
 	})
-	out.tag = createAndID(t, e, "/v1/tags", apptest.AnyMap{"name": "required-ids"})
-	out.project = createAndID(t, e, "/v1/projects", apptest.AnyMap{
+	out.tag = createAndID(t, e, "/v1/tags", AnyMap{"name": "required-ids"})
+	out.project = createAndID(t, e, "/v1/projects", AnyMap{
 		"name": "Stakeholder probe", "organization_id": out.organization, "source": "manual",
 	})
 	out.deal = seedDealForRequiredIDs(t, e)
@@ -102,7 +102,7 @@ func seedRequiredIDFixtures(t *testing.T, e *apptest.AppEnv) requiredIDFixtures 
 // createAndID posts one fixture and returns its id, failing loudly if the create
 // itself was refused — a fixture that silently did not exist would turn every row
 // below into a 404 about the path.
-func createAndID(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
+func createAndID(t *testing.T, e *apptest.AppEnv, path string, body AnyMap) string {
 	t.Helper()
 	var created struct {
 		ID string `json:"id"`
@@ -120,7 +120,7 @@ func createAndID(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyM
 // the id under test, so the status difference cannot come from anything else.
 type requiredIDCase struct {
 	method, path      string
-	omitted, supplied apptest.AnyMap
+	omitted, supplied AnyMap
 	field             string
 }
 
@@ -135,64 +135,64 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		// that has to keep up: one rule, one answer, whichever surface asks.
 		"AdvanceDealRequest.to_stage_id": {
 			method: "POST", path: "/v1/deals/" + f.deal + "/advance",
-			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"to_stage_id": absent}, field: "to_stage_id",
+			omitted: AnyMap{}, supplied: AnyMap{"to_stage_id": absent}, field: "to_stage_id",
 		},
 		"CreateStageRequest.pipeline_id": {
 			method: "POST", path: "/v1/stages",
-			omitted:  apptest.AnyMap{"name": "Orphan stage", "position": 9},
-			supplied: apptest.AnyMap{"name": "Orphan stage", "position": 9, "pipeline_id": absent},
+			omitted:  AnyMap{"name": "Orphan stage", "position": 9},
+			supplied: AnyMap{"name": "Orphan stage", "position": 9, "pipeline_id": absent},
 			field:    "pipeline_id",
 		},
 		"MergePersonJSONBody.target_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/merge",
-			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"target_id": absent}, field: "target_id",
+			omitted: AnyMap{}, supplied: AnyMap{"target_id": absent}, field: "target_id",
 		},
 		"MergeOrganizationJSONBody.target_id": {
 			method: "POST", path: "/v1/organizations/" + f.organization + "/merge",
-			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"target_id": absent}, field: "target_id",
+			omitted: AnyMap{}, supplied: AnyMap{"target_id": absent}, field: "target_id",
 		},
 		"RelinkActivityJSONBody.entity_id": {
 			method: "POST", path: "/v1/activities/" + f.activity + "/relink",
-			omitted:  apptest.AnyMap{"entity_type": "person"},
-			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  AnyMap{"entity_type": "person"},
+			supplied: AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"RecordConsentRequest.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent",
-			omitted:  apptest.AnyMap{"new_state": "granted"},
-			supplied: apptest.AnyMap{"new_state": "granted", "purpose_id": absent},
+			omitted:  AnyMap{"new_state": "granted"},
+			supplied: AnyMap{"new_state": "granted", "purpose_id": absent},
 			field:    "purpose_id",
 		},
 		"IssueDoubleOptInJSONBody.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
-			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"purpose_id": absent}, field: "purpose_id",
+			omitted: AnyMap{}, supplied: AnyMap{"purpose_id": absent}, field: "purpose_id",
 		},
 		"AddListMemberRequest.entity_id": {
 			method: "POST", path: "/v1/lists/" + f.list + "/members",
-			omitted:  apptest.AnyMap{"entity_type": "person"},
-			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  AnyMap{"entity_type": "person"},
+			supplied: AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"ApplyTagRequest.entity_id": {
 			method: "POST", path: "/v1/tags/" + f.tag + "/apply",
-			omitted:  apptest.AnyMap{"entity_type": "person"},
-			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  AnyMap{"entity_type": "person"},
+			supplied: AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"SetProjectStakeholderRequest.person_id": {
 			method: "PUT", path: "/v1/projects/" + f.project + "/stakeholders",
-			omitted:  apptest.AnyMap{"role": "sponsor"},
-			supplied: apptest.AnyMap{"role": "sponsor", "person_id": absent},
+			omitted:  AnyMap{"role": "sponsor"},
+			supplied: AnyMap{"role": "sponsor", "person_id": absent},
 			field:    "person_id",
 		},
 		// Two required ids, so two rows: a guard that named only the first would
 		// leave the second answering not-found for a subject nobody sent.
 		"CreateRecordGrantRequest.record_id": {
 			method: "POST", path: "/v1/record-grants",
-			omitted: apptest.AnyMap{
+			omitted: AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user", "subject_id": f.subjectUser,
 			},
-			supplied: apptest.AnyMap{
+			supplied: AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user",
 				"subject_id": f.subjectUser, "record_id": absent,
 			},
@@ -200,10 +200,10 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		},
 		"CreateRecordGrantRequest.subject_id": {
 			method: "POST", path: "/v1/record-grants",
-			omitted: apptest.AnyMap{
+			omitted: AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user", "record_id": f.person,
 			},
-			supplied: apptest.AnyMap{
+			supplied: AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user",
 				"record_id": f.person, "subject_id": absent,
 			},
@@ -277,7 +277,7 @@ func seedDealForRequiredIDs(t *testing.T, e *apptest.AppEnv) string {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/deals", AnyMap{
 		"name": "Advance probe", "pipeline_id": pipeline.ID, "stage_id": open,
 		"currency": "EUR", "amount_minor": 1000, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
@@ -301,7 +301,7 @@ func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "stage agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -309,8 +309,8 @@ func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
 	var asSession, asPassport problemBody
-	sessionStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", apptest.AnyMap{}, nil, &asSession)
-	passportStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", apptest.AnyMap{}, bearer, &asPassport)
+	sessionStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", AnyMap{}, nil, &asSession)
+	passportStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", AnyMap{}, bearer, &asPassport)
 
 	if sessionStatus != http.StatusUnprocessableEntity || passportStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("session → %d, passport → %d; want 422 from both", sessionStatus, passportStatus)

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -226,7 +226,7 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 	}
 
 	// Now the deny arm, from the rep's own session.
-	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
 		"email": "rep@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rep login → %d, want 200", status)

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -58,9 +58,9 @@ func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) 
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := p.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := p.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": name,
-		"emails":    []apptest.AnyMap{{"email": email}},
+		"emails":    []AnyMap{{"email": email}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create %s → %d", email, status)
 	}
@@ -82,7 +82,7 @@ func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) 
 	if transactional == "" {
 		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "contract",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant consent for %s → %d", email, status)
@@ -133,7 +133,7 @@ func (p *preflightEnv) scheduleFor(t *testing.T, at time.Time) ids.UUID {
 		ID     string `json:"id"`
 		Status string `json:"status"`
 	}
-	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", apptest.AnyMap{
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Monday morning", "body": "Written the night before.",
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
 		"scheduled_at": at.UTC().Format(time.RFC3339),
@@ -253,7 +253,7 @@ func (p *preflightEnv) setTransactionalConsent(t *testing.T, state string) {
 	if transactional == "" {
 		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", apptest.AnyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", AnyMap{
 		"purpose_id": transactional, "new_state": state, "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("setting consent to %s → %d", state, status)
@@ -417,7 +417,7 @@ func (p *preflightEnv) rescheduleTo(t *testing.T, id ids.UUID, at time.Time) {
 		t.Fatalf("reading the scheduled send before moving it → %d", status)
 	}
 	status := p.Call(t, "PATCH", "/v1/scheduled-sends/"+id.String(),
-		apptest.AnyMap{
+		AnyMap{
 			"scheduled_at": at.UTC().Format(time.RFC3339),
 			"scheduled_tz": "Europe/Berlin",
 		},
@@ -573,7 +573,7 @@ func TestARepCanRetryAHeldMessageFromTheirInbox(t *testing.T) {
 
 	// The rep fixes the problem and clicks Accept.
 	p.grantTransactionalConsent(t)
-	if status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/approve", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("accepting the card → %d, want 200", status)
 	}
 
@@ -605,7 +605,7 @@ func TestARepCanAbandonAHeldMessageFromTheirInbox(t *testing.T) {
 	if !found {
 		t.Fatal("no card to reject — this test is about rejecting one")
 	}
-	if status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/reject", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+	if status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/reject", AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rejecting the card → %d, want 200", status)
 	}
 
@@ -647,7 +647,7 @@ func TestARejectionThatCannotCancelLeavesTheCardRetryable(t *testing.T) {
 	p.forceStatus(t, id, activities.ScheduledStatusCancelled)
 
 	// The rejection must now fail as a whole rather than commit half of itself.
-	status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/reject", apptest.AnyMap{}, nil, nil)
+	status := p.Call(t, "POST", "/v1/approvals/"+card.ID+"/reject", AnyMap{}, nil, nil)
 	if status == http.StatusOK {
 		t.Fatal("the rejection reported success while its cancellation could not run — the card would be decided and the message left in the wrong state")
 	}

--- a/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
@@ -148,12 +148,12 @@ func TestABlindCopiedSubjectSeesTheirOwnMailAndNobodyElsesAddress(t *testing.T) 
 	var scheduled struct {
 		ID string `json:"id"`
 	}
-	status := p.Call(t, "POST", "/v1/emails", apptest.AnyMap{
+	status := p.Call(t, "POST", "/v1/emails", AnyMap{
 		"subject": "Quiet copy", "body": "You were blind-copied on this.",
 		"to":              []string{"visible@preflight.test"},
 		"bcc":             []string{"buyer@preflight.test", otherBlind},
 		"consent_purpose": "transactional",
-		"links": []apptest.AnyMap{
+		"links": []AnyMap{
 			{"entity_type": "person", "entity_id": p.personID},
 		},
 		"scheduled_at": time.Now().Add(6 * time.Hour).UTC().Format(time.RFC3339),

--- a/backend/internal/compose/integration/scheduling_integration_test.go
+++ b/backend/internal/compose/integration/scheduling_integration_test.go
@@ -15,8 +15,6 @@ import (
 	"net/http"
 	"testing"
 	"time"
-
-	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestAvailabilityAndBooking(t *testing.T) {
@@ -52,9 +50,9 @@ func TestAvailabilityAndBooking(t *testing.T) {
 		ID   string `json:"id"`
 		Kind string `json:"kind"`
 	}
-	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", AnyMap{
 		"start": first.Start, "end": first.End, "subject": "Discovery call",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": e.personID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": e.personID}},
 	}, nil, &booked); status != http.StatusCreated || booked.Kind != "meeting" {
 		t.Fatalf("book → %d %+v", status, booked)
 	}
@@ -63,9 +61,9 @@ func TestAvailabilityAndBooking(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", AnyMap{
 		"start": first.Start, "end": first.End,
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": e.personID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": e.personID}},
 	}, nil, &problem); status != http.StatusConflict || problem.Code != "slot_taken" {
 		t.Fatalf("double-book → %d %q, want 409 slot_taken", status, problem.Code)
 	}
@@ -80,9 +78,9 @@ func TestAvailabilityAndBooking(t *testing.T) {
 	}
 
 	// A link target outside visibility refuses the booking (H1).
-	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", AnyMap{
 		"start": first.Start.Add(3 * time.Hour), "end": first.End.Add(3 * time.Hour),
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead"}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead"}},
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("booking with invisible link → %d, want 404", status)
 	}

--- a/backend/internal/compose/integration/seatmatrix_integration_test.go
+++ b/backend/internal/compose/integration/seatmatrix_integration_test.go
@@ -58,7 +58,7 @@ func seatActions() []seatAction {
 		{
 			class: "mutate (create)", object: "person", verb: "create",
 			call: func(t *testing.T, e *apptest.AppEnv, _ seatFixtures) (int, string) {
-				return callForCode(t, e, "POST", "/v1/people", apptest.AnyMap{
+				return callForCode(t, e, "POST", "/v1/people", AnyMap{
 					"full_name": "Matrix Probe", "source": "manual",
 				})
 			},
@@ -66,14 +66,14 @@ func seatActions() []seatAction {
 		{
 			class: "mutate (update)", object: "person", verb: "update",
 			call: func(t *testing.T, e *apptest.AppEnv, f seatFixtures) (int, string) {
-				return callForCode(t, e, "PATCH", "/v1/people/"+f.personID, apptest.AnyMap{"title": "Probed"})
+				return callForCode(t, e, "PATCH", "/v1/people/"+f.personID, AnyMap{"title": "Probed"})
 			},
 		},
 		{
 			class: "advance", object: "deal", verb: "update",
 			call: func(t *testing.T, e *apptest.AppEnv, f seatFixtures) (int, string) {
 				return callForCode(t, e, "POST", "/v1/deals/"+f.dealID+"/advance",
-					apptest.AnyMap{"to_stage_id": f.nextStage})
+					AnyMap{"to_stage_id": f.nextStage})
 			},
 		},
 		{
@@ -82,16 +82,16 @@ func seatActions() []seatAction {
 				// owner_id is the person vocabulary's one filterable leaf,
 				// and a filterless export is refused for its own reasons
 				// before it ever reaches the gate this cell is about.
-				return exportForCode(t, e, apptest.AnyMap{
+				return exportForCode(t, e, AnyMap{
 					"object": "person", "format": "csv",
-					"filter": apptest.AnyMap{"field": "owner_id", "op": "eq", "value": ids.NewV7().String()},
+					"filter": AnyMap{"field": "owner_id", "op": "eq", "value": ids.NewV7().String()},
 				})
 			},
 		},
 		{
 			class: "share (write record_grant)", object: "person", verb: "update",
 			call: func(t *testing.T, e *apptest.AppEnv, f seatFixtures) (int, string) {
-				return callForCode(t, e, "POST", "/v1/record-grants", apptest.AnyMap{
+				return callForCode(t, e, "POST", "/v1/record-grants", AnyMap{
 					"record_type": "person", "record_id": f.personID,
 					"subject_type": "user", "subject_id": f.colleague, "access": "write",
 				})
@@ -178,7 +178,7 @@ func TestAWriteGrantIsRefusedToAReadSeat(t *testing.T) {
 	readSeatColleague(t, e, fixtures.colleague)
 
 	share := func(access string) (int, string) {
-		return callForCode(t, e, "POST", "/v1/record-grants", apptest.AnyMap{
+		return callForCode(t, e, "POST", "/v1/record-grants", AnyMap{
 			"record_type": "person", "record_id": fixtures.personID,
 			"subject_type": "user", "subject_id": fixtures.colleague, "access": access,
 		})
@@ -195,7 +195,7 @@ func TestAWriteGrantIsRefusedToAReadSeat(t *testing.T) {
 	// directly because team CRUD is deferred in the contract — the row is
 	// a fixture here, not the writer under test.
 	team := teamFixture(t, e)
-	if status, code := callForCode(t, e, "POST", "/v1/record-grants", apptest.AnyMap{
+	if status, code := callForCode(t, e, "POST", "/v1/record-grants", AnyMap{
 		"record_type": "person", "record_id": fixtures.personID,
 		"subject_type": "team", "subject_id": team, "access": "write",
 	}); status != http.StatusCreated {
@@ -235,7 +235,7 @@ func TestAReAssertCannotWalkAWriteGrantPastTheSeatCeiling(t *testing.T) {
 	readSeatColleague(t, e, fixtures.colleague)
 
 	share := func(access string) (int, string) {
-		return callForCode(t, e, "POST", "/v1/record-grants", apptest.AnyMap{
+		return callForCode(t, e, "POST", "/v1/record-grants", AnyMap{
 			"record_type": "person", "record_id": fixtures.personID,
 			"subject_type": "user", "subject_id": fixtures.colleague, "access": access,
 		})
@@ -371,7 +371,7 @@ func readSeatColleague(t *testing.T, e *apptest.AppEnv, userID string) {
 // exportForCode is callForCode for the one action whose SUCCESS is not JSON:
 // a granted export answers text/csv, which the shared decode would choke on.
 // Status always, code only from a problem body.
-func exportForCode(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) (int, string) {
+func exportForCode(t *testing.T, e *apptest.AppEnv, body AnyMap) (int, string) {
 	t.Helper()
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -405,7 +405,7 @@ func exportForCode(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) (int, s
 
 // callForCode issues one request and answers its status and problem code —
 // the two things every cell of the matrix is about.
-func callForCode(t *testing.T, e *apptest.AppEnv, method, path string, body apptest.AnyMap) (int, string) {
+func callForCode(t *testing.T, e *apptest.AppEnv, method, path string, body AnyMap) (int, string) {
 	t.Helper()
 	var problem struct {
 		Code string `json:"code"`
@@ -421,7 +421,7 @@ func seedSeatFixtures(t *testing.T, e *apptest.AppEnv) seatFixtures {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Matrix Subject", "source": "manual",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("seed person → %d", status)
@@ -463,7 +463,7 @@ func inviteColleague(t *testing.T, e *apptest.AppEnv) string {
 	var user struct {
 		ID string `json:"id"`
 	}
-	status := e.Call(t, "POST", "/v1/users", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/users", AnyMap{
 		"email": "colleague@fable.test", "display_name": "Colleague", "role": "rep",
 	}, nil, &user)
 	if status != http.StatusCreated || user.ID == "" {

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -99,18 +99,18 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Consented Buyer",
-		"emails":    []apptest.AnyMap{{"email": "buyer@preflight.test"}},
+		"emails":    []AnyMap{{"email": "buyer@preflight.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "subject": "Inbound question", "direction": "inbound",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -135,7 +135,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	if transactional == "" {
 		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
 	}
-	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -172,7 +172,7 @@ func (p *preflightEnv) send(t *testing.T) (status int, code, message string) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", apptest.AnyMap{
+	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
 	}, nil, &problem)

--- a/backend/internal/compose/integration/stage_removal_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_integration_test.go
@@ -48,7 +48,7 @@ func TestStageRemovalRefusesWhileDealsSitOnIt(t *testing.T) {
 	}
 
 	// Step 7: the terminal pair is out of the add/remove surface.
-	var refusal apptest.AnyMap
+	var refusal AnyMap
 	if status := e.Call(t, "DELETE", "/v1/stages/"+seeded.Won, nil, nil, &refusal); status != http.StatusUnprocessableEntity ||
 		refusal["code"] != "terminal_stage_not_removable" {
 		t.Fatalf("removing the won stage → %d %v, want 422 terminal_stage_not_removable", status, refusal)
@@ -76,7 +76,7 @@ func TestStageRemovalRefusesWhileDealsSitOnIt(t *testing.T) {
 
 	// Once the deal moves, the guard lifts.
 	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/advance",
-		apptest.AnyMap{"to_stage_id": stages[1].ID}, nil, nil); status != http.StatusOK {
+		AnyMap{"to_stage_id": stages[1].ID}, nil, nil); status != http.StatusOK {
 		t.Fatalf("advancing the deal off the occupied stage → %d, want 200", status)
 	}
 	if status := e.Call(t, "DELETE", "/v1/stages/"+occupied.ID, nil, nil, nil); status != http.StatusNoContent {
@@ -103,7 +103,7 @@ func TestStageRemovalTakesTheVersionGuard(t *testing.T) {
 	seeded := apptest.DiscoverSeededPipeline(t, e)
 	stages := readStages(t, e, seeded.PipelineID)
 
-	var problem apptest.AnyMap
+	var problem AnyMap
 	if status := e.Call(t, "DELETE", "/v1/stages/"+stages[0].ID, nil,
 		map[string]string{"If-Match": "999"}, &problem); status != http.StatusConflict ||
 		problem["code"] != "version_skew" {
@@ -131,8 +131,8 @@ func TestStageRemovalRenumbersWhateverLayoutItFinds(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"stages"`
 	}
-	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{
-		"name": "Gapped", "stages": []apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/pipelines", AnyMap{
+		"name": "Gapped", "stages": []AnyMap{
 			{"name": "Scout", "position": 2},
 			{"name": "Pitch", "position": 5},
 			{"name": "Close", "position": 9},

--- a/backend/internal/compose/integration/strength_http_integration_test.go
+++ b/backend/internal/compose/integration/strength_http_integration_test.go
@@ -41,7 +41,7 @@ func seedStrengthPersonWithActivities(t *testing.T, e *apptest.AppEnv) string {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Strength Target", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
@@ -52,9 +52,9 @@ func seedStrengthPersonWithActivities(t *testing.T, e *apptest.AppEnv) string {
 	// a live recency/frequency/reciprocity signal rather than a bare
 	// zero-interaction "none" bucket.
 	for _, direction := range []string{"inbound", "outbound"} {
-		if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 			"kind": "email", "subject": "Touch", "source": "ui", "direction": direction,
-			"links": []apptest.AnyMap{{"entity_id": person.ID, "entity_type": "person"}},
+			"links": []AnyMap{{"entity_id": person.ID, "entity_type": "person"}},
 		}, nil, nil); status != http.StatusCreated {
 			t.Fatalf("log %s activity → %d", direction, status)
 		}
@@ -124,13 +124,13 @@ func TestOrganizationStrengthHTTPReconciles(t *testing.T) {
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", AnyMap{
 		"display_name": "Strength Co", "source": "ui",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 	personID := seedStrengthPersonWithActivities(t, e)
-	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", AnyMap{
 		"kind": "employment", "person_id": personID, "organization_id": org.ID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("create employment relationship → %d", status)

--- a/backend/internal/compose/integration/transcriptread_http_integration_test.go
+++ b/backend/internal/compose/integration/transcriptread_http_integration_test.go
@@ -86,7 +86,7 @@ func logTranscript(t *testing.T, e *apptest.AppEnv, body string) string {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "meeting", "subject": "Rollout call", "body": body,
 		"source_system": "transcript", "source": "ui",
 	}, nil, &activity)
@@ -159,7 +159,7 @@ func TestAnActivityNobodyHasReadIsNotFoundRatherThanEmpty(t *testing.T) {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "meeting", "subject": "Rollout call", "body": transcriptText,
 		"source": "manual",
 	}, nil, &activity)
@@ -201,7 +201,7 @@ func TestTheDoorRefusesWhatHasNoLinesToCite(t *testing.T) {
 	var note struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "note", "subject": "An ordinary note", "body": "No transcript here.", "source": "ui",
 	}, nil, &note); status != http.StatusCreated {
 		t.Fatalf("logging the note → %d", status)

--- a/backend/internal/compose/integration/uploadceiling_integration_test.go
+++ b/backend/internal/compose/integration/uploadceiling_integration_test.go
@@ -141,7 +141,7 @@ func attachmentForm(t *testing.T, e *apptest.AppEnv, content []byte) (*bytes.Buf
 // upload is filed against is one the product itself made.
 func anOrganizationID(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	return createdID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Ceiling Test GmbH"})
+	return createdID(t, e, "/v1/organizations", AnyMap{"display_name": "Ceiling Test GmbH"})
 }
 
 func importForm(t *testing.T, size int) (*bytes.Buffer, string) {

--- a/backend/internal/compose/integration/voice_integration_test.go
+++ b/backend/internal/compose/integration/voice_integration_test.go
@@ -96,7 +96,7 @@ and follow up on Friday.</v>
 func createVoiceProfile(t *testing.T, e *apptest.AppEnv) voiceProfileWire {
 	t.Helper()
 	var created voiceProfileWire
-	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", AnyMap{}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
 	if created.Status != "collecting" || created.Maturity != "collecting" || created.ProfileVersion != 0 || created.OwnerID == nil {
@@ -112,17 +112,17 @@ func TestVoiceProfileLifecycle(t *testing.T) {
 	base := "/v1/voice-profiles/" + created.ID
 
 	// One live personal profile per user: a second create conflicts.
-	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", AnyMap{}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("second create → %d, want 409", status)
 	}
 
 	// The human-authored half edits under If-Match; skew is refused.
-	if status := e.Call(t, "PATCH", base, apptest.AnyMap{"personality_md": "Direct, warm, no filler."},
+	if status := e.Call(t, "PATCH", base, AnyMap{"personality_md": "Direct, warm, no filler."},
 		map[string]string{"If-Match": "99"}, nil); status != http.StatusConflict {
 		t.Fatalf("stale If-Match → %d, want 409", status)
 	}
 	var edited voiceProfileWire
-	if status := e.Call(t, "PATCH", base, apptest.AnyMap{"personality_md": "Direct, warm, no filler."},
+	if status := e.Call(t, "PATCH", base, AnyMap{"personality_md": "Direct, warm, no filler."},
 		map[string]string{"If-Match": "1"}, &edited); status != http.StatusOK {
 		t.Fatalf("personality edit → %d", status)
 	}
@@ -143,7 +143,7 @@ func TestVoiceProfileLifecycle(t *testing.T) {
 }
 
 // ingest posts one corpus source and asserts the 201.
-func ingest(t *testing.T, e *apptest.AppEnv, base string, body apptest.AnyMap) voiceIngestResponse {
+func ingest(t *testing.T, e *apptest.AppEnv, base string, body AnyMap) voiceIngestResponse {
 	t.Helper()
 	kind, _ := body["kind"].(string)
 	if _, ok := body["register"]; !ok {
@@ -169,7 +169,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 	base := "/v1/voice-profiles/" + created.ID
 
 	// A pasted post: social register, words counted.
-	post := ingest(t, e, base, apptest.AnyMap{
+	post := ingest(t, e, base, AnyMap{
 		"kind": "linkedin", "source_label": "LinkedIn posts", "source_ref": "post-2026-06",
 		"content": "Shipping beats planning. We shipped the audit story this week and it landed.",
 	})
@@ -182,7 +182,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// A both-sided transcript: spoken register by default, and ONLY the
 	// owner's 20 words enter — zero other-party text (§B1.2).
-	transcript := ingest(t, e, base, apptest.AnyMap{
+	transcript := ingest(t, e, base, AnyMap{
 		"kind": "transcript", "source_label": "Discovery call", "source_ref": "call-77",
 		"format": "transcript", "speaker_label": "Ada Admin", "content": voiceTestVTT,
 	})
@@ -195,7 +195,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// Idempotency: re-ingesting source_ref post-2026-06 replaces the row
 	// — same source count, new word count, no double-counted meter.
-	reingested := ingest(t, e, base, apptest.AnyMap{
+	reingested := ingest(t, e, base, AnyMap{
 		"kind": "linkedin", "source_label": "LinkedIn posts", "source_ref": "post-2026-06",
 		"content": "Five clean words replace thirteen.",
 	})
@@ -208,7 +208,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// A rich enough source moves the band; the boundary logic itself is
 	// unit-tested — here the wire meter reflects the stored corpus.
-	bulk := ingest(t, e, base, apptest.AnyMap{
+	bulk := ingest(t, e, base, AnyMap{
 		"kind": "document", "source_label": "Blog archive", "source_ref": "blog-dump",
 		"content": strings.Repeat("wort ", 8500),
 	})
@@ -218,7 +218,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// Excluding a source pulls it from the meter (manifest opt-out).
 	var excluded voiceIngestResponse
-	if status := e.Call(t, "PATCH", base+"/sources/"+bulk.Source.ID, apptest.AnyMap{
+	if status := e.Call(t, "PATCH", base+"/sources/"+bulk.Source.ID, AnyMap{
 		"included": false,
 	}, nil, &excluded); status != http.StatusOK {
 		t.Fatalf("exclude → %d", status)
@@ -247,20 +247,20 @@ func TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold(t *testing.T) {
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
 
-	ingest(t, e, base, apptest.AnyMap{
+	ingest(t, e, base, AnyMap{
 		"kind": "document", "source_label": "Working sample", "source_ref": "threshold",
 		"content": strings.Repeat("word ", 799),
 	})
-	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "onboarding"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", base+"/builds", AnyMap{"reason": "onboarding"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("build below 800 words → %d, want 422", status)
 	}
 
-	ingest(t, e, base, apptest.AnyMap{
+	ingest(t, e, base, AnyMap{
 		"kind": "document", "source_label": "Working sample", "source_ref": "threshold",
 		"content": strings.Repeat("word ", 800),
 	})
 	var queued voiceBuildWire
-	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "onboarding"}, nil, &queued); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", base+"/builds", AnyMap{"reason": "onboarding"}, nil, &queued); status != http.StatusAccepted {
 		t.Fatalf("build at 800 words → %d, want 202", status)
 	}
 	if queued.ProfileID != created.ID || queued.Status != "queued" || queued.SourceCount != 1 || queued.SourceHash == "" || queued.ResultVersion != nil {
@@ -268,7 +268,7 @@ func TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold(t *testing.T) {
 	}
 
 	var replay voiceBuildWire
-	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "manual"}, nil, &replay); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", base+"/builds", AnyMap{"reason": "manual"}, nil, &replay); status != http.StatusAccepted {
 		t.Fatalf("active-build replay → %d, want 202", status)
 	}
 	if replay.ID != queued.ID {
@@ -297,7 +297,7 @@ func TestVoiceBinaryDocumentIngestIsRefusedWith422(t *testing.T) {
 			Code   string `json:"code"`
 			Detail string `json:"detail"`
 		}
-		if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", apptest.AnyMap{
+		if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", AnyMap{
 			"kind": "document", "register": "long_form", "source_label": "office upload", "source_ref": "bin-" + format,
 			"format": format, "content": "opaque binary payload",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
@@ -328,7 +328,7 @@ func TestVoiceTranscriptIngestRequiresTheOwnersSpeakerLabel(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 
-	if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Unattributed", "source_ref": "call-78",
 		"format": "transcript", "content": voiceTestVTT,
 	}, nil, nil); status != 422 {
@@ -346,14 +346,14 @@ func TestVoiceProfileMutationsRejectAgents(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/passports", AnyMap{
 		"label": "voice prober", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
-	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, bearer, nil); status != http.StatusForbidden {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", AnyMap{}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent create voice profile → %d, want 403", status)
 	}
 }
@@ -369,7 +369,7 @@ func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	var created voiceProfileWire
-	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", AnyMap{}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
 

--- a/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
+++ b/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
@@ -157,7 +157,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
-	removable := ingest(t, e, base, apptest.AnyMap{
+	removable := ingest(t, e, base, AnyMap{
 		"kind": "email", "source_label": "Removable sample", "source_ref": "remove-me",
 		"content": "This source proves permanent removal through the governed HTTP lifecycle.",
 	})
@@ -198,7 +198,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/voice-profiles/"+ids.NewV7().String()+"/learning", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown learning profile → %d, want 404", status)
 	}
-	if status := e.Call(t, "POST", base+"/draft-rejections", apptest.AnyMap{"draft_ref": ""}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", base+"/draft-rejections", AnyMap{"draft_ref": ""}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("empty draft reference → %d, want 422", status)
 	}
 
@@ -261,7 +261,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 		t.Fatalf("learning summary before rejection = %+v", beforeReject)
 	}
 	var afterReject voiceLearningSummaryWire
-	if status := e.Call(t, "POST", base+"/draft-rejections", apptest.AnyMap{"draft_ref": draftRef}, nil, &afterReject); status != http.StatusOK {
+	if status := e.Call(t, "POST", base+"/draft-rejections", AnyMap{"draft_ref": draftRef}, nil, &afterReject); status != http.StatusOK {
 		t.Fatalf("reject draft → %d", status)
 	}
 	if afterReject.Drafted != 0 || afterReject.Rejected != 1 {

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -68,9 +68,9 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
 		"full_name": "Draft Reader",
-		"emails":    []apptest.AnyMap{{"email": "reader@buyer.test"}},
+		"emails":    []AnyMap{{"email": "reader@buyer.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
@@ -80,12 +80,12 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var purpose struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/consent-purposes", AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &purpose); status != http.StatusCreated {
 		t.Fatalf("create consent purpose → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": purpose.ID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -93,9 +93,9 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities", AnyMap{
 		"kind": "email", "subject": "Pricing question", "direction": "inbound",
-		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -167,7 +167,7 @@ func (e *voiceSendEnv) send(t *testing.T, ref, body string) ids.UUID {
 	var sent struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/activities/"+e.activityID+"/send-email", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+e.activityID+"/send-email", AnyMap{
 		"to": []string{"reader@buyer.test"}, "subject": "Pricing",
 		"body": body, "consent_purpose": "newsletter", "draft_ref": ref,
 	}, nil, &sent); status != http.StatusAccepted {

--- a/backend/internal/compose/integration/voicepreview_http_integration_test.go
+++ b/backend/internal/compose/integration/voicepreview_http_integration_test.go
@@ -56,7 +56,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 
 	var preview voicePreviewWire
 	if status := e.Call(t, "POST", base+"/sources/preview",
-		apptest.AnyMap{"format": "transcript", "content": previewMeetingTranscript},
+		AnyMap{"format": "transcript", "content": previewMeetingTranscript},
 		nil, &preview); status != http.StatusOK {
 		t.Fatalf("preview → %d", status)
 	}
@@ -80,7 +80,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 
 	// The raw request keeps the response headers: the refusal contract is
 	// the 422 body AND its problem+json media type.
-	rawBody, err := json.Marshal(apptest.AnyMap{"format": "docx", "content": "binary"})
+	rawBody, err := json.Marshal(AnyMap{"format": "docx", "content": "binary"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 			SpeakersSeen   []string `json:"speakers_seen"`
 		} `json:"ingest_stats"`
 	}
-	if status := e.Call(t, "POST", base+"/sources", apptest.AnyMap{
+	if status := e.Call(t, "POST", base+"/sources", AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
 		"source_ref": "meeting-1", "format": "transcript",
 		"speaker_label": "Lars Jankowfsky", "content": previewMeetingTranscript,
@@ -137,7 +137,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 	}
 
 	var unlabeled problemWire
-	if status := e.Call(t, "POST", base+"/sources", apptest.AnyMap{
+	if status := e.Call(t, "POST", base+"/sources", AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
 		"source_ref": "meeting-2", "format": "transcript",
 		"content": previewMeetingTranscript,

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/webhooks"
@@ -212,7 +213,7 @@ func (we *webhookEnv) createSubscription(t *testing.T, target string, eventTypes
 		} `json:"subscription"`
 		SigningSecret string `json:"signing_secret"`
 	}
-	status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	status := we.Call(t, "POST", "/v1/webhook-subscriptions", integration.AnyMap{
 		"target_url": target, "event_types": eventTypes,
 	}, nil, &created)
 	if status != http.StatusCreated {
@@ -248,19 +249,19 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 	we := setupWebhooks(t)
 
 	// http:// is rejected at create.
-	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", integration.AnyMap{
 		"target_url": "http://insecure.example/hook", "event_types": []string{"deal.created"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("http target → %d, want 422", status)
 	}
 	// An unknown event type is rejected.
-	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", integration.AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"nonsense.happened"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("unknown event type → %d, want 422", status)
 	}
 	// A pipeline (entity-less) event type is not subscribable (BYO-EVT-4).
-	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", integration.AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"capture.received"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("pipeline event type → %d, want 422", status)
@@ -310,12 +311,12 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 
 	// An empty update body is a 422 at runtime, matching the contract's
 	// minProperties:1 — never a silent no-op.
-	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, apptest.AnyMap{}, nil, nil); status != 422 {
+	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, integration.AnyMap{}, nil, nil); status != 422 {
 		t.Fatalf("empty PATCH → %d, want 422", status)
 	}
 
 	// Pause via PATCH, then archive.
-	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, apptest.AnyMap{"state": "paused"}, nil, nil); status != http.StatusOK {
+	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, integration.AnyMap{"state": "paused"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("pause → %d", status)
 	}
 	if status := we.Call(t, "DELETE", "/v1/webhook-subscriptions/"+subID, nil, nil, nil); status != http.StatusOK {


### PR DESCRIPTION
Closes #588.

Two things the suite-package split (#546) left behind.

## 1. Sixteen helpers took `(env, t, …)`

The promoted sibling in `apptest` — and Go's own convention — takes `(t, env, …)`. These were written receiver-first and became plain functions when `AppEnv` moved to a package they could not declare a method on. Two orders for the same shape in one package makes every call site a small guess.

They take the `testing.T` first now, like everything around them.

**On the embedding suggestion:** the issue asks whether `type appEnv struct{ *apptest.AppEnv }` would let them stay methods instead. It would not, not without more churn than it saves — the call sites hold a `*apptest.AppEnv`, so either every call would have to wrap before calling, or every fixture would have to hand back the wrapper. Reordering is the smaller change and it lands *on* the convention rather than beside it.

## 2. `AnyMap` moves out of `apptest`

`apptest`'s subject is the booted application. `AnyMap` is `= map[string]any` — the alias a suite spells when it builds an ad-hoc JSON body — and fourteen files were importing the app-fixture package for that alone. A dependency saying the suite needed a running server when all it needed was a map.

It lives in `internal/compose/integration` now, which may import `apptest`, so the subpackages reach it as `integration.AnyMap` (all of them already import that package for the harness) and `apptest`'s own two uses are plain `map[string]any` again.

## Verification

Mechanical throughout — no assertion changes, and the compiler is what verifies the 127 touched files still say what they said. `go vet -tags integration ./internal/compose/integration/...` is clean, and a suite exercising both changes at once (`agentaccess`, which uses `mcpRaw` and `integration.AnyMap`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized integration-test request and response payload handling across booking, messaging, automation, permissions, records, voice, webhooks, and other workflows.
  * Updated shared test helpers and call conventions for more consistent test execution.
  * Preserved existing test coverage, assertions, endpoints, and runtime behavior.
  * Improved maintainability of the integration test suite through consistent shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->