### PR TITLE
fix(http): an empty list is an empty array, not null (#1606)

### DIFF
--- a/backend/gates/emptylistwire_test.go
+++ b/backend/gates/emptylistwire_test.go
@@ -55,22 +55,9 @@ func TestEveryListEnvelopeCarriesItsRowsWhereTheWriterLooks(t *testing.T) {
 		t.Fatalf("parsing the generated contract: %v", err)
 	}
 
-	envelopes := 0
-	for name, fields := range structsIn(file) {
-		rows, page := fields[rowsField], fields["Page"]
-		// A list envelope is one that pages ROWS: it has a page, and a slice of
-		// something to put on it. Identified by shape rather than by a name
-		// ending in "ListResponse", so a renamed envelope is still judged and a
-		// type that merely reads like one is not.
-		if page == nil || rows == nil {
-			continue
-		}
-		if _, isSlice := rows.(*ast.ArrayType); !isSlice {
-			t.Errorf("%s pages something that is not a slice, so httperr.WriteJSON cannot "+
-				"normalise it and an empty one goes out as JSON null", name)
-			continue
-		}
-		envelopes++
+	envelopes, findings := judgeEnvelopes(file)
+	for _, finding := range findings {
+		t.Error(finding)
 	}
 
 	// The generated contract carries dozens. A census that found a handful is
@@ -110,4 +97,128 @@ func structsIn(file *ast.File) map[string]map[string]ast.Expr {
 		}
 	}
 	return out
+}
+
+// judgeEnvelopes returns how many list envelopes the file declares and what is
+// wrong with them.
+//
+// Split out so the cases below can drive it over sources this tree does not
+// contain. The mutation that matters — an envelope whose rows are named
+// something else — cannot be made in the generated contract, because renaming
+// the field stops every handler compiling. So the compiler prevents the bug and
+// prevents proving the gate would catch it, which is exactly when a synthetic
+// case earns its place.
+func judgeEnvelopes(file *ast.File) (int, []string) {
+	envelopes := 0
+	var findings []string
+	for name, fields := range structsIn(file) {
+		// A list envelope is one that IS a page: it carries a Page by value.
+		// Never identified by whether it has a `Data` field — a census that
+		// required `Data` to recognise an envelope would SKIP the one thing it
+		// exists to catch, a renamed rows field, and report the same green as a
+		// tree where every envelope is correct.
+		//
+		// By VALUE is the discriminator, and it is the contract's own: a `Page
+		// PageInfo` says this response IS a page of something, while a `Page
+		// *PageInfo` says a response may INCLUDE one — LeadScoreExplanation is
+		// a record that optionally carries its score history. The second kind
+		// has no problem to fix: its rows are a `*[]T` under `omitempty`, so an
+		// absent history is absent rather than null.
+		page := fields["Page"]
+		if page == nil {
+			continue
+		}
+		if _, optional := page.(*ast.StarExpr); optional {
+			continue
+		}
+		envelopes++
+		rows := fields[rowsField]
+		if rows == nil {
+			findings = append(findings, name+" pages rows and has no "+rowsField+
+				" field, so httperr.WriteJSON cannot find them — an empty one goes out as JSON "+
+				"null, which the contract declares an array")
+			continue
+		}
+		if _, isSlice := rows.(*ast.ArrayType); !isSlice {
+			findings = append(findings, name+" carries "+rowsField+" but not as a slice, so "+
+				"httperr.WriteJSON cannot normalise it and an empty one goes out as JSON null")
+		}
+	}
+	return envelopes, findings
+}
+
+// What the census must and must not report, over sources the generated contract
+// cannot hold.
+func TestTheEnvelopeCensusJudgesTheRightStructs(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		source    string
+		envelopes int
+		findings  int
+	}{
+		"a list envelope": {
+			source: `package p
+type PageInfo struct{ HasMore bool }
+type PersonListResponse struct {
+	Data []int
+	Page PageInfo
+}`,
+			envelopes: 1,
+		},
+		// THE case. The writer finds rows by field name, so an envelope that
+		// pages them under another name is correct on every list that has rows
+		// and null on exactly the empty ones nobody tests.
+		"an envelope whose rows are named something else": {
+			source: `package p
+type PageInfo struct{ HasMore bool }
+type PersonListResponse struct {
+	Rows []int
+	Page PageInfo
+}`,
+			envelopes: 1,
+			findings:  1,
+		},
+		"an envelope whose rows are not a slice": {
+			source: `package p
+type PageInfo struct{ HasMore bool }
+type PersonListResponse struct {
+	Data *[]int
+	Page PageInfo
+}`,
+			envelopes: 1,
+			findings:  1,
+		},
+		// A record that may INCLUDE a page is not a page. Its rows are optional
+		// and omitted when absent, so there is no null to fix.
+		"a record that optionally carries a page": {
+			source: `package p
+type PageInfo struct{ HasMore bool }
+type LeadScoreExplanation struct {
+	History *[]int
+	Page    *PageInfo
+	Score   int
+}`,
+			envelopes: 0,
+		},
+		"a record with no page at all": {
+			source: `package p
+type Person struct{ Name string }`,
+			envelopes: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			file, err := parser.ParseFile(token.NewFileSet(), "probe.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			envelopes, findings := judgeEnvelopes(file)
+			if envelopes != tc.envelopes {
+				t.Errorf("counted %d envelope(s), want %d", envelopes, tc.envelopes)
+			}
+			if len(findings) != tc.findings {
+				t.Errorf("reported %d finding(s) %v, want %d", len(findings), findings, tc.findings)
+			}
+		})
+	}
 }

