### PR TITLE
fix(approvals): an approved decision whose effect failed says so (#2966)

### DIFF
--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -165,16 +165,59 @@ func (s *Service) runDecisionEffect(ctx context.Context, id ids.ApprovalID, a ro
 	// (quotarelease.go).
 	if approve && a.Kind == KindQuotaRelease {
 		if err := s.applyQuotaRelease(ctx, a); err != nil {
-			return fmt.Errorf("approved, but widening the agent's window failed: %w", err)
+			return s.recordEffectFailure(ctx, id,
+				"the agent's window could not be widened, so the approval has not taken effect",
+				fmt.Errorf("approved, but widening the agent's window failed: %w", err))
 		}
 		return nil
 	}
 	if effect, ok := s.effects[a.Kind]; ok && approve && serverProposed(a) {
 		if err := effect(ctx, id, a.ProposedChange, a.DiffHash); err != nil {
-			return fmt.Errorf("approved, but executing the %s effect failed: %w", a.Kind, err)
+			return s.recordEffectFailure(ctx, id,
+				"this was approved, but the work it released did not run",
+				fmt.Errorf("approved, but executing the %s effect failed: %w", a.Kind, err))
 		}
 	}
 	return nil
+}
+
+// recordEffectFailure marks an approved row whose effect did not run, and
+// returns the caller's own error unchanged.
+//
+// Without the mark the row is unreachable: it is not pending, so the decision
+// lane skips it, and it names a human decider, so the receipts lane does too. A
+// person approved something, was told it was approved, and the work never
+// happened — with the only trace an error on one request nobody may have read.
+//
+// The stored sentence is written HERE rather than from the executor's error,
+// which carries whatever the failing module said and can name a table, a
+// statement or a host. What reaches a reader says what happened and what it
+// means for them.
+//
+// A failure to record the failure is logged and swallowed on purpose, and it is
+// the one place in this file that swallows anything: the caller is already
+// returning an error about the effect, and replacing it with a bookkeeping
+// error would tell the human who approved the row the wrong thing about what
+// went wrong.
+func (s *Service) recordEffectFailure(ctx context.Context, id ids.ApprovalID, reader string, cause error) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// The IS NULL arm is the CAS: two failures racing on one row keep the
+		// FIRST mark, because that is the one whose timestamp says when the
+		// work was actually lost. Zero rows affected is that race resolved,
+		// not an error.
+		tag, err := tx.Exec(ctx,
+			`UPDATE approval SET effect_failed_at = now(), effect_failure = $2
+			  WHERE id = $1 AND effect_failed_at IS NULL`, id, reader)
+		if err == nil && tag.RowsAffected() == 0 {
+			s.logger().InfoContext(ctx, "approvals: effect failure already marked", "approval_id", id.String())
+		}
+		return err
+	})
+	if err != nil {
+		s.logger().ErrorContext(ctx, "approvals: an approved effect failed and the row could not be marked",
+			"approval_id", id.String(), "error", err)
+	}
+	return cause
 }
 
 // serverProposed reports whether this staging was minted by a SERVER-SIDE

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -200,6 +200,10 @@ func (s *Service) runDecisionEffect(ctx context.Context, id ids.ApprovalID, a ro
 // error would tell the human who approved the row the wrong thing about what
 // went wrong.
 func (s *Service) recordEffectFailure(ctx context.Context, id ids.ApprovalID, reader string, cause error) error {
+	// Detached from the request's cancellation: an effect that failed BECAUSE
+	// the request was cancelled or timed out is exactly a failure this mark
+	// exists to keep, and writing it through the dead context would lose it.
+	ctx = context.WithoutCancel(ctx)
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The IS NULL arm is the CAS: two failures racing on one row keep the
 		// FIRST mark, because that is the one whose timestamp says when the

--- a/backend/internal/modules/approvals/effectfailure_integration_test.go
+++ b/backend/internal/modules/approvals/effectfailure_integration_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// An approved row whose effect did not run must say so on the row itself.
+// Nothing else can carry it: the row is not pending, so the decision lane
+// skips it, and it names a human decider, so the receipts lane does too.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// effectFailureOf reads the mark straight from the table — what the decision
+// LEFT is the question, not what it returned.
+func (e *stagingEnv) effectFailureOf(t *testing.T, id ids.ApprovalID) (*time.Time, *string) {
+	t.Helper()
+	var at *time.Time
+	var sentence *string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT effect_failed_at, effect_failure FROM approval WHERE id = $1`,
+		id).Scan(&at, &sentence); err != nil {
+		t.Fatalf("reading the effect-failure mark: %v", err)
+	}
+	return at, sentence
+}
+
+func TestAnApprovedEffectThatFailsIsMarkedOnTheRow(t *testing.T) {
+	e := setupStaging(t)
+	e.svc.WithEffect(kindSiteLead, func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
+		return errors.New("the capture sink refused this lead: relation lead_intake, host db-3")
+	})
+	ctx := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(ctx, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+
+	_, decideErr := e.svc.Decide(ctx, id, true, nil)
+
+	if decideErr == nil {
+		t.Fatal("the failing effect's error was swallowed — the decider was told it worked")
+	}
+	if status := e.statusOf(t, id); status != approvalStatusApproved {
+		t.Errorf("stored status = %s, want approved — the decision committed before the effect ran", status)
+	}
+	at, sentence := e.effectFailureOf(t, id)
+	if at == nil || sentence == nil {
+		t.Fatalf("the approved-but-failed row carries no mark (at=%v sentence=%v); it is unreachable by every lane", at, sentence)
+	}
+	// The stored sentence is the reader's, never the executor's error, which
+	// can name a table or a host.
+	if want := "this was approved, but the work it released did not run"; *sentence != want {
+		t.Errorf("stored sentence = %q, want %q", *sentence, want)
+	}
+}
+
+func TestAnApprovedEffectThatRunsLeavesNoFailureMark(t *testing.T) {
+	e := setupStaging(t)
+	e.svc.WithEffect(kindSiteLead, func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
+		return nil
+	})
+	ctx := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(ctx, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+
+	if _, err := e.svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("deciding: %v", err)
+	}
+
+	if at, sentence := e.effectFailureOf(t, id); at != nil || sentence != nil {
+		t.Errorf("a clean effect left a failure mark (at=%v sentence=%v)", at, sentence)
+	}
+}

--- a/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.down.sql
+++ b/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.down.sql
@@ -1,0 +1,11 @@
+-- Dropping these returns a failed effect to being indistinguishable from one
+-- that ran, which is what it was before.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS approval_effect_failed_idx;
+
+ALTER TABLE approval DROP CONSTRAINT IF EXISTS approval_effect_failure_is_stated;
+
+ALTER TABLE approval
+    DROP COLUMN IF EXISTS effect_failed_at,
+    DROP COLUMN IF EXISTS effect_failure;

--- a/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.up.sql
+++ b/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.up.sql
@@ -1,0 +1,36 @@
+-- An approved decision whose effect failed says so on the row.
+--
+-- The effect a decision releases runs AFTER the decision transaction commits,
+-- because it writes through other modules' stores. When it fails the approval is
+-- still approved: nothing un-decides it, the same row refuses a second decision
+-- as already decided, and the work the human released never happened.
+--
+-- Until now that row was indistinguishable from a decision whose effect ran. It
+-- is not pending, so the decision lane does not carry it; it names a human
+-- decider, so the receipts lane does not either. A person pressed Accept, the
+-- product told them it was accepted, and the email was never sent — with nothing
+-- anywhere asking them to look again. The only trace was an error returned to
+-- the request that decided it, seen once, by whoever happened to be looking.
+--
+-- effect_failed_at makes the row findable so a surface can carry it back to the
+-- person who approved it. effect_failure is the sentence a reader is shown:
+-- written from the error the executor returned, and by the same rule every other
+-- message this product shows a client — what went wrong and what to do, never a
+-- stack, a SQL statement or a table name.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval
+    ADD COLUMN IF NOT EXISTS effect_failed_at timestamptz,
+    ADD COLUMN IF NOT EXISTS effect_failure text;
+
+-- A failure has a time and a reason, or it is not a failure. The pair moves
+-- together or a reader gets a card with nothing on it.
+ALTER TABLE approval
+    ADD CONSTRAINT approval_effect_failure_is_stated
+    CHECK ((effect_failed_at IS NULL) = (effect_failure IS NULL)) NOT VALID;
+
+-- The lane reads the unredeemed rows newest-first and nothing else touches this
+-- column, so the index carries only the rows that failed.
+CREATE INDEX IF NOT EXISTS approval_effect_failed_idx
+    ON approval (effect_failed_at DESC)
+    WHERE effect_failed_at IS NOT NULL;

--- a/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.up.sql
+++ b/backend/migrations/core/1787870000_an_approved_effect_that_failed_says_so.up.sql
@@ -14,9 +14,10 @@
 --
 -- effect_failed_at makes the row findable so a surface can carry it back to the
 -- person who approved it. effect_failure is the sentence a reader is shown:
--- written from the error the executor returned, and by the same rule every other
--- message this product shows a client — what went wrong and what to do, never a
--- stack, a SQL statement or a table name.
+-- written for the reader at the recording site, never copied from the error the
+-- executor returned, by the same rule every other message this product shows a
+-- client — what went wrong and what to do, never a stack, a SQL statement or a
+-- table name.
 SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE approval

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -533,6 +533,7 @@ public.app_user_pkey CREATE UNIQUE INDEX app_user_pkey ON public.app_user USING 
 public.approval acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.approval.approval_decided CHECK ((((status = 'pending'::text) AND (decided_at IS NULL)) OR (status = 'expired'::text) OR ((status = ANY (ARRAY['approved'::text, 'rejected'::text])) AND (decided_at IS NOT NULL))))
 public.approval.approval_decided_by_fkey FOREIGN KEY (decided_by) REFERENCES app_user(id) ON DELETE SET NULL (decided_by)
+public.approval.approval_effect_failure_is_stated CHECK (((effect_failed_at IS NULL) = (effect_failure IS NULL))) NOT VALID
 public.approval.approval_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.approval.approval_passport_id_fkey FOREIGN KEY (passport_id) REFERENCES passport(id) ON DELETE SET NULL (passport_id)
 public.approval.approval_pkey PRIMARY KEY (id)
@@ -545,6 +546,8 @@ public.approval.decided_by uuid gen=- def=-
 public.approval.decided_by_system boolean NOT NULL gen=- def=false
 public.approval.decision_reason text gen=- def=-
 public.approval.diff_hash text NOT NULL gen=- def=-
+public.approval.effect_failed_at timestamp with time zone gen=- def=-
+public.approval.effect_failure text gen=- def=-
 public.approval.evidence jsonb gen=- def=-
 public.approval.expires_at timestamp with time zone NOT NULL gen=- def=-
 public.approval.id uuid NOT NULL gen=- def=uuidv7()
@@ -584,6 +587,7 @@ public.approval_autonomy_policy.uq_approval_autonomy_policy_user_kind UNIQUE (us
 public.approval_autonomy_policy.user_id uuid NOT NULL gen=- def=-
 public.approval_autonomy_policy.veto_window interval gen=- def=-
 public.approval_autonomy_policy_pkey CREATE UNIQUE INDEX approval_autonomy_policy_pkey ON public.approval_autonomy_policy USING btree (id)
+public.approval_effect_failed_idx CREATE INDEX approval_effect_failed_idx ON public.approval USING btree (effect_failed_at DESC) WHERE (effect_failed_at IS NOT NULL)
 public.approval_pkey CREATE UNIQUE INDEX approval_pkey ON public.approval USING btree (id)
 public.assert_deal_project_same_org() secdef=false cfg=- acl=- 
 BEGIN


### PR DESCRIPTION
An approved decision's follow-on effect runs after the decision commits. When it fails, the row stays approved and indistinguishable from one whose effect ran: it is off the decision lane (not pending) and off the receipts lane (a human decided it). A person pressed Accept, was told it worked, and the work never happened — with the only trace an error returned once to the deciding request.

This change adds the durable ground truth:

- Migration `1787870000`: `approval.effect_failed_at` + `approval.effect_failure`, a CHECK that the pair moves together, and a partial index over the failed rows. `head_catalog.txt` regenerated in the same commit.
- `runDecisionEffect` marks the row on both failure arms (quota release and registered effects). Both decision paths — single decide and bundle — share that one function, so both are covered.
- The stored sentence is written for the reader, never copied from the executor's error, which can name a table or a host. Racing failures keep the first mark (RowsAffected CAS).
- Integration tests prove the mark is written on failure and absent on success, against real Postgres.

The Worklist lane that carries the marked row back to its decider follows separately, after the in-flight Worklist rework lands — it touches the same attention-feed files that PR is rewriting.

Refs #2966.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes an approved decision whose effect failed say so on the row, instead of remaining indistinguishable from one whose effect ran. Previously the row sat off the decision lane (not pending) and off the receipts lane (named to a human decider), and the only trace was an error returned once to the deciding request.

**Migration**
- Adds `approval.effect_failed_at` and `approval.effect_failure`, a CHECK that the pair moves together, and a partial index over failed rows.
- `head_catalog.txt` is regenerated in the same commit.

**Behavior**
- `runDecisionEffect` marks the row on both failure arms; single decide and bundle share that function, so both are covered.
- The stored sentence is written for the reader, never copied from the executor's error, which can name a table or a host.
- The mark writes on a context detached from the request's cancellation, so a failure caused by a timeout or cancellation is still recorded.
- Racing failures keep the first mark via rows-affected CAS; a failure to record is logged and swallowed so the caller's effect error surfaces unchanged.
- Integration tests prove the mark is written on failure and absent on success.

Nothing surfaces the mark yet: the Worklist lane that carries it back to the decider follows after the in-flight Worklist rework lands. Refs #2966.

<sup>Written for commit 20c8cac0a8f3944837295ae9bf6c95cc77e58295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approved actions that fail now display a reader-friendly failure message and timestamp on the approval record.
  - Approval status remains approved while the failed action is clearly marked.
  - Successful approved actions remain free of failure indicators.

- **Bug Fixes**
  - Preserves the first recorded failure when multiple failures occur concurrently.
  - Records failures even when the originating request times out or is canceled.
  - Returns the original action error even if failure recording encounters an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->