### PR TITLE
feat(attention): a decision whose work failed comes back to its decider (#2966)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27884,6 +27884,18 @@ components:
         approval_token: { type: [string, 'null'], description: 'Signed single-use token minted on approve (schema ApprovalToken, serialized as compact JWS); authorizes exactly the downstream 🟡 operation it is bound to.' }
         decided_by: { type: [string, 'null'], format: uuid }
         decided_at: { type: [string, 'null'], format: date-time }
+        effect_failed_at:
+          type: [string, 'null']
+          format: date-time
+          description: |
+            When the work an APPROVED decision released failed to run. Absent on every
+            row whose effect ran — an approved row carrying this is a decision a person
+            made whose promised work never happened.
+        effect_failure:
+          type: [string, 'null']
+          description: |
+            The sentence a reader is shown about that failure — written for them, never
+            copied from the executor's error. Present exactly when `effect_failed_at` is.
         created_at: { type: string, format: date-time }
 
     ApproveRequest:
@@ -30132,9 +30144,25 @@ components:
           type: array
           items: { $ref: '#/components/schemas/AttentionItem' }
           description: "What the system did on its own, most recent first. Receipts, not questions."
+        did_not_run:
+          type: array
+          items: { $ref: '#/components/schemas/AttentionItem' }
+          description: |
+            Decisions THIS reader approved whose released work then failed, reading
+            the queue newest-staged first. The row is not pending (it was decided) and not a receipt
+            (a person decided it), so no other lane can carry it; without this one the
+            person who pressed Accept is the last to learn nothing happened.
+
+            Each card carries the server's own sentence about what did not run, and
+            `open` when the decision named a record. Re-driving the failed work is a
+            separate decision the product has not made yet; this lane only ends the
+            silence.
+
+            Absent — not empty — on an installation whose feed does not read approvals'
+            failure marks.
         lanes_omitted:
           type: array
-          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk, meetings, relationship_decay] }
+          items: { type: string, enum: [this_morning, needs_you, planned, done_for_you, commitments, at_risk, meetings, relationship_decay, did_not_run] }
           description: "Lanes withheld because the caller may not read what they contain. Never returned empty instead."
         counts: { $ref: '#/components/schemas/AttentionCounts' }
 
@@ -30176,6 +30204,12 @@ components:
             How many lapsed relationships this lane is CARRYING — the bounded page, as the
             other lanes report. A rep past the bound sees the longest silences, which is the
             order the lane is in.
+        did_not_run:
+          type: integer
+          minimum: 0
+          description: >-
+            How many failed decisions this lane is CARRYING — the bounded page, as the
+            other lanes report.
 
 
     AttentionItem:
@@ -30190,7 +30224,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting, relationship_decay]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting, relationship_decay, failed_approval]
           description: "Which producer raised it, and therefore which endpoint its verbs go to."
         kind: { type: string, description: 'The producer''s own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority.' }
         title:

--- a/backend/internal/compose/attention/failedlane_test.go
+++ b/backend/internal/compose/attention/failedlane_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The did_not_run lane: a decision this reader approved whose released work
+// then failed comes back to them, with the recorded sentence and — when the
+// decision named a record — a way to open it.
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+type stubFailedEffects struct {
+	rows []FailedEffect
+	err  error
+}
+
+func (s *stubFailedEffects) Failed(context.Context, int) ([]FailedEffect, error) {
+	return s.rows, s.err
+}
+
+func failedLaneService(failed FailedEffects) *Service {
+	return NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{}, nil, nil, nil, nil, failed, fixedClock)
+}
+
+func TestAFailedDecisionComesBackToItsDecider(t *testing.T) {
+	person := ids.NewV7()
+	svc := failedLaneService(&stubFailedEffects{rows: []FailedEffect{{
+		ID: ids.NewV7(), Kind: "send_email",
+		Sentence:   "this was approved, but the work it released did not run",
+		FailedAt:   readInstant,
+		TargetType: "person", TargetID: person,
+	}, {
+		ID: ids.NewV7(), Kind: "quota_release",
+		Sentence: "the agent's window could not be widened, so the approval has not taken effect",
+		FailedAt: readInstant,
+	}}})
+
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if out.DidNotRun == nil {
+		t.Fatal("the lane is absent although the feed reads failure marks")
+	}
+	items := *out.DidNotRun
+	if len(items) != 2 || out.Counts.DidNotRun == nil || *out.Counts.DidNotRun != 2 {
+		t.Fatalf("lane carries %d items (count %v), want 2 and 2", len(items), out.Counts.DidNotRun)
+	}
+	targeted := items[0]
+	if targeted.Title == nil || *targeted.Title != "this was approved, but the work it released did not run" {
+		t.Errorf("the card's title = %v, want the recorded sentence", targeted.Title)
+	}
+	if targeted.Subject == nil || targeted.Subject.Type != "person" || !slices.Contains(targeted.Actions, "open") {
+		t.Errorf("a failure about a named record must offer open on it: %+v", targeted)
+	}
+	// The second decision named no record, so the card points nowhere rather
+	// than guessing — and must not claim it can.
+	untargeted := items[1]
+	if untargeted.Subject != nil || slices.Contains(untargeted.Actions, "open") {
+		t.Errorf("a failure naming no record offered navigation: %+v", untargeted)
+	}
+}
+
+// Absent versus withheld versus empty are three different answers, and each
+// must survive as itself: no reader wired means no lane on the wire, a
+// refusal names the lane, and a clear lane is an empty list.
+func TestTheFailedLaneKeepsAbsentWithheldAndEmptyApart(t *testing.T) {
+	unwired, err := failedLaneService(nil).Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling without the reader: %v", err)
+	}
+	if unwired.DidNotRun != nil || unwired.Counts.DidNotRun != nil {
+		t.Error("an installation that reads no failure marks still sent the lane")
+	}
+
+	refused, err := failedLaneService(&stubFailedEffects{err: apperrors.ErrPermissionDenied}).Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling with a refused read: %v", err)
+	}
+	if refused.LanesOmitted == nil || !slices.Contains(*refused.LanesOmitted, crmcontracts.AttentionLanesOmitted("did_not_run")) {
+		t.Errorf("a refused lane is not named in lanes_omitted: %v", refused.LanesOmitted)
+	}
+
+	clearDay, err := failedLaneService(&stubFailedEffects{}).Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling a clear lane: %v", err)
+	}
+	if clearDay.DidNotRun == nil || len(*clearDay.DidNotRun) != 0 {
+		t.Errorf("a clear lane should be an empty list, got %v", clearDay.DidNotRun)
+	}
+}

--- a/backend/internal/compose/attention/failedlane_test.go
+++ b/backend/internal/compose/attention/failedlane_test.go
@@ -71,6 +71,27 @@ func TestAFailedDecisionComesBackToItsDecider(t *testing.T) {
 	}
 }
 