--- a/backend/gates/emptylistwire_test.go
+++ b/backend/gates/emptylistwire_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+//go:build !integration
+
+package gates
+
+// Every list envelope carries its rows in a field the writer can find.
+//
+// The contract declares each list response `required: [data, page]` with `data`
+// of `type: array`. `null` is not an array, so an envelope carrying a nil Go
+// slice breaks its own contract on the wire — and Go makes that the EASY
+// mistake rather than an unusual one: a nil slice IS the idiomatic empty list,
+// `append` works on it, `len` and `range` work, and the only place it behaves
+// differently is encoding/json.
+//
+// The cost falls on the client. Generated TypeScript reads `data: Person[]`,
+// because the contract says so, and gives a caller no reason to guard — 36
+// reads across 18 files call `.map` on it directly, and each takes down the
+// screen rendering it (issue #1606). No compiler on either side can see it: the
+// Go type is a slice, the TS type is an array, and only the encoder disagrees.
+//
+// httperr.WriteJSON fixes it for all of them at once, by replacing a nil slice
+// in the body's `Data` field with an empty one. THAT IS WHAT THIS CENSUS HOLDS:
+// the writer finds the rows by the field NAME, so an envelope whose rows live
+// under a different name would silently stop being normalised — correct on
+// every list that has rows, and `null` on exactly the empty ones nobody tests.
+//
+// The envelopes are read out of the generated contract, so one added by
+// `make gen` is judged the day it lands and there is no list here to go short.
+// The mechanism itself — that a nil Data becomes `[]`, through a value and
+// through a pointer — is held by httperr's own tests, because it is a property
+// of the writer rather than of the contract.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+// The field WriteJSON reflects for. Spelled here because this census exists to
+// hold the two together: a rename on either side and the normalisation stops.
+const rowsField = "Data"
+
+func TestEveryListEnvelopeCarriesItsRowsWhereTheWriterLooks(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot, "backend", "internal", "contracts", "api_gen.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing the generated contract: %v", err)
+	}
+
+	envelopes := 0
+	for name, fields := range structsIn(file) {
+		rows, page := fields[rowsField], fields["Page"]
+		// A list envelope is one that pages ROWS: it has a page, and a slice of
+		// something to put on it. Identified by shape rather than by a name
+		// ending in "ListResponse", so a renamed envelope is still judged and a
+		// type that merely reads like one is not.
+		if page == nil || rows == nil {
+			continue
+		}
+		if _, isSlice := rows.(*ast.ArrayType); !isSlice {
+			t.Errorf("%s pages something that is not a slice, so httperr.WriteJSON cannot "+
+				"normalise it and an empty one goes out as JSON null", name)
+			continue
+		}
+		envelopes++
+	}
+
+	// The generated contract carries dozens. A census that found a handful is
+	// one whose discovery broke, and it would report the same green as a tree
+	// where every envelope is correct.
+	if envelopes < 20 {
+		t.Fatalf("found %d list envelope(s) in the generated contract, which is too few to be "+
+			"the whole set — the walk is broken, or the generated shape changed", envelopes)
+	}
+	t.Logf("%d list envelope(s) carry their rows in %s", envelopes, rowsField)
+}
+
+// structsIn maps every struct type declared in the file to its fields.
+func structsIn(file *ast.File) map[string]map[string]ast.Expr {
+	out := map[string]map[string]ast.Expr{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok || structType.Fields == nil {
+				continue
+			}
+			fields := map[string]ast.Expr{}
+			for _, field := range structType.Fields.List {
+				for _, name := range field.Names {
+					fields[name.Name] = field.Type
+				}
+			}
+			out[typeSpec.Name.Name] = fields
+		}
+	}
+	return out
+}

