### PR TITLE
feat(frontend): the scheduled queue has a door (#1533)

### DIFF
--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -283,4 +283,27 @@ describe("useBuiltinCommands", () => {
     await user.keyboard("{Enter}");
     expect(window.location.hash).toBe("#/filters");
   });
+
+  // The scheduled queue is off the rail deliberately, so the rail-derived rows
+  // above cannot carry it and nothing else did: it was reachable only by typing
+  // the address, while a rep sat on a message they wanted back.
+  it("reaches the scheduled queue, which no rail row names", async () => {
+    const user = userEvent.setup();
+    renderProbe();
+    await user.type(screen.getByRole("textbox"), "scheduled");
+    const rows = screen.getAllByRole("button");
+    expect(rows[0].textContent).toContain("Scheduled messages");
+    await user.keyboard("{Enter}");
+    expect(window.location.hash).toBe("#/scheduled");
+  });
+
+  // The words a rep would actually type: they think "send later", which is the
+  // control they used, not "scheduled", which is what the page is called.
+  it("finds it under the words the composer's control uses", async () => {
+    const user = userEvent.setup();
+    renderProbe();
+    await user.type(screen.getByRole("textbox"), "send later");
+    await user.keyboard("{Enter}");
+    expect(window.location.hash).toBe("#/scheduled");
+  });
 });

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -297,12 +297,14 @@ describe("useBuiltinCommands", () => {
     expect(window.location.hash).toBe("#/scheduled");
   });
 
-  // The words a rep would actually type: they think "send later", which is the
-  // control they used, not "scheduled", which is what the page is called.
+  // The words a rep would actually type: they think of the CONTROL they used,
+  // not of the destination. The alias is that control's own label, so it is
+  // translated with it — English prose here would be words a German or
+  // Vietnamese reader would never type.
   it("finds it under the words the composer's control uses", async () => {
     const user = userEvent.setup();
     renderProbe();
-    await user.type(screen.getByRole("textbox"), "send later");
+    await user.type(screen.getByRole("textbox"), "Schedule send");
     await user.keyboard("{Enter}");
     expect(window.location.hash).toBe("#/scheduled");
   });

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -4,6 +4,7 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api/client";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { SCHEDULED_SCREEN } from "../screens/scheduledsends";
 import {
   settingsAddress,
   useSettingsEntryVisibility,
@@ -122,10 +123,36 @@ export function useBuiltinCommands(): Command[] {
         route: settingsAddress("ai"),
       },
     ];
+    // The scheduled queue, which is off the rail deliberately — a queue of one
+    // person's own unsent mail is not an eleventh destination (pagemeta.ts says
+    // so) — and was therefore reachable only by typing the address. The
+    // composer that queued a message is one door; this is the other, for the
+    // rep who closed that toast an hour ago and now wants the message back.
+    //
+    // Beside the settings shortcuts rather than among the rail screens above,
+    // because those are built FROM the rail: a command for a screen the rail
+    // does not carry belongs where the other off-rail ones already are.
+    const offRailScreens: Command[] = [
+      {
+        id: `screen:${SCHEDULED_SCREEN}`,
+        label: t("nav.scheduled"),
+        // The words a rep would type for it, which are not the words on the
+        // page: they think "send later", which is the control they used.
+        keywords: [SCHEDULED_SCREEN, "send later", "queue"],
+        type: "screen",
+        route: { screen: SCHEDULED_SCREEN },
+      },
+    ];
     const settingsScreens: Command[] = settingsShortcuts.filter(
       (shortcut) => visible[shortcut.entry],
     );
