### PR TITLE
fix(ai): navigation is not evidence

### DIFF
--- a/backend/internal/compose/siteboilerplate.go
+++ b/backend/internal/compose/siteboilerplate.go
@@ -92,10 +92,24 @@ const (
 // Returns the pages in the same order, with Text trimmed where a shared
 // opening was found. The input is not modified.
 func stripSharedPrefix(pages []crawlPage) []crawlPage {
+	out, _ := stripSharedPrefixBlocks(pages)
+	return out
+}
+
+// stripSharedPrefixBlocks is stripSharedPrefix, and also answers WHICH blocks
+// it cut.
+//
+// The blocks leave with the pages because two callers need the same answer for
+// opposite reasons. The profile lane wants the text without them, so its
+// excerpt budget is spent on the company's own words. The evidence filter
+// wants the blocks themselves, so a finding cited to nothing but the menu can
+// be recognised — and a second measurement, taken separately, would be a
+// second definition of chrome free to disagree with this one.
+func stripSharedPrefixBlocks(pages []crawlPage) ([]crawlPage, []string) {
 	out := make([]crawlPage, len(pages))
 	copy(out, pages)
 	if len(pages) < boilerplateMinPages {
-		return out
+		return out, nil
 	}
 	total := 0
 	for _, page := range pages {
@@ -104,27 +118,31 @@ func stripSharedPrefix(pages []crawlPage) []crawlPage {
 	if total > boilerplateMaxCorpusBytes {
 		// Fail open: keeping the chrome is the old behaviour, and it beats
 		// spending unbounded CPU on a corpus the crawled site chose.
-		return out
+		return out, nil
 	}
 
 	// A multilingual site has one menu PER LANGUAGE, and each covers only
 	// its own pages: arvato.com's largest covers 10 of 38. One pass removes
 	// one menu and leaves the other locales carrying theirs, so the search
 	// repeats on what remains until nothing more qualifies.
+	var blocks []string
 	for round := 0; round < boilerplateMaxRounds; round++ {
-		if !stripOneSharedBlock(out) {
+		block := stripOneSharedBlock(out)
+		if block == "" {
 			break
 		}
+		blocks = append(blocks, block)
 	}
-	return out
+	return out, blocks
 }
 
 // stripOneSharedBlock finds the single most-shared opening in pages and cuts
-// it from every page carrying it, in place. Reports whether it cut anything.
-func stripOneSharedBlock(out []crawlPage) bool {
+// it from every page carrying it, in place. Answers the block it cut, or empty
+// when nothing qualified.
+func stripOneSharedBlock(out []crawlPage) string {
 	prefix := sharedOpening(out)
 	if utf8.RuneCountInString(prefix) < boilerplateMinRunes {
-		return false
+		return ""
 	}
 
 	cut := false
@@ -158,7 +176,10 @@ func stripOneSharedBlock(out []crawlPage) bool {
 		out[i].Text = trimmed
 		cut = true
 	}
-	return cut
+	if !cut {
+		return ""
+	}
+	return prefix
 }
 
 // chromeSearchRunes is how far into a page the shared header may start. Real

--- a/backend/internal/compose/sitechromeevidence.go
+++ b/backend/internal/compose/sitechromeevidence.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Navigation is not evidence.
+//
+// The per-page fact lane reads a page as it arrives, which is before the crawl
+// exists — so unlike the profile lane it cannot have its chrome removed before
+// the prompt is built. What it can do is answer for what it found once the
+// corpus is whole, which is where this runs.
+//
+// Two things a live read produced made the case. A legal-entity candidate came
+// back cited to the site's flattened mega-menu:
+//
+//	Imprint | Gradion | Gradion Solutions Products Industries About English
+//	Contact Us Solutions Products Industries About English Deutsch Tiếng Việt …
+//
+// True, and useless: the reader is asked to choose between entities, and that
+// passage names all of them. And the language switcher's own labels came back
+// as `language` facts scored 100 — true statements about the WEBSITE, not
+// about the business, pre-selected into the company context with everything
+// else.
+//
+// One rule covers both, because both are the same mistake: a finding whose
+// evidence lies inside a block the crawl carries on most of its pages is
+// supported by the site's furniture rather than by anything the company said.
+//
+// Dropped rather than stripped of its evidence. A candidate with no support is
+// worse on that screen than one fewer candidate: the decision is which entity
+// this installation is for, and an option a reader cannot judge is an option
+// that makes the judgement harder. Every drop is reported through the same
+// trail a gate refusal takes, so nothing disappears without saying so.
+
+import (
+	"strings"
+)
+
+const (
+	// chromeEvidenceLane names these drops in the trail the read reports.
+	chromeEvidenceLane = "chrome-evidence"
+	// The two finding kinds that are not a field of the company profile, named
+	// so the trail says what was dropped rather than leaving it to the value.
+	chromeEvidencePersonField = "person"
+	chromeEvidenceEntityField = "legal_entity"
+)
+
+// suppressChromeEvidence removes the findings whose evidence is the site's own
+// navigation, and answers what it dropped.
+//
+// The chrome blocks come from the SAME measurement the profile lane's excerpt
+// uses, rather than from a second reading of what furniture is. A crawl too
+// small or too large to measure yields no blocks and nothing is dropped —
+// failing open, because a missing finding is harder to notice than a noisy
+// one.
+func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pageFactsResult, []droppedFinding) {
+	_, blocks := stripSharedPrefixBlocks(pages)
+	if len(blocks) == 0 {
+		return results, nil
+	}
+	normalized := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if n := normalizeEvidence(block); n != "" {
+			normalized = append(normalized, n)
+		}
+	}
+	if len(normalized) == 0 {
+		return results, nil
+	}
+
+	var dropped []droppedFinding
+	kept := make([]pageFactsResult, len(results))
+	for i, result := range results {
+		out := result
+		out.facts = nil
+		for _, fact := range result.facts {
+			if isChromeEvidence(fact.EvidenceSnippet, normalized) {
+				dropped = append(dropped, droppedFinding{
+					Lane: chromeEvidenceLane, Field: fact.Field, Value: fact.Value,
+					EvidenceSnippet: fact.EvidenceSnippet,
+					Reason:          "the only passage citing it is the site's navigation, which every page carries",
+				})
+				continue
+			}
+			out.facts = append(out.facts, fact)
+		}
+		out.people = nil
+		for _, person := range result.people {
+			if isChromeEvidence(person.EvidenceSnippet, normalized) {
+				dropped = append(dropped, droppedFinding{
+					Lane: chromeEvidenceLane, Field: chromeEvidencePersonField, Value: person.Name,
+					EvidenceSnippet: person.EvidenceSnippet,
+					Reason:          "the only passage naming them is the site's navigation, which every page carries",
+				})
+				continue
+			}
+			out.people = append(out.people, person)
+		}
+		out.entities = nil
+		for _, entity := range result.entities {
+			if isChromeEvidence(entity.EvidenceSnippet, normalized) {
+				dropped = append(dropped, droppedFinding{
+					Lane: chromeEvidenceLane, Field: chromeEvidenceEntityField, Value: entity.Name,
+					EvidenceSnippet: entity.EvidenceSnippet,
+					Reason:          "the only passage naming it is the site's navigation, which names every candidate equally",
+				})
+				continue
+			}
+			out.entities = append(out.entities, entity)
+		}
+		kept[i] = out
+	}
+	return kept, dropped
+}
+
+// isChromeEvidence reports whether this snippet lies inside a chrome block.
+//
+// Containment, not equality: the model cites a PASSAGE, and the passage
+// segmentation may cut the menu into several — so a snippet is chrome when the
+// block contains it, however much of the block it happens to be.
+//
+// An empty snippet is not chrome. A finding with no evidence at all is the
+// citation gate's business, and answering it here would make this the reason a
+// reader is told when it was not.
+func isChromeEvidence(snippet string, blocks []string) bool {
+	normalized := normalizeEvidence(snippet)
+	if normalized == "" {
+		return false
+	}
+	for _, block := range blocks {
+		if strings.Contains(block, normalized) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/sitechromeevidence.go
+++ b/backend/internal/compose/sitechromeevidence.go
@@ -54,7 +54,7 @@ const (
 // failing open, because a missing finding is harder to notice than a noisy
 // one.
 func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pageFactsResult, []droppedFinding) {
-	_, blocks := stripSharedPrefixBlocks(pages)
+	trimmed, blocks := stripSharedPrefixBlocks(pages)
 	if len(blocks) == 0 {
 		return results, nil
 	}
@@ -67,14 +67,24 @@ func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pag
 	if len(normalized) == 0 {
 		return results, nil
 	}
+	// What each page still says once its furniture is off. A snippet found in
+	// the chrome AND in the page's own words is the page's own words: menus
+	// repeat the site's vocabulary, so "Contact Us" or a company's name appears
+	// in both, and dropping on the chrome match alone would take real evidence
+	// with it. Over-trimming is the failure this whole lane is written to avoid.
+	own := make(map[string]string, len(trimmed))
+	for _, page := range trimmed {
+		own[page.URL] = normalizeEvidence(page.Text)
+	}
 
 	var dropped []droppedFinding
 	kept := make([]pageFactsResult, len(results))
 	for i, result := range results {
 		out := result
+		prose := own[result.url]
 		out.facts = nil
 		for _, fact := range result.facts {
-			if isChromeEvidence(fact.EvidenceSnippet, normalized) {
+			if isChromeEvidence(fact.EvidenceSnippet, normalized, prose) {
 				dropped = append(dropped, droppedFinding{
 					Lane: chromeEvidenceLane, Field: fact.Field, Value: fact.Value,
 					EvidenceSnippet: fact.EvidenceSnippet,
@@ -86,7 +96,7 @@ func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pag
 		}
 		out.people = nil
 		for _, person := range result.people {
-			if isChromeEvidence(person.EvidenceSnippet, normalized) {
+			if isChromeEvidence(person.EvidenceSnippet, normalized, prose) {
 				dropped = append(dropped, droppedFinding{
 					Lane: chromeEvidenceLane, Field: chromeEvidencePersonField, Value: person.Name,
 					EvidenceSnippet: person.EvidenceSnippet,
@@ -98,7 +108,7 @@ func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pag
 		}
 		out.entities = nil
 		for _, entity := range result.entities {
-			if isChromeEvidence(entity.EvidenceSnippet, normalized) {
+			if isChromeEvidence(entity.EvidenceSnippet, normalized, prose) {
 				dropped = append(dropped, droppedFinding{
 					Lane: chromeEvidenceLane, Field: chromeEvidenceEntityField, Value: entity.Name,
 					EvidenceSnippet: entity.EvidenceSnippet,
@@ -113,7 +123,16 @@ func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pag
 	return kept, dropped
 }
 
-// isChromeEvidence reports whether this snippet lies inside a chrome block.
+// isChromeEvidence reports whether this snippet is furniture and ONLY
+// furniture: inside a chrome block, and absent from what the page itself still
+// says once that block is off.
+//
+// Both halves are load-bearing. A menu repeats the site's own vocabulary, so
+// text can sit in the navigation AND in the prose — "Contact Us", a company's
+// name, a product's — and a finding cited to the page's own words is a finding
+// however many times the header also says them. Dropping on the chrome match
+// alone would take real evidence with it, which is the over-trimming this lane
+// is written to avoid: a missing fact is harder to notice than a noisy one.
 //
 // Containment, not equality: the model cites a PASSAGE, and the passage
 // segmentation may cut the menu into several — so a snippet is chrome when the
@@ -122,15 +141,17 @@ func suppressChromeEvidence(pages []crawlPage, results []pageFactsResult) ([]pag
 // An empty snippet is not chrome. A finding with no evidence at all is the
 // citation gate's business, and answering it here would make this the reason a
 // reader is told when it was not.
-func isChromeEvidence(snippet string, blocks []string) bool {
+func isChromeEvidence(snippet string, blocks []string, prose string) bool {
 	normalized := normalizeEvidence(snippet)
 	if normalized == "" {
 		return false
 	}
+	inChrome := false
 	for _, block := range blocks {
 		if strings.Contains(block, normalized) {
-			return true
+			inChrome = true
+			break
 		}
 	}
-	return false
+	return inChrome && !strings.Contains(prose, normalized)
 }

--- a/backend/internal/compose/sitechromeevidence_test.go
+++ b/backend/internal/compose/sitechromeevidence_test.go
@@ -96,6 +96,44 @@ func TestAFindingCitedOnlyToTheMenuIsDropped(t *testing.T) {
 	}
 }
 
+// The menu repeats the site's own vocabulary, so a phrase can sit in BOTH the
+// navigation and the page's prose. A finding cited to the page's own words is a
+// finding however many times the header also says them — dropping on the chrome
+// match alone would take real evidence with it, which is the over-trimming this
+// whole lane is written to avoid.
+//
+// Against the rule itself rather than through a crawl: the boilerplate
+// measurement has its own thresholds, and a fixture tuned to trip them would be
+// asserting those instead of this.
+func TestOnlyEvidenceTheProseDoesNotAlsoCarryIsChrome(t *testing.T) {
+	blocks := []string{normalizeEvidence(theMenu)}
+	prose := normalizeEvidence(
+		"Contact Us at hello@example.test and we will answer within one working day.")
+
+	for _, tc := range []struct {
+		name    string
+		snippet string
+		prose   string
+		chrome  bool
+	}{
+		// In the menu and nowhere else: furniture.
+		{"a switcher label", "English Deutsch Tiếng Việt", "", true},
+		// In the menu AND in the page's own sentence: the page's own words.
+		{"a phrase the page also states", "Contact Us", prose, false},
+		// The same phrase on a page that does not state it is furniture again,
+		// which is what makes the exemption about the PAGE rather than the word.
+		{"the same phrase on a page that does not", "Contact Us", "", true},
+		// Not in the menu at all.
+		{"the page's own prose", "hello@example.test", prose, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isChromeEvidence(tc.snippet, blocks, tc.prose); got != tc.chrome {
+				t.Errorf("isChromeEvidence(%q) = %t, want %t", tc.snippet, got, tc.chrome)
+			}
+		})
+	}
+}
+
 // A crawl this cannot measure keeps everything. A missing finding is harder to
 // notice than a noisy one, so the failure direction is deliberate.
 func TestACrawlWithNoMeasurableChromeKeepsEveryFinding(t *testing.T) {

--- a/backend/internal/compose/sitechromeevidence_test.go
+++ b/backend/internal/compose/sitechromeevidence_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A finding cited to the site's own navigation is not a finding about the
+// business.
+//
+// Both cases here come from one live read of a real multi-entity site: a legal
+// entity whose evidence was the flattened mega-menu, and language-switcher
+// labels returned as `language` facts scored 100. The menu names every
+// candidate equally, so it distinguishes none of them; the switcher's labels
+// are true about the WEBSITE and were being pre-selected into the company
+// context as facts about the company.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+)
+
+// theMenu is the shared opening a real site carries on every page: long enough
+// to qualify as chrome, and carrying exactly the two things that came back as
+// findings — the entity names and the language switcher.
+const theMenu = "Imprint | Gradion | Gradion Solutions Products Industries About English Contact Us " +
+	"Solutions Products Industries About English Deutsch Tiếng Việt ไทย العربية 日本語 Contact Us " +
+	"Imprint Careers Newsroom Partners Investors Legal Privacy Terms Cookies Sitemap Accessibility " +
+	"Solutions Products Industries About Contact Us Imprint Careers Newsroom Partners Investors"
+
+// chromedCrawl is a crawl whose pages all open with the menu and then say
+// something of their own — the shape the boilerplate measurement is built for.
+func chromedCrawl(own ...string) []crawlPage {
+	pages := make([]crawlPage, 0, len(own))
+	for i, text := range own {
+		pages = append(pages, crawlPage{
+			URL:  "https://example.test/p" + string(rune('a'+i)),
+			Text: theMenu + " " + text,
+		})
+	}
+	return pages
+}
+
+func TestAFindingCitedOnlyToTheMenuIsDropped(t *testing.T) {
+	pages := chromedCrawl(
+		"Gradion Solutions GmbH is registered in Berlin under HRB 12345. The company was founded in 2014 and files its annual accounts with the Amtsgericht Charlottenburg each spring. The registered office has not moved since incorporation, and the managing directors are listed on this page together with the supervisory board. Correspondence about the register entry should go to the address printed below rather than to the sales team, who cannot answer it.",
+		"We build inventory software for wholesalers across Europe and Asia, and have done so since the company was founded. Our customers run distribution networks of every size, from a single warehouse to a continent of them, and the platform is the same one either way. What changes is how much of it a customer switches on, which is a decision they make gradually rather than at the start, and which our pricing is deliberately built to allow.",
+		"Our team of forty works from Berlin, Hanoi and Bangkok, and we hire in all three cities. Most of the engineering happens in Berlin; support follows the sun across the others, so a customer in any timezone reaches somebody who can act rather than somebody who can log it. We have kept that arrangement since the second year, and it is the reason our response times do not have a nightly cliff in them the way our competitors' do.",
+		"Contact our sales team at hello@example.test for a demonstration of the platform. We will walk you through the catalogue, the replenishment engine and the reporting surface, using your own data if you can share an export and ours if you would rather not. A demonstration takes about an hour and there is no obligation attached to it. If you would prefer to read first, the documentation is public and the pricing page states every number.",
+		"Careers at Gradion: we are hiring engineers and account managers in every office we run. Applications are read by the team you would join rather than by a recruiting funnel, and we answer every one of them whether or not we take it further. The interview is a conversation about work you have actually done, not a whiteboard exercise, and we pay for any take-home we ask for. Our salary bands are published on the same page as the roles.",
+	)
+	results := []pageFactsResult{{
+		url: pages[0].URL,
+		facts: []people.DeepReadFact{
+			// The switcher's own labels, cited to the block that carries them.
+			{
+				Category: "language", Field: "language", Value: "Tiếng Việt",
+				EvidenceSnippet: "English Deutsch Tiếng Việt ไทย العربية 日本語", Confidence: 1,
+			},
+			// A fact the page actually states, cited to its own prose.
+			{
+				Category: "registration", Field: "register_number", Value: "HRB 12345",
+				EvidenceSnippet: "Gradion Solutions GmbH is registered in Berlin under HRB 12345.", Confidence: 1,
+			},
+		},
+		entities: []corpusLegalEntity{
+			{Name: "Gradion Solutions", EvidenceSnippet: "Imprint | Gradion | Gradion Solutions Products Industries About"},
+			{Name: "Gradion Solutions GmbH", EvidenceSnippet: "Gradion Solutions GmbH is registered in Berlin under HRB 12345."},
+		},
+	}}
+
+	kept, dropped := suppressChromeEvidence(pages, results)
+
+	if len(kept) != 1 {
+		t.Fatalf("the suppression returned %d results for 1 page", len(kept))
+	}
+	if len(kept[0].facts) != 1 || kept[0].facts[0].Field != "register_number" {
+		t.Errorf("facts kept = %+v, want only the one its page states — a switcher label is true "+
+			"about the website and was being offered as a fact about the company", kept[0].facts)
+	}
+	if len(kept[0].entities) != 1 || kept[0].entities[0].Name != "Gradion Solutions GmbH" {
+		t.Errorf("entities kept = %+v, want only the one named in prose — the menu names every "+
+			"candidate equally, so it distinguishes none of them", kept[0].entities)
+	}
+	if len(dropped) != 2 {
+		t.Fatalf("%d finding(s) reported as dropped, want 2 — a finding that disappears without "+
+			"saying so is worse than one that stays", len(dropped))
+	}
+	for _, d := range dropped {
+		if d.Lane != chromeEvidenceLane {
+			t.Errorf("a drop was filed under lane %q, want %q", d.Lane, chromeEvidenceLane)
+		}
+		if !strings.Contains(d.Reason, "navigation") {
+			t.Errorf("the drop reason %q does not say what was wrong with the evidence", d.Reason)
+		}
+	}
+}
+
+// A crawl this cannot measure keeps everything. A missing finding is harder to
+// notice than a noisy one, so the failure direction is deliberate.
+func TestACrawlWithNoMeasurableChromeKeepsEveryFinding(t *testing.T) {
+	pages := []crawlPage{
+		{URL: "https://example.test/a", Text: "We build inventory software for wholesalers."},
+		{URL: "https://example.test/b", Text: "Our team of forty works from Berlin and Hanoi."},
+	}
+	results := []pageFactsResult{{
+		url:   pages[0].URL,
+		facts: []people.DeepReadFact{{Field: "language", Value: "Tiếng Việt", EvidenceSnippet: "Tiếng Việt"}},
+	}}
+
+	kept, dropped := suppressChromeEvidence(pages, results)
+
+	if len(kept[0].facts) != 1 {
+		t.Errorf("a finding was dropped on a crawl with no measurable chrome: %+v", kept[0].facts)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("%d drop(s) reported where nothing could be measured", len(dropped))
+	}
+}
+
+// A finding with no evidence at all is the citation gate's business. Answering
+// it here would tell a reader the wrong reason.
+func TestAFindingWithNoEvidenceIsNotChrome(t *testing.T) {
+	pages := chromedCrawl(
+		"We build inventory software for wholesalers across Europe and Asia, and have done so since the company was founded. Our customers run distribution networks of every size, from a single warehouse to a continent of them, and the platform is the same one either way. What changes is how much of it a customer switches on, which is a decision they make gradually rather than at the start, and which our pricing is deliberately built to allow.",
+		"Our team of forty works from Berlin, Hanoi and Bangkok, and we hire in all three cities. Most of the engineering happens in Berlin; support follows the sun across the others, so a customer in any timezone reaches somebody who can act rather than somebody who can log it. We have kept that arrangement since the second year, and it is the reason our response times do not have a nightly cliff in them the way our competitors' do.",
+		"Contact our sales team at hello@example.test for a demonstration of the platform. We will walk you through the catalogue, the replenishment engine and the reporting surface, using your own data if you can share an export and ours if you would rather not. A demonstration takes about an hour and there is no obligation attached to it. If you would prefer to read first, the documentation is public and the pricing page states every number.",
+		"Careers at Gradion: we are hiring engineers and account managers in every office we run. Applications are read by the team you would join rather than by a recruiting funnel, and we answer every one of them whether or not we take it further. The interview is a conversation about work you have actually done, not a whiteboard exercise, and we pay for any take-home we ask for. Our salary bands are published on the same page as the roles.",
+		"Gradion Solutions GmbH is registered in Berlin under HRB 12345. The company was founded in 2014 and files its annual accounts with the Amtsgericht Charlottenburg each spring. The registered office has not moved since incorporation, and the managing directors are listed on this page together with the supervisory board. Correspondence about the register entry should go to the address printed below rather than to the sales team, who cannot answer it.",
+	)
+	results := []pageFactsResult{{
+		url:   pages[0].URL,
+		facts: []people.DeepReadFact{{Field: "industry", Value: "software", EvidenceSnippet: ""}},
+	}}
+
+	kept, dropped := suppressChromeEvidence(pages, results)
+
+	if len(kept[0].facts) != 1 {
+		t.Error("a finding with no evidence was dropped as chrome — it has a reason of its own, " +
+			"and this is not it")
+	}
+	if len(dropped) != 0 {
+		t.Errorf("%d drop(s) reported for a finding this lane does not judge", len(dropped))
+	}
+}

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -175,7 +175,11 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 		collected.failed = append(collected.failed, fmt.Errorf("profile lane: %w", profileErr))
 	}
 	out.legalCensusIncomplete = collected.legalCensusIncomplete
-	out.merged = mergeInCommitOrder(crawl, collected.results)
+	// Here and not earlier: the fact lane reads a page as it commits, so the
+	// crawl it would have to be measured against does not exist until now.
+	results, chrome := suppressChromeEvidence(crawl.Pages, collected.results)
+	x.reportDrops(ctx, crawl.SeedURL, chrome)
+	out.merged = mergeInCommitOrder(crawl, results)
 	out.err = errors.Join(collected.failed...)
 	return crawl, out, nil
 }
@@ -425,6 +429,8 @@ func extractSite(ctx context.Context, x evidenceExtractor, pages []crawlPage, on
 	if profileErr != nil {
 		failed = append(failed, fmt.Errorf("profile lane: %w", profileErr))
 	}
+	kept, chrome := suppressChromeEvidence(pages, kept)
+	x.reportDrops(ctx, "", chrome)
 	out.merged = mergePageResults(kept)
 	out.err = errors.Join(failed...)
 	return out


### PR DESCRIPTION
Closes #596.

One live read of a multi-entity site produced two findings that were true and useless.

**A legal-entity candidate cited to the mega-menu.** The evidence snippet was the site's flattened navigation — a passage that names *every* candidate the site has, so it distinguishes none of them — on the one screen whose whole purpose is choosing between them.

**Language-switcher labels as company facts.** `Tiếng Việt`, `ไทย`, `العربية`, `日本語`, each of category `language`, each scored 100, each cited to `/en/about`. True about the **website**, not about the business, and pre-selected into the company context with everything else.

## One rule, because they are one mistake

A finding whose evidence lies inside a block the crawl carries on most of its pages is supported by the site's *furniture* rather than by anything the company said.

## Why it runs where it does

The profile lane already strips that chrome before it builds its prompt. The per-page fact lane **cannot** — it reads a page as it commits, which is before the crawl it would have to be measured against exists. So it answers for what it found once the corpus is whole, which is the issue's own suggestion: suppression before a snippet is stored as evidence.

The blocks come from the **same measurement** the profile lane's excerpt uses (`stripSharedPrefixBlocks`, which is `stripSharedPrefix` also answering what it cut) rather than from a second reading of what furniture is.

## The failure direction is deliberate

A crawl too small or too large to measure yields no blocks and nothing is dropped. A missing finding is harder to notice than a noisy one.

## Dropped, not stripped of its evidence

A candidate with no support is worse on that screen than one fewer candidate: the decision is which entity this installation is *for*, and an option a reader cannot judge makes the judgement harder. Every drop is reported through the same trail a gate refusal takes, so nothing disappears without saying so.

A finding with **no** evidence at all is left alone — it has a reason of its own, and this is not it.

## Held

Three cases, on a fixture built from the real menu that prompted the issue: the drops happen and are reported; a crawl with no measurable chrome keeps everything; a finding with no evidence is not judged here. Mutation-checked — disabling the suppression fails the first by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction accuracy by filtering out page facts supported only by shared navigation or menu content.
  * Preserved valid page evidence while retaining findings without evidence for separate citation handling.
  * Added detailed reporting for findings removed as navigation-derived content.
  * Applied consistent behavior across streaming and non-streaming extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->