### PR TITLE
feat(attention): a relationship going quiet reaches the rep's day

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30088,13 +30088,32 @@ components:
             actually used, so the card never implies a patience the server did not apply.
 
             Absent — not empty — on an installation whose feed does not read deals.
+        relationship_decay:
+          type: array
+          items: { $ref: '#/components/schemas/AttentionItem' }
+          description: |
+            The reader's OWN relationships that have gone silent, longest silence first —
+            people they were in contact with and are not any more.
+
+            A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
+            a contact carrying no open deal never reaches that lane, and those are exactly
+            the relationships that lapse unnoticed. `detail` carries the silence in days,
+            from the same §4 derivation the contact's own page shows, so the two surfaces
+            cannot come to disagree about when somebody went quiet.
+
+            Only relationships this reader actually had: a contact nobody here ever spoke
+            to has not gone quiet, and a lane that said otherwise would report every
+            dormant record as a lapse.
+
+            Absent — not empty — on an installation whose feed does not derive relationship
+            changes.
         done_for_you:
           type: array
           items: { $ref: '#/components/schemas/AttentionItem' }
           description: "What the system did on its own, most recent first. Receipts, not questions."
         lanes_omitted:
           type: array
-          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk, meetings] }
+          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk, meetings, relationship_decay] }
           description: "Lanes withheld because the caller may not read what they contain. Never returned empty instead."
         counts: { $ref: '#/components/schemas/AttentionCounts' }
 
@@ -30129,6 +30148,13 @@ components:
             How many promises this lane is CARRYING, which is the bounded page rather than every
             promise due — the same bound `planned` reports under. A rep past the bound sees the
             soonest-due ones, which is the order the lane is in.
+        relationship_decay:
+          type: integer
+          minimum: 0
+          description: >-
+            How many lapsed relationships this lane is CARRYING — the bounded page, as the
+            other lanes report. A rep past the bound sees the longest silences, which is the
+            order the lane is in.
 
 
     AttentionItem:
@@ -30143,7 +30169,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting, relationship_decay]
           description: "Which producer raised it, and therefore which endpoint its verbs go to."
         kind: { type: string, description: 'The producer''s own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority.' }
         title:

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -204,6 +204,38 @@ type RiskyDeal struct {
 	ExpectedCloseDate *time.Time
 }
 
+// Decay is the reader's own relationships that have gone silent.
+//
+// A separate lane from AtRisk rather than more rows in it, because the two rest
+// on different records and warn about different things: AtRisk is a DEAL nobody
+// is moving, and this is a PERSON nobody is talking to. A contact carrying no
+// open deal never reaches that lane at all, and those are exactly the
+// relationships that lapse without anyone noticing.
+//
+// The seam behind it derives the silence through the same §4 change engine the
+// contact's own page reads, so there is one quiet rule in the product rather
+// than a second threshold spelled here.
+//
+// Optional exactly as the others are: nil means this feed does not derive
+// relationship changes, which is a different fact from a rep whose
+// relationships are all current.
+type Decay interface {
+	Lapsed(ctx context.Context) ([]QuietRelationship, error)
+}
+
+// QuietRelationship is one contact this reader has stopped talking to.
+type QuietRelationship struct {
+	PersonID ids.UUID
+	Name     string
+	// QuietDays is how long the silence has run, which is the number the card
+	// says out loud. It comes from the derivation rather than from the
+	// projection's own last_at, so the card and the contact's page agree.
+	QuietDays int
+	// LastAt is when they last spoke, so the card can date the silence rather
+	// than only measure it.
+	LastAt time.Time
+}
+
 // Meetings is today's booked meetings that have not happened yet.
 //
 // Optional as the other two are: nil means this feed does not read meetings,
@@ -236,7 +268,10 @@ type Service struct {
 	// array. The contract makes the lane optional for exactly that reason.
 	commitments Commitments
 	// atRisk is OPTIONAL for the reason commitments is: absent lane, not empty.
-	atRisk   AtRisk
+	atRisk AtRisk
+	// decay is OPTIONAL for the same reason, and says nothing about atRisk:
+	// an installation can warn about deals without deriving relationships.
+	decay    Decay
 	meetings Meetings
 	now      Clock
 }
@@ -244,11 +279,11 @@ type Service struct {
 // NewService binds the feed to its readers.
 func NewService(
 	a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing,
-	c Commitments, k AtRisk, m Meetings, now Clock,
+	c Commitments, k AtRisk, q Decay, m Meetings, now Clock,
 ) *Service {
 	return &Service{
 		approvals: a, duplicates: d, tasks: t, receipts: r,
-		briefing: b, commitments: c, atRisk: k, meetings: m, now: now,
+		briefing: b, commitments: c, atRisk: k, decay: q, meetings: m, now: now,
 	}
 }
 

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -117,7 +117,7 @@ func TestADuplicateOutranksAnApprovalBecauseAMergeCannotBeUndone(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: []crmcontracts.Approval{approval("Send the Weber follow-up")}},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "person", Confidence: 0.9}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -135,7 +135,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 		stubApprovals{},
 		stubDuplicates{err: apperrors.ErrPermissionDenied},
 		&stubTasks{rows: []Task{{ID: ids.NewV7(), Subject: "Call Anna"}}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a refused lane must not fail the read: %v", err)
@@ -157,7 +157,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestABrokenLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{err: fmt.Errorf("the database is unreachable")},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a lane that FAILED was reported as an empty day")
 	}
@@ -171,7 +171,7 @@ func TestTheCountReportsTheTotalThoughTheLaneIsBounded(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: pairs, open: 40},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -194,7 +194,7 @@ func TestTheCountCoversStagedProposalsToo(t *testing.T) {
 	}
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 20},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -213,7 +213,7 @@ func TestAnOverdueTaskLeadsThePlannedLane(t *testing.T) {
 			{ID: ids.NewV7(), Subject: "Due later today", DueAt: &later},
 			{ID: ids.NewV7(), Subject: "Was due yesterday", DueAt: &yesterday},
 		}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -236,7 +236,7 @@ func TestAReceiptOffersNoDecision(t *testing.T) {
 			ID: ids.NewV7(), Kind: "close_date_correction",
 			Summary: "Moved the Acme close date to 27 Sep", OccurredAt: readInstant.Add(-time.Hour),
 		}}},
