### PR TITLE
fix(capture): the key says whether it names a person (#1465)

### DIFF
--- a/backend/internal/compose/extingress.go
+++ b/backend/internal/compose/extingress.go
@@ -351,7 +351,15 @@ func refuseUnitIdentity(unit, provider string) error {
 // system half is core-derived, so two units — or one unit and a core connector
 // — can never collide in it whatever they name their records.
 func (r *callRuntime) naturalKey(rec extension.Record) connector.NaturalKey {
-	return connector.NaturalKey{SourceSystem: r.sourceSystem(rec.System), SourceID: rec.Key}
+	return connector.NaturalKey{
+		SourceSystem: r.sourceSystem(rec.System),
+		SourceID:     rec.Key,
+		// Carried from the unit's own answer rather than inferred here: a key
+		// is opaque to the core, and the trace used to guess at it from how the
+		// record named its counterparty — which had one unit's direct messages
+		// hashed and its mentions not, on identical key semantics.
+		SourceIDNamesAPerson: rec.KeyNamesAPerson,
+	}
 }
 
 func (r *callRuntime) sourceSystem(system string) string {

--- a/backend/internal/modules/capture/sinktrace.go
+++ b/backend/internal/modules/capture/sinktrace.go
@@ -86,27 +86,25 @@ func (s *Sink) traceEntry(ctx context.Context, rec connector.NormalizedRecord,
 	stage pipelinetrace.Stage, outcome TraceOutcome, reason string,
 ) TraceEntry {
 	_, owner := capturePrincipal(ctx)
-	// Read from the COUNTERPARTY on purpose, unlike traceConnector below, and
-	// the two are not inconsistent: this flag does not ask whether the message
-	// arrived on a channel, it asks whether SourceID is a provider ACCOUNT id
-	// that has to be hashed. Which is a question about how the record names its
-	// human. Do not "correct" it to match its neighbour.
+	// Read from the KEY, because the question is about the key: does SourceID
+	// embed a person's provider account id, and so have to be hashed before the
+	// trace stores it.
 	//
-	// It is imperfect — a connector whose natural key is a message id on BOTH
-	// branches has one branch hashed and one not (issue #1465) — but the error
-	// is toward hashing, and the fix belongs with the natural key rather than
-	// here.
-	channel := rec.Counterparty.ChannelIdentity.Provider != ""
+	// It used to be read off the counterparty, which asks how the record names
+	// its HUMAN — a different question, and one that comes apart from this one
+	// on any connector that names some counterparties by a channel account and
+	// others by an address while keying every record the same way. Only the
+	// producer of a key knows what is in it, so the producer now says.
 	return TraceEntry{
-		Stage:           stage,
-		UserID:          owner,
-		Connector:       traceConnector(rec),
-		SourceSystem:    rec.NaturalKey.SourceSystem,
-		SourceID:        rec.NaturalKey.SourceID,
-		Outcome:         outcome,
-		Reason:          reason,
-		ChannelIdentity: channel,
-		Counterparty:    rec.Counterparty.Email,
+		Stage:                stage,
+		UserID:               owner,
+		Connector:            traceConnector(rec),
+		SourceSystem:         rec.NaturalKey.SourceSystem,
+		SourceID:             rec.NaturalKey.SourceID,
+		Outcome:              outcome,
+		Reason:               reason,
+		SourceIDNamesAPerson: rec.NaturalKey.SourceIDNamesAPerson,
+		Counterparty:         rec.Counterparty.Email,
 		// Carried so the trace can name a counterparty that has no address —
 		// which is every counterparty, for a connector whose provider gives it
 		// none. tracePayload decides which of the two it may write, and against

--- a/backend/internal/modules/capture/sourceidhashing_test.go
+++ b/backend/internal/modules/capture/sourceidhashing_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/pipelinetrace"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// The two questions this flag used to answer at once, held apart.
+//
+// Hashing is a property of the KEY: does source_id embed a person's provider
+// account. Payload attribution is a property of the COUNTERPARTY: does the
+// record name its human by an account rather than an address. A record can be
+// either, both or neither, and the four combinations below are what a single
+// field could not represent — which is how one connector ended up with its
+// direct messages hashed and its mentions not, on identical key semantics.
+func TestHashingFollowsTheKeyAndAttributionFollowsTheCounterparty(t *testing.T) {
+	const notificationID = "dispact:88421"
+	for name, tc := range map[string]struct {
+		keyNamesAPerson bool
+		channelProvider string
+		wantHashed      bool
+		wantAttributed  bool
+	}{
+		// The reported case, both halves. One connector, one key shape, two
+		// ways of naming a counterparty — and the source id is a notification
+		// id in both, so neither may be hashed.
+		"a notification from a channel account": {
+			channelProvider: "dispact",
+			wantAttributed:  true,
+		},
+		"a notification from an address": {},
+		// A chat message keyed by an account id: hashed, and the counterparty
+		// is named by an account too.
+		"a chat message": {
+			keyNamesAPerson: true,
+			channelProvider: "telegram",
+			wantHashed:      true,
+			wantAttributed:  true,
+		},
+		// The combination that proves the two are independent: a key that
+		// names a person, on a record whose counterparty has an address.
+		"an account-keyed record with an addressable sender": {
+			keyNamesAPerson: true,
+			wantHashed:      true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := connector.NormalizedRecord{
+				EntityType: datasource.EntityActivity,
+				NaturalKey: connector.NaturalKey{
+					SourceSystem:         "dispact",
+					SourceID:             notificationID,
+					SourceIDNamesAPerson: tc.keyNamesAPerson,
+				},
+			}
+			rec.Counterparty.ChannelIdentity.Provider = tc.channelProvider
+			if tc.channelProvider != "" {
+				rec.Counterparty.ChannelIdentity.ChannelUserID = "u-1"
+			}
+
+			entry := (&Sink{}).traceEntry(context.Background(), rec,
+				pipelinetrace.StageActivityWrite, TraceCaptured, "")
+
+			stored := traceSourceID(entry.SourceID, entry.SourceIDNamesAPerson)
+			hashed := strings.HasPrefix(stored, "sha256:")
+			if hashed != tc.wantHashed {
+				t.Errorf("the trace stores %q (hashed=%v), want hashed=%v — hashing is the KEY's "+
+					"question, and this key %s", stored, hashed, tc.wantHashed,
+					map[bool]string{true: "names a person", false: "names a notification"}[tc.keyNamesAPerson])
+			}
+			if !tc.wantHashed && stored != notificationID {
+				t.Errorf("an unhashed trace must keep the provider's own id verbatim, got %q — "+
+					"it is what makes a support question answerable (ADR-0082 §1)", stored)
+			}
+			if got := entry.namesItsHumanByAccount(); got != tc.wantAttributed {
+				t.Errorf("namesItsHumanByAccount = %v, want %v — attribution is the COUNTERPARTY's "+
+					"question, and this record names its human %s", got, tc.wantAttributed,
+					map[bool]string{true: "by an account", false: "by an address"}[tc.channelProvider != ""])
+			}
+		})
+	}
+}
+
+// The flag is carried, not re-derived. A trace whose hashing decision came from
+// anywhere but the key it is hashing is the bug this replaced, and it would
+// pass every case above as long as the two happened to agree.
+func TestTheTraceHashesTheKeyItWasGiven(t *testing.T) {
+	for _, namesAPerson := range []bool{false, true} {
+		rec := connector.NormalizedRecord{
+			EntityType: datasource.EntityActivity,
+			NaturalKey: connector.NaturalKey{
+				SourceSystem: "dispact", SourceID: "k-1", SourceIDNamesAPerson: namesAPerson,
+			},
+		}
+		// The counterparty says the OPPOSITE of the key, every time: this is
+		// the disagreement the old inference could not survive.
+		if !namesAPerson {
+			rec.Counterparty.ChannelIdentity.Provider = "dispact"
+			rec.Counterparty.ChannelIdentity.ChannelUserID = "u-1"
+		}
+		entry := (&Sink{}).traceEntry(context.Background(), rec,
+			pipelinetrace.StageActivityWrite, TraceCaptured, "")
+		if entry.SourceIDNamesAPerson != namesAPerson {
+			t.Errorf("the key said SourceIDNamesAPerson=%v and the trace entry says %v — the trace "+
+				"is reading something other than the key", namesAPerson, entry.SourceIDNamesAPerson)
+		}
+	}
+}

--- a/backend/internal/modules/capture/telegram/normalize.go
+++ b/backend/internal/modules/capture/telegram/normalize.go
@@ -202,7 +202,17 @@ func Normalize(_ context.Context, raw connector.RawRecord) ([]connector.Normaliz
 
 	return []connector.NormalizedRecord{{
 		EntityType: datasource.EntityActivity,
-		NaturalKey: connector.NaturalKey{SourceSystem: Provider, SourceID: naturalID},
+		NaturalKey: connector.NaturalKey{
+			SourceSystem: Provider,
+			SourceID:     naturalID,
+			// A private chat's id IS the human's own Telegram account id, which
+			// this key embeds — so the pipeline trace stores a hash of it. Set
+			// unconditionally rather than per chat type: a group chat's id is
+			// not an account, but a connector that hashed only some of its keys
+			// would answer "was this hashed" with the chat's shape, which is
+			// the inference this field exists to replace.
+			SourceIDNamesAPerson: true,
+		},
 		Fields: ActivityFields{
 			// The two axes, stated separately (ADR-0107/A158): WHAT happened is
 			// a message, WHAT CARRIED IT is telegram. They were briefly spelled

--- a/backend/internal/modules/capture/telegram/normalize_test.go
+++ b/backend/internal/modules/capture/telegram/normalize_test.go
@@ -100,6 +100,16 @@ func TestNormalizeBuildsTheChatScopedNaturalKey(t *testing.T) {
 	if rec.NaturalKey.SourceSystem != Provider {
 		t.Errorf("NaturalKey.SourceSystem = %q, want %q", rec.NaturalKey.SourceSystem, Provider)
 	}
+	// The chat id in the middle of that key IS the sender's own Telegram
+	// account id for a private chat, so the pipeline trace stores a hash of the
+	// key rather than the key. Pinned rather than left to the field's default,
+	// because the default is right for the message id a natural key usually is
+	// and wrong here — and a producer that quietly stopped declaring would put
+	// an account id in a diagnostic table with nothing failing.
+	if !rec.NaturalKey.SourceIDNamesAPerson {
+		t.Errorf("the key %q does not declare that it names a person, so the trace would store "+
+			"the account id in it verbatim", rec.NaturalKey.SourceID)
+	}
 }
 
 // The conversation IS the chat for a channel (connector.go's amended

--- a/backend/internal/modules/capture/trace.go
+++ b/backend/internal/modules/capture/trace.go
@@ -137,9 +137,11 @@ type TraceEntry struct {
 
 	ActivityID ids.UUID
 
-	// ChannelIdentity reports that SourceID is a provider ACCOUNT id rather than
-	// a message id — which is personal data, and is hashed on write.
-	ChannelIdentity bool
+	// SourceIDNamesAPerson reports that SourceID embeds a provider ACCOUNT id
+	// rather than naming a message — which is personal data, and is hashed on
+	// write. Carried from the natural key, whose producer is the only party
+	// that knows what its own key is made of.
+	SourceIDNamesAPerson bool
 
 	// Counterparty and Subject are written only when the deployment turned
 	// payload capture on.
@@ -162,6 +164,16 @@ type TraceEntry struct {
 	// records in place of an address.
 	CounterpartyName string
 }
+
+// namesItsHumanByAccount reports that this record identifies its counterparty
+// by a provider account rather than by an address.
+//
+// Asked of the counterparty fields, which are where the answer is, and named so
+// that a reader cannot mistake it for the question the source id asks. A record
+// can be either, both or neither: a notification keyed by its own id may still
+// name a person by their channel account, and a chat message keyed by an
+// account id may still be from somebody with an address.
+func (in TraceEntry) namesItsHumanByAccount() bool { return in.CounterpartyProvider != "" }
 
 // traceOutcomeTotals counts what this PROCESS has traced since it started, one
 // counter per outcome.
@@ -222,7 +234,7 @@ func Trace(ctx context.Context, tx pgx.Tx, in TraceEntry, payloads bool) error {
 		ON CONFLICT (COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid),
 		             source_system, source_id, stage, outcome) DO NOTHING`,
 		nullableID(in.UserID), in.Connector, in.SourceSystem,
-		traceSourceID(in.SourceID, in.ChannelIdentity),
+		traceSourceID(in.SourceID, in.SourceIDNamesAPerson),
 		string(in.Stage), string(in.Outcome), in.Reason, nullableID(in.ActivityID),
 		counterparty, subject)
 	if err != nil {
@@ -273,8 +285,11 @@ func tracePayload(ctx context.Context, tx pgx.Tx, in TraceEntry, payloads bool) 
 	// written either way, because a member is owed the answer that their message
 	// was handled; but the second case is ALSO the class a manager can read, and
 	// a fault must not be the thing that carries somebody's mail across that
-	// boundary. ChannelIdentity is what tells the two apart.
-	if in.UserID.IsZero() && !in.ChannelIdentity {
+	// boundary. How the record NAMES ITS HUMAN is what tells the two apart, and
+	// that is a different question from the one the source id asks — this one is
+	// about the counterparty, so it is asked of the counterparty. The two shared
+	// a field until they disagreed (issue #1465).
+	if in.UserID.IsZero() && !in.namesItsHumanByAccount() {
 		return nil, nil, nil
 	}
 	if !payloads {
@@ -369,8 +384,8 @@ func (in TraceEntry) validate() error {
 // id, and that permission was written about mail, where the id identifies a
 // message rather than a person — and where it is what makes a support question
 // answerable at all.
-func traceSourceID(sourceID string, channelIdentity bool) string {
-	if !channelIdentity {
+func traceSourceID(sourceID string, namesAPerson bool) string {
+	if !namesAPerson {
 		return sourceID
 	}
 	sum := sha256.Sum256([]byte(sourceID))

--- a/backend/internal/modules/capture/trace_integration_test.go
+++ b/backend/internal/modules/capture/trace_integration_test.go
@@ -125,7 +125,7 @@ func TestWorkspaceOwnedRowsCarryNoMemberAndStillDedupe(t *testing.T) {
 	entry := capture.TraceEntry{
 		Stage:     pipelinetrace.StageTierLadder,
 		Connector: "telegram", SourceSystem: "telegram", SourceID: "chat-1:42",
-		Outcome: capture.TraceCaptured, ChannelIdentity: true,
+		Outcome: capture.TraceCaptured, SourceIDNamesAPerson: true,
 	}
 
 	writeTrace(ctx, t, db, entry, false)
@@ -159,7 +159,7 @@ func TestAChannelAccountIdIsHashedNeverStored(t *testing.T) {
 	writeTrace(ctx, t, db, capture.TraceEntry{
 		Stage:     pipelinetrace.StageTierLadder,
 		Connector: "telegram", SourceSystem: "telegram", SourceID: accountID,
-		Outcome: capture.TraceCaptured, ChannelIdentity: true,
+		Outcome: capture.TraceCaptured, SourceIDNamesAPerson: true,
 	}, false)
 
 	var stored string
@@ -315,7 +315,6 @@ func TestTraceNamesACounterpartyThatHasNoAddress(t *testing.T) {
 
 	entry := mailTrace("chan-named", capture.TraceCaptured)
 	entry.Connector, entry.SourceSystem = "zalo_oa", "ext:zalo-oa:zalo-oa"
-	entry.ChannelIdentity = true
 	entry.Counterparty = "" // the provider gives an Official Account no address
 	entry.CounterpartyProvider = "zalo_oa"
 	entry.CounterpartyAccountID = "4033837145949898046:6677650832821588240"
@@ -372,7 +371,6 @@ func TestTraceWithholdsTheNameOfAnErasedChannelIdentity(t *testing.T) {
 
 	entry := mailTrace("chan-erased", capture.TraceCaptured)
 	entry.Connector, entry.SourceSystem = provider, "ext:zalo-oa:zalo-oa"
-	entry.ChannelIdentity = true
 	entry.Counterparty = ""
 	entry.CounterpartyProvider, entry.CounterpartyAccountID = provider, account
 	entry.CounterpartyName, entry.Subject = "Tin Nguyen", "Zalo message from Tin Nguyen"
@@ -405,7 +403,6 @@ func TestTraceRecordsNoCounterpartyWhenTheRecordNamesNobody(t *testing.T) {
 	ctx, db := traceWorkspace(t)
 
 	entry := mailTrace("chan-anon", capture.TraceCaptured)
-	entry.ChannelIdentity = true
 	entry.Counterparty, entry.CounterpartyName = "", ""
 	entry.Subject = "a message from nobody nameable"
 	writeTrace(ctx, t, db, entry, true)

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -198,6 +198,25 @@ type NormalizedRecord struct {
 type NaturalKey struct {
 	SourceSystem string
 	SourceID     string
+
+	// SourceIDNamesAPerson reports that SourceID embeds the provider's
+	// identifier for a HUMAN — a chat id that is the customer's own account id,
+	// say — rather than naming a message, an event or a notification.
+	//
+	// It decides whether the pipeline trace stores the id or a hash of it, and
+	// it is declared HERE because the producer is the only party that knows.
+	// The trace used to infer it from how the record named its counterparty,
+	// which is a different question with a different answer: a connector whose
+	// key is a notification id on every branch, and which names some
+	// counterparties by a channel account and others by an address, had half
+	// its traces hashed and half not (issue #1465). Neither half was wrong
+	// about privacy and both were wrong about the key.
+	//
+	// False is the ordinary case and the zero value on purpose: a message id is
+	// what a natural key almost always is, and it is what ADR-0082 §1 permits a
+	// trace to record — it identifies a message rather than a person, and it is
+	// what makes a support question answerable.
+	SourceIDNamesAPerson bool
 }
 
 type (

--- a/backend/pkg/extension/ingress.go
+++ b/backend/pkg/extension/ingress.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 // RecordKind is which kind of record a unit lands. It is the vocabulary a unit
@@ -251,6 +250,17 @@ type Record struct {
 	// second copy of the record on every poll, and nothing fails.
 	Key string
 
+	// KeyNamesAPerson reports that Key embeds the provider's identifier for a
+	// HUMAN — a chat id that is the customer's own account id, say — rather
+	// than naming a message, a notification or an event.
+	//
+	// It decides whether the pipeline trace stores the key or a hash of it, and
+	// the unit answers because the core cannot: a key is opaque to it. Leave it
+	// false for the ordinary case, which is what a provider id almost always
+	// is; a message id in the trace is what makes a support question
+	// answerable, and ADR-0082 §1 permits it for exactly that reason.
+	KeyNamesAPerson bool
+
 	// Activity is the record itself. One field rather than a kind-tagged union
 	// because one kind is landable today (see KindActivity); a second kind
 	// arrives as a second field plus a rule that exactly one is set, which
@@ -285,141 +295,6 @@ type Record struct {
 
 	// Raw is the provider's record as received, kept as evidence.
 	Raw []byte
-}
-
-// Validate checks everything decidable without knowing which unit is calling.
-// Whether System is one the CALLER declared, and whether the caller may ingest
-// at all, are the core's checks — made at the port against the invocation, for
-// the same reason a Change's entity namespace is.
-func (r Record) Validate() error {
-	if err := r.validateKey(); err != nil {
-		return err
-	}
-	if err := r.Activity.validate(); err != nil {
-		return err
-	}
-	if err := r.validateAddresses(); err != nil {
-		return err
-	}
-	if err := r.Counterparty.validate(); err != nil {
-		return err
-	}
-	if len(r.ThreadKey) > MaxThreadKeyLength {
-		return fmt.Errorf("extension: the thread key is %d bytes, over the %d-byte cap", len(r.ThreadKey), MaxThreadKeyLength)
-	}
-	if len(r.Raw) > MaxRawBytes {
-		return fmt.Errorf("extension: the raw record is %d bytes, over the %d-byte cap every landed record pays for", len(r.Raw), MaxRawBytes)
-	}
-	return nil
-}
-
-func (r Record) validateKey() error {
-	switch {
-	case strings.TrimSpace(r.System) == "":
-		return errors.New("extension: the record names no ingress system")
-	case strings.TrimSpace(r.Key) == "":
-		return errors.New("extension: the record carries no key — unkeyed capture cannot be idempotent, so a replay would land a second copy")
-	case len(r.Key) > MaxKeyLength:
-		return fmt.Errorf("extension: the record key is %d bytes, over the %d-byte cap", len(r.Key), MaxKeyLength)
-	}
-	return nil
-}
-
-func (r Record) validateAddresses() error {
-	// A record that names no ADDRESS at all may name no addresses: a chat
-	// message can have none anywhere in it, and the core's own shape already
-	// says so — connector.NormalizedRecord treats an empty set as "I cannot
-	// enumerate the parties", which the internal-message gate reads as NOT
-	// internal and keeps. Refusing it here would have turned away every record
-	// from a provider that issues opaque account ids and no mail, before it
-	// reached a core that would have accepted it.
-	//
-	// The condition is the counterparty's EMAIL rather than "is this a channel
-	// record", because that is the partition the core itself draws: a record
-	// naming its human by a channel account and one naming nobody at all are
-	// the same case here, and both are legal.
-	if len(r.Addresses) == 0 {
-		if r.Counterparty.Email == "" {
-			return nil
-		}
-		return errors.New("extension: the record names an address for its counterparty and no addresses at all — the internal-message gate reads every party from that set, and over an empty one it answers \"not internal\" and keeps the record, so leaving it empty disables the gate rather than passing it")
-	}
-	if len(r.Addresses) > MaxAddresses {
-		return fmt.Errorf("extension: the record names %d addresses, over the cap of %d", len(r.Addresses), MaxAddresses)
-	}
-	for _, addr := range r.Addresses {
-		switch {
-		case strings.TrimSpace(addr) == "":
-			return errors.New("extension: the record names a blank address — the internal-message gate skips a party it cannot read, so a blank one is a party the gate never judges")
-		case len(addr) > MaxAddressLength:
-			return fmt.Errorf("extension: an address is %d bytes, over the %d-byte cap", len(addr), MaxAddressLength)
-		}
-	}
-	return nil
-}
-
-func (c Counterparty) validate() error {
-	if len(c.Email) > MaxAddressLength {
-		return fmt.Errorf("extension: the counterparty address is %d bytes, over the %d-byte cap", len(c.Email), MaxAddressLength)
-	}
-	if utf8.RuneCountInString(c.DisplayName) > MaxDisplayNameRunes {
-		return fmt.Errorf("extension: the counterparty display name is over the %d-rune cap", MaxDisplayNameRunes)
-	}
-	if c.Direction != "" && c.Direction != DirectionInbound && c.Direction != DirectionOutbound {
-		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty for a record with no honest direction)",
-			c.Direction, DirectionInbound, DirectionOutbound)
-	}
-	// A counterparty carrying BOTH is well-formed here, and deliberately so: the
-	// channel identity NAMES the human and the address CORROBORATES them, which
-	// is a shape only the core can admit or refuse, because only the core knows
-	// which merge keys this source declared. Refusing it here would refuse it
-	// for every source alike and put the decision in the wrong place.
-	return c.ChannelIdentity.validate()
-}
-
-// validate refuses a HALF-stated channel identity, which is the shape that
-// looks populated and routes nowhere.
-//
-// Either both the provider and the account id are present or neither is. One
-// without the other reaches the core as a binding it cannot key — and the core
-// would drop it rather than fail, so the record would land, look ordinary, and
-// carry no reply address, which is indistinguishable from a provider that
-// simply does not identify its senders.
-func (c ChannelIdentity) validate() error {
-	switch {
-	case c.Provider == "" && c.ChannelUserID == "":
-		return nil
-	case c.Provider == "":
-		return errors.New("extension: the channel identity names an account with no provider — the binding is keyed on the pair, so half of it binds nothing")
-	case c.ChannelUserID == "":
-		return errors.New("extension: the channel identity names a provider with no account id — a party identified only by transport cannot be replied to")
-	case !providerGrammar.MatchString(c.Provider):
-		return fmt.Errorf("extension: channel identity provider %q must start with a letter and contain only lower-case letters, digits and underscores", c.Provider)
-	case len(c.ChannelUserID) > MaxChannelUserIDLength:
-		return fmt.Errorf("extension: the channel account id is %d bytes, over the %d-byte cap", len(c.ChannelUserID), MaxChannelUserIDLength)
-	case utf8.RuneCountInString(c.DisplayName) > MaxDisplayNameRunes:
-		return fmt.Errorf("extension: the channel identity display name is over the %d-rune cap", MaxDisplayNameRunes)
-	}
-	return nil
-}
-
-func (a ActivityFields) validate() error {
-	if strings.TrimSpace(a.Kind) == "" {
-		return errors.New("extension: the activity names no kind")
-	}
-	if utf8.RuneCountInString(a.Subject) > MaxSubjectRunes {
-		return fmt.Errorf("extension: the subject is over the %d-rune cap", MaxSubjectRunes)
-	}
-	if utf8.RuneCountInString(a.Body) > MaxBodyRunes {
-		return fmt.Errorf("extension: the body is over the %d-rune cap", MaxBodyRunes)
-	}
-	if a.OccurredAt.IsZero() {
-		return errors.New("extension: the activity has no occurred-at — a timeline ordered by when a poll noticed is a timeline of this system's own scheduling")
-	}
-	if a.Direction != "" && a.Direction != DirectionInbound && a.Direction != DirectionOutbound {
-		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty)", a.Direction, DirectionInbound, DirectionOutbound)
-	}
-	return nil
 }
 
 // Disposition is what became of an ingested record. It exists because a row is

--- a/backend/pkg/extension/ingressvalidate.go
+++ b/backend/pkg/extension/ingressvalidate.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// What the ingress seam refuses, and why. Separate from the declarations in
+// ingress.go because the shapes are what a unit author reads and these are what
+// a unit author trips over, and the two are read at different times.
+//
+//margince:extension-surface
+
+package extension
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Validate checks everything decidable without knowing which unit is calling.
+// Whether System is one the CALLER declared, and whether the caller may ingest
+// at all, are the core's checks — made at the port against the invocation, for
+// the same reason a Change's entity namespace is.
+func (r Record) Validate() error {
+	if err := r.validateKey(); err != nil {
+		return err
+	}
+	if err := r.Activity.validate(); err != nil {
+		return err
+	}
+	if err := r.validateAddresses(); err != nil {
+		return err
+	}
+	if err := r.Counterparty.validate(); err != nil {
+		return err
+	}
+	if len(r.ThreadKey) > MaxThreadKeyLength {
+		return fmt.Errorf("extension: the thread key is %d bytes, over the %d-byte cap", len(r.ThreadKey), MaxThreadKeyLength)
+	}
+	if len(r.Raw) > MaxRawBytes {
+		return fmt.Errorf("extension: the raw record is %d bytes, over the %d-byte cap every landed record pays for", len(r.Raw), MaxRawBytes)
+	}
+	return nil
+}
+
+func (r Record) validateKey() error {
+	switch {
+	case strings.TrimSpace(r.System) == "":
+		return errors.New("extension: the record names no ingress system")
+	case strings.TrimSpace(r.Key) == "":
+		return errors.New("extension: the record carries no key — unkeyed capture cannot be idempotent, so a replay would land a second copy")
+	case len(r.Key) > MaxKeyLength:
+		return fmt.Errorf("extension: the record key is %d bytes, over the %d-byte cap", len(r.Key), MaxKeyLength)
+	}
+	return nil
+}
+
+func (r Record) validateAddresses() error {
+	// A record that names no ADDRESS at all may name no addresses: a chat
+	// message can have none anywhere in it, and the core's own shape already
+	// says so — connector.NormalizedRecord treats an empty set as "I cannot
+	// enumerate the parties", which the internal-message gate reads as NOT
+	// internal and keeps. Refusing it here would have turned away every record
+	// from a provider that issues opaque account ids and no mail, before it
+	// reached a core that would have accepted it.
+	//
+	// The condition is the counterparty's EMAIL rather than "is this a channel
+	// record", because that is the partition the core itself draws: a record
+	// naming its human by a channel account and one naming nobody at all are
+	// the same case here, and both are legal.
+	if len(r.Addresses) == 0 {
+		if r.Counterparty.Email == "" {
+			return nil
+		}
+		return errors.New("extension: the record names an address for its counterparty and no addresses at all — the internal-message gate reads every party from that set, and over an empty one it answers \"not internal\" and keeps the record, so leaving it empty disables the gate rather than passing it")
+	}
+	if len(r.Addresses) > MaxAddresses {
+		return fmt.Errorf("extension: the record names %d addresses, over the cap of %d", len(r.Addresses), MaxAddresses)
+	}
+	for _, addr := range r.Addresses {
+		switch {
+		case strings.TrimSpace(addr) == "":
+			return errors.New("extension: the record names a blank address — the internal-message gate skips a party it cannot read, so a blank one is a party the gate never judges")
+		case len(addr) > MaxAddressLength:
+			return fmt.Errorf("extension: an address is %d bytes, over the %d-byte cap", len(addr), MaxAddressLength)
+		}
+	}
+	return nil
+}
+
+func (c Counterparty) validate() error {
+	if len(c.Email) > MaxAddressLength {
+		return fmt.Errorf("extension: the counterparty address is %d bytes, over the %d-byte cap", len(c.Email), MaxAddressLength)
+	}
+	if utf8.RuneCountInString(c.DisplayName) > MaxDisplayNameRunes {
+		return fmt.Errorf("extension: the counterparty display name is over the %d-rune cap", MaxDisplayNameRunes)
+	}
+	if c.Direction != "" && c.Direction != DirectionInbound && c.Direction != DirectionOutbound {
+		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty for a record with no honest direction)",
+			c.Direction, DirectionInbound, DirectionOutbound)
+	}
+	// A counterparty carrying BOTH is well-formed here, and deliberately so: the
+	// channel identity NAMES the human and the address CORROBORATES them, which
+	// is a shape only the core can admit or refuse, because only the core knows
+	// which merge keys this source declared. Refusing it here would refuse it
+	// for every source alike and put the decision in the wrong place.
+	return c.ChannelIdentity.validate()
+}
+
+// validate refuses a HALF-stated channel identity, which is the shape that
+// looks populated and routes nowhere.
+//
+// Either both the provider and the account id are present or neither is. One
+// without the other reaches the core as a binding it cannot key — and the core
+// would drop it rather than fail, so the record would land, look ordinary, and
+// carry no reply address, which is indistinguishable from a provider that
+// simply does not identify its senders.
+func (c ChannelIdentity) validate() error {
+	switch {
+	case c.Provider == "" && c.ChannelUserID == "":
+		return nil
+	case c.Provider == "":
+		return errors.New("extension: the channel identity names an account with no provider — the binding is keyed on the pair, so half of it binds nothing")
+	case c.ChannelUserID == "":
+		return errors.New("extension: the channel identity names a provider with no account id — a party identified only by transport cannot be replied to")
+	case !providerGrammar.MatchString(c.Provider):
+		return fmt.Errorf("extension: channel identity provider %q must start with a letter and contain only lower-case letters, digits and underscores", c.Provider)
+	case len(c.ChannelUserID) > MaxChannelUserIDLength:
+		return fmt.Errorf("extension: the channel account id is %d bytes, over the %d-byte cap", len(c.ChannelUserID), MaxChannelUserIDLength)
+	case utf8.RuneCountInString(c.DisplayName) > MaxDisplayNameRunes:
+		return fmt.Errorf("extension: the channel identity display name is over the %d-rune cap", MaxDisplayNameRunes)
+	}
+	return nil
+}
+
+func (a ActivityFields) validate() error {
+	if strings.TrimSpace(a.Kind) == "" {
+		return errors.New("extension: the activity names no kind")
+	}
+	if utf8.RuneCountInString(a.Subject) > MaxSubjectRunes {
+		return fmt.Errorf("extension: the subject is over the %d-rune cap", MaxSubjectRunes)
+	}
+	if utf8.RuneCountInString(a.Body) > MaxBodyRunes {
+		return fmt.Errorf("extension: the body is over the %d-rune cap", MaxBodyRunes)
+	}
+	if a.OccurredAt.IsZero() {
+		return errors.New("extension: the activity has no occurred-at — a timeline ordered by when a poll noticed is a timeline of this system's own scheduling")
+	}
+	if a.Direction != "" && a.Direction != DirectionInbound && a.Direction != DirectionOutbound {
+		return fmt.Errorf("extension: %q is not a direction (%q, %q, or empty)", a.Direction, DirectionInbound, DirectionOutbound)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #1465.

## The flag and its source disagreed

`TraceEntry.ChannelIdentity` documents itself precisely:

> ChannelIdentity reports that SourceID is a provider ACCOUNT id rather than a message id — which is personal data, and is hashed on write.

and `sinktrace.go` set it from `rec.Counterparty.ChannelIdentity.Provider != ""`. That asks **how the record names its human**, which is a different question. The dispact connector shows them coming apart: one natural-key shape for every notification it lands (`providerWorkspace:notificationID`), while naming direct messages by a channel account and mentions by an address. Identical key semantics, and on the dev database in the issue: 15 DMs hashed, 31 mentions not.

Neither half is a leak — hashing a notification id is conservative, and the unhashed half is unhashed correctly. The cost is diagnostic: half of one connector's traces can no longer be looked up by the provider's own id, which is what ADR-0082 §1 kept the id for.

## The producer says

`connector.NaturalKey` gains `SourceIDNamesAPerson`, declared where the key is minted, because the producer is the only party that knows what its own key is made of.

- **telegram** sets it: the key is `botID:chatID:messageID`, and a private chat's id *is* the sender's own Telegram account id. Set unconditionally rather than per chat type — a connector that hashed only some of its keys would answer "was this hashed" with the chat's shape, which is the inference this replaces.
- **gcal, mailmap, offlinedemo, siteread** leave it false. Their keys name an event, a message, a proposal.
- **extensions** answer through `extension.Record.KeyNamesAPerson`, because a unit's key is opaque to the core. `false` is the zero value and the ordinary case, which is also what restores dispact's DM traces to being lookupable.

## The second job the flag was doing

It could not simply move, because `tracePayload` also read it — to tell a workspace-owned channel binding (genuinely no member) from a personal connector's `no_granting_human` fault, so a fault does not carry somebody's mail across the manager-readable boundary. That one **is** the counterparty's question, and it is now asked of the counterparty fields, which already carried the answer:

```go
func (in TraceEntry) namesItsHumanByAccount() bool { return in.CounterpartyProvider != "" }
```

Three integration cases set `entry.ChannelIdentity = true` beside a `CounterpartyProvider` they had already set; those lines are gone, and the tests pass unchanged, because the answer now comes from the field that held it.

## Tests

`TestHashingFollowsTheKeyAndAttributionFollowsTheCounterparty` runs the four combinations a single field could not represent — a notification from a channel account, a notification from an address, a chat message, and an account-keyed record whose sender has an address. The reported bug is the first two rows.

`TestTheTraceHashesTheKeyItWasGiven` makes the counterparty say the **opposite** of the key on every case, which is the disagreement the old inference could not survive.

`TestNormalizeBuildsTheChatScopedNaturalKey` now pins telegram's declaration, because the field's default is right for the message id a natural key usually is and wrong there.

Mutation-checked from the other end:

| mutation | caught by |
|---|---|
| `sinktrace` back to inferring from the counterparty | the four-combination test — a notification comes back `sha256:…` |
| `namesItsHumanByAccount` reading the key instead | the same test's attribution arm |
| telegram silently dropping its declaration | the normalize test |

## Also

`pkg/extension/ingress.go` crossed the 500-line cap with the new field. Its validation moves to `ingressvalidate.go` — the shapes are what a unit author reads and the refusals are what a unit author trips over, and those are read at different times.

`make check-backend` green; `make test-it DIR=backend/internal/modules/capture RUN='Trace|Hash'` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Improved source identifier handling to distinguish person-identifying IDs from message or event IDs.
  * Ensured sensitive identifiers are consistently protected while preserving accurate counterparty attribution.

* **Bug Fixes**
  * Corrected identity classification in activity traces, including notification and chat records.
  * Improved Telegram record handling for person-identifying account IDs.

* **Validation**
  * Added comprehensive validation for record keys, activity details, addresses, counterparties, thread keys, timestamps, and record size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->