### PR TITLE
fix(privacy): a qualification in flight wins the race (#1618)

### DIFF
--- a/backend/internal/compose/integration/erasure_qualification_race_integration_test.go
+++ b/backend/internal/compose/integration/erasure_qualification_race_integration_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A qualification in flight when an erasure starts WINS, and its correspondence
+// is held rather than destroyed.
+//
+// The erasure decides erase-or-hold by reading `activity.retention_class` — the
+// column a deal win or a sent offer stamps, in its own transaction. Both read
+// and write the same rows, and the erasure used to lock only the subject's
+// identifier keys: not the activities, and not the deals they hang off. So the
+// two could interleave with the erasure reading a NULL class, destroying the
+// correspondence, and the qualification committing afterwards.
+//
+// Nothing readable survived that either way — the row is gone — but A165 /
+// ADR-0114 §1 says the correspondence was to be HELD, and the obligation was
+// not honoured (issue #1618). The class is monotonic, so the failure is not
+// symmetric: a hold that should have been an erase cannot happen, and an erase
+// that should have been a hold destroys evidence somebody is required to keep.
+//
+// The lock is what gives the race a winner. This test makes the interleaving
+// happen rather than waiting for it: the stamp's rows are pinned by a
+// transaction of this test's own, the erasure is started and must BLOCK, the
+// stamp lands, and the erasure then proceeds — and must hold.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/privacy"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestAQualificationInFlightHoldsItsCorrespondence(t *testing.T) {
+	e := Setup(t)
+	f := seedRestrictionFixture(t, e)
+	// A deal the correspondence hangs off, so the stamp below is the one the
+	// product runs — StampCorrespondenceForDeal works from activity_link.
+	deal := linkCorrespondenceToADeal(t, e, f.email)
+
+	// The Handelsbrief carries NO retention class yet — this is a lead nobody
+	// has qualified. Unstamped on purpose: a row already stamped is held by the
+	// ordinary path and proves nothing about the race.
+	assertRetentionClass(t, e, f.email, "")
+
+	// The qualification, held open in its own transaction. It IS the holder —
+	// which is the real interleaving, and simpler than pinning the row with a
+	// third party: the erasure must wait for the stamp itself.
+	holderCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	holder, err := e.Pool.Begin(holderCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := holder.Exec(holderCtx,
+		`SELECT set_config('app.workspace_id', $1::text, true)`, e.WS); err != nil {
+		t.Fatal(err)
+	}
+	// The REAL stamp, not a hand-written UPDATE. The class and its evidence are
+	// one statement on purpose — a CHECK refuses a restricted row whose
+	// evidence does not say what qualified it — and a test that wrote only the
+	// column would be racing something the product never does.
+	var holderPID int
+	if err := holder.QueryRow(holderCtx, `SELECT pg_backend_pid()`).Scan(&holderPID); err != nil {
+		t.Fatal(err)
+	}
+	if err := activities.StampCorrespondenceForDeal(holderCtx, holder, deal, "deal_won"); err != nil {
+		t.Fatalf("stamping the qualifying deal's correspondence: %v", err)
+	}
+
+	erased := make(chan error, 1)
+	go func() {
+		erased <- privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), f.person, "test")
+	}()
+
+	// Wait until the erasure is genuinely PARKED behind the stamp, asked of
+	// Postgres rather than assumed after a sleep. Without this the stamp could
+	// commit before the erasure has opened its transaction, and the test would
+	// pass against an erasure that takes no lock at all.
+	waitForBlockedOn(holderCtx, t, holder, holderPID)
+
+	// The qualification commits while the erasure waits, so the class the
+	// erasure eventually reads is one that did not exist when it started.
+	if err := holder.Commit(holderCtx); err != nil {
+		t.Fatalf("committing the qualification: %v", err)
+	}
+
+	if err := <-erased; err != nil {
+		t.Fatalf("erasing the subject → %v", err)
+	}
+
+	// The whole assertion: the erasure saw the class the qualification wrote,
+	// and held the correspondence rather than destroying it.
+	assertHeldNotDestroyed(t, e, f.email)
+}
+
+func assertRetentionClass(t *testing.T, e *Env, activity ids.UUID, want string) {
+	t.Helper()
+	var class string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT coalesce(retention_class, '') FROM activity WHERE id = $1`, activity).Scan(&class)
+	}); err != nil {
+		t.Fatalf("reading the retention class: %v", err)
+	}
+	if class != want {
+		t.Fatalf("retention_class = %q, want %q", class, want)
+	}
+}
+
+func assertHeldNotDestroyed(t *testing.T, e *Env, activity ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		var subject, class string
+		var body *string
+		var restricted bool
+		if err := tx.QueryRow(context.Background(), `
+			SELECT subject, body, restricted_at IS NOT NULL, coalesce(retention_class, '')
+			  FROM activity WHERE id = $1`, activity).Scan(&subject, &body, &restricted, &class); err != nil {
+			return err
+		}
+		if class != "commercial_correspondence" {
+			return fmt.Errorf("retention_class = %q — the qualification's stamp did not survive", class)
+		}
+		// The substance is what the obligation is about. An erased row has an
+		// emptied body and the tombstone name; a held one keeps both.
+		if body == nil {
+			return fmt.Errorf("the correspondence was DESTROYED: the erasure read a null class "+
+				"and ran its destroy arm before the qualification committed (subject=%q)", subject)
+		}
+		if !restricted {
+			return fmt.Errorf("the correspondence survived but was not restricted: subject=%q", subject)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// linkCorrespondenceToADeal gives the Handelsbrief a deal to be qualified BY,
+// which is what StampCorrespondenceForDeal reads: it stamps every activity
+// linked to the deal, so the link is the whole fixture this race needs.
+func linkCorrespondenceToADeal(t *testing.T, e *Env, activity ids.UUID) ids.DealID {
+	t.Helper()
+	pipeline, open, _ := DealFixture(t, e)
+	var deal ids.DealID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		id := ids.NewV7()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO deal (id, name, pipeline_id, stage_id, status, source, captured_by)
+			VALUES ($1, 'Qualifying deal', $2, $3, 'open', 'manual', 'human:x')`,
+			id, pipeline, open); err != nil {
+			return err
+		}
+		deal = ids.From[ids.DealKind](id)
+		_, err := tx.Exec(ctx, `
+			INSERT INTO activity_link (activity_id, entity_type, deal_id)
+			VALUES ($1, 'deal', $2)`, activity, id)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the qualifying deal: %v", err)
+	}
+	return deal
+}

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -136,6 +136,12 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		if err := eraseDealRoomSeats(ctx, tx, emails, reason); err != nil {
 			return err
 		}