-		stubBriefing{}, nil, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -255,7 +255,7 @@ func TestADuplicateCarriesNoServerWrittenSentence(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "organization", Confidence: 0.92}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -291,7 +291,7 @@ func TestAFloodOfDuplicatesDoesNotBuryTheStagedDecisions(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 79},
 		stubDuplicates{pairs: pairs, open: len(pairs)},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -319,7 +319,7 @@ func TestADuplicateCardNamesBothRecords(t *testing.T) {
 			LeftID: left, RightID: right,
 			Evidence: []FieldComparison{{Field: "display_name", Signal: "collide"}},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -344,7 +344,7 @@ func TestAnUnreadableSideCostsTheMergeVerbRatherThanLeakingTheRecord(t *testing.
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: hidden,
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a record this reader may not see must not fail the whole day: %v", err)
@@ -375,7 +375,7 @@ func TestEvidenceNeverReachesAReaderAsAColumnName(t *testing.T) {
 				{Field: "org", Signal: "collide"},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -400,7 +400,7 @@ func TestARecordReadThatBrokeIsNotReportedAsWithheld(t *testing.T) {
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: ids.NewV7(),
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a record read that FAILED was rendered as a pair the reader may not see")
 	}
@@ -421,7 +421,7 @@ func TestAnIdentityConflictKeepsTheOneRowThatExplainsIt(t *testing.T) {
 				{Field: "matched_lane", Signal: "exact_conflict", Left: &lane},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -440,6 +440,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
 		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil, nil, nil,
+		nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -472,7 +473,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{}, nil, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -493,7 +494,7 @@ func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, nil, fixedClock)
+		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -509,7 +510,7 @@ func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, nil, fixedClock)
+		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a broken briefing read was reported as a quiet morning")
 	}
@@ -519,6 +520,7 @@ func TestABriefingItemOffersItsOwnThreeVerbs(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
 		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil, nil, nil,
+		nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -582,6 +584,7 @@ func TestACommitmentCarriesThePromiseAndTheWordsItWasReadFrom(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}}, nil, nil,
+		nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -622,6 +625,7 @@ func TestAnOverduePromiseSaysSoRatherThanLeavingTheReaderToCompareDates(t *testi
 			promise("Angebot nachfassen", readInstant.Add(-48*time.Hour)),
 			promise("Termin bestätigen", readInstant.Add(3*time.Hour)),
 		}}, nil, nil,
+		nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -647,7 +651,7 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 	tasks := &stubTasks{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
-		commitments, nil, nil, fixedClock)
+		commitments, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
 	}
@@ -667,6 +671,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{err: apperrors.ErrPermissionDenied}, nil, nil,
+		nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -695,7 +700,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, nil, nil, fixedClock)
+		nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -714,6 +719,7 @@ func TestABrokenCommitmentReadFailsTheFeedRatherThanReadingAsAClearDay(t *testin
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{err: errors.New("the claim read fell over")}, nil, nil,
+		nil,
 		fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a failed commitment read assembled a day, want the error surfaced")
@@ -728,119 +734,6 @@ func overdueOf(item crmcontracts.AttentionItem) string {
 		return "absent"
 	}
 	return strconv.FormatBool(*item.Overdue)
-}
-
-type stubAtRisk struct {
-	rows []RiskyDeal
-	err  error
-}
-
-func (s stubAtRisk) Quiet(context.Context) ([]RiskyDeal, error) { return s.rows, s.err }
-
-// A quiet deal names the number of days it has been quiet. The whole reason the
-// lane asks at a shorter window than the stalled status is to speak sooner, and
-// a card that said only "at risk" would hide which patience produced it.
-func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
-	deal := ids.NewV7()
-	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
-		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}}, nil,
-		fixedClock)
-	out, err := svc.Assemble(context.Background())
-	if err != nil {
-		t.Fatalf("assembling: %v", err)
-	}
-	if out.AtRisk == nil {
-		t.Fatal("the at-risk lane is absent, want one deal")
-	}
-	items := *out.AtRisk
-	if len(items) != 1 {
-		t.Fatalf("the lane carries %d items, want 1", len(items))
-	}
-	if items[0].Title == nil || *items[0].Title != "Fleet retrofit" {
-		t.Errorf("title = %v, want the deal name", items[0].Title)
-	}
-	if items[0].Detail == nil || *items[0].Detail != "19" {
-		t.Errorf("detail = %s, want the idle day count", stringOr(items[0].Detail))
-	}
-	if items[0].Kind == nil || *items[0].Kind != "quiet" {
-		t.Errorf("kind = %s, want the ground it was admitted on", stringOr(items[0].Kind))
-	}
-	if items[0].Subject == nil || items[0].Subject.Type != "deal" {
-		t.Errorf("subject = %v, want the deal", items[0].Subject)
-	}
-}
-
-// A deal past its close date is reported as overdue rather than merely quiet.
-// The two grounds read differently to a rep: a date the customer agreed to has
-// passed, which is a harder fact than a silence nobody agreed to.
-func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
-	closed := readInstant.AddDate(0, 0, -30)
-	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
-		stubAtRisk{rows: []RiskyDeal{{
-			DealID: ids.NewV7(), Name: "Closing last month",
-			QuietDays: 2, CloseOverdue: true, ExpectedCloseDate: &closed,
-		}}}, nil,
-		fixedClock)
-	out, err := svc.Assemble(context.Background())
-	if err != nil {
-		t.Fatalf("assembling: %v", err)
-	}
-	item := (*out.AtRisk)[0]
-	if item.Kind == nil || *item.Kind != "close_overdue" {
-		t.Errorf("kind = %s, want close_overdue", stringOr(item.Kind))
-	}
-	if item.Overdue == nil || !*item.Overdue {
-		t.Errorf("overdue = %v, want true", item.Overdue)
-	}
-	if item.DueAt == nil || !item.DueAt.Equal(closed) {
-		t.Errorf("due_at = %v, want the expected close date", item.DueAt)
-	}
-}
-
-// A withheld risk lane is NAMED, not reported empty. "Nothing is at risk" is a
-// claim about the pipeline; "you may not read the deals" is a claim about the
-// reader, and only one of them is true here.
-func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
-	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
-		stubAtRisk{err: apperrors.ErrPermissionDenied}, nil,
-		fixedClock)
-	out, err := svc.Assemble(context.Background())
-	if err != nil {
-		t.Fatalf("assembling: %v", err)
-	}
-	if out.AtRisk != nil {
-		t.Errorf("a withheld lane sent %v, want no lane at all", *out.AtRisk)
-	}
-	var named bool
-	for _, lane := range *out.LanesOmitted {
-		if lane == "at_risk" {
-			named = true
-		}
-	}
-	if !named {
-		t.Errorf("lanes_omitted = %v, want it to name at_risk", *out.LanesOmitted)
-	}
-}
-
-// A feed with no risk reader sends no lane at all, the same absent-not-empty
-// rule the commitments lane keeps.
-func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
-	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
-		fixedClock)
-	out, err := svc.Assemble(context.Background())
-	if err != nil {
-		t.Fatalf("assembling: %v", err)
-	}
-	if out.AtRisk != nil {
-		t.Errorf("at_risk = %v, want the lane absent", *out.AtRisk)
-	}
-	if out.Counts.AtRisk != nil {
-		t.Errorf("counts.at_risk = %v, want it absent too", out.Counts.AtRisk)
-	}
 }
 
 // stringOr reads a wire string for a failure message. Printing the pointer
