### PR TITLE
fix(storekit): a nil version is the request's answer, never the call site's (#1505)

### DIFF
--- a/backend/gates/guardedversion_test.go
+++ b/backend/gates/guardedversion_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A nil version is the request's answer, never the call site's.
+//
+// storekit.Patch.ApplyGuarded takes an *int64 If-Match, and a nil one drops the
+// version clause: the write then locks the row and applies, which is serialized
+// but is not the compare-and-set the caller's signature suggests it might be.
+// The contract keeps If-Match OPTIONAL (data-model §1.3a), so that path has to
+// exist — a client that sends no precondition still gets a write.
+//
+// What must not exist is a call site that writes the nil itself. The two spell
+// the same thing and mean opposite things: one is a client declining a
+// precondition, and the other is a programmer who had no version and reached for
+// the argument that compiled. Nothing distinguishes them at the call site, which
+// is how optimistic locking stayed opt-in on a seam whose whole purpose is to
+// make it the default (issue #1505).
+//
+// So the pointer must come from somewhere — a request field, a variable, a
+// parameter — and never from the `nil` keyword. A call site with genuinely no
+// version has an honest spelling already: take the lock by name with
+// storekit.LockRow and write through the witness with ApplyLocked, which is what
+// ApplyGuarded(nil) does anyway and says so in the types.
+//
+// A prohibition rather than a census, and the difference matters here: the rule
+// is about a literal that must appear nowhere, so a walk that missed a file
+// would report the same green as a tree that has none. The census half is the
+// sweep itself — every file in internal/ that names the seam is parsed, and a
+// file naming it outside the roots fails the scope rather than being skipped.
+
+import (
+	"go/ast"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// The seams that take an If-Match pointer. Both, because ApplyGuardedIn is the
+// same door with the archive filter spelled out, and a rule that bound only the
+// short one would be one refactor from meaning nothing.
+var guardedApplyDoors = map[string]bool{
+	"ApplyGuarded":   true,
+	"ApplyGuardedIn": true,
+}
+
+// ifVersionArg is the pointer's position: (ctx, tx, table, id, ifVersion, …).
+const ifVersionArg = 4
+
+func TestNoCallSiteWritesItsOwnNilVersion(t *testing.T) {
+	t.Parallel()
+
+	files := gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: fileCallsAGuardedApply,
+		// Not the extension tier: extensions/ are separate modules that cannot
+		// import storekit at all, so a unit reaches a guarded write only through
+		// a wrapper inside this root.
+	}.Files(t)
+
+	sites := 0
+	for _, parsed := range files {
+		for _, site := range guardedApplySitesIn(parsed) {
+			sites++
+			if site.versionIsNilLiteral {
+				t.Errorf("%s: %s is handed a literal nil version.\n"+
+					"\tA nil here drops the If-Match clause, so this write is last-writer-wins "+
+					"against anything the row lock does not cover — and it reads as a caller who "+
+					"HAD a version and declined it.\n"+
+					"\tIf there is genuinely no version to compare (the wire takes no If-Match, or "+
+					"the table has no version column), say so in the types: storekit.LockRow for "+
+					"the lock and Patch.ApplyLocked through its witness.",
+					site.key, site.door)
+			}
+		}
+	}
+	// A prohibition that swept nothing passes for the wrong reason. The seam has
+	// call sites in every module that serves a client-driven update, so a zero
+	// here is a broken walk rather than a clean tree.
+	if sites == 0 {
+		t.Fatal("no ApplyGuarded call site was found at all, so this gate judged nothing — " +
+			"the walk is broken, or the seam was renamed and this rule now binds a name nobody calls")
+	}
+}
+
+// guardedApplySite is one call, keyed for a message a reader can open.
+type guardedApplySite struct {
+	key                 string
+	door                string
+	versionIsNilLiteral bool
+}
+
+func fileCallsAGuardedApply(_ string, file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && guardedApplyDoors[sel.Sel.Name] {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+func guardedApplySitesIn(parsed gatekit.ParsedFile) []guardedApplySite {
+	// The DECLARATION is out of scope: storekit's own signature is where the
+	// pointer is allowed to be nil, and the forward from ApplyGuarded into
+	// ApplyGuardedIn is that same argument travelling one frame.
+	if strings.Contains(filepath.ToSlash(parsed.Path), "/platform/database/storekit/") {
+		return nil
+	}
+	var sites []guardedApplySite
+	for _, decl := range parsed.File.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !guardedApplyDoors[sel.Sel.Name] || len(call.Args) <= ifVersionArg {
+				return true
+			}
+			sites = append(sites, guardedApplySite{
+				key:                 parsed.Path + ":" + fn.Name.Name,
+				door:                sel.Sel.Name,
+				versionIsNilLiteral: isNilIdent(call.Args[ifVersionArg]),
+			})
+			return true
+		})
+	}
+	return sites
+}

