### PR TITLE
fix(capture): the digest counts what its reader can see

### DIFF
--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -148,6 +148,14 @@ func NewCaptureRegistry(pool *pgxpool.Pool, vault keyvault.Vault, cfg CaptureCon
 		// The digest's projects section is answered here because its reads
 		// span the deals module's tables (digestprojects.go).
 		WithDigestProjects(digestProjectsSource)
+	// What is waiting for the reader, counted through the same seams the Today
+	// surface counts it with (digestreview.go). Skipped without a pool, which
+	// is the enumerate-only construction CoreChannelProviders makes: it builds
+	// no digest, so a source reading a database it does not have would fail on
+	// a path that never counts anything.
+	if pool != nil {
+		r = r.WithDigestReview(newDigestReviewSource(pool, approvals.NewService(db)))
+	}
 	// The standing IMAP connector needs no deployment config — credentials
 	// are per-connection, vault-sealed — so every capture-capable role
 	// carries it.

--- a/backend/internal/compose/capturedigestreview_integration_test.go
+++ b/backend/internal/compose/capturedigestreview_integration_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What the digest says is waiting, against a real database.
+//
+// The two counts name records whose visibility is per-reader — a duplicate pair
+// needs BOTH sides visible, a staged proposal needs the authority to decide it —
+// so the question this suite answers is whether the stored payload reports what
+// the READER could open or what the workspace happens to hold. A count that
+// travels workspace-wide is an existence oracle: the same number for everybody,
+// moving as records they cannot see come and go.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/authz"
+)
+
+// decidesNothing is the harness authority with no grant that admits a staged
+// proposal or a duplicate pair: the reader is connected, so they get a digest,
+// and neither queue is theirs to see.
+type decidesNothing struct{ backfillAuthority }
+
+func (decidesNothing) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{Permissions: principal.Permissions{
+		Objects:  map[string]principal.ObjectGrant{"activity": {Create: true, Read: true}},
+		RowScope: principal.RowScopeAll,
+	}}, nil
+}
+
+// decidesDeals holds exactly what a close-date proposal asks of its decider.
+type decidesDeals struct{ backfillAuthority }
+
+func (decidesDeals) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{Permissions: principal.Permissions{
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Read: true},
+			"deal":     {Read: true, Update: true},
+		},
+		RowScope: principal.RowScopeAll,
+	}}, nil
+}
+
+// seedDecidableDeal creates the deal a staged proposal points at, with the
+// pipeline and stage a deal cannot exist without.
+//
+// The decision's target-visibility probe reads that deal, so a proposal aimed
+// at nothing would be refused before the count is ever reached — and the test
+// would then pass for the wrong reason.
+func (b *backfillWireEnv) seedDecidableDeal(t *testing.T) ids.UUID {
+	t.Helper()
+	owner := integration.OwnerConn(t)
+	pipeline := integration.SeedIDRow(t, owner,
+		`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Digest', false, 0)`)
+	stage := integration.SeedIDRow(t, owner,
+		`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		 VALUES ($1, '`+pipeline.String()+`', 'Open', 0, 'open', 30)`)
+	return b.env.SeedDeal(t, "Digest deal",
+		ids.From[ids.PipelineKind](pipeline), ids.From[ids.StageKind](stage), &b.env.Rep1)
+}
+
+// stageCloseDateProposal stages one proposal through the engine that stages
+// every other one, so the row the count reads is the row production writes.
+func (b *backfillWireEnv) stageCloseDateProposal(t *testing.T, deal ids.UUID) {
+	t.Helper()
+	svc := approvals.NewService(b.env.DB())
+	if _, err := svc.Stage(b.env.Admin(), approvals.StageInput{
+		Kind:           deals.CloseDateCorrectionKind,
+		ProposedChange: []byte(`{"deal_id":"` + deal.String() + `","expected_close_date":"2026-12-01"}`),
+		DiffHash:       deal.String(),
+		TargetType:     "deal",
+		TargetID:       deal,
+		Summary:        "Confirm the real close date",
+	}); err != nil {
+		t.Fatalf("staging a close-date proposal: %v", err)
+	}
+}
+
+// buildWith runs the nightly pass under one authority and returns the counts
+// the reader's stored payload carries.
+//
+// The registry is rebuilt per authority rather than mutated, matching the
+// projects suite beside it: the authority is a constructor argument, and a
+// digest is only honest about a reader if it was built as that reader.
+func (b *backfillWireEnv) buildWith(
+	t *testing.T, authority authz.Resolver, now time.Time,
+) (approvalsPending int) {
+	t.Helper()
+	e := b.env
+	reg := capture.NewRegistry(e.DB(), capture.NewSink(e.DB()), authority, keyvault.NewMemory()).
+		WithDigestReview(newDigestReviewSource(e.Pool, approvals.NewService(e.DB())))
+	if err := reg.BuildDigests(b.human, now); err != nil {
+		t.Fatalf("BuildDigests: %v", err)
+	}
+	_, digest := b.readDigest(t, nil)
+	if digest.Review.ApprovalsPending == nil {
+		t.Fatal("a wired build reported no count at all, which is the answer reserved " +
+			"for a build that could not count")
+	}
+	return *digest.Review.ApprovalsPending
+}
+
+// A staged proposal this reader could not decide is not in their count.
+//
+// This is the disclosure the seam closes: before it, the digest counted every
+// pending approval in the workspace and wrote that number into every payload,
+// so a reader holding no deal grant was told how many deal decisions exist.
+func TestTheDigestCountsOnlyTheProposalsItsReaderCouldDecide(t *testing.T) {
+	b := setupBackfillWire(t)
+	b.stageCloseDateProposal(t, b.seedDecidableDeal(t))
+	now := time.Now().UTC()
+
+	if pending := b.buildWith(t, decidesNothing{}, now); pending != 0 {
+		t.Errorf("a reader who cannot decide a deal proposal was told %d are waiting, want 0", pending)
+	}
+	if pending := b.buildWith(t, decidesDeals{}, now); pending != 1 {
+		t.Errorf("a reader who CAN decide it was told %d are waiting, want 1 — "+
+			"a count that hides from everyone proves nothing about scope", pending)
+	}
+}
+
+// An installation that never wired the seam reports NO count, rather than zero
+// and rather than the workspace-wide number the seam exists to retire. Zero
+// would say "nothing is waiting for you", which is a claim this build cannot
+// make about a reader whose queues it never asked about.
+func TestAnUnwiredDigestReportsNothingWaitingRatherThanEverything(t *testing.T) {
+	b := setupBackfillWire(t)
+	e := b.env
+	b.stageCloseDateProposal(t, b.seedDecidableDeal(t))
+
+	unwired := capture.NewRegistry(e.DB(), capture.NewSink(e.DB()), decidesDeals{}, keyvault.NewMemory())
+	if err := unwired.BuildDigests(b.human, time.Now().UTC()); err != nil {
+		t.Fatalf("BuildDigests without the review seam: %v", err)
+	}
+	_, digest := b.readDigest(t, nil)
+	if digest.Review.ApprovalsPending != nil || digest.Review.DedupeOpen != nil {
+		t.Fatalf("an unwired build reported counts (%v approvals, %v duplicates) — "+
+			"absent is the honest answer, and the workspace-wide number this seam "+
+			"replaces is not something to fall back to",
+			digest.Review.ApprovalsPending, digest.Review.DedupeOpen)
+	}
+}

