### PR TITLE
fix(integration): edgereverse names AnyMap from the package that declares it

### DIFF
--- a/backend/internal/compose/integration/edgereverse_integration_test.go
+++ b/backend/internal/compose/integration/edgereverse_integration_test.go
@@ -55,23 +55,23 @@ func seedEmploymentOverHTTP(t *testing.T, e *apptest.AppEnv) linkedPair {
 	role := seededEdgeRole
 	var person personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
+		AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	var org struct {
 		ID string `json:"id"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, apptest.AnyMap{
+	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, AnyMap{
 		"kind": "employment", "person_id": person.ID, "organization_id": org.ID,
 		"role": role, "source": "manual",
 	})}
 }
 
-func linkEdge(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) relationshipRecord {
+func linkEdge(t *testing.T, e *apptest.AppEnv, body AnyMap) relationshipRecord {
 	t.Helper()
 	var rel relationshipRecord
 	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &rel); status != 201 {
@@ -264,10 +264,10 @@ func TestEndToEnd_reversingAProjectCompanyRefusesByNameAndWritesNothing(t *testi
 		Version int64  `json:"version"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Joint rollout", "organization_id": org.ID, "source": "manual",
 	}, nil, nil); status != 201 {
 		t.Fatalf("create project → %d", status)
@@ -305,7 +305,7 @@ func TestEndToEnd_reversingAnEdgeChangeReplaysWhatTheLinkHeld(t *testing.T) {
 	pair := seedEmploymentOverHTTP(t, e)
 	var patched relationshipRecord
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+pair.edge.ID,
-		apptest.AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
+		AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
 		&patched); status != 200 {
 		t.Fatalf("patch the link → %d", status)
 	}
@@ -430,7 +430,7 @@ func TestEndToEnd_reversingALinkFromAStaleRecordScreenIsRefusedAndWritesNothing(
 	stale := readPerson(t, e, pair.person)
 	// The record moves under the open screen, which is the whole premise.
 	if status := e.Call(t, "PATCH", "/v1/people/"+pair.person,
-		apptest.AnyMap{"title": "COO"}, nil, nil); status != 200 {
+		AnyMap{"title": "COO"}, nil, nil); status != 200 {
 		t.Fatalf("move the person under the screen → %d", status)
 	}
 


### PR DESCRIPTION
## main does not compile

`main-health` run `33081704383`, tip `c1584ea00` — **10 failed, 6 success, 1
skipped**. Nine of the ten are one cause:

```
internal/compose/integration/edgereverse_integration_test.go:58:11: undefined: apptest.AnyMap
FAIL github.com/margince/margince/backend/internal/compose/integration [build failed]
```

| job | why |
|---|---|
| `backend gate (main)` | golangci's typecheck reads the `integration` tag |
| `integration / integration shard (1..6/6)` | the package will not build |
| `integration / integration (RLS + erasure + HTTP e2e)` | fan-in over the shards |
| `integration / integration unit coverage` | same package |
| `sonarcloud (main)` | skipped — its dependency never produced coverage |
| `uat (main)` | **unrelated** — #2924, third occurrence |
| `dco (main)` | **unrelated** — `188598a90`, #2785 |

## The fix

`AnyMap` is declared in `integration/anymap.go` as a package-level alias:

```go
type AnyMap = map[string]any
```

`edgereverse_integration_test.go` is in that same package, so it needs no
qualifier. Eight sites, and a tree-wide grep confirms they are the only
`apptest.AnyMap` anywhere.

## Nobody could have caught this

Two changes that each compiled on its own base:

- one moved the JSON alias so that it is **not** the app fixture's;
- the other added this file, naming it where it used to live.

Their branches share no line. The merge is the first tree in which both are true,
and `apptest.` stayed valid right up to the moment the other side landed. Every
one of the nine commits in this window merged with **no red check** — I checked
each before writing this, precisely because "somebody bypassed a gate" has been
the right answer several times today and is the wrong answer here.

This is the same class as the `gate-inventory.md` collision in #2944 earlier: two
PRs that share no file, colliding on a fact that only exists in the merged tree.
There the shared fact was a count; here it is a symbol's package.

## Verification

`make check-backend` green, including the golangci typecheck that was failing.
`go vet -tags integration ./internal/compose/integration/` clean — that is the
build the shards do.

Not verified locally: the integration lane itself. The port that `make db-up`
needs is held by this repository's own shared dev stack (see the note on #2929),
and the failure here is a **compile** error, which `go vet -tags integration`
answers completely.

## What this does not fix

`uat` and `dco` stay red, and neither is in reach of this change:

- `uat` — #2924, now its **third** occurrence, and the second failed the test
  that already carries the assertion once proposed as its fix. It needs the two
  address writers instrumented, not another test change.
- `dco` — `188598a90` needs a `DCO-Remediation-Commit` trailer from its own
  author; `check-dco.sh` accepts one from nobody else.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a merge collision that broke compilation of the `integration` package on `main`, failing nine CI jobs. `edgereverse_integration_test.go` referenced `apptest.AnyMap`, but `AnyMap` is declared in the same `integration` package, so the qualifier was invalid after another change moved the alias. Removes the `apptest.` prefix from all eight call sites.

<sup>Written for commit a7b3d1e0dbdf43672102de58cd4cefac42822220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test request data handling without changing test behavior or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->