@@ -874,7 +767,7 @@ func TestTheMeetingLaneAsksFromNowRatherThanFromTheStartOfTheDay(t *testing.T) {
 	meetings := &stubMeetings{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, nil, meetings, fixedClock,
+		nil, nil, nil, meetings, fixedClock,
 	)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -892,7 +785,7 @@ func TestTheMeetingLaneAsksFromNowRatherThanFromTheStartOfTheDay(t *testing.T) {
 func TestAMeetingCarriesItsSubjectAndWhenItStarts(t *testing.T) {
 	starts := readInstant.Add(90 * time.Minute)
 	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
 		&stubMeetings{rows: []Meeting{{ID: ids.NewV7(), Subject: "Vogt — Angebotsbesprechung", StartsAt: starts}}},
 		fixedClock,
 	)
@@ -923,7 +816,7 @@ func TestAMeetingCarriesItsSubjectAndWhenItStarts(t *testing.T) {
 // the calendar" are different answers and only one of them is true.
 func TestAWithheldMeetingLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
-		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
 		&stubMeetings{err: apperrors.ErrPermissionDenied}, fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
@@ -955,9 +848,10 @@ func TestAWithheldMeetingLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 	commitments := &stubCommitments{rows: []Commitment{promise("a promise", readInstant)}}
 	meetings := &stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}}
+	decay := &stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		commitments, stubAtRisk{}, meetings, fixedClock,
+		commitments, stubAtRisk{}, decay, meetings, fixedClock,
 	)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -968,6 +862,9 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 	if meetings.calls != 1 {
 		t.Errorf("the meetings lane was read %d times, want once", meetings.calls)
 	}
+	if decay.calls != 1 {
+		t.Errorf("the relationship decay lane was read %d times, want once", decay.calls)
+	}
 }
 
 // A withheld lane appears in lanes_omitted exactly one time. Two entries is
@@ -976,7 +873,7 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 func TestAWithheldLaneAppearsInLanesOmittedExactlyOneTime(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, fixedClock,
+		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, nil, fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {

--- a/backend/internal/compose/attention/lanewiring_test.go
+++ b/backend/internal/compose/attention/lanewiring_test.go
@@ -10,7 +10,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
-// Each optional lane fills ITS OWN field. The three are wired through
+// Each optional lane fills ITS OWN field. The four are wired through
 // pointers-to-pointers into one response struct, which is exactly the shape
 // where a copy-paste slip puts the meetings into at_risk and nothing fails to
 // compile.
@@ -19,6 +19,7 @@ func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{rows: []Commitment{promise("a promise", readInstant)}},
 		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
+		&stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}},
 		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
 		fixedClock,
 	)
@@ -33,6 +34,7 @@ func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 	}{
 		{"meetings", out.Meetings, "a meeting"},
 		{"at_risk", out.AtRisk, "a deal"},
+		{"relationship_decay", out.RelationshipDecay, "a contact"},
 		{"commitments", out.Commitments, "a promise"},
 	} {
 		if lane.items == nil || len(*lane.items) != 1 {
@@ -63,6 +65,7 @@ func TestNoOptionalLaneOffersAnActionTheSurfaceCannotPerform(t *testing.T) {
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{rows: []Commitment{promise("a promise", readInstant)}},
 		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
+		&stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}},
 		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
 		fixedClock,
 	)
@@ -72,6 +75,7 @@ func TestNoOptionalLaneOffersAnActionTheSurfaceCannotPerform(t *testing.T) {
 	}
 	for name, lane := range map[string]*[]crmcontracts.AttentionItem{
 		"meetings": out.Meetings, "at_risk": out.AtRisk, "commitments": out.Commitments,
+		"relationship_decay": out.RelationshipDecay,
 	} {
 		if lane == nil {
 			t.Fatalf("%s is absent, so this gate checked nothing", name)

--- a/backend/internal/compose/attention/optionallanes.go
+++ b/backend/internal/compose/attention/optionallanes.go
@@ -59,7 +59,7 @@ func (l optionalLane) collect(
 	}
 }
 
-// optionalLanes describes the three, in the order they are read.
+// optionalLanes describes the four, in the order they are read.
 //
 // The meetings window opens at NOW rather than at midnight: a meeting that
 // began an hour ago cannot be prepared for, and one that ended would be plainly
@@ -93,6 +93,14 @@ func (s *Service) optionalLanes(
 				}), err
 			},
 			into: &out.Commitments, count: &out.Counts.Commitments,
+		},
+		{
+			name: "relationship_decay", bound: s.decay != nil,
+			read: func() ([]crmcontracts.AttentionItem, error) {
+				lapsed, err := s.decay.Lapsed(ctx)
+				return renderEach(lapsed, lapsedItem), err
+			},
+			into: &out.RelationshipDecay, count: &out.Counts.RelationshipDecay,
 		},
 	}
 }

--- a/backend/internal/compose/attention/quietlanes_test.go
+++ b/backend/internal/compose/attention/quietlanes_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// Two lanes report a silence: a deal nobody is moving, and a person nobody is
+// talking to. They rest on different records and answer to different readers,
+// so each proves separately that it speaks only when it has ground to.
+
+type stubAtRisk struct {
+	rows []RiskyDeal
+	err  error
+}
+
+func (s stubAtRisk) Quiet(context.Context) ([]RiskyDeal, error) { return s.rows, s.err }
+
+type stubDecay struct {
+	rows  []QuietRelationship
+	err   error
+	calls int
+}
+
+func (s *stubDecay) Lapsed(context.Context) ([]QuietRelationship, error) {
+	s.calls++
+	return s.rows, s.err
+}
+
+// A quiet deal names the number of days it has been quiet. The whole reason the
+// lane asks at a shorter window than the stalled status is to speak sooner, and
+// a card that said only "at risk" would hide which patience produced it.
+func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
+	deal := ids.NewV7()
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}}, nil,
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk == nil {
+		t.Fatal("the at-risk lane is absent, want one deal")
+	}
+	items := *out.AtRisk
+	if len(items) != 1 {
+		t.Fatalf("the lane carries %d items, want 1", len(items))
+	}
+	if items[0].Title == nil || *items[0].Title != "Fleet retrofit" {
+		t.Errorf("title = %v, want the deal name", items[0].Title)
+	}
+	if items[0].Detail == nil || *items[0].Detail != "19" {
+		t.Errorf("detail = %s, want the idle day count", stringOr(items[0].Detail))
+	}
+	if items[0].Kind == nil || *items[0].Kind != "quiet" {
+		t.Errorf("kind = %s, want the ground it was admitted on", stringOr(items[0].Kind))
+	}
+	if items[0].Subject == nil || items[0].Subject.Type != "deal" {
+		t.Errorf("subject = %v, want the deal", items[0].Subject)
+	}
+}
+
+// A deal past its close date is reported as overdue rather than merely quiet.
+// The two grounds read differently to a rep: a date the customer agreed to has
+// passed, which is a harder fact than a silence nobody agreed to.
+func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
+	closed := readInstant.AddDate(0, 0, -30)
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{
+			DealID: ids.NewV7(), Name: "Closing last month",
+			QuietDays: 2, CloseOverdue: true, ExpectedCloseDate: &closed,
+		}}}, nil,
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	item := (*out.AtRisk)[0]
+	if item.Kind == nil || *item.Kind != "close_overdue" {
+		t.Errorf("kind = %s, want close_overdue", stringOr(item.Kind))
+	}
+	if item.Overdue == nil || !*item.Overdue {
+		t.Errorf("overdue = %v, want true", item.Overdue)
+	}
+	if item.DueAt == nil || !item.DueAt.Equal(closed) {
+		t.Errorf("due_at = %v, want the expected close date", item.DueAt)
+	}
+}
+
+// A withheld risk lane is NAMED, not reported empty. "Nothing is at risk" is a
+// claim about the pipeline; "you may not read the deals" is a claim about the
+// reader, and only one of them is true here.
+func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{err: apperrors.ErrPermissionDenied}, nil,
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk != nil {
+		t.Errorf("a withheld lane sent %v, want no lane at all", *out.AtRisk)
+	}
+	var named bool
+	for _, lane := range *out.LanesOmitted {
+		if lane == "at_risk" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("lanes_omitted = %v, want it to name at_risk", *out.LanesOmitted)
+	}
+}
+
+// A feed with no risk reader sends no lane at all, the same absent-not-empty
+// rule the commitments lane keeps.
+func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.AtRisk != nil {
+		t.Errorf("at_risk = %v, want the lane absent", *out.AtRisk)
+	}
+	if out.Counts.AtRisk != nil {
+		t.Errorf("counts.at_risk = %v, want it absent too", out.Counts.AtRisk)
+	}
+}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -304,6 +304,35 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 	return item
 }
 