+// An activity is a timeline entry with no page of its own: the card may name
+// it, but offering `open` on it would be a link the client cannot route.
+func TestAFailureAboutATimelineEntryNamesItWithoutOfferingOpen(t *testing.T) {
+	svc := failedLaneService(&stubFailedEffects{rows: []FailedEffect{{
+		ID: ids.NewV7(), Kind: "send_email",
+		Sentence: "this was approved, but the work it released did not run",
+		FailedAt: readInstant, TargetType: "activity", TargetID: ids.NewV7(),
+	}}})
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	item := (*out.DidNotRun)[0]
+	if item.Subject == nil || item.Subject.Type != "activity" {
+		t.Fatalf("the card lost its subject: %+v", item)
+	}
+	if slices.Contains(item.Actions, "open") {
+		t.Error("open was offered on a timeline entry no screen answers to")
+	}
+}
+
 // Absent versus withheld versus empty are three different answers, and each
 // must survive as itself: no reader wired means no lane on the wire, a
 // refusal names the lane, and a clear lane is an empty list.

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -54,17 +54,18 @@ type Service struct {
 	// an installation can warn about deals without deriving relationships.
 	decay    Decay
 	meetings Meetings
+	failed   FailedEffects
 	now      Clock
 }
 
 // NewService binds the feed to its readers.
 func NewService(
 	a Approvals, d Duplicates, t Tasks, r Receipts, b Briefing,
-	c Commitments, k AtRisk, q Decay, m Meetings, now Clock,
+	c Commitments, k AtRisk, q Decay, m Meetings, f FailedEffects, now Clock,
 ) *Service {
 	return &Service{
 		approvals: a, duplicates: d, tasks: t, receipts: r,
-		briefing: b, commitments: c, atRisk: k, decay: q, meetings: m, now: now,
+		briefing: b, commitments: c, atRisk: k, decay: q, meetings: m, failed: f, now: now,
 	}
 }
 

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -120,7 +120,7 @@ func TestADuplicateOutranksAnApprovalBecauseAMergeCannotBeUndone(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: []crmcontracts.Approval{approval("Send the Weber follow-up")}},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "person", Confidence: 0.9}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -138,7 +138,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 		stubApprovals{},
 		stubDuplicates{err: apperrors.ErrPermissionDenied},
 		&stubTasks{rows: []Task{{ID: ids.NewV7(), Subject: "Call Anna"}}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a refused lane must not fail the read: %v", err)
@@ -160,7 +160,7 @@ func TestAWithheldLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestABrokenLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{err: fmt.Errorf("the database is unreachable")},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a lane that FAILED was reported as an empty day")
 	}
@@ -174,7 +174,7 @@ func TestTheCountReportsTheTotalThoughTheLaneIsBounded(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: pairs, open: 40},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -197,7 +197,7 @@ func TestTheCountCoversStagedProposalsToo(t *testing.T) {
 	}
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 20},
-		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -216,7 +216,7 @@ func TestAnOverdueTaskLeadsThePlannedLane(t *testing.T) {
 			{ID: ids.NewV7(), Subject: "Due later today", DueAt: &later},
 			{ID: ids.NewV7(), Subject: "Was due yesterday", DueAt: &yesterday},
 		}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -247,7 +247,7 @@ func TestATaskCarriesTheRecordItWasRaisedFor(t *testing.T) {
 			ID: ids.NewV7(), Subject: "Follow up with the new lead", DueAt: &due,
 			LinkType: "lead", LinkID: lead,
 		}}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -274,7 +274,7 @@ func TestATaskUnderNoRecordCarriesNoSubject(t *testing.T) {
 		&stubTasks{rows: []Task{{
 			ID: ids.NewV7(), Subject: "Call the accountant", DueAt: &due,
 		}}},
-		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -291,7 +291,7 @@ func TestAReceiptOffersNoDecision(t *testing.T) {
 			ID: ids.NewV7(), Kind: "close_date_correction",
 			Summary: "Moved the Acme close date to 27 Sep", OccurredAt: readInstant.Add(-time.Hour),
 		}}},
-		stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -310,7 +310,7 @@ func TestADuplicateCarriesNoServerWrittenSentence(t *testing.T) {
 	svc := NewService(
 		stubApprovals{},
 		stubDuplicates{pairs: []DuplicatePair{{ID: ids.NewV7(), EntityType: "organization", Confidence: 0.92}}, open: 1},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -346,7 +346,7 @@ func TestAFloodOfDuplicatesDoesNotBuryTheStagedDecisions(t *testing.T) {
 	svc := NewService(
 		stubApprovals{rows: staged, pending: 79},
 		stubDuplicates{pairs: pairs, open: len(pairs)},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -374,7 +374,7 @@ func TestADuplicateCardNamesBothRecords(t *testing.T) {
 			LeftID: left, RightID: right,
 			Evidence: []FieldComparison{{Field: "display_name", Signal: "collide"}},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -399,7 +399,7 @@ func TestAnUnreadableSideCostsTheMergeVerbRatherThanLeakingTheRecord(t *testing.
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: hidden,
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("a record this reader may not see must not fail the whole day: %v", err)
@@ -430,7 +430,7 @@ func TestEvidenceNeverReachesAReaderAsAColumnName(t *testing.T) {
 				{Field: "org", Signal: "collide"},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -455,7 +455,7 @@ func TestARecordReadThatBrokeIsNotReportedAsWithheld(t *testing.T) {
 			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
 			LeftID: ids.NewV7(), RightID: ids.NewV7(),
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a record read that FAILED was rendered as a pair the reader may not see")
 	}
@@ -476,7 +476,7 @@ func TestAnIdentityConflictKeepsTheOneRowThatExplainsIt(t *testing.T) {
 				{Field: "matched_lane", Signal: "exact_conflict", Left: &lane},
 			},
 		}}},
-		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -495,7 +495,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
 		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: deal, Rank: 1}}}, nil, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -528,7 +528,7 @@ func TestTheBriefingLaneIsItsOwnAndNotADecision(t *testing.T) {
 func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{}, nil, nil, nil, nil, fixedClock)
+		stubBriefing{}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -549,7 +549,7 @@ func TestAMorningWithNoRunIsEmptyRatherThanWithheld(t *testing.T) {
 func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, nil, nil, fixedClock)
+		stubBriefing{err: apperrors.ErrPermissionDenied}, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -565,7 +565,7 @@ func TestABriefingLaneRefusedIsNamedRatherThanReportedQuiet(t *testing.T) {
 func TestABrokenBriefingLaneFailsTheReadRatherThanReadingAsQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
-		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, nil, nil, fixedClock)
+		stubBriefing{err: errors.New("the brief read fell over")}, nil, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a broken briefing read was reported as a quiet morning")
 	}
