### PR TITLE
feat(history): one recorded event is one read (#1611)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9491,9 +9491,23 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Limit'
+        - name: action
+          in: query
+          required: false
+          description: |
+            Return only the rows recording this verb. A caller that wants ONE event —
+            "how was this lead promoted", "when was it erased" — asks for it rather than
+            paging the trail looking for it: without this, reading a single event costs a
+            walk whose length is the record's whole history, and a caller who reads only
+            the first page gets a confidently wrong answer on exactly the records somebody
+            worked hardest.
+            The vocabulary is `audit_log.action`'s own; an unknown verb is `422` rather
+            than an empty page, because "no such verb" and "that never happened here" are
+            different answers and only one of them is worth acting on.
+          schema: { type: string }
       responses:
         '200':
-          description: A page of rendered history lines, oldest first (empty when none).
+          description: A page of rendered history lines, newest first (empty when none).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/AuditHistoryListResponse' }

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -434,3 +434,71 @@ func TestRecordHistoryMalformedCursorIsAClientFault(t *testing.T) {
 		t.Fatalf("err = %v, want *storekit.MalformedCursorError untouched", err)
 	}
 }
+
+// One recorded event is one read.
+//
+// The trail is served newest-first and 20 to a page, so a caller after a single
+// event — "how was this lead promoted", "when was it erased" — either pages
+// until it turns up or reads the first page and gets a confident wrong answer.
+// The promoted-lead panel hit exactly that: it reported the outcome as
+// unknowable on the leads somebody had worked hardest, because those are the
+// ones with enough other rows to push the one it wanted off the page it read
+// (issue #1611).
+//
+// Seeded so the wanted row is NOT the newest and NOT the oldest. A filter that
+// silently did nothing would still return it at one of those two ends, and the
+// case would pass over a `WHERE` nobody wired.
+func TestRecordHistoryAnswersOneVerbWithoutAWalk(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Filtered Subject", nil)
+	actor := seedWorkspaceUser(t, e, "Vera Verb")
+
+	base := time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond)
+	for i, action := range []string{"update", "assign", "archive", "update", "restore"} {
+		seedRecordAuditRow(t, e, action, personID, "human", "human:"+actor.String(), nil,
+			nil, map[string]any{"n": i}, base.Add(time.Duration(i)*time.Hour))
+	}
+
+	archive := "archive"
+	page, err := privacy.ListRecordHistory(e.Admin(), e.DB(), privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID, Action: &archive,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("entries = %d, want exactly the one archive row — a filter that narrowed "+
+			"nothing would answer the whole trail: %+v", len(page.Entries), page.Entries)
+	}
+	if page.Entries[0].Action != archive {
+		t.Errorf("answered a %q row for action=%q", page.Entries[0].Action, archive)
+	}
+	// And it is the WHOLE answer: a caller reading one verb must be told there
+	// is no more, or they page on for rows that do not exist.
+	if page.HasMore || page.NextCursor != "" {
+		t.Errorf("a filtered page that holds every match must report exhaustion: "+
+			"has_more=%v cursor=%q", page.HasMore, page.NextCursor)
+	}
+}
+
+// A verb that happened to this record NEVER answers the same as a verb that
+// does not exist. The first is a fact about the record; the second is a
+// mistyped request, and a caller who reads an empty page for it concludes
+// something false about their data.
+func TestRecordHistoryRefusesAVerbItDoesNotRecord(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Refusal Subject", nil)
+
+	// Reaches the store, which is where an empty page would be manufactured.
+	// The wire refusal is the handler's and is asserted where the handler is.
+	neverHappened := "restore"
+	page, err := privacy.ListRecordHistory(e.Admin(), e.DB(), privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID, Action: &neverHappened,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Entries) != 0 {
+		t.Errorf("entries = %d, want none — this record has no restore row", len(page.Entries))
+	}
+}

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -481,11 +481,18 @@ func TestRecordHistoryAnswersOneVerbWithoutAWalk(t *testing.T) {
 	}
 }
 
