### PR TITLE
test(composition): a fixture manifest enrols itself (#1594)

### DIFF
--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -115,11 +115,11 @@ func TestDeriveUnitManifestIgnoresGoIgnoredFiles(t *testing.T) {
 
 const repoRoot = "../../.."
 
-// committedUnitVerbs merges the repository's real contracts with one unit's
-// real fragments and returns that unit's declared operations. It composes the
-// unit in ISOLATION (a one-element unit list) so a manifest assertion is not
-// coupled to whatever else happens to be enabled in the tree.
-func committedUnitVerbs(t *testing.T, unit extensionUnit) []declaredVerb {
+// committedUnitDeclarations merges the repository's real contracts with one
+// unit's real fragments and returns that unit's declared operations and jobs.
+// It composes the unit in ISOLATION (a one-element unit list) so a manifest
+// assertion is not coupled to whatever else happens to be enabled in the tree.
+func committedUnitDeclarations(t *testing.T, unit extensionUnit) ([]declaredVerb, []extension.JobDeclaration) {
 	t.Helper()
 	units := []extensionUnit{unit}
 	contracts, err := composedContracts(repoRoot, units)
@@ -130,7 +130,13 @@ func committedUnitVerbs(t *testing.T, unit extensionUnit) []declaredVerb {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return verbs
+	// From the same composed contracts as the verbs, so the two halves of a
+	// manifest cannot be derived from different readings of one tree.
+	jobs, err := extensionJobs(units, contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return verbs, jobs
 }
 
 func realVocabulary(t *testing.T) map[string]string {
@@ -169,11 +175,59 @@ func TestDeManifestMatchesItsDerivation(t *testing.T) {
 		`"name": "de"`, `"version": "1.0.0"`, `"risk_tiers": []`)
 }
 
-// TestCrmHelloManifestMatchesItsDerivation is the worked example: the
+// TestEveryFixtureManifestMatchesItsDerivation enrols the fixture tree the way
+// the real one is enrolled: by walking it.
+//
+// Units under extensions/ are held byte-identical by verifyUnitManifests, which
+// derives its list from os.ReadDir — so a unit added later is covered the day it
+// lands. scanExtensions never visits fixtures/extensions/, so that tree was held
+// by exactly one hand-named test, and a SECOND fixture shipping a manifest would
+// have had no byte-identity check at all: its committed file could disagree with
+// its declaration indefinitely, and the thing that would have caught it is a
+// test somebody has to remember to write (issue #1594).
+//
+// The content assertion below stays as its own case. What stops being a list is
+// the enrolment, not the claim about what a particular fixture publishes.
+func TestEveryFixtureManifestMatchesItsDerivation(t *testing.T) {
+	root := filepath.Join(repoRoot, "fixtures", "extensions")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("reading the fixture tree: %v", err)
+	}
+	found := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, entry.Name())
+		if _, err := os.Stat(filepath.Join(dir, unitManifestFile)); err != nil {
+			// A fixture with no manifest has nothing to hold. Several exist on
+			// purpose — the bad-* units are shaped to be REFUSED, and a
+			// refused unit never gets one.
+			continue
+		}
+		found++
+		t.Run(entry.Name(), func(t *testing.T) {
+			assertCommittedManifest(t, dir, entry.Name())
+		})
+	}
+	// The walk has to have found the fixture that exists. A tree-derived
+	// enrolment that enrolled nothing reports the same green as one where every
+	// manifest agrees, which is the failure this replaced a list to avoid.
+	if found == 0 {
+		t.Fatal("no fixture unit ships a manifest, so this test held nothing — either the " +
+			"tree moved or the manifest file was renamed, and in both cases the check is off")
+	}
+}
+
+// TestCrmHelloManifestPublishesItsGovernedTool is the worked example: the
 // crm-hello fixture declares a jurisdiction pack (skipped) AND a governed
 // 🟡 tool, so its committed manifest carries exactly one risk-tier
 // request with its security descriptor and digest.
-func TestCrmHelloManifestMatchesItsDerivation(t *testing.T) {
+//
+// The byte-identity half is the walk above; this is the claim about what THIS
+// fixture publishes, which no walk can derive.
+func TestCrmHelloManifestPublishesItsGovernedTool(t *testing.T) {
 	assertCommittedManifest(t, filepath.Join(repoRoot, "fixtures", "extensions", "crm-hello"), "crm-hello",
 		`"id": "tool/hello_ping"`,
 		`"operation": "agent.tool.invoke"`,
@@ -188,10 +242,18 @@ func assertCommittedManifest(t *testing.T, dir, name string, wantSubstrings ...s
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The verbs come from the MERGED contract, the same way `make gen` derives
-	// them, so this test binds the committed manifest to both halves of the
-	// declaration — the unit's Go file and its api/ fragment.
-	derived, err := deriveUnitManifest(unit, realVocabulary(t), committedUnitVerbs(t, unit), nil)
+	// The verbs AND the jobs come from the MERGED contract, the same way
+	// `make gen` derives them, so this binds the committed manifest to both
+	// halves of the declaration — the unit's Go file and its api/ fragment.
+	//
+	// Jobs were `nil` here, which was correct for the two units that had one of
+	// these tests and wrong for the tree: a fixture declaring a job derives a
+	// manifest missing its job/* risk-tier entries, so the CORRECT committed
+	// file would have failed against an incomplete derivation. Now that the
+	// enrolment is a walk, that is not a hypothetical about a unit somebody
+	// might add — it is what the next one does.
+	verbs, jobs := committedUnitDeclarations(t, unit)
+	derived, err := deriveUnitManifest(unit, realVocabulary(t), verbs, jobs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -190,26 +191,35 @@ func TestDeManifestMatchesItsDerivation(t *testing.T) {
 // the enrolment, not the claim about what a particular fixture publishes.
 func TestEveryFixtureManifestMatchesItsDerivation(t *testing.T) {
 	root := filepath.Join(repoRoot, "fixtures", "extensions")
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		t.Fatalf("reading the fixture tree: %v", err)
-	}
 	found := 0
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+	// WalkDir, not ReadDir: the manifest is found wherever it is, rather than
+	// only one level down. A fixture nested a directory deeper would otherwise
+	// be exactly the case this replaced a hand-named test to cover — enrolled
+	// by nothing, and passing.
+	err := filepath.WalkDir(root, func(dir string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-		dir := filepath.Join(root, entry.Name())
+		if !entry.IsDir() {
+			return nil
+		}
 		if _, err := os.Stat(filepath.Join(dir, unitManifestFile)); err != nil {
-			// A fixture with no manifest has nothing to hold. Several exist on
-			// purpose — the bad-* units are shaped to be REFUSED, and a
+			// A directory with no manifest has nothing to hold. Several exist
+			// on purpose — the bad-* units are shaped to be REFUSED, and a
 			// refused unit never gets one.
-			continue
+			return nil
 		}
 		found++
-		t.Run(entry.Name(), func(t *testing.T) {
-			assertCommittedManifest(t, dir, entry.Name())
+		// The unit's name is its own directory's, whatever the depth: that is
+		// what scanUnit reads and what the manifest names itself.
+		name := filepath.Base(dir)
+		t.Run(name, func(t *testing.T) {
+			assertCommittedManifest(t, dir, name)
 		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the fixture tree: %v", err)
 	}
 	// The walk has to have found the fixture that exists. A tree-derived
 	// enrolment that enrolled nothing reports the same green as one where every

--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -204,10 +204,18 @@ func TestEveryFixtureManifestMatchesItsDerivation(t *testing.T) {
 			return nil
 		}
 		if _, err := os.Stat(filepath.Join(dir, unitManifestFile)); err != nil {
-			// A directory with no manifest has nothing to hold. Several exist
-			// on purpose — the bad-* units are shaped to be REFUSED, and a
-			// refused unit never gets one.
-			return nil
+			// ABSENT is the only reason to skip. A directory with no manifest
+			// has nothing to hold, and several exist on purpose — the bad-*
+			// units are shaped to be REFUSED, and a refused unit never gets
+			// one.
+			//
+			// Any OTHER error is propagated, because skipping on it would leave
+			// a committed manifest unverified while another fixture keeps the
+			// count above zero — a green run over a file nothing read.
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
 		}
 		found++
 		// The unit's name is its own directory's, whatever the depth: that is


### PR DESCRIPTION
Closes #1594.

## The asymmetry

Two mechanisms hold a committed `manifest.generated.json` to its derivation, over different sets:

- **`extensions/`** — `verifyUnitManifests` holds them byte-identical, and its list comes from `os.ReadDir`. A unit added later is covered the day it lands.
- **`fixtures/extensions/`** — held by exactly one hand-named test, because `scanExtensions` never visits that tree.

So a **second** fixture shipping a manifest had no byte-identity check at all. Its committed file could disagree with its declaration indefinitely, and the thing that would have caught it is a test somebody has to remember to write. The file list was derived from the tree; the verification was still a maintained list of one.

## It is a walk now, and the walk found what a list could not

Dropping a manifest into a second fixture is judged and fails:

```
--- FAIL: TestEveryFixtureManifestMatchesItsDerivation/crm-nosy
```

Before this, that file was ignored entirely.

The walk skips fixtures with no manifest, deliberately and with the reason on the line: the `bad-*` units are shaped to be **refused**, and a refused unit never gets one. And it fatals if it finds none at all — a tree-derived enrolment that enrolled nothing reports the same green as one where every manifest agrees, which is the failure it replaced a list to avoid.

## The `nil` jobs, which the issue is right to call out

`assertCommittedManifest` passed `nil` for the job declarations. That was correct for the two units that happened to have one of these tests and wrong for the tree: a fixture declaring a job derives a manifest missing its `job/*` risk-tier entries, so the **correct** committed file would have failed against an incomplete derivation.

With the enrolment automatic that stops being a hypothesis about a unit somebody might add and becomes what the next one does. `committedUnitDeclarations` now returns verbs **and** jobs from the same composed contracts, so the two halves of a manifest cannot be derived from different readings of one tree.

## What stays a claim

`TestCrmHelloManifestPublishesItsGovernedTool` keeps the content assertions — one risk-tier request, `agent.tool.invoke`, `confirmation_required`, a `sha256:` digest. No walk can derive what a particular fixture is *supposed* to publish, and the issue says the same: it is the enrolment that should stop being a list, not the claim.

| mutation | caught by |
|---|---|
| a second fixture ships a manifest | the walk, as its own subtest |
| the committed manifest drifts from its declaration | byte equality, printing both |
| the walk points at a tree with no manifests | the `found == 0` fatal |

`make check-backend` green.

*(Method note: I lost this change once to `git checkout <file>` on uncommitted work while undoing a mutation — worth saying because the redone version is what is here, and it is identical by construction rather than by memory: the same script produced it.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded manifest validation to cover both declared actions and jobs.
  - Added automatic coverage for all fixture directories containing manifests.
  - Improved test naming and assertions for clearer, more comprehensive verification.
  - Strengthened confidence that composed contracts and their manifests are interpreted consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->