### PR TITLE
fix(contracts): a live anchor is a property of the record, not a privilege

### DIFF
--- a/backend/internal/compose/integration/contract_archived_anchor_integration_test.go
+++ b/backend/internal/compose/integration/contract_archived_anchor_integration_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A contract on an archived anchor is not readable, whoever asks.
+//
+// A contract's visibility requires a LIVE anchor: an archived deal keeps its
+// foreign key and its grants, so without the filter a contract stays readable
+// through a record whose own read already answers 404.
+//
+// These pass on the tree before the change too, and that is the point of
+// keeping them. The requirement travelled with the row-scope NARROWING, and the
+// only thing making it unconditional was that `organization` is owner-private
+// so its clause is never empty — an invariant holding on a neighbouring table's
+// privacy setting. These cases assert the property directly, so it now has
+// something of its own to stand on.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// anchorOnOrg puts the seeded deal on the organization the contract names: a
+// contract validates that the two agree, and SeedDeal leaves the deal
+// company-less.
+func anchorOnOrg(t *testing.T, e *Env, deal, org ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE deal SET organization_id = $1 WHERE id = $2`, org, deal)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// contractOnArchivedDeal plants an active contract and then archives the deal
+// it hangs off, leaving the contract itself live.
+func contractOnArchivedDeal(t *testing.T, e *Env) ids.ContractID {
+	t.Helper()
+	org := e.SeedOrg(t, "Acme", nil)
+	pipeline, open, _ := DealFixture(t, e)
+	dealUUID := e.SeedDeal(t, "Anchor", pipeline, open, &e.Rep1)
+	deal := ids.From[ids.DealKind](dealUUID)
+	anchorOnOrg(t, e, dealUUID, org)
+
+	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		DealID:         &deal,
+		Title:          "An agreement on a deal that goes away",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE deal SET archived_at = now() WHERE id = $1`, dealUUID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return ids.From[ids.ContractKind](ids.UUID(created.Id))
+}
+
+// The admin is the caller the old clause exempted: unbounded row scope, so
+// nothing to narrow, so no clause — and the liveness filter disappeared with it.
+func TestAnUnboundedCallerCannotReadAContractOnAnArchivedAnchor(t *testing.T) {
+	e := Setup(t)
+	id := contractOnArchivedDeal(t, e)
+
+	_, err := e.Contracts.GetContract(e.Admin(), id)
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("reading a contract whose anchor is archived answered %v, want not-found — a "+
+			"live anchor is a property of the record, not a privilege a caller can out-rank", err)
+	}
+}
+
+// The ordinary case still works: a live anchor is readable, so the change is a
+// narrowing of exactly one shape rather than of the surface.
+func TestAContractOnALiveAnchorStaysReadable(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	pipeline, open, _ := DealFixture(t, e)
+	dealUUID := e.SeedDeal(t, "Anchor", pipeline, open, &e.Rep1)
+	deal := ids.From[ids.DealKind](dealUUID)
+	anchorOnOrg(t, e, dealUUID, org)
+
+	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		DealID:         &deal,
+		Title:          "An agreement on a live deal",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Contracts.GetContract(e.Admin(),
+		ids.From[ids.ContractKind](ids.UUID(created.Id))); err != nil {
+		t.Fatalf("a contract on a live anchor stopped being readable: %v", err)
+	}
+}

--- a/backend/internal/modules/contracts/visibility.go
+++ b/backend/internal/modules/contracts/visibility.go
@@ -38,6 +38,19 @@ import (
 // its grants, so without the filter a contract would stay readable — and
 // mutable — through a record whose own read already answers 404.
 //
+// That requirement is UNCONDITIONAL, and it is stated here rather than left to
+// hold by accident. This used to return NO CLAUSE when both scopes came back
+// empty — bundling the liveness into the narrowing, so a caller who reads every
+// deal and every organization would have read contracts on archived anchors
+// that the document-filing gate refuses.
+//
+// That caller does not exist today, and the reason is unrelated to contracts:
+// `organization` is owner-private (platform/auth), so its scope clause is never
+// empty and the early return was unreachable. An invariant that survives on a
+// neighbouring table's privacy setting is one a change to that table quietly
+// ends — so liveness is now a property of the anchor rather than of who is
+// asking.
+//
 // The two arms are a disjunction because a contract has one anchor or the
 // other: a contract WITH a deal is judged by that deal, and a contract with no
 // deal is judged by its organization. A contract with a deal is deliberately
@@ -53,12 +66,6 @@ func VisibleClause(ctx context.Context, alias string, arg func(any) int) (string
 	if err != nil {
 		return "", err
 	}
-	// Both empty means the caller reads every row of both anchors, so there is
-	// nothing to narrow and the caller composes no clause at all.
-	if dealScope == "" && orgScope == "" {
-		return "", nil
-	}
-
 	qualified := alias
 	if qualified != "" {
 		qualified += "."


### PR DESCRIPTION
Addresses part of #1398, and reports what the rest of it turned out to be. **Not closing it** — see the last section.

## The change

`VisibleClause` returned **no clause** when both anchor scopes came back empty, which bundled the live-anchor requirement into the row-scope narrowing it sits beside. Its own doc says *"Both arms require a LIVE anchor"* and gives the reason: an archived deal keeps its foreign key and its grants, so without the filter a contract stays readable — and mutable — through a record whose own read already answers 404.

Now the clause always renders, and only the scope halves become `TRUE` where the caller is unbounded. Every caller composes it conditionally already, so a clause that is always present changes nothing about how it is used.

## The disagreement the issue describes cannot currently happen

I could not reproduce it, and the reason is worth recording. The early return was **unreachable**: `organization` is owner-private (`platform/auth`), so its scope clause is never empty, so both-empty never held. A contract on an archived anchor was already refused for every caller, including an admin — verified by running the new cases against the unmodified tree, where they pass.

That makes this change defence rather than repair: the invariant was surviving on a neighbouring table's privacy setting, which a change to that table would quietly end.

## Why the issue's fix direction is not here

> have the filing gate compose `contracts.VisibleClause` rather than re-deriving the anchor rule

`activities` cannot import `contracts` — `TestNoSiblingModuleImports` refuses it, and it is right to. Doing this properly needs an injected seam through the activities store's constructor, the shape #1392 uses for FX. That is a real anti-drift measure and I have not judged it worth a widely-used constructor's signature for a divergence that cannot currently occur.

**Leaving #1398 open with this finding** rather than closing it on my own judgement: whether the seam is worth adding is a call about how much the two rules are expected to move, and that is yours.

## Held

Two cases: an unbounded caller cannot read a contract on an archived anchor, and a contract on a live anchor stays readable — so the change narrows exactly one shape rather than the surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived deals and their associated contracts are now hidden from contract visibility results.
  * Live deal-linked contracts remain accessible, including for unbounded searches.
* **Tests**
  * Added integration coverage to verify contract visibility for archived and live deal anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->