### PR TITLE
fix(contracts): the contract table is not the contract RBAC object

### DIFF
--- a/backend/gates/moduletablespelling_test.go
+++ b/backend/gates/moduletablespelling_test.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A package that names its table does not pass that name as a bare string.
+//
+// A store hands its table to storekit and to auth as a plain string. The word
+// is usually the RBAC object as well, and often a wire field, so one spelling
+// ends up doing three jobs with nothing at a given site saying which was meant.
+// Naming the table — `dealTable`, `contractTable` — separates the subjects.
+//
+// What this gate holds is narrower than that convention, and the difference
+// matters: it reads the table ARGUMENTS of the calls tableAndObjectArgs names,
+// and nothing else. A table spelled inside SQL text is out of view on purpose
+// (tableownership_test.go reads write targets out of that text, so a
+// constant there would take the statement out of the ownership census), and so
+// is any call family absent from that map.
+//
+// Two shapes fail. A bare literal beside a constant that already names it: the
+// reader sees the constant, assumes the sites follow it, and the rename leaves
+// the literals behind. And a SWAP — the package's other constant holding the
+// same word, passed where the table belongs, or the table's passed where the
+// RBAC object belongs. Nothing else can see that one: both are untyped strings
+// of one value, so the exchange compiles, type-checks and reads correctly until
+// the day one of the names moves.
+//
+// The rule binds only packages that OPTED IN by declaring the constant.
+// Deliberately not "every package must declare one": a table named at a single
+// site is not a duplication, and demanding the constant everywhere would invent
+// work rather than hold an invariant somebody chose. Scope is this module —
+// extensions/ declares table constants of its own, built by concatenation, and
+// both this sweep and its literal reader stop at the module root.
+
+import (
+	"go/ast"
+	"go/token"
+	"maps"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// tableConstName matches a constant whose name declares it to BE a table:
+// `dealTable`, `contractTable`. The suffix is the opt-in.
+var tableConstName = regexp.MustCompile(`^[a-z][A-Za-z0-9]*Table$`)
+
+// authorityPackages define the calls this gate reads. They are parsed rather
+// than listed, because the distinction the gate turns on — is this argument a
+// TABLE or an RBAC OBJECT — is one these packages already draw, in the names
+// they give their own parameters.
+//
+// A hand-kept list was short by nine calls the day it was written, and the
+// comment claiming it came from auth is what stopped the next reader checking.
+// Derived, it also picks up whatever either package grows next.
+var authorityPackages = []string{
+	"internal/platform/auth",
+	"internal/platform/database/storekit",
+}
+
+// The parameter names that say which subject an argument is. `entityType` is
+// the audit row's — storekit.Audit's fourth argument is the same subject as
+// auth.Require's second, under a different word.
+var (
+	tableParams  = map[string]bool{"table": true}
+	objectParams = map[string]bool{"object": true, "entityType": true}
+)
+
+// authorityArgs maps each exported call in authorityPackages to the argument
+// position at which it takes a table, and to the position at which it takes an
+// RBAC object. A call taking neither is absent from both.
+//
+// Positions are ARGUMENT positions, so a method's receiver does not count and a
+// call written `p.ApplyGuarded(ctx, tx, table, …)` lines up with the signature
+// exactly as a free function does.
+func authorityArgs(t *testing.T, fset *token.FileSet) (tables, objects map[string]int) {
+	t.Helper()
+	tables, objects = map[string]int{}, map[string]int{}
+	for _, dir := range authorityPackages {
+		for _, file := range parsePackageDir(t, fset, dir) {
+			for _, decl := range file.Decls {
+				fn, isFunc := decl.(*ast.FuncDecl)
+				if !isFunc || !fn.Name.IsExported() || fn.Type.Params == nil {
+					continue
+				}
+				position := 0
+				for _, field := range fn.Type.Params.List {
+					for _, name := range namesOf(field) {
+						if isStringType(field.Type) {
+							if tableParams[name] {
+								tables[fn.Name.Name] = position
+							}
+							if objectParams[name] {
+								objects[fn.Name.Name] = position
+							}
+						}
+						position++
+					}
+				}
+			}
+		}
+	}
+	if len(tables) < 10 || len(objects) < 3 {
+		t.Fatalf("derived %d table-taking and %d object-taking call(s) from %v — the parameter names "+
+			"this derivation reads have moved, and a short list is a gate that judges fewer sites "+
+			"while reporting a clean tree", len(tables), len(objects), authorityPackages)
+	}
+	return tables, objects
+}
+
+// namesOf yields a parameter field's names, and one empty name for an unnamed
+// parameter so the position still advances.
+func namesOf(field *ast.Field) []string {
+	if len(field.Names) == 0 {
+		return []string{""}
+	}
+	out := make([]string, 0, len(field.Names))
+	for _, name := range field.Names {
+		out = append(out, name.Name)
+	}
+	return out
+}
+
+func isStringType(expr ast.Expr) bool {
+	ident, isIdent := expr.(*ast.Ident)
+	return isIdent && ident.Name == "string"
+}
+
+func TestAModuleThatNamedItsTableUsesThatName(t *testing.T) {
+	t.Parallel()
+
+	// The sweep finds the DECLARATIONS, and proves the roots are where they are.
+	// The judgement then reads each declaring package WHOLE: a store keeps its
+	// constants in one file and its writes in several, so a corpus of declaring
+	// files alone would judge the one file least likely to contain a call.
+	declared := map[string]map[string]string{} // package dir -> const name -> table
+	for _, parsed := range (gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: func(_ string, file *ast.File) bool { return len(tableConstsIn(file)) > 0 },
+	}).Files(t) {
+		dir := filepath.Dir(parsed.Path)
+		if declared[dir] == nil {
+			declared[dir] = map[string]string{}
+		}
+		maps.Copy(declared[dir], tableConstsIn(parsed.File))
+	}
+
+	fset := token.NewFileSet()
+	tableArgs, objectArgs := authorityArgs(t, fset)
+
+	judged, gated, opted := 0, 0, 0
+	for _, dir := range slices.Sorted(maps.Keys(declared)) {
+		opted++
+		// One walk per package, feeding both the constant index and the
+		// judgement: a table argument written as an identifier is resolved
+		// against the constants of the very files being judged.
+		files := packageFiles(t, fset, dir)
+		consts := map[string]string{}
+		for _, parsed := range files {
+			collectStringConstants(parsed.File, consts)
+		}
+		for _, parsed := range files {
+			judged += judgeTableArgs(t, fset, parsed, declared[dir], consts, tableArgs)
+			gated += judgeObjectArgs(t, fset, parsed, objectArgs)
+		}
+	}
+
+	// Floors under the REAL numbers, and one per half. Three packages opt in
+	// today, carrying 67 table arguments and 94 object arguments between them —
+	// measured, not estimated, because the corpus doubled when the derivation
+	// replaced a hand-list and a floor calibrated against the old number would
+	// have let a whole package fall out unnoticed.
+	//
+	// The object half needs its own floor for the reason the table half has one:
+	// it reports findings and returns a count, and a count nobody checks is a
+	// census that can go to zero while the gate reports a clean tree.
+	if opted < 3 || judged < 60 || gated < 80 {
+		t.Errorf("judged %d package(s) that name a table, %d table argument(s) and %d object "+
+			"argument(s) among them — one of the ways of finding a call has stopped working",
+			opted, judged, gated)
+	}
+}
+
+// judgeTableArgs reports every table argument in one file written as a bare
+// string its own package has already named, or as the package's OTHER constant
+// holding that same string, and returns how many table arguments it read.
+func judgeTableArgs(t *testing.T, fset *token.FileSet, parsed gatekit.ParsedFile,
+	named, siblings map[string]string, reads map[string]int,
+) int {
+	t.Helper()
+	seen := 0
+	ast.Inspect(parsed.File, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+		position, reading := reads[selector.Sel.Name]
+		if !reading || position >= len(call.Args) {
+			return true
+		}
+		seen++
+		where := fset.Position(call.Pos())
+		if value, isLiteral := plainStringLiteral(call.Args[position]); isLiteral {
+			for name, declared := range named {
+				if declared != value {
+					continue
+				}
+				t.Errorf("%s:%d passes %q to %s, and this package already names that table %s.\n"+
+					"\tUse the constant. A package that declares one and keeps the literal beside it reads "+
+					"as though the sites follow it, and the rename that moves the table leaves them behind.",
+					parsed.Path, where.Line, value, selector.Sel.Name, name)
+			}
+			return true
+		}
+		// A constant that is not the table's, but holds the table's exact string.
+		//
+		// This is the swap the convention exists to prevent, and it is the one
+		// shape nothing else can see: `contractObject` and `contractTable` are
+		// untyped strings of the same word, so passing either where the other
+		// belongs compiles, type-checks and reads correctly. Narrow on purpose —
+		// a constant holding a DIFFERENT value is a different table or a
+		// different object, and saying anything about it would be this gate
+		// legislating a naming scheme rather than holding an ambiguity.
+		ident, isIdent := call.Args[position].(*ast.Ident)
+		if !isIdent || tableConstName.MatchString(ident.Name) {
+			return true
+		}
+		for name, declared := range named {
+			if siblings[ident.Name] != declared {
+				continue
+			}
+			t.Errorf("%s:%d passes %s to %s, which takes a TABLE — and %s holds %q, the same string "+
+				"this package named %s.\n"+
+				"\tOne of the two is the RBAC object or the audit entity type. Passing it here writes "+
+				"one row and gates on another the day either name moves, and the compiler cannot tell "+
+				"them apart to say so.",
+				parsed.Path, where.Line, ident.Name, selector.Sel.Name, ident.Name, declared, name)
+		}
+		return true
+	})
+	return seen
+}
+
+// judgeObjectArgs is the mirror of judgeTableArgs: a `…Table` constant reaching
+// a call that takes an RBAC OBJECT. It returns how many object arguments it
+// read, so the caller can floor it.
+//
+// The two directions are one defect. A package that names its table has two
+// untyped string constants holding the same word, so passing either where the
+// other belongs compiles, type-checks, and reads correctly at a glance. The
+// swap only becomes visible on the day one of the two names moves — and by then
+// it is a permissions change, or an audit row filed under a table, that nobody
+// wrote down.
+func judgeObjectArgs(t *testing.T, fset *token.FileSet, parsed gatekit.ParsedFile,
+	objectArgs map[string]int,
+) int {
+	t.Helper()
+	seen := 0
+	ast.Inspect(parsed.File, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+		position, takesObject := objectArgs[selector.Sel.Name]
+		if !takesObject || position >= len(call.Args) {
+			return true
+		}
+		seen++
+		ident, isIdent := call.Args[position].(*ast.Ident)
+		if isIdent && tableConstName.MatchString(ident.Name) {
+			t.Errorf("%s:%d passes %s to %s, which takes an RBAC OBJECT — and %s names a TABLE.\n"+
+				"\tThe two are equal strings in this package and the compiler cannot tell them apart, "+
+				"so this reads correctly right up until one of the names moves and the call starts "+
+				"asking about a permission nobody granted, or filing an audit row under a table.",
+				parsed.Path, fset.Position(call.Pos()).Line, ident.Name, selector.Sel.Name, ident.Name)
+		}
+		return true
+	})
+	return seen
+}
+
+// tableConstsIn indexes a file's package-level `…Table` string constants by
+// name. The suffix is what makes this a rule the package chose rather than one
+// imposed on it.
+func tableConstsIn(file *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+			for i, name := range value.Names {
+				if i >= len(value.Values) || !tableConstName.MatchString(name.Name) {
+					continue
+				}
+				if literal, ok := plainStringLiteral(value.Values[i]); ok {
+					out[name.Name] = literal
+				}
+			}
+		}
+	}
+	return out
+}
+
+// plainStringLiteral reads a bare string literal and nothing else. Distinct
+// from replayscope's stringLiteral, which also resolves identifiers through a
+// cache that gate fills as it walks: borrowing it would make this gate's answer
+// depend on whether that one had run first.
+func plainStringLiteral(expr ast.Expr) (string, bool) {
+	literal, isLiteral := expr.(*ast.BasicLit)
+	if !isLiteral || literal.Kind != token.STRING {
+		return "", false
+	}
+	unquoted, err := strconv.Unquote(literal.Value)
+	return unquoted, err == nil
+}

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -461,7 +461,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
 	"cannot-drift":   160,
