### PR TITLE
feat(contracts): activation freezes the conversion the schema promised

### DIFF
--- a/backend/internal/compose/contractfxseam.go
+++ b/backend/internal/compose/contractfxseam.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The one place a contract's frozen conversion rate comes from.
+//
+// fx_rate belongs to deals, and the reading a contract freezes at activation is
+// the same one a deal freezes at close: the latest rate on or before the day,
+// against the installation's own base, with the same-currency shortcut and the
+// same refusal when no rate exists. Contracts takes that as a seam rather than
+// taking the module, so there is one spelling of the rule and no second one to
+// drift from it.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/modules/deals"
+)
+
+// ContractFreezeRate is the resolver every contract store is wired with.
+func ContractFreezeRate(pool *pgxpool.Pool) contracts.FreezeRateFunc {
+	store := deals.NewStore(InstallationDB(pool), DealsInstallation())
+	return func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
+		return store.FreezeRateAt(ctx, tx, currency, asOf)
+	}
+}

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -145,7 +145,7 @@ func (s *Server) wireProject360(pool *pgxpool.Pool) {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		ProjectsStore(pool),
 		s.peopleStore,
-		contracts.NewStore(InstallationDB(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
 		activities.NewStore(InstallationDB(pool)),
 		time.Now,
 	)

--- a/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
+++ b/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A contract freezes its conversion at activation, which is what makes its
+// base-currency value the one the parties agreed to rather than the one a
+// report happens to be run on.
+//
+// The schema documented the freeze and nothing wrote it, so every activated
+// foreign-currency contract carried NULL — and the base-currency freeze guard
+// counts a contract by its frozen rate, so an installation holding only
+// contract rows could still change its base currency and silently restate them.
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedRate loads a published rate the freeze can find.
+func seedRate(t *testing.T, e *Env, from, to string, rate string, on time.Time) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+			 VALUES ($1, $2, $3::numeric, $4)
+			 ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE SET rate = EXCLUDED.rate`,
+			from, to, rate, on.UTC().Truncate(24*time.Hour))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// draftInCurrency stages a contract carrying a value in the named currency.
+func draftInCurrency(t *testing.T, e *Env, org ids.UUID, currency string) ids.ContractID {
+	t.Helper()
+	value := int64(250_000)
+	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "A foreign-currency agreement",
+		ValueMinor:     &value,
+		Currency:       &currency,
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ids.From[ids.ContractKind](ids.UUID(created.Id))
+}
+
+func TestActivationFreezesTheContractsConversion(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	seedRate(t, e, "USD", "EUR", "0.9", time.Now())
+
+	id := draftInCurrency(t, e, org, "USD")
+	activated, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil)
+	if err != nil {
+		t.Fatalf("activating a contract whose rate is published: %v", err)
+	}
+
+	if activated.FxRateToBase == nil {
+		t.Fatal("an activated foreign-currency contract carries no frozen rate — the base-currency " +
+			"freeze guard counts a contract by that rate, so this one is invisible to it")
+	}
+	// Compared as a NUMBER, not as text: the column is numeric with a scale, so
+	// the rate reads back as 0.9000000000 — the same form a closing deal
+	// freezes, and a text comparison here would be asserting the scale rather
+	// than the rate.
+	frozen, err := strconv.ParseFloat(*activated.FxRateToBase, 64)
+	if err != nil {
+		t.Fatalf("the frozen rate %q does not parse as a number: %v", *activated.FxRateToBase, err)
+	}
+	if frozen != 0.9 {
+		t.Errorf("the frozen rate is %v, want the published 0.9", frozen)
+	}
+	// Both, always together: a rate without its date is not a frozen
+	// conversion, which is what contract_fx_pair holds in the schema.
+	if activated.FxRateDate == nil {
+		t.Error("the rate was frozen without the day it is the rate FOR")
+	}
+}
+
+// The freeze is at ACTIVATION and never re-read: a contract that already
+// carries a rate keeps it, so re-activating after a cancellation does not
+// re-price an agreement nobody renegotiated.
+func TestReActivationDoesNotRePriceTheAgreement(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	seedRate(t, e, "USD", "EUR", "0.9", time.Now())
+
+	id := draftInCurrency(t, e, org, "USD")
+	first, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil)
+	if err != nil {
+		t.Fatalf("activating: %v", err)
+	}
+
+	// The market moves.
+	seedRate(t, e, "USD", "EUR", "0.5", time.Now())
+
+	again, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil)
+	if err != nil {
+		t.Fatalf("re-asserting the status: %v", err)
+	}
+	if again.FxRateToBase == nil || first.FxRateToBase == nil || *again.FxRateToBase != *first.FxRateToBase {
+		t.Errorf("the frozen rate moved to %v — it is what the agreement was worth when it was "+
+			"made, not what it is worth when somebody re-asserts its status", again.FxRateToBase)
+	}
+}
+
+// No rate to freeze is a refusal, not a NULL. The alternative is an activated
+// contract the freeze guard cannot count, which is the state this exists to
+// end.
+func TestActivationRefusesWhenNoRateIsPublished(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+
+	id := draftInCurrency(t, e, org, "JPY")
+	_, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil)
+
+	var missing *deals.MissingFxRateError
+	if !errors.As(err, &missing) {
+		t.Fatalf("activating with no published rate answered %v, want the missing-rate refusal", err)
+	}
+
+	// And nothing moved: a refused activation leaves the contract a draft.
+	read, err := e.Contracts.GetContract(e.Admin(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Status == nil || string(*read.Status) != contracts.StatusDraft {
+		t.Errorf("the contract is %v after a refused activation, want it left as a draft", read.Status)
+	}
+}
+
+// A contract with no currency has nothing to convert, and freezing nothing is
+// the right answer rather than a refusal.
+func TestAContractWithNoCurrencyActivatesWithoutARate(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+
+	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "An agreement with no money in it",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ids.From[ids.ContractKind](ids.UUID(created.Id))
+
+	activated, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil)
+	if err != nil {
+		t.Fatalf("activating a contract with no currency: %v", err)
+	}
+	if activated.FxRateToBase != nil {
+		t.Errorf("a contract with nothing to convert froze %q", *activated.FxRateToBase)
+	}
+}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -127,7 +128,7 @@ func Setup(t *testing.T) *Env {
 	e.People = people.NewStore(harnessDB(pool, e.WS))
 	e.Deals = deals.NewStore(harnessDB(pool, e.WS), installseam.Deals())
 	e.Projects = ProjectsStore(harnessDB(pool, e.WS))
-	e.Contracts = contracts.NewStore(harnessDB(pool, e.WS))
+	e.Contracts = ContractsStore(harnessDB(pool, e.WS), e.Deals)
 	e.Activities = activities.NewStore(harnessDB(pool, e.WS))
 	return e
 }
@@ -148,6 +149,21 @@ func Setup(t *testing.T) *Env {
 func ProjectsStore(db *database.DB) *projects.Store {
 	return projects.NewStore(db).
 		WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx))
+}
+
+// ContractsStore builds the contract store the way compose builds it.
+//
+// The rate resolver is why it exists. Activation freezes a contract's
+// conversion, and a store built without one refuses every activation of a
+// foreign-currency contract — deliberately, since a contract activated with no
+// frozen rate is one the base-currency freeze guard cannot see. A suite calling
+// contracts.NewStore directly would have to invent that seam, and would then be
+// testing its own idea of the rate rather than the one production freezes.
+func ContractsStore(db *database.DB, dealStore *deals.Store) *contracts.Store {
+	return contracts.NewStore(db,
+		func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
+			return dealStore.FreezeRateAt(ctx, tx, currency, asOf)
+		})
 }
 
 // SchemaPool opens the owner-privileged schema-change pool the

--- a/backend/internal/compose/integration/writeauthorityreview_integration_test.go
+++ b/backend/internal/compose/integration/writeauthorityreview_integration_test.go
@@ -78,7 +78,7 @@ func TestAReadShareOfADealCannotRewriteItsContracts(t *testing.T) {
 		VALUES ($1, $2, 'Anchored Deal', $3, $4, $5, 'manual', 'human:x')`,
 		deal, e.Rep3, pipeline, open, org)
 
-	store := contracts.NewStore(e.DB())
+	store := ContractsStore(e.DB(), e.Deals)
 	// Fixed, because nothing here is about WHEN: the term's dates never reach an
 	// assertion, and a fixture reading the wall clock is one that can fail for a
 	// reason its own name does not mention.

--- a/backend/internal/compose/project360seam.go
+++ b/backend/internal/compose/project360seam.go
@@ -33,7 +33,7 @@ func project360Reader(pool *pgxpool.Pool) agents.Project360Reader {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(catalog),
 		ProjectsStore(pool),
 		people.NewStore(InstallationDB(pool)).WithFieldCatalog(catalog),
-		contracts.NewStore(InstallationDB(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
 		activities.NewStore(InstallationDB(pool)),
 		clockNow,
 	)

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -76,7 +76,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 		BaseURL: httpserver.BaseURL,
 		Middlewares: []crmcontracts.MiddlewareFunc{
 			agentGate(registry, staging, provider, provider, fieldOwnership{pool: pool}, importsFor(&srv), gate),
-			idempotency(pool, replayProbes(staging.svc, contracts.NewStore(InstallationDB(pool)), dealrooms.NewStore(InstallationDB(pool)))),
+			idempotency(pool, replayProbes(staging.svc, contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)), dealrooms.NewStore(InstallationDB(pool)))),
 			// Outermost: an overlay-mode SoR write is refused before it can
 			// be recorded under an idempotency key or staged as an agent
 			// approval — the honest unsupported_by_sor, for every principal.

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -104,7 +104,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		peopleHandlers:      newPeopleHandlers(pool).WithUploadLimit(limits.LinkedInImport),
 		dealsHandlers:       dealsH,
 		projectsHandlers:    projects.HandlersOver(ProjectsStore(pool)),
-		contractsHandlers:   contracts.NewHandlers(InstallationDB(pool)),
+		contractsHandlers:   contracts.NewHandlers(InstallationDB(pool), ContractFreezeRate(pool)),
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -94,7 +94,11 @@ func (s *Store) ChangeStatus(ctx context.Context, id ids.ContractID, to string, 
 		if err := refuseInvalidTransition(statusOf(existing), to); err != nil {
 			return err
 		}
-		out, err = applyStatusTx(ctx, tx, id, existing, to, nil, ifVersion, s.today())
+		frozen, err := s.freezeRateForActivation(ctx, tx, existing, to)
+		if err != nil {
+			return err
+		}
+		out, err = applyStatusTx(ctx, tx, id, existing, to, nil, ifVersion, s.today(), frozen)
 		return err
 	})
 	return out, err
@@ -128,12 +132,19 @@ func statusOf(c crmcontracts.Contract) string {
 
 // applyStatusTx writes one status transition with its audit and event.
 func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing crmcontracts.Contract,
-	to string, supersededBy *ids.ContractID, ifVersion *int64, asOf time.Time,
+	to string, supersededBy *ids.ContractID, ifVersion *int64, asOf time.Time, frozen *frozenRate,
 ) (crmcontracts.Contract, error) {
 	patch := storekit.NewPatch()
 	patch.Set("status", statusOf(existing), to)
 	if supersededBy != nil {
 		patch.Set("superseded_by_id", existing.SupersededById, supersededBy.UUID)
+	}
+	if frozen != nil {
+		// Both, always together: the schema's contract_fx_pair CHECK holds that
+		// a rate without its date is not a frozen conversion, and a caller
+		// reading one without the other cannot say what it converted at.
+		patch.Set("fx_rate_to_base", existing.FxRateToBase, frozen.rate)
+		patch.Set("fx_rate_date", existing.FxRateDate, frozen.on)
 	}
 	if err := patch.ApplyGuarded(ctx, tx, "contract", id.UUID, ifVersion); err != nil {
 		if constraint, ok := storekit.CheckViolation(err); ok {
@@ -159,6 +170,51 @@ func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing c
 		return crmcontracts.Contract{}, fmt.Errorf("emit contract.status_changed: %w", err)
 	}
 	return readContract(ctx, tx, id, asOf)
+}
+
+// frozenRate is what activation stamps: the conversion and the day it is the
+// conversion for. A pointer at the call site, because most status changes
+// freeze nothing and a zero value would be indistinguishable from a rate of
+// zero on the zero date.
+type frozenRate struct {
+	rate string
+	on   time.Time
+}
+
+// freezeRateForActivation resolves the conversion a contract activates at, or
+// nil when this transition freezes nothing.
+//
+// The rate is frozen AT ACTIVATION and never re-read, which is the whole point:
+// a contract's base-currency value is what it was worth when the parties agreed
+// it, not what it is worth at the moment somebody runs a report. The schema
+// documented that; nothing wrote it, so every activated foreign-currency
+// contract carried NULL — and the base-currency freeze guard counts a contract
+// by its frozen rate, so an installation holding only contract rows could still
+// change its base currency and silently restate them.
+//
+// Only into `active`, and only once: a contract that already carries a rate
+// keeps it. Re-activating after a cancellation must not re-price an agreement
+// nobody renegotiated.
+//
+// A contract with no currency has nothing to convert and freezes nothing —
+// which is not the same as a contract whose rate is unavailable, and that one
+// refuses.
+func (s *Store) freezeRateForActivation(ctx context.Context, tx pgx.Tx,
+	existing crmcontracts.Contract, to string,
+) (*frozenRate, error) {
+	//nolint:nilnil // "this transition freezes nothing" is an answer, not a missing one: most status changes carry no conversion, and a sentinel error would make the ordinary case an error path.
+	if to != StatusActive || existing.Currency == nil || *existing.Currency == "" {
+		return nil, nil
+	}
+	//nolint:nilnil // same answer for a contract that already froze: it keeps what it has.
+	if existing.FxRateToBase != nil {
+		return nil, nil
+	}
+	rate, on, err := s.freezeRate(ctx, tx, *existing.Currency, s.today())
+	if err != nil {
+		return nil, err
+	}
+	return &frozenRate{rate: rate, on: on}, nil
 }
 
 // Cancel records notice of cancellation and when it takes effect, and changes
@@ -237,7 +293,7 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 			return err
 		}
 		successorID := ids.ContractID{UUID: ids.UUID(created.Id)}
-		if _, err := applyStatusTx(ctx, tx, id, predecessor, StatusSuperseded, &successorID, ifVersion, s.today()); err != nil {
+		if _, err := applyStatusTx(ctx, tx, id, predecessor, StatusSuperseded, &successorID, ifVersion, s.today(), nil); err != nil {
 			return err
 		}
 		out = created

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -24,8 +24,8 @@ type Handlers struct {
 }
 
 // NewHandlers builds the contract handler set.
-func NewHandlers(db *database.DB) Handlers {
-	return Handlers{store: NewStore(db)}
+func NewHandlers(db *database.DB, freezeRate FreezeRateFunc) Handlers {
+	return Handlers{store: NewStore(db, freezeRate)}
 }
 
 // pathID converts a contract path parameter into its typed id.

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -52,11 +52,28 @@ type Store struct {
 	// injected so a date-boundary test is deterministic rather than a race
 	// against midnight.
 	clock func() time.Time
+	// freezeRate resolves what a contract's currency converts at, on the day
+	// it activates. Injected because the reading belongs to the module that
+	// owns fx_rate, and contracts takes a seam rather than that module —
+	// the shape quotas' BaseCurrencyFunc already uses.
+	//
+	// REQUIRED by the constructor. A store built without one would activate
+	// foreign-currency contracts carrying no frozen rate at all, which is the
+	// state this exists to end: the base-currency freeze guard counts a
+	// contract by its frozen rate, so a NULL one is a contract the guard
+	// cannot see and an installation can restate underneath.
+	freezeRate FreezeRateFunc
 }
 
+// FreezeRateFunc answers what one currency converts to the installation's base
+// at, as of a day, inside a transaction the caller already holds. It reports
+// the rate and the day it is the rate FOR, which are two facts: the rate a
+// contract froze and the date that rate was published on.
+type FreezeRateFunc func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error)
+
 // NewStore builds the contract store.
-func NewStore(db *database.DB) *Store {
-	return &Store{db: db, clock: time.Now}
+func NewStore(db *database.DB, freezeRate FreezeRateFunc) *Store {
+	return &Store{db: db, clock: time.Now, freezeRate: freezeRate}
 }
 
 func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -353,6 +353,26 @@ func (e *MissingFxRateError) MessageFault() (code, message string) {
 	return "fx_rate_unavailable", e.Error() + " — an admin must load the rate for this currency pair before this close can succeed"
 }
 
+// FreezeRateAt resolves what a currency converts at, as of a day, against the
+// installation's own base — the same reading a closing deal freezes.
+//
+// Exported for a caller outside this module that has to freeze the same
+// number: a contract, at activation. It could read fx_rate itself — the table
+// is deals', and the ownership gate binds writes rather than reads — and then
+// there would be two spellings of "the latest rate on or before this day", free
+// to disagree about the boundary, the same-currency shortcut, or what a missing
+// rate means. One of them would be corrected.
+//
+// Handed over as a function rather than as this store, so the caller takes a
+// seam and not a module (the shape quotas' BaseCurrencyFunc already uses).
+func (s *Store) FreezeRateAt(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
+	base, err := s.installation.BaseCurrency(ctx, tx)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return s.freezeFx(ctx, tx, base, currency, asOf)
+}
+
 // freezeFx resolves the frozen currency→base conversion for a closed
 // deal: the latest fx_rate on or before asOf. Used at close (asOf = now)
 // and when a closed deal is re-priced (asOf = its close date), so the


### PR DESCRIPTION
Closes #1392.

`contract` carries `fx_rate_to_base` and `fx_rate_date`, documented as *frozen at activation*, and nothing wrote them. `ChangeStatus` patched only the status, and the patch schema deliberately offers no way to set either — so every activated foreign-currency contract carried NULL.

**That is not a cosmetic gap.** The base-currency freeze guard counts a contract by its frozen rate, so a NULL one is a contract the guard cannot see: an installation holding only contract rows could still change its base currency and silently restate every one of them.

## What activation now does

| case | answer |
| --- | --- |
| foreign currency, rate published | freezes the rate and the day it is the rate for |
| foreign currency, no rate published | **refuses** — the alternative is the invisible contract this exists to end |
| already carries a rate | keeps it |
| no currency at all | freezes nothing, which is not an error |

The rate is frozen at activation and never re-read, which is the point: a contract's base value is what it was worth when the parties agreed it, not what it is worth when somebody runs a report. Re-activating after a cancellation keeps the rate the agreement was made at rather than re-pricing an agreement nobody renegotiated.

## One spelling of the rule

`fx_rate` belongs to `deals`, and the reading is the same one a closing deal freezes: the latest rate on or before the day, against the installation's base, with the same same-currency shortcut and the same refusal.

The issue named the cross-module seam as its own design step. It is a **function**, following `quotas.BaseCurrencyFunc` — the shape this repo already ratified for exactly this: contracts declares `FreezeRateFunc`, compose supplies deals' `FreezeRateAt`. No new import edge, and no second implementation to drift from the first.

Required by the constructor rather than optional. A store built without one would activate foreign-currency contracts carrying no rate at all — the state before this change, reachable again by omission.

## Held

Four integration cases over a real database, one per row of the table above. The harness gains `ContractsStore` for the same reason it has `ProjectsStore`: a suite that built the store by hand would have to invent the seam, and would then be testing its own idea of the rate rather than the one production freezes.

The frozen rate is compared as a **number**, not as text — the column is `numeric` with a scale, so it reads back as `0.9000000000`, the same form a closing deal freezes, and a text comparison would be asserting the scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract activation now freezes the applicable foreign-currency conversion rate and date.
  * Frozen rates remain unchanged when contracts are reactivated.
  * Contracts without a currency can activate without an exchange rate.

* **Bug Fixes**
  * Activation is prevented when no published conversion rate is available, helping avoid incorrect contract valuations.

* **Tests**
  * Added coverage for rate freezing, reactivation behavior, missing rates, and contracts without currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->