### PR TITLE
fix(ai): a carriage declaration names what the vendor decodes (#1439)

### DIFF
--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -463,7 +463,7 @@ var shapeCensus = map[string]int{
 	"cannot-drift":   160,
 	"once":           158,
 	"one-of-a-kind":  156,
-	"is-every-named": 95,
+	"is-every-named": 94,
 	"only-noun":      16,
 	"no-second":      10,
 	"never-twice":    6,

--- a/backend/internal/modules/ai/anthropicparts.go
+++ b/backend/internal/modules/ai/anthropicparts.go
@@ -148,7 +148,7 @@ func anthropicAttachmentBlock(a model.Attachment) anthropicBlock {
 // rather than mapped to a block the vendor would reject for a reason that names
 // the wrong thing.
 func anthropicRefuseAttachments(atts []model.Attachment, declared []string) error {
-	if err := refuseNarrowedAttachments("anthropic", atts, declared, carriesImagesAndPDF); err != nil {
+	if err := refuseNarrowedAttachments("anthropic", atts, declared, anthropicCarries); err != nil {
 		return err
 	}
 	for _, a := range atts {

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -152,7 +152,7 @@ func TestAnthropicAndOllamaAdvertiseWhatTheyCarry(t *testing.T) {
 		cfg  ProviderConfig
 		want []string
 	}{
-		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m"}, want: carriesImagesAndPDF},
+		"anthropic": {cfg: ProviderConfig{Provider: "anthropic", Model: "m"}, want: anthropicCarries},
 		"ollama":    {cfg: ProviderConfig{Provider: "ollama", Model: "m"}, want: carriesImages},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/modules/ai/carriage.go
+++ b/backend/internal/modules/ai/carriage.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"slices"
+	"strings"
+)
+
+// What each wire carries, in model.CarriesMIME's spelling.
+//
+// The rule these declarations follow: an adapter bound to ONE vendor names the
+// media types that vendor documents it decodes, and an adapter pointed at an
+// endpoint the OPERATOR chose keeps the wildcard, because the decoder is the
+// operator's model rather than ours.
+//
+// The wildcard was the wrong answer for the first group, and wrong in the
+// direction capability negotiation exists to prevent. `image/*` admits
+// image/svg+xml, image/bmp and image/tiff; no vendor here decodes any of them.
+// An attachment labelled that way passed Caps(), passed attachmentUnsupported,
+// went on the wire with that media_type and came back a vendor 400 — the shape
+// the negotiation is supposed to refuse before the call, with a sentinel a
+// caller can route on.
+//
+// Narrowing these was only possible once model.IntersectMIMEs read patterns
+// rather than spellings: a ladder mixing a narrowed rung with a wildcard rung
+// used to intersect to nothing and lose its document lane silently.
+
+// The media types the declarations below are written from. Constants because a
+// typo in a media type is not a compile error — it is a lane that quietly
+// refuses everything, or one that quietly refuses nothing.
+//
+// Naming a spelling is not sharing a list: each vendor's declaration is still
+// composed on its own, so narrowing one cannot narrow another.
+const (
+	mimeAnyImage = "image/*"
+	mimeJPEG     = "image/jpeg"
+	mimePNG      = "image/png"
+	mimeGIF      = "image/gif"
+	mimeWebP     = "image/webp"
+	mimeHEIC     = "image/heic"
+	mimeHEIF     = "image/heif"
+	mimePDF      = "application/pdf"
+)
+
+// carriesNothing is the carriage declaration of an adapter whose wire has no
+// attachment parts at all. Named rather than written as a bare nil at each
+// site, so "this wire is text-only" reads as a decision instead of an omission.
+var carriesNothing []string
+
+// anthropicCarries is the Messages API's image block plus its document block:
+// the four image types the image source accepts, and PDF.
+var anthropicCarries = []string{mimeJPEG, mimePNG, mimeGIF, mimeWebP, mimePDF}
+
+// openAICarries is what the Responses API's input_image accepts, plus the PDF
+// its input_file takes. The same four images as Anthropic, which is a
+// coincidence of two vendors converging rather than one list serving both —
+// they are written twice on purpose, so narrowing one cannot narrow the other
+// by accident.
+var openAICarries = []string{mimeJPEG, mimePNG, mimeGIF, mimeWebP, mimePDF}
+
+// geminiCarries is the inline-data set the Gemini API documents. It is NOT the
+// same four: Gemini takes HEIC and HEIF, which neither other vendor does, and
+// does not document GIF, which both others do. That divergence is the whole
+// argument against a single shared constant.
+var geminiCarries = []string{mimeJPEG, mimePNG, mimeWebP, mimeHEIC, mimeHEIF, mimePDF}
+
+// carriesImagesAndPDF is the widest document carriage any adapter in this build
+// has, and belongs to the adapters whose endpoint is the operator's choice: the
+// injected fake, which stands in for whichever binding named it. What the
+// endpoint behind it decodes is not knowable here, so this stays a claim about
+// the WIRE's shape — it has image parts and document parts — rather than about
+// a decoder.
+var carriesImagesAndPDF = []string{mimeAnyImage, mimePDF}
+
+// carriesImages is the declaration of an adapter whose wire takes images and
+// nothing else: the Ollama chat API, which spells an image as an entry in a
+// per-message `images` array and has no document part at all. Not a narrowing
+// of carriesImagesAndPDF but a different wire — there is no document lane here
+// to give a binding, which is why `input: [text, image]` on an ollama binding
+// buys nothing and takes nothing away.
+//
+// Still a wildcard after the narrowing pass, and deliberately: Ollama serves
+// whichever vision model the operator pulled, and what that model's projector
+// was built for is a property of the pull, not of this adapter.
+var carriesImages = []string{mimeAnyImage}
+
+// wildcardWires names every adapter that keeps a wildcard in its declaration,
+// with the reason it is not a vendor list. Written down so the census below
+// reads a decision rather than an omission, and so adding a vendor adapter that
+// forgets to narrow has to argue with this list.
+var wildcardWires = map[string]string{
+	ProviderFake:             "stands in for whichever binding named it, so it claims the wire's shape rather than a decoder",
+	providerOllama:           "serves whichever vision model the operator pulled",
+	providerVLLM:             "serves whichever model the operator loaded",
+	providerOpenAICompatible: "serves whichever vendor the operator pointed base_url at",
+}
+
+// DocumentMIMEs is every media type some adapter in this build carries as an
+// input part. It answers "could any binding have been handed this", which is a
+// different question from "will THIS binding take it" (that is Caps()) — the
+// certification corpus asks the first, because a fixture pinning a media type
+// no adapter accepts describes a call this build cannot make.
+//
+// A union over the declarations rather than a copy of one of them: they stopped
+// agreeing when each vendor started naming its own decoder, and a copy of the
+// widest would have quietly become a copy of one vendor's answer.
+//
+// Held by: TestDocumentMIMEsCoversEveryAdaptersDeclaration (backend/internal/modules/ai/carriage_test.go)
+func DocumentMIMEs() []string {
+	var all []string
+	for _, declaration := range wireCarriage() {
+		for _, pattern := range declaration {
+			if !slices.Contains(all, pattern) {
+				all = append(all, pattern)
+			}
+		}
+	}
+	return all
+}
+
+// wireCarriage is every shipping adapter's declaration, keyed by the provider
+// word that selects it. The census and DocumentMIMEs both read it, so neither
+// can go looking at a set of adapters the other does not.
+//
+// Held by: TestOnlyAnOperatorPointedWireDeclaresAWildcard (backend/internal/modules/ai/carriage_test.go)
+func wireCarriage() map[string][]string {
+	return map[string][]string{
+		ProviderFake:             carriesImagesAndPDF,
+		providerAnthropic:        anthropicCarries,
+		providerOllama:           carriesImages,
+		providerVLLM:             carriesImagesAndPDF,
+		providerOpenAICompatible: carriesImagesAndPDF,
+		providerOpenAI:           openAICarries,
+		providerGemini:           geminiCarries,
+	}
+}
+
+// declaresAWildcard reports whether a carriage declaration leaves a media type
+// unnamed — the property the census is about, asked once so the test and any
+// future caller cannot spell it two ways.
+func declaresAWildcard(declared []string) bool {
+	for _, pattern := range declared {
+		if _, wildcard := strings.CutSuffix(pattern, "*"); wildcard {
+			return true
+		}
+	}
+	return false
+}
+
+// isImage selects which KIND of wire part an accepted attachment becomes, once
+// carriage has already been decided. It is not a carriage check — that is
+// model.CarriesMIME over the adapter's declaration — and using it as one is how
+// the two answers drift apart.
+func isImage(mime string) bool { return strings.HasPrefix(mime, "image/") }

--- a/backend/internal/modules/ai/carriage_test.go
+++ b/backend/internal/modules/ai/carriage_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// The census this file exists for: a wildcard in a carriage declaration is a
+// claim that the wire decodes every media type under a whole top-level type,
+// and no vendor does. Where one remains it is because the endpoint is the
+// operator's choice, and that is written down in wildcardWires rather than
+// inferred — so an adapter added against a NEW vendor cannot keep `image/*` by
+// saying nothing.
+//
+// Over knownProviders, which is the list SelectBrain switches on, so a provider
+// that ships without a declaration fails here rather than being skipped.
+func TestOnlyAnOperatorPointedWireDeclaresAWildcard(t *testing.T) {
+	carriage := wireCarriage()
+	for _, provider := range knownProviders {
+		declared, described := carriage[provider]
+		if !described {
+			t.Errorf("%s ships and declares no carriage; wireCarriage must answer for every provider "+
+				"SelectBrain builds, or the census below sees a smaller build than the one that runs", provider)
+			continue
+		}
+		reason, allowed := wildcardWires[provider]
+		switch {
+		case declaresAWildcard(declared) && !allowed:
+			t.Errorf("%s declares %v, and a wildcard claims every media type under its type — "+
+				"name what the vendor documents it decodes, or add %s to wildcardWires with the reason "+
+				"its endpoint is the operator's choice", provider, declared, provider)
+		case !declaresAWildcard(declared) && allowed:
+			t.Errorf("%s is in wildcardWires (%q) and declares no wildcard (%v) — the exemption is stale "+
+				"and now hides the next one", provider, reason, declared)
+		}
+	}
+	// The other direction: an exemption for a provider this build does not have
+	// is an exemption nothing is checking.
+	for provider := range wildcardWires {
+		if !slices.Contains(knownProviders, provider) {
+			t.Errorf("wildcardWires exempts %q, which is not a known provider", provider)
+		}
+	}
+}
+
+// Every media type a vendor list names must be one a vendor could send. The
+// spelling is the whole contract with model.CarriesMIME — a subtype written
+// with a trailing "*" would silently become a wildcard, and a bare type with no
+// subtype matches nothing at all.
+func TestEveryDeclaredMediaTypeIsSpelledLikeOne(t *testing.T) {
+	for provider, declared := range wireCarriage() {
+		for _, pattern := range declared {
+			base, wildcard := strings.CutSuffix(pattern, "*")
+			if !strings.Contains(base, "/") {
+				t.Errorf("%s declares %q, which names no subtype and so matches nothing", provider, pattern)
+			}
+			if !wildcard && strings.Contains(pattern, "*") {
+				t.Errorf("%s declares %q: a star anywhere but the end is a literal character to "+
+					"CarriesMIME, so this matches only itself", provider, pattern)
+			}
+		}
+	}
+}
+
+// DocumentMIMEs answers "could any binding have been handed this". A union, so
+// a type only one vendor decodes still counts — the certification corpus is
+// asking about the build, not about a particular binding.
+func TestDocumentMIMEsCoversEveryAdaptersDeclaration(t *testing.T) {
+	all := DocumentMIMEs()
+	for provider, declared := range wireCarriage() {
+		for _, pattern := range declared {
+			if !model.CarriesMIME(all, pattern) {
+				t.Errorf("%s carries %q and DocumentMIMEs (%v) does not admit it, so a corpus fixture "+
+					"pinning it would be rejected as unreachable while %s could in fact be handed it",
+					provider, pattern, all, provider)
+			}
+		}
+	}
+	// And nothing beyond them: a union that grew a type no adapter declares
+	// would admit a fixture describing a call this build cannot make.
+	for _, pattern := range all {
+		carried := false
+		for _, declared := range wireCarriage() {
+			if slices.Contains(declared, pattern) {
+				carried = true
+				break
+			}
+		}
+		if !carried {
+			t.Errorf("DocumentMIMEs offers %q and no adapter declares it", pattern)
+		}
+	}
+}
+
+// The types the wildcard used to admit and no vendor decodes — the failure this
+// whole change is about. Asserted at the boundary an operator actually meets:
+// a binding built the way production builds one.
+func TestAVendorBindingRefusesAnImageTypeItsVendorCannotDecode(t *testing.T) {
+	undecodable := []string{"image/svg+xml", "image/bmp", "image/tiff"}
+	for _, provider := range []string{providerAnthropic, providerOpenAI, providerGemini} {
+		for _, mime := range undecodable {
+			caps := capsFor(t, provider, nil)
+			if model.CarriesMIME(caps, mime) {
+				t.Errorf("%s advertises %q, which it cannot decode — the call goes out with that "+
+					"media_type and comes back a vendor 400, instead of being refused here (%v)",
+					provider, mime, caps)
+			}
+		}
+	}
+}

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -244,7 +244,7 @@ func (c *geminiClient) Caps() model.Capabilities {
 func (c *geminiClient) generate(ctx context.Context, req model.Request, stream bool) (io.ReadCloser, error) {
 	// Gemini carries image and PDF parts natively; reject any other MIME rather
 	// than silently drop it (spec §3.8).
-	if err := refuseNarrowedAttachments("gemini", req.Attachments, c.attachmentMIMEs, carriesImagesAndPDF); err != nil {
+	if err := refuseNarrowedAttachments("gemini", req.Attachments, c.attachmentMIMEs, geminiCarries); err != nil {
 		return nil, err
 	}
 	// Native functionDeclarations mapping is a follow-up; reject tools rather than

--- a/backend/internal/modules/ai/inputmodality.go
+++ b/backend/internal/modules/ai/inputmodality.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
 // The accepted modality words. `text` is every chat binding's baseline and
@@ -56,6 +58,14 @@ var acceptedModalities = []string{modalityText, modalityImage}
 // modalityCarriage maps one modality word to the media types it admits, in
 // model.CarriesMIME's spelling. `text` admits none: it is the baseline every
 // chat binding already has, not an attachment kind.
+//
+// `image` stays a wildcard while the adapters name their vendor's types, and
+// the asymmetry is the point: this side is a PERMISSION — the operator saying
+// which kinds of thing may leave their deployment — and the adapter's side is a
+// DECODER. An operator writing `image` is not claiming their vendor reads SVG;
+// they are declining to enumerate a vendor's list in their config, which is not
+// theirs to keep current. model.IntersectMIMEs composes the two, so the binding
+// gets exactly what the wire decodes and nothing the operator did not permit.
 var modalityCarriage = map[string][]string{
 	modalityText:  nil,
 	modalityImage: {"image/*"},
@@ -90,7 +100,7 @@ func narrowedCarriage(wireCarries, input []string) []string {
 	if input == nil {
 		return wireCarries
 	}
-	return intersectMIMEs(wireCarries, carriageFor(input))
+	return model.IntersectMIMEs(wireCarries, carriageFor(input))
 }
 
 // blankInputDeclarations names every binding that wrote `input:` with no value.

--- a/backend/internal/modules/ai/localrouter.go
+++ b/backend/internal/modules/ai/localrouter.go
@@ -6,6 +6,8 @@ package ai
 import (
 	"context"
 	"sync"
+
+	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
 // localOpts collects the LocalOption knobs NewLocalRouter assembles a
@@ -80,7 +82,7 @@ func WithPayloadCapture() LocalOption {
 func sharedFakeCarriage(inputs [][]string) []string {
 	carriage := narrowedCarriage(carriesImagesAndPDF, inputs[0])
 	for _, input := range inputs[1:] {
-		carriage = intersectMIMEs(carriage, narrowedCarriage(carriesImagesAndPDF, input))
+		carriage = model.IntersectMIMEs(carriage, narrowedCarriage(carriesImagesAndPDF, input))
 	}
 	return carriage
 }

--- a/backend/internal/modules/ai/narrowing_test.go
+++ b/backend/internal/modules/ai/narrowing_test.go
@@ -23,13 +23,17 @@ func TestADeclarationNarrowsANativeProvidersCarriage(t *testing.T) {
 		cfg  ProviderConfig
 		want []string
 	}{
+		// Written out rather than derived from geminiCarries: the point of the
+		// case is that Caps() reports the media types the vendor decodes, so a
+		// want computed from the same declaration would agree with it however
+		// wrong the declaration became.
 		"undeclared gemini keeps its whole wire": {
 			cfg:  ProviderConfig{Provider: providerGemini, Model: "m"},
-			want: carriesImagesAndPDF,
+			want: []string{"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif", "application/pdf"},
 		},
 		"gemini narrowed to images loses the document lane": {
 			cfg:  ProviderConfig{Provider: providerGemini, Model: "m", Input: []string{"text", "image"}},
-			want: []string{"image/*"},
+			want: []string{"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"},
 		},
 		"gemini narrowed to text carries nothing": {
 			cfg:  ProviderConfig{Provider: providerGemini, Model: "m", Input: []string{"text"}},
@@ -37,14 +41,18 @@ func TestADeclarationNarrowsANativeProvidersCarriage(t *testing.T) {
 		},
 		"undeclared anthropic keeps its whole wire": {
 			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m"},
-			want: carriesImagesAndPDF,
+			want: []string{"image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"},
 		},
 		// The privacy narrowing this field exists for, on the tier most
 		// deployments bind: keep the model for text and images, keep scanned
 		// documents off it.
+		// `input: [text, image]` is a permission spelled `image/*`, and the wire
+		// is a decoder spelled as four types. The operator gets the four — which
+		// is what the wildcard MEANT, and what a literal intersection used to
+		// answer as nothing at all.
 		"anthropic narrowed to images loses the document lane": {
 			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m", Input: []string{"text", "image"}},
-			want: []string{"image/*"},
+			want: []string{"image/jpeg", "image/png", "image/gif", "image/webp"},
 		},
 		"anthropic narrowed to text carries nothing": {
 			cfg:  ProviderConfig{Provider: providerAnthropic, Model: "m", Input: []string{"text"}},
@@ -120,9 +128,14 @@ func TestNoDeclarationCanWidenAnyProvidersCarriage(t *testing.T) {
 
 				// At most what was asked for. True of every provider, including
 				// the two where the declaration IS the carriage.
+				// Coverage, not literal membership: `image/*` asked for and
+				// `image/png` answered is the narrowing working, while a
+				// literal test would read it as a violation. CarriesMIME is
+				// what decides whether a set admits a pattern anywhere else, so
+				// it is what decides it here.
 				asked := carriageFor(input)
 				for _, mime := range declared {
-					if !slices.Contains(asked, mime) {
+					if !model.CarriesMIME(asked, mime) {
 						t.Errorf("declaring %v got %q, which was not asked for (%v)", input, mime, asked)
 					}
 				}
@@ -134,7 +147,7 @@ func TestNoDeclarationCanWidenAnyProvidersCarriage(t *testing.T) {
 					return
 				}
 				for _, mime := range declared {
-					if !slices.Contains(undeclared, mime) {
+					if !model.CarriesMIME(undeclared, mime) {
 						t.Errorf("declaring %v got %q, which %s does not carry undeclared (%v)",
 							input, mime, provider, undeclared)
 					}
@@ -166,7 +179,7 @@ func capsFor(t *testing.T, provider string, input []string) []string {
 func TestANarrowedRefusalNamesTheLineThatCausedIt(t *testing.T) {
 	narrowed := refuseNarrowedAttachments("gemini",
 		[]model.Attachment{{MIME: "application/pdf", Bytes: []byte("%PDF")}},
-		[]string{"image/*"}, carriesImagesAndPDF)
+		[]string{"image/*"}, geminiCarries)
 	if !errors.Is(narrowed, model.ErrAttachmentUnsupported) {
 		t.Fatalf("a narrowed binding must still refuse with the sentinel, got %v", narrowed)
 	}

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -197,7 +197,7 @@ func (c *openaiClient) Caps() model.Capabilities {
 func (c *openaiClient) post(ctx context.Context, path string, req model.Request, stream bool) (io.ReadCloser, error) {
 	// OpenAI carries image and PDF/file parts natively; reject any other MIME
 	// rather than silently drop it (spec §3.8).
-	if err := refuseNarrowedAttachments("openai", req.Attachments, c.attachmentMIMEs, carriesImagesAndPDF); err != nil {
+	if err := refuseNarrowedAttachments("openai", req.Attachments, c.attachmentMIMEs, openAICarries); err != nil {
 		return nil, err
 	}
 	// Native Responses-API tool mapping is a follow-up; reject tools rather than

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -133,42 +133,6 @@ func (c *openAICompatClient) Embed(ctx context.Context, req model.EmbedRequest) 
 	return openAIWireEmbed(ctx, c.post, c.defaultModel, req)
 }
 
-// carriesNothing is the carriage declaration of an adapter whose wire has no
-// attachment parts at all. Named rather than written as a bare nil at each
-// site, so "this wire is text-only" reads as a decision instead of an omission.
-var carriesNothing []string
-
-// carriesImagesAndPDF is the carriage declaration shared by the adapters whose
-// wires take document parts natively.
-var carriesImagesAndPDF = []string{"image/*", "application/pdf"}
-
-// carriesImages is the declaration of an adapter whose wire takes images and
-// nothing else: the Ollama chat API, which spells an image as an entry in a
-// per-message `images` array and has no document part at all. Not a narrowing
-// of carriesImagesAndPDF but a different wire — there is no document lane here
-// to give a binding, which is why `input: [text, image]` on an ollama binding
-// buys nothing and takes nothing away.
-var carriesImages = []string{"image/*"}
-
-// DocumentMIMEs is every media type some adapter in this build carries as an
-// input part. It answers "could any binding have been handed this", which is a
-// different question from "will THIS binding take it" (that is Caps()) — the
-// certification corpus asks the first, because a fixture pinning a media type
-// no adapter accepts describes a call this build cannot make.
-//
-// Derived from the adapters whose carriage is fixed in code, which is the whole
-// answer while `image` — the only modality a binding may declare — is a subset
-// of what those adapters already carry. A modality that widens PAST this set
-// (audio, say) would have to widen this too, or the corpus would reject a
-// fixture some binding could in fact be handed.
-func DocumentMIMEs() []string { return slices.Clone(carriesImagesAndPDF) }
-
-// isImage selects which KIND of wire part an accepted attachment becomes, once
-// carriage has already been decided. It is not a carriage check — that is
-// CarriesMIME over the adapter's declaration — and using it as one is how the
-// two answers drift apart.
-func isImage(mime string) bool { return strings.HasPrefix(mime, "image/") }
-
 // isFetchableURL reports whether an attachment's URI is a URL the vendor can
 // fetch for itself, as opposed to a handle scoped to some provider's own file
 // registry. Every adapter that takes a URI has to answer this — openai to pick

--- a/backend/internal/modules/ai/routing_bind.go
+++ b/backend/internal/modules/ai/routing_bind.go
@@ -3,7 +3,7 @@
 
 package ai
 
-import "slices"
+import "github.com/margince/margince/backend/internal/shared/ports/model"
 
 // ModelRef is a bound (provider, model) pair — the identity a rate is keyed
 // on. The cost pre-flight estimator prices an observed served slice against
@@ -83,24 +83,9 @@ func (r *Router) AttachmentMIMEs(task Task) []string {
 			carried, started = declared, true
 			continue
 		}
-		carried = intersectMIMEs(carried, declared)
+		carried = model.IntersectMIMEs(carried, declared)
 	}
 	return carried
-}
-
-// intersectMIMEs keeps the declarations both rungs make, compared as the
-// literal patterns they are. Two rungs spelling the same carriage differently
-// ("image/*" against "image/png") intersect to nothing, which is the safe
-// direction: it costs a document lane that might have worked, where the other
-// direction would promise carriage one rung cannot honour.
-func intersectMIMEs(a, b []string) []string {
-	kept := make([]string, 0, len(a))
-	for _, pattern := range a {
-		if slices.Contains(b, pattern) {
-			kept = append(kept, pattern)
-		}
-	}
-	return kept
 }
 
 // CurrentModelForTier returns the model currently bound to tier; ok=false when

--- a/backend/internal/modules/ai/routing_bind_carriage_test.go
+++ b/backend/internal/modules/ai/routing_bind_carriage_test.go
@@ -57,3 +57,35 @@ func TestDeclaringInputOnOneRungOfATwoRungLadderCarriesNothing(t *testing.T) {
 		}
 	})
 }
+
+// A ladder whose rungs are bound to DIFFERENT vendors, which is the ordinary
+// cloud-frontier shape and the case a literal intersection lost in silence:
+// anthropic and gemini decode overlapping but unequal image sets, so the task
+// carries what both of them do — not nothing, and not either one's whole list.
+func TestAMixedVendorLadderCarriesWhatBothVendorsDecode(t *testing.T) {
+	const twoRung = TaskRateExtract
+	if len(TaskLadder(twoRung)) != 2 {
+		t.Fatalf("this test needs a two-rung ladder; %s has %v", twoRung, TaskLadder(twoRung))
+	}
+	router, err := NewRouter(RoutingConfig{
+		Profile: ProfileCloudFrontier,
+		Tiers: map[Tier]ProviderConfig{
+			TierPremium:    {Provider: providerAnthropic, Model: "m"},
+			TierCheapCloud: {Provider: providerGemini, Model: "c"},
+		},
+		Embeddings: EmbeddingsConfig{
+			ProviderConfig: ProviderConfig{Provider: providerGemini, Model: "e"},
+			Dimensions:     defaultEmbedDimensions,
+		},
+	}.WithKeys(allCloudKeys()), nil, nil, nil, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// jpeg, png and webp are on both vendors' lists; gif is anthropic's alone
+	// and heic gemini's alone, and a call this router serves can land on either
+	// rung, so neither may be advertised.
+	want := []string{"image/jpeg", "image/png", "image/webp", "application/pdf"}
+	if got := router.AttachmentMIMEs(twoRung); !slices.Equal(got, want) {
+		t.Fatalf("a mixed-vendor ladder carries %v, want %v", got, want)
+	}
+}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -127,7 +127,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			baseURL:         defaulted(cfg.BaseURL, defaultAnthropicBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
-			attachmentMIMEs: narrowedCarriage(carriesImagesAndPDF, cfg.Input),
+			attachmentMIMEs: narrowedCarriage(anthropicCarries, cfg.Input),
 		}, nil
 	case providerOllama:
 		return &ollamaClient{
@@ -171,7 +171,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			baseURL:         defaulted(cfg.BaseURL, defaultOpenAIBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
-			attachmentMIMEs: narrowedCarriage(carriesImagesAndPDF, cfg.Input),
+			attachmentMIMEs: narrowedCarriage(openAICarries, cfg.Input),
 		}, nil
 	case providerGemini:
 		key := cloudKey(providerGemini, keys)
@@ -183,7 +183,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			baseURL:         defaulted(cfg.BaseURL, defaultGeminiBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
-			attachmentMIMEs: narrowedCarriage(carriesImagesAndPDF, cfg.Input),
+			attachmentMIMEs: narrowedCarriage(geminiCarries, cfg.Input),
 		}, nil
 	case "":
 		return nil, fmt.Errorf("ai: binding has no provider")

--- a/backend/internal/shared/ports/model/intersectmimes_test.go
+++ b/backend/internal/shared/ports/model/intersectmimes_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package model_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+func TestTheIntersectionIsWhatBothSidesAdmit(t *testing.T) {
+	for name, tc := range map[string]struct {
+		a, b []string
+		want []string
+	}{
+		// The case the literal comparison got wrong, and the reason this
+		// function exists: a permission written as a wildcard against a decoder
+		// written as types is agreement, not contradiction.
+		"a wildcard meets the types it covers": {
+			a:    []string{"image/*"},
+			b:    []string{"image/jpeg", "image/png"},
+			want: []string{"image/jpeg", "image/png"},
+		},
+		"and in the other order": {
+			a:    []string{"image/jpeg", "image/png"},
+			b:    []string{"image/*"},
+			want: []string{"image/jpeg", "image/png"},
+		},
+		"two wildcards keep the narrower": {
+			a:    []string{"image/*"},
+			b:    []string{"image/x-*"},
+			want: []string{"image/x-*"},
+		},
+		"disjoint wildcards share nothing": {
+			a:    []string{"image/*"},
+			b:    []string{"audio/*"},
+			want: []string{},
+		},
+		"exact types intersect as a set": {
+			a:    []string{"image/jpeg", "image/png", "application/pdf"},
+			b:    []string{"image/png", "image/webp", "application/pdf"},
+			want: []string{"image/png", "application/pdf"},
+		},
+		// The document lane a mixed ladder used to lose in silence: one rung
+		// narrowed to a vendor's types, the other still declaring the pattern.
+		"a mixed ladder keeps its lane": {
+			a:    []string{"image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"},
+			b:    []string{"image/*", "application/pdf"},
+			want: []string{"image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"},
+		},
+		"an empty side carries nothing": {
+			a:    []string{"image/*"},
+			b:    nil,
+			want: []string{},
+		},
+		// Two spellings of one set would make equality depend on argument
+		// order, and a caller comparing carriage sets is the normal case.
+		"a covered type does not survive beside the pattern covering it": {
+			a:    []string{"image/*", "image/png"},
+			b:    []string{"image/*", "image/png"},
+			want: []string{"image/*"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := model.IntersectMIMEs(tc.a, tc.b); !slices.Equal(got, tc.want) {
+				t.Fatalf("IntersectMIMEs(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// The safety property, and the one this replaced a blunt rule to keep. Checked
+// over concrete media types rather than over spellings, because a set is what
+// it admits: whatever survives the intersection must have been admitted by both
+// inputs, and whatever both inputs admit must survive.
+func TestTheIntersectionIsNeverWiderThanEitherSideAndNeverNarrower(t *testing.T) {
+	// Every media type these declarations can distinguish, including the ones
+	// no vendor decodes — svg is the type that started this.
+	probes := []string{
+		"image/jpeg", "image/png", "image/gif", "image/webp", "image/heic",
+		"image/svg+xml", "image/x-icon", "application/pdf", "text/plain", "audio/mpeg",
+	}
+	sets := [][]string{
+		nil,
+		{"image/*"},
+		{"image/*", "application/pdf"},
+		{"image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"},
+		{"image/jpeg", "image/png", "image/webp", "image/heic", "application/pdf"},
+		{"image/x-*"},
+		{"application/pdf"},
+		{"*"},
+	}
+	for _, a := range sets {
+		for _, b := range sets {
+			got := model.IntersectMIMEs(a, b)
+			for _, probe := range probes {
+				inBoth := model.CarriesMIME(a, probe) && model.CarriesMIME(b, probe)
+				if model.CarriesMIME(got, probe) != inBoth {
+					t.Errorf("IntersectMIMEs(%v, %v) = %v: admits %q = %v, both sides admit it = %v",
+						a, b, got, probe, !inBoth, inBoth)
+				}
+			}
+		}
+	}
+}

--- a/backend/internal/shared/ports/model/model.go
+++ b/backend/internal/shared/ports/model/model.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 )
 
@@ -56,6 +57,89 @@ func CarriesMIME(declared []string, mime string) bool {
 		}
 	}
 	return false
+}
+
+// IntersectMIMEs is the other half of CarriesMIME: the carriage set two
+// declarations both admit, computed over the patterns rather than over their
+// spellings.
+//
+// The spellings are the whole point. Two declarations can describe overlapping
+// sets and share no literal — a wire that decodes {image/jpeg, image/png} and
+// an operator who wrote `image/*` agree completely, and a literal comparison
+// reads that agreement as a contradiction and carries nothing. That is what a
+// binding-side permission written as a wildcard has to compose with, so the
+// intersection has to understand what CarriesMIME understands.
+//
+// Never wider than either input: every pattern returned is the narrower of one
+// pattern from each side, so anything it admits both sides already admitted.
+// That is the safety property the literal comparison used to buy by being
+// blunt, and it is now bought by construction instead.
+//
+// Order follows a, then b within each element of a, so the answer is stable for
+// a caller that compares sets by equality.
+func IntersectMIMEs(a, b []string) []string {
+	kept := make([]string, 0, len(a))
+	for _, left := range a {
+		for _, right := range b {
+			narrow, overlap := narrower(left, right)
+			if !overlap || slices.Contains(kept, narrow) {
+				continue
+			}
+			kept = append(kept, narrow)
+		}
+	}
+	// A pattern already covered by a wider one that survived describes nothing
+	// the set does not already admit, and two spellings of one set would make
+	// equality comparisons depend on which order the inputs arrived in.
+	return dropCovered(kept)
+}
+
+// narrower reports the pattern admitting exactly what both a and b admit, and
+// whether they overlap at all. The four cases are the two pattern kinds
+// CarriesMIME reads, squared.
+func narrower(a, b string) (string, bool) {
+	aPrefix, aWild := strings.CutSuffix(a, "*")
+	bPrefix, bWild := strings.CutSuffix(b, "*")
+	switch {
+	case !aWild && !bWild:
+		return a, a == b
+	case aWild && !bWild:
+		// The exact type is the narrower one, when the wildcard admits it.
+		return b, strings.HasPrefix(b, aPrefix)
+	case !aWild && bWild:
+		return a, strings.HasPrefix(a, bPrefix)
+	}
+	// Both wildcards: one contains the other, or they are disjoint. "image/*"
+	// and "image/x-*" overlap in the second; "image/*" and "audio/*" in
+	// neither direction, and share nothing.
+	if strings.HasPrefix(bPrefix, aPrefix) {
+		return b, true
+	}
+	if strings.HasPrefix(aPrefix, bPrefix) {
+		return a, true
+	}
+	return "", false
+}
+
+// dropCovered removes every pattern another kept pattern already admits.
+func dropCovered(patterns []string) []string {
+	kept := make([]string, 0, len(patterns))
+	for i, pattern := range patterns {
+		covered := false
+		for j, other := range patterns {
+			if i == j || other == pattern {
+				continue
+			}
+			if CarriesMIME([]string{other}, pattern) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			kept = append(kept, pattern)
+		}
+	}
+	return kept
 }
 
 // Client is the swappable model interface; selection is config.

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -323,7 +323,6 @@ internal/modules/agents/tools_tags.go#func decodeTagging
 internal/modules/agents/tools_tags.go#func taggingSchema
 internal/modules/ai/feedback.go#const fieldSubjectType
 internal/modules/ai/feedback.go#type RecordInput.ClaimPath
-internal/modules/ai/openaicompat.go#func DocumentMIMEs
 internal/modules/ai/railemit_test.go#func TestADegradedCallSaysWhyEvenWithNoSentinel
 internal/modules/ai/routing.go#method RoutingConfig.BoundModelIDsByProvider
 internal/modules/ai/selectbrain.go#var knownProviders


### PR DESCRIPTION
Closes #1439.

## The gap

`Capabilities.AttachmentMIMEs` is the closed set an adapter says it carries, and four adapters spelled the image half of it `image/*`. No vendor behind those wires decodes every `image/*`: Anthropic's image source takes jpeg/png/gif/webp, OpenAI's the same four, Gemini's is jpeg/png/webp/heic/heif.

So an attachment labelled `image/svg+xml`, `image/bmp` or `image/tiff` passed `Caps()`, passed `attachmentUnsupported`, went on the wire with that `media_type`, and came back a vendor 400 — instead of being refused by capability negotiation with `ErrAttachmentUnsupported`, which is a sentinel a caller can route on. It reaches production input rather than just the port: `documentextractrun.go` routes on the uploader's declared content type, and `model.CarriesMIME` matches `image/*` by prefix.

## Why the intersection had to move first

`Router.AttachmentMIMEs` walks a task's ladder and intersects, because the budget guardrail can demote a call mid-month — the conservative set is the only one true on any rung it might serve. `intersectMIMEs` compared **spellings**, so a rung declaring `{image/jpeg, …}` and a rung declaring `image/*` intersected to **nothing**, and a mixed ladder lost its document lane in silence. Narrowing one adapter without fixing that would have broken every mixed ladder.

`model.IntersectMIMEs` now sits beside `CarriesMIME` — the two halves of one idea, both reading patterns rather than strings. Its safety property is unchanged and is now bought by construction: **every pattern it returns is the narrower of one pattern from each side**, so anything it admits both sides already admitted. `TestTheIntersectionIsNeverWiderThanEitherSideAndNeverNarrower` checks that over concrete media types across 8×8 declaration pairs, in both directions — it must admit a type exactly when both inputs do.

## The split the declarations now make

- **One vendor behind the wire** → name that vendor's types. `anthropicCarries`, `openAICarries`, `geminiCarries`. Written three times on purpose: Gemini's list is *not* the other two's — it takes HEIC and HEIF and does not document GIF — and that divergence is the argument against one shared constant.
- **The operator chose the endpoint** → the wildcard stays, because the decoder is the operator's model. Ollama serves whichever vision model was pulled; vllm whichever was loaded; `openai_compatible` whichever vendor `base_url` points at; the fake stands in for whichever binding named it. Recorded in `wildcardWires` **with the reason**, so a new vendor adapter cannot keep `image/*` by saying nothing.

## What `input: [image]` expands to — the third question in the issue

It stays `image/*`, and the asymmetry is the point. The binding side is a **permission** — the operator saying which kinds of thing may leave their deployment — and the adapter side is a **decoder**. An operator writing `image` is not claiming their vendor reads SVG; they are declining to enumerate a vendor's list in a config file that is not theirs to keep current. The pattern-aware intersection composes the two, so `input: [text, image]` on an anthropic tier now yields exactly `{jpeg, png, gif, webp}` — which is what the wildcard *meant*, and what a literal intersection used to answer as nothing at all.

## The fitness functions

- `TestOnlyAnOperatorPointedWireDeclaresAWildcard` — the census, over `knownProviders` (the list `SelectBrain` switches on, so a provider that ships without a declaration fails rather than being skipped). Bidirectional: a wildcard with no exemption fails, and an exemption for a narrowed or absent provider fails as stale.
- `TestAVendorBindingRefusesAnImageTypeItsVendorCannotDecode` — the bug itself, at the boundary an operator meets: a binding built the way production builds one must not advertise svg/bmp/tiff.
- `TestEveryDeclaredMediaTypeIsSpelledLikeOne` — a subtype with a trailing `*` would silently become a wildcard; a bare type with no subtype matches nothing.
- `TestDocumentMIMEsCoversEveryAdaptersDeclaration` — `DocumentMIMEs` is now a union, both directions checked.
- `TestAMixedVendorLadderCarriesWhatBothVendorsDecode` — anthropic + gemini carries jpeg/png/webp/pdf: not nothing, and not either one's whole list.

Every one was mutation-checked from the other end:

| mutation | caught by |
|---|---|
| `anthropicCarries` back to `image/*` | the census, and the svg/bmp/tiff test |
| ollama narrowed while still exempt | the census's stale-exemption arm |
| a provider dropped from `wireCarriage` | the census's "ships and declares no carriage" arm |
| `DocumentMIMEs` back to one vendor's list | the union test |
| `narrower` back to literal equality | the ladder tests and the intersection's own property test |

## What already existed and was not rebuilt

`model.CarriesMIME` is still the one matcher; `narrowedCarriage` and `refuseNarrowedAttachments` are unchanged in shape. `TestDeclaringInputOnOneRungOfATwoRungLadderCarriesNothing` still passes untouched — an undeclared sibling rung still vetoes the lane, because nil ∩ anything is still empty. That behaviour never depended on the literal comparison.

`TestNoDeclarationCanWidenAnyProvidersCarriage` kept its shape and changed its test from literal membership to `CarriesMIME` coverage: `image/*` asked for and `image/png` answered is the narrowing working, and a literal check now reads it as a violation.

`internal/modules/ai/openaicompat.go` gave up the carriage declarations to a new `carriage.go`, which is where the rule they follow is written down.

## Register

`DocumentMIMEs`'s uniqueness claim moved out of the debt register and is now held by a gate; `wireCarriage`'s new claim names its gate too. The `is-every-named` census drops 95 → 94.

`make check-backend` green on a cold golangci cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific attachment support for Anthropic, OpenAI, and Gemini.
  * Improved handling of MIME type patterns, including wildcard declarations and shared formats across multiple providers.
* **Bug Fixes**
  * Prevented unsupported image and document attachments from being sent to providers that cannot process them.
  * Improved attachment capability reporting when requests use multiple AI providers.
* **Reliability**
  * Added validation to ensure advertised attachment types accurately reflect provider capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->