@@ -575,7 +575,7 @@ func TestABriefingItemOffersItsOwnThreeVerbs(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
 		stubBriefing{rows: []BriefEntry{{ID: ids.NewV7(), DealID: ids.NewV7(), Rank: 1}}}, nil, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -615,7 +615,7 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 	decay := &stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		commitments, stubAtRisk{}, decay, meetings, fixedClock,
+		commitments, stubAtRisk{}, decay, meetings, nil, fixedClock,
 	)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -637,7 +637,7 @@ func TestEveryLaneIsReadOncePerFeed(t *testing.T) {
 func TestAWithheldLaneAppearsInLanesOmittedExactlyOneTime(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, nil, fixedClock,
+		&stubCommitments{err: apperrors.ErrPermissionDenied}, stubAtRisk{}, nil, nil, nil, fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -122,7 +122,8 @@ type Receipt struct {
 }
 
 // FailedEffects reads the decisions the acting rep approved whose released
-// work then failed — newest failure first, bounded.
+// work then failed — bounded, newest-staged first (the approvals queue's own
+// order; a failure on an old staging sorts beneath newer rows).
 type FailedEffects interface {
 	Failed(ctx context.Context, limit int) ([]FailedEffect, error)
 }

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -121,6 +121,26 @@ type Receipt struct {
 	TargetID   ids.UUID
 }
 
+// FailedEffects reads the decisions the acting rep approved whose released
+// work then failed — newest failure first, bounded.
+type FailedEffects interface {
+	Failed(ctx context.Context, limit int) ([]FailedEffect, error)
+}
+
+// FailedEffect is one approved decision whose promised work never happened.
+type FailedEffect struct {
+	ID   ids.UUID
+	Kind string
+	// Sentence is the server's own line about what did not run, written for
+	// the reader when the failure was recorded.
+	Sentence string
+	FailedAt time.Time
+	// The record the decision was about; empty TargetType when it named none,
+	// and the card offers `open` only when it did.
+	TargetType string
+	TargetID   ids.UUID
+}
+
 // Briefing is the overnight brief's queue for the acting rep, best-ranked
 // first.
 //

--- a/backend/internal/compose/attention/lanewiring_test.go
+++ b/backend/internal/compose/attention/lanewiring_test.go
@@ -23,6 +23,11 @@ func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
 		&stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}},
 		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
+		&stubFailedEffects{rows: []FailedEffect{{
+			ID: ids.NewV7(), Kind: "send_email",
+			Sentence: "this was approved, but the work it released did not run",
+			FailedAt: readInstant, TargetType: "person", TargetID: ids.NewV7(),
+		}}},
 		fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
@@ -73,6 +78,11 @@ func TestNoOptionalLaneOffersAnActionTheSurfaceCannotPerform(t *testing.T) {
 		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
 		&stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}},
 		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
+		&stubFailedEffects{rows: []FailedEffect{{
+			ID: ids.NewV7(), Kind: "send_email",
+			Sentence: "this was approved, but the work it released did not run",
+			FailedAt: readInstant, TargetType: "person", TargetID: ids.NewV7(),
+		}}},
 		fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
