### PR TITLE
feat(attention): the morning names its state, the risk card states its facts, and the unfillable lane steps down

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30056,8 +30056,10 @@ components:
           enum: [no_run_today, all_answered, items_waiting]
           description: |
             Why `this_morning` holds what it holds: the night produced no run for this
-            reader; a run exists and every item is answered; or items are waiting (and
-            the lane carries them). Named because the lane's emptiness is ambiguous on
+            reader; a run exists and nothing in it still needs an answer (every item
+            answered — or the run ranked nothing worth the morning, which is the same
+            message to a reader); or items are waiting (and the lane carries them).
+            Named because the lane's emptiness is ambiguous on
             its own — "the night found nothing" and "you finished the morning" render
             identically as zero rows, and only one of them has earned a tick. Absent
             when the lane itself was withheld (`lanes_omitted` names it).

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30051,6 +30051,16 @@ components:
             proceeds; a briefing item is a suggestion about where to start, and answering
             it is optional. Merging them would put "nothing is waiting on you" and
             "nothing was worth flagging" behind one number.
+        this_morning_state:
+          type: string
+          enum: [no_run_today, all_answered, items_waiting]
+          description: |
+            Why `this_morning` holds what it holds: the night produced no run for this
+            reader; a run exists and every item is answered; or items are waiting (and
+            the lane carries them). Named because the lane's emptiness is ambiguous on
+            its own — "the night found nothing" and "you finished the morning" render
+            identically as zero rows, and only one of them has earned a tick. Absent
+            when the lane itself was withheld (`lanes_omitted` names it).
         needs_you:
           type: array
           items: { $ref: '#/components/schemas/AttentionItem' }
@@ -30200,6 +30210,8 @@ components:
           $ref: '#/components/schemas/AttentionSubject'
         pair:
           $ref: '#/components/schemas/AttentionPair'
+        deal:
+          $ref: '#/components/schemas/AttentionDealFacts'
         due_at: { type: string, format: date-time, description: "When this is due (tasks), or when it lapses (approvals)." }
         overdue: { type: boolean, description: "Past due at the read instant, resolved server-side so every surface agrees." }
         occurred_at: { type: string, format: date-time, description: "When a done_for_you receipt actually happened." }
@@ -30240,6 +30252,20 @@ components:
             print: a reader asked to compare `full_name` is being shown the
             database rather than their own records.
           items: { $ref: '#/components/schemas/AttentionPairEvidence' }
+    AttentionDealFacts:
+      type: object
+      description: |
+        The deal behind a `deal_at_risk` item: the facts its card states, so a client
+        draws value and ownership without a second read per row. Sent only for
+        `source: deal_at_risk`. The stage travels as its id rather than a label — the
+        client already holds the pipelines vocabulary and writes the label in the
+        reader's own language; a label composed server-side would not be.
+      properties:
+        stage_id: { type: [string, 'null'], format: uuid, description: "The deal's current stage; null for an overlay-mirror deal, whose stage lives with the incumbent." }
+        amount_minor: { type: [integer, 'null'], format: int64 }
+        currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
+        owner_id: { type: [string, 'null'], format: uuid }
+
     AttentionPairEvidence:
       type: object
       description: 'One field the detector compared across the two records.'

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -88,10 +88,11 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 	}
 	var omitted []crmcontracts.AttentionLanesOmitted
 
