### PR TITLE
fix(recordtabs): the rail no longer covers the record's first tabs

### DIFF
--- a/frontend/e2e/recordtabs.spec.ts
+++ b/frontend/e2e/recordtabs.spec.ts
@@ -1,0 +1,101 @@
+import { expect, type Page, test } from "@playwright/test";
+import { mockApi } from "./seed";
+
+/**
+ * The record tab strip is never covered by the rail beside it.
+ *
+ * The strip's rules span the WORK column, so they read as the seam between a
+ * record's identity and its content rather than as a box drawn around the
+ * tabs. The rail is a column INSIDE that same container, so a strip that
+ * centres itself on the container runs underneath it: on the contact page the
+ * rail's card sat over the first three tabs, and a reader met "Network" cut to
+ * "twork" with the two tabs before it missing entirely. That reads as a broken
+ * menu, not as a strip that continues.
+ *
+ * A geometry test rather than a unit one, because the defect is layout: the
+ * markup, the labels and the order were all correct while the page was wrong.
+ * jsdom has no box model and would have passed throughout.
+ */
+
+// Where the columns fold. Above it the rail is BESIDE the tabs and can cover
+// them; below it the rail stacks underneath and the question does not arise.
+const RAILED_WIDTHS = [1280, 1440, 1600];
+
+async function openContact(page: Page) {
+  await mockApi(page);
+  await page.goto("/#/contacts/p-anna");
+  await expect(page.locator(".record-head h1")).toBeVisible();
+  await expect(page.locator(".recordtabs-tab").first()).toBeVisible();
+}
+
+test.describe("the record tab strip", () => {
+  for (const width of RAILED_WIDTHS) {
+    test(`is clear of the rail at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await openContact(page);
+
+      const rail = await page.locator(".record-rail").boundingBox();
+      const tabs = await page.locator(".recordtabs-tab").all();
+      expect(tabs.length).toBeGreaterThan(0);
+      if (!rail) {
+        throw new Error("the rail is present but has no box — cannot place it");
+      }
+
+      for (const tab of tabs) {
+        const box = await tab.boundingBox();
+        const label = (await tab.textContent())?.trim();
+        if (!box) {
+          throw new Error(`tab "${label}" has no box`);
+        }
+        // Only a rail on the same row can cover a tab. Once the columns fold
+        // the rail sits below, and a left-edge comparison alone would read
+        // that stacking as an overlap.
+        const sameRow =
+          box.y < rail.y + rail.height && box.y + box.height > rail.y;
+        if (sameRow) {
+          expect(
+            box.x,
+            `tab "${label}" starts left of the rail's right edge, so the rail covers it`,
+          ).toBeGreaterThanOrEqual(rail.x + rail.width);
+        }
+      }
+    });
+  }
+
+  // The strip may scroll — it says so — but it must not OPEN scrolled, which
+  // is what hid the first tabs while the last ones were in view.
+  test("opens at its first tab", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await openContact(page);
+    const scrolled = await page
+      .locator(".recordtabs-strip")
+      .evaluate((el) => el.scrollLeft);
+    expect(scrolled).toBe(0);
+  });
+
+  // Every tab is readable in full. A strip whose last tab is half-drawn is the
+  // same defect one column over.
+  test("draws every tab whole", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openContact(page);
+    const strip = await page.locator(".recordtabs-strip").boundingBox();
+    if (!strip) {
+      throw new Error("the strip is present but has no box");
+    }
+    for (const tab of await page.locator(".recordtabs-tab").all()) {
+      const box = await tab.boundingBox();
+      const label = (await tab.textContent())?.trim();
+      if (!box) {
+        throw new Error(`tab "${label}" has no box`);
+      }
+      expect(
+        box.x,
+        `tab "${label}" is cut off at the strip's left`,
+      ).toBeGreaterThanOrEqual(strip.x - 1);
+      expect(
+        box.x + box.width,
+        `tab "${label}" is cut off at the strip's right`,
+      ).toBeLessThanOrEqual(strip.x + strip.width + 1);
+    }
+  });
+});

