### PR TITLE
fix(siteread): a register entry and a VAT ID are two numbers, and reach two fields

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27296,7 +27296,8 @@ components:
       properties:
         name: { type: string, description: "The entity's registered name exactly as the legal notice prints it." }
         registered_address: { type: string, description: "Its registered address as printed; absent when the page states none for this entity." }
-        register_number: { type: string, description: "Its registration, VAT, UID or tax number as printed; absent when the page states none for this entity." }
+        register_number: { type: string, description: "Its commercial-register entry as printed (HRB/HRA or the local equivalent); absent when the page states none for this entity. A dossier read before the two numbers were told apart may hold a VAT ID here." }
+        vat_number: { type: string, description: "Its VAT, UID or tax number as printed; absent when the page states none for this entity." }
         evidence_snippet: { type: string }
         source_url: { type: string, format: uri }
 

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -344,6 +344,7 @@ func siteReadLegalEntities(entities []corpusLegalEntity) []people.SiteReadLegalE
 			Name:              e.Name,
 			RegisteredAddress: e.RegisteredAddress,
 			RegisterNumber:    e.RegisterNumber,
+			VatNumber:         e.VatNumber,
 			EvidenceSnippet:   e.EvidenceSnippet,
 			SourceURL:         e.SourceURL,
 		})