-	morning, err := s.thisMorning(ctx)
+	morning, morningState, err := s.thisMorning(ctx)
 	omitted, err = fill(omitted, "this_morning", err, func() {
 		out.ThisMorning = morning
 		out.Counts.ThisMorning = len(morning)
+		out.ThisMorningState = &morningState
 	})
 	if err != nil {
 		return crmcontracts.Attention{}, err
@@ -155,16 +156,27 @@ type laneCount struct {
 // this lane is a worklist that must be finishable and a row that cannot be
 // removed is the opposite of finishing. Home still shows what was answered,
 // which is where a rep looks to see what she did.
-func (s *Service) thisMorning(ctx context.Context) ([]crmcontracts.AttentionItem, error) {
-	queue, err := s.briefing.Queue(ctx)
+func (s *Service) thisMorning(ctx context.Context) ([]crmcontracts.AttentionItem, crmcontracts.AttentionThisMorningState, error) {
+	queue, ran, err := s.briefing.Queue(ctx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	items := make([]crmcontracts.AttentionItem, 0, len(queue))
 	for _, entry := range queue {
 		items = append(items, briefItem(entry))
 	}
-	return items, nil
+	// The state names WHY the lane holds what it holds. A run that ranked
+	// nothing reads all_answered too: "nothing worth your first hour" and
+	// "you answered everything" are the same message to a reader — nothing
+	// to do here — while no_run_today is the one that must not wear a tick.
+	state := crmcontracts.ItemsWaiting
+	switch {
+	case !ran:
+		state = crmcontracts.NoRunToday
+	case len(items) == 0:
+		state = crmcontracts.AllAnswered
+	}
+	return items, state, nil
 }
 
 // decisions is the needs_you lane: staged approvals and open duplicate pairs,

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -97,11 +97,15 @@ func (s stubReceipts) Recent(context.Context, time.Time, int) ([]Receipt, error)
 
 type stubBriefing struct {
 	rows []BriefEntry
-	err  error
+	// ran mirrors the seam's own contract: a found run with zero unanswered
+	// entries is ran=true, a night that produced nothing is ran=false. The
+	// zero value is the no-run morning, so a test must opt in to a run.
+	ran bool
+	err error
 }
 
-func (s stubBriefing) Queue(context.Context) ([]BriefEntry, error) {
-	return s.rows, s.err
+func (s stubBriefing) Queue(context.Context) ([]BriefEntry, bool, error) {
+	return s.rows, s.ran || len(s.rows) > 0, s.err
 }
 
 func approval(summary string) crmcontracts.Approval {

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -130,7 +130,12 @@ type Receipt struct {
 // case, and reserves apperrors.ErrPermissionDenied for a caller who may not
 // read the queue at all.
 type Briefing interface {
-	Queue(ctx context.Context) ([]BriefEntry, error)
+	// Queue answers the unanswered entries AND whether a run exists at all:
+	// ran=false means the night produced nothing for this reader, ran=true
+	// with no entries means every item is answered. The two render as the
+	// same empty lane, and only the second has earned a tick — so the seam
+	// states which rather than leaving the feed to infer it from emptiness.
+	Queue(ctx context.Context) (entries []BriefEntry, ran bool, err error)
 }
 
 // BriefEntry is one UNANSWERED queue entry: what it is about, and where it
@@ -202,6 +207,13 @@ type AtRisk interface {
 type RiskyDeal struct {
 	DealID ids.UUID
 	Name   string
+	// The card's facts, carried so the client draws value, stage and
+	// ownership without a second read per row. All optional: a deal can be
+	// ownerless, unpriced, or an overlay mirror with no native stage.
+	StageID     *ids.UUID
+	OwnerID     *ids.UUID
+	AmountMinor *int64
+	Currency    *string
 	// QuietDays is how long the deal has been idle, which is the number the
 	// card says out loud. Zero for a deal admitted only by its close date.
 	QuietDays int

--- a/backend/internal/compose/attention/morningstate_test.go
+++ b/backend/internal/compose/attention/morningstate_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// this_morning_state and the at-risk card's facts, as specs: the state must
+// separate the three morning answers an empty lane conflates, and the risk
+// card must state the deal's value and ownership without inventing a facts
+// object where it has none.
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// assembleMorning builds the feed around one briefing stub and returns the day.
+func assembleMorning(t *testing.T, briefing stubBriefing) crmcontracts.Attention {
+	t.Helper()
+	svc := NewService(stubApprovals{}, stubDuplicates{}, &stubTasks{},
+		stubReceipts{}, briefing, nil, nil, nil, nil, fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	return out
+}
+
+// The three states name why the lane holds what it holds. Empty-because-no-run
+// and empty-because-finished render identically as zero rows, and only one has
+// earned a tick — so the server says which, instead of leaving the client to
+// infer a claim the data cannot carry.
+func TestTheMorningStateSeparatesNoRunFromAllAnswered(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		briefing stubBriefing
+		want     crmcontracts.AttentionThisMorningState
+	}{
+		{"no run produced overnight", stubBriefing{}, crmcontracts.NoRunToday},
+		{"a run whose every item is answered", stubBriefing{ran: true}, crmcontracts.AllAnswered},
+		{"items still waiting", stubBriefing{rows: []BriefEntry{
+			{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1},
+		}}, crmcontracts.ItemsWaiting},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := assembleMorning(t, tc.briefing)
+			if out.ThisMorningState == nil {
+				t.Fatal("this_morning_state is absent — the morning's emptiness is ambiguous again")
+			}
+			if *out.ThisMorningState != tc.want {
+				t.Errorf("state = %q, want %q", *out.ThisMorningState, tc.want)
+			}
+		})
+	}
+}
+
+// The at-risk card carries the deal's own facts so the client draws value,
+// stage and ownership without a second read per row — and carries the `open`
+// verb the surface now routes through the subject.
+func TestARiskCardCarriesTheDealsFacts(t *testing.T) {
+	stage, owner := ids.NewV7(), ids.NewV7()
+	amount := int64(250000)
+	currency := "EUR"
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{
+			DealID: ids.NewV7(), Name: "Fleet retrofit", QuietDays: 19,
+			StageID: &stage, OwnerID: &owner, AmountMinor: &amount, Currency: &currency,
+		}}}, nil, nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	item := (*out.AtRisk)[0]
+	if item.Deal == nil {
+		t.Fatal("the card carries no deal facts — the client is back to one read per row")
+	}
+	if item.Deal.AmountMinor == nil || *item.Deal.AmountMinor != amount {
+		t.Errorf("amount_minor = %v, want %d", item.Deal.AmountMinor, amount)
+	}
+	if item.Deal.Currency == nil || *item.Deal.Currency != currency {
+		t.Errorf("currency = %v, want %s", item.Deal.Currency, currency)
+	}
+	if item.Deal.StageId == nil || ids.UUID(*item.Deal.StageId) != stage {
+		t.Errorf("stage_id = %v, want the deal's stage", item.Deal.StageId)
+	}
+	if item.Deal.OwnerId == nil || ids.UUID(*item.Deal.OwnerId) != owner {
+		t.Errorf("owner_id = %v, want the deal's owner", item.Deal.OwnerId)
+	}
+	if len(item.Actions) != 1 || item.Actions[0] != "open" {
+		t.Errorf("actions = %v, want [open]", item.Actions)
+	}
+}
+
+// A deal with no facts sends no facts object: an empty object would say less
+// than its absence and still cost every client a nil-vs-empty branch.
+func TestARiskCardWithNoFactsSendsNoFactsObject(t *testing.T) {
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
+		stubAtRisk{rows: []RiskyDeal{{DealID: ids.NewV7(), Name: "Bare deal", QuietDays: 5}}},
+		nil, nil,
+		fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if item := (*out.AtRisk)[0]; item.Deal != nil {
+		t.Errorf("deal facts = %+v, want none for a deal that has none", item.Deal)
+	}
+}
+
+// The unbound commitments lane is ABSENT, and absent is not withheld: nothing
+// names it in lanes_omitted, because nothing was hidden from this reader —
+// the installation simply serves no such lane until its writer exists.
+func TestAnUnboundCommitmentsLaneIsAbsentNotWithheld(t *testing.T) {
+	out := assembleMorning(t, stubBriefing{})
+	if out.Commitments != nil {
+		t.Errorf("commitments = %v, want no lane at all", *out.Commitments)
+	}
+	if out.LanesOmitted != nil {
+		for _, lane := range *out.LanesOmitted {
+			if lane == "commitments" {
+				t.Error("lanes_omitted names commitments — absent must not read as withheld")
+			}
+		}
+	}
+}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -282,6 +282,8 @@ func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionIt
 // and a queue that answered it here would be deciding rather than warning. It
 // does offer `open`, which decides nothing: naming a deal as drifting and then
 // leaving the reader to go and find it by hand is a warning they cannot act on.
+// The `deal` facts ride along so the card states value, stage and ownership
+// without a second read per row.
 func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 	name := deal.Name
 	ground := "quiet"
@@ -295,6 +297,7 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 		Title:   &name,
 		Subject: subjectOf("deal", deal.DealID),
 		Overdue: &deal.CloseOverdue,
+		Deal:    dealFacts(deal),
 		Actions: []crmcontracts.AttentionItemActions{actionOpen},
 	}
 	// The idle count rides as the detail's own number, so the card can say the
@@ -393,6 +396,27 @@ func receiptItem(receipt Receipt) crmcontracts.AttentionItem {
 		OccurredAt: &occurred,
 		Actions:    actions,
 	}
+}
+
+// dealFacts carries the at-risk deal's card facts onto the wire, or nothing:
+// a facts object with every field empty says less than its absence.
+func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
+	if deal.StageID == nil && deal.OwnerID == nil && deal.AmountMinor == nil && deal.Currency == nil {
+		return nil
+	}
+	facts := &crmcontracts.AttentionDealFacts{
+		AmountMinor: deal.AmountMinor,
+		Currency:    deal.Currency,
+	}
+	if deal.StageID != nil {
+		stage := openapi_types.UUID(*deal.StageID)
+		facts.StageId = &stage
+	}
+	if deal.OwnerID != nil {
+		owner := openapi_types.UUID(*deal.OwnerID)
+		facts.OwnerId = &owner
+	}
+	return facts
 }
 
 // subjectOf names the record an item concerns, when the producer named one.

--- a/backend/internal/compose/attentionbriefing_integration_test.go
+++ b/backend/internal/compose/attentionbriefing_integration_test.go
@@ -55,12 +55,15 @@ func TestAMorningWithNoRunReadsAsAnEmptyLaneNotARefusal(t *testing.T) {
 	// The rep has never had a brief. The engine answers not-found, and this
 	// lane must turn that into "nothing this morning" — reporting it as a
 	// refusal would tell her something was hidden when nothing was.
-	entries, err := b.reader.Queue(b.repCtx)
+	entries, ran, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatalf("a rep with no run got an error rather than an empty morning: %v", err)
 	}
 	if len(entries) != 0 {
 		t.Fatalf("the lane carries %d entries for a rep with no run, want none", len(entries))
+	}
+	if ran {
+		t.Fatal("ran = true for a rep with no run — the feed would tick a morning that never happened")
 	}
 }
 
@@ -76,9 +79,12 @@ func TestAnAnsweredBriefingItemLeavesTheLane(t *testing.T) {
 		t.Fatalf("the fixture queued %d items, and this test needs 2 to tell removal from emptiness", len(run.Items))
 	}
 
-	before, err := b.reader.Queue(b.repCtx)
+	before, ran, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("ran = false over a snapshotted run — the feed would report a morning that plainly exists as never produced")
 	}
 	if len(before) != len(run.Items) {
 		t.Fatalf("the lane carries %d of the run's %d items before anything is answered", len(before), len(run.Items))
@@ -89,7 +95,7 @@ func TestAnAnsweredBriefingItemLeavesTheLane(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after, err := b.reader.Queue(b.repCtx)
+	after, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +126,7 @@ func TestASetAsideBriefingItemComesBackWhenItsWindowPasses(t *testing.T) {
 
 	// While the window runs, the item is out of the lane.
 	b.now = b.now.Add(time.Hour)
-	during, err := b.reader.Queue(b.repCtx)
+	during, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +140,7 @@ func TestASetAsideBriefingItemComesBackWhenItsWindowPasses(t *testing.T) {
 	// The engine's own read resurfaces it, which is why the lane asks the
 	// engine rather than deciding what a state means for itself.
 	b.now = until.Add(time.Minute)
-	after, err := b.reader.Queue(b.repCtx)
+	after, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -90,6 +90,10 @@ func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, erro
 		risky = append(risky, attention.RiskyDeal{
 			DealID:            deal.DealID,
 			Name:              deal.Name,
+			StageID:           deal.StageID,
+			OwnerID:           deal.OwnerID,
+			AmountMinor:       deal.AmountMinor,
+			Currency:          deal.Currency,
 			QuietDays:         idleDaysOf(deal, now),
 			CloseOverdue:      deal.CloseOverdue,
 			ExpectedCloseDate: deal.ExpectedCloseDate,

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -3,8 +3,10 @@
 
 package compose
 
-// The four OPTIONAL attention lanes, bound to the engines that already own
-// what they read.
+// The four OPTIONAL attention lanes' seams over the engines that already own
+// what they read. Three are bound today; commitments is deliberately not
+// (newAttentionService passes nil until its production writer, issue #849,
+// exists), and its seam stays compiled here for that rebinding.
 //
 // Each is a binding rather than an implementation, which is the point: the
 // promises come from the people module's claim read, the deal risk from the
@@ -44,6 +46,13 @@ import (
 // promises of its own to keep, which is a refusal rather than an empty lane —
 // the feed omits and NAMES the lane instead of reporting a clear day.
 type attentionCommitments struct{ store *people.Store }
+
+// The binding is deliberately not wired today (newAttentionService passes nil
+// — the lane's production writer is issue #849's), so this assertion is the
+// one thing keeping the seam compiled against the interface it will be
+// rebound as. The store read behind it keeps its own integration test; the
+// seam wiring itself is untested exactly because nothing wires it.
+var _ attention.Commitments = attentionCommitments{}
 
 func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int) ([]attention.Commitment, error) {
 	actor, ok := principal.Actor(ctx)

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -344,24 +344,28 @@ type attentionBriefing struct {
 	now    attention.Clock
 }
 
-// Queue serves the acting rep's unanswered briefing entries for today.
+// Queue serves the acting rep's unanswered briefing entries for today, and
+// whether a run exists at all.
 //
-// No run for today reads as an EMPTY lane, not a refusal. LatestRun answers
-// ErrNotFound both when the night has not produced one and when a rep is new,
-// and neither is a permission problem — reporting them as a withheld lane
-// would tell the rep something was hidden from her when nothing was.
+// No run for today reads as an EMPTY lane with ran=false, not a refusal.
+// LatestRun answers ErrNotFound both when the night has not produced one and
+// when a rep is new, and neither is a permission problem — reporting them as
+// a withheld lane would tell the rep something was hidden from her when
+// nothing was. ran is what lets the feed tell that emptiness from a morning
+// the rep finished: a found run counts as ran even with zero unanswered
+// entries.
 //
 // Answered entries are dropped here rather than in the feed, because what the
 // states mean belongs to the brief. The engine already resolves an expired
 // snooze on this read, so an item whose set-aside has run out comes back
 // actionable without anything here knowing that rule either.
-func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, error) {
+func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, bool, error) {
 	run, err := a.engine.LatestRun(ctx, a.now())
 	if errors.Is(err, apperrors.ErrNotFound) {
-		return nil, nil
+		return nil, false, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	entries := make([]attention.BriefEntry, 0, len(run.Items))
 	for _, item := range run.Items {
@@ -372,7 +376,7 @@ func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, e
 			ID: item.ID, DealID: item.DealID, Rank: item.Rank,
 		})
 	}
-	return entries, nil
+	return entries, true, nil
 }
 
 // newAttentionHandlers assembles the surface for the API role.
@@ -395,7 +399,16 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, now attenti
 		attentionTasks{store: activities.NewStore(db)},
 		attentionReceipts{svc: svc},
 		attentionBriefing{engine: briefs.NewBriefEngine(pool, people.NewStore(db)), now: now},
-		attentionCommitments{store: people.NewStore(db)},
+		// Commitments is deliberately UNBOUND: the lane's production writer —
+		// the extraction task that reads promises out of captured
+		// conversations — does not exist yet (issue #849), so no real
+		// installation can put a row behind it, and a lane fed only by demo
+		// seeds would show every real customer an empty promise list dressed
+		// as a feature. A nil binding renders the lane ABSENT (the contract's
+		// honest "this feed does not do commitments"), and rebinding is the
+		// one-line attentionCommitments{store: people.NewStore(db)} when #849
+		// lands. The seam type below stays, tested, ready for that day.
+		nil,
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
 		attentionDecay{pool: pool, store: people.NewStore(db), now: now},
 		attentionMeetings{store: activities.NewStore(db)},

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -407,7 +407,10 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, now attenti
 		// as a feature. A nil binding renders the lane ABSENT (the contract's
 		// honest "this feed does not do commitments"), and rebinding is the
 		// one-line attentionCommitments{store: people.NewStore(db)} when #849
-		// lands. The seam type below stays, tested, ready for that day.
+		// lands. The seam type stays compiled against the interface (the
+		// assertion beside it in attentionlanesseam.go), and the store read
+		// behind it keeps its own integration test — what is NOT tested is
+		// the seam wiring itself, because nothing wires it.
 		nil,
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
 		attentionDecay{pool: pool, store: people.NewStore(db), now: now},

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -105,6 +105,14 @@ func slippingCandidate(d crmcontracts.Deal, today time.Time) agents.SlippingDeal
 		LastActivityAt: d.LastActivityAt,
 		CreatedAt:      d.CreatedAt,
 	}
+	if d.StageId != nil {
+		stage := ids.UUID(*d.StageId)
+		candidate.StageID = &stage
+	}
+	if d.OwnerId != nil {
+		owner := ids.UUID(*d.OwnerId)
+		candidate.OwnerID = &owner
+	}
 	if d.ExpectedCloseDate != nil {
 		closeDate := d.ExpectedCloseDate.Time
 		candidate.ExpectedCloseDate = &closeDate

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1264,6 +1264,27 @@ func (e AttentionLanesOmitted) Valid() bool {
 	}
 }
 
+// Defines values for AttentionThisMorningState.
+const (
+	AllAnswered  AttentionThisMorningState = "all_answered"
+	ItemsWaiting AttentionThisMorningState = "items_waiting"
+	NoRunToday   AttentionThisMorningState = "no_run_today"
+)
+
+// Valid indicates whether the value is a known member of the AttentionThisMorningState enum.
+func (e AttentionThisMorningState) Valid() bool {
+	switch e {
+	case AllAnswered:
+		return true
+	case ItemsWaiting:
+		return true
+	case NoRunToday:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AttentionItemActions.
 const (
 	AttentionItemActionsAct      AttentionItemActions = "act"
@@ -13638,10 +13659,26 @@ type Attention struct {
 	// it is optional. Merging them would put "nothing is waiting on you" and
 	// "nothing was worth flagging" behind one number.
 	ThisMorning []AttentionItem `json:"this_morning"`
+
+	// ThisMorningState Why `this_morning` holds what it holds: the night produced no run for this
+	// reader; a run exists and every item is answered; or items are waiting (and
+	// the lane carries them). Named because the lane's emptiness is ambiguous on
+	// its own — "the night found nothing" and "you finished the morning" render
+	// identically as zero rows, and only one of them has earned a tick. Absent
+	// when the lane itself was withheld (`lanes_omitted` names it).
+	ThisMorningState *AttentionThisMorningState `json:"this_morning_state,omitempty"`
 }
 
 // AttentionLanesOmitted defines model for Attention.LanesOmitted.
 type AttentionLanesOmitted string
+
+// AttentionThisMorningState Why `this_morning` holds what it holds: the night produced no run for this
+// reader; a run exists and every item is answered; or items are waiting (and
+// the lane carries them). Named because the lane's emptiness is ambiguous on
+// its own — "the night found nothing" and "you finished the morning" render
+// identically as zero rows, and only one of them has earned a tick. Absent
+// when the lane itself was withheld (`lanes_omitted` names it).
+type AttentionThisMorningState string
 
 // AttentionCounts How many items each lane holds for THIS caller. `duplicates_open` is the dedupe
 // queue's own count under its both-sides-visible rule, kept separate because the
@@ -13668,6 +13705,20 @@ type AttentionCounts struct {
 	ThisMorning int `json:"this_morning"`
 }
 
+// AttentionDealFacts The deal behind a `deal_at_risk` item: the facts its card states, so a client
+// draws value and ownership without a second read per row. Sent only for
+// `source: deal_at_risk`. The stage travels as its id rather than a label — the
+// client already holds the pipelines vocabulary and writes the label in the
+// reader's own language; a label composed server-side would not be.
+type AttentionDealFacts struct {
+	AmountMinor *int64              `json:"amount_minor,omitempty"`
+	Currency    *string             `json:"currency,omitempty"`
+	OwnerId     *openapi_types.UUID `json:"owner_id,omitempty"`
+
+	// StageId The deal's current stage; null for an overlay-mirror deal, whose stage lives with the incumbent.
+	StageId *openapi_types.UUID `json:"stage_id,omitempty"`
+}
+
 // AttentionItem One thing waiting, in the words a reader recognises, with a typed reference back to
 // the record that owns it. The client routes a verb to that owner's endpoint — this
 // feed adds no decision authority of its own, exactly as the second approvals door
@@ -13686,6 +13737,13 @@ type AttentionItem struct {
 
 	// Confidence How sure the detector was, 0..1, where an item rests on a detection rather than a rule.
 	Confidence *float32 `json:"confidence,omitempty"`
+
+	// Deal The deal behind a `deal_at_risk` item: the facts its card states, so a client
+	// draws value and ownership without a second read per row. Sent only for
+	// `source: deal_at_risk`. The stage travels as its id rather than a label — the
+	// client already holds the pipelines vocabulary and writes the label in the
+	// reader's own language; a label composed server-side would not be.
+	Deal *AttentionDealFacts `json:"deal,omitempty"`
 
 	// Detail One supporting line: what changed, or what the evidence said.
 	Detail *string `json:"detail,omitempty"`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13661,8 +13661,10 @@ type Attention struct {
 	ThisMorning []AttentionItem `json:"this_morning"`
 
 	// ThisMorningState Why `this_morning` holds what it holds: the night produced no run for this
-	// reader; a run exists and every item is answered; or items are waiting (and
-	// the lane carries them). Named because the lane's emptiness is ambiguous on
+	// reader; a run exists and nothing in it still needs an answer (every item
+	// answered — or the run ranked nothing worth the morning, which is the same
+	// message to a reader); or items are waiting (and the lane carries them).
+	// Named because the lane's emptiness is ambiguous on
 	// its own — "the night found nothing" and "you finished the morning" render
 	// identically as zero rows, and only one of them has earned a tick. Absent
 	// when the lane itself was withheld (`lanes_omitted` names it).
@@ -13673,8 +13675,10 @@ type Attention struct {
 type AttentionLanesOmitted string
 
 // AttentionThisMorningState Why `this_morning` holds what it holds: the night produced no run for this
-// reader; a run exists and every item is answered; or items are waiting (and
-// the lane carries them). Named because the lane's emptiness is ambiguous on
+// reader; a run exists and nothing in it still needs an answer (every item
+// answered — or the run ranked nothing worth the morning, which is the same
+// message to a reader); or items are waiting (and the lane carries them).
+// Named because the lane's emptiness is ambiguous on
 // its own — "the night found nothing" and "you finished the morning" render
 // identically as zero rows, and only one of them has earned a tick. Absent
 // when the lane itself was withheld (`lanes_omitted` names it).

--- a/backend/internal/modules/agents/tools_slipping.go
+++ b/backend/internal/modules/agents/tools_slipping.go
@@ -30,10 +30,17 @@ import (
 // raw flags plus the fields that evidence them. The TOOL decides what is
 // presentable — a flag without its grounding field is dropped here.
 type SlippingDeal struct {
-	DealID            ids.UUID
-	Name              string
-	AmountMinor       *int64
-	Currency          *string
+	DealID      ids.UUID
+	Name        string
+	AmountMinor *int64
+	Currency    *string
+	// StageID and OwnerID ride the same row-scoped list read as the rest:
+	// the attention card states value, stage and ownership without a
+	// second read per deal, and nothing here widens what the list already
+	// showed the caller. Nil where the row carries none (an overlay-mirror
+	// deal has no native stage; a deal can be ownerless).
+	StageID           *ids.UUID
+	OwnerID           *ids.UUID
 	Stalled           bool
 	CloseOverdue      bool
 	LastActivityAt    *time.Time

--- a/backend/internal/modules/people/conversationclaim.go
+++ b/backend/internal/modules/people/conversationclaim.go
@@ -16,10 +16,15 @@ package people
 // can check against what was actually written is the thing the whole mechanism
 // exists to prevent.
 //
-// The extraction task that will call this is still to come (issue #849). Until
-// then the demo seed is its only caller, which is exactly why the seed goes
-// through THIS writer rather than SQL: a card filled by rows the real writer
-// never produces proves nothing about the real writer.
+// The extraction task that will call this is still to come (issue #849), and
+// the demo seed does not call it either — both arrive with #849. Until then
+// the HTTP endpoint below is the only door, and no product flow feeds it.
+// That is why the attention feed's commitments lane is unbound
+// (compose/attentionseam.go): a lane no production writer can fill would show
+// every real customer an empty promise list dressed as a feature, and
+// rebinding it is a one-line change when #849 ships. The endpoint stays: it
+// is the correction surface extracted claims will need, and it is how a test
+// seeds through the real writer rather than SQL.
 
 import (
 	"context"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22615,8 +22615,10 @@ export interface components {
             this_morning: components["schemas"]["AttentionItem"][];
             /**
              * @description Why `this_morning` holds what it holds: the night produced no run for this
-             *     reader; a run exists and every item is answered; or items are waiting (and
-             *     the lane carries them). Named because the lane's emptiness is ambiguous on
+             *     reader; a run exists and nothing in it still needs an answer (every item
+             *     answered — or the run ranked nothing worth the morning, which is the same
+             *     message to a reader); or items are waiting (and the lane carries them).
+             *     Named because the lane's emptiness is ambiguous on
              *     its own — "the night found nothing" and "you finished the morning" render
              *     identically as zero rows, and only one of them has earned a tick. Absent
              *     when the lane itself was withheld (`lanes_omitted` names it).

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22613,6 +22613,16 @@ export interface components {
              *     "nothing was worth flagging" behind one number.
              */
             this_morning: components["schemas"]["AttentionItem"][];
+            /**
+             * @description Why `this_morning` holds what it holds: the night produced no run for this
+             *     reader; a run exists and every item is answered; or items are waiting (and
+             *     the lane carries them). Named because the lane's emptiness is ambiguous on
+             *     its own — "the night found nothing" and "you finished the morning" render
+             *     identically as zero rows, and only one of them has earned a tick. Absent
+             *     when the lane itself was withheld (`lanes_omitted` names it).
+             * @enum {string}
+             */
+            this_morning_state?: "no_run_today" | "all_answered" | "items_waiting";
             /** @description Decisions only a person can make, highest-stakes first. */
             needs_you: components["schemas"]["AttentionItem"][];
             /** @description Work already agreed: overdue first, then due today. */
@@ -22729,6 +22739,7 @@ export interface components {
             confidence?: number;
             subject?: components["schemas"]["AttentionSubject"];
             pair?: components["schemas"]["AttentionPair"];
+            deal?: components["schemas"]["AttentionDealFacts"];
             /**
              * Format: date-time
              * @description When this is due (tasks), or when it lapses (approvals).
@@ -22774,6 +22785,25 @@ export interface components {
              *     database rather than their own records.
              */
             evidence: components["schemas"]["AttentionPairEvidence"][];
+        };
+        /**
+         * @description The deal behind a `deal_at_risk` item: the facts its card states, so a client
+         *     draws value and ownership without a second read per row. Sent only for
+         *     `source: deal_at_risk`. The stage travels as its id rather than a label — the
+         *     client already holds the pipelines vocabulary and writes the label in the
+         *     reader's own language; a label composed server-side would not be.
+         */
+        AttentionDealFacts: {
+            /**
+             * Format: uuid
+             * @description The deal's current stage; null for an overlay-mirror deal, whose stage lives with the incumbent.
+             */
+            stage_id?: string | null;
+            /** Format: int64 */
+            amount_minor?: number | null;
+            currency?: string | null;
+            /** Format: uuid */
+            owner_id?: string | null;
         };
         /** @description One field the detector compared across the two records. */
         AttentionPairEvidence: {


### PR DESCRIPTION
Three optional, additive contract changes the Worklist redesign consumes (plan problems E, F2 and G), sequenced behind #3039.

## this_morning_state

`no_run_today | all_answered | items_waiting`. An empty morning lane was ambiguous — "the night produced nothing" and "you finished everything" rendered identically, and only one deserves a tick. The Briefing seam now answers whether a run exists at all (`attentionseam.go`; a found run with zero unanswered entries counts as ran, and a run that ranked nothing reads `all_answered` — same message to a reader), and the feed maps the three answers onto the enum.

## AttentionDealFacts on deal_at_risk items

`stage_id`, `amount_minor`, `currency`, `owner_id` — enough to draw the card without a second read per row. The stage travels as its id: the client holds the pipelines vocabulary and writes the label in the reader's language. The facts ride the same row-scoped `ListDeals` read as the candidate itself (`agents.SlippingDeal` grows StageID/OwnerID), so nothing widens what the caller could already see. A deal with no facts sends no facts object. Meetings deliberately still send no `open` — their subject is the activity, which has no page; the open-verb gate from #3039 holds that.

## Commitments lane unbound

The lane's production writer (the claim-extraction task, issue #849) does not exist, and the demo seed never calls the claim writer — which the claim store's header wrongly said it did and now states correctly. A nil binding renders the lane ABSENT (the contract's honest "this feed does not do commitments"); a test holds that `lanes_omitted` never names it, since absent is not withheld. Rebinding is one line when #849 lands; the seam type stays compiled and integration-tested.

## Testing

`make check-backend` and `make check-fe` green in full; craft static clean. New specs: three-state morning mapping, facts presence/absence on the risk card, unbound-lane absence; the briefing-lane integration suite extended for the ran flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three optional, additive contract fields the Worklist redesign needs: the morning lane states why it holds zero rows, at-risk cards carry the deal's own facts, and the commitments lane is now absent instead of shown empty.

**New Features**
- `this_morning_state` now distinguishes `no_run_today` from `all_answered`, which previously rendered identically as an empty lane; the briefing seam's ran flag is asserted in the integration suite in both directions.
- `deal_at_risk` items gain `AttentionDealFacts` (stage id, amount, currency, owner id) so clients skip a second read per row; a deal with no facts sends no facts object.
- The commitments lane is unbound until issue #849 ships, so it renders as ABSENT and `lanes_omitted` never names it; a compile-time interface assertion keeps the seam compiled, and rebinding is a one-line change.
- The stage travels as its id, not a label, since the client already holds the pipelines vocabulary.

<sup>Written for commit 37203a30a1150228052da507c6885245d6093614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Morning briefings now indicate whether no briefing ran, all items were answered, or items remain pending.
  * At-risk deal attention items may include stage, amount, currency, and owner details.
* **Bug Fixes**
  * Empty completed briefings are now distinguished from days without a briefing.
  * Unavailable commitment items are no longer displayed as empty lanes.
* **Documentation**
  * Clarified current claim-writing behavior and commitment-lane availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->