### PR TITLE
fix(activities): a system write is recognised by its namespaced principal

### DIFF
--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -145,10 +145,15 @@ func TestTheEnginesOwnRowStillDoesNotCountAsEngagement(t *testing.T) {
 	backdateCreatedAt(t, owner, "deal", deal, longEstablished)
 	linkQuietTouch(t, owner, e.WS, "organization", org)
 
+	// captured_by is the NAMESPACED principal the time scan actually binds,
+	// not the bare "system" the bus path uses. A case planting the bare form
+	// passes against an equality on it and says nothing about the rows this
+	// engine writes — which is how a reminder that reset its own clock
+	// reached main behind a green gate.
 	engineRow := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, 'task', 'Follow up (engine-minted)', $2, 'system', 'system')`,
+		 VALUES ($1, 'task', 'Follow up (engine-minted)', $2, 'system', 'system:time-scan')`,
 		engineRow, eligibilityScanNow.AddDate(0, 0, -1)); err != nil {
 		t.Fatalf("seeding the engine row: %v", err)
 	}

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -49,6 +49,22 @@ const systemSource = "system"
 // unforgeable half of the "the system wrote this row" predicate.
 const systemCapturedBy = "system"
 
+// systemCapturedByPattern is the LIKE pattern that matches every system
+// principal, because captured_by carries the principal's ID and those IDs
+// are NAMESPACED: the bus binds a bare "system", while every job binds its
+// own "system:<job>" — "system:time-scan", "system:brief-overnight",
+// "system:comms-send" and thirty-odd more.
+//
+// Comparing against the bare literal alone is what let a reminder task the
+// TIME SCAN minted count as a genuine engagement: it carries
+// captured_by "system:time-scan", the equality missed it, and the row the
+// engine wrote reset the very clock the engine reads. A prefix match is a
+// spelling test and would normally be refused here — it earns its place
+// because the ':' namespace IS the convention every system actor is bound
+// under, and because captured_by is server-stamped from the principal, so
+// no caller can reach this pattern by writing one.
+const systemCapturedByPattern = systemCapturedBy + ":%"
+
 // FollowUpWorkflows returns the system handlers that complete open system
 // follow-up tasks when the follow-up demonstrably happened: a real
 // activity lands on the lead, or the lead leaves the open pool (promoted
@@ -189,9 +205,10 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 			SELECT a.id FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
 			WHERE l.lead_id = $1 AND a.kind = $2 AND a.source = $3
-			  AND a.captured_by = $4
+			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
 			  AND a.is_done = false AND a.archived_at IS NULL