--- a/backend/gates/emptylistwire_test.go
+++ b/backend/gates/emptylistwire_test.go
@@ -124,11 +124,7 @@ func judgeEnvelopes(file *ast.File) (int, []string) {
 		// a record that optionally carries its score history. The second kind
 		// has no problem to fix: its rows are a `*[]T` under `omitempty`, so an
 		// absent history is absent rather than null.
-		page := fields["Page"]
-		if page == nil {
-			continue
-		}
-		if _, optional := page.(*ast.StarExpr); optional {
+		if !pagesRows(fields["Page"]) {
 			continue
 		}
 		envelopes++
@@ -145,6 +141,25 @@ func judgeEnvelopes(file *ast.File) (int, []string) {
 		}
 	}
 	return envelopes, findings
+}
+
+// pagesRows reports a `Page PageInfo` — the field that says this response IS a
+// page of something.
+//
+// The TYPE as well as the shape. A non-pointer `Page` alone admits any struct
+// with a field of that name — `Page string` on a record about a printed page —
+// which the census would then count as an envelope and report for having no
+// rows. Two wrong answers from one loose test: a type nobody paginates named as
+// a defect, and the count that guards against a broken walk quietly inflated by
+// it.
+//
+// A POINTER is the other half and is not this: `Page *PageInfo` says a response
+// may INCLUDE a page, which is what a record carrying optional history does.
+// Those have no problem to fix — their rows are a `*[]T` under `omitempty`, so
+// an absent list is absent rather than null.
+func pagesRows(page ast.Expr) bool {
+	ident, isValue := page.(*ast.Ident)
+	return isValue && ident.Name == "PageInfo"
 }
 
 // What the census must and must not report, over sources the generated contract
@@ -198,6 +213,17 @@ type LeadScoreExplanation struct {
 	History *[]int
 	Page    *PageInfo
 	Score   int
+}`,
+			envelopes: 0,
+		},
+		// A field named Page that is not a page. Counted as an envelope by a
+		// test that looks only at the name, and then reported for having no
+		// rows — a defect invented out of a type nobody paginates.
+		"a record whose Page is not a PageInfo": {
+			source: `package p
+type Leaflet struct {
+	Page  string
+	Title string
 }`,
 			envelopes: 0,
 		},

--- a/backend/internal/platform/httperr/emptylist_test.go
+++ b/backend/internal/platform/httperr/emptylist_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type row struct {
+	Name string `json:"name"`
+}
+
+type listEnvelope struct {
+	Data []row  `json:"data"`
+	Page string `json:"page"`
+}
+
+// A list with no rows goes out as `[]`, never `null`.
+//
+// The contract says every list envelope is `required: [data, page]` with `data`
+// of `type: array`, and `null` is not an array. Go makes the violation the easy
+// mistake: a nil slice IS the idiomatic empty list, and the only place it
+// behaves differently is encoding/json.
+//
+// Written as a VALUE, because that is how every handler in this tree calls
+// WriteJSON — `crmcontracts.PersonListResponse{Data: people, …}`. A reflection
+// fix that only reached a pointer would pass its own unit test and do nothing
+// in production, which is the shape this case exists to refuse.
+func TestAnEmptyListIsAnArrayNotNull(t *testing.T) {
+	for name, body := range map[string]any{
+		"a value envelope":   listEnvelope{Page: "p"},
+		"a pointer envelope": &listEnvelope{Page: "p"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			WriteJSON(rec, http.StatusOK, body)
+			got := strings.TrimSpace(rec.Body.String())
+			if strings.Contains(got, `"data":null`) {
+				t.Errorf("wrote %s — a client reading this per the contract calls .map on null "+
+					"and takes down the screen rendering it", got)
+			}
+			if !strings.Contains(got, `"data":[]`) {
+				t.Errorf("wrote %s, want an empty array for data", got)
+			}
+		})
+	}
+}
+
+// And a list that HAS rows is untouched — the normalisation must not be a
+// filter that quietly empties a page.
+func TestAPopulatedListIsUnchanged(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteJSON(rec, http.StatusOK, listEnvelope{Data: []row{{Name: "a"}, {Name: "b"}}, Page: "p"})
+	var out listEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decoding what was written: %v", err)
+	}
+	if len(out.Data) != 2 || out.Data[0].Name != "a" {
+		t.Errorf("wrote %v, want both rows in order", out.Data)
+	}
+}
+
+// A body with no Data field at all — a single record, a problem document — is
+// left exactly as it was.
+func TestABodyWithNoListIsLeftAlone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteJSON(rec, http.StatusOK, row{Name: "solo"})
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"name":"solo"}` {
+		t.Errorf("wrote %s, want the record untouched", got)
+	}
+}

