### PR TITLE
Every workflow write is the system's, under one id

### DIFF
--- a/backend/gates/claimedspelling_test.go
+++ b/backend/gates/claimedspelling_test.go
@@ -66,7 +66,6 @@ const driftShape = "cannot-drift"
 // from "second writer", and only naming the other subject does that.
 var sharedSpellings = gatekit.Waive(map[string]string{
 	"internal/modules/ai/feedback.go:fieldSubjectType":           "the second is the same word as a key in the AuditEvent image, where it names a column of the ledger row rather than the request field a refusal points at",
-	"internal/modules/automation/engine.go:systemSource":         "the second is the actor id on principal.Principal, which identifies WHO acted; systemSource is the provenance stamped on what was written",
 	"internal/modules/search/queryjoins.go:objectRelationship":   "the second is the relationship TABLE's name in the join spec beside it, not the RBAC object governing it — the two agree today and are free to diverge",
 	"internal/shared/ports/datasource/shapewords.go:objectShape": "the second is the same two words inside a rendered sentence, where they are English rather than the shape word this constant names",
 })

--- a/backend/gates/workflowactor_test.go
+++ b/backend/gates/workflowactor_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The id a workflow write is attributed to, and the id the selectors that
+// recognise those writes look for, are ONE id.
+//
+// captured_by is written from the acting principal's id and never from a
+// request body, which is what makes it the unforgeable half of "the system
+// wrote this row" — the forgeable half, source, is a value any caller can
+// spell. Two selectors rest on that half: the last-touch scan excludes the
+// engine's own reminders from what counts as genuine engagement, and the
+// follow-up resolver finds the open tasks the engine minted so it can close
+// them. Both live in `activities`; the writer lives in `automation`; a module
+// never imports a sibling, so the fact is spelled twice and nothing but this
+// holds the two spellings equal.
+//
+// It has already come apart once. The time-scan acted as "system:time-scan"
+// while both selectors looked for "system", so every reminder the clock minted
+// counted as a touch on the record it was reminding about: one pass made the
+// record look freshly worked, it was never reminded about again, and the task
+// it left open was never closed. Nothing failed loudly — the reminder landed,
+// the run row said applied, and the second one simply never came.
+//
+// Two halves, because either alone reads green over the defect:
+//
+//   - the CONSTANTS must agree, which is the drift a rename causes;
+//   - every system principal the writing module binds must be that constant,
+//     which is the drift a NEW entry point causes — the one that actually
+//     happened, where the shared constant was right and a second caller
+//     spelled its own.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The two files that spell the one id, and the constants in them. Named
+// rather than searched: a gate that hunted for "whichever constant looks like
+// an actor id" would go quiet the day one is renamed, which is the drift it
+// exists to report.
+const (
+	workflowActorFile  = "internal/modules/automation/engine.go"
+	workflowActorConst = "systemActor"
+
+	workflowSelectorFile  = "internal/modules/activities/followupresolve.go"
+	workflowSelectorConst = "systemCapturedBy"
+
+	// workflowActorBinders are every file in the writing module that puts an
+	// actor on a context. Stated so the census below can say it read them
+	// rather than that it found nothing.
+	workflowRunnerDir = "internal/modules/automation"
+)
+
+func TestTheEngineActsUnderTheIdItsOwnSelectorsLookFor(t *testing.T) {
+	t.Parallel()
+	actor := namedConst(t, workflowActorFile, workflowActorConst)
+	selector := namedConst(t, workflowSelectorFile, workflowSelectorConst)
+	if actor != selector {
+		t.Fatalf("the workflow engine acts as %q (%s.%s) and its own selectors look for %q (%s.%s).\n\n"+
+			"captured_by is written from the acting principal's id, so a row the engine writes under one "+
+			"spelling is invisible to a selector reading the other: the last-touch scan counts the engine's "+
+			"reminders as genuine engagement, and the follow-up resolver never finds the tasks it minted.",
+			actor, workflowActorFile, workflowActorConst, selector, workflowSelectorFile, workflowSelectorConst)
+	}
+
+	bindings := systemActorBindings(t, workflowRunnerDir)
+	// A census that can fail short has already failed: the module has two
+	// entries into runOne and both bind one, so finding fewer means this gate
+	// stopped recognising the shape rather than that the module stopped using
+	// it.
+	if len(bindings) < 2 {
+		t.Fatalf("found %d system principal binding(s) under %s, and the module has at least two (the "+
+			"matcher and the time-scan): this gate is reading a shape the module no longer uses",
+			len(bindings), workflowRunnerDir)
+	}
+	for _, binding := range bindings {
+		if binding.id != workflowActorConst {
+			t.Errorf("%s binds the system principal as %s rather than %s — a second spelling of the actor "+
+				"is a second answer to \"did the system write this row\", and the selectors only know one",
+				binding.where, binding.id, workflowActorConst)
+		}
+	}
+}
+
+// actorBinding is one place the module names the principal it acts as.
+type actorBinding struct {
+	where string
+	// id is the EXPRESSION the ID field was given, as source text. A literal
+	// fails this gate the same way a wrong constant does: the point is that
+	// there is one name for the id, not that two literals happen to match
+	// today.
+	id string
+}
+
+// systemActorBindings finds every principal.Principal composite literal in the
+// module that names PrincipalSystem, and reports what it set ID to.
+func systemActorBindings(t *testing.T, dir string) []actorBinding {
+	t.Helper()
+	// Read here rather than through parsePackageFiles, which the call-graph
+	// censuses share: that one returns syntax without paths, and a finding
+	// naming only the module is one a reader has to go looking for.
+	sources, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("listing %s to find the actors it binds: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var found []actorBinding
+	for _, where := range sources {
+		if strings.HasSuffix(where, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, where, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", where, parseErr)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			lit, isLit := node.(*ast.CompositeLit)
+			if !isLit {
+				return true
+			}
+			kind, id := principalFields(lit)
+			if kind != "PrincipalSystem" {
+				return true
+			}
+			found = append(found, actorBinding{where: where, id: id})
+			return true
+		})
+	}
+	return found
+}
+
+// principalFields reads the Type and ID a principal literal sets, as the
+// selector or identifier name each was given. A field set to something this
+// cannot read comes back as the empty string, which fails the comparison
+// above rather than passing it.
+func principalFields(lit *ast.CompositeLit) (kind, id string) {
+	for _, element := range lit.Elts {
+		kv, isKV := element.(*ast.KeyValueExpr)
+		if !isKV {
+			continue
+		}
+		key, isIdent := kv.Key.(*ast.Ident)
+		if !isIdent {
+			continue
+		}
+		switch key.Name {
+		case "Type":
+			kind = exprName(kv.Value)
+		case "ID":
+			id = exprName(kv.Value)
+		}
+	}
+	return kind, id
+}
+
+// exprName is the name a value was written as: an identifier, the selected
+// name of a qualified one, or the quoted text of a literal — so a hard-coded
+// id is reported as the string it is rather than as nothing.
+func exprName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.SelectorExpr:
+		return value.Sel.Name
+	case *ast.BasicLit:
+		if text, err := strconv.Unquote(value.Value); err == nil {
+			return strconv.Quote(text)
+		}
+		return value.Value
+	}
+	return ""
+}
+
+// namedConst reads one string constant out of one file, and fatals when it is
+// not there. Not-there is the interesting case: a renamed constant means this
+// gate is comparing something it no longer understands, and answering "they
+// differ" would send a reader looking for a drift that is really a rename.
+func namedConst(t *testing.T, file, name string) string {
+	t.Helper()
+	value, declared := constValuesIn(t, file)[name]
+	if !declared {
+		t.Fatalf("%s declares no string constant %s — this gate holds two spellings of one id equal and "+
+			"can no longer find one of them, so it is judging nothing", file, name)
+	}
+	return value
+}