--- a/backend/internal/compose/onboardingsitereadmessage.go
+++ b/backend/internal/compose/onboardingsitereadmessage.go
@@ -49,7 +49,8 @@ const companyReadMessageSystem = `You are Margince, the professional AI helping 
 Answer the administrator's question using only the supplied dossier evidence and the administrator's own statement.
 Conversation history exists only to resolve follow-up references; it is not dossier evidence.
 Classify the response as status, answer, recommendation, correction, confirmation, clarification, or off_topic. Ordinary questions and status checks never propose changes. Use recommendation only when the administrator explicitly asks what a field should contain or asks you to suggest or recommend a value for a named field. Use correction only when the administrator explicitly supplies or corrects a company detail. Ambiguity defaults to answer or clarification. Off-topic requests get one short scope reminder. Do not apologize unless acknowledging a concrete error or correction.
-Never claim that you saved anything. Use only these fields: display_name, legal_name, registered_address, register_vat, industry, history, offer_summary, icp, value_proposition, usp, customer_pains, desired_outcomes, buying_center, buying_intents, common_objections, sales_motion.
+Never claim that you saved anything. Use only these fields: display_name, legal_name, registered_address, legal_form, register_court, register_number, register_vat, industry, history, offer_summary, icp, value_proposition, usp, customer_pains, desired_outcomes, buying_center, buying_intents, common_objections, sales_motion.
+register_number is the court's commercial-register entry ("HRB 12345 B") and register_vat is the tax identifier ("DE123456789") — never put one in the other's place.
 Return JSON with kind, message, proposed_changes (at most 5 objects with field, value, reason, source_ids), and global source_ids. status, answer, confirmation, clarification, and off_topic MUST have no proposed changes. Every dossier-derived proposed value must carry the dossier source ids that contain that value, and those ids must also appear in global source_ids. Use an empty per-change source_ids list only when the value comes from an administrator statement. Cite only source ids supplied in the dossier. Do not invent a source, legal identity, address, registration, VAT/UID number, product, customer, or market.`
 
 type companyReadEvidence struct {
@@ -292,19 +293,25 @@ var companyFieldAliases = map[string][]string{
 	fieldDisplayName:       {"company name", "brand name", "firmenname", "unternehmensname", "kurzname", "anzeigename"},
 	fieldLegalName:         {"registered name", "legal company name", "rechtlicher name", "juristischer name", "firmierung", "eingetragener name", "gesetzlicher name"},
 	fieldRegisteredAddress: {"registered address", "registered office", "company address", "geschäftsanschrift", "geschäftsadresse", "firmenanschrift", "unternehmensanschrift", "unternehmensadresse", "geschäftssitz", "firmensitz", "anschrift", "adresse"},
-	fieldRegisterVat:       {"vat", "uid", "tax number", "company register", "ust-id", "umsatzsteuer", "handelsregister", "handelsregisternummer", "registernummer", "steuernummer"},
-	fieldIndustry:          {"industry", "sector", "branche", "industrie", "wirtschaftszweig"},
-	fieldHistory:           {"company history", "background", "unternehmensgeschichte", "firmengeschichte", "geschichte", "historie"},
-	fieldICP:               {"ideal customer", "ideal customer profile", "zielkunde", "zielkunden", "zielgruppe", "idealer kunde", "ideales kundenprofil"},
-	fieldOfferSummary:      {"what we offer", companyProductTerm, "service", "angebot", "produkt", "dienstleistung", "leistungsangebot"},
-	fieldValueProposition:  {"value proposition", "customer value", "wertversprechen", "nutzenversprechen", "kundennutzen"},
-	fieldUSP:               {"unique selling proposition", "differentiator", "alleinstellungsmerkmal", "differenzierungsmerkmal"},
-	fieldCustomerPains:     {"customer pain", "customer problem", "kundenproblem", "kundenprobleme", "herausforderungen", "schmerzpunkte"},
-	fieldDesiredOutcomes:   {"desired outcome", "customer outcome", "gewünschte ergebnisse", "gewünschten ergebnisse", "kundenziele", "kundenresultate"},
-	fieldBuyingCenter:      {"buying center", "decision makers", "einkaufsgremium", "kaufentscheider", "entscheidungsgremium"},
-	fieldBuyingIntents:     {"buying intent", "buying signal", "kaufabsicht", "kaufabsichten", "kaufsignal", "kaufsignale", "kaufinteresse"},
-	fieldCommonObjections:  {"common objection", "sales objection", "häufige einwände", "einwände", "kundenbedenken"},
-	fieldSalesMotion:       {"sales motion", "sales process", "go-to-market", "vertriebsmodell", "vertriebsprozess", "verkaufsprozess"},
+	// The court's register and the tax office's number take their own aliases.
+	// Both sets used to sit on register_vat, so a rep saying
+	// "Handelsregisternummer" was offered the VAT field.
+	fieldRegisterVat:      {"vat", "uid", "tax number", "ust-id", "umsatzsteuer", "steuernummer"},
+	fieldRegisterNumber:   {"company register", "commercial register", "register number", "handelsregister", "handelsregisternummer", "registernummer", "hrb", "hra"},
+	fieldRegisterCourt:    {"register court", "registergericht", "amtsgericht", "registry court"},
+	fieldLegalForm:        {"legal form", "rechtsform", "gesellschaftsform"},
+	fieldIndustry:         {fieldIndustry, "sector", "branche", "industrie", "wirtschaftszweig"},
+	fieldHistory:          {"company history", "background", "unternehmensgeschichte", "firmengeschichte", "geschichte", "historie"},
+	fieldICP:              {"ideal customer", "ideal customer profile", "zielkunde", "zielkunden", "zielgruppe", "idealer kunde", "ideales kundenprofil"},
+	fieldOfferSummary:     {"what we offer", companyProductTerm, "service", "angebot", "produkt", "dienstleistung", "leistungsangebot"},
+	fieldValueProposition: {"value proposition", "customer value", "wertversprechen", "nutzenversprechen", "kundennutzen"},
+	fieldUSP:              {"unique selling proposition", "differentiator", "alleinstellungsmerkmal", "differenzierungsmerkmal"},
+	fieldCustomerPains:    {"customer pain", "customer problem", "kundenproblem", "kundenprobleme", "herausforderungen", "schmerzpunkte"},
+	fieldDesiredOutcomes:  {"desired outcome", "customer outcome", "gewünschte ergebnisse", "gewünschten ergebnisse", "kundenziele", "kundenresultate"},
+	fieldBuyingCenter:     {"buying center", "decision makers", "einkaufsgremium", "kaufentscheider", "entscheidungsgremium"},
+	fieldBuyingIntents:    {"buying intent", "buying signal", "kaufabsicht", "kaufabsichten", "kaufsignal", "kaufsignale", "kaufinteresse"},
+	fieldCommonObjections: {"common objection", "sales objection", "häufige einwände", "einwände", "kundenbedenken"},
+	fieldSalesMotion:      {"sales motion", "sales process", "go-to-market", "vertriebsmodell", "vertriebsprozess", "verkaufsprozess"},
 }
 
 func companyFieldMentioned(message, field string) bool {

--- a/backend/internal/compose/onboardingsitereadmessage.go
+++ b/backend/internal/compose/onboardingsitereadmessage.go
@@ -418,6 +418,9 @@ func companyReadEvidenceSet(read people.SiteRead) []companyReadEvidence {
 		if entity.RegisterNumber != "" {
 			parts = append(parts, entity.RegisterNumber)
 		}
+		if entity.VatNumber != "" {
+			parts = append(parts, entity.VatNumber)
+		}
 		value := strings.Join(parts, " · ")
 		add("legal_entity", "legal_identity", value, entity.EvidenceSnippet, entity.SourceURL)
 	}

--- a/backend/internal/compose/onboardingsitereadmessage_test.go
+++ b/backend/internal/compose/onboardingsitereadmessage_test.go
@@ -402,19 +402,25 @@ func TestCompanyFieldMentionUnderstandsTheCompleteGermanVocabulary(t *testing.T)
 		fieldDisplayName:       "Unser Firmenname ist Acme",
 		fieldLegalName:         "Unsere Firmierung ist Acme GmbH",
 		fieldRegisteredAddress: "Unsere Geschäftsanschrift ist Berlin",
-		fieldRegisterVat:       "Unsere Handelsregisternummer ist HRB 42",
-		fieldIndustry:          "Unsere Branche ist Software",
-		fieldHistory:           "Unsere Unternehmensgeschichte begann 2020",
-		fieldOfferSummary:      "Unser Leistungsangebot ist Beratung",
-		fieldICP:               "Unser ideales Kundenprofil sind Mittelständler",
-		fieldValueProposition:  "Unser Wertversprechen ist Zeitersparnis",
-		fieldUSP:               "Unser Alleinstellungsmerkmal ist Geschwindigkeit",
-		fieldCustomerPains:     "Die Kundenprobleme sind hohe Kosten",
-		fieldDesiredOutcomes:   "Die gewünschten Ergebnisse sind mehr Umsatz",
-		fieldBuyingCenter:      "Unser Einkaufsgremium umfasst IT und Einkauf",
-		fieldBuyingIntents:     "Die Kaufsignale sind konkrete Projektanfragen",
-		fieldCommonObjections:  "Die häufigen Einwände betreffen den Preis",
-		fieldSalesMotion:       "Unser Vertriebsmodell ist founder-led",
+		// The court's register and the tax office's number are different
+		// questions in German too, and a rep naming one must not be offered
+		// the other's field.
+		fieldRegisterNumber:   "Unsere Handelsregisternummer ist HRB 42",
+		fieldRegisterVat:      "Unsere Umsatzsteuer-ID ist DE123456789",
+		fieldRegisterCourt:    "Unser Registergericht ist Charlottenburg",
+		fieldLegalForm:        "Unsere Rechtsform ist GmbH",
+		fieldIndustry:         "Unsere Branche ist Software",
+		fieldHistory:          "Unsere Unternehmensgeschichte begann 2020",
+		fieldOfferSummary:     "Unser Leistungsangebot ist Beratung",
+		fieldICP:              "Unser ideales Kundenprofil sind Mittelständler",
+		fieldValueProposition: "Unser Wertversprechen ist Zeitersparnis",
+		fieldUSP:              "Unser Alleinstellungsmerkmal ist Geschwindigkeit",
+		fieldCustomerPains:    "Die Kundenprobleme sind hohe Kosten",
+		fieldDesiredOutcomes:  "Die gewünschten Ergebnisse sind mehr Umsatz",
+		fieldBuyingCenter:     "Unser Einkaufsgremium umfasst IT und Einkauf",
+		fieldBuyingIntents:    "Die Kaufsignale sind konkrete Projektanfragen",
+		fieldCommonObjections: "Die häufigen Einwände betreffen den Preis",
+		fieldSalesMotion:      "Unser Vertriebsmodell ist founder-led",
 	}
 	for field, message := range examples {
 		if !companyFieldMentioned(message, field) {

--- a/backend/internal/compose/onboardingsitereadtransport.go
+++ b/backend/internal/compose/onboardingsitereadtransport.go
@@ -374,6 +374,9 @@ func contractSiteReadLegalEntities(entities []people.SiteReadLegalEntity) []crmc
 		if entity.RegisterNumber != "" {
 			wire.RegisterNumber = &entity.RegisterNumber
 		}
+		if entity.VatNumber != "" {
+			wire.VatNumber = &entity.VatNumber
+		}
 		if entity.EvidenceSnippet != "" {
 			wire.EvidenceSnippet = &entity.EvidenceSnippet
 		}

--- a/backend/internal/compose/onboardingsitereadtransport.go
+++ b/backend/internal/compose/onboardingsitereadtransport.go
@@ -129,7 +129,9 @@ func (e *deepReadEngine) confirmCompanySiteRead(w http.ResponseWriter, r *http.R
 		Fields: map[string]*string{
 			fieldOfferSummary: trimOptional(req.Profile.OfferSummary), fieldLegalName: trimOptional(req.Profile.LegalName),
 			fieldRegisteredAddress: trimOptional(req.Profile.RegisteredAddress), fieldRegisterVat: trimOptional(req.Profile.RegisterVat),
-			fieldIndustry: trimOptional(req.Profile.Industry), fieldICP: trimOptional(req.Profile.Icp),
+			fieldLegalForm: trimOptional(req.Profile.LegalForm), fieldRegisterCourt: trimOptional(req.Profile.RegisterCourt),
+			fieldRegisterNumber: trimOptional(req.Profile.RegisterNumber),
+			fieldIndustry:       trimOptional(req.Profile.Industry), fieldICP: trimOptional(req.Profile.Icp),
 			fieldValueProposition: trimOptional(req.Profile.ValueProposition), fieldUSP: trimOptional(req.Profile.Usp),
 			fieldCustomerPains: trimOptional(req.Profile.CustomerPains), fieldDesiredOutcomes: trimOptional(req.Profile.DesiredOutcomes),
 			fieldBuyingCenter: trimOptional(req.Profile.BuyingCenter), fieldBuyingIntents: trimOptional(req.Profile.BuyingIntents),

--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -25,10 +25,16 @@ import (
 // stated, which is the one thing this read exists to prevent.
 type corpusLegalEntity struct {
 	Name string `json:"name"`
-	// RegisteredAddress and RegisterNumber are empty when the page states
-	// the entity but not that detail — never guessed to fill the block.
+	// RegisteredAddress, RegisterNumber and VatNumber are empty when the page
+	// states the entity but not that detail — never guessed to fill the block.
+	//
+	// The two numbers are separate because the authorities behind them are: a
+	// court issues the register entry and a tax office issues the VAT ID, and
+	// a company states both. Reading them into one field meant whichever the
+	// page printed first stood for the other.
 	RegisteredAddress string `json:"registered_address,omitempty"`
 	RegisterNumber    string `json:"register_number,omitempty"`
+	VatNumber         string `json:"vat_number,omitempty"`
 	EvidenceSnippet   string `json:"evidence_snippet,omitempty"`
 	SourceURL         string `json:"source_url"`
 }
@@ -122,8 +128,10 @@ func removeBrandOnlyLegalAliases(entities []corpusLegalEntity) []corpusLegalEnti
 // enrichLegalEntitiesFromProfile shares already-gated legal trio values
 // with the single legal choice shown to the human. Both lanes cite shallow
 // legal pages and the census has established that there is only one entity;
-// this avoids asking the user to retype a VAT number one lane recovered when
-// the entity lane's 300-rune block ended between the address and identifier.
+// this avoids asking the user to retype a number one lane recovered when the
+// entity lane's 300-rune block ended between the address and the identifiers.
+// Each field fills its own: a register entry recovered elsewhere cannot stand
+// in for a VAT ID the page never printed.
 func enrichLegalEntitiesFromProfile(entities []corpusLegalEntity, fields []evidencedField) []corpusLegalEntity {
 	if len(entities) != 1 {
 		return entities
@@ -135,9 +143,13 @@ func enrichLegalEntitiesFromProfile(entities []corpusLegalEntity, fields []evide
 			if out[0].RegisteredAddress == "" {
 				out[0].RegisteredAddress = field.Value
 			}
-		case string(crmcontracts.ColdStartFieldFieldRegisterVat):
+		case string(crmcontracts.ColdStartFieldFieldRegisterNumber):
 			if out[0].RegisterNumber == "" {
 				out[0].RegisterNumber = field.Value
+			}
+		case string(crmcontracts.ColdStartFieldFieldRegisterVat):
+			if out[0].VatNumber == "" {
+				out[0].VatNumber = field.Value
 			}
 		}
 	}
@@ -194,7 +206,8 @@ func fillLegalTrioFromCensus(fields []evidencedField, entities []corpusLegalEnti
 	}{
 		{string(crmcontracts.ColdStartFieldFieldLegalName), entity.Name},
 		{string(crmcontracts.ColdStartFieldFieldRegisteredAddress), entity.RegisteredAddress},
-		{string(crmcontracts.ColdStartFieldFieldRegisterVat), entity.RegisterNumber},
+		{string(crmcontracts.ColdStartFieldFieldRegisterNumber), entity.RegisterNumber},
+		{string(crmcontracts.ColdStartFieldFieldRegisterVat), entity.VatNumber},
 	} {
 		if present[candidate.field] || strings.TrimSpace(candidate.value) == "" {
 			continue
@@ -228,7 +241,7 @@ const censusFieldConfidence = 1
 // printed — the tie-break when the same entity is seen twice.
 func legalEntityDetail(entity corpusLegalEntity) int {
 	filled := 0
-	for _, value := range []string{entity.RegisteredAddress, entity.RegisterNumber} {
+	for _, value := range []string{entity.RegisteredAddress, entity.RegisterNumber, entity.VatNumber} {
 		if strings.TrimSpace(value) != "" {
 			filled++
 		}

--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -45,8 +45,16 @@ type corpusLegalEntity struct {
 // ("Gradion Singapur") above the entity that trades there. A register
 // number is the identity a registry issues, so blocks sharing one are the
 // same company however they are labelled; entities without one fall back
-// to their normalized name. The richest sighting wins, so a locale that
-// printed the address is not lost to one that omitted it.
+// to their normalized name. The richest sighting wins the block it is shown
+// under, so a locale that printed the address is not lost to one that
+// omitted it.
+//
+// Details the winner lacks are taken from the sighting it replaced rather
+// than discarded. They are three different facts about one company and the
+// page order decides nothing: an imprint printing the address and the VAT ID
+// and a second locale printing the address and the register entry tie on
+// count, so a winner-takes-all rule kept whichever came first and dropped
+// the other's number entirely.
 func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 	var out []corpusLegalEntity
 	for _, entity := range entities {
@@ -56,10 +64,39 @@ func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 			continue
 		}
 		if legalEntityDetail(entity) > legalEntityDetail(out[at]) {
+			entity = fillLegalDetailsFrom(entity, out[at])
 			out[at] = entity
+			continue
 		}
+		out[at] = fillLegalDetailsFrom(out[at], entity)
 	}
 	return removeBrandOnlyLegalAliases(out)
+}
+
+// fillLegalDetailsFrom completes one sighting of an entity from another of
+// the same entity on the SAME page. Only a detail the kept sighting lacks is
+// taken.
+//
+// The page restriction is what keeps the evidence honest. An entity carries
+// ONE snippet and one source URL, and every field filled from it is published
+// citing them (fillLegalTrioFromCensus). A number borrowed from another page
+// would arrive quoting a passage that never printed it — the exact claim the
+// no-guess gate exists to refuse. Two sightings on one page are two blocks of
+// the same notice, which that page's snippet does cover.
+func fillLegalDetailsFrom(kept, other corpusLegalEntity) corpusLegalEntity {
+	if kept.SourceURL != other.SourceURL {
+		return kept
+	}
+	if kept.RegisteredAddress == "" {
+		kept.RegisteredAddress = other.RegisteredAddress
+	}
+	if kept.RegisterNumber == "" {
+		kept.RegisterNumber = other.RegisterNumber
+	}
+	if kept.VatNumber == "" {
+		kept.VatNumber = other.VatNumber
+	}
+	return kept
 }
 
 // matchingLegalEntity joins locale variants without collapsing genuinely
@@ -67,20 +104,39 @@ func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 // number that another locale printed; those sightings still match by name.
 // When both sightings carry different register numbers, the registry
 // identities win and the entities remain separate even if their names match.
+//
+// A VAT ID is the same kind of evidence one authority weaker: a tax office
+// issues it to one company, so two sightings sharing one are the same
+// company and two carrying different ones are not. It decides only where no
+// register number does, because a group's entities can share neither.
+// Without it a page printing only VAT IDs had no identity at all: sightings
+// of one entity split under their locale names and could trip the
+// multi-entity abstention, and two different companies printed under one
+// name merged into whichever was seen first.
 func matchingLegalEntity(existing []corpusLegalEntity, candidate corpusLegalEntity) int {
 	candidateName := legalEntityNameKey(candidate.Name)
 	candidateRegister := normalizeEvidence(candidate.RegisterNumber)
+	candidateVat := normalizeEvidence(candidate.VatNumber)
 	for i, entity := range existing {
 		name := legalEntityNameKey(entity.Name)
 		register := normalizeEvidence(entity.RegisterNumber)
+		vat := normalizeEvidence(entity.VatNumber)
 		sameRegister := candidateRegister != "" && register != "" && candidateRegister == register
+		sameVat := candidateVat != "" && vat != "" && candidateVat == vat
 		compatibleName := candidateName != "" && candidateName == name &&
-			(candidateRegister == "" || register == "" || candidateRegister == register)
-		if sameRegister || compatibleName {
+			bothOrEitherEmpty(candidateRegister, register) &&
+			bothOrEitherEmpty(candidateVat, vat)
+		if sameRegister || sameVat || compatibleName {
 			return i
 		}
 	}
 	return -1
+}
+
+// bothOrEitherEmpty reports whether two identifiers can belong to one
+// company: they agree, or at least one sighting did not print its own.
+func bothOrEitherEmpty(left, right string) bool {
+	return left == "" || right == "" || left == right
 }
 
 // legalEntityNameKey treats punctuation-only legal-form variants as the

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -78,13 +78,17 @@ func TestDedupeLegalEntitiesKeepsTheOnlyBareLegalName(t *testing.T) {
 
 func TestEnrichSingleLegalEntityFromGatedProfile(t *testing.T) {
 	entities := []corpusLegalEntity{{Name: "Acme GmbH", SourceURL: seedURL + "/imprint"}}
+	// Each number fills its OWN field. A register entry recovered by the
+	// profile lane cannot stand in for a VAT ID the page never printed, and
+	// the two authorities behind them are why.
 	fields := []evidencedField{
 		{Field: "registered_address", Value: "Deliusstrasse 7, 24114 Kiel"},
-		{Field: "register_vat", Value: "HRB 123456"},
+		{Field: "register_number", Value: "HRB 123456"},
+		{Field: "register_vat", Value: "DE123456789"},
 	}
 	got := enrichLegalEntitiesFromProfile(entities, fields)
-	if got[0].RegisteredAddress == "" || got[0].RegisterNumber != "HRB 123456" {
-		t.Fatalf("the single legal choice must reuse the already-gated trio: %+v", got)
+	if got[0].RegisteredAddress == "" || got[0].RegisterNumber != "HRB 123456" || got[0].VatNumber != "DE123456789" {
+		t.Fatalf("the single legal choice must reuse the already-gated fields: %+v", got)
 	}
 	if entities[0].RegisteredAddress != "" {
 		t.Fatal("enrichment must not mutate the source slice")
@@ -186,6 +190,7 @@ func TestCensusFillsTheAddressTheProfileLaneMissed(t *testing.T) {
 		Name:              "communicode GmbH",
 		RegisteredAddress: "Wittekindstr. 1a, 45131 Essen",
 		RegisterNumber:    "HRB 37643",
+		VatNumber:         "DE216235279",
 		EvidenceSnippet:   "Impressum communicode GmbH, Wittekindstr. 1a in 45131 Essen",
 		SourceURL:         impressum,
 	}}
@@ -204,8 +209,14 @@ func TestCensusFillsTheAddressTheProfileLaneMissed(t *testing.T) {
 	if got["legal_name"] != "communicode GmbH" {
 		t.Errorf("legal_name = %q", got["legal_name"])
 	}
-	if got["register_vat"] != "HRB 37643" {
-		t.Errorf("register_vat = %q", got["register_vat"])
+	// The court's entry and the tax office's number reach their own fields.
+	// One field for both meant an imprint printing an HRB number filed it as
+	// a VAT ID, and the field added for it stayed empty.
+	if got["register_number"] != "HRB 37643" {
+		t.Errorf("register_number = %q, want the register entry the census proved", got["register_number"])
+	}
+	if got["register_vat"] != "DE216235279" {
+		t.Errorf("register_vat = %q, want the VAT ID and not the register entry", got["register_vat"])
 	}
 	// Every filled field must carry the evidence and the page, so the legal
 	// gate can judge it exactly as it judges a profile-lane field.
@@ -216,6 +227,40 @@ func TestCensusFillsTheAddressTheProfileLaneMissed(t *testing.T) {
 		if f.EvidenceSnippet == "" || f.SourceURL != impressum {
 			t.Errorf("%s arrived without evidence or a source page", f.Field)
 		}
+	}
+}
+
+// A register entry never lands in the VAT field, and a VAT ID never lands in
+// the register field.
+//
+// The two numbers come from different authorities — a court issues the
+// register entry, a tax office the VAT ID — and a company states both. While
+// the census carried one identifier, an imprint printing an HRB number filed
+// it as the VAT ID, so register_number stayed empty on every read and an
+// accepted refresh could overwrite a real VAT ID with a court entry.
+//
+// The case is stated in both directions on purpose: an implementation that
+// simply swapped the two destinations would pass a test that checked one.
+func TestEachLegalNumberReachesItsOwnField(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	kinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
+	entities := []corpusLegalEntity{{
+		Name:            "Acme GmbH",
+		RegisterNumber:  "HRB 12345 B",
+		VatNumber:       "DE123456789",
+		EvidenceSnippet: "Acme GmbH, HRB 12345 B, USt-IdNr. DE123456789",
+		SourceURL:       impressum,
+	}}
+
+	got := map[string]string{}
+	for _, f := range fillLegalTrioFromCensus(nil, entities, kinds, false) {
+		got[f.Field] = f.Value
+	}
+	if got["register_number"] != "HRB 12345 B" {
+		t.Errorf("register_number = %q, want the court's entry", got["register_number"])
+	}
+	if got["register_vat"] != "DE123456789" {
+		t.Errorf("register_vat = %q, want the tax number", got["register_vat"])
 	}
 }
 
@@ -306,9 +351,10 @@ func TestCensusFillIsDeterministic(t *testing.T) {
 	kinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
 	entities := []corpusLegalEntity{{
 		Name: "Order GmbH", RegisteredAddress: "Weg 1 11111 Ort", RegisterNumber: "HRB 999",
-		EvidenceSnippet: "Order GmbH Weg 1 11111 Ort HRB 999", SourceURL: impressum,
+		VatNumber:       "DE999999999",
+		EvidenceSnippet: "Order GmbH Weg 1 11111 Ort HRB 999 DE999999999", SourceURL: impressum,
 	}}
-	want := []string{"legal_name", "registered_address", "register_vat"}
+	want := []string{"legal_name", "registered_address", "register_number", "register_vat"}
 	for range 20 {
 		out := fillLegalTrioFromCensus(nil, entities, kinds, false)
 		if len(out) != len(want) {

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -123,7 +123,11 @@ func TestLegalEntityDetailCountsWhatWasPrinted(t *testing.T) {
 	}{
 		{"name only", corpusLegalEntity{Name: "Acme GmbH"}, 0},
 		{"with address", corpusLegalEntity{Name: "Acme GmbH", RegisteredAddress: "Kiel"}, 1},
-		{"the whole block", corpusLegalEntity{Name: "Acme GmbH", RegisteredAddress: "Kiel", RegisterNumber: "HRB 1"}, 2},
+		{"with a register entry", corpusLegalEntity{Name: "Acme GmbH", RegisteredAddress: "Kiel", RegisterNumber: "HRB 1"}, 2},
+		{"the whole block", corpusLegalEntity{
+			Name: "Acme GmbH", RegisteredAddress: "Kiel", RegisterNumber: "HRB 1", VatNumber: "DE1",
+		}, 3},
+		{"a VAT ID counts like the register entry beside it", corpusLegalEntity{Name: "Acme GmbH", VatNumber: "DE1"}, 1},
 		{"blank is not printed", corpusLegalEntity{Name: "Acme GmbH", RegisteredAddress: "  "}, 0},
 	} {
 		if got := legalEntityDetail(tc.entity); got != tc.want {
@@ -227,6 +231,79 @@ func TestCensusFillsTheAddressTheProfileLaneMissed(t *testing.T) {
 		if f.EvidenceSnippet == "" || f.SourceURL != impressum {
 			t.Errorf("%s arrived without evidence or a source page", f.Field)
 		}
+	}
+}
+
+// A VAT ID is an identity when no register number is printed.
+//
+// A tax office issues one per company, so two sightings sharing one are the
+// same company however their locales name it, and two carrying different ones
+// are two companies however alike their names read. Without this a notice
+// printing only VAT IDs had no identity at all: one entity split under its
+// locale names and could trip the multi-entity abstention, and two companies
+// under one name merged into whichever the crawl saw first.
+func TestAVatNumberIsAnIdentityWhereNoRegisterNumberIs(t *testing.T) {
+	const imprint = "https://example.com/impressum"
+	same := dedupeLegalEntities([]corpusLegalEntity{
+		{Name: "Acme GmbH", VatNumber: "DE111111111", SourceURL: imprint},
+		{Name: "Acme Deutschland", VatNumber: "DE111111111", SourceURL: imprint},
+	})
+	if len(same) != 1 {
+		t.Errorf("one VAT ID under two locale names folded to %d entities, want 1: %+v", len(same), same)
+	}
+
+	distinct := dedupeLegalEntities([]corpusLegalEntity{
+		{Name: "Acme GmbH", VatNumber: "DE111111111", SourceURL: imprint},
+		{Name: "Acme GmbH", VatNumber: "DE222222222", SourceURL: imprint},
+	})
+	if len(distinct) != 2 {
+		t.Errorf("two VAT IDs under one name folded to %d entities, want 2: %+v", len(distinct), distinct)
+	}
+}
+
+// Two sightings of one entity on one page keep BOTH numbers.
+//
+// An imprint block naming the address and the VAT ID and another naming the
+// address and the register entry tie on how much each states, so a rule that
+// kept the richer sighting whole kept whichever came first and dropped the
+// other's number. They are three facts about one company and the page order
+// decides nothing.
+func TestOneEntitySeenTwiceKeepsBothItsNumbers(t *testing.T) {
+	const imprint = "https://example.com/impressum"
+	got := dedupeLegalEntities([]corpusLegalEntity{
+		{Name: "Acme GmbH", RegisteredAddress: "Werkstr. 1", VatNumber: "DE111111111", SourceURL: imprint},
+		{Name: "Acme GmbH", RegisteredAddress: "Werkstr. 1", RegisterNumber: "HRB 42", SourceURL: imprint},
+	})
+	if len(got) != 1 {
+		t.Fatalf("one entity seen twice folded to %d, want 1: %+v", len(got), got)
+	}
+	if got[0].RegisterNumber != "HRB 42" || got[0].VatNumber != "DE111111111" {
+		t.Errorf("the fold dropped a number: %+v", got[0])
+	}
+}
+
+// A detail is never borrowed across pages, because the evidence would lie.
+//
+// An entity carries ONE snippet and one source URL, and every field filled
+// from it is published citing them. A number taken from another page would
+// arrive quoting a passage that never printed it — the claim the no-guess
+// gate exists to refuse.
+func TestADetailIsNeverBorrowedFromAnotherPage(t *testing.T) {
+	got := dedupeLegalEntities([]corpusLegalEntity{
+		{
+			Name: "Acme GmbH", RegisteredAddress: "Werkstr. 1", RegisterNumber: "HRB 42",
+			EvidenceSnippet: "Acme GmbH, Werkstr. 1, HRB 42", SourceURL: "https://example.com/impressum",
+		},
+		{
+			Name: "Acme GmbH", VatNumber: "DE111111111",
+			EvidenceSnippet: "Acme GmbH, USt-IdNr. DE111111111", SourceURL: "https://example.com/en/imprint",
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("one entity across two locales folded to %d, want 1: %+v", len(got), got)
+	}
+	if got[0].VatNumber != "" {
+		t.Errorf("a VAT ID from another page rode in on this page's evidence: %+v", got[0])
 	}
 }
 

--- a/backend/internal/compose/sitepageentities.go
+++ b/backend/internal/compose/sitepageentities.go
@@ -59,11 +59,16 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 			// legal identity that was never theirs.
 			entity.RegisteredAddress = groundedDetail(blockNorm, e.A)
 			entity.RegisterNumber = groundedDetail(blockNorm, e.R)
+			entity.VatNumber = groundedDetail(blockNorm, e.V)
 			// A detail the model stated but the page does not print is the
 			// no-guess gate working; report it rather than dropping it in
-			// silence, so a systematically-lost field is visible.
+			// silence, so a systematically-lost field is visible. Each number
+			// is reported under the field it would have filled, so a lane
+			// losing register entries is not read as losing VAT IDs.
 			for field, claimed := range map[string]string{
-				fieldRegisteredAddress: e.A, fieldRegisterVat: e.R,
+				fieldRegisteredAddress: e.A,
+				fieldRegisterNumber:    e.R,
+				fieldRegisterVat:       e.V,
 			} {
 				if strings.TrimSpace(claimed) != "" && groundedDetail(blockNorm, claimed) == "" {
 					drop(laneLegal, field, claimed, dropValueNotInSnippet)

--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -27,7 +27,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
-	"github.com/margince/margince/backend/internal/shared/schema"
 )
 
 // pageMenu is what one page kind is asked for: the fact fields it may
@@ -113,121 +112,6 @@ func invertFactFields() map[string]string {
 	return byField
 }
 
-// pageFactsSystem is the per-page prompt. Small on purpose: the field
-// menu and the guidance line are the whole instruction. The fence is the
-// one wrapping the passages in the SAME call — its rule closes the prompt,
-// because the boundary is minted per call and the model has to be told
-// which marker it is looking at.
-func pageFactsSystem(menu pageMenu, fence promptfence.Fence) string {
-	var b strings.Builder
-	b.WriteString("You extract company facts from ONE page of a company's website for a CRM. The page is given as numbered passages [s0], [s1], ….\n")
-	b.WriteString(`Return ONLY a JSON object: {"facts":[...]`)
-	if menu.people {
-		b.WriteString(`,"people":[...]`)
-	}
-	if menu.entities {
-		b.WriteString(`,"entities":[...]`)
-	}
-	b.WriteString("}.\n")
-	if len(menu.factFields) > 0 {
-		fmt.Fprintf(&b, "facts — one entry per distinct item: {\"f\":field,\"v\":value,\"e\":passage id}. Allowed fields: %s. %s\n",
-			strings.Join(menu.factFields, ", "), menuGuidance(menu.factFields))
-		b.WriteString("For list fields spell v as the item's name, then ' — ', then a short description when the page gives one. The item's NAME must appear in the passage you cite.\n")
-	} else {
-		b.WriteString("facts must be empty for this page.\n")
-	}
-	if menu.people {
-		b.WriteString("people — ONLY people this page itself publishes: {\"n\":full name,\"r\":stated role,\"q\":the words tying them together,\"w\":the other people inside q,\"m\":email,\"l\":linkedin url,\"e\":passage id}. " +
-			"r is the person's WHOLE title as printed — \"Senior Amazon Account-Manager\", never just \"Senior\". " +
-			"q is a VERBATIM copy of the page, running from the role to the name or from the name to the role, unbroken — copy every word in between, change nothing, add nothing. " +
-			"A page listing several people under one heading gives each of them a q that starts at that heading, and w then names the colleagues that q reaches over. " +
-			"w is empty unless q prints somebody else; a name in q that w omits means the claim is refused. " +
-			"When the page never states that THIS person holds THIS role, leave the person out entirely rather than guessing a q. " +
-			"Include m or l ONLY when the page prints that exact address or URL — omit otherwise, NEVER guess.\n")
-	}
-	if menu.entities {
-		b.WriteString("entities — EVERY distinct legal entity this legal page names: {\"n\":entity name,\"a\":registered address,\"r\":registration/VAT/tax number,\"e\":passage id}. " +
-			"A legal notice states each entity as a block: give the address and the registration number printed WITH that entity's name, copied exactly as printed. " +
-			"For r copy ONE complete legal identifier exactly as printed, preferring a commercial-register number over a VAT/tax number; never combine several identifiers. " +
-			"a and r are ALWAYS present in your answer — use an empty string when the page states none for that entity, and never carry one entity's detail onto another. " +
-			"A market, office or brand label (\"Acme Singapore\", \"DACH\") is NOT an entity: the entity is the registered company name printed under that label (\"Acme Pte. Ltd.\"). List every entity.\n")
-	}
-	b.WriteString("Cite the passage id that states each item. OMIT anything the page does not state — never guess.\n")
-	b.WriteString(fence.Rule("page"))
-	return b.String()
-}
-
-// menuGuidance narrows categoryGuidance to the fields the menu offers.
-func menuGuidance(fields []string) string {
-	present := map[string]bool{}
-	for _, f := range fields {
-		present[f] = true
-	}
-	var parts []string
-	// EVERY category the vocabulary describes, "market" included. It was
-	// missing, so a page offering company_size or served_industry reached the
-	// model with no guidance for either — and company_size then collected
-	// whatever looked numeric: a headcount that belonged in employee_range,
-	// the company's own name, a revenue figure. The categories are listed in
-	// the order the guidance reads best, not the order the map iterates.
-	for _, category := range []string{companyWord, "offering", "market", "signal"} {
-		for _, f := range people.OrganizationFactFields[category] {
-			if present[f] {
-				parts = append(parts, categoryGuidance[category])
-				break
-			}
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
-// pageFactsSchema pins the reply shape at generation: the field AND the
-// snippet id are enums of exactly what this page offers.
-func pageFactsSchema(menu pageMenu, snippetIDs []string) json.RawMessage {
-	props := map[string]schema.Node{}
-	required := []string{"facts"}
-	factItem := map[string]schema.Node{
-		"v": schema.String().Describe("The item's value."),
-		"e": schema.Enum(snippetIDs...).Describe("The passage id that states it."),
-	}
-	if len(menu.factFields) > 0 {
-		factItem["f"] = schema.Enum(menu.factFields...).Describe("Which fact field this is.")
-		props["facts"] = schema.Array(schema.Object(factItem, "f", "v", "e"))
-	} else {
-		// The lane key stays present (one envelope shape for the shared
-		// validator) but can only hold nothing.
-		props["facts"] = schema.Array(schema.Object(factItem, "v", "e"))
-	}
-	if menu.people {
-		props["people"] = schema.Array(schema.Object(map[string]schema.Node{
-			"n": schema.String().Describe("The person's full name as printed."),
-			"r": schema.String().Describe("The person's stated role."),
-			"q": schema.String().Describe(
-				"Copy the page's own words that give THIS person THIS role, " +
-					"from the role to the name or the name to the role, exactly as printed " +
-					"and with nothing left out in between. If the page never puts the two " +
-					"together, omit the person."),
-			"w": schema.String().Describe(
-				"Every OTHER person printed inside q, separated by '; '. " +
-					"Empty string when q names nobody else. Copy each name exactly as printed."),
-			"m": schema.String().Describe("An email ONLY if this page prints it verbatim."),
-			"l": schema.String().Describe("A LinkedIn URL ONLY if this page prints it verbatim."),
-			"e": schema.Enum(snippetIDs...).Describe("The passage id naming the person."),
-		}, "n", "r", "q", "w", "e"))
-		required = append(required, "people")
-	}
-	if menu.entities {
-		props["entities"] = schema.Array(schema.Object(map[string]schema.Node{
-			"n": schema.String().Describe("The legal entity's name as printed."),
-			"a": schema.String().Describe("Its registered address exactly as printed for THIS entity; empty string if the page states none."),
-			"r": schema.String().Describe("Its registration, VAT, UID or tax number exactly as printed for THIS entity; empty string if the page states none."),
-			"e": schema.Enum(snippetIDs...).Describe("The passage id naming it."),
-		}, "n", "a", "r", "e"))
-		required = append(required, "entities")
-	}
-	return schema.Must(schema.Object(props, required...))
-}
-
 // pageFactsReply is the compact JSON shape every page call answers in.
 // pageFactsPerson is one claimed person in a page-facts reply: name, stated
 // role, optional published email and LinkedIn, and the passage cited for it.
@@ -252,6 +136,7 @@ type pageFactsReply struct {
 		N string `json:"n"`
 		A string `json:"a"`
 		R string `json:"r"`
+		V string `json:"v"`
 		E string `json:"e"`
 	} `json:"entities"`
 }

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -358,17 +358,22 @@ func TestGatePageEntitiesRefusesDetailsThePageNeverPrinted(t *testing.T) {
 	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindImpressum, seedURL+"/imprint",
 		"Imprint. Acme Robotics GmbH, Kiel, Germany. This notice states no register number at all.")
 	reply := `{"facts":[],"entities":[
-		{"n":"Acme Robotics GmbH","a":"Baker Street 221B, London","r":"HRB 99999","e":"s0"}]}`
+		{"n":"Acme Robotics GmbH","a":"Baker Street 221B, London","r":"HRB 99999","v":"DE999999999","e":"s0"}]}`
 	res, dropped := gatePageEntities2(t, reply, page, menu, idx)
 	if len(res) != 1 {
 		t.Fatalf("the entity itself is printed and must survive: %+v", res)
 	}
-	if res[0].RegisteredAddress != "" || res[0].RegisterNumber != "" {
-		t.Errorf("an invented address or register number reached the block: %+v", res[0])
+	if res[0].RegisteredAddress != "" || res[0].RegisterNumber != "" || res[0].VatNumber != "" {
+		t.Errorf("an invented address or number reached the block: %+v", res[0])
 	}
+	// Each invention is reported under the field it would have filled, so a
+	// lane systematically losing register entries cannot read as one losing
+	// VAT IDs.
 	reasons := dropReasons(dropped)
-	if reasons[fieldRegisteredAddress] != dropValueNotInSnippet || reasons[fieldRegisterVat] != dropValueNotInSnippet {
-		t.Errorf("both inventions must be REPORTED, not dropped in silence: %+v", dropped)
+	if reasons[fieldRegisteredAddress] != dropValueNotInSnippet ||
+		reasons[fieldRegisterNumber] != dropValueNotInSnippet ||
+		reasons[fieldRegisterVat] != dropValueNotInSnippet {
+		t.Errorf("every invention must be REPORTED, not dropped in silence: %+v", dropped)
 	}
 }
 

--- a/backend/internal/compose/sitepagefactsprompt.go
+++ b/backend/internal/compose/sitepagefactsprompt.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the page-facts call ASKS, and the shape it must answer in.
+//
+// The two belong together and apart from the gate that judges the answer: the
+// prompt describes each field in prose and the schema describes the same
+// fields to the decoder, so a field named in one and missing from the other is
+// a call that cannot answer what it was asked. Changing what a field means is
+// therefore two edits in this file, never one — the entity block's `r` and `v`
+// are the worked example, being two different authorities' numbers that a
+// single loose description had let the model merge.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/margince/margince/backend/internal/shared/schema"
+)
+
+// pageFactsSystem is the per-page prompt. Small on purpose: the field
+// menu and the guidance line are the whole instruction. The fence is the
+// one wrapping the passages in the SAME call — its rule closes the prompt,
+// because the boundary is minted per call and the model has to be told
+// which marker it is looking at.
+func pageFactsSystem(menu pageMenu, fence promptfence.Fence) string {
+	var b strings.Builder
+	b.WriteString("You extract company facts from ONE page of a company's website for a CRM. The page is given as numbered passages [s0], [s1], ….\n")
+	b.WriteString(`Return ONLY a JSON object: {"facts":[...]`)
+	if menu.people {
+		b.WriteString(`,"people":[...]`)
+	}
+	if menu.entities {
+		b.WriteString(`,"entities":[...]`)
+	}
+	b.WriteString("}.\n")
+	if len(menu.factFields) > 0 {
+		fmt.Fprintf(&b, "facts — one entry per distinct item: {\"f\":field,\"v\":value,\"e\":passage id}. Allowed fields: %s. %s\n",
+			strings.Join(menu.factFields, ", "), menuGuidance(menu.factFields))
+		b.WriteString("For list fields spell v as the item's name, then ' — ', then a short description when the page gives one. The item's NAME must appear in the passage you cite.\n")
+	} else {
+		b.WriteString("facts must be empty for this page.\n")
+	}
+	if menu.people {
+		b.WriteString("people — ONLY people this page itself publishes: {\"n\":full name,\"r\":stated role,\"q\":the words tying them together,\"w\":the other people inside q,\"m\":email,\"l\":linkedin url,\"e\":passage id}. " +
+			"r is the person's WHOLE title as printed — \"Senior Amazon Account-Manager\", never just \"Senior\". " +
+			"q is a VERBATIM copy of the page, running from the role to the name or from the name to the role, unbroken — copy every word in between, change nothing, add nothing. " +
+			"A page listing several people under one heading gives each of them a q that starts at that heading, and w then names the colleagues that q reaches over. " +
+			"w is empty unless q prints somebody else; a name in q that w omits means the claim is refused. " +
+			"When the page never states that THIS person holds THIS role, leave the person out entirely rather than guessing a q. " +
+			"Include m or l ONLY when the page prints that exact address or URL — omit otherwise, NEVER guess.\n")
+	}
+	if menu.entities {
+		b.WriteString("entities — EVERY distinct legal entity this legal page names: {\"n\":entity name,\"a\":registered address,\"r\":commercial-register entry,\"v\":VAT/tax number,\"e\":passage id}. " +
+			"A legal notice states each entity as a block: give the address and the numbers printed WITH that entity's name, copied exactly as printed. " +
+			"r and v are DIFFERENT identifiers issued by different authorities, so never put one in the other's place and never combine several into one string. " +
+			"r is the court register entry — \"HRB 12345 B\", \"HRA 4711\", a companies-house number. " +
+			"v is the tax identifier — a VAT ID like \"DE123456789\", a UID, a tax number. " +
+			"a, r and v are ALWAYS present in your answer — use an empty string when the page states none for that entity, and never carry one entity's detail onto another. " +
+			"A market, office or brand label (\"Acme Singapore\", \"DACH\") is NOT an entity: the entity is the registered company name printed under that label (\"Acme Pte. Ltd.\"). List every entity.\n")
+	}
+	b.WriteString("Cite the passage id that states each item. OMIT anything the page does not state — never guess.\n")
+	b.WriteString(fence.Rule("page"))
+	return b.String()
+}
+
+// menuGuidance narrows categoryGuidance to the fields the menu offers.
+func menuGuidance(fields []string) string {
+	present := map[string]bool{}
+	for _, f := range fields {
+		present[f] = true
+	}
+	var parts []string
+	// EVERY category the vocabulary describes, "market" included. It was
+	// missing, so a page offering company_size or served_industry reached the
+	// model with no guidance for either — and company_size then collected
+	// whatever looked numeric: a headcount that belonged in employee_range,
+	// the company's own name, a revenue figure. The categories are listed in
+	// the order the guidance reads best, not the order the map iterates.
+	for _, category := range []string{companyWord, "offering", "market", "signal"} {
+		for _, f := range people.OrganizationFactFields[category] {
+			if present[f] {
+				parts = append(parts, categoryGuidance[category])
+				break
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// pageFactsSchema pins the reply shape at generation: the field AND the
+// snippet id are enums of exactly what this page offers.
+func pageFactsSchema(menu pageMenu, snippetIDs []string) json.RawMessage {
+	props := map[string]schema.Node{}
+	required := []string{"facts"}
+	factItem := map[string]schema.Node{
+		"v": schema.String().Describe("The item's value."),
+		"e": schema.Enum(snippetIDs...).Describe("The passage id that states it."),
+	}
+	if len(menu.factFields) > 0 {
+		factItem["f"] = schema.Enum(menu.factFields...).Describe("Which fact field this is.")
+		props["facts"] = schema.Array(schema.Object(factItem, "f", "v", "e"))
+	} else {
+		// The lane key stays present (one envelope shape for the shared
+		// validator) but can only hold nothing.
+		props["facts"] = schema.Array(schema.Object(factItem, "v", "e"))
+	}
+	if menu.people {
+		props["people"] = schema.Array(schema.Object(map[string]schema.Node{
+			"n": schema.String().Describe("The person's full name as printed."),
+			"r": schema.String().Describe("The person's stated role."),
+			"q": schema.String().Describe(
+				"Copy the page's own words that give THIS person THIS role, " +
+					"from the role to the name or the name to the role, exactly as printed " +
+					"and with nothing left out in between. If the page never puts the two " +
+					"together, omit the person."),
+			"w": schema.String().Describe(
+				"Every OTHER person printed inside q, separated by '; '. " +
+					"Empty string when q names nobody else. Copy each name exactly as printed."),
+			"m": schema.String().Describe("An email ONLY if this page prints it verbatim."),
+			"l": schema.String().Describe("A LinkedIn URL ONLY if this page prints it verbatim."),
+			"e": schema.Enum(snippetIDs...).Describe("The passage id naming the person."),
+		}, "n", "r", "q", "w", "e"))
+		required = append(required, "people")
+	}
+	if menu.entities {
+		props["entities"] = schema.Array(schema.Object(map[string]schema.Node{
+			"n": schema.String().Describe("The legal entity's name as printed."),
+			"a": schema.String().Describe("Its registered address exactly as printed for THIS entity; empty string if the page states none."),
+			"r": schema.String().Describe("Its commercial-register entry (HRB/HRA or the local equivalent) exactly as printed for THIS entity; empty string if the page states none."),
+			"v": schema.String().Describe("Its VAT, UID or tax number exactly as printed for THIS entity; empty string if the page states none."),
+			"e": schema.Enum(snippetIDs...).Describe("The passage id naming it."),
+		}, "n", "a", "r", "v", "e"))
+		required = append(required, "entities")
+	}
+	return schema.Must(schema.Object(props, required...))
+}

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -67,7 +67,8 @@ const (
 var profileSystem = fmt.Sprintf(`You extract a company's profile from numbered passages of key pages of its website, for a CRM.
 Return ONLY a JSON object: {"fields":[{"f":field,"v":value,"e":passage id,"c":confidence 0.0-1.0}]} with at most one entry per field.
 Allowed fields: %s.
-Cite the passage id that grounds each value; write v in the site's own terms. legal_name, registered_address and register_vat ONLY from a legal-notice page's passages, and ONLY when the site's legal pages name exactly one entity.
+Cite the passage id that grounds each value; write v in the site's own terms. legal_name, registered_address, legal_form, register_court, register_number and register_vat ONLY from a legal-notice page's passages, and ONLY when the site's legal pages name exactly one entity.
+register_number is the court's commercial-register entry ("HRB 12345 B"); register_vat is the tax identifier ("DE123456789"). Different authorities issue them and a notice prints both — never put one in the other's place.
 OMIT any field the passages do not ground — never guess.`,
 	strings.Join(extractionFieldNames, ", "))
 
@@ -84,6 +85,14 @@ var hardGateProfileFields = map[string]bool{
 	string(crmcontracts.ColdStartFieldFieldLegalName):         true,
 	string(crmcontracts.ColdStartFieldFieldRegisteredAddress): true,
 	string(crmcontracts.ColdStartFieldFieldRegisterVat):       true,
+	// The rest of the imprint block. Each is copied off the page verbatim —
+	// a legal form, a court's name and a register entry are quotations, not
+	// paraphrases — so each earns the same gate the two beside it have. A
+	// register entry that reached the warning-only path would be a legal
+	// identity nobody printed, appended with a drop already reported.
+	string(crmcontracts.ColdStartFieldFieldLegalForm):      true,
+	string(crmcontracts.ColdStartFieldFieldRegisterCourt):  true,
+	string(crmcontracts.ColdStartFieldFieldRegisterNumber): true,
 }
 
 // profileReply is the profile call's JSON shape.

--- a/backend/internal/compose/sitereaddebugreport.go
+++ b/backend/internal/compose/sitereaddebugreport.go
@@ -70,11 +70,13 @@ type DebugExtraction struct {
 	Dropped []DebugDrop `json:"dropped"`
 }
 
-// DebugLegalEntity is one entity a legal page names.
+// DebugLegalEntity is one entity a legal page names. The field order mirrors
+// corpusLegalEntity exactly, because the conversion below is a direct one.
 type DebugLegalEntity struct {
 	Name              string `json:"name"`
 	RegisteredAddress string `json:"registered_address,omitempty"`
 	RegisterNumber    string `json:"register_number,omitempty"`
+	VatNumber         string `json:"vat_number,omitempty"`
 	EvidenceSnippet   string `json:"evidence_snippet,omitempty"`
 	SourceURL         string `json:"source_url"`
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15261,12 +15261,15 @@ type CompanySiteReadLegalEntity struct {
 	// Name The entity's registered name exactly as the legal notice prints it.
 	Name string `json:"name"`
 
-	// RegisterNumber Its registration, VAT, UID or tax number as printed; absent when the page states none for this entity.
+	// RegisterNumber Its commercial-register entry as printed (HRB/HRA or the local equivalent); absent when the page states none for this entity. A dossier read before the two numbers were told apart may hold a VAT ID here.
 	RegisterNumber *string `json:"register_number,omitempty"`
 
 	// RegisteredAddress Its registered address as printed; absent when the page states none for this entity.
 	RegisteredAddress *string `json:"registered_address,omitempty"`
 	SourceUrl         string  `json:"source_url"`
+
+	// VatNumber Its VAT, UID or tax number as printed; absent when the page states none for this entity.
+	VatNumber *string `json:"vat_number,omitempty"`
 }
 
 // CompanySiteReadMessageReply defines model for CompanySiteReadMessageReply.

--- a/backend/internal/modules/people/companysiteread.go
+++ b/backend/internal/modules/people/companysiteread.go
@@ -415,13 +415,15 @@ func selectedLegalEntityFields(entities []SiteReadLegalEntity, in ConfirmCompany
 		return nil
 	}
 	address := PrintedSiteReadValue(pointerValue(in.Fields[fieldRegisteredAddress]))
-	register := PrintedSiteReadValue(pointerValue(in.Fields[fieldRegisterVat]))
+	register := PrintedSiteReadValue(pointerValue(in.Fields[fieldRegisterNumber]))
+	vat := PrintedSiteReadValue(pointerValue(in.Fields[fieldRegisterVat]))
 	var selected *SiteReadLegalEntity
 	for i := range entities {
 		entity := &entities[i]
 		if !samePrintedValue(entity.Name, legalName) ||
 			(address != "" && !samePrintedValue(entity.RegisteredAddress, address)) ||
-			(register != "" && !samePrintedValue(entity.RegisterNumber, register)) {
+			(register != "" && !samePrintedValue(entity.RegisterNumber, register)) ||
+			(vat != "" && !samePrintedValue(entity.VatNumber, vat)) {
 			continue
 		}
 		if selected != nil {
@@ -444,7 +446,8 @@ func selectedLegalEntityFields(entities []SiteReadLegalEntity, in ConfirmCompany
 		value string
 	}{
 		{name: fieldRegisteredAddress, value: PrintedSiteReadValue(selected.RegisteredAddress)},
-		{name: fieldRegisterVat, value: PrintedSiteReadValue(selected.RegisterNumber)},
+		{name: fieldRegisterNumber, value: PrintedSiteReadValue(selected.RegisterNumber)},
+		{name: fieldRegisterVat, value: PrintedSiteReadValue(selected.VatNumber)},
 	} {
 		if field.value != "" {
 			fields = append(fields, DeepReadField{

--- a/backend/internal/modules/people/companysitereadcomparison_test.go
+++ b/backend/internal/modules/people/companysitereadcomparison_test.go
@@ -360,7 +360,7 @@ func TestSplitConfirmedProfileKeepsSelectedLegalEntityWebsiteGrounding(t *testin
 	entities := []SiteReadLegalEntity{
 		{Name: "Gradion Pte. Ltd.", SourceURL: "https://gradion.com/imprint"},
 		{
-			Name: "NFQ Solutions GmbH", RegisteredAddress: address, RegisterNumber: vat,
+			Name: "NFQ Solutions GmbH", RegisteredAddress: address, VatNumber: vat,
 			EvidenceSnippet: "NFQ Solutions GmbH, Deliusstraße 7, VAT DE346175276",
 			SourceURL:       "https://gradion.com/de/imprint",
 		},

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -79,12 +79,18 @@ type SiteRead struct {
 // SiteReadLegalEntity is one legal entity a legal notice states, with the
 // identity details printed alongside it. A group publishes several, and
 // the read refuses to guess which one an installation belongs to — so it
-// keeps them all and the human picks. Address and register number are
-// empty when the page named the entity without them.
+// keeps them all and the human picks. Address, register number and VAT
+// number are empty when the page named the entity without them.
+//
+// A dossier written before the two numbers were told apart carries only
+// RegisterNumber, holding whichever of the two its page printed. Nothing
+// rewrites those: which one it holds cannot be recovered without parsing,
+// and the read that replaces it will fill both fields honestly.
 type SiteReadLegalEntity struct {
 	Name              string `json:"name"`
 	RegisteredAddress string `json:"registered_address,omitempty"`
 	RegisterNumber    string `json:"register_number,omitempty"`
+	VatNumber         string `json:"vat_number,omitempty"`
 	EvidenceSnippet   string `json:"evidence_snippet,omitempty"`
 	SourceURL         string `json:"source_url"`
 }

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -86,6 +86,13 @@ type SiteRead struct {
 // RegisterNumber, holding whichever of the two its page printed. Nothing
 // rewrites those: which one it holds cannot be recovered without parsing,
 // and the read that replaces it will fill both fields honestly.
+//
+// Picking an entity out of such a dossier therefore offers that value as the
+// register entry, which is right when it is one and wrong when it is a VAT
+// ID. It was equally a coin flip before, filed under the other field, and a
+// person sees the value on the card they are picking from and can correct it.
+// A dossier is a crawl result rather than a record: re-reading the site is
+// what settles one, and is cheaper than a scheme for guessing backwards.
 type SiteReadLegalEntity struct {
 	Name              string `json:"name"`
 	RegisteredAddress string `json:"registered_address,omitempty"`

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -19937,8 +19937,10 @@ export interface components {
             name: string;
             /** @description Its registered address as printed; absent when the page states none for this entity. */
             registered_address?: string;
-            /** @description Its registration, VAT, UID or tax number as printed; absent when the page states none for this entity. */
+            /** @description Its commercial-register entry as printed (HRB/HRA or the local equivalent); absent when the page states none for this entity. A dossier read before the two numbers were told apart may hold a VAT ID here. */
             register_number?: string;
+            /** @description Its VAT, UID or tax number as printed; absent when the page states none for this entity. */
+            vat_number?: string;
             evidence_snippet?: string;
             /** Format: uri */
             source_url: string;

--- a/frontend/src/screens/onboarding-company-form.tsx
+++ b/frontend/src/screens/onboarding-company-form.tsx
@@ -291,9 +291,13 @@ function LegalEntityChoice({
                 {entity.registered_address ? (
                   <span>{entity.registered_address}</span>
                 ) : null}
+                {/* Both numbers, because either may be the only one a notice
+                    printed — and this is the moment a person tells two
+                    candidates apart. */}
                 {entity.register_number ? (
                   <small>{entity.register_number}</small>
                 ) : null}
+                {entity.vat_number ? <small>{entity.vat_number}</small> : null}
               </span>
             </button>
           );

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -805,7 +805,11 @@ export function CompanyAct({
             ? null
             : {
                 meta: entity.registered_address,
-                mono: entity.register_number,
+                // The card has one slot for a number, so it shows the
+                // registry identity and falls back to the tax one: an entity
+                // whose notice printed only a VAT ID would otherwise be a
+                // bare name at the moment somebody has to pick between two.
+                mono: entity.register_number ?? entity.vat_number,
                 snippet: entity.evidence_snippet,
                 source: entity.source_url,
               };

--- a/frontend/src/screens/onboarding-conversation/company-proposal.test.ts
+++ b/frontend/src/screens/onboarding-conversation/company-proposal.test.ts
@@ -33,13 +33,13 @@ describe("draftWithLegalEntity", () => {
     expect(next.values.registered_address).toBe(
       "Level 12, Bitexco Tower, 2 Hai Trieu, District 1, Ho Chi Minh City",
     );
-    expect(next.values.register_vat).toBe("0318 447 291");
+    expect(next.values.register_number).toBe("0318 447 291");
     // Grounded, not edited: the review must be able to tell this came from
     // the site's own legal notice, the same as any other scraped field.
     for (const field of [
       "legal_name",
       "registered_address",
-      "register_vat",
+      "register_number",
     ] as const) {
       expect(next.grounded[field]).toMatchObject({
         source_kind: "url",
@@ -58,7 +58,7 @@ describe("draftWithLegalEntity", () => {
     for (const field of [
       "legal_name",
       "registered_address",
-      "register_vat",
+      "register_number",
     ] as const) {
       expect(next.grounded[field]?.confidence).toBeUndefined();
     }
@@ -127,7 +127,7 @@ describe("draftWithLegalEntity", () => {
     expect(next.grounded.registered_address).toBeUndefined();
     expect(next.edited.has("registered_address")).toBe(true);
     // The fields the human never touched still fill normally.
-    expect(next.values.register_vat).toBe("0318 447 291");
+    expect(next.values.register_number).toBe("0318 447 291");
   });
 });
 
@@ -228,7 +228,7 @@ describe("draftWithSoleLegalEntity", () => {
   it("fills the blanks the profile lane left, from the only company on the site", () => {
     const next = draftWithSoleLegalEntity(EMPTY_DRAFT, [gradionEntity]);
     expect(next.values.legal_name).toBe("Gradion Co., Ltd.");
-    expect(next.values.register_vat).toBe("0318 447 291");
+    expect(next.values.register_number).toBe("0318 447 291");
     expect(next.grounded.legal_name).toMatchObject({
       source_url: gradionEntity.source_url,
       evidence_snippet: gradionEntity.evidence_snippet,
@@ -279,10 +279,10 @@ describe("draftWithSoleLegalEntity", () => {
 
   it("leaves an emptied address and registration number alone too", () => {
     let cleared = changeDraftField(EMPTY_DRAFT, "registered_address", "");
-    cleared = changeDraftField(cleared, "register_vat", "");
+    cleared = changeDraftField(cleared, "register_number", "");
     const next = draftWithSoleLegalEntity(cleared, [gradionEntity]);
     expect(next.values.registered_address).toBe("");
-    expect(next.values.register_vat).toBe("");
+    expect(next.values.register_number).toBe("");
     // The one field nobody touched still fills from the read.
     expect(next.values.legal_name).toBe("Gradion Co., Ltd.");
   });
@@ -293,7 +293,7 @@ describe("draftWithSoleLegalEntity", () => {
     expect(next.values.registered_address).toBe(
       gradionEntity.registered_address,
     );
-    expect(next.values.register_vat).toBe("0318 447 291");
+    expect(next.values.register_number).toBe("0318 447 291");
   });
 });
 

--- a/frontend/src/screens/onboarding-conversation/company-proposal.ts
+++ b/frontend/src/screens/onboarding-conversation/company-proposal.ts
@@ -203,6 +203,7 @@ function collapseWhitespace(value: string): string {
 export const LEGAL_BLOCK: ReadonlySet<string> = new Set([
   "legal_name",
   "registered_address",
+  "register_number",
   "register_vat",
 ]);
 

--- a/frontend/src/screens/onboarding-conversation/company-proposal.ts
+++ b/frontend/src/screens/onboarding-conversation/company-proposal.ts
@@ -258,7 +258,8 @@ export function draftWithLegalEntity(
   const candidates: ReadonlyArray<[ColdField["field"], string | undefined]> = [
     ["legal_name", entity.name],
     ["registered_address", entity.registered_address],
-    ["register_vat", entity.register_number],
+    ["register_number", entity.register_number],
+    ["register_vat", entity.vat_number],
   ];
   for (const [field, value] of candidates) {
     if (edited.has(field) || value === undefined || value.trim() === "") {
@@ -308,19 +309,21 @@ export function draftWithSoleLegalEntity(
     registered_address: unanswered("registered_address")
       ? entity.registered_address
       : undefined,
-    register_number: unanswered("register_vat")
+    register_number: unanswered("register_number")
       ? entity.register_number
       : undefined,
+    vat_number: unanswered("register_vat") ? entity.vat_number : undefined,
   });
 }
 
-// The three fields only a legal/imprint page can ground — the same trio
+// The fields only a legal/imprint page can ground — the same set
 // draftWithLegalEntity fills and the server's own legal gate governs. A
 // blank display_name or offer_summary carries no such page to have checked,
-// so this stays scoped to the trio rather than every empty field.
-const LEGAL_TRIO_FIELDS: ReadonlySet<CompanyFieldName> = new Set([
+// so this stays scoped to these rather than every empty field.
+const LEGAL_PAGE_FIELDS: ReadonlySet<CompanyFieldName> = new Set([
   "legal_name",
   "registered_address",
+  "register_number",
   "register_vat",
 ]);
 
@@ -351,7 +354,7 @@ export function legalFieldGap(
   draft: CompanyDraft,
   entities?: readonly LegalEntity[],
 ): LegalFieldGap | null {
-  if (!LEGAL_TRIO_FIELDS.has(field) || pages === undefined) {
+  if (!LEGAL_PAGE_FIELDS.has(field) || pages === undefined) {
     return null;
   }
   const candidates = entities ?? [];
@@ -378,7 +381,7 @@ export function legalFieldGap(
 // the entity the choice landed on — including when the cleared box is the very
 // name it was picked by.
 function legalBlockChosen(draft: CompanyDraft): boolean {
-  for (const field of LEGAL_TRIO_FIELDS) {
+  for (const field of LEGAL_PAGE_FIELDS) {
     const grounding = provenanceOf(draft, field);
     if (grounding !== null && grounding.confidence === undefined) {
       return true;
@@ -393,6 +396,8 @@ function entityCarries(entity: LegalEntity, field: CompanyFieldName): boolean {
       ? entity.name
       : field === "registered_address"
         ? entity.registered_address
-        : entity.register_number;
+        : field === "register_number"
+          ? entity.register_number
+          : entity.vat_number;
   return carried !== undefined && carried.trim() !== "";
 }

--- a/frontend/src/screens/onboarding-conversation/confirm-card.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.test.tsx
@@ -246,8 +246,8 @@ describe("a field the read did not return", () => {
   });
 
   // The notice is a claim about what the crawl DID, and the wire accounts for
-  // exactly one group of fields: the legal trio, through the pages and
-  // candidates the read reports. For every other blank field it carries
+  // exactly one group of fields: the ones a legal page grounds, through the
+  // pages and candidates the read reports. For every other blank field it carries
   // silence — which covers a crawl that stopped early, an extraction that
   // abstained, and a value the read proposed that the human then cleared. A
   // box over that silence would name a cause the read never gave, which is
@@ -260,6 +260,7 @@ describe("a field the read did not return", () => {
     );
     expect(omitted.sort()).toEqual([
       "ob-triage-row-legal_name",
+      "ob-triage-row-register_number",
       "ob-triage-row-register_vat",
       "ob-triage-row-registered_address",
     ]);

--- a/frontend/src/screens/onboarding-conversation/use-clarify-answers.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/use-clarify-answers.test.tsx
@@ -182,7 +182,7 @@ describe("useClarifyAnswers — the legal-entity fill", () => {
     expect(draftRef.current.values.registered_address).toBe(
       gradionEntity.registered_address,
     );
-    expect(draftRef.current.values.register_vat).toBe(
+    expect(draftRef.current.values.register_number).toBe(
       gradionEntity.register_number,
     );
     // Grounded, not typed by hand — the review must show this as the site's
@@ -212,7 +212,7 @@ describe("useClarifyAnswers — the legal-entity fill", () => {
     for (const field of [
       "legal_name",
       "registered_address",
-      "register_vat",
+      "register_number",
     ] as const) {
       expect(draftRef.current.grounded[field]).toMatchObject({
         source_kind: "url",
@@ -307,7 +307,9 @@ describe("useClarifyAnswers — the legal-entity fill", () => {
     expect(draftRef.current.values.registered_address).toBe(
       padded.registered_address,
     );
-    expect(draftRef.current.values.register_vat).toBe(padded.register_number);
+    expect(draftRef.current.values.register_number).toBe(
+      padded.register_number,
+    );
     expect(draftRef.current.edited.has("legal_name")).toBe(false);
   });
 
@@ -342,7 +344,9 @@ describe("useClarifyAnswers — the legal-entity fill", () => {
     expect(draftRef.current.values.registered_address).toBe(
       doubled.registered_address,
     );
-    expect(draftRef.current.values.register_vat).toBe(doubled.register_number);
+    expect(draftRef.current.values.register_number).toBe(
+      doubled.register_number,
+    );
     expect(draftRef.current.grounded.registered_address).toMatchObject({
       source_kind: "url",
       source_url: doubled.source_url,
@@ -400,7 +404,7 @@ describe("useClarifyAnswers — the legal-entity fill", () => {
     ]);
     // Nothing of the nameless candidate's own block reaches the draft.
     expect(draftRef.current.values.registered_address).toBe("");
-    expect(draftRef.current.values.register_vat).toBe("");
+    expect(draftRef.current.values.register_number).toBe("");
   });
 
   it("never triggers the entity fill for a clarify over a different field, even when the value happens to match a candidate's name", async () => {


### PR DESCRIPTION
Closes #3031.

## The defect

A court issues a commercial-register entry (`HRB 12345 B`). A tax office issues a VAT ID (`DE123456789`). A German imprint prints both, and they are not the same thing.

The legal-entity census read **one** identifier per entity. The extraction prompt told the model to copy "ONE complete legal identifier ... preferring a commercial-register number over a VAT/tax number", and `fillLegalTrioFromCensus` then wrote whatever came back into `register_vat`. Three consequences:

- An imprint printing an HRB number filed a court entry as a tax number.
- `register_number` — the field added for exactly that value — stayed empty on every site read.
- An accepted refresh could overwrite a real VAT ID a person had typed with a register entry.

## The fix

The census reads both numbers. The prompt asks for `r` and `v` as separate identifiers and names the authority behind each; the response schema describes them the same way; `corpusLegalEntity` carries `VatNumber` beside `RegisterNumber`. Each lands in its own profile field on both paths that write one — the automatic census fill, and the one where a human picks their entity out of a group's imprint.

The drop report carried the same confusion: an invented register entry was reported as a lost VAT ID, so a lane systematically losing one read as losing the other. Each number is now reported under the field it would have filled.

## What is deliberately not done

**Nothing rewrites what is already stored.** A `register_vat` row written before this holds one number or the other with nothing recording which, and a dossier written before it carries only `RegisterNumber`. Neither can be disambiguated without parsing a value a human may have typed, so both keep their meaning and the next read fills the two fields honestly rather than guessing backwards. The contract descriptions say so, and the persisted-dossier comment in `people/siteread.go` says so where the next reader will find it.

## A file split, for the length cap

`sitepagefacts.go` crossed 500 lines, so what the call **asks** — the prompt and the response schema — moves to `sitepagefactsprompt.go`. They belong together and apart from the gate that judges the answer: a field named in the prose and missing from the schema is a call that cannot answer what it was asked, which is how one loose description let the model merge two authorities' numbers to begin with.

## Test

`TestEachLegalNumberReachesItsOwnField` asserts the mapping in **both** directions, because an implementation that simply swapped the two destinations would pass a test that checked one. Mutation-checked: swapping them fails it on both assertions.

Several existing tests encoded the old behaviour and now describe the corrected one — `TestCensusFillsTheAddressTheProfileLaneMissed` asserted an HRB number arriving in `register_vat`, and the frontend suite asserted `values.register_vat === entity.register_number` in four places.

## Verified

`make check-backend` and `make check-fe` green (5297 frontend tests). `make craft-static`, `make rls-store-path`, `make no-jurisdiction` clean. Integration lane run against real Postgres for both `internal/modules/people` and `internal/compose`, under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes site reads treating a commercial-register entry (HRB/HRA, issued by a court) and a VAT ID (issued by a tax office) as one number. The census previously preferred the register entry and stored whatever it found in `register_vat`, so register numbers were filed as tax numbers and `register_number` stayed empty on every read.

**Bug Fixes**
- The census and the human entity-pick path now store each number in its own field: `register_number` for the register entry, `register_vat` for the VAT ID.
- All lanes that write a legal identity now honor the split: the confirm transport carries every imprint field, the profile extraction lane hard-gates them, and conversation corrections map register aliases to `register_number` and tax aliases to `register_vat`.
- The drop report now tracks each number under the field it would have filled, so losing register entries no longer reads as losing VAT IDs.
- A VAT ID now serves as an entity identity where no register entry is printed, and same-page sightings of one entity keep both numbers; the prompt and schema moved to `sitepagefactsprompt.go`.
- Onboarding choice cards show both numbers a notice printed.
- Nothing rewrites stored data: old `register_vat` rows and persisted dossiers keep their meaning, and the next read fills both fields honestly.

<sup>Written for commit 5e845bb45674990d830859024b110d6cc9670791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate support for commercial registration numbers and VAT/tax identifiers.
  * Legal-entity details now display and transmit VAT numbers independently when available.
  * Improved onboarding and evidence extraction for registration, VAT, legal-form, and register-court information.
  * Added attention-feed visibility for approvals whose effects did not run or failed, including status details.

* **Bug Fixes**
  * Corrected registration numbers being reported as VAT numbers.
  * Improved legal-entity matching, field grounding, and missing-field diagnostics.
  * Prevented unsupported or fabricated legal identifiers from being retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->