### PR TITLE
fix(consent): the preference centre stops offering a switch the write refuses

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28117,20 +28117,28 @@ components:
       type: object
       description: |
         The buyer-facing preference center's per-purpose view (B-E11.32): each tracked consent purpose
-        with the recipient's current state and whether it is locked (transactional cannot be withdrawn
-        while a deal is live).
+        with the recipient's current state, whether it is locked (transactional cannot be withdrawn
+        while a deal is live), and whether granting it needs a confirmation round-trip this surface
+        cannot perform.
       required: [purposes]
       properties:
         purposes:
           type: array
           items:
             type: object
-            required: [key, label, state, locked]
+            required: [key, label, state, locked, grant_needs_confirmation]
             properties:
               key:    { type: string }
               label:  { type: string }
               state:  { type: string, enum: [unknown, granted, withdrawn] }
               locked: { type: boolean, description: A locked purpose (transactional) cannot be changed from this surface. }
+              grant_needs_confirmation:
+                type: boolean
+                description: |
+                  A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
+                  this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
+                  the way a confirmation round-trip does. A client must not offer the grant — the write refuses
+                  it with 422, and an offered switch that always fails is worse than an absent one.
 
     # ---- Automations (E15/ADR-0035, feedback/14) ----
     AutomationCatalogEntry:

