### PR TITLE
fix(test): edgereverse follows AnyMap to its new home, again

### DIFF
--- a/backend/internal/compose/integration/edgereverse_integration_test.go
+++ b/backend/internal/compose/integration/edgereverse_integration_test.go
@@ -55,23 +55,23 @@ func seedEmploymentOverHTTP(t *testing.T, e *apptest.AppEnv) linkedPair {
 	role := seededEdgeRole
 	var person personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
+		AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	var org struct {
 		ID string `json:"id"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, apptest.AnyMap{
+	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, AnyMap{
 		"kind": "employment", "person_id": person.ID, "organization_id": org.ID,
 		"role": role, "source": "manual",
 	})}
 }
 
-func linkEdge(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) relationshipRecord {
+func linkEdge(t *testing.T, e *apptest.AppEnv, body AnyMap) relationshipRecord {
 	t.Helper()
 	var rel relationshipRecord
 	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &rel); status != 201 {
@@ -264,10 +264,10 @@ func TestEndToEnd_reversingAProjectCompanyRefusesByNameAndWritesNothing(t *testi
 		Version int64  `json:"version"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Joint rollout", "organization_id": org.ID, "source": "manual",
 	}, nil, nil); status != 201 {
 		t.Fatalf("create project → %d", status)
@@ -305,7 +305,7 @@ func TestEndToEnd_reversingAnEdgeChangeReplaysWhatTheLinkHeld(t *testing.T) {
 	pair := seedEmploymentOverHTTP(t, e)
 	var patched relationshipRecord
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+pair.edge.ID,
-		apptest.AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
+		AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
 		&patched); status != 200 {
 		t.Fatalf("patch the link → %d", status)
 	}
@@ -430,7 +430,7 @@ func TestEndToEnd_reversingALinkFromAStaleRecordScreenIsRefusedAndWritesNothing(
 	stale := readPerson(t, e, pair.person)
 	// The record moves under the open screen, which is the whole premise.
 	if status := e.Call(t, "PATCH", "/v1/people/"+pair.person,
-		apptest.AnyMap{"title": "COO"}, nil, nil); status != 200 {
+		AnyMap{"title": "COO"}, nil, nil); status != 200 {
 		t.Fatalf("move the person under the screen → %d", status)
 	}
 


### PR DESCRIPTION
**`main` does not compile, for the second time and by the same collision.**

#2951 moved `AnyMap` out of `apptest` — whose subject is the booted application, not a JSON literal. #2930 and now #2957 each landed a change to `edgereverse_integration_test.go` written against a tree where `apptest.AnyMap` still existed. #2956 fixed the first; this fixes the second.

**Neither PR is at fault and neither could have seen it.** What lets it recur is that a pull request merges on the CI it ran against its own base, and a base that predates the move compiles the old spelling. The type checker catches it on whichever branch runs next — which is after main is already red.

Worth someone deciding whether this repo wants branches required to be up to date before merge, or a merge queue. I have not changed either; that is a repository setting and not mine to pick.

Same one-line change as before: the alias is the same `map[string]any`, reached by the name the package it now lives in gives it. `make check-backend` is green on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test helpers and HTTP test calls without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->