### PR TITLE
test(gates): a constraint name never reaches a caller (#1522)

### DIFF
--- a/backend/gates/constraintnameleak_test.go
+++ b/backend/gates/constraintnameleak_test.go
@@ -62,21 +62,24 @@ var constraintDoors = map[string]bool{
 // storekitDoor reports a call to one of those doors THROUGH this file's storekit
 // import, under whatever name the file gave it.
 func storekitDoor(file *ast.File, expr ast.Expr) bool {
-	sel, ok := expr.(*ast.SelectorExpr)
-	if !ok || !constraintDoors[sel.Sel.Name] {
-		return false
-	}
 	qualifier, dotImported := gatekit.ImportedAs(file, storekitPkg)
-	receiver, ok := sel.X.(*ast.Ident)
-	if !ok {
-		return false
+	switch fun := expr.(type) {
+	case *ast.Ident:
+		// A DOT-IMPORT puts the door in scope bare, so the call is a plain
+		// identifier with no receiver at all. This arm used to sit after an
+		// early return that required a selector, which made it unreachable —
+		// the comment claimed the case and the code skipped it, which is worse
+		// than not claiming it: a dot-importing file was excluded from the
+		// sweep entirely, and every leak in it passed.
+		return dotImported && constraintDoors[fun.Name]
+	case *ast.SelectorExpr:
+		if !constraintDoors[fun.Sel.Name] {
+			return false
+		}
+		receiver, ok := fun.X.(*ast.Ident)
+		return ok && qualifier != "" && receiver.Name == qualifier
 	}
-	// A dot-import puts the door in scope bare, and there is no receiver to
-	// check — the selector itself is then the whole reference.
-	if dotImported {
-		return true
-	}
-	return qualifier != "" && receiver.Name == qualifier
+	return false
 }
 
 // The formatters a leak would travel through. A name reaching one of these is
@@ -308,6 +311,24 @@ import (
 func f(err error) error {
 	var constraint, ok = storekit.CheckViolation(err)
 	if ok {
+		return fmt.Errorf("violates %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 1,
+		},
+		// A dot-import: the door is in scope bare, so the call is an identifier
+		// with no receiver. Nothing in this tree does it, which is exactly how
+		// the arm handling it stayed unreachable without anything noticing.
+		"storekit dot-imported, leaked": {
+			source: `package p
+import (
+	"fmt"
+	. "github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	if constraint, ok := CheckViolation(err); ok {
 		return fmt.Errorf("violates %s", constraint)
 	}
 	return err

--- a/backend/gates/constraintnameleak_test.go
+++ b/backend/gates/constraintnameleak_test.go
@@ -39,6 +39,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"slices"
 	"strings"
 	"testing"
 
@@ -82,12 +83,38 @@ func storekitDoor(file *ast.File, expr ast.Expr) bool {
 	return false
 }
 
-// The formatters a leak would travel through. A name reaching one of these is
-// on its way into a string, and every string this tree builds from an error is
-// a string somebody may write to a client.
-var stringBuilders = map[string]bool{
-	"Sprintf": true, "Errorf": true, "Sprint": true, "Sprintln": true,
-	"Join": true, "Replace": true, "ReplaceAll": true,
+// The formatters a leak would travel through, BY PACKAGE. A name reaching one
+// of these is on its way into a string, and every string this tree builds from
+// an error is a string somebody may write to a client.
+//
+// Keyed on the import path rather than the function name, because the name
+// alone is wrong in both directions. `logger.Errorf(…, constraint)` is a LOG
+// line — which is exactly where this design says the name should go — and a
+// matcher on `Errorf` reports it as a leak. And a dot-imported `fmt` calls
+// `Errorf` bare, which a selector-only matcher never sees at all.
+var stringBuilders = map[string][]string{
+	"fmt":     {"Sprintf", "Errorf", "Sprint", "Sprintln"},
+	"strings": {"Join", "Replace", "ReplaceAll"},
+}
+
+// buildsAString names the formatter this call is, or "" for a call that is not
+// one of them — resolved through the file's own imports, dot-imports included.
+func buildsAString(file *ast.File, fun ast.Expr) string {
+	for path, names := range stringBuilders {
+		qualifier, dotImported := gatekit.ImportedAs(file, path)
+		switch f := fun.(type) {
+		case *ast.Ident:
+			if dotImported && slices.Contains(names, f.Name) {
+				return path + "." + f.Name
+			}
+		case *ast.SelectorExpr:
+			pkg, ok := f.X.(*ast.Ident)
+			if ok && qualifier != "" && pkg.Name == qualifier && slices.Contains(names, f.Sel.Name) {
+				return path + "." + f.Sel.Name
+			}
+		}
+	}
+	return ""
 }
 
 func TestNoConstraintNameIsBuiltIntoAMessage(t *testing.T) {
@@ -159,13 +186,13 @@ func constraintNameLeaksIn(parsed gatekit.ParsedFile) []string {
 					leaks = append(leaks, "`"+name+"` is concatenated into a string")
 				}
 			case *ast.CallExpr:
-				sel, ok := node.Fun.(*ast.SelectorExpr)
-				if !ok || !stringBuilders[sel.Sel.Name] {
+				formatter := buildsAString(parsed.File, node.Fun)
+				if formatter == "" {
 					return true
 				}
 				for _, arg := range node.Args {
 					if identIs(arg, name) {
-						leaks = append(leaks, "`"+name+"` is formatted by "+sel.Sel.Name)
+						leaks = append(leaks, "`"+name+"` is formatted by "+formatter)
 					}
 				}
 			}
@@ -330,6 +357,42 @@ import (
 func f(err error) error {
 	if constraint, ok := CheckViolation(err); ok {
 		return fmt.Errorf("violates %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 1,
+		},
+		// A LOG line, which is where this design says the name belongs — the
+		// operator needs it and the caller must not have it. A matcher on the
+		// function name alone reports `Errorf` here as a leak, which would make
+		// the gate refuse the very thing it tells you to do.
+		"a logger of the same shape": {
+			source: `package p
+import (
+	"example.test/logger"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(l *logger.Logger, err error) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		l.Errorf("a schema rule refused a write: %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 0,
+		},
+		// fmt dot-imported: the formatter is a bare identifier, which a
+		// selector-only matcher never sees.
+		"a dot-imported formatter, leaked": {
+			source: `package p
+import (
+	. "fmt"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		return Errorf("violates %s", constraint)
 	}
 	return err
 }`,

--- a/backend/gates/constraintnameleak_test.go
+++ b/backend/gates/constraintnameleak_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+//go:build !integration
+
+package gates
+
+// A constraint's name goes in the operator's log, never in the caller's refusal.
+//
+// storekit.CheckViolation and UniqueViolation hand back the name of the rule
+// that fired, and there are two things to do with it. Switch on it, to answer
+// with a refusal written for that rule — which every site in this tree does, and
+// which is the whole point of exposing it. Or put it in the message, which
+// `activities/handlers.go` once did:
+//
+//	"the request violates the " + constraint + " business rule"
+//
+// A schema identifier tells a caller the shape of a table they cannot otherwise
+// see and nothing they can act on — `activity_link_shape` names no field in the
+// published contract — and it is not API: renaming a constraint in a migration
+// would silently change a response body. httperr's own constraint net says so
+// at its generic path, and refuses to name one there (issue #1522).
+//
+// A PROHIBITION rather than a census, because the failure is a leak by default:
+// interpolation costs nothing to write and the next constraint inherits it. The
+// rule is that the value never becomes message text — passing it to a mapper
+// that switches on it is the sanctioned use and is what the sweep expects to
+// find.
+//
+// What this cannot see, stated rather than implied: a name copied into another
+// variable first, or one that reaches a message through a helper this walk does
+// not follow. The walk is syntactic. It catches the shape that was actually
+// written here and the shape the next author would reach for, which is the
+// concatenation and the format verb — not an author determined to launder it.
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// The two storekit doors that hand back a constraint name.
+var constraintDoors = map[string]bool{
+	"CheckViolation":  true,
+	"UniqueViolation": true,
+}
+
+// The formatters a leak would travel through. A name reaching one of these is
+// on its way into a string, and every string this tree builds from an error is
+// a string somebody may write to a client.
+var stringBuilders = map[string]bool{
+	"Sprintf": true, "Errorf": true, "Sprint": true, "Sprintln": true,
+	"Join": true, "Replace": true, "ReplaceAll": true,
+}
+
+func TestNoConstraintNameIsBuiltIntoAMessage(t *testing.T) {
+	t.Parallel()
+
+	files := gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: fileReadsAConstraintName,
+		// Not extensions/: a unit cannot import storekit at all, so it never
+		// holds one of these names to leak.
+	}.Files(t)
+
+	sites := 0
+	for _, parsed := range files {
+		// storekit itself is where the name is produced and named; its own
+		// error text is the operator's, not a caller's.
+		if strings.Contains(parsed.Path, "/platform/database/storekit/") {
+			continue
+		}
+		for _, leak := range constraintNameLeaksIn(parsed) {
+			sites++
+			t.Errorf("%s: %s\n"+
+				"\tA constraint name is schema the caller cannot otherwise see, and nothing they "+
+				"can act on — it names no field in the published contract, and renaming it in a "+
+				"migration would silently change a response body.\n"+
+				"\tSwitch on it to answer with a refusal written for that rule, and let anything "+
+				"unmapped fall through to httperr's field-less one. Log the name if an operator "+
+				"needs it.", parsed.Path, leak)
+		}
+	}
+	// The gate has to have swept the sites it judges. Every module that answers
+	// a schema refusal reads one of these doors, so nothing found means the
+	// walk broke or the doors were renamed.
+	if len(files) == 0 {
+		t.Fatal("no file reads a constraint name at all, so this prohibition judged nothing — " +
+			"the walk is broken, or storekit's doors were renamed and this rule now binds names " +
+			"nobody calls")
+	}
+	if sites == 0 {
+		t.Logf("swept %d file(s) that read a constraint name; none builds it into a message", len(files))
+	}
+}
+
+func fileReadsAConstraintName(_ string, file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && constraintDoors[sel.Sel.Name] {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// constraintNameLeaksIn reports each place a name bound from one of the doors is
+// concatenated or formatted, described for the message above.
+func constraintNameLeaksIn(parsed gatekit.ParsedFile) []string {
+	var leaks []string
+	for _, name := range constraintBindings(parsed.File) {
+		ast.Inspect(parsed.File, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.BinaryExpr:
+				// `"…" + constraint + "…"` — the shape that was written.
+				if node.Op == token.ADD && (identIs(node.X, name) || identIs(node.Y, name)) {
+					leaks = append(leaks, "`"+name+"` is concatenated into a string")
+				}
+			case *ast.CallExpr:
+				sel, ok := node.Fun.(*ast.SelectorExpr)
+				if !ok || !stringBuilders[sel.Sel.Name] {
+					return true
+				}
+				for _, arg := range node.Args {
+					if identIs(arg, name) {
+						leaks = append(leaks, "`"+name+"` is formatted by "+sel.Sel.Name)
+					}
+				}
+			}
+			return true
+		})
+	}
+	return dedupeLeaks(leaks)
+}
+
+// constraintBindings reads the identifiers this file binds from a door — the
+// `constraint` in `constraint, ok := storekit.CheckViolation(err)`, whatever it
+// is spelled.
+//
+// Held by: TestNoConstraintNameIsBuiltIntoAMessage
+func constraintBindings(file *ast.File) []string {
+	var names []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !constraintDoors[sel.Sel.Name] {
+			return true
+		}
+		if ident, ok := assign.Lhs[0].(*ast.Ident); ok && ident.Name != "_" {
+			names = append(names, ident.Name)
+		}
+		return true
+	})
+	return names
+}
+
+func identIs(expr ast.Expr, name string) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == name
+}
+
+func dedupeLeaks(items []string) []string {
+	var kept []string
+	seen := map[string]bool{}
+	for _, item := range items {
+		if !seen[item] {
+			seen[item] = true
+			kept = append(kept, item)
+		}
+	}
+	return kept
+}

--- a/backend/gates/constraintnameleak_test.go
+++ b/backend/gates/constraintnameleak_test.go
@@ -37,6 +37,7 @@ package gates
 
 import (
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"strings"
 	"testing"
@@ -44,10 +45,38 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
+const storekitPkg = "github.com/margince/margince/backend/internal/platform/database/storekit"
+
 // The two storekit doors that hand back a constraint name.
+//
+// Matched through the file's own import of storekit, never by the selector name
+// alone. `CheckViolation` is an ordinary method name — an unrelated receiver
+// carrying one would enter this sweep, produce findings about a value that is
+// not a constraint name, and, worse, keep the empty-sweep guard below satisfied
+// after every real storekit call had gone.
 var constraintDoors = map[string]bool{
 	"CheckViolation":  true,
 	"UniqueViolation": true,
+}
+
+// storekitDoor reports a call to one of those doors THROUGH this file's storekit
+// import, under whatever name the file gave it.
+func storekitDoor(file *ast.File, expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || !constraintDoors[sel.Sel.Name] {
+		return false
+	}
+	qualifier, dotImported := gatekit.ImportedAs(file, storekitPkg)
+	receiver, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	// A dot-import puts the door in scope bare, and there is no receiver to
+	// check — the selector itself is then the whole reference.
+	if dotImported {
+		return true
+	}
+	return qualifier != "" && receiver.Name == qualifier
 }
 
 // The formatters a leak would travel through. A name reaching one of these is
@@ -68,13 +97,14 @@ func TestNoConstraintNameIsBuiltIntoAMessage(t *testing.T) {
 		// holds one of these names to leak.
 	}.Files(t)
 
-	sites := 0
+	sites, judged := 0, 0
 	for _, parsed := range files {
 		// storekit itself is where the name is produced and named; its own
 		// error text is the operator's, not a caller's.
 		if strings.Contains(parsed.Path, "/platform/database/storekit/") {
 			continue
 		}
+		judged++
 		for _, leak := range constraintNameLeaksIn(parsed) {
 			sites++
 			t.Errorf("%s: %s\n"+
@@ -86,23 +116,26 @@ func TestNoConstraintNameIsBuiltIntoAMessage(t *testing.T) {
 				"needs it.", parsed.Path, leak)
 		}
 	}
-	// The gate has to have swept the sites it judges. Every module that answers
-	// a schema refusal reads one of these doors, so nothing found means the
-	// walk broke or the doors were renamed.
-	if len(files) == 0 {
-		t.Fatal("no file reads a constraint name at all, so this prohibition judged nothing — " +
-			"the walk is broken, or storekit's doors were renamed and this rule now binds names " +
-			"nobody calls")
+	// The gate has to have JUDGED something, and the count is taken after the
+	// exclusion rather than before it. `len(files)` includes storekit's own
+	// files, so a tree where every remaining caller had gone — or a walk that
+	// found only storekit — would report a swept, successful, empty run. Every
+	// module that answers a schema refusal reads one of these doors, so nothing
+	// judged means the walk broke or the doors were renamed.
+	if judged == 0 {
+		t.Fatal("no file OUTSIDE storekit reads a constraint name, so this prohibition judged " +
+			"nothing — the walk is broken, or storekit's doors were renamed and this rule now " +
+			"binds names nobody calls")
 	}
 	if sites == 0 {
-		t.Logf("swept %d file(s) that read a constraint name; none builds it into a message", len(files))
+		t.Logf("judged %d file(s) that read a constraint name; none builds it into a message", judged)
 	}
 }
 
 func fileReadsAConstraintName(_ string, file *ast.File) bool {
 	found := false
 	ast.Inspect(file, func(n ast.Node) bool {
-		if sel, ok := n.(*ast.SelectorExpr); ok && constraintDoors[sel.Sel.Name] {
+		if call, ok := n.(*ast.CallExpr); ok && storekitDoor(file, call.Fun) {
 			found = true
 		}
 		return true
@@ -146,21 +179,33 @@ func constraintNameLeaksIn(parsed gatekit.ParsedFile) []string {
 // Held by: TestNoConstraintNameIsBuiltIntoAMessage
 func constraintBindings(file *ast.File) []string {
 	var names []string
-	ast.Inspect(file, func(n ast.Node) bool {
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
-			return true
+	// Both spellings of one binding. `constraint, ok := storekit.CheckViolation(err)`
+	// is an assignment; `var constraint, ok = storekit.CheckViolation(err)` is a
+	// declaration, and Go gives it a different node. A walk that knew only the
+	// first would sweep such a file — it calls a door — and then track no name
+	// in it, so every leak there would pass.
+	bind := func(lhs []ast.Expr, rhs []ast.Expr) {
+		if len(rhs) != 1 || len(lhs) == 0 {
+			return
 		}
-		call, ok := assign.Rhs[0].(*ast.CallExpr)
-		if !ok {
-			return true
+		call, ok := rhs[0].(*ast.CallExpr)
+		if !ok || !storekitDoor(file, call.Fun) {
+			return
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || !constraintDoors[sel.Sel.Name] {
-			return true
-		}
-		if ident, ok := assign.Lhs[0].(*ast.Ident); ok && ident.Name != "_" {
+		if ident, ok := lhs[0].(*ast.Ident); ok && ident.Name != "_" {
 			names = append(names, ident.Name)
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			bind(node.Lhs, node.Rhs)
+		case *ast.ValueSpec:
+			lhs := make([]ast.Expr, 0, len(node.Names))
+			for _, name := range node.Names {
+				lhs = append(lhs, name)
+			}
+			bind(lhs, node.Values)
 		}
 		return true
 	})
@@ -182,4 +227,127 @@ func dedupeLeaks(items []string) []string {
 		}
 	}
 	return kept
+}
+
+// The falsification half: what the rule must NOT catch, and what it must.
+//
+// Every case above runs over a clean tree, so all of them pass whether the
+// qualifier is checked or not — there is no unrelated `CheckViolation` in this
+// repository to be confused by. That is exactly why the check is easy to write
+// wrongly and impossible to notice: `CheckViolation` is an ordinary method name,
+// and a receiver that grew one would enter the sweep, produce findings about a
+// value that is not a constraint name, and keep the empty-sweep guard satisfied
+// long after every real storekit call had gone.
+//
+// So the decoy is written here rather than committed to the tree.
+func TestOnlyStorekitsOwnDoorsCount(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		source string
+		reads  bool
+		leaks  int
+	}{
+		"storekit's door, leaked": {
+			source: `package p
+import (
+	"fmt"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		return fmt.Errorf("violates %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 1,
+		},
+		"storekit's door under an alias": {
+			source: `package p
+import (
+	"fmt"
+	sk "github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	if constraint, ok := sk.UniqueViolation(err); ok {
+		return fmt.Errorf("violates %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 1,
+		},
+		// The decoy. Same method name, a receiver that is not storekit — an
+		// audit log, a policy engine, anything. Neither its value nor its
+		// message is this rule's business, and a gate that swept it would
+		// report a leak about a string that is not a constraint name.
+		"an unrelated receiver of the same name": {
+			source: `package p
+import "fmt"
+type checker struct{}
+func (checker) CheckViolation(err error) (string, bool) { return "", false }
+func f(c checker, err error) error {
+	if reason, ok := c.CheckViolation(err); ok {
+		return fmt.Errorf("violates %s", reason)
+	}
+	return err
+}`,
+			reads: false,
+			leaks: 0,
+		},
+		// The declaration form, which Go gives a different node from the
+		// assignment above. A walk that knew only `:=` would SWEEP this file —
+		// it calls a door — and then track no name in it, so the leak passes.
+		"a var declaration binding, leaked": {
+			source: `package p
+import (
+	"fmt"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	var constraint, ok = storekit.CheckViolation(err)
+	if ok {
+		return fmt.Errorf("violates %s", constraint)
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 1,
+		},
+		"the sanctioned use — switched on, never printed": {
+			source: `package p
+import (
+	"errors"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+func f(err error) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		switch constraint {
+		case "contract_term_order":
+			return errors.New("a term cannot end before it starts")
+		}
+	}
+	return err
+}`,
+			reads: true,
+			leaks: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			file, err := parser.ParseFile(token.NewFileSet(), "probe.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			if got := fileReadsAConstraintName("probe.go", file); got != tc.reads {
+				t.Errorf("fileReadsAConstraintName = %v, want %v — the sweep %s this file",
+					got, tc.reads,
+					map[bool]string{true: "must not enter", false: "must enter"}[got])
+			}
+			leaks := constraintNameLeaksIn(gatekit.ParsedFile{Path: "probe.go", File: file})
+			if len(leaks) != tc.leaks {
+				t.Errorf("found %d leak(s) %v, want %d", len(leaks), leaks, tc.leaks)
+			}
+		})
+	}
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -169,11 +169,12 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (26)
+## Prohibition (27)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
+| `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |
 | `dealforecastmovement_test.go` | H2 | A deal row changes through one door, and that door records the forecast. |
 | `errmatch_test.go` | H2 | Postgres failures are classified by SQLSTATE/constraint name (the storekit.UniqueViolation / CheckViolation helpers), never by message text: an error-string substring match silently breaks on a locale change, a driver upgrade, or an unrelated error that happens to mention the same identifier — and it misclassifies infrastructure faults as client faults. |


### PR DESCRIPTION
Closes #1522.

## The leak is gone; nothing was holding it

The line the issue quotes is not in the tree any more:

```go
"the request violates the " + constraint + " business rule"
```

`activities/handlers.go` now maps `uq_activity_link_project` onto its own actionable 422 and lets everything else fall through to `httperr`'s constraint net, with a comment saying why there is deliberately no CHECK arm below it. And every sibling does the same — `projects/handlers_plumbing.go` and `deals/handlers.go` log the name and answer `value_not_allowed`; `contractCheckError` and `projectCheckError` switch on it and default to a field-less refusal. Their own comments already state the rule: *"A schema identifier tells a caller our table's shape and nothing it can act on."*

So the point fix has landed. What has not is **anything holding it**, and that is the issue's sharper point:

> A per-constraint map also makes the set of translatable failures reviewable, where the current string interpolation makes every future constraint a leak by default.

Concatenation costs nothing to write, and the next author reaching for it gets no argument. This is the argument.

## The gate

`backend/gates/constraintnameleak_test.go`, `//gate:kind prohibition H2`. It sweeps every file that reads `storekit.CheckViolation` or `UniqueViolation` — 25 of them — finds whatever identifier each binds the name to, and refuses the two shapes it travels in on the way to a message: **concatenation**, and the **Sprintf family** (`Sprintf`, `Errorf`, `Sprint`, `Sprintln`, `Join`, `Replace`, `ReplaceAll`).

Switching on the name is the sanctioned use and is exactly what the sweep expects to find, so the rule costs the existing mapping pattern nothing.

It refuses to pass on an empty sweep. A prohibition that judged nothing reads exactly like a clean tree, and every module that answers a schema refusal reads one of these doors — so no files found is a broken walk, not a tidy one.

Mutation-checked with both shapes, each restored into a real call site:

| mutation | caught by |
|---|---|
| the issue's own line, verbatim, back in `activities/handlers.go` | `` `constraint` is concatenated into a string `` |
| the same leak through `fmt.Errorf` in `projects/keymint.go` | `` `constraint` is formatted by Errorf `` |
| both storekit doors renamed | the sweep finds no file and the gate fatals |

The `Errorf` case needed a call site that already imports `fmt`, because a mutation that does not compile never reaches the gate — worth saying, since the first attempt at it looked like a pass.

## What it cannot see

Stated in the gate rather than implied. The walk is **syntactic**: a name copied into another variable first, or laundered through a helper this walk does not follow, would pass. It catches the shape that was actually written here and the shape the next author would reach for — not an author determined to get around it.

## Siblings

The issue asks to check for them. All four other `CheckViolation` call sites and both mapper functions were read; none leaks, and all six are now covered by the sweep rather than by having been read once.

`docs/reference/gate-inventory.md` regenerated. `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated checks to prevent internal database constraint details from appearing in error messages.
  - Improved validation by covering approved handling patterns, missing scan targets, and duplicate findings.

- **Documentation**
  - Updated the gate inventory to include the new validation check and revised the total gate count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->