--- a/frontend/e2e/recordtabs.spec.ts
+++ b/frontend/e2e/recordtabs.spec.ts
@@ -2,100 +2,108 @@ import { expect, type Page, test } from "@playwright/test";
 import { mockApi } from "./seed";
 
 /**
- * The record tab strip is never covered by the rail beside it.
+ * A railed record's tab strip is never covered by the rail beside it.
  *
  * The strip's rules span the WORK column, so they read as the seam between a
  * record's identity and its content rather than as a box drawn around the
  * tabs. The rail is a column INSIDE that same container, so a strip that
- * centres itself on the container runs underneath it: on the contact page the
- * rail's card sat over the first three tabs, and a reader met "Network" cut to
- * "twork" with the two tabs before it missing entirely. That reads as a broken
- * menu, not as a strip that continues.
+ * centres itself on the container runs underneath it — 138px of it, which on
+ * the contact page is the first three tabs.
  *
  * A geometry test rather than a unit one, because the defect is layout: the
  * markup, the labels and the order were all correct while the page was wrong.
  * jsdom has no box model and would have passed throughout.
+ *
+ * BOTH railed records, not just the one the defect was reported on: the
+ * invariant is that a rail never covers the strip, and two pages carry a rail.
  */
 
 // Where the columns fold. Above it the rail is BESIDE the tabs and can cover
 // them; below it the rail stacks underneath and the question does not arise.
 const RAILED_WIDTHS = [1280, 1440, 1600];
 
-async function openContact(page: Page) {
+// Every record whose layout places a rail to the left of the work column.
+const RAILED_RECORDS = [
+  { name: "contact", route: "/#/contacts/p-anna" },
+  { name: "lead", route: "/#/leads/l-1" },
+];
+
+async function openRecord(page: Page, route: string) {
   await mockApi(page);
-  await page.goto("/#/contacts/p-anna");
-  await expect(page.locator(".record-head h1")).toBeVisible();
+  await page.goto(route);
   await expect(page.locator(".recordtabs-tab").first()).toBeVisible();
+  await expect(page.locator(".record-rail")).toBeVisible();
 }
 
 test.describe("the record tab strip", () => {
-  for (const width of RAILED_WIDTHS) {
-    test(`is clear of the rail at ${width}px`, async ({ page }) => {
-      await page.setViewportSize({ width, height: 900 });
-      await openContact(page);
+  for (const record of RAILED_RECORDS) {
+    for (const width of RAILED_WIDTHS) {
+      test(`is clear of the rail on a ${record.name} at ${width}px`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width, height: 900 });
+        await openRecord(page, record.route);
 
-      const rail = await page.locator(".record-rail").boundingBox();
-      const tabs = await page.locator(".recordtabs-tab").all();
-      expect(tabs.length).toBeGreaterThan(0);
-      if (!rail) {
-        throw new Error("the rail is present but has no box — cannot place it");
-      }
+        const rail = await page.locator(".record-rail").boundingBox();
+        const tabs = await page.locator(".recordtabs-tab").all();
+        expect(tabs.length).toBeGreaterThan(0);
+        if (!rail) {
+          throw new Error("the rail is visible but has no box");
+        }
 
-      for (const tab of tabs) {
-        const box = await tab.boundingBox();
-        const label = (await tab.textContent())?.trim();
-        if (!box) {
-          throw new Error(`tab "${label}" has no box`);
+        for (const tab of tabs) {
+          const box = await tab.boundingBox();
+          const label = (await tab.textContent())?.trim();
+          if (!box) {
+            throw new Error(`tab "${label}" has no box`);
+          }
+          // Only a rail on the same row can cover a tab. Once the columns fold
+          // the rail sits below, and a left-edge comparison alone would read
+          // that stacking as an overlap.
+          const sameRow =
+            box.y < rail.y + rail.height && box.y + box.height > rail.y;
+          if (sameRow) {
+            expect(
+              box.x,
+              `tab "${label}" starts left of the rail's right edge, so the rail covers it`,
+            ).toBeGreaterThanOrEqual(rail.x + rail.width);
+          }
         }
-        // Only a rail on the same row can cover a tab. Once the columns fold
-        // the rail sits below, and a left-edge comparison alone would read
-        // that stacking as an overlap.
-        const sameRow =
-          box.y < rail.y + rail.height && box.y + box.height > rail.y;
-        if (sameRow) {
-          expect(
-            box.x,
-            `tab "${label}" starts left of the rail's right edge, so the rail covers it`,
-          ).toBeGreaterThanOrEqual(rail.x + rail.width);
-        }
-      }
-    });
+      });
+    }
   }
 
-  // The strip may scroll — it says so — but it must not OPEN scrolled, which
-  // is what hid the first tabs while the last ones were in view.
-  test("opens at its first tab", async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 900 });
-    await openContact(page);
-    const scrolled = await page
-      .locator(".recordtabs-strip")
-      .evaluate((el) => el.scrollLeft);
-    expect(scrolled).toBe(0);
-  });
+  // The strip belongs to its column, on EVERY railed record.
+  //
+  // Measured against the column rather than against its own children, which is
+  // what makes it fail when the breakout returns: a strip and its tabs move
+  // TOGETHER under the broken rule, so any assertion comparing the two passes
+  // in both states. It is also the only check the lead page can fail — it
+  // carries two tabs, so its strip can overhang the rail without a tab
+  // landing under one, and the overhang is the defect either way.
+  for (const record of RAILED_RECORDS) {
+    test(`keeps the width of the column it sits in on a ${record.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await openRecord(page, record.route);
 
-  // Every tab is readable in full. A strip whose last tab is half-drawn is the
-  // same defect one column over.
-  test("draws every tab whole", async ({ page }) => {
-    await page.setViewportSize({ width: 1440, height: 900 });
-    await openContact(page);
-    const strip = await page.locator(".recordtabs-strip").boundingBox();
-    if (!strip) {
-      throw new Error("the strip is present but has no box");
-    }
-    for (const tab of await page.locator(".recordtabs-tab").all()) {
-      const box = await tab.boundingBox();
-      const label = (await tab.textContent())?.trim();
-      if (!box) {
-        throw new Error(`tab "${label}" has no box`);
+      const strip = await page.locator(".recordtabs").boundingBox();
+      const column = await page.locator(".page-zones-main").boundingBox();
+      if (!strip || !column) {
+        throw new Error(
+          "the strip and its column are visible but one has no box",
+        );
       }
+      // One pixel of tolerance: the boxes are laid out in fractional CSS pixels.
       expect(
-        box.x,
-        `tab "${label}" is cut off at the strip's left`,
-      ).toBeGreaterThanOrEqual(strip.x - 1);
+        strip.x,
+        "the strip starts left of its column, which is where it ran under the rail",
+      ).toBeGreaterThanOrEqual(column.x - 1);
       expect(
-        box.x + box.width,
-        `tab "${label}" is cut off at the strip's right`,
-      ).toBeLessThanOrEqual(strip.x + strip.width + 1);
-    }
-  });
+        strip.x + strip.width,
+        "the strip runs past its column's right edge",
+      ).toBeLessThanOrEqual(column.x + column.width + 1);
+    });
+  }
 });