+// lapsedItem renders one relationship this reader has stopped talking to.
+//
+// The contact's NAME travels as the title because a person's name is a
+// sentence in every language, and the silence rides as the detail's own
+// number, the way the risk card carries its idle count — so the client writes
+// "quiet 63 days" and the server implies no window it did not apply.
+//
+// `occurred_at` is the last time they spoke. It is the fact the card dates
+// itself from, and it lets the lane be read as a chronology rather than only
+// as a list of numbers.
+//
+// It offers NO verb, exactly as the risk card does not. What to do about a
+// lapsed relationship is a judgement about that person, and a queue that
+// answered it here would be deciding rather than warning.
+func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
+	name := quiet.Name
+	days := strconv.Itoa(quiet.QuietDays)
+	lastAt := quiet.LastAt
+	return crmcontracts.AttentionItem{
+		Id:         quiet.PersonID.String(),
+		Source:     crmcontracts.AttentionItemSource("relationship_decay"),
+		Title:      &name,
+		Detail:     &days,
+		Subject:    subjectOf("person", quiet.PersonID),
+		OccurredAt: &lastAt,
+		Actions:    []crmcontracts.AttentionItemActions{},
+	}
+}
+
 // meetingItem renders one appointment still ahead today.
 //
 // The subject IS the sentence a rep recognises — somebody wrote it when the

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -3,7 +3,7 @@
 
 package compose
 
-// The three OPTIONAL attention lanes, bound to the engines that already own
+// The four OPTIONAL attention lanes, bound to the engines that already own
 // what they read.
 //
 // Each is a binding rather than an implementation, which is the point: the
@@ -18,15 +18,21 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/margince/margince/backend/internal/compose/attention"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/idlebase"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // attentionCommitments reads the acting rep's own promises through the people
@@ -103,6 +109,108 @@ func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
 		return 0
 	}
 	return days
+}
+
+// decayCandidateCap bounds the candidate set the decay lane derives.
+//
+// It is a bound on WORK, not a display cap: the projection answers "whose
+// silence is oldest" cheaply over an index, and the §4 derivation that follows
+// costs a pass over each candidate's interactions. Capping between the two is
+// what keeps the lane from becoming the walk over every person that the change
+// engine warns against, and the oldest silences are the ones worth the passes.
+const decayCandidateCap = 40
+
+// attentionDecay reads the acting rep's own lapsed relationships.
+//
+// TWO steps, and the order is the design. The projection narrows to the
+// reader's own edges that have been silent past the §4 threshold — one indexed
+// range rather than a sweep. Only then does the people module derive what
+// actually changed about those few, through the SAME engine the contact's own
+// page reads, so the lane and that page cannot come to disagree about when
+// somebody went quiet.
+//
+// A principal with no human behind it holds no relationships of its own, which
+// is a refusal rather than an empty lane: the feed omits and NAMES it instead
+// of reporting a clear day. Same rule the commitments lane keeps.
+type attentionDecay struct {
+	pool  *pgxpool.Pool
+	store *people.Store
+	now   func() time.Time
+}
+
+func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationship, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return nil, apperrors.ErrPermissionDenied
+	}
+	now := d.now()
+	var lapsed []attention.QuietRelationship
+	err := database.WithWorkspaceTx(ctx, d.pool, func(tx pgx.Tx) error {
+		quiet, err := search.QuietEdgesForUser(
+			ctx, tx, actor.UserID,
+			now.AddDate(0, 0, -relstrength.QuietDays),
+			decayCandidateCap,
+		)
+		if err != nil {
+			return err
+		}
+		candidates := make([]ids.PersonID, 0, len(quiet))
+		for _, edge := range quiet {
+			candidates = append(candidates, ids.From[ids.PersonKind](edge.PersonID))
+		}
+		changed, err := d.store.RelationshipChangesForPeople(ctx, tx, candidates, now)
+		if err != nil {
+			return err
+		}
+		lapsed = quietRelationships(quiet, changed)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return lapsed, nil
+}
+
+// quietRelationships keeps only the contacts the DERIVATION calls quiet.
+//
+// The projection's threshold admitted the candidates; this is the verdict. A
+// candidate whose derived changes say something else — they replied, the band
+// moved — is not on this lane, because the lane's sentence would then be a
+// second opinion about a relationship the contact's own page describes
+// differently.
+//
+// The walk follows the EDGES, not the derivations: the projection handed the
+// candidates over oldest silence first, the derivation returns them in its own
+// order, and the lane owes the rep the projection's — the longest-lapsed
+// contact on top.
+func quietRelationships(
+	quiet []search.InteractionEdge,
+	changed []people.PersonChanges,
+) []attention.QuietRelationship {
+	byPerson := make(map[ids.UUID]people.PersonChanges, len(changed))
+	for _, row := range changed {
+		byPerson[row.PersonID.UUID] = row
+	}
+	lapsed := make([]attention.QuietRelationship, 0, len(changed))
+	for _, edge := range quiet {
+		row, ok := byPerson[edge.PersonID]
+		if !ok {
+			continue
+		}
+		for _, change := range row.Changes {
+			if change.Kind != relstrength.ChangeWentQuiet {
+				continue
+			}
+			lapsed = append(lapsed, attention.QuietRelationship{
+				PersonID:  row.PersonID.UUID,
+				Name:      row.DisplayName,
+				QuietDays: change.Days,
+				LastAt:    edge.LastAt,
+			})
+			break
+		}
+	}
+	return lapsed
 }
 
 // attentionMeetings reads today's remaining meetings through the activities

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -345,6 +345,7 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, now attenti
 		attentionBriefing{engine: briefs.NewBriefEngine(pool, people.NewStore(db)), now: now},
 		attentionCommitments{store: people.NewStore(db)},
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
+		attentionDecay{pool: pool, store: people.NewStore(db), now: now},
 		attentionMeetings{store: activities.NewStore(db)},
 		now,
 	)

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -10,7 +10,10 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // The receipt lane makes a claim about WHO acted, and the claim is the whole
@@ -104,4 +107,74 @@ func (s *stubApprovalPage) list(limit int) ([]crmcontracts.Approval, error) {
 		limit = len(s.rows)
 	}
 	return s.rows[:limit], nil