--- a/backend/internal/modules/automation/engine.go
+++ b/backend/internal/modules/automation/engine.go
@@ -145,7 +145,7 @@ func (e *WorkflowEngine) HandleEvent(ctx context.Context, env kevents.Envelope) 
 	// Workflows are deterministic system automations; their writes are
 	// attributed to the system actor and grouped per trigger event.
 	runCtx := principal.WithWorkspaceID(ctx, ws.UUID)
-	runCtx = principal.WithActor(runCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system"})
+	runCtx = principal.WithActor(runCtx, principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
 	runCtx = principal.WithCorrelationID(runCtx, ids.NewV7())
 	runCtx = principal.WithCausationEvent(runCtx, env.EventID)
 
@@ -244,6 +244,26 @@ func (e *WorkflowEngine) liveInstances(ctx context.Context) (map[string][]automa
 // Create/Update calls and applyAssignOwner's (handlers_actions.go)
 // cannot drift into three independent spellings of the same fact.
 const systemSource = "system"
+
+// systemActor is the principal id every workflow write is attributed to, and
+// it is ONE id for both entries into runOne.
+//
+// captured_by is written from the acting principal's id and never from a
+// request body, which is what makes it the unforgeable half of "the system
+// wrote this row". Two selectors depend on that half being one value: the
+// last-touch scan excludes the engine's own reminders from what counts as
+// genuine engagement, and the follow-up resolver finds the open tasks the
+// engine minted so it can close them.
+//
+// The time-scan used to act as "system:time-scan". Nothing read that spelling
+// — it named which entry had fired, which the run row already records — and
+// both selectors looked for the other one, so every reminder the clock minted
+// counted as a touch on the record it was reminding about. One pass then made
+// the record look freshly worked, and it was never reminded about again; the
+// task it left open was never closed either.
+//
+// Held by TestTheEngineActsUnderTheIdItsOwnSelectorsLookFor.
+const systemActor = "system"
 
 // ApplyActions is the shared executor handlers delegate Apply to: each
 // typed action runs through the SAME set of seams every surface uses

--- a/backend/internal/modules/automation/timescan.go
+++ b/backend/internal/modules/automation/timescan.go
@@ -173,7 +173,10 @@ func NewTimeScanner(engine *WorkflowEngine, scan ActivityScan, dateScan DateFiel
 // recorded as completed.
 func (s *TimeScanner) ScanWorkspace(ctx context.Context, wsID ids.UUID) error {
 	now := s.now()
-	wsCtx := principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:time-scan"})
+	// systemActor, the same id HandleEvent acts under: both entries reach the
+	// same runOne and write the same rows, and the selectors that recognise
+	// those rows key on this id.
+	wsCtx := principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
 	wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
 
 	instances, err := s.engine.liveInstances(wsCtx)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (38)
+## Parity (39)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -57,6 +57,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
+| `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 
 ## Census (65)
 


### PR DESCRIPTION
**`main` is red on this.** Thirteen integration tests in `backend/internal/compose/integration` fail on a clean checkout of `origin/main`, and every open PR inherits the failure — 3037 has failed its `integration shard (5/6)` twice on it. This is the fix.

## The defect

`captured_by` is written from the acting principal's id and never from a request body. That is what makes it the **unforgeable** half of "the system wrote this row" — `source` is the forgeable half, and #3040 reverted a reservation on it for exactly that reason, leaving the pairing as the security boundary.

Two selectors rest on that half, both in `activities`:

- `LastTouchBefore` excludes the engine's own reminders from what counts as genuine engagement;
- `followUpAutoResolve` finds the open tasks the engine minted so it can close them — the "system closes the loops it opens" half of #3035.

Both look for `captured_by = 'system'`.

The matcher (`HandleEvent`) acts as `"system"`. The **time-scan** — the other entry into the very same `runOne`, writing the very same rows — acted as `"system:time-scan"`.

So neither selector recognised a clock-minted reminder:

1. the reminder task counted as a **touch on the record it was reminding about**;
2. that record then looked freshly worked, so it fell out of the stale set and was **never reminded about again**;
3. and the task it left open was **never auto-closed**.

Nothing failed loudly. The reminder landed, the run row said `applied`, and the second one simply never came — which is why #3035's own integration tests (a fake provider) and #3040's fix both passed over it.

`"system:time-scan"` had exactly one reference in the tree: its own binding. Which entry fired is already on the run row, so nothing was lost by removing the spelling.

## The fix

Both entries bind `systemActor`, named once in `automation/engine.go` beside `systemSource` — the provenance stamped on *what was written*, which it is deliberately not. One line of behaviour; the rest is the name and why it has to be one.

## Held by a gate, in two halves

`TestTheEngineActsUnderTheIdItsOwnSelectorsLookFor` (`backend/gates/workflowactor_test.go`, parity, H2). Either half alone reads green over this defect:

- **the constants must agree** across the module boundary they are spelled either side of — `automation.systemActor` and `activities.systemCapturedBy`. A module never imports a sibling, so nothing else holds them equal. This is the drift a rename causes.
- **every system principal the writing module binds must be that constant.** This is the drift a *new entry point* causes — the one that actually happened, where the shared constant was right and a second caller spelled its own.

Mutation-checked from the other end:

| mutation | result |
|---|---|
| the time-scan spells its own id again (the defect verbatim) | **caught** — names the file and the spelling |
| `systemCapturedBy` drifts to another value | **caught** — names both constants and what breaks |
| the actor constant is renamed away | **caught** — fatals rather than comparing something it no longer understands |

The census fatals below two bindings, so a gate that stopped recognising the shape reports itself instead of reading green over a module it can no longer see.

One stale entry is dropped from `sharedSpellings` in `claimedspelling_test.go`: the raw `"system"` literal it ratified is gone, and that gate correctly refuses a waiver over a value now spelled once.

## Verification

- `make check-backend` — green
- `make test-it DIR=backend/internal/compose/integration` — green (**13 tests that fail on `origin/main`**, including `TestTimeScannerFiresOnceThenTheOccurrenceKeySuppressesTheRefire`, the one failing CI on 3037)
- `make test-it DIR=backend/internal/modules/automation` — green
- `make test-it DIR=backend/internal/modules/activities` — green

Confirmed against `origin/main` in a clean worktree before and after: same failure, same message as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when workflow and scheduled automation actions are attributed to the system actor.
  * Prevented mismatches between workflow actor identifiers and the selectors used to find related actions.

* **Tests**
  * Added validation to detect inconsistent system actor bindings across workflow automation.

* **Documentation**
  * Updated the gate inventory to include the new consistency check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->