-	"once":           158,
+	"once":           157,
 	"one-of-a-kind":  156,
 	"is-every-named": 94,
 	"only-noun":      16,

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -146,7 +146,7 @@ func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing c
 		patch.Set("fx_rate_to_base", existing.FxRateToBase, frozen.rate)
 		patch.Set("fx_rate_date", existing.FxRateDate, frozen.on)
 	}
-	if err := patch.ApplyGuarded(ctx, tx, "contract", id.UUID, ifVersion); err != nil {
+	if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
 		if constraint, ok := storekit.CheckViolation(err); ok {
 			return crmcontracts.Contract{}, contractCheckError(constraint)
 		}
@@ -235,7 +235,7 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 		patch := storekit.NewPatch()
 		patch.Set("cancellation_notice_on", existing.CancellationNoticeOn, noticeOn)
 		patch.Set("cancellation_effective_on", existing.CancellationEffectiveOn, effectiveOn)
-		if err := patch.ApplyGuarded(ctx, tx, "contract", id.UUID, ifVersion); err != nil {
+		if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
 			if constraint, ok := storekit.CheckViolation(err); ok {
 				return contractCheckError(constraint)
 			}

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -152,7 +152,7 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 			out = existing
 			return nil
 		}
-		if err := patch.ApplyGuarded(ctx, tx, "contract", id.UUID, ifVersion); err != nil {
+		if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
 			if constraint, ok := storekit.CheckViolation(err); ok {
 				return contractCheckError(constraint)
 			}
@@ -189,7 +189,7 @@ func (s *Store) ArchiveContract(ctx context.Context, id ids.ContractID) error {
 		// the row lock instead. Taken by name rather than by handing the guarded
 		// seam a nil version, which does the same thing while reading as a
 		// caller who had a version and chose not to use it.
-		lock, err := storekit.LockRow(ctx, tx, "contract", id.UUID, storekit.LiveOnly)
+		lock, err := storekit.LockRow(ctx, tx, contractTable, id.UUID, storekit.LiveOnly)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -23,8 +23,23 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// contractObject is this record type's RBAC object name, spelled once.
-const contractObject = "contract"
+// Three different subjects in this module answer to the word "contract", and
+// none of them follows another.
+//
+// contractObject is the RBAC OBJECT — what auth.Require gates on and what an
+// audit row names as its entity type. contractTable is the ROW the patches
+// write. They are equal today and moving either is a different act: renaming
+// the object is a permissions change a deployment migrates its grants for,
+// renaming the table is a schema migration. One constant for both would make
+// each rename silently perform the other.
+//
+// The third is a wire field name — handlers.go faults on "contract" when a
+// terms check contradicts and no narrower field is to blame. That one belongs
+// to the HTTP contract and is spelled where it is used.
+const (
+	contractObject = "contract"
+	contractTable  = "contract"
+)
 
 // Status values. Asserted by a human or an approved proposal — never derived
 // from a date, here or anywhere (ADR-0109 §2).

--- a/backend/internal/modules/deals/claim.go
+++ b/backend/internal/modules/deals/claim.go
@@ -38,7 +38,7 @@ func (s *Store) ClaimDeal(ctx context.Context, id ids.DealID, ifVersion *int64) 
 	}
 	out := DealClaim{OwnerID: actor.UserID}
 	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		claim, auditID, err := storekit.ClaimOwnership(ctx, tx, "deal", id.UUID, actor.UserID, ifVersion)
+		claim, auditID, err := storekit.ClaimOwnership(ctx, tx, dealTable, id.UUID, actor.UserID, ifVersion)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -79,7 +79,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 
 	var out crmcontracts.Deal
 	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureWritable(ctx, tx, "deal", id.UUID); err != nil {
+		if err := auth.EnsureWritable(ctx, tx, dealTable, id.UUID); err != nil {
 			return err
 		}
 		// A decision read (stage/amount snapshot for the transition patch

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -33,7 +33,7 @@ func (s *Store) GetDeal(ctx context.Context, id ids.DealID, archived storekit.Ar
 	}
 	var out crmcontracts.Deal
 	err = s.Tx(ctx, func(tx pgx.Tx) (err error) {
-		if err := auth.EnsureVisible(ctx, tx, "deal", id.UUID); err != nil {
+		if err := auth.EnsureVisible(ctx, tx, dealTable, id.UUID); err != nil {
 			return err
 		}
 		out, err = readDealForCaller(ctx, tx, id, archived, active)
@@ -119,7 +119,7 @@ func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontract
 	if err != nil {
 		return nil, storekit.Page{}, err
 	}
-	return storekit.RunListPage(ctx, s, pre, "deal", dealColumns, active, where, scanDealPage,
+	return storekit.RunListPage(ctx, s, pre, dealTable, dealColumns, active, where, scanDealPage,
 		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) },
 		func(tx pgx.Tx, page []crmcontracts.Deal) error { return maskDeals(ctx, tx, page) })
 }
@@ -137,7 +137,7 @@ func (s *Store) ListDealsTx(ctx context.Context, tx pgx.Tx, in ListDealsInput, a
 	if err != nil {
 		return nil, storekit.Page{}, err
 	}
-	return storekit.RunListPageTx(ctx, tx, pre, "deal", dealColumns, active.cols, where, scanDealPage,
+	return storekit.RunListPageTx(ctx, tx, pre, dealTable, dealColumns, active.cols, where, scanDealPage,
 		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) },
 		func(tx pgx.Tx, page []crmcontracts.Deal) error { return maskDeals(ctx, tx, page) })
 }

--- a/backend/internal/modules/deals/deal_update.go
+++ b/backend/internal/modules/deals/deal_update.go
@@ -102,7 +102,7 @@ func (s *Store) UpdateDealTx(ctx context.Context, tx pgx.Tx, id ids.DealID,
 func (s *Store) updateDealInTx(ctx context.Context, tx pgx.Tx,
 	id ids.DealID, in UpdateDealInput, active []fieldcatalog.Column,
 ) (crmcontracts.Deal, error) {
-	if err := auth.EnsureWritable(ctx, tx, "deal", id.UUID); err != nil {
+	if err := auth.EnsureWritable(ctx, tx, dealTable, id.UUID); err != nil {
 		return crmcontracts.Deal{}, err
 	}
 	// current reads WITH active columns so the patch's audit before-image

--- a/backend/internal/modules/deals/dealarchive.go
+++ b/backend/internal/modules/deals/dealarchive.go
@@ -35,7 +35,7 @@ func (s *Store) RefuseArchiveDeal(ctx context.Context, id ids.DealID) error {
 		return err
 	}
 	return s.Tx(ctx, func(tx pgx.Tx) error {
-		return auth.EnsureWritable(ctx, tx, "deal", id.UUID)
+		return auth.EnsureWritable(ctx, tx, dealTable, id.UUID)
 	})
 }
 
@@ -55,7 +55,7 @@ func (s *Store) ArchiveDeal(ctx context.Context, id ids.DealID, ifVersion *int64
 	}
 	var out crmcontracts.Deal
 	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureWritable(ctx, tx, "deal", id.UUID); err != nil {
+		if err := auth.EnsureWritable(ctx, tx, dealTable, id.UUID); err != nil {
 			return err
 		}
 		// A liveness probe, not a wire read — no custom columns needed.

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -92,7 +92,7 @@ func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error 
 	// both consumers read it: the wire flag a client draws its edit affordances
 	// from, and the masks conditioned on write authority. Asking twice would be
 	// two round trips for one question, and two answers that can disagree.
-	writable, err := auth.StampWritable(ctx, tx, "deal", deals,
+	writable, err := auth.StampWritable(ctx, tx, dealTable, deals,
 		func(d crmcontracts.Deal) ids.UUID { return ids.UUID(d.Id) },
 		func(d *crmcontracts.Deal, may bool) { d.Writable = &may })
 	if err != nil {

--- a/backend/internal/modules/deals/health.go
+++ b/backend/internal/modules/deals/health.go
@@ -266,7 +266,7 @@ func (s *Store) DealHealth(ctx context.Context, dealID ids.DealID, now time.Time
 	}
 	in := dealHealthInputs{dealID: dealID}
 	err := s.Tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureVisible(ctx, tx, "deal", dealID.UUID); err != nil {
+		if err := auth.EnsureVisible(ctx, tx, dealTable, dealID.UUID); err != nil {
 			return err
 		}
 		return healthInputs(ctx, tx, now, &in)

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -95,7 +95,7 @@ func createOfferTx(ctx context.Context, tx pgx.Tx, dealID ids.DealID, in CreateO
 	wsID := storekit.MustWorkspace(ctx)
 	// The deal anchors the offer's visibility: it must exist, be live
 	// and sit inside the caller's row scope (miss = 404).
-	if err := auth.EnsureLinkTarget(ctx, tx, "deal", dealID.UUID); err != nil {
+	if err := auth.EnsureLinkTarget(ctx, tx, dealTable, dealID.UUID); err != nil {
 		return crmcontracts.Offer{}, err
 	}
 	buyerOrg, err := resolveBuyerOrg(ctx, tx, dealID, in.BuyerOrgID)
@@ -300,7 +300,7 @@ func visibleOffer(ctx context.Context, tx pgx.Tx, id ids.OfferID, archived store
 	if err != nil {
 		return crmcontracts.Offer{}, err
 	}
-	if err := auth.EnsureVisible(ctx, tx, "deal", ids.UUID(offer.DealId)); err != nil {
+	if err := auth.EnsureVisible(ctx, tx, dealTable, ids.UUID(offer.DealId)); err != nil {
 		return crmcontracts.Offer{}, err
 	}
 	return offer, nil
@@ -326,7 +326,7 @@ func writableOffer(ctx context.Context, tx pgx.Tx, id ids.OfferID, archived stor
 	if err != nil {
 		return crmcontracts.Offer{}, err
 	}
-	if err := auth.EnsureWritable(ctx, tx, "deal", ids.UUID(offer.DealId)); err != nil {
+	if err := auth.EnsureWritable(ctx, tx, dealTable, ids.UUID(offer.DealId)); err != nil {
 		return crmcontracts.Offer{}, err
 	}
 	return offer, nil

--- a/backend/internal/modules/deals/offer_read.go
+++ b/backend/internal/modules/deals/offer_read.go
@@ -62,7 +62,7 @@ func (s *Store) ListDealOffers(ctx context.Context, dealID ids.DealID, in ListDe
 		// The deal is the offer's visibility anchor: out of the caller's
 		// row scope, the whole listing answers 404, never an empty page
 		// that discloses the deal exists.
-		if err := auth.EnsureLinkTarget(ctx, tx, "deal", dealID.UUID); err != nil {
+		if err := auth.EnsureLinkTarget(ctx, tx, dealTable, dealID.UUID); err != nil {
 			return err
 		}
 

--- a/backend/internal/modules/deals/project_rollup.go
+++ b/backend/internal/modules/deals/project_rollup.go
@@ -59,7 +59,7 @@ func (s *Store) ProjectDealTotalsTx(ctx context.Context, tx pgx.Tx, id ids.Proje
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	basePos := arg(base)
 	where := []string{storekit.SQLf("d.project_id = $%d", arg(id)), "d.archived_at IS NULL"}
-	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
 	if err != nil {
 		return ProjectDealTotals{}, err
 	}

--- a/backend/internal/modules/deals/stageremoval.go
+++ b/backend/internal/modules/deals/stageremoval.go
@@ -221,7 +221,7 @@ func refuseIfOccupied(ctx context.Context, tx pgx.Tx, id ids.StageID) error {
 	}
 	args := []any{id, namedBlockingDeals}
 	arg := func(v any) int { args = append(args, v); return len(args) }
-	scope, err := auth.ScopeClauseFor(ctx, "deal", "", arg)
+	scope, err := auth.ScopeClauseFor(ctx, dealTable, "", arg)
 	if err != nil {
 		return err
 	}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -393,7 +393,6 @@ internal/modules/consent/gate.go#type Gate
 internal/modules/contracts/contract_write.go#func contractPatch
 internal/modules/contracts/contract_write.go#func ensureLinksVisible
 internal/modules/contracts/store.go#const contractColumns
-internal/modules/contracts/store.go#const contractObject
 internal/modules/contracts/visibility.go#func VisibleClause
 internal/modules/customfields/create.go#func marshalOptions
 internal/modules/customfields/create.go#func unmarshalOptions

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -168,7 +168,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (25)
+## Prohibition (26)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -188,6 +188,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `keyvaultonceperrole_test.go` | H2 | A role resolves its key vault ONCE. |
 | `logsecrets_test.go` | H2 | A credential reaches a log field only on the failure of the channel that was supposed to carry it. |
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
+| `moduletablespelling_test.go` | H2 | A package that names its table does not pass that name as a bare string. |
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |
 | `publicreferences_test.go` | H1 | This repository is public. |


### PR DESCRIPTION
Wave 12 of the one-source-of-truth audit. First of the eighteen raw-spelling
sites the `claimedspelling` census surfaces, and it turned out to be the general
case rather than one module's tidy-up.

## In one sentence

Three subjects in `internal/modules/contracts` answer to the word "contract",
one constant stood for one of them, and four writes of the table were literals
beside it.

## The three subjects

| | what it is | where it moves |
|---|---|---|
| `contractObject` | the RBAC object `auth.Require` gates on, and the audit entity type | a permissions change; a deployment migrates its grants |
| `contractTable` | the row the patches write | a schema migration |
| `"contract"` in `handlers.go` | a wire field name — the 422 fault when a terms check contradicts and no narrower field is to blame | the HTTP contract |

They are equal strings today and none of them follows another. One constant for
the first two would make each rename silently perform the other, which is why
this splits rather than collapses.

## The gate, and why it is not one module's rule

`TestAModuleThatNamedItsTableUsesThatName`: a package that has declared a
`…Table` constant may not pass that same string as a table argument beside it.
Binding only packages that OPTED IN is deliberate — a table named at a single
site is not a duplication, and demanding the constant everywhere would invent
work rather than hold an invariant somebody chose.

Three packages are under it today: `contracts`, `deals`, and `dealrooms`, which
had named its parent table before any of this.

**It holds two shapes, and the second is the one nothing else can see.** A bare
literal beside the constant is the obvious half. The other is a SWAP — the
package's other constant, holding the same word, passed where the table belongs
or vice versa. The security review proved that exchanging `contractObject` and
`contractTable` in both directions **compiles, type-checks and passes every
other gate in the tree**, including `tableownership_test.go`, because both are
untyped strings of one value. That mutant now fails.

## What the gate found beyond contracts

Twelve sites in `deals` passing `"deal"` to `auth.EnsureWritable` /
`EnsureVisible` / `EnsureLinkTarget` / `ScopeClauseFor` — all of which take a
TABLE — beside the `dealTable` constant introduced in the deal-forecast work.
Fixed here, because the rule is the piece of work and the module is not.
`auth.Require`'s object argument is deliberately untouched at every one of those
files; that is the other subject.

## The claim

`contractObject`'s docblock claimed it was "spelled once". That was true of the
RBAC object and silent about the table, which is exactly how the census found
the twins through it. The claim is deleted rather than reworded — the register
shrinks 609 → 608 and `shapeCensus["once"]` 158 → 157.

To be precise about what that does and does not buy: the deleted claim was about
the RBAC OBJECT and the new gate holds the TABLE. A stray
`auth.Require(ctx, "contract", …)` is watched by nothing now and was watched by
nothing before. This is not a substitution.

## What the gate deliberately does not see

Four spellings of the table stay literal in raw SQL — `INSERT INTO contract`,
three `FROM contract`. Constant-ising them would be actively wrong:
`tableownership_test.go` reads write targets out of `*ast.BasicLit` SQL text, so
`"INSERT INTO " + contractTable` leaves it nothing to match and drops the
module's only INSERT out of the ownership census silently. The `contractTable`
docblock says so, following the precedent `dealTable` set for
`frozenRateTables`.

Also out of view, and stated in the gate's own docblock rather than implied:
`extensions/` declares table constants of its own, built by concatenation, and
both the sweep and the literal reader stop at the module root.

## Verification

**9 mutants, each proven to have applied before the gate ran:**

- the literal reintroduced in `contracts`, and independently in `deals` — so the
  rule is not one package's;
- **both directions of the swap** — the object constant into a storekit table
  argument, and the table constant into `auth.Require`;
- `dealrooms`' `roomObject`/`threadObject`, whose values differ from its declared
  table, correctly NOT reported — the narrowing that keeps this a rule about an
  ambiguity rather than about a naming scheme;
- a package that never opted in, left alone;
- the opt-in itself: rename the constant off the convention and the package
  leaves the rule.

Floors raised from `opted ≥ 1 / judged ≥ 3` to `≥ 3 / ≥ 30` after review — the
originals were satisfiable by one of the three packages, so two could have
fallen out silently.

**Lanes:** `make check` green, `craft static --strict` clean across all four
roots, full `make test-integration` green.

## Reviewed before opening

A craftsmanship pass (nine findings, all applied — the headline claimed more
than the gate held, `dealrooms` could not fail it in any way that mattered, the
floor was vacuous, `packageFiles` duplicated `parsePackageDir`, an extraction
with no caller, two spellings of "count the rows", and three docblock
corrections) and a security pass (clean on behaviour; it found the swap
described above, which is now gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the word "contract" in the contracts module into three subjects: the RBAC object (`contractObject`), the row the patches write (`contractTable`), and the wire field. The table was previously a literal `"contract"` at four write sites; they now use `contractTable`, so renaming the object becomes a permissions change and renaming the table a schema migration — neither silently performs the other.

Adds `moduletablespelling_test.go`, which flags bare literals and swapped constants in packages that declared a `…Table` constant. It caught sixteen `"deal"` literals in `deals` beside `dealTable`; those now use the constant.

**Gate notes**
- Binds only packages that opt in by declaring a `…Table` constant; a table named at a single site is not a duplication.
- Derives the calls it reads from `auth` and `storekit` signatures — `table` vs. `object`/`entityType` parameters — rather than a hand-kept list.
- Deliberately ignores table names in raw SQL, because the ownership census reads write targets from that text.
- Deletes the "spelled once" claim on `contractObject`; the gate holds the table's spelling, not the object's, so the two are not substitutes.

<sup>Written for commit 692b063f0a4217668c9ff52f2a48ae4ca8d57603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in authorization and visibility checks for contracts and deals.
  * Standardized table references across deal creation, updates, archiving, ownership, offers, and reporting.
  * Preserved existing access-control, ownership, and archival behavior.

* **Tests**
  * Added validation for inconsistent table naming and invalid authorization references.
  * Updated uniqueness-check coverage expectations.

* **Documentation**
  * Updated the gate inventory to include the new table-naming validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->