+}
+
+// The decay lane's CANDIDATES come from the projection's own threshold, and its
+// VERDICT comes from the §4 derivation. Keeping the two apart is the whole
+// design: the projection knows when a pair last spoke and nothing about why,
+// so a candidate whose derivation says something else — they replied, the band
+// moved — is not a lapsed relationship however old its last row is.
+//
+// Reported otherwise, the lane would contradict the contact's own page about
+// the same relationship, which is the one thing two surfaces reading one engine
+// must never do.
+func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
+	oldest := ids.NewV7()
+	newer := ids.NewV7()
+	returned := ids.NewV7()
+	oldestSpoke := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	newerSpoke := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	// The derivation answers in ITS order — here deliberately not the
+	// projection's — because the lane, not the derivation, owes the rep the
+	// oldest silence on top.
+	quiet := quietRelationships(
+		[]search.InteractionEdge{
+			{PersonID: oldest, LastAt: oldestSpoke},
+			{PersonID: newer, LastAt: newerSpoke},
+			{PersonID: returned, LastAt: newerSpoke},
+		},
+		[]people.PersonChanges{
+			{
+				PersonID:    ids.From[ids.PersonKind](returned),
+				DisplayName: "Tomas Berg",
+				Changes:     []relstrength.Change{{Kind: relstrength.ChangeRepliedAfterGap, Days: 41}},
+			},
+			{
+				PersonID:    ids.From[ids.PersonKind](newer),
+				DisplayName: "Ines Sommer",
+				Changes:     []relstrength.Change{{Kind: relstrength.ChangeWentQuiet, Days: 41}},
+			},
+			{
+				PersonID:    ids.From[ids.PersonKind](oldest),
+				DisplayName: "Dana Weiss",
+				Changes:     []relstrength.Change{{Kind: relstrength.ChangeWentQuiet, Days: 63}},
+			},
+		},
+	)
+
+	if len(quiet) != 2 {
+		t.Fatalf("the lane carries %d relationships, want the two derived silences", len(quiet))
+	}
+	if quiet[0].Name != "Dana Weiss" || quiet[1].Name != "Ines Sommer" {
+		t.Errorf("the lane reads %q then %q, want the oldest silence first", quiet[0].Name, quiet[1].Name)
+	}
+	// The DERIVATION's span, not the projection's: the card says this number out
+	// loud, and the contact's own page says the same one.
+	if quiet[0].QuietDays != 63 {
+		t.Errorf("the card says %d days, want the derived 63", quiet[0].QuietDays)
+	}
+	if !quiet[0].LastAt.Equal(oldestSpoke) {
+		t.Errorf("the card dates the silence at %s, want the last exchange %s", quiet[0].LastAt, oldestSpoke)
+	}
+}
+
+// A contact the caller may not read never reaches the derivation, so the lane
+// simply has nothing to say about them — no row, and no empty-handed entry that
+// would disclose the pair exists.
+func TestTheDecayLaneReportsNothingItCannotDerive(t *testing.T) {
+	edge := search.InteractionEdge{PersonID: ids.NewV7(), LastAt: time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)}
+	if quiet := quietRelationships([]search.InteractionEdge{edge}, nil); len(quiet) != 0 {
+		t.Errorf("the lane invented %d relationships from an empty derivation", len(quiet))
+	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1230,13 +1230,14 @@ func (e AttachmentReadStartedStatus) Valid() bool {
 
 // Defines values for AttentionLanesOmitted.
 const (
-	AttentionLanesOmittedAtRisk      AttentionLanesOmitted = "at_risk"
-	AttentionLanesOmittedCommitments AttentionLanesOmitted = "commitments"
-	AttentionLanesOmittedDoneForYou  AttentionLanesOmitted = "done_for_you"
-	AttentionLanesOmittedMeetings    AttentionLanesOmitted = "meetings"
-	AttentionLanesOmittedNeedsYou    AttentionLanesOmitted = "needs_you"
-	AttentionLanesOmittedPlanned     AttentionLanesOmitted = "planned"
-	AttentionLanesOmittedThisMorning AttentionLanesOmitted = "this_morning"
+	AttentionLanesOmittedAtRisk            AttentionLanesOmitted = "at_risk"
+	AttentionLanesOmittedCommitments       AttentionLanesOmitted = "commitments"
+	AttentionLanesOmittedDoneForYou        AttentionLanesOmitted = "done_for_you"
+	AttentionLanesOmittedMeetings          AttentionLanesOmitted = "meetings"
+	AttentionLanesOmittedNeedsYou          AttentionLanesOmitted = "needs_you"
+	AttentionLanesOmittedPlanned           AttentionLanesOmitted = "planned"
+	AttentionLanesOmittedRelationshipDecay AttentionLanesOmitted = "relationship_decay"
+	AttentionLanesOmittedThisMorning       AttentionLanesOmitted = "this_morning"
 )
 
 // Valid indicates whether the value is a known member of the AttentionLanesOmitted enum.
@@ -1253,6 +1254,8 @@ func (e AttentionLanesOmitted) Valid() bool {
 	case AttentionLanesOmittedNeedsYou:
 		return true
 	case AttentionLanesOmittedPlanned:
+		return true
+	case AttentionLanesOmittedRelationshipDecay:
 		return true
 	case AttentionLanesOmittedThisMorning:
 		return true
@@ -1305,6 +1308,7 @@ const (
 	AttentionItemSourceDealAtRisk        AttentionItemSource = "deal_at_risk"
 	AttentionItemSourceDedupeCandidate   AttentionItemSource = "dedupe_candidate"
 	AttentionItemSourceMeeting           AttentionItemSource = "meeting"
+	AttentionItemSourceRelationshipDecay AttentionItemSource = "relationship_decay"
 	AttentionItemSourceTask              AttentionItemSource = "task"
 )
 
@@ -1322,6 +1326,8 @@ func (e AttentionItemSource) Valid() bool {
 	case AttentionItemSourceDedupeCandidate:
 		return true
 	case AttentionItemSourceMeeting:
+		return true
+	case AttentionItemSourceRelationshipDecay:
 		return true
 	case AttentionItemSourceTask:
 		return true
@@ -10494,16 +10500,16 @@ func (e VoiceBuildStatusCode) Valid() bool {
 
 // Defines values for VoiceCorpusPreviewRequestFormat.
 const (
-	VoiceCorpusPreviewRequestFormatText       VoiceCorpusPreviewRequestFormat = "text"
-	VoiceCorpusPreviewRequestFormatTranscript VoiceCorpusPreviewRequestFormat = "transcript"
+	Text       VoiceCorpusPreviewRequestFormat = "text"
+	Transcript VoiceCorpusPreviewRequestFormat = "transcript"
 )
 
 // Valid indicates whether the value is a known member of the VoiceCorpusPreviewRequestFormat enum.
 func (e VoiceCorpusPreviewRequestFormat) Valid() bool {
 	switch e {
-	case VoiceCorpusPreviewRequestFormatText:
+	case Text:
 		return true
-	case VoiceCorpusPreviewRequestFormatTranscript:
+	case Transcript:
 		return true
 	default:
 		return false
@@ -10881,22 +10887,22 @@ func (e VoiceProfileVersionStatus) Valid() bool {
 
 // Defines values for WebhookDeliveryStatus.
 const (
-	DeadLettered WebhookDeliveryStatus = "dead_lettered"
-	Delivered    WebhookDeliveryStatus = "delivered"
-	Pending      WebhookDeliveryStatus = "pending"
-	Retrying     WebhookDeliveryStatus = "retrying"
+	WebhookDeliveryStatusDeadLettered WebhookDeliveryStatus = "dead_lettered"
+	WebhookDeliveryStatusDelivered    WebhookDeliveryStatus = "delivered"
+	WebhookDeliveryStatusPending      WebhookDeliveryStatus = "pending"
+	WebhookDeliveryStatusRetrying     WebhookDeliveryStatus = "retrying"
 )
 
 // Valid indicates whether the value is a known member of the WebhookDeliveryStatus enum.
 func (e WebhookDeliveryStatus) Valid() bool {
 	switch e {
-	case DeadLettered:
+	case WebhookDeliveryStatusDeadLettered:
 		return true
-	case Delivered:
+	case WebhookDeliveryStatusDelivered:
 		return true
-	case Pending:
+	case WebhookDeliveryStatusPending:
 		return true
-	case Retrying:
+	case WebhookDeliveryStatusRetrying:
 		return true
 	default:
 		return false
@@ -13570,6 +13576,23 @@ type Attention struct {
 	// Planned Work already agreed: overdue first, then due today.
 	Planned []AttentionItem `json:"planned"`
 
+	// RelationshipDecay The reader's OWN relationships that have gone silent, longest silence first —
+	// people they were in contact with and are not any more.
+	//
+	// A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
+	// a contact carrying no open deal never reaches that lane, and those are exactly
+	// the relationships that lapse unnoticed. `detail` carries the silence in days,
+	// from the same §4 derivation the contact's own page shows, so the two surfaces
+	// cannot come to disagree about when somebody went quiet.
+	//
+	// Only relationships this reader actually had: a contact nobody here ever spoke
+	// to has not gone quiet, and a lane that said otherwise would report every
+	// dormant record as a lapse.
+	//
+	// Absent — not empty — on an installation whose feed does not derive relationship
+	// changes.
+	RelationshipDecay *[]AttentionItem `json:"relationship_decay,omitempty"`
+
 	// ThisMorning The overnight brief's queue, best-ranked first — what the night found worth
 	// the rep's first hour.
 	//
@@ -13601,6 +13624,9 @@ type AttentionCounts struct {
 	Meetings *int `json:"meetings,omitempty"`
 	NeedsYou int  `json:"needs_you"`
 	Planned  int  `json:"planned"`
+
+	// RelationshipDecay How many lapsed relationships this lane is CARRYING — the bounded page, as the other lanes report. A rep past the bound sees the longest silences, which is the order the lane is in.
+	RelationshipDecay *int `json:"relationship_decay,omitempty"`
 
 	// ThisMorning Briefing items still unanswered in the rep's run for today.
 	ThisMorning int `json:"this_morning"`

--- a/backend/internal/modules/people/relationshipchange.go
+++ b/backend/internal/modules/people/relationshipchange.go
@@ -55,6 +55,102 @@ func (s *Store) PersonRelationshipChangesTx(
 	return relstrength.Changes(in, now), nil
 }
 
+// PersonChanges is one contact's derived changes, carrying the id and the name
+// so a batched caller can say whose they are without a second read.
+type PersonChanges struct {
+	PersonID    ids.PersonID
+	DisplayName string
+	Changes     []relstrength.Change
+}
+
+// RelationshipChangesForPeople derives changes for a SET of contacts.
+//
+// The per-person reader above probes the one contact it was handed, because
+// that id came off a request. This one filters the whole set through the
+// caller's row scope in a single pass instead — same rule, one query, and a
+// contact the caller cannot read is simply absent rather than 404-ing a lane
+// that is about somebody else's relationships too.
+//
+// It is bounded on purpose. `change.go` states that the derivation cannot
+// answer "everyone who went cold" without walking every person, and that stays
+// true — what makes this affordable is that the caller narrows to a capped
+// candidate set FIRST and derives only those. Handing it the workspace would be
+// the walk that comment warns against.
+func (s *Store) RelationshipChangesForPeople(
+	ctx context.Context,
+	tx pgx.Tx,
+	people []ids.PersonID,
+	now time.Time,
+) ([]PersonChanges, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	if len(people) == 0 {
+		return nil, nil
+	}
+	visible, err := visibleContactNames(ctx, tx, people)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PersonChanges, 0, len(visible))
+	for _, contact := range visible {
+		in, err := changeInputs(ctx, tx, contact.id, now)
+		if err != nil {
+			return nil, err
+		}
+		changes := relstrength.Changes(in, now)
+		if len(changes) == 0 {
+			continue
+		}
+		out = append(out, PersonChanges{
+			PersonID:    contact.id,
+			DisplayName: contact.name,
+			Changes:     changes,
+		})
+	}
+	return out, nil
+}
+
+// contactName is one readable contact: who they are, and what to call them.
+type contactName struct {
+	id   ids.PersonID
+	name string
+}
+
+// visibleContactNames narrows a candidate set to the contacts this caller may
+// actually read, and names them in the same pass.
+//
+// One query rather than a probe each: the row scope is a predicate, so asking
+// it once for the set is the same rule the per-person path applies one at a
+// time. Archived contacts are excluded here exactly as every ordinary person
+// read excludes them.
+func visibleContactNames(ctx context.Context, tx pgx.Tx, people []ids.PersonID) ([]contactName, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	peoplePos := arg(people)
+	scope, err := personScopePredicate(ctx, arg)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT p.id, p.display_name FROM person p
+		WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND (%s)
+		ORDER BY p.id`, peoplePos, scope), args...)
+	if err != nil {
+		return nil, fmt.Errorf("people: reading a contact set this caller may see: %w", err)
+	}
+	defer rows.Close()
+	var out []contactName
+	for rows.Next() {
+		var contact contactName
+		if err := rows.Scan(&contact.id, &contact.name); err != nil {
+			return nil, err
+		}
+		out = append(out, contact)
+	}
+	return out, rows.Err()
+}
+
 // changeInputs gathers the present fold, the same fold as it stood one
 // comparison window ago, and the two timestamps a returning reply is measured
 // between.

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -378,6 +378,51 @@ func EdgesForPeople(ctx context.Context, tx pgx.Tx, people []ids.UUID) ([]Intera
 	return scanEdges(rows)
 }
 
+// QuietEdgesForUser answers "which of MY relationships have gone silent",
+// oldest silence first.
+//
+// It is the CANDIDATE half of the decay lane and deliberately not the verdict.
+// The projection stores when a pair last spoke, so the reader's own quiet
+// relationships are one indexed range over idx_graph_edge_user — but whether a
+// silence is worth reporting is a §4 derivation over the contact's own
+// interactions, and that stays where it already lives. Answering it here would
+// be a second quiet rule, and the two would disagree in front of a rep.
+//
+// `quietBefore` is the caller's, derived from relstrength.QuietDays: the
+// threshold belongs to the derivation, and this read applies it rather than
+// holding an opinion about how long is too long.
+//
+// Established relationships only: a pair with no interaction on record has not
+// gone quiet, they were never loud, and admitting them turns every dormant
+// contact into an alert. The colleague filter is the live-member join every
+// other read of this table carries — a departed colleague's silences are not
+// the reader's work.
+func QuietEdgesForUser(
+	ctx context.Context,
+	tx pgx.Tx,
+	userID ids.UUID,
+	quietBefore time.Time,
+	limit int,
+) ([]InteractionEdge, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT e.user_id, e.person_id, e.last_at, e.last_inbound_at, e.last_outbound_at,
+		       e.count_90d, e.in_count_90d, e.out_count_90d, e.count_total
+		  FROM graph_interaction_edge e
+		  `+liveMemberJoin+`
+		  JOIN person p ON p.id = e.person_id AND p.archived_at IS NULL
+		 WHERE e.user_id = $1 AND e.last_at < $2 AND e.count_total > 0
+		 ORDER BY e.last_at ASC, e.person_id
+		 LIMIT $3`, userID, quietBefore, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search: reading a colleague's quiet relationships: %w", err)
+	}
+	defer rows.Close()
+	return scanEdges(rows)
+}
+
 func scanEdges(rows pgx.Rows) ([]InteractionEdge, error) {
 	var out []InteractionEdge
 	for rows.Next() {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22637,10 +22637,28 @@ export interface components {
              *     Absent — not empty — on an installation whose feed does not read deals.
              */
             at_risk?: components["schemas"]["AttentionItem"][];
+            /**
+             * @description The reader's OWN relationships that have gone silent, longest silence first —
+             *     people they were in contact with and are not any more.
+             *
+             *     A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
+             *     a contact carrying no open deal never reaches that lane, and those are exactly
+             *     the relationships that lapse unnoticed. `detail` carries the silence in days,
+             *     from the same §4 derivation the contact's own page shows, so the two surfaces
+             *     cannot come to disagree about when somebody went quiet.
+             *
+             *     Only relationships this reader actually had: a contact nobody here ever spoke
+             *     to has not gone quiet, and a lane that said otherwise would report every
+             *     dormant record as a lapse.
+             *
+             *     Absent — not empty — on an installation whose feed does not derive relationship
+             *     changes.
+             */
+            relationship_decay?: components["schemas"]["AttentionItem"][];
             /** @description What the system did on its own, most recent first. Receipts, not questions. */
             done_for_you: components["schemas"]["AttentionItem"][];
             /** @description Lanes withheld because the caller may not read what they contain. Never returned empty instead. */
-            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk" | "meetings")[];
+            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk" | "meetings" | "relationship_decay")[];
             counts: components["schemas"]["AttentionCounts"];
         };
         /**
@@ -22661,6 +22679,8 @@ export interface components {
             at_risk?: number;
             /** @description How many promises this lane is CARRYING, which is the bounded page rather than every promise due — the same bound `planned` reports under. A rep past the bound sees the soonest-due ones, which is the order the lane is in. */
             commitments?: number;
+            /** @description How many lapsed relationships this lane is CARRYING — the bounded page, as the other lanes report. A rep past the bound sees the longest silences, which is the order the lane is in. */
+            relationship_decay?: number;
         };
         /**
          * @description One thing waiting, in the words a reader recognises, with a typed reference back to
@@ -22675,7 +22695,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting" | "relationship_decay";
             /** @description The producer's own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority. */
             kind?: string;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -190,6 +190,11 @@ export const de = {
   "day.atRisk": "Wird still",
   "day.atRisk.empty": "Kein Deal driftet ab.",
   "day.risk.quiet": "Seit {days} Tagen kein Kontakt.",
+  "day.decay": "Beziehungen, die einschlafen",
+  "day.decay.empty": "Sie sind mit allen in Kontakt, mit denen Sie es waren.",
+  "day.decay.quiet": "Seit {days} Tagen kein Austausch.",
+  "day.decay.quietSince":
+    "Seit {days} Tagen kein Austausch — zuletzt am {date}.",
   "day.risk.closeOverdue": "Abschluss war für {date} geplant — noch offen.",
   "day.commitments": "Du hast zugesagt",
   "day.commitments.empty": "Keine Zusagen werden f\u00e4llig.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -190,6 +190,11 @@ export const en = {
   "day.atRisk": "Going quiet",
   "day.atRisk.empty": "No deal is drifting.",
   "day.risk.quiet": "No contact for {days} days.",
+  "day.decay": "Relationships going quiet",
+  "day.decay.empty": "You are in touch with everyone you were.",
+  "day.decay.quiet": "You have not spoken in {days} days.",
+  "day.decay.quietSince":
+    "You have not spoken in {days} days — last on {date}.",
   "day.risk.closeOverdue": "Expected to close {date} — still open.",
   "day.commitments": "You promised",
   "day.commitments.empty": "No promises coming due.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -196,6 +196,12 @@ export const vi = {
   "day.atRisk": "Đang lặng đi",
   "day.atRisk.empty": "Không có thương vụ nào trôi đi.",
   "day.risk.quiet": "Không liên hệ trong {days} ngày.",
+  "day.decay": "Những mối quan hệ đang nguội dần",
+  "day.decay.empty":
+    "Bạn vẫn giữ liên lạc với tất cả những người từng trao đổi.",
+  "day.decay.quiet": "Đã {days} ngày hai bên không trao đổi.",
+  "day.decay.quietSince":
+    "Đã {days} ngày không trao đổi — lần cuối vào {date}.",
   "day.risk.closeOverdue": "Dự kiến chốt {date} — vẫn còn mở.",
   "day.commitments": "Bạn đã hứa",
   "day.commitments.empty": "Không có lời hứa nào đến hạn.",

--- a/frontend/src/screens/attentionitemcopy.ts
+++ b/frontend/src/screens/attentionitemcopy.ts
@@ -48,6 +48,50 @@ function duplicateNoun(
   return "generic";
 }
 
+// A lapsed relationship says how long the silence has run and when it started.
+// Both, because the number is what a rep acts on and the date is what makes it
+// checkable against the contact's own timeline.
+function decayDetail(
+  item: AttentionItem,
+  t: T,
+  locale: Locale,
+  zone: string,
+): string | null {
+  if (!item.detail) {
+    return null;
+  }
+  const days = formatNumber(Number(item.detail), locale);
+  return item.occurred_at
+    ? t("day.decay.quietSince", {
+        days,
+        date: formatDateTime(item.occurred_at, locale, zone),
+      })
+    : t("day.decay.quiet", { days });
+}
+
+// A risk card's sentence is written HERE, not sent: the server has no language,
+// and "quiet 19 days" versus "the close date passed" read differently in each of
+// the three. `kind` names the ground and `detail` carries the number the server
+// actually measured, so the line can never imply a patience nobody applied.
+function riskDetail(
+  item: AttentionItem,
+  t: T,
+  locale: Locale,
+  zone: string,
+): string | null {
+  if (item.kind === "close_overdue" && item.due_at) {
+    return t("day.risk.closeOverdue", {
+      date: formatDateTime(item.due_at, locale, zone),
+    });
+  }
+  if (item.detail) {
+    return t("day.risk.quiet", {
+      days: formatNumber(Number(item.detail), locale),
+    });
+  }
+  return null;
+}
+
 // The supporting line under a headline: how sure the detector was, or when this
 // is due, or when it happened. At most one — a card that stacked all three
 // would make the reader read three things to learn one.
@@ -57,23 +101,11 @@ export function itemDetail(
   locale: Locale,
   zone: string,
 ): string | null {
-  // A risk card's sentence is written HERE, not sent: the server has no
-  // language, and "quiet 19 days" versus "the close date passed" read
-  // differently in each of the three. `kind` names the ground and `detail`
-  // carries the number the server actually measured, so the line can never
-  // imply a patience nobody applied.
+  if (item.source === "relationship_decay") {
+    return decayDetail(item, t, locale, zone);
+  }
   if (item.source === "deal_at_risk") {
-    if (item.kind === "close_overdue" && item.due_at) {
-      return t("day.risk.closeOverdue", {
-        date: formatDateTime(item.due_at, locale, zone),
-      });
-    }
-    if (item.detail) {
-      return t("day.risk.quiet", {
-        days: formatNumber(Number(item.detail), locale),
-      });
-    }
-    return null;
+    return riskDetail(item, t, locale, zone);
   }
   // A promise is the one item whose supporting line carries TWO facts, and it
   // needs both: the words it was read from are what make the claim checkable,

--- a/frontend/src/screens/attentionsource.ts
+++ b/frontend/src/screens/attentionsource.ts
@@ -28,6 +28,7 @@ export const FOCUS_SURFACE = {
   conversation_claim: "report",
   deal_at_risk: "report",
   meeting: "report",
+  relationship_decay: "report",
 } as const satisfies Record<AttentionItem["source"], FocusSurface>;
 
 export function focusSurfaceOf(source: AttentionItem["source"]): FocusSurface {

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -6,6 +6,7 @@ import {
   Sparkles,
   Sunrise,
   TrendingDown,
+  UserMinus,
 } from "lucide-react";
 import { useState } from "react";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
@@ -135,6 +136,7 @@ function quietLead(
   if (
     day.counts.commitments === undefined ||
     day.counts.at_risk === undefined ||
+    day.counts.relationship_decay === undefined ||
     day.counts.meetings === undefined
   ) {
     return t("day.lead.clearOfWhatWasRead");
@@ -514,6 +516,7 @@ function TodayLanes({
   const commitments = day.commitments;
   // Same absent-versus-empty rule: no lane at all when nothing reads deals.
   const atRisk = day.at_risk;
+  const lapsed = day.relationship_decay;
   const meetings = day.meetings;
   const done = day.done_for_you ?? [];
   const omitted = day.lanes_omitted ?? [];
@@ -609,6 +612,21 @@ function TodayLanes({
         omitted={omitted}
         lane="at_risk"
         total={day.counts.at_risk ?? 0}
+        onComplete={onComplete}
+        onSnooze={onSnooze}
+        completing={complete.isPending}
+      />
+      <OptionalLane
+        items={lapsed}
+        shape={{
+          title: t("day.decay"),
+          empty: t("day.decay.empty"),
+          withheld: t("day.lane.withheld"),
+          icon: UserMinus,
+        }}
+        omitted={omitted}
+        lane="relationship_decay"
+        total={day.counts.relationship_decay ?? 0}
         onComplete={onComplete}
         onSnooze={onSnooze}
         completing={complete.isPending}


### PR DESCRIPTION
The engine already derived "went quiet" and only the contact's own page showed it, so a lapsed relationship was visible exactly to the reader who went looking for it. This puts it on the Worklist, where the rep already is.

## Its own lane, not rows on at_risk

The two rest on different records: `at_risk` is a DEAL nobody is moving, this is a PERSON nobody is talking to. A contact carrying no open deal never reaches that lane at all, and those are precisely the relationships that lapse unnoticed.

## Candidates and verdict stay split

`change.go` states it cannot report everyone who went cold without walking every person. That stays true and the lane never asks it to. The projection already stores when each pair last spoke, with an index on the reader's own edges, so the candidates are one range scan bounded by the reader's relationships. The verdict comes from the existing derivation, so a candidate whose derivation says something else (they replied, the band moved) does not appear. That split is what keeps the lane and the contact's page from disagreeing about one relationship, and a test holds it: admit any change kind and it fails.

The batched derivation filters the whole candidate set through the caller's row scope in one pass and names the contacts in the same query, so a contact the reader may not see is absent rather than 404-ing a lane about other people's relationships.

The day's "clear" line now checks this lane with the others. It is the one sentence an absent lane can falsify.

## Fixed along the way

- A uniqueness claim in `graphedge.go` said the quiet threshold was "not spelled twice" without a test holding it, which `backend/gates/uniquenessclaims_test.go` rejects. Rewritten to state what is true: the threshold belongs to the derivation and this read applies it.
- `feed_test.go` crossed the 1000-line test ceiling, so the two silence-reporting lanes (at-risk and decay) moved to `quietlanes_test.go`.
- `itemDetail` in `attentionitemcopy.ts` crossed the cognitive-complexity ceiling; its two sentence-writing branches are now named helpers.

## Verification

`make check-backend` and `make check-fe` green, `make craft-static`, `make rls-store-path` and `make no-jurisdiction` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `relationship_decay` lane to the attention feed so lapsed relationships reach the rep on the Worklist instead of only on the contact's own page. It stays separate from `at_risk` — that lane warns about deals nobody is moving, while this warns about people nobody is talking to, and a contact with no open deal never reaches `at_risk` at all.

**Candidates and verdict stay split**
- The projection supplies candidates in one indexed range scan over the reader's own edges, capped so the derivation never walks every person.
- The existing §4 change engine supplies the verdict, so the lane and the contact's page cannot disagree about one relationship.
- The batched derivation filters candidates through the caller's row scope in one pass, so a contact the reader cannot see is absent rather than 404-ing.
- The day's "clear" line now counts this lane too.

**Fixed along the way**
- Rewrote a uniqueness claim in `graphedge.go` that `backend/gates/uniquenessclaims_test.go` rejected — the quiet threshold belongs to the derivation, and this read applies it.
- Moved the two silence-reporting lane tests to `quietlanes_test.go`.
- Extracted the two sentence-writing branches in `attentionitemcopy.ts` into named helpers.

<sup>Written for commit 62bb791c9446125b1dc40f1c1b9d1f32b190af4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a relationship-decay section to the Today worklist for contacts whose interactions have gone quiet.
  - Displays contact names, days since last contact, and the last-contact date.
  - Orders entries by longest silence and provides appropriate report actions.
  - Added English, German, and Vietnamese translations.

- **Bug Fixes**
  - Improved attention-item details for relationship decay and deal risk.
  - Ensured only visible, active relationships with derived changes appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->