--- a/frontend/src/design-system/recordtabs.css
+++ b/frontend/src/design-system/recordtabs.css
@@ -27,17 +27,21 @@
   }
 }
 
-/* A record with a rail is the exception, and it has to be: the rail is a COLUMN
-   INSIDE the work container, so a strip that centres itself on the container
-   runs underneath it. On the contact page that put the rail's card over the
-   first tabs — a reader saw "Network" cut to "twork" and the two tabs before it
-   not at all, which reads as a broken menu rather than as a strip that
-   continues.
+/* A record with a RAIL is the exception, and it has to be: the rail is a
+   column INSIDE the work container, so a strip that centres itself on the
+   container runs underneath it, and the rail's cards are drawn over the tabs.
 
-   Inside a railed record the strip keeps its own column. The rules stop where
-   the reading column does, which is the narrower answer the fallback above
-   already takes when there is no container to measure. */
-.page-zones-main .recordtabs {
+   Scoped to the two shapes that place a column to the LEFT of the work column,
+   because a breakout centred on the container reaches leftward by half its
+   overhang and those are the only shapes with anything there to collide with.
+   An `aside` is to the RIGHT: the strip still crosses that track, which is
+   the full-width seam the rules are for and is left as it was.
+
+   Inside these two the strip keeps its own column: the rules stop where the
+   reading column does, which is the narrower answer the fallback above already
+   takes when there is no container to measure. */
+.page-zones-rail .recordtabs,
+.page-zones-both .recordtabs {
   inline-size: auto;
   margin-inline: 0;
 }
@@ -46,7 +50,8 @@
    record measure so the first tab lands under the record's mark; inside a
    column that measure is wider than the column, so centring pushed the first
    tabs off the left of it and the strip opened part-way along. */
-.page-zones-main .recordtabs-row {
+.page-zones-rail .recordtabs-row,
+.page-zones-both .recordtabs-row {
   max-inline-size: none;
   padding-inline: 0;
 }

--- a/frontend/src/design-system/recordtabs.css
+++ b/frontend/src/design-system/recordtabs.css
@@ -27,6 +27,30 @@
   }
 }
 
