### PR TITLE
fix(worklist): the decision lane draws every source it is handed

### DIFF
--- a/backend/gates/frontendattentionsources_test.go
+++ b/backend/gates/frontendattentionsources_test.go
@@ -21,6 +21,14 @@ package gates
 // yet. Both directions are compared — a source with no entry fails, and an entry
 // naming no source fails too, because a dead entry teaches the next author that
 // the map is not maintained.
+//
+// The contract is PARSED, not pattern-matched. A first cut read the enum with a
+// regex over the raw file and had the one defect a gate must not have: writing
+// the same enum block-style instead of inline — an edit that changes nothing
+// about the contract — walked the match onto a different schema's vocabulary
+// entirely, and it reported a confident wrong answer about a list it was no
+// longer reading. Every way the document can be reshaped without changing its
+// meaning has to leave this corpus identical, and only a parser gives that.
 
 import (
 	"os"
@@ -28,16 +36,14 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
-	attentionContract      = "api/crm.yaml"
-	frontendAttentionMap   = "../frontend/src/screens/attentionsource.ts"
-	attentionItemSchemaKey = "\n    AttentionItem:"
+	attentionContract    = "api/crm.yaml"
+	frontendAttentionMap = "../frontend/src/screens/attentionsource.ts"
 )
-
-// sourceEnumLine reads the inline enum off the `source` property.
-var sourceEnumLine = regexp.MustCompile(`(?m)^\s*enum:\s*\[([^\]]*)\]`)
 
 // focusSurfaceEntry reads one `source: "surface"` pair out of the map.
 var focusSurfaceEntry = regexp.MustCompile(`["']?\b([a-z][a-z0-9_]*)\b["']?:\s*["']([a-z]+)["']`)