--- a/backend/internal/platform/httperr/servedmeter.go
+++ b/backend/internal/platform/httperr/servedmeter.go
@@ -58,3 +58,67 @@ func recordsIn(body any) int {
 		return 1
 	}
 }
+
+// withEmptyLists returns body with a nil Data slice replaced by an empty one,
+// so a list with no rows goes out as `"data": []` rather than `"data": null`.
+//
+// The contract says every list envelope is `required: [data, page]` with `data`
+// of `type: array`, and `null` is not an array — so a handler that returned a
+// nil slice was violating its own contract on the wire. Go makes that the EASY
+// mistake rather than an unusual one: a nil slice IS the idiomatic empty list,
+// `append` to it works, `len` and `range` work, and the only place it behaves
+// differently is `encoding/json`.
+//
+// The cost fell on every client. The generated TypeScript reads `data: Person[]`
+// — because the contract says so — and gives a caller no reason to guard, so
+// `data.data.map(...)` on such a response threw and took down the screen
+// rendering it (issue #1606). Thirty-six reads across eighteen files were one
+// thin response away from that, and no compiler could have told them.
+//
+// Fixed HERE rather than at those thirty-six, and rather than at each handler:
+// WriteJSON is the one door every list envelope leaves by, and it already
+// reflects for this exact field to count rows. A guard at the readers would
+// have taught thirty-six call sites to expect a shape the contract forbids; a
+// guard at each handler is a rule somebody has to remember. This is the only
+// place that can be wrong once.
+//
+// A COPY, not a mutation of the caller's value. Every handler in this tree
+// writes a struct VALUE — `crmcontracts.PersonListResponse{Data: people, …}` —
+// and a value handed to an `any` parameter is not addressable, so a version of
+// this that set the field in place did nothing at all for the case that
+// actually ships. It passed its own unit test through a pointer.
+//
+//craft:ignore naked-any the response-body seam: it takes whatever envelope a handler wrote, which is the same any WriteJSON above it takes
+func withEmptyLists(body any) any {
+	value := reflect.ValueOf(body)
+	// Through a pointer the field is settable in place, and the caller holds
+	// the same struct either way, so there is nothing to copy.
+	if value.Kind() == reflect.Pointer && !value.IsNil() {
+		if data := nilDataField(value.Elem()); data.IsValid() && data.CanSet() {
+			data.Set(reflect.MakeSlice(data.Type(), 0, 0))
+		}
+		return body
+	}
+	if !nilDataField(value).IsValid() {
+		return body
+	}
+	// An addressable copy, so the field this one carries can be set.
+	fixed := reflect.New(value.Type()).Elem()
+	fixed.Set(value)
+	data := fixed.FieldByName("Data")
+	data.Set(reflect.MakeSlice(data.Type(), 0, 0))
+	return fixed.Interface()
+}
+
+// nilDataField is the struct's `Data` field when it is a nil slice, and the
+// zero Value otherwise — the one condition this normalisation acts on.
+func nilDataField(value reflect.Value) reflect.Value {
+	if value.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+	data := value.FieldByName("Data")
+	if !data.IsValid() || data.Kind() != reflect.Slice || !data.IsNil() {
+		return reflect.Value{}
+	}
+	return data
+}

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -230,6 +230,9 @@ func WriteJSON(w http.ResponseWriter, status int, body any) {
 	if meter, metered := w.(ServedMeter); metered && !meter.NoteServed(recordsIn(body)) {
 		return
 	}
+	// A list with no rows is `[]`, never `null` — see withEmptyLists for why
+	// that is a contract question rather than a cosmetic one.
+	body = withEmptyLists(body)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	//craft:ignore swallowed-errors WriteHeader already committed the response — nothing can report an encode failure to the client anymore

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -57,7 +57,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (63)
+## Census (64)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -81,6 +81,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `docslinktargets_test.go` | H3 | Every relative link under docs/ points at a file that exists. |
 | `edgeendpointcensus_test.go` | H2 | Every end a link can have is an end that link's history is read from. |
 | `edgereaders_test.go` | H2 | `relationship` is a first-class RBAC object, and it is the only join table in the schema that is one. |
+| `emptylistwire_test.go` | H2 | Every list envelope carries its rows in a field the writer can find. |
 | `envcontract_test.go` | H3 | Environment-variable contract fitness functions. |
 | `errtaxonomy_test.go` | H2 | Every error sentinel must have a verdict, on every surface. |
 | `eventtypeownership_test.go` | H3 | One module owns an event type. |


### PR DESCRIPTION
Closes #1606.

## What the five reads were actually exposed to

The contract declares every list envelope `required: [data, page]` with `data` of `type: array`. A **nil Go slice marshals to `null`**, and `null` is not an array — so a handler whose store found nothing broke its own contract on the wire:

```
nil slice   -> {"data":null}
empty slice -> {"data":[]}
```

Go makes that the *easy* mistake rather than an unusual one. A nil slice **is** the idiomatic empty list — `append` works on it, `len` and `range` work — and the only place it behaves differently is `encoding/json`.

The cost falls on the client. Generated TypeScript reads `data: Person[]`, because the contract says so, and gives a caller no reason to guard. No compiler on either side can see it: the Go type is a slice, the TS type is an array, and only the encoder disagrees.

## Not five, and not thirty-six either

The issue lists five reads. There are now **36 across 18 files** — the enumeration rotted, as these enumerations do. But the issue also asks the better question:

> Worth checking whether the generated client can express the body as required instead, which would fix the class rather than the five instances.

The contract **already** says `required: [data, page]`. The client is right and the server is wrong, so `(data.data ?? [])` at 36 sites would have taught 36 call sites to expect a shape the contract forbids — hardening the reader against a bug in the writer.

## One door

`httperr.WriteJSON` is the single door every list envelope leaves by, and it **already reflects for this exact field** to count served rows (`recordsIn`). The normalisation goes there: a nil `Data` slice becomes an empty one on the way out.

A guard at each handler would be a rule somebody has to remember. This is the only place that can be wrong once.

## The first cut did nothing, and passed its own test

It set the field in place. Every handler in this tree writes a struct **value** — `crmcontracts.PersonListResponse{Data: people, Page: …}` — and a value handed to an `any` parameter is not addressable, so `CanSet()` is false and the fix was a no-op for every case that ships. It passed through a pointer.

Both shapes are now cases, and the value one is the one that matters:

```
--- FAIL: TestAnEmptyListIsAnArrayNotNull/a_value_envelope
--- PASS: TestAnEmptyListIsAnArrayNotNull/a_pointer_envelope
```

That is why the unit tests are written against a **value** first.

## The census, and what it holds

`WriteJSON` finds the rows by **field name**. So an envelope whose rows lived under a different name would silently stop being normalised — correct on every list that has rows, and `null` on exactly the empty ones nobody tests.

`TestEveryListEnvelopeCarriesItsRowsWhereTheWriterLooks` reads the generated contract and finds **38** list envelopes by shape (a `Page` and a slice), not by a name ending in `ListResponse`. It fatals below 20, because a discovery that broke reports the same green as a tree where every envelope is correct.

| mutation | caught by |
|---|---|
| the writer looks for a differently-named field | both unit cases, value and pointer |
| the census's field name drifts from the writer's | `found 0 list envelope(s) … too few to be the whole set` |
| the normalisation empties a populated page | `TestAPopulatedListIsUnchanged` |
| it touches a body with no list at all | `TestABodyWithNoListIsLeftAlone` |

## One thing I did not ship, and why

I wrote an integration case hitting `/v1/people`, `/v1/organizations` and `/v1/leads` with a filter matching nothing, asserting `"data": []` on the real wire. **It passed without the fix**, because all three stores already initialise their slices — so it measured nothing, and I deleted it rather than leave a test that cannot fail.

The endpoint that gets this wrong is the one nobody has written yet, which is why the guard belongs at the writer and the census belongs over the contract.

`make check-backend` green. `make test-it DIR=backend/internal/compose/integration`: 1507 passed, over the changed writer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty list fields in JSON responses are now returned as `[]` instead of `null`.
  * Populated lists retain their contents and ordering.
  * Responses without list fields remain unchanged.

* **Tests**
  * Added coverage for empty-list formatting across paginated responses.
  * Added validation to ensure list responses consistently expose their row data.

* **Documentation**
  * Updated the gate inventory to include the new validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->