### PR TITLE
refactor(test): one loop for waiting on a contended backend, not two

### DIFF
--- a/backend/internal/compose/integration/stage_removal_race_integration_test.go
+++ b/backend/internal/compose/integration/stage_removal_race_integration_test.go
@@ -32,12 +32,12 @@ import (
 	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/testdb"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -182,66 +182,29 @@ const (
 // on a message that carries the row's identity and changes with it.
 const lockNotAvailable = "55P03"
 
-// probeBudget bounds the wait for a racer that never takes its lock, and
-// probeInterval paces the looking. The pair is the one this repo already
-// settled on for waiting out a contended backend (the approvals package's
-// lock probe): a DURATION rather than a probe count, because a count is a
-// race between round-trip speed and how fast the racer arrives, and both move
-// with the lane's own load — and a paced poll, because an unpaced one competes
-// for the very lock manager it is observing.
+// waitUntilRowLockIsRefused waits until the contested row is held hard enough
+// to refuse this probe, which is what proves the racer reached it.
 //
-// Two call sites here, each able to spend the budget once, against the lane's
-// 600s per-package timeout: a run in which both miss reports what it found
-// instead of reading as a hung suite.
-const (
-	probeBudget   = 60 * time.Second
-	probeInterval = 25 * time.Millisecond
-)
-
-// waitUntilRowLockIsRefused returns once the row is locked hard enough to
-// refuse query, which is the direct evidence that the racer holds it. The two
-// ways that can fail to happen are different diagnoses and get different
-// sentences: the racer finished without ever locking (finishedEarly), or it is
-// still running and the lock never appeared (missed). Neither may pass — a
-// round that proved nothing must say so.
+// The look is the whole of this suite's contribution; the loop around it —
+// budget, pacing, and the rule that a probe which gave up says what the run
+// failed to prove — is testdb.WaitForContention, shared with the
+// pg_stat_activity probe that asks a different question in the same shape.
 func waitUntilRowLockIsRefused(
 	t *testing.T, query string, id ids.UUID, racerReturned <-chan struct{}, finishedEarly, missed string,
 ) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), probeBudget)
-	defer cancel()
 	conn := freshConnection(t)
-	pace := time.NewTicker(probeInterval)
-	defer pace.Stop()
-	for {
+	testdb.WaitForContention(t, racerReturned, finishedEarly, missed, func(ctx context.Context) (bool, error) {
 		// The probe's own lock is held for the statement and no longer, so a
 		// look taken before the racer arrives delays it by a round trip at
 		// most and never changes which side wins.
 		_, err := conn.Exec(ctx, query, id)
 		var pgErr *pgconn.PgError
-		switch {
-		case errors.As(err, &pgErr) && pgErr.Code == lockNotAvailable:
-			return
-		case err != nil && ctx.Err() == nil:
-			t.Fatalf("probing the contested row: %v", err)
+		if errors.As(err, &pgErr) && pgErr.Code == lockNotAvailable {
+			return true, nil
 		}
-		select {
-		case <-racerReturned:
-			t.Fatal(finishedEarly)
-		case <-ctx.Done():
-			// A racer that finishes as the budget expires leaves both channels
-			// ready, and select would pick between them arbitrarily — so the
-			// finished case is re-read here rather than reported as a miss it
-			// was not.
-			select {
-			case <-racerReturned:
-				t.Fatal(finishedEarly)
-			default:
-				t.Fatal(missed)
-			}
-		case <-pace.C:
-		}
-	}
+		return false, err
+	})
 }
 
 // holdRow pins one row until the returned release runs: a connection of this