+		// Before the timeline is JUDGED, not merely before it is written: the
+		// erase-or-hold decision reads a column another transaction stamps, so
+		// the lock has to precede the read that decides.
+		if err := lockSubjectTimeline(ctx, tx, subject, emails, channelActivityKeys(identities)); err != nil {
+			return err
+		}
 		activitiesRedacted, err := redactSubjectTimeline(ctx, tx, subject, emails, channelActivityKeys(identities), floorInterval, floorAnchor)
 		if err != nil {
 			return err

--- a/backend/internal/modules/privacy/erasuretimeline.go
+++ b/backend/internal/modules/privacy/erasuretimeline.go
@@ -70,8 +70,19 @@ var subjectTimelineLockSQL = `
 // The same three id sets the destroy and the hold select from, so a row cannot
 // be judged by one spelling and locked by another.
 func lockSubjectTimeline(ctx context.Context, tx pgx.Tx, personID ids.PersonID, emails []string, channelKeys []string) error {
-	// ORDER BY id: two erasures against overlapping subjects take the same rows
-	// in the same order, so they queue instead of deadlocking.
+	// ORDER BY id is BEST EFFORT against a deadlock between two erasures whose
+	// subjects share activities, and is written down as best effort because it
+	// is not a guarantee: Postgres does not promise that `FOR UPDATE` acquires
+	// in the sort's order, only that the rows come back in it. The plan it
+	// usually chooses locks after sorting, which is why this helps at all.
+	//
+	// When it does not hold, the loser gets 40P01 and ErasePerson returns it —
+	// the whole transaction rolls back, so no half-erasure commits and the
+	// request is safe to re-issue. That is the honest cost, and it is small
+	// because the collision needs two erasures overlapping on the same
+	// activities at the same moment. Retrying inside the eraser was considered
+	// and left alone: a retry loop around a transaction this long belongs to
+	// whoever decides the policy for every such write, not to this one.
 	_, err := tx.Exec(ctx, subjectTimelineLockSQL, personID, emails, channelKeys)
 	return err
 }

--- a/backend/internal/modules/privacy/erasuretimeline.go
+++ b/backend/internal/modules/privacy/erasuretimeline.go
@@ -12,6 +12,7 @@ package privacy
 
 import (
 	"context"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -27,6 +28,54 @@ import (
 // the timeline text and its field-level provenance. It returns the
 // redacted activity ids so the caller can tombstone each record's own
 // audit spine.
+// subjectTimelineLockSQL selects every row this erasure will judge, FOR UPDATE.
+//
+// The three id sets come from the same fragments the destroy and the hold
+// select from, so a row cannot be judged by one spelling and locked by another.
+// Only the NUMBERING is adapted: the fragments are written for the destroy's
+// argument list, where the channel keys are $6 behind the floor and the
+// tombstone name, and this statement wants none of those. Renumbering one
+// placeholder is the smallest adaptation that keeps one definition of the row
+// set; TestTheTimelineLockBindsEveryPlaceholderItNames holds it to three.
+var subjectTimelineLockSQL = `
+	SELECT a.id FROM activity a
+	WHERE a.id IN (` + subjectOnlyActivities + `)
+	   OR a.id IN (` + unlinkedSubjectMail + `)
+	   OR a.id IN (` + strings.ReplaceAll(unlinkedSubjectChannel, "$6", "$3") + `)
+	ORDER BY a.id
+	FOR UPDATE`
+
+// lockSubjectTimeline takes a row lock on every activity this erasure will
+// judge, BEFORE it judges any of them.
+//
+// The judgement is erase-or-hold, and it reads `retention_class` — which a deal
+// win or a sent offer stamps on the same rows, in its own transaction
+// (activities.StampCorrespondenceForDeal). Without this lock the two can
+// interleave: the erasure reads a NULL class, destroys the correspondence, and
+// the qualification commits afterwards. The row is gone either way, so nothing
+// readable survives — but A165/ADR-0114 §1 says that correspondence was to be
+// HELD, and the obligation was not honoured (issue #1618).
+//
+// The lock is what makes the race have a winner. Under READ COMMITTED a
+// qualification already holding these rows makes this statement wait, and the
+// erasure then re-reads the class it just waited for — so an in-flight
+// qualification wins and its correspondence is held. One that starts after this
+// lock waits for the commit and stamps a row already erased, which is the
+// residual and is the honest one: by then there was nothing to hold.
+//
+// NO FLOOR PREDICATE, deliberately. The floor is what the judgement uses to
+// decide, and a lock that pre-applied it would leave exactly the rows whose
+// class is about to change unlocked — the ones this exists for.
+//
+// The same three id sets the destroy and the hold select from, so a row cannot
+// be judged by one spelling and locked by another.
+func lockSubjectTimeline(ctx context.Context, tx pgx.Tx, personID ids.PersonID, emails []string, channelKeys []string) error {
+	// ORDER BY id: two erasures against overlapping subjects take the same rows
+	// in the same order, so they queue instead of deadlocking.
+	_, err := tx.Exec(ctx, subjectTimelineLockSQL, personID, emails, channelKeys)
+	return err
+}
+
 func redactSubjectTimeline(ctx context.Context, tx pgx.Tx, personID ids.PersonID, emails []string, channelKeys []string, floorInterval string, floorAnchor bool) ([]ids.UUID, error) {
 	// Redact the subject's own timeline rows, the unlinked mail about them — in
 	// both directions, captured and sent (unlinkedSubjectMail) — and the

--- a/backend/internal/modules/privacy/erasuretimelinelock_test.go
+++ b/backend/internal/modules/privacy/erasuretimelinelock_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// The lock statement binds every placeholder it names, and names no more than
+// it binds.
+//
+// It reuses the destroy statement's own id-set fragments so a row cannot be
+// judged by one spelling and locked by another — but those fragments are
+// written for the destroy's six-argument list, where the channel keys are $6
+// behind the floor and the tombstone name. This statement wants three
+// arguments, so one placeholder is renumbered.
+//
+// That renumbering is the fragile part, and it fails LOUDLY but late: Postgres
+// answers `could not determine data type of parameter $3` at run time, which is
+// an integration failure in whatever suite happens to erase a person. A
+// fragment that grows a $7 tomorrow would do it again. This is the cheap check
+// that catches it in a unit test instead.
+func TestTheTimelineLockBindsEveryPlaceholderItNames(t *testing.T) {
+	t.Parallel()
+
+	const bound = 3 // personID, emails, channelKeys
+	seen := map[int]bool{}
+	for _, match := range regexp.MustCompile(`\$(\d+)`).FindAllStringSubmatch(subjectTimelineLockSQL, -1) {
+		n, err := strconv.Atoi(match[1])
+		if err != nil {
+			t.Fatalf("unreadable placeholder %q", match[0])
+		}
+		seen[n] = true
+		if n > bound {
+			t.Errorf("the lock names $%d and binds %d arguments — Postgres refuses a placeholder "+
+				"nothing types, as `could not determine data type of parameter`, at run time in "+
+				"whichever suite erases a person next", n, bound)
+		}
+	}
+	// And every one it binds is used: an argument the statement never mentions
+	// is the same refusal from the other side.
+	for n := 1; n <= bound; n++ {
+		if !seen[n] {
+			t.Errorf("the lock binds $%d and never names it", n)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1618.

## The race

`ErasePerson` decides erase-or-hold by reading `activity.retention_class` — the column a deal win or a sent offer stamps, in its own transaction (`activities.StampCorrespondenceForDeal`). It locked the subject's identifier keys (`storekit.LockSubjectKeys`) but **not the activities**, so the two could interleave: the erasure reads a NULL class, destroys the correspondence, and the qualification commits afterwards.

Nothing readable survived that either way — the row is gone. But A165 / ADR-0114 §1 says that correspondence was to be **held**, and the class is monotonic, so **the failure is not symmetric**: a hold that should have been an erase cannot happen, and an erase that should have been a hold destroys evidence somebody is required to keep.

## The lock, and where it goes

Before the timeline is **judged**, not merely before it is written. The decision reads a column another transaction stamps, so the lock has to precede the read that decides.

Under READ COMMITTED a qualification already holding those rows makes the erasure wait, and the erasure then re-reads the class it waited for — so an in-flight qualification wins. One that starts *after* the lock waits for the commit and stamps a row already erased: that is the residual, and it is the honest one, because by then there was nothing to hold.

**No floor predicate on the lock**, deliberately. The floor is what the judgement uses to decide, so a lock that pre-applied it would leave exactly the rows whose class is about to change unlocked — the ones this exists for.

## One definition of the row set

The lock reuses the destroy's own id-set fragments, so a row cannot be judged by one spelling and locked by another. Only the **numbering** is adapted: the fragments are written for the destroy's six-argument list, where the channel keys are `$6` behind the floor and the tombstone name.

That renumbering fails loudly but *late* — Postgres answers `could not determine data type of parameter $3` at run time, in whichever suite erases a person next. I hit it twice getting this right. `TestTheTimelineLockBindsEveryPlaceholderItNames` catches it in a unit test instead, in both directions: a placeholder past what is bound, and an argument the statement never names.

## The race test forces the interleaving

Not a sequential test with a comment about concurrency. The qualification **is** the holder, pinned open in its own transaction; the erasure is started and must park behind it — asked of Postgres via `pg_blocking_pids`, not assumed after a sleep — and the qualification then commits while the erasure waits.

| | result |
|---|---|
| with the lock | `--- PASS` — the correspondence is held, class `commercial_correspondence`, body intact, `restricted_at` set |
| **without the lock** | `--- FAIL` — the erasure never waits, reads a NULL class, and destroys it |

**It caught something while I was writing it.** A hand-written stamp of the class alone is refused:

```
activity … cannot be restricted with no retention evidence recording what qualified it (SQLSTATE 23514)
```

A restricted row must carry the evidence saying what qualified it, and the class and its evidence are one statement for exactly that reason. The test runs the real `StampCorrespondenceForDeal` now — which is also the transaction the erasure actually races, so the fixture is the product rather than an approximation of it.

`make check-backend` green. `make test-it DIR=backend/internal/modules/privacy`: 78 passed. `RUN=Eras` over the compose suite: 43 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy erasure handling during concurrent retention qualification.
  * Ensured timeline records are safely synchronized before erasure decisions, preventing inconsistent redaction or retention outcomes.

* **Tests**
  * Added coverage for concurrent qualification and erasure scenarios.
  * Added validation to ensure timeline locking uses the correct query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->