@@ -125,6 +135,11 @@ func TestOpenIsOfferedOnlyWithARecordToOpen(t *testing.T) {
 		stubAtRisk{rows: []RiskyDeal{{Name: "a deal", QuietDays: 20}}},
 		&stubDecay{rows: []QuietRelationship{{Name: "a contact", QuietDays: 63, LastAt: readInstant}}},
 		&stubMeetings{rows: []Meeting{{Subject: "a meeting", StartsAt: readInstant}}},
+		&stubFailedEffects{rows: []FailedEffect{{
+			ID: ids.NewV7(), Kind: "send_email",
+			Sentence: "this was approved, but the work it released did not run",
+			FailedAt: readInstant, TargetType: "person", TargetID: ids.NewV7(),
+		}}},
 		fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
@@ -139,6 +154,7 @@ func TestOpenIsOfferedOnlyWithARecordToOpen(t *testing.T) {
 		"meetings": out.Meetings, "at_risk": out.AtRisk,
 		"commitments": out.Commitments, "planned": &out.Planned,
 		"relationship_decay": out.RelationshipDecay,
+		"did_not_run":        out.DidNotRun,
 		"needs_you":          &out.NeedsYou,
 		"done_for_you":       &out.DoneForYou,
 	}

--- a/backend/internal/compose/attention/morningstate_test.go
+++ b/backend/internal/compose/attention/morningstate_test.go
@@ -20,7 +20,7 @@ import (
 func assembleMorning(t *testing.T, briefing stubBriefing) crmcontracts.Attention {
 	t.Helper()
 	svc := NewService(stubApprovals{}, stubDuplicates{}, &stubTasks{},
-		stubReceipts{}, briefing, nil, nil, nil, nil, fixedClock)
+		stubReceipts{}, briefing, nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -68,7 +68,7 @@ func TestARiskCardCarriesTheDealsFacts(t *testing.T) {
 		stubAtRisk{rows: []RiskyDeal{{
 			DealID: ids.NewV7(), Name: "Fleet retrofit", QuietDays: 19,
 			StageID: &stage, OwnerID: &owner, AmountMinor: &amount, Currency: &currency,
-		}}}, nil, nil,
+		}}}, nil, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -101,7 +101,7 @@ func TestARiskCardWithNoFactsSendsNoFactsObject(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
 		stubAtRisk{rows: []RiskyDeal{{DealID: ids.NewV7(), Name: "Bare deal", QuietDays: 5}}},
-		nil, nil,
+		nil, nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {

--- a/backend/internal/compose/attention/optionallanes.go
+++ b/backend/internal/compose/attention/optionallanes.go
@@ -95,6 +95,14 @@ func (s *Service) optionalLanes(
 			into: &out.Commitments, count: &out.Counts.Commitments,
 		},
 		{
+			name: "did_not_run", bound: s.failed != nil,
+			read: func() ([]crmcontracts.AttentionItem, error) {
+				undone, err := s.failed.Failed(ctx, doneCap)
+				return renderEach(undone, failedItem), err
+			},
+			into: &out.DidNotRun, count: &out.Counts.DidNotRun,
+		},
+		{
 			name: "relationship_decay", bound: s.decay != nil,
 			read: func() ([]crmcontracts.AttentionItem, error) {
 				lapsed, err := s.decay.Lapsed(ctx)

--- a/backend/internal/compose/attention/optionallanes_test.go
+++ b/backend/internal/compose/attention/optionallanes_test.go
@@ -63,7 +63,7 @@ func TestACommitmentCarriesThePromiseAndTheWordsItWasReadFrom(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{rows: []Commitment{promise("Referenzliste an Herrn Vogt schicken", due)}}, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -104,7 +104,7 @@ func TestAnOverduePromiseSaysSoRatherThanLeavingTheReaderToCompareDates(t *testi
 			promise("Angebot nachfassen", readInstant.Add(-48*time.Hour)),
 			promise("Termin bestätigen", readInstant.Add(3*time.Hour)),
 		}}, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -130,7 +130,7 @@ func TestBothDueDatedLanesStopAtTheSameEndOfDay(t *testing.T) {
 	tasks := &stubTasks{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
-		commitments, nil, nil, nil, fixedClock)
+		commitments, nil, nil, nil, nil, fixedClock)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{err: apperrors.ErrPermissionDenied}, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -179,7 +179,7 @@ func TestAWithheldCommitmentLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoClaimReaderSendsNoCommitmentLaneAtAll(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, nil, nil, nil, fixedClock)
+		nil, nil, nil, nil, nil, fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -198,7 +198,7 @@ func TestABrokenCommitmentReadFailsTheFeedRatherThanReadingAsAClearDay(t *testin
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
 		&stubCommitments{err: errors.New("the claim read fell over")}, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	if _, err := svc.Assemble(context.Background()); err == nil {
 		t.Fatal("a failed commitment read assembled a day, want the error surfaced")
@@ -246,7 +246,7 @@ func TestTheMeetingLaneAsksFromNowRatherThanFromTheStartOfTheDay(t *testing.T) {
 	meetings := &stubMeetings{}
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
-		nil, nil, nil, meetings, fixedClock,
+		nil, nil, nil, meetings, nil, fixedClock,
 	)
 	if _, err := svc.Assemble(context.Background()); err != nil {
 		t.Fatalf("assembling: %v", err)
@@ -265,7 +265,7 @@ func TestAMeetingCarriesItsSubjectAndWhenItStarts(t *testing.T) {
 	starts := readInstant.Add(90 * time.Minute)
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
-		&stubMeetings{rows: []Meeting{{ID: ids.NewV7(), Subject: "Vogt — Angebotsbesprechung", StartsAt: starts}}},
+		&stubMeetings{rows: []Meeting{{ID: ids.NewV7(), Subject: "Vogt — Angebotsbesprechung", StartsAt: starts}}}, nil,
 		fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
@@ -296,7 +296,7 @@ func TestAMeetingCarriesItsSubjectAndWhenItStarts(t *testing.T) {
 func TestAWithheldMeetingLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
-		&stubMeetings{err: apperrors.ErrPermissionDenied}, fixedClock,
+		&stubMeetings{err: apperrors.ErrPermissionDenied}, nil, fixedClock,
 	)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {

--- a/backend/internal/compose/attention/quietlanes_test.go
+++ b/backend/internal/compose/attention/quietlanes_test.go
@@ -41,7 +41,7 @@ func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
 		stubAtRisk{rows: []RiskyDeal{{DealID: deal, Name: "Fleet retrofit", QuietDays: 19}}}, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -79,7 +79,7 @@ func TestADealPastItsCloseDateReportsThatGroundRatherThanSilence(t *testing.T) {
 			DealID: ids.NewV7(), Name: "Closing last month",
 			QuietDays: 2, CloseOverdue: true, ExpectedCloseDate: &closed,
 		}}}, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -104,7 +104,7 @@ func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil,
 		stubAtRisk{err: apperrors.ErrPermissionDenied}, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -129,7 +129,7 @@ func TestAWithheldRiskLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoRiskReaderSendsNoRiskLane(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -155,7 +155,7 @@ func TestALapsedRelationshipCarriesItsSpanAndItsLastExchange(t *testing.T) {
 		&stubDecay{rows: []QuietRelationship{
 			{PersonID: person, Name: "Dana Weiss", QuietDays: 63, LastAt: spoke},
 		}},
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -198,7 +198,7 @@ func TestAWithheldDecayLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil,
 		&stubDecay{err: apperrors.ErrPermissionDenied},
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
@@ -223,7 +223,7 @@ func TestAWithheldDecayLaneIsNamedRatherThanReportedEmpty(t *testing.T) {
 func TestAFeedWithNoDecayReaderSendsNoDecayLane(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil,
-		nil,
+		nil, nil,
 		fixedClock)
 	out, err := svc.Assemble(context.Background())
 	if err != nil {

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -419,6 +419,30 @@ func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
 	return facts
 }
 
+// failedItem is one approved decision whose released work did not run,
+// carried back to the person who approved it. The sentence was written for
+// the reader when the failure was recorded; `open` is offered only when the
+// decision named a record the client can route to.
+func failedItem(failed FailedEffect) crmcontracts.AttentionItem {
+	kind := failed.Kind
+	sentence := failed.Sentence
+	occurred := failed.FailedAt
+	subject := subjectOf(failed.TargetType, failed.TargetID)
+	actions := []crmcontracts.AttentionItemActions{}
+	if subject != nil {
+		actions = append(actions, actionOpen)
+	}
+	return crmcontracts.AttentionItem{
+		Id:         failed.ID.String(),
+		Source:     crmcontracts.AttentionItemSource("failed_approval"),
+		Kind:       &kind,
+		Title:      &sentence,
+		Subject:    subject,
+		OccurredAt: &occurred,
+		Actions:    actions,
+	}
+}
+
 // subjectOf names the record an item concerns, when the producer named one.
 //
 // The label is deliberately absent here: resolving a display name is a read of

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -384,7 +384,7 @@ func receiptItem(receipt Receipt) crmcontracts.AttentionItem {
 	summary := receipt.Summary
 	subject := subjectOf(receipt.TargetType, receipt.TargetID)
 	actions := []crmcontracts.AttentionItemActions{}
-	if subject != nil {
+	if openableSubject(subject) {
 		actions = append(actions, actionOpen)
 	}
 	return crmcontracts.AttentionItem{
@@ -429,7 +429,7 @@ func failedItem(failed FailedEffect) crmcontracts.AttentionItem {
 	occurred := failed.FailedAt
 	subject := subjectOf(failed.TargetType, failed.TargetID)
 	actions := []crmcontracts.AttentionItemActions{}
-	if subject != nil {
+	if openableSubject(subject) {
 		actions = append(actions, actionOpen)
 	}
 	return crmcontracts.AttentionItem{
@@ -468,4 +468,19 @@ var subjectKinds = map[string]crmcontracts.AttentionSubjectType{
 	"lead":         "lead",
 	"activity":     "activity",
 	"project":      "project",
+}
+
+// openableSubject reports whether a subject names a record with a page of its
+// own — the only kind `open` may be offered on. An activity is a timeline
+// entry: naming it on the card is honest, promising navigation to it is not,
+// and the client's router answers exactly this set.
+func openableSubject(subject *crmcontracts.AttentionSubject) bool {
+	if subject == nil {
+		return false
+	}
+	switch subject.Type {
+	case "organization", "person", "deal", "lead", "project":
+		return true
+	}
+	return false
 }

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -336,6 +336,41 @@ func receiptsWithin(rows []crmcontracts.Approval, since time.Time) []attention.R
 	return out
 }
 
+// attentionFailedEffects reads the decisions this rep approved whose released
+// work then failed — the mark decide.go leaves on the approved row. The
+// service binds the acting user itself (FailedForDecider), so this lane can
+// only ever carry the reader's own decisions back to them.
+type attentionFailedEffects struct{ svc *approvals.Service }
+
+func (f attentionFailedEffects) Failed(ctx context.Context, limit int) ([]attention.FailedEffect, error) {
+	rows, _, err := f.svc.ListWire(ctx, approvals.ListInput{FailedForDecider: true, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]attention.FailedEffect, 0, len(rows))
+	for _, row := range rows {
+		if row.EffectFailedAt == nil || row.EffectFailure == nil {
+			// The SQL filter guarantees the pair; the re-check is what makes
+			// the derefs safe in this package, where that SQL is elsewhere.
+			continue
+		}
+		failed := attention.FailedEffect{
+			ID:       ids.UUID(row.Id),
+			Kind:     row.Kind,
+			Sentence: *row.EffectFailure,
+			FailedAt: *row.EffectFailedAt,
+		}
+		// Both or neither: a type with no id names nothing, and an id with no
+		// type says where to look without saying at what.
+		if row.TargetEntityType != nil && row.TargetEntityId != nil {
+			failed.TargetType = *row.TargetEntityType
+			failed.TargetID = ids.UUID(*row.TargetEntityId)
+		}
+		out = append(out, failed)
+	}
+	return out, nil
+}
+
 // attentionBriefing binds the briefing lane to the same engine entry point Home
 // and the agent tool read, so all three read one queue rather than three
 // readings of it.
@@ -415,6 +450,7 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, now attenti
 		attentionAtRisk{lister: quietDealLister(pool, deals.QuietThresholdDays)},
 		attentionDecay{pool: pool, store: people.NewStore(db), now: now},
 		attentionMeetings{store: activities.NewStore(db)},
+		attentionFailedEffects{svc: svc},
 		now,
 	)
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1232,6 +1232,7 @@ func (e AttachmentReadStartedStatus) Valid() bool {
 const (
 	AttentionLanesOmittedAtRisk            AttentionLanesOmitted = "at_risk"
 	AttentionLanesOmittedCommitments       AttentionLanesOmitted = "commitments"
+	AttentionLanesOmittedDidNotRun         AttentionLanesOmitted = "did_not_run"
 	AttentionLanesOmittedDoneForYou        AttentionLanesOmitted = "done_for_you"
 	AttentionLanesOmittedMeetings          AttentionLanesOmitted = "meetings"
 	AttentionLanesOmittedNeedsYou          AttentionLanesOmitted = "needs_you"
@@ -1246,6 +1247,8 @@ func (e AttentionLanesOmitted) Valid() bool {
 	case AttentionLanesOmittedAtRisk:
 		return true
 	case AttentionLanesOmittedCommitments:
+		return true
+	case AttentionLanesOmittedDidNotRun:
 		return true
 	case AttentionLanesOmittedDoneForYou:
 		return true
@@ -1328,6 +1331,7 @@ const (
 	AttentionItemSourceConversationClaim AttentionItemSource = "conversation_claim"
 	AttentionItemSourceDealAtRisk        AttentionItemSource = "deal_at_risk"
 	AttentionItemSourceDedupeCandidate   AttentionItemSource = "dedupe_candidate"
+	AttentionItemSourceFailedApproval    AttentionItemSource = "failed_approval"
 	AttentionItemSourceMeeting           AttentionItemSource = "meeting"
 	AttentionItemSourceRelationshipDecay AttentionItemSource = "relationship_decay"
 	AttentionItemSourceTask              AttentionItemSource = "task"
@@ -1345,6 +1349,8 @@ func (e AttentionItemSource) Valid() bool {
 	case AttentionItemSourceDealAtRisk:
 		return true
 	case AttentionItemSourceDedupeCandidate:
+		return true
+	case AttentionItemSourceFailedApproval:
 		return true
 	case AttentionItemSourceMeeting:
 		return true
@@ -13302,6 +13308,15 @@ type Approval struct {
 	// DiffHash Hash of the staged proposed_change; the minted approval_token is bound to this hash so a token cannot authorize a different effect.
 	DiffHash *string `json:"diff_hash,omitempty"`
 
+	// EffectFailedAt When the work an APPROVED decision released failed to run. Absent on every
+	// row whose effect ran — an approved row carrying this is a decision a person
+	// made whose promised work never happened.
+	EffectFailedAt *time.Time `json:"effect_failed_at,omitempty"`
+
+	// EffectFailure The sentence a reader is shown about that failure — written for them, never
+	// copied from the executor's error. Present exactly when `effect_failed_at` is.
+	EffectFailure *string `json:"effect_failure,omitempty"`
+
 	// Evidence Per-claim evidence (snippet + source id) backing the proposal.
 	Evidence *[]ApprovalEvidence `json:"evidence,omitempty"`
 
@@ -13607,6 +13622,20 @@ type Attention struct {
 	// lane shows a bounded slice of it.
 	Counts AttentionCounts `json:"counts"`
 
+	// DidNotRun Decisions THIS reader approved whose released work then failed, reading
+	// the queue newest-staged first. The row is not pending (it was decided) and not a receipt
+	// (a person decided it), so no other lane can carry it; without this one the
+	// person who pressed Accept is the last to learn nothing happened.
+	//
+	// Each card carries the server's own sentence about what did not run, and
+	// `open` when the decision named a record. Re-driving the failed work is a
+	// separate decision the product has not made yet; this lane only ends the
+	// silence.
+	//
+	// Absent — not empty — on an installation whose feed does not read approvals'
+	// failure marks.
+	DidNotRun *[]AttentionItem `json:"did_not_run,omitempty"`
+
 	// DoneForYou What the system did on its own, most recent first. Receipts, not questions.
 	DoneForYou []AttentionItem `json:"done_for_you"`
 
@@ -13693,6 +13722,9 @@ type AttentionCounts struct {
 
 	// Commitments How many promises this lane is CARRYING, which is the bounded page rather than every promise due — the same bound `planned` reports under. A rep past the bound sees the soonest-due ones, which is the order the lane is in.
 	Commitments *int `json:"commitments,omitempty"`
+
+	// DidNotRun How many failed decisions this lane is CARRYING — the bounded page, as the other lanes report.
+	DidNotRun *int `json:"did_not_run,omitempty"`
 
 	// DuplicatesOpen Open duplicate pairs both of whose sides this caller can see.
 	DuplicatesOpen *int `json:"duplicates_open,omitempty"`

--- a/backend/internal/modules/approvals/effectfailure_integration_test.go
+++ b/backend/internal/modules/approvals/effectfailure_integration_test.go
@@ -106,6 +106,22 @@ func TestAFailedEffectIsListedForItsDeciderAlone(t *testing.T) {
 		t.Errorf("the wire row carries no failure mark: %+v", rows[0])
 	}
 
+	// The target archived AFTER the failure must not hide the row: the lane
+	// exists to tell the decider work they released did not run, and the
+	// probe that would re-ask "could you decide this now" answers a
+	// different question.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE organization SET archived_at = now() WHERE id = $1`, org); err != nil {
+		t.Fatal(err)
+	}
+	rows, _, err = e.svc.ListWire(deciding, ListInput{FailedForDecider: true, Limit: 8})
+	if err != nil {
+		t.Fatalf("listing after the target archived: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the failure vanished when its target archived: %d rows", len(rows))
+	}
+
 	stranger := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
 		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Other Rep')`,

--- a/backend/internal/modules/approvals/effectfailure_integration_test.go
+++ b/backend/internal/modules/approvals/effectfailure_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // effectFailureOf reads the mark straight from the table — what the decision
@@ -76,5 +77,52 @@ func TestAnApprovedEffectThatRunsLeavesNoFailureMark(t *testing.T) {
 
 	if at, sentence := e.effectFailureOf(t, id); at != nil || sentence != nil {
 		t.Errorf("a clean effect left a failure mark (at=%v sentence=%v)", at, sentence)
+	}
+}
+
+// The failure comes back to the person who decided it, and to nobody else:
+// FailedForDecider binds the acting user inside List, so one rep cannot read
+// another's failed decisions by asking nicely.
+func TestAFailedEffectIsListedForItsDeciderAlone(t *testing.T) {
+	e := setupStaging(t)
+	e.svc.WithEffect(kindSiteLead, func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
+		return errors.New("the capture sink refused this lead")
+	})
+	deciding := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(deciding, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+	if _, err := e.svc.Decide(deciding, id, true, nil); err == nil {
+		t.Fatal("the failing effect reported no error")
+	}
+
+	rows, _, err := e.svc.ListWire(deciding, ListInput{FailedForDecider: true, Limit: 8})
+	if err != nil {
+		t.Fatalf("listing the decider's failures: %v", err)
+	}
+	if len(rows) != 1 || ids.UUID(rows[0].Id) != id.UUID {
+		t.Fatalf("the decider's list = %d rows, want their one failed decision", len(rows))
+	}
+	if rows[0].EffectFailedAt == nil || rows[0].EffectFailure == nil {
+		t.Errorf("the wire row carries no failure mark: %+v", rows[0])
+	}
+
+	stranger := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Other Rep')`,
+		stranger, "other-"+stranger.String()+"@st.test"); err != nil {
+		t.Fatal(err)
+	}
+	otherCtx := principal.WithWorkspaceID(context.Background(), e.ws)
+	otherCtx = principal.WithCorrelationID(otherCtx, ids.NewV7())
+	otherCtx = principal.WithActor(otherCtx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + stranger.String(), UserID: stranger,
+		Permissions: decidesEverything(),
+	})
+	others, _, err := e.svc.ListWire(otherCtx, ListInput{FailedForDecider: true, Limit: 8})
+	if err != nil {
+		t.Fatalf("listing as another rep: %v", err)
+	}
+	if len(others) != 0 {
+		t.Errorf("another rep read %d of the decider's failures, want none", len(others))
 	}
 }

--- a/backend/internal/modules/approvals/handlers.go
+++ b/backend/internal/modules/approvals/handlers.go
@@ -273,6 +273,8 @@ func wire(a row, now time.Time) crmcontracts.Approval {
 		}
 	}
 	out.Evidence = wireEvidence(a.Evidence)
+	out.EffectFailedAt = a.EffectFailedAt
+	out.EffectFailure = a.EffectFailure
 	return out
 }
 

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -52,19 +52,24 @@ type row struct {
 	// Evidence is what each claim was read out of, nil for a staging that read
 	// nothing (evidence.go).
 	Evidence json.RawMessage
+	// EffectFailedAt + EffectFailure are the mark decide.go leaves on an
+	// approved row whose released work did not run: when, and the sentence a
+	// reader is shown. Nil on every row whose effect ran.
+	EffectFailedAt *time.Time
+	EffectFailure  *string
 }
 
 const columns = `id, kind, status, proposed_by, on_behalf_of, passport_id,
 	target_entity_type, target_entity_id, target_version, summary,
 	proposed_change, diff_hash, expires_at, decided_by, decided_at, consumed_at, created_at,
-	bundle_id, evidence`
+	bundle_id, evidence, effect_failed_at, effect_failure`
 
 func scan(r pgx.Row) (row, error) {
 	var a row
 	err := r.Scan(&a.ID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
 		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.Summary,
 		&a.ProposedChange, &a.DiffHash, &a.ExpiresAt, &a.DecidedBy, &a.DecidedAt, &a.ConsumedAt, &a.CreatedAt,
-		&a.BundleID, &a.Evidence)
+		&a.BundleID, &a.Evidence, &a.EffectFailedAt, &a.EffectFailure)
 	return a, err
 }
 
@@ -136,10 +141,19 @@ type ListInput struct {
 	// page can discard everything the page held and hide the recent decision
 	// underneath. In SQL, the limit only ever counts rows inside the window.
 	DecidedAfter *time.Time
-	Limit        int
+	// FailedForDecider narrows to the approved rows THIS caller decided whose
+	// released work then failed (decide.go's mark) — the one lane that can
+	// carry a decision back to the person who made it. A flag rather than a
+	// caller-supplied decider id, so no caller can read another person's
+	// failures by naming them; List binds the acting user itself.
+	FailedForDecider bool
+	Limit            int
 	// Cursor continues a previous page: the opaque keyset token that page
 	// reported as next_cursor. Empty starts at the newest row.
 	Cursor string
+	// failedDecider is FailedForDecider resolved to the acting user — set by
+	// List from the principal, never by a caller.
+	failedDecider *ids.UUID
 }
 
 // targeted reports whether the read is scoped to one record.
@@ -163,6 +177,12 @@ func (s *Service) List(ctx context.Context, in ListInput) ([]row, storekit.Page,
 		return nil, storekit.Page{}, err
 	}
 	p, _ := principal.Actor(ctx)
+	if in.FailedForDecider {
+		if p.UserID.IsZero() {
+			return nil, storekit.Page{}, apperrors.ErrPermissionDenied
+		}
+		in.failedDecider = &p.UserID
+	}
 	if in.Limit <= 0 || in.Limit > inboxBatch {
 		in.Limit = 50
 	}
@@ -292,6 +312,9 @@ func approvalWhere(in ListInput, from *keysetStart, arg func(any) int) string {
 	}
 	if in.DecidedAfter != nil {
 		terms = append(terms, fmt.Sprintf("decided_at > $%d", arg(*in.DecidedAfter)))
+	}
+	if in.failedDecider != nil {
+		terms = append(terms, fmt.Sprintf("effect_failed_at IS NOT NULL AND decided_by = $%d", arg(*in.failedDecider)))
 	}
 	if from != nil {
 		terms = append(terms, fmt.Sprintf("(created_at, id) < ($%d, $%d)", arg(from.createdAt), arg(from.id)))

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -141,18 +141,17 @@ type ListInput struct {
 	// page can discard everything the page held and hide the recent decision
 	// underneath. In SQL, the limit only ever counts rows inside the window.
 	DecidedAfter *time.Time
-	// FailedForDecider narrows to the approved rows THIS caller decided whose
-	// released work then failed (decide.go's mark) — the one lane that can
-	// carry a decision back to the person who made it. A flag rather than a
-	// caller-supplied decider id, so no caller can read another person's
-	// failures by naming them; List binds the acting user itself.
+	// FailedForDecider narrows to the approved rows THIS caller decided
+	// whose released work then failed (decide.go's mark). A flag rather
+	// than a caller-supplied decider id — List binds the acting user
+	// itself, so nobody reads another person's failures by naming them.
 	FailedForDecider bool
 	Limit            int
 	// Cursor continues a previous page: the opaque keyset token that page
 	// reported as next_cursor. Empty starts at the newest row.
 	Cursor string
-	// failedDecider is FailedForDecider resolved to the acting user — set by
-	// List from the principal, never by a caller.
+	// failedDecider is FailedForDecider resolved to the acting user;
+	// set by List from the principal, never by a caller.
 	failedDecider *ids.UUID
 }
 
@@ -195,6 +194,15 @@ func (s *Service) List(ctx context.Context, in ListInput) ([]row, storekit.Page,
 	err = s.db.Tx(ctx, func(tx pgx.Tx) (err error) {
 		if in.targeted() {
 			out, page, err = listForTarget(ctx, tx, p, in, start)
+			return err
+		}
+		// The caller's own failed decisions skip the per-row decidability
+		// probe: it asks "could this caller decide this NOW", and a failure
+		// must not vanish when that answer changes — target archived, grant
+		// narrowed — because the row exists to tell its decider that work
+		// THEY released did not run. Scope is decided_by = the acting user.
+		if in.failedDecider != nil {
+			out, page, err = scanOwnDecisions(ctx, tx, in, start)
 			return err
 		}
 		out, page, err = scanInbox(ctx, tx, p, in, start)

--- a/backend/internal/modules/approvals/owndecisions.go
+++ b/backend/internal/modules/approvals/owndecisions.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// scanOwnDecisions is the probe-free walk for a read the SQL already scopes
+// to the caller's own decided rows — see the FailedForDecider branch in List
+// for why re-probing decidability would hide exactly the rows it exists for.
+func scanOwnDecisions(ctx context.Context, tx pgx.Tx, in ListInput, start *keysetStart) ([]row, storekit.Page, error) {
+	q, args := approvalPageQuery(in, start)
+	batch, err := collect(ctx, tx, q, args)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
+	rows, page := capPage(batch, in.Limit, nil)
+	return rows, page, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -20437,6 +20437,18 @@ export interface components {
             decided_by?: string | null;
             /** Format: date-time */
             decided_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When the work an APPROVED decision released failed to run. Absent on every
+             *     row whose effect ran — an approved row carrying this is a decision a person
+             *     made whose promised work never happened.
+             */
+            effect_failed_at?: string | null;
+            /**
+             * @description The sentence a reader is shown about that failure — written for them, never
+             *     copied from the executor's error. Present exactly when `effect_failed_at` is.
+             */
+            effect_failure?: string | null;
             /** Format: date-time */
             created_at: string;
         };
@@ -22684,8 +22696,23 @@ export interface components {
             relationship_decay?: components["schemas"]["AttentionItem"][];
             /** @description What the system did on its own, most recent first. Receipts, not questions. */
             done_for_you: components["schemas"]["AttentionItem"][];
+            /**
+             * @description Decisions THIS reader approved whose released work then failed, reading
+             *     the queue newest-staged first. The row is not pending (it was decided) and not a receipt
+             *     (a person decided it), so no other lane can carry it; without this one the
+             *     person who pressed Accept is the last to learn nothing happened.
+             *
+             *     Each card carries the server's own sentence about what did not run, and
+             *     `open` when the decision named a record. Re-driving the failed work is a
+             *     separate decision the product has not made yet; this lane only ends the
+             *     silence.
+             *
+             *     Absent — not empty — on an installation whose feed does not read approvals'
+             *     failure marks.
+             */
+            did_not_run?: components["schemas"]["AttentionItem"][];
             /** @description Lanes withheld because the caller may not read what they contain. Never returned empty instead. */
-            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk" | "meetings" | "relationship_decay")[];
+            lanes_omitted?: ("this_morning" | "needs_you" | "planned" | "done_for_you" | "commitments" | "at_risk" | "meetings" | "relationship_decay" | "did_not_run")[];
             counts: components["schemas"]["AttentionCounts"];
         };
         /**
@@ -22708,6 +22735,8 @@ export interface components {
             commitments?: number;
             /** @description How many lapsed relationships this lane is CARRYING — the bounded page, as the other lanes report. A rep past the bound sees the longest silences, which is the order the lane is in. */
             relationship_decay?: number;
+            /** @description How many failed decisions this lane is CARRYING — the bounded page, as the other lanes report. */
+            did_not_run?: number;
         };
         /**
          * @description One thing waiting, in the words a reader recognises, with a typed reference back to
@@ -22722,7 +22751,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting" | "relationship_decay";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval";
             /** @description The producer's own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority. */
             kind?: string;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -172,6 +172,8 @@ export const de = {
   "day.lead.plannedOnly": "Nichts zu entscheiden — {count} für heute geplant.",
   "day.lead.promises": "Du hast {count} zugesagt — das geht vor.",
   "day.lead.meetings": "{count} heute im Kalender.",
+  "day.lead.didNotRun":
+    "{count} freigegebene Aufgaben sind nicht gelaufen. Sieh sie dir zuerst an.",
   "day.lead.atRisk": "{count} werden still. Sonst wartet nichts auf dich.",
   "day.lead.decay":
     "Mit {count} hast du länger nicht gesprochen. Es wartet nichts auf dich.",
@@ -192,6 +194,8 @@ export const de = {
   "day.atRisk": "Wird still",
   "day.atRisk.empty": "Kein Deal driftet ab.",
   "day.risk.quiet": "Seit {days} Tagen kein Kontakt.",
+  "day.didNotRun": "Beschlossen, aber nicht passiert",
+  "day.didNotRun.empty": "Alles, was du freigegeben hast, ist auch gelaufen.",
   "day.decay": "Beziehungen, die einschlafen",
   "day.decay.empty": "Sie sind mit allen in Kontakt, mit denen Sie es waren.",
   "day.decay.quiet": "Seit {days} Tagen kein Austausch.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -174,6 +174,8 @@ export const en = {
   "day.lead.plannedOnly": "Nothing to decide — {count} planned for today.",
   "day.lead.promises": "You promised {count} — those come first.",
   "day.lead.meetings": "{count} on the calendar today.",
+  "day.lead.didNotRun":
+    "{count} you approved did not run. Look at those first.",
   "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",
   "day.lead.decay":
     "{count} you have not spoken to in a while. Nothing is waiting on you.",
@@ -192,6 +194,8 @@ export const en = {
   "day.atRisk": "Going quiet",
   "day.atRisk.empty": "No deal is drifting.",
   "day.risk.quiet": "No contact for {days} days.",
+  "day.didNotRun": "Approved, but did not run",
+  "day.didNotRun.empty": "Everything you approved actually ran.",
   "day.decay": "Relationships going quiet",
   "day.decay.empty": "You are in touch with everyone you were.",
   "day.decay.quiet": "You have not spoken in {days} days.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -179,6 +179,8 @@ export const vi = {
     "Không có gì phải quyết định — {count} việc theo kế hoạch hôm nay.",
   "day.lead.promises": "Bạn đã hứa {count} việc — những việc đó trước tiên.",
   "day.lead.meetings": "{count} cuộc họp trên lịch hôm nay.",
+  "day.lead.didNotRun":
+    "{count} việc bạn đã duyệt không chạy. Hãy xem những việc đó trước.",
   "day.lead.atRisk": "{count} đang lặng đi. Không còn gì khác chờ bạn.",
   "day.lead.decay":
     "{count} bạn đã lâu không trao đổi. Không có gì đang chờ bạn.",
@@ -198,6 +200,8 @@ export const vi = {
   "day.atRisk": "Đang lặng đi",
   "day.atRisk.empty": "Không có thương vụ nào trôi đi.",
   "day.risk.quiet": "Không liên hệ trong {days} ngày.",
+  "day.didNotRun": "Đã duyệt nhưng chưa chạy",
+  "day.didNotRun.empty": "Mọi việc bạn đã duyệt đều đã chạy.",
   "day.decay": "Những mối quan hệ đang nguội dần",
   "day.decay.empty":
     "Bạn vẫn giữ liên lạc với tất cả những người từng trao đổi.",

--- a/frontend/src/screens/attentionsource.ts
+++ b/frontend/src/screens/attentionsource.ts
@@ -29,6 +29,7 @@ export const FOCUS_SURFACE = {
   deal_at_risk: "report",
   meeting: "report",
   relationship_decay: "report",
+  failed_approval: "report",
 } as const satisfies Record<AttentionItem["source"], FocusSurface>;
 
 export function focusSurfaceOf(source: AttentionItem["source"]): FocusSurface {

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -3,6 +3,7 @@ import {
   CheckSquare,
   GitMerge,
   Handshake,
+  ShieldAlert,
   Sparkles,
   Sunrise,
   TrendingDown,
@@ -112,6 +113,12 @@ function quietLead(
 ): string {
   // A drifting deal is money leaving on its own — nobody is waiting on the
   // reader for it, which is exactly why it needs saying.
+  // Above the drifting deals, because it is worse news: a rep already DECIDED
+  // these, was told they worked, and they did not.
+  const failed = day.counts.did_not_run ?? 0;
+  if (failed > 0) {
+    return t("day.lead.didNotRun", { count: formatNumber(failed, locale) });
+  }
   const drifting = day.counts.at_risk ?? 0;
   if (drifting > 0) {
     return t("day.lead.atRisk", { count: formatNumber(drifting, locale) });
@@ -148,6 +155,7 @@ function quietLead(
     day.counts.commitments === undefined ||
     day.counts.at_risk === undefined ||
     day.counts.relationship_decay === undefined ||
+    day.counts.did_not_run === undefined ||
     day.counts.meetings === undefined
   ) {
     return t("day.lead.clearOfWhatWasRead");
@@ -571,6 +579,10 @@ function TodayLanes({
   const commitments = day.commitments;
   // Same absent-versus-empty rule: no lane at all when nothing reads deals.
   const atRisk = day.at_risk;
+  // Decisions this reader approved whose released work then failed. Warn-toned
+  // whenever it holds anything: every row is a promise the product broke.
+  const failed = day.did_not_run;
+  const failedTone = (failed ?? []).length > 0 ? "warn" : undefined;
   const lapsed = day.relationship_decay;
   // Tinted only when the lane HAS a finding: a warn-toned panel drawn over "no
   // deal is drifting" would dress good news as bad.
@@ -671,6 +683,22 @@ function TodayLanes({
         lane="at_risk"
         total={day.counts.at_risk ?? 0}
         tone={driftingTone}
+        onComplete={onComplete}
+        onSnooze={onSnooze}
+        completing={complete.isPending}
+      />
+      <OptionalLane
+        items={failed}
+        shape={{
+          title: t("day.didNotRun"),
+          empty: t("day.didNotRun.empty"),
+          withheld: t("day.lane.withheld"),
+          icon: ShieldAlert,
+        }}
+        omitted={omitted}
+        lane="did_not_run"
+        total={day.counts.did_not_run ?? 0}
+        tone={failedTone}
         onComplete={onComplete}
         onSnooze={onSnooze}
         completing={complete.isPending}


### PR DESCRIPTION
PR #3029 gave an approved-but-failed decision its durable mark; nothing read it. This is the reader: a **did_not_run** Worklist lane carrying the decisions THIS rep approved whose released work then failed.

**What a rep sees**: a warn-toned lane on the Worklist, one card per failed decision, with the server's own sentence about what did not run and — when the decision named a record — an `open` action routed to that record (the open-verb gate holds this: no subject, no open). The day's lead line ranks it above drifting deals, because a rep was told these worked. Three locales carry the copy.

**How the read is scoped**: `ListInput.FailedForDecider` is a flag, not a caller-supplied id — the approvals service binds the acting user itself, so one rep cannot read another's failed decisions. Integration-tested: the decider sees their one failed decision with its mark; another rep with full grants sees none.

**Lane semantics**: the optional-lane contract as the other lanes hold it — absent where no reader is wired, named in `lanes_omitted` on a refusal, an empty list when everything ran. Contract additions (`did_not_run` lane + count + `failed_approval` source) regenerated on both sides; the frontend source registry and the backend census gate both hold the new source.

**Deliberately not here**: re-driving the failed work (#2749, needs-decision) — the card ends the silence, it does not yet retry; and failures never age out of the lane, which is honest but may want an acknowledge mechanism once #2749 is decided.

Refs #2966.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces approved-but-failed decisions back to the rep who approved them in a new `did_not_run` Worklist lane, carrying the server's recorded sentence and an `open` action when the decision named a record.

- The lane is bound to the acting user inside the approvals service (`FailedForDecider`), so no rep can read another's failures.
- Failures outlive their target: the read skips the "could you decide this now" re-probe, so a decision stays visible after its record archives or a grant narrows.
- `open` is offered only on records with a page of their own; an activity-targeted card names its subject without promising navigation. The shared `openableSubject` guard now also covers receipts the same way.
- It follows the optional-lane contract: absent when no reader is wired, named in `lanes_omitted` on refusal, empty when everything ran.
- The day's lead line ranks it above drifting deals, and the lane is warn-toned whenever it holds any card.
- Re-driving failed work (#2749) is deliberately not part of this change; failures also don't age out of the lane.
- Contract additions (`did_not_run` lane + count, `failed_approval` source) are regenerated on both sides, with copy in `en`, `de`, and `vi`.

<sup>Written for commit dce5e7ea18578870872d5d97cb5c9df3d8c437c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Did not run” lane to Today for approved work that failed to execute.
  - Failure details now include an explanation and timestamp.
  - Related records provide an open action when available.
  - Failed approvals are visible only to the person who made the decision.
  - Added English, German, and Vietnamese translations for the new status and empty states.

- **Bug Fixes**
  - Improved handling of missing, withheld, and empty failure data in attention feeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->