-// A verb that happened to this record NEVER answers the same as a verb that
-// does not exist. The first is a fact about the record; the second is a
-// mistyped request, and a caller who reads an empty page for it concludes
-// something false about their data.
-func TestRecordHistoryRefusesAVerbItDoesNotRecord(t *testing.T) {
+// A KNOWN verb this record never saw answers an honest empty page.
+//
+// Named for what it checks, which is the store's half. The other half — a verb
+// the installation does not record at all — is refused 422 by the HANDLER, and
+// asserting it here would be asserting it of a function that never sees it:
+// ListRecordHistory takes a filter, not a request, so a bad verb reaching it
+// has already passed the door that was supposed to stop it.
+//
+// The two answers must stay different. This one is a fact about the record;
+// the other is a mistyped request, and a caller who reads an empty page for it
+// concludes something false about their data.
+func TestRecordHistoryAnswersAnEmptyPageForAVerbThisRecordNeverSaw(t *testing.T) {
 	e := Setup(t)
 	personID := e.SeedPerson(t, "Refusal Subject", nil)
 

--- a/backend/internal/compose/integration/recordhistoryaction_http_integration_test.go
+++ b/backend/internal/compose/integration/recordhistoryaction_http_integration_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The `action` filter at the DOOR, which is where the refusal lives.
+//
+// The store's half — a known verb this record never saw answers an honest empty
+// page — is asserted against ListRecordHistory, which takes a filter rather than
+// a request. A verb the installation does not record at all never reaches it:
+// the handler refuses that, so it has to be asserted where the handler is.
+//
+// The two answers must stay different. An empty page is a fact about the
+// record; a 422 is a mistyped request. A caller who reads the first for the
+// second concludes something false about their data (issue #1611).
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestRecordHistoryRefusesAVerbThisInstallationDoesNotRecord(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	pid := seedPersonWithActivity(t, e)
+
+	var problem struct {
+		Code    string `json:"code"`
+		Details struct {
+			Errors []struct {
+				Field string `json:"field"`
+				Code  string `json:"code"`
+			} `json:"errors"`
+		} `json:"details"`
+	}
+	// `promoted` is the plausible typo for `promote` — the shape a caller
+	// actually sends, rather than a string nothing could be mistaken for.
+	status := e.Call(t, "GET", "/v1/records/person/"+pid+"/history?action=promoted", nil, nil, &problem)
+	if status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 — an unknown verb answered as an empty page tells a "+
+			"caller this record never saw something, which is not what they asked", status)
+	}
+	if len(problem.Details.Errors) == 0 || problem.Details.Errors[0].Field != "action" {
+		t.Errorf("the refusal must name the parameter that was wrong, got %+v", problem)
+	}
+	if len(problem.Details.Errors) > 0 && problem.Details.Errors[0].Code != "unknown_action" {
+		t.Errorf("code = %q, want unknown_action", problem.Details.Errors[0].Code)
+	}
+
+	// And a verb the installation DOES record is admitted, so the refusal is
+	// about the vocabulary rather than about the parameter existing at all.
+	var page struct {
+		Data []map[string]any `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/records/person/"+pid+"/history?action=create", nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("a recorded verb = %d, want 200", status)
+	}
+	if len(page.Data) == 0 {
+		t.Error("filtering by a verb this record DOES carry answered nothing")
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29018,6 +29018,17 @@ type GetRecordHistoryParams struct {
 
 	// Limit Max items in the page.
 	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Action Return only the rows recording this verb. A caller that wants ONE event —
+	// "how was this lead promoted", "when was it erased" — asks for it rather than
+	// paging the trail looking for it: without this, reading a single event costs a
+	// walk whose length is the record's whole history, and a caller who reads only
+	// the first page gets a confidently wrong answer on exactly the records somebody
+	// worked hardest.
+	// The vocabulary is `audit_log.action`'s own; an unknown verb is `422` rather
+	// than an empty page, because "no such verb" and "that never happened here" are
+	// different answers and only one of them is worth acting on.
+	Action *string `form:"action,omitempty" json:"action,omitempty"`
 }
 
 // RestoreRecordChangeParams defines parameters for RestoreRecordChange.
@@ -60395,6 +60406,19 @@ func (siw *ServerInterfaceWrapper) GetRecordHistory(w http.ResponseWriter, r *ht
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "action" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "action", r.URL.Query(), &params.Action, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "action"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "action", Err: err})
 		}
 		return
 	}

--- a/backend/internal/modules/privacy/handlers_recordhistory.go
+++ b/backend/internal/modules/privacy/handlers_recordhistory.go
@@ -9,6 +9,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -26,11 +27,22 @@ func (h Handlers) GetRecordHistory(w http.ResponseWriter, r *http.Request,
 			"entity_type must be one of "+fieldHistoryEntityTypeList))
 		return
 	}
+	// An unknown verb is refused rather than answered with an empty page: a
+	// caller who mistyped `promoted` for `promote` would otherwise read "that
+	// never happened to this record", which is a confident answer to a question
+	// they did not ask. The vocabulary is auth's own grant map, which must
+	// already name every verb the tree records.
+	if params.Action != nil && !auth.IsAuditAction(*params.Action) {
+		httperr.Write(w, r, httperr.Validation("action", "unknown_action",
+			"action must be an audit verb this installation records"))
+		return
+	}
 	f := RecordHistoryFilter{
 		EntityType: entityType,
 		EntityID:   ids.UUID(id),
 		Cursor:     params.Cursor,
 		Limit:      params.Limit,
+		Action:     params.Action,
 	}
 
 	page, err := ListRecordHistory(r.Context(), h.db, f)

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -40,6 +40,11 @@ type RecordHistoryFilter struct {
 	EntityID   ids.UUID
 	Cursor     *string
 	Limit      *int
+	// Action narrows to one audit verb. A caller after ONE event asks for it
+	// rather than paging the trail looking for it — a walk whose length is the
+	// record's whole history, and whose first page is a confidently wrong
+	// answer on exactly the records somebody worked hardest.
+	Action *string
 }
 
 // RecordHistoryEntry is one audit_log row rendered as a history line —
@@ -287,6 +292,10 @@ func queryRecordHistoryWindow(ctx context.Context, tx pgx.Tx, f RecordHistoryFil
 		// image holds the role and the dates the scrub covered.
 		conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) >= ($%d, $%d)", len(args)+1, len(args)+2))
 		args = append(args, boundary.occurredAt, boundary.id)
+	}
+	if f.Action != nil {
+		conds = append(conds, fmt.Sprintf("a.action = $%d", len(args)+1))
+		args = append(args, *f.Action)
 	}
 	if useCursor {
 		// The page walks BACKWARDS in time, so the keyset takes what is older

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -146,6 +146,22 @@ func RequireHuman(ctx context.Context) error {
 // corpus is gated as an update. A verb missing here renders a BLANK
 // authorization_rule, which reads as "no rule applied" years later —
 // TestEveryAuditVerbRendersItsAuthorizationRule keeps the set closed.
+// IsAuditAction reports whether a verb is one audit_log records.
+//
+// Derived from the grant map below rather than from a list of its own: that map
+// must already name every verb — a missing entry renders a blank
+// authorization_rule, and TestEveryAuditVerbRendersItsAuthorizationRule keeps
+// the set closed — so it is the vocabulary, and a second copy could only ever
+// disagree with it.
+//
+// A reader of the record-history filter asks this so an unknown verb answers
+// 422 rather than an empty page: "no such verb" and "that never happened to
+// this record" are different answers, and only one of them is worth acting on.
+func IsAuditAction(verb string) bool {
+	_, known := auditActionGrant[verb]
+	return known
+}
+
 var auditActionGrant = map[string]principal.Action{
 	"create":        principal.ActionCreate,
 	"update":        principal.ActionUpdate,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -33790,6 +33790,18 @@ export interface operations {
                 cursor?: components["parameters"]["Cursor"];
                 /** @description Max items in the page. */
                 limit?: components["parameters"]["Limit"];
+                /**
+                 * @description Return only the rows recording this verb. A caller that wants ONE event —
+                 *     "how was this lead promoted", "when was it erased" — asks for it rather than
+                 *     paging the trail looking for it: without this, reading a single event costs a
+                 *     walk whose length is the record's whole history, and a caller who reads only
+                 *     the first page gets a confidently wrong answer on exactly the records somebody
+                 *     worked hardest.
+                 *     The vocabulary is `audit_log.action`'s own; an unknown verb is `422` rather
+                 *     than an empty page, because "no such verb" and "that never happened here" are
+                 *     different answers and only one of them is worth acting on.
+                 */
+                action?: string;
             };
             header?: never;
             path: {
@@ -33801,7 +33813,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description A page of rendered history lines, oldest first (empty when none). */
+            /** @description A page of rendered history lines, newest first (empty when none). */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/screens/historyentries.tsx
+++ b/frontend/src/screens/historyentries.tsx
@@ -57,9 +57,18 @@ export function useRecordHistory(
   // says so rather than paying for a page nothing renders. Defaults to on, so
   // the History tab is unchanged.
   enabled = true,
+  // One verb, for a caller describing a single recorded event. Without it that
+  // caller pages the whole trail looking for its row — and one that read only
+  // the first page got a confident wrong answer on exactly the records somebody
+  // worked hardest, because those are the ones with enough other rows to push
+  // it off. Absent means the whole history, which is what the History tab wants.
+  action?: string,
 ): UseInfiniteQueryResult<InfiniteData<AuditHistoryListResponse>> {
   return useInfiniteQuery({
-    queryKey: ["record-history", kind, id],
+    // The verb is part of the key: a filtered read and the whole trail are
+    // different answers, and sharing a cache entry would serve one for the
+    // other depending on which mounted first.
+    queryKey: ["record-history", kind, id, action ?? null],
     enabled,
     initialPageParam: FIRST_PAGE,
     queryFn: async ({ pageParam }) => {
@@ -68,7 +77,11 @@ export function useRecordHistory(
         {
           params: {
             path: { entity_type: kind, id },
-            query: { limit: 20, ...(pageParam ? { cursor: pageParam } : {}) },
+            query: {
+              limit: 20,
+              ...(pageParam ? { cursor: pageParam } : {}),
+              ...(action ? { action } : {}),
+            },
           },
         },
       );

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -710,45 +710,32 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(screen.queryByText(/Disqualified — this lead/)).toBeNull();
   });
 
-  it("finds the promotion when earlier audit rows push it onto a later page", async () => {
-    // The history is served OLDEST FIRST, 20 to a page, and `promote` is the
-    // LAST thing that happens to a lead. So a lead worked long enough to
-    // collect a page of earlier rows carries its promotion on a later one, and
-    // reading only the first page reported "we cannot tell" on exactly the
-    // leads someone worked hardest.
-    const filler = Array.from({ length: 20 }, (_, i) => ({
-      id: `a-${i}`,
-      actor_type: "human",
-      actor_id: "human:u-9",
-      action: "update",
-      occurred_at: "2026-06-01T08:00:00Z",
-      after: { status: "contacted" },
-    }));
+  it("asks for the promotion by verb, and reads it without a second page", async () => {
+    // What this replaced: the history is 20 rows to a page, so a lead worked
+    // long enough to collect other audit rows carried its promotion on a later
+    // one — and reading the first page reported "we cannot tell" on exactly the
+    // leads somebody had worked hardest. The client answer was to page on until
+    // it turned up; the server answer is to ask for the row (#1611).
+    //
+    // So the assertion is BOTH halves: the request names the verb, and there is
+    // exactly one request. A screen that still walked would pass the first.
+    const historyURLs: string[] = [];
     stubFetch(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/records/lead/")) {
-        // The second page is asked for by cursor; the first hands one back.
-        if (url.includes("cursor=")) {
-          return jsonResponse({
-            data: [
-              {
-                id: "a-99",
-                actor_type: "human",
-                actor_id: "human:u-9",
-                action: "promote",
-                occurred_at: "2026-06-20T08:00:00Z",
-                after: {
-                  dedupe_outcome: "merged",
-                  trigger: "inbound_reply",
-                },
-              },
-            ],
-            page: { next_cursor: null, has_more: false },
-          });
-        }
+        historyURLs.push(url);
         return jsonResponse({
-          data: filler,
-          page: { next_cursor: "page-2", has_more: true },
+          data: [
+            {
+              id: "a-99",
+              actor_type: "human",
+              actor_id: "human:u-9",
+              action: "promote",
+              occurred_at: "2026-06-20T08:00:00Z",
+              after: { dedupe_outcome: "merged", trigger: "inbound_reply" },
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
         });
       }
       return jsonResponse({
@@ -765,32 +752,19 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
         "This lead merged into a contact we already knew — no duplicate was created.",
       ),
     ).toBeTruthy();
+    expect(historyURLs).toHaveLength(1);
+    expect(historyURLs[0]).toContain("action=promote");
   });
 
-  it("stops walking when a later page fails, and says so", async () => {
-    // The pages already read stay cached, so hasNextPage stays true and
-    // isFetchingNextPage falls back to false the moment the failure settles.
-    // Without a stop that re-arms the walk forever — and `pending` outranking
-    // `failed` would hide the error behind a waiting line the whole time.
-    let historyCalls = 0;
-    const filler = Array.from({ length: 20 }, (_, i) => ({
-      id: `a-${i}`,
-      actor_type: "human",
-      actor_id: "human:u-9",
-      action: "update",
-      occurred_at: "2026-06-01T08:00:00Z",
-      after: { status: "contacted" },
-    }));
+  it("reports a failed history read as failed, never as still pending", async () => {
+    // `pending` outranking `failed` renders a waiting line over an error
+    // nobody ever sees — which is what a walk that re-armed on failure did.
     stubFetch(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/records/lead/")) {
-        historyCalls += 1;
-        if (url.includes("cursor=")) {
-          return jsonResponse({ title: "boom" }, 500);
-        }
-        return jsonResponse({
-          data: filler,
-          page: { next_cursor: "page-2", has_more: true },
+        return new Response(JSON.stringify({ title: "Server Error" }), {
+          status: 500,
+          headers: { "Content-Type": "application/problem+json" },
         });
       }
       return jsonResponse({
@@ -803,13 +777,14 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     render(<LeadScreen id="l-1" />);
 
     expect(
-      await screen.findByText(
-        "We cannot show whether this merged or created a contact.",
-      ),
+      await screen.findByText("Promoted — this lead is now read-only."),
     ).toBeTruthy();
-    // And it stopped rather than hammering the endpoint: page 1 plus a bounded
-    // number of failed attempts, not an unbounded retry storm.
-    expect(historyCalls).toBeLessThan(6);
+    // The outcome line never claims a result it could not read.
+    expect(
+      screen.queryByText(
+        "This lead merged into a contact we already knew — no duplicate was created.",
+      ),
+    ).toBeNull();
   });
 
   it("re-reads the history after promoting, so the new audit row is not missed", async () => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1058,48 +1058,25 @@ type PromotionRecord = {
  * every other one rather than fetching a history nothing renders.
  */
 function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
-  const history = useRecordHistory("lead", id, promoted);
+  // ONE row, asked for by verb. The history endpoint takes an `action` filter
+  // now (#1611), so the promotion is the answer to the read rather than
+  // something found by walking towards it.
+  //
+  // What that replaced is worth remembering, because it was a real wrong
+  // answer and not merely a slow one: the trail is 20 rows to a page, so a lead
+  // worked long enough to collect other audit rows carried its promotion on a
+  // later page, and a reader that took the first page reported the outcome as
+  // unknowable on exactly the leads somebody had worked hardest. Paging on
+  // until it turned up fixed the answer and cost a round trip per page.
+  //
+  // A filtered read has at most one promote row — a lead is promoted once —
+  // so there is no page after the first and nothing to walk.
+  const history = useRecordHistory("lead", id, promoted, "promote");
   // `page?.data` for the same reason getNextPageParam needs it: a 200 with no
   // body is a shape the contract permits, and this read runs on every promoted
   // lead page.
   const entries = history.data?.pages.flatMap((page) => page?.data ?? []) ?? [];
-  const row = entries.find((entry) => entry.action === "promote");
-
-  // The history is served OLDEST FIRST, 20 to a page, and `promote` is the
-  // LAST thing that ever happens to a lead — it retires the record. So a lead
-  // worked long enough to collect 20 earlier audit rows carries its promotion
-  // on a later page, and reading only the first one found nothing and reported
-  // the outcome as unknowable on exactly the leads someone worked hardest.
-  //
-  // Paging on until it turns up is the client half of the fix. The server half
-  // — an `action` filter on the history endpoint, so this is one row rather
-  // than a walk — needs a contract change, filed as issue 1611.
-  const { fetchNextPage, hasNextPage, isFetchingNextPage } = history;
-  const pagesRead = history.data?.pages.length ?? 0;
-  // Two things end the walk besides finding the row, and each is a way it
-  // would otherwise never end:
-  //
-  //   - a later page FAILING. The pages already read stay cached, so
-  //     `hasNextPage` stays true and `isFetchingNextPage` falls back to false
-  //     the moment the failure settles — which re-arms the effect and retries
-  //     forever, while `pending` masks the error the panel should be showing.
-  //   - a history long enough that the walk is itself the problem, or a server
-  //     bug handing back a cursor that never advances. The cap is generous
-  //     against a real lead and finite against a pathological one; stopping
-  //     early reports the outcome as unavailable, which is true.
-  const WALK_PAGE_CAP = 25;
-  const seeking =
-    promoted &&
-    !row &&
-    hasNextPage &&
-    !isFetchingNextPage &&
-    !history.isError &&
-    pagesRead < WALK_PAGE_CAP;
-  useEffect(() => {
-    if (seeking) {
-      fetchNextPage();
-    }
-  }, [seeking, fetchNextPage]);
+  const row = entries[0];
 
   const after = (row?.after ?? {}) as Record<string, unknown>;
   const str = (key: string) =>
@@ -1110,14 +1087,11 @@ function usePromotionRecord(id: string, promoted: boolean): PromotionRecord {
       recorded === "merged" || recorded === "created" ? recorded : "unknown",
     trigger: str("trigger"),
     evidenceNote: str("evidence_note"),
-    // Still walking is still pending: reporting "we cannot tell" while pages
-    // are in flight is the same false certainty as reporting "created".
-    // A FAILED read is never pending — the panel checks pending first, so
-    // leaving both true renders a waiting line over an error nobody ever sees.
-    pending:
-      promoted &&
-      !history.isError &&
-      (history.isPending || Boolean(seeking) || isFetchingNextPage),
+    // A read in flight is pending: reporting "we cannot tell" before the answer
+    // arrives is the same false certainty as reporting "created". A FAILED read
+    // is never pending — the panel checks pending first, so leaving both true
+    // renders a waiting line over an error nobody ever sees.
+    pending: promoted && !history.isError && history.isPending,
     failed: promoted && history.isError,
   };
 }


### PR DESCRIPTION
Closes #1611.

## What the walk was for

`GET /records/{entity_type}/{id}/history` took a cursor and nothing else, so a caller after a **single** event had to page the trail looking for it. The promoted-lead panel did exactly that — and before the walk existed it read only the first page, reporting the outcome as unknowable on precisely the leads somebody had worked hardest, because those are the ones with enough other audit rows to push the one it wanted off the page it read.

## The filter

The trail now takes an `action`. The vocabulary is **`auth`'s own grant map** — which must already name every verb the tree records (a missing entry renders a blank `authorization_rule`, and `TestEveryAuditVerbRendersItsAuthorizationRule` keeps it closed) — so `IsAuditAction` derives from it rather than from a second list that could only ever disagree with it.

An unknown verb is **422, never an empty page**. "No such verb" and "that never happened to this record" are different answers, and a caller who mistyped `promoted` for `promote` would otherwise read a confident answer to a question they did not ask.

## The walk goes

`usePromotionRecord` asks for `action=promote` and reads one row. Gone with it: the page cap, the effect, and the two ways it could fail to terminate (a later page failing re-armed it forever; a cursor that never advanced ran it to the cap).

Its test is replaced by one asserting **both halves** of what replaced it:

```ts
expect(historyURLs).toHaveLength(1);
expect(historyURLs[0]).toContain("action=promote");
```

A screen that still walked would pass the first assertion. The failure case keeps its own test, because `pending` outranking `failed` renders a waiting line over an error nobody ever sees — which is what the walk did on a failed page.

## The sort half was already done, and the contract still said otherwise

The issue also asks whether a `sort` control is worth adding. It is not needed: the read is already newest-first (`occurred_at DESC`, `id` tiebreak), and the operation description says so. But the **200 description directly beneath it still said "oldest first"** — the sort was changed and that line was not, so the contract contradicted itself about the order a client should expect. Corrected here.

That also means the walk's own comment was stale: it explained that `promote` lands on a *later* page because the trail is oldest-first, which stopped being true when the order flipped.

## Verification

| mutation | caught by |
|---|---|
| the `WHERE a.action` clause removed | `entries = 6, want exactly the one archive row — a filter that narrowed nothing would answer the whole trail` |
| the hook drops `action` from the query | `asks for the promotion by verb, and reads it without a second page` |

The store test seeds the wanted row **neither newest nor oldest**, so a filter that silently did nothing would still return it at one of those two ends and the case would pass over a `WHERE` nobody wired.

`make check-backend` and `make check-fe` green. `make test-it DIR=backend/internal/compose/integration RUN=RecordHistory`: 11 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added action-based filtering for record history.
  * History results are now ordered newest first.
  * Unknown action filters return a validation error.
  * Lead promotion status now checks only promotion-related history entries.

* **Bug Fixes**
  * Improved promotion status handling when history requests fail, avoiding incorrect unread-promotion messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->