### PR TITLE
fix(worklist): a bounded lane bounds the rows that qualify

### DIFF
--- a/backend/internal/compose/attentionfeed_integration_test.go
+++ b/backend/internal/compose/attentionfeed_integration_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/margince/margince/backend/internal/compose/attention"
-	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
@@ -36,28 +34,15 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// assembleFeed reads the whole feed through the real seams, at a chosen instant.
+// assembleFeed reads the whole feed at a chosen instant, through the wiring the
+// route itself serves.
 //
-// Built from newAttentionHandlers' own wiring rather than a second arrangement
-// of it: a test that assembled its own service would pass while the wiring the
-// product ships was broken.
+// newAttentionService is the production binding: arranging these seams here
+// instead would let a test keep passing while the shipped feed lost a lane,
+// which is exactly the gap the feed's stub-driven unit tests leave.
 func assembleFeed(ctx context.Context, t *testing.T, e *integration.Env, now time.Time) crmcontracts.Attention {
 	t.Helper()
-	db := InstallationDB(e.Pool)
-	svc := approvals.NewService(e.DB())
-	clock := func() time.Time { return now }
-	// The four required seams are real. The last three are optional by
-	// construction — nil means the installation does not serve that lane — and
-	// leaving them out keeps each test's subject to the lane it is about.
-	feed := attention.NewService(
-		attentionApprovals{svc: svc},
-		attentionDuplicates{store: people.NewStore(db)},
-		attentionTasks{store: activities.NewStore(db)},
-		attentionReceipts{svc: svc},
-		attentionBriefing{engine: briefs.NewBriefEngine(e.Pool, people.NewStore(db)), now: clock},
-		nil, nil, nil,
-		clock,
-	)
+	feed := newAttentionService(e.Pool, approvals.NewService(e.DB()), func() time.Time { return now })
 	day, err := feed.Assemble(ctx)
 	if err != nil {
 		t.Fatalf("assembling the day: %v", err)
@@ -246,12 +231,98 @@ func TestADepartedColleaguesDecisionIsNotReportedAsTheSystemsWork(t *testing.T) 
 	if _, err := svc.Decide(e.Admin(), id, true, nil); err != nil {
 		t.Fatalf("approving as a human: %v", err)
 	}
-	// The decider leaves. The foreign key empties decided_by on the row they
-	// decided, which is exactly the state the old predicate read as a receipt.
-	e.WsExec(t, `UPDATE approval SET decided_by = NULL WHERE id = $1`, id)
+	// The decider leaves. Deleting the app_user is what a real departure does,
+	// and approval_decided_by_fkey's ON DELETE SET NULL empties decided_by on
+	// every approval they decided — the state the old predicate read as a
+	// receipt. Driven through the deletion rather than by writing the NULL, so
+	// the test still means something if that foreign key is ever changed.
+	e.WsExec(t, `DELETE FROM app_user WHERE id = $1`, e.AdminUser)
+	var decider *ids.UUID
+	if err := e.Pool.QueryRow(e.Admin(), `SELECT decided_by FROM approval WHERE id = $1`, id).Scan(&decider); err != nil {
+		t.Fatalf("reading back the decider: %v", err)
+	}
+	if decider != nil {
+		t.Fatalf("deleting the decider left decided_by set: this test no longer reproduces a departure")
+	}
 
 	day := assembleFeed(e.Admin(), t, e, time.Now().UTC())
 	if got := sourcesOn(day.DoneForYou); len(got) != 0 {
 		t.Fatalf("the done-for-you lane = %v, want nothing: a person decided this", got)
 	}
+}
+
+// The lane's bound is the end of the day, and a task due exactly at it belongs
+// to tomorrow. Both sides of that boundary are pinned because it moved once: a
+// clause written `<=` put a promise due at tomorrow 00:00 on today's list, which
+// reports work late a day before it is.
+func TestATaskDueExactlyAtTheBoundaryBelongsToTomorrow(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC()
+	endOfDay := now.Truncate(24 * time.Hour).Add(24 * time.Hour)
+	logTask(t, e, "Due a moment before midnight", endOfDay.Add(-time.Second), false)
+	logTask(t, e, "Due exactly at midnight", endOfDay, false)
+
+	day := assembleFeed(e.Admin(), t, e, now)
+	got := titlesOn(day.Planned)
+	if len(got) != 1 || got[0] != "Due a moment before midnight" {
+		t.Fatalf("the planned lane = %v, want only the task due before the day ends", got)
+	}
+}
+
+// A receipt decided minutes ago must not be hidden by approvals staged since.
+//
+// The page is ordered by when an approval was STAGED, while the lane's window
+// asks when it was DECIDED. Those disagree: a proposal staged last week and
+// decided this morning sorts below one staged this morning. Applying the window
+// after the page therefore discards rows the page spent its limit on and reports
+// a quiet night over work that just ran. The window is asked in SQL for exactly
+// this reason, and this seeds the shape that would otherwise starve.
+func TestARecentReceiptIsNotBuriedByNewerStagings(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC()
+	person, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{FullName: "Anna Weber"})
+	if err != nil {
+		t.Fatalf("creating the target: %v", err)
+	}
+	svc := approvals.NewService(e.DB())
+	// The receipt: staged first, so every later staging sorts above it, and
+	// marked as the system's own act decided just now.
+	old := stageFor(t, e, svc, person, "Filed a message under Riverty")
+	e.WsExec(t, `UPDATE approval
+		    SET status = 'approved', decided_by_system = true, decided_at = now(),
+		        created_at = now() - interval '7 days'
+		  WHERE id = $1`, old)
+	// Enough newer stagings, decided outside the window, to fill any page the
+	// lane would ask for.
+	for i := 0; i < doneLaneWidth+4; i++ {
+		id := stageFor(t, e, svc, person, fmt.Sprintf("An older act %d", i))
+		e.WsExec(t, `UPDATE approval
+			    SET status = 'approved', decided_by_system = true,
+			        decided_at = now() - interval '30 days'
+			  WHERE id = $1`, id)
+	}
+
+	day := assembleFeed(e.Admin(), t, e, now)
+	if got := titlesOn(day.DoneForYou); len(got) != 1 || got[0] != "Filed a message under Riverty" {
+		t.Fatalf("the done-for-you lane = %v, want this morning's act", got)
+	}
+}
+
+// stageFor stages one proposal against a person through the real service.
+func stageFor(t *testing.T, e *integration.Env, svc *approvals.Service,
+	person crmcontracts.Person, summary string,
+) ids.ApprovalID {
+	t.Helper()
+	id, err := svc.Stage(e.Admin(), approvals.StageInput{
+		Kind:           "send_email",
+		ProposedChange: json.RawMessage(`{"body":"the follow-up"}`),
+		DiffHash:       "receipt-" + ids.NewV7().String(),
+		Summary:        summary,
+		TargetType:     "person",
+		TargetID:       ids.UUID(person.Id),
+	})
+	if err != nil {
+		t.Fatalf("staging %q: %v", summary, err)
+	}
+	return id
 }

