### PR TITLE
fix(audit): an absent image cannot reach the column as the JSON scalar null

### DIFF
--- a/backend/internal/compose/auditimagenull_integration_test.go
+++ b/backend/internal/compose/auditimagenull_integration_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// An absent audit image reaches the column as SQL NULL, and the JSON scalar
+// `null` cannot get in at all.
+//
+// The two look alike and answer differently. Every "there was no prior state"
+// query in this tree is `WHERE before IS NULL`, and a column holding the four
+// bytes `null` is not null — it misses the row, silently, in exactly the place
+// a reader is trying to establish that nothing preceded a change.
+//
+// storekit.AbsentImage answers this correctly at the door it owns. The
+// constraint is here because not every writer goes through that door: the
+// approvals module INSERTs its own row, and a caller that marshals an image
+// itself hands over bytes the seam never sees.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// writeAuditImage inserts one audit row with the given before/after literals,
+// as a direct INSERT — the shape that does not pass storekit at all, which is
+// the whole reason the refusal lives in the table.
+func writeAuditImage(t *testing.T, e *integration.Env, before, after string) error {
+	t.Helper()
+	return database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id,
+			                       before, after, occurred_at)
+			VALUES ('human', 'user:'||$1::text, 'update', 'person', $2, nullif($3,'')::jsonb, nullif($4,'')::jsonb, $5)`,
+			ids.NewV7(), ids.NewV7(), before, after, time.Now().UTC())
+		return err
+	})
+}
+
+func TestAnAuditImageCannotBeTheJSONScalarNull(t *testing.T) {
+	e := integration.Setup(t)
+
+	// The absent image, which is the shape every reader's `IS NULL` is written
+	// for. Asserted first: a constraint that refused this would break the
+	// honest case rather than the dishonest one.
+	if err := writeAuditImage(t, e, "", `{"full_name":"Sara"}`); err != nil {
+		t.Fatalf("an absent before-image was refused: %v — SQL NULL is what an image that says "+
+			"nothing is supposed to be", err)
+	}
+
+	for _, tc := range []struct{ name, before, after string }{
+		{"a null before-image", "null", `{"full_name":"Sara"}`},
+		{"a null after-image", `{"full_name":"Sara"}`, "null"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := writeAuditImage(t, e, tc.before, tc.after)
+			if err == nil {
+				t.Fatal("the JSON scalar null was stored — every `WHERE before IS NULL` reader " +
+					"now misses this row while the column claims to carry an image")
+			}
+			if !strings.Contains(err.Error(), "audit_log_images_are_absent_or_present") {
+				t.Errorf("refused by %v, want the image constraint — a different refusal means this "+
+					"case is passing for a reason that has nothing to do with what it asserts", err)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -111,14 +111,7 @@ func seedAgentFieldHistoryRow(t *testing.T, e *Env, entityType string, entityID,
 	evidence, before, after map[string]any, occurredAt time.Time,
 ) ids.UUID {
 	t.Helper()
-	beforeJSON, err := json.Marshal(before)
-	if err != nil {
-		t.Fatalf("marshal before: %v", err)
-	}
-	afterJSON, err := json.Marshal(after)
-	if err != nil {
-		t.Fatalf("marshal after: %v", err)
-	}
+	beforeJSON, afterJSON := auditImageJSON(t, before), auditImageJSON(t, after)
 	evidenceJSON, err := json.Marshal(evidence)
 	if err != nil {
 		t.Fatalf("marshal evidence: %v", err)

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -38,21 +38,34 @@ import (
 // before/after are marshaled to jsonb bytes explicitly: pgx does not
 // accept a bare map[string]any for a jsonb column without a registered
 // type, the same reason storekit.Audit marshals before binding.
+// auditImageJSON renders an audit image for a raw INSERT, answering nil bytes
+// — SQL NULL — for an image that says nothing.
+//
+// json.Marshal of a nil map is the four bytes `null`, and that is not the same
+// column value: every "there was no prior state" query is `WHERE before IS
+// NULL`, and the scalar is not null. storekit.AbsentImage settles this for
+// every production writer; a fixture writing the row itself goes around that
+// door, so it has to answer the same way.
+func auditImageJSON(t *testing.T, image map[string]any) []byte {
+	t.Helper()
+	if image == nil {
+		return nil
+	}
+	rendered, err := json.Marshal(image)
+	if err != nil {
+		t.Fatalf("marshal audit image: %v", err)
+	}
+	return rendered
+}
+
 func seedAuditActionRow(t *testing.T, e *Env, action, entityType string, entityID ids.UUID,
 	actorType string, before, after map[string]any, occurredAt time.Time,
 ) ids.UUID {
 	t.Helper()
-	beforeJSON, err := json.Marshal(before)
-	if err != nil {
-		t.Fatalf("marshal before: %v", err)
-	}
-	afterJSON, err := json.Marshal(after)
-	if err != nil {
-		t.Fatalf("marshal after: %v", err)
-	}
+	beforeJSON, afterJSON := auditImageJSON(t, before), auditImageJSON(t, after)
 	rowID := ids.NewV7()
 	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
-	err = database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
 			`INSERT INTO audit_log (id, actor_type, actor_id, action,
 			                        entity_type, entity_id, before, after, occurred_at)

--- a/backend/migrations/core/1787839429_an_absent_audit_image_is_sql_null.down.sql
+++ b/backend/migrations/core/1787839429_an_absent_audit_image_is_sql_null.down.sql
@@ -1,0 +1,5 @@
+-- Dropping the constraint restores nothing and destroys nothing: it never
+-- rewrote a row, and the rows it refused were never written.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_images_are_absent_or_present;

--- a/backend/migrations/core/1787839429_an_absent_audit_image_is_sql_null.up.sql
+++ b/backend/migrations/core/1787839429_an_absent_audit_image_is_sql_null.up.sql
@@ -1,0 +1,29 @@
+-- An audit image that says nothing reaches the column as SQL NULL, not as the
+-- JSON scalar `null`.
+--
+-- The two look alike and answer differently. Every "there was no prior state"
+-- query in this tree is `WHERE before IS NULL`, and a column holding the four
+-- bytes `null` is not null — it misses the row silently. `coalesce(before,
+-- after)` is wrong for the same reason: it returns the JSON null rather than
+-- falling through to the after-image.
+--
+-- storekit.AbsentImage is the chokepoint and it already answers this correctly,
+-- for an untyped nil and for a typed one alike. What it cannot cover is
+-- everything that does not go through it: the approvals module INSERTs its own
+-- audit row, and a caller that marshals an image itself hands over bytes this
+-- seam never sees. A constraint binds the table rather than the door.
+--
+-- NOT VALID, and it stays that way. audit_log is append-only, so the rows
+-- written before storekit was hardened cannot be rewritten — and validating
+-- would fail the migration on exactly those installations, blocking an upgrade
+-- over history nobody can change. What this constraint is for is the next
+-- write, and NOT VALID binds every one of them.
+--
+-- The predicate reads as false only for the JSON scalar: `before <> 'null'` is
+-- NULL when before IS NULL, and a CHECK admits NULL. So an absent image passes
+-- and a `null` image is refused, which is the whole distinction.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_images_are_absent_or_present
+    CHECK (before <> 'null'::jsonb AND after <> 'null'::jsonb)
+    NOT VALID;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -668,6 +668,7 @@ public.audit_log.actor_type text NOT NULL gen=- def=-
 public.audit_log.after jsonb gen=- def=-
 public.audit_log.audit_log_action_check CHECK ((action = ANY (ARRAY['create'::text, 'update'::text, 'archive'::text, 'merge'::text, 'promote'::text, 'restore'::text, 'export'::text, 'erase'::text, 'assign'::text, 'advance_stage'::text, 'advance_phase'::text, 'approve'::text, 'reject'::text, 'consent_grant'::text, 'consent_withdraw'::text, 'activity_relink'::text, 'record_share'::text, 'record_unshare'::text, 'resolve'::text, 'demote'::text, 'import'::text, 'import_undo'::text, 'disqualify'::text, 'anonymize'::text, 'send_email'::text, 'reset_data'::text, 'password_link_issued'::text, 'connect'::text, 'disconnect'::text, 'schedule'::text, 'reschedule'::text, 'cancel'::text, 'release'::text, 'hold'::text, 'expire'::text, 'restrict'::text, 'pin'::text, 'accrue'::text, 'pay'::text, 'publish'::text, 'pause'::text, 'resume'::text, 'close'::text, 'invite'::text, 'revoke'::text, 'delete'::text])))
 public.audit_log.audit_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text, 'buyer'::text])))
+public.audit_log.audit_log_images_are_absent_or_present CHECK (((before <> 'null'::jsonb) AND (after <> 'null'::jsonb))) NOT VALID
 public.audit_log.audit_log_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.audit_log.audit_log_pkey PRIMARY KEY (id)
 public.audit_log.authorization_rule text gen=- def=-


### PR DESCRIPTION
Closes #589.

SQL `NULL` and the four bytes `null` look alike and answer differently. Every "there was no prior state" query in this tree is `WHERE before IS NULL`, and a column holding `null` **is not null** — it misses the row, silently, in exactly the place a reader is trying to establish that nothing preceded a change. `coalesce(before, after)` is wrong for the same reason: it returns the JSON null rather than falling through.

## Option 1 is already in

The issue's preferred fix — harden `marshalOrNil` against a typed nil — landed with the audited-update work (#2653) as `storekit.AbsentImage`, and it is unit-tested across every kind of nil that can carry one.

## What was left is what does not go through that door

`AbsentImage` binds the seam, not the table. The approvals module `INSERT`s its own audit row, and a caller that marshals an image itself hands over bytes the seam never sees. So this is the issue's option 3, as a constraint rather than a test — it binds every future writer instead of sampling what one suite happened to write.

The predicate reads false only for the scalar: `before <> 'null'` is **NULL** when `before IS NULL`, and a CHECK admits NULL. An absent image passes, a `null` image is refused.

## NOT VALID, and it stays that way

`audit_log` is append-only, so rows written before storekit was hardened cannot be rewritten — and validating would fail the migration on exactly those installations, blocking an upgrade over history nobody can change. That is also the sweep the issue asked for before landing option 1, answered by not needing one: the constraint is for the next write.

The test template carries 0 offending rows today.

## Held

`TestAnAuditImageCannotBeTheJSONScalarNull` inserts **directly**, which is the shape that does not pass storekit at all.

The honest absence is asserted **first**: a constraint that refused an absent before-image would have broken the case every reader's `IS NULL` is written for rather than the case they miss. And the refusal is matched by constraint name, so a case cannot pass because something else rejected the row.

Mutation-checked — relaxing the CHECK to `true` fails both arms by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audit log validation so missing audit images are represented as absent values.
  - Prevented invalid JSON `null` values from being stored for “before” and “after” audit images.
  - Continued supporting valid existing audit records while enforcing consistency for new data.

- **Tests**
  - Added integration coverage confirming that absent images are accepted and JSON `null` values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->