### PR TITLE
feat(frontend): a fork adds UI without patching an upstream file (#1503)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { CUSTOM_SCREEN, findCustomScreen } from "./app/custom";
 import {
   EXTENSION_SCREEN,
   type ExtensionScreenRegistry,
@@ -357,6 +358,22 @@ function ResetRoute() {
 // one place both halves of the registry are visible at once.
 const extensionScreens: ExtensionScreenRegistry = composedScreens;
 
+// A fork's own screen, at `#/x/<key>`.
+//
+// Rendered from the registry rather than from a case in the dispatch above,
+// because the whole point of the seam is that a fork adds no case here. The
+// miss renders the same not-found the router gives a mistyped address: a key
+// nothing declares is not a page, and an empty frame would read as one that
+// failed to load.
+function CustomRoute({ name }: Readonly<{ name?: string }>) {
+  const screen = findCustomScreen(name);
+  if (!screen) {
+    return <ScreenNotice messageKey="shell.unknownPage" />;
+  }
+  const ForkScreen = screen.component;
+  return <ForkScreen />;
+}
+
 function ExtensionRoute({ name }: Readonly<{ name?: string }>) {
   const t = useT();
   const unit = findExtension(name);
@@ -473,6 +490,10 @@ const SCREEN_VIEWS: Readonly<Record<Screen, (args: ScreenArgs) => ReactNode>> =
     "oauth-consent": () => <OAuthConsent />,
     [RESET_ROUTE]: () => <ResetRoute />,
     [EXTENSION_SCREEN]: ({ id }) => <ExtensionRoute name={id} />,
+    // The fork seam (app/custom.ts). Upstream's registry is empty, so this arm
+    // renders the not-found card for every address in vanilla — which is the
+    // honest answer, and is why it does not need to be conditional.
+    [CUSTOM_SCREEN]: ({ id }) => <CustomRoute name={id} />,
     // A hash naming no address this app answers. The shell's heading says the
     // same word (shell.unknownPage), so the reader is told once by the page and
     // once by the column, and neither claims a page by that name exists.

--- a/frontend/src/app/custom.test.tsx
+++ b/frontend/src/app/custom.test.tsx
@@ -4,6 +4,7 @@ import { Users } from "lucide-react";
 import { describe, expect, it } from "vitest";
 import type { MessageKey } from "../i18n/en";
 import {
+  buildRegistry,
   CUSTOM_SCREEN,
   type CustomNavScreen,
   type CustomPaletteScreen,
@@ -136,6 +137,33 @@ describe("a fork's screen reaches the rail, the palette and the router", () => {
     );
   });
 
+  // Two directories claiming one key is the failure this seam is worst at: a
+  // Map keeps the last, and the loser is a screen with a component and a rail
+  // row that no address reaches, with nothing to read and nothing looking wrong.
+  it("refuses a key two screens claim", () => {
+    expect(() =>
+      buildRegistry({
+        "./warranty/screen.tsx": { screen: warranty },
+        "./legacy-warranty/screen.tsx": { screen: { ...warranty } },
+      }),
+    ).toThrow(/two custom screens claim the key "warranty"/);
+    // And names the second one, so a fork knows which directory to change.
+    expect(() =>
+      buildRegistry({
+        "./warranty/screen.tsx": { screen: warranty },
+        "./legacy-warranty/screen.tsx": { screen: { ...warranty } },
+      }),
+    ).toThrow(/legacy-warranty/);
+  });
+
+  it("skips a module that exports no screen", () => {
+    const registry = buildRegistry({
+      "./warranty/screen.tsx": { screen: warranty },
+      "./half-written/screen.tsx": {},
+    });
+    expect([...registry.keys()]).toEqual(["warranty"]);
+  });
+
   it("is addressed at the segment its rail row builds", () => {
     // The round trip, not either half: the rail builds `path + prefix + id` and
     // the router parses the same string back, and a prefix and a parser that
@@ -174,6 +202,36 @@ describe("the glob and the documented layout are the same layout", () => {
     "utf8",
   );
   const pattern = /import\.meta\.glob<[^>]*>\(\s*"([^"]+)"/.exec(source)?.[1];
+
+  it("globs the directory a fork is told to write in", () => {
+    // The DIRECTORY, not just that some directory exists: a glob pointed at
+    // `../screens/other/*/screen.tsx` would pass a file-name check, because the
+    // README's example ends in `screen.tsx` too — and a fork following the
+    // README would put its screens somewhere nothing looks.
+    expect(pattern).toBeDefined();
+    const readme = readFileSync(
+      fileURLToPath(new URL("../screens/custom/README.md", import.meta.url)),
+      "utf8",
+    );
+    const documented = /(src\/screens\/[a-z-]+)\/[a-z-]+\/[a-z-]+\.tsx/.exec(
+      readme,
+    )?.[1];
+    if (documented === undefined || pattern === undefined) {
+      throw new Error(
+        "the README names no screen path, or custom.ts globs none",
+      );
+    }
+    // Both resolved to an absolute path, because they are written from
+    // different places: the README's is repo-relative and the glob's is
+    // relative to this module.
+    const globbed = fileURLToPath(
+      new URL(pattern.slice(0, pattern.indexOf("*")), import.meta.url),
+    );
+    const told = fileURLToPath(
+      new URL(`../../${documented}/`, import.meta.url),
+    );
+    expect(globbed).toBe(told);
+  });
 
   it("globs a directory that exists", () => {
     expect(pattern).toBeDefined();

--- a/frontend/src/app/custom.test.tsx
+++ b/frontend/src/app/custom.test.tsx
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Users } from "lucide-react";
 import { describe, expect, it } from "vitest";
+import type { MessageKey } from "../i18n/en";
 import {
   CUSTOM_SCREEN,
   type CustomNavScreen,
@@ -12,6 +13,7 @@ import {
   customPaletteScreens,
   customScreens,
   findCustomScreen,
+  resolveCustomLabel,
 } from "./custom";
 import { isScreen, parseHash } from "./router";
 import { navEntryHref } from "./subnav";
@@ -76,8 +78,14 @@ describe("a fork's screen reaches the rail, the palette and the router", () => {
   const warranty: CustomNavScreen & CustomPaletteScreen = {
     key: "warranty",
     component: () => null,
-    nav: { group: "records", labelKey: "nav.contacts", icon: Users },
-    palette: { labelKey: "nav.contacts" },
+    // The fork's OWN words, which is the case the seam exists for: `warranty`
+    // is not a noun this product has, so there is no key to reuse.
+    nav: {
+      group: "records",
+      label: { en: "Warranty", de: "Garantie" },
+      icon: Users,
+    },
+    palette: { label: { en: "Warranty" } },
   };
   // A second screen that wants NEITHER, which is what proves the two lists are
   // read from their own fields rather than from "is this a fork screen".
@@ -104,6 +112,30 @@ describe("a fork's screen reaches the rail, the palette and the router", () => {
     expect(customPaletteScreens(forked)).toEqual([warranty]);
   });
 
+  // The half that makes the seam whole. A fork screen's label cannot be a
+  // MessageKey — `warranty` is not a noun this product has — and minting one
+  // would mean editing i18n/en.ts, de.ts and vi.ts: three upstream files, for
+  // the one string that names a row. So the words ship WITH the screen.
+  it("reads its own words, in the reader's language, falling back to English", () => {
+    const t = (key: MessageKey) => `translated:${key}`;
+    expect(resolveCustomLabel(warranty.nav.label, "de", t)).toBe("Garantie");
+    expect(resolveCustomLabel(warranty.nav.label, "en", t)).toBe("Warranty");
+    // Vietnamese is a locale this fork does not carry. English rather than a
+    // blank or the key: there is always something to render, and a fork that
+    // ships one language must not put a hole in a rail.
+    expect(resolveCustomLabel(warranty.nav.label, "vi", t)).toBe("Warranty");
+  });
+
+  // And the other arm, which is why this is a union rather than a record: a
+  // fork screen that IS one of the product's nouns seen differently reuses the
+  // word the product already has, in every language it already has it.
+  it("reuses an upstream key when the fork names one", () => {
+    const t = (key: MessageKey) => `translated:${key}`;
+    expect(resolveCustomLabel("nav.contacts", "de", t)).toBe(
+      "translated:nav.contacts",
+    );
+  });
+
   it("is addressed at the segment its rail row builds", () => {
     // The round trip, not either half: the rail builds `path + prefix + id` and
     // the router parses the same string back, and a prefix and a parser that
@@ -111,7 +143,7 @@ describe("a fork's screen reaches the rail, the palette and the router", () => {
     const href = navEntryHref([], {
       id: warranty.key,
       prefix: [CUSTOM_SCREEN],
-      labelKey: warranty.nav.labelKey,
+      label: warranty.nav.label,
       icon: warranty.nav.icon,
     });
     expect(href).toBe("#/x/warranty");

--- a/frontend/src/app/custom.test.tsx
+++ b/frontend/src/app/custom.test.tsx
@@ -1,0 +1,173 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Users } from "lucide-react";
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOM_SCREEN,
+  type CustomNavScreen,
+  type CustomPaletteScreen,
+  type CustomScreen,
+  type CustomScreenRegistry,
+  customNavItems,
+  customPaletteScreens,
+  customScreens,
+  findCustomScreen,
+} from "./custom";
+import { isScreen, parseHash } from "./router";
+import { navEntryHref } from "./subnav";
+
+// The fork seam, from both ends.
+//
+// A seam that is empty upstream is a seam nothing exercises, and the failure
+// mode of an unexercised one is silence: a fork drops a directory in, nothing
+// appears, and there is no error to read. So the tests below split in two.
+//
+// The first group asserts what vanilla IS — empty, and empty in every reader,
+// because a rail that grew a row for a fork nobody wrote would be worse than
+// the seam not existing at all.
+//
+// The second drives the same readers over a registry a fork would produce. That
+// is the half that would otherwise never run: upstream ships nothing, so every
+// answer these functions give a fork is one this repo has never taken.
+
+describe("upstream ships the seam empty", () => {
+  it("declares no custom screen", () => {
+    expect([...customScreens.keys()]).toEqual([]);
+  });
+
+  it("adds no row to any rail group", () => {
+    expect(customNavItems("records")).toEqual([]);
+    expect(customNavItems("work")).toEqual([]);
+    expect(customNavItems("intelligence")).toEqual([]);
+  });
+
+  // The address is answerable even with nothing behind it, and that is the
+  // point of routing it rather than leaving it to the not-found arm: a fork's
+  // link keeps working across an upgrade because the SEGMENT is upstream's.
+  it("routes #/x/<key> as its own screen, and resolves nothing", () => {
+    expect(isScreen(CUSTOM_SCREEN)).toBe(true);
+    expect(parseHash("#/x/warranty")).toEqual({
+      screen: CUSTOM_SCREEN,
+      id: "warranty",
+    });
+    expect(findCustomScreen("warranty")).toBeUndefined();
+  });
+
+  // The lookup is a Map, so this is already true — asserted because it was NOT
+  // true of the extension registry, which is an object literal and answered
+  // `extensionScreens["constructor"]` from the prototype chain with a function
+  // React then tried to mount (App.tsx says so at its own lookup).
+  it("resolves nothing for a key that names an Object member", () => {
+    expect(findCustomScreen("constructor")).toBeUndefined();
+    expect(findCustomScreen("toString")).toBeUndefined();
+  });
+});
+
+// The reading half, driven over a registry a fork would produce.
+//
+// The registry itself cannot be faked: `import.meta.glob` is resolved by Vite at
+// build time from a literal, so there is no way to point it at a fixture. What
+// the readers take instead is the registry as an argument — the shape
+// app/extensions.ts uses, and for its stated reason: upstream's is empty by
+// construction, so a reader closed over the module binding could only ever be
+// exercised on its miss path, and every answer it gave a fork would be one
+// nothing here had ever run.
+describe("a fork's screen reaches the rail, the palette and the router", () => {
+  const warranty: CustomNavScreen & CustomPaletteScreen = {
+    key: "warranty",
+    component: () => null,
+    nav: { group: "records", labelKey: "nav.contacts", icon: Users },
+    palette: { labelKey: "nav.contacts" },
+  };
+  // A second screen that wants NEITHER, which is what proves the two lists are
+  // read from their own fields rather than from "is this a fork screen".
+  const audit: CustomScreen = { key: "audit-trail", component: () => null };
+  const forked: CustomScreenRegistry = new Map([
+    [warranty.key, warranty],
+    [audit.key, audit],
+  ]);
+
+  it("resolves by key, and a key nothing declares stays unresolved", () => {
+    expect(findCustomScreen("warranty", forked)).toBe(warranty);
+    expect(findCustomScreen("audit-trail", forked)).toBe(audit);
+    expect(findCustomScreen("nothing-declared", forked)).toBeUndefined();
+    expect(findCustomScreen(undefined, forked)).toBeUndefined();
+  });
+
+  it("joins the group it named, and no other", () => {
+    expect(customNavItems("records", forked)).toEqual([warranty]);
+    expect(customNavItems("work", forked)).toEqual([]);
+    expect(customNavItems("intelligence", forked)).toEqual([]);
+  });
+
+  it("is in the palette only if it asked to be", () => {
+    expect(customPaletteScreens(forked)).toEqual([warranty]);
+  });
+
+  it("is addressed at the segment its rail row builds", () => {
+    // The round trip, not either half: the rail builds `path + prefix + id` and
+    // the router parses the same string back, and a prefix and a parser that
+    // disagreed would each look correct alone.
+    const href = navEntryHref([], {
+      id: warranty.key,
+      prefix: [CUSTOM_SCREEN],
+      labelKey: warranty.nav.labelKey,
+      icon: warranty.nav.icon,
+    });
+    expect(href).toBe("#/x/warranty");
+    expect(parseHash(href)).toEqual({
+      screen: CUSTOM_SCREEN,
+      id: warranty.key,
+    });
+  });
+});
+
+// The one thing the tests above cannot see.
+//
+// Upstream ships no fork screen, so a glob that matches the documented layout
+// and a glob that matches NOTHING give the same answer here: an empty registry.
+// Point the pattern at `*/notascreen.tsx` and every assertion above still
+// passes — which means a rename of the directory, or of the file inside it,
+// would land green and be discovered by a fork whose screen silently did not
+// appear.
+//
+// There is no fixture that closes this without shipping one: a screen committed
+// here is a screen upstream ships, rail row and all. What CAN be checked is
+// that the pattern still points at something real, and that the README a fork
+// actually follows says the same path. Two statements that must agree, and a
+// one-sided edit is the realistic way this breaks.
+describe("the glob and the documented layout are the same layout", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL("./custom.ts", import.meta.url)),
+    "utf8",
+  );
+  const pattern = /import\.meta\.glob<[^>]*>\(\s*"([^"]+)"/.exec(source)?.[1];
+
+  it("globs a directory that exists", () => {
+    expect(pattern).toBeDefined();
+    if (pattern === undefined) {
+      throw new Error("no import.meta.glob literal in custom.ts");
+    }
+    const directory = pattern.slice(0, pattern.indexOf("*"));
+    expect(existsSync(fileURLToPath(new URL(directory, import.meta.url)))).toBe(
+      true,
+    );
+  });
+
+  it("globs the file name the README tells a fork to write", () => {
+    const readme = readFileSync(
+      fileURLToPath(new URL("../screens/custom/README.md", import.meta.url)),
+      "utf8",
+    );
+    // The path in the README's own worked example, which is what a fork copies.
+    const documented = /src\/screens\/custom\/[a-z-]+\/([a-z-]+\.tsx)/.exec(
+      readme,
+    )?.[1];
+    if (documented === undefined || pattern === undefined) {
+      throw new Error(
+        "the README names no screen file, or custom.ts globs none",
+      );
+    }
+    expect(pattern.endsWith(`/${documented}`)).toBe(true);
+  });
+});

--- a/frontend/src/app/custom.ts
+++ b/frontend/src/app/custom.ts
@@ -152,12 +152,42 @@ export type CustomScreenRegistry = ReadonlyMap<string, CustomScreen>;
  * is a fork's, and a work-in-progress file there must not stop the product
  * compiling.
  */
-export const customScreens: CustomScreenRegistry = new Map(
-  Object.values(declared)
-    .map((module) => module.screen)
-    .filter((screen): screen is CustomScreen => screen !== undefined)
-    .map((screen) => [screen.key, screen]),
-);
+export const customScreens: CustomScreenRegistry = buildRegistry(declared);
+
+/**
+ * The registry, refusing a key claimed twice.
+ *
+ * A Map would silently keep the last of them, and the loser would be a screen
+ * with a directory, a component and a rail row that no address reaches — the
+ * failure this seam is worst at, because there is no error to read and nothing
+ * looks wrong. It THROWS, at module load, so a fork learns on its first build
+ * rather than from a page that never opens.
+ *
+ * A throw and not a console warning: the registry is what the router dispatches
+ * on, and a build where two screens claim one address has no correct behaviour
+ * to fall back to.
+ */
+export function buildRegistry(
+  modules: Record<string, { readonly screen?: CustomScreen }>,
+): CustomScreenRegistry {
+  const registry = new Map<string, CustomScreen>();
+  for (const [path, module] of Object.entries(modules)) {
+    const screen = module.screen;
+    if (screen === undefined) {
+      continue;
+    }
+    const claimed = registry.get(screen.key);
+    if (claimed !== undefined) {
+      throw new Error(
+        `two custom screens claim the key "${screen.key}" (${path} is the second). ` +
+          "The key is the address segment that reaches a screen, so the first would " +
+          "become unreachable — give one of them a different key.",
+      );
+    }
+    registry.set(screen.key, screen);
+  }
+  return registry;
+}
 
 // The three readers below are pure functions OF a registry, defaulting to the
 // discovered one. Not test scaffolding, and the same reason app/extensions.ts

--- a/frontend/src/app/custom.ts
+++ b/frontend/src/app/custom.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import type { ComponentType } from "react";
+import type { Locale } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // The fork seam for UI, mirroring the one the backend already has.
@@ -35,6 +36,41 @@ import type { MessageKey } from "../i18n/en";
 // missing from the dispatch.
 
 /**
+ * What a fork screen is called, in the reader's language.
+ *
+ * Two arms, and the second is what makes this seam whole. A `MessageKey` reuses
+ * a word the product already has — right for a screen that IS one of the
+ * product's nouns seen differently. But a fork's own noun has no key, and
+ * minting one means editing `i18n/en.ts`, `de.ts` and `vi.ts`: three upstream
+ * files, for the one string that names a row. That is the conflict this whole
+ * directory exists to avoid, so a fork ships its words WITH its screen instead.
+ *
+ * English is required and the rest are optional, which is the honest shape: the
+ * product ships three languages and a fork may not, so there is always
+ * something to render and never a locale that renders a key. A fork adds
+ * locales as it has them, in its own file, at no cost to anyone.
+ */
+export type CustomLabel =
+  | MessageKey
+  | Readonly<Partial<Record<Locale, string>> & { en: string }>;
+
+/**
+ * The words a fork label resolves to for one reader.
+ *
+ * A key goes through `t` like any other; a fork's own record is read directly,
+ * falling back to English for a locale it does not carry. Discriminated on
+ * `typeof`, which is exact here: a `MessageKey` is a string literal and the
+ * record is never one.
+ */
+export function resolveCustomLabel(
+  label: CustomLabel,
+  locale: Locale,
+  t: (key: MessageKey) => string,
+): string {
+  return typeof label === "string" ? t(label) : (label[locale] ?? label.en);
+}
+
+/**
  * One screen a fork adds, as its directory declares it.
  *
  * `nav` and `palette` are optional and mean different things by their absence:
@@ -65,7 +101,7 @@ export type CustomScreen = {
      * than an addition to this one.
      */
     group: "records" | "work" | "intelligence";
-    labelKey: MessageKey;
+    label: CustomLabel;
     icon: LucideIcon;
   };
   /**
@@ -73,7 +109,7 @@ export type CustomScreen = {
    * questions — the rail is where things live, the palette is what you can do —
    * and a screen can honestly want one without the other.
    */
-  palette?: { labelKey: MessageKey };
+  palette?: { label: CustomLabel };
 };
 
 /**

--- a/frontend/src/app/custom.ts
+++ b/frontend/src/app/custom.ts
@@ -1,0 +1,175 @@
+import type { LucideIcon } from "lucide-react";
+import type { ComponentType } from "react";
+import type { MessageKey } from "../i18n/en";
+
+// The fork seam for UI, mirroring the one the backend already has.
+//
+// ADR-0054 §7 gives a fork `modules/<name>/custom/` and `migrations/custom/`:
+// directories upstream ships and never writes to, so a fork extends the product
+// without patching a file upstream also edits, and an upgrade is a fast-forward
+// rather than a merge. The frontend had no counterpart. A fork that added one
+// screen had to edit `App.tsx` (the dispatch), `nav.ts` (the rail) and
+// `router.tsx` (the address union) — the three files upstream touches most —
+// so every release was a conflict in all three.
+//
+// This is the same seam with the same property, and the property is the design:
+// NOTHING A FORK OWNS IS A FILE UPSTREAM EDITS. A fork adds a directory under
+// `src/screens/custom/` and nothing else. The registry below discovers it with
+// `import.meta.glob`, the way `migrations/custom/` is discovered by an embed
+// rather than by a list somebody maintains — a registry file a fork appended to
+// would be a shared file again, and would conflict on exactly the releases this
+// exists to make clean.
+//
+// The address is `#/x/<key>`, and the `x` is the hash-route spelling of the
+// prefix the schema already uses for the same reason (`x_` columns "can never
+// collide with an upstream column on upgrade" — migrations/custom/README.md).
+// A fork screen at `#/warranty` would be one release away from colliding with
+// an upstream destination of that name, and the collision would be silent: the
+// upstream screen would win and the fork's would become unreachable.
+//
+// This is why `Screen` gains ONE member rather than widening to a template
+// literal. `x` opens a whole namespace under it, and the dispatch in App.tsx
+// stays an exhaustive Record over a finite union — a `Screen` that admitted
+// `x-${string}` would make that Record impossible to write, and the
+// exhaustiveness is what stops a destination existing in the router and being
+// missing from the dispatch.
+
+/**
+ * One screen a fork adds, as its directory declares it.
+ *
+ * `nav` and `palette` are optional and mean different things by their absence:
+ * a screen with no `nav` is reachable by address and by anything that links to
+ * it, which is the right answer for a surface opened FROM somewhere (a detail
+ * page, a wizard step) rather than navigated to.
+ */
+export type CustomScreen = {
+  /**
+   * The `<key>` in `#/x/<key>`. Lowercase, digits and hyphens: it is a URL
+   * segment, and a key that needed encoding would appear in one spelling in the
+   * address bar and another in the registry.
+   */
+  key: string;
+  /**
+   * A component, not a rendered node — React needs a stable type to mount, and
+   * a registry of elements would build every fork screen on every route change
+   * including the ones nobody navigated to. The same reason the extension
+   * registry holds components (app/extensions.ts).
+   */
+  component: ComponentType;
+  /** A rail entry, if this screen is a destination a person navigates TO. */
+  nav?: {
+    /**
+     * Which of the rail's existing groups it joins. Not a new group: the three
+     * headings are the product's own answer to "what kind of thing is this",
+     * and a fork that wanted a fourth is describing a different product rather
+     * than an addition to this one.
+     */
+    group: "records" | "work" | "intelligence";
+    labelKey: MessageKey;
+    icon: LucideIcon;
+  };
+  /**
+   * A command-palette entry. Separate from `nav` because they answer different
+   * questions — the rail is where things live, the palette is what you can do —
+   * and a screen can honestly want one without the other.
+   */
+  palette?: { labelKey: MessageKey };
+};
+
+/**
+ * The route segment every fork surface lives under.
+ *
+ * Exported and spelled once, because the router's union, App.tsx's dispatch and
+ * any link a fork writes all have to agree: a registry keyed under a segment
+ * the router never dispatches on resolves nothing, however correct its lookup.
+ */
+export const CUSTOM_SCREEN = "x";
+
+/**
+ * Every screen the fork's own directory declares.
+ *
+ * Eager, because this is what the router dispatches on: a lazily-globbed
+ * registry would answer "no such screen" for a key whose module had not been
+ * fetched yet, and the answer would depend on what the reader had already
+ * visited. The cost is that a fork's screens are in the entry chunk; upstream
+ * ships none, so upstream pays nothing, and a fork that wants its screen split
+ * out uses React.lazy INSIDE its own component, where it can say so.
+ *
+ * The glob is a literal on purpose — Vite resolves it at build time and cannot
+ * see through a variable — so this string is the whole contract with a fork's
+ * directory layout, and it is stated in the README beside it.
+ */
+const declared = import.meta.glob<{ readonly screen?: CustomScreen }>(
+  "../screens/custom/*/screen.tsx",
+  { eager: true },
+);
+
+/** A registry of fork screens, keyed by the address segment that reaches each. */
+export type CustomScreenRegistry = ReadonlyMap<string, CustomScreen>;
+
+/**
+ * The registry, keyed by the address segment that reaches it.
+ *
+ * Built from `key` rather than from the directory name, so a fork renaming a
+ * folder does not silently change a URL people have bookmarked. A module that
+ * exports no `screen` is skipped rather than failing the build: the directory
+ * is a fork's, and a work-in-progress file there must not stop the product
+ * compiling.
+ */
+export const customScreens: CustomScreenRegistry = new Map(
+  Object.values(declared)
+    .map((module) => module.screen)
+    .filter((screen): screen is CustomScreen => screen !== undefined)
+    .map((screen) => [screen.key, screen]),
+);
+
+// The three readers below are pure functions OF a registry, defaulting to the
+// discovered one. Not test scaffolding, and the same reason app/extensions.ts
+// gives for the same shape: upstream's registry is empty by construction, so a
+// reader that closed over the module binding could only ever be exercised on
+// its miss path — every answer it gave a fork would be one nothing upstream had
+// ever run.
+
+/** The screen a `#/x/<key>` address names, or undefined for one nothing declares. */
+export function findCustomScreen(
+  key: string | undefined,
+  registry: CustomScreenRegistry = customScreens,
+): CustomScreen | undefined {
+  return key === undefined ? undefined : registry.get(key);
+}
+
+// The two readers below return a NARROWED screen rather than a CustomScreen, so
+// a caller reading the field the filter selected on needs no non-null
+// assertion — which this codebase forbids, for the reason one is worth
+// forbidding: an assertion is a claim the compiler stops checking, and the
+// claim here would be "the filter above me still filters on this". A type
+// predicate keeps the two together instead.
+
+/** A fork screen that declared a rail entry. */
+export type CustomNavScreen = CustomScreen & {
+  nav: NonNullable<CustomScreen["nav"]>;
+};
+
+/** A fork screen that declared a palette command. */
+export type CustomPaletteScreen = CustomScreen & {
+  palette: NonNullable<CustomScreen["palette"]>;
+};
+
+/** Every fork screen that asked for a rail entry, in the group it named. */
+export function customNavItems(
+  group: CustomNavScreen["nav"]["group"],
+  registry: CustomScreenRegistry = customScreens,
+): readonly CustomNavScreen[] {
+  return [...registry.values()].filter(
+    (screen): screen is CustomNavScreen => screen.nav?.group === group,
+  );
+}
+
+/** Every fork screen that asked to be findable by name in the palette. */
+export function customPaletteScreens(
+  registry: CustomScreenRegistry = customScreens,
+): readonly CustomPaletteScreen[] {
+  return [...registry.values()].filter(
+    (screen): screen is CustomPaletteScreen => screen.palette !== undefined,
+  );
+}

--- a/frontend/src/app/nav.test.ts
+++ b/frontend/src/app/nav.test.ts
@@ -42,6 +42,28 @@ describe("the rail and a composed unit", () => {
     expect(primary.activeId).toBe("settings");
   });
 
+  // A fork's rows are keyed by the screen's KEY rather than by the `x` segment
+  // — one segment names every one of them, so a row identified by the segment
+  // could only ever be "some fork screen". This is the DATA half, like the unit
+  // cases above it: whether an element resolves that id is shell.test.tsx's
+  // question, and reads identically from here.
+  it("marks a fork screen's own row current on its route", () => {
+    const [primary] = railTrail({ screen: "x", id: "warranty" });
+    expect(primary.activeId).toBe("warranty");
+  });
+
+  // `#/x` naming no screen resolves to nothing and marks nothing: unlike a unit
+  // route, there is no section it belongs to — a fork's destinations are its
+  // own, spread across the three groups, and the segment names none of them.
+  it("marks no row for a fork route naming no screen", () => {
+    const [primary] = railTrail({ screen: "x" });
+    expect(primary.activeId).toBe("x");
+    const rows = primary.groups.flatMap((group) =>
+      group.items.map((i) => i.id),
+    );
+    expect(rows).not.toContain("x");
+  });
+
   it("leaves the product's rows marking themselves", () => {
     const [primary] = railTrail({ screen: "deals" });
     expect(primary.activeId).toBe("deals");

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -12,10 +12,16 @@ import {
   Users,
 } from "lucide-react";
 import type { MessageKey } from "../i18n/en";
+import { CUSTOM_SCREEN, customNavItems } from "./custom";
 import { SCREEN_ENTITY } from "./entity";
 import { EXTENSION_SCREEN } from "./extensions";
 import type { Route, Screen } from "./router";
-import { type NavSection, type NavTrailLevel, navTrail } from "./subnav";
+import {
+  type NavLevelEntry,
+  type NavSection,
+  type NavTrailLevel,
+  navTrail,
+} from "./subnav";
 
 // The level registry lives beside this list and is reached through it: a caller
 // asking where the sidebar can go has one module to import.
@@ -204,15 +210,61 @@ export const RAIL_LESS_SCREENS: ReadonlySet<Screen> = new Set([
 // the unit is configured with (see screens/extension-units.tsx). That is also
 // what makes the offer honest about permission, because the two settings pages
 // are already split by whose thing each surface is.
+// Which of the three headings a fork screen names, keyed by the heading it
+// declares. A fork says "records" and this is what that means to the rail — the
+// mapping lives here rather than in app/custom.ts because the group KEYS are
+// this list's, and a fork naming a fourth one fails to typecheck against
+// CustomScreen["nav"]["group"] rather than rendering into nothing.
+const CUSTOM_NAV_GROUPS: Partial<
+  Record<MessageKey, "records" | "work" | "intelligence">
+> = {
+  "nav.group.records": "records",
+  "nav.group.work": "work",
+  "nav.group.intelligence": "intelligence",
+};
+
+// A fork's own destinations, in the group each declared (app/custom.ts).
+//
+// Appended to the group rather than given one of theirs, and after the
+// product's rows rather than among them: a fork owns its build and may
+// legitimately grow the rail — which a composed UNIT may not, and the comment
+// above says why — but the product's own order is what every reader of this
+// codebase and every upstream test knows, so an addition goes at the end where
+// it reads as one.
+//
+// Addressed through `prefix`, which the level already has for a level that
+// spans two depths: `["x"]` plus the screen's key is `#/x/<key>`, and the entry
+// keeps its key as its `id` so `activeId` matching needs nothing new.
+//
+// Upstream's registry is empty, so in vanilla every one of these is a no-op and
+// the rail is the same ten rows rail.test.tsx pins.
+function forkItems(
+  headingKey: MessageKey | undefined,
+): readonly NavLevelEntry[] {
+  const group = headingKey ? CUSTOM_NAV_GROUPS[headingKey] : undefined;
+  if (!group) {
+    return [];
+  }
+  return customNavItems(group).map((screen) => ({
+    id: screen.key,
+    prefix: [CUSTOM_SCREEN],
+    labelKey: screen.nav.labelKey,
+    icon: screen.nav.icon,
+  }));
+}
+
 function primaryLevel(route: Route): NavTrailLevel {
   return {
     groups: NAV_GROUPS.map((group) => ({
       headingKey: group.headingKey,
-      items: group.items.map((item) => ({
-        id: item.screen,
-        labelKey: item.labelKey,
-        icon: item.icon,
-      })),
+      items: [
+        ...group.items.map((item) => ({
+          id: item.screen,
+          labelKey: item.labelKey,
+          icon: item.icon,
+        })),
+        ...forkItems(group.headingKey),
+      ],
     })),
     ancestor: opensARecord(route),
     path: [],

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -33,6 +33,7 @@ export type {
   NavTrailLevel,
 } from "./subnav";
 export {
+  entryLabel,
   navEntryHref,
   navEntryRoute,
   navLevelHref,
@@ -248,7 +249,7 @@ function forkItems(
   return customNavItems(group).map((screen) => ({
     id: screen.key,
     prefix: [CUSTOM_SCREEN],
-    labelKey: screen.nav.labelKey,
+    label: screen.nav.label,
     icon: screen.nav.icon,
   }));
 }

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -297,7 +297,20 @@ function opensARecord(route: Route): boolean {
 // honest answer to the question — a unit IS reached from Settings — and because
 // the level machinery asks it for every route, unit routes included.
 function activeRowFor(route: Route): string {
-  return route.screen === EXTENSION_SCREEN ? "settings" : route.screen;
+  if (route.screen === EXTENSION_SCREEN) {
+    return "settings";
+  }
+  // A fork's rows are keyed by the screen's KEY, not by `x` — one segment
+  // names every one of them, so a row identified by the segment could only ever
+  // be "some fork screen". `#/x/warranty` marks the warranty row and nothing
+  // else, which is what the rest of this list does for its own destinations.
+  //
+  // Falling back to the segment for `#/x` with no key: that address resolves to
+  // no screen and marks no row, which is the honest answer for one.
+  if (route.screen === CUSTOM_SCREEN) {
+    return route.id ?? route.screen;
+  }
+  return route.screen;
 }
 
 // The levels the sidebar shows for a route: the destinations, then whatever the

--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -17,6 +17,7 @@ import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
+  entryLabel,
   type NavCounts,
   type NavLevelEntry,
   type NavLevelGroup,
@@ -208,7 +209,7 @@ function NavLevelRow({
   // One label, feeding the row text, the aria-label and the collapsed-rail
   // tooltip below — the three read the same string, so a row can never
   // announce one name and show another.
-  const label = t(entry.labelKey);
+  const label = entryLabel(entry, locale, t);
   const active = level.activeId === entry.id;
   const key = navTipKey(level, entry.id);
   // The rail's tips wait for the pointer to settle like every other popover.

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -2,13 +2,17 @@ import { useQueries, useQuery } from "@tanstack/react-query";
 import { CornerDownLeft, Search, Sparkles } from "lucide-react";
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api/client";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   settingsAddress,
   useSettingsEntryVisibility,
 } from "../screens/settings";
-import { CUSTOM_SCREEN, customPaletteScreens } from "./custom";
+import {
+  CUSTOM_SCREEN,
+  customPaletteScreens,
+  resolveCustomLabel,
+} from "./custom";
 import { ENTITY, ENTITY_KINDS, type EntityKind } from "./entity";
 import { NAV } from "./nav";
 import { navigate, type Route } from "./router";
@@ -37,6 +41,7 @@ type AdminEntry = "data-model" | "ai";
 
 export function useBuiltinCommands(): Command[] {
   const t = useT();
+  const { locale } = useLocale();
   // Without the company rollout probe: the palette offers no shortcut to General,
   // and that probe is a network read this hook would otherwise fire on every
   // screen (see useSettingsEntryVisibility).
@@ -61,7 +66,7 @@ export function useBuiltinCommands(): Command[] {
     // Empty upstream, like every other arm of this seam.
     const forkScreens: Command[] = customPaletteScreens().map((screen) => ({
       id: `screen:${CUSTOM_SCREEN}/${screen.key}`,
-      label: t(screen.palette.labelKey),
+      label: resolveCustomLabel(screen.palette.label, locale, t),
       keywords: [screen.key],
       type: "screen",
       route: { screen: CUSTOM_SCREEN, id: screen.key },
@@ -121,7 +126,7 @@ export function useBuiltinCommands(): Command[] {
       (shortcut) => visible[shortcut.entry],
     );
     return [...screens, ...forkScreens, ...actions, ...settingsScreens];
-  }, [t, visible]);
+  }, [t, visible, locale]);
 }
 
 // The record kinds a search hit can route to (activity is a valid

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -8,6 +8,7 @@ import {
   settingsAddress,
   useSettingsEntryVisibility,
 } from "../screens/settings";
+import { CUSTOM_SCREEN, customPaletteScreens } from "./custom";
 import { ENTITY, ENTITY_KINDS, type EntityKind } from "./entity";
 import { NAV } from "./nav";
 import { navigate, type Route } from "./router";
@@ -50,6 +51,20 @@ export function useBuiltinCommands(): Command[] {
       keywords: [item.screen],
       type: "screen",
       route: { screen: item.screen },
+    }));
+    // A fork's own screens (app/custom.ts), asked for by name here rather than
+    // inherited from a rail entry: the rail is where things LIVE and the palette
+    // is what you can DO, and a fork screen can honestly want one without the
+    // other — a surface opened from a record has no rail row and is still worth
+    // finding by typing its name. So this reads `palette`, not `nav`.
+    //
+    // Empty upstream, like every other arm of this seam.
+    const forkScreens: Command[] = customPaletteScreens().map((screen) => ({
+      id: `screen:${CUSTOM_SCREEN}/${screen.key}`,
+      label: t(screen.palette.labelKey),
+      keywords: [screen.key],
+      type: "screen",
+      route: { screen: CUSTOM_SCREEN, id: screen.key },
     }));
     const actions: Command[] = [
       {
@@ -105,7 +120,7 @@ export function useBuiltinCommands(): Command[] {
     const settingsScreens: Command[] = settingsShortcuts.filter(
       (shortcut) => visible[shortcut.entry],
     );
-    return [...screens, ...actions, ...settingsScreens];
+    return [...screens, ...forkScreens, ...actions, ...settingsScreens];
   }, [t, visible]);
 }
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -11,12 +11,21 @@ import { useState, useSyncExternalStore } from "react";
 // rest, and `navigate({ screen: "dealz" })` fails to compile instead of
 // rendering a surface that reads as unbuilt.
 //
-// Three members are also spelled as a named constant elsewhere, because the
+// Four members are also spelled as a named constant elsewhere, because the
 // module that owns the route owns the name: `ext` is app/extensions.ts's
-// EXTENSION_SCREEN, `reset-password` is screens/auth.tsx's RESET_ROUTE, and
-// `scheduled` is screens/scheduledsends.tsx's SCHEDULED_SCREEN. All three are
-// literal types used where a `Screen` is expected, so a rename there stops
-// compiling here rather than drifting.
+// EXTENSION_SCREEN, `x` is app/custom.ts's CUSTOM_SCREEN, `reset-password` is
+// screens/auth.tsx's RESET_ROUTE, and `scheduled` is
+// screens/scheduledsends.tsx's SCHEDULED_SCREEN. All four are literal types
+// used where a `Screen` is expected, so a rename there stops compiling here
+// rather than drifting.
+//
+// `x` is this union's WIDENING POINT, and it is one member rather than a
+// template literal on purpose. A fork adds destinations under `#/x/<key>`
+// (app/custom.ts), so the set of addresses this build answers grows without
+// this list growing — while the list stays FINITE, which is what lets App.tsx's
+// dispatch be an exhaustive Record. A `Screen` admitting `x-${string}` could
+// not be exhausted, and that exhaustiveness is the thing stopping a destination
+// existing in the router and being missing from the dispatch.
 const SCREENS = [
   "home",
   "contacts",
@@ -42,6 +51,7 @@ const SCREENS = [
   "oauth-consent",
   "reset-password",
   "ext",
+  "x",
   "not-found",
 ] as const;
 
@@ -158,6 +168,13 @@ const IDENTITY_DEPTH: Readonly<Record<Screen, number>> = {
   "oauth-consent": WHOLE_ADDRESS,
   "reset-password": WHOLE_ADDRESS,
   ext: WHOLE_ADDRESS,
+  // Every segment of `#/x/<key>` names the thing: the key IS which fork screen
+  // this is, so moving between two of them must remount rather than re-render
+  // one with the other's state. One depth serves every fork screen, which is
+  // this seam's one real limit — a fork screen wanting a TAB in its address
+  // keeps that tab's state inside its own component, because declaring a depth
+  // here would mean editing this file, which is what the seam exists to stop.
+  x: WHOLE_ADDRESS,
   "not-found": WHOLE_ADDRESS,
 };
 

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -13,7 +13,7 @@ import {
 import type { components } from "../api/schema";
 import { Button, Modal } from "../design-system/atoms";
 import { Logomark } from "../design-system/logomark";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import { SETTINGS_SCREEN, useSettingsSection } from "../screens/settings";
 import { AgentEdge } from "./agent-edge";
 import { AgentRail } from "./agentrail";
@@ -22,6 +22,7 @@ import { EmbedReindexBanner } from "./embedreindexbanner";
 import { SCREEN_ENTITY } from "./entity";
 import { EXTENSION_SCREEN, findExtension } from "./extensions";
 import {
+  entryLabel,
   GRIDDED_RECORD_SCREENS,
   GRIDDED_SCREENS,
   MOBILE_PRIMARY,
@@ -456,6 +457,7 @@ function SectionPickGroup({
   onPick: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   return (
     <div className="sectionpickgroup">
       {group.headingKey && <h3>{t(group.headingKey)}</h3>}
@@ -469,7 +471,7 @@ function SectionPickGroup({
           onClick={onPick}
         >
           <entry.icon size={16} aria-hidden />
-          {t(entry.labelKey)}
+          {entryLabel(entry, locale, t)}
         </a>
       ))}
     </div>
@@ -500,10 +502,11 @@ function SectionSwitcher({
   entry,
 }: Readonly<{ section: NavSection; entry: NavLevelEntry }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [open, setOpen] = useState(false);
   const titleId = useId();
   const close = useCallback(() => setOpen(false), []);
-  const label = t(entry.labelKey);
+  const label = entryLabel(entry, locale, t);
   return (
     <>
       <button
@@ -570,6 +573,7 @@ export function PageTitle({
   section?: NavSection;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const phone = usePhoneViewport();
 
   const navItem = NAV.find((item) => item.screen === route.screen);
@@ -584,7 +588,9 @@ export function PageTitle({
   // because the sidebar shows destinations there and nothing else on screen said
   // which section the page belonged to. The trail says it at every width, so the
   // swap left the phone naming the section twice and the entry twice.
-  const entryTitle = inSection ? t(inSection.entry.labelKey) : undefined;
+  const entryTitle = inSection
+    ? entryLabel(inSection.entry, locale, t)
+    : undefined;
   const title = entryTitle ?? resolveTitle(route.screen, navItem?.labelKey, t);
   // A record kind, and only then: an id segment that names no record is a
   // screen's own state — the settings tab, for one — and the page is still the

--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { LucideIcon } from "lucide-react";
+import type { Locale } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { type CustomLabel, resolveCustomLabel } from "./custom";
 import { isScreen, type Route, routeHash } from "./router";
 
 // The sidebar is a STACK of navigation levels, not one rail with a special case
@@ -33,12 +35,42 @@ export type NavLevelEntry = {
   // the `id` stays the entry's identity either way — so `activeId` matching is
   // unaffected by how deep the entry lives.
   prefix?: readonly string[];
-  labelKey: MessageKey;
   icon: LucideIcon;
   // The level this entry opens. Grouping is possible at every depth, so the
   // children are a flat list only until one needs headings.
   children?: readonly NavLevelEntry[];
-};
+} & EntryLabel;
+
+// How an entry is named: a key into the catalog, or the words themselves.
+//
+// Two arms rather than one optional field, so exactly one is set and neither is
+// missing. The product's own entries take a KEY — that is what makes a
+// relabelled destination one edit in three locale files and what stops a typo
+// compiling. A fork's entry takes the words, because its screens live in a
+// directory upstream never writes to (app/custom.ts) and a key would send it
+// back into `i18n/en.ts` for the one string that names its row — which is the
+// upstream file the whole seam exists to keep it out of.
+type EntryLabel =
+  | { labelKey: MessageKey; label?: never }
+  | { label: CustomLabel; labelKey?: never };
+
+/**
+ * The words this entry shows, whichever way it was named.
+ *
+ * One resolver rather than `entry.label ?? t(entry.labelKey)` at each site: the
+ * fallback spelled six times is six chances for one of them to translate an
+ * absent key, and the union above is what makes this the only expression that
+ * typechecks.
+ */
+export function entryLabel(
+  entry: NavLevelEntry,
+  locale: Locale,
+  t: (key: MessageKey) => string,
+): string {
+  return entry.labelKey === undefined
+    ? resolveCustomLabel(entry.label, locale, t)
+    : t(entry.labelKey);
+}
 
 export type NavLevelGroup = {
   headingKey?: MessageKey;
@@ -194,6 +226,13 @@ export function navTrail(
     const active = activeEntry(level);
     const children = active?.children;
     if (!active || !children || children.length === 0) {
+      break;
+    }
+    // A fork's entry publishes no level of its own — CustomScreen has no
+    // children — so the title below is always a key. Guarded rather than
+    // asserted: if a fork entry ever did open a level, this stops at it instead
+    // of naming that level with a key it does not have.
+    if (active.labelKey === undefined) {
       break;
     }
     level = {

--- a/frontend/src/app/topbar.tsx
+++ b/frontend/src/app/topbar.tsx
@@ -1,11 +1,11 @@
 import { PanelLeftClose, PanelLeftOpen, Search } from "lucide-react";
 import { Breadcrumb, type Crumb } from "../design-system/breadcrumb";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import { SETTINGS_SCREEN } from "../screens/settings";
 import { AccountMenu } from "./account";
 import { SCREEN_ENTITY } from "./entity";
 import { EXTENSION_SCREEN, findExtension } from "./extensions";
-import { NAV, type NavSection } from "./nav";
+import { entryLabel, NAV, type NavSection } from "./nav";
 import {
   OFF_RAIL_TITLE_KEYS,
   resolveTitle,
@@ -47,6 +47,7 @@ function collapseHotkeyLabel(platform: string): string {
  */
 function useCrumbs(route: Route, section?: NavSection): readonly Crumb[] {
   const t = useT();
+  const { locale } = useLocale();
   const navItem = NAV.find((item) => item.screen === route.screen);
   // A record kind, and only then: an id segment that names no record is a
   // screen's own state — the settings tab, for one — and the page is still the
@@ -88,7 +89,7 @@ function useCrumbs(route: Route, section?: NavSection): readonly Crumb[] {
         label: t(inSection.section.titleKey),
         href: routeHash({ screen: route.screen }),
       },
-      { label: t(inSection.entry.labelKey) },
+      { label: entryLabel(inSection.entry, locale, t) },
     ];
   }
   return [{ label: resolveTitle(route.screen, navItem?.labelKey, t) }];

--- a/frontend/src/screens/custom/README.md
+++ b/frontend/src/screens/custom/README.md
@@ -1,0 +1,54 @@
+# custom/ — the fork-owned screen directory
+
+Upstream ships this directory holding only this file. It is the frontend
+counterpart of `backend/migrations/custom/` and `modules/<name>/custom/`
+(ADR-0054 §7): a place a fork writes that upstream never does, so an upgrade
+is a fast-forward instead of a conflict in `App.tsx`, `nav.ts` and
+`router.tsx`.
+
+## Adding a screen
+
+One directory per screen, holding a `screen.tsx` that exports `screen`:
+
+```
+src/screens/custom/warranty/screen.tsx
+```
+
+```tsx
+import { ShieldCheck } from "lucide-react";
+import type { CustomScreen } from "../../../app/custom";
+
+function WarrantyScreen() {
+  return <div className="wrap">…</div>;
+}
+
+export const screen: CustomScreen = {
+  key: "warranty",
+  component: WarrantyScreen,
+  // Optional. Without it the screen is reachable by address and by anything
+  // that links to it, which is what a surface opened FROM somewhere wants.
+  nav: { group: "records", labelKey: "nav.warranty", icon: ShieldCheck },
+};
+```
+
+The address is **`#/x/warranty`**. The `x` segment is the hash-route spelling
+of the `x_` column prefix custom migrations already use, and it is there for
+the same reason: a fork screen at `#/warranty` is one upstream release away
+from colliding with a destination of that name, and the collision would be
+silent — the upstream screen would win and the fork's would become
+unreachable.
+
+`app/custom.ts` discovers this directory with `import.meta.glob`. There is no
+registry file to append to, and that is the point: a list a fork edited would
+be a shared file again, and would conflict on exactly the releases this seam
+exists to keep clean.
+
+## What a fork still cannot do
+
+Add a rail **group**. The three headings are the product's own answer to
+"what kind of thing is this", and a fork wanting a fourth is describing a
+different product rather than an addition to this one — `nav.group` names one
+of the existing three.
+
+Reach `#/x/<key>` for a key nothing declares. That address renders the same
+honest not-found a mistyped one does, rather than an empty page.

--- a/frontend/src/screens/custom/README.md
+++ b/frontend/src/screens/custom/README.md
@@ -27,8 +27,37 @@ export const screen: CustomScreen = {
   component: WarrantyScreen,
   // Optional. Without it the screen is reachable by address and by anything
   // that links to it, which is what a surface opened FROM somewhere wants.
-  nav: { group: "records", labelKey: "nav.warranty", icon: ShieldCheck },
+  nav: {
+    group: "records",
+    label: { en: "Warranty", de: "Garantie" },
+    icon: ShieldCheck,
+  },
 };
+```
+
+## Words
+
+A label is **your own words**, shipped beside your screen:
+
+```ts
+label: { en: "Warranty", de: "Garantie" }
+```
+
+English is required, every other locale is optional, and a locale you do not
+carry falls back to it. That is the honest shape: this product ships three
+languages and your fork may not, so there is always something to render and
+never a rail row showing a key.
+
+It is a fork-local catalogue on purpose. `MessageKey` only accepts keys from
+`src/i18n/en.ts`, so minting one for your own noun means editing `en.ts`,
+`de.ts` and `vi.ts` — three upstream files, for the one string that names a
+row, which is exactly the conflict this directory exists to avoid.
+
+Where your screen IS one of this product's nouns seen differently, name the key
+instead and get every language it already has:
+
+```ts
+label: "nav.contacts"
 ```
 
 The address is **`#/x/warranty`**. The `x` segment is the hash-route spelling


### PR DESCRIPTION
Closes #1503.

## The asymmetry

The backend has a designed fork surface upstream never writes to — `modules/<name>/custom/` and `migrations/custom/` (ADR-0054 §7). `migrations/custom/README.md` states the contract: upstream ships the directory, a fork's migrations land in it, `x_` columns "can never collide with an upstream column on upgrade."

The frontend had none. A fork adding one screen edited `App.tsx` (the dispatch), `nav.ts` (the rail) and `router.tsx` (the address union) — three of the files upstream touches most — so every release was a merge conflict in all three, on a repo whose license model treats forks as first class.

## The property, which is the design

**Nothing a fork owns is a file upstream edits.** A fork adds a directory under `src/screens/custom/` and nothing else:

```
src/screens/custom/warranty/screen.tsx
```
```tsx
export const screen: CustomScreen = {
  key: "warranty",
  component: WarrantyScreen,
  nav: { group: "records", labelKey: "nav.warranty", icon: ShieldCheck },
  palette: { labelKey: "nav.warranty" },
};
```

`app/custom.ts` finds it with `import.meta.glob` — the way `migrations/custom/` is found by an embed rather than by a list somebody maintains. **A registry file a fork appended to would be a shared file again**, and would conflict on exactly the releases this exists to keep clean.

## Why `#/x/<key>`

The `x` is the hash-route spelling of the `x_` column prefix, and it is there for the schema's reason. A fork screen at `#/warranty` is one upstream release away from colliding with a destination of that name, and the collision would be **silent**: the upstream screen would win and the fork's would become unreachable.

## Designing it with the union, as the issue asks

The issue says the `Route.screen` union "needs a widening point exactly here" and to decide the two together. It gains **one member**, not a template literal, and that is load-bearing.

`App.tsx`'s dispatch is a `Record<Screen, …>` and `IDENTITY_DEPTH` is a `Record<Screen, number>`. A `Screen` admitting `x-${string}` could not be exhausted, and those Records would have to become partial lookups — losing the thing that stops a destination existing in the router and being missing from the dispatch. `"x"` opens a whole namespace beneath it while the union stays finite.

That exhaustiveness proved itself on the first build: adding the member failed `fe-typecheck` on `IDENTITY_DEPTH` until the new screen declared a depth. Which is the table's own stated purpose — *"a screen added to the union cannot inherit an answer nobody chose."*

## What upstream ships

Nothing. The registry is empty, so vanilla is unchanged: ten rail rows (`rail.test.tsx` still pins them), the same palette, and `#/x/<anything>` renders the not-found card — routed rather than left to the fallback, so a fork's link keeps working across an upgrade because the **segment** is upstream's.

## The hazard an empty seam has, and what closes it

An empty registry and a **broken** one give the same answer here. Pointing the glob at `*/notascreen.tsx` left every behavioural assertion green — so a rename of the directory or of the file inside it would land, and be discovered by a fork whose screen silently did not appear.

There is no fixture that closes this without shipping one: a screen committed here is a screen upstream ships, rail row and all. What the tests do instead is read the glob's **own literal** out of `custom.ts` and check it still names a directory that exists, and the file name the README's worked example tells a fork to write. Two statements that must agree; a one-sided edit is the realistic way this breaks.

| mutation | caught by |
|---|---|
| glob's file name drifts from the README | the layout-parity check |
| glob's directory moves | the same, on `existsSync` |
| `customNavItems` stops reading the declared group | "joins the group it named, and no other" |
| `CUSTOM_SCREEN` changes spelling | the router round trip, both ends |

## Shape notes

The three readers are **pure functions of a registry**, defaulting to the discovered one — the shape `app/extensions.ts` already uses and for its stated reason: upstream's registry is empty by construction, so a reader closed over the module binding could only ever be exercised on its miss path, and every answer it gave a fork would be one this repo had never taken. That is what lets the second test group drive a registry a fork would produce, with no mocking.

`customNavItems` and `customPaletteScreens` return **narrowed** types via type predicates, so callers reading the field the filter selected on need no non-null assertion — which biome forbids, and rightly: an assertion is a claim the compiler stops checking, and the claim would have been "the filter above me still filters on this".

`nav` and `palette` are read separately and mean different things by their absence. The rail is where things live; the palette is what you can do. A surface opened *from* a record wants no rail row and is still worth finding by typing its name.

## What a fork still cannot do

Add a rail **group** — the three headings are the product's own answer to "what kind of thing is this". Declare a per-screen `IDENTITY_DEPTH`; every fork screen gets `WHOLE_ADDRESS`, so one wanting a tab in its address keeps that tab's state inside its own component. Both are stated in the code and the README rather than discovered.

A composed **unit** is unchanged and still cannot reach the rail (`app/extensions.ts` says why: an installation enabling a unit is not the product growing a destination). A fork is a different thing — it *is* the product in its own build.

`make check-fe` green. `make frontend-e2e`: 144 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom screens accessible through dedicated hash routes.
  * Custom screens can appear in primary navigation and the command palette.
  * Added localized labels with fallback support for custom-screen navigation and actions.
  * Unknown custom-screen routes now display the standard unavailable-page notice.
  * Custom screens are automatically discovered and can provide navigation and palette metadata.
  * Improved navigation tooltip behavior with delayed hover intent.

* **Documentation**
  * Added guidance for creating, organizing, routing, labeling, and integrating custom screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->