### PR TITLE
fix(deals): a deal's forecast moves through one door, and that door records it

### DIFF
--- a/backend/gates/dealforecastmovement_test.go
+++ b/backend/gates/dealforecastmovement_test.go
@@ -1,0 +1,770 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A deal row changes through one door, and that door records the forecast.
+//
+// deal_forecast_history exists because deal_stage_history is written on creation
+// and on a stage move and nowhere else, so an amount revised in place and a close
+// date slipped leave no trace in it at all — and the second of those is the most
+// common reason a real forecast moves. A reconstruction built from what remains
+// reconciles over stage movement, omits the rest, and presents itself as the
+// whole answer: a partial sum wearing the label of a total.
+//
+// Completeness is therefore a property of the WRITE, not a duty each of the
+// deal's several writers discharges. Applying a patch to the deal row IS the
+// recording, and a test suite cannot hold that: one written against the table
+// drives the doors that call the recorder, and is silent about a door that does
+// not. So this gate holds the two ways round the seam:
+//
+//   - a storekit patch applied to the deal table from a function that does not
+//     record;
+//   - a statement that assigns a forecast column with its own SQL, anywhere in
+//     the tree.
+//
+// Both halves take their vocabulary from the deals module rather than restating
+// it: the table name from its own constant, the forecast columns from the list
+// the recorder consults. A gate that spelled either itself would go on guarding
+// the old name the day the module moved to a new one.
+//
+// The classification is exhaustive rather than filtered. A patch apply whose
+// target table this walk cannot resolve FAILS saying so — under-recognition is
+// the one way a census must not break, because it reads a smaller tree, reports
+// nothing wrong, and leaves no failing assertion to notice.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"maps"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// recorderFunc is the call that puts a row in deal_forecast_history. A function
+// that makes it is a door; one that applies a deal patch without it is a bypass.
+const recorderFunc = "recordForecastMovement"
+
+// patchApplyMethods are storekit.Patch's apply verbs, and the argument position
+// each one names its table in. ApplyLocked carries no table argument at all —
+// the table is inside the lock — so it resolves through the lock instead, which
+// is what lockTables below is for.
+var patchApplyMethods = map[string]int{
+	"ApplyGuarded":     2,
+	"ApplyGuardedIn":   2,
+	"ApplyWithVersion": 2,
+	"ApplyLocked":      -1,
+}
+
+// lockMinters are the storekit calls that mint a RowLock, and the argument
+// position each names its table in.
+var lockMinters = map[string]int{"LockRow": 2, "LockPair": 2}
+
+func TestEveryDealRowWriteRecordsTheForecastItMoved(t *testing.T) {
+	t.Parallel()
+
+	table, forecastColumns := dealWriteVocabulary(t)
+
+	// The patch half reads the packages allowed to write the deal row: the module
+	// that owns it, plus the ones tableownership_test.go ratifies as cross-store
+	// writers of it. Reading only the owner would leave the ratified writers — a
+	// merge relinking deals, a retention sweep archiving one — inside the fence
+	// and outside the census, and the SQL half cannot see them either, because a
+	// storekit patch has no SET clause in the source for it to match.
+	//
+	// The corpus is DERIVED from that gate's waiver map rather than listed here,
+	// so ratifying a third cross-store writer of this table brings it under this
+	// rule in the same edit.
+	//
+	// Whole packages, not the files that happen to apply a patch: a helper that
+	// mints a lock and returns it applies nothing, and resolving only appliers
+	// would call each of its callers unplaceable.
+	fset := token.NewFileSet()
+	var recorded, elsewhere int
+	for _, scope := range packagesThatMayWrite(t, table) {
+		parsedPackage := parsePackageDir(t, fset, scope.dir)
+		// The package's own string constants, so a table named by constant
+		// resolves exactly as a literal one does. Without them the walk reports
+		// an unplaceable write and tells the author to take a row lock — advice
+		// that is wrong, for a table that was legible all along.
+		consts := map[string]string{}
+		for _, file := range parsedPackage {
+			collectStringConstants(file, consts)
+		}
+		locks := packageLockTables(parsedPackage, consts)
+		for _, parsed := range packageFiles(t, fset, scope.dir) {
+			r, e := judgeDealPatchApplies(t, parsed, table, locks, consts, scope)
+			recorded, elsewhere = recorded+r, elsewhere+e
+		}
+	}
+
+	// The SQL half sweeps the tree, because a statement of its own is exactly how
+	// a write escapes both the patch seam and the module boundary — which is the
+	// shape the accepted offer had.
+	statements := 0
+	for _, parsed := range (gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: func(_ string, file *ast.File) bool { return assignsAForecastColumn(file, forecastColumns) },
+	}).Files(t) {
+		statements += judgeDealStatements(t, parsed, table, forecastColumns)
+	}
+
+	// Three floors, because the walk has three ways to stop seeing things and
+	// one total would hide which. Each sits below the real number, so a detector
+	// that quietly stopped matching fails here instead of finding nothing.
+	if recorded < 2 || elsewhere < 8 || statements < 2 {
+		t.Errorf("resolved %d recording deal patch apply/applies, %d on other tables and %d statement(s) "+
+			"writing the deal row — one of the ways of finding a write has stopped working",
+			recorded, elsewhere, statements)
+	}
+}
+
+// packagesThatMayWrite lists the package directories allowed to write one
+// table: the module that owns it, and every package tableownership_test.go
+// ratifies as a cross-store writer of it.
+//
+// Derived from that gate's own waiver map, whose keys are
+// `module:table:file:receiver.func`. A hand-kept list here would be a second
+// answer to "who may write this table", and the copy that went stale would be
+// this one — the census reading a smaller tree and reporting it clean.
+func packagesThatMayWrite(t *testing.T, table string) []writeScope {
+	t.Helper()
+	// The owner's whole package: every function in it may write the row, so
+	// every function in it is judged.
+	scopes := []writeScope{{dir: dealsDir}}
+
+	// A ratified cross-store writer is judged at the FUNCTION the waiver names
+	// and nowhere else. Its package writes many tables this rule has nothing to
+	// say about, and judging all of them would make this gate demand that a
+	// foreign module keep every one of its locks statically placeable — which is
+	// legislating over code whose table is not its business.
+	byDir := map[string]map[string]bool{}
+	for _, waived := range crossStoreWrites.Subjects() {
+		parts := strings.Split(string(waived), ":")
+		if len(parts) < 4 || parts[1] != table {
+			continue
+		}
+		name := parts[3]
+		if dot := strings.LastIndex(name, "."); dot >= 0 {
+			name = name[dot+1:] // receiver.func -> func
+		}
+		if byDir[parts[0]] == nil {
+			byDir[parts[0]] = map[string]bool{}
+		}
+		byDir[parts[0]][name] = true
+	}
+	if len(byDir) == 0 {
+		t.Fatalf("no cross-store writer of %q found in crossStoreWrites: either the waiver key shape "+
+			"changed under this derivation, or the ratified writers went away. Both are worth knowing, "+
+			"because this half of the gate silently narrows to one package either way.", table)
+	}
+	for _, dir := range slices.Sorted(maps.Keys(byDir)) {
+		scopes = append(scopes, writeScope{dir: dir, only: byDir[dir]})
+	}
+	return scopes
+}
+
+// writeScope is one package this gate judges, and which of its functions. An
+// empty `only` means all of them — the owner's package.
+type writeScope struct {
+	dir  string
+	only map[string]bool
+}
+
+func (s writeScope) judges(fn string) bool { return s.only == nil || s.only[fn] }
+
+// packageFiles pairs each of a package's parsed sources with the path it came
+// from, so a finding names a file rather than a syntax tree.
+//
+// It walks nothing itself: parsePackageDir is the package walk this directory
+// already has, and a second one would learn a new exclusion in only one place —
+// the half that stopped parsing would read green over whatever it no longer saw.
+func packageFiles(t *testing.T, fset *token.FileSet, dir string) []gatekit.ParsedFile {
+	t.Helper()
+	var out []gatekit.ParsedFile
+	for _, file := range parsePackageDir(t, fset, dir) {
+		out = append(out, gatekit.ParsedFile{
+			Path: filepath.ToSlash(fset.Position(file.Pos()).Filename),
+			File: file,
+		})
+	}
+	return out
+}
+
+// judgeDealPatchApplies holds the patch half over one file, returning how many
+// applies it saw inside a recording function and how many it resolved to another
+// table. An apply it can place neither way is a finding.
+func judgeDealPatchApplies(t *testing.T, parsed gatekit.ParsedFile, table string,
+	locks, consts map[string]string, scope writeScope,
+) (recorded, elsewhere int) {
+	t.Helper()
+	for _, decl := range parsed.File.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil || !scope.judges(fn.Name.Name) {
+			continue
+		}
+		records := callsFunction(fn, recorderFunc)
+		for _, apply := range patchAppliesIn(fn) {
+			switch target, known := apply.table(fn, locks, consts); {
+			case records:
+				// The door itself. It has satisfied the rule whichever row it
+				// writes, so its lock is deliberately not resolved.
+				recorded++
+			case !known:
+				t.Errorf("%s:%s applies a patch through %s and this gate cannot tell which table it writes.\n"+
+					"\tTake the lock in this function with storekit.LockRow, or return it from one that does, "+
+					"so the walk can place the write. An unplaceable deal write is how the forecast history "+
+					"went short in the first place.",
+					parsed.Path, fn.Name.Name, apply.method)
+			case target == table:
+				t.Errorf("%s:%s applies a patch to %q without recording the forecast it may have moved.\n"+
+					"\tApply it through the deals module's own seam (applyDealPatchGuarded / "+
+					"applyDealPatchLocked), which records for every writer, rather than calling "+
+					"storekit's %s directly.",
+					parsed.Path, fn.Name.Name, table, apply.method)
+			default:
+				elsewhere++
+			}
+		}
+	}
+	return recorded, elsewhere
+}
+
+// judgeDealStatements holds the SQL half over one file, returning how many
+// statements writing the deal row it read. A statement that sets a forecast
+// column is a finding wherever in the tree it is written.
+func judgeDealStatements(t *testing.T, parsed gatekit.ParsedFile, table string, forecastColumns []string) int {
+	t.Helper()
+	seen := 0
+	for _, statement := range statementsIn(parsed.File) {
+		column, assigns := assignedForecastColumn(statement, forecastColumns)
+		if !assigns {
+			continue
+		}
+		seen++
+		switch target, known := statementWriteTarget(statement); {
+		case !known:
+			t.Errorf("%s assigns %s in a statement whose table this gate cannot read:\n\t%s\n"+
+				"\tSpell the table as a literal in the SQL. A statement that assembles its target at "+
+				"run time is one this census cannot place, and an unplaceable write is where a census "+
+				"goes blind without saying so.",
+				parsed.Path, column, statement)
+		case target == table:
+			t.Errorf("%s writes %s.%s with its own statement:\n\t%s\n"+
+				"\tA forecast column moves through the deals module's patch seam, which records the "+
+				"move in deal_forecast_history. A statement of its own writes the column and no "+
+				"history, and the table's contract to whoever reconstructs a forecast is that it "+
+				"holds every move a stage transition did not.",
+				parsed.Path, table, column, statement)
+		}
+	}
+	return seen
+}
+
+// patchApply is one storekit patch apply, located.
+type patchApply struct {
+	method string
+	args   []ast.Expr
+}
+
+// table resolves the row the apply writes: the argument the verb names it in,
+// or — for ApplyLocked, whose table rides the lock — the table the lock was
+// taken on. Reporting false is a result, not a shrug: the caller fails on it.
+func (a patchApply) table(fn *ast.FuncDecl, locks, consts map[string]string) (string, bool) {
+	position := patchApplyMethods[a.method]
+	if position >= 0 {
+		if position >= len(a.args) {
+			return "", false
+		}
+		return resolveString(a.args[position], consts)
+	}
+	if len(a.args) < 3 {
+		return "", false
+	}
+	name, isIdent := a.args[2].(*ast.Ident)
+	if !isIdent {
+		return "", false
+	}
+	target, known := lockTableFor(fn, name.Name, locks, consts)
+	return target, known
+}
+
+// patchAppliesIn finds every storekit patch apply in one function body.
+func patchAppliesIn(fn *ast.FuncDecl) []patchApply {
+	var out []patchApply
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+		if _, isApply := patchApplyMethods[selector.Sel.Name]; !isApply {
+			return true
+		}
+		// storekit's own package qualifier would make this a type name rather
+		// than a patch value; every apply in the tree is a method on a *Patch.
+		out = append(out, patchApply{method: selector.Sel.Name, args: call.Args})
+		return true
+	})
+	return out
+}
+
+// lockTableFor resolves which table a named RowLock held in this function was
+// taken on: one this function's own body minted, or — when the name is a
+// parameter — the table every caller in the package locked before handing it in.
+func lockTableFor(fn *ast.FuncDecl, name string, locks, consts map[string]string) (string, bool) {
+	if isParam(fn, name) {
+		table, known := locks[lockKey(fn.Name.Name, name)]
+		return table, known
+	}
+	var table string
+	var known bool
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign || !assignsName(assign, name) {
+			return true
+		}
+		for _, rhs := range assign.Rhs {
+			call, isCall := rhs.(*ast.CallExpr)
+			if !isCall {
+				continue
+			}
+			if target, ok := lockTableOfCall(call, locks, consts); ok {
+				table, known = target, true
+			}
+		}
+		return true
+	})
+	return table, known
+}
+
+// lockKey names one thing in a package that holds a RowLock: a function's
+// returned lock, or one of its parameters. Two namespaces in one map, because
+// resolving either can depend on the other and a fixed point over both is the
+// only order that terminates without a topological sort.
+func lockKey(fn, held string) string { return fn + "#" + held }
+
+const lockReturn = ""
+
+// packageLockTables resolves, for one package, which table every RowLock that
+// crosses a function boundary was taken on — locks returned by a minting helper
+// and locks handed in as parameters.
+//
+// It iterates to a fixed point rather than resolving in one pass: a parameter's
+// table comes from its callers, and a caller may itself have been handed the
+// lock. Three passes settle this tree; the loop stops when a pass learns
+// nothing, so it terminates on any shape.
+//
+// A lock it cannot place stays absent, which is what makes the apply that uses
+// it fail. Guessing would be worse than not knowing: the guess that a lock is
+// NOT on the deal row is exactly the answer that lets an unrecorded deal write
+// through.
+func packageLockTables(files []*ast.File, consts map[string]string) map[string]string {
+	locks := map[string]string{}
+	for changed := true; changed; {
+		changed = false
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				fn, isFunc := decl.(*ast.FuncDecl)
+				if !isFunc || fn.Body == nil {
+					continue
+				}
+				changed = learnReturnedLock(fn, locks, consts) || changed
+				changed = learnPassedLocks(fn, files, locks, consts) || changed
+			}
+		}
+	}
+	return locks
+}
+
+// learnReturnedLock records the table a lock-returning helper mints its lock on.
+func learnReturnedLock(fn *ast.FuncDecl, locks, consts map[string]string) bool {
+	key := lockKey(fn.Name.Name, lockReturn)
+	if _, known := locks[key]; known || !returnsRowLock(fn) {
+		return false
+	}
+	learned := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		if table, ok := lockTableOfCall(call, locks, consts); ok {
+			locks[key] = table
+			learned = true
+		}
+		return true
+	})
+	return learned
+}
+
+// learnPassedLocks resolves each of fn's RowLock parameters from the arguments
+// its callers pass. Callers that disagree leave the parameter unresolved: a
+// helper reached with two different tables cannot be placed, and placing it
+// wrongly is the failure this gate exists to prevent.
+func learnPassedLocks(fn *ast.FuncDecl, files []*ast.File, locks, consts map[string]string) bool {
+	learned := false
+	for position, name := range rowLockParams(fn) {
+		key := lockKey(fn.Name.Name, name)
+		if _, known := locks[key]; known {
+			continue
+		}
+		table, agreed := calledWithLockOn(fn.Name.Name, position, files, locks, consts)
+		if !agreed {
+			continue
+		}
+		locks[key] = table
+		learned = true
+	}
+	return learned
+}
+
+// calledWithLockOn reads the table every call to callee locks before passing its
+// argument at position, reporting false unless at least one call resolves and
+// all that resolve agree.
+func calledWithLockOn(callee string, position int, files []*ast.File,
+	locks, consts map[string]string,
+) (string, bool) {
+	table, agreed := "", false
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			caller, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || caller.Body == nil {
+				continue
+			}
+			for _, args := range callsTo(caller, callee) {
+				if position >= len(args) {
+					continue
+				}
+				ident, isIdent := args[position].(*ast.Ident)
+				if !isIdent {
+					continue
+				}
+				found, known := lockTableFor(caller, ident.Name, locks, consts)
+				switch {
+				case !known:
+				case !agreed:
+					table, agreed = found, true
+				case found != table:
+					return "", false
+				}
+			}
+		}
+	}
+	return table, agreed
+}
+
+// rowLockParams maps each storekit.RowLock parameter's position to its name.
+func rowLockParams(fn *ast.FuncDecl) map[int]string {
+	out := map[int]string{}
+	position := 0
+	for _, field := range fn.Type.Params.List {
+		selector, isSelector := field.Type.(*ast.SelectorExpr)
+		names := max(len(field.Names), 1)
+		for i := 0; i < names; i++ {
+			if isSelector && selector.Sel.Name == "RowLock" && i < len(field.Names) {
+				out[position] = field.Names[i].Name
+			}
+			position++
+		}
+	}
+	return out
+}
+
+// callsTo returns the argument list of every call to the named package function
+// inside one function body.
+func callsTo(fn *ast.FuncDecl, callee string) [][]ast.Expr {
+	var out [][]ast.Expr
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		switch named := call.Fun.(type) {
+		case *ast.Ident:
+			if named.Name == callee {
+				out = append(out, call.Args)
+			}
+		case *ast.SelectorExpr:
+			if named.Sel.Name == callee {
+				out = append(out, call.Args)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+func isParam(fn *ast.FuncDecl, name string) bool {
+	for _, field := range fn.Type.Params.List {
+		for _, param := range field.Names {
+			if param.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// lockTableOfCall reads the table out of a lock-minting storekit call, or out of
+// a package function this walk already resolved to one.
+func lockTableOfCall(call *ast.CallExpr, locks, consts map[string]string) (string, bool) {
+	switch callee := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		position, mints := lockMinters[callee.Sel.Name]
+		if !mints || position >= len(call.Args) {
+			return "", false
+		}
+		return resolveString(call.Args[position], consts)
+	case *ast.Ident:
+		table, resolved := locks[lockKey(callee.Name, lockReturn)]
+		return table, resolved
+	}
+	return "", false
+}
+
+func returnsRowLock(fn *ast.FuncDecl) bool {
+	if fn.Type.Results == nil {
+		return false
+	}
+	for _, result := range fn.Type.Results.List {
+		selector, isSelector := result.Type.(*ast.SelectorExpr)
+		if isSelector && selector.Sel.Name == "RowLock" {
+			return true
+		}
+	}
+	return false
+}
+
+func assignsName(assign *ast.AssignStmt, name string) bool {
+	for _, lhs := range assign.Lhs {
+		if ident, isIdent := lhs.(*ast.Ident); isIdent && ident.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func callsFunction(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		if ident, isIdent := call.Fun.(*ast.Ident); isIdent && ident.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// dealWriteVocabulary asks the deals module what this gate is about: the table
+// its writes target, and the columns a forecast reconstruction reads.
+//
+// Derived rather than restated. A gate carrying its own copy of either would
+// keep guarding the old spelling on the day the module changed it — passing over
+// the rename, which is when a rule is least likely to still hold.
+func dealWriteVocabulary(t *testing.T) (table string, forecastColumns []string) {
+	t.Helper()
+	files := parsePackageDir(t, token.NewFileSet(), dealsDir)
+
+	consts := map[string]string{}
+	for _, file := range files {
+		collectStringConstants(file, consts)
+	}
+	table, known := consts[dealTableConst]
+	if !known {
+		t.Fatalf("%s declares no %s constant: this gate no longer knows which table it protects",
+			dealsDir, dealTableConst)
+	}
+
+	for _, element := range packageVarCompositeLit(t, files, forecastColumnsVar).Elts {
+		column, resolved := resolveString(element, consts)
+		if !resolved {
+			t.Fatalf("%s holds an element this gate cannot resolve to a column name, so its census "+
+				"would silently cover fewer columns than the recorder does", forecastColumnsVar)
+		}
+		forecastColumns = append(forecastColumns, column)
+	}
+	if len(forecastColumns) == 0 {
+		t.Fatalf("%s resolved to no columns: the SQL half would then judge nothing and report a clean tree",
+			forecastColumnsVar)
+	}
+	return table, forecastColumns
+}
+
+// The two declarations the vocabulary comes out of.
+const (
+	dealTableConst     = "dealTable"
+	forecastColumnsVar = "forecastColumns"
+)
+
+// The SQL half reads a statement in two independent steps, and that order is
+// the whole design.
+//
+// It does not start from the table, because a table has many legal spellings —
+// aliased, quoted, schema-qualified, ONLY-prefixed, reached through DO UPDATE or
+// MERGE, assembled by a format string — and a pattern that knows some of them
+// reads a clean tree over the rest. It starts from the COLUMN, of which there
+// are three, each spelled one way. Only then does it ask which table the
+// statement writes, and a statement that assigns a forecast column and whose
+// table cannot be read FAILS: an unplaceable write is a finding, never a pass.
+var (
+	// setClause isolates what a statement ASSIGNS from what it merely names. A
+	// column read in a WHERE predicate or listed in a SELECT is not a write, and
+	// `SET` is the one token every assigning form shares — a plain UPDATE, an
+	// upsert's DO UPDATE, a MERGE's WHEN MATCHED THEN UPDATE. `\b` keeps it out
+	// of `offset`.
+	setClause = regexp.MustCompile(`(?is)\bset\b(.*?)(?:\bwhere\b|\breturning\b|;|$)`)
+	// writeTarget matches the table an UPDATE, an INSERT (whose ON CONFLICT can
+	// carry an UPDATE) or a MERGE writes, through every identifier spelling
+	// Postgres accepts: quoted, schema-qualified, ONLY-prefixed.
+	writeTarget = regexp.MustCompile(
+		`(?is)\b(?:update|insert\s+into|merge\s+into)\s+(?:only\s+)?(?:"?[a-z_][a-z0-9_]*"?\.)?"?([a-z_][a-z0-9_]*)"?`)
+	// assignmentFmt matches `col = …` and the multi-column form
+	// `(a, col) = (…)`, with or without the identifier quoted. Anchored on the
+	// whole identifier so `currency` is not found inside `base_currency` — the
+	// substring reading is the half that survives a careless escape — and the
+	// parenthesised branch may not cross a `(` of its own, so a column list
+	// cannot reach forward to an unrelated `=`.
+	assignmentFmt = `(?i)(?:(?:^|[,\s"])%[1]s"?\s*=)|(?:\([^()=]*[,\s"]?%[1]s"?[^()=]*\)\s*=)`
+)
+
+// assignsAForecastColumn is the SQL half's sweep subject: a file holding a
+// statement that assigns one of the deal's forecast columns. It is the same
+// question the detector asks, so the negative-space sweep proves the roots
+// against every file the judgment would have something to say about.
+func assignsAForecastColumn(file *ast.File, forecastColumns []string) bool {
+	for _, statement := range statementsIn(file) {
+		if _, assigns := assignedForecastColumn(statement, forecastColumns); assigns {
+			return true
+		}
+	}
+	return false
+}
+
+// assignedForecastColumn names the forecast column a statement assigns, if any.
+// It reads only the statement's SET clauses, so a forecast column a SELECT
+// returns or a WHERE narrows on is correctly not a write.
+func assignedForecastColumn(statement string, forecastColumns []string) (string, bool) {
+	for _, assigned := range setClause.FindAllStringSubmatch(statement, -1) {
+		for _, column := range forecastColumns {
+			if regexp.MustCompile(fmt.Sprintf(assignmentFmt, regexp.QuoteMeta(column))).MatchString(assigned[1]) {
+				return column, true
+			}
+		}
+	}
+	return "", false
+}
+
+// statementWriteTarget names the table a statement writes. Reporting false is a
+// result the caller fails on: a target assembled at run time — a %s in a format
+// string, a name concatenated from a variable — is one this census cannot place.
+func statementWriteTarget(statement string) (string, bool) {
+	match := writeTarget.FindStringSubmatch(statement)
+	if match == nil {
+		return "", false
+	}
+	return strings.ToLower(match[1]), true
+}
+
+// statementsIn returns every SQL-shaped string in one file, comments stripped
+// and whitespace collapsed, with adjacent literals joined the way the compiler
+// joins them.
+//
+// It matches STATEMENTS and not lines: a statement broken across lines is one
+// write however it is laid out, a column named in a `--` comment is prose, and
+// a statement a Go author split with `+` is still one statement.
+func statementsIn(file *ast.File) []string {
+	var out []string
+	for _, literal := range concatenatedStringsIn(file) {
+		// Split on `;` AFTER stripping comments, so a semicolon inside a `--`
+		// comment does not cut a statement in half.
+		//
+		// One Go string can hold two statements, and placing the pair by its
+		// first table is a FALSE PASS — `UPDATE offer SET status = 'x';
+		// UPDATE deal SET amount_minor = $1` would resolve to `offer` and report
+		// nothing. That is the one outcome this census must not produce, so each
+		// statement is placed on its own.
+		for _, statement := range strings.Split(stripSQLComments(literal), ";") {
+			if collapsed := collapsedSQL(statement); collapsed != "" {
+				out = append(out, collapsed)
+			}
+		}
+	}
+	return out
+}
+
+// stripSQLComments removes `--` line comments so a column named in one is not
+// read as an assignment.
+func stripSQLComments(sql string) string {
+	var kept []string
+	for _, line := range strings.Split(sql, "\n") {
+		if at := strings.Index(line, "--"); at >= 0 {
+			line = line[:at]
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// concatenatedStringsIn returns every string expression in one file with its
+// `+` concatenations folded, so a statement an author split across two literals
+// reads here as the one statement the database receives. A concatenation with a
+// non-literal operand folds to the literal halves joined by nothing, which
+// reads as an unplaceable table rather than as no statement at all.
+func concatenatedStringsIn(file *ast.File) []string {
+	var out []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch expr := node.(type) {
+		case *ast.BinaryExpr:
+			if expr.Op != token.ADD {
+				return true
+			}
+			out = append(out, foldStringExpr(expr))
+			return false // its literal halves are this one string, not two
+		case *ast.BasicLit:
+			if expr.Kind == token.STRING {
+				if unquoted, err := strconv.Unquote(expr.Value); err == nil {
+					out = append(out, unquoted)
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// foldStringExpr renders a `+` expression as the string it builds, with every
+// operand this walk cannot read contributing nothing.
+func foldStringExpr(expr ast.Expr) string {
+	switch node := expr.(type) {
+	case *ast.BinaryExpr:
+		if node.Op != token.ADD {
+			return ""
+		}
+		return foldStringExpr(node.X) + foldStringExpr(node.Y)
+	case *ast.BasicLit:
+		if node.Kind != token.STRING {
+			return ""
+		}
+		if unquoted, err := strconv.Unquote(node.Value); err == nil {
+			return unquoted
+		}
+	}
+	return ""
+}

--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -81,7 +81,7 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 // run.
 func (e *closeDateEnv) sweep() error {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:close-date"})
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: closeDateSweepActor})
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return e.corrector.SweepWorkspace(ctx)
 }
@@ -266,6 +266,67 @@ func TestCloseDateSweepAutoRollsClearOverdueActiveDeal(t *testing.T) {
 	}
 	if !strings.Contains(before, "expected_close_date") || !strings.Contains(after, want.Format(time.DateOnly)) {
 		t.Errorf("audit diff (before %s, after %s) does not carry the rollback images", before, after)
+	}
+}
+
+// A slipped close date is, by deal_forecast_history's own reckoning, the single
+// most common reason a real forecast moves — and the nightly corrector is the
+// writer that slips the most of them. It moves the date without touching the
+// stage, which is exactly the move deal_stage_history cannot see, so a
+// reconstruction blind to the sweep reconciles over human edits and silently
+// omits every machine re-date while presenting itself as the whole answer.
+//
+// The row is stamped with the corrector's own principal rather than a human's:
+// changed_by exists to say who moved it, and "nobody" is not one of the answers.
+func TestCloseDateSweepRecordsTheForecastItMoved(t *testing.T) {
+	e := setupCloseDate(t)
+	// The 🟢 worked example again: overdue, active, no override — the tier that
+	// re-dates the deal outright, so the move is the sweep's and nothing else's.
+	id := e.seedSweepDeal(t, "Slipped but alive", e.early, nil, intp(-12), 3)
+
+	forecastRows := func(t *testing.T) int {
+		t.Helper()
+		var n int
+		if err := e.owner.QueryRow(context.Background(),
+			`SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, id).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		return n
+	}
+	if got := forecastRows(t); got != 0 {
+		t.Fatalf("the seed wrote %d forecast rows, want 0 — it plants the row directly", got)
+	}
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := today().AddDate(0, 0, 2*deals.CloseDateStageDays)
+	if swept := e.readSwept(t, id); swept.expectedClose == nil || !swept.expectedClose.Equal(want) {
+		t.Fatalf("the sweep did not re-date the deal (%v), so the rest of this test proves nothing", swept.expectedClose)
+	}
+	if got := forecastRows(t); got != 1 {
+		t.Fatalf("the sweep wrote %d forecast rows, want 1 — it moved the close date and a "+
+			"reconstruction of the forecast as of any date after the run would read the overdue one", got)
+	}
+
+	var recordedDate *time.Time
+	var changedBy string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT close_date_at_change, changed_by FROM deal_forecast_history WHERE deal_id = $1`,
+		id).Scan(&recordedDate, &changedBy); err != nil {
+		t.Fatal(err)
+	}
+	if recordedDate == nil || !recordedDate.Equal(want) {
+		t.Errorf("recorded close date = %v, want %s — the row carries the date the deal now has",
+			recordedDate, want.Format(time.DateOnly))
+	}
+	// closeDateSweepActor is what the WORKER binds (jobs_deals.go), so this
+	// asserts the attribution production actually writes rather than a spelling
+	// the fixture chose for itself.
+	if changedBy != closeDateSweepActor {
+		t.Errorf("changed_by = %q, want %q — the recorder takes the running principal, so a "+
+			"machine re-date is attributable rather than anonymous history", changedBy, closeDateSweepActor)
 	}
 }
 

--- a/backend/internal/compose/integration/dealforecasthistory_integration_test.go
+++ b/backend/internal/compose/integration/dealforecasthistory_integration_test.go
@@ -38,11 +38,11 @@ func TestAForecastMovedWithoutAStageChangeIsRecorded(t *testing.T) {
 
 	stageRows := func(t *testing.T) int {
 		t.Helper()
-		return countRows(admin, t, e, `SELECT count(*) FROM deal_stage_history WHERE deal_id = $1`, deal.UUID)
+		return e.WsCount(t, `SELECT count(*) FROM deal_stage_history WHERE deal_id = $1`, deal.UUID)
 	}
 	forecastRows := func(t *testing.T) int {
 		t.Helper()
-		return countRows(admin, t, e, `SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal.UUID)
+		return e.WsCount(t, `SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal.UUID)
 	}
 
 	stageAtStart := stageRows(t)
@@ -96,15 +96,229 @@ func TestAForecastMovedWithoutAStageChangeIsRecorded(t *testing.T) {
 	}
 }
 
-func countRows(ctx context.Context, t *testing.T, e *Env, query string, deal ids.UUID) int {
-	t.Helper()
-	var n int
-	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query, deal).Scan(&n)
-	}); err != nil {
-		t.Fatalf("counting rows for %q: %v", query, err)
+// A sparse update supplies fields; it does not necessarily move them. Re-sending
+// the amount a deal already carries is the shape a client retry and an
+// edit-nothing save both take, and recording it would fill the history with
+// moves that never happened — each one a date a reconstruction has to explain
+// and cannot.
+func TestReSendingTheSameMoneyRecordsNoForecastMove(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.Admin()
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Idempotent save", pipeline, open, &e.Rep1))
+
+	rows := func(t *testing.T) int {
+		t.Helper()
+		return e.WsCount(t, `SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal.UUID)
 	}
-	return n
+
+	amount, currency := int64(250_000), "EUR"
+	if _, err := e.Deals.UpdateDeal(admin, deal,
+		deals.UpdateDealInput{AmountMinor: &amount, Currency: &currency}); err != nil {
+		t.Fatalf("pricing the deal: %v", err)
+	}
+	priced := rows(t)
+	if priced != 1 {
+		t.Fatalf("pricing wrote %d forecast rows, want 1 — the baseline is wrong", priced)
+	}
+
+	// The identical request again, and a third carrying the name as well, so the
+	// deal genuinely changes while its forecast does not.
+	renamed := "Idempotent save, renamed"
+	for _, in := range []deals.UpdateDealInput{
+		{AmountMinor: &amount, Currency: &currency},
+		{AmountMinor: &amount, Currency: &currency, Name: &renamed},
+	} {
+		if _, err := e.Deals.UpdateDeal(admin, deal, in); err != nil {
+			t.Fatalf("re-sending the same money: %v", err)
+		}
+	}
+	if got := rows(t); got != priced {
+		t.Fatalf("re-sending the same amount wrote %d further forecast row(s), want none — "+
+			"the deal's forecast did not move", got-priced)
+	}
+
+	// And the field that DID move is still recorded, so the comparison has not
+	// simply switched the recorder off.
+	revised := int64(300_000)
+	if _, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{AmountMinor: &revised}); err != nil {
+		t.Fatalf("revising the amount: %v", err)
+	}
+	if got := rows(t); got != priced+1 {
+		t.Fatalf("a real revision wrote %d rows in total, want %d", got, priced+1)
+	}
+}
+
+// Accepting an offer is "an amount revised in place" — the accepted gross
+// BECOMES the deal's headline amount, which the offer lifecycle's own docblock
+// calls restoring forecast honesty. It is the largest forecast move the product
+// makes and it leaves no stage transition behind, so a reconstruction that
+// cannot see it answers "what was the forecast as of T" with a figure the deal
+// has not carried since the offer was signed.
+func TestAcceptingAnOfferRecordsTheForecastItMoved(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Offer-priced deal", pipeline, open, &e.Rep1)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, offerDeskPerms)
+
+	// 1 × 100.00 @19% → gross 11900, which is what the deal must end up holding.
+	description, price, taxRate := "Retainer", int64(10000), "19.00"
+	created, err := e.Deals.CreateOffer(ctx, ids.From[ids.DealKind](deal), deals.CreateOfferInput{
+		Currency: "EUR", Source: "manual",
+		LineItems: []deals.OfferLineInputRow{{
+			Description: &description, Quantity: "1", UnitPriceMinor: &price, TaxRate: &taxRate,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	offer := ids.From[ids.OfferKind](ids.UUID(created.Id))
+	if _, err := e.Deals.SendOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("send offer: %v", err)
+	}
+
+	// The deal is unpriced until the accept, so any row that exists afterwards
+	// is the accept's own — nothing earlier in this fixture moves a forecast field.
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal); got != 0 {
+		t.Fatalf("the fixture wrote %d forecast rows before the accept, want 0", got)
+	}
+
+	if _, err := e.Deals.AcceptOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("accept offer: %v", err)
+	}
+
+	const acceptedGross = int64(11900)
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal WHERE id = $1 AND amount_minor = $2 AND currency = 'EUR'`,
+		deal, acceptedGross); got != 1 {
+		t.Fatalf("the accept did not put the gross onto the deal, so the rest of this test proves nothing")
+	}
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal); got != 1 {
+		t.Fatalf("accepting an offer wrote %d forecast rows, want 1 — the deal's amount moved and a "+
+			"reconstruction of the forecast as of any date after the accept would read the pre-offer figure", got)
+	}
+	// The recorded figure is the deal's state AFTER the move, the same contract
+	// the direct-edit path keeps: a row carrying the pre-accept amount would
+	// leave every as-of answer one signature stale.
+	if recorded := recordedForecastAmount(e.Admin(), t, e, deal); recorded == nil || *recorded != acceptedGross {
+		t.Fatalf("recorded amount = %v, want %d — the row must carry the gross the deal now has",
+			recorded, acceptedGross)
+	}
+}
+
+// A deal that closed with no amount has no frozen conversion rate, so the
+// accept that finally prices it must freeze one in the same write — as of the
+// CLOSE, not as of the signature — or deal_closed_fx refuses the row outright.
+// It is also the move a forecast reconstruction most needs to see: the deal was
+// worth nothing on the books until the offer landed.
+func TestAcceptingAnOfferOntoAClosedDealFreezesAndRecords(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, won := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Won before it was priced", pipeline, open, &e.Rep1)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, offerDeskPerms)
+
+	description, price, taxRate := "Retainer", int64(10000), "19.00"
+	created, err := e.Deals.CreateOffer(ctx, ids.From[ids.DealKind](deal), deals.CreateOfferInput{
+		Currency: "EUR", Source: "manual",
+		LineItems: []deals.OfferLineInputRow{{
+			Description: &description, Quantity: "1", UnitPriceMinor: &price, TaxRate: &taxRate,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	offer := ids.From[ids.OfferKind](ids.UUID(created.Id))
+	if _, err := e.Deals.SendOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("send offer: %v", err)
+	}
+
+	// Closed with no amount: legal (deal_closed_fx exempts an amountless row)
+	// and precisely why the accept cannot simply write the money.
+	reason := "verbal"
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.From[ids.DealKind](deal), deals.AdvanceDealInput{
+		ToStageID: won, WonWithoutContractReason: &reason,
+	}); err != nil {
+		t.Fatalf("winning the deal before it is priced: %v", err)
+	}
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal WHERE id = $1 AND status = 'won'
+		   AND amount_minor IS NULL AND fx_rate_to_base IS NULL`, deal); got != 1 {
+		t.Fatalf("the deal did not close amountless and rate-less, so this test proves nothing")
+	}
+
+	if _, err := e.Deals.AcceptOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("accept offer onto the closed deal: %v", err)
+	}
+
+	const acceptedGross = int64(11900)
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal WHERE id = $1 AND amount_minor = $2 AND currency = 'EUR'
+		   AND fx_rate_to_base IS NOT NULL AND fx_rate_date IS NOT NULL`,
+		deal, acceptedGross); got != 1 {
+		t.Fatalf("the accept left the closed deal without both the gross and a frozen rate — " +
+			"deal_closed_fx is the only thing standing between that row and a corrupt base-currency roll-up")
+	}
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal); got != 1 {
+		t.Fatalf("pricing a closed deal wrote %d forecast rows, want 1", got)
+	}
+	if recorded := recordedForecastAmount(e.Admin(), t, e, deal); recorded == nil || *recorded != acceptedGross {
+		t.Fatalf("recorded amount = %v, want %d", recorded, acceptedGross)
+	}
+}
+
+// An accept that prices the deal at what it already holds moved no forecast.
+// The row it would otherwise write is not harmless: a reconstruction reads the
+// history as the record of when the number changed, and a row saying it changed
+// on a day it did not is a move somebody has to explain.
+func TestAcceptingAnOfferAtThePriceTheDealAlreadyHoldsRecordsNothing(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Already priced", pipeline, open, &e.Rep1)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, offerDeskPerms)
+
+	// The deal is set by hand to exactly what the offer below will gross.
+	const gross = int64(11900)
+	amount, currency := gross, "EUR"
+	if _, err := e.Deals.UpdateDeal(e.Admin(), ids.From[ids.DealKind](deal),
+		deals.UpdateDealInput{AmountMinor: &amount, Currency: &currency}); err != nil {
+		t.Fatalf("pricing the deal by hand: %v", err)
+	}
+	priced := e.WsCount(t, `SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal)
+	if priced != 1 {
+		t.Fatalf("the hand edit wrote %d forecast rows, want 1 — the baseline is wrong", priced)
+	}
+
+	description, price, taxRate := "Retainer", int64(10000), "19.00"
+	created, err := e.Deals.CreateOffer(ctx, ids.From[ids.DealKind](deal), deals.CreateOfferInput{
+		Currency: "EUR", Source: "manual",
+		LineItems: []deals.OfferLineInputRow{{
+			Description: &description, Quantity: "1", UnitPriceMinor: &price, TaxRate: &taxRate,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	offer := ids.From[ids.OfferKind](ids.UUID(created.Id))
+	if _, err := e.Deals.SendOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("send offer: %v", err)
+	}
+	if _, err := e.Deals.AcceptOffer(ctx, offer, nil); err != nil {
+		t.Fatalf("accept offer: %v", err)
+	}
+
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal WHERE id = $1 AND amount_minor = $2 AND currency = 'EUR'`,
+		deal, gross); got != 1 {
+		t.Fatalf("the deal no longer carries the price both sides agreed on")
+	}
+	if got := e.WsCount(t,
+		`SELECT count(*) FROM deal_forecast_history WHERE deal_id = $1`, deal); got != priced {
+		t.Fatalf("the accept wrote %d forecast row(s) on top of the %d already there, want none — "+
+			"nothing about the deal's forecast moved", got-priced, priced)
+	}
 }
 
 // recordedForecastAmount reads back the one column whose VALUE this suite

--- a/backend/internal/compose/jobs_deals.go
+++ b/backend/internal/compose/jobs_deals.go
@@ -86,12 +86,20 @@ type closeDateWorkspaceWorker struct {
 	corrector *deals.CloseDateCorrector
 }
 
+// closeDateSweepActor is the principal the nightly close-date sweep runs as, and
+// therefore the one every row it writes is attributed to — the corrector's
+// audit entries and the deal_forecast_history rows its re-dates record. Declared
+// rather than typed at the call site because the suite that asserts that
+// attribution has to name the same principal the worker binds, and two hand-typed
+// copies of it would agree only until one of them moved.
+const closeDateSweepActor = "system:close-date"
+
 func (w *closeDateWorkspaceWorker) Work(ctx context.Context, job *river.Job[CloseDateWorkspaceArgs]) error {
 	wsCtx, err := workspaceJobCtx(ctx, job.Args)
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
-	wsCtx = principal.WithActor(wsCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:close-date"})
+	wsCtx = principal.WithActor(wsCtx, principal.Principal{Type: principal.PrincipalSystem, ID: closeDateSweepActor})
 	wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
 	return jobs.FaultContext(ctx, w.corrector.SweepWorkspace(wsCtx))
 }

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -292,6 +292,22 @@ func forecastDowngrade(category string) string {
 	}
 }
 
+// setCloseDate assigns the sweep's proposed date only where it differs from the
+// one the deal already claims.
+//
+// The sweep re-flags a deal every night it stays quiet, and its proposal is
+// derived from stage velocity rather than from the calendar — so it frequently
+// recomputes the date the deal already has. storekit.Patch records an assignment
+// without comparing it, so an unconditional Set would put that date in the audit
+// diff and in deal_forecast_history on every pass, and a reconstruction would
+// read a forecast moving nightly while standing still.
+func setCloseDate(p *storekit.Patch, before *time.Time, proposed time.Time) {
+	if before != nil && before.Equal(proposed) {
+		return
+	}
+	p.Set(closeDateField, before, proposed)
+}
+
 // correct applies one deal's A6 tier. The write runs in its own audited
 // transaction; the 🟡 staging follows it (Stage opens its own) — if the
 // staging fails the provisional row simply re-enters the next sweep.
@@ -322,7 +338,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 	switch hygiene.Action {
 	case CloseDateActionAutoApply:
 		_, err := c.apply(ctx, cand, "auto_apply", func(p *storekit.Patch) {
-			p.Set("expected_close_date", cand.expectedClose, *hygiene.ProposedClose)
+			setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
 			if cand.provisional {
 				p.Set("close_date_provisional", true, false)
 			}
@@ -331,7 +347,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 
 	case CloseDateActionProvisionalConfirm:
 		version, err := c.apply(ctx, cand, "provisional_confirm", func(p *storekit.Patch) {
-			p.Set("expected_close_date", cand.expectedClose, *hygiene.ProposedClose)
+			setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
 			if !cand.provisional {
 				p.Set("close_date_provisional", false, true)
 			}
@@ -348,7 +364,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 			if hygiene.Provisional {
 				// Only the invariant forces a date onto a quiet deal —
 				// never an optimistic re-date on top of the downgrade.
-				p.Set("expected_close_date", cand.expectedClose, *hygiene.ProposedClose)
+				setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
 				if !cand.provisional {
 					p.Set("close_date_provisional", false, true)
 				}
@@ -396,7 +412,7 @@ func (c *CloseDateCorrector) apply(ctx context.Context, cand closeDateCandidate,
 	err := c.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The candidate scan and this write are separate transactions:
 		// a deal closed or archived in between must not be re-dated.
-		lock, err := storekit.LockRow(ctx, tx, "deal", cand.id.UUID, storekit.LiveOnly)
+		lock, err := storekit.LockRow(ctx, tx, dealTable, cand.id.UUID, storekit.LiveOnly)
 		if errors.Is(err, apperrors.ErrNotFound) {
 			return nil
 		}
@@ -412,7 +428,14 @@ func (c *CloseDateCorrector) apply(ctx context.Context, cand closeDateCandidate,
 		}
 		patch := storekit.NewPatch()
 		build(patch)
-		if err := patch.ApplyLocked(ctx, tx, lock); err != nil {
+		if patch.Empty() {
+			// The tier fired but the deal already holds everything it proposes —
+			// a quiet deal re-flagged on a night its velocity date has not moved.
+			// There is no write to make, and no audit row or event to raise about
+			// one. The version is still read, because a 🟡 staging binds to it.
+			return tx.QueryRow(ctx, `SELECT version FROM deal WHERE id = $1`, cand.id).Scan(&version)
+		}
+		if err := applyDealPatchLocked(ctx, tx, patch, lock); err != nil {
 			return fmt.Errorf("apply %s patch: %w", correction, err)
 		}
 		if err := tx.QueryRow(ctx, `SELECT version FROM deal WHERE id = $1`, cand.id).Scan(&version); err != nil {

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -64,9 +64,6 @@ func recordDealUpdate(ctx context.Context, tx pgx.Tx, id ids.DealID, current crm
 			return fmt.Errorf("emit deal.owner_changed: %w", err)
 		}
 	}
-	if err := recordForecastMovement(ctx, tx, id, current, in, after); err != nil {
-		return err
-	}
 	rest := make(map[string]any, len(after))
 	for field, v := range after {
 		if ownerChanged && field == "owner_id" {
@@ -82,6 +79,17 @@ func recordDealUpdate(ctx context.Context, tx pgx.Tx, id ids.DealID, current crm
 	return nil
 }
 
+// moved answers whether a supplied value differs from the one the row holds.
+// A request that did not supply the field moved nothing; one that supplied the
+// value already there moved nothing either, and the second is the reading a
+// sparse update makes it easy to lose.
+func moved[T comparable](current, supplied *T) bool {
+	if supplied == nil {
+		return false
+	}
+	return current == nil || *current != *supplied
+}
+
 // dealUpdatePatch folds the caller's sparse update onto the current row
 // as a field patch. Re-pointing the deal at an organization (or partner
 // organization) is a read of that record, so each link target must be
@@ -94,11 +102,16 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 	if in.Name != nil {
 		p.Set(dealNameColumn, current.Name, *in.Name)
 	}
-	if in.AmountMinor != nil {
-		p.Set("amount_minor", current.AmountMinor, *in.AmountMinor)
+	// The forecast fields are assigned only where the request actually moves
+	// them. Every other column may be re-set freely — the audit diff records a
+	// no-op edit and nothing reads it as an event — but these three are what
+	// deal_forecast_history is keyed on, and a row saying the forecast moved on a
+	// day it did not is a move a reconstruction has to explain.
+	if moved(current.AmountMinor, in.AmountMinor) {
+		p.Set(amountField, current.AmountMinor, *in.AmountMinor)
 	}
-	if in.Currency != nil {
-		p.Set("currency", current.Currency, *in.Currency)
+	if moved(current.Currency, in.Currency) {
+		p.Set(currencyField, current.Currency, *in.Currency)
 	}
 	if err := applyDealLinkPatches(ctx, tx, current, in, p,
 		s.installation.EnsurePartner, s.ensureProjectAttachable); err != nil {
@@ -112,9 +125,13 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 				return nil, err
 			}
 		}
-		p.Set("expected_close_date", current.ExpectedCloseDate, *in.ExpectedClose)
+		if current.ExpectedCloseDate == nil || !current.ExpectedCloseDate.Equal(*in.ExpectedClose) {
+			p.Set(closeDateField, current.ExpectedCloseDate, *in.ExpectedClose)
+		}
 		// A human setting the date IS the §11 confirmation — the machine's
-		// provisional guess stops excluding the deal from Commit.
+		// provisional guess stops excluding the deal from Commit. This one turns
+		// on the request, not on the date moving: re-sending the provisional date
+		// unchanged is exactly how a person confirms it.
 		if current.CloseDateProvisional != nil && *current.CloseDateProvisional {
 			p.Set("close_date_provisional", true, false)
 		}
@@ -256,12 +273,8 @@ func validPartnerAttribution(v string) error {
 // applyMoneyInvariants enforces the amount/currency rules on the
 // RESULTING row, not just the request. The pair comes together or not at
 // all: an amount stranded without a currency would skip the FX freeze at
-// close and then violate deal_closed_fx. And re-pricing a CLOSED deal
-// must re-freeze FX as of the original close date, or the frozen rate
-// goes stale against the new currency (silent base-currency corruption)
-// — a deal closed amountless has no frozen rate at all, so adding an
-// amount later would trip deal_closed_fx. Same-day rate lookup as at
-// close, so roll-ups stay reproducible.
+// close and then violate deal_closed_fx. Re-pricing a CLOSED deal carries
+// the freeze freezeBaseRate states.
 func (s *Store) applyMoneyInvariants(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
 ) error {
@@ -284,19 +297,19 @@ func (s *Store) applyMoneyInvariants(ctx context.Context, tx pgx.Tx,
 		}
 	}
 
-	if string(current.Status) != "open" && resultingAmount != nil &&
-		(in.AmountMinor != nil || in.Currency != nil) {
+	// Keyed on what the PATCH carries for the MONEY, not on what the request
+	// supplied and not on the forecast fields at large: a request that re-sent
+	// the price the deal already has re-prices nothing, and a slipped close date
+	// is not a re-price at all. Either would otherwise re-freeze, and the frozen
+	// rate is supposed to answer for the close.
+	_, amountMoved := p.After()[amountField]
+	_, currencyMoved := p.After()[currencyField]
+	if string(current.Status) != "open" && resultingAmount != nil && (amountMoved || currencyMoved) {
 		// deal_closed_at guarantees ClosedAt on a non-open row.
-		base, err := s.installation.BaseCurrency(ctx, tx)
-		if err != nil {
-			return err
-		}
-		rate, rateDate, err := s.freezeFx(ctx, tx, base, *resultingCurrency, *current.ClosedAt)
-		if err != nil {
+		rateBefore, rateDateBefore := frozenBefore(current)
+		if err := s.freezeBaseRate(ctx, tx, p, string(*resultingCurrency), *current.ClosedAt, rateBefore, rateDateBefore); err != nil {
 			return fmt.Errorf("re-freeze fx for closed deal: %w", err)
 		}
-		p.Set("fx_rate_to_base", nil, rate)
-		p.Set("fx_rate_date", nil, rateDate)
 	}
 	return nil
 }
@@ -348,11 +361,22 @@ func (e *PastCloseDateError) Error() string {
 
 // FieldFault refuses an expected close date already in the past.
 func (e *PastCloseDateError) FieldFault() (field, code, message string) {
-	return "expected_close_date", "close_date_past", e.Error()
+	return closeDateField, "close_date_past", e.Error()
 }
 
 // AmountCurrencyPairError maps to 422: amount_minor and currency come
 // together or not at all (data-model §6 money rules).
+// The deal's money and forecast fields, whose wire name and column name are the
+// SAME word — deliberately, because the contract was written from the schema, and
+// a refusal that named a different field from the column it guards would send a
+// caller looking for an input they did not send. So these three do duty at both
+// layers: a FieldFault names them, every p.Set on the deal row spells them, and
+// forecastColumns is built from them.
+//
+// dealTable is the opposite case and says so: a table name and an RBAC object
+// that happen to share a word are two subjects, so the constant stands for the
+// table and the RBAC object stays a literal.
+//
 // currencyField names the wire field a money-pair refusal points at: amount and
 // currency are atomic, and the currency is the half a caller can supply.
 const currencyField = "currency"
@@ -362,6 +386,14 @@ const amountField = "amount_minor"
 
 // closeDateField names the column a slipped forecast moves.
 const closeDateField = "expected_close_date"
+
+// The frozen base-currency pair, which moves together or not at all: a rate
+// without the date it was taken on cannot be reproduced, and a date without a
+// rate converts nothing.
+const (
+	fxRateColumn     = "fx_rate_to_base"
+	fxRateDateColumn = "fx_rate_date"
+)
 
 // missingMoneyHalf names whichever half of the pair was left out.
 func missingMoneyHalf(amountMissing bool) string {

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -116,7 +116,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		if err != nil {
 			return err
 		}
-		if err := p.ApplyGuarded(ctx, tx, "deal", id.UUID, in.IfVersion); err != nil {
+		if err := applyDealPatchGuarded(ctx, tx, id, p, in.IfVersion); err != nil {
 			return fmt.Errorf("apply stage advance: %w", err)
 		}
 
@@ -215,7 +215,7 @@ func dealStageChangedPayload(current crmcontracts.Deal, toStageID ids.StageID, t
 // consumer reading the deal back afterwards can lose the rate entirely — a
 // reopen clears the column.
 func frozenFxFromPatch(p *storekit.Patch, current crmcontracts.Deal) *string {
-	rate, changed := p.After()["fx_rate_to_base"]
+	rate, changed := p.After()[fxRateColumn]
 	if !changed {
 		return current.FxRateToBase
 	}
@@ -252,26 +252,6 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 // and the resulting status: terminal fields (closed_at, lost_reason,
 // frozen FX) are set when the target semantic closes the deal and
 // cleared when a won/lost deal reopens.
-// freezeClosingRate resolves the installation's base currency and stamps the
-// frozen conversion onto the patch. Split out of stageTransitionPatch so the
-// resolve-then-freeze pair reads as one step there rather than as four more
-// branches in an already-branchy transition.
-func (s *Store) freezeClosingRate(ctx context.Context, tx pgx.Tx,
-	currency string, p *storekit.Patch,
-) error {
-	base, err := s.installation.BaseCurrency(ctx, tx)
-	if err != nil {
-		return err
-	}
-	rate, rateDate, err := s.freezeFx(ctx, tx, base, currency, time.Now().UTC())
-	if err != nil {
-		return fmt.Errorf("freeze fx at close: %w", err)
-	}
-	p.Set("fx_rate_to_base", nil, rate)
-	p.Set("fx_rate_date", nil, rateDate)
-	return nil
-}
-
 func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in AdvanceDealInput, semantic string,
 ) (*storekit.Patch, string, error) {
@@ -317,11 +297,16 @@ func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 		p.Set("won_without_contract_reason", current.WonWithoutContractReason, nil)
 		p.Set("won_without_contract_detail", current.WonWithoutContractDetail, nil)
 	}
-	// Closing with an amount freezes today's FX rate so base-currency
-	// roll-ups stay reproducible (deal_closed_fx).
+	// Closing with an amount freezes the FX rate so base-currency roll-ups stay
+	// reproducible (deal_closed_fx). As of the moment recorded as the close, and
+	// read from `closedAt` rather than from the clock a second time: two reads
+	// either side of UTC midnight would date the frozen rate a day after the
+	// close it is supposed to price, and the roll-up would then reconcile
+	// against a rate the deal never closed at.
 	if DealStatus(status) != DealOpen && current.AmountMinor != nil && current.Currency != nil {
-		if err := s.freezeClosingRate(ctx, tx, *current.Currency, p); err != nil {
-			return nil, "", err
+		rateBefore, rateDateBefore := frozenBefore(current)
+		if err := s.freezeBaseRate(ctx, tx, p, string(*current.Currency), *closedAt, rateBefore, rateDateBefore); err != nil {
+			return nil, "", fmt.Errorf("freeze fx at close: %w", err)
 		}
 	}
 	// Reopening a won/lost deal must clear the remaining terminal fields —
@@ -331,8 +316,12 @@ func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 	// which covers the reopen too.
 	if DealStatus(status) == DealOpen && DealStatus(current.Status) != DealOpen {
 		p.Set("closed_at", current.ClosedAt, nil)
-		p.Set("fx_rate_to_base", nil, nil)
-		p.Set("fx_rate_date", nil, nil)
+		// The pre-images are what the row HELD, not nil. A closed deal carrying an
+		// amount carries a rate — deal_closed_fx requires it — and the reopen's
+		// audit row is precisely what a reversal reads to put the old rate back.
+		rateBefore, rateDateBefore := frozenBefore(current)
+		p.Set(fxRateColumn, rateBefore, nil)
+		p.Set(fxRateDateColumn, rateDateBefore, nil)
 	}
 	return p, status, nil
 }
@@ -371,6 +360,58 @@ func (s *Store) FreezeRateAt(ctx context.Context, tx pgx.Tx, currency string, as
 		return "", time.Time{}, err
 	}
 	return s.freezeFx(ctx, tx, base, currency, asOf)
+}
+
+// frozenBefore is a deal's currently frozen pair in the shape the patch records
+// it. The rate is already a decimal string; the date sheds the contract's Date
+// wrapper, because a `date` column is what the driver is being handed and a
+// wrapper it has to be taught about is a second place the column's type is
+// decided.
+func frozenBefore(deal crmcontracts.Deal) (rate *string, rateDate *time.Time) {
+	if deal.FxRateDate == nil {
+		return deal.FxRateToBase, nil
+	}
+	return deal.FxRateToBase, &deal.FxRateDate.Time
+}
+
+// freezeBaseRate stamps a frozen conversion onto a patch: FreezeRateAt above
+// decides WHAT the rate is, and this decides which two columns carry it.
+//
+// It is built on that seam rather than resolving the base currency itself,
+// because "the latest rate on or before this day" is one question and two
+// spellings of it would be free to disagree about the day boundary, the
+// same-currency shortcut, or what a missing rate means.
+//
+// A closed deal must carry a rate for the currency it is priced in. Re-pricing
+// one into a DIFFERENT currency and leaving the old rate would convert the wrong
+// pair, which corrupts the base-currency roll-up silently; and a deal closed
+// with no amount has no frozen rate at all, so the write that first prices it
+// trips deal_closed_fx unless it freezes one in the same statement.
+//
+// asOf is the caller's, because it is the only thing the three writers disagree
+// about: a stage advance closing the deal freezes as of the close, while the two
+// re-pricing doors freeze as of the ORIGINAL close date, for the reason freezeFx
+// states below.
+//
+// The caller passes what the row held, because two of the three writers reach
+// here for a deal that ALREADY carries a frozen rate — deal_closed_fx requires
+// one on any closed deal with an amount — and re-pricing replaces it. Recording
+// the pre-image as nil would put "there was no rate" in the audit diff of every
+// re-price, which is the one row a reversal reads to restore the old one.
+//
+// The error comes back unwrapped: a caller closing a deal, re-pricing one and
+// accepting an offer each tell an operator more by naming which than a shared
+// sentence could.
+func (s *Store) freezeBaseRate(ctx context.Context, tx pgx.Tx, p *storekit.Patch,
+	currency string, asOf time.Time, rateBefore *string, rateDateBefore *time.Time,
+) error {
+	rate, rateDate, err := s.FreezeRateAt(ctx, tx, currency, asOf)
+	if err != nil {
+		return err
+	}
+	p.Set(fxRateColumn, rateBefore, rate)
+	p.Set(fxRateDateColumn, rateDateBefore, rateDate)
+	return nil
 }
 
 // freezeFx resolves the frozen currency→base conversion for a closed

--- a/backend/internal/modules/deals/deal_update.go
+++ b/backend/internal/modules/deals/deal_update.go
@@ -128,7 +128,7 @@ func (s *Store) updateDealInTx(ctx context.Context, tx pgx.Tx,
 		return crmcontracts.Deal{}, err
 	}
 
-	if err := p.ApplyGuarded(ctx, tx, "deal", id.UUID, in.IfVersion); err != nil {
+	if err := applyDealPatchGuarded(ctx, tx, id, p, in.IfVersion); err != nil {
 		if constraint, ok := storekit.CheckViolation(err); ok && constraint == dealProjectSameOrgConstraint {
 			return crmcontracts.Deal{}, &DealProjectOrgMismatchError{}
 		}

--- a/backend/internal/modules/deals/dealarchive.go
+++ b/backend/internal/modules/deals/dealarchive.go
@@ -65,7 +65,7 @@ func (s *Store) ArchiveDeal(ctx context.Context, id ids.DealID, ifVersion *int64
 		now := time.Now().UTC()
 		p := storekit.NewPatch()
 		p.Set("archived_at", nil, now)
-		if err := p.ApplyGuarded(ctx, tx, "deal", id.UUID, ifVersion); err != nil {
+		if err := applyDealPatchGuarded(ctx, tx, id, p, ifVersion); err != nil {
 			return fmt.Errorf("archive deal: %w", err)
 		}
 		if _, err := tx.Exec(ctx,

--- a/backend/internal/modules/deals/dealwrite.go
+++ b/backend/internal/modules/deals/dealwrite.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The one way a deal row changes.
+//
+// This module writes the deal row from flows that agree on nothing else: a
+// client's partial update under an If-Match, a stage advance, an archive, an
+// accepted offer syncing its gross, and the nightly close-date corrector
+// re-dating under a held lock. They differ in what guards the write and in what
+// else their transaction does.
+//
+// What they may not differ in is whether the forecast move is recorded, because
+// deal_forecast_history's completeness is a property of its READERS: a
+// reconstruction that omits one writer's moves is a partial sum wearing the
+// label of a total. So recording is not a step a writer performs. It is what
+// applying a deal patch means, and the two seams below are where it means it.
+//
+// TestEveryDealRowWriteRecordsTheForecastItMoved holds it: a patch applied to
+// the deal row from a function that does not record fails that gate.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// dealTable names the row the seams below write, and the row the sweep and the
+// offer sync take their locks on. It exists so the gate can ask this module
+// which table it protects instead of carrying its own copy of the name — a gate
+// that spelled the table itself would go on guarding the old one through a
+// rename.
+//
+// The identical string appears in this package as the RBAC object and as the
+// audit entity type (auth.Require, storekit.Audit): different subjects wearing
+// the same word, which is why those are not spelled with this constant. So is
+// basecurrencyfreeze.go's frozenRateTables, which genuinely names this table —
+// it stays a literal because the gate that derives it from the migrations reads
+// the list as string literals, and would stop seeing the entry.
+const dealTable = "deal"
+
+// applyDealPatchGuarded is the client-driven write: the caller's If-Match
+// version when it sent one, a row lock when it did not (storekit's ApplyGuarded
+// contract). Errors come back unwrapped so the caller can still map a
+// constraint violation onto the refusal that names the field.
+func applyDealPatchGuarded(ctx context.Context, tx pgx.Tx, id ids.DealID,
+	p *storekit.Patch, ifVersion *int64,
+) error {
+	if err := p.ApplyGuarded(ctx, tx, dealTable, id.UUID, ifVersion); err != nil {
+		return err
+	}
+	return recordForecastMovement(ctx, tx, id, p.After())
+}
+
+// applyDealPatchLocked is the internal-flow write: the caller took the row lock
+// before the reads that decided this patch, so the decision cannot have gone
+// stale under it.
+//
+// The row it records is the row the LOCK names, not one the caller passes
+// alongside. ApplyLocked writes where the lock points, so a second id would be a
+// second answer to "which deal is this" — and the two disagreeing would write
+// one deal's figures into another deal's history, with both rows resolving and
+// nothing to notice. A guard the caller supplies is not a guard.
+func applyDealPatchLocked(ctx context.Context, tx pgx.Tx, p *storekit.Patch, lock storekit.RowLock) error {
+	if err := p.ApplyLocked(ctx, tx, lock); err != nil {
+		return err
+	}
+	return recordForecastMovement(ctx, tx, ids.From[ids.DealKind](lock.ID()), p.After())
+}

--- a/backend/internal/modules/deals/forecasthistory.go
+++ b/backend/internal/modules/deals/forecasthistory.go
@@ -11,11 +11,9 @@ package deals
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 
-	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -44,49 +42,62 @@ var forecastColumns = []string{amountField, currencyField, closeDateField}
 //
 // The values are the deal's state AFTER the change, which is what a
 // reconstruction asking "what was the forecast as of date T" needs from the
-// latest row at or before T. The patch decides WHETHER to write; it already
-// compared old against new, so a close date cleared or set for the first time
-// counts as movement exactly as a revision does.
-func recordForecastMovement(ctx context.Context, tx pgx.Tx, id ids.DealID,
-	current crmcontracts.Deal, in UpdateDealInput, after map[string]any,
-) error {
-	moved := false
-	for _, column := range forecastColumns {
-		if _, ok := after[column]; ok {
-			moved = true
-			break
-		}
-	}
-	if !moved {
+// latest row at or before T. They are read back off the ROW, inside the write's
+// own transaction, rather than folded together from a before-image and the
+// caller's input: the writers that reach this hold the deal in different shapes
+// — a wire record, a candidate row, a set of scanned columns — and each of them
+// assembling the resulting state itself is each of them able to assemble it
+// wrongly. The row already knows.
+//
+// The patch decides WHETHER to write, by which columns it assigns: a write that
+// assigned no forecast column records nothing, or the table would answer "the
+// forecast moved" for every edit anyone makes to a deal. A close date cleared or
+// set for the first time is an assignment like any other, and counts as movement
+// exactly as a revision does.
+//
+// Assigned, not changed — storekit.Patch records an assignment without comparing
+// it to what the row held, so "the patch decided" means the writer decided. A
+// writer that would otherwise re-assign a value the row already carries compares
+// first, so that a pass which moved nothing records nothing.
+//
+// Call it only after the patch has landed, because it reads the row it is
+// recording. applyDealPatchGuarded and applyDealPatchLocked are the two seams
+// that guarantee that order, and every write this module makes to the deal row
+// goes through one of them.
+func recordForecastMovement(ctx context.Context, tx pgx.Tx, id ids.DealID, moved map[string]any) error {
+	if !movesForecast(moved) {
 		return nil
 	}
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
 		return err
 	}
-	amount, currency := current.AmountMinor, current.Currency
-	if in.AmountMinor != nil {
-		amount = in.AmountMinor
-	}
-	if in.Currency != nil {
-		currency = in.Currency
-	}
-	// Carried as *time.Time rather than the contract's Date wrapper: this is
-	// the value the driver encodes into a `date` column, and a wrapper it has
-	// to be taught about is a second place the column's type is decided.
-	var closeDate *time.Time
-	if current.ExpectedCloseDate != nil {
-		closeDate = &current.ExpectedCloseDate.Time
-	}
-	if in.ExpectedClose != nil {
-		closeDate = in.ExpectedClose
-	}
-	if _, err := tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`INSERT INTO deal_forecast_history
 		   (deal_id, changed_by, amount_minor_at_change, currency_at_change, close_date_at_change)
-		 VALUES ($1, $2, $3, $4, $5)`,
-		id, by, amount, currency, closeDate); err != nil {
+		 SELECT d.id, $2, d.amount_minor, d.currency, d.expected_close_date
+		   FROM deal d WHERE d.id = $1`,
+		id, by)
+	if err != nil {
 		return fmt.Errorf("record forecast history: %w", err)
 	}
+	if tag.RowsAffected() != 1 {
+		// The caller just wrote this row in this transaction, so a SELECT that
+		// resolves nothing is a programming error. Insert-from-select reports it
+		// as zero rows and no error, which is the shape that would leave the
+		// history quietly short — the failure this whole file exists to prevent.
+		return fmt.Errorf("record forecast history: deal %s did not resolve after its own write", id)
+	}
 	return nil
+}
+
+// movesForecast answers whether a patch's changed columns include one a forecast
+// reconstruction reads.
+func movesForecast(moved map[string]any) bool {
+	for _, column := range forecastColumns {
+		if _, ok := moved[column]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/modules/deals/forecasthistory_test.go
+++ b/backend/internal/modules/deals/forecasthistory_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The forecast recorder's two silent-failure modes, which are the ones the
+// integration suite cannot show: an insert that matched no row, and one the
+// database refused. Both have to reach the caller as errors — a recorder that
+// swallows either leaves the history short by exactly the write that failed,
+// and short history is indistinguishable from a forecast that did not move.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// aMovedAmount is a patch's after-image carrying a forecast column, so the
+// recorder gets past its own "nothing moved" guard and reaches the insert.
+func aMovedAmount() map[string]any { return map[string]any{amountField: int64(250_000)} }
+
+func recordingContext() context.Context {
+	return principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String()})
+}
+
+// INSERT ... SELECT reports "matched nothing" as zero rows and no error. The
+// recorder runs immediately after its own write inside that write's transaction,
+// so a SELECT that resolves no deal is a programming error — an ordering the
+// patch seams make unrepresentable, and one that would otherwise show up as a
+// reconstruction quietly missing a move rather than as a failure.
+func TestAForecastRowThatMatchedNoDealIsAnError(t *testing.T) {
+	tx := &forecastTx{tag: pgconn.NewCommandTag("INSERT 0 0")}
+	err := recordForecastMovement(recordingContext(), tx, ids.New[ids.DealKind](), aMovedAmount())
+	if err == nil {
+		t.Fatal("an insert that matched no deal was accepted, so the history is short and nothing says so")
+	}
+	if !strings.Contains(err.Error(), "did not resolve") {
+		t.Errorf("the error does not say what went wrong: %v", err)
+	}
+}
+
+func TestARefusedForecastRowReachesTheCaller(t *testing.T) {
+	refused := errors.New("deadlock detected")
+	tx := &forecastTx{execErr: refused}
+	err := recordForecastMovement(recordingContext(), tx, ids.New[ids.DealKind](), aMovedAmount())
+	if !errors.Is(err, refused) {
+		t.Fatalf("the database's refusal did not reach the caller: %v", err)
+	}
+}
+
+// A write that moved no forecast column must not reach the database at all —
+// otherwise the table answers "the forecast moved" for every edit anyone makes.
+func TestAWriteThatMovedNoForecastColumnSendsNothing(t *testing.T) {
+	tx := &forecastTx{tag: pgconn.NewCommandTag("INSERT 0 1")}
+	if err := recordForecastMovement(recordingContext(), tx,
+		ids.New[ids.DealKind](), map[string]any{dealNameColumn: "renamed"}); err != nil {
+		t.Fatalf("recording a rename: %v", err)
+	}
+	if tx.execSQL != "" {
+		t.Errorf("a rename sent a statement: %s", tx.execSQL)
+	}
+}
+
+// forecastTx answers the one method the recorder uses and panics on the rest,
+// so a future call reaching for the database through this fake fails loudly
+// rather than being quietly answered by a zero value.
+type forecastTx struct {
+	execSQL string
+	execErr error
+	tag     pgconn.CommandTag
+}
+
+func (f *forecastTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.execSQL = sql
+	if f.execErr != nil {
+		return pgconn.CommandTag{}, f.execErr
+	}
+	return f.tag, nil
+}
+
+func (f *forecastTx) Begin(context.Context) (pgx.Tx, error) { panic("forecastTx: Begin") }
+func (f *forecastTx) Commit(context.Context) error          { panic("forecastTx: Commit") }
+func (f *forecastTx) Rollback(context.Context) error        { panic("forecastTx: Rollback") }
+func (f *forecastTx) Conn() *pgx.Conn                       { panic("forecastTx: Conn") }
+func (f *forecastTx) LargeObjects() pgx.LargeObjects        { panic("forecastTx: LargeObjects") }
+
+func (f *forecastTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	panic("forecastTx: CopyFrom")
+}
+
+func (f *forecastTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	panic("forecastTx: SendBatch")
+}
+
+func (f *forecastTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	panic("forecastTx: Prepare")
+}
+
+func (f *forecastTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	panic("forecastTx: Query")
+}
+
+func (f *forecastTx) QueryRow(context.Context, string, ...any) pgx.Row {
+	panic("forecastTx: QueryRow")
+}

--- a/backend/internal/modules/deals/offer_lifecycle.go
+++ b/backend/internal/modules/deals/offer_lifecycle.go
@@ -88,8 +88,8 @@ func (s *Store) SendOffer(ctx context.Context, id ids.OfferID, ifVersion *int64)
 
 		p := storekit.NewPatch()
 		p.Set("status", current.Status, "sent")
-		p.Set("fx_rate_to_base", current.FxRateToBase, rate)
-		p.Set("fx_rate_date", current.FxRateDate, rateDate)
+		p.Set(fxRateColumn, current.FxRateToBase, rate)
+		p.Set(fxRateDateColumn, current.FxRateDate, rateDate)
 		p.Set("buyer_snapshot", nil, storekit.JSONArg(buyer))
 		p.Set("issuer_snapshot", nil, storekit.JSONArg(issuer))
 		if err := p.ApplyGuarded(ctx, tx, "offer", id.UUID, ifVersion); err != nil {
@@ -203,10 +203,8 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 			return err
 		}
 
-		auditID, err := storekit.Audit(ctx, tx, "update", "offer", id.UUID, p.Before(), map[string]any{
-			"status": "accepted", "accepted_at": now,
-			"deal_amount_minor": current.GrossMinor, "deal_currency": current.Currency,
-		})
+		auditID, err := storekit.Audit(ctx, tx, "update", "offer", id.UUID, p.Before(),
+			acceptedOfferImage(now, dealChanged))
 		if err != nil {
 			return fmt.Errorf("audit offer accept: %w", err)
 		}
@@ -219,11 +217,15 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 		// The paired deal.updated carries the FULL set of deal columns the sync
 		// actually wrote — including the re-frozen fx_rate_to_base/fx_rate_date
 		// on a closed deal — so a subscriber never retains stale
-		// base-currency state.
-		if err := storekit.EmitEvent(ctx, tx, auditID, dealID.UUID, crmcontracts.PublicEventDealUpdated{
-			ChangedFields: dealChanged,
-		}); err != nil {
-			return fmt.Errorf("emit paired deal.updated: %w", err)
+		// base-currency state. An accept that priced the deal at what it already
+		// held wrote none, and emits nothing: a deal.updated naming no field
+		// tells a subscriber the deal changed when it did not.
+		if len(dealChanged) > 0 {
+			if err := storekit.EmitEvent(ctx, tx, auditID, dealID.UUID, crmcontracts.PublicEventDealUpdated{
+				ChangedFields: dealChanged,
+			}); err != nil {
+				return fmt.Errorf("emit paired deal.updated: %w", err)
+			}
 		}
 		if out, err = readOfferWithLines(ctx, tx, id, storekit.LiveOnly); err != nil {
 			return fmt.Errorf("read accepted offer: %w", err)
@@ -233,55 +235,102 @@ func (s *Store) AcceptOffer(ctx context.Context, id ids.OfferID, ifVersion *int6
 	return out, err
 }
 
+// acceptedOfferImage is the accept's audit after-image: the offer's own
+// transition, plus what the accept did to the DEAL.
+//
+// The deal's columns are prefixed because this row's entity_type is `offer`, and
+// a bare `amount_minor` on it would read as the offer's own. They are taken from
+// what the sync WROTE rather than from the offer's gross, so an accept onto a
+// deal that already held the price records no re-price — the same fact the paired
+// deal.updated declines to announce, said the same way.
+func acceptedOfferImage(acceptedAt time.Time, dealChanged map[string]any) map[string]any {
+	image := map[string]any{"status": "accepted", "accepted_at": acceptedAt}
+	for column, value := range dealChanged {
+		image["deal_"+column] = value
+	}
+	return image
+}
+
 // syncDealAmountFromOffer writes the accepted gross onto the deal. A
-// still-open deal takes the amount as-is; a deal that already closed
-// must re-freeze FX as of its close date or the amount change would trip
-// deal_closed_fx / corrupt the frozen base-currency roll-up — the same
-// invariant applyMoneyInvariants enforces on direct deal edits.
-// It returns the deal columns the sync actually wrote, so the caller's paired
-// deal.updated reports the complete delta — on a closed deal that includes the
-// re-frozen fx_rate_to_base/fx_rate_date, not just amount_minor/currency.
+// still-open deal takes the amount as-is; a deal that already closed carries the
+// re-freeze freezeBaseRate states, which is the invariant applyMoneyInvariants
+// enforces on direct deal edits: re-pricing a deal is one rule whichever door
+// the price arrives through.
+//
+// The write goes through the deal patch seam rather than its own UPDATE, so the
+// deal's forecast move is recorded with it. Pricing a deal from its accepted
+// offer changes no stage, which is exactly the move deal_stage_history cannot
+// carry.
+//
+// It writes the money only where the deal does not already hold it. An accept
+// that prices the deal at what it was already priced at moved no forecast, and a
+// history row saying otherwise is a move a reconstruction would have to explain.
+//
+// It returns the deal columns the sync actually wrote — nothing when it wrote
+// nothing — so the caller's paired deal.updated reports the complete delta: on a
+// closed deal that includes the re-frozen fx_rate_to_base/fx_rate_date, not just
+// amount_minor/currency.
 func (s *Store) syncDealAmountFromOffer(ctx context.Context, tx pgx.Tx,
 	dealID ids.DealID, offer crmcontracts.Offer,
 ) (map[string]any, error) {
+	if offer.GrossMinor == nil {
+		// The totals engine derives a gross for every line and send refuses an
+		// offer with none, so a sent offer always carries one. Refusing rather
+		// than writing NULL keeps that reasoning falsifiable: a null amount
+		// beside the currency below would trip deal_amount_currency_pair, and
+		// the row would fail with nothing naming the offer that did it.
+		return nil, fmt.Errorf("accepted offer %s carries no gross to price deal %s with", offer.Id, dealID)
+	}
 	// The row lock makes the status read and the amount write below one
 	// race-free unit. IncludeArchived preserves the read below, which
 	// follows the deal row regardless of archived state.
-	if _, err := storekit.LockRow(ctx, tx, "deal", dealID.UUID, storekit.IncludeArchived); err != nil {
+	lock, err := storekit.LockRow(ctx, tx, dealTable, dealID.UUID, storekit.IncludeArchived)
+	if err != nil {
 		return nil, fmt.Errorf("lock deal for amount sync: %w", err)
 	}
 	var status string
 	var closedAt *time.Time
+	var amountBefore *int64
+	var currencyBefore *string
+	var rateBefore *string
+	var rateDateBefore *time.Time
+	// The frozen pair is read for its pre-image, not for a decision: re-pricing a
+	// closed deal replaces a rate it already carries, and the audit diff has to
+	// say which one.
 	if err := tx.QueryRow(ctx,
-		`SELECT status, closed_at FROM deal WHERE id = $1`, dealID).Scan(&status, &closedAt); err != nil {
+		`SELECT status, closed_at, amount_minor, currency, fx_rate_to_base::text, fx_rate_date
+		   FROM deal WHERE id = $1`,
+		dealID).Scan(&status, &closedAt, &amountBefore, &currencyBefore,
+		&rateBefore, &rateDateBefore); err != nil {
 		return nil, fmt.Errorf("read deal for amount sync: %w", err)
 	}
-	changed := map[string]any{"amount_minor": offer.GrossMinor, "currency": offer.Currency}
-	if DealStatus(status) == DealOpen {
-		if _, err := tx.Exec(ctx,
-			`UPDATE deal SET amount_minor = $2, currency = $3 WHERE id = $1`,
-			dealID, offer.GrossMinor, offer.Currency); err != nil {
-			return nil, fmt.Errorf("sync deal amount from offer: %w", err)
+
+	// The columns are nullable and the offer's figures are not, so each half is
+	// compared on its own terms. An unpriced deal and a priced one are different
+	// forecasts; so are two different prices; and re-pricing at the figure the
+	// deal already carries is neither.
+	p := storekit.NewPatch()
+	if amountBefore == nil || *amountBefore != *offer.GrossMinor {
+		p.Set(amountField, amountBefore, *offer.GrossMinor)
+	}
+	if currencyBefore == nil || *currencyBefore != offer.Currency {
+		p.Set(currencyField, currencyBefore, offer.Currency)
+	}
+	if p.Empty() {
+		// The deal already holds this offer's figures: no write, so no history
+		// row, and an empty delta for the caller's paired event to find nothing in.
+		return p.After(), nil
+	}
+	if DealStatus(status) != DealOpen {
+		// deal_closed_at guarantees closedAt on a non-open row.
+		if err := s.freezeBaseRate(ctx, tx, p, offer.Currency, *closedAt, rateBefore, rateDateBefore); err != nil {
+			return nil, fmt.Errorf("re-freeze fx for closed deal on accept: %w", err)
 		}
-		return changed, nil
 	}
-	base, err := s.installation.BaseCurrency(ctx, tx)
-	if err != nil {
-		return nil, err
+	if err := applyDealPatchLocked(ctx, tx, p, lock); err != nil {
+		return nil, fmt.Errorf("sync deal amount from offer: %w", err)
 	}
-	// deal_closed_at guarantees closedAt on a non-open row.
-	rate, rateDate, err := s.freezeFx(ctx, tx, base, offer.Currency, *closedAt)
-	if err != nil {
-		return nil, fmt.Errorf("re-freeze fx for closed deal on accept: %w", err)
-	}
-	if _, err := tx.Exec(ctx,
-		`UPDATE deal SET amount_minor = $2, currency = $3, fx_rate_to_base = $4, fx_rate_date = $5 WHERE id = $1`,
-		dealID, offer.GrossMinor, offer.Currency, rate, rateDate); err != nil {
-		return nil, fmt.Errorf("sync closed deal amount from offer: %w", err)
-	}
-	changed["fx_rate_to_base"] = rate
-	changed["fx_rate_date"] = rateDate
-	return changed, nil
+	return p.After(), nil
 }
 
 // RejectOffer runs sent → rejected. The optional reason rides the event

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -168,12 +168,13 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (23)
+## Prohibition (24)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |
+| `dealforecastmovement_test.go` | H2 | A deal row changes through one door, and that door records the forecast. |
 | `errmatch_test.go` | H2 | Postgres failures are classified by SQLSTATE/constraint name (the storekit.UniqueViolation / CheckViolation helpers), never by message text: an error-string substring match silently breaks on a locale change, a driver upgrade, or an unrelated error that happens to mention the same identifier — and it misclassifies infrastructure faults as client faults. |
 | `extensions_arch_test.go` | H2 | Extension-tier fitness functions (ADR-0069 §3): the compiler already walls extensions off from internal/\*\* (their module paths sit outside the backend module), these tests hold the rest of the import contract from the tree — every extension source dir (enabled or fixture) is enrolled the moment it exists. |
 | `flagdefault_test.go` | H2 | No string flag takes its default straight from the environment. |


### PR DESCRIPTION
Closes #2774.

## In one sentence

`deal_forecast_history` records a deal's amount or close date moving without a
stage change; its recorder had one caller, and two of the module's other writers
moved a forecast field and recorded nothing.

## The census, at `origin/main`

`recordForecastMovement` had exactly one caller. Every writer of the deal row:

| writer | patch path | audit | forecast history |
|---|---|---|---|
| `deal_update.go` `updateDealInTx` | `NewPatch`/`ApplyGuarded` | deal | **yes** |
| `deal_advance.go` `AdvanceDeal` | patch | deal | n/a — moves no forecast column |
| `dealarchive.go` `ArchiveDeal` | patch | deal | n/a — moves no forecast column |
| `offer_lifecycle.go` `syncDealAmountFromOffer` | **two hand-rolled `UPDATE deal SET`** | on the OFFER | **no** |
| `closedatesweep.go` `CloseDateCorrector.apply` | patch + `ApplyLocked` | deal | **no** |

## Why the two misses are the ones that matter

`recordForecastMovement`'s own docblock names both:

> an amount revised in place and a close date slipped leave no trace at all, and
> the second of those is the single most common reason a real forecast moves

- **Accepting an offer** IS "an amount revised in place". `offer_lifecycle.go`'s
  own header calls it *"the offer becomes the deal's value source, restoring
  forecast honesty"* — the largest forecast move the product makes, and it
  changes no stage.
- **The nightly close-date corrector** IS "a close date slipped". Slipping close
  dates is its entire job.

## Why nothing failed

`dealforecasthistory_integration_test.go` drives `UpdateDeal` — the one door that
already called the recorder. It exercises the mechanism through its own caller
and is silent about the callers that skip it.

## The change

**Applying a patch to the deal row IS the recording.** `dealwrite.go` adds
`applyDealPatchGuarded` / `applyDealPatchLocked` — apply, then record — and all
five deal-row writers go through one of them. The seam guarantees the order,
which matters because:

**The recorder now reads the resulting state off the ROW** (`INSERT … SELECT`)
rather than folding a before-image together with the caller's input. Three
writers hold the deal in three different shapes; three assemblies of one value
are three chances to record a forecast the deal does not have. It also refuses a
zero-row insert rather than passing silently — insert-from-select reports "matched
nothing" as success, which is exactly the shape that leaves history short.

**One FX freeze where there were three.** The closed-deal re-freeze was spelled
in `stageTransitionPatch`, `applyMoneyInvariants` and the accept, differing only
in the as-of moment. `freezeBaseRate` takes that moment as an argument and
leaves the error unwrapped so each caller still says which door it was.

**The accept writes only what moved.** `storekit.Patch` records an assignment
without comparing it, so the sync compares first: re-pricing a deal at the figure
it already carries records nothing and emits no `deal.updated`.

## The gate

`TestEveryDealRowWriteRecordsTheForecastItMoved` holds both bypass shapes:

- a storekit patch applied to the deal table from a function that does not record
  (the corrector's shape), over the deals package;
- a statement that assigns a forecast column with its own SQL (the accept's
  shape), over the whole tree.

It asks the module for its vocabulary — the table from `dealTable`, the columns
from `forecastColumns` — rather than restating either, and it **fails on a write
it cannot place** rather than passing over it. The SQL half starts from the
COLUMN, not the table: a table has many legal spellings and a pattern that knows
some of them reads a clean tree over the rest.

## Verification

**29 gate mutants, every one proven applied before the gate ran** (a mutant that
never lands reports green, which is indistinguishable from one that survived):

- 11 spellings that must be caught: plain, aliased, `"quoted"`, `public.`-qualified,
  `UPDATE ONLY`, quoted column, `SET (a, b) = (…)`, `ON CONFLICT DO UPDATE SET`,
  `MERGE … WHEN MATCHED`, split across lines, Go-level `+` concatenation, and a
  table assembled at run time;
- 5 near-misses that must NOT fire: a column in a `--` comment, `deal_room`,
  `currency` inside `fx_base_currency`, a forecast column only READ, another
  table assigning one;
- the patch half both ways, the seam itself, and the vocabulary derivation.

Two of the vocabulary mutants are caught by the compiler rather than by the
gate's own assertion — stated because it is a weaker signal than the rest.

**UAT — the same flow, the same database, two binaries.** Deal created, offer
drafted at 100.00 EUR + 19% VAT, sent, accepted, all through the HTTP API:

```
origin/main   deal is worth 11900 EUR    deal_forecast_history: 0 -> 0    FAIL
this branch   deal is worth 11900 EUR    deal_forecast_history: 0 -> 1    PASS
              row: human:01a04395-…  11900 EUR
              deal_stage_history unchanged at 1 — the deal changed no stage
```

The forecast moved identically in both; only one of them recorded it.

**Lanes:** `make check` green; `internal/compose/integration`,
`internal/compose` and `internal/modules/deals` integration lanes green;
`craft static --strict` clean across all four roots. New/changed statement
coverage **86.2%** — the remainder are `if err != nil` branches on lock, query
and apply failures.

## Two things a reviewer will reasonably ask

1. **`deal_forecast_history` has no reader yet** — no Go, no view, no screen. The
   docblocks are phrased as the table's contract to whoever reconstructs a
   forecast, not as observed behaviour.
2. **The seam absorbed the forecast recording but not the audit row or the outbox
   event** — each writer still does its own `Audit`/`EmitEvent`, because their
   verbs and payloads genuinely differ (`advance_stage` vs `update`,
   `deal.stage_changed` vs `deal.updated`). Named so it reads as a decision
   rather than an oversight.

## Reviewed before opening

Codex (no correctness regression in the migrated writers, four gate holes — all
four fixed, and their spellings are now mutation-tested) and a craftsmanship pass
(eight findings, all applied: a renamed function still named in two docblocks, a
`dealTable` claim that was false at the sweep, the column constants used at every
`Set` site, the discarded before-image made load-bearing, and four sites of fix
narration removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes every deal-row write through one recording seam so `deal_forecast_history` records every forecast move. Previously, accepting an offer and the nightly close-date corrector both moved the amount or close date and recorded nothing.

**What changed**
- All five deal-row writers now apply through `applyDealPatchGuarded`/`applyDealPatchLocked`, which record the forecast after the patch lands.
- The recorder reads the resulting state off the row (`INSERT ... SELECT`) and errors on a zero-row insert instead of passing silently.
- The closed-deal FX re-freeze is one shared `freezeBaseRate`; closing freezes as of the recorded close time, and the reopen's audit row records the held FX values as pre-images.
- Writers compare before setting: the sweep skips a no-op re-date, and an accept that prices the deal at its current figure records nothing and emits no `deal.updated`.
- An accept whose offer carries no gross is refused instead of writing NULL.

**The gate**
- Adds `dealforecastmovement_test.go`, which fails on a deal patch applied without recording, or a statement that assigns a forecast column anywhere in the tree.
- The gate derives the table name and forecast columns from the module and fails on any write it cannot place.
- Adds unit tests proving the recorder's failures reach the caller: a zero-row insert and a refused insert surface as errors, and a write that moved no forecast column never reaches the database.

<sup>Written for commit 4a75b1457a23847bda2bf1443269139832b70604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forecast history now accurately records amount, currency, and close-date changes from deal updates and offer acceptance.
  - Automatic close-date corrections record the corrected date and system attribution.
  - Closed-deal currency conversions are preserved consistently when deals are closed or reopened.

- **Bug Fixes**
  - Prevented duplicate history entries and unnecessary update events when values remain unchanged.
  - Improved audit records to include only fields actually modified.
  - Deal updates now handle missing offer amounts and failed writes more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->