### PR TITLE
fix(uat): the deal's overlay count counts the committee map

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1047,14 +1047,17 @@ test.describe("B-EP09.23: overlay mode", () => {
     await expect(page.getByTestId("person-strip")).toBeVisible();
     await expect(page.getByText(errorBox)).toHaveCount(0);
 
-    // Deal 360: timeline, coverage, offers, and the context panel. Coverage
-    // joins the interaction projection too, so it is unavailable for the same
-    // reason rather than reporting a clean deal.
+    // Deal 360: timeline, coverage, offers, the context panel, and the buying
+    // committee map. Coverage joins the interaction projection too, so it is
+    // unavailable for the same reason rather than reporting a clean deal.
     //
-    // FOUR, not five: stakeholders is no longer a panel of its own. The seats
-    // and the findings about them are one card now, and that card states the
-    // overlay case itself — so the stakeholder fact is still refused honestly,
-    // it is refused by the coverage card rather than beside it.
+    // FIVE. Stakeholders is not a panel of its own — the seats and the findings
+    // about them are one card, and that card states the overlay case itself.
+    // The fifth is the committee MAP, which draws how the deal is threaded and
+    // where cover is missing: a working surface rather than a second listing of
+    // the same seats, and it refuses under overlay in the same words for the
+    // same reason. A picture of who is missing cannot be drawn from a store
+    // that does not carry the seats.
     await page.goto("/#/deals/d-fleet");
     // `exact`, and this is the case that shows why: another test in this file
     // renames the same deal to "Fleet retrofit — expanded scope", and a
@@ -1066,7 +1069,7 @@ test.describe("B-EP09.23: overlay mode", () => {
         exact: true,
       }),
     ).toBeVisible();
-    await expect(page.getByText(unavailable)).toHaveCount(4);
+    await expect(page.getByText(unavailable)).toHaveCount(5);
     await expect(page.getByText(errorBox)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
**`main`'s UAT is red.** The buying-committee map (#2980) landed on the deal overview and refuses under overlay in the same words as the panels beside it, so the count of *"In der HubSpot-Ansicht nicht verfügbar"* on that page is **five**, not four.

The map is not a second listing of the same seats — it draws how the deal is threaded and where cover is missing, a working surface rather than a restatement of the rail. And it is exactly the shape that cannot survive an overlay store: **a picture of who is MISSING cannot be drawn from a store that does not carry the seats.** So its refusal belongs in the count, and the comment now says what the fifth is rather than arguing it should not be there.

The assertion's old comment made the opposite case ("FOUR, not five"), about a different panel — stakeholders, which genuinely was folded into coverage. That reasoning still holds; it just no longer accounts for everything on the page.

Verified by running the lane, not by reading it: **144 passed, 14 skipped**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Deal 360 overlay accessibility coverage to include the committee map.
  * Adjusted validation for unavailable sections to reflect the current experience, including five unavailable-message states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->