### PR TITLE
fix(contracts): one write shape for a contract update

### DIFF
--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -235,22 +235,12 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 		patch := storekit.NewPatch()
 		patch.Set("cancellation_notice_on", existing.CancellationNoticeOn, noticeOn)
 		patch.Set("cancellation_effective_on", existing.CancellationEffectiveOn, effectiveOn)
-		if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
-			if constraint, ok := storekit.CheckViolation(err); ok {
-				return contractCheckError(constraint)
-			}
-			return fmt.Errorf("record contract cancellation: %w", err)
-		}
-		auditID, err := storekit.Audit(ctx, tx, "update", contractObject, id.UUID, patch.Before(), patch.After())
-		if err != nil {
-			return fmt.Errorf("audit contract cancellation: %w", err)
-		}
 		// A cancellation is a column patch, not a transition, so it rides
-		// contract.updated. A consumer watching for the state change gets it
-		// when the status actually moves, which is the honest moment.
-		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
-			crmcontracts.PublicEventContractUpdated{ChangedFields: patch.After()}); err != nil {
-			return fmt.Errorf("emit contract.updated: %w", err)
+		// contract.updated like any other field write. A consumer watching for
+		// the state change gets it when the status actually moves, which is the
+		// honest moment.
+		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract cancellation"); err != nil {
+			return err
 		}
 		out, err = readContract(ctx, tx, id, s.today())
 		return err

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -152,25 +152,42 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 			out = existing
 			return nil
 		}
-		if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
-			if constraint, ok := storekit.CheckViolation(err); ok {
-				return contractCheckError(constraint)
-			}
-			return fmt.Errorf("patch contract: %w", err)
-		}
-
-		auditID, err := storekit.Audit(ctx, tx, "update", contractObject, id.UUID, patch.Before(), patch.After())
-		if err != nil {
-			return fmt.Errorf("audit contract update: %w", err)
-		}
-		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
-			crmcontracts.PublicEventContractUpdated{ChangedFields: patch.After()}); err != nil {
-			return fmt.Errorf("emit contract.updated: %w", err)
+		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract update"); err != nil {
+			return err
 		}
 		out, err = readContract(ctx, tx, id, s.today())
 		return err
 	})
 	return out, err
+}
+
+// applyContractUpdate is the update write shape: guard the patch, audit it,
+// emit contract.updated, and leave the row read to the caller.
+//
+// Two verbs spelled this out identically — a field patch and a cancellation
+// notice — and the only difference between the two copies was the noun in the
+// error text. Two copies of a write shape drift towards whichever one gets
+// edited, and the half that does not is where an audit row or an event goes
+// missing while the domain row still lands.
+func applyContractUpdate(ctx context.Context, tx pgx.Tx, id ids.ContractID,
+	patch *storekit.Patch, ifVersion *int64, what string,
+) error {
+	if err := patch.ApplyGuarded(ctx, tx, contractTable, id.UUID, ifVersion); err != nil {
+		if constraint, ok := storekit.CheckViolation(err); ok {
+			return contractCheckError(constraint)
+		}
+		return fmt.Errorf("write %s: %w", what, err)
+	}
+	auditID, err := storekit.Audit(ctx, tx, "update", contractObject, id.UUID,
+		patch.Before(), patch.After())
+	if err != nil {
+		return fmt.Errorf("audit %s: %w", what, err)
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
+		crmcontracts.PublicEventContractUpdated{ChangedFields: patch.After()}); err != nil {
+		return fmt.Errorf("emit contract.updated: %w", err)
+	}
+	return nil
 }
 
 // ArchiveContract soft-deletes an agreement. The row and its history stay:

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -162,20 +162,20 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 }
 
 // applyContractUpdate is the update write shape: guard the patch, audit it,
-// emit contract.updated, and leave the row read to the caller.
+// emit contract.updated, and leave the row read to the caller. `what` names the
+// change for an operator reading a failure — which of the four steps broke, and
+// on which verb.
 //
-// It authorizes NOTHING. Every caller has already run auth.Require for the
-// action and resolved the row through writableContract, which is what carries
-// the row scope; this function is handed a patch and a row that were both
-// already permitted. Said out loud because a shared write seam is exactly the
-// thing a later caller reaches for directly, and the two obligations above are
-// invisible from in here.
+// It authorizes NOTHING. Every caller runs auth.Require for the action and
+// resolves the row through writableContract, which is what carries the row
+// scope; this is handed a patch and a row that were both already permitted.
 //
-// Two verbs spelled this out identically — a field patch and a cancellation
-// notice — and the only difference between the two copies was the noun in the
-// error text. Two copies of a write shape drift towards whichever one gets
-// edited, and the half that does not is where an audit row or an event goes
-// missing while the domain row still lands.
+// And it PUBLISHES the patch's after-image, whole, as contract.updated's
+// changed_fields — which is `additionalProperties: true` on the public webhook
+// contract. Both obligations are invisible from in here, and a shared write
+// seam is exactly the thing a later caller reaches for directly: a patch built
+// over custom-field columns would put their values in front of external
+// subscribers with nothing at the call site saying so.
 func applyContractUpdate(ctx context.Context, tx pgx.Tx, id ids.ContractID,
 	patch *storekit.Patch, ifVersion *int64, what string,
 ) error {
@@ -192,7 +192,7 @@ func applyContractUpdate(ctx context.Context, tx pgx.Tx, id ids.ContractID,
 	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
 		crmcontracts.PublicEventContractUpdated{ChangedFields: patch.After()}); err != nil {
-		return fmt.Errorf("emit contract.updated: %w", err)
+		return fmt.Errorf("emit contract.updated for %s: %w", what, err)
 	}
 	return nil
 }

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -164,6 +164,13 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 // applyContractUpdate is the update write shape: guard the patch, audit it,
 // emit contract.updated, and leave the row read to the caller.
 //
+// It authorizes NOTHING. Every caller has already run auth.Require for the
+// action and resolved the row through writableContract, which is what carries
+// the row scope; this function is handed a patch and a row that were both
+// already permitted. Said out loud because a shared write seam is exactly the
+// thing a later caller reaches for directly, and the two obligations above are
+// invisible from in here.
+//
 // Two verbs spelled this out identically — a field patch and a cancellation
 // notice — and the only difference between the two copies was the noun in the
 // error text. Two copies of a write shape drift towards whichever one gets

