### PR TITLE
feat(records): reading a company's site asks what it publicly runs

### DIFF
--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -247,6 +247,12 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 	// guarded egress, under its own deadline, whose failure is never the
 	// read's. A company that publishes no newsroom is the ordinary case.
 	w.readNewsroom(ctx, claim, crawl)
+	// The third side lane, and the only one that queues rather than fetches:
+	// what the company publicly RUNS, beside what its pages SAY. Its three
+	// services are paced on their own single-threaded queue, so a deep-read
+	// worker hands the question over instead of waiting on it
+	// (technicalonsiteread.go).
+	w.askWhatTheCompanyRuns(ctx, claim)
 
 	return w.reportRead(ctx, args, claim, crawl, extraction)
 }

--- a/backend/internal/compose/technicalonsiteread.go
+++ b/backend/internal/compose/technicalonsiteread.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Reading a company's site asks what that company publicly runs, in the same
+// breath.
+//
+// The two answer one question between them. A deep read says what the company
+// TELLS you — the words on its pages — and the technical lookup says what it
+// demonstrably RUNS, from records it does not write. A reader who opened an
+// account to look at it wants both, and wanting them at different times was an
+// artefact of the lookup shipping behind its own button rather than a property
+// of the product.
+//
+// So this lane hangs off every read that reaches a company, automatic or
+// human-pressed, on the same terms as the logo and newsroom lanes beside it:
+// additive to a read that already succeeded, and never able to fail one.
+//
+// It ENQUEUES rather than reads. The other two side lanes fetch inline because
+// each is one bounded request; a technical lookup is three services, one of
+// them a certificate log whose own pacer may hold a caller for five seconds
+// before the query is even built. Doing that inline would park a deep-read
+// worker — the scarcest kind in the fleet, since a crawl already holds one for
+// minutes — on a wait that has nothing to do with crawling. The lookup has its
+// own single-threaded queue for exactly this reason, and joining that queue is
+// how a read stays a read.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// askWhatTheCompanyRuns queues the technical lookup for the company this read
+// was about.
+//
+// Errors are logged and dropped, never returned. The dossier this read is about
+// to close is complete without the lookup, and a queue that would not take the
+// row is not a reason to fail a crawl that already succeeded — the scheduled
+// sweep comes back round for the same company either way.
+//
+// Two ways it correctly does nothing. A read that resolved no organization has
+// no company to look up: the domain-triage lane runs before an account exists,
+// and reading a site to decide whether to CREATE a company cannot enrich one.
+// And a deployment whose worker role registered no enricher rejects the kind at
+// insert, which is the honest answer rather than a row nothing will ever work.
+func (w *siteDeepReadWorker) askWhatTheCompanyRuns(ctx context.Context, claim people.SiteReadClaim) {
+	if claim.OrganizationID == nil {
+		return
+	}
+	workspace, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		w.log.WarnContext(ctx, "technical lookup not queued after site read: no workspace on the job context",
+			"organization", claim.OrganizationID.String())
+		return
+	}
+	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
+	if err != nil {
+		w.log.WarnContext(ctx, "technical lookup not queued after site read",
+			"organization", claim.OrganizationID.String(), "err", err)
+		return
+	}
+	// Deduplicated by args while queued or running (technicalInsertOpts), so a
+	// read of a company the sweep just nominated — or that a rep pressed the
+	// button on a moment ago — joins that lookup instead of asking the same
+	// three services twice.
+	if _, err := client.Insert(ctx, TechnicalEnrichOrganizationArgs{
+		Workspace:      workspace,
+		OrganizationID: *claim.OrganizationID,
+	}, technicalInsertOpts()); err != nil {
+		w.log.WarnContext(ctx, "technical lookup not queued after site read",
+			"organization", claim.OrganizationID.String(), "err", err)
+	}
+}