--- a/backend/internal/modules/approvals/bundle_integration_test.go
+++ b/backend/internal/modules/approvals/bundle_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/testdb"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -478,9 +479,9 @@ func (e *stagingEnv) competingTx(t *testing.T) pgx.Tx {
 // connection it runs on.
 func waitForRowLockWaiter(t *testing.T, e *stagingEnv, blocker int, done <-chan struct{}) {
 	t.Helper()
-	waitForBlockedBackend(t, done,
+	testdb.WaitForContention(t, done,
 		"the bundle decision finished without ever blocking on the contested member — it never reached the row the competing transaction was holding, so this run proved nothing",
-		fmt.Sprintf("nothing waited on backend %d within %s — the decision never reached the row it should have blocked on", blocker, probeBudget),
+		fmt.Sprintf("nothing waited on backend %d within %s — the decision never reached the row it should have blocked on", blocker, testdb.ProbeBudget),
 		func(ctx context.Context) (bool, error) {
 			// The competing transaction is open ON THIS CONNECTION, so every
 			// probe below runs inside it — and pg_stat_activity's row set is

--- a/backend/internal/modules/approvals/lockprobe_integration_test.go
+++ b/backend/internal/modules/approvals/lockprobe_integration_test.go
@@ -5,10 +5,11 @@
 
 package approvals
 
-// The one way this package waits for a backend that is provably blocked. Both
-// contention suites here — the bundle decision racing a held row, the staging
-// racing a held identity lock — ask the database the same question in the same
-// shape, and they used to disagree about how to give up on it.
+// The pg_stat_activity half of this repository's contention probing: is anyone
+// blocked by THIS backend. The loop around that question — the budget, the
+// pacing, and the rule that a probe which gave up says what the run failed to
+// prove — is testdb.WaitForContention, shared with the row-lock probe that asks
+// a different question in the same shape.
 
 import (
 	"context"
@@ -16,98 +17,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 )
-
-// probeBudget bounds the wait for a backend that never blocks.
-//
-// It is a DURATION, and it used to be a count of 20 000 probes. A count is not a
-// budget: it is a race between how fast probe round trips complete and how fast
-// the racer reaches its lock, and the lane's own concurrency slows BOTH, so a
-// count generous on an idle machine is not generous on a loaded one. A duration
-// means the same thing on every machine.
-//
-// Generous enough that only a genuine miss trips it, short enough that the miss
-// reports itself rather than running into the package timeout, where it would
-// read as a hung suite instead of a stated fact. That ceiling is arithmetic
-// rather than taste: five call sites in this package can each spend this budget,
-// against the lane's 600s per-package timeout (INTEGRATION_TIMEOUT). At 90s a run
-// in which every one of them misses spends 450s and still reports what it found.
-// Raise this number and that sum moves with it.
-const probeBudget = 90 * time.Second
-
-// probeInterval paces the poll, so the observer is not competing for the very
-// resource it is waiting on.
-//
-// Unpaced, these loops issued round trips as fast as the server would answer
-// them, and the pg_stat_activity probe's pg_blocking_pids is documented as
-// needing exclusive access to the lock manager's shared state for a short time —
-// the same state the racer must acquire to register its own lock wait. A watcher
-// holding that thousands of times a second is not a neutral observer of
-// contention; on a loaded runner it is part of it.
-//
-// 25ms is far finer than anything here needs: every block these tests wait for
-// persists until the holding transaction ends, so it cannot be missed between
-// ticks, and a racer that FINISHES is seen at once through done rather than on a
-// tick.
-const probeInterval = 25 * time.Millisecond
-
-// waitForBlockedBackend polls look until it reports the wait the caller needs,
-// the racer finishes without ever blocking, or the budget runs out. Both of the
-// latter are failures, and each caller supplies what they mean in its own terms:
-// a probe that gave up must say what the run failed to prove, never pass having
-// proved nothing.
-func waitForBlockedBackend(
-	t *testing.T,
-	done <-chan struct{},
-	finishedEarly, missed string,
-	look func(context.Context) (bool, error),
-) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), probeBudget)
-	defer cancel()
-	pace := time.NewTicker(probeInterval)
-	defer pace.Stop()
-	for {
-		blocked, err := look(ctx)
-		switch {
-		case err != nil && ctx.Err() != nil:
-			t.Fatal(racerMessage(done, finishedEarly, missed))
-		case err != nil:
-			t.Fatalf("probing for a blocked backend: %v", err)
-		}
-		if blocked {
-			return
-		}
-		// One select for all three answers: the racer finished, the budget ran
-		// out, or it is time to look again.
-		select {
-		case <-done:
-			t.Fatal(finishedEarly)
-		case <-ctx.Done():
-			t.Fatal(racerMessage(done, finishedEarly, missed))
-		case <-pace.C:
-		}
-	}
-}
-
-// racerMessage picks which failure actually happened when the budget expires.
-//
-// When the racer finishes AS the budget runs out, both channels are ready and
-// select picks between them arbitrarily — so the timeout branch can be taken
-// while a finished racer sits unread, and the run would be reported as "nothing
-// ever blocked" when what really happened is that the racer never blocked at
-// all. Those are different diagnoses and the second one is the useful one.
-func racerMessage(done <-chan struct{}, finishedEarly, missed string) string {
-	select {
-	case <-done:
-		return finishedEarly
-	default:
-		return missed
-	}
-}
 
 // The row-lock probe sees a backend that dials AFTER it starts looking.
 //

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -214,9 +214,9 @@ func TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading(t *testing.T) {
 // ordering it claims to exercise and pass having proved nothing.
 func waitForLockWaiter(t *testing.T, e *stagingEnv, done <-chan struct{}) {
 	t.Helper()
-	waitForBlockedBackend(t, done,
+	testdb.WaitForContention(t, done,
 		"the staging finished without ever blocking on the identity lock — it read the world before the competing pass wrote to it, which is the defect this test exists to catch",
-		fmt.Sprintf("no backend waited on an advisory lock in this database within %s — the staging never reached the lock, so this run proved nothing", probeBudget),
+		fmt.Sprintf("no backend waited on an advisory lock in this database within %s — the staging never reached the lock, so this run proved nothing", testdb.ProbeBudget),
 		func(ctx context.Context) (bool, error) {
 			// pg_locks reads the lock manager directly rather than the
 			// statistics snapshot, so it answers live even from inside a

--- a/backend/internal/platform/testdb/lockprobe.go
+++ b/backend/internal/platform/testdb/lockprobe.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+// The one way this repository waits for a racer that is provably contended.
+//
+// Two suites had their own: approvals polls pg_stat_activity for a backend
+// blocked by a known pid, and the stage-removal race polls FOR UPDATE NOWAIT
+// until 55P03. Those are genuinely different QUESTIONS — "is anyone blocked by
+// this pid" against "is this row held hard enough to refuse me" — and neither
+// is redundant.
+//
+// What was duplicated is everything around the question: the budget, the
+// pacing, the select over racer-finished / budget-expired / look-again, and the
+// rule that a probe which gave up must say what the run failed to prove rather
+// than pass having proved nothing. Two copies of that meant the reasoning could
+// be corrected in one of them.
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ProbeBudget bounds the wait for a racer that never blocks.
+//
+// It is a DURATION, and it used to be a count of 20 000 probes. A count is not
+// a budget: it is a race between how fast probe round trips complete and how
+// fast the racer reaches its lock, and the lane's own concurrency slows BOTH,
+// so a count generous on an idle machine is not generous on a loaded one. A
+// duration means the same thing on every machine.
+//
+// Generous enough that only a genuine miss trips it, short enough that the miss
+// reports itself rather than running into the package timeout, where it would
+// read as a hung suite instead of a stated fact. That ceiling is arithmetic
+// rather than taste: the approvals package alone has five call sites that can
+// each spend this budget, against the lane's 600s per-package timeout
+// (INTEGRATION_TIMEOUT). At 90s a run in which every one of them misses spends
+// 450s and still reports what it found. Raise this number and that sum moves
+// with it.
+const ProbeBudget = 90 * time.Second
+
+// ProbeInterval paces the poll, so the observer is not competing for the very
+// resource it is waiting on.
+//
+// Unpaced, these loops issued round trips as fast as the server would answer
+// them, and the pg_stat_activity probe's pg_blocking_pids is documented as
+// needing exclusive access to the lock manager's shared state for a short time
+// — the same state the racer must acquire to register its own lock wait. A
+// watcher holding that thousands of times a second is not a neutral observer of
+// contention; on a loaded runner it is part of it.
+//
+// 25ms is far finer than anything here needs: every block these tests wait for
+// persists until the holding transaction ends, so it cannot be missed between
+// ticks, and a racer that FINISHES is seen at once through racerReturned rather
+// than on a tick.
+const ProbeInterval = 25 * time.Millisecond
+
+// WaitForContention polls look until it reports the contention the caller
+// needs, the racer finishes without ever blocking, or the budget runs out.
+//
+// Both of the latter are failures, and each caller supplies what they mean in
+// its own terms: a probe that gave up must say what the run failed to prove,
+// never pass having proved nothing. finishedEarly is what a racer that returned
+// without contending means for that test; missed is what a budget that expired
+// with the racer still running means.
+//
+// look answers whether the contention is visible YET. An error it returns is
+// fatal unless the budget has expired underneath it — at which point the
+// failure is the budget's, not the query's, and reporting the query would name
+// the wrong thing.
+func WaitForContention(
+	t *testing.T,
+	racerReturned <-chan struct{},
+	finishedEarly, missed string,
+	look func(context.Context) (bool, error),
+) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), ProbeBudget)
+	defer cancel()
+	pace := time.NewTicker(ProbeInterval)
+	defer pace.Stop()
+	for {
+		contended, err := look(ctx)
+		switch {
+		case err != nil && ctx.Err() != nil:
+			t.Fatal(whichFailure(racerReturned, finishedEarly, missed))
+		case err != nil:
+			t.Fatalf("probing for a contended backend: %v", err)
+		}
+		if contended {
+			return
+		}
+		// One select for all three answers: the racer finished, the budget ran
+		// out, or it is time to look again.
+		select {
+		case <-racerReturned:
+			t.Fatal(finishedEarly)
+		case <-ctx.Done():
+			t.Fatal(whichFailure(racerReturned, finishedEarly, missed))
+		case <-pace.C:
+		}
+	}
+}
+
+// whichFailure picks which failure actually happened when the budget expires.
+//
+// When the racer finishes AS the budget runs out, both channels are ready and
+// select picks between them arbitrarily — so the timeout branch can be taken
+// while a finished racer sits unread, and the run would be reported as "nothing
+// ever blocked" when what really happened is that the racer never blocked at
+// all. Those are different diagnoses and the second one is the useful one.
+func whichFailure(racerReturned <-chan struct{}, finishedEarly, missed string) string {
+	select {
+	case <-racerReturned:
+		return finishedEarly
+	default:
+		return missed
+	}
+}


### PR DESCRIPTION
Closes #1384.

Two suites wait for a racer that is provably contended, and they ask genuinely different questions:

- `approvals` polls `pg_stat_activity` for a backend blocked by a known pid
- the stage-removal race polls `FOR UPDATE NOWAIT` until `55P03`

Those questions are not redundant, and neither is deleted. What was duplicated is everything **around** them: the budget, the pacing, the `select` over racer-finished / budget-expired / look-again, and the rule that a probe which gave up must say what the run failed to prove rather than pass having proved nothing.

## They had already drifted

The argument, made concrete. One budget was **90 seconds** and the other **60** — under a comment in the second citing the first as the reasoning for it.

Neither number is wrong. The point is that only one of them could be corrected.

## The shape

`testdb.WaitForContention` takes the *look* — `func(context.Context) (bool, error)`, which was already `approvals`' shape — and each caller supplies its own question and its own two failure sentences. The reasoning for `ProbeBudget` and `ProbeInterval` lives with the loop, where correcting it corrects both.

`internal/platform/testdb` is the home the issue suggested: already imported by both trees, already `//go:build integration`, already takes a `*testing.T`.

## Unchanged

Both suites' own properties, and their tests for them: the `approvals` proof that its probe sees a backend dialled *after* its first look, and the stage-removal race's two orderings. Both suites pass — run individually, not only through the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration-test reliability by standardizing contention and lock-wait detection.
  * Added consistent timeout handling and clearer diagnostics for contention checks.
  * Reduced duplicated test-waiting logic across approval and stage-removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->