--- a/backend/internal/compose/digestreview.go
+++ b/backend/internal/compose/digestreview.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What is waiting for one digest reader, counted the way the surfaces that
+// serve those queues count it.
+//
+// Both numbers name records whose visibility is per-reader: a duplicate pair is
+// shown only to someone who can open BOTH sides, and a staged proposal only to
+// someone who could decide it. The digest used to count each with a raw
+// workspace-wide subquery and write the same number into every reader's
+// payload, which told everyone how many records exist whether or not they could
+// open one.
+//
+// Neither count is computed here. attentionApprovals and attentionDuplicates
+// already answer these two questions for the Today surface, under the caller's
+// own authority, and a second implementation would drift from the queues the
+// numbers are supposed to describe — a digest promising nine duplicates over a
+// page that shows two.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// newDigestReviewSource binds the two readers the nightly build asks.
+//
+// capture calls this once per reader with that reader bound as the acting
+// principal, so both counts resolve through their live grants and row scope
+// without either seam needing to know it is serving a digest.
+func newDigestReviewSource(pool *pgxpool.Pool, svc *approvals.Service) capture.DigestReviewSource {
+	duplicates := attentionDuplicates{store: people.NewStore(InstallationDB(pool))}
+	pending := attentionApprovals{svc: svc}
+	return func(ctx context.Context) (capture.DigestReviewCounts, error) {
+		open, err := countOrNoneVisible(duplicates.CountOpen(ctx))
+		if err != nil {
+			return capture.DigestReviewCounts{}, err
+		}
+		waiting, err := countOrNoneVisible(pending.CountPending(ctx))
+		if err != nil {
+			return capture.DigestReviewCounts{}, err
+		}
+		return capture.DigestReviewCounts{DedupeOpen: open, ApprovalsPending: waiting}, nil
+	}
+}
+
+// countOrNoneVisible reads a refusal as an empty queue rather than a fault.
+//
+// A store refuses a reader who holds no grant for the records it counts, which
+// is the right answer to "show me these" and the wrong one to "how many are
+// waiting for you". None are: the queue that surfaces them would be empty for
+// this reader too. Propagating the refusal would fail the whole nightly build
+// for that reader — one seat without a person grant would cost a colleague
+// their digest — which is the same reasoning the projects section states for
+// answering no section instead of an error.
+func countOrNoneVisible(count int, err error) (int, error) {
+	if errors.Is(err, apperrors.ErrPermissionDenied) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/backend/internal/modules/capture/digest.go
+++ b/backend/internal/modules/capture/digest.go
@@ -45,8 +45,14 @@ type DigestCapture struct {
 
 // DigestReview is what awaits the human.
 type DigestReview struct {
-	DedupeOpen       int            `json:"dedupe_open"`
-	ApprovalsPending int            `json:"approvals_pending"`
+	// Both are per-reader counts and both are OPTIONAL, which the wire has
+	// always allowed. Absent means the build could not count for this reader —
+	// the review seam is unwired — and that is a different statement from zero.
+	// Zero says "nothing is waiting for you"; absent says "we did not count",
+	// and a build that reported the first when it meant the second would be the
+	// same dishonest number this section replaced, pointing the other way.
+	DedupeOpen       *int           `json:"dedupe_open,omitempty"`
+	ApprovalsPending *int           `json:"approvals_pending,omitempty"`
 	Classify         DigestClassify `json:"classify"`
 }
 
@@ -121,9 +127,14 @@ func connectedUsers(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
 
 func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids.UUID, day string, since time.Time) (DigestPayload, error) {
 	p := DigestPayload{Date: day, GeneratedAt: r.now().UTC()}
-	// Workspace-level truths: what the pipeline did and what awaits review
-	// is shared work, not per-owner arithmetic — the same numbers for every
-	// digest reader in the workspace.
+	// Workspace-level truths: what the PIPELINE did overnight is shared work,
+	// and the same number for every reader is the honest report of it.
+	//
+	// What awaits REVIEW is not, and is counted per reader below. A duplicate
+	// pair is visible only to someone who can open both sides, and a staged
+	// proposal only to someone who could decide it, so a workspace-wide count
+	// of either tells every reader how many records exist that they may not be
+	// able to see.
 	err := tx.QueryRow(ctx, `
 		SELECT
 		  (SELECT count(*) FROM activity WHERE captured_by LIKE 'connector:%' AND kind = 'email' AND created_at >= $1),
@@ -136,14 +147,11 @@ func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids
 		  (SELECT count(*) FROM organization
 		    WHERE (captured_by LIKE 'connector:%' OR source LIKE 'domain\_triage:%')
 		      AND created_at >= $1),
-		  (SELECT count(*) FROM dedupe_candidate WHERE disposition = 'open' AND archived_at IS NULL),
-		  (SELECT count(*) FROM approval WHERE status = 'pending'),
 		  (SELECT count(*) FROM activity WHERE capture_label = 'commitment' AND capture_labeled_at >= $1),
 		  (SELECT count(*) FROM activity WHERE capture_label = 'meeting' AND capture_labeled_at >= $1),
 		  (SELECT count(*) FROM activity WHERE capture_label = 'noise' AND capture_labeled_at >= $1)`,
 		since).Scan(
 		&p.Capture.ActivitiesCreated, &p.Capture.PeopleCreated, &p.Capture.OrganizationsCreated,
-		&p.Review.DedupeOpen, &p.Review.ApprovalsPending,
 		&p.Review.Classify.Commitments, &p.Review.Classify.Meetings, &p.Review.Classify.Noise,
 	)
 	if err != nil {
@@ -176,14 +184,27 @@ func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids
 	if err := rows.Err(); err != nil {
 		return DigestPayload{}, err
 	}
-	if r.digestProjects != nil {
-		// Per READER, unlike the counts above: the section names projects and
-		// the work on them, so it is built under this user's own live grants
-		// and row scope, and a user with no project grant gets none.
-		readerCtx, err := r.digestReaderContext(ctx, userID)
+	// Everything below is per READER rather than per workspace: it names
+	// records, and which records a person can see is theirs. One context binds
+	// that reader once, with the live authority the resolver answers.
+	if r.digestProjects == nil && r.digestReview == nil {
+		return p, nil
+	}
+	readerCtx, err := r.digestReaderContext(ctx, userID)
+	if err != nil {
+		return DigestPayload{}, err
+	}
+	if r.digestReview != nil {
+		review, err := r.digestReview(readerCtx)
 		if err != nil {
-			return DigestPayload{}, err
+			return DigestPayload{}, fmt.Errorf("capture: digest review counts: %w", err)
 		}
+		p.Review.DedupeOpen = &review.DedupeOpen
+		p.Review.ApprovalsPending = &review.ApprovalsPending
+	}
+	if r.digestProjects != nil {
+		// The section names projects and the work on them, so a user with no
+		// project grant gets none rather than an empty one.
 		projects, err := r.digestProjects(readerCtx, tx, since, p.GeneratedAt)
 		if err != nil {
 			return DigestPayload{}, fmt.Errorf("capture: digest projects section: %w", err)

--- a/backend/internal/modules/capture/digestreview.go
+++ b/backend/internal/modules/capture/digestreview.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// What is waiting for review, counted as the READER can see it.
+//
+// The two numbers here name records whose visibility is per-reader by design: a
+// duplicate pair is shown only to someone who can open BOTH sides of it, and a
+// staged proposal only to someone who could decide it. Counted workspace-wide
+// they become an existence oracle — the same number for everyone, moving as
+// records the reader cannot open are created and resolved.
+//
+// The rest of the digest's counts stay workspace-wide and are right to. What
+// the pipeline captured overnight is shared work, and the section says so.
+//
+// The counts are not computed here. The dedupe queue's both-sides-visible rule
+// lives in the people store and decidability is a per-row probe inside the
+// approvals engine; a count re-derived in this module would be a second answer
+// to each, drifting the moment either rule changed.
+
+import (
+	"context"
+)
+
+// DigestReviewSource answers what is waiting for one reader.
+//
+// ctx carries THAT reader as the acting principal — their live grants and row
+// scope — exactly as DigestProjectsSource does, so the numbers name only what
+// they could open themselves.
+//
+// It takes no transaction, which is the difference from the projects source
+// beside it: both counts are answered by engines that open their own, and
+// handing them this build's transaction would mean either re-implementing their
+// rules here or threading a transaction through two modules that do not take
+// one. The cost is that the counts are read a moment outside the build's
+// snapshot, which for a nightly tally of what is waiting is not a difference
+// anybody can observe.
+type DigestReviewSource func(ctx context.Context) (DigestReviewCounts, error)
+
+// DigestReviewCounts is the pair, as the reader's own authority answers them.
+type DigestReviewCounts struct {
+	DedupeOpen       int
+	ApprovalsPending int
+}
+
+// WithDigestReview wires the per-reader review counts into every digest this
+// registry builds.
+//
+// Unwired, the counts stay zero rather than falling back to a workspace-wide
+// number. A zero says "nothing waiting for you", which is wrong but harmless;
+// the raw count says "this many exist", which is the disclosure this seam is
+// here to close, and a fallback that reinstates it on any install that forgot
+// to wire the seam would defeat the whole change.
+func (r *Registry) WithDigestReview(src DigestReviewSource) *Registry {
+	r.digestReview = src
+	return r
+}

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -60,6 +60,10 @@ type Registry struct {
 	// digestProjects answers the morning digest's projects section
 	// (digestprojects.go); nil builds a digest without one.
 	digestProjects DigestProjectsSource
+
+	// digestReview answers what is waiting for the digest's reader
+	// (digestreview.go); nil leaves those counts at zero.
+	digestReview DigestReviewSource
 }
 
 // defaultSyncInterval paces a healthy connection between syncs; the push


### PR DESCRIPTION
Closes #2822.

The overnight digest counted open duplicate pairs and pending approvals with raw workspace-wide subqueries and wrote the same two numbers into **every** reader's payload:

```sql
(SELECT count(*) FROM dedupe_candidate WHERE disposition = 'open' AND archived_at IS NULL),
(SELECT count(*) FROM approval WHERE status = 'pending'),
```

Both name records whose visibility is per-reader — a pair needs BOTH sides visible, a proposal needs the authority to decide it. So the counts told every reader how many such records exist whether or not they could open one, and moved as records they cannot see were created and resolved.

## Counted per reader, by the seams that already do it

`attentionApprovals.CountPending` and `attentionDuplicates.CountOpen` already answer these two questions for the Today surface, under the caller's own authority. The digest now asks them.

Nothing new computes a count. The both-sides-visible rule lives in the people store and decidability is a per-row probe inside the approvals engine; a second implementation would drift from the queues the numbers are meant to describe — a digest promising nine duplicates over a page that shows two.

## The reader context already existed

`buildDigestPayload` already binds each reader's live authority for the projects section, via `digestReaderContext`. The counts above it were the exception, and the comment beside them said so in as many words: *"Per READER, unlike the counts above."* Both halves now share the one binding, and the new seam mirrors `DigestProjectsSource` exactly.

## Two judgement calls worth reviewing

**A refusal reads as an empty queue, not a fault.** A reader holding no person grant sees nothing in the duplicates queue either, and propagating the store's `ErrPermissionDenied` would fail the entire nightly build for that seat — one seat without a grant costing a colleague their digest. Same reasoning the projects section states for answering no section rather than an error. This surfaced as a real test failure, not a hypothetical.

**The counts became optional**, which the wire already allowed (neither is `required` in `crm.yaml`, and the frontend already reads them with `?? 0`). Absent means the build could not count for this reader; zero means nothing is waiting. An unwired install now says the first rather than the second, and never falls back to the workspace-wide number.

## Verification

- Two integration tests against real Postgres: a reader who cannot decide a deal proposal is told 0, a reader who can is told 1. The admit case matters — a count that hides from everyone would pass the refusal test while being broken.
- **Mutation-checked**: a count that answers the same for every reader fails the scope test with `told 1 are waiting, want 0`.
- `make check-backend` and `make check-fe` both green.

## Scope

The dedupe half is proven by the seam it calls (`CountOpen` applies `dedupeVisibilityClause` to page and count alike) rather than re-proven here — producing a duplicate pair needs the detector fixture, which is a larger harness than this fix warrants.

**#2823** (the agent rail's approvals count is a bare page length with no `more` flag) is untouched and stays open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #2822. The overnight digest now counts open duplicate pairs and pending approvals per reader—showing only what that reader can actually open or decide—instead of reporting the same workspace-wide totals to everyone.

- Counts come from the same visibility rules as the Today surface, so a digest never promises more than the reader can see.
- The counts are now optional: absent means we didn't count for this reader; zero means nothing is waiting. Permission refusals are read as an empty queue, not a failure.

<sup>Written for commit d707265f6894b4800b1d9eb06472cb2a8bf8eecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Digest review counts now reflect only items the current reader is authorized to decide.
  * Digest views can show pending deduplication and approval work separately for each reader.
  * Unavailable review data is distinguished from a true zero count.

* **Bug Fixes**
  * Prevented unauthorized or workspace-wide items from appearing in digest review totals.
  * Unwired digests no longer incorrectly report all pending items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->