### PR TITLE
fix(ci): the label taxonomy has one source, and the rest derive from it (#1508)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,130 @@
+# The label taxonomy, and the only copy of it that anything derives from.
+#
+# It was written down in three places — the long-form reference, the rulebook's
+# digest of it, and the repository's own labels, which is the only one that does
+# anything. Nothing connected them, so adding an area, renaming one or retiring
+# one meant remembering all three, and two of the three were prose: an agent
+# reads a list naming a label that does not exist, files with it, and
+# `gh issue create` fails — or reads one that omits a label that does exist and
+# picks a worse-fitting area (issue #1508).
+#
+# This file is the source. `docs/reference/issue-labels.md` is checked against it
+# offline by backend/gates/issuelabels_test.go, and `.github/workflows/labels.yml`
+# reconciles the repository's own labels from it — so the third copy stops being
+# a copy and becomes an output.
+#
+# Colour carries meaning within an axis and none between them. Every `area:` is
+# one colour on purpose: an area is a place, not a severity, and colouring
+# fifteen of them differently would put a visual ranking on a set that has none.
+# The four priorities are a ramp, red down to grey, because they ARE ranked.
+
+# ---------------------------------------------------------------------------
+# Priority — a claim about severity, never about a schedule.
+# ---------------------------------------------------------------------------
+- name: "priority: critical"
+  color: "B60205"
+  description: "Drop everything: data loss, reachable breach, CI red, or unusable on a default install"
+- name: "priority: high"
+  color: "D93F0B"
+  description: "A real user or operator hits it on a live path, or it blocks another workstream"
+- name: "priority: normal"
+  color: "bce9a5"
+  description: "Real but narrow, guarded or latent; hygiene, test-lane work, polish"
+- name: "priority: low"
+  color: "C5D0D8"
+  description: "A want, not a defect - or needs a product/spec decision first. No date"
+
+# ---------------------------------------------------------------------------
+# Area — where the fix lives. Exactly one, so a filter never double-counts.
+# ---------------------------------------------------------------------------
+- name: "area: agents-mcp"
+  color: "BFD4F2"
+  description: "Tool surface, governed calls, approvals and staging, passports, certification"
+- name: "area: ai-models"
+  color: "BFD4F2"
+  description: "Model adapters, wire formats, cost, prompts, drafting"
+- name: "area: authz"
+  color: "BFD4F2"
+  description: "RBAC, row-scope, record grants, seats, shares"
+- name: "area: capture"
+  color: "BFD4F2"
+  description: "Mail and chat ingestion, activities, attachments, threads, LinkedIn ghosts"
+- name: "area: ci-tests"
+  color: "BFD4F2"
+  description: "Test lanes, flakes, harness, gates, coverage"
+- name: "area: contract-api"
+  color: "BFD4F2"
+  description: "OpenAPI contract, HTTP conventions, error mapping, versioning"
+- name: "area: deals"
+  color: "BFD4F2"
+  description: "Deals, pipeline, stages, leads, offers"
+- name: "area: extensions"
+  color: "BFD4F2"
+  description: "The extension tier (ADR-0069): units, the published pkg surface, composition"
+- name: "area: finance"
+  color: "BFD4F2"
+  description: "Invoices, payments, FX, contracts"
+- name: "area: frontend"
+  color: "BFD4F2"
+  description: "SPA, design system, screens, Storybook, i18n"
+- name: "area: overlay"
+  color: "BFD4F2"
+  description: "External system-of-record mirror, HubSpot, flip and import"
+- name: "area: platform"
+  color: "BFD4F2"
+  description: "Database, migrations, events and outbox, config, boot, workers, Docker and deploy"
+- name: "area: privacy"
+  color: "BFD4F2"
+  description: "Erasure, retention, consent"
+- name: "area: records"
+  color: "BFD4F2"
+  description: "People, organizations, employment, custom fields, merge and dedupe"
+- name: "area: reports"
+  color: "BFD4F2"
+  description: "Reporting, saved views, filters, export"
+
+# ---------------------------------------------------------------------------
+# Status — an issue that is not yet workable.
+# ---------------------------------------------------------------------------
+- name: "status: needs-decision"
+  color: "FBCA04"
+  description: "Unactionable until someone rules on it - 'decide or decline X'"
+
+# ---------------------------------------------------------------------------
+# Provenance — why the issue exists, which is the one thing nobody can
+# reconstruct later. Additive and independent of the three axes above.
+# ---------------------------------------------------------------------------
+- name: "bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+- name: "enhancement"
+  color: "a2eeef"
+  description: "New feature or request"
+- name: "security"
+  color: "af2a01"
+  description: "Security related changes"
+- name: "capability-gap"
+  color: "0E8A16"
+  description: "Missing capability found in the 2026-08 requirements verification pass"
+- name: "fast-track-debt"
+  color: "6E5494"
+  description: "Shipped fast under time pressure; known issue deferred for team cleanup"
+
+# ---------------------------------------------------------------------------
+# GitHub's own defaults, kept because they are what a drive-by contributor and
+# Dependabot reach for. They are NOT part of the taxonomy the reference page
+# documents, and the gate below knows it: it asks the page to account for every
+# label in the four sections above and no others.
+# ---------------------------------------------------------------------------
+- name: "documentation"
+  color: "0075ca"
+  description: "Improvements or additions to documentation"
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+- name: "dependencies"
+  color: "ededed"
+  description: ""

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -9,9 +9,16 @@
 # picks a worse-fitting area (issue #1508).
 #
 # This file is the source. `docs/reference/issue-labels.md` is checked against it
-# offline by backend/gates/issuelabels_test.go, and `.github/workflows/labels.yml`
+# offline by backend/gates/issuelabels_test.go, and `scripts/sync-labels.sh`
 # reconciles the repository's own labels from it — so the third copy stops being
 # a copy and becomes an output.
+#
+# THE SYNC IS RUN BY HAND, for now. The workflow that would call the script on a
+# push to main is not in this tree: pushing a file under .github/workflows/ needs
+# an OAuth scope the agent that wrote this does not hold, so it is written down
+# in the pull request instead of half-added here. Until somebody adds it, an edit
+# to this file reaches the repository when a person runs the script — and the
+# gate keeps the reference page honest either way.
 #
 # Colour carries meaning within an axis and none between them. Every `area:` is
 # one colour on purpose: an area is a place, not a severity, and colouring

--- a/backend/gates/issuelabels_test.go
+++ b/backend/gates/issuelabels_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+//go:build !integration
+
+package gates
+
+// The label taxonomy is written down once and read from there.
+//
+// It used to be written down three times: the long-form reference, the
+// rulebook's digest of it, and the repository's own labels — the only one of
+// the three that does anything. Nothing connected them, so adding an area,
+// renaming one or retiring one meant remembering all three, and two of the
+// three were prose. That fails SILENTLY in both directions: an agent reads a
+// list naming a label that does not exist, files with it, and `gh issue create`
+// fails; or reads one that omits a label that does exist and picks a
+// worse-fitting area, which nothing ever notices.
+//
+// `.github/labels.yml` is the source now. This gate is the offline half of
+// making it one — it asserts the reference page names exactly the labels the
+// file declares, in both directions — and `scripts/sync-labels.sh` reconciles
+// the repository from the same file, which is what stops the file being a
+// fourth copy.
+//
+// The direction that matters is the one a hand-kept list gets wrong. A gate
+// asserting only "every documented label exists in the file" would pass a file
+// that had grown a label the page never mentions, which is the omission an
+// agent silently pays for. So both are checked, and each failure says which
+// half moved.
+//
+// DELIBERATELY OFFLINE. The authoritative list lives on GitHub and `make check`
+// must pass without a network, reproducibly — so this gate cannot ask GitHub
+// anything, and does not try. What it proves is that the two copies IN THE TREE
+// agree; the workflow is what makes the tree's copy true.
+//
+// The four taxonomy sections are judged and GitHub's own defaults are not.
+// `documentation`, `good first issue`, `help wanted` and `dependencies` are what
+// a drive-by contributor and Dependabot reach for; they are labels this
+// repository has rather than a taxonomy it teaches, and requiring the reference
+// page to document them would put four rows in front of a reader that answer no
+// question the page is for.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The two files, from the module root the gates package chdirs to.
+var (
+	labelSourcePath = filepath.Join(repoRoot, ".github", "labels.yml")
+	labelDocPath    = filepath.Join(repoRoot, "docs", "reference", "issue-labels.md")
+)
+
+// declaredLabel matches one entry of the source file. A hand-rolled reader
+// rather than a YAML dependency: the file's shape is fixed by the action that
+// consumes it, three scalar fields in a fixed order, and a parser that accepted
+// more than the action does would pass a file the action then rejects.
+var declaredLabel = regexp.MustCompile(`(?m)^- name: "([^"]*)"\n  color: "([0-9a-fA-F]{6})"\n  description: "([^"]*)"$`)
+
+// githubDefaults are the labels this repository has and does not teach.
+var githubDefaults = []string{"documentation", "good first issue", "help wanted", "dependencies"}
+
+// The page's own sections, and how each spells the labels it lists.
+//
+// Driven by the SECTION rather than by a pattern for "what a label name looks
+// like", because a pattern is a hand-kept list of the taxonomy in a third
+// spelling — the shape this gate exists to remove. A section, by contrast,
+// derives its subjects: a provenance label added to the source and to that
+// paragraph agrees, and one added to only one of them does not, without this
+// file learning its name.
+var labelSections = []struct {
+	heading string
+	// prefix the source spells these labels with; "" for the unprefixed axis.
+	prefix string
+	// bare is true where the page names them without that prefix, which is what
+	// the Area run and the Provenance sentence do — fifteen names read as a set
+	// where fifteen `area: x` would read as fifteen rows.
+	bare bool
+}{
+	{heading: "## Priority", prefix: "priority: "},
+	{heading: "## Area", prefix: "area: ", bare: true},
+	{heading: "## Status", prefix: "status: "},
+	{heading: "## Provenance", prefix: "", bare: true},
+}
+
+// labelSpan matches a label name as the page writes one: a fenced span holding
+// only the name, so `gh issue list --label "area: <x>"` — which has spaces — is
+// prose about a label rather than a listing of one.
+var labelSpan = regexp.MustCompile("`((?:priority: |area: |status: )?[a-z][a-z-]*)`")
+
+func TestEachSectionOfTheReferencePageListsExactlyItsLabels(t *testing.T) {
+	t.Parallel()
+
+	declared := declaredLabels(t)
+	page := readLabelDoc(t)
+
+	for _, section := range labelSections {
+		t.Run(strings.TrimPrefix(section.heading, "## "), func(t *testing.T) {
+			want := labelsOfAxis(declared, section.prefix)
+			if len(want) == 0 {
+				t.Fatalf("the source declares no label for %s, so this case measures nothing — "+
+					"an axis with no members is a section the page should not have either",
+					section.heading)
+			}
+			got := listedIn(page, section.heading, section.prefix, section.bare)
+			if !slices.Equal(want, got) {
+				t.Errorf("%s lists %v and the source declares %v.\n"+
+					"\tThis section is what a person reads when choosing one, so a name only in "+
+					"the source is a label nobody picks, and a name only here is one "+
+					"`gh issue create` will refuse.", section.heading, got, want)
+			}
+		})
+	}
+}
+
+// labelsOfAxis reads one axis out of the source, sorted, with the GitHub
+// defaults left out. An empty prefix means the unprefixed axis — provenance —
+// which is whatever remains rather than a list written here.
+//
+// Held by: TestEachSectionOfTheReferencePageListsExactlyItsLabels
+func labelsOfAxis(declared []string, prefix string) []string {
+	var want []string
+	for _, label := range declared {
+		if slices.Contains(githubDefaults, label) {
+			continue
+		}
+		switch {
+		case prefix != "":
+			if name, ok := strings.CutPrefix(label, prefix); ok {
+				want = append(want, name)
+			}
+		case !strings.Contains(label, ": "):
+			want = append(want, label)
+		}
+	}
+	slices.Sort(want)
+	return want
+}
+
+// listedIn reads the labels one section names, stripped to their bare form so
+// both spellings compare against one set.
+//
+// Held by: TestEachSectionOfTheReferencePageListsExactlyItsLabels
+func listedIn(page, heading, prefix string, bare bool) []string {
+	section := page
+	start := strings.Index(section, "\n"+heading+"\n")
+	if start < 0 {
+		return nil
+	}
+	section = section[start+len(heading)+2:]
+	if end := strings.Index(section, "\n## "); end >= 0 {
+		section = section[:end]
+	}
+	var listed []string
+	for _, match := range labelSpan.FindAllStringSubmatch(section, -1) {
+		// A section names its own axis and nothing else: a bare word in the
+		// Priority section is prose, and a prefixed name in the Provenance
+		// section is a cross-reference rather than a listing. `strings.CutPrefix`
+		// is not the test — an empty prefix "matches" every string — so the
+		// unprefixed axis is asked its own question: no axis prefix at all.
+		name := match[1]
+		if prefix == "" {
+			if strings.Contains(name, ": ") {
+				continue
+			}
+		} else if bare {
+			if strings.Contains(name, ": ") {
+				continue
+			}
+		} else {
+			cut, ok := strings.CutPrefix(name, prefix)
+			if !ok {
+				continue
+			}
+			name = cut
+		}
+		if !slices.Contains(listed, name) {
+			listed = append(listed, name)
+		}
+	}
+	slices.Sort(listed)
+	return listed
+}
+
+func declaredLabels(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile(labelSourcePath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", labelSourcePath, err)
+	}
+	var declared []string
+	for _, match := range declaredLabel.FindAllStringSubmatch(string(source), -1) {
+		declared = append(declared, match[1])
+	}
+	// A parse that found nothing would agree with a page that lists nothing,
+	// which is the shape this whole gate exists to refuse.
+	if len(declared) == 0 {
+		t.Fatalf("%s declared no label this gate could read — either the file is empty or its "+
+			"shape changed and this parser now matches nothing, and a parser matching nothing "+
+			"agrees with every page", labelSourcePath)
+	}
+	return declared
+}
+
+func readLabelDoc(t *testing.T) string {
+	t.Helper()
+	page, err := os.ReadFile(labelDocPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", labelDocPath, err)
+	}
+	return string(page)
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (36)
+## Parity (37)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -43,6 +43,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |
 | `idempotencymap_test.go` | H3 | The idempotency allowlist as a fitness function: the contract is the authority on which operations promise Idempotency-Key retry safety, and internal/compose's hand-maintained replayableOperations map must mirror it exactly. |
+| `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `minorunitscale_test.go` | H3 | A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one fact, and the table that holds it lives in shared/kernel/values. |
 | `netguardparity_test.go` | H3 | The egress SSRF denylist exists twice, and this is where the two are held equal. |

--- a/docs/reference/issue-labels.md
+++ b/docs/reference/issue-labels.md
@@ -5,6 +5,14 @@ Every issue in this repository carries **exactly one `priority:` and exactly one
 labels apply. This page is the full taxonomy; the binding short form is in
 `AGENTS.md`.
 
+The label set itself lives in [`.github/labels.yml`](../../.github/labels.yml),
+which is the source rather than another copy: `scripts/sync-labels.sh`
+reconciles the repository's own labels from it, and
+`backend/gates/issuelabels_test.go` fails `make check` if a section below and
+that file stop naming the same set. So editing this page alone changes nothing,
+and editing the file alone fails the gate — which is the point. Adding a label
+is one edit to the file and one to the section it belongs in.
+
 ## Why an unlabeled issue is worse than no issue
 
 The labels protect one invariant: **unlabeled means nobody has looked at it yet.**

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -66,9 +66,21 @@ echo
 echo "reconciled $declared label(s) from $SOURCE"
 
 # What the repository has and the file does not name. Reported, never removed.
+#
+# The listing is captured and CHECKED before the comparison. Inside a process
+# substitution its failure does not reach the enclosing command — `set -e` sees
+# only `comm`, which happily compares against nothing — so a `gh` that was rate
+# limited, unauthenticated or offline would report "nothing extra" and exit 0.
+# That is the worst answer this script can give: it is the reading somebody
+# would act on to conclude the repository holds exactly what the file names.
+if ! live="$(gh label list --limit 200 --json name --jq '.[].name')"; then
+  echo "FAIL: could not list this repository's labels, so the report below cannot be made."
+  echo "The reconcile above already ran; only the 'what is not in the file' half is missing."
+  exit 1
+fi
 extra="$(comm -13 \
   <(awk '/^- name: "/ { n = $0; sub(/^- name: "/, "", n); sub(/"$/, "", n); print n }' "$SOURCE" | sort) \
-  <(gh label list --limit 200 --json name --jq '.[].name' | sort))"
+  <(printf '%s\n' "$live" | sort))"
 if [[ -n "$extra" ]]; then
   echo
   echo "NOT IN $SOURCE, and left alone:"

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Reconcile this repository's labels from .github/labels.yml.
+#
+# The file is the source (issue #1508). Without this, it is a fourth copy of a
+# list that already had three — and the copy that does anything is still the one
+# on GitHub, which nothing derives from. This is what makes the tree's copy true.
+#
+# ADDS AND UPDATES; NEVER DELETES. A label removed from the file stays on the
+# repository and is REPORTED here instead, because deleting one strips it from
+# every issue that carries it and there is no undo — an issue's provenance is
+# the one thing nobody can reconstruct later (docs/reference/issue-labels.md
+# says so about these very labels). Retiring a label is a decision with a cost,
+# so it belongs to a person who has decided to pay it, not to a sync run.
+#
+# `gh label create --force` is create-or-update, so the two cases are one call
+# and the run is idempotent: a second pass changes nothing and says so.
+#
+# No third-party action. Every `uses:` in this repo is pinned to a commit sha,
+# and a label reconciler is twenty lines of `gh` — a pinned dependency to run
+# them would be more supply chain than the task is worth.
+#
+# RUN BY HAND for now, and by a workflow once one exists: the workflow that
+# would call this on a push to main is the one piece of #1508 not in this tree,
+# because pushing a file under .github/workflows/ needs an OAuth scope the agent
+# that wrote this does not hold. Until then the file is authoritative the moment
+# somebody runs this, and the gate keeps the reference page honest either way.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+readonly SOURCE=".github/labels.yml"
+[[ -f "$SOURCE" ]] || { echo "FAIL: $SOURCE is missing"; exit 1; }
+
+# Parsed with awk rather than a YAML reader, because the file's shape is fixed
+# by this script and the gate that reads it: three scalar fields in a fixed
+# order. A parser that accepted more than those two do would let a file through
+# that one of them then rejects.
+declared=0
+while IFS=$'\t' read -r name color description; do
+  declared=$((declared + 1))
+  if gh label create "$name" --color "$color" --description "$description" --force >/dev/null; then
+    echo "ok: $name"
+  else
+    echo "FAIL: could not reconcile $name"
+    exit 1
+  fi
+done < <(awk '
+  /^- name: "/ { name = $0; sub(/^- name: "/, "", name); sub(/"$/, "", name); next }
+  /^  color: "/ { color = $0; sub(/^  color: "/, "", color); sub(/"$/, "", color); next }
+  /^  description: "/ {
+    description = $0
+    sub(/^  description: "/, "", description); sub(/"$/, "", description)
+    printf "%s\t%s\t%s\n", name, color, description
+    name = ""; color = ""; description = ""
+  }
+' "$SOURCE")
+
+# A sync that parsed nothing would report success over a file it could not read,
+# which is the failure this whole exercise is about.
+if [[ "$declared" -eq 0 ]]; then
+  echo "FAIL: $SOURCE declared no label this script could read — the file is empty, or its"
+  echo "shape changed and the parser above now matches nothing."
+  exit 1
+fi
+
+echo
+echo "reconciled $declared label(s) from $SOURCE"
+
+# What the repository has and the file does not name. Reported, never removed.
+extra="$(comm -13 \
+  <(awk '/^- name: "/ { n = $0; sub(/^- name: "/, "", n); sub(/"$/, "", n); print n }' "$SOURCE" | sort) \
+  <(gh label list --limit 200 --json name --jq '.[].name' | sort))"
+if [[ -n "$extra" ]]; then
+  echo
+  echo "NOT IN $SOURCE, and left alone:"
+  printf '  %s\n' $extra
+  echo
+  echo "Each is a label somebody added by hand. Add it to the file if it belongs to the"
+  echo "taxonomy, or retire it deliberately with 'gh label delete' — which strips it from"
+  echo "every issue carrying it, and cannot be undone."
+fi

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -73,7 +73,11 @@ echo "reconciled $declared label(s) from $SOURCE"
 # limited, unauthenticated or offline would report "nothing extra" and exit 0.
 # That is the worst answer this script can give: it is the reading somebody
 # would act on to conclude the repository holds exactly what the file names.
-if ! live="$(gh label list --limit 200 --json name --jq '.[].name')"; then
+# `--paginate`, not a limit. `gh label list --limit N` truncates at N, and a
+# truncated listing looks exactly like a complete one here: labels past the cut
+# are simply absent from `extra` and the run reports nothing to decide about.
+# The number would also have to be guessed, and guessed high enough forever.
+if ! live="$(gh api --paginate "repos/{owner}/{repo}/labels" --jq '.[].name')"; then
   echo "FAIL: could not list this repository's labels, so the report below cannot be made."
   echo "The reconcile above already ran; only the 'what is not in the file' half is missing."
   exit 1

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -72,7 +72,14 @@ extra="$(comm -13 \
 if [[ -n "$extra" ]]; then
   echo
   echo "NOT IN $SOURCE, and left alone:"
-  printf '  %s\n' $extra
+  # One line at a time, quoted. A label name may hold spaces — `good first issue`
+  # and `help wanted` both do — and an unquoted expansion would report one label
+  # as three, then let the shell try to glob any `*` or `?` in it. The report is
+  # what somebody reads before deciding to retire a label; it has to name the
+  # label they would type.
+  while IFS= read -r label; do
+    printf '  %s\n' "$label"
+  done <<<"$extra"
   echo
   echo "Each is a label somebody added by hand. Add it to the file if it belongs to the"
   echo "taxonomy, or retire it deliberately with 'gh label delete' — which strips it from"


### PR DESCRIPTION
Closes #1508 — with **one piece I could not push**; see the last section.

## The state now, which is not quite the state filed

The issue names three copies. Since it was filed, `AGENTS.md` stopped duplicating the list and links to the reference instead, and `CLAUDE.md` is the one-line `@AGENTS.md` shim. So two remained: `docs/reference/issue-labels.md`, and the repository's own labels — the only one that does anything, and the one nothing derived from.

The failure was silent in both directions. An agent reads a list naming a label that does not exist, files with it, and `gh issue create` fails. Or it reads one that omits a label that *does* exist and picks a worse-fitting area, which nothing ever notices.

## The three steps, in the order the issue says they must go

The issue is explicit that ordering matters — *"doing 2 without 1 just gates one prose copy against another."*

**1. `.github/labels.yml` is the source.** Twenty-nine labels: the four axes plus GitHub's own defaults. Verified byte-for-byte against the live repository as it stands today, so it starts true rather than aspirational.

**2. An offline gate** — `backend/gates/issuelabels_test.go`, `//gate:kind parity H3`. The reference page's four sections must name exactly the labels the file declares on each axis, in both directions. Deliberately offline: the authoritative list is on GitHub and `make check` has to pass without a network, so this proves the two copies *in the tree* agree and never asks GitHub anything.

**3. `scripts/sync-labels.sh`** reconciles the repository from the same file. This is what stops the file being a fourth copy.

## The gate is driven by sections, not by a pattern

My first version matched label names with a regex alternation — `priority: …|area: …|bug|enhancement|…`. It passed, and it was the taxonomy written down again in a third spelling: a page naming a brand-new provenance label went undetected, because the pattern did not know the name.

It now reads each of the page's four **sections** and compares that section's set to the source's labels on that axis. A provenance label added to the file and to that paragraph agrees; one added to only one of them does not; and the gate never learns any label's name.

Both spellings are handled because the page uses both deliberately — priorities and statuses carry their prefix, areas and provenance are named bare. Fifteen `area: x` rows would read as fifteen rows where fifteen names read as a set.

Mutation-checked on every axis:

| mutation | caught |
|---|---|
| an area in the source the page never lists | `## Area lists […15] and the source declares […16]` |
| a provenance label on the page the source lacks | `## Provenance lists [… needs-triage …]` |
| a priority retired from the source only | `## Priority lists [critical high low normal] and the source declares [critical high normal]` |
| a status on the page the source lacks | `## Status lists [blocked needs-decision]` |
| the source parser stops matching | `declared no label this gate could read … a parser matching nothing agrees with every page` |

The last matters most: a parity gate whose parser breaks reports the same green as two files that agree.

## The sync adds and updates; it never deletes

A label removed from the file **stays on the repository and is reported**. Deleting one strips it from every issue that carries it, with no undo — and `docs/reference/issue-labels.md` says of these very labels that provenance is "the one thing nobody can reconstruct later". Retiring a label is a decision with a cost, so it belongs to a person who has decided to pay it, not to a sync run.

No third-party action: every `uses:` in this repo is pinned to a commit sha, and a label reconciler is twenty lines of `gh` — a pinned dependency to run them would be more supply chain than the task is worth.

## The piece I could not push

A workflow calling the script on push to main. The remote refused it:

```
! [remote rejected] refusing to allow an OAuth App to create or update workflow
  `.github/workflows/labels.yml` without `workflow` scope
```

That is a permission boundary, not something to route around, so the branch carries the script and not the workflow, and nothing in the tree names a file that is not there. The file is authoritative the moment somebody runs `bash scripts/sync-labels.sh`; the gate keeps the reference page honest either way.

To finish it, `gh auth refresh -s workflow` and then commit `.github/workflows/labels.yml`:

```yaml
name: labels
on:
  push:
    branches: [main]
    paths:
      - ".github/labels.yml"
      - "scripts/sync-labels.sh"
      - ".github/workflows/labels.yml"
  workflow_dispatch:
permissions:
  contents: read
concurrency:
  group: labels
  cancel-in-progress: false
jobs:
  sync:
    runs-on: ubuntu-latest
    timeout-minutes: 5
    permissions:
      contents: read
      issues: write
    steps:
      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
      - run: bash scripts/sync-labels.sh
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Push-to-main only and not on a pull request: a branch would reconcile the repository to a proposal nobody has merged, and a fork's PR cannot be given write on labels. `issues: write` is the one write `gh label` needs.

## Also

Two doc comments in the new gate tripped the uniqueness-claim gate; both now name the test that holds them. `docs/reference/gate-inventory.md` regenerated.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized issue-label taxonomy covering priority, area, status, and provenance.
  * Added a manual synchronization tool to create and update repository labels from the approved taxonomy.
  * Added reporting for repository labels not included in the approved taxonomy.
* **Documentation**
  * Documented the authoritative label source, synchronization process, and consistency checks.
  * Updated the gate inventory to include label documentation validation.
* **Tests**
  * Added checks ensuring documented labels exactly match the approved taxonomy.
  * Added validation for missing, undocumented, empty, or invalid label definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->