### PR TITLE
fix(http): every JSON body is bounded in one place (#1548)

### DIFF
--- a/backend/gates/requestbodybound_test.go
+++ b/backend/gates/requestbodybound_test.go
@@ -48,7 +48,11 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-const httperrPkg = "github.com/margince/margince/backend/internal/platform/httperr"
+const (
+	netHTTPPkg      = "net/http"
+	encodingJSONPkg = "encoding/json"
+	ioPkg           = "io"
+)
 
 // The package that owns the bound. Its own reader is the one every other file
 // is required to reach, so it cannot be required to reach itself.
@@ -95,7 +99,7 @@ func fileTouchesRequestBody(_ string, file *ast.File) bool {
 		if !ok || fn.Body == nil {
 			continue
 		}
-		if request := requestParam(fn); request != "" && touchesBodyOf(fn.Body, request) {
+		if requests := requestParams(file, fn); len(requests) > 0 && touchesBodyOf(fn.Body, requests) {
 			return true
 		}
 	}
@@ -111,34 +115,57 @@ func fileTouchesRequestBody(_ string, file *ast.File) bool {
 // sent — a matcher on `.Body` alone reported both, plus every test harness that
 // builds a request to send. What this rule is about is the one body that
 // arrives from outside and whose size the sender chooses.
-func requestParam(fn *ast.FuncDecl) string {
+func requestParams(file *ast.File, fn *ast.FuncDecl) []string {
 	if fn.Type.Params == nil {
-		return ""
+		return nil
 	}
+	qualifier, dotImported := gatekit.ImportedAs(file, netHTTPPkg)
+	var names []string
 	for _, field := range fn.Type.Params.List {
 		star, ok := field.Type.(*ast.StarExpr)
 		if !ok {
 			continue
 		}
-		sel, ok := star.X.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "Request" {
+		if !isHTTPRequestType(star.X, qualifier, dotImported) {
 			continue
 		}
-		pkg, ok := sel.X.(*ast.Ident)
-		if !ok || pkg.Name != "http" {
-			continue
-		}
-		if len(field.Names) > 0 && field.Names[0].Name != "_" {
-			return field.Names[0].Name
+		// EVERY name in the field, not the first. `func h(w http.ResponseWriter,
+		// r, next *http.Request)` declares two, and a matcher taking only
+		// `field.Names[0]` would read one of them and let the other through.
+		for _, name := range field.Names {
+			if name.Name != "_" {
+				names = append(names, name.Name)
+			}
 		}
 	}
-	return ""
+	return names
 }
 
-func touchesBodyOf(body *ast.BlockStmt, request string) bool {
+// isHTTPRequestType matches `http.Request` under the name this file gave
+// net/http, or the bare `Request` a dot-import puts in scope.
+//
+// Resolved from the IMPORT PATH rather than from the identifier `http`. An
+// alias — `stdhttp "net/http"` — would otherwise slip every handler in the file
+// past this gate, and the alias is not exotic: a file importing two packages
+// that both end in `http` has to rename one.
+func isHTTPRequestType(expr ast.Expr, qualifier string, dotImported bool) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return dotImported && t.Name == "Request"
+	case *ast.SelectorExpr:
+		if t.Sel.Name != "Request" {
+			return false
+		}
+		pkg, ok := t.X.(*ast.Ident)
+		return ok && qualifier != "" && pkg.Name == qualifier
+	}
+	return false
+}
+
+func touchesBodyOf(body *ast.BlockStmt, requests []string) bool {
 	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
-		if isBodyOf(n, request) {
+		if isBodyOfAny(n, requests) {
 			found = true
 		}
 		return true
@@ -155,8 +182,8 @@ func rawBodyDecodesIn(parsed gatekit.ParsedFile) []string {
 		if !ok || fn.Body == nil {
 			continue
 		}
-		request := requestParam(fn)
-		if request == "" {
+		requests := requestParams(parsed.File, fn)
+		if len(requests) == 0 {
 			continue
 		}
 		// A function that has already replaced the body with a bounded reader
@@ -164,7 +191,7 @@ func rawBodyDecodesIn(parsed gatekit.ParsedFile) []string {
 		// The overlay webhook does exactly that and says why: MaxBytesReader
 		// rather than a bare LimitReader, so an over-cap batch answers 413
 		// instead of being truncated and then rejected as a bad signature.
-		if boundsItsOwnBody(fn.Body, request) {
+		if boundsItsOwnBody(fn.Body, requests) {
 			continue
 		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -188,7 +215,7 @@ func rawBodyDecodesIn(parsed gatekit.ParsedFile) []string {
 			// TRUNCATE rather than refuse, which is right for a peek that falls
 			// back and wrong for a decode, and the handler behind them still
 			// answers the oversized body itself.
-			shape := forbiddenBodyRead(call, request)
+			shape := forbiddenBodyRead(parsed.File, call, requests)
 			if shape == "" {
 				return true
 			}
@@ -199,28 +226,36 @@ func rawBodyDecodesIn(parsed gatekit.ParsedFile) []string {
 	return dedupeSites(sites)
 }
 
-// isBodyOf matches `<request>.Body` for the name this function gave its
+// isBodyOfAny matches `<request>.Body` for ANY name this function gave an
 // *http.Request, and nothing else.
-func isBodyOf(n ast.Node, request string) bool {
+func isBodyOfAny(n ast.Node, requests []string) bool {
 	sel, ok := n.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Body" {
 		return false
 	}
 	ident, ok := sel.X.(*ast.Ident)
-	return ok && ident.Name == request
+	if !ok {
+		return false
+	}
+	for _, request := range requests {
+		if ident.Name == request {
+			return true
+		}
+	}
+	return false
 }
 
 // boundsItsOwnBody reports `<request>.Body = http.MaxBytesReader(…)` anywhere in
 // this function — the one way a handler may take the bound into its own hands,
 // and it can only ever TIGHTEN what the chassis already granted.
-func boundsItsOwnBody(body *ast.BlockStmt, request string) bool {
+func boundsItsOwnBody(body *ast.BlockStmt, requests []string) bool {
 	bounded := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		assign, ok := n.(*ast.AssignStmt)
 		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
 			return true
 		}
-		if !isBodyOf(assign.Lhs[0], request) {
+		if !isBodyOfAny(assign.Lhs[0], requests) {
 			return true
 		}
 		call, ok := assign.Rhs[0].(*ast.CallExpr)
@@ -236,23 +271,39 @@ func boundsItsOwnBody(body *ast.BlockStmt, request string) bool {
 }
 
 // forbiddenBodyRead names the shape if this call is one of the two, or "".
-func forbiddenBodyRead(call *ast.CallExpr, request string) string {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
+//
+// Both are resolved through the file's own imports. `codec "encoding/json"` and
+// `reader "io"` are legal and would otherwise walk straight past a matcher
+// keyed on the identifiers `json` and `io` — which is the same hole the request
+// type had, one layer along.
+func forbiddenBodyRead(file *ast.File, call *ast.CallExpr, requests []string) string {
+	if len(call.Args) == 0 || !isBodyOfAny(call.Args[0], requests) {
 		return ""
 	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-	takesBody := len(call.Args) > 0 && isBodyOf(call.Args[0], request)
-	switch {
-	case pkg.Name == "json" && sel.Sel.Name == "NewDecoder" && takesBody:
+	if callsPackageFunc(file, call.Fun, encodingJSONPkg, "NewDecoder") {
 		return "json.NewDecoder"
-	case pkg.Name == "io" && sel.Sel.Name == "ReadAll" && takesBody:
+	}
+	if callsPackageFunc(file, call.Fun, ioPkg, "ReadAll") {
 		return "io.ReadAll with no limiter"
 	}
 	return ""
+}
+
+// callsPackageFunc reports a call to importPath.name under whatever name this
+// file gave that import, dot-imports included.
+func callsPackageFunc(file *ast.File, fun ast.Expr, importPath, name string) bool {
+	qualifier, dotImported := gatekit.ImportedAs(file, importPath)
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return dotImported && f.Name == name
+	case *ast.SelectorExpr:
+		if f.Sel.Name != name {
+			return false
+		}
+		pkg, ok := f.X.(*ast.Ident)
+		return ok && qualifier != "" && pkg.Name == qualifier
+	}
+	return false
 }
 
 func dedupeSites(items []string) []string {
@@ -342,6 +393,75 @@ import ("io"; "net/http")
 const peek = 4096
 func h(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.ReadAll(io.LimitReader(r.Body, peek))
+}`,
+			leaks: 0,
+		},
+		// Every one of these renames something the matcher used to key on by
+		// spelling. None is exotic — a file importing two packages that both
+		// end in `http` has to rename one — and each would have walked a whole
+		// file past the gate.
+		"net/http under an alias": {
+			source: `package p
+import (
+	"encoding/json"
+	stdhttp "net/http"
+)
+func h(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	var req struct{ A string }
+	_ = json.NewDecoder(r.Body).Decode(&req)
+}`,
+			leaks: 1,
+		},
+		"encoding/json under an alias": {
+			source: `package p
+import (
+	codec "encoding/json"
+	"net/http"
+)
+func h(w http.ResponseWriter, r *http.Request) {
+	var req struct{ A string }
+	_ = codec.NewDecoder(r.Body).Decode(&req)
+}`,
+			leaks: 1,
+		},
+		"io under an alias": {
+			source: `package p
+import (
+	reader "io"
+	"net/http"
+)
+func h(w http.ResponseWriter, r *http.Request) {
+	_, _ = reader.ReadAll(r.Body)
+}`,
+			leaks: 1,
+		},
+		// A grouped parameter declares two names in one field, and the matcher
+		// took only the first — so a read through the second was invisible.
+		"the second of two request parameters": {
+			source: `package p
+import (
+	"encoding/json"
+	"net/http"
+)
+func h(w http.ResponseWriter, first, second *http.Request) {
+	var req struct{ A string }
+	_ = json.NewDecoder(second.Body).Decode(&req)
+}`,
+			leaks: 1,
+		},
+		// And the other direction, which is what makes resolving the import
+		// load-bearing rather than decorative: a same-named function from a
+		// DIFFERENT package. `bounded.ReadAll` is somebody's own helper that
+		// already applies a cap, and a matcher keyed on the name alone would
+		// report it as an unbounded read.
+		"a same-named helper from another package": {
+			source: `package p
+import (
+	"net/http"
+	"example.test/bounded"
+)
+func h(w http.ResponseWriter, r *http.Request) {
+	_, _ = bounded.ReadAll(r.Body)
 }`,
 			leaks: 0,
 		},

--- a/backend/gates/requestbodybound_test.go
+++ b/backend/gates/requestbodybound_test.go
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+//go:build !integration
+
+package gates
+
+// Every JSON request body is bounded in one place.
+//
+// "A JSON body is at most 1 MiB" used to live in two: the chassis
+// (httpserver.LimitBodies) and httperr.Decode. A handler decoding r.Body
+// directly was correct — the chassis bounds it — and nothing said so, so the
+// chassis was its ONLY bound. Nineteen handlers did, two of them
+// unauthenticated, and three took []string bodies, which is the shape where a
+// widened ceiling becomes heap amplification rather than a big string.
+//
+// The cost is not that they were wrong. It is that they were correct BY
+// ACCIDENT of a decision made somewhere else: an earlier cut of the
+// route-ceiling work widened on Content-Type alone and those nineteen silently
+// became 25 MB each, and no test anywhere failed. That is what this refuses —
+// a bound a handler inherits without naming, which the next change to the
+// chassis can take away in silence.
+//
+// The enumeration in the issue that found this listed sixteen. By the time it
+// was fixed there were nineteen. Which is the argument for a rule rather than a
+// list, and this gate is that rule.
+//
+// WHAT IS PERMITTED. httperr.Decode for a handler answering problem+json, and
+// httperr.DecodeOrRefusal for the two whose wire shape is somebody else's — dynamic
+// client registration speaks RFC 7591, a report run treats an absent body as
+// its defaults. Both go through the same reader and the same cap; only the
+// refusal differs. What is forbidden is reaching r.Body with a decoder at all.
+//
+// NOT A SIZE CHECK. This gate cannot see how large a body may be — that is
+// httperr.MaxBodyBytes and the operator's per-route upload ceiling. It sees
+// only whether a handler asked for the bound or inherited it, which is the
+// property that decides whether a chassis change can silently unbind it.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+const httperrPkg = "github.com/margince/margince/backend/internal/platform/httperr"
+
+// The package that owns the bound. Its own reader is the one every other file
+// is required to reach, so it cannot be required to reach itself.
+const httperrDir = "/platform/httperr/"
+
+func TestNoHandlerDecodesARequestBodyItself(t *testing.T) {
+	t.Parallel()
+
+	files := gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: fileTouchesRequestBody,
+		// Not extensions/: a unit never holds an *http.Request. The core
+		// answers its routes and hands it a decoded record.
+	}.Files(t)
+
+	judged := 0
+	for _, parsed := range files {
+		if strings.Contains(parsed.Path, httperrDir) {
+			continue
+		}
+		judged++
+		for _, site := range rawBodyDecodesIn(parsed) {
+			t.Errorf("%s: %s reads r.Body with its own decoder.\n"+
+				"\tThe 1 MiB cap then comes only from the chassis, which this file does not "+
+				"mention and cannot be held to — an earlier widening of the route ceiling made "+
+				"exactly these handlers 25 MB each with no test failing.\n"+
+				"\tUse httperr.Decode, or httperr.DecodeOrRefusal if this endpoint answers in a wire "+
+				"shape that is not problem+json.", parsed.Path, site)
+		}
+	}
+	// A prohibition that swept nothing reads exactly like a clean tree, and the
+	// count is taken after the exclusion: httperr's own files touch r.Body by
+	// definition, so counting before it would let a walk that found only those
+	// report a successful empty run.
+	if judged == 0 {
+		t.Fatal("no file outside httperr touches a request body, so this prohibition judged " +
+			"nothing — the walk is broken, or the shapes it looks for were renamed")
+	}
+}
+
+func fileTouchesRequestBody(_ string, file *ast.File) bool {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if request := requestParam(fn); request != "" && touchesBodyOf(fn.Body, request) {
+			return true
+		}
+	}
+	return false
+}
+
+// requestParam is the name this function gave its *http.Request, or "" for one
+// that takes none.
+//
+// The PARAMETER, not any identifier spelled `r`. `resp.Body` on an outbound
+// call is a response this code is reading back, `req.Body` on a request this
+// code is BUILDING is a body it wrote itself, and neither is a body a caller
+// sent — a matcher on `.Body` alone reported both, plus every test harness that
+// builds a request to send. What this rule is about is the one body that
+// arrives from outside and whose size the sender chooses.
+func requestParam(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil {
+		return ""
+	}
+	for _, field := range fn.Type.Params.List {
+		star, ok := field.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		sel, ok := star.X.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Request" {
+			continue
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "http" {
+			continue
+		}
+		if len(field.Names) > 0 && field.Names[0].Name != "_" {
+			return field.Names[0].Name
+		}
+	}
+	return ""
+}
+
+func touchesBodyOf(body *ast.BlockStmt, request string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if isBodyOf(n, request) {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// rawBodyDecodesIn reports each place this file builds a reader over r.Body,
+// named by the function it sits in.
+func rawBodyDecodesIn(parsed gatekit.ParsedFile) []string {
+	var sites []string
+	for _, decl := range parsed.File.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		request := requestParam(fn)
+		if request == "" {
+			continue
+		}
+		// A function that has already replaced the body with a bounded reader
+		// has named its cap in view, which is the property this gate is about.
+		// The overlay webhook does exactly that and says why: MaxBytesReader
+		// rather than a bare LimitReader, so an over-cap batch answers 413
+		// instead of being truncated and then rejected as a bad signature.
+		if boundsItsOwnBody(fn.Body, request) {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// TWO SHAPES, and only two.
+			//
+			// `json.NewDecoder(r.Body)` — a decoder straight onto the body,
+			// which is the shape with no cap of its own anywhere in view.
+			//
+			// `io.ReadAll(r.Body)` with no limiter — the same, one layer down.
+			//
+			// What is NOT forbidden is a bounded peek: several edges read a
+			// prefix of the body to throttle on, put it back in front of the
+			// unread remainder, and hand the handler the request the client
+			// actually sent. Those name their own cap on the line
+			// (`io.LimitReader(r.Body, linkRequestBodyLimit)`), which is the
+			// property this gate is about — a bound a reader can see. They
+			// TRUNCATE rather than refuse, which is right for a peek that falls
+			// back and wrong for a decode, and the handler behind them still
+			// answers the oversized body itself.
+			shape := forbiddenBodyRead(call, request)
+			if shape == "" {
+				return true
+			}
+			sites = append(sites, fn.Name.Name+" ("+shape+")")
+			return false
+		})
+	}
+	return dedupeSites(sites)
+}
+
+// isBodyOf matches `<request>.Body` for the name this function gave its
+// *http.Request, and nothing else.
+func isBodyOf(n ast.Node, request string) bool {
+	sel, ok := n.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Body" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == request
+}
+
+// boundsItsOwnBody reports `<request>.Body = http.MaxBytesReader(…)` anywhere in
+// this function — the one way a handler may take the bound into its own hands,
+// and it can only ever TIGHTEN what the chassis already granted.
+func boundsItsOwnBody(body *ast.BlockStmt, request string) bool {
+	bounded := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		if !isBodyOf(assign.Lhs[0], request) {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "MaxBytesReader" {
+			bounded = true
+		}
+		return true
+	})
+	return bounded
+}
+
+// forbiddenBodyRead names the shape if this call is one of the two, or "".
+func forbiddenBodyRead(call *ast.CallExpr, request string) string {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	takesBody := len(call.Args) > 0 && isBodyOf(call.Args[0], request)
+	switch {
+	case pkg.Name == "json" && sel.Sel.Name == "NewDecoder" && takesBody:
+		return "json.NewDecoder"
+	case pkg.Name == "io" && sel.Sel.Name == "ReadAll" && takesBody:
+		return "io.ReadAll with no limiter"
+	}
+	return ""
+}
+
+func dedupeSites(items []string) []string {
+	var kept []string
+	seen := map[string]bool{}
+	for _, item := range items {
+		if !seen[item] {
+			seen[item] = true
+			kept = append(kept, item)
+		}
+	}
+	return kept
+}
+
+// What the rule must and must not catch, written here because the tree no
+// longer contains either kind.
+//
+// Every case above runs over a converted tree, so all of them pass whether the
+// walk distinguishes a request body from a response body or not — and that
+// distinction is the whole of the matcher. A `.Body` matcher with no request
+// parameter behind it reported thirteen files on its first run: outbound
+// responses being read back, requests this code was BUILDING, and every test
+// harness that sends one.
+func TestOnlyAnInboundRequestBodyIsJudged(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		source string
+		leaks  int
+	}{
+		"a decoder straight onto the request body": {
+			source: `package p
+import ("encoding/json"; "net/http")
+func h(w http.ResponseWriter, r *http.Request) {
+	var req struct{ A string }
+	_ = json.NewDecoder(r.Body).Decode(&req)
+}`,
+			leaks: 1,
+		},
+		// Whatever the handler named its request. Several in this tree do not
+		// call it `r`, and a matcher keyed on the spelling would miss them.
+		"the same, on a request named something else": {
+			source: `package p
+import ("encoding/json"; "net/http")
+func h(w http.ResponseWriter, req *http.Request) {
+	var body struct{ A string }
+	_ = json.NewDecoder(req.Body).Decode(&body)
+}`,
+			leaks: 1,
+		},
+		"an unlimited read of the request body": {
+			source: `package p
+import ("io"; "net/http")
+func h(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.ReadAll(r.Body)
+}`,
+			leaks: 1,
+		},
+		// A RESPONSE this code read back from somewhere else. Its size is the
+		// far end's problem, and it is not a body a caller sent here.
+		"a response body from an outbound call": {
+			source: `package p
+import ("encoding/json"; "net/http")
+func h(w http.ResponseWriter, r *http.Request) {
+	resp, _ := http.Get("https://example.invalid")
+	var out struct{ A string }
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+}`,
+			leaks: 0,
+		},
+		// The handler bounded it itself, which is the one sanctioned way — and
+		// it can only tighten what the chassis already granted.
+		"a body the handler bounded first": {
+			source: `package p
+import ("io"; "net/http")
+func h(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+	_, _ = io.ReadAll(r.Body)
+}`,
+			leaks: 0,
+		},
+		// A bounded peek: the cap is on the line, and the handler behind it
+		// still answers the body the client actually sent.
+		"a peek with its own named cap": {
+			source: `package p
+import ("io"; "net/http")
+const peek = 4096
+func h(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.ReadAll(io.LimitReader(r.Body, peek))
+}`,
+			leaks: 0,
+		},
+		"the sanctioned decode": {
+			source: `package p
+import (
+	"net/http"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+func h(w http.ResponseWriter, r *http.Request) {
+	var req struct{ A string }
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+}`,
+			leaks: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			file, err := parser.ParseFile(token.NewFileSet(), "probe.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			sites := rawBodyDecodesIn(gatekit.ParsedFile{Path: "probe.go", File: file})
+			if len(sites) != tc.leaks {
+				t.Errorf("found %d site(s) %v, want %d", len(sites), sites, tc.leaks)
+			}
+			// The scope predicate must agree with the finder: a file the sweep
+			// never enters is one whose findings nobody reads.
+			if reads := fileTouchesRequestBody("probe.go", file); tc.leaks > 0 && !reads {
+				t.Error("the finder reports a site in a file the sweep would not enter")
+			}
+		})
+	}
+}

--- a/backend/internal/compose/backfilltransport.go
+++ b/backend/internal/compose/backfilltransport.go
@@ -182,7 +182,16 @@ func (h backfillHandlers) PreviewConnectorBackfill(w http.ResponseWriter, r *htt
 		return
 	}
 	var req crmcontracts.BackfillPreviewRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// The refusal is the DOMAIN's, not the decoder's: this endpoint takes one
+	// field and a body it cannot read is a caller who has not picked a window,
+	// which is what they need to be told. So the bound and the decode come from
+	// httperr and the answer stays here — a size refusal excepted, because
+	// "your request was too big" is not "pick a window".
+	if err := httperr.DecodeOrRefusal(w, r, &req); err != nil {
+		if httperr.BodyTooLarge(err) {
+			httperr.Write(w, r, err)
+			return
+		}
 		httperr.Write(w, r, &httperr.DetailedError{
 			Status: http.StatusUnprocessableEntity, Code: "window_required",
 			Detail: "Pick a window: none, " + windowOffer + ".",
@@ -249,7 +258,16 @@ func (h backfillHandlers) StartConnectorBackfill(w http.ResponseWriter, r *http.
 		return
 	}
 	var req crmcontracts.StartBackfillRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// The refusal is the DOMAIN's, not the decoder's: this endpoint takes one
+	// field and a body it cannot read is a caller who has not picked a window,
+	// which is what they need to be told. So the bound and the decode come from
+	// httperr and the answer stays here — a size refusal excepted, because
+	// "your request was too big" is not "pick a window".
+	if err := httperr.DecodeOrRefusal(w, r, &req); err != nil {
+		if httperr.BodyTooLarge(err) {
+			httperr.Write(w, r, err)
+			return
+		}
 		httperr.Write(w, r, &httperr.DetailedError{
 			Status: http.StatusUnprocessableEntity, Code: "window_required",
 			Detail: "Pick a window: " + windowOffer + ".",

--- a/backend/internal/compose/handlers_ai_routing.go
+++ b/backend/internal/compose/handlers_ai_routing.go
@@ -11,7 +11,6 @@ package compose
 // wire mapping and the human-only refusal.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -50,8 +49,7 @@ func (h aiRoutingHandlers) ReplaceAiRouting(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	var req crmcontracts.AiRouting
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	cfg, err := h.store.Replace(r.Context(), fromContractAiRouting(req))

--- a/backend/internal/compose/handlers_blockeddomains.go
+++ b/backend/internal/compose/handlers_blockeddomains.go
@@ -10,7 +10,6 @@ package compose
 // the company.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -62,8 +61,7 @@ func (h blockedDomainHandlers) SetBlockedDomain(w http.ResponseWriter, r *http.R
 		return
 	}
 	var body crmcontracts.SetBlockedDomainRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &body) {
 		return
 	}
 	// Shape is the transport's job, and it is checked HERE so a caller learns

--- a/backend/internal/compose/handlers_capture_settings.go
+++ b/backend/internal/compose/handlers_capture_settings.go
@@ -9,7 +9,6 @@ package compose
 // audit-only write.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -47,8 +46,7 @@ func (h captureSettingsHandlers) UpdateCaptureSettings(w http.ResponseWriter, r 
 		return
 	}
 	var req crmcontracts.UpdateCaptureSettingsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	settings, err := h.store.Update(r.Context(), req.AutoEnrich, req.MailSharing, req.SignatureEnrich)

--- a/backend/internal/compose/handlers_captureexclusions.go
+++ b/backend/internal/compose/handlers_captureexclusions.go
@@ -9,7 +9,6 @@ package compose
 // the audited write.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -39,8 +38,7 @@ func (h captureExclusionHandlers) ListCaptureExclusions(w http.ResponseWriter, r
 
 func (h captureExclusionHandlers) CreateCaptureExclusion(w http.ResponseWriter, r *http.Request) {
 	var req crmcontracts.CreateCaptureExclusionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	rule, err := h.store.Add(r.Context(), string(req.Scope), string(req.Kind), req.Value)

--- a/backend/internal/compose/handlers_consumermaildomains.go
+++ b/backend/internal/compose/handlers_consumermaildomains.go
@@ -11,7 +11,6 @@ package compose
 // RBAC gates, the normalization and the audit-only write.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -83,8 +82,7 @@ func (h consumerMailDomainHandlers) AddConsumerMailDomain(w http.ResponseWriter,
 		return
 	}
 	var req crmcontracts.AddConsumerMailDomainRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	// Vetted here so a bad domain answers 422 naming what is wrong with it,

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -9,7 +9,6 @@ package compose
 // per-setting validation, the base-currency freeze and the audit-only write.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -56,8 +55,7 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 		return
 	}
 	var req crmcontracts.UpdateInstallationSettingsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	patch := identity.InstallationPatch{

--- a/backend/internal/compose/handlers_integrations.go
+++ b/backend/internal/compose/handlers_integrations.go
@@ -12,7 +12,6 @@ package compose
 // declares.
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -64,8 +63,7 @@ func (h integrationsHandlers) ConnectProvider(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var body crmcontracts.ConnectProviderRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &body) {
 		return
 	}
 	conn, err := h.store.Connect(r.Context(), integrations.ConnectInput{
@@ -90,8 +88,7 @@ func (h integrationsHandlers) UpdateProviderConnection(w http.ResponseWriter, r 
 		return
 	}
 	var body crmcontracts.UpdateProviderConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &body) {
 		return
 	}
 	// Read off the header rather than the generated params struct, which is
@@ -157,8 +154,7 @@ func (h integrationsHandlers) CreatePersonEnrichmentRun(w http.ResponseWriter, r
 		return
 	}
 	var body crmcontracts.CreatePersonEnrichmentRunRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &body) {
 		return
 	}
 	run, err := h.runs.QueueRun(r.Context(), provider.QueueInput{

--- a/backend/internal/compose/handlers_owndomains.go
+++ b/backend/internal/compose/handlers_owndomains.go
@@ -8,7 +8,6 @@ package compose
 // transport — the capture store owns the RBAC gate and the audited write.
 
 import (
-	"encoding/json"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -56,8 +55,7 @@ func (h ownDomainHandlers) CreateWorkspaceEmailDomain(w http.ResponseWriter, r *
 		return
 	}
 	var req crmcontracts.CreateWorkspaceEmailDomainRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	// Vetted here so a bad domain answers 422 naming what is wrong with it,

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -4,7 +4,6 @@
 package compose
 
 import (
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -25,8 +24,12 @@ func (h reportHandlers) RunReport(w http.ResponseWriter, r *http.Request, report
 	var req reportRequest
 	// The body is optional (a prebuilt report runs on its defaults);
 	// anything present must decode strictly.
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+	// io.EOF and nothing else: DecodeOrRefusal passes an empty body through
+	// unwrapped precisely so a caller whose body is optional can tell it from a
+	// body that was wrong, and every other refusal it returns is already the
+	// one this endpoint should write.
+	if err := httperr.DecodeOrRefusal(w, r, &req); err != nil && !errors.Is(err, io.EOF) {
+		httperr.Write(w, r, err)
 		return
 	}
 

--- a/backend/internal/modules/approvals/handlers.go
+++ b/backend/internal/modules/approvals/handlers.go
@@ -124,8 +124,7 @@ func (h Handlers) GetApproval(w http.ResponseWriter, r *http.Request, id crmcont
 func (h Handlers) ApproveApproval(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.ApproveApprovalParams) {
 	var req crmcontracts.ApproveRequest
 	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+		if !httperr.Decode(w, r, &req) {
 			return
 		}
 	}
@@ -164,8 +163,7 @@ func (h Handlers) RejectApproval(w http.ResponseWriter, r *http.Request, id crmc
 		Reason *string `json:"reason"`
 	}
 	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+		if !httperr.Decode(w, r, &req) {
 			return
 		}
 	}

--- a/backend/internal/modules/identity/handlers.go
+++ b/backend/internal/modules/identity/handlers.go
@@ -5,7 +5,6 @@ package identity
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"slices"
@@ -278,8 +277,7 @@ func (h Handlers) GetAuthCapabilities(w http.ResponseWriter, r *http.Request) {
 // organization is bound by the middleware (installation.go).
 func (h Handlers) Login(w http.ResponseWriter, r *http.Request) {
 	var req crmcontracts.LoginRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 	// Throttle BEFORE the Argon2 verification — the work factor that

--- a/backend/internal/modules/identity/handlers_agentgrants.go
+++ b/backend/internal/modules/identity/handlers_agentgrants.go
@@ -18,7 +18,6 @@ package identity
 // the feature on at all.
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -127,8 +126,7 @@ func (h Handlers) SetMyAgentGrant(w http.ResponseWriter, r *http.Request, spec c
 		return
 	}
 	var req crmcontracts.SetMyAgentGrantRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 

--- a/backend/internal/modules/identity/handlers_passports.go
+++ b/backend/internal/modules/identity/handlers_passports.go
@@ -8,7 +8,6 @@ package identity
 // only handlers in this module that speak about passports rather than sessions.
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -31,8 +30,7 @@ func (h Handlers) IssuePassport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req crmcontracts.IssuePassportRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httperr.Write(w, r, httperr.Validation("body", "malformed_json", err.Error()))
+	if !httperr.Decode(w, r, &req) {
 		return
 	}
 

--- a/backend/internal/modules/identity/oauth.go
+++ b/backend/internal/modules/identity/oauth.go
@@ -16,7 +16,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -61,7 +60,17 @@ type dcrRequest struct {
 
 func (h Handlers) oauthRegister(w http.ResponseWriter, r *http.Request) {
 	var req dcrRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// The bound is httperr's and the ANSWER is RFC 7591's: a registration
+	// endpoint speaks `{"error": …}`, and a problem+json body here would be a
+	// document no conforming client parses. Public and unauthenticated, which
+	// is why the bound matters most on this one — before this it had no bound
+	// of its own at all and rode whatever the chassis happened to apply.
+	if err := httperr.DecodeOrRefusal(w, r, &req); err != nil {
+		if httperr.BodyTooLarge(err) {
+			oauthError(w, http.StatusRequestEntityTooLarge, "invalid_client_metadata",
+				"registration document exceeds the 1 MiB cap")
+			return
+		}
 		oauthError(w, http.StatusBadRequest, "invalid_client_metadata", "malformed registration document")
 		return
 	}

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -23,6 +23,12 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
+// codeBodyTooLarge is the contract's wire code for a body over the cap, named
+// once: the writer that emits it and the predicate that recognises it have to
+// agree, and a second spelling would make BodyTooLarge answer false for the
+// refusal DecodeOrRefusal just built.
+const codeBodyTooLarge = "body_too_large"
+
 // MaxBodyBytes bounds every JSON request body (1 MiB): no contract
 // payload is legitimately larger, and an unbounded read is free memory
 // amplification on the cheapest endpoints.
@@ -46,41 +52,86 @@ const MaxBodyBytes = 1 << 20
 //
 //craft:ignore naked-any the JSON deserialization seam: the decode target is whichever contract request struct the handler owns
 func Decode(w http.ResponseWriter, r *http.Request, into any) bool {
+	err := DecodeOrRefusal(w, r, into)
+	if err == nil {
+		return true
+	}
+	// An empty body reaches here as a bare io.EOF, because DecodeOrRefusal leaves
+	// that question to its caller. THIS caller answers it the way it always
+	// did: a missing payload is something the sender got wrong, so it is the
+	// 422 that says the payload is empty rather than a bare EOF written as a
+	// server fault.
+	if errors.Is(err, io.EOF) {
+		err = bodyDecodeRefusal(r, nil, into, err)
+	}
+	Write(w, r, err)
+	return false
+}
+
+// DecodeOrRefusal is Decode with the refusal RETURNED rather than written.
+//
+// It exists for the handful of handlers whose wire shape is not this package's.
+// Dynamic client registration answers RFC 7591's `{"error": …}` and a report run
+// treats an absent body as its defaults; neither can be served by a function
+// that writes problem+json, and before this both simply decoded `r.Body`
+// directly — which left the chassis as their only size bound and put the 1 MiB
+// invariant in two places (issue #1548).
+//
+// So the BOUND is here and the ANSWER is the caller's. A handler that needs its
+// own refusal takes this one and writes what its contract says; every other
+// handler takes Decode above and writes nothing.
+//
+// io.EOF passes through unwrapped, because "the body was empty" is a question
+// some callers answer differently from "the body was wrong".
+//
+//craft:ignore naked-any the JSON deserialization seam: the decode target is whichever contract request struct the handler owns
+func DecodeOrRefusal(w http.ResponseWriter, r *http.Request, into any) error {
 	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, MaxBodyBytes))
 	if err != nil {
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
-			Write(w, r, &DetailedError{Status: http.StatusRequestEntityTooLarge,
-				Code: "body_too_large", Detail: "request body exceeds the 1 MiB cap"})
-			return false
+			return &DetailedError{
+				Status: http.StatusRequestEntityTooLarge,
+				Code:   codeBodyTooLarge, Detail: "request body exceeds the 1 MiB cap",
+			}
 		}
 		// A read that failed mid-body is a transport fact — timed-out sockets
 		// carry host and port — so the caller is told what to do about it and
 		// the operator's half stays in the log.
 		slog.WarnContext(r.Context(), "reading request body", "method", r.Method, "path", r.URL.Path, "err", err)
-		Write(w, r, Validation("body", "malformed_json",
-			"the request body could not be read to the end; resend the request with a complete body"))
-		return false
+		return Validation("body", "malformed_json",
+			"the request body could not be read to the end; resend the request with a complete body")
 	}
 	// A field key that only case-folds onto a contract field (or is
 	// unknown) is refused rather than matched by encoding/json's
 	// case-insensitive fallback — the same gate the provider seam applies,
 	// so REST and MCP agree on which keys are a field patch.
 	if kErr := datasource.RejectNonCanonicalKeys(raw, into); kErr != nil {
-		Write(w, r, Validation("body", "unknown_field", kErr.Error()))
-		return false
+		return Validation("body", "unknown_field", kErr.Error())
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	if err := dec.Decode(into); err != nil {
-		Write(w, r, bodyDecodeRefusal(r, raw, into, err))
-		return false
+		// Unwrapped, so `errors.Is(err, io.EOF)` still answers for a caller
+		// whose body is optional. Every other decode error becomes the refusal.
+		if errors.Is(err, io.EOF) {
+			return err
+		}
+		return bodyDecodeRefusal(r, raw, into, err)
 	}
 	if dec.More() {
-		Write(w, r, Validation("body", "malformed_json", "trailing content after the JSON value"))
-		return false
+		return Validation("body", "malformed_json", "trailing content after the JSON value")
 	}
 	stashPresentFields(r, raw)
-	return true
+	return nil
+}
+
+// BodyTooLarge reports whether a DecodeOrRefusal refusal is the size cap rather than
+// a shape problem, for a caller answering in its own vocabulary: the two are
+// different things to tell a client, and only one of them is worth retrying
+// with a smaller request.
+func BodyTooLarge(err error) bool {
+	var detailed *DetailedError
+	return errors.As(err, &detailed) && detailed.Code == codeBodyTooLarge
 }
 
 // presentFieldsKey carries the decoded body's top-level keys, so a handler can

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -169,7 +169,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (26)
+## Prohibition (27)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -193,6 +193,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |
 | `publicreferences_test.go` | H1 | This repository is public. |
+| `requestbodybound_test.go` | H2 | Every JSON request body is bounded in one place. |
 | `retentionscope_test.go` | H2 | retentionScopeBuilder is the fixture whose reach these gates bound, retentionScopeSink is the one call it may feed, and retentionScopeSinkOwner is the package that call must live in. |
 | `rlsclaims_test.go` | H1 | Fitness function over a guarantee this codebase no longer has. |
 | `rulebookdirection_test.go` | H1 | The reference direction is one-way: AGENTS.md links down into docs/, and nothing under docs/ links back up to a rulebook. |


### PR DESCRIPTION
Closes #1548 — the two conversions and the fitness function. The two "related dead caps" it raises are **not** done here; see the end.

## The problem was not that they were wrong

Nineteen handlers decoded `r.Body` directly, so the chassis was their only bound. Two are unauthenticated (`POST /oauth/register`, `POST /v1/auth/login`) and three take `[]string` bodies, which is the shape where a widened ceiling becomes heap amplification rather than one big string.

They were **correct by accident of a decision made somewhere else**. An earlier cut of the route-ceiling work widened on `Content-Type` alone and those nineteen silently became 25 MB each, and nothing failed. That is what this closes: a bound a handler inherits without naming, which the next change to the chassis can take away in silence.

## Sixteen became nineteen

The issue enumerated sixteen. By the time I came to fix it there were nineteen — `handlers_captureexclusions.go`, `handlers_ai_routing.go` and `handlers_agentgrants.go` had joined. Which is the issue's own argument for a rule instead of a list, demonstrated in the interval between filing and fixing.

## Fifteen convert unchanged; four cannot

Four have a wire shape that is not problem+json:

- **`oauth.go`** — dynamic client registration answers RFC 7591's `{"error": …}`. A problem+json body here is a document no conforming client parses.
- **`reporthandlers.go`** — a prebuilt report runs on its defaults, so an absent body is not an error.
- **`backfilltransport.go` ×2** — this endpoint takes one field, and a body it cannot read is a caller who has not picked a window. That is what they need to be told.

So `Decode` splits. `DecodeOrRefusal` carries the reader and the cap and **returns** the refusal; `Decode` wraps it and writes. One reader, one cap, four answer shapes — and a **size** refusal stays a size refusal on all of them, via `httperr.BodyTooLarge`, because "your request was too big" is not "pick a window".

`io.EOF` passes through unwrapped so the optional-body caller can still tell an empty body from a wrong one; `Decode` translates it back to the 422 it always wrote, which `TestDecode_refusalNamesTheInputAndNeverTheProgram` caught me getting wrong.

## The gate

`backend/gates/requestbodybound_test.go`, `//gate:kind prohibition H2`. Two forbidden shapes on **the request the handler was given**: a decoder straight onto it, and an unlimited read.

What it permits, deliberately:

- a **bounded peek** — several throttle edges read a prefix with their own named cap on the line, put it back in front of the unread remainder, and let the handler answer the body the client actually sent. Their cap is visible, which is the property this is about.
- a handler that **bounded the body itself** with `http.MaxBytesReader`, which can only ever tighten what the chassis granted. The overlay webhook does exactly that and says why.

**Distinguishing an inbound request body from a response body is the whole of the matcher.** A bare `.Body` walk reported thirteen files on its first run — outbound responses read back, requests this code was *building*, and every test harness that sends one. It keys on the function's own `*http.Request` parameter now, whatever it named it.

Mutation-checked:

| mutation | caught by |
|---|---|
| one handler reverted to a raw decoder | the sweep, naming file and function |
| the request-parameter narrowing removed | `a response body from an outbound call` |
| the self-bound no longer recognised | `a body the handler bounded first` |

The falsification suite is synthetic because a converted tree contains neither kind any more — the response-body case in particular would never run over it, and it is the one the matcher exists for.

## Not done here, and why

The issue raises two more, both flagged as posture decisions rather than edits:

- **`agents/httpmcp.go`** declares an 8 MiB `LimitReader` under a 1 MiB chassis ceiling, so the 8 MiB never runs. Whether MCP needs a body above 1 MiB is a product question, and raising a ceiling on the agent surface is not something to slip into a hygiene PR. The gate does not flag it: it is a bounded read with its cap in view, and the cap being *dead* is a different defect from the cap being *absent*.
- **`identity/handlers.go`** consults login's per-IP throttle *after* the decode, so it bounds database calls and not memory. Real, and its own change: moving a throttle earlier alters when a caller is refused, which wants its own tests and its own review.

`make check-backend` green. `make test-it` green across every touched module: compose/integration 1507, identity 236, approvals 99, deals 99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation with consistent handling of malformed, oversized, empty, and trailing-content JSON bodies.
  * Preserved specialized responses for oversized requests, including OAuth registration and backfill operations.
  * Standardized error responses across settings, integrations, identity, approvals, domains, and reporting endpoints.

* **Tests**
  * Added safeguards to detect unsafe, unbounded request-body reads.

* **Documentation**
  * Updated the gate inventory to include the new request-body safety check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->