-    return [...screens, ...forkScreens, ...actions, ...settingsScreens];
+    return [
+      ...screens,
+      ...forkScreens,
+      ...actions,
+      ...offRailScreens,
+      ...settingsScreens,
+    ];
   }, [t, visible, locale]);
 }
 

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -137,8 +137,14 @@ export function useBuiltinCommands(): Command[] {
         id: `screen:${SCHEDULED_SCREEN}`,
         label: t("nav.scheduled"),
         // The words a rep would type for it, which are not the words on the
-        // page: they think "send later", which is the control they used.
-        keywords: [SCHEDULED_SCREEN, "send later", "queue"],
+        // page: they think of the CONTROL they used, not the destination. So
+        // the alias is that control's own label — already translated, so it is
+        // the right words in each language rather than English prose a German
+        // or Vietnamese reader would never type.
+        //
+        // The route id rides along beside it for the reason every rail command
+        // above carries one: a stable English name that survives a relabel.
+        keywords: [SCHEDULED_SCREEN, t("compose.scheduleSend")],
         type: "screen",
         route: { screen: SCHEDULED_SCREEN },
       },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2787,6 +2787,12 @@ export const de = {
     "Sie senden diese E-Mail jetzt. Dies ist eine ausgehende, unwiderrufliche Aktion.",
   "compose.schedule": "Einplanen",
   "compose.scheduleConfirmTitle": "Diese E-Mail einplanen?",
+  // The composer computed that it had scheduled a send and said nothing —
+  // it closed the way a SENT message closes it. The confirm dialog above
+  // promises a place to move or withdraw the message from; these two are how a
+  // rep gets there.
+  "compose.scheduledQueued": "Geplant. Sie ist noch nicht rausgegangen.",
+  "compose.scheduledOpenQueue": "Geplante Nachrichten",
   "compose.scheduleBody":
     "Sie geht nicht jetzt hinaus. Sie wartet auf den gewählten Zeitpunkt, und die Einwilligungs- und Postfachprüfungen laufen dann erneut. Bis sie hinausgeht, können Sie sie unter „Geplante Nachrichten“ verschieben oder zurückziehen.",
   "compose.sendMessageConfirmTitle": "Diese Nachricht senden?",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2824,6 +2824,12 @@ export const en = {
   // neither, and it can be moved or withdrawn until it goes.
   "compose.schedule": "Schedule send",
   "compose.scheduleConfirmTitle": "Schedule this email?",
+  // The composer computed that it had scheduled a send and said nothing —
+  // it closed the way a SENT message closes it. The confirm dialog above
+  // promises a place to move or withdraw the message from; these two are how a
+  // rep gets there.
+  "compose.scheduledQueued": "Scheduled. It has not gone out yet.",
+  "compose.scheduledOpenQueue": "Scheduled messages",
   "compose.scheduleBody":
     "This does not go out now. It waits for the moment you picked, and the consent and mailbox checks run again then. Until it goes you can move it or take it back from Scheduled messages.",
   "compose.sendMessageConfirmTitle": "Send this message?",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2766,6 +2766,12 @@ export const vi = {
     "Bạn đang gửi email này ngay bây giờ. Đây là hành động gửi ra ngoài, không đảo ngược được.",
   "compose.schedule": "Hẹn giờ",
   "compose.scheduleConfirmTitle": "Hẹn giờ gửi email này?",
+  // The composer computed that it had scheduled a send and said nothing —
+  // it closed the way a SENT message closes it. The confirm dialog above
+  // promises a place to move or withdraw the message from; these two are how a
+  // rep gets there.
+  "compose.scheduledQueued": "Đã lên lịch. Thư chưa được gửi đi.",
+  "compose.scheduledOpenQueue": "Thư đã lên lịch",
   "compose.scheduleBody":
     "Email không đi ngay lúc này. Nó chờ đến thời điểm bạn đã chọn, và các bước kiểm tra đồng ý cùng hộp thư sẽ chạy lại khi đó. Trước khi nó đi, bạn có thể chuyển thời điểm hoặc thu hồi nó ở “Tin nhắn đã hẹn giờ”.",
   "compose.sendMessageConfirmTitle": "Gửi tin nhắn này?",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2770,8 +2770,8 @@ export const vi = {
   // it closed the way a SENT message closes it. The confirm dialog above
   // promises a place to move or withdraw the message from; these two are how a
   // rep gets there.
-  "compose.scheduledQueued": "Đã lên lịch. Thư chưa được gửi đi.",
-  "compose.scheduledOpenQueue": "Thư đã lên lịch",
+  "compose.scheduledQueued": "Đã lên lịch. Tin nhắn chưa được gửi đi.",
+  "compose.scheduledOpenQueue": "Tin nhắn đã lên lịch",
   "compose.scheduleBody":
     "Email không đi ngay lúc này. Nó chờ đến thời điểm bạn đã chọn, và các bước kiểm tra đồng ý cùng hộp thư sẽ chạy lại khi đó. Trước khi nó đi, bạn có thể chuyển thời điểm hoặc thu hồi nó ở “Tin nhắn đã hẹn giờ”.",
   "compose.sendMessageConfirmTitle": "Gửi tin nhắn này?",

--- a/frontend/src/screens/compose.scheduled.test.tsx
+++ b/frontend/src/screens/compose.scheduled.test.tsx
@@ -1,0 +1,180 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { pickOption } from "../design-system/select-testing";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+
+// The door out of a scheduled send.
+//
+// The composer already computed whether it had scheduled — 201 waits, 202 has
+// gone — and its own comment said the caller is told "so it can say so". It
+// then closed both the same way and said nothing, while the confirm dialog the
+// rep had just read promised: "you can move it or take it back from Scheduled
+// messages." Nothing in the product went there (issue #1533).
+//
+// Its own file rather than compose.test.tsx, which is 2128 lines against the
+// 1000-line ceiling frontend/AGENTS.md sets.
+
+type Activity = components["schemas"]["Activity"];
+
+// The one purpose with no unsubscribe requirement, so the form is sendable with
+// nothing else filled in.
+const PURPOSE_LABEL = "Deal messages";
+
+const ACTIVITY: Activity = {
+  id: "act-1",
+  kind: "email",
+  subject: "Re: Q3",
+  occurred_at: "2026-07-01T00:00:00Z",
+  is_done: false,
+  source: "manual",
+  captured_by: "human:u1",
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// The send answers with the status under test and everything else answers
+// empty, so nothing this screen reads on mount can fail the case for a reason
+// that is not about the door.
+function stubSend(status: number) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      if (method === "POST" && url.pathname.endsWith("/send-email")) {
+        return jsonResponse(ACTIVITY, status);
+      }
+      // The one purpose the form needs to be sendable. Transactional because it
+      // is the unsubscribe-free lane, so nothing else has to be filled in.
+      if (url.pathname.endsWith("/consent-purposes")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "p1",
+              key: "transactional",
+              label: PURPOSE_LABEL,
+              requires_double_opt_in: false,
+              is_active: true,
+            },
+          ],
+          page: { next_cursor: null },
+        });
+      }
+      return jsonResponse({ data: [], page: { next_cursor: null } });
+    }),
+  );
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          {ui}
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function composeAndSend() {
+  const onClose = vi.fn();
+  render(
+    <ComposeModal
+      activityId="act-1"
+      entityType="person"
+      entityId="p-1"
+      open
+      onClose={onClose}
+    />,
+  );
+  await screen.findByRole("combobox");
+  await userEvent.type(screen.getByLabelText("To"), "a@x.com");
+  await userEvent.tab();
+  await userEvent.type(screen.getByPlaceholderText("Subject"), "Hi there");
+  await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
+  await pickOption(
+    userEvent.setup(),
+    screen.getByRole("combobox"),
+    PURPOSE_LABEL,
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Send" }));
+  return onClose;
+}
+
+beforeEach(() => {
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("a scheduled send is reachable again", () => {
+  it("names the queue and opens it", async () => {
+    stubSend(201);
+    await composeAndSend();
+
+    // The message says the send has NOT happened, which is the half a rep acts
+    // on: a confirmation reading "sent" beside a door to withdraw it would
+    // contradict itself.
+    expect(
+      await screen.findByText("Scheduled. It has not gone out yet."),
+    ).toBeTruthy();
+
+    const door = screen.getByRole("button", { name: "Scheduled messages" });
+    await userEvent.click(door);
+    expect(window.location.hash).toBe("#/scheduled");
+  });
+
+  // The door belongs to the outcome, not to the composer: a message that has
+  // GONE cannot be moved or taken back, and offering the queue for one would
+  // point a rep at a screen their message is not on.
+  it("offers no door when the message has already gone", async () => {
+    stubSend(202);
+    const onClose = await composeAndSend();
+
+    // Waited on the send having COMPLETED, not on a duration: an absence
+    // asserted before the response landed is an absence that would survive the
+    // door being added back.
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("button", { name: "Scheduled messages" }),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Scheduled. It has not gone out yet."),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -37,6 +37,7 @@ import {
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { Select, type SelectOption } from "../design-system/select";
+import { useToast } from "../design-system/toast";
 import {
   formatDateAbbrev,
   formatDateTime,
@@ -63,6 +64,7 @@ import {
   useProjectRecord,
   withSubjectTag,
 } from "./projectrecord";
+import { SCHEDULED_SCREEN } from "./scheduledsends";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
 
@@ -1908,6 +1910,7 @@ export function ComposeModal({
   const [pickingMoment, setPickingMoment] = useState(false);
   const { locale } = useLocale();
   const zone = viewerZone();
+  const toast = useToast();
   const [provenance, setProvenance] = useState<DraftProvenance | null>(null);
   // The served voice draft the body in this form came from. It is what lets the
   // server say whether the rep sent the draft or rewrote it, so it may only ever
@@ -2110,6 +2113,23 @@ export function ComposeModal({
       }
       for (const queryKey of entityTimelineKeys(entityType, entityId)) {
         queryClient.invalidateQueries({ queryKey });
+      }
+      // A scheduled send is the one outcome here the rep may need to UNDO, and
+      // until now the composer computed that it had scheduled one and said
+      // nothing — it closed the same way a sent message closes it. The confirm
+      // dialog they just read promised "you can move it or take it back from
+      // Scheduled messages", and nothing in the product went there.
+      //
+      // The verb makes it sticky, which is what this needs and a plain
+      // confirmation does not: the door is the point, and a toast that withdrew
+      // itself after three and a half seconds would take the door with it.
+      if (result.scheduled) {
+        toast.show(t("compose.scheduledQueued"), {
+          action: {
+            label: t("compose.scheduledOpenQueue"),
+            onAct: () => navigate({ screen: SCHEDULED_SCREEN }),
+          },
+        });
       }
       onClose();
     },


### PR DESCRIPTION
Closes #1533.

## The screen was not the gap

`frontend/src/screens/scheduledsends.tsx` lists the queue, PATCHes a new time, and POSTs a cancel — and has since it shipped. The issue's premise ("nothing in `frontend/src` calls the scheduled-send endpoints") is stale.

What is not stale is its conclusion. **Nothing links to it.** `#/scheduled` is in `SCREENS` and in `App.tsx`'s dispatch and appears in no rail row, no palette command, and no affordance anywhere — reachable only by typing the address. So "send later" was still a one-way door, and the composer's own confirm dialog was promising otherwise:

> This does not go out now. … Until it goes you can move it or take it back from **Scheduled messages**.

## Where the doors belong was already decided

`pagemeta.ts` records it, and I did not relitigate it:

> Off the rail deliberately. The rail carries the product's ten destinations and a queue of one person's own unsent mail is not an eleventh; it is reached **from the composer that put a message in it** and from Today, where the same rep's other waiting work already lives.

Two of those three did not exist. This builds the composer door and a palette one; **Today is not touched**, because its lanes come from the server's `/attention` response — a lane there is a contract change and a backend change, which is a different piece of work from the one this issue describes as frontend-shaped.

## The composer

It already knew. `send`'s result carries `scheduled: response.status === 201`, under a comment saying *"201 is a message that will go later; 202 is one that has gone. Both close the composer, and the caller is told which so it can say so."* `onSuccess` then closed both the same way and said nothing.

A scheduled send now says so and carries the door. The **verb makes the toast sticky**, which is the point rather than a side effect: a confirmation that withdrew itself after 3.5s would take the door with it.

A **sent** message gets neither the message nor the door, and that is asserted. A message that has gone cannot be moved or taken back, and offering the queue for one would point a rep at a screen their message is not on.

## The palette

For the rep who dismissed that toast an hour ago and now wants the message back.

Beside the settings shortcuts rather than among the rail rows above them — those are built *from* `NAV`, so a command for a screen the rail deliberately does not carry belongs where the other off-rail ones already are. Findable under **"send later"** as well as the page's name: that is the control they used, and it is not what the page is called.

## Tests

| case | what it holds |
|---|---|
| names the queue and opens it | the message says the send has **not** happened, and the door lands on `#/scheduled` |
| offers no door when the message has already gone | waits on the send *completing* — an absence asserted before the response landed would survive the door being added back |
| reaches the scheduled queue, which no rail row names | the palette row exists at all, which no rail-derived row could supply |
| finds it under the words the composer's control uses | `"send later"` reaches it |

Mutation-checked:

| mutation | caught by |
|---|---|
| the composer stops naming the queue | `names the queue and opens it` |
| the door navigates to `today` instead | the same case, on the hash |
| the palette drops the command | both palette cases |

## Notes

Copy added to all three locales together. The composer's cases are in their own `compose.scheduled.test.tsx`: `compose.test.tsx` is 2128 lines against the 1000-line ceiling `frontend/AGENTS.md` sets, and adding to it would push it further.

Rebased onto #1503's fork seam, which also touched the palette's command list; the two compose cleanly — fork screens and off-rail screens are separate arms of the same return.

`make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled messages to the command palette, searchable by “scheduled” and the localized “Schedule send” action.
  * After scheduling a message, a persistent confirmation notification links directly to the scheduled messages queue.
  * Added localized scheduled-message confirmations and queue labels in English, German, and Vietnamese.
* **Bug Fixes**
  * Improved composer handling so scheduled messages display the correct confirmation and regular sends continue without scheduled-message messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->