--- a/backend/internal/compose/attentionfeed_integration_test.go
+++ b/backend/internal/compose/attentionfeed_integration_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What actually reaches the day's page, against a real database.
+//
+// The feed's own tests answer every lane against stubs, which prove the
+// assembly and nothing about the producers: a stub returns a row because the
+// test told it to, so a producer that stopped reaching the surface would leave
+// every one of them green. These drive the REAL writers — the staging service,
+// the activity store, the person store — and read the whole feed back through
+// the same wiring the HTTP handler uses, so a break anywhere between the write
+// and the lane fails here.
+//
+// One lane is deliberately absent: `done_for_you` reads approvals that were
+// approved with no decider, and no ordinary writer produces that pair. Seeding
+// one by hand would prove only that this file can write a row.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	"github.com/margince/margince/backend/internal/compose/briefs"
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// assembleFeed reads the whole feed through the real seams, at a chosen instant.
+//
+// Built from newAttentionHandlers' own wiring rather than a second arrangement
+// of it: a test that assembled its own service would pass while the wiring the
+// product ships was broken.
+func assembleFeed(ctx context.Context, t *testing.T, e *integration.Env, now time.Time) crmcontracts.Attention {
+	t.Helper()
+	db := InstallationDB(e.Pool)
+	svc := approvals.NewService(e.DB())
+	clock := func() time.Time { return now }
+	// The four required seams are real. The last three are optional by
+	// construction — nil means the installation does not serve that lane — and
+	// leaving them out keeps each test's subject to the lane it is about.
+	feed := attention.NewService(
+		attentionApprovals{svc: svc},
+		attentionDuplicates{store: people.NewStore(db)},
+		attentionTasks{store: activities.NewStore(db)},
+		attentionReceipts{svc: svc},
+		attentionBriefing{engine: briefs.NewBriefEngine(e.Pool, people.NewStore(db)), now: clock},
+		nil, nil, nil,
+		clock,
+	)
+	day, err := feed.Assemble(ctx)
+	if err != nil {
+		t.Fatalf("assembling the day: %v", err)
+	}
+	return day
+}
+
+// sourcesOn names what a lane carries, for an assertion that reads as a
+// sentence rather than as an index into a slice.
+func sourcesOn(items []crmcontracts.AttentionItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, string(item.Source))
+	}
+	return out
+}
+
+func titlesOn(items []crmcontracts.AttentionItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Title != nil {
+			out = append(out, *item.Title)
+		}
+	}
+	return out
+}
+
+// logTask writes one task through the real activity writer, completing it
+// through the real completion path rather than inserting a done row — a task is
+// logged open and finished by an update, and a test that wrote the end state
+// directly would prove nothing about how a task actually leaves the lane.
+func logTask(t *testing.T, e *integration.Env, subject string, due time.Time, done bool) {
+	t.Helper()
+	row, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "task", Subject: &subject, DueAt: &due, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("logging task %q: %v", subject, err)
+	}
+	if done {
+		finished := true
+		id := ids.From[ids.ActivityKind](ids.UUID(row.Id))
+		if _, err := e.Activities.UpdateActivity(e.Admin(), id, activities.UpdateActivityInput{IsDone: &finished}); err != nil {
+			t.Fatalf("completing task %q: %v", subject, err)
+		}
+	}
+}
+
+// A staged proposal is what the decision lane exists for. This drives the real
+// staging service and asserts the proposal arrives with the verb that answers
+// it — not a link to somewhere else it could be answered.
+func TestAStagedProposalReachesTheDecisionLane(t *testing.T) {
+	e := integration.Setup(t)
+	person, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{FullName: "Anna Weber"})
+	if err != nil {
+		t.Fatalf("creating the target: %v", err)
+	}
+	svc := approvals.NewService(e.DB())
+	if _, err := svc.Stage(e.Admin(), approvals.StageInput{
+		Kind:           "send_email",
+		ProposedChange: json.RawMessage(`{"body":"the follow-up"}`),
+		DiffHash:       "feed-" + ids.NewV7().String(),
+		Summary:        "Send the follow-up to Anna Weber",
+		TargetType:     "person",
+		TargetID:       ids.UUID(person.Id),
+	}); err != nil {
+		t.Fatalf("staging the proposal: %v", err)
+	}
+
+	day := assembleFeed(e.Admin(), t, e, time.Now().UTC())
+	if got := sourcesOn(day.NeedsYou); len(got) != 1 || got[0] != "approval" {
+		t.Fatalf("the decision lane = %v, want the one staged approval", got)
+	}
+	item := day.NeedsYou[0]
+	if item.Title == nil || *item.Title != "Send the follow-up to Anna Weber" {
+		t.Errorf("the card reads %v, want the summary composed at staging", item.Title)
+	}
+	if !containsAction(item.Actions, "decide") {
+		t.Errorf("the card offers %v, want the verb that answers it", item.Actions)
+	}
+	if day.Counts.NeedsYou != 1 {
+		t.Errorf("the lane counts %d, want the one decision it can page to", day.Counts.NeedsYou)
+	}
+}
+
+// A near-match found by the real dedupe ladder. The pair is what the reader
+// compares, so a candidate that arrives without both faces named is a card
+// nobody can answer.
+func TestADetectedDuplicateReachesTheDecisionLane(t *testing.T) {
+	e := integration.Setup(t)
+	if _, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{FullName: "Lucy Vo"}); err != nil {
+		t.Fatalf("creating the incumbent: %v", err)
+	}
+	if _, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{FullName: "LUCY VO"}); err != nil {
+		t.Fatalf("creating the near-match: %v", err)
+	}
+
+	day := assembleFeed(e.Admin(), t, e, time.Now().UTC())
+	if got := sourcesOn(day.NeedsYou); len(got) != 1 || got[0] != "dedupe_candidate" {
+		t.Fatalf("the decision lane = %v, want the pair the create detected", got)
+	}
+	item := day.NeedsYou[0]
+	if item.Pair == nil {
+		t.Fatal("the pair is absent: a merge card names both records or it cannot be answered")
+	}
+	if item.Pair.Left.Label == "" || item.Pair.Right.Label == "" {
+		t.Errorf("the pair reads %q vs %q, want both records named", item.Pair.Left.Label, item.Pair.Right.Label)
+	}
+}
+
+// An overdue task is today's agreed work. Both halves of the filter are pinned:
+// what is due is carried, and what is done or still ahead is not.
+func TestAnOverdueTaskReachesThePlannedLane(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC()
+	logTask(t, e, "Ring the buyer back", now.Add(-2*time.Hour), false)
+	logTask(t, e, "Already handled", now.Add(-3*time.Hour), true)
+	logTask(t, e, "Next week's prep", now.AddDate(0, 0, 7), false)
+
+	day := assembleFeed(e.Admin(), t, e, now)
+	got := titlesOn(day.Planned)
+	if len(got) != 1 || got[0] != "Ring the buyer back" {
+		t.Fatalf("the planned lane = %v, want only the task actually due", got)
+	}
+	if day.Planned[0].Overdue == nil || !*day.Planned[0].Overdue {
+		t.Error("the task is not marked overdue, so the reader cannot see which work slipped")
+	}
+}
+
+// The cap-before-filter case, from the reader's side.
+//
+// The task read is bounded and the "open and due" test is applied afterwards in
+// Go, so a pile of finished tasks ahead of one overdue promise can fill the scan
+// and leave the lane empty. The day would read clear while the work was still
+// there, and nobody reports a quiet day as a bug.
+func TestAPileOfFinishedTasksDoesNotHideAnOverdueOne(t *testing.T) {
+	e := integration.Setup(t)
+	now := time.Now().UTC()
+	// The overdue one is written FIRST so every finished task is newer, which
+	// is the order the store returns and therefore the order that buries it.
+	logTask(t, e, "The promise that slipped", now.Add(-48*time.Hour), false)
+	for i := 1; i <= 140; i++ {
+		logTask(t, e, fmt.Sprintf("Finished %d", i), now.Add(-time.Duration(i)*time.Minute), true)
+	}
+
+	day := assembleFeed(e.Admin(), t, e, now)
+	if got := titlesOn(day.Planned); len(got) != 1 || got[0] != "The promise that slipped" {
+		t.Fatalf("the planned lane = %v, want the overdue promise under a pile of finished work", got)
+	}
+}
+
+func containsAction(actions []crmcontracts.AttentionItemActions, want string) bool {
+	for _, action := range actions {
+		if string(action) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A human's decision stays a human's decision, even after that human is gone.
+//
+// The receipt lane used to read "approved with no decider" as "the system did
+// this". Deleting an app_user empties decided_by on every approval they ever
+// decided, so their work would reappear on a lane headed "done for you" — the
+// product claiming nobody was asked about something somebody was asked about.
+// The lane now reads the decision's own marker, which a deletion cannot rewrite.
+func TestADepartedColleaguesDecisionIsNotReportedAsTheSystemsWork(t *testing.T) {
+	e := integration.Setup(t)
+	person, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{FullName: "Anna Weber"})
+	if err != nil {
+		t.Fatalf("creating the target: %v", err)
+	}
+	svc := approvals.NewService(e.DB())
+	id, err := svc.Stage(e.Admin(), approvals.StageInput{
+		Kind:           "send_email",
+		ProposedChange: json.RawMessage(`{"body":"the follow-up"}`),
+		DiffHash:       "receipt-" + ids.NewV7().String(),
+		Summary:        "Send the follow-up to Anna Weber",
+		TargetType:     "person",
+		TargetID:       ids.UUID(person.Id),
+	})
+	if err != nil {
+		t.Fatalf("staging the proposal: %v", err)
+	}
+	if _, err := svc.Decide(e.Admin(), id, true, nil); err != nil {
+		t.Fatalf("approving as a human: %v", err)
+	}
+	// The decider leaves. The foreign key empties decided_by on the row they
+	// decided, which is exactly the state the old predicate read as a receipt.
+	e.WsExec(t, `UPDATE approval SET decided_by = NULL WHERE id = $1`, id)
+
+	day := assembleFeed(e.Admin(), t, e, time.Now().UTC())
+	if got := sourcesOn(day.DoneForYou); len(got) != 0 {
+		t.Fatalf("the done-for-you lane = %v, want nothing: a person decided this", got)
+	}
+}

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -181,6 +181,14 @@ func (t attentionTasks) OpenForViewer(ctx context.Context, until time.Time, limi
 	}
 	open := make([]attention.Task, 0, len(rows))
 	for _, row := range rows {
+		// The filter above answers only dated rows, so this skip is unreachable
+		// today. It is here because the alternative to a skip is a nil deref
+		// that panics the WHOLE day's page, and the guarantee lives in a WHERE
+		// clause one package away — too far for the next reader of this loop to
+		// see it.
+		if row.DueAt == nil {
+			continue
+		}
 		due := *row.DueAt
 		open = append(open, attention.Task{
 			ID:      ids.UUID(row.Id),
@@ -222,18 +230,23 @@ func (r attentionReceipts) Recent(ctx context.Context, since time.Time, limit in
 		status := approvalStatusApproved
 		bySystem := true
 		rows, _, err := r.svc.ListWire(ctx, approvals.ListInput{
-			Status: &status, DecidedBySystem: &bySystem, Limit: scan,
+			Status: &status, DecidedBySystem: &bySystem, DecidedAfter: &since, Limit: scan,
 		})
 		return rows, err
 	})
 }
 
-// recentReceipts keeps the system-decided rows inside the lane's window.
+// recentReceipts turns the store's rows into the lane's cards.
 //
-// The read is bounded by the lane rather than widened past it: the store now
-// answers "approved AND decided by the system" itself, so the limit applies to
-// rows that qualify. The window test stays here because it is the lane's own
-// horizon rather than a property of the row.
+// The read is bounded by the lane rather than widened past it: the store answers
+// "approved, decided by the system, decided since" itself, so the limit applies
+// to rows that qualify. The window belongs in SQL with the rest — the page is
+// ordered by created_at while the window is about decided_at, so a window
+// applied afterwards can discard a whole page and hide a decision made minutes
+// ago beneath approvals staged more recently.
+//
+// The re-check below is not a second filter. It is what makes the deref of
+// DecidedAt safe in this package, where the SQL guaranteeing it is elsewhere.
 //
 // The page reader is a parameter so a test can answer exactly the width it was
 // asked for; nothing else varies it.
@@ -312,9 +325,19 @@ func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, e
 
 // newAttentionHandlers assembles the surface for the API role.
 func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.Handlers {
+	return attention.NewHandlers(newAttentionService(pool, svc, func() time.Time { return time.Now().UTC() }))
+}
+
+// newAttentionService binds every lane to the module that owns what it shows.
+//
+// Separate from the handler above so a test can assemble the day through the
+// SAME wiring the route serves. A test that arranged these seams itself would
+// keep passing while the shipped feed lost one — which is the failure the feed's
+// stub-driven unit tests already have, and the reason its producers went so long
+// without a test that reads them end to end.
+func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, now attention.Clock) *attention.Service {
 	db := InstallationDB(pool)
-	now := func() time.Time { return time.Now().UTC() }
-	return attention.NewHandlers(attention.NewService(
+	return attention.NewService(
 		attentionApprovals{svc: svc},
 		attentionDuplicates{store: people.NewStore(db)},
 		attentionTasks{store: activities.NewStore(db)},
@@ -324,7 +347,7 @@ func newAttentionHandlers(pool *pgxpool.Pool, svc *approvals.Service) attention.
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
 		attentionMeetings{store: activities.NewStore(db)},
 		now,
-	))
+	)
 }
 
 // The three faces a merge decision compares.

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -163,44 +163,24 @@ func (d attentionDuplicates) CountOpen(ctx context.Context) (int, error) {
 	return d.store.CountOpenDedupeCandidates(ctx)
 }
 
-// taskScanFactor is how much wider than the lane the task read goes.
-//
-// The store returns tasks by recency regardless of whether they are done or
-// due, and this seam filters afterwards, so the scan has to carry enough rows
-// for the filter to still find today's work under a pile of finished ones. Ten
-// times the lane is a guess with a floor rather than a measurement: what it
-// must not be is EQUAL to the lane, which is what silently dropped overdue
-// work.
-const taskScanFactor = 10
-
 // attentionTasks reads open tasks through the activities store. A task is an
 // activity of kind `task`, so this is the same read the task queue makes.
 type attentionTasks struct{ store *activities.Store }
 
 func (t attentionTasks) OpenForViewer(ctx context.Context, until time.Time, limit int) ([]attention.Task, error) {
-	kind := activityKindTask
-	// Read WIDER than the lane shows, because the store cannot filter on
-	// "open and due by now" and this does the filtering afterwards. Asking for
-	// exactly the lane's size let a dozen completed or future-dated tasks fill
-	// the page and push a genuinely overdue one off it — the day would read
-	// clear while the task queue still showed the promise it had missed.
-	scan := limit * taskScanFactor
-	rows, _, err := t.store.ListActivities(ctx, activities.ListActivitiesInput{Kind: &kind, Limit: &scan})
+	// The store answers "open and due by then" itself, so the limit bounds the
+	// rows that QUALIFY. This used to read ten times the lane and narrow
+	// afterwards, which put the bound on the wrong set: a pile of completed
+	// tasks filled the scan, the overdue promise underneath never reached the
+	// reader, and the day rendered clear while the work was still there.
+	rows, _, err := t.store.ListActivities(ctx, activities.ListActivitiesInput{
+		OpenAndDueBy: &until, Limit: &limit,
+	})
 	if err != nil {
 		return nil, err
 	}
 	open := make([]attention.Task, 0, len(rows))
 	for _, row := range rows {
-		if row.IsDone != nil && *row.IsDone {
-			continue
-		}
-		// A task with no due date is still work somebody agreed to, but it is
-		// not work for TODAY, and a queue that promised today's list would be
-		// lying if it carried the undated backlog too. `until` is the end of
-		// the day, so anything not yet past it is still ahead of the reader.
-		if row.DueAt == nil || !deadline.Passed(row.DueAt, until) {
-			continue
-		}
 		due := *row.DueAt
 		open = append(open, attention.Task{
 			ID:      ids.UUID(row.Id),
@@ -228,57 +208,49 @@ const approvalStatusApproved = "approved"
 
 // attentionReceipts reads what ran without asking.
 //
-// The test is decided_by IS NULL, which is the convention the expiry sweep
-// states in its own words: "decided_by stays NULL and the actor is the system:
-// nobody decided". Filtering on status alone would put the reader's OWN
-// approvals in a lane headed "Done for you" — telling somebody the system
-// handled a thing they handled themselves, which is the one claim this lane
-// exists to make and the easiest one to get wrong.
+// The test is the decision's own decided_by_system marker. It used to be
+// decided_by IS NULL, inferring "nobody decided" from an empty column, and that
+// read the wrong thing twice over: no writer produces approved-with-no-decider,
+// and deleting an app_user empties decided_by on every approval that person
+// decided — which would move their decisions into a lane headed "Done for you".
+// Filtering on status alone would do the same thing to every reader's own
+// approvals, which is the one claim this lane exists to make.
 type attentionReceipts struct{ svc *approvals.Service }
 
 func (r attentionReceipts) Recent(ctx context.Context, since time.Time, limit int) ([]attention.Receipt, error) {
 	return recentReceipts(since, limit, func(scan int) ([]crmcontracts.Approval, error) {
 		status := approvalStatusApproved
-		rows, _, err := r.svc.ListWire(ctx, approvals.ListInput{Status: &status, Limit: scan})
+		bySystem := true
+		rows, _, err := r.svc.ListWire(ctx, approvals.ListInput{
+			Status: &status, DecidedBySystem: &bySystem, Limit: scan,
+		})
 		return rows, err
 	})
 }
 
-// recentReceipts pages the approved queue and keeps what ran without asking.
+// recentReceipts keeps the system-decided rows inside the lane's window.
 //
-// The read is WIDER than the lane shows, and that is the whole of this
-// function's reason to exist: the engine can only page approvals by status,
-// while `decided_by IS NULL` — the test for "nobody was asked" — is applied
-// afterwards. A read the size of the lane is filled by the reader's OWN recent
-// approvals and filters to nothing, so the lane reports a quiet night while
-// dozens of things ran. The same shape as the task lane's scan factor, and for
-// the same reason.
+// The read is bounded by the lane rather than widened past it: the store now
+// answers "approved AND decided by the system" itself, so the limit applies to
+// rows that qualify. The window test stays here because it is the lane's own
+// horizon rather than a property of the row.
 //
 // The page reader is a parameter so a test can answer exactly the width it was
 // asked for; nothing else varies it.
 func recentReceipts(
 	since time.Time, limit int, page func(scan int) ([]crmcontracts.Approval, error),
 ) ([]attention.Receipt, error) {
-	rows, err := page(approvals.PendingScanCap)
+	rows, err := page(limit)
 	if err != nil {
 		return nil, err
 	}
-	receipts := receiptsWithin(rows, since)
-	if len(receipts) > limit {
-		receipts = receipts[:limit]
-	}
-	return receipts, nil
+	return receiptsWithin(rows, since), nil
 }
 
-// receiptsWithin keeps the decided rows this lane may claim: inside the window,
-// and decided by nobody.
+// receiptsWithin keeps the decided rows inside the lane's window.
 func receiptsWithin(rows []crmcontracts.Approval, since time.Time) []attention.Receipt {
 	out := make([]attention.Receipt, 0, len(rows))
 	for _, row := range rows {
-		// A human's own decision is not something that ran for them.
-		if row.DecidedBy != nil {
-			continue
-		}
 		// Inside the window, not before it: `since` is the receipt lane's own
 		// horizon, and the same authority answers "is this behind that" here as
 		// answers it for a task's due date.

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -19,68 +19,72 @@ import (
 // themselves is not a cosmetic error — it misreports their own work back to
 // them, and it inflates what the product looks like it is doing.
 //
-// The test is decided_by IS NULL, the convention the expiry sweep states in its
-// own words ("decided_by stays NULL and the actor is the system: nobody
-// decided"). Status alone cannot tell the two apart: a human approval and a
-// system one are both `approved`.
-func TestAReceiptIsSomethingNobodyWasAskedAbout(t *testing.T) {
-	decidedAt := time.Date(2026, 8, 25, 8, 0, 0, 0, time.UTC)
-	since := decidedAt.Add(-time.Hour)
-	human := openapi_types.UUID(ids.NewV7())
+// WHICH rows are the system's is now answered in SQL, by the decision's own
+// decided_by_system marker, so what is left here is the lane's own horizon: a
+// receipt older than the window belongs to a morning the reader has already
+// seen. The window is the reason this function still exists.
+func TestAReceiptOlderThanTheWindowIsNotTodaysNews(t *testing.T) {
+	since := time.Date(2026, 8, 25, 7, 0, 0, 0, time.UTC)
+	thisMorning := approvalRow("Moved the Acme close date to 27 Sep", since.Add(time.Hour))
+	lastWeek := approvalRow("Filed a message under Riverty", since.AddDate(0, 0, -7))
 
-	byTheSystem := approvalRow("Moved the Acme close date to 27 Sep", decidedAt, nil)
-	byTheReader := approvalRow("Sent the Weber follow-up", decidedAt, &human)
-
-	receipts := receiptsWithin([]crmcontracts.Approval{byTheSystem, byTheReader}, since)
+	receipts := receiptsWithin([]crmcontracts.Approval{thisMorning, lastWeek}, since)
 
 	if len(receipts) != 1 {
-		t.Fatalf("the lane carries %d receipts, want only the system's one", len(receipts))
+		t.Fatalf("the lane carries %d receipts, want only the one inside the window", len(receipts))
 	}
 	if receipts[0].Summary != "Moved the Acme close date to 27 Sep" {
-		t.Errorf("the lane kept %q — a reader's own decision is not something that ran for them", receipts[0].Summary)
+		t.Errorf("the lane kept %q, want this morning's act", receipts[0].Summary)
 	}
 }
 
-func approvalRow(summary string, decidedAt time.Time, decidedBy *openapi_types.UUID) crmcontracts.Approval {
+// A row the store answered with no decision time cannot be placed against the
+// window, and a receipt the reader cannot date is not a receipt.
+func TestAnUndatedDecisionIsNotAReceipt(t *testing.T) {
+	since := time.Date(2026, 8, 25, 7, 0, 0, 0, time.UTC)
+	undated := crmcontracts.Approval{
+		Id: openapi_types.UUID(ids.NewV7()), Kind: "close_date_correction",
+	}
+
+	if receipts := receiptsWithin([]crmcontracts.Approval{undated}, since); len(receipts) != 0 {
+		t.Fatalf("the lane carries %d receipts, want none: nothing dates this row", len(receipts))
+	}
+}
+
+func approvalRow(summary string, decidedAt time.Time) crmcontracts.Approval {
 	return crmcontracts.Approval{
 		Id:        openapi_types.UUID(ids.NewV7()),
 		Kind:      "close_date_correction",
 		Summary:   &summary,
 		DecidedAt: &decidedAt,
-		DecidedBy: decidedBy,
 	}
 }
 
-// The receipts read reaches past the reader's own approvals.
+// The receipts read is bounded by the lane it fills.
 //
-// The filter that decides a receipt — decided_by IS NULL — runs AFTER the page
-// is read, because the engine can only page by status. So the SIZE of that read
-// decides whether an autonomous act is visible at all: a read the size of the
-// lane is filled by the reader's own recent decisions, filters down to nothing,
-// and the lane reports a quiet night while dozens of things ran.
-//
-// The bug was invisible while nothing was auto-applied: there was never an
-// autonomous act to crowd out. The stub answers a page of the reader's own
-// decisions with ONE autonomous act behind them, so a read that stops at the
-// lane's width finds nothing.
-func TestTheReceiptsReadIsWiderThanTheLaneItFills(t *testing.T) {
+// It used to read far wider and narrow afterwards, because "nobody was asked"
+// could only be tested in Go. That put the bound on the wrong set: a page of the
+// reader's own decisions filtered to nothing while real receipts sat behind it.
+// The store now answers the question itself, so asking for the lane's width is
+// the honest read — and this pins that the seam does not quietly go back to
+// over-reading.
+func TestTheReceiptsReadAsksForTheLaneItFills(t *testing.T) {
 	decidedAt := time.Date(2026, 8, 25, 8, 0, 0, 0, time.UTC)
-	human := openapi_types.UUID(ids.NewV7())
-
-	page := make([]crmcontracts.Approval, 0, doneLaneWidth+2)
-	for i := 0; i < doneLaneWidth+1; i++ {
-		page = append(page, approvalRow("A decision the reader made", decidedAt, &human))
+	page := make([]crmcontracts.Approval, 0, doneLaneWidth)
+	for i := 0; i < doneLaneWidth; i++ {
+		page = append(page, approvalRow("Filed a message under Riverty", decidedAt))
 	}
-	page = append(page, approvalRow("Filed a message under Riverty", decidedAt, nil))
 
 	engine := &stubApprovalPage{rows: page}
 	receipts, err := recentReceipts(decidedAt.Add(-time.Hour), doneLaneWidth, engine.list)
 	if err != nil {
 		t.Fatalf("reading the receipts: %v", err)
 	}
-	if len(receipts) != 1 {
-		t.Fatalf("the lane carries %d receipts; the read stopped at %d rows and never reached the autonomous act",
-			len(receipts), engine.asked)
+	if engine.asked != doneLaneWidth {
+		t.Errorf("the seam asked for %d rows to fill a lane of %d", engine.asked, doneLaneWidth)
+	}
+	if len(receipts) != doneLaneWidth {
+		t.Fatalf("the lane carries %d receipts, want the %d the store answered", len(receipts), doneLaneWidth)
 	}
 }
 
@@ -88,8 +92,7 @@ func TestTheReceiptsReadIsWiderThanTheLaneItFills(t *testing.T) {
 const doneLaneWidth = 8
 
 // stubApprovalPage answers exactly the number of rows it is asked for, which is
-// the whole subject: a seam that asks for the lane's width gets a page of human
-// decisions and filters it to nothing.
+// what lets a test see the width the seam requested.
 type stubApprovalPage struct {
 	rows  []crmcontracts.Approval
 	asked int

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -88,6 +88,20 @@ type ListActivitiesInput struct {
 	// [day 00:00, next day 00:00) with no double-counting at midnight.
 	OccurredAfter  *time.Time
 	OccurredBefore *time.Time
+	// OpenAndDueBy narrows to tasks still open and already due at an instant:
+	// the day's work, asked as one question.
+	//
+	// It exists because the caller that wants this cannot express it any other
+	// way. Reading a page by recency and dropping the finished rows afterwards
+	// puts the bound on the WRONG set — a pile of completed tasks fills the
+	// page, the one overdue promise never reaches the reader, and the day
+	// renders clear while the work is still there. A limit is only honest over
+	// the rows that qualify, which means the test belongs here.
+	//
+	// A task with no due date is excluded: it is agreed work, but it is not
+	// work for a given instant, and a queue that promised today's list would be
+	// lying if it carried the undated backlog too.
+	OpenAndDueBy *time.Time
 }
 
 // ListActivities is the timeline read: newest first, optionally scoped to

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -255,6 +255,11 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	if clause := openTaskAssigneeClause(in.AssigneeID, arg); clause != "" {
 		where = append(where, clause)
 	}
+	if in.OpenAndDueBy != nil {
+		where = append(where,
+			sprintf("a.kind = 'task' AND NOT a.is_done AND a.due_at IS NOT NULL AND a.due_at <= $%d",
+				arg(*in.OpenAndDueBy)))
+	}
 	if in.EntityType != nil && in.EntityID != nil {
 		// The SAME vocabulary the write uses. A second list here drifted from
 		// linkTargets and silently dropped two kinds: an activity could be

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -256,8 +256,12 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 		where = append(where, clause)
 	}
 	if in.OpenAndDueBy != nil {
+		// Strictly before the instant, which is what deadline.Passed means and
+		// what this clause replaced. The bound the caller passes is the END of
+		// the day, so `<=` would put a task due at exactly tomorrow 00:00 on
+		// today's list — a promise reported late a day early.
 		where = append(where,
-			sprintf("a.kind = 'task' AND NOT a.is_done AND a.due_at IS NOT NULL AND a.due_at <= $%d",
+			sprintf("a.kind = 'task' AND NOT a.is_done AND a.due_at IS NOT NULL AND a.due_at < $%d",
 				arg(*in.OpenAndDueBy)))
 	}
 	if in.EntityType != nil && in.EntityID != nil {

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -127,7 +127,16 @@ type ListInput struct {
 	// puts the limit on the wrong set, and a page full of ordinary decisions
 	// narrows to nothing while real receipts sit behind it.
 	DecidedBySystem *bool
-	Limit           int
+	// DecidedAfter keeps decisions made since an instant.
+	//
+	// It travels with DecidedBySystem for one reason: the page is ordered by
+	// created_at, and a receipt's window is about decided_at. Those disagree —
+	// an approval staged last week and decided this morning sorts BELOW one
+	// staged this morning and decided days ago — so a window applied after the
+	// page can discard everything the page held and hide the recent decision
+	// underneath. In SQL, the limit only ever counts rows inside the window.
+	DecidedAfter *time.Time
+	Limit        int
 	// Cursor continues a previous page: the opaque keyset token that page
 	// reported as next_cursor. Empty starts at the newest row.
 	Cursor string
@@ -280,6 +289,9 @@ func approvalWhere(in ListInput, from *keysetStart, arg func(any) int) string {
 	}
 	if in.DecidedBySystem != nil {
 		terms = append(terms, fmt.Sprintf("decided_by_system = $%d", arg(*in.DecidedBySystem)))
+	}
+	if in.DecidedAfter != nil {
+		terms = append(terms, fmt.Sprintf("decided_at > $%d", arg(*in.DecidedAfter)))
 	}
 	if from != nil {
 		terms = append(terms, fmt.Sprintf("(created_at, id) < ($%d, $%d)", arg(from.createdAt), arg(from.id)))

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -114,7 +114,20 @@ type ListInput struct {
 	// not relax the per-row decidability probe: a member the caller could not
 	// decide is as absent here as it is from the unfiltered inbox.
 	BundleID *ids.UUID
-	Limit    int
+	// DecidedBySystem narrows to what ran with nobody asked — the receipts a
+	// "done for you" surface may claim.
+	//
+	// It reads the decision's own marker rather than inferring the answer from
+	// an empty decided_by. Two reasons the inference was wrong: no writer
+	// produces approved-with-no-decider, so the test matched nothing; and
+	// decided_by is emptied by ON DELETE SET NULL when an app_user is deleted,
+	// which would relabel that person's decisions as the system's own.
+	//
+	// Asked in SQL because the caller bounds its read: filtering after a page
+	// puts the limit on the wrong set, and a page full of ordinary decisions
+	// narrows to nothing while real receipts sit behind it.
+	DecidedBySystem *bool
+	Limit           int
 	// Cursor continues a previous page: the opaque keyset token that page
 	// reported as next_cursor. Empty starts at the newest row.
 	Cursor string
@@ -264,6 +277,9 @@ func approvalWhere(in ListInput, from *keysetStart, arg func(any) int) string {
 	}
 	if in.BundleID != nil {
 		terms = append(terms, fmt.Sprintf("bundle_id = $%d", arg(*in.BundleID)))
+	}
+	if in.DecidedBySystem != nil {
+		terms = append(terms, fmt.Sprintf("decided_by_system = $%d", arg(*in.DecidedBySystem)))
 	}
 	if from != nil {
 		terms = append(terms, fmt.Sprintf("(created_at, id) < ($%d, $%d)", arg(from.createdAt), arg(from.id)))

--- a/backend/migrations/core/1787867100_a_receipt_says_the_system_decided_it.down.sql
+++ b/backend/migrations/core/1787867100_a_receipt_says_the_system_decided_it.down.sql
@@ -1,0 +1,5 @@
+-- Dropping the column returns the receipt lane to inferring its own meaning
+-- from an empty decider, which is what it was doing before.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval DROP COLUMN IF EXISTS decided_by_system;

--- a/backend/migrations/core/1787867100_a_receipt_says_the_system_decided_it.up.sql
+++ b/backend/migrations/core/1787867100_a_receipt_says_the_system_decided_it.up.sql
@@ -1,0 +1,36 @@
+-- A receipt says the system decided it, rather than leaving it to be inferred
+-- from an empty column.
+--
+-- The "done for you" lane means: this ran, and nobody was asked. It selected
+-- rows with status 'approved' and decided_by IS NULL, reading the absent decider
+-- as "no human decided". Two things are wrong with inferring it.
+--
+-- First, no writer produces that pair. Staging inserts 'pending'; a human
+-- decision writes decided_by; the expiry sweep leaves decided_by NULL but
+-- writes 'expired', not 'approved'. The lane's own test matches nothing the
+-- product writes, so it has been reporting an empty night on every
+-- installation.
+--
+-- Second, and worse, the column can BECOME null under a row nobody touched:
+-- approval_decided_by_fkey is ON DELETE SET NULL, so deleting an app_user
+-- empties decided_by on every approval that person ever decided. Their
+-- decisions would then read as things the system did on its own — the product
+-- telling a team "nobody was asked" about work a departed colleague was in fact
+-- asked about, on the one surface whose whole job is to report honestly what
+-- happened.
+--
+-- decided_by_system is written by the decider and never inferred, so a deleted
+-- user changes who is named and not what happened.
+-- Deliberately a column and NO check constraint.
+--
+-- The obvious constraint — "a decided approval names the system or a person" —
+-- would be enforced on UPDATE, and the ON DELETE SET NULL above IS an update.
+-- Adding it would make deleting an app_user fail against their own decision
+-- history, turning an honesty fix into a blocked erasure path. Whether a
+-- decided row still names its decider is a question about a person who may have
+-- been erased on purpose; whether the SYSTEM decided it is a fact about the
+-- decision, and that is what this column holds.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval
+    ADD COLUMN IF NOT EXISTS decided_by_system boolean NOT NULL DEFAULT false;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -542,6 +542,7 @@ public.approval.consumed_at timestamp with time zone gen=- def=-
 public.approval.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.approval.decided_at timestamp with time zone gen=- def=-
 public.approval.decided_by uuid gen=- def=-
+public.approval.decided_by_system boolean NOT NULL gen=- def=false
 public.approval.decision_reason text gen=- def=-
 public.approval.diff_hash text NOT NULL gen=- def=-
 public.approval.evidence jsonb gen=- def=-


### PR DESCRIPTION
Closes #2967. Closes #2965. Closes #2973.

The day's page could report a clear day over work that was still there, and could credit the system with a decision a person made. Both came from asking the database a wide question and narrowing the answer in Go.

## Tasks: the limit applied to the wrong set

`attentionTasks.OpenForViewer` read `limit * 10` rows by recency and dropped the finished and future-dated ones afterwards. A pile of completed tasks fills that scan and the overdue promise underneath never reaches the reader — the day renders clear while the work is still there, and nobody reports a quiet day as a bug.

`ListActivities` now takes `OpenAndDueBy` and answers the question in SQL, so the limit bounds rows that qualify. `TestAPileOfFinishedTasksDoesNotHideAnOverdueOne` seeds one overdue promise under 140 finished tasks; it failed against the old seam and passes now.

## Receipts: a predicate no writer produced

The `done_for_you` lane tested `status = 'approved' AND decided_by IS NULL` for "nobody was asked". Nothing writes that pair — staging writes `pending`, a human decision writes `decided_by`, the expiry sweep writes `expired` — so the lane matched nothing on every installation.

Worse, `approval_decided_by_fkey` is `ON DELETE SET NULL`. Deleting an `app_user` empties `decided_by` on every approval that person decided, moving their work onto a lane headed "done for you" — the product claiming nobody was asked about something somebody was asked about.

A decision now carries `decided_by_system`, written rather than inferred, and the store filters on it. `TestADepartedColleaguesDecisionIsNotReportedAsTheSystemsWork` deletes the decider the way the foreign key does and asserts the lane stays empty; it fails against the old predicate.

**The migration adds the column and deliberately no CHECK constraint.** The obvious one ("a decided approval names the system or a person") is enforced on UPDATE, and `ON DELETE SET NULL` *is* an update — adding it would make deleting a user fail against their own decision history, turning an honesty fix into a blocked erasure path.

## Coverage

Five integration tests drive the real producers and read the whole feed back through the wiring `newAttentionHandlers` uses: a staged proposal, a detected duplicate pair, an overdue task, the pile-of-finished case, and the departed decider. The feed's unit tests answer every lane from stubs, so a producer that stopped reaching the surface left all of them green.

`done_for_you` has no creation test on purpose: there is still no writer that sets `decided_by_system`, and seeding one by hand would prove only that a test can write a row. The lane is now *capable* of being correct; giving it a real producer is the autonomous-execution feature, which is not this PR.

The two receipts unit tests were rewritten rather than deleted — the Go-side filtering they pinned now lives in SQL, so they cover the lane's window instead, plus the read width.

## Verification

`make check-backend` green; `make test-it` green for `internal/compose` (full lane), `modules/activities`, `modules/approvals`, and `migrations` (head catalog regenerated in this commit); `make craft-static` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the day's page so overdue tasks can no longer be buried behind a pile of finished ones, and a person's decisions can no longer be reported as the system's. Both came from reading wide and narrowing in Go; the questions are now answered in SQL.

**Bug Fixes**
- The task lane now asks for tasks open and due by the day's end, so the page limit bounds rows that qualify; the boundary is exclusive, so a task due exactly at midnight belongs to tomorrow.
- The `done_for_you` lane now reads the new `decided_by_system` marker and takes the receipt window in SQL, so a recent decision can't be hidden beneath newer stagings; `decided_by IS NULL` matched nothing the product writes and could be falsified by user deletion.
- Five integration tests drive the real producers through the same wiring the handler uses, closing the gap left by the feed's stub-based unit tests.

**Migration**
- Adds `decided_by_system` to `approval`, defaulting to false; deliberately no CHECK constraint, since the obvious one would run on the `ON DELETE SET NULL` update and block deleting users.

<sup>Written for commit b8012f184fa0e303c52be0143e0bf374a3e97972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved attention feed filtering for open, due tasks and recent decision items.
  * System-decided approvals are now identified separately from human approvals.
  * Added support for reliably showing relevant items even when many completed tasks exist.

* **Bug Fixes**
  * Excluded tasks without due dates and handled deadline boundaries correctly.
  * Prevented human-approved receipts from appearing in system-generated work items.

* **Tests**
  * Added coverage for midnight task boundaries, staged proposals, and recent approval receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->