### PR TITLE
fix(gates): the Prohibition heading counts the rows beneath it

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -169,7 +169,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (27)
+## Prohibition (28)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
## main's backend gate is red

`TestTheGateInventoryPageIsCurrent` — `docs/reference/gate-inventory.md` no longer
matches the `//gate:kind` declarations. Audited every section rather than the one
the gate names:

```
Parity        declared=37  rows=37
Census        declared=61  rows=61
Reachability  declared=16  rows=16
Shape         declared=20  rows=20
Prohibition   declared=27  rows=28   <-- MISMATCH
Claim         declared=5   rows=5
Budget        declared=4   rows=4
Falsification declared=6   rows=6
```

Seven of eight consistent, so this is one heading rather than a stale page. The
whole diff:

```diff
-## Prohibition (27)
+## Prohibition (28)
```

## Nobody's change is wrong

The heading count and the table are one derived artifact with no merge queue
behind it. A gate row lands at its alphabetical position; the heading merges
as-is. Two PRs that share no line then produce a tree where the page disagrees
with itself — **no conflict for either author to resolve, and nothing in either
diff for a reviewer to look at.**

This is the second instance today. #2944 was the same failure on the whole-page
`## Census` total; this is the per-section variant, which is strictly harder to
see because the page's overall count stays right.

## Verification

`make check-backend` green, including the gate that was failing. Every section
re-audited after regeneration — all eight consistent.

Rebased onto the current tip and regenerated again before pushing, rather than
trusting the first regeneration: this artifact's whole failure mode is that a
correct value goes stale when somebody else's row lands, so a count computed
against an older base is exactly the thing that produced the bug.

## Note for anything currently green

CI builds `refs/pull/N/merge`, recomputed against the current `main`. Any PR whose
`deterministic-gates` passed on a merge computed **before** the offending commit
landed is now stale-green: the check says pass, and a re-run would go red on a
defect the diff does not contain. That is the mirror of a red check against a
fixed base — neither colour corrects itself without a new push, because both are
facts about a merge nobody is looking at any more.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red `TestTheGateInventoryPageIsCurrent` gate on `main` by correcting the `Prohibition` heading count from 27 to 28, matching the 28 rows beneath it. The heading is a derived artifact that went stale when a row landed without the count being updated; this restores parity across all eight sections.

<sup>Written for commit 98b27fdaaa23ad68fa2fd870f80550e20c9758cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the gate inventory reference to reflect 28 Prohibition section headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->