+/* A record with a rail is the exception, and it has to be: the rail is a COLUMN
+   INSIDE the work container, so a strip that centres itself on the container
+   runs underneath it. On the contact page that put the rail's card over the
+   first tabs — a reader saw "Network" cut to "twork" and the two tabs before it
+   not at all, which reads as a broken menu rather than as a strip that
+   continues.
+
+   Inside a railed record the strip keeps its own column. The rules stop where
+   the reading column does, which is the narrower answer the fallback above
+   already takes when there is no container to measure. */
+.page-zones-main .recordtabs {
+  inline-size: auto;
+  margin-inline: 0;
+}
+
+/* And its tabs start at the column's own edge. The row centres itself in the
+   record measure so the first tab lands under the record's mark; inside a
+   column that measure is wider than the column, so centring pushed the first
+   tabs off the left of it and the strip opened part-way along. */
+.page-zones-main .recordtabs-row {
+  max-inline-size: none;
+  padding-inline: 0;
+}
+
 /* The tabs themselves keep the record's own column, so the first tab sits
    under the record's mark rather than against the window's edge. Only the
    RULES cross the page; the tabs belong to the document under them. */


### PR DESCRIPTION
On a record with a rail the tab strip opened part-way along. The contact page
drew "Network" cut to "twork", with Overview and History not visible at all —
which reads as a broken menu rather than as a strip that continues.

## Cause

The strip's rules are meant to span the work column, so they read as the seam
between a record's identity and its content rather than as a box around the
tabs. The rail is a column INSIDE that container, so a strip centred on the
container runs underneath it. Measured at 138px on the contact page, which is
exactly the first three tabs.

**Not caused by the seventh tab.** The overlap measured 138px with the Network
tab removed from the DOM as well. Seven tabs made it visible; six had the same
defect with a less noticeable tab under the rail.

## Fix

Two rules scoped to `page-zones-rail` and `page-zones-both` — the shapes that
place a column to the LEFT of the work column, which is the only side a
container-centred breakout reaches into. Inside those the strip keeps its own
column, which is the narrower answer the no-container fallback already takes.
An `aside` sits to the right and keeps the full-width rules unchanged.

`container-name: work` stays where it is. Re-homing it onto the main column
would be structurally cleaner but changes what every future `@container work`
consumer measures, and this is the smaller diff.

## Verification

A geometry test, because the defect is layout: the markup, the labels and the
order were all correct while the page was wrong, and jsdom has no box model.

It covers both railed records (contact and lead) at three widths above the fold,
asserts no tab starts left of the rail's right edge on the same row, and
measures the strip against its column — the comparison the defect actually
moves, since a strip and its tabs travel together under the broken rule.

Mutation-checked: five of the eight fail with the CSS reverted. `make check-fe`
green, full e2e suite green at 160 passed.

An earlier cut of this used a broader selector and two tests that could not
fail; review caught both and the second commit is the correction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the record tab strip being covered by the rail on railed records. The strip used to center on the work container, but the rail sits inside that container, so the strip ran underneath it and the first tabs were cut off or hidden — on the contact page "Network" read as "twork" with Overview and History not visible.

**Bug Fixes**
- The strip now keeps its own column on `page-zones-rail` and `page-zones-both`, the two layouts that place a column to the left of the work column.
- The defect isn't caused by the seventh tab; six tabs had the same overlap less visibly.

**Verification**
- Adds a geometry e2e test, since jsdom has no box model and the markup, labels, and order were all correct while the page was wrong.
- It covers both railed records (contact and lead) at three widths, asserting no tab starts left of the rail's right edge on the same row, and measures the strip against its column — the comparison the defect actually moves.
- Five of the eight tests fail with the fix reverted; the full e2e suite passes.

<sup>Written for commit 2101990b5b9e2efec063d78dcd5579a85ba375bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record tab layouts when a left-side rail is present.
  * Prevented visible tabs from overlapping the record rail.
  * Kept tab strips within the main content column across desktop screen sizes.

* **Tests**
  * Added geometry coverage for contact and lead record tab layouts at multiple desktop widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->