@@ -47,38 +53,45 @@ var focusSurfaceEntry = regexp.MustCompile(`["']?\b([a-z][a-z0-9_]*)\b["']?:\s*[
 // mentioned above it would keep this gate green.
 var tsCommentInSources = regexp.MustCompile(`(?s)//[^\n]*|/\*.*?\*/`)
 
+// contract is as much of the OpenAPI document as this gate reads: one schema's
+// one property's enum. Named down to that so the corpus comes from the path the
+// contract actually declares, rather than from whatever the first match in a
+// 30,000-line file happened to be.
+type contract struct {
+	Components struct {
+		Schemas struct {
+			// The tag spells the schema's own name, which OpenAPI writes in
+			// PascalCase. A snake_case tag would match no key in the document
+			// and leave this gate reading an empty enum.
+			//nolint:tagliatelle // the key is the contract's schema name, not ours to style
+			AttentionItem struct {
+				Properties struct {
+					Source struct {
+						Enum []string `yaml:"enum"`
+					} `yaml:"source"`
+				} `yaml:"properties"`
+			} `yaml:"AttentionItem"`
+		} `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
 // contractSources reads the AttentionItem.source enum out of the OpenAPI schema.
-//
-// Scoped to the AttentionItem schema rather than the whole document: crm.yaml
-// holds hundreds of inline enums, and the first one a file-wide scan met would
-// be some other schema's vocabulary entirely.
 func contractSources(t *testing.T) []string {
 	t.Helper()
 	document, err := os.ReadFile(attentionContract)
 	if err != nil {
 		t.Fatalf("reading the API contract: %v", err)
 	}
-	start := strings.Index(string(document), attentionItemSchemaKey)
-	if start < 0 {
-		t.Fatalf("no %s schema in %s — this gate is reading the wrong document", attentionItemSchemaKey, attentionContract)
+	var parsed contract
+	if err := yaml.Unmarshal(document, &parsed); err != nil {
+		t.Fatalf("parsing the API contract: %v", err)
 	}
-	schema := string(document)[start:]
-	property := strings.Index(schema, "\n        source:")
-	if property < 0 {
-		t.Fatalf("AttentionItem declares no source property: this gate no longer knows what it is guarding")
-	}
-	match := sourceEnumLine.FindStringSubmatch(schema[property:])
-	if match == nil {
-		t.Fatalf("AttentionItem.source carries no inline enum: the corpus this gate derives has moved")
-	}
-	var sources []string
-	for _, value := range strings.Split(match[1], ",") {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			sources = append(sources, trimmed)
-		}
-	}
+	sources := parsed.Components.Schemas.AttentionItem.Properties.Source.Enum
 	if len(sources) == 0 {
-		t.Fatalf("read no values out of the AttentionItem.source enum — the parser has stopped seeing it")
+		// Not "no sources" — there is no such contract. The schema was renamed
+		// or the property moved, and a gate that shrugged at that would report
+		// PASS over a list it had stopped reading.
+		t.Fatalf("components.schemas.AttentionItem.properties.source declares no enum in %s: this gate no longer knows what it is guarding", attentionContract)
 	}
 	slices.Sort(sources)
 	return slices.Compact(sources)

--- a/backend/gates/frontendattentionsources_test.go
+++ b/backend/gates/frontendattentionsources_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H1
+
+package gates
+
+// Every source the Worklist can carry must have a body the decision lane knows
+// how to draw, or the lane asks the wrong endpoint about it.
+//
+// The decision lane used to branch on one source and treat everything else as a
+// staged proposal, fetching `/approvals/{id}` with the item's own id. That read
+// answers 404 for an item that is not an approval, so the card rendered as a
+// failed one — on the single surface whose promise is that it can be finished.
+// Nothing failed when a source was added, because the assumption was spelled as
+// an `else` rather than as a case.
+//
+// The corpus is the contract's own enum, read out of crm.yaml rather than out of
+// the generated Go constants: a source is added to the schema first, and a gate
+// that read the generated side would agree with a tree nobody had regenerated
+// yet. Both directions are compared — a source with no entry fails, and an entry
+// naming no source fails too, because a dead entry teaches the next author that
+// the map is not maintained.
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	attentionContract      = "api/crm.yaml"
+	frontendAttentionMap   = "../frontend/src/screens/attentionsource.ts"
+	attentionItemSchemaKey = "\n    AttentionItem:"
+)
+
+// sourceEnumLine reads the inline enum off the `source` property.
+var sourceEnumLine = regexp.MustCompile(`(?m)^\s*enum:\s*\[([^\]]*)\]`)
+
+// focusSurfaceEntry reads one `source: "surface"` pair out of the map.
+var focusSurfaceEntry = regexp.MustCompile(`["']?\b([a-z][a-z0-9_]*)\b["']?:\s*["']([a-z]+)["']`)
+
+// tsCommentInSources strips comments before the entries are read: the map is
+// commented and the prose names sources, so a source deleted from the map but
+// mentioned above it would keep this gate green.
+var tsCommentInSources = regexp.MustCompile(`(?s)//[^\n]*|/\*.*?\*/`)
+
+// contractSources reads the AttentionItem.source enum out of the OpenAPI schema.
+//
+// Scoped to the AttentionItem schema rather than the whole document: crm.yaml
+// holds hundreds of inline enums, and the first one a file-wide scan met would
+// be some other schema's vocabulary entirely.
+func contractSources(t *testing.T) []string {
+	t.Helper()
+	document, err := os.ReadFile(attentionContract)
+	if err != nil {
+		t.Fatalf("reading the API contract: %v", err)
+	}
+	start := strings.Index(string(document), attentionItemSchemaKey)
+	if start < 0 {
+		t.Fatalf("no %s schema in %s — this gate is reading the wrong document", attentionItemSchemaKey, attentionContract)
+	}
+	schema := string(document)[start:]
+	property := strings.Index(schema, "\n        source:")
+	if property < 0 {
+		t.Fatalf("AttentionItem declares no source property: this gate no longer knows what it is guarding")
+	}
+	match := sourceEnumLine.FindStringSubmatch(schema[property:])
+	if match == nil {
+		t.Fatalf("AttentionItem.source carries no inline enum: the corpus this gate derives has moved")
+	}
+	var sources []string
+	for _, value := range strings.Split(match[1], ",") {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			sources = append(sources, trimmed)
+		}
+	}
+	if len(sources) == 0 {
+		t.Fatalf("read no values out of the AttentionItem.source enum — the parser has stopped seeing it")
+	}
+	slices.Sort(sources)
+	return slices.Compact(sources)
+}
+
+// surfacedSources reads the FOCUS_SURFACE literal out of the TypeScript module.
+func surfacedSources(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile(frontendAttentionMap)
+	if err != nil {
+		t.Fatalf("reading the frontend focus-surface map: %v", err)
+	}
+	const opener = "export const FOCUS_SURFACE"
+	start := strings.Index(string(source), opener)
+	if start < 0 {
+		t.Fatalf("no %s declaration in %s", opener, frontendAttentionMap)
+	}
+	body := string(source)[start:]
+	if end := strings.Index(body, "\n}"); end >= 0 {
+		body = body[:end]
+	}
+	body = tsCommentInSources.ReplaceAllString(body, "")
+	var sources []string
+	for _, match := range focusSurfaceEntry.FindAllStringSubmatch(body, -1) {
+		sources = append(sources, match[1])
+	}
+	if len(sources) == 0 {
+		t.Fatalf("read no entries out of FOCUS_SURFACE — the parser has stopped seeing the map")
+	}
+	slices.Sort(sources)
+	return slices.Compact(sources)
+}
+
+func TestEveryAttentionSourceHasAFocusSurface(t *testing.T) {
+	t.Parallel()
+	contract := contractSources(t)
+	surfaced := surfacedSources(t)
+
+	for _, source := range contract {
+		if !slices.Contains(surfaced, source) {
+			t.Errorf("source %q can reach the Worklist but has no entry in FOCUS_SURFACE: the decision lane would read /approvals with an id that is not an approval's", source)
+		}
+	}
+	for _, source := range surfaced {
+		if !slices.Contains(contract, source) {
+			t.Errorf("FOCUS_SURFACE carries %q, which the contract cannot emit: a dead entry teaches the next author the map is not maintained", source)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (35)
+## Parity (36)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -35,6 +35,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |
 | `filtervocabularyparity_test.go` | H3 | Two surfaces answer a filtered question: the list/segment compiler in `platform/database/storekit`, and the query compiler in `modules/search`. |
 | `frontendapprovalkinds_test.go` | H1 | Every kind a proposal can be staged under must have words a reader recognises, or the queue prints the wire enum at them. |
+| `frontendattentionsources_test.go` | H1 | Every source the Worklist can carry must have a body the decision lane knows how to draw, or the lane asks the wrong endpoint about it. |
 | `frontendfiscalyear_test.go` | H1 | A fiscal year's label is spelled twice: the server builds it in SQL (internal/compose/reportperiod.go) because that is what a report is actually cut by, and the browser builds it in TypeScript (frontend/src/format/fiscalyear.ts) to show an admin what the setting they are about to save will produce. |
 | `frontendidlebase_test.go` | H3 | The deal board and the server must measure silence from the SAME timestamp, or a card ages differently from the list that filed the deal stalled. |
 | `frontendlaneparity_test.go` | H3 | The frontend gate is spelled once as `make check-fe` and run by CI as three parallel jobs. |

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -205,6 +205,7 @@ export const de = {
   "day.duplicate.person": "Zwei Kontakte sehen nach derselben Person aus",
   "day.duplicate.org": "Zwei Unternehmen sehen nach demselben aus",
   "day.duplicate.lead": "Zwei Leads sehen nach demselben aus",
+  "day.duplicate.generic": "Zwei Einträge sehen nach demselben aus",
   "day.duplicatesOpen": "{count} Dubletten-Paare insgesamt offen",
   "day.focus.progress": "Entscheidung {position} von {total}",
   "day.focus.clear": "Nichts mehr zu entscheiden.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -203,6 +203,7 @@ export const en = {
   "day.duplicate.person": "Two contacts look like the same person",
   "day.duplicate.org": "Two companies look like the same one",
   "day.duplicate.lead": "Two leads look like the same one",
+  "day.duplicate.generic": "Two records look like the same one",
   "day.duplicatesOpen": "{count} duplicate pairs open in all",
   // The decision lane, one at a time: how far through the reader is, and the
   // cleared plate the whole surface is built to reach.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -211,6 +211,7 @@ export const vi = {
   "day.duplicate.person": "Hai liên hệ trông giống cùng một người",
   "day.duplicate.org": "Hai công ty trông giống cùng một công ty",
   "day.duplicate.lead": "Hai khách hàng tiềm năng trông giống nhau",
+  "day.duplicate.generic": "Hai bản ghi trông giống nhau",
   "day.duplicatesOpen": "Tổng cộng {count} cặp trùng lặp đang mở",
   "day.focus.progress": "Quyết định {position} trên {total}",
   "day.focus.clear": "Không còn gì để quyết định.",

--- a/frontend/src/screens/attentionitemcopy.ts
+++ b/frontend/src/screens/attentionitemcopy.ts
@@ -1,0 +1,103 @@
+import { formatDateTime, formatNumber } from "../format/format";
+import type { Locale, useT } from "../i18n";
+import { approvalKindLabel } from "./approvalkind";
+import type { AttentionItem } from "./today.queries";
+
+type T = ReturnType<typeof useT>;
+
+// One item's headline and supporting line, written once for every lane that
+// draws an item. Both lanes need them — the reporting rows and the decision
+// card's report body — and a second spelling is how one product comes to
+// describe the same item two ways on one page.
+
+// One item's headline.
+//
+// The server sends a sentence when it HAS one — an approval summary is composed
+// at staging time out of the proposal's own facts. It deliberately sends none
+// for a duplicate pair, because that sentence would have to be invented and the
+// server has no language to invent it in. So the client writes that one, in the
+// reader's.
+export function itemTitle(item: AttentionItem, t: T): string {
+  if (item.title) {
+    return item.title;
+  }
+  if (item.source === "dedupe_candidate") {
+    return t(`day.duplicate.${duplicateNoun(item.kind)}` as const);
+  }
+  return item.kind ? approvalKindLabel(item.kind, t) : t("day.item.untitled");
+}
+
+// Which noun a duplicate pair is about.
+//
+// Only a kind this reader has a sentence for names itself; anything else takes
+// the generic line. Naming the wrong noun is worse than naming none: the pair
+// the server found may be two deals or two projects, and calling them contacts
+// tells the reader to compare something that is not on screen.
+function duplicateNoun(
+  kind: string | undefined,
+): "person" | "org" | "lead" | "generic" {
+  if (kind === "person") {
+    return "person";
+  }
+  if (kind === "organization") {
+    return "org";
+  }
+  if (kind === "lead") {
+    return "lead";
+  }
+  return "generic";
+}
+
+// The supporting line under a headline: how sure the detector was, or when this
+// is due, or when it happened. At most one — a card that stacked all three
+// would make the reader read three things to learn one.
+export function itemDetail(
+  item: AttentionItem,
+  t: T,
+  locale: Locale,
+  zone: string,
+): string | null {
+  // A risk card's sentence is written HERE, not sent: the server has no
+  // language, and "quiet 19 days" versus "the close date passed" read
+  // differently in each of the three. `kind` names the ground and `detail`
+  // carries the number the server actually measured, so the line can never
+  // imply a patience nobody applied.
+  if (item.source === "deal_at_risk") {
+    if (item.kind === "close_overdue" && item.due_at) {
+      return t("day.risk.closeOverdue", {
+        date: formatDateTime(item.due_at, locale, zone),
+      });
+    }
+    if (item.detail) {
+      return t("day.risk.quiet", {
+        days: formatNumber(Number(item.detail), locale),
+      });
+    }
+    return null;
+  }
+  // A promise is the one item whose supporting line carries TWO facts, and it
+  // needs both: the words it was read from are what make the claim checkable,
+  // and the deadline is why it is on today's page at all. Showing only the
+  // quote would drop the date the lane is ordered by.
+  if (item.source === "conversation_claim" && item.detail && item.due_at) {
+    return t("day.commitment.detail", {
+      quote: item.detail,
+      due: formatDateTime(item.due_at, locale, zone),
+    });
+  }
+  if (item.detail) {
+    return item.detail;
+  }
+  if (item.confidence != null) {
+    return t("day.match", {
+      percent: formatNumber(Math.round(item.confidence * 100), locale),
+    });
+  }
+  if (item.occurred_at) {
+    return formatDateTime(item.occurred_at, locale, zone);
+  }
+  if (item.due_at) {
+    return formatDateTime(item.due_at, locale, zone);
+  }
+  return null;
+}

--- a/frontend/src/screens/attentionsource.ts
+++ b/frontend/src/screens/attentionsource.ts
@@ -1,0 +1,37 @@
+import type { AttentionItem } from "./today.queries";
+
+/** What the decision lane can do with an item of a given source. */
+export type FocusSurface = "merge" | "approval" | "report";
+
+// Which body the decision lane draws for each source it can be handed.
+//
+// Spelled as a total map rather than a chain of ifs with an assumed else. The
+// else was the defect: every source that was not a duplicate pair was handed to
+// the staged-proposal card, which fetches `/approvals/{id}` with the item's id.
+// For an item that is not an approval that read is a 404, so a card the reader
+// cannot act on renders as a failed one, and the lane that exists to be
+// finishable holds an item nothing can finish.
+//
+// `satisfies` is what keeps this honest: a source added to the contract has no
+// entry here, and the build stops. That is the frontend half of the mirror —
+// backend/gates/frontendattentionsources_test.go holds the other half, so a
+// source can neither arrive unrendered nor be listed here without being emitted.
+//
+// "report" is a real answer, not a fallback: a source the lane cannot decide
+// still gets drawn, with its headline and its detail, and without a read that
+// asks the wrong endpoint about it.
+export const FOCUS_SURFACE = {
+  approval: "approval",
+  dedupe_candidate: "merge",
+  task: "report",
+  brief_item: "report",
+  conversation_claim: "report",
+  deal_at_risk: "report",
+  meeting: "report",
+} as const satisfies Record<AttentionItem["source"], FocusSurface>;
+
+export function focusSurfaceOf(source: AttentionItem["source"]): FocusSurface {
+  // Indexed through the map's own key type: an unknown string cannot reach
+  // here from the contract, and a missing key would have failed the build.
+  return FOCUS_SURFACE[source];
+}

--- a/frontend/src/screens/today.focus.css
+++ b/frontend/src/screens/today.focus.css
@@ -69,3 +69,15 @@
   margin: 0;
   color: var(--textMeta);
 }
+
+.focus-report {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4) 0;
+}
+
+.focus-report-detail {
+  margin: 0;
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/today.focus.tsx
+++ b/frontend/src/screens/today.focus.tsx
@@ -3,8 +3,11 @@ import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
+import { itemDetail, itemTitle } from "./attentionitemcopy";
+import { focusSurfaceOf } from "./attentionsource";
 import { problemMessageOf } from "./common";
 import { MergeDecision } from "./today.merge";
 import {
@@ -72,12 +75,34 @@ function AllClear({ decided }: Readonly<{ decided: number }>) {
   );
 }
 
+// An item this lane cannot decide, drawn as what it is.
+//
+// The lane is fed by producers, and a producer can put a source here that has
+// no decision behind it. Drawing that item plainly is the honest answer: the
+// reader sees what arrived and can move past it. The dishonest answer was to
+// assume it was a staged proposal and read `/approvals/{id}` with its id, which
+// answers 404 for anything that is not an approval and renders as a failed card.
+function ReportBody({ item }: Readonly<{ item: AttentionItem }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const detail = itemDetail(item, t, locale, viewerZone());
+  return (
+    <div className="focus-report">
+      <p className="t-body">{itemTitle(item, t)}</p>
+      {detail && <p className="t-caption focus-report-detail">{detail}</p>}
+    </div>
+  );
+}
+
 // One item's body, chosen by what the item IS.
 //
 // A duplicate is a choice between two records; a staged proposal is an accept
 // or a reject on one payload. They are different decisions and they get
 // different bodies — the failure this replaces was a single generic row that
 // could express neither, so both ended up as a link.
+//
+// The choice runs through FOCUS_SURFACE rather than a chain of ifs, so a source
+// the contract adds has to be given a body before the build passes.
 function FocusBody({
   item,
   onDone,
@@ -85,8 +110,13 @@ function FocusBody({
   const t = useT();
   const dispose = useDisposeDuplicate();
   const pending = dispose.isPending;
+  const surface = focusSurfaceOf(item.source);
 
-  if (item.source === "dedupe_candidate") {
+  if (surface === "report") {
+    return <ReportBody item={item} />;
+  }
+
+  if (surface === "merge") {
     return (
       <MergeDecision
         item={item}
@@ -116,10 +146,10 @@ function FocusBody({
     );
   }
 
-  // Everything else on this lane is a staged proposal, and the row that decides
-  // one already exists — the same component the record surfaces draw, carrying
-  // edit-then-approve and reject-with-reason. A second spelling of a decision
-  // is how one product comes to answer the same question two ways.
+  // A staged proposal, and the row that decides one already exists — the same
+  // component the record surfaces draw, carrying edit-then-approve and
+  // reject-with-reason. A second spelling of a decision is how one product comes
+  // to answer the same question two ways.
   //
   // The feed sends what a LANE needs — a sentence, a kind, a deadline — and the
   // row needs the whole proposal: the payload it edits, who staged it, what

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -750,3 +750,62 @@ describe("what the night left on the worklist", () => {
     ).toBeTruthy();
   });
 });
+
+describe("a decision lane handed something it cannot decide", () => {
+  // The lane branched on duplicates and treated everything else as a staged
+  // proposal, reading /approvals/{id} with the item's own id. For an item that
+  // is not an approval that read answers 404, so the card rendered as a failed
+  // one — on the surface whose whole promise is that it can be finished.
+  //
+  // A producer putting an undecidable source on this lane is the case that
+  // shipped it, so the test drives exactly that and asserts two things: the
+  // reader gets the item's own words, and no approval was ever asked for.
+  it("draws the item instead of asking the approvals endpoint about it", async () => {
+    stub({
+      ...emptyDay,
+      needs_you: [
+        {
+          id: "task-1",
+          source: "task",
+          title: "Call the buyer back",
+          actions: [],
+        },
+      ],
+      counts: { this_morning: 0, needs_you: 1, planned: 0 },
+    });
+    renderToday();
+
+    expect(await screen.findByText("Call the buyer back")).toBeTruthy();
+    const asked = vi
+      .mocked(fetch)
+      .mock.calls.map(([input]) =>
+        String(input instanceof Request ? input.url : input),
+      );
+    expect(asked.some((url) => url.includes("/approvals/"))).toBe(false);
+  });
+
+  // A duplicate pair whose entity type the reader has no sentence for, drawn on
+  // a reporting lane — the rows that write the headline themselves. Naming the
+  // wrong noun is worse than naming none: the pair may be two deals, and calling
+  // them contacts sends the reader looking for something not on screen.
+  it("names an unfamiliar duplicate generically rather than calling it a contact", async () => {
+    stub({
+      ...emptyDay,
+      done_for_you: [
+        {
+          id: "dc-1",
+          source: "dedupe_candidate",
+          kind: "deal",
+          actions: [],
+        },
+      ],
+      counts: { this_morning: 0, needs_you: 0, planned: 0 },
+    });
+    renderToday();
+
+    expect(
+      await screen.findByText("Two records look like the same one"),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Two contacts/)).toBeNull();
+  });
+});

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -809,3 +809,31 @@ describe("a decision lane handed something it cannot decide", () => {
     expect(screen.queryByText(/Two contacts/)).toBeNull();
   });
 });
+
+describe("pushing a decision to the back of the queue", () => {
+  // "Later" deferred the head of the LANE rather than the card on screen. The
+  // two are the same only until the first deferral, after which the lane's head
+  // is already at the back — so the second card's "Later" deferred something
+  // already deferred and the queue stopped moving. A reader who cannot pass the
+  // second card cannot reach the third.
+  it("advances past the second card too", async () => {
+    const user = userEvent.setup();
+    stub({
+      ...emptyDay,
+      needs_you: [
+        { id: "t-1", source: "task", title: "First promise", actions: [] },
+        { id: "t-2", source: "task", title: "Second promise", actions: [] },
+        { id: "t-3", source: "task", title: "Third promise", actions: [] },
+      ],
+      counts: { this_morning: 0, needs_you: 3, planned: 0 },
+    });
+    renderToday();
+
+    await screen.findByText("First promise");
+    await user.click(screen.getByRole("button", { name: "Later" }));
+    expect(await screen.findByText("Second promise")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Later" }));
+    expect(await screen.findByText("Third promise")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -528,12 +528,6 @@ function TodayLanes({
   const [decided, setDecided] = useState(0);
   const [deferred, setDeferred] = useState<readonly string[]>([]);
   const onDecided = () => setDecided((n) => n + 1);
-  const onSkip = () =>
-    setDeferred((ids) =>
-      needsYou[0] && !ids.includes(needsYou[0].id)
-        ? [...ids, needsYou[0].id]
-        : ids,
-    );
   // Deferred items go to the BACK, never away: a reader who put three things
   // off still has three things to do, and a queue that dropped them would
   // report a clear day that is not one.
@@ -541,6 +535,14 @@ function TodayLanes({
     ...needsYou.filter((item) => !deferred.includes(item.id)),
     ...needsYou.filter((item) => deferred.includes(item.id)),
   ];
+  // Defers the card the reader is LOOKING at, which is the head of the queue
+  // and not the head of the lane. The two are the same only until the first
+  // deferral; after that the lane's head has moved to the back, so deferring it
+  // again is a no-op and every later press of "later" does nothing.
+  const onSkip = () =>
+    setDeferred((ids) =>
+      queue[0] && !ids.includes(queue[0].id) ? [...ids, queue[0].id] : ids,
+    );
   const onComplete = (id: string) =>
     complete.mutate({ id, body: { is_done: true } });
   // One day later, through the same helper the task queue snoozes with, so the

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -11,11 +11,11 @@ import { useState } from "react";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDateTime, formatNumber } from "../format/format";
+import { formatNumber } from "../format/format";
 import { useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
-import { approvalKindLabel } from "./approvalkind";
+import { itemDetail, itemTitle } from "./attentionitemcopy";
 import { BriefQueueItem } from "./briefqueue";
 import {
   useBriefItemMark,
@@ -140,89 +140,6 @@ function quietLead(
     return t("day.lead.clearOfWhatWasRead");
   }
   return t("day.lead.clear");
-}
-
-// One item's headline.
-//
-// The server sends a sentence when it HAS one — an approval summary is composed
-// at staging time out of the proposal's own facts. It deliberately sends none
-// for a duplicate pair, because that sentence would have to be invented and the
-// server has no language to invent it in. So the client writes that one, in the
-// reader's.
-function itemTitle(item: AttentionItem, t: ReturnType<typeof useT>): string {
-  if (item.title) {
-    return item.title;
-  }
-  if (item.source === "dedupe_candidate") {
-    return t(`day.duplicate.${duplicateNoun(item.kind)}` as const);
-  }
-  return item.kind ? approvalKindLabel(item.kind, t) : t("day.item.untitled");
-}
-
-// Which noun a duplicate pair is about. An unrecognised entity type falls back
-// to the generic line rather than printing the wire word at a reader.
-function duplicateNoun(kind: string | undefined): "person" | "org" | "lead" {
-  if (kind === "organization") {
-    return "org";
-  }
-  if (kind === "lead") {
-    return "lead";
-  }
-  return "person";
-}
-
-// The supporting line under a headline: how sure the detector was, or when this
-// is due, or when it happened. At most one — a card that stacked all three
-// would make the reader read three things to learn one.
-function itemDetail(
-  item: AttentionItem,
-  t: ReturnType<typeof useT>,
-  locale: Locale,
-  zone: string,
-): string | null {
-  // A risk card's sentence is written HERE, not sent: the server has no
-  // language, and "quiet 19 days" versus "the close date passed" read
-  // differently in each of the three. `kind` names the ground and `detail`
-  // carries the number the server actually measured, so the line can never
-  // imply a patience nobody applied.
-  if (item.source === "deal_at_risk") {
-    if (item.kind === "close_overdue" && item.due_at) {
-      return t("day.risk.closeOverdue", {
-        date: formatDateTime(item.due_at, locale, zone),
-      });
-    }
-    if (item.detail) {
-      return t("day.risk.quiet", {
-        days: formatNumber(Number(item.detail), locale),
-      });
-    }
-    return null;
-  }
-  // A promise is the one item whose supporting line carries TWO facts, and it
-  // needs both: the words it was read from are what make the claim checkable,
-  // and the deadline is why it is on today's page at all. Showing only the
-  // quote would drop the date the lane is ordered by.
-  if (item.source === "conversation_claim" && item.detail && item.due_at) {
-    return t("day.commitment.detail", {
-      quote: item.detail,
-      due: formatDateTime(item.due_at, locale, zone),
-    });
-  }
-  if (item.detail) {
-    return item.detail;
-  }
-  if (item.confidence != null) {
-    return t("day.match", {
-      percent: formatNumber(Math.round(item.confidence * 100), locale),
-    });
-  }
-  if (item.occurred_at) {
-    return formatDateTime(item.occurred_at, locale, zone);
-  }
-  if (item.due_at) {
-    return formatDateTime(item.due_at, locale, zone);
-  }
-  return null;
 }
 
 // One row of the two REPORTING lanes — today's agreed work, and what already


### PR DESCRIPTION
The Worklist's decision lane branched on duplicate pairs and treated everything else as a staged proposal, reading `/approvals/{id}` with the item's own id. For an item that is not an approval that read answers 404, so the card rendered as a failed one — on the surface whose whole promise is that it can be finished. The assumption lived in an `else`, so nothing failed when a source was added.

Found while auditing whether every flow that needs a human reaches the Worklist.

## What changed

- `FOCUS_SURFACE` (`frontend/src/screens/attentionsource.ts`) names a body for every source the contract can emit, and `FocusBody` dispatches over it. A source the lane cannot decide is drawn as what it is — headline and detail — instead of being asked about at an endpoint that does not know it. `satisfies Record<AttentionItem["source"], …>` stops the build when the generated enum grows.
- An unfamiliar duplicate entity type takes a generic line. `duplicateNoun` promised that in a comment and returned `"person"`, so a pair of deals would have read "Two contacts look like the same person". Backend `subjectKinds` also emits deal, activity and project.
- `itemTitle` / `itemDetail` move to `attentionitemcopy.ts`. Both lanes draw an item now, and a second spelling is how one product comes to describe the same item two ways on one page.
- `backend/gates/frontendattentionsources_test.go` holds both directions: a source with no body fails, a body naming no source fails. Its corpus is the `AttentionItem.source` enum in `crm.yaml`, not the generated Go constants — a source is added to the schema first, and a gate reading the generated side would agree with a tree nobody had regenerated yet.

## Verification

- Both new frontend tests were mutation-checked: reverting each fix makes its test fail, restoring it passes.
- The gate was mutation-checked in both directions (source missing from the map; entry naming no source).
- `make check-backend` and `make check-fe` green; `make craft-static` clean.

Deliberately not in this PR: the approvals/receipts provenance question (`approved AND decided_by IS NULL` has no normal production writer) and the missing worklist producers, both filed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Worklist decision lane so every source it is handed gets drawn properly. Anything that was not a duplicate pair used to be read as a staged proposal, fetching `/approvals/{id}` with the item's own id, which answers 404 for a non-approval and rendered the card as failed.

**Bug Fixes**

- Adds `FOCUS_SURFACE`, a total map naming a body for every source the contract emits, with the lane dispatching over it; `satisfies Record<AttentionItem["source"], …>` stops the build when the enum grows.
- Draws a source the lane cannot decide with its own headline and detail instead of asking an endpoint that does not know it.
- Unfamiliar duplicate entity types take a generic line, where the previous fallback called a pair of deals "two contacts".
- Moves the shared `itemTitle`/`itemDetail` into `attentionitemcopy.ts` since both lanes now draw an item.
- Adds a parity gate that parses `crm.yaml` (not generated constants, and not regex over the file, which drifted onto another schema when the enum was reformatted) and compares `AttentionItem.source` against `FOCUS_SURFACE` in both directions.
- Fixes "Later" deferring the lane's head instead of the card on screen, so after the first deferral the queue no longer stops moving.

<sup>Written for commit 040c01ccf9cf9655471d9b5ce93f99b37e7318e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added report views for attention items without decisions, with timezone-aware details.
  - Added clearer titles and details for risks, commitments, confidence, dates, approvals, and duplicate records.
  - Added generic wording for unfamiliar duplicate record types.
  - Added German, English, and Vietnamese translations for duplicate-record messages.

- **Bug Fixes**
  - Prevented non-approval items from incorrectly requesting approval data.
  - Undecidable task items now display directly without requesting approval.
  - Deferring consecutive items now advances to the correct next item.

- **Tests**
  - Added validation ensuring every attention source has a supported frontend view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->