### PR TITLE
fix(attention): the decay lane answers, and its card reads one clock

### DIFF
--- a/backend/internal/compose/attention/quietlanes_test.go
+++ b/backend/internal/compose/attention/quietlanes_test.go
@@ -142,3 +142,97 @@ func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
 		t.Errorf("counts.at_risk = %v, want it absent too", out.Counts.AtRisk)
 	}
 }
+
+// A lapsed relationship carries the span, the person it is about, and when
+// they last spoke. All three, because the card is read as a chronology: the
+// number is what a rep acts on, the name is who to act on, and the date is
+// what makes the claim checkable against that contact's own timeline.
+func TestALapsedRelationshipCarriesItsSpanAndItsLastExchange(t *testing.T) {
+	person := ids.NewV7()
+	spoke := readInstant.AddDate(0, 0, -63)
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		&stubDecay{rows: []QuietRelationship{
+			{PersonID: person, Name: "Dana Weiss", QuietDays: 63, LastAt: spoke},
+		}},
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.RelationshipDecay == nil {
+		t.Fatal("the decay lane is absent, want one lapsed relationship")
+	}
+	item := (*out.RelationshipDecay)[0]
+	if item.Title == nil || *item.Title != "Dana Weiss" {
+		t.Errorf("title = %s, want the contact's name", stringOr(item.Title))
+	}
+	if item.Detail == nil || *item.Detail != "63" {
+		t.Errorf("detail = %s, want the derived silence in days", stringOr(item.Detail))
+	}
+	if item.OccurredAt == nil || !item.OccurredAt.Equal(spoke) {
+		t.Errorf("occurred_at = %v, want the last exchange %v", item.OccurredAt, spoke)
+	}
+	// The subject is the PERSON, not the edge: the card's one move is opening
+	// that contact, and a subject naming anything else sends the reader
+	// somewhere they cannot act.
+	if item.Subject == nil || item.Subject.Type != "person" {
+		t.Errorf("subject = %v, want the person the silence is about", item.Subject)
+	}
+	// No verb, exactly as the risk card offers none. What to do about a lapsed
+	// relationship is a judgement about that person; a lane answering it here
+	// would be deciding rather than warning.
+	if len(item.Actions) != 0 {
+		t.Errorf("actions = %v, want none — the lane warns, it does not decide", item.Actions)
+	}
+	if out.Counts.RelationshipDecay == nil || *out.Counts.RelationshipDecay != 1 {
+		t.Errorf("counts.relationship_decay = %v, want 1", out.Counts.RelationshipDecay)
+	}
+}
+
+// A withheld decay lane is NAMED. "You are in touch with everyone" and "you
+// may not read these relationships" are different answers, and reporting the
+// second as the first tells a rep their day is clear when it is not.
+func TestAWithheldDecayLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
+		&stubDecay{err: apperrors.ErrPermissionDenied},
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("a refused lane must not fail the read: %v", err)
+	}
+	if out.RelationshipDecay != nil {
+		t.Errorf("a withheld lane sent %v, want no lane", *out.RelationshipDecay)
+	}
+	var named bool
+	for _, lane := range *out.LanesOmitted {
+		if lane == "relationship_decay" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("lanes_omitted = %v, want it to name relationship_decay", *out.LanesOmitted)
+	}
+}
+
+// A feed with no decay reader sends no lane at all, the same absent-not-empty
+// rule the other optional lanes keep.
+func TestAFeedWithNoDecayReaderSendsNoDecayLane(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
+		nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.RelationshipDecay != nil {
+		t.Errorf("relationship_decay = %v, want the lane absent", *out.RelationshipDecay)
+	}
+	if out.Counts.RelationshipDecay != nil {
+		t.Errorf("counts.relationship_decay = %v, want it absent too", out.Counts.RelationshipDecay)
+	}
+}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -139,15 +139,18 @@ type attentionDecay struct {
 }
 
 func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationship, error) {
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID.IsZero() {
+	// The read refuses a principal with no human of its own, so this is the
+	// same refusal taken one step earlier: before a transaction is opened for
+	// a lane that cannot produce a row. It is not the security boundary — that
+	// lives in QuietEdgesForUser, where the reader is bound to the actor.
+	if actor, ok := principal.Actor(ctx); !ok || actor.UserID.IsZero() {
 		return nil, apperrors.ErrPermissionDenied
 	}
 	now := d.now()
 	var lapsed []attention.QuietRelationship
 	err := database.WithWorkspaceTx(ctx, d.pool, func(tx pgx.Tx) error {
 		quiet, err := search.QuietEdgesForUser(
-			ctx, tx, actor.UserID,
+			ctx, tx,
 			now.AddDate(0, 0, -relstrength.QuietDays),
 			decayCandidateCap,
 		)
@@ -201,11 +204,20 @@ func quietRelationships(
 			if change.Kind != relstrength.ChangeWentQuiet {
 				continue
 			}
+			// BOTH halves of the sentence come from the derivation, never one
+			// from each source. The projection folds only workspace-audience
+			// activity and only this rep's own participation, while the
+			// derivation folds the contact's qualifying interactions, so their
+			// last-touch instants can differ. Taking the number from one and
+			// the date from the other renders "quiet 46 days — last on
+			// <120 days ago>": a card disagreeing with itself, and with the
+			// contact's own page. `change.At` is the touch `change.Days`
+			// counts from, so the two agree by construction.
 			lapsed = append(lapsed, attention.QuietRelationship{
 				PersonID:  row.PersonID.UUID,
 				Name:      row.DisplayName,
 				QuietDays: change.Days,
-				LastAt:    edge.LastAt,
+				LastAt:    change.At,
 			})
 			break
 		}

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -124,6 +124,12 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 	returned := ids.NewV7()
 	oldestSpoke := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
 	newerSpoke := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	// The projection and the derivation are given DIFFERENT last-touch instants
+	// on purpose. They genuinely differ in production — the projection folds
+	// only workspace-audience activity this rep took part in, the derivation
+	// folds the contact's qualifying interactions — so a test agreeing on one
+	// instant cannot tell which source the card read.
+	oldestDerived := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
 
 	// The derivation answers in ITS order — here deliberately not the
 	// projection's — because the lane, not the derivation, owes the rep the
@@ -148,7 +154,9 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 			{
 				PersonID:    ids.From[ids.PersonKind](oldest),
 				DisplayName: "Dana Weiss",
-				Changes:     []relstrength.Change{{Kind: relstrength.ChangeWentQuiet, Days: 63}},
+				Changes: []relstrength.Change{
+					{Kind: relstrength.ChangeWentQuiet, At: oldestDerived, Days: 63},
+				},
 			},
 		},
 	)
@@ -164,8 +172,11 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 	if quiet[0].QuietDays != 63 {
 		t.Errorf("the card says %d days, want the derived 63", quiet[0].QuietDays)
 	}
-	if !quiet[0].LastAt.Equal(oldestSpoke) {
-		t.Errorf("the card dates the silence at %s, want the last exchange %s", quiet[0].LastAt, oldestSpoke)
+	// The derivation's instant too, and for the same reason: the card prints
+	// the span and the date in ONE sentence, so a date from the projection
+	// beside a span from the derivation reads as a contradiction to the rep.
+	if !quiet[0].LastAt.Equal(oldestDerived) {
+		t.Errorf("the card dates the silence at %s, want the derived %s", quiet[0].LastAt, oldestDerived)
 	}
 }
 

--- a/backend/internal/compose/integration/decaylane_integration_test.go
+++ b/backend/internal/compose/integration/decaylane_integration_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The decay lane's two reads against a real database.
+//
+// Both claims are about the person row scope, which is SQL: the candidate read
+// scopes at source so the cap is spent on rows the reader may see, and the
+// batched derivation admits only readable contacts. A unit test with
+// hand-built rows cannot fail on either — nor on a column name — so the
+// refusal AND the admission are both asserted here.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+)
+
+// seedLapsedPair seeds one exchange old enough to be past the §4 quiet
+// threshold, then folds it through the REAL projection writer.
+//
+// The edge row is never inserted directly. A hand-written row is a row the
+// fold never produced, so a test seeded that way can pass over a projection
+// that no longer writes what the read expects — which is the whole failure
+// this lane's candidate half would hide.
+func seedLapsedPair(t *testing.T, e *Env, colleague, person ids.UUID, subject string) {
+	t.Helper()
+	owner := OwnerConn(t)
+	ctx := context.Background()
+	quietSince := time.Now().UTC().AddDate(0, 0, -(relstrength.QuietDays + 35))
+
+	activity := ids.NewV7()
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', $2, $3, 'outbound', 'manual', 'human:x')`,
+		activity, subject, quietSince); err != nil {
+		t.Fatal(err)
+	}
+	LinkActivity(t, owner, activity, "person", person)
+	for _, seed := range []struct {
+		column string
+		id     ids.UUID
+		role   string
+	}{{"user_id", colleague, "from"}, {"person_id", person, "to"}} {
+		if _, err := owner.Exec(ctx, `
+			INSERT INTO activity_participant (activity_id, `+seed.column+`, role) VALUES ($1, $2, $3)`,
+			activity, seed.id, seed.role); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wsCtx := principal.WithWorkspaceID(ctx, e.WS)
+	if err := database.WithWorkspaceTx(wsCtx, e.Pool, func(tx pgx.Tx) error {
+		return search.RecomputeEdgesForActivities(wsCtx, tx, []ids.UUID{activity})
+	}); err != nil {
+		t.Fatalf("folding the seeded exchange into the projection: %v", err)
+	}
+}
+
+// A quiet edge to a contact outside the caller's row scope is not a candidate.
+// The refusal alone cannot show the read works — a query that returned nothing
+// for everyone would pass it — so the same call must admit the caller's own
+// lapsed contact.
+func TestQuietCandidatesCarryOnlyContactsInsideRowScope(t *testing.T) {
+	e := Setup(t)
+	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
+	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
+	e.MakeCapturePrivate(t, "person", theirs, e.Rep3)
+	seedLapsedPair(t, e, e.Rep1, mine, "the thread that lapsed")
+	seedLapsedPair(t, e, e.Rep1, theirs, "their private thread")
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, graphPerms)
+	var quiet []search.InteractionEdge
+	err := database.WithWorkspaceTx(rep, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		quiet, err = search.QuietEdgesForUser(
+			rep, tx, time.Now().UTC().AddDate(0, 0, -relstrength.QuietDays), 10)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("reading quiet candidates: %v", err)
+	}
+	if len(quiet) != 1 {
+		t.Fatalf("candidates = %d, want only the readable lapsed contact", len(quiet))
+	}
+	if quiet[0].PersonID != mine {
+		t.Errorf("candidate is %s, want the caller's own contact %s", quiet[0].PersonID, mine)
+	}
+}
+
+// The batched derivation filters the whole candidate set through the caller's
+// row scope in one pass: an unreadable contact is absent from the answer, and
+// the readable one arrives derived and named.
+func TestBatchedChangesAdmitOnlyReadableContacts(t *testing.T) {
+	e := Setup(t)
+	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
+	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
+	e.MakeCapturePrivate(t, "person", theirs, e.Rep3)
+	seedLapsedPair(t, e, e.Rep1, mine, "the thread that lapsed")
+	seedLapsedPair(t, e, e.Rep1, theirs, "their private thread")
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, graphPerms)
+	store := people.NewStore(e.DB())
+	var changed []people.PersonChanges
+	err := database.WithWorkspaceTx(rep, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		changed, err = store.RelationshipChangesForPeople(rep, tx,
+			[]ids.PersonID{ids.From[ids.PersonKind](mine), ids.From[ids.PersonKind](theirs)},
+			time.Now().UTC())
+		return err
+	})
+	if err != nil {
+		t.Fatalf("deriving the candidate set: %v", err)
+	}
+	if len(changed) != 1 {
+		t.Fatalf("derived contacts = %d, want only the readable one", len(changed))
+	}
+	if changed[0].PersonID.UUID != mine {
+		t.Errorf("derived %s, want the caller's own contact %s", changed[0].PersonID.UUID, mine)
+	}
+	if changed[0].DisplayName != "Anna Weber" {
+		t.Errorf("the contact is named %q, want the person record's own name", changed[0].DisplayName)
+	}
+	sawQuiet := false
+	for _, change := range changed[0].Changes {
+		if change.Kind == relstrength.ChangeWentQuiet {
+			sawQuiet = true
+		}
+	}
+	if !sawQuiet {
+		t.Errorf("changes = %v, want the lapse the seeding arranged", changed[0].Changes)
+	}
+}

