### PR TITLE
fix(people): an attach cannot outrun the archive (#1625)

### DIFF
--- a/backend/gates/personattachlock_test.go
+++ b/backend/gates/personattachlock_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+//go:build !integration
+
+package gates
+
+// A relationship carrying a person is written under that person's row lock.
+//
+// archivePersonRows archives the person AND sweeps their relationships in one
+// transaction. A writer that inserted a relationship without holding the person
+// row could commit between the archive's own probe and its sweep, leaving a
+// LIVE relationship pointing at an ARCHIVED person — the orphan the "block
+// rather than orphan" rule exists to prevent (issue #1625).
+//
+// FOUR writers had to be found by hand to fix it, in four files, and the issue
+// itself named one. That is the shape this census replaces: the next writer is
+// the one nobody remembers, and the failure it causes is a row that looks fine
+// in every sequential test.
+//
+// TWO SPELLINGS OF THE LOCK, because two shapes of writer need it:
+//
+//   - a writer that names ONE person calls lockPersonForAttach before its
+//     insert, and LiveOnly is both the lock and the liveness check.
+//   - a SET-BASED writer has no id to lock before the select that finds it, so
+//     it takes the lock inside the statement — `FOR UPDATE OF p` over the
+//     person rows the insert is about to attach.
+//
+// Either satisfies this. What does not is an insert naming person_id with
+// neither, which is the state every one of them was in.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The two ways a writer takes the lock, one per shape.
+const (
+	singlePersonLock = "lockPersonForAttach"
+	setBasedLock     = "FOR UPDATE OF p"
+)
+
+func TestEveryRelationshipCarryingAPersonIsWrittenUnderItsLock(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(repoRoot, "backend", "internal", "modules", "people")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the people module: %v", err)
+	}
+
+	writers := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(dir, name), nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, fn := range personRelationshipWriters(file) {
+			writers++
+			if !fn.locked {
+				t.Errorf("%s: %s inserts a relationship naming person_id and takes no person lock.\n"+
+					"\tAn archive in flight can then commit between its own probe and its sweep, "+
+					"leaving a live relationship on an archived person — which every sequential "+
+					"test reads as fine.\n"+
+					"\tCall %s before the insert, or take the lock in the statement with `%s` "+
+					"if the people are found by the select rather than named.",
+					name, fn.name, singlePersonLock, setBasedLock)
+			}
+		}
+	}
+	// Four of these exist. A census that found none is one whose walk broke,
+	// and it would report the same green as a tree where every writer locks.
+	if writers < 4 {
+		t.Fatalf("found %d writer(s) inserting a relationship with a person_id, and there are at "+
+			"least four — the walk is broken, or the statements changed shape", writers)
+	}
+}
+
+type relationshipWriter struct {
+	name   string
+	locked bool
+}
+
+// personRelationshipWriters finds each function whose body contains an INSERT
+// into relationship naming person_id, and whether that same function takes the
+// lock in either of its two spellings.
+func personRelationshipWriters(file *ast.File) []relationshipWriter {
+	var found []relationshipWriter
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		inserts, statementLock := false, false
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			sql := lit.Value
+			if strings.Contains(sql, "INSERT INTO relationship") && strings.Contains(sql, "person_id") {
+				inserts = true
+			}
+			if strings.Contains(sql, setBasedLock) {
+				statementLock = true
+			}
+			return true
+		})
+		if !inserts {
+			continue
+		}
+		found = append(found, relationshipWriter{
+			name:   fn.Name.Name,
+			locked: statementLock || callsLock(fn.Body),
+		})
+	}
+	return found
+}
+
+func callsLock(body *ast.BlockStmt) bool {
+	called := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == singlePersonLock {
+			called = true
+		}
+		return true
+	})
+	return called
+}

