### PR TITLE
fix(ci): the unsigned scheduled-lane squash is attested rather than skipped

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -317,6 +317,11 @@ jobs:
           # gate now reads, so the baseline returns to the parent of the oldest
           # — the three are covered again and pass on their attestations.
           #
+          # A fourth, 188598a90, landed unsigned later and is attested the same
+          # way rather than by moving this line: an attestation costs one commit
+          # and covers exactly the hole, where an advance would silently drop
+          # every commit between here and there.
+          #
           # Moving it forward is what a hole costs, and it is why remediation is
           # worth reading: every advance is a stretch of main this gate stops
           # asking about, and nothing afterwards reports that it stopped.


### PR DESCRIPTION
## What this fixes

`main-health` has been red on every run since `188598a90` ("ci(scheduled): the six use cases run weekly against a real model", #2872) landed on main without a `Signed-off-by` trailer. Every other lane in that workflow passes — backend gate, frontend, all six integration shards, uat. The `dco (main)` job is the whole failure.

## Why attestation and not a new baseline

The two answers are not equivalent, and the comment beside `DCO_MAIN_BASELINE` already argues this for the three earlier unsigned squashes:

- An attestation costs one commit and closes exactly the one hole.
- Advancing the baseline past `188598a90` would drop every commit between the current line and that one out of range permanently, and nothing afterwards reports that the gate stopped asking.

So the baseline stays at `c4a230155` and the commit is attested by its author, which is the form `scripts/check-dco.sh` reads. The comment gains four lines recording that this fourth hole was closed the same way as the first three, so the next reader does not have to reconstruct why the line did not move.

## Verified

`./scripts/check-dco.sh c4a230155 HEAD` now reports `all commits in c4a230155..HEAD are signed off`, and names the attestation explicitly:

```
DCO: commit 188598a90… is unsigned but attested by its author in 02ea039a2…
```

`make check-backend` green. The only file changed is a comment in `.github/workflows/main-health.yml`; the attestation itself lives in this commit's trailer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `dco (main)` CI job, which has been red since `188598a90` landed without a `Signed-off-by` trailer. The unsigned commit is now attested instead of skipping the check by advancing `DCO_MAIN_BASELINE`.

- The only workflow change is a comment explaining why the baseline stays put; the attestation is in this commit's trailer.

<sup>Written for commit 02ea039a2af2687692ed316d9870fcf4446d909c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that commit `188598a90` is handled through author attestation while preserving coverage of intervening commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->