--- a/backend/internal/modules/people/relationshipchange.go
+++ b/backend/internal/modules/people/relationshipchange.go
@@ -133,7 +133,7 @@ func visibleContactNames(ctx context.Context, tx pgx.Tx, people []ids.PersonID) 
 		return nil, err
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT p.id, p.display_name FROM person p
+		SELECT p.id, p.full_name FROM person p
 		WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND (%s)
 		ORDER BY p.id`, peoplePos, scope), args...)
 	if err != nil {

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -288,6 +288,15 @@ const audienceWorkspaceOnly = ` AND a.audience = 'workspace'`
 // departed colleague as a route in.
 const liveMemberJoin = `JOIN app_user u ON u.id = e.user_id AND u.status = 'active' AND u.archived_at IS NULL`
 
+// laterMemberJoin is the same rule asked about a SECOND edge in one statement:
+// has any live colleague spoken to this contact since. It is spelled out rather
+// than derived from liveMemberJoin because TestOnlyOneSpellingOfALiveMember
+// reads source text, and a predicate assembled at runtime is a predicate that
+// census cannot see — under-recognition being the one way that gate must not
+// break. Both spellings are ratified there by name, and it fails if either
+// stops naming both halves.
+const laterMemberJoin = `JOIN app_user lu ON lu.id = later.user_id AND lu.status = 'active' AND lu.archived_at IS NULL`
+
 // EdgesForPerson answers "who on our team knows this contact".
 //
 // It returns edges in LAST-CONTACT order and does NOT rank by warmth, because
@@ -373,51 +382,6 @@ func EdgesForPeople(ctx context.Context, tx pgx.Tx, people []ids.UUID) ([]Intera
 		 ORDER BY e.person_id, e.last_at DESC, e.user_id`, people)
 	if err != nil {
 		return nil, fmt.Errorf("search: reading who knows a contact set: %w", err)
-	}
-	defer rows.Close()
-	return scanEdges(rows)
-}
-
-// QuietEdgesForUser answers "which of MY relationships have gone silent",
-// oldest silence first.
-//
-// It is the CANDIDATE half of the decay lane and deliberately not the verdict.
-// The projection stores when a pair last spoke, so the reader's own quiet
-// relationships are one indexed range over idx_graph_edge_user — but whether a
-// silence is worth reporting is a §4 derivation over the contact's own
-// interactions, and that stays where it already lives. Answering it here would
-// be a second quiet rule, and the two would disagree in front of a rep.
-//
-// `quietBefore` is the caller's, derived from relstrength.QuietDays: the
-// threshold belongs to the derivation, and this read applies it rather than
-// holding an opinion about how long is too long.
-//
-// Established relationships only: a pair with no interaction on record has not
-// gone quiet, they were never loud, and admitting them turns every dormant
-// contact into an alert. The colleague filter is the live-member join every
-// other read of this table carries — a departed colleague's silences are not
-// the reader's work.
-func QuietEdgesForUser(
-	ctx context.Context,
-	tx pgx.Tx,
-	userID ids.UUID,
-	quietBefore time.Time,
-	limit int,
-) ([]InteractionEdge, error) {
-	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
-		return nil, err
-	}
-	rows, err := tx.Query(ctx, `
-		SELECT e.user_id, e.person_id, e.last_at, e.last_inbound_at, e.last_outbound_at,
-		       e.count_90d, e.in_count_90d, e.out_count_90d, e.count_total
-		  FROM graph_interaction_edge e
-		  `+liveMemberJoin+`
-		  JOIN person p ON p.id = e.person_id AND p.archived_at IS NULL
-		 WHERE e.user_id = $1 AND e.last_at < $2 AND e.count_total > 0
-		 ORDER BY e.last_at ASC, e.person_id
-		 LIMIT $3`, userID, quietBefore, limit)
-	if err != nil {
-		return nil, fmt.Errorf("search: reading a colleague's quiet relationships: %w", err)
 	}
 	defer rows.Close()
 	return scanEdges(rows)