--- a/backend/internal/compose/integration/person_attach_race_integration_test.go
+++ b/backend/internal/compose/integration/person_attach_race_integration_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// An attach cannot outrun the archive that is retiring the person it hangs off.
+//
+// archivePersonRows archives the person AND sweeps their relationships, in one
+// transaction. A writer that inserted a relationship without holding the person
+// row could commit between the archive's own probe and its sweep, leaving a
+// LIVE relationship pointing at an ARCHIVED person — the orphan the "block
+// rather than orphan" rule exists to prevent (issue #1625).
+//
+// Forced rather than hoped for, the same shape as the erasure race: the archive
+// is held open on its own transaction, the attach is started and must PARK
+// behind it, the archive commits, and the attach must then be refused because
+// there is no live person left to attach to.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestAnAttachCannotOutrunTheArchive(t *testing.T) {
+	e := Setup(t)
+	person := ids.From[ids.PersonKind](e.SeedPerson(t, "Retiring Stakeholder", nil))
+	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Attaching Company", nil))
+
+	// The archive, held open. It IS the holder — the real interleaving, and the
+	// transaction the attach actually races.
+	holderCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	holder, err := e.Pool.Begin(holderCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := holder.Exec(holderCtx,
+		`SELECT set_config('app.workspace_id', $1::text, true)`, e.WS); err != nil {
+		t.Fatal(err)
+	}
+	var holderPID int
+	if err := holder.QueryRow(holderCtx,
+		`UPDATE person SET archived_at = now() WHERE id = $1 RETURNING pg_backend_pid()`,
+		person.UUID).Scan(&holderPID); err != nil {
+		t.Fatal(err)
+	}
+
+	attached := make(chan error, 1)
+	go func() {
+		_, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+			Kind:           "employment",
+			PersonID:       &person,
+			OrganizationID: &org,
+		})
+		attached <- err
+	}()
+
+	// It has to actually PARK behind the archive, asked of Postgres rather than
+	// assumed after a sleep — otherwise the archive could commit before the
+	// attach opened its transaction, and the test would pass against a writer
+	// that takes no lock at all.
+	waitForBlockedOn(holderCtx, t, holder, holderPID)
+
+	if err := holder.Commit(holderCtx); err != nil {
+		t.Fatalf("committing the archive: %v", err)
+	}
+
+	// The attach is refused, because the person it named is no longer live.
+	// That is the right answer, and the alternative is the orphan: a live
+	// relationship on an archived person, which the archive's sweep has already
+	// run past and will never come back for.
+	err = <-attached
+	if err == nil {
+		t.Fatal("the attach succeeded against a person archived while it waited — that is a live " +
+			"relationship on an archived person, and the sweep that would have caught it has run")
+	}
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("the attach failed with %v, want a not-found: the person is gone, which is a "+
+			"fact about the target rather than a fault of the request", err)
+	}
+	assertNoLiveRelationship(t, e, person)
+}
+
+func assertNoLiveRelationship(t *testing.T, e *Env, personID ids.PersonID) {
+	t.Helper()
+	var live int
+	if err := e.DB().Tx(e.Admin(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM relationship WHERE person_id = $1 AND archived_at IS NULL`,
+			personID.UUID).Scan(&live)
+	}); err != nil {
+		t.Fatalf("counting the person's live relationships: %v", err)
+	}
+	if live != 0 {
+		t.Errorf("%d live relationship(s) point at an archived person", live)
+	}
+}

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -276,6 +276,13 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 	if err != nil {
 		return 0, err
 	}
+	// The lock is IN the statement here, not beside it: this writer attaches a
+	// SET of people found by domain rather than one named person, so there is
+	// no id to lock before the select that finds it. `FOR UPDATE OF p` at the
+	// bottom locks each person this insert is about to attach, which is the
+	// same guarantee lockPersonForAttach gives the single-person writers — an
+	// archive in flight either commits first and drops the row out of this
+	// select, or waits and sweeps the edge this plants.
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
 		SELECT 'employment', p.id, $1, true, $2, $3
@@ -295,6 +302,7 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 		  AND NOT EXISTS (
 			SELECT 1 FROM relationship r
 			WHERE r.person_id = p.id AND `+CurrentPrimarySlotSQL("r")+`)
+		FOR UPDATE OF p
 		ON CONFLICT DO NOTHING`,
 		orgID, domainTriageSource(domain), by, domain)
 	if err != nil {

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -70,6 +70,11 @@ func organizationIsLive(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 // employment that already exists. The NOT EXISTS keeps a concurrent race with
 // the first from surfacing as a 500.
 func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyInput, personID ids.PersonID, orgID ids.OrganizationID) error {
+	// The employment edge hangs off the person, so an archive in flight must
+	// not be outrun — see lockPersonForAttach.
+	if err := lockPersonForAttach(ctx, tx, personID); err != nil {
+		return err
+	}
 	var edgeID ids.UUID
 	err := tx.QueryRow(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)

--- a/backend/internal/modules/people/personattachlock.go
+++ b/backend/internal/modules/people/personattachlock.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// lockPersonForAttach takes the person's row lock before an edge is hung off
+// them, so an archive in flight cannot be outrun.
+//
+// archivePersonRows archives the person AND sweeps their relationships, in one
+// transaction. A writer that inserted a relationship without holding the person
+// row could commit between the archive's own probe and its sweep, leaving a
+// LIVE relationship pointing at an ARCHIVED person — which is the orphan the
+// "block rather than orphan" rule exists to prevent (issue #1625).
+//
+// The lock closes the window rather than narrowing it, and it does so in
+// whichever order the two arrive:
+//
+//   - the archive commits first, and this returns ErrNotFound because LiveOnly
+//     does not resolve an archived row. The attach fails, which is the right
+//     answer: there is nothing live left to attach to.
+//   - the attach commits first, and the archive's sweep — which runs after its
+//     own lock on the same row — sees the new relationship and archives it with
+//     everything else.
+//
+// The statement is written here rather than taken from storekit.LockRow, and
+// the reason is a rule this must not quietly decide.
+//
+// LockRow is how a MUTATION of a row begins in this tree — LockRow then
+// ApplyLocked — and the write-authority census reads it as exactly that: reach
+// it on a shareable record and the function must also take a row-level
+// write-authority probe. That census also records, in its own header, the one
+// question it deliberately does not settle: auth.EnsureLinkTarget asks whether
+// a caller may REFERENCE a record, and "whether `add` needs write authority on
+// the thing added TO is a product question UC-E11-08 E2 raises rather than
+// settles."
+//
+// Attaching an edge to a person is precisely that question. This lock does not
+// change the person — it holds the row so an archive cannot slip past — and
+// borrowing the mutation door would have answered a product question as a side
+// effect of a concurrency fix, on eleven call sites, inside a PR about a race.
+//
+// So it says what it is. LiveOnly's two jobs are kept: the row is locked and
+// its liveness is the same read, because a caller that locked and then asked
+// separately whether the row was live would have written the same race one
+// level down.
+func lockPersonForAttach(ctx context.Context, tx pgx.Tx, personID ids.PersonID) error {
+	var got ids.UUID
+	err := tx.QueryRow(ctx,
+		`SELECT id FROM person WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
+		personID.UUID).Scan(&got)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The same refusal storekit.LockRow gives for a row its filter cannot
+		// resolve, so an attach onto an archived person reads the way an attach
+		// onto a missing one does — which is what it is.
+		return apperrors.ErrNotFound
+	}
+	return err
+}

--- a/backend/internal/modules/people/promotedeal.go
+++ b/backend/internal/modules/people/promotedeal.go
@@ -119,6 +119,12 @@ func seatPersonOnQualifiedDeal(ctx context.Context, tx pgx.Tx, personID ids.Pers
 	if err != nil {
 		return err
 	}
+	// The stakeholder edge this writes hangs off the person, so an archive in
+	// flight must not be outrun — see lockPersonForAttach. This is the edge the
+	// race was found on.
+	if err := lockPersonForAttach(ctx, tx, personID); err != nil {
+		return err
+	}
 	row := tx.QueryRow(ctx, `
 		INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
 		VALUES ('deal_stakeholder', $1, $2, NULL, $3, $4)

--- a/backend/internal/modules/people/relationshipcreate.go
+++ b/backend/internal/modules/people/relationshipcreate.go
@@ -117,6 +117,16 @@ func writeRelationshipInTx(
 	capturedBy string,
 ) (relationshipRow, error) {
 	var out relationshipRow
+	// Before the endpoints are checked, because the check is what this lock
+	// makes true: an archive in flight either commits first and LiveOnly
+	// refuses this attach, or waits and sweeps the edge this writes with
+	// everything else. Without it the two can interleave into a live
+	// relationship on an archived person.
+	if in.PersonID != nil {
+		if err := lockPersonForAttach(ctx, tx, *in.PersonID); err != nil {
+			return out, err
+		}
+	}
 	if err := ensureRelationshipEndpoints(ctx, tx, in); err != nil {
 		return out, err
 	}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -108,6 +108,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `onevoiceversionwriter_test.go` | H2 | voice\_profile\_version and voice\_profile\_delta each have ONE writer. |
 | `parallelgates_test.go` | H3 | Every gate here runs in parallel with the others, and this is what keeps that true as gates are added. |
 | `passportmint_test.go` | H1 | A passport is minted for the session user, and for nobody else. |
+| `personattachlock_test.go` | H2 | A relationship carrying a person is written under that person's row lock. |
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
 | `precheckwiring_test.go` | H2 | A precheck that exists but is not wired protects nothing. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -57,7 +57,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (64)
+## Census (65)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #1625.

## The orphan

`archivePersonRows` archives the person **and** sweeps their relationships, in one transaction. A writer that inserted a relationship without holding the person row could commit between the archive's own probe and its sweep, leaving a **live relationship pointing at an archived person** — the orphan the "block rather than orphan" rule exists to prevent.

## Four writers, and why that argues for a census

The issue names `CreateRelationship`. There were four:

| writer | shape |
|---|---|
| `writeRelationshipInTx` | shared by `CreateRelationship` and `CreateRelationshipTx` |
| `seatPersonOnQualifiedDeal` | the `deal_stakeholder` edge the race was found on |
| `plantEmploymentEdge` | one named person |
| `plantDomainEmployment` | a **set** of people found by domain |

The next writer is the one nobody remembers, and the row it leaves looks fine in every sequential test — so the fix is a census, not four edits.

## Two spellings, because two shapes need it

- A writer naming **one** person calls `lockPersonForAttach` before its insert.
- A **set-based** writer has no id to lock before the select that finds it, so it takes the lock inside the statement: `FOR UPDATE OF p` over the person rows the insert is about to attach.

Either satisfies `TestEveryRelationshipCarryingAPersonIsWrittenUnderItsLock`. An insert naming `person_id` with neither does not — which is the state all four were in.

## The load-bearing decision: not borrowing `storekit.LockRow`

This is the part worth reviewing. `LockRow` is how a *mutation* begins in this tree (`LockRow` then `ApplyLocked`), and `TestEveryWriteToAShareableRecordReachesAWriteAuthorityProbe` reads it as exactly that. Using it made **eleven** functions "change person" and demanded a row-level write-authority probe on each:

```
internal/modules/people: CreateRelationship changes person and reaches no write-authority probe
internal/modules/people: QuickCapture changes person and reaches no write-authority probe
… nine more
```

That census records, in its own header, the one question it deliberately does not settle:

> `auth.EnsureLinkTarget` … asks whether the caller may REFERENCE a record — attach an activity, name a parent org, add a list member — and whether "add" needs write authority on the thing added TO is a product question UC-E11-08 E2 raises rather than settles. It is tracked as its own issue rather than decided inside a security sweep.

**Attaching an edge to a person is precisely that question.** Answering it as a side effect of a concurrency fix — on eleven call sites, in a PR about a race — would have been the wrong way to decide it, and waiving eleven entries would have been the same decision written as an exception.

So the lock says what it is: a `SELECT … WHERE archived_at IS NULL FOR UPDATE` that holds the row and answers `ErrNotFound` for one that is gone. `LiveOnly`'s two jobs are kept deliberately — the lock and the liveness check are one read, because a caller that locked and then asked separately whether the row was live would have written the same race one level down.

## Verification

The race is forced, not hoped for: the archive is held open on its own transaction, the attach is started and must **park** behind it (asked of Postgres via `pg_blocking_pids`), the archive commits, and the attach must then be refused.

| mutation | result |
|---|---|
| `lockPersonForAttach` removed from the shared writer | `--- FAIL` — the attach succeeds against a person archived while it waited |
| `seatPersonOnQualifiedDeal` drops its lock | census: `inserts a relationship naming person_id and takes no person lock` |
| the set-based writer drops `FOR UPDATE OF p` | census names `plantDomainEmployment` |

`make check-backend` green. `make test-it DIR=backend/internal/modules/people`: 587 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented archived people from retaining newly attached relationships during concurrent updates.
  - Relationship attachments now fail cleanly when the associated person is missing or archived.
  - Improved consistency when creating employment, deal stakeholder, and other person relationships.

- **Tests**
  - Added coverage for concurrent archive and relationship-attachment scenarios.
  - Added safeguards to verify relationship writes consistently protect associated person records.

- **Documentation**
  - Documented the new relationship-integrity verification in the gate inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->