--- a/backend/internal/compose/technicalonsiteread_integration_test.go
+++ b/backend/internal/compose/technicalonsiteread_integration_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// Reading a company's site asks what that company publicly runs.
+//
+// The claim is worth a real river_job table because the enqueue happens through
+// the client WORKING the read's own job, and a unit test cannot tell a context
+// that carries such a client from one that does not — both compile, and the one
+// without it takes the silent path this lane deliberately chose. So the test
+// that matters drives the real worker over a real client and reads the row back
+// out of the queue.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertest"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+)
+
+// workClient is the insert-only client a working job carries, built here
+// because rivertest.WorkContext needs the *river.Client itself and
+// platform/jobs holds its own unexported.
+func workClient(t *testing.T, e *integration.Env) *river.Client[pgx.Tx] {
+	t.Helper()
+	client, err := river.NewClient(riverpgxv5.New(e.Pool), &river.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("river.NewClient: %v", err)
+	}
+	return client
+}
+
+func TestASiteReadAsksWhatTheCompanyPubliclyRuns(t *testing.T) {
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	org := insertOrg(t, e, e.Rep1, "acme.example", "")
+	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
+	_, args := startDeepRead(t, e, org)
+
+	ctx := rivertest.WorkContext(context.Background(), workClient(t, e))
+	if err := worker.run(ctx, args); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// The lookup the reader never had to ask for. Its args name the company the
+	// read was about — a lookup pointed at another record would enrich the
+	// wrong account while looking exactly like this one.
+	job := rivertest.RequireInserted(ctx, t, riverpgxv5.New(e.Pool),
+		TechnicalEnrichOrganizationArgs{}, nil)
+	if job.Args.OrganizationID != org || job.Args.Workspace != e.WS {
+		t.Fatalf("queued lookup = %+v, want the company this read was about (%s in %s)",
+			job.Args, org, e.WS)
+	}
+	if job.Queue != technicalLookupQueue {
+		t.Fatalf("queued on %q, want %q — the lookup's pacing is the queue's, not the crawl's",
+			job.Queue, technicalLookupQueue)
+	}
+}
+
+// A read that resolved no company has nothing to look up. The triage lane runs
+// before an account exists, so an enqueue here would name a nil record — and
+// the args are not nullable, so the failure would be a panic inside a lane
+// whose whole contract is that it cannot fail the read.
+func TestASiteReadWithNoCompanyQueuesNoLookup(t *testing.T) {
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	worker, _ := newDeepReadTestWorker(e, acmeDeepSite(), acmeDeepBrain())
+	ctx := rivertest.WorkContext(context.Background(), workClient(t, e))
+
+	// The triage lane's shape: a claim whose read is about a DOMAIN, with no
+	// account resolved behind it yet.
+	worker.askWhatTheCompanyRuns(ctx, people.SiteReadClaim{
+		OrganizationID: nil,
+		TargetKind:     "domain",
+		SeedURL:        "https://acme.example",
+	})
+
+	rivertest.RequireNotInserted(ctx, t, riverpgxv5.New(e.Pool),
+		TechnicalEnrichOrganizationArgs{}, nil)
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1670,7 +1670,7 @@ export const de = {
   "co.tech.read": "Nachschauen",
   "co.tech.reading": "Schaue nach…",
   "co.tech.empty":
-    "Noch nichts nachgeschaut. Die Abfrage liest öffentliche Einträge zur Domain auf diesem Datensatz.",
+    "Noch nichts Technisches gelesen. Das füllt sich von selbst, sobald die Website der Firma gelesen wird, und frischt sich selbst auf — der Knopf ist nur da, wenn du nicht warten willst.",
   "co.tech.unavailable": "Diese Installation macht keine technischen Abfragen.",
   "co.tech.queued": "Die Abfrage läuft. Meist dauert das keine Minute.",
   "co.tech.laneFailed":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1707,7 +1707,7 @@ export const en = {
   "co.tech.read": "Look up",
   "co.tech.reading": "Looking up…",
   "co.tech.empty":
-    "Nothing looked up yet. The lookup reads public records for the domain on this record.",
+    "No technical reading yet. This fills itself in when the company's site is read, and refreshes on its own — the button is only there when you do not want to wait.",
   "co.tech.unavailable": "This installation makes no technical lookups.",
   "co.tech.queued": "The lookup is queued. It usually takes under a minute.",
   "co.tech.laneFailed":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1663,7 +1663,7 @@ export const vi = {
   "co.tech.read": "Tra cứu",
   "co.tech.reading": "Đang tra cứu…",
   "co.tech.empty":
-    "Chưa tra cứu. Việc tra cứu đọc các bản ghi công khai của tên miền trên hồ sơ này.",
+    "Chưa có dữ liệu kỹ thuật. Mục này tự điền khi website của công ty được đọc, và tự làm mới — nút bấm chỉ dành cho khi bạn không muốn chờ.",
   "co.tech.unavailable": "Bản cài đặt này không thực hiện tra cứu kỹ thuật.",
   "co.tech.queued": "Đã xếp hàng tra cứu. Thường mất chưa đến một phút.",
   "co.tech.laneFailed":

--- a/frontend/src/screens/companytechnical.stories.tsx
+++ b/frontend/src/screens/companytechnical.stories.tsx
@@ -143,11 +143,14 @@ export const Read: Story = {
 };
 
 /**
- * Never looked up. The card offers the lookup and says plainly that there is
- * nothing yet — an empty card with no sentence reads as "this company runs
- * nothing", which is a different and false claim.
+ * Not read yet — an account whose site nothing has crawled.
+ *
+ * The sentence carries the weight: an empty card with no sentence reads as
+ * "this company runs nothing", and one that only offered a button would ask
+ * for a press the reader does not owe. The reading arrives with the site read
+ * and refreshes on a schedule; the button is the impatient path.
  */
-export const NeverLookedUp: Story = {
+export const NotReadYet: Story = {
   render: () => {
     installFetchStub({
       "GET /me": CAN_ENRICH,

--- a/frontend/src/screens/technicalprofile.test.tsx
+++ b/frontend/src/screens/technicalprofile.test.tsx
@@ -110,8 +110,10 @@ describe("the technical profile card", () => {
   });
 
   // An empty card with no sentence reads as "this company runs nothing", which
-  // is a different and false claim from "nobody has looked".
-  it("says plainly when nothing has been looked up", async () => {
+  // is a different and false claim from "this has not been read yet". The
+  // sentence also has to say the reading happens on its own, or the card asks
+  // for a press it does not need.
+  it("says plainly that nothing has been read yet", async () => {
     installFetchStub({
       "GET /me": CAN_ENRICH,
       [`GET /organizations/${ORG}/facts`]: () => jsonResponse({ data: [] }),
@@ -119,7 +121,9 @@ describe("the technical profile card", () => {
         jsonResponse({ title: "not found" }, 404),
     });
     renderCard();
-    expect(await screen.findByText(/Noch nichts nachgeschaut/)).toBeTruthy();
+    expect(
+      await screen.findByText(/Noch nichts Technisches gelesen/),
+    ).toBeTruthy();
   });
 
   // The notice is what tells a reader that an absent service means "not checked


### PR DESCRIPTION
The technical lookup shipped behind its own button. It should not need one — the
lookups are free, public and paced, and a reader who opened an account wants what
the company runs at the same moment they want what its pages say.

**Every site read now queues the technical lookup.** The automatic capture read
and a human-pressed read alike, so a company captured from an email arrives with
its technical picture without anyone asking.

**It enqueues rather than reads inline.** The two side lanes beside it (logo,
newsroom) each make one bounded request. This one asks three services, and the
certificate log's own pacer can hold a caller for five seconds before the query
is even built — waiting on that would park a deep-read worker, the scarcest kind
in the fleet, on something that has nothing to do with crawling. The lookup
already has a single-threaded queue sized for exactly this.

**Two ways it correctly does nothing.** A read that resolved no company has
nothing to look up (the triage lane runs before an account exists). A deployment
whose worker registered no enricher rejects the kind at insert, which is honest
rather than a row nothing will work.

Deduplicated by args while queued or running, so a read of a company the sweep
just nominated — or that a rep pressed the button on a moment ago — joins that
lookup instead of asking the same three services twice.

**Copy.** The empty state said "nothing looked up yet" beside a button, which
reads as a request for a press. It now says the reading arrives on its own and
the button is only for not waiting. All three locales.

**Tests.** `technicalonsiteread_integration_test.go` drives the real deep-read
worker over a real River client and reads the queued job back out of
`river_job` — a unit test cannot tell a context carrying a client from one that
does not, and the one without it takes the silent path this lane deliberately
chose. Mutation-checked: removing the call fails the test.

`make check-backend`, `make check-fe`, the whole `internal/compose` integration
package (221s, all green), `craft static --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every site read now queues the technical lookup, so a company's technical picture arrives without a button press. The lookup previously ran only when asked; now automatic capture reads and human-pressed reads both enqueue it.

**Behavior**
- It enqueues rather than reads inline: the certificate log can hold a caller for five seconds, and waiting would park the scarce deep-read worker.
- Lookups are deduplicated by args while queued or running, so a second read joins the existing lookup instead of asking the same three services twice.
- Reads that resolve no company queue nothing, and deployments without the enricher worker reject the insert at queue time.
- The empty-state copy now says the reading arrives on its own; updated in all three locales.
- An integration test drives the real deep-read worker over a real River client and reads the queued job back; removing the enqueue call fails the test.

<sup>Written for commit 0b3bdaf8953fbaca447411b1e9e387588c1f5112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Technical information now populates automatically after a company website is read.
  * Technical data refreshes automatically, with an option to start a lookup immediately.

* **Bug Fixes**
  * Improved empty-state messaging to distinguish between information not yet read and no information found.
  * Added support for German, English, and Vietnamese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->