--- a/backend/internal/modules/search/quietedges.go
+++ b/backend/internal/modules/search/quietedges.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// QuietEdgesForUser answers "which of MY relationships have gone silent",
+// oldest silence first.
+//
+// It is the CANDIDATE half of the decay lane and deliberately not the verdict.
+// The projection stores when a pair last spoke, so the reader's own quiet
+// relationships are one indexed range over idx_graph_edge_user — but whether a
+// silence is worth reporting is a §4 derivation over the contact's own
+// interactions, and that stays where it already lives. Answering it here would
+// be a second quiet rule, and the two would disagree in front of a rep.
+//
+// `quietBefore` is the caller's, derived from relstrength.QuietDays: the
+// threshold belongs to the derivation, and this read applies it rather than
+// holding an opinion about how long is too long. Inclusive on both sides,
+// because the derivation admits at `days >= QuietDays`: a strict `<` here would
+// drop a contact at exactly the threshold that their own page calls quiet, and
+// the two surfaces would disagree for one day about one relationship.
+//
+// The pair's own silence is not enough to admit a candidate — a contact a
+// colleague spoke to last week has been handed over, not lost, and the
+// derivation would reject them anyway. The NOT EXISTS spells the derivation's
+// person-wide ground here so those rows do not consume LIMIT slots ahead of
+// genuine lapses.
+//
+// That suppression counts only LIVE colleagues, which is why it applies the
+// live-member rule under its own alias, through laterMemberJoin. A handover to
+// somebody who has since left is not a handover: nobody is holding that
+// relationship now, and suppressing it would hide the exact lapse this lane
+// exists to surface.
+//
+// The person row scope is applied AT SOURCE, not left to the caller: this read
+// originates the candidate set, an edge row disclosing that a withheld contact
+// exists is exactly what capture privacy forbids, and a LIMIT over unscoped
+// rows would let unreadable contacts evict readable lapses from the budget.
+//
+// Established relationships only: a pair with no interaction on record has not
+// gone quiet, they were never loud, and admitting them turns every dormant
+// contact into an alert. What actually enforces that today is the derivation's
+// own nil check on the last interaction — both writers of this projection count
+// over rows that must exist, so `count_total > 0` refuses nothing they produce.
+// It stays as the predicate a candidate read owes its own table rather than
+// borrowing from the verdict, and it is the line to check first if a future
+// writer ever inserts a pair before its evidence.
+//
+// The colleague filter is the live-member join every other read of this table
+// carries — a departed colleague's silences are not the reader's work.
+func QuietEdgesForUser(
+	ctx context.Context,
+	tx pgx.Tx,
+	quietBefore time.Time,
+	limit int,
+) ([]InteractionEdge, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	// The reader is taken from the context, never from a parameter. This read
+	// answers "which of MY relationships lapsed" and returns who a colleague
+	// talks to and when they last did — so a user id off a call site would let
+	// any future caller ask that question about somebody else, and the person
+	// row scope below would not refuse it: their contacts can be perfectly
+	// readable while their private relationship history is not the asker's.
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return nil, apperrors.ErrPermissionDenied
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	userPos := arg(actor.UserID)
+	beforePos := arg(quietBefore)
+	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = "TRUE"
+	}
+	limitPos := arg(limit)
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT e.user_id, e.person_id, e.last_at, e.last_inbound_at, e.last_outbound_at,
+		       e.count_90d, e.in_count_90d, e.out_count_90d, e.count_total
+		  FROM graph_interaction_edge e
+		  %s
+		  JOIN person p ON p.id = e.person_id AND p.archived_at IS NULL
+		 WHERE e.user_id = $%d AND e.last_at <= $%d AND e.count_total > 0
+		   AND NOT EXISTS (SELECT 1 FROM graph_interaction_edge later
+		                     %s
+		                    WHERE later.person_id = e.person_id AND later.last_at >= $%d)
+		   AND (%s)
+		 ORDER BY e.last_at ASC, e.person_id
+		 LIMIT $%d`, liveMemberJoin, userPos, beforePos,
+		laterMemberJoin, beforePos, scope, limitPos), args...)
+	if err != nil {
+		return nil, fmt.Errorf("search: reading a rep's own quiet relationships: %w", err)
+	}
+	defer rows.Close()
+	return scanEdges(rows)
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -173,6 +173,8 @@ export const de = {
   "day.lead.promises": "Du hast {count} zugesagt — das geht vor.",
   "day.lead.meetings": "{count} heute im Kalender.",
   "day.lead.atRisk": "{count} werden still. Sonst wartet nichts auf dich.",
+  "day.lead.decay":
+    "Mit {count} hast du länger nicht gesprochen. Es wartet nichts auf dich.",
   "day.lead.morningOnly":
     "Nichts wartet auf dich — die Nacht hat {count} zum Anfangen herausgesucht.",
   "day.lead.ranOvernight":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -175,6 +175,8 @@ export const en = {
   "day.lead.promises": "You promised {count} — those come first.",
   "day.lead.meetings": "{count} on the calendar today.",
   "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",
+  "day.lead.decay":
+    "{count} you have not spoken to in a while. Nothing is waiting on you.",
   "day.lead.morningOnly":
     "Nothing waiting on you — the night picked out {count} to start with.",
   "day.lead.ranOvernight": "Nothing needs you. Here is what ran overnight.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -180,6 +180,8 @@ export const vi = {
   "day.lead.promises": "Bạn đã hứa {count} việc — những việc đó trước tiên.",
   "day.lead.meetings": "{count} cuộc họp trên lịch hôm nay.",
   "day.lead.atRisk": "{count} đang lặng đi. Không còn gì khác chờ bạn.",
+  "day.lead.decay":
+    "{count} bạn đã lâu không trao đổi. Không có gì đang chờ bạn.",
   "day.lead.morningOnly":
     "Không có gì chờ bạn — đêm qua đã chọn ra {count} việc để bắt đầu.",
   "day.lead.ranOvernight":

--- a/frontend/src/screens/today.stories.tsx
+++ b/frontend/src/screens/today.stories.tsx
@@ -145,6 +145,42 @@ export const NothingToDecide: Story = {
 // accident: the reader should be able to close the page and believe it.
 export const ClearDay: Story = { render: today(quiet) };
 
+// Relationships that went quiet, and NOTHING else on the page. This is the one
+// state the lane can get wrong in a way a reader would notice: nobody is
+// waiting on them, so every "is anything waiting?" branch is false, and a
+// headline that only asked those would print "your day is clear" directly above
+// three contacts nobody has spoken to in months. The story exists to keep that
+// combination on screen.
+export const RelationshipsGoingQuiet: Story = {
+  render: today({
+    ...quiet,
+    relationship_decay: [
+      {
+        id: "rd-1",
+        source: "relationship_decay",
+        title: "Dana Weiss",
+        detail: "63",
+        occurred_at: "2026-06-23T09:00:00Z",
+        actions: [],
+      },
+      {
+        id: "rd-2",
+        source: "relationship_decay",
+        title: "Ines Sommer",
+        detail: "48",
+        occurred_at: "2026-07-08T09:00:00Z",
+        actions: [],
+      },
+    ],
+    counts: {
+      this_morning: 0,
+      needs_you: 0,
+      planned: 0,
+      relationship_decay: 2,
+    },
+  }),
+};
+
 // A lane the reader may not read. Said out loud in the warn family — nothing is
 // broken, they are simply not seeing everything, and a page that stayed silent
 // would report a clear day it cannot actually see.

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -115,6 +115,16 @@ function quietLead(
   if (drifting > 0) {
     return t("day.lead.atRisk", { count: formatNumber(drifting, locale) });
   }
+  // A lapsed relationship is the same shape of news as a drifting deal:
+  // nobody is waiting on the reader for it, and it is the thing that goes
+  // unnoticed precisely because nobody is. Counted here rather than left to
+  // the check below, because that check only catches a lane that was never
+  // READ — a lane read and holding three contacts would still have printed
+  // "clear" above them.
+  const lapsed = day.counts.relationship_decay ?? 0;
+  if (lapsed > 0) {
+    return t("day.lead.decay", { count: formatNumber(lapsed, locale) });
+  }
   // Before "clear", because the briefing lane is on this page: a line reading
   // "your day is clear" above two items the night picked out is the one thing
   // this line exists to prevent. It sits below decisions and planned work,


### PR DESCRIPTION
The decay lane merged in #3027 and does not work: `RelationshipChangesForPeople` selects `p.display_name` from `person`, which has no such column, so every read of the lane returns an error. Not degraded — dead.

Four more defects came out of reviewing the merged branch, and the integration test that would have caught the first one did not land with the feature.

## What was wrong

**The lane errors on every read.** `person` has `full_name`. The Go struct field was renamed to `DisplayName` and the SQL column name went with it, but the column was never called that. No test covered the query, so nothing failed.

**The card contradicted itself.** `QuietDays` came from the derivation and `LastAt` from the projection. Those fold different activity — the projection takes only workspace-audience rows this rep took part in — so a card could read "quiet 46 days — last on" a date twelve weeks older. Both halves now come from the derivation, whose `At` is the touch its `Days` counts from.

**"Your day is clear" printed above lapsed relationships.** Every branch of the headline asked whether something was *waiting* on the reader. Nothing waits on a silence; that is what makes it lapse. The lane now has its own lead line.

**`QuietEdgesForUser` took the reader as a parameter.** It answers "which of my relationships lapsed" and returns who a colleague talks to and when. The person row scope does not refuse that: a contact can be readable while somebody else's relationship history is not the asker's. The reader now comes from the context.

**The handover suppression counted departed colleagues.** A contact whose only recent conversation was with somebody who has since left was dropped as handed over, when nobody holds that relationship at all — the exact lapse this lane exists to surface.

Also: the candidate threshold is now inclusive, matching the derivation's `days >= QuietDays` instead of dropping a contact at exactly the threshold their own page calls quiet.

## Tests

The integration test seeds through the real activity writer and the real projection fold rather than inserting an edge row by hand, and asserts both the refusal and the admission — a query returning nothing for everyone would pass the refusal alone. Both cases run green against Postgres.

The unit test for the card gives the projection and the derivation deliberately different instants, so it fails if either half of the sentence goes back to the wrong source. Mutation-checked: reverting the fix fails it. The lane also gained unit tests for its rendered shape, its withheld case and its absent case, and Today gained the story for a page holding decay and nothing else.

## Verification

`make check-backend`, `make check-fe`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` all green, plus the two decay integration tests against a real database.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the decay lane, which errored on every read and showed inconsistent data, and corrects four more defects found in reviewing the merged branch.

