### PR TITLE
fix(provenance): the engine's own creates must not be refused as forged

### DIFF
--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -94,6 +94,73 @@ func TestQuietOrganizationWithAnOpenDealFiresOnceAndStaysClaimed(t *testing.T) {
 	}
 }
 
+// A row a CALLER dressed as the system's still counts as engagement. source
+// arrives verbatim on the create wire, so anyone can write source='system' —
+// only the pair (source AND captured_by, which is stamped from the principal)
+// marks the engine's own output. Were source alone the exclusion, a caller
+// could hide real engagement from this scan, or plant an old-dated row to
+// drag a worked account into the reminder draw forever.
+func TestAPlantedSystemSourceRowStillCountsAsEngagement(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open, _ := DealFixture(t, e)
+
+	org := e.SeedOrg(t, "Planted Account", nil)
+	deal := e.SeedDeal(t, "Planted Account Renewal", pipeline, open, nil)
+	attachDealToOrg(t, owner, deal, org)
+	backdateCreatedAt(t, owner, "organization", org, longEstablished)
+	backdateCreatedAt(t, owner, "deal", deal, longEstablished)
+	linkQuietTouch(t, owner, e.WS, "organization", org)
+
+	// The planted row: recent, source claims the system, captured_by names
+	// the human who actually wrote it. It IS this account's latest touch.
+	planted := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'note', 'Dressed as the system', $2, 'system', 'human:x')`,
+		planted, eligibilityScanNow.AddDate(0, 0, -1)); err != nil {
+		t.Fatalf("seeding the planted row: %v", err)
+	}
+	linkTouch(t, owner, e.WS, planted, "organization", org)
+	seedNoActivityReminder(t, owner, e.WS)
+
+	runEligibilityScan(t, e)
+	if got := taskCountOn(t, e, "organization", org); got != 0 {
+		t.Fatalf("reminder tasks = %d, want 0 — the planted row is a real recent touch, and excluding it on its source alone would let a caller steer the scan", got)
+	}
+}
+
+// The engine's OWN recent output still does not count: both halves of the
+// pair are the system's, and a reminder task must not reset the very clock
+// it fires off.
+func TestTheEnginesOwnRowStillDoesNotCountAsEngagement(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open, _ := DealFixture(t, e)
+
+	org := e.SeedOrg(t, "Reminded Account", nil)
+	deal := e.SeedDeal(t, "Reminded Account Renewal", pipeline, open, nil)
+	attachDealToOrg(t, owner, deal, org)
+	backdateCreatedAt(t, owner, "organization", org, longEstablished)
+	backdateCreatedAt(t, owner, "deal", deal, longEstablished)
+	linkQuietTouch(t, owner, e.WS, "organization", org)
+
+	engineRow := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'task', 'Follow up (engine-minted)', $2, 'system', 'system')`,
+		engineRow, eligibilityScanNow.AddDate(0, 0, -1)); err != nil {
+		t.Fatalf("seeding the engine row: %v", err)
+	}
+	linkTouch(t, owner, e.WS, engineRow, "organization", org)
+	seedNoActivityReminder(t, owner, e.WS)
+
+	runEligibilityScan(t, e)
+	if got := taskCountOn(t, e, "organization", org); got == 0 {
+		t.Fatal("no reminder fired — the engine's own output counted as engagement and reset the clock it fires off")
+	}
+}
+
 func TestTwoRecordsSharingOneLastTouchInstantEachGetTheirOwnReminder(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -30,11 +30,13 @@ import (
 
 // taskSourceSystem is activity.source as the automation engine's create
 // executor stamps it (automation's systemSource — spelled again here
-// because a module cannot import a sibling's constant; the provenance
-// reservation that keeps clients from writing it names the same value,
-// provenance.ReservedSystemSource). Never trusted alone: source arrives
-// on the client create wire, so every selector below pairs it with
-// systemCapturedBy, which no client can write.
+// because a module cannot import a sibling's constant). Never trusted
+// alone, and deliberately NOT reserved at the create wire: the engine's
+// own creates flow through the same mapper as a client's
+// (LogActivityInputFrom), so a value-level refusal there would refuse the
+// engine itself. A caller can spell it — every selector below therefore
+// pairs it with systemCapturedBy, which no client can write, and that
+// pairing is the security boundary.
 const taskSourceSystem = "system"
 
 // systemCapturedBy is captured_by as the workflow engine's runs stamp it:

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -28,22 +28,25 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
 
-// taskSourceSystem is activity.source as the automation engine's create
-// executor stamps it (automation's systemSource — spelled again here
+// systemSource is activity.source as the automation engine's create
+// executor stamps it (automation's own systemSource — spelled again here
 // because a module cannot import a sibling's constant). Never trusted
 // alone, and deliberately NOT reserved at the create wire: the engine's
 // own creates flow through the same mapper as a client's
 // (LogActivityInputFrom), so a value-level refusal there would refuse the
-// engine itself. A caller can spell it — every selector below therefore
-// pairs it with systemCapturedBy, which no client can write, and that
-// pairing is the security boundary.
-const taskSourceSystem = "system"
+// engine itself. A caller can spell it — so every selector over it in
+// this package (the follow-up resolver below, the last-touch scan's
+// genuine-engagement exclusion) pairs it with systemCapturedBy, which no
+// client can write, and that PAIRING is the security boundary. The one
+// pair of constants for the package, so the next selector cannot copy
+// half the predicate.
+const systemSource = "system"
 
 // systemCapturedBy is captured_by as the workflow engine's runs stamp it:
 // storekit.CapturedBy writes the authenticated principal's ID, and the
 // engine binds the system principal with ID "system" (automation's
 // HandleEvent). captured_by never comes from a request body, so it is the
-// unforgeable half of the "the system minted this task" predicate.
+// unforgeable half of the "the system wrote this row" predicate.
 const systemCapturedBy = "system"
 
 // FollowUpWorkflows returns the system handlers that complete open system
@@ -173,8 +176,8 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // task no longer matches the open filter.
 //
 // "System-minted" is decided by source AND captured_by together: source
-// rides the client create wire (and is merely refused there, not
-// impossible), while captured_by is stamped from the authenticated
+// rides the client create wire verbatim (any caller can spell "system" —
+// see systemSource's doc), while captured_by is stamped from the authenticated
 // principal — a planted source alone hands nothing to this path. It
 // answers a COUNT rather than rows, so nothing about which records exist
 // leaves a call that takes no read gate of its own; each completion's
@@ -188,7 +191,7 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 			WHERE l.lead_id = $1 AND a.kind = $2 AND a.source = $3
 			  AND a.captured_by = $4
 			  AND a.is_done = false AND a.archived_at IS NULL
-			ORDER BY a.id`, leadID, string(crmcontracts.ActivityKindTask), taskSourceSystem, systemCapturedBy)
+			ORDER BY a.id`, leadID, string(crmcontracts.ActivityKindTask), systemSource, systemCapturedBy)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/activities/lasttouch.go
+++ b/backend/internal/modules/activities/lasttouch.go
@@ -27,22 +27,14 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
-// automationSource is the activity.source value the automation engine
-// stamps on every activity it creates (its create_task / create_record
-// output, automation/engine.go's systemSource). LastTouchBefore
-// excludes these so the engine's OWN reminder task cannot count as a
-// "touch" that resets the very clock it fires off. A module never imports
-// a sibling (ADR-0054 §9), so this is the value-level shadow of that
-// constant, not a shared symbol — kept in lockstep by the integration
-// proof (compose/integration), which fires a real reminder and asserts
-// the anchor does not move.
-const automationSource = "system"
-
 // LastTouchCandidate is one REMINDER-ELIGIBLE linked entity whose most
 // recent GENUINE engagement (across every kind and every link) landed
 // before the caller's cutoff. "Genuine" excludes the automation engine's
-// own output (automationSource); "eligible" is the live-work test each
-// entity type gets in the query — see LastTouchBefore.
+// own output — source AND captured_by together (systemSource,
+// systemCapturedBy, followupresolve.go), because source alone rides the
+// client create wire and a planted value must not let a caller hide real
+// engagement or move a record's anchor; "eligible" is the live-work test
+// each entity type gets in the query — see LastTouchBefore.
 type LastTouchCandidate struct {
 	EntityType string
 	EntityID   ids.UUID
@@ -55,14 +47,16 @@ type LastTouchCandidate struct {
 // the link-id coalesce, and the organization walk — and it sits apart from the
 // scan so the scan reads as what it does with the rows.
 //
-// $1 is the source the automation engine stamps, $2 the cutoff, $3 the cap.
+// $1/$4 are the source and captured_by the automation engine stamps —
+// excluded only TOGETHER, since source alone is a client's to spell —
+// $2 the cutoff, $3 the cap.
 func lastTouchCandidateQuery() string {
 	return storekit.SQLf(`
 			WITH genuine AS (
 				SELECT a.id, a.occurred_at
 				FROM activity a
 				WHERE a.archived_at IS NULL
-				  AND a.source <> $1
+				  AND NOT (a.source = $1 AND a.captured_by = $4)
 			), direct AS (
 				SELECT al.entity_type AS entity_type,
 				       %[1]s AS entity_id,
@@ -131,11 +125,11 @@ func lastTouchCandidateQuery() string {
 // "No activity for N days" means the rep has not ENGAGED the record — a
 // human touch (call, email, meeting, note), an inbound reply, or a
 // captured mail (Gmail/IMAP, source "gmail:…"/"imap:…") all count. The
-// automation engine's OWN writes (source = automationSource) do NOT: a
+// automation engine's OWN writes (source AND captured_by both "system") do NOT: a
 // reminder task the engine created must not look like engagement, or the
 // firing would reset its own anchor to ~now, age out of the candidate
 // set, then re-surface with the task's timestamp as a fresh anchor and
-// nag every N days forever. Excluding automationSource keeps the anchor
+// nag every N days forever. Excluding the engine's writes keeps the anchor
 // pinned to the last real touch, so no_activity_reminder fires ONCE per
 // quiet spell (recurring "check in every N days regardless" is
 // check_in_cadence's job, not this trigger's).
@@ -198,7 +192,7 @@ func (s *Store) LastTouchBefore(ctx context.Context, cutoff time.Time, limit int
 		// vocabulary (linktarget.go), the same source the coalesce
 		// expression is built from, so a renamed record type cannot leave a
 		// stale string behind in this query.
-		rows, err := tx.Query(ctx, lastTouchCandidateQuery(), automationSource, cutoff, limit)
+		rows, err := tx.Query(ctx, lastTouchCandidateQuery(), systemSource, cutoff, limit, systemCapturedBy)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/shared/kernel/provenance/importnamespace.go
+++ b/backend/internal/shared/kernel/provenance/importnamespace.go
@@ -25,28 +25,15 @@ func ReservedSourceSystem(sourceSystem string) bool {
 	return strings.HasPrefix(sourceSystem, ReservedSourceSystemPrefix)
 }
 
-// ReservedSystemSource is the source value the automation engine's own
-// writes carry (automation's create executor stamps it on every record a
-// workflow mints). A client-facing create must not spell it: the follow-up
-// auto-resolver and the duplicate-fold data repair select system-minted
-// rows by this value, so a caller who could write it would hand their own
-// row — or a colleague's lead's row — to the system's completion and
-// archival paths, and claim system provenance in every reader that trusts
-// the column. Both of those paths ALSO predicate on captured_by (which no
-// client can write), so this reservation is the loud front door rather
-// than the only lock.
-const ReservedSystemSource = "system"
-
-// ReservedError refuses a client write into a reserved provenance value,
-// naming the field it arrived on and why that value is not a client's to
-// spell. One type rather than one per module: the rule is a single
-// invariant — no client-facing path writes reserved provenance — and
-// three copies of it would be three places for the next provenance field
-// to be forgotten.
-type ReservedError struct{ Field, Value, Reason string }
+// ReservedError refuses a client write into the importer's namespace,
+// naming the field it arrived on. One type rather than one per module:
+// the rule is a single invariant — no client-facing path may write this
+// namespace — and three copies of it would be three places for the next
+// provenance field to be forgotten.
+type ReservedError struct{ Field, Value string }
 
 func (e *ReservedError) Error() string {
-	return e.Field + " " + e.Value + " is reserved " + e.Reason
+	return e.Field + " " + e.Value + " is reserved for imports; omit it or use a value outside the " + ReservedSourceSystemPrefix + " namespace"
 }
 
 // FieldFault states the refusal as caller-fixable, which is how it
@@ -62,16 +49,7 @@ func (e *ReservedError) FieldFault() (field, code, message string) {
 // else can spell the prefix.
 func Refuse(field, value string) error {
 	if ReservedSourceSystem(value) {
-		return &ReservedError{
-			Field: field, Value: value,
-			Reason: "for imports; omit it or use a value outside the " + ReservedSourceSystemPrefix + " namespace",
-		}
-	}
-	if value == ReservedSystemSource {
-		return &ReservedError{
-			Field: field, Value: value,
-			Reason: "for the system's own writes; use a value naming the real capture source",
-		}
+		return &ReservedError{Field: field, Value: value}
 	}
 	return nil
 }

--- a/backend/internal/shared/kernel/provenance/importnamespace_test.go
+++ b/backend/internal/shared/kernel/provenance/importnamespace_test.go
@@ -49,28 +49,6 @@ func TestRefuseNamesTheFieldAndLetsOrdinaryValuesThrough(t *testing.T) {
 	}
 }
 
-// "system" is the automation engine's own provenance stamp: a client who
-// could spell it would hand their row — or a colleague's lead's row — to
-// the system's own completion and archival paths.
-func TestRefuseReservesTheSystemsOwnSource(t *testing.T) {
-	err := provenance.Refuse("source", provenance.ReservedSystemSource)
-	var reserved *provenance.ReservedError
-	if !errors.As(err, &reserved) {
-		t.Fatalf("err = %v, want ReservedError — a client must not claim the system's own provenance", err)
-	}
-	var fault apperrors.FieldFault
-	if !errors.As(err, &fault) {
-		t.Errorf("the refusal must read as caller-fixable (FieldFault), got %v", err)
-	}
-	// Only the exact value is the system's; lookalikes stay a caller's to
-	// spell, so nobody's real source system named "systematic" breaks.
-	for _, ordinary := range []string{"systematic", "System", "system:x"} {
-		if err := provenance.Refuse("source", ordinary); err != nil {
-			t.Errorf("Refuse(%q) = %v, want nil", ordinary, err)
-		}
-	}
-}
-
 func TestReservedErrorStatesItselfAsCallerFixable(t *testing.T) {
 	// Implementing apperrors.FieldFault is what carries this refusal to
 	// the caller as a 422 naming the field — on the HTTP surface AND on


### PR DESCRIPTION
#3035 reserved activity source `system` at the create wire. The automation engine's own creates flow through the same mapper (`LogActivityInputFrom` — the composition hands every provider write through it), so the reservation refused the writer it was protecting: every task-minting workflow on main failed its create with "source system is reserved". Caught by the `backend/internal/compose/integration` no_activity lane (green again with this change); #3035's own integration tests used a fake provider and could not see it.

The reservation is reverted rather than special-cased. The security boundary never was the source value: the follow-up auto-resolver and the cleanup migration select system tasks by `source AND captured_by`, and `captured_by` is stamped from the authenticated principal — a planted source alone hands nothing to either path. The comment beside `taskSourceSystem` now states that boundary.

Gate: full `make check-backend` green, `make test-it DIR=backend/internal/compose/integration` green, craft static clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the reservation of the source value `system` from the create wire so the automation engine's own creates are no longer refused as forged. The reservation broke every task-minting workflow because engine creates flow through the same mapper as client writes.

The security boundary is `source` AND `captured_by` together; `captured_by` comes from the authenticated principal, so a planted source alone can't claim system provenance. The follow-up auto-resolver already paired both halves, but the last-touch scan's genuine-engagement exclusion still trusted `source` alone. With the wire refusal gone, a caller could now dress a row as the engine's to hide real engagement, or plant an old-dated row that drags a worked account into the reminder draw on every tick. The exclusion requires both halves, and the package spells the pair once (`systemSource`/`systemCapturedBy` in `followupresolve.go`). Two integration tests hold it from both sides: a planted row counts as the real engagement it is, and the engine's own output still never resets the clock it fires off.

<sup>Written for commit b2b8716042554083cd77e75ef9685d12baa4e263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how system-generated activity sources are identified and trusted.
* **Bug Fixes**
  * Updated provenance validation to reject only reserved import namespaces.
  * Standardized messaging for reserved namespace violations.
  * Allowed values resembling reserved namespaces when outside the reserved prefix.
  * Improved activity tracking so human-recorded system-source activity counts toward engagement, while automation-generated activity does not reset eligibility or last-touch results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->