### PR TITLE
fix(integration): edgereverse names AnyMap from its own package, again

### DIFF
--- a/backend/internal/compose/integration/edgereverse_integration_test.go
+++ b/backend/internal/compose/integration/edgereverse_integration_test.go
@@ -55,23 +55,23 @@ func seedEmploymentOverHTTP(t *testing.T, e *apptest.AppEnv) linkedPair {
 	role := seededEdgeRole
 	var person personRecord
 	if status := e.Call(t, "POST", "/v1/people",
-		apptest.AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
+		AnyMap{"full_name": "Ada Employed"}, nil, &person); status != 201 {
 		t.Fatalf("create person → %d", status)
 	}
 	var org struct {
 		ID string `json:"id"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Employer GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, apptest.AnyMap{
+	return linkedPair{person: person.ID, org: org.ID, edge: linkEdge(t, e, AnyMap{
 		"kind": "employment", "person_id": person.ID, "organization_id": org.ID,
 		"role": role, "source": "manual",
 	})}
 }
 
-func linkEdge(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) relationshipRecord {
+func linkEdge(t *testing.T, e *apptest.AppEnv, body AnyMap) relationshipRecord {
 	t.Helper()
 	var rel relationshipRecord
 	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &rel); status != 201 {
@@ -264,10 +264,10 @@ func TestEndToEnd_reversingAProjectCompanyRefusesByNameAndWritesNothing(t *testi
 		Version int64  `json:"version"`
 	}
 	if status := e.Call(t, "POST", "/v1/organizations",
-		apptest.AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
+		AnyMap{"display_name": "Client GmbH"}, nil, &org); status != 201 {
 		t.Fatalf("create organization → %d", status)
 	}
-	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+	if status := e.Call(t, "POST", "/v1/projects", AnyMap{
 		"name": "Joint rollout", "organization_id": org.ID, "source": "manual",
 	}, nil, nil); status != 201 {
 		t.Fatalf("create project → %d", status)
@@ -305,7 +305,7 @@ func TestEndToEnd_reversingAnEdgeChangeReplaysWhatTheLinkHeld(t *testing.T) {
 	pair := seedEmploymentOverHTTP(t, e)
 	var patched relationshipRecord
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+pair.edge.ID,
-		apptest.AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
+		AnyMap{"role": "coo"}, map[string]string{"If-Match": fmt.Sprint(pair.edge.Version)},
 		&patched); status != 200 {
 		t.Fatalf("patch the link → %d", status)
 	}
@@ -430,7 +430,7 @@ func TestEndToEnd_reversingALinkFromAStaleRecordScreenIsRefusedAndWritesNothing(
 	stale := readPerson(t, e, pair.person)
 	// The record moves under the open screen, which is the whole premise.
 	if status := e.Call(t, "PATCH", "/v1/people/"+pair.person,
-		apptest.AnyMap{"title": "COO"}, nil, nil); status != 200 {
+		AnyMap{"title": "COO"}, nil, nil); status != 200 {
 		t.Fatalf("move the person under the screen → %d", status)
 	}
 


### PR DESCRIPTION
## main does not compile, again, with the same error

```
$ git grep -c "apptest.AnyMap" origin/main
backend/internal/compose/integration/edgereverse_integration_test.go:8
```

`edgereverse_integration_test.go:58:11: undefined: apptest.AnyMap` — the error
#2956 fixed at `14:44:33Z`. It reds the backend gate, all six integration shards,
the RLS+erasure fan-in and unit coverage, because a `//go:build integration` file
that will not compile is invisible to `go build ./...` and visible to everything
that carries the tag.

## What brought it back

**#2957 (`1831c710c`) reverted #2956**, and its own diff says so:

```diff
-		AnyMap{"full_name": "Ada Employed"}
+		apptest.AnyMap{"full_name": "Ada Employed"}
```

| | |
|---|---|
| #2957 branch created | `14:32:12Z` |
| #2956 merged the fix | `14:44:33Z` |
| #2957 CI run created | `15:10:07Z` |
| #2957 merged | `15:13:04Z` |

The branch predates the fix and had touched that file for its own reasons, so the
squash re-applied the old text over the new one. The branch was correct against
the tree it was written on; the tree it landed on was a different one.

## The innocent explanation, checked and rejected

"Its red was inherited from a main that was already broken" would excuse the
merge. It does not hold: #2957's CI run was created **26 minutes after** #2956
fixed main, so the merge ref it built already contained the fix, and the red was
about the branch's own reversal of it. #2957 was merged past a red `ci`, a red
`deterministic-gates` and all six red integration shards, each naming these
lines.

I checked the two commits either side before saying that — `425acc284` (#2931)
and `ac2f485d3` (#2960) both carry zero sites. Only #2957.

## The fix, and the thing that is not a fix

Eight sites, `apptest.AnyMap` → `AnyMap`, identical to #2956. A tree-wide grep
confirms zero remaining. `apptest` stays imported — 14 other references to it in
the file, which is why `go vet` would have caught an unused import and did not.

**There is no code change that prevents the recurrence**, and it would be
dishonest to imply this PR does. What prevents it is rebuilding after rebasing
onto the current tip before merging: a green lane is a statement about a *base*,
a merge is a statement about a *tip*, and the two stop agreeing the moment
somebody else's fix lands in your file. That is the third collision of this shape
today — #2944 on a shared count, #2956 on a shared symbol, this one on a file two
branches both edited.

## Verification

`make check-backend` green, including the golangci typecheck that was failing.
`go vet -tags integration ./internal/compose/integration/` clean — the compile is
the whole claim here, so that is complete rather than partial.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the edgereverse integration test so main compiles again. The old `apptest.AnyMap` qualifier was reintroduced by a branch cut before the earlier fix, and this restores the plain `AnyMap` at all eight sites.

- `apptest` stays imported; the file still references it 14 times elsewhere.
- This diff adds no safeguard against the same collision; rebuilding after rebasing onto the current tip is what prevents it.

<sup>Written for commit dadaea074cdb7fb097a0e06879af329232fa45ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test setup to use the locally available request-body type.
  * Test coverage and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->