-			ORDER BY a.id`, leadID, string(crmcontracts.ActivityKindTask), systemSource, systemCapturedBy)
+			ORDER BY a.id`, leadID, string(crmcontracts.ActivityKindTask), systemSource,
+			systemCapturedBy, systemCapturedByPattern)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/activities/lasttouch.go
+++ b/backend/internal/modules/activities/lasttouch.go
@@ -47,16 +47,20 @@ type LastTouchCandidate struct {
 // the link-id coalesce, and the organization walk — and it sits apart from the
 // scan so the scan reads as what it does with the rows.
 //
-// $1/$4 are the source and captured_by the automation engine stamps —
-// excluded only TOGETHER, since source alone is a client's to spell —
-// $2 the cutoff, $3 the cap.
+// $1/$4/$5 are the source and captured_by the automation engine stamps —
+// excluded only TOGETHER, since source alone is a client's to spell. $5 is
+// the namespaced form: captured_by carries the principal's ID and every job
+// binds its own ("system:time-scan"), so matching the bare "system" alone
+// missed the engine's own writes and let a reminder reset the clock it
+// reads. $2 the cutoff, $3 the cap.
 func lastTouchCandidateQuery() string {
 	return storekit.SQLf(`
 			WITH genuine AS (
 				SELECT a.id, a.occurred_at
 				FROM activity a
 				WHERE a.archived_at IS NULL
-				  AND NOT (a.source = $1 AND a.captured_by = $4)
+				  AND NOT (a.source = $1
+				           AND (a.captured_by = $4 OR a.captured_by LIKE $5))
 			), direct AS (
 				SELECT al.entity_type AS entity_type,
 				       %[1]s AS entity_id,
@@ -192,7 +196,8 @@ func (s *Store) LastTouchBefore(ctx context.Context, cutoff time.Time, limit int
 		// vocabulary (linktarget.go), the same source the coalesce
 		// expression is built from, so a renamed record type cannot leave a
 		// stale string behind in this query.
-		rows, err := tx.Query(ctx, lastTouchCandidateQuery(), systemSource, cutoff, limit, systemCapturedBy)
+		rows, err := tx.Query(ctx, lastTouchCandidateQuery(), systemSource, cutoff, limit,
+			systemCapturedBy, systemCapturedByPattern)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## main's integration lane is red

`main-health 33129417100`, built `5105120d0` — and it still reproduces on the
current tip:

```
--- FAIL: TestTimeScannerFiresOnceThenTheOccurrenceKeySuppressesTheRefire
    timescan_integration_test.go:116: reminder tasks after the anchor moved = 1,
    want exactly 2 — a new genuine engagement must re-arm the trigger
```

**A reminder the time scan mints counts as a genuine engagement**, so the record
it reminds about stops being quiet the moment it is reminded about. One reminder
lands, and no later genuine touch can ever re-arm the trigger.

## The cause, probed rather than reasoned

`LastTouchBefore` excludes the engine's own rows on the pair `(source,
captured_by)` — `source` rides the create wire and any caller can spell it, so
`captured_by` is the load-bearing half. But `captured_by` carries the
**principal's ID**, and those IDs are **namespaced**:

```
kind=call  source="manual"  captured_by="human:x"
kind=call  source="manual"  captured_by="human:x"
kind=task  source="system"  captured_by="system:time-scan"   <- excluded on "system"
```

The bus binds a bare `"system"`; every job binds its own `"system:<job>"`. The
equality missed `system:time-scan`, so the engine's write reset the very clock
the engine reads — the exact outcome the exclusion's own docblock says it
prevents.

**Census before choosing the predicate**, because a prefix test can be short the
same way an equality was: every `PrincipalSystem` in the tree binds either
`"system"` or `"system:<name>"` — 38 of them, one separator, no third shape.

A prefix test is a spelling test and would normally be refused here. It earns its
place because `':'` **is** the namespace every system actor is bound under, and
because `captured_by` is server-stamped from the principal, so no caller can
reach the pattern by writing one.

## Why the existing gate was green

The case guarding this planted the row by raw INSERT:

```sql
VALUES ($1, 'task', 'Follow up (engine-minted)', $2, 'system', 'system')
```

`'system'` is a shape the engine never writes. The case proves the SQL does what
it says and cannot prove what the engine stamps — *a test that supplies its own
version of production*. It plants `system:time-scan` now.

## Verification

Reproduced and fixed against a real Postgres, both directions, same command:

| | `TestTimeScannerFiresOnce…` | `TestQuietOrganizationWith…` |
|---|---|---|
| exclusion on the bare literal (main today) | **FAIL** | **FAIL** |
| exclusion matching the namespace | PASS | PASS |

The second was already passing before this change and fails under the mutant
**because its plant now uses the namespaced form** — that is the plant being
load-bearing rather than merely present.

Also green: the whole clock/reminder neighbourhood (20 cases), and
`make check-backend`.

## Note

Both readers of the pair are updated — `lasttouch.go`'s candidate query and
`followupresolve.go`'s open-system-task count. Fixing one would have left the
second spelling of the same fact behind.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the system-write exclusion in last-touch and open-task queries so reminders from the time scan no longer count as genuine engagement (which was resetting the quiet clock). The `captured_by` field carries namespaced principal IDs like `system:time-scan`, not just `system`, so the previous equality missed them.

- Updated both `lasttouch.go` and `followupresolve.go` to also match the namespaced prefix (`system:%`).
- Updated the integration test to plant `system:time-scan` instead of the bare `system`, so the case now fails if the exclusion regresses.

<sup>Written for commit b50fb05ccf942f27487d65d7f612e2f454bdfc64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system-generated activities across follow-up resolution and last-touch calculations.
  * Activities created by namespaced system processes are now recognized consistently.
  * Prevented automated activities from incorrectly affecting last-touch results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->