### PR TITLE
test(uat): the filters screen enters the AC sweep, and it was hiding three defects (#1468)

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -82,6 +82,13 @@ const CORE_SCREENS = [
   // whose primary surface a reader can swap under the same address, so the
   // 390px pass has two layouts to find a horizontal scroll in rather than one.
   "leads",
+  // Filters & views. It is a rail destination AC-shell-1 already asserts by
+  // name, and it was in neither sweep — so the one screen in the product whose
+  // body is a nested editor grew clause rows, an operator control and a preview
+  // table with nobody measuring them at 390px or against axe. It is also the
+  // screen most able to be WIDE: a clause is a row of three controls, and a
+  // second level of nesting indents it again.
+  "filters",
   "today",
   "reports",
   "settings",
@@ -1794,4 +1801,166 @@ test("PERF-1: a record's heading does not wait on GET /people/{id}", async ({
   ).toBeVisible();
   expect(readStarted).toBe(true);
   expect(readAnswered).toBe(false);
+});
+
+// AC-filters-and-views: authoring a dynamic list's filter in the product.
+//
+// The screen shipped without entering either sweep and with no criterion of its
+// own asserted, which is why #1468 could read as open against a surface that had
+// been live for weeks: nothing in this file mentioned it, so nothing here
+// contradicted the report. Adding `filters` to CORE_SCREENS above puts it in the
+// 390px and axe passes — which found a 257px overflow and two 1.5:1 captions on
+// their first run. These four say what the screen is FOR.
+//
+// Four rather than eight. 2, 6 and 7 are cited nowhere in this tree, and a test
+// naming a criterion whose text nobody here can read would assert whatever I
+// guessed it said.
+test.describe("filters and views", () => {
+  // Every clause below is authored the way a person authors one — through the
+  // picker — rather than by seeding a tree in code. "A human can build this" is
+  // the claim, and a tree set in code is one no human went through.
+  async function authorIndustryIs(page: Page) {
+    await page.getByRole("button", { name: "Bedingung hinzufügen" }).click();
+    await page.getByRole("combobox", { name: "Feld" }).click();
+    await page.getByRole("option", { name: "industry" }).click();
+    await page.getByRole("combobox", { name: "Operator" }).click();
+    await page.getByRole("option", { name: "ist", exact: true }).click();
+    await page.getByRole("textbox", { name: "Wert" }).fill("automotive");
+  }
+
+  test("AC-filters-and-views-3: a clause is a field, an operator its type admits, and a value", async ({
+    page,
+  }) => {
+    await page.goto("/#/filters/companies");
+    await expectShellRendered(page);
+
+    // Before anything is authored the count says so, rather than showing a zero
+    // that would read as "no companies match".
+    await expect(
+      page.getByText("Bedingung hinzufügen, um die Treffer zu sehen"),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Bedingung hinzufügen" }).click();
+
+    // The field picker is the SERVER's vocabulary, not a list this screen keeps:
+    // `industry` and `lifecycle` are organization fields, `tag` is the leaf that
+    // is an EXISTS over a join rather than a column, and none of them is
+    // spelled anywhere in the frontend.
+    await page.getByRole("combobox", { name: "Feld" }).click();
+    expect(await page.getByRole("option").allTextContents()).toEqual([
+      "owner id",
+      "industry",
+      "lifecycle",
+      "tag",
+    ]);
+    await page.getByRole("option", { name: "industry" }).click();
+
+    // And the operator set is the FIELD's. `industry` is text, so `enthält` is
+    // offered; the tag clause in AC-4 proves the narrowing by its absence.
+    await page.getByRole("combobox", { name: "Operator" }).click();
+    expect(await page.getByRole("option").allTextContents()).toEqual([
+      "ist",
+      "ist nicht",
+      "ist eines von",
+      "enthält",
+      "hat einen Wert",
+    ]);
+    await page.getByRole("option", { name: "ist", exact: true }).click();
+
+    await page.getByRole("textbox", { name: "Wert" }).fill("automotive");
+
+    // The count is the SERVER's — 812 is the fixture's match_count, a number no
+    // arithmetic on the two returned rows could produce.
+    await expect(page.getByText("812 Firmen treffen zu")).toBeVisible();
+  });
+
+  test("AC-filters-and-views-4: clauses combine, the group names the join, and a linked field is narrowed", async ({
+    page,
+  }) => {
+    await page.goto("/#/filters/companies");
+    await expectShellRendered(page);
+
+    // The join control is present before a second clause exists, because it is a
+    // property of the GROUP rather than of having two of anything.
+    const joins = page.getByRole("group", {
+      name: "Wie diese Gruppe ihre Bedingungen verknüpft",
+    });
+    await expect(joins).toHaveCount(1);
+    await expect(
+      joins.getByRole("button", { name: "ALLE · UND", pressed: true }),
+    ).toBeVisible();
+    await joins.getByRole("button", { name: "BELIEBIGE · ODER" }).click();
+    await expect(
+      joins.getByRole("button", { name: "BELIEBIGE · ODER", pressed: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Bedingung hinzufügen" }).click();
+    await page.getByRole("button", { name: "Bedingung hinzufügen" }).click();
+    await expect(page.getByRole("combobox", { name: "Feld" })).toHaveCount(2);
+
+    // A tag leaf is reached through a join, so the engine narrows it to the link
+    // operators — `enthält` is gone, and a picker that offered it would produce
+    // a 422 the reader could not interpret.
+    await page.getByRole("combobox", { name: "Feld" }).first().click();
+    await page.getByRole("option", { name: "tag" }).click();
+    await page.getByRole("combobox", { name: "Operator" }).first().click();
+    expect(await page.getByRole("option").allTextContents()).toEqual([
+      "ist",
+      "ist nicht",
+      "ist eines von",
+      "hat einen Wert",
+    ]);
+    await page.keyboard.press("Escape");
+
+    // And nesting: a group inside a group is what mixing AND with OR needs.
+    await page.getByRole("button", { name: "Gruppe hinzufügen" }).click();
+    await expect(joins).toHaveCount(2);
+  });
+
+  test("AC-filters-and-views-5: the preview shows matching records, and says it is a page of them", async ({
+    page,
+  }) => {
+    await page.goto("/#/filters/companies");
+    await expectShellRendered(page);
+    await authorIndustryIs(page);
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Passende Datensätze" }),
+    ).toBeVisible();
+    // By CELL: the shell's own workspace strip carries the same company name,
+    // and a bare text match would pass on the chrome while the table was empty.
+    await expect(
+      page.getByRole("cell", { name: "Brandt Automotive", exact: true }),
+    ).toBeVisible();
+    // The caption that keeps the page honest: 812 match and two are shown, so
+    // the reader is told this is a sample rather than the selection.
+    await expect(
+      page.getByText(
+        "Die erste Seite der Treffer — genug, um den Filter zu prüfen, nicht die gesamte Auswahl.",
+      ),
+    ).toBeVisible();
+  });
+
+  test("AC-filters-and-views-1: the object tab is part of the address", async ({
+    page,
+  }) => {
+    await page.goto("/#/filters/deals");
+    await expectShellRendered(page);
+    const objects = page.getByRole("group", {
+      name: "Welche Datensätze gefiltert werden",
+    });
+    await expect(
+      objects.getByRole("button", { name: "Geschäfte", pressed: true }),
+    ).toBeVisible();
+
+    await objects.getByRole("button", { name: "Kontakte" }).click();
+    await expect(page).toHaveURL(/#\/filters\/contacts$/);
+
+    // Reloaded, not just navigated: the tab is where you ARE, so a shared link
+    // and a refresh have to land on the same object.
+    await page.reload();
+    await expect(
+      objects.getByRole("button", { name: "Kontakte", pressed: true }),
+    ).toBeVisible();
+  });
 });

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1852,6 +1852,9 @@ test.describe("filters and views", () => {
       "industry",
       "lifecycle",
       "tag",
+      // The custom field, and it sorts after the core ones — a reader scanning
+      // for a column they added finds it in one place rather than interleaved.
+      "fleet size",
     ]);
     await page.getByRole("option", { name: "industry" }).click();
 
@@ -1872,6 +1875,41 @@ test.describe("filters and views", () => {
     // The count is the SERVER's — 812 is the fixture's match_count, a number no
     // arithmetic on the two returned rows could produce.
     await expect(page.getByText("812 Firmen treffen zu")).toBeVisible();
+  });
+
+  // #1286 made custom fields and tags selectable beside core fields, and the
+  // issue's own "done when" names that: a picker that offered only core fields
+  // would satisfy every other case here. The badge is the half a reader needs —
+  // `cf_fleet_size` and a core column look identical without it.
+  test("AC-filters-and-views-2: a custom field is offered beside the core ones, and says it is one", async ({
+    page,
+  }) => {
+    await page.goto("/#/filters/companies");
+    await expectShellRendered(page);
+    await page.getByRole("button", { name: "Bedingung hinzufügen" }).click();
+    await page.getByRole("combobox", { name: "Feld" }).click();
+    await page.getByRole("option", { name: "fleet size" }).click();
+
+    // The badge is beside the picker rather than inside the option, which is
+    // where it has to be: a chosen field's option is no longer on screen, and
+    // "this is a column somebody here added" is the fact a reader needs while
+    // reading the clause, not while opening the menu.
+    await expect(page.getByText("eigenes Feld")).toBeVisible();
+
+    // Its operators are its TYPE's — number, so the comparisons appear, and
+    // `enthält` does not. A picker that offered a fixed set here would produce
+    // a 422 the reader could not interpret.
+    await page.getByRole("combobox", { name: "Operator" }).click();
+    expect(await page.getByRole("option").allTextContents()).toEqual([
+      "ist",
+      "ist nicht",
+      "ist größer als",
+      "ist mindestens",
+      "ist kleiner als",
+      "ist höchstens",
+      "ist eines von",
+      "hat einen Wert",
+    ]);
   });
 
   test("AC-filters-and-views-4: clauses combine, the group names the join, and a linked field is narrowed", async ({
@@ -1932,6 +1970,18 @@ test.describe("filters and views", () => {
     await expect(
       page.getByRole("cell", { name: "Brandt Automotive", exact: true }),
     ).toBeVisible();
+    // EVERY row satisfies the filter, and that is asserted rather than assumed.
+    // A preview is what a reader checks a filter against before saving it as a
+    // list, so a row the predicate excludes is the one thing it must never
+    // show — and a test naming only the row it expected would pass over exactly
+    // that.
+    await expect(
+      page.getByRole("cell", { name: "Kessler Fahrzeugbau", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: "automotive", exact: true }),
+    ).toHaveCount(2);
+    await expect(page.getByRole("cell", { name: "logistics" })).toHaveCount(0);
     // The caption that keeps the page honest: 812 match and two are shown, so
     // the reader is told this is a sample rather than the selection.
     await expect(

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -35,6 +35,11 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // role. Read alone, because no spec exercises a person write from here and a
   // grant this fixture does not need is a grant it should not claim.
   person: ["read"],
+  // Filters & views reads the vocabulary and previews a tree under `list:read`
+  // (collections/handlers.go), and saving a filter as a dynamic list is a
+  // `list:create`. Without them the sweep would measure a screen whose picker
+  // never loaded — a page that renders and says nothing, which both sweeps pass.
+  list: ["create", "read", "update", "delete"],
 };
 
 // The coherent seed (mirrors design/seed-fixtures.md entities: Anna Weber,
@@ -1284,6 +1289,87 @@ export async function mockApi(
           },
         ]),
       );
+    }
+    if (path === "/filters/vocabulary" && method === "GET") {
+      // What a record type may be filtered on, as the server would answer it.
+      //
+      // The operator sets are NOT invented here: each is what
+      // storekit.operatorsByType admits for that type, narrowed by
+      // linkOperators where the field is reached through a join. A fixture that
+      // offered an operator the engine refuses would let a spec build a tree
+      // the product cannot, and the screen would look correct while doing
+      // something the server would 422.
+      const resource = url.searchParams.get("resource") ?? "person";
+      const owner = {
+        name: "owner_id",
+        type: "id",
+        operators: ["eq", "neq", "in", "exists"],
+        custom: false,
+        references: "app_user",
+      };
+      // A linked field: `contains` is gone, which is the narrowing a picker has
+      // to honour and the reason the fixture carries one.
+      const tag = {
+        name: "tag",
+        type: "id",
+        operators: ["eq", "neq", "in", "exists"],
+        custom: false,
+        references: "tag",
+      };
+      const byResource: Record<string, unknown[]> = {
+        person: [owner, tag],
+        organization: [
+          owner,
+          {
+            name: "industry",
+            type: "text",
+            operators: ["eq", "neq", "in", "contains", "exists"],
+            custom: false,
+          },
+          {
+            name: "lifecycle",
+            type: "picklist",
+            operators: ["eq", "neq", "in", "exists"],
+            custom: false,
+            options: ["prospect", "customer", "churned"],
+          },
+          tag,
+        ],
+        deal: [
+          owner,
+          {
+            name: "status",
+            type: "picklist",
+            operators: ["eq", "neq", "in", "exists"],
+            custom: false,
+            options: ["open", "won", "lost"],
+          },
+          tag,
+        ],
+      };
+      return json({
+        resource,
+        fields: byResource[resource] ?? [owner],
+      });
+    }
+    if (path === "/filters/preview" && method === "POST") {
+      // A count and the export's own projection. Two rows against a count of 812
+      // so `truncated` is the true answer rather than a flag nothing reads: the
+      // screen says "showing N of 812", and a fixture whose count equalled its
+      // page would let that sentence be wrong and still pass.
+      return json({
+        resource: "organization",
+        match_count: 812,
+        columns: ["id", "name", "industry"],
+        rows: [
+          { id: "o1", name: "Brandt Automotive", industry: "automotive" },
+          { id: "o2", name: "Kessler Logistik", industry: "logistics" },
+        ],
+        truncated: true,
+      });
+    }
+    if (path === "/lists" && method === "GET") {
+      return json(page([]));
     }
     if (path === "/views" && method === "GET") {
       // One saved deals view, and it names the NON-default pipeline. A view is

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1326,6 +1326,18 @@ export async function mockApi(
             operators: ["eq", "neq", "in", "contains", "exists"],
             custom: false,
           },
+          // A custom field, because a picker offering only core fields is not
+          // the picker this product ships: #1286 made `cf_*` columns and tags
+          // selectable, and a fixture with `custom: false` on every row leaves
+          // that half of the vocabulary unexercised. Named as the physical
+          // column, which is what the wire carries — the label lives in
+          // /custom-fields and the picker joins on `column_name`.
+          {
+            name: "cf_fleet_size",
+            type: "number",
+            operators: ["eq", "neq", "gt", "gte", "lt", "lte", "in", "exists"],
+            custom: true,
+          },
           {
             name: "lifecycle",
             type: "picklist",
@@ -1401,9 +1413,13 @@ export async function mockApi(
         resource: "organization",
         match_count: 812,
         columns: ["id", "name", "industry"],
+        // Both rows match the authored predicate. A preview returning a row the
+        // filter excludes would let a results assertion pass over a screen
+        // rendering something the filter must not select — the fixture would be
+        // disagreeing with itself about what a filter means.
         rows: [
           { id: "o1", name: "Brandt Automotive", industry: "automotive" },
-          { id: "o2", name: "Kessler Logistik", industry: "logistics" },
+          { id: "o2", name: "Kessler Fahrzeugbau", industry: "automotive" },
         ],
         truncated: true,
       });

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1357,6 +1357,46 @@ export async function mockApi(
       // so `truncated` is the true answer rather than a flag nothing reads: the
       // screen says "showing N of 812", and a fixture whose count equalled its
       // page would let that sentence be wrong and still pass.
+      //
+      // ANSWERED FROM THE REQUEST, not from the path. A handler that returned
+      // these rows whatever was posted would let the preview assertions pass
+      // over a screen that sent the wrong resource, or a filter that was not
+      // the one the reader authored — the count on screen would be right and
+      // the thing it counted would be nobody's. So the body is read, and a
+      // request that does not match what the spec authored gets an honest empty
+      // answer instead of somebody else's rows.
+      type Leaf = { field?: string; op?: string; value?: unknown };
+      type Predicate = Leaf & { and?: Predicate[]; or?: Predicate[] };
+      const asked = (route.request().postDataJSON() ?? {}) as {
+        resource?: string;
+        filter?: Predicate;
+      };
+      // The root a builder sends is the group, not the clause: `encode`
+      // (segmentpredicate.ts) renders the tree, and its root is always a join.
+      // Flattened here rather than matched shape-for-shape, so the fixture
+      // answers the same filter however the reader nested it.
+      const leaves = (node: Predicate | undefined): Leaf[] =>
+        node === undefined
+          ? []
+          : node.and || node.or
+            ? [...(node.and ?? []), ...(node.or ?? [])].flatMap(leaves)
+            : [node];
+      const clauses = leaves(asked.filter);
+      const authored =
+        asked.resource === "organization" &&
+        clauses.length === 1 &&
+        clauses[0].field === "industry" &&
+        clauses[0].op === "eq" &&
+        clauses[0].value === "automotive";
+      if (!authored) {
+        return json({
+          resource: asked.resource ?? "organization",
+          match_count: 0,
+          columns: [],
+          rows: [],
+          truncated: false,
+        });
+      }
       return json({
         resource: "organization",
         match_count: 812,

--- a/frontend/src/screens/filterbuilder.css
+++ b/frontend/src/screens/filterbuilder.css
@@ -40,7 +40,10 @@
 
 .filter-group-empty {
   margin: 0;
-  color: var(--textMuted);
+  /* --textMeta is the canonical AA role for text this size; --textMuted is the
+   * decorative tone and measured 1.53:1 here. This line tells a reader what an
+   * empty group needs from them, which is not text to make hard to read. */
+  color: var(--textMeta);
   font-size: var(--fs-sm);
 }
 

--- a/frontend/src/screens/filters.css
+++ b/frontend/src/screens/filters.css
@@ -25,6 +25,20 @@
   flex-wrap: wrap;
 }
 
+/* SectionHeader makes its actions `flex: none` because the usual cluster is a
+ * button or two that must not be squeezed narrower than their labels. This
+ * cluster is a toolbar — a count, a badge that spells out what "dynamic" means,
+ * and three menus — and `flex: none` meant it kept its content width whatever
+ * the viewport was: 614px at a 390px viewport, taking the page 257px sideways.
+ *
+ * The row already declares flex-wrap. Being ALLOWED to shrink is the half that
+ * was missing, so this says so for this header only rather than changing what
+ * `flex: none` means for every other one. */
+.filters-screen .section-header-actions {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .filters-count {
   font-weight: 600;
   color: var(--textContent);
@@ -37,15 +51,21 @@
 /* A count being recomputed is the LAST answer, dimmed — not a spinner. It reads
  * as "this is a moment behind", which is true, where a spinner reads as "there
  * is no answer", which is not. */
+/* --textMeta, not --textMuted: this is a count a person reads, and --textMuted
+ * is the decorative tone (1.53:1 on the page). The stale state means "this
+ * number is one edit behind", not "stop reading it". */
 .filters-count[data-stale="true"] {
-  color: var(--textMuted);
+  color: var(--textMeta);
 }
 
 /* No complete clause yet: not a number at all, because zero would claim nothing
  * matches when in fact nothing has been asked. */
 .filters-count-unasked {
   font-weight: 400;
-  color: var(--textMuted);
+  /* The AA small-text role. This line is the whole instruction a reader has
+   * before they have authored anything, so it is the last text on the screen
+   * that may be unreadable. */
+  color: var(--textMeta);
 }
 
 /* Asked and refused. Not muted like the state above it: a reader with a finished


### PR DESCRIPTION
Closes #1468.

## The ticket's premise had drifted

#1468 says the Filters & views screen "does not exist" and that "nothing in `frontend/` builds a predicate". Both were true when it was filed. On `main` today:

| what the issue says is missing | where it is |
|---|---|
| a screen for authoring a filter | `frontend/src/screens/filters.tsx` |
| picking a field, operator, value | `filterbuilder.tsx` (617 lines) + `segmentpredicate.ts` |
| combining the leaves, AND/OR nesting | same, `joins` group per level |
| a nav entry | `app/nav.ts:84`, `#/filters` — **already asserted by name in `AC-shell-1`** |
| the field picker served by the live vocabulary | `GET /filters/vocabulary`, `filterdata.ts` |
| custom fields and tags beside core fields | merged in `collections.SegmentEngine` |
| a saved view's filter authored on the same surface | `savedviews.tsx` |
| filtered export | `filterexport.tsx` |

So every "Done when" box is ticked, and the two the issue calls out specifically hold by construction: the picker reads the same `SegmentEngine` map the compiler validates against (`filtervocabulary.go` only *subtracts* retired fields), and `OperatorsFor(Field)` narrows a linked field to `linkOperators` — so an offered field cannot 422 and an offered operator cannot either.

## What was actually missing

`"filters"` was not in `CORE_SCREENS`, and no `AC-filters-and-views-*` test existed. The criteria are cited in five source comments and three locale files and asserted nowhere. That is why an issue could read as open against a surface that had been live for weeks: **nothing in `ac.spec.ts` mentioned the screen, so nothing contradicted the report** — and nothing measured it either.

Adding it to the sweep found three real defects on the first run.

**257px of horizontal overflow at 390px.** The screen's `SectionHeader` actions are a toolbar — a count, a badge that spells out what "dynamic" means, and three menus — and the design system makes `.section-header-actions` `flex: none`, correctly, because the usual cluster is a button or two that must not be squeezed narrower than their labels. Here it kept its content width whatever the viewport was: 614px inside 390px. The row already declared `flex-wrap`; being *allowed to shrink* is the half that was missing, so this says so for this header only rather than changing what `flex: none` means everywhere else.

**Two AA contrast failures, in both themes.** `.filters-count[data-stale]` and `.filter-group-empty` read `--textMuted`, which is the decorative tone — `#cbd2cd on #ffffff = 1.53:1` in light, `1.95:1` in dark, against the 4.5:1 AA needs. `--textMeta` is documented in `tokens.css` as "the canonical AA small-text role — all 11–13px meta/caption text reads it", and both of these are text a person reads to know what to do next: the count while an edit is in flight, and the line telling them an empty group needs a condition.

## The four criteria

Four rather than eight: **2, 6 and 7 are cited nowhere in this tree**, and a test naming a criterion whose text nobody here can read would assert whatever I guessed it said. This repo is public and the specification records are not in it.

- **AC-3** — a clause is a field, an operator its type admits, and a value. Asserts the picker's contents are the *server's* vocabulary: `industry`, `lifecycle` and the `tag` leaf are organization fields spelled nowhere in the frontend. The count that lands is `812`, the fixture's `match_count` — a number no arithmetic on the two returned rows could produce.
- **AC-4** — clauses combine, the group names the join, nesting adds a second one. And the narrowing: `tag` is reached through a join, so `enthält` is *gone* from its operator list. A picker that offered it would produce the 422 the issue warns about.
- **AC-5** — the preview shows matching rows and says it is a page of them: 812 match, two are shown, and the caption says so.
- **AC-1** — the object tab is part of the address, and survives a reload.

Every clause is authored **through the picker**, not seeded in code. "A human can author a filter in the product" is the claim, and a tree set in code is one no human went through.

## The fixture

`E2E_ADMIN_GRANTS` gains `list` — the screen's reads are gated on `list:read` (`collections/handlers.go`), and without it the sweep would have measured a screen whose picker never loaded: a page that renders and says nothing, which both sweeps pass.

The mock's operator sets are **storekit's own** — `operatorsByType`, narrowed by `linkOperators` — rather than invented. A fixture offering an operator the engine refuses would let a spec build a tree the product cannot, and the screen would look correct while doing something the server would reject.

## Not done here

`OBJECT_TABS` is `contacts | companies | deals`. `lead` and `project` have complete backend vocabularies and no tab. That is a real increment and a visible one, and it is a product decision about what belongs in a rail destination rather than a gap in what this issue asked for — so it is not smuggled in here.

`make frontend-e2e`: **151 passed** (144 before). `make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Filters screen with field-specific operators, custom fields, linked tags, nested groups, and configurable AND/OR joins.
  * Added filter previews with server-reported match counts, truncation details, and sample records.
  * Filter selections now persist in the URL and restore after reloading the page.

* **Accessibility & Usability**
  * Improved empty-state text contrast and accessibility.
  * Updated the filter header layout to wrap cleanly in narrower spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->