--- a/backend/gates/auditbeforeimage_test.go
+++ b/backend/gates/auditbeforeimage_test.go
@@ -163,7 +163,7 @@ var unresolvableAuditActions = gatekit.Waive(map[string]string{
 	"internal/modules/capture/freemaildomain.go:Add":                                  "a fresh carve-out and an amended one take different verbs, and the amended one carries the rule it replaced",
 	"internal/modules/commissions/decide.go:decideTx":                                 "the verb names the decision and the images are the patch's own, so what the decision moved is recorded with it",
 	"internal/modules/commissions/decide.go:voidOne":                                  "a void is spelled as its own verb and carries the patch images for the row it retired",
-	"internal/modules/consent/store.go:Record":                                        "a grant and a withdrawal are separate verbs, and both record the consent state they moved from",
+	"internal/modules/consent/store.go:recordAdmittedTx":                              "a grant and a withdrawal are separate verbs, and both record the consent state they moved from",
 	"internal/modules/dealrooms/lifecycle.go:moveRoom":                                "each room transition names its own verb and carries the patch images the move built",
 	"internal/modules/privacy/retentionpolicystore.go:Delete":                         "the verb is an archive of the policy row, and the image is the policy as it stood",
 	"internal/platform/settings/store.go:SetRawTx":                                    "each setting declares its own verb, and the value on either side is rendered by the same declaration",

--- a/backend/gates/oneconsentcarry_test.go
+++ b/backend/gates/oneconsentcarry_test.go
@@ -85,7 +85,8 @@ func TestTheConsentCarryIsSpelledOnceInPeople(t *testing.T) {
 		Roots:   []string{"internal/modules/people"},
 		Subject: writesConsentState,
 		Exempt: gatekit.Waive(map[string]string{
-			"internal/modules/consent/store.go": "the consent module OWNS these tables and writes them for its own reasons — a preference-centre save, a double opt-in confirmation, a withdrawal a person asked for. None of those is a carry: they record what a subject decided, where a carry decides what happens to a decision when the record holding it retires. The two would not share an implementation even if they were in one package",
+			"internal/modules/consent/store.go":        "the consent module OWNS these tables and writes them for its own reasons — a preference-centre save, a double opt-in confirmation, a withdrawal a person asked for. None of those is a carry: they record what a subject decided, where a carry decides what happens to a decision when the record holding it retires. The two would not share an implementation even if they were in one package",
+			"internal/modules/consent/consentproof.go": "the paired state-and-proof write the consent module's own Record makes, split out of store.go for the file-length cap. Same reason as store.go beside it: recording a decision a subject made, never deciding what becomes of one when a record retires",
 		}),
 	}
 	inside := scope.Files(t)

--- a/backend/internal/compose/integration/edgereverse_integration_test.go
+++ b/backend/internal/compose/integration/edgereverse_integration_test.go
@@ -55,23 +55,23 @@ func seedEmploymentOverHTTP(t *testing.T, e *apptest.AppEnv) linkedPair {
 	role := seededEdgeRole
 	var person personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
+		apptest.AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	var org struct {
 		ID string `json:"id"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
+		apptest.AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, AnyMap{
+	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, apptest.AnyMap{
 		"kind": "employment", "person_id": person.ID, "organization_id": org.ID,
 		"role": role, "source": "manual",
 	})}
 }
 
-func linkEdge(t *testing.T, e *apptest.AppEnv, body AnyMap) relationshipRecord {
+func linkEdge(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) relationshipRecord {
 	t.Helper()
 	var rel relationshipRecord
 	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &rel); status != 201 {
@@ -264,10 +264,10 @@ func TestEndToEnd_reversingAProjectCompanyRefusesByNameAndWritesNothing(t *testi
 		Version int64  `json:"version"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
+		apptest.AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Joint rollout", "organization_id": org.ID, "source": "manual",
 	}, nil, nil); status != 201 {
 		t.Fatalf("create project → %d", status)
@@ -305,7 +305,7 @@ func TestEndToEnd_reversingAnEdgeChangeReplaysWhatTheLinkHeld(t *testing.T) {
 	pair := seedEmploymentOverHTTP(t, e)
 	var patched relationshipRecord
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+pair.edge.ID,
-		AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
+		apptest.AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
 		&patched); status != 200 {
 		t.Fatalf("patch the link → %d", status)
 	}
@@ -430,7 +430,7 @@ func TestEndToEnd_reversingALinkFromAStaleRecordScreenIsRefusedAndWritesNothing(
 	stale := readPerson(t, e, pair.person)
 	// The record moves under the open screen, which is the whole premise.
 	if status := e.Call(t, "PATCH", "/v1/people/"+pair.person,
-		AnyMap{"title": "COO"}, nil, nil); status != 200 {
+		apptest.AnyMap{"title": "COO"}, nil, nil); status != 200 {
 		t.Fatalf("move the person under the screen → %d", status)
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22151,12 +22151,18 @@ type PostDealRoomCommentRequest struct {
 }
 
 // PreferenceCenter The buyer-facing preference center's per-purpose view (B-E11.32): each tracked consent purpose
-// with the recipient's current state and whether it is locked (transactional cannot be withdrawn
-// while a deal is live).
+// with the recipient's current state, whether it is locked (transactional cannot be withdrawn
+// while a deal is live), and whether granting it needs a confirmation round-trip this surface
+// cannot perform.
 type PreferenceCenter struct {
 	Purposes []struct {
-		Key   string `json:"key"`
-		Label string `json:"label"`
+		// GrantNeedsConfirmation A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
+		// this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
+		// the way a confirmation round-trip does. A client must not offer the grant — the write refuses
+		// it with 422, and an offered switch that always fails is worse than an absent one.
+		GrantNeedsConfirmation bool   `json:"grant_needs_confirmation"`
+		Key                    string `json:"key"`
+		Label                  string `json:"label"`
 
 		// Locked A locked purpose (transactional) cannot be changed from this surface.
 		Locked bool                          `json:"locked"`

--- a/backend/internal/modules/consent/consentproof.go
+++ b/backend/internal/modules/consent/consentproof.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// How a recorded decision becomes a proof row: which purpose was named, what
+// confirmed a grant that needed confirming, and the paired write that leaves
+// the current state and its append-only evidence saying the same thing.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// loadConsentPurpose resolves the target purpose's key and DOI flag; an
+// unknown or archived purpose is 404.
+func loadConsentPurpose(ctx context.Context, tx pgx.Tx, purposeID ids.PurposeID) (key string, requiresDOI bool, err error) {
+	err = tx.QueryRow(ctx,
+		`SELECT key, requires_double_opt_in FROM consent_purpose WHERE id = $1 AND archived_at IS NULL`,
+		purposeID).Scan(&key, &requiresDOI)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, fmt.Errorf("purpose %s: %w", purposeID, apperrors.ErrNotFound)
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return key, requiresDOI, nil
+}
+
+// resolveDOIConfirmation enforces the German email norm: a DOI purpose's
+// grant is only effective once the double-opt-in round-trip confirmed.
+// The token must be one this server issued (hash-matched, unconsumed,
+// unexpired) — consuming it here makes the confirmation single-use and
+// unfabricatable rather than stored half-true. Non-DOI paths return nil.
+// The DOI round-trip is person-keyed (consent_doi_token has no lead arm),
+// so a DOI grant on a lead subject is refused rather than recorded
+// unconfirmed — the lead promotes first, then confirms.
+func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, requiresDOI bool) (*time.Time, error) {
+	if ConsentState(in.NewState) != StateGranted || !requiresDOI {
+		return nil, nil
+	}
+	if sub.entityType != "person" {
+		return nil, &ValidationError{
+			// The subject, not the purpose: the purpose is fine and the caller
+			// cannot fix it. What they must change is which subject they named,
+			// which is the field consentSubject's own refusals already use.
+			Field:  "subject",
+			Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it",
+		}
+	}
+	if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
+		return nil, &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}
+	}
+	confirmed, err := s.consumeDOIToken(ctx, tx, in.PersonID, in.PurposeID, *in.DoubleOptInToken)
+	if err != nil {
+		return nil, err
+	}
+	return &confirmed, nil
+}
+
+// upsertConsentWithProof writes the state row and appends the immutable
+// proof row — one concept: the current state is always backed by an
+// append-only consent_event that says when, how, and by whom. The upsert
+// targets the subject arm's own unique key (person×purpose or
+// lead×purpose); the other arm's column stays NULL.
+func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, doiConfirmedAt *time.Time, capturedAt time.Time, actorID string) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO person_consent (`+sub.column+`, purpose_id, state, lawful_basis, captured_at, source)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (`+sub.column+`, purpose_id)
+		DO UPDATE SET state = EXCLUDED.state, lawful_basis = EXCLUDED.lawful_basis,
+		              captured_at = EXCLUDED.captured_at, source = EXCLUDED.source`,
+		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, capturedAt, in.Source); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO consent_event (`+sub.column+`, purpose_id, new_state, lawful_basis, source,
+		                           policy_text, policy_version, double_opt_in_confirmed_at, captured_at, captured_by)
+		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), coalesce($6, 'recorded via API'), coalesce($7, 'v1'), $8, $9, $10)`,
+		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, in.Source,
+		in.PolicyText, in.PolicyVersion, doiConfirmedAt, capturedAt, actorID)
+	return err
+}

--- a/backend/internal/modules/consent/handlers_public.go
+++ b/backend/internal/modules/consent/handlers_public.go
@@ -178,10 +178,11 @@ func wirePurposeChoices(choices []PurposeChoice) []map[string]any {
 	out := make([]map[string]any, 0, len(choices))
 	for _, c := range choices {
 		out = append(out, map[string]any{
-			"key":    c.Key,
-			"label":  c.Label,
-			"state":  c.State,
-			"locked": c.Locked,
+			"key":                      c.Key,
+			"label":                    c.Label,
+			"state":                    c.State,
+			"locked":                   c.Locked,
+			"grant_needs_confirmation": c.GrantNeedsConfirmation,
 		})
 	}
 	return out

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -50,12 +50,19 @@ type PreferenceRef struct {
 }
 
 // PurposeChoice is one row of the preference center: the purpose, the
-// recipient's current state, and whether it is locked.
+// recipient's current state, and the two reasons this surface may not offer a
+// change — locked at all, or grantable only through a confirmation round-trip
+// it cannot perform.
 type PurposeChoice struct {
-	Key    string
-	Label  string
-	State  string
+	Key   string
+	Label string
+	State string
+	// Locked: no change at all from this surface.
 	Locked bool
+	// GrantNeedsConfirmation: withdrawing works, granting does not. Carried to
+	// the client so the switch is never OFFERED as a grant, because the write
+	// refuses it and a control that always fails is worse than an absent one.
+	GrantNeedsConfirmation bool
 }
 
 // preferenceTokenTTLDays is how long one preference link stays honoured
@@ -118,20 +125,43 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 	}
 	email = strings.ToLower(strings.TrimSpace(email))
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		var personID ids.PersonID
-		lookup := tx.QueryRow(ctx, `
-			SELECT pe.person_id
+		// The SAME resolution the send gate applies (gate.go resolvePerson), and
+		// it has to be: this mints the unsubscribe credential for a send the
+		// gate has already authorized against one person, so a lookup that can
+		// name a different one puts that person's link in this recipient's
+		// mailbox.
+		//
+		// Only a LIVE address resolves. uq_person_email_dedupe is partial on
+		// archived_at IS NULL, so one string can sit archived on one person and
+		// live on another — and the archived arm belongs to nobody who currently
+		// holds it.
+		//
+		// Ambiguity refuses rather than picks, for the reason the gate gives:
+		// a bare LIMIT 1 over two live matches is a silent choice between two
+		// people made by row order. The dedupe index should make that
+		// impossible; this refuses anyway rather than trusting an invariant it
+		// does not check.
+		rows, err := tx.Query(ctx, `
+			SELECT DISTINCT pe.person_id
 			FROM person_email pe
 			JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
-			WHERE lower(pe.email) = $1
-			  
-			LIMIT 1`, email).Scan(&personID)
-		if errors.Is(lookup, pgx.ErrNoRows) {
+			WHERE lower(pe.email) = $1 AND pe.archived_at IS NULL
+			LIMIT 2`, email)
+		if err != nil {
+			return err
+		}
+		matches, err := pgx.CollectRows(rows, pgx.RowTo[ids.PersonID])
+		if err != nil {
+			return err
+		}
+		if len(matches) == 0 {
 			return nil // not a known recipient in this workspace: no token, no header
 		}
-		if lookup != nil {
-			return lookup
+		if len(matches) > 1 {
+			return fmt.Errorf("consent: the recipient address is live on more than one person, so no unsubscribe link can name which: %w",
+				apperrors.ErrConflict)
 		}
+		personID := matches[0]
 		// The token this mints is a bearer credential over the recipient's
 		// consent record — it reads their per-purpose state, withdraws, and
 		// grants, all with no session. So the mint carries the SAME row-scope
@@ -249,8 +279,11 @@ func (s *Store) PublicPurposeStates(ctx context.Context, personID ids.PersonID) 
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
+		// requires_double_opt_in comes from the catalog rather than a constant:
+		// an operator may define their own DOI purpose, and a page that only
+		// knew about the seeded one would offer that switch and fail.
 		rows, err := tx.Query(ctx, `
-			SELECT cp.key, cp.label, coalesce(pc.state, 'unknown')
+			SELECT cp.key, cp.label, coalesce(pc.state, 'unknown'), cp.requires_double_opt_in
 			FROM consent_purpose cp
 			LEFT JOIN person_consent pc ON pc.purpose_id = cp.id AND pc.person_id = $1
 			WHERE cp.archived_at IS NULL
@@ -261,7 +294,7 @@ func (s *Store) PublicPurposeStates(ctx context.Context, personID ids.PersonID) 
 		defer rows.Close()
 		for rows.Next() {
 			var c PurposeChoice
-			if err := rows.Scan(&c.Key, &c.Label, &c.State); err != nil {
+			if err := rows.Scan(&c.Key, &c.Label, &c.State, &c.GrantNeedsConfirmation); err != nil {
 				return err
 			}
 			c.Locked = LockedPurpose(c.Key)

--- a/backend/internal/modules/consent/preferencetokensubject_integration_test.go
+++ b/backend/internal/modules/consent/preferencetokensubject_integration_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// Which person an unsubscribe link speaks for.
+//
+// The send gate and the token mint each resolve a recipient address to a
+// person, and they have to reach the same one: the gate authorizes the send
+// against whoever it found, and the mint decides whose consent record the
+// emailed link opens. A mint that can name a different person puts one
+// recipient's credential in another recipient's mailbox.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedPersonWithEmail creates a second subject in the same workspace carrying
+// one address, live or archived, through the columns the real writer uses.
+func seedPersonWithEmail(t *testing.T, e *channelConsentEnv, address string, archived bool) ids.PersonID {
+	t.Helper()
+	personID := ids.New[ids.PersonKind]()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'Second Holder', 'test', 'human:x')`, personID); err != nil {
+		t.Fatalf("seed person: %v", err)
+	}
+	archivedAt := "NULL"
+	if archived {
+		archivedAt = "now()"
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person_email (person_id, email, is_primary, source, captured_by, archived_at)
+		 VALUES ($1, lower($2), true, 'test', 'human:x', `+archivedAt+`)`,
+		personID, address); err != nil {
+		t.Fatalf("seed person_email: %v", err)
+	}
+	return personID
+}
+
+// The defect: uq_person_email_dedupe is partial on archived_at IS NULL, so one
+// address can sit archived on one person and live on another. A lookup that
+// does not filter archived rows could resolve to the person who no longer holds
+// the address, and mail THEIR unsubscribe link to the person who does.
+func TestAnUnsubscribeLinkNamesTheLivingHolderOfTheAddress(t *testing.T) {
+	e := setupChannelConsent(t)
+	address := "shared-" + e.person.String() + "@example.test"
+
+	// The address as somebody's detached history, seeded FIRST so a lookup
+	// deciding by row order would find this one.
+	formerHolder := seedPersonWithEmail(t, e, address, true)
+	// And as the live address of the person who actually holds it now.
+	currentHolder := seedPersonWithEmail(t, e, address, false)
+
+	token, found, err := e.store.PreferenceTokenForEmail(e.ctx, address)
+	if err != nil {
+		t.Fatalf("mint a preference token: %v", err)
+	}
+	if !found {
+		t.Fatal("no token minted for an address one person live-holds")
+	}
+
+	ref, err := e.store.ResolvePreferenceToken(e.ctx, token)
+	if err != nil {
+		t.Fatalf("resolve the minted token: %v", err)
+	}
+	if ref.PersonID == formerHolder {
+		t.Fatal("the link opens the consent record of the person who ARCHIVED this address — " +
+			"it would reach the current holder's mailbox and speak for somebody else")
+	}
+	if ref.PersonID != currentHolder {
+		t.Fatalf("link names %s, want the live holder %s", ref.PersonID, currentHolder)
+	}
+}
+
+// An address nobody live-holds carries no unsubscribe surface, which is
+// found=false rather than a token for the person who detached it.
+func TestAnArchivedAddressAloneMintsNoLink(t *testing.T) {
+	e := setupChannelConsent(t)
+	address := "detached-" + e.person.String() + "@example.test"
+	seedPersonWithEmail(t, e, address, true)
+
+	_, found, err := e.store.PreferenceTokenForEmail(e.ctx, address)
+	if err != nil {
+		t.Fatalf("look up an address only held archived: %v", err)
+	}
+	if found {
+		t.Error("minted a link for an address no live person holds")
+	}
+}
+
+// The preference centre must SAY which purposes it cannot grant, because the
+// page can only withhold a switch it knows about. The defect this holds: the
+// wire carried `locked` and nothing else, so a double-opt-in purpose rendered
+// as an ordinary toggle and every grant through it was refused.
+func TestThePreferenceCentreNamesThePurposesItCannotGrant(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	choices, err := e.store.PublicPurposeStates(e.ctx, e.person)
+	if err != nil {
+		t.Fatalf("read the preference centre: %v", err)
+	}
+
+	byKey := map[string]PurposeChoice{}
+	for _, c := range choices {
+		byKey[c.Key] = c
+	}
+	doi, ok := byKey["doi_newsletter"]
+	if !ok {
+		t.Fatal("the double-opt-in purpose is absent from the centre it is offered in")
+	}
+	if !doi.GrantNeedsConfirmation {
+		t.Error("a double-opt-in purpose does not say its grant needs confirmation — " +
+			"the page would offer a switch the write refuses")
+	}
+	plain, ok := byKey["newsletter"]
+	if !ok {
+		t.Fatal("the ordinary purpose is absent")
+	}
+	if plain.GrantNeedsConfirmation {
+		t.Error("an ordinary purpose claims its grant needs confirmation, withholding a switch that works")
+	}
+}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -304,100 +304,116 @@ func admitRecord(ctx context.Context, in RecordInput) (subject, ConsentState, er
 // person or, before promotion, a lead (E12.20). Re-asserting the
 // current state is idempotent: no second proof row, no second event.
 func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
+	// Admitted before a connection is taken: a malformed subject or a caller
+	// without authority is refused without opening a transaction, which is what
+	// keeps a bad request off the pool. RecordTx does not repeat it — this is
+	// the one admission, and RecordTx documents that its callers have passed it.
 	sub, state, err := admitRecord(ctx, in)
 	if err != nil {
 		return State{}, err
 	}
+	var out State
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		out, err = s.recordAdmittedTx(ctx, tx, in, sub, state)
+		return err
+	})
+	return out, err
+}
+
+// recordAdmittedTx is the write itself, on input Record has already admitted —
+// so admission runs once per request and its authorization check is never
+// evaluated twice.
+func (s *Store) recordAdmittedTx(
+	ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, state ConsentState,
+) (State, error) {
 	actor, _ := principal.Actor(ctx)
 
 	var out State
-	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Which row probe runs depends on WHAT is being recorded.
-		// A WITHDRAWAL stays recordable against an archived — including an
-		// Art. 17 anonymized — subject: suppression is what you most want still
-		// working once somebody has asked to be forgotten.
-		//
-		// A GRANT does not. Anonymize-in-place leaves the person row standing,
-		// so an erased subject would go on accruing person_consent,
-		// consent_event, audit and outbox rows — the accrual erasure destroys
-		// the emailed capabilities to stop. This closes it from the other end.
-		//
-		// "Permissive" is weaker than it sounds: EnsureWritable runs NO
-		// statement for an actor unbounded on the table, and every human is
-		// unbounded on `lead` — so that arm is ungated for a lead, and gated
-		// for a person only by capture privacy. Nothing outside tests sets
-		// LeadID, which is why that is a note not a finding (#2574).
-		//
-		// Exhaustive rather than defaulted: a state added to
-		// ParseRecordableState must come here and say whether it is a claim or
-		// a suppression, and is refused until it does.
-		var probe func(context.Context, pgx.Tx, string, ids.UUID) error
-		switch state {
-		case StateGranted:
-			probe = auth.EnsureWritableLive
-		case StateWithdrawn:
-			probe = auth.EnsureWritable
-		default:
-			// Not a bad request: ParseRecordableState already admitted this
-			// value, so arriving here means the vocabulary grew and this
-			// decision was not made. That is a defect in the code, and it
-			// refuses rather than guessing which probe the new state wants.
-			return fmt.Errorf("consent: %q is recordable but no row probe has been chosen for it — decide whether it is a lawful-basis claim (live subject only) or a suppression (any subject)", state)
-		}
-		if err := probe(ctx, tx, sub.entityType, sub.id); err != nil {
-			return err
-		}
-		purposeKey, requiresDOI, err := loadConsentPurpose(ctx, tx, in.PurposeID)
-		if err != nil {
-			return err
-		}
-		var current string
-		err = tx.QueryRow(ctx,
-			`SELECT state FROM person_consent WHERE `+sub.column+` = $1 AND purpose_id = $2`,
-			sub.id, in.PurposeID).Scan(&current)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return err
-		}
-		if current == in.NewState {
-			out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current, LawfulBasis: in.LawfulBasis}
-			return nil // idempotent re-assertion: no proof row, no event, no fresh token demanded
-		}
-		if in.NeverOverrideExisting && current != "" {
-			out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current}
-			return nil // the decision on record stands; an anonymous capture cannot flip it
-		}
+	// Which row probe runs depends on WHAT is being recorded.
+	// A WITHDRAWAL stays recordable against an archived — including an
+	// Art. 17 anonymized — subject: suppression is what you most want still
+	// working once somebody has asked to be forgotten.
+	//
+	// A GRANT does not. Anonymize-in-place leaves the person row standing,
+	// so an erased subject would go on accruing person_consent,
+	// consent_event, audit and outbox rows — the accrual erasure destroys
+	// the emailed capabilities to stop. This closes it from the other end.
+	//
+	// "Permissive" is weaker than it sounds: EnsureWritable runs NO
+	// statement for an actor unbounded on the table, and every human is
+	// unbounded on `lead` — so that arm is ungated for a lead, and gated
+	// for a person only by capture privacy. Nothing outside tests sets
+	// LeadID, which is why that is a note not a finding (#2574).
+	//
+	// Exhaustive rather than defaulted: a state added to
+	// ParseRecordableState must come here and say whether it is a claim or
+	// a suppression, and is refused until it does.
+	var probe func(context.Context, pgx.Tx, string, ids.UUID) error
+	switch state {
+	case StateGranted:
+		probe = auth.EnsureWritableLive
+	case StateWithdrawn:
+		probe = auth.EnsureWritable
+	default:
+		// Not a bad request: ParseRecordableState already admitted this
+		// value, so arriving here means the vocabulary grew and this
+		// decision was not made. That is a defect in the code, and it
+		// refuses rather than guessing which probe the new state wants.
+		return State{}, fmt.Errorf("consent: %q is recordable but no row probe has been chosen for it — decide whether it is a lawful-basis claim (live subject only) or a suppression (any subject)", state)
+	}
+	if err := probe(ctx, tx, sub.entityType, sub.id); err != nil {
+		return State{}, err
+	}
+	purposeKey, requiresDOI, err := loadConsentPurpose(ctx, tx, in.PurposeID)
+	if err != nil {
+		return State{}, err
+	}
+	var current string
+	err = tx.QueryRow(ctx,
+		`SELECT state FROM person_consent WHERE `+sub.column+` = $1 AND purpose_id = $2`,
+		sub.id, in.PurposeID).Scan(&current)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return State{}, err
+	}
+	if current == in.NewState {
+		out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current, LawfulBasis: in.LawfulBasis}
+		return out, nil // idempotent re-assertion: no proof row, no event, no fresh token demanded
+	}
+	if in.NeverOverrideExisting && current != "" {
+		out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current}
+		return out, nil // the decision on record stands; an anonymous capture cannot flip it
+	}
 
-		doiConfirmedAt, err := s.resolveDOIConfirmation(ctx, tx, in, sub, requiresDOI)
-		if err != nil {
-			return err
-		}
+	doiConfirmedAt, err := s.resolveDOIConfirmation(ctx, tx, in, sub, requiresDOI)
+	if err != nil {
+		return State{}, err
+	}
 
-		capturedAt := s.now().UTC()
-		if err := upsertConsentWithProof(ctx, tx, in, sub, doiConfirmedAt, capturedAt, actor.ID); err != nil {
-			return err
-		}
+	capturedAt := s.now().UTC()
+	if err := upsertConsentWithProof(ctx, tx, in, sub, doiConfirmedAt, capturedAt, actor.ID); err != nil {
+		return State{}, err
+	}
 
-		action := "consent_grant"
-		if ConsentState(in.NewState) == StateWithdrawn {
-			action = "consent_withdraw"
-		}
-		auditID, err := storekit.Audit(ctx, tx, action, sub.entityType, sub.id, map[string]any{"state": stateOrUnknown(current)}, map[string]any{
-			"purpose": purposeKey, "state": in.NewState,
-		})
-		if err != nil {
-			return err
-		}
-		if err := storekit.EmitEventForEntity(ctx, tx, auditID, sub.entityType, sub.id,
-			consentChangedPayload(in.PurposeID, purposeKey, in.NewState)); err != nil {
-			return err
-		}
-		out = State{
-			PurposeID: in.PurposeID, PurposeKey: purposeKey, State: in.NewState,
-			LawfulBasis: in.LawfulBasis, DoubleOptInConfirmedAt: doiConfirmedAt, UpdatedAt: &capturedAt,
-		}
-		return nil
+	action := "consent_grant"
+	if ConsentState(in.NewState) == StateWithdrawn {
+		action = "consent_withdraw"
+	}
+	auditID, err := storekit.Audit(ctx, tx, action, sub.entityType, sub.id, map[string]any{"state": stateOrUnknown(current)}, map[string]any{
+		"purpose": purposeKey, "state": in.NewState,
 	})
-	return out, err
+	if err != nil {
+		return State{}, err
+	}
+	if err := storekit.EmitEventForEntity(ctx, tx, auditID, sub.entityType, sub.id,
+		consentChangedPayload(in.PurposeID, purposeKey, in.NewState)); err != nil {
+		return State{}, err
+	}
+	out = State{
+		PurposeID: in.PurposeID, PurposeKey: purposeKey, State: in.NewState,
+		LawfulBasis: in.LawfulBasis, DoubleOptInConfirmedAt: doiConfirmedAt, UpdatedAt: &capturedAt,
+	}
+	return out, nil
 }
 
 // consentChangedPayload builds the consent.changed wire payload — the
@@ -411,76 +427,6 @@ func consentChangedPayload(purposeID ids.PurposeID, purposeKey, newState string)
 		Purpose:   purposeKey,
 		NewState:  newState,
 	}
-}
-
-// loadConsentPurpose resolves the target purpose's key and DOI flag; an
-// unknown or archived purpose is 404.
-func loadConsentPurpose(ctx context.Context, tx pgx.Tx, purposeID ids.PurposeID) (key string, requiresDOI bool, err error) {
-	err = tx.QueryRow(ctx,
-		`SELECT key, requires_double_opt_in FROM consent_purpose WHERE id = $1 AND archived_at IS NULL`,
-		purposeID).Scan(&key, &requiresDOI)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return "", false, fmt.Errorf("purpose %s: %w", purposeID, apperrors.ErrNotFound)
-	}
-	if err != nil {
-		return "", false, err
-	}
-	return key, requiresDOI, nil
-}
-
-// resolveDOIConfirmation enforces the German email norm: a DOI purpose's
-// grant is only effective once the double-opt-in round-trip confirmed.
-// The token must be one this server issued (hash-matched, unconsumed,
-// unexpired) — consuming it here makes the confirmation single-use and
-// unfabricatable rather than stored half-true. Non-DOI paths return nil.
-// The DOI round-trip is person-keyed (consent_doi_token has no lead arm),
-// so a DOI grant on a lead subject is refused rather than recorded
-// unconfirmed — the lead promotes first, then confirms.
-func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, requiresDOI bool) (*time.Time, error) {
-	if ConsentState(in.NewState) != StateGranted || !requiresDOI {
-		return nil, nil
-	}
-	if sub.entityType != "person" {
-		return nil, &ValidationError{
-			// The subject, not the purpose: the purpose is fine and the caller
-			// cannot fix it. What they must change is which subject they named,
-			// which is the field consentSubject's own refusals already use.
-			Field:  "subject",
-			Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it",
-		}
-	}
-	if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
-		return nil, &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}
-	}
-	confirmed, err := s.consumeDOIToken(ctx, tx, in.PersonID, in.PurposeID, *in.DoubleOptInToken)
-	if err != nil {
-		return nil, err
-	}
-	return &confirmed, nil
-}
-
-// upsertConsentWithProof writes the state row and appends the immutable
-// proof row — one concept: the current state is always backed by an
-// append-only consent_event that says when, how, and by whom. The upsert
-// targets the subject arm's own unique key (person×purpose or
-// lead×purpose); the other arm's column stays NULL.
-func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub subject, doiConfirmedAt *time.Time, capturedAt time.Time, actorID string) error {
-	if _, err := tx.Exec(ctx, `
-		INSERT INTO person_consent (`+sub.column+`, purpose_id, state, lawful_basis, captured_at, source)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (`+sub.column+`, purpose_id)
-		DO UPDATE SET state = EXCLUDED.state, lawful_basis = EXCLUDED.lawful_basis,
-		              captured_at = EXCLUDED.captured_at, source = EXCLUDED.source`,
-		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, capturedAt, in.Source); err != nil {
-		return err
-	}
-	_, err := tx.Exec(ctx, `
-		INSERT INTO consent_event (`+sub.column+`, purpose_id, new_state, lawful_basis, source,
-		                           policy_text, policy_version, double_opt_in_confirmed_at, captured_at, captured_by)
-		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), coalesce($6, 'recorded via API'), coalesce($7, 'v1'), $8, $9, $10)`,
-		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, in.Source,
-		in.PolicyText, in.PolicyVersion, doiConfirmedAt, capturedAt, actorID)
-	return err
 }
 
 func stateOrUnknown(state string) string {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -20723,8 +20723,9 @@ export interface components {
         };
         /**
          * @description The buyer-facing preference center's per-purpose view (B-E11.32): each tracked consent purpose
-         *     with the recipient's current state and whether it is locked (transactional cannot be withdrawn
-         *     while a deal is live).
+         *     with the recipient's current state, whether it is locked (transactional cannot be withdrawn
+         *     while a deal is live), and whether granting it needs a confirmation round-trip this surface
+         *     cannot perform.
          */
         PreferenceCenter: {
             purposes: {
@@ -20734,6 +20735,13 @@ export interface components {
                 state: "unknown" | "granted" | "withdrawn";
                 /** @description A locked purpose (transactional) cannot be changed from this surface. */
                 locked: boolean;
+                /**
+                 * @description A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
+                 *     this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
+                 *     the way a confirmation round-trip does. A client must not offer the grant — the write refuses
+                 *     it with 422, and an offered switch that always fails is worse than an absent one.
+                 */
+                grant_needs_confirmation: boolean;
             }[];
         };
         /** @description An automation *type* in the closed starter library (E15/ADR-0035, feedback/14). */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4713,6 +4713,8 @@ export const de = {
     "Nicht abonniert — du bekommst für diesen Zweck nichts",
   "prefs.alwaysOn": "immer an",
   "prefs.lockedWhy": "Transaktional — von der Abmeldung ausgenommen.",
+  "prefs.confirmationNeededWhy":
+    "Um dies zu erhalten, nutzen Sie den Bestätigungslink aus unserer E-Mail. Abbestellen können Sie hier jederzeit.",
   "prefs.notSaved": "Noch nicht gespeichert.",
   "prefs.savePending": "Ausstehend: {changes}.",
   "prefs.saveProof":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4776,6 +4776,8 @@ export const en = {
     "Not subscribed — you receive nothing for this purpose",
   "prefs.alwaysOn": "always on",
   "prefs.lockedWhy": "Transactional — exempt from opt-out.",
+  "prefs.confirmationNeededWhy":
+    "To start receiving this, use the confirmation link we email you. You can stop it here at any time.",
   "prefs.notSaved": "Not saved yet.",
   "prefs.savePending": "Pending: {changes}.",
   "prefs.saveProof":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4675,6 +4675,8 @@ export const vi = {
   "prefs.notSubscribed": "Chưa đăng ký — bạn không nhận gì cho mục đích này",
   "prefs.alwaysOn": "luôn bật",
   "prefs.lockedWhy": "Thư giao dịch — không thuộc diện từ chối nhận.",
+  "prefs.confirmationNeededWhy":
+    "Để bắt đầu nhận, hãy dùng liên kết xác nhận trong email của chúng tôi. Bạn có thể dừng nhận tại đây bất cứ lúc nào.",
   "prefs.notSaved": "Chưa lưu.",
   "prefs.savePending": "Đang chờ: {changes}.",
   "prefs.saveProof":

--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -13,15 +13,49 @@ const purposes: PurposeView[] = [
     label: "Deal & service messages",
     state: "granted",
     locked: true,
+    grant_needs_confirmation: false,
   },
   {
     key: "marketing_email",
     label: "Product updates",
     state: "granted",
     locked: false,
+    grant_needs_confirmation: false,
   },
-  { key: "events", label: "Events", state: "withdrawn", locked: false },
-  { key: "research", label: "Surveys", state: "unknown", locked: false },
+  {
+    key: "events",
+    label: "Events",
+    state: "withdrawn",
+    locked: false,
+    grant_needs_confirmation: false,
+  },
+  {
+    key: "research",
+    label: "Surveys",
+    state: "unknown",
+    locked: false,
+    grant_needs_confirmation: false,
+  },
+];
+
+// A purpose the server will only grant through a confirmation round-trip.
+// Withdrawing it here is honoured; granting it is refused, so the two
+// directions are asserted apart.
+const doiPurposes: PurposeView[] = [
+  {
+    key: "doi_newsletter",
+    label: "Newsletter",
+    state: "withdrawn",
+    locked: false,
+    grant_needs_confirmation: true,
+  },
+  {
+    key: "doi_granted",
+    label: "Already subscribed",
+    state: "granted",
+    locked: false,
+    grant_needs_confirmation: true,
+  },
 ];
 
 describe("display state", () => {
@@ -84,5 +118,21 @@ describe("choice building", () => {
 
   it("submits nothing when nothing moved", () => {
     expect(toChoices(purposes, initialDraft(purposes), wordingOf)).toEqual([]);
+  });
+});
+
+describe("a purpose needing a confirmation round-trip", () => {
+  // The defect this holds: the page offered the switch, the person turned it
+  // on, and the save came back 422 with nothing recorded.
+  it("never submits a grant the server refuses", () => {
+    const draft = { doi_newsletter: true, doi_granted: true };
+    expect(dirtyKeys(doiPurposes, draft)).toEqual([]);
+  });
+
+  // And the half that must keep working: an unsubscribe is honoured, so
+  // filtering the whole purpose would strip somebody's opt-out.
+  it("still submits a withdrawal", () => {
+    const draft = { doi_newsletter: false, doi_granted: false };
+    expect(dirtyKeys(doiPurposes, draft)).toEqual(["doi_granted"]);
   });
 });

--- a/frontend/src/screens/preferences.logic.ts
+++ b/frontend/src/screens/preferences.logic.ts
@@ -20,12 +20,21 @@ export function initialDraft(purposes: PurposeView[]): Draft {
   return draft;
 }
 
-// Locked purposes are excluded unconditionally: the server refuses them
-// (preference.go:206) and the toggle is disabled, so a draft that claims one
-// moved is noise, never a pending change.
+// Locked purposes are excluded unconditionally: the server refuses them and the
+// toggle is disabled, so a draft that claims one moved is noise, never a pending
+// change.
+//
+// A double-opt-in purpose is excluded only in the GRANT direction, and for a
+// different reason: the server refuses that write too, but the withdrawal
+// beside it is honoured. Filtering the whole purpose would strip somebody's
+// unsubscribe; filtering neither would submit a choice that 422s and lose the
+// rest of the save with it.
 export function dirtyKeys(purposes: PurposeView[], draft: Draft): string[] {
   return purposes
     .filter((purpose) => !purpose.locked)
+    .filter(
+      (purpose) => !(purpose.grant_needs_confirmation && draft[purpose.key]),
+    )
     .filter((purpose) => draft[purpose.key] !== displayOn(purpose.state))
     .map((purpose) => purpose.key);
 }

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -411,6 +411,12 @@ function PreferenceRow({
   // conditions just combine below rather than this prop overriding that one.
   disabled: boolean;
 }>) {
+  // A double-opt-in purpose can be turned OFF here but never ON: the write
+  // refuses the grant, because this page's token is reusable and long-lived,
+  // so it cannot evidence one deliberate choice the way a confirmation
+  // round-trip does. Offering a switch that always fails is worse than not
+  // offering it, so the grant is withheld while the withdrawal stays.
+  const grantBlocked = purpose.grant_needs_confirmation && !on;
   return (
     <li className="pref-row">
       <div className="pref-row-main">
@@ -430,13 +436,18 @@ function PreferenceRow({
         {purpose.locked && (
           <p className="t-caption pref-locked-why">{t("prefs.lockedWhy")}</p>
         )}
+        {grantBlocked && (
+          <p className="t-caption pref-locked-why">
+            {t("prefs.confirmationNeededWhy")}
+          </p>
+        )}
       </div>
       <button
         type="button"
         role="switch"
         aria-checked={on}
         aria-label={purpose.label}
-        disabled={purpose.locked || disabled}
+        disabled={purpose.locked || grantBlocked || disabled}
         className={`pref-toggle${on ? " on" : ""}`}
         onClick={onToggle}
       >


### PR DESCRIPTION
Closes #2955.

Rewritten. An earlier version of this branch tried to let a preference-centre
click complete a double-opt-in grant. Review showed that was wrong, and the
reasoning is at the bottom.

## Defect 1: the page offers a switch the write refuses

The preference centre showed a toggle for every unlocked purpose. A purpose
requiring double opt-in cannot be granted from there — `crm.yaml` says so
("a purpose requiring double-opt-in cannot be re-granted from this surface
without the confirmation round-trip (422)") and `Record` enforces it.

So a person clicking "yes" on the newsletter got a 422 and nothing was
recorded. The page had no way to know which purposes those were: the wire
carried `locked` and nothing else.

`PreferenceCenter` now carries `grant_needs_confirmation`, read from
`consent_purpose.requires_double_opt_in` rather than a hardcoded key, so an
operator-defined double-opt-in purpose is covered too.

The client withholds the switch **only in the grant direction**:

- `preferences.tsx` disables the toggle when the purpose needs confirmation
  and is currently off, with a line saying to use the emailed confirmation
  link. A purpose already granted can still be switched off.
- `preferences.logic.ts` drops such a grant from `dirtyKeys`, so a stale draft
  cannot submit one — and a save carrying a withdrawal beside it still records
  the withdrawal rather than failing whole.

Filtering the purpose outright would have stripped somebody's unsubscribe,
which is the half that was never broken.

## Defect 2: an unsubscribe link could name the wrong person

`PreferenceTokenForEmail` resolved a recipient address to a person with:

```sql
JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
WHERE lower(pe.email) = $1
LIMIT 1
```

No `pe.archived_at IS NULL`, and a bare `LIMIT 1`. The send gate that
authorized the same send filters both (`gate.go` `resolvePerson`), and its own
comment explains why: `uq_person_email_dedupe` is partial on
`archived_at IS NULL`, so one address can sit archived on person A and live on
person B.

The gate authorizes the send for B; this mint could return A's token. B then
receives a working link to A's consent record — reads A's per-purpose state,
withdraws for A, and (for a non-DOI purpose) grants for A.

It now applies the gate's own resolution, and refuses ambiguity rather than
picking by row order.

## Verification

`preferencetokensubject_integration_test.go`:

- an unsubscribe link names the living holder of a shared address, with the
  archived holder seeded first so a row-order lookup would find the wrong one
- an address only held archived mints no link at all
- the preference centre names the purposes it cannot grant

`preferences.logic.test.ts`:

- a grant the server refuses is never submitted
- a withdrawal of the same purpose still is

Both guards mutation-checked: reverting either makes its test fail, and the
withdrawal test correctly stays green, which is what proves the two directions
are independent.

Backend and frontend gates green; consent and privacy integration lanes green.

## Along the way

`store.go` crossed the 500-line cap, so the purpose read, the DOI confirmation
rule and the paired state-and-proof write moved to `consentproof.go`. Both
writes stay in one function, which is what `gates/consentproof_test.go` holds.
`Record`'s admission moved ahead of the transaction so a malformed subject
costs no connection, and now runs once rather than twice.

## What this branch no longer does, and why

The first version added a `MailboxProof` type letting a preference-centre
click stand in for a double-opt-in round trip, on the reasoning that a link
delivered to a mailbox already proves control of it.

That reasoning is sound. It does not fit this token. `preference.go` states
that reuse is deliberate — the centre is revisitable, so the token is never
consumed, slides 30 days per use and lives up to a 180-day ceiling. Anyone who
ever holds the URL could therefore replay a grant, including re-granting after
a withdrawal, each replay stamping a fresh confirmation timestamp in the
subject's name. Single-use is exactly the property that makes a confirmation
mean anything.

Review also found the consequence: the retention anonymizer destroys the
double-opt-in token but not the preference token, so that change would have
promoted the one surviving credential into a consent-granting one.

The `confirm_token` work built for #2943 — single-use, hashed, 14-day — does
carry the argument properly, and is out of this branch until the page that
uses it exists. Nothing here is a foundation for it; it will land whole.

## Not fixed here

`lint` is red on `origin/main`:
`internal/compose/integration/edgereverse_integration_test.go` still calls
`apptest.AnyMap` after #2951 moved it. PR #2956 already fixes it. Untouched by
this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for consent purposes requiring email confirmation before activation.
  * Preference centers now identify confirmation-required purposes and explain the confirmation process.
  * Users can still withdraw consent for these purposes at any time.
  * Consent decisions now retain confirmation, policy, capture, and actor details.

* **Bug Fixes**
  * Preference links now resolve to the current live contact and are not created for archived-only addresses.
  * Prevented unsupported consent grants through the preference center with clear validation feedback.
  * Added localized messaging in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->