--- a/backend/internal/modules/contracts/contractupdatefailure_test.go
+++ b/backend/internal/modules/contracts/contractupdatefailure_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contracts
+
+// The three ways the update shape can fail, which the integration suite cannot
+// show because each needs the database to refuse a statement that normally
+// succeeds.
+//
+// All three matter for the same reason. An update is a domain row, an audit row
+// and an event that land in ONE transaction, so a step that fails and does not
+// say so leaves the transaction to commit the parts that worked: the row moves
+// and the trail does not, or the row and the trail move and no consumer hears.
+// Each failure has to reach the caller, and each has to say which step it was —
+// "something went wrong writing a contract" does not tell an operator whether
+// to look at the row, the audit table or the outbox.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// updatingContext carries what every real write path binds before reaching the
+// store: the actor the audit row is filed under, and the correlation id that
+// links that row to the event. Emit refuses without the second, so a context
+// missing it fails the shape one step earlier than the step under test.
+func updatingContext() context.Context {
+	ctx := principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String()})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
+
+// aContractPatch carries one column, so the patch is not empty and the shape
+// runs all the way through rather than returning early.
+func aContractPatch() *storekit.Patch {
+	patch := storekit.NewPatch()
+	patch.Set("title", nil, "renamed")
+	return patch
+}
+
+func TestARefusedContractPatchReachesTheCaller(t *testing.T) {
+	refused := errors.New("deadlock detected")
+	tx := &failingTx{failOn: contractTable, err: refused}
+	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update")
+	if !errors.Is(err, refused) {
+		t.Fatalf("the database's refusal did not reach the caller: %v", err)
+	}
+	if !strings.Contains(err.Error(), "write contract update") {
+		t.Errorf("the error does not say which step failed: %v", err)
+	}
+}
+
+// The audit row is the half a reader would not notice missing. A patch that
+// lands while its audit insert fails silently is a change with no trail, and
+// the row itself looks exactly like one that was recorded properly.
+func TestARefusedAuditRowStopsTheContractUpdate(t *testing.T) {
+	refused := errors.New("audit_log is full")
+	tx := &failingTx{failOn: "audit_log", err: refused}
+	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update")
+	if !errors.Is(err, refused) {
+		t.Fatalf("a refused audit row did not reach the caller: %v", err)
+	}
+	if !strings.Contains(err.Error(), "audit contract update") {
+		t.Errorf("the error does not say which step failed: %v", err)
+	}
+}
+
+// The event is the half no consumer would notice missing, because a consumer
+// that never receives a message cannot tell it apart from one that was never
+// sent.
+func TestARefusedEventStopsTheContractUpdate(t *testing.T) {
+	refused := errors.New("outbox unavailable")
+	tx := &failingTx{failOn: "event_outbox", err: refused}
+	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update")
+	if !errors.Is(err, refused) {
+		t.Fatalf("a refused event did not reach the caller: %v", err)
+	}
+	if !strings.Contains(err.Error(), "emit contract.updated") {
+		t.Errorf("the error does not say which step failed: %v", err)
+	}
+}
+
+// A CHECK the database refuses is not an infrastructure failure — it is the
+// caller having asked for something the schema forbids, and it has to arrive as
+// the field-level refusal a caller can act on rather than as a wrapped driver
+// error. The shape owns that translation for both verbs, so it is tested where
+// the translation lives.
+func TestARefusedCheckBecomesAFieldLevelRefusal(t *testing.T) {
+	tx := &failingTx{failOn: contractTable, err: &pgconn.PgError{
+		Code: "23514", ConstraintName: "contract_term_order",
+	}}
+	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update")
+	var refusal *ContractCheckError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("a refused CHECK did not become a field-level refusal: %v", err)
+	}
+	if refusal.Field != "ends_on" {
+		t.Errorf("the refusal names %q, so a caller is pointed at the wrong field", refusal.Field)
+	}
+}
+
+// The shape's own success, which is what makes the four refusals above mean
+// something: the same fake, refusing nothing, must reach the end AND send all
+// three writes. A shape that quietly sent two of them would pass every refusal
+// test above, because a write that never happens cannot be refused.
+func TestTheContractUpdateShapeSendsAllThreeWrites(t *testing.T) {
+	tx := &failingTx{failOn: "a string no statement contains"}
+	if err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update"); err != nil {
+		t.Fatalf("the update shape refused a transaction that accepted everything: %v", err)
+	}
+	for _, table := range []string{contractTable, "audit_log", "event_outbox"} {
+		sent := false
+		for _, sql := range tx.seen {
+			if strings.Contains(sql, table) {
+				sent = true
+			}
+		}
+		if !sent {
+			t.Errorf("nothing was written to %s: an update is a row, a trail and an event, and "+
+				"a shape that sends two of the three commits a change nobody can see", table)
+		}
+	}
+}
+
+// failingTx refuses the first statement naming failOn and answers every other
+// one as though it had worked, so each test breaks exactly one step of the
+// shape and the steps before it are reached for real.
+//
+// It panics on the methods the shape does not use: a future step reaching for
+// the database another way fails loudly here rather than being answered by a
+// zero value that makes the test pass for the wrong reason.
+type failingTx struct {
+	failOn string
+	err    error
+	seen   []string
+}
+
+func (f *failingTx) matches(sql string) bool {
+	f.seen = append(f.seen, sql)
+	return strings.Contains(sql, f.failOn)
+}
+
+func (f *failingTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	if f.matches(sql) {
+		return pgconn.CommandTag{}, f.err
+	}
+	return pgconn.NewCommandTag("UPDATE 1"), nil
+}
+
+func (f *failingTx) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	if f.matches(sql) {
+		return errorRow{err: f.err}
+	}
+	return newIDRow()
+}
+
+func (f *failingTx) Begin(context.Context) (pgx.Tx, error) { panic("failingTx: Begin") }
+func (f *failingTx) Commit(context.Context) error          { panic("failingTx: Commit") }
+func (f *failingTx) Rollback(context.Context) error        { panic("failingTx: Rollback") }
+func (f *failingTx) Conn() *pgx.Conn                       { panic("failingTx: Conn") }
+func (f *failingTx) LargeObjects() pgx.LargeObjects        { panic("failingTx: LargeObjects") }
+
+func (f *failingTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	panic("failingTx: CopyFrom")
+}
+
+func (f *failingTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	panic("failingTx: SendBatch")
+}
+
+func (f *failingTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	panic("failingTx: Prepare")
+}
+
+func (f *failingTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	panic("failingTx: Query")
+}
+
+// errorRow hands the refusal back through Scan, which is where a QueryRow
+// reports one.
+type errorRow struct{ err error }
+
+func (r errorRow) Scan(...any) error { return r.err }
+
+// idRow answers a scan for a generated identifier, which is what the audit
+// insert asks for.
+type idRow struct{ id ids.UUID }
+
+func newIDRow() idRow { return idRow{id: ids.NewV7()} }
+
+func (r idRow) Scan(into ...any) error {
+	for _, target := range into {
+		if slot, isUUID := target.(*ids.UUID); isUUID {
+			*slot = r.id
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/contracts/contractupdatefailure_test.go
+++ b/backend/internal/modules/contracts/contractupdatefailure_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -210,7 +211,7 @@ func TestARefusedCheckBecomesAFieldLevelRefusal(t *testing.T) {
 
 // An If-Match request takes a different branch of the guarded patch — a
 // compare-and-set rather than a row lock — and that branch mints the skew a
-// caller must be able to retry on. The new wrap must not bury it: a client that
+// caller must be able to retry on. The wrap must not bury it: a client that
 // gets an opaque failure instead of a version conflict cannot tell "try again
 // with a fresh read" from "this will never work".
 func TestAStaleIfMatchSurvivesTheUpdateShapesWrap(t *testing.T) {
@@ -275,8 +276,14 @@ func (r *recordingTx) Exec(_ context.Context, sql string, args ...any) (pgconn.C
 	if r.record(sql, args) {
 		return pgconn.CommandTag{}, r.err
 	}
-	if r.missed && domainWrite.MatchString(sql) {
+	switch {
+	case r.missed && domainWrite.MatchString(sql):
 		return pgconn.NewCommandTag("UPDATE 0"), nil
+	case auditWrite.MatchString(sql), eventWrite.MatchString(sql):
+		// An INSERT tagged as an UPDATE would answer a RowsAffected check on
+		// either of these vacuously, which is the shape of fake that makes a
+		// future assertion pass without being true.
+		return pgconn.NewCommandTag("INSERT 0 1"), nil
 	}
 	return pgconn.NewCommandTag("UPDATE 1"), nil
 }
@@ -320,6 +327,11 @@ type answerRow struct {
 	err    error
 }
 
+// Scan REFUSES a destination it does not serve, for the reason recordingTx
+// panics on the methods the shape does not call. Returning nil and leaving an
+// unrecognised destination at its zero value is how a future step — a version
+// read, a RETURNING clause — gets a silent answer and every test here goes on
+// passing over it. A fake that cannot answer must say so.
 func (a answerRow) Scan(into ...any) error {
 	if a.err != nil {
 		return a.err
@@ -330,6 +342,9 @@ func (a answerRow) Scan(into ...any) error {
 			*slot = a.id
 		case *bool:
 			*slot = a.exists
+		default:
+			return fmt.Errorf("answerRow: no answer for %T — the update shape issued a query "+
+				"this fake does not serve, so a test using it would pass on a zero value", target)
 		}
 	}
 	return nil

--- a/backend/internal/modules/contracts/contractupdatefailure_test.go
+++ b/backend/internal/modules/contracts/contractupdatefailure_test.go
@@ -3,21 +3,28 @@
 
 package contracts
 
-// The three ways the update shape can fail, which the integration suite cannot
-// show because each needs the database to refuse a statement that normally
+// The update shape's own behaviour, which the integration suite cannot show
+// because most of it needs the database to refuse a statement that normally
 // succeeds.
 //
-// All three matter for the same reason. An update is a domain row, an audit row
-// and an event that land in ONE transaction, so a step that fails and does not
-// say so leaves the transaction to commit the parts that worked: the row moves
-// and the trail does not, or the row and the trail move and no consumer hears.
-// Each failure has to reach the caller, and each has to say which step it was —
-// "something went wrong writing a contract" does not tell an operator whether
-// to look at the row, the audit table or the outbox.
+// An update is a domain row, an audit row and an event that land in ONE
+// transaction, so a step that fails without saying so leaves the transaction to
+// commit the parts that worked: the row moves and the trail does not, or both
+// move and no consumer hears. Each failure has to reach the caller, and each has
+// to say WHICH step it was — "something went wrong writing a contract" does not
+// tell an operator whether to look at the row, the audit table or the outbox.
+//
+// The fake records what each statement was HANDED, not only that one was sent.
+// Recording the SQL alone leaves the payloads untested, and the event's is not
+// guarded anywhere else: events.Envelope.Validate checks the id, type, actor,
+// entity and trace and never inspects the payload, so an emit that shipped
+// patch.Before() as ChangedFields satisfies every other gate in the tree.
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -25,6 +32,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -47,9 +55,97 @@ func aContractPatch() *storekit.Patch {
 	return patch
 }
 
+// The three statements an update sends, matched by what they DO rather than by
+// the table they mention. `contract` appears in the row lock's own SELECT, so a
+// substring test is satisfied by a shape that locked the row and never wrote it.
+var (
+	domainWrite = regexp.MustCompile(`(?is)^\s*UPDATE\s+contract\s+SET`)
+	auditWrite  = regexp.MustCompile(`(?is)INSERT\s+INTO\s+audit_log`)
+	eventWrite  = regexp.MustCompile(`(?is)INSERT\s+INTO\s+event_outbox`)
+)
+
+// The shape's success, and the assertion that makes the refusals below mean
+// something: all THREE writes are sent. A shape that quietly stopped sending
+// one would pass every refusal test here, because a write that never happens
+// cannot be refused.
+func TestTheContractUpdateShapeSendsAllThreeWrites(t *testing.T) {
+	tx := &recordingTx{}
+	if err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), nil, "contract update"); err != nil {
+		t.Fatalf("the update shape refused a transaction that accepted everything: %v", err)
+	}
+	for what, statement := range map[string]*regexp.Regexp{
+		"the contract row": domainWrite, "the audit row": auditWrite, "the event": eventWrite,
+	} {
+		if tx.find(statement) == nil {
+			t.Errorf("%s was never written: an update is a row, a trail and an event, and a "+
+				"shape that sends two of the three commits a change nobody can see.\n"+
+				"Statements sent:\n\t%s", what, strings.Join(tx.sql(), "\n\t"))
+		}
+	}
+}
+
+// What the event CARRIES, which nothing else in the tree checks. Swapping
+// patch.After() for patch.Before() at the emit leaves every other gate green
+// and ships every consumer the pre-change values under the name "changed
+// fields" — the drift a one-writer gate cannot see, because there is still only
+// one writer.
+func TestTheContractUpdateEventCarriesWhatChanged(t *testing.T) {
+	tx := &recordingTx{}
+	patch := aContractPatch()
+	if err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		patch, nil, "contract update"); err != nil {
+		t.Fatalf("applying the update: %v", err)
+	}
+	sent := tx.find(eventWrite)
+	if sent == nil {
+		t.Fatal("no event was written, so there is nothing to check what it carries")
+	}
+	body, isBytes := sent.args[len(sent.args)-1].([]byte)
+	if !isBytes {
+		t.Fatalf("the outbox row's last bind is %T, not the marshalled envelope", sent.args[len(sent.args)-1])
+	}
+	var envelope struct {
+		Payload struct {
+			ChangedFields map[string]any `json:"changed_fields"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("reading the envelope the shape emitted: %v", err)
+	}
+	after := patch.After()
+	if len(envelope.Payload.ChangedFields) != len(after) {
+		t.Fatalf("the event carries %v; the write changed %v", envelope.Payload.ChangedFields, after)
+	}
+	for field := range after {
+		if _, present := envelope.Payload.ChangedFields[field]; !present {
+			t.Errorf("the event omits %s, which this write changed", field)
+			continue
+		}
+		// The RENDERED forms, because that is what a consumer reads: the write
+		// holds Go values and the envelope holds what survived a JSON round
+		// trip, where `int64(1)` and `float64(1)` are the same field.
+		got := fieldText(envelope.Payload.ChangedFields, field)
+		want := fieldText(after, field)
+		if got != want {
+			t.Errorf("the event says %s is %s; the write set it to %s", field, got, want)
+		}
+	}
+}
+
+// fieldText renders one field of a changed-field set as a consumer would read
+// it, or a marker naming why it could not be rendered.
+func fieldText(fields map[string]any, name string) string {
+	rendered, err := json.Marshal(fields[name])
+	if err != nil {
+		return "<unrenderable: " + err.Error() + ">"
+	}
+	return string(rendered)
+}
+
 func TestARefusedContractPatchReachesTheCaller(t *testing.T) {
 	refused := errors.New("deadlock detected")
-	tx := &failingTx{failOn: contractTable, err: refused}
+	tx := &recordingTx{refuse: domainWrite, err: refused}
 	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
 		aContractPatch(), nil, "contract update")
 	if !errors.Is(err, refused) {
@@ -65,7 +161,7 @@ func TestARefusedContractPatchReachesTheCaller(t *testing.T) {
 // the row itself looks exactly like one that was recorded properly.
 func TestARefusedAuditRowStopsTheContractUpdate(t *testing.T) {
 	refused := errors.New("audit_log is full")
-	tx := &failingTx{failOn: "audit_log", err: refused}
+	tx := &recordingTx{refuse: auditWrite, err: refused}
 	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
 		aContractPatch(), nil, "contract update")
 	if !errors.Is(err, refused) {
@@ -77,11 +173,10 @@ func TestARefusedAuditRowStopsTheContractUpdate(t *testing.T) {
 }
 
 // The event is the half no consumer would notice missing, because a consumer
-// that never receives a message cannot tell it apart from one that was never
-// sent.
+// that never receives a message cannot tell it apart from one never sent.
 func TestARefusedEventStopsTheContractUpdate(t *testing.T) {
 	refused := errors.New("outbox unavailable")
-	tx := &failingTx{failOn: "event_outbox", err: refused}
+	tx := &recordingTx{refuse: eventWrite, err: refused}
 	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
 		aContractPatch(), nil, "contract update")
 	if !errors.Is(err, refused) {
@@ -94,11 +189,12 @@ func TestARefusedEventStopsTheContractUpdate(t *testing.T) {
 
 // A CHECK the database refuses is not an infrastructure failure — it is the
 // caller having asked for something the schema forbids, and it has to arrive as
-// the field-level refusal a caller can act on rather than as a wrapped driver
-// error. The shape owns that translation for both verbs, so it is tested where
-// the translation lives.
+// the field-level refusal a caller can act on rather than a wrapped driver
+// error. It is refused by the UPDATE, which is the only statement that can
+// raise one: a fake that raised it from the row lock's SELECT would still pass
+// while the UPDATE stopped propagating it.
 func TestARefusedCheckBecomesAFieldLevelRefusal(t *testing.T) {
-	tx := &failingTx{failOn: contractTable, err: &pgconn.PgError{
+	tx := &recordingTx{refuse: domainWrite, err: &pgconn.PgError{
 		Code: "23514", ConstraintName: "contract_term_order",
 	}}
 	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
@@ -112,100 +208,128 @@ func TestARefusedCheckBecomesAFieldLevelRefusal(t *testing.T) {
 	}
 }
 
-// The shape's own success, which is what makes the four refusals above mean
-// something: the same fake, refusing nothing, must reach the end AND send all
-// three writes. A shape that quietly sent two of them would pass every refusal
-// test above, because a write that never happens cannot be refused.
-func TestTheContractUpdateShapeSendsAllThreeWrites(t *testing.T) {
-	tx := &failingTx{failOn: "a string no statement contains"}
-	if err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
-		aContractPatch(), nil, "contract update"); err != nil {
-		t.Fatalf("the update shape refused a transaction that accepted everything: %v", err)
+// An If-Match request takes a different branch of the guarded patch — a
+// compare-and-set rather than a row lock — and that branch mints the skew a
+// caller must be able to retry on. The new wrap must not bury it: a client that
+// gets an opaque failure instead of a version conflict cannot tell "try again
+// with a fresh read" from "this will never work".
+func TestAStaleIfMatchSurvivesTheUpdateShapesWrap(t *testing.T) {
+	stale := int64(3)
+	tx := &recordingTx{missed: true, exists: true}
+	err := applyContractUpdate(updatingContext(), tx, ids.New[ids.ContractKind](),
+		aContractPatch(), &stale, "contract update")
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("a stale If-Match did not reach the caller as version skew: %v", err)
 	}
-	for _, table := range []string{contractTable, "audit_log", "event_outbox"} {
-		sent := false
-		for _, sql := range tx.seen {
-			if strings.Contains(sql, table) {
-				sent = true
-			}
-		}
-		if !sent {
-			t.Errorf("nothing was written to %s: an update is a row, a trail and an event, and "+
-				"a shape that sends two of the three commits a change nobody can see", table)
-		}
+	if tx.find(auditWrite) != nil {
+		t.Error("a write that never landed still filed an audit row")
 	}
 }
 
-// failingTx refuses the first statement naming failOn and answers every other
-// one as though it had worked, so each test breaks exactly one step of the
-// shape and the steps before it are reached for real.
+// recordingTx answers each statement as though it had worked, unless it matches
+// `refuse`. It keeps what every statement was handed, because the SQL alone
+// leaves the payloads untested.
 //
 // It panics on the methods the shape does not use: a future step reaching for
 // the database another way fails loudly here rather than being answered by a
-// zero value that makes the test pass for the wrong reason.
-type failingTx struct {
-	failOn string
+// zero value that makes a test pass for the wrong reason.
+type recordingTx struct {
+	refuse *regexp.Regexp
 	err    error
-	seen   []string
+	// missed makes the compare-and-set match no row, and exists answers the
+	// follow-up that tells a stale version from a deleted row.
+	missed bool
+	exists bool
+	sent   []statement
 }
 
-func (f *failingTx) matches(sql string) bool {
-	f.seen = append(f.seen, sql)
-	return strings.Contains(sql, f.failOn)
+type statement struct {
+	text string
+	args []any
 }
 
-func (f *failingTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
-	if f.matches(sql) {
-		return pgconn.CommandTag{}, f.err
+func (r *recordingTx) record(sql string, args []any) bool {
+	r.sent = append(r.sent, statement{text: sql, args: args})
+	return r.refuse != nil && r.refuse.MatchString(sql)
+}
+
+// find returns the first statement matching want, or nil.
+func (r *recordingTx) find(want *regexp.Regexp) *statement {
+	for i := range r.sent {
+		if want.MatchString(r.sent[i].text) {
+			return &r.sent[i]
+		}
+	}
+	return nil
+}
+
+func (r *recordingTx) sql() []string {
+	var out []string
+	for _, sent := range r.sent {
+		out = append(out, strings.Join(strings.Fields(sent.text), " "))
+	}
+	return out
+}
+
+func (r *recordingTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if r.record(sql, args) {
+		return pgconn.CommandTag{}, r.err
+	}
+	if r.missed && domainWrite.MatchString(sql) {
+		return pgconn.NewCommandTag("UPDATE 0"), nil
 	}
 	return pgconn.NewCommandTag("UPDATE 1"), nil
 }
 
-func (f *failingTx) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
-	if f.matches(sql) {
-		return errorRow{err: f.err}
+func (r *recordingTx) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	if r.record(sql, args) {
+		return answerRow{err: r.err}
 	}
-	return newIDRow()
+	return answerRow{id: ids.NewV7(), exists: r.exists}
 }
 
-func (f *failingTx) Begin(context.Context) (pgx.Tx, error) { panic("failingTx: Begin") }
-func (f *failingTx) Commit(context.Context) error          { panic("failingTx: Commit") }
-func (f *failingTx) Rollback(context.Context) error        { panic("failingTx: Rollback") }
-func (f *failingTx) Conn() *pgx.Conn                       { panic("failingTx: Conn") }
-func (f *failingTx) LargeObjects() pgx.LargeObjects        { panic("failingTx: LargeObjects") }
+func (r *recordingTx) Begin(context.Context) (pgx.Tx, error) { panic("recordingTx: Begin") }
+func (r *recordingTx) Commit(context.Context) error          { panic("recordingTx: Commit") }
+func (r *recordingTx) Rollback(context.Context) error        { panic("recordingTx: Rollback") }
+func (r *recordingTx) Conn() *pgx.Conn                       { panic("recordingTx: Conn") }
+func (r *recordingTx) LargeObjects() pgx.LargeObjects        { panic("recordingTx: LargeObjects") }
 
-func (f *failingTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
-	panic("failingTx: CopyFrom")
+func (r *recordingTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	panic("recordingTx: CopyFrom")
 }
 
-func (f *failingTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
-	panic("failingTx: SendBatch")
+func (r *recordingTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	panic("recordingTx: SendBatch")
 }
 
-func (f *failingTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
-	panic("failingTx: Prepare")
+func (r *recordingTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	panic("recordingTx: Prepare")
 }
 
-func (f *failingTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
-	panic("failingTx: Query")
+func (r *recordingTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	panic("recordingTx: Query")
 }
 
-// errorRow hands the refusal back through Scan, which is where a QueryRow
-// reports one.
-type errorRow struct{ err error }
+// answerRow serves the two QueryRow the shape can issue: the row lock's
+// `SELECT id … FOR UPDATE`, and the compare-and-set's follow-up `SELECT EXISTS`
+// that tells a stale version from a row that is gone. The audit insert does not
+// appear here — it is an Exec, and mints its own id in Go.
+type answerRow struct {
+	id     ids.UUID
+	exists bool
+	err    error
+}
 
-func (r errorRow) Scan(...any) error { return r.err }
-
-// idRow answers a scan for a generated identifier, which is what the audit
-// insert asks for.
-type idRow struct{ id ids.UUID }
-
-func newIDRow() idRow { return idRow{id: ids.NewV7()} }
-
-func (r idRow) Scan(into ...any) error {
+func (a answerRow) Scan(into ...any) error {
+	if a.err != nil {
+		return a.err
+	}
 	for _, target := range into {
-		if slot, isUUID := target.(*ids.UUID); isUUID {
-			*slot = r.id
+		switch slot := target.(type) {
+		case *ids.UUID:
+			*slot = a.id
+		case *bool:
+			*slot = a.exists
 		}
 	}
 	return nil

--- a/backend/internal/modules/contracts/onewriteshape_test.go
+++ b/backend/internal/modules/contracts/onewriteshape_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contracts
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// An update to a contract row is four things that must happen together: the
+// guarded patch, the audit row, the contract.updated event, and the check
+// violation translated into the error a caller can act on. Two verbs spelled
+// all four out separately — a field patch and a cancellation notice — and the
+// only thing that differed between the copies was the noun in the error text.
+//
+// That is the shape a write loses a half of. The two copies drift towards
+// whichever one is edited, and the half nobody edited is where an audit row or
+// an event stops being written while the domain row still lands: the change
+// happened, the trail says it did not, and the consumers never hear.
+//
+// So the claim is that the update shape has one writer, found by the event it
+// publishes.
+
+// updateShapeOwner is the function that performs a contract update.
+const updateShapeOwner = "applyContractUpdate"
+
+// updateEvent is what an update publishes, and it is what separates this shape
+// from its neighbours.
+//
+// The audit ACTION does not separate them: a field patch and a status
+// transition both file an "update" audit row, correctly, because both update
+// the row. Keying on the action would report applyStatusTx as a second copy of
+// a shape it does not share — the status change publishes
+// contract.status_changed and carries the from/to a consumer needs. The event
+// is the discriminator, and the only one.
+//
+// What this gate does NOT hold: a patch that audits and publishes nothing at
+// all. That has no event to be found by, and it is held tree-wide by the write
+// shape gate rather than here.
+const updateEvent = "PublicEventContractUpdated"
+
+func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
+	emitters := functionsWhere(t, func(fn *ast.FuncDecl) bool {
+		return buildsType(fn.Body, "crmcontracts."+updateEvent)
+	})
+	switch {
+	case len(emitters) == 0:
+		t.Fatalf("nothing in this package publishes %s, so the update shape has moved and this "+
+			"gate judged nothing", updateEvent)
+	case len(emitters) == 1 && emitters[0] == updateShapeOwner:
+	case len(emitters) == 1:
+		t.Errorf("%s publishes %s, not %s — this gate is now watching the wrong function",
+			emitters[0], updateEvent, updateShapeOwner)
+	default:
+		t.Errorf("%d functions publish %s: %s.\n\nAn update is a guarded patch, an audit row "+
+			"and an event that must land together. Spelled twice they drift towards whichever "+
+			"copy is edited, and the other one writes the row while the trail and the consumers "+
+			"hear nothing. Go through %s.",
+			len(emitters), updateEvent, strings.Join(emitters, ", "), updateShapeOwner)
+	}
+}
+
+// functionsWhere names the package's non-test functions satisfying want.
+func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	var found []string
+	files := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files++
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parsing %s: %v", name, perr)
+		}
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if isFunc && fn.Body != nil && fn.Name != nil && want(fn) {
+				found = append(found, fn.Name.Name)
+			}
+		}
+	}
+	if files == 0 {
+		t.Fatal("this package has no non-test source, so the census read nothing")
+	}
+	sort.Strings(found)
+	return found
+}
+
+// buildsType reports a composite literal of the named type, however few fields
+// it carries — an event with no fields set is still an event published.
+func buildsType(body *ast.BlockStmt, typeName string) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.CompositeLit)
+		if isLit && lit.Type != nil && exprText(lit.Type) == typeName {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func exprText(expr ast.Expr) string {
+	switch node := expr.(type) {
+	case *ast.Ident:
+		return node.Name
+	case *ast.SelectorExpr:
+		return exprText(node.X) + "." + node.Sel.Name
+	case *ast.StarExpr:
+		return exprText(node.X)
+	}
+	return ""
+}

--- a/backend/internal/modules/contracts/onewriteshape_test.go
+++ b/backend/internal/modules/contracts/onewriteshape_test.go
@@ -139,11 +139,22 @@ func declaredPackageName(t *testing.T, dir string) string {
 	fset := token.NewFileSet()
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+		// A `_test.go` may declare the EXTERNAL test package — `crmcontracts_test`
+		// — and os.ReadDir returns entries by name, so one sorting first would
+		// hand back a package no production file imports. That is the fail-short
+		// direction again, and it is not caught by the fatal below: a wrong name
+		// is not an absent one.
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
 		file, perr := parser.ParseFile(fset, dir+"/"+name, nil, parser.PackageClauseOnly)
 		if perr != nil || file.Name == nil {
+			continue
+		}
+		if strings.HasSuffix(file.Name.Name, "_test") {
+			// Belt and braces: every source in the directory being a test
+			// package would otherwise resolve to one, and the skip above only
+			// covers the filename convention rather than the clause itself.
 			continue
 		}
 		return file.Name.Name

--- a/backend/internal/modules/contracts/onewriteshape_test.go
+++ b/backend/internal/modules/contracts/onewriteshape_test.go
@@ -47,7 +47,7 @@ const updateEvent = "PublicEventContractUpdated"
 
 func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
 	emitters := functionsWhere(t, func(fn *ast.FuncDecl) bool {
-		return buildsType(fn.Body, "crmcontracts."+updateEvent)
+		return namesType(fn, "crmcontracts."+updateEvent)
 	})
 	switch {
 	case len(emitters) == 0:
@@ -100,17 +100,36 @@ func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
 	return found
 }
 
-// buildsType reports a composite literal of the named type, however few fields
-// it carries — an event with no fields set is still an event published.
-func buildsType(body *ast.BlockStmt, typeName string) bool {
+// namesType reports whether fn mentions the named type anywhere — in its
+// signature or its body.
+//
+// A mention, not a composite literal. Under-recognition is the one direction a
+// census must not fail in: a second writer that declared `var updated
+// crmcontracts.PublicEventContractUpdated` and filled it in by assignment, or
+// that took the payload as a parameter, contributes nothing to a literal-only
+// count. The count stays at one, the gate reports PASS, and the duplicate this
+// exists to catch lands unseen.
+//
+// Naming the type is how a function comes to publish it, and there is no way to
+// publish it without naming it. The width costs nothing here: a reader of this
+// event would name it too, and this module produces it rather than consuming
+// it — a consumer appearing later is a thing worth failing on and looking at,
+// not a false positive to design around in advance.
+func namesType(fn *ast.FuncDecl, typeName string) bool {
 	found := false
-	ast.Inspect(body, func(node ast.Node) bool {
-		lit, isLit := node.(*ast.CompositeLit)
-		if isLit && lit.Type != nil && exprText(lit.Type) == typeName {
+	inspect := func(node ast.Node) bool {
+		if node == nil {
+			return !found
+		}
+		if expr, isExpr := node.(ast.Expr); isExpr && exprText(expr) == typeName {
 			found = true
 		}
 		return !found
-	})
+	}
+	ast.Inspect(fn.Type, inspect)
+	if fn.Body != nil {
+		ast.Inspect(fn.Body, inspect)
+	}
 	return found
 }
 

--- a/backend/internal/modules/contracts/onewriteshape_test.go
+++ b/backend/internal/modules/contracts/onewriteshape_test.go
@@ -9,20 +9,19 @@ import (
 	"go/token"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 // An update to a contract row is four things that must happen together: the
 // guarded patch, the audit row, the contract.updated event, and the check
-// violation translated into the error a caller can act on. Two verbs spelled
-// all four out separately — a field patch and a cancellation notice — and the
-// only thing that differed between the copies was the noun in the error text.
+// violation translated into the error a caller can act on.
 //
-// That is the shape a write loses a half of. The two copies drift towards
-// whichever one is edited, and the half nobody edited is where an audit row or
-// an event stops being written while the domain row still lands: the change
-// happened, the trail says it did not, and the consumers never hear.
+// It is the shape a write loses a half of. Spelled in two places the copies
+// drift towards whichever one is edited, and the half nobody edited is where an
+// audit row or an event stops being written while the domain row still lands:
+// the change happened, the trail says it did not, and no consumer hears.
 //
 // So the claim is that the update shape has one writer, found by the event it
 // publishes.
@@ -40,21 +39,50 @@ const updateShapeOwner = "applyContractUpdate"
 // contract.status_changed and carries the from/to a consumer needs. The event
 // is the discriminator, and the only one.
 //
-// What this gate does NOT hold: a patch that audits and publishes nothing at
-// all. That has no event to be found by, and it is held tree-wide by the write
-// shape gate rather than here.
+// Two neighbouring cases, and only one of them is covered elsewhere. A patch
+// that files an audit row and publishes NO event is held tree-wide, by
+// TestEveryAuditedMutationEmitsAnEvent. A patch that writes the contract row
+// and files neither an audit row nor an event is held by NOTHING — that gate
+// starts counting once it has seen an Audit call, and the module-granularity
+// audit gate is already satisfied by this package's other writes. Said plainly
+// because the shorter sentence read as covering both.
 const updateEvent = "PublicEventContractUpdated"
 
-// contractsPackage is where the event type is declared. The gate resolves each
-// file's own name for it rather than assuming one: `crmcontracts` is the
-// convention here, and a file that imported it as `cc`, or dot-imported it,
-// names the same type in a spelling a fixed comparison does not match — and a
-// census that cannot see a spelling reports the writer it cannot see as absent.
-const contractsPackage = "github.com/margince/margince/backend/internal/contracts"
+// contractsPackage is where the event type is declared, and contractsDir is
+// that package's directory relative to this one.
+//
+// The gate resolves each file's own name for the type rather than assuming one:
+// a file that imported the package as `cc`, or dot-imported it, names the same
+// type in a spelling a fixed comparison does not match, and a census that
+// cannot see a spelling reports the writer using it as absent.
+//
+// The DECLARED package name is read from the source rather than taken from the
+// directory. They differ here — the directory is `contracts` and the package is
+// `crmcontracts` — so an unaliased import binds `crmcontracts`, and a census
+// built on the directory name hunts a string no file in this tree can produce.
+// That is the fail-short direction again, so the name is derived and its
+// absence is fatal rather than empty.
+const (
+	contractsPackage = "github.com/margince/margince/backend/internal/contracts"
+	contractsDir     = "../../contracts"
+)
+
+// updateEventType is how the event names itself on the wire, and the second way
+// a function can publish it.
+//
+// storekit.Emit takes the event type as a STRING rather than deriving it from a
+// payload, so a writer reaching for it publishes contract.updated without ever
+// naming the Go type — invisible to a census over type names, and invisible to
+// the tree-wide event-ownership gate for the same reason. One raw caller exists
+// today and it is in another module, so this arm holds a route rather than a
+// present defect.
+const updateEventType = "contract.updated"
 
 func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
+	declared := declaredPackageName(t, contractsDir)
 	emitters := functionsWhere(t, func(file *ast.File, fn *ast.FuncDecl) bool {
-		return namesType(fn, localNamesFor(file, contractsPackage, updateEvent))
+		return namesType(fn, localNamesFor(file, contractsPackage, declared, updateEvent)) ||
+			namesLiteral(fn, updateEventType)
 	})
 	switch {
 	case len(emitters) == 0:
@@ -75,7 +103,7 @@ func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
 
 // localNamesFor renders every spelling the named type has in this file: one per
 // import of its package, plus the bare name when that import is a dot import.
-func localNamesFor(file *ast.File, path, typeName string) []string {
+func localNamesFor(file *ast.File, path, declared, typeName string) []string {
 	var names []string
 	for _, spec := range file.Imports {
 		if strings.Trim(spec.Path.Value, `"`) != path {
@@ -83,7 +111,9 @@ func localNamesFor(file *ast.File, path, typeName string) []string {
 		}
 		switch {
 		case spec.Name == nil:
-			names = append(names, "contracts."+typeName)
+			// An unaliased import binds the package's DECLARED name, which is
+			// not always its directory's.
+			names = append(names, declared+"."+typeName)
 		case spec.Name.Name == ".":
 			names = append(names, typeName)
 		case spec.Name.Name == "_":
@@ -93,6 +123,34 @@ func localNamesFor(file *ast.File, path, typeName string) []string {
 		}
 	}
 	return names
+}
+
+// declaredPackageName reads the package clause of the sources in dir.
+//
+// Derived rather than assumed, and fatal rather than empty: a gate that
+// silently resolved no name would judge a population of nothing and report a
+// clean package, which is the one way a census must not fail.
+func declaredPackageName(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s for its package name: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, dir+"/"+name, nil, parser.PackageClauseOnly)
+		if perr != nil || file.Name == nil {
+			continue
+		}
+		return file.Name.Name
+	}
+	t.Fatalf("no package clause found in %s, so this gate cannot say what an unaliased "+
+		"import of it binds and would hunt a spelling no file can produce", dir)
+	return ""
 }
 
 // functionsWhere names the package's non-test functions satisfying want. The
@@ -128,6 +186,24 @@ func functionsWhere(t *testing.T, want func(*ast.File, *ast.FuncDecl) bool) []st
 		t.Fatal("this package has no non-test source, so the census read nothing")
 	}
 	sort.Strings(found)
+	return found
+}
+
+// namesLiteral reports whether fn contains the given string literal.
+func namesLiteral(fn *ast.FuncDecl, want string) bool {
+	if fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.BasicLit)
+		if isLit && lit.Kind == token.STRING {
+			if text, err := strconv.Unquote(lit.Value); err == nil && text == want {
+				found = true
+			}
+		}
+		return !found
+	})
 	return found
 }
 

--- a/backend/internal/modules/contracts/onewriteshape_test.go
+++ b/backend/internal/modules/contracts/onewriteshape_test.go
@@ -45,9 +45,16 @@ const updateShapeOwner = "applyContractUpdate"
 // shape gate rather than here.
 const updateEvent = "PublicEventContractUpdated"
 
+// contractsPackage is where the event type is declared. The gate resolves each
+// file's own name for it rather than assuming one: `crmcontracts` is the
+// convention here, and a file that imported it as `cc`, or dot-imported it,
+// names the same type in a spelling a fixed comparison does not match — and a
+// census that cannot see a spelling reports the writer it cannot see as absent.
+const contractsPackage = "github.com/margince/margince/backend/internal/contracts"
+
 func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
-	emitters := functionsWhere(t, func(fn *ast.FuncDecl) bool {
-		return namesType(fn, "crmcontracts."+updateEvent)
+	emitters := functionsWhere(t, func(file *ast.File, fn *ast.FuncDecl) bool {
+		return namesType(fn, localNamesFor(file, contractsPackage, updateEvent))
 	})
 	switch {
 	case len(emitters) == 0:
@@ -66,8 +73,32 @@ func TestTheContractUpdateShapeHasOneWriter(t *testing.T) {
 	}
 }
 
-// functionsWhere names the package's non-test functions satisfying want.
-func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
+// localNamesFor renders every spelling the named type has in this file: one per
+// import of its package, plus the bare name when that import is a dot import.
+func localNamesFor(file *ast.File, path, typeName string) []string {
+	var names []string
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != path {
+			continue
+		}
+		switch {
+		case spec.Name == nil:
+			names = append(names, "contracts."+typeName)
+		case spec.Name.Name == ".":
+			names = append(names, typeName)
+		case spec.Name.Name == "_":
+			// A blank import binds no name, so the type is unreachable here.
+		default:
+			names = append(names, spec.Name.Name+"."+typeName)
+		}
+	}
+	return names
+}
+
+// functionsWhere names the package's non-test functions satisfying want. The
+// file is handed to want because what a type is CALLED is a fact about the file
+// that names it, not about the package.
+func functionsWhere(t *testing.T, want func(*ast.File, *ast.FuncDecl) bool) []string {
 	t.Helper()
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -88,7 +119,7 @@ func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
 		}
 		for _, decl := range file.Decls {
 			fn, isFunc := decl.(*ast.FuncDecl)
-			if isFunc && fn.Body != nil && fn.Name != nil && want(fn) {
+			if isFunc && fn.Body != nil && fn.Name != nil && want(file, fn) {
 				found = append(found, fn.Name.Name)
 			}
 		}
@@ -100,8 +131,8 @@ func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
 	return found
 }
 
-// namesType reports whether fn mentions the named type anywhere — in its
-// signature or its body.
+// namesType reports whether fn mentions the type under ANY of the spellings it
+// has in the file that declares fn — in its signature or its body.
 //
 // A mention, not a composite literal. Under-recognition is the one direction a
 // census must not fail in: a second writer that declared `var updated
@@ -115,14 +146,24 @@ func functionsWhere(t *testing.T, want func(*ast.FuncDecl) bool) []string {
 // event would name it too, and this module produces it rather than consuming
 // it — a consumer appearing later is a thing worth failing on and looking at,
 // not a false positive to design around in advance.
-func namesType(fn *ast.FuncDecl, typeName string) bool {
+func namesType(fn *ast.FuncDecl, spellings []string) bool {
+	if len(spellings) == 0 {
+		return false
+	}
 	found := false
 	inspect := func(node ast.Node) bool {
 		if node == nil {
 			return !found
 		}
-		if expr, isExpr := node.(ast.Expr); isExpr && exprText(expr) == typeName {
-			found = true
+		expr, isExpr := node.(ast.Expr)
+		if !isExpr {
+			return !found
+		}
+		text := exprText(expr)
+		for _, spelling := range spellings {
+			if text == spelling {
+				found = true
+			}
 		}
 		return !found
 	}


### PR DESCRIPTION
## What

An update to a contract row is four things that must happen together: the guarded patch, the audit row, the `contract.updated` event, and the check violation translated into an error a caller can act on.

Two verbs spelled all four out separately — `UpdateContract`'s field patch and `RecordCancellation`'s notice — and **the only difference between the two copies was the noun in the error text**.

Both go through `applyContractUpdate` now.

## Why this is the shape a write loses a half of

Two copies drift towards whichever one gets edited. The half nobody edited is where an audit row or an event stops being written while the domain row still lands: the change happened, the trail says it did not, and no consumer hears. Nothing fails; the record is simply wrong afterwards, and there is no way to tell from the row.

## How it was found

SonarCloud reported 5.4% duplication on new code for #2986, against a denominator of 37 lines — that PR changed one line inside each copy, and Sonar excludes `_test.go`, so two touched lines inside a pre-existing duplicate block tripped a 3% bar.

The percentage was an artifact of the small denominator. **The duplicate it pointed at was real and predates both PRs.**

## The gate, and why it keys on the event

`TestTheContractUpdateShapeHasOneWriter` finds the shape by the event it publishes.

The audit **action** does not separate the shapes, and the first draft of this gate keyed on it and was wrong: a field patch and a status transition both file an `"update"` audit row, correctly, because both update the row. That draft reported `applyStatusTx` as a second copy of a shape it does not share — it publishes `contract.status_changed` and carries the from/to a consumer needs.

The event is the discriminator, and the gate says so in the place someone would go looking.

What this gate deliberately does **not** hold: a patch that audits and publishes nothing at all. That has no event to be found by, and it is held tree-wide by the write-shape gate rather than here — said out loud so the next reader does not assume this covers it.

## Verification

- `make check` green; `craft static --strict` PASS (0 blocker, 0 major, 0 minor)
- `make test-it DIR=backend/internal/compose/integration RUN='Contract|Cancel|Renew|Supersede'` green
- **4 mutants, each proven to have applied before the gate ran:**

| mutant | want | got |
|---|---|---|
| a second publisher of the update event | catch | catch |
| the owner renamed out from under the gate | catch | catch |
| `applyStatusTx` left alone (audit action is not the discriminator) | **allow** | allow |
| the update event gone from the package entirely | catch | catch |

The third is the false positive the narrowing exists to avoid, kept as a permanent case rather than a note.

Error text changes from `patch contract:` / `record contract cancellation:` to `write contract update:` / `write contract cancellation:`. Nothing asserts the old strings — checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combines the field patch in `UpdateContract` and the cancellation notice in `Cancel` into one shared write path, `applyContractUpdate`, so the guarded patch, audit row, and `contract.updated` event always land together. The two copies could previously drift apart and silently drop the audit or event while the row still changed. Error messages change from `patch contract:`/`record contract cancellation:` to `write contract update:`/`write contract cancellation:`; nothing depends on the old strings.

**Tests**
- The one-writer gate finds the update shape by the `contract.updated` event it publishes, not the audit action, because status transitions also file an `"update"` audit row.
- The census resolves each file's own import alias and the event package's declared name (`crmcontracts`, while the directory is `contracts`), skips test packages when reading that name, and catches a raw `storekit.Emit` publishing by the event's string.
- Failure tests show a refused patch, audit row, or event stops the update and reaches the caller naming the failed step; a refused CHECK becomes a field-level refusal, and a stale If-Match becomes version skew with no audit row filed.
- Success tests assert all three writes land, matched by what the statements do rather than by table name, and that the event carries the write's after-values as changed fields.

<sup>Written for commit 46626695b6f9c02108792a52af4fe328a91c7733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when updating or canceling contracts.
  * Improved reliability of validation, auditing, persistence, and update notifications.
  * Preserved cancellation behavior without triggering status-change notifications.
  * Improved handling of failed updates, invalid values, and stale versions.
  * Ensured update notifications accurately reflect changed fields and values.

* **Tests**
  * Added safeguards for consistent contract update notifications.
  * Expanded coverage for failed updates, stale versions, and notification payload accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->