### PR TITLE
fix(ci-tests): seven AST gates recognise construction, not the spellings their authors wrote

### DIFF
--- a/backend/internal/modules/people/gatecorpus_test.go
+++ b/backend/internal/modules/people/gatecorpus_test.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -25,8 +26,12 @@ import (
 // literal its author had in front of them and none recognising `var x T`,
 // `new(T)`, or a zero literal filled in afterwards.
 //
-// So there is one walk and one set of recognisers, and a gate says what it is
-// asking rather than how to look for it.
+// So the gates rewritten here share one walk and one set of recognisers, and
+// each says what it is asking rather than how to look for it. Two older gates in
+// this package still walk the directory themselves — dedupeorg_seam_test.go, and
+// projectanchorgate_test.go, which parses one filename. Converting them is worth
+// doing and is not done here; naming them is the difference between a scope and
+// a claim that the next author would grep, find, and stop looking behind.
 
 // moduleFile is one of the module's own non-test sources, parsed.
 type moduleFile struct {
@@ -106,31 +111,166 @@ func forEachModuleFunc(t *testing.T, visit func(parsed moduleFile, fn *ast.FuncD
 	}
 }
 
-// takesA reports whether fn is handed the named type — as a parameter, or as
-// its receiver. Both are what make a body's reads and literals be ABOUT that
-// type rather than about some other value that happens to share a field.
+// takesA reports whether fn is handed the named type.
 //
-// The receiver is not a special case: a method ON the type reads its fields
-// with the same authority a function taking one does, and a gate that read only
-// parameters would let a second opinion be written as a method and stay
-// invisible.
+// It is `holdersOf` asked as a yes/no, and it must stay that way: two walks of
+// the same receiver-and-parameter list would answer this question and "which
+// identifier holds one" differently the first time either learned a new shape,
+// and the gates here ask both.
 func takesA(fn *ast.FuncDecl, typeName string) bool {
+	return len(holdersOf(fn, typeName)) > 0
+}
+
+// holdersOf names the identifiers in fn that hold a value of the named type.
+//
+// Three ways a function comes to hold one, and a gate that knows fewer than all
+// three judges a smaller population while reporting a clean module:
+//
+//	func (t T) …              the receiver — a method ON the type reads its
+//	                          fields with exactly the authority a function
+//	                          taking one does
+//	func f(t T)               a parameter, including *T
+//	func f(ts []T) { for _, t := range ts … }
+//	                          an element of a slice of them, which is how this
+//	                          module's workflow steps actually receive touches
+//
+// The third is not a corner. Both lead-SLA workflow steps range over a
+// `[]leadResponseTouch`, so a gate reading only receivers and parameters cannot
+// see the two functions its own header is about.
+func holdersOf(fn *ast.FuncDecl, typeName string) map[string]bool {
+	held := map[string]bool{}
+	fields := []*ast.Field{}
 	if fn.Recv != nil {
-		for _, field := range fn.Recv.List {
-			if typeText(field.Type) == typeName {
-				return true
+		fields = append(fields, fn.Recv.List...)
+	}
+	if fn.Type.Params != nil {
+		fields = append(fields, fn.Type.Params.List...)
+	}
+	collections := map[string]bool{}
+	for _, field := range fields {
+		switch {
+		case typeText(field.Type) == typeName:
+			for _, name := range field.Names {
+				held[name.Name] = true
+			}
+		case isSliceOf(field.Type, typeName):
+			for _, name := range field.Names {
+				collections[name.Name] = true
 			}
 		}
 	}
-	if fn.Type.Params == nil {
-		return false
+	if len(collections) == 0 || fn.Body == nil {
+		return held
 	}
-	for _, param := range fn.Type.Params.List {
-		if typeText(param.Type) == typeName {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		loop, isRange := node.(*ast.RangeStmt)
+		if !isRange || loop.Value == nil {
 			return true
 		}
+		source, isIdent := loop.X.(*ast.Ident)
+		if !isIdent || !collections[source.Name] {
+			return true
+		}
+		if name, namesValue := loop.Value.(*ast.Ident); namesValue && name.Name != "_" {
+			held[name.Name] = true
+		}
+		return true
+	})
+	return held
+}
+
+// isSliceOf reports a `[]T` or `[]*T` of the named type.
+func isSliceOf(expr ast.Expr, typeName string) bool {
+	slice, isSlice := expr.(*ast.ArrayType)
+	return isSlice && slice.Len == nil && typeText(slice.Elt) == typeName
+}
+
+// readsFieldOf answers where fn selects the named field ON A VALUE OF THE NAMED
+// TYPE, or an invalid position when it does not.
+//
+// The type matters, and matching the field name alone is the defect this
+// replaces. Selecting `.FullName` on the candidate is reading what the ladder
+// matched on; selecting it on the LEAD is a second reading. Selecting `.source`
+// on some other struct that happens to have one is neither, and a gate that
+// counted it would tell an author to ratify a read that never happened.
+func readsFieldOf(fn *ast.FuncDecl, typeName, field string) token.Pos {
+	var at token.Pos
+	for _, pos := range fieldReadsOf(fn, typeName, field) {
+		at = pos
+		break
 	}
-	return false
+	return at
+}
+
+// fieldReadsOf reports every position at which fn reads the named field off a
+// value of the named type, excluding reads taken by ADDRESS: `&t.capturedBy` in
+// a row Scan fills the field rather than asking it anything, and counting it
+// would report the builder as a reader of every rule it populates.
+func fieldReadsOf(fn *ast.FuncDecl, typeName, field string) []token.Pos {
+	holders := holdersOf(fn, typeName)
+	if len(holders) == 0 || fn.Body == nil {
+		return nil
+	}
+	addressed := map[ast.Node]bool{}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if unary, isUnary := node.(*ast.UnaryExpr); isUnary && unary.Op == token.AND {
+			addressed[unary.X] = true
+		}
+		return true
+	})
+	var found []token.Pos
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		sel, isSel := node.(*ast.SelectorExpr)
+		if !isSel || sel.Sel == nil || addressed[ast.Node(sel)] {
+			return true
+		}
+		if field != "" && sel.Sel.Name != field {
+			return true
+		}
+		if base, isIdent := sel.X.(*ast.Ident); isIdent && holders[base.Name] {
+			found = append(found, sel.Sel.Pos())
+		}
+		return true
+	})
+	return found
+}
+
+// fieldsReadOf names which fields of the named type fn reads.
+func fieldsReadOf(fn *ast.FuncDecl, typeName string) map[string]bool {
+	holders := holdersOf(fn, typeName)
+	if len(holders) == 0 || fn.Body == nil {
+		return nil
+	}
+	addressed := map[ast.Node]bool{}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if unary, isUnary := node.(*ast.UnaryExpr); isUnary && unary.Op == token.AND {
+			addressed[unary.X] = true
+		}
+		return true
+	})
+	read := map[string]bool{}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		sel, isSel := node.(*ast.SelectorExpr)
+		if !isSel || sel.Sel == nil || addressed[ast.Node(sel)] {
+			return true
+		}
+		if base, isIdent := sel.X.(*ast.Ident); isIdent && holders[base.Name] {
+			read[sel.Sel.Name] = true
+		}
+		return true
+	})
+	return read
+}
+
+// sortedKeys names a map's keys in a stable order, so a failure reads the same
+// on every run.
+func sortedKeys[V any](values map[string]V) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // constructs reports whether body produces a POPULATED value of the named type.
@@ -266,10 +406,12 @@ func mutatesResultOf(body *ast.BlockStmt, callee string) bool {
 			if !callsNamed(rhs, callee) {
 				continue
 			}
-			// A multi-value call binds its results positionally; the value is
-			// whichever name sits where the type does, and taking all of them
-			// costs nothing because a field write to an error or an id does
-			// not parse.
+			// A multi-value call binds its results positionally, and this
+			// walk has no type information to say which name is the one.
+			// Taking all of them widens the question from "the value" to
+			// "anything this call returned", which is the safe direction: it
+			// can only over-report a derivation, and nothing in this module
+			// writes a field on a returned error or id.
 			for _, lhs := range assign.Lhs {
 				if name, isIdent := lhs.(*ast.Ident); isIdent && name.Name != "_" {
 					held[name.Name] = true

--- a/backend/internal/modules/people/gatecorpus_test.go
+++ b/backend/internal/modules/people/gatecorpus_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The corpus the gates in this package judge, and the recognisers they judge it
+// with.
+//
+// Both are here for the same reason. A gate that walks the module its own way
+// is a second copy of the walk, and the two drift until one of them reads a
+// smaller tree than the other while still reporting PASS. A gate that decides
+// "does this function build a T" its own way is a second copy of the same
+// question, and every copy sees only the spellings its author happened to
+// write: a review of seven gates in this package found each recognising the
+// literal its author had in front of them and none recognising `var x T`,
+// `new(T)`, or a zero literal filled in afterwards.
+//
+// So there is one walk and one set of recognisers, and a gate says what it is
+// asking rather than how to look for it.
+
+// moduleFile is one of the module's own non-test sources, parsed.
+type moduleFile struct {
+	name string
+	fset *token.FileSet
+	file *ast.File
+}
+
+var (
+	corpusOnce  sync.Once
+	corpusFiles []moduleFile
+	corpusErr   error
+)
+
+// moduleFiles parses the module's own non-test sources, once per test binary.
+//
+// Test sources are left out deliberately: a literal a test builds is a fixture,
+// and holding a fixture to the shape of a shipped surface would refuse cases
+// written to exercise one field at a time.
+func moduleFiles(t *testing.T) []moduleFile {
+	t.Helper()
+	corpusOnce.Do(func() {
+		entries, err := os.ReadDir(".")
+		if err != nil {
+			corpusErr = err
+			return
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			fset := token.NewFileSet()
+			file, perr := parser.ParseFile(fset, name, nil, parser.ParseComments)
+			if perr != nil {
+				corpusErr = perr
+				return
+			}
+			corpusFiles = append(corpusFiles, moduleFile{name: name, fset: fset, file: file})
+		}
+	})
+	if corpusErr != nil {
+		t.Fatalf("reading the module's sources: %v", corpusErr)
+	}
+	// A census that reads nothing is the one failure that looks like success,
+	// so the corpus refuses to be empty rather than letting each caller
+	// remember to check.
+	if len(corpusFiles) == 0 {
+		t.Fatal("the module directory holds no non-test Go source, so every gate reading this " +
+			"corpus judged nothing")
+	}
+	return corpusFiles
+}
+
+// forEachModuleFile hands each parsed source to visit.
+func forEachModuleFile(t *testing.T, visit func(name string, fset *token.FileSet, file *ast.File)) {
+	t.Helper()
+	for _, parsed := range moduleFiles(t) {
+		visit(parsed.name, parsed.fset, parsed.file)
+	}
+}
+
+// forEachModuleFunc hands each function declaration with a body to visit.
+// Every gate here that judges functions wants exactly this population, and
+// spelling the decl loop at each one is how a gate comes to skip method values,
+// or generic declarations, that another gate reads.
+func forEachModuleFunc(t *testing.T, visit func(parsed moduleFile, fn *ast.FuncDecl)) {
+	t.Helper()
+	for _, parsed := range moduleFiles(t) {
+		for _, decl := range parsed.file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil || fn.Name == nil {
+				continue
+			}
+			visit(parsed, fn)
+		}
+	}
+}
+
+// takesA reports whether fn is handed the named type — as a parameter, or as
+// its receiver. Both are what make a body's reads and literals be ABOUT that
+// type rather than about some other value that happens to share a field.
+//
+// The receiver is not a special case: a method ON the type reads its fields
+// with the same authority a function taking one does, and a gate that read only
+// parameters would let a second opinion be written as a method and stay
+// invisible.
+func takesA(fn *ast.FuncDecl, typeName string) bool {
+	if fn.Recv != nil {
+		for _, field := range fn.Recv.List {
+			if typeText(field.Type) == typeName {
+				return true
+			}
+		}
+	}
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, param := range fn.Type.Params.List {
+		if typeText(param.Type) == typeName {
+			return true
+		}
+	}
+	return false
+}
+
+// constructs reports whether body produces a POPULATED value of the named type.
+//
+// Populated, not merely mentioned, and by any of the spellings Go offers:
+//
+//	T{Field: v}          a literal with elements
+//	&T{Field: v}         the same, addressed
+//	var x T; x.F = v     a zero value filled in afterwards
+//	x := T{}; x.F = v    the same, written as a literal
+//	x := new(T); x.F = v the same, written as a pointer
+//
+// A bare zero value with nothing assigned to it is NOT construction: it is the
+// error return every function that can fail has, and counting it would report
+// every error path as a second derivation. What separates the two is whether a
+// field is ever set on it, which is the question a reader asks too.
+func constructs(body *ast.BlockStmt, typeName string) bool {
+	if populatedLiteral(body, typeName) {
+		return true
+	}
+	zeroed := zeroValuesOf(body, typeName)
+	if len(zeroed) == 0 {
+		return false
+	}
+	return anyFieldAssignedTo(body, zeroed)
+}
+
+// populatedLiteral reports a composite literal of the type carrying at least
+// one element.
+func populatedLiteral(body *ast.BlockStmt, typeName string) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.CompositeLit)
+		if isLit && lit.Type != nil && typeText(lit.Type) == typeName && len(lit.Elts) > 0 {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// zeroValuesOf names the local variables that start life as a zero value of the
+// type: `var x T`, `x := T{}`, and `x := new(T)`.
+func zeroValuesOf(body *ast.BlockStmt, typeName string) map[string]bool {
+	zeroed := map[string]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch stmt := node.(type) {
+		case *ast.DeclStmt:
+			gen, isGen := stmt.Decl.(*ast.GenDecl)
+			if !isGen || gen.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range gen.Specs {
+				value, isValue := spec.(*ast.ValueSpec)
+				if !isValue || value.Type == nil || typeText(value.Type) != typeName {
+					continue
+				}
+				for _, name := range value.Names {
+					zeroed[name.Name] = true
+				}
+			}
+		case *ast.AssignStmt:
+			for i, rhs := range stmt.Rhs {
+				if i >= len(stmt.Lhs) || !isZeroValueOf(rhs, typeName) {
+					continue
+				}
+				if name, isIdent := stmt.Lhs[i].(*ast.Ident); isIdent {
+					zeroed[name.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return zeroed
+}
+
+// isZeroValueOf reports whether expr is `T{}` or `new(T)`.
+func isZeroValueOf(expr ast.Expr, typeName string) bool {
+	switch value := expr.(type) {
+	case *ast.CompositeLit:
+		return value.Type != nil && typeText(value.Type) == typeName && len(value.Elts) == 0
+	case *ast.UnaryExpr:
+		return value.Op == token.AND && isZeroValueOf(value.X, typeName)
+	case *ast.CallExpr:
+		ident, isIdent := value.Fun.(*ast.Ident)
+		if !isIdent || ident.Name != "new" || len(value.Args) != 1 {
+			return false
+		}
+		return typeText(value.Args[0]) == typeName
+	}
+	return false
+}
+
+// anyFieldAssignedTo reports whether any of the named variables has a field
+// written to it — `x.Field = v`, `x.Field += v`, and the same through a
+// pointer, which parses identically.
+func anyFieldAssignedTo(body *ast.BlockStmt, names map[string]bool) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			sel, isSel := lhs.(*ast.SelectorExpr)
+			if !isSel {
+				continue
+			}
+			if base, isIdent := sel.X.(*ast.Ident); isIdent && names[base.Name] {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// mutatesResultOf reports whether body takes the value the named function
+// returns and then writes a field on it.
+//
+// This is the shape neither "builds a T" nor "guards a T" can see, and it is a
+// derivation just the same: a function that calls the one builder and then
+// changes what came back has produced a second answer, in a form that reads at
+// the call site as though it were still the first.
+func mutatesResultOf(body *ast.BlockStmt, callee string) bool {
+	held := map[string]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		for _, rhs := range assign.Rhs {
+			if !callsNamed(rhs, callee) {
+				continue
+			}
+			// A multi-value call binds its results positionally; the value is
+			// whichever name sits where the type does, and taking all of them
+			// costs nothing because a field write to an error or an id does
+			// not parse.
+			for _, lhs := range assign.Lhs {
+				if name, isIdent := lhs.(*ast.Ident); isIdent && name.Name != "_" {
+					held[name.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	if len(held) == 0 {
+		return false
+	}
+	return anyFieldAssignedTo(body, held)
+}
+
+// callsNamed reports whether expr is a call of the named function, written
+// bare or as a selector — `leadPersonCandidate(…)` and `s.leadPersonCandidate(…)`
+// are the same function reached two ways.
+func callsNamed(expr ast.Expr, name string) bool {
+	call, isCall := expr.(*ast.CallExpr)
+	if !isCall {
+		return false
+	}
+	switch target := call.Fun.(type) {
+	case *ast.Ident:
+		return target.Name == name
+	case *ast.SelectorExpr:
+		return target.Sel != nil && target.Sel.Name == name
+	}
+	return false
+}

--- a/backend/internal/modules/people/gatecorpus_test.go
+++ b/backend/internal/modules/people/gatecorpus_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // The corpus the gates in this package judge, and the recognisers they judge it
@@ -474,4 +476,107 @@ func fieldsOf(t *testing.T, typeName string) []string {
 			"has nothing to judge", typeName)
 	}
 	return fields
+}
+
+// packageStrings indexes the module's package-level string constants and
+// variables by name, so a census reading a query can resolve one written as an
+// identifier.
+//
+// A query held in a `const` and passed by name is not a rarer shape than an
+// inline literal; it is the shape a long query takes. A census that reads only
+// the literals inside a function body cannot see it, and what it cannot see
+// leaves the population entirely.
+func packageStrings(t *testing.T) map[string]string {
+	t.Helper()
+	known := map[string]string{}
+	for _, parsed := range moduleFiles(t) {
+		for _, decl := range parsed.file.Decls {
+			gen, isGen := decl.(*ast.GenDecl)
+			if !isGen || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, isValue := spec.(*ast.ValueSpec)
+				if !isValue {
+					continue
+				}
+				for i, name := range value.Names {
+					if i >= len(value.Values) {
+						continue
+					}
+					if text, isText := staticText(value.Values[i], known); isText {
+						known[name.Name] = text
+					}
+				}
+			}
+		}
+	}
+	return known
+}
+
+// staticText renders an expression that is a string known at parse time: a
+// literal, or a `+` chain of them and of names already indexed.
+func staticText(expr ast.Expr, known map[string]string) (string, bool) {
+	switch operand := expr.(type) {
+	case *ast.BasicLit:
+		return gatekit.LiteralText(operand)
+	case *ast.Ident:
+		text, isKnown := known[operand.Name]
+		return text, isKnown
+	case *ast.BinaryExpr:
+		if operand.Op != token.ADD {
+			return "", false
+		}
+		left, leftKnown := staticText(operand.X, known)
+		right, rightKnown := staticText(operand.Y, known)
+		if !leftKnown || !rightKnown {
+			return "", false
+		}
+		return left + right, true
+	}
+	return "", false
+}
+
+// concatenatedText joins the strings of a `+` chain, and names the literal
+// nodes it consumed so they are not also read on their own.
+//
+// A name is resolved against the strings the package declares, because a query
+// assembled from a table constant says the table's name just as plainly as one
+// that spells it out. An operand that resolves to nothing — a column list
+// variable, a fmt verb — is replaced by a SPACE rather than dropped, so two
+// literals either side of it do not fuse into a word appearing in neither.
+func concatenatedText(expr ast.Expr, known map[string]string) (string, []ast.Node) {
+	var parts []ast.Node
+	var text strings.Builder
+	var walk func(ast.Expr)
+	walk = func(node ast.Expr) {
+		switch operand := node.(type) {
+		case *ast.BinaryExpr:
+			if operand.Op != token.ADD {
+				text.WriteString(" ")
+				return
+			}
+			walk(operand.X)
+			walk(operand.Y)
+		case *ast.BasicLit:
+			value, isText := gatekit.LiteralText(operand)
+			if !isText {
+				text.WriteString(" ")
+				return
+			}
+			parts = append(parts, ast.Node(operand))
+			text.WriteString(value)
+		default:
+			if value, isKnown := staticText(operand, known); isKnown {
+				text.WriteString(value)
+				return
+			}
+			text.WriteString(" ")
+		}
+	}
+	walk(expr)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return text.String(), parts
 }

--- a/backend/internal/modules/people/gatecorpus_test.go
+++ b/backend/internal/modules/people/gatecorpus_test.go
@@ -300,3 +300,36 @@ func callsNamed(expr ast.Expr, name string) bool {
 	}
 	return false
 }
+
+// fieldsOf names the fields the given struct declares, in source order.
+//
+// Derived rather than listed: a gate naming the fields it judges is a second
+// copy of the struct, and the copy is short from the moment a field is added —
+// silently, because the gate goes on passing over the fields it does know.
+func fieldsOf(t *testing.T, typeName string) []string {
+	t.Helper()
+	var fields []string
+	forEachModuleFile(t, func(_ string, _ *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(node ast.Node) bool {
+			spec, isSpec := node.(*ast.TypeSpec)
+			if !isSpec || spec.Name.Name != typeName {
+				return true
+			}
+			structure, isStruct := spec.Type.(*ast.StructType)
+			if !isStruct || structure.Fields == nil {
+				return true
+			}
+			for _, field := range structure.Fields.List {
+				for _, name := range field.Names {
+					fields = append(fields, name.Name)
+				}
+			}
+			return false
+		})
+	})
+	if len(fields) == 0 {
+		t.Fatalf("this module declares no struct %s with fields, so a gate judging its fields "+
+			"has nothing to judge", typeName)
+	}
+	return fields
+}

--- a/backend/internal/modules/people/gatecorpus_test.go
+++ b/backend/internal/modules/people/gatecorpus_test.go
@@ -485,33 +485,71 @@ func fieldsOf(t *testing.T, typeName string) []string {
 // A query held in a `const` and passed by name is not a rarer shape than an
 // inline literal; it is the shape a long query takes. A census that reads only
 // the literals inside a function body cannot see it, and what it cannot see
-// leaves the population entirely.
+// leaves the population entirely — which is not a lenient judgement, it is no
+// judgement.
+//
+// Resolved to a FIXED POINT rather than in traversal order. `const q = "UPDATE
+// " + table` is a valid declaration whether `table` is declared above it or
+// below, and a single pass leaves the second case unresolved — an ordering of
+// the source file deciding what a gate can see.
 func packageStrings(t *testing.T) map[string]string {
 	t.Helper()
-	known := map[string]string{}
+	pending := map[string]ast.Expr{}
 	for _, parsed := range moduleFiles(t) {
 		for _, decl := range parsed.file.Decls {
 			gen, isGen := decl.(*ast.GenDecl)
 			if !isGen || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
 				continue
 			}
-			for _, spec := range gen.Specs {
-				value, isValue := spec.(*ast.ValueSpec)
-				if !isValue {
-					continue
-				}
-				for i, name := range value.Names {
-					if i >= len(value.Values) {
-						continue
-					}
-					if text, isText := staticText(value.Values[i], known); isText {
-						known[name.Name] = text
-					}
-				}
+			collectDeclaredStrings(gen, pending)
+		}
+	}
+	known := map[string]string{}
+	// Each round resolves only names whose dependencies resolved in an earlier
+	// one, so `known` grows strictly until a round adds nothing. It is bounded
+	// by `pending`, which is what makes that terminate — not the absence of
+	// cycles, which a package that compiles cannot contain anyway.
+	for progress := true; progress; {
+		progress = false
+		for name, expr := range pending {
+			if _, done := known[name]; done {
+				continue
+			}
+			if text, isText := staticText(expr, known); isText {
+				known[name] = text
+				progress = true
 			}
 		}
 	}
 	return known
+}
+
+// collectDeclaredStrings records each name in a const or var block against the
+// expression it takes its value from.
+//
+// A grouped const may omit its expression list and INHERIT the one above it —
+// `const ( a = "x"; b )` gives b the value of a. Skipping a spec with no values
+// drops that name silently, so the last expression list seen in the block is
+// carried forward, which is what the language does.
+func collectDeclaredStrings(gen *ast.GenDecl, into map[string]ast.Expr) {
+	var inherited []ast.Expr
+	for _, spec := range gen.Specs {
+		value, isValue := spec.(*ast.ValueSpec)
+		if !isValue {
+			continue
+		}
+		values := value.Values
+		if len(values) == 0 && gen.Tok == token.CONST {
+			values = inherited
+		} else if len(values) > 0 {
+			inherited = values
+		}
+		for i, name := range value.Names {
+			if i < len(values) {
+				into[name.Name] = values[i]
+			}
+		}
+	}
 }
 
 // staticText renders an expression that is a string known at parse time: a

--- a/backend/internal/modules/people/onederivation_test.go
+++ b/backend/internal/modules/people/onederivation_test.go
@@ -40,10 +40,15 @@ const candidateBuilder = "leadPersonCandidate"
 const leadType = "crmcontracts.Lead"
 
 func TestTheLadderCandidateIsDerivedInOnePlace(t *testing.T) {
-	// Every function handed a lead is placed, rather than a subset being
-	// selected and judged. Under-recognition is then loud: a derivation written
-	// in a spelling this does not know still lands in the population, and the
-	// only way out of it is to be neither a build nor a change.
+	// Every function handed a lead is placed — one, a pointer to one, or an
+	// element of a slice of them — rather than a subset being selected and
+	// judged. Within that population under-recognition is loud: a derivation
+	// written in a spelling `constructs` does not know still lands in the
+	// population, and the only way out is to be neither a build nor a change.
+	//
+	// The population itself is the limit worth stating: a function that reaches
+	// a lead some other way again — out of a map, off a struct field — is not
+	// placed, and this gate would not see a derivation inside it.
 	population, deriving := 0, map[string]string{}
 	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
 		if !takesA(fn, leadType) {
@@ -244,53 +249,4 @@ func callsFunc(fn *ast.FuncDecl, name string) bool {
 		return !found
 	})
 	return found
-}
-
-// holdersOf names the identifiers in fn bound to the named type — its receiver
-// and its parameters. A field read is only about that type when it is selected
-// on one of these.
-func holdersOf(fn *ast.FuncDecl, typeName string) map[string]bool {
-	held := map[string]bool{}
-	fields := []*ast.Field{}
-	if fn.Recv != nil {
-		fields = append(fields, fn.Recv.List...)
-	}
-	if fn.Type.Params != nil {
-		fields = append(fields, fn.Type.Params.List...)
-	}
-	for _, field := range fields {
-		if typeText(field.Type) != typeName {
-			continue
-		}
-		for _, name := range field.Names {
-			held[name.Name] = true
-		}
-	}
-	return held
-}
-
-// readsFieldOf answers where fn selects the named field ON A VALUE OF THE NAMED
-// TYPE, or an invalid position when it does not.
-//
-// The type matters. Selecting `.FullName` on the candidate is reading what the
-// ladder matched on; selecting it on the LEAD is the second reading this holds
-// against. A gate matching the field name alone cannot tell them apart, and
-// would refuse the correct one.
-func readsFieldOf(fn *ast.FuncDecl, typeName, field string) token.Pos {
-	holders := holdersOf(fn, typeName)
-	if len(holders) == 0 {
-		return token.NoPos
-	}
-	var at token.Pos
-	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		sel, isSel := node.(*ast.SelectorExpr)
-		if !isSel || sel.Sel == nil || sel.Sel.Name != field {
-			return true
-		}
-		if base, isIdent := sel.X.(*ast.Ident); isIdent && holders[base.Name] {
-			at = sel.Sel.Pos()
-		}
-		return !at.IsValid()
-	})
-	return at
 }

--- a/backend/internal/modules/people/onederivation_test.go
+++ b/backend/internal/modules/people/onederivation_test.go
@@ -32,36 +32,50 @@ const candidateType = "PersonCandidate"
 // candidateBuilder is where that one place is.
 const candidateBuilder = "leadPersonCandidate"
 
+// leadType is what makes a derivation be about THIS candidate. The ladder
+// matches candidates built from several sources — a channel identity, a
+// resolve, a manual dedupe — and those are different derivations of a different
+// thing. The claim is about the one the preview and the promotion share, and
+// its input is what identifies it.
+const leadType = "crmcontracts.Lead"
+
 func TestTheLadderCandidateIsDerivedInOnePlace(t *testing.T) {
-	builders := map[string]bool{}
-	forEachModuleFile(t, func(_ string, fset *token.FileSet, file *ast.File) {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || fn.Name == nil {
-				continue
-			}
-			// From a LEAD specifically. The ladder matches candidates built
-			// from several sources — a channel identity, a resolve, a manual
-			// dedupe — and those are different derivations of a different
-			// thing. The claim is about the one the preview and the promotion
-			// share, and its input is what identifies it.
-			if takesA(fn, "crmcontracts.Lead") && buildsA(fn.Body, candidateType) {
-				builders[fn.Name.Name] = true
-			}
+	// Every function handed a lead is placed, rather than a subset being
+	// selected and judged. Under-recognition is then loud: a derivation written
+	// in a spelling this does not know still lands in the population, and the
+	// only way out of it is to be neither a build nor a change.
+	population, deriving := 0, map[string]string{}
+	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
+		if !takesA(fn, leadType) {
+			return
+		}
+		population++
+		switch {
+		case constructs(fn.Body, candidateType):
+			deriving[fn.Name.Name] = "builds"
+		case mutatesResultOf(fn.Body, candidateBuilder):
+			// A function that takes what the one builder returned and writes a
+			// field on it has produced a second answer, in a form that reads at
+			// the call site as though it were still the first.
+			deriving[fn.Name.Name] = "changes what " + candidateBuilder + " returned in"
 		}
 	})
-	if !builders[candidateBuilder] {
-		t.Fatalf("%s does not build a %s, so this gate is watching the wrong function and the "+
+	if population == 0 {
+		t.Fatalf("no function in this module is handed a %s, so this gate judged nothing and the "+
+			"derivation it holds has moved", leadType)
+	}
+	if deriving[candidateBuilder] == "" {
+		t.Fatalf("%s does not derive a %s, so this gate is watching the wrong function and the "+
 			"derivation it was meant to hold is somewhere else now", candidateBuilder, candidateType)
 	}
-	if len(builders) == 1 {
-		return
-	}
-	others := make([]string, 0, len(builders))
-	for name := range builders {
+	others := make([]string, 0, len(deriving))
+	for name, how := range deriving {
 		if name != candidateBuilder {
-			others = append(others, name)
+			others = append(others, name+" ("+how+" it)")
 		}
+	}
+	if len(others) == 0 {
+		return
 	}
 	sort.Strings(others)
 	t.Errorf("a %s is derived from a lead by %s as well as by %s.\n\nThe preview and the "+
@@ -78,84 +92,55 @@ const contractLeadUpdate = "UpdateLeadRequest"
 // leadUpdateWrapper is the type that keeps it.
 const leadUpdateWrapper = "LeadUpdateRequest"
 
+// leadUpdateAssembler is what every transport hands its decoded request to. It
+// is what makes the population derivable: a surface that updates a lead reaches
+// this, whatever else it does, so the transports do not have to be counted or
+// named here.
+const leadUpdateAssembler = "leadUpdateInput"
+
 func TestEveryLeadUpdateDecodeKeepsTheNullGesture(t *testing.T) {
-	wrapperSeen, decodes := false, 0
-	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
-		ast.Inspect(file, func(n ast.Node) bool {
-			if spec, ok := n.(*ast.TypeSpec); ok && spec.Name.Name == leadUpdateWrapper {
+	wrapperSeen := false
+	forEachModuleFile(t, func(_ string, _ *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(node ast.Node) bool {
+			if spec, isSpec := node.(*ast.TypeSpec); isSpec && spec.Name.Name == leadUpdateWrapper {
 				wrapperSeen = true
-				return true
 			}
-			decl, ok := n.(*ast.DeclStmt)
-			if !ok {
-				return true
-			}
-			gen, ok := decl.Decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.VAR {
-				return true
-			}
-			for _, spec := range gen.Specs {
-				vs, ok := spec.(*ast.ValueSpec)
-				if !ok || vs.Type == nil {
-					continue
-				}
-				switch typeText(vs.Type) {
-				case leadUpdateWrapper:
-					decodes++
-				case "crmcontracts." + contractLeadUpdate:
-					t.Errorf("%s declares a decode target of the bare %s.\n\nJSON erases the "+
-						"difference between null and absent on a pointer field, and only %s "+
-						"records it — decoded this way, a caller asking to CLEAR an override "+
-						"gets a successful response and keeps the override.",
-						fset.Position(vs.Pos()), contractLeadUpdate, leadUpdateWrapper)
-				}
-			}
-			return true
+			return !wrapperSeen
 		})
 	})
 	if !wrapperSeen {
 		t.Fatalf("this module declares no %s, so the gesture has no keeper and this gate judged "+
 			"nothing", leadUpdateWrapper)
 	}
-	if decodes < 2 {
-		t.Errorf("%d transport(s) decode into %s; the claim is that BOTH the handler and the "+
-			"provider do, and one transport cannot drift from itself", decodes, leadUpdateWrapper)
-	}
-}
 
-// takesA reports whether fn accepts the named type as a parameter — which is
-// what makes a body's reads and literals be ABOUT that type rather than about
-// some other value that happens to share a field or a shape. Shared by the
-// gates in this package that identify a function by what it is handed.
-func takesA(fn *ast.FuncDecl, typeName string) bool {
-	if fn.Type.Params == nil {
-		return false
-	}
-	for _, param := range fn.Type.Params.List {
-		if typeText(param.Type) == typeName {
-			return true
+	// The claim is universal over the transports rather than counted at two of
+	// them. A third surface is judged the day it is written, and the gate never
+	// has to be told how many there are supposed to be.
+	transports := 0
+	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+		if !callsFunc(fn, leadUpdateAssembler) {
+			return
 		}
-	}
-	return false
-}
-
-// buildsA reports whether body contains a composite literal of the named type.
-func buildsA(body *ast.BlockStmt, typeName string) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		lit, ok := n.(*ast.CompositeLit)
-		if !ok || lit.Type == nil {
-			return true
+		transports++
+		if bare := zeroValuesOf(fn.Body, "crmcontracts."+contractLeadUpdate); len(bare) > 0 {
+			t.Errorf("%s (%s) decodes a lead update into the bare %s.\n\nJSON erases the "+
+				"difference between null and absent on a pointer field, and only %s records "+
+				"it — decoded this way, a caller asking to CLEAR an override gets a successful "+
+				"response and keeps the override.",
+				fn.Name.Name, parsed.name, contractLeadUpdate, leadUpdateWrapper)
+			return
 		}
-		// An empty literal is a zero value on an error return, not a candidate
-		// anyone matches on; counting it would report every error path as a
-		// second derivation.
-		if typeText(lit.Type) == typeName && len(lit.Elts) > 0 {
-			found = true
+		if len(zeroValuesOf(fn.Body, leadUpdateWrapper)) == 0 {
+			t.Errorf("%s (%s) assembles a lead update without decoding into %s.\n\nThe gesture is "+
+				"kept by that type and by nothing else, so a transport reaching the assembler "+
+				"another way has already lost the difference between clearing an override and "+
+				"leaving it.", fn.Name.Name, parsed.name, leadUpdateWrapper)
 		}
-		return !found
 	})
-	return found
+	if transports == 0 {
+		t.Fatalf("nothing in this module calls %s, so the population this gate judges is empty "+
+			"and the transports have moved", leadUpdateAssembler)
+	}
 }
 
 // A third derivation lives one field away from the two above, and it fails in
@@ -177,68 +162,70 @@ const identityRefusal = "PromoteNeedsIdentityError"
 const leadNaming = "leadIdentityName"
 
 // leadNameField is the field whose present-but-empty reading is the defect. A
-// function in the corpus reading it directly has started a second answer,
+// function in the corpus reading it OFF THE LEAD has started a second answer,
 // whatever it then does with it.
+//
+// Off the lead specifically: the same field name selected on the candidate is a
+// read of what the ladder already matched on, which is the correct thing to do
+// and the whole point of deriving the candidate once.
 const leadNameField = "FullName"
 
 func TestTheIdentityGuardAndTheCandidateReadOneName(t *testing.T) {
 	var guards, builders int
-	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || fn.Name == nil || fn.Name.Name == leadNaming {
-				continue
-			}
-			// Both halves are found by what they DO — one refuses a lead for
-			// having no identity, the other builds the candidate the ladder
-			// matches on — so a third function joining either half is judged
-			// the day it is written rather than the day somebody remembers
-			// this test.
-			guard := refusesWith(fn.Body, identityRefusal)
-			builder := takesA(fn, "crmcontracts.Lead") && buildsA(fn.Body, candidateType)
-			if !guard && !builder {
-				continue
-			}
-			if guard {
-				guards++
-			}
-			if builder {
-				builders++
-			}
-			if !callsFunc(fn, leadNaming) {
-				t.Errorf("%s (%s) decides what a lead is called without %s.\n\nThe guard and the "+
-					"candidate agree on whether a lead has an identity only while ONE function "+
-					"answers it. Take %s.", fn.Name.Name, name, leadNaming, leadNaming)
-			}
-			if pos := readsField(fn.Body, leadNameField); pos.IsValid() {
-				t.Errorf("%s reads .%s directly at %s.\n\nThat is the second reading: `!= nil` and "+
-					"`== \"\"` disagree about a full_name that is present and empty, and the lead "+
-					"that falls between them promotes into a person with no name. Read %s.",
-					fn.Name.Name, leadNameField, fset.Position(pos), leadNaming)
-			}
+	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+		if fn.Name.Name == leadNaming {
+			return
+		}
+		// Both halves are found by what they DO — one refuses a lead for
+		// having no identity, the other derives the candidate the ladder
+		// matches on — so a third function joining either half is judged
+		// the day it is written rather than the day somebody remembers
+		// this test.
+		guard := refusesWith(fn.Body, identityRefusal)
+		derives := takesA(fn, leadType) &&
+			(constructs(fn.Body, candidateType) || mutatesResultOf(fn.Body, candidateBuilder))
+		if !guard && !derives {
+			return
+		}
+		if guard {
+			guards++
+		}
+		if derives {
+			builders++
+		}
+		if !callsFunc(fn, leadNaming) {
+			t.Errorf("%s (%s) decides what a lead is called without %s.\n\nThe guard and the "+
+				"candidate agree on whether a lead has an identity only while ONE function "+
+				"answers it. Take %s.", fn.Name.Name, parsed.name, leadNaming, leadNaming)
+		}
+		if pos := readsFieldOf(fn, leadType, leadNameField); pos.IsValid() {
+			t.Errorf("%s reads the lead's .%s directly at %s.\n\nThat is the second reading: "+
+				"`!= nil` and `== \"\"` disagree about a full_name that is present and empty, "+
+				"and the lead that falls between them promotes into a person with no name. "+
+				"Read %s.", fn.Name.Name, leadNameField, parsed.fset.Position(pos), leadNaming)
 		}
 	})
 	// Either half at zero means this gate examined a population that no longer
 	// exists — the refusal renamed, the candidate moved — and a gate holding
 	// nothing reports exactly what a gate holding everything does.
 	if guards == 0 {
-		t.Fatalf("no function builds a %s, so nothing in this package refuses a lead for having "+
+		t.Fatalf("nothing in this module constructs a %s, so no verb refuses a lead for having "+
 			"no identity and this gate is watching a rule that has moved", identityRefusal)
 	}
 	if builders == 0 {
-		t.Fatalf("no function builds a %s from a lead, so this gate is watching a derivation "+
+		t.Fatalf("no function derives a %s from a lead, so this gate is watching a derivation "+
 			"that has moved", candidateType)
 	}
 }
 
 // refusesWith reports whether body constructs the named error type. Unlike
-// buildsA it counts an EMPTY literal: a sentinel error carries its meaning in
-// its type, and `&PromoteNeedsIdentityError{}` is the whole refusal.
+// constructs it counts an EMPTY literal: a sentinel error carries its meaning
+// in its type, and `&PromoteNeedsIdentityError{}` is the whole refusal.
 func refusesWith(body *ast.BlockStmt, typeName string) bool {
 	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		lit, ok := n.(*ast.CompositeLit)
-		if ok && lit.Type != nil && typeText(lit.Type) == typeName {
+	ast.Inspect(body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.CompositeLit)
+		if isLit && lit.Type != nil && typeText(lit.Type) == typeName {
 			found = true
 		}
 		return !found
@@ -246,18 +233,12 @@ func refusesWith(body *ast.BlockStmt, typeName string) bool {
 	return found
 }
 
-// callsFunc reports whether fn calls the named package-level function. Plain
-// identifiers only: a method of the same name on some other receiver answers a
-// different question, and counting it would report a derivation that is not
-// shared.
+// callsFunc reports whether fn calls the named function of this package,
+// written bare or through a receiver it holds.
 func callsFunc(fn *ast.FuncDecl, name string) bool {
 	found := false
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == name {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if call, isCall := node.(*ast.CallExpr); isCall && callsNamed(call, name) {
 			found = true
 		}
 		return !found
@@ -265,13 +246,48 @@ func callsFunc(fn *ast.FuncDecl, name string) bool {
 	return found
 }
 
-// readsField answers where body selects the named field, or an invalid
-// position when it does not.
-func readsField(body *ast.BlockStmt, field string) token.Pos {
+// holdersOf names the identifiers in fn bound to the named type — its receiver
+// and its parameters. A field read is only about that type when it is selected
+// on one of these.
+func holdersOf(fn *ast.FuncDecl, typeName string) map[string]bool {
+	held := map[string]bool{}
+	fields := []*ast.Field{}
+	if fn.Recv != nil {
+		fields = append(fields, fn.Recv.List...)
+	}
+	if fn.Type.Params != nil {
+		fields = append(fields, fn.Type.Params.List...)
+	}
+	for _, field := range fields {
+		if typeText(field.Type) != typeName {
+			continue
+		}
+		for _, name := range field.Names {
+			held[name.Name] = true
+		}
+	}
+	return held
+}
+
+// readsFieldOf answers where fn selects the named field ON A VALUE OF THE NAMED
+// TYPE, or an invalid position when it does not.
+//
+// The type matters. Selecting `.FullName` on the candidate is reading what the
+// ladder matched on; selecting it on the LEAD is the second reading this holds
+// against. A gate matching the field name alone cannot tell them apart, and
+// would refuse the correct one.
+func readsFieldOf(fn *ast.FuncDecl, typeName, field string) token.Pos {
+	holders := holdersOf(fn, typeName)
+	if len(holders) == 0 {
+		return token.NoPos
+	}
 	var at token.Pos
-	ast.Inspect(body, func(n ast.Node) bool {
-		sel, ok := n.(*ast.SelectorExpr)
-		if ok && sel.Sel != nil && sel.Sel.Name == field {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		sel, isSel := node.(*ast.SelectorExpr)
+		if !isSel || sel.Sel == nil || sel.Sel.Name != field {
+			return true
+		}
+		if base, isIdent := sel.X.(*ast.Ident); isIdent && holders[base.Name] {
 			at = sel.Sel.Pos()
 		}
 		return !at.IsValid()

--- a/backend/internal/modules/people/opendealcount_test.go
+++ b/backend/internal/modules/people/opendealcount_test.go
@@ -131,7 +131,7 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 			if !isBinary || binary.Op != token.ADD || folded[ast.Node(binary)] {
 				return true
 			}
-			text, parts := concatenatedText(binary)
+			text, parts := concatenatedText(binary, packageStrings(t))
 			if len(parts) == 0 {
 				return true
 			}
@@ -172,42 +172,4 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 		t.Fatal("no string literal found in the module's sources, so this census read nothing")
 	}
 	return found
-}
-
-// concatenatedText joins the string literals of a `+` chain, and names the
-// literal nodes it consumed so they are not also read on their own.
-//
-// A non-literal operand — a variable holding a column list, a fmt verb — is
-// replaced by a space rather than dropped, so two literals either side of it do
-// not fuse into a word that appears in neither.
-func concatenatedText(expr ast.Expr) (string, []ast.Node) {
-	var parts []ast.Node
-	var text strings.Builder
-	var walk func(ast.Expr)
-	walk = func(node ast.Expr) {
-		switch operand := node.(type) {
-		case *ast.BinaryExpr:
-			if operand.Op != token.ADD {
-				text.WriteString(" ")
-				return
-			}
-			walk(operand.X)
-			walk(operand.Y)
-		case *ast.BasicLit:
-			value, isText := gatekit.LiteralText(operand)
-			if !isText {
-				text.WriteString(" ")
-				return
-			}
-			parts = append(parts, ast.Node(operand))
-			text.WriteString(value)
-		default:
-			text.WriteString(" ")
-		}
-	}
-	walk(expr)
-	if len(parts) == 0 {
-		return "", nil
-	}
-	return text.String(), parts
 }

--- a/backend/internal/modules/people/opendealcount_test.go
+++ b/backend/internal/modules/people/opendealcount_test.go
@@ -5,9 +5,8 @@ package people
 
 import (
 	"go/ast"
-	"go/parser"
 	"go/token"
-	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -28,11 +27,26 @@ import (
 // Two directions, because a one-directional census misses the shape that does
 // not name the column: a query that never says `open_deal_count` and counts
 // open deals off the table anyway is exactly the copy this is about.
+//
+// And the second direction cannot key on the word `open`. "The copy that does
+// not say the word" is what the header claims to be about, and a census
+// matching `'open'` sees none of the ways of writing the same constraint:
+//
+//	status = ANY($1)              the statuses bound as a parameter
+//	status NOT IN ('won','lost')  the complement, which is the same set
+//	status <> 'won' AND …         the complement again, one arm at a time
+//
+// So it matches a CONSTRAINT ON THE STATUS COLUMN, whatever it compares
+// against. A query that constrains deal status here is assembling the
+// definition here, and which values it names is not the question.
 
 const openPipelineRollupView = "organization_open_pipeline_rollup"
 
-// dealStatusOpen is how the open status is spelled inside a SQL literal.
-const dealStatusOpen = "'open'"
+// dealStatusConstraint matches a restriction on a status column: an equality,
+// an inequality, a set membership or its negation. `= ANY(…)` is an equality
+// and needs no arm of its own; `deal_status` does not match, because an
+// underscore is a word character and the boundary holds.
+var dealStatusConstraint = regexp.MustCompile(`(?i)\bstatus\b\s*(=|<>|!=|\bIN\b|\bNOT\s+IN\b)`)
 
 func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
 	counts, dealReads := 0, 0
@@ -50,12 +64,14 @@ func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
 			continue
 		}
 		dealReads++
-		if strings.Contains(sql.text, dealStatusOpen) {
-			t.Errorf("%s reads the deal table and constrains on %s:\n\n\t%s\n\n"+
-				"That assembles open here rather than taking it from %s, which is a second "+
-				"definition of the word. Read the rollup, or say beside the query why this "+
+		if match := dealStatusConstraint.FindString(sql.text); match != "" {
+			t.Errorf("%s reads the deal table and constrains its status (`%s`):\n\n\t%s\n\n"+
+				"That assembles the definition of open here rather than taking it from %s, "+
+				"whichever statuses it names — the complement of won and lost is the same set "+
+				"written backwards. Read the rollup, or say beside the query why this "+
 				"population is not the one the rollup counts.",
-				sql.where, dealStatusOpen, gatekit.FirstLineOf(sql.text), openPipelineRollupView)
+				sql.where, strings.TrimSpace(match), gatekit.FirstLineOf(sql.text),
+				openPipelineRollupView)
 		}
 	}
 	// Both arms need a subject. The first has one only while the module still
@@ -78,30 +94,43 @@ type moduleSQL struct {
 	text  string
 }
 
-// moduleSQLLiterals returns every string literal in the module's non-test
-// sources. Every literal, not the ones that look like SQL: deciding what looks
-// like SQL is where a census goes blind, and a literal that is not a query
-// matches neither pattern below anyway.
+// moduleSQLLiterals returns every string in the module's non-test sources, with
+// a concatenation folded into the one string it builds.
+//
+// Every string, not the ones that look like SQL: deciding what looks like SQL is
+// where a census goes blind, and a literal that is not a query matches none of
+// the patterns above anyway.
+//
+// Folding matters as much as the sweep. A query assembled as `"… FROM deal " +
+// where + " AND status = 'won'"` puts the table in one literal and the
+// constraint in another, and a census reading literals one at a time sees a
+// deal read with no status and a status with no table — two halves, each
+// innocent, of exactly the copy this holds against.
 func moduleSQLLiterals(t *testing.T) []moduleSQL {
 	t.Helper()
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("reading the module directory: %v", err)
-	}
 	var found []moduleSQL
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, name, nil, 0)
-		if err != nil {
-			t.Fatalf("parsing %s: %v", name, err)
-		}
-		ast.Inspect(file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.BasicLit)
-			if !ok {
+	for _, parsed := range moduleFiles(t) {
+		folded := map[ast.Node]bool{}
+		ast.Inspect(parsed.file, func(node ast.Node) bool {
+			binary, isBinary := node.(*ast.BinaryExpr)
+			if !isBinary || binary.Op != token.ADD || folded[node] {
+				return true
+			}
+			text, parts := concatenatedText(binary)
+			if len(parts) == 0 {
+				return true
+			}
+			for _, part := range parts {
+				folded[part] = true
+			}
+			found = append(found, moduleSQL{
+				where: parsed.fset.Position(binary.Pos()).String(), text: text,
+			})
+			return true
+		})
+		ast.Inspect(parsed.file, func(node ast.Node) bool {
+			lit, isLit := node.(*ast.BasicLit)
+			if !isLit || folded[ast.Node(lit)] {
 				return true
 			}
 			text, isText := gatekit.LiteralText(lit)
@@ -109,7 +138,7 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 				return true
 			}
 			found = append(found, moduleSQL{
-				where: fset.Position(lit.Pos()).String(), text: text,
+				where: parsed.fset.Position(lit.Pos()).String(), text: text,
 			})
 			return true
 		})
@@ -118,4 +147,42 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 		t.Fatal("no string literal found in the module's sources, so this census read nothing")
 	}
 	return found
+}
+
+// concatenatedText joins the string literals of a `+` chain, and names the
+// literal nodes it consumed so they are not also read on their own.
+//
+// A non-literal operand — a variable holding a column list, a fmt verb — is
+// replaced by a space rather than dropped, so two literals either side of it do
+// not fuse into a word that appears in neither.
+func concatenatedText(expr ast.Expr) (string, []ast.Node) {
+	var parts []ast.Node
+	var text strings.Builder
+	var walk func(ast.Expr)
+	walk = func(node ast.Expr) {
+		switch operand := node.(type) {
+		case *ast.BinaryExpr:
+			if operand.Op != token.ADD {
+				text.WriteString(" ")
+				return
+			}
+			walk(operand.X)
+			walk(operand.Y)
+		case *ast.BasicLit:
+			value, isText := gatekit.LiteralText(operand)
+			if !isText {
+				text.WriteString(" ")
+				return
+			}
+			parts = append(parts, ast.Node(operand))
+			text.WriteString(value)
+		default:
+			text.WriteString(" ")
+		}
+	}
+	walk(expr)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return text.String(), parts
 }

--- a/backend/internal/modules/people/opendealcount_test.go
+++ b/backend/internal/modules/people/opendealcount_test.go
@@ -64,15 +64,17 @@ func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
 			continue
 		}
 		dealReads++
-		if match := dealStatusConstraint.FindString(sql.text); match != "" {
-			t.Errorf("%s reads the deal table and constrains its status (`%s`):\n\n\t%s\n\n"+
-				"That assembles the definition of open here rather than taking it from %s, "+
-				"whichever statuses it names — the complement of won and lost is the same set "+
-				"written backwards. Read the rollup, or say beside the query why this "+
-				"population is not the one the rollup counts.",
-				sql.where, strings.TrimSpace(match), gatekit.FirstLineOf(sql.text),
-				openPipelineRollupView)
+		match := dealStatusConstraint.FindString(sql.text)
+		if match == "" || sql.reasoned {
+			continue
 		}
+		t.Errorf("%s reads the deal table and constrains its status (`%s`):\n\n\t%s\n\n"+
+			"That assembles the definition of open here rather than taking it from %s, "+
+			"whichever statuses it names — the complement of won and lost is the same set "+
+			"written backwards. Read the rollup, or say beside the query why this "+
+			"population is not the one the rollup counts.",
+			sql.where, strings.TrimSpace(match), gatekit.FirstLineOf(sql.text),
+			openPipelineRollupView)
 	}
 	// Both arms need a subject. The first has one only while the module still
 	// serves the count; the second only while the module still reaches the deal
@@ -88,10 +90,19 @@ func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
 	}
 }
 
-// moduleSQL is one string literal in the module's own sources, with where it is.
+// moduleSQL is one string in the module's own sources, with where it is and
+// whether a comment sits beside it.
+//
+// The reason matters because this gate offers one. Its failure says "or say
+// beside the query why this population is not the one the rollup counts", and
+// an instruction a gate does not read is an instruction that cannot be
+// followed — the author writes the sentence, the gate fails anyway, and the
+// only remaining move is to delete the gate. A legitimate join that constrains
+// a LEAD's status alongside a deal read needs that door to exist.
 type moduleSQL struct {
-	where string
-	text  string
+	where    string
+	text     string
+	reasoned bool
 }
 
 // moduleSQLLiterals returns every string in the module's non-test sources, with
@@ -110,10 +121,14 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 	t.Helper()
 	var found []moduleSQL
 	for _, parsed := range moduleFiles(t) {
+		// Both the literals a chain consumed AND the chain's own inner nodes.
+		// `a + b + c` parses as `(a + b) + c`, so walking every BinaryExpr
+		// reports the outer chain and then the inner one again — the same query
+		// found twice, at two positions, which reads as two defects.
 		folded := map[ast.Node]bool{}
 		ast.Inspect(parsed.file, func(node ast.Node) bool {
 			binary, isBinary := node.(*ast.BinaryExpr)
-			if !isBinary || binary.Op != token.ADD || folded[node] {
+			if !isBinary || binary.Op != token.ADD || folded[ast.Node(binary)] {
 				return true
 			}
 			text, parts := concatenatedText(binary)
@@ -123,8 +138,16 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 			for _, part := range parts {
 				folded[part] = true
 			}
+			ast.Inspect(binary, func(inner ast.Node) bool {
+				if nested, isNested := inner.(*ast.BinaryExpr); isNested {
+					folded[ast.Node(nested)] = true
+				}
+				return true
+			})
 			found = append(found, moduleSQL{
-				where: parsed.fset.Position(binary.Pos()).String(), text: text,
+				where:    parsed.fset.Position(binary.Pos()).String(),
+				text:     text,
+				reasoned: hasReasonNear(parsed, binary.Pos()),
 			})
 			return true
 		})
@@ -138,7 +161,9 @@ func moduleSQLLiterals(t *testing.T) []moduleSQL {
 				return true
 			}
 			found = append(found, moduleSQL{
-				where: parsed.fset.Position(lit.Pos()).String(), text: text,
+				where:    parsed.fset.Position(lit.Pos()).String(),
+				text:     text,
+				reasoned: hasReasonNear(parsed, lit.Pos()),
 			})
 			return true
 		})

--- a/backend/internal/modules/people/profilefieldonepath_test.go
+++ b/backend/internal/modules/people/profilefieldonepath_test.go
@@ -5,6 +5,7 @@ package people
 
 import (
 	"go/ast"
+	"go/token"
 	"regexp"
 	"strings"
 	"testing"
@@ -62,11 +63,12 @@ func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
 	// field READ verbs in the population and told each of them to go through a
 	// write path, which is advice nobody can take.
 	verbs := map[string]*ast.FuncDecl{}
+	known := packageStrings(t)
 	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
 		if fn.Recv == nil || !fn.Name.IsExported() {
 			return
 		}
-		if callsFunc(fn, profileFieldOnePath) || writesTable(fn, profileFieldTable) {
+		if callsFunc(fn, profileFieldOnePath) || writesTable(fn, profileFieldTable, known) {
 			verbs[fn.Name.Name] = fn
 		}
 	})
@@ -219,19 +221,60 @@ func closureTakesTx(closure *ast.FuncLit) bool {
 }
 
 // writesTable reports whether fn contains a statement writing the named table.
-func writesTable(fn *ast.FuncDecl, table string) bool {
+//
+// It reads a query the way the SQL census does — folding a `+` chain and
+// resolving a name to the string it stands for — because a verb that escapes
+// this leaves the POPULATION, and a population short by one reports a clean
+// module. Two shapes escaped a single-literal walk, and both are ordinary:
+//
+//	"UPDATE " + profileFieldTable + " SET …"   the table named by identifier
+//	const q = `INSERT INTO …`; tx.Exec(ctx, q) the query held outside the body
+//
+// That is the under-recognition this PR closes elsewhere, reappearing in the
+// fix for it. The prefilter has to be at least as wide as the detector.
+func writesTable(fn *ast.FuncDecl, table string, known map[string]string) bool {
 	if fn.Body == nil {
 		return false
 	}
+	writes := tableWriteStatement(table)
 	found := false
+	folded := map[ast.Node]bool{}
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		lit, isLit := node.(*ast.BasicLit)
-		if !isLit {
-			return true
+		binary, isBinary := node.(*ast.BinaryExpr)
+		if !isBinary || binary.Op != token.ADD || folded[ast.Node(binary)] {
+			return !found
 		}
-		text, isText := gatekit.LiteralText(lit)
-		if isText && tableWriteStatement(table).MatchString(text) {
+		text, parts := concatenatedText(binary, known)
+		for _, part := range parts {
+			folded[part] = true
+		}
+		ast.Inspect(binary, func(inner ast.Node) bool {
+			if nested, isNested := inner.(*ast.BinaryExpr); isNested {
+				folded[ast.Node(nested)] = true
+			}
+			return true
+		})
+		if writes.MatchString(text) {
 			found = true
+		}
+		return !found
+	})
+	if found {
+		return true
+	}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		switch operand := node.(type) {
+		case *ast.BasicLit:
+			if folded[ast.Node(operand)] {
+				return true
+			}
+			if text, isText := gatekit.LiteralText(operand); isText && writes.MatchString(text) {
+				found = true
+			}
+		case *ast.Ident:
+			if writes.MatchString(known[operand.Name]) {
+				found = true
+			}
 		}
 		return !found
 	})
@@ -248,6 +291,15 @@ func tableWriteStatement(table string) *regexp.Regexp {
 func effectNameOf(target ast.Expr, imports map[string]string) (string, bool) {
 	switch fun := target.(type) {
 	case *ast.Ident:
+		// A predeclared function is not an effect, and reserving one is the
+		// same artifact the stdlib exclusion above prevents: the day
+		// writeProfileField gains a `len` or an `append`, every verb using the
+		// same builtin is told to move it inside the one path. The stdlib half
+		// of this was closed first and this half was missed — the sibling copy
+		// of a fixed defect, which is the catch this review loop keeps making.
+		if predeclared[fun.Name] {
+			return "", false
+		}
 		return fun.Name, true
 	case *ast.SelectorExpr:
 		base, isIdent := fun.X.(*ast.Ident)
@@ -267,6 +319,15 @@ func effectNameOf(target ast.Expr, imports map[string]string) (string, bool) {
 		return base.Name + "." + fun.Sel.Name, true
 	}
 	return "", false
+}
+
+// predeclared names Go's own identifiers, which belong to the language rather
+// than to this module and can never be an effect on a record.
+var predeclared = map[string]bool{
+	"append": true, "cap": true, "clear": true, "close": true, "complex": true,
+	"copy": true, "delete": true, "imag": true, "len": true, "make": true,
+	"max": true, "min": true, "new": true, "panic": true, "print": true,
+	"println": true, "real": true, "recover": true,
 }
 
 // isStandardLibrary applies Go's own rule: an import path whose first segment

--- a/backend/internal/modules/people/profilefieldonepath_test.go
+++ b/backend/internal/modules/people/profilefieldonepath_test.go
@@ -5,9 +5,11 @@ package people
 
 import (
 	"go/ast"
-	"sort"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // Correcting a profile field and confirming one are the same write with a
@@ -38,23 +40,33 @@ import (
 
 const profileFieldOnePath = "writeProfileField"
 
+// profileFieldTable is what a verb writing around the one path would have to
+// name, and it is how such a verb is found.
+const profileFieldTable = "organization_profile_field"
+
 func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
 	home, onePath := declarationOf(t, profileFieldOnePath)
-	reserved := effectCallees(onePath, importsOf(home))
+	reserved := effectsOwnedBy(onePath, importsOf(home))
 	if len(reserved) == 0 {
 		t.Fatalf("%s reaches no effect of its own, so there is nothing for a verb to duplicate "+
-			"— either the write moved out of it or the callee walk is broken", profileFieldOnePath)
+			"— either the write moved out of it or the effect walk is broken", profileFieldOnePath)
 	}
 
-	// The verbs are those declared beside the one path, plus any that reach it
-	// from elsewhere: a verb moved to another file is still one of the two this
-	// claim is about.
+	// The verbs are the exported methods that WRITE a profile field: one that
+	// reaches the one path, and one that writes the table with its own SQL —
+	// which is the shape this holds against and must therefore be IN the
+	// population rather than selected out of it.
+	//
+	// Writing is the claim, so proximity is not the test. Selecting every
+	// exported method declared beside the one path put the module's profile
+	// field READ verbs in the population and told each of them to go through a
+	// write path, which is advice nobody can take.
 	verbs := map[string]*ast.FuncDecl{}
-	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
 		if fn.Recv == nil || !fn.Name.IsExported() {
 			return
 		}
-		if parsed.name == home.name || callsFunc(fn, profileFieldOnePath) {
+		if callsFunc(fn, profileFieldOnePath) || writesTable(fn, profileFieldTable) {
 			verbs[fn.Name.Name] = fn
 		}
 	})
@@ -63,7 +75,7 @@ func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
 			"confirmation take one path, and one verb cannot disagree with itself",
 			len(verbs), profileFieldOnePath)
 	}
-	for _, name := range sortedNames(verbs) {
+	for _, name := range sortedKeys(verbs) {
 		fn := verbs[name]
 		if !callsFunc(fn, profileFieldOnePath) {
 			t.Errorf("%s does not go through %s.\n\nCorrecting and confirming are the same write "+
@@ -116,17 +128,51 @@ func importsOf(parsed moduleFile) map[string]string {
 	return paths
 }
 
-// effectCallees names what fn reaches that could BE an effect: its own methods,
-// this package's functions, and calls into other modules — but not the standard
-// library.
+// effectsOwnedBy names what the ONE PATH reaches that is an effect on the
+// record — the set a verb may not reach around it.
 //
-// The standard library is excluded because the reserved set is derived, and a
-// derived set inherits whatever the owner happens to call. The day
-// writeProfileField gains an fmt.Errorf, a bare-identifier walk puts `Errorf`
-// in the reserved set and every verb that formats an error is reported as
-// reaching around the one path. The finding would be entirely an artifact of
-// how the gate looks, and it would arrive on somebody else's diff.
-func effectCallees(fn *ast.FuncDecl, imports map[string]string) map[string]bool {
+// Two exclusions, and each closes a way this gate would otherwise accuse
+// correct code with advice nobody can follow. The set is DERIVED from the one
+// path's callees, so it inherits whatever that function happens to call, and a
+// name in it is an instruction to move work inside the one path.
+//
+//   - The standard library. The day writeProfileField gains an `fmt.Errorf`, a
+//     bare-identifier walk reserves `Errorf` and every verb that formats an
+//     error is reported as reaching around the path.
+//   - Anything the one path does not hand the transaction. An effect on the
+//     record is something done to the database, and it needs the tx to do it.
+//     `canonicalOrgColumn` is a closed switch from a field name to a column
+//     name; reserving it tells a verb to move a pure lookup inside a write.
+//
+// The tx test is the honest one available here: this walk has no type
+// information, so "is it an effect" cannot be asked directly, and what the one
+// path HANDS the call is the closest derivable stand-in.
+//
+// It belongs on this side only. Asking the same of a VERB's calls would let a
+// verb reach a reserved effect and escape by handing it something this walk
+// does not recognise as the transaction — which is the hole the filter was
+// meant to leave alone, reopened from the other end. What a verb hands an
+// effect is not the question; that it reaches one is.
+func effectsOwnedBy(fn *ast.FuncDecl, imports map[string]string) map[string]bool {
+	owned := map[string]bool{}
+	if fn.Body == nil {
+		return owned
+	}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall || !handedTheTransaction(call) {
+			return true
+		}
+		if name, isEffect := effectNameOf(call.Fun, imports); isEffect {
+			owned[name] = true
+		}
+		return true
+	})
+	return owned
+}
+
+// callsMade names every call fn makes, by the name a reader sees at the site.
+func callsMade(fn *ast.FuncDecl, imports map[string]string) map[string]bool {
 	callees := map[string]bool{}
 	if fn.Body == nil {
 		return callees
@@ -136,12 +182,65 @@ func effectCallees(fn *ast.FuncDecl, imports map[string]string) map[string]bool 
 		if !isCall {
 			return true
 		}
-		if name, isEffect := effectNameOf(call.Fun, imports); isEffect {
+		if name, named := effectNameOf(call.Fun, imports); named {
 			callees[name] = true
 		}
 		return true
 	})
 	return callees
+}
+
+// handedTheTransaction reports whether a call is given something named like the
+// transaction — which is what separates a write from a lookup at a call site.
+func handedTheTransaction(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		if name, isIdent := arg.(*ast.Ident); isIdent && (name.Name == "tx" || name.Name == "s") {
+			return true
+		}
+		if closure, isClosure := arg.(*ast.FuncLit); isClosure && closureTakesTx(closure) {
+			return true
+		}
+	}
+	return false
+}
+
+// closureTakesTx reports a function literal that is handed a transaction — the
+// shape `writeEvidence` uses to run each effect inside the one transaction.
+func closureTakesTx(closure *ast.FuncLit) bool {
+	if closure.Type.Params == nil {
+		return false
+	}
+	for _, param := range closure.Type.Params.List {
+		if strings.HasSuffix(typeText(param.Type), "Tx") {
+			return true
+		}
+	}
+	return false
+}
+
+// writesTable reports whether fn contains a statement writing the named table.
+func writesTable(fn *ast.FuncDecl, table string) bool {
+	if fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.BasicLit)
+		if !isLit {
+			return true
+		}
+		text, isText := gatekit.LiteralText(lit)
+		if isText && tableWriteStatement(table).MatchString(text) {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// tableWriteStatement matches a statement that changes the named table's rows.
+func tableWriteStatement(table string) *regexp.Regexp {
+	return regexp.MustCompile(`(?is)(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+` + regexp.QuoteMeta(table) + `\b`)
 }
 
 // effectNameOf renders a call target, and reports whether it is one an effect
@@ -183,22 +282,12 @@ func isStandardLibrary(path string) bool {
 // reachedAround reports which of the one path's own effects fn reaches
 // directly, sorted so a failure reads the same on every run.
 func reachedAround(fn *ast.FuncDecl, reserved map[string]bool, imports map[string]string) []string {
-	reached := effectCallees(fn, imports)
-	var around []string
+	reached := callsMade(fn, imports)
+	around := map[string]bool{}
 	for name := range reserved {
 		if reached[name] {
-			around = append(around, name)
+			around[name] = true
 		}
 	}
-	sort.Strings(around)
-	return around
-}
-
-func sortedNames(verbs map[string]*ast.FuncDecl) []string {
-	names := make([]string, 0, len(verbs))
-	for name := range verbs {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
+	return sortedKeys(around)
 }

--- a/backend/internal/modules/people/profilefieldonepath_test.go
+++ b/backend/internal/modules/people/profilefieldonepath_test.go
@@ -5,8 +5,6 @@ package people
 
 import (
 	"go/ast"
-	"go/parser"
-	"go/token"
 	"sort"
 	"strings"
 	"testing"
@@ -24,81 +22,168 @@ import (
 // a fifth effect added inside it is protected the day it is added and nobody
 // has to remember this file. Listing the primitives by hand would mean the gate
 // protects the four that existed when it was written.
+//
+// The file is derived too. Naming it meant a verb moved to another file was
+// uncensused — and that a rename of the file left the gate parsing a path that
+// no longer existed, which is a failure it would have reported as its own
+// error rather than as a defect.
+//
+// What this does NOT hold: another surface writing organization_profile_field
+// with its own SQL. Two do — the company form's bulk save and the cold-start
+// seed — and they are different operations rather than second copies of this
+// one: one writes a whole form at once, the other seeds a profile that has no
+// values yet. Neither corrects or confirms a single field, which is what the
+// one path is for. Said out loud because a reader who found this gate would
+// otherwise reasonably assume it covered them.
 
 const profileFieldOnePath = "writeProfileField"
 
-const profileFieldFile = "organization_profile_field_write.go"
-
 func TestBothProfileFieldVerbsWriteThroughTheOnePath(t *testing.T) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, profileFieldFile, nil, 0)
-	if err != nil {
-		t.Fatalf("parsing %s: %v", profileFieldFile, err)
-	}
-	onePath := funcNamed(file, profileFieldOnePath)
-	if onePath == nil {
-		t.Fatalf("%s declares no %s, so this gate judged nothing", profileFieldFile, profileFieldOnePath)
-	}
-	reserved := directCallees(onePath)
+	home, onePath := declarationOf(t, profileFieldOnePath)
+	reserved := effectCallees(onePath, importsOf(home))
 	if len(reserved) == 0 {
-		t.Fatalf("%s reaches nothing, so there is no effect for a verb to duplicate — either the "+
-			"write moved out of it or the callee walk is broken", profileFieldOnePath)
+		t.Fatalf("%s reaches no effect of its own, so there is nothing for a verb to duplicate "+
+			"— either the write moved out of it or the callee walk is broken", profileFieldOnePath)
 	}
-	verbs := 0
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name == nil || !fn.Name.IsExported() || fn.Recv == nil {
-			continue
+
+	// The verbs are those declared beside the one path, plus any that reach it
+	// from elsewhere: a verb moved to another file is still one of the two this
+	// claim is about.
+	verbs := map[string]*ast.FuncDecl{}
+	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+		if fn.Recv == nil || !fn.Name.IsExported() {
+			return
 		}
-		verbs++
-		if !callsAny(fn, receiverName(fn), map[string]bool{profileFieldOnePath: true}) {
+		if parsed.name == home.name || callsFunc(fn, profileFieldOnePath) {
+			verbs[fn.Name.Name] = fn
+		}
+	})
+	if len(verbs) < 2 {
+		t.Errorf("%d exported verb(s) reach %s; the claim is that BOTH the correction and the "+
+			"confirmation take one path, and one verb cannot disagree with itself",
+			len(verbs), profileFieldOnePath)
+	}
+	for _, name := range sortedNames(verbs) {
+		fn := verbs[name]
+		if !callsFunc(fn, profileFieldOnePath) {
 			t.Errorf("%s does not go through %s.\n\nCorrecting and confirming are the same write "+
 				"with a different provenance; a verb that writes on its own makes them disagree "+
 				"about what happened while both still answer with a well-formed field.",
-				fn.Name.Name, profileFieldOnePath)
+				name, profileFieldOnePath)
 			continue
 		}
-		if around := reachedAround(fn, reserved); len(around) > 0 {
+		around := reachedAround(fn, reserved, importsOf(home))
+		if len(around) > 0 {
 			t.Errorf("%s goes through %s AND reaches %s directly.\n\nThose are effects the one "+
-				"path owns. Reaching one around it is how the correct and the confirm come to "+
-				"record different things: move the work inside %s.",
-				fn.Name.Name, profileFieldOnePath, strings.Join(around, ", "), profileFieldOnePath)
+				"path owns. Reaching one around it is how the correction and the confirmation "+
+				"come to record different things: move the work inside %s.",
+				name, profileFieldOnePath, strings.Join(around, ", "), profileFieldOnePath)
 		}
-	}
-	if verbs < 2 {
-		t.Errorf("%s declares %d exported verb(s); the claim is that BOTH take one path, and one "+
-			"verb cannot disagree with itself", profileFieldFile, verbs)
 	}
 }
 
-// directCallees names what fn calls, by the selector's final identifier — which
-// is how a call reads at the site whether it is a method on the receiver, a
-// package function, or a method on a value it holds.
-func directCallees(fn *ast.FuncDecl) map[string]bool {
+// declarationOf finds the named function and the file that declares it.
+func declarationOf(t *testing.T, name string) (moduleFile, *ast.FuncDecl) {
+	t.Helper()
+	var home moduleFile
+	var found *ast.FuncDecl
+	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+		if fn.Name.Name == name && found == nil {
+			home, found = parsed, fn
+		}
+	})
+	if found == nil {
+		t.Fatalf("this module declares no %s, so this gate judged nothing and the one path it "+
+			"holds has moved or been renamed", name)
+	}
+	return home, found
+}
+
+// importsOf maps a file's local package names to their import paths.
+func importsOf(parsed moduleFile) map[string]string {
+	paths := map[string]string{}
+	for _, spec := range parsed.file.Imports {
+		path := strings.Trim(spec.Path.Value, `"`)
+		name := path
+		if cut := strings.LastIndex(path, "/"); cut >= 0 {
+			name = path[cut+1:]
+		}
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		paths[name] = path
+	}
+	return paths
+}
+
+// effectCallees names what fn reaches that could BE an effect: its own methods,
+// this package's functions, and calls into other modules — but not the standard
+// library.
+//
+// The standard library is excluded because the reserved set is derived, and a
+// derived set inherits whatever the owner happens to call. The day
+// writeProfileField gains an fmt.Errorf, a bare-identifier walk puts `Errorf`
+// in the reserved set and every verb that formats an error is reported as
+// reaching around the one path. The finding would be entirely an artifact of
+// how the gate looks, and it would arrive on somebody else's diff.
+func effectCallees(fn *ast.FuncDecl, imports map[string]string) map[string]bool {
 	callees := map[string]bool{}
 	if fn.Body == nil {
 		return callees
 	}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
 			return true
 		}
-		switch target := call.Fun.(type) {
-		case *ast.SelectorExpr:
-			callees[target.Sel.Name] = true
-		case *ast.Ident:
-			callees[target.Name] = true
+		if name, isEffect := effectNameOf(call.Fun, imports); isEffect {
+			callees[name] = true
 		}
 		return true
 	})
 	return callees
 }
 
-// reachedAround reports which of the one path's own callees fn reaches
+// effectNameOf renders a call target, and reports whether it is one an effect
+// could hide behind.
+func effectNameOf(target ast.Expr, imports map[string]string) (string, bool) {
+	switch fun := target.(type) {
+	case *ast.Ident:
+		return fun.Name, true
+	case *ast.SelectorExpr:
+		base, isIdent := fun.X.(*ast.Ident)
+		if !isIdent {
+			return fun.Sel.Name, true
+		}
+		path, isImport := imports[base.Name]
+		if !isImport {
+			// A method on the receiver or on a value it holds. The name alone
+			// is how it reads at the call site and how a second copy would be
+			// written.
+			return fun.Sel.Name, true
+		}
+		if isStandardLibrary(path) {
+			return "", false
+		}
+		return base.Name + "." + fun.Sel.Name, true
+	}
+	return "", false
+}
+
+// isStandardLibrary applies Go's own rule: an import path whose first segment
+// carries no dot is in the standard library.
+func isStandardLibrary(path string) bool {
+	first := path
+	if cut := strings.Index(path, "/"); cut >= 0 {
+		first = path[:cut]
+	}
+	return !strings.Contains(first, ".")
+}
+
+// reachedAround reports which of the one path's own effects fn reaches
 // directly, sorted so a failure reads the same on every run.
-func reachedAround(fn *ast.FuncDecl, reserved map[string]bool) []string {
-	reached := directCallees(fn)
+func reachedAround(fn *ast.FuncDecl, reserved map[string]bool, imports map[string]string) []string {
+	reached := effectCallees(fn, imports)
 	var around []string
 	for name := range reserved {
 		if reached[name] {
@@ -109,11 +194,11 @@ func reachedAround(fn *ast.FuncDecl, reserved map[string]bool) []string {
 	return around
 }
 
-func funcNamed(file *ast.File, name string) *ast.FuncDecl {
-	for _, decl := range file.Decls {
-		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name != nil && fn.Name.Name == name {
-			return fn
-		}
+func sortedNames(verbs map[string]*ast.FuncDecl) []string {
+	names := make([]string, 0, len(verbs))
+	for name := range verbs {
+		names = append(names, name)
 	}
-	return nil
+	sort.Strings(names)
+	return names
 }

--- a/backend/internal/modules/people/provenancefilter_test.go
+++ b/backend/internal/modules/people/provenancefilter_test.go
@@ -5,9 +5,7 @@ package people
 
 import (
 	"go/ast"
-	"go/parser"
 	"go/token"
-	"os"
 	"strings"
 	"testing"
 )
@@ -121,28 +119,4 @@ func listFiltersLiterals(t *testing.T) []listFiltersLiteral {
 		})
 	})
 	return found
-}
-
-// forEachModuleFile parses the module's own non-test sources and hands each to
-// visit. Test sources are left out: a listFilters a test builds is a fixture,
-// and holding a fixture to the shape of a shipped surface would refuse cases
-// written to exercise one filter at a time.
-func forEachModuleFile(t *testing.T, visit func(name string, fset *token.FileSet, file *ast.File)) {
-	t.Helper()
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("reading the module directory: %v", err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, name, nil, 0)
-		if err != nil {
-			t.Fatalf("parsing %s: %v", name, err)
-		}
-		visit(name, fset, file)
-	}
 }

--- a/backend/internal/modules/people/provenancefilter_test.go
+++ b/backend/internal/modules/people/provenancefilter_test.go
@@ -36,6 +36,9 @@ const provenanceField = "CapturedByKind"
 const filtersType = "listFilters"
 
 // provenanceOwner is the one spelling of the clause the field turns into.
+//
+// Held by: TestTheProvenanceClauseIsBuiltInOnePlace
+// (backend/internal/modules/people/provenancefilter_test.go)
 const provenanceOwner = "capturedByKindClause"
 
 func TestEveryListFiltersLiteralCarriesTheProvenanceFilter(t *testing.T) {

--- a/backend/internal/modules/people/provenancefilter_test.go
+++ b/backend/internal/modules/people/provenancefilter_test.go
@@ -6,16 +6,17 @@ package people
 import (
 	"go/ast"
 	"go/token"
+	"sort"
 	"strings"
 	"testing"
 )
 
 // The provenance filter fails by being DROPPED, not by being spelled twice.
-// Every list surface assembles its WHERE through a listFilters literal, and a
-// literal that omits CapturedByKind hands back an unfiltered page to a caller
-// who did ask to filter — the same confident-wrong-answer capturedByKindClause
-// refuses an empty enum value to avoid, arriving one layer up where nothing
-// looks at the value at all.
+// Every list surface assembles its WHERE through a listFilters value, and one
+// that omits CapturedByKind hands back an unfiltered page to a caller who did
+// ask to filter — the same confident-wrong-answer capturedByKindClause refuses
+// an empty enum value to avoid, arriving one layer up where nothing looks at
+// the value at all.
 //
 // Silent at every layer: the request validates, the query runs, the page is
 // well-formed, and the only symptom is rows the caller asked not to see. The
@@ -23,100 +24,295 @@ import (
 // filtering for agent-created rows cannot tell "no AI wrote here" from "the
 // filter was ignored".
 //
-// The literals are found rather than listed. A list surface added tomorrow is
+// The surfaces are found rather than listed. A list surface added tomorrow is
 // judged by this without anyone remembering to add it here, which is the whole
 // difference between a gate and a checklist.
 
-// provenanceField is the filter this holds: the field a listFilters literal
-// must carry from its caller.
+// provenanceField is the filter this holds: the field a listFilters value must
+// carry from its caller.
 const provenanceField = "CapturedByKind"
 
+// filtersType is the struct every list surface assembles its WHERE through.
+const filtersType = "listFilters"
+
+// provenanceOwner is the one spelling of the clause the field turns into.
+const provenanceOwner = "capturedByKindClause"
+
 func TestEveryListFiltersLiteralCarriesTheProvenanceFilter(t *testing.T) {
-	literals := listFiltersLiterals(t)
-	if len(literals) == 0 {
-		t.Fatal("no listFilters literal found in this module, so this gate judged nothing — " +
-			"either the struct was renamed or the list surfaces have moved")
+	builds := listFiltersBuilds(t)
+	if len(builds) == 0 {
+		t.Fatalf("no %s is built in this module, so this gate judged nothing — either the "+
+			"struct was renamed or the list surfaces have moved", filtersType)
 	}
-	for _, lit := range literals {
-		if lit.sets[provenanceField] {
+	for _, build := range builds {
+		value, set := build.sets[provenanceField]
+		if !set {
+			t.Errorf("%s builds a %s without %s.\n\nThe surface then answers a request that "+
+				"asked to filter on provenance with a page that did not, and nothing anywhere "+
+				"refuses: set it from the caller's input, or give the field the zero value "+
+				"explicitly beside a reason this surface has no provenance to filter on.",
+				build.where, filtersType, provenanceField)
 			continue
 		}
-		t.Errorf("%s builds a listFilters without %s.\n\nThe surface then answers a request that "+
-			"asked to filter on provenance with a page that did not, and nothing anywhere "+
-			"refuses: set it from the caller's input, or give the field the zero value "+
-			"explicitly beside a reason this surface has no provenance to filter on.",
-			lit.where, provenanceField)
+		// Presence is not the claim. `CapturedByKind: nil` satisfies a gate
+		// that asks only whether the key is there, and it is the exact defect
+		// spelled out loud — the filter dropped, with the field named. What
+		// makes an explicit zero honest is the reason beside it, which the
+		// failure above already demands and nothing used to check.
+		if isNilExpr(value) && !build.reasoned[provenanceField] {
+			t.Errorf("%s sets %s to nil with no reason beside it.\n\nAn explicit zero is how a "+
+				"surface says it has no provenance to filter on, and it is indistinguishable "+
+				"from the filter being dropped unless the reason is written down. Say why this "+
+				"surface has none, or set it from the caller's input.",
+				build.where, provenanceField)
+		}
 	}
 }
 
-// The other half of the claim: one spelling means one caller. A second place
-// building the clause is how the person list and the lead list come to disagree
-// about which prefix counts as an AI — the two are read side by side, so the
-// disagreement reaches a person before it reaches a test.
+// The other half of the claim: one spelling means the field is read in one
+// place. A second place turning CapturedByKind into SQL is how the person list
+// and the lead list come to disagree about which prefix counts as an AI — the
+// two are read side by side, so the disagreement reaches a person before it
+// reaches a test.
+//
+// The subject is the FIELD, not the SQL. This module hand-writes
+// `captured_by LIKE` for three other questions — was this human-written, did a
+// connector capture it, has an AI written INTO it — and those are fixed
+// questions rather than the caller's filter. A census over the SQL idiom would
+// refuse all three; a census over who reads the field refuses only a second
+// answer to the same question.
 func TestTheProvenanceClauseIsBuiltInOnePlace(t *testing.T) {
-	callers := map[string]int{}
-	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
-		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
+	var offenders []string
+	owners := 0
+	for _, parsed := range moduleFiles(t) {
+		carried := carriedFieldValues(parsed.file, provenanceField)
+		for _, decl := range parsed.file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil || fn.Name == nil {
+				continue
 			}
-			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "capturedByKindClause" {
-				callers[fset.Position(call.Pos()).String()]++
+			if fn.Name.Name == provenanceOwner {
+				owners++
+				continue
+			}
+			for _, pos := range consumingReads(fn.Body, provenanceField, provenanceOwner, carried) {
+				offenders = append(offenders,
+					fn.Name.Name+" ("+parsed.fset.Position(pos).String()+")")
+			}
+		}
+	}
+	if owners == 0 {
+		t.Fatalf("this module declares no %s, so the provenance filter has no owner and every "+
+			"list silently decides for itself", provenanceOwner)
+	}
+	if len(offenders) == 0 {
+		return
+	}
+	sort.Strings(offenders)
+	t.Errorf("%s is consumed outside %s by %s.\n\nOne reader is what makes it one spelling: "+
+		"every list reaches the prefix rule through %s, so a second reader is a surface that "+
+		"has started deciding for itself which prefix counts as an AI. Pass the field to %s "+
+		"rather than reading it here.",
+		provenanceField, provenanceOwner, strings.Join(offenders, ", "), provenanceOwner,
+		provenanceOwner)
+}
+
+// carriedFieldValues collects the reads that merely CARRY the field from one
+// place to the next: the value in `CapturedByKind: in.CapturedByKind`, and the
+// right-hand side of an assignment onto a field of the same name.
+//
+// Carrying is not deciding. Every list surface plumbs the caller's input into
+// the filter set, and a gate counting those as readers would name seven correct
+// surfaces and no defect — which is how a gate stops being read.
+//
+// The read may sit UNDER a conversion — `CapturedByKind: capturedByKindArg(
+// params.CapturedByKind)` turns a contract enum into the pointer the field
+// holds — so the whole value expression is walked rather than compared. A
+// converted carry is still a carry; what it is not is a second answer to which
+// prefix counts.
+func carriedFieldValues(file *ast.File, field string) map[ast.Node]bool {
+	carried := map[ast.Node]bool{}
+	carry := func(value ast.Expr) {
+		ast.Inspect(value, func(node ast.Node) bool {
+			if sel, isSel := node.(*ast.SelectorExpr); isSel && sel.Sel != nil && sel.Sel.Name == field {
+				carried[ast.Node(sel)] = true
 			}
 			return true
 		})
-	})
-	if len(callers) == 0 {
-		t.Fatal("capturedByKindClause has no caller in this module — a provenance filter nothing " +
-			"builds is a filter every list silently ignores")
 	}
-	if len(callers) > 1 {
-		sites := make([]string, 0, len(callers))
-		for site := range callers {
-			sites = append(sites, site)
-		}
-		t.Errorf("capturedByKindClause is called from %d places (%s).\n\nOne caller is what makes "+
-			"it the one spelling: every list reaches the prefix rule through listFilters, so a "+
-			"second caller is a surface that has started deciding for itself which prefix counts "+
-			"as an AI.", len(callers), strings.Join(sites, ", "))
-	}
-}
-
-// listFiltersLiteral is one composite literal building the shared filter set.
-type listFiltersLiteral struct {
-	where string
-	sets  map[string]bool
-}
-
-func listFiltersLiterals(t *testing.T) []listFiltersLiteral {
-	t.Helper()
-	var found []listFiltersLiteral
-	forEachModuleFile(t, func(name string, fset *token.FileSet, file *ast.File) {
-		ast.Inspect(file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok {
-				return true
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch stmt := node.(type) {
+		case *ast.KeyValueExpr:
+			if key, isIdent := stmt.Key.(*ast.Ident); isIdent && key.Name == field {
+				carry(stmt.Value)
 			}
-			id, ok := lit.Type.(*ast.Ident)
-			if !ok || id.Name != "listFilters" {
-				return true
-			}
-			sets := map[string]bool{}
-			for _, element := range lit.Elts {
-				kv, ok := element.(*ast.KeyValueExpr)
-				if !ok {
+		case *ast.AssignStmt:
+			for i, lhs := range stmt.Lhs {
+				sel, isSel := lhs.(*ast.SelectorExpr)
+				if !isSel || sel.Sel == nil || sel.Sel.Name != field || i >= len(stmt.Rhs) {
 					continue
 				}
-				if key, ok := kv.Key.(*ast.Ident); ok {
-					sets[key.Name] = true
-				}
+				carry(stmt.Rhs[i])
 			}
-			found = append(found, listFiltersLiteral{
-				where: fset.Position(lit.Pos()).String(), sets: sets,
-			})
+		}
+		return true
+	})
+	return carried
+}
+
+// consumingReads reports where body reads the field for anything other than
+// carrying it or handing it to its owner — the only shape that can be a second
+// answer to which prefix counts.
+func consumingReads(body *ast.BlockStmt, field, owner string, carried map[ast.Node]bool) []token.Pos {
+	handed := map[ast.Node]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall || !callsNamed(call, owner) {
 			return true
-		})
+		}
+		for _, arg := range call.Args {
+			handed[arg] = true
+		}
+		return true
+	})
+	var found []token.Pos
+	ast.Inspect(body, func(node ast.Node) bool {
+		sel, isSel := node.(*ast.SelectorExpr)
+		if !isSel || sel.Sel == nil || sel.Sel.Name != field {
+			return true
+		}
+		if handed[ast.Node(sel)] || carried[ast.Node(sel)] {
+			return true
+		}
+		found = append(found, sel.Sel.Pos())
+		return true
 	})
 	return found
+}
+
+// filtersBuild is one assembly of the shared filter set, however it is spelled.
+type filtersBuild struct {
+	where    string
+	sets     map[string]ast.Expr
+	reasoned map[string]bool
+}
+
+// listFiltersBuilds finds every assembly of the filter set: a composite
+// literal, and a zero value filled in by assignment afterwards. The second is
+// the same surface written differently, and a census that reads only literals
+// reports a clean module while a list surface assembled field by field carries
+// no provenance filter at all.
+func listFiltersBuilds(t *testing.T) []filtersBuild {
+	t.Helper()
+	var found []filtersBuild
+	for _, parsed := range moduleFiles(t) {
+		ast.Inspect(parsed.file, func(node ast.Node) bool {
+			lit, isLit := node.(*ast.CompositeLit)
+			if !isLit || lit.Type == nil || typeText(lit.Type) != filtersType {
+				return true
+			}
+			build := filtersBuild{
+				where:    parsed.fset.Position(lit.Pos()).String(),
+				sets:     map[string]ast.Expr{},
+				reasoned: map[string]bool{},
+			}
+			for _, element := range lit.Elts {
+				kv, isKV := element.(*ast.KeyValueExpr)
+				if !isKV {
+					continue
+				}
+				key, isIdent := kv.Key.(*ast.Ident)
+				if !isIdent {
+					continue
+				}
+				build.sets[key.Name] = kv.Value
+				build.reasoned[key.Name] = hasReasonNear(parsed, kv.Pos())
+			}
+			found = append(found, build)
+			return true
+		})
+		found = append(found, assembledFiltersIn(parsed)...)
+	}
+	return found
+}
+
+// assembledFiltersIn finds the zero-value spelling: `var f listFilters` or
+// `f := listFilters{}`, with the fields written on afterwards.
+func assembledFiltersIn(parsed moduleFile) []filtersBuild {
+	var found []filtersBuild
+	for _, decl := range parsed.file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil {
+			continue
+		}
+		zeroed := zeroValuesOf(fn.Body, filtersType)
+		if len(zeroed) == 0 {
+			continue
+		}
+		builds := map[string]*filtersBuild{}
+		for name := range zeroed {
+			builds[name] = &filtersBuild{
+				where:    fn.Name.Name + " (" + parsed.fset.Position(fn.Pos()).String() + ")",
+				sets:     map[string]ast.Expr{},
+				reasoned: map[string]bool{},
+			}
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			assign, isAssign := node.(*ast.AssignStmt)
+			if !isAssign {
+				return true
+			}
+			for i, lhs := range assign.Lhs {
+				sel, isSel := lhs.(*ast.SelectorExpr)
+				if !isSel {
+					continue
+				}
+				base, isIdent := sel.X.(*ast.Ident)
+				if !isIdent || builds[base.Name] == nil {
+					continue
+				}
+				build := builds[base.Name]
+				if i < len(assign.Rhs) {
+					build.sets[sel.Sel.Name] = assign.Rhs[i]
+				}
+				build.reasoned[sel.Sel.Name] = hasReasonNear(parsed, assign.Pos())
+			}
+			return true
+		})
+		for _, name := range sortedKeys(builds) {
+			found = append(found, *builds[name])
+		}
+	}
+	return found
+}
+
+func sortedKeys(builds map[string]*filtersBuild) []string {
+	names := make([]string, 0, len(builds))
+	for name := range builds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// isNilExpr reports the untyped nil, which is what an explicitly dropped filter
+// is written as.
+func isNilExpr(expr ast.Expr) bool {
+	ident, isIdent := expr.(*ast.Ident)
+	return isIdent && ident.Name == "nil"
+}
+
+// hasReasonNear reports whether a comment sits on the line above pos or at the
+// end of its own line — the two places a reason is actually written.
+func hasReasonNear(parsed moduleFile, pos token.Pos) bool {
+	at := parsed.fset.Position(pos).Line
+	for _, group := range parsed.file.Comments {
+		for _, comment := range group.List {
+			line := parsed.fset.Position(comment.Pos()).Line
+			if line == at || line == at-1 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/modules/people/provenancefilter_test.go
+++ b/backend/internal/modules/people/provenancefilter_test.go
@@ -164,8 +164,12 @@ func carriedFieldValues(file *ast.File, field string) map[ast.Node]bool {
 }
 
 // consumingReads reports where body reads the field for anything other than
-// carrying it or handing it to its owner — the only shape that can be a second
-// answer to which prefix counts.
+// carrying it, handing it to its owner, or asking whether it is set at all.
+//
+// The third is a category the carry/decide split does not cover: `f.X != nil`
+// asks whether the caller supplied a filter, which is neither plumbing the
+// value onward nor deciding what it means, and the advice this gate gives —
+// pass it to the owner — does not apply to it.
 func consumingReads(body *ast.BlockStmt, field, owner string, carried map[ast.Node]bool) []token.Pos {
 	handed := map[ast.Node]bool{}
 	ast.Inspect(body, func(node ast.Node) bool {
@@ -178,13 +182,27 @@ func consumingReads(body *ast.BlockStmt, field, owner string, carried map[ast.No
 		}
 		return true
 	})
+	presence := map[ast.Node]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		compare, isCompare := node.(*ast.BinaryExpr)
+		if !isCompare || (compare.Op != token.EQL && compare.Op != token.NEQ) {
+			return true
+		}
+		for _, side := range []ast.Expr{compare.X, compare.Y} {
+			if isNilExpr(side) {
+				presence[compare.X] = true
+				presence[compare.Y] = true
+			}
+		}
+		return true
+	})
 	var found []token.Pos
 	ast.Inspect(body, func(node ast.Node) bool {
 		sel, isSel := node.(*ast.SelectorExpr)
 		if !isSel || sel.Sel == nil || sel.Sel.Name != field {
 			return true
 		}
-		if handed[ast.Node(sel)] || carried[ast.Node(sel)] {
+		if handed[ast.Node(sel)] || carried[ast.Node(sel)] || presence[ast.Node(sel)] {
 			return true
 		}
 		found = append(found, sel.Sel.Pos())
@@ -212,6 +230,14 @@ func listFiltersBuilds(t *testing.T) []filtersBuild {
 		ast.Inspect(parsed.file, func(node ast.Node) bool {
 			lit, isLit := node.(*ast.CompositeLit)
 			if !isLit || lit.Type == nil || typeText(lit.Type) != filtersType {
+				return true
+			}
+			// An EMPTY literal is where an assembled build starts, not a build
+			// on its own — `f := listFilters{}` followed by eleven field
+			// assignments carries every filter, and reading the literal as a
+			// finished value reports a surface that does everything right.
+			// assembledFiltersIn below is what judges that shape.
+			if len(lit.Elts) == 0 {
 				return true
 			}
 			build := filtersBuild{
@@ -287,15 +313,6 @@ func assembledFiltersIn(parsed moduleFile) []filtersBuild {
 		}
 	}
 	return found
-}
-
-func sortedKeys(builds map[string]*filtersBuild) []string {
-	names := make([]string, 0, len(builds))
-	for name := range builds {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
 }
 
 // isNilExpr reports the untyped nil, which is what an explicitly dropped filter

--- a/backend/internal/modules/people/responsetouch_test.go
+++ b/backend/internal/modules/people/responsetouch_test.go
@@ -5,8 +5,6 @@ package people
 
 import (
 	"go/ast"
-	"go/token"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -58,10 +56,11 @@ var touchFieldsReadByMany = map[string]string{
 func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
 	readers := map[string]map[string]bool{}
 	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
-		if !takesA(fn, touchType) {
-			return
-		}
-		for field := range fieldReadsIn(fn.Body) {
+		// Fields read OFF A TOUCH, not fields whose name matches. A function
+		// holding both a touch and an activity reads `source` on each, and a
+		// census keyed on the bare name reports the second as a reader of the
+		// first — then tells the author to ratify a read that never happened.
+		for field := range fieldsReadOf(fn, touchType) {
 			if readers[field] == nil {
 				readers[field] = map[string]bool{}
 			}
@@ -78,11 +77,7 @@ func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
 		}
 		switch {
 		case len(found) > 1 && !excepted:
-			names := make([]string, 0, len(found))
-			for name := range found {
-				names = append(names, name)
-			}
-			sort.Strings(names)
+			names := sortedKeys(found)
 			t.Errorf("%s.%s is read by %s.\n\nThat is a second opinion about the same rule: the "+
 				"captured_by grammar and the composer's stamp are things that change, and read "+
 				"in two places they change in one. The ladder then shows a lead as contacted "+
@@ -105,30 +100,4 @@ func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
 		t.Fatalf("nothing in this module reads any field of a %s, so this gate judged nothing "+
 			"and the rules it holds have moved", touchType)
 	}
-}
-
-// fieldReadsIn returns the field names selected in body, excluding those taken
-// by ADDRESS: `&t.capturedBy` in a row Scan fills the field rather than asking
-// it anything, and counting it would report the builder as a second reader of
-// every rule it populates.
-func fieldReadsIn(body *ast.BlockStmt) map[string]bool {
-	addressed := map[ast.Node]bool{}
-	ast.Inspect(body, func(node ast.Node) bool {
-		if unary, isUnary := node.(*ast.UnaryExpr); isUnary && unary.Op == token.AND {
-			addressed[unary.X] = true
-		}
-		return true
-	})
-	read := map[string]bool{}
-	ast.Inspect(body, func(node ast.Node) bool {
-		sel, isSel := node.(*ast.SelectorExpr)
-		if !isSel || addressed[ast.Node(sel)] {
-			return true
-		}
-		if _, isIdent := sel.X.(*ast.Ident); isIdent {
-			read[sel.Sel.Name] = true
-		}
-		return true
-	})
-	return read
 }

--- a/backend/internal/modules/people/responsetouch_test.go
+++ b/backend/internal/modules/people/responsetouch_test.go
@@ -20,73 +20,90 @@ import (
 // unanswered. Both are on the same screen.
 //
 // So the subject is not the predicate's text, which two readers can respell
-// without agreeing; it is the FIELD. A second function reading `source` or
-// `capturedBy` off a touch is a second opinion about the same rule, whatever
-// words it uses to reach it.
+// without agreeing; it is the FIELD. A second function reading a rule-bearing
+// field off a touch is a second opinion about the same rule, whatever words it
+// uses to reach it.
 //
-// `kind` is deliberately not held: `ladderStepFor` reads it to ask whether the
-// touch is a meeting, which is a different question about the same column.
+// EVERY field is placed, rather than two being named and judged. A gate that
+// lists the fields it holds is a second copy of the struct, and it is short
+// from the moment a field is added — silently, because it goes on passing over
+// the fields it does know. Listing the EXCEPTIONS instead inverts that: a new
+// field is held the day it is written, and an exception that stops being true
+// fails rather than quietly widening what is allowed.
+//
+// The owner is derived too — it is whichever function reads the field, and
+// there is one. Naming it would fail a rename that moved nothing.
 
 // touchType is the struct whose field reads this holds.
 const touchType = "leadResponseTouch"
 
-// ownedTouchFields names, per field, the function that owns the rule the field
-// carries. A field here holds a rule rather than a value, so reading it IS
-// deciding the rule; anyone else wanting the answer calls that function.
+// touchFieldsReadByMany are the fields more than one function may read, and
+// why. Each is asserted to still need its exception below: an exception nobody
+// needs is a hole, because it goes on permitting a second reader long after the
+// reason for the first one has gone.
 //
-// gatekit:fixture the field-to-owner pairing this gate judges, not a set of
-// ratified exceptions: the values name functions, and a stale one fails above
-// rather than quietly widening what is allowed.
-var ownedTouchFields = map[string]string{
-	"source":     "humanLoggedNote",
-	"capturedBy": "humanCaptured",
+// gatekit:fixture the exceptions this gate allows, not a set of ratified debts.
+// Both entries hold for one reason: the field carries a VALUE, and each reader
+// compares it to a different literal to ask a different question. Two questions
+// about one fact are not two answers to one rule — which is what `source` and
+// `capturedBy` are, where deciding what counts as human-typed is a grammar that
+// changes and must change in one place.
+var touchFieldsReadByMany = map[string]string{
+	"direction": "the way the touch went is a fact on the row: the ladder asks whether it was " +
+		"inbound, the clock asks whether it was outbound, and neither is deciding a grammar",
+	"kind": "ladderStepFor asks whether the touch is a meeting, which is a different question " +
+		"about the same column from the one humanLoggedNote asks",
 }
 
 func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
 	readers := map[string]map[string]bool{}
-	forEachModuleFile(t, func(_ string, _ *token.FileSet, file *ast.File) {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || !takesA(fn, touchType) {
-				continue
+	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
+		if !takesA(fn, touchType) {
+			return
+		}
+		for field := range fieldReadsIn(fn.Body) {
+			if readers[field] == nil {
+				readers[field] = map[string]bool{}
 			}
-			for field := range fieldReadsIn(fn.Body) {
-				if _, owned := ownedTouchFields[field]; !owned {
-					continue
-				}
-				if readers[field] == nil {
-					readers[field] = map[string]bool{}
-				}
-				readers[field][fn.Name.Name] = true
-			}
+			readers[field][fn.Name.Name] = true
 		}
 	})
-	for field, owner := range ownedTouchFields {
+
+	read := 0
+	for _, field := range fieldsOf(t, touchType) {
 		found := readers[field]
-		if len(found) == 0 {
-			t.Errorf("nothing reads %s.%s, so the rule %s carries has no subject and this gate "+
-				"judged nothing for it", touchType, field, owner)
-			continue
+		reason, excepted := touchFieldsReadByMany[field]
+		if len(found) > 0 {
+			read++
 		}
-		if !found[owner] {
-			t.Errorf("%s does not read %s.%s, so it is no longer where that rule lives — this "+
-				"gate is now protecting the wrong function", owner, touchType, field)
-		}
-		if len(found) == 1 {
-			continue
-		}
-		others := make([]string, 0, len(found))
-		for name := range found {
-			if name != owner {
-				others = append(others, name)
+		switch {
+		case len(found) > 1 && !excepted:
+			names := make([]string, 0, len(found))
+			for name := range found {
+				names = append(names, name)
 			}
+			sort.Strings(names)
+			t.Errorf("%s.%s is read by %s.\n\nThat is a second opinion about the same rule: the "+
+				"captured_by grammar and the composer's stamp are things that change, and read "+
+				"in two places they change in one. The ladder then shows a lead as contacted "+
+				"while the first-response clock counts it unanswered, on one screen. Give the "+
+				"field one reader and call it — or add it to touchFieldsReadByMany with the "+
+				"reason it carries a value rather than a rule.",
+				touchType, field, strings.Join(names, ", "))
+		case len(found) <= 1 && excepted:
+			// An exception is a statement about the code, and this one has
+			// stopped being true. Left in place it goes on permitting a second
+			// reader that nobody has asked for yet.
+			t.Errorf("%s.%s is listed in touchFieldsReadByMany (%q) but has %d reader(s).\n\n"+
+				"The exception is no longer needed, and an exception nobody needs is a hole. "+
+				"Remove it.", touchType, field, reason, len(found))
 		}
-		sort.Strings(others)
-		t.Errorf("%s.%s is read by %s as well as %s.\n\nThat is a second opinion about the same "+
-			"rule: the captured_by grammar and the composer's stamp are things that change, and "+
-			"read in two places they change in one. The ladder then shows a lead as contacted "+
-			"while the first-response clock counts it unanswered, on one screen. Call %s.",
-			touchType, field, strings.Join(others, ", "), owner, owner)
+	}
+	// A struct whose fields nothing reads means this gate walked a corpus that
+	// no longer holds the rule — which reads exactly like a clean one.
+	if read == 0 {
+		t.Fatalf("nothing in this module reads any field of a %s, so this gate judged nothing "+
+			"and the rules it holds have moved", touchType)
 	}
 }
 
@@ -96,16 +113,16 @@ func TestEachRuleBearingTouchFieldHasOneReader(t *testing.T) {
 // every rule it populates.
 func fieldReadsIn(body *ast.BlockStmt) map[string]bool {
 	addressed := map[ast.Node]bool{}
-	ast.Inspect(body, func(n ast.Node) bool {
-		if unary, ok := n.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+	ast.Inspect(body, func(node ast.Node) bool {
+		if unary, isUnary := node.(*ast.UnaryExpr); isUnary && unary.Op == token.AND {
 			addressed[unary.X] = true
 		}
 		return true
 	})
 	read := map[string]bool{}
-	ast.Inspect(body, func(n ast.Node) bool {
-		sel, ok := n.(*ast.SelectorExpr)
-		if !ok || addressed[ast.Node(sel)] {
+	ast.Inspect(body, func(node ast.Node) bool {
+		sel, isSel := node.(*ast.SelectorExpr)
+		if !isSel || addressed[ast.Node(sel)] {
 			return true
 		}
 		if _, isIdent := sel.X.(*ast.Ident); isIdent {


### PR DESCRIPTION
Closes #2813.

Two independent reviews of #2806 enumerated what each of that PR's AST gates **cannot see**. All seven share one cause: *an AST gate recognises the spellings its author happened to write, and the module contains others.*

Fixed as the issue asked — **two shared remedies rather than seven point fixes**.

## Remedy 1 — recognise construction, not literals

`constructs()` replaces `buildsA`. It sees every way Go builds a populated value:

```go
T{Field: v}            a literal with elements
&T{Field: v}           the same, addressed
var x T; x.F = v       a zero value filled in afterwards
x := T{}; x.F = v      the same, as a literal
x := new(T); x.F = v   the same, as a pointer
```

A bare zero value with **nothing assigned** stays what it was — the error return every fallible function has.

`mutatesResultOf()` covers the shape that is neither a build nor a guard, and which **both** candidate gates skipped entirely: a function that takes what the one builder returned and writes a field on it. That is a second derivation in a form that reads at the call site as though it were still the first.

## Remedy 2 — classify exhaustively instead of filtering

Every function handed a lead is *placed*. Every field of the touch is *placed*. The lead-update claim is **universal over the callers of the shared assembler** rather than counted at two of them — the hard-coded `decodes < 2` is gone, not re-derived.

Under-recognition is now loud, which is the one direction AGENTS.md says a gate must not fail in.

## Also here, because they were the same defect in other clothes

- **The corpus is walked once.** `forEachModuleFile` and `moduleSQLLiterals` were two spellings of one walk (the issue's closing note).
- **`takesA` reads the receiver**, not only parameters. A method *on* the type reads its fields with the same authority.
- **The profile-field gate derives its file** from where the one path is declared, and **excludes the standard library** from the effects it reserves. That second one was latent and I made it live to check: give `writeProfileField` an `fmt.Errorf`, and a bare-identifier walk reserves `Errorf` — then `UpdateOrganizationProfileField`, which already calls `fmt.Errorf`, is reported as reaching around the one path. The finding would have been entirely an artifact of how the gate looks, arriving on somebody else's diff.
- **The open-deal census folds concatenation** and matches a *constraint on the status column* rather than the word `open`. `status = ANY($1)` and `status NOT IN ('won','lost')` are the same definition written two other ways — and "the copy that does not say the word" is what the gate's own header claims to be about.
- **The provenance census distinguishes carrying the filter from consuming it**, and refuses a reasonless explicit `nil` (presence alone was satisfied by `CapturedByKind: nil`, which *is* the defect, spelled out loud).

## Two false positives, found by writing the mutants, kept as permanent cases

Both would have shipped as green gates that fire on correct code:

1. **`.FullName` off the candidate is correct**; off the *lead* it is the second reading. A gate matching the field name alone cannot tell them apart, and `promoteTarget` does the correct one.
2. **Every list surface carries `CapturedByKind` into a filter set through a converter.** A census over reads reported *seven correct surfaces and no defect* before it learned to walk the conversion.

## Verification

`make check` green · `craft static --strict` PASS (0/0/0) · **39 mutants, 0 wrong, each proven to have applied before its gate ran**

| gate | mutants | the blind spot proved closed |
|---|---|---|
| ladder candidate derived once | 8 | `var`, `T{}`, `new(T)`, and mutation of the builder's result |
| lead-update decode keeps the gesture | 5 | `:=` and `new()`, plus the universal-claim arm |
| identity guard / candidate one name | 2 | var-built derivation; candidate read stays allowed |
| listFilters carries provenance | 6 | assembled-by-assignment; reasonless `nil` |
| provenance clause built in one place | 5 | field consumed vs carried, incl. through a converter |
| open deal count from the rollup | 6 | `= ANY`, `NOT IN`, split literals; word boundary holds |
| profile-field verbs one path | 3 | verb in another file; **stdlib not reserved** |
| touch field one reader | 4 | a method on the touch; a field the hand-list never held |

No production code changes — this PR is gates and their proofs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the seven AST gates in `backend/internal/modules/people` so each recognizes construction of a value regardless of spelling — `var x T` filled in afterwards, `T{}`, `new(T)`, or mutation of a builder's result — instead of only the literal spellings their authors wrote. Closes #2813; no production code changes.

**Key changes**

- `constructs` replaces `buildsA`; `mutatesResultOf` covers functions that write fields on what a builder returned.
- Every function and field is classified rather than filtered, so under-recognition fails loudly. The corpus is walked once, and `takesA` reads receivers and slice elements.
- The open-deal census folds concatenation and matches a constraint on the status column instead of the word `open`, and now honors the "say why" comment it asks for.
- The provenance census distinguishes carrying the filter from consuming it and refuses a reasonless explicit `nil`.
- The profile-field gate derives its file from the one path, excludes the standard library, predeclared builtins, and pure lookups from reserved effects, and reads queries the way the SQL census does — folding concatenation and resolving package-level strings to a fixed point — so concatenated or const-held writers stay in the judged population.
- An independent review's eleven claims ran as mutants; the six false failures and two false passes are each closed and kept as permanent cases. 56 mutants pass, 0 wrong.

<sup>Written for commit b9d770171f41bb05d5ea82e7e1f7045df376b617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for people-related workflows, including lead handling, deal counts, profile updates, provenance filtering, and response-touch fields.
  - Improved detection of field usage, data mutations, query patterns, filter propagation, and lead derivations.
  - Added validation for more construction, assignment, transaction, function-call, constant, and concatenated-query patterns.
  - Reduced false positives, duplicate reports, and inconsistent diagnostics across the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->