- Fixes the dead query: `relationshipchange.go` now selects `p.full_name` instead of the nonexistent `p.display_name`.
- The card now takes both the span and the last-touch date from the derivation so "quiet 46 days—last on" can no longer contradict itself.
- Lapsed relationships get their own headline, so "your day is clear" no longer prints above them.
- The reader for `QuietEdgesForUser` comes from the context, not a parameter, so future callers cannot ask about someone else's relationships.
- Handover suppression now counts only active colleagues—a contact whose only recent talk was with someone departed is surfaced as lapsed.
- The candidate threshold is inclusive, matching the derivation's `days >= QuietDays` so contacts at exactly the threshold are not dropped.

**Tests**
- Added integration tests that seed via the real activity writer and projection fold and assert both permission refusal and row admission.
- Unit tests cover the card's consistency, the withheld lane, the absent lane, and the Today story for a decay-only page.

<sup>Written for commit e3bd6d05ce9e34281c546dc6090ae5e3bcfc0322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added worklist messaging for relationships that have gone quiet.
  - Added localized decay messages in English, German, and Vietnamese.

- **Bug Fixes**
  - Improved quiet-relationship results with accurate contact names and last-contact dates.
  - Excluded contacts that cannot be viewed and handled unavailable contact records safely.
  - Ensured relationship decay counts and messages appear consistently in the daily briefing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->