--- a/backend/internal/modules/activities/documents.go
+++ b/backend/internal/modules/activities/documents.go
@@ -329,8 +329,15 @@ func (s *Store) UpdateAttachmentMetadata(
 		}
 		// No version guard: attachment carries no version column, so there is
 		// nothing to compare a precondition against (the wire operation does not
-		// advertise If-Match for the same reason).
-		if err := p.ApplyGuarded(ctx, tx, "attachment", id, nil); err != nil {
+		// advertise If-Match for the same reason). The row lock is what
+		// serializes the write, and it is taken by name — a nil version here
+		// would read as a precondition this caller could have supplied, when the
+		// table has none to supply.
+		lock, err := storekit.LockRow(ctx, tx, "attachment", id, storekit.LiveOnly)
+		if err != nil {
+			return err
+		}
+		if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 			return err
 		}
 		// Audited against the PARENT's object type, which is where the authority

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -185,9 +185,17 @@ func (s *Store) ArchiveContract(ctx context.Context, id ids.ContractID) error {
 		if err != nil {
 			return err
 		}
+		// Archiving takes no If-Match on the wire, so the write is serialized by
+		// the row lock instead. Taken by name rather than by handing the guarded
+		// seam a nil version, which does the same thing while reading as a
+		// caller who had a version and chose not to use it.
+		lock, err := storekit.LockRow(ctx, tx, "contract", id.UUID, storekit.LiveOnly)
+		if err != nil {
+			return err
+		}
 		patch := storekit.NewPatch()
 		patch.Set("archived_at", existing.ArchivedAt, time.Now().UTC())
-		if err := patch.ApplyGuarded(ctx, tx, "contract", id.UUID, nil); err != nil {
+		if err := patch.ApplyLocked(ctx, tx, lock); err != nil {
 			return fmt.Errorf("archive contract: %w", err)
 		}
 		auditID, err := storekit.Audit(ctx, tx, "archive", contractObject, id.UUID, patch.Before(), patch.After())

--- a/backend/internal/modules/dealrooms/lifecycle.go
+++ b/backend/internal/modules/dealrooms/lifecycle.go
@@ -125,7 +125,8 @@ func (s *Store) moveRoom(ctx context.Context, id ids.DealRoomID, move roomMove) 
 		// Lock before deciding: without it two concurrent pauses both read
 		// `live`, both pass the check, and the second writes over a state the
 		// first already changed.
-		if _, err := storekit.LockRow(ctx, tx, roomObject, id.UUID, storekit.LiveOnly); err != nil {
+		lock, err := storekit.LockRow(ctx, tx, roomObject, id.UUID, storekit.LiveOnly)
+		if err != nil {
 			return err
 		}
 		current, err = readRoom(ctx, tx, id)
@@ -143,8 +144,11 @@ func (s *Store) moveRoom(ctx context.Context, id ids.DealRoomID, move roomMove) 
 			p.Set(move.stampsCol, nil, time.Now().UTC())
 		}
 		// No If-Match: none of the three access moves takes one on the wire, and
-		// the row lock above already serializes them against each other.
-		if err := p.ApplyGuarded(ctx, tx, roomObject, id.UUID, nil); err != nil {
+		// the row lock above already serializes them against each other. Written
+		// through the lock's own witness rather than as a nil version, so the
+		// serialization this relies on is the one the compiler can see — a nil
+		// there re-derives the same lock and says nothing about holding it.
+		if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 			return fmt.Errorf("apply deal room %s: %w", move.action, err)
 		}
 		auditID, err := storekit.Audit(ctx, tx, move.action, roomObject, id.UUID, p.Before(), p.After())

--- a/backend/internal/modules/dealrooms/participant_write.go
+++ b/backend/internal/modules/dealrooms/participant_write.go
@@ -347,8 +347,14 @@ func applyParticipantPatch(ctx context.Context, tx pgx.Tx, room crmcontracts.Dea
 	}
 	// No If-Match: a participant carries no version column, and the corrections
 	// this accepts are last-writer-wins by nature — two stewards fixing the same
-	// typo do not need to be told they collided.
-	if err := p.ApplyGuardedIn(ctx, tx, participantObject, id.UUID, nil, storekit.NoArchiveColumn); err != nil {
+	// typo do not need to be told they collided. The row lock is still what
+	// orders them, and it is taken by name rather than left implicit in a nil
+	// version, which reads as a precondition this caller chose not to use.
+	lock, err := storekit.LockRow(ctx, tx, participantObject, id.UUID, storekit.NoArchiveColumn)
+	if err != nil {
+		return err
+	}
+	if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 		if storekit.IsUniqueViolation(err) {
 			return errAlreadyInvited
 		}

--- a/backend/internal/modules/dealrooms/thread_write.go
+++ b/backend/internal/modules/dealrooms/thread_write.go
@@ -349,7 +349,15 @@ func (s *Store) ResolveThread(ctx context.Context, roomID ids.DealRoomID, thread
 		p.Set("state", threadOpen, threadResolved)
 		p.Set("resolved_at", nil, time.Now().UTC())
 		p.Set("resolved_by_user_id", nil, userID)
-		if err := p.ApplyGuardedIn(ctx, tx, threadObject, threadID, nil, storekit.NoArchiveColumn); err != nil {
+		// No If-Match: a thread carries no version column, so there is no
+		// precondition to compare. The row lock is what serializes two people
+		// resolving at once, and it is taken by name — a nil version reads as a
+		// caller who had one and declined it.
+		lock, err := storekit.LockRow(ctx, tx, threadObject, threadID, storekit.NoArchiveColumn)
+		if err != nil {
+			return err
+		}
+		if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 			return err
 		}
 		auditID, err := storekit.Audit(ctx, tx, "resolve", threadObject, threadID, p.Before(), p.After())

--- a/backend/internal/modules/people/leaddisqualifyreason.go
+++ b/backend/internal/modules/people/leaddisqualifyreason.go
@@ -197,7 +197,13 @@ func (s *Store) UpdateLeadDisqualifyReason(ctx context.Context, id ids.UUID, in 
 			out = before
 			return nil
 		}
-		if err := p.ApplyGuardedIn(ctx, tx, "lead_disqualify_reason", id, nil, storekit.NoArchiveColumn); err != nil {
+		// No If-Match: the table carries no version column, so the row lock is
+		// the whole of the serialization and is taken by name.
+		lock, err := storekit.LockRow(ctx, tx, "lead_disqualify_reason", id, storekit.NoArchiveColumn)
+		if err != nil {
+			return err
+		}
+		if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 			return err
 		}
 		if _, err := storekit.Audit(ctx, tx, "update", "lead_disqualify_reason", id, p.Before(), p.After()); err != nil {

--- a/backend/internal/modules/people/leadsource.go
+++ b/backend/internal/modules/people/leadsource.go
@@ -411,7 +411,13 @@ func (s *Store) UpdateLeadSource(ctx context.Context, id ids.UUID, in UpdateLead
 			out = before
 			return nil
 		}
-		if err := p.ApplyGuardedIn(ctx, tx, "lead_source", id, nil, storekit.NoArchiveColumn); err != nil {
+		// No If-Match: the table carries no version column, so the row lock is
+		// the whole of the serialization and is taken by name.
+		lock, err := storekit.LockRow(ctx, tx, "lead_source", id, storekit.NoArchiveColumn)
+		if err != nil {
+			return err
+		}
+		if err := p.ApplyLocked(ctx, tx, lock); err != nil {
 			return err
 		}
 		if _, err := storekit.Audit(ctx, tx, "update", "lead_source", id, p.Before(), p.After()); err != nil {

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -168,7 +168,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (24)
+## Prohibition (25)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -179,6 +179,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensions_arch_test.go` | H2 | Extension-tier fitness functions (ADR-0069 §3): the compiler already walls extensions off from internal/\*\* (their module paths sit outside the backend module), these tests hold the rest of the import contract from the tree — every extension source dir (enabled or fixture) is enrolled the moment it exists. |
 | `flagdefault_test.go` | H2 | No string flag takes its default straight from the environment. |
 | `formulafieldscope_test.go` | H3 | The negative-scope half of the formula-field boundary proof (RD-AC-7): a formula field is a database-GENERATED artifact, never a runtime-authored one, so NO contract operation may accept a writable formula\_sql in its request body — ComputedField.formula\_sql (crm.yaml) is a response-only display field, never echoed back as an editable one. |
+| `guardedversion_test.go` | H2 | A nil version is the request's answer, never the call site's. |
 | `integrationmigrateonce_test.go` | H2 | Migrate-once discipline for everything the integration lane compiles, as a fitness function. |
 | `jobargscontent_test.go` | H2 | Job args carry REFERENCES, never content. |
 | `jobfleetscan_test.go` | H2 | The fleet enumeration lives at ratified sites only. |


### PR DESCRIPTION
Closes #1505.

## What the nil meant, twice

`storekit.Patch.ApplyGuarded` takes an `ifVersion *int64`. Nil drops the version clause, and the write instead takes the row lock and applies — serialized, but not the compare-and-set the seam is for.

That path has to exist: the contract keeps `If-Match` **optional** (data-model §1.3a), so a client that sends no precondition still gets a write. What must not exist is a **call site that writes the nil itself**. The two spell the same thing and mean opposite things — one is a client declining a precondition, the other is a programmer who had no version and reached for the argument that compiled — and nothing at the call site told them apart. That is how optimistic locking stayed opt-in on the seam whose whole purpose is to make it the default.

So this does not make the version required, and that is deliberate: requiring it would delete the optional-`If-Match` path the contract promises. Forbidding the **literal** keeps that path and closes the way to forget it.

## Seven sites, not two

The issue counted two. An AST gate found seven, because four of them go through `ApplyGuardedIn`, where the nil sits mid-argument-list:

```go
p.ApplyGuardedIn(ctx, tx, "lead_source", id, nil, storekit.NoArchiveColumn)
```

A grep for `ApplyGuarded(…, nil)` cannot see those. The four the grep missed were `dealrooms/participant_write.go`, `dealrooms/thread_write.go`, `people/leaddisqualifyreason.go`, `people/leadsource.go`.

Every one of the seven means the same thing — *this table has no version column*, or *this wire takes no If-Match* — and every one now says so in the types:

```go
lock, err := storekit.LockRow(ctx, tx, table, id, storekit.LiveOnly)
if err != nil { return err }
if err := p.ApplyLocked(ctx, tx, lock); err != nil { … }
```

which is exactly what `ApplyGuarded(nil)` already did, spelled so a reader can tell. `RowLock`'s fields are unexported and only `LockRow`/`LockPair` mint it, so `ApplyLocked` structurally proves the lock is held — where the nil proved nothing.

One site was better than that: `dealrooms/lifecycle.go` already held a `LockRow` and discarded the witness, then handed `ApplyGuarded` a nil that re-derived the same lock. It now passes the witness it had.

## The gate

`backend/gates/guardedversion_test.go`, `//gate:kind prohibition H2`. It sweeps `internal/` for calls to either door, reads argument 4, and fails on the `nil` **keyword** — not on a nil-valued expression, because a variable holding nil is the request's answer arriving through a field, which is what the rule permits.

It also refuses to pass on an empty sweep. A prohibition that judged nothing reads exactly like a clean tree, so a zero site count is a `t.Fatal` naming the two ways that happens: a broken walk, or a renamed seam.

Mutation-checked:

| mutation | result |
|---|---|
| one `ApplyLocked` reverted to `ApplyGuardedIn(…, nil, …)` | named, with the file and function |
| both door names changed to ones nobody calls | both arms fire — `gatekit.Scope` reports the root finds nothing, and the site-count guard reports the walk judged nothing |
| a live `in.IfVersion` pointer | not flagged — the many existing call sites passing it are the standing proof |

`docs/reference/gate-inventory.md` regenerated: Prohibition 24 → 25.

## Not done here

The issue's last line notes a frontend half — the missing `If-Match` on the deal advance mutation. That is a different file, a different failure, and belongs in its own change.

`make check-backend` green. `make test-it` green on all four touched modules: dealrooms (21), people (576), contracts (14), activities (196).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and safety for contract, activity, deal room, thread, and lead record updates by applying changes under explicit row locks.
  * Prevented invalid version-guarded updates when no version is available.

* **Tests**
  * Added automated checks to detect unsafe guarded updates lacking a valid version requirement.

* **Documentation**
  * Updated the gate inventory to include the new validation check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->