### PR TITLE
test(gates): the profile vocabulary is held in the browser and per contract enum

### DIFF
--- a/backend/gates/companyprofilevocabulary_test.go
+++ b/backend/gates/companyprofilevocabulary_test.go
@@ -24,6 +24,10 @@ package gates
 // The CHECK is the authority because it is what the database enforces: a value
 // it refuses cannot be stored whatever any Go file believes.
 //
+// The browser's five mirrors of the same vocabulary — two label maps, the
+// section grouping, the interview's question list and the draft serializer —
+// are held by frontendprofilevocabulary_test.go, which reads TypeScript.
+//
 // WHAT IT CANNOT SEE, two things:
 //
 // Whether a field is offered to a HUMAN. The company form's typed properties
@@ -252,4 +256,162 @@ func declMentions(decl *ast.GenDecl, name string) bool {
 		}
 	}
 	return false
+}
+
+// Each contract enum carries the WHOLE vocabulary, checked one enum at a time.
+//
+// The contract inlines this vocabulary as a separate enum per schema that
+// names a profile field, and the gate above resolves an identifier against all
+// of them flattened together. That is right for what it does — it is asking
+// what a Go name stands for — and wrong as a check on the enums themselves: a
+// value present in one and missing from another resolves anyway, so a schema
+// that fell short would be covered by its siblings and nothing would fail.
+//
+// What that costs is a field the API refuses on one endpoint and accepts on
+// the next. The generated client for the short enum cannot even name it.
+func TestEveryContractEnumCarriesTheWholeProfileVocabulary(t *testing.T) {
+	t.Parallel()
+	admitted := tableCheckSets(t)[theProfileVocabulary]
+	if len(admitted) < 10 {
+		t.Fatalf("only %d value(s) derived for %s — the migration scan has stopped reading it",
+			len(admitted), theProfileVocabulary)
+	}
+	wholeVocabulary := map[string]bool{}
+	for _, value := range admitted {
+		wholeVocabulary[value] = true
+	}
+
+	byType := profileFieldEnums(t, "internal/contracts/api_gen.go")
+	if len(byType) == 0 {
+		t.Fatal("no enum constants parsed out of the generated contract — this gate reads nothing")
+	}
+
+	for enum, part := range profileFieldEnumRoster {
+		values, generated := byType[enum]
+		if !generated {
+			t.Errorf("the contract no longer generates %s, which this gate is rostered to check.\n"+
+				"  Either the schema was renamed — update the roster — or it is gone and the roster entry is dead.", enum)
+			continue
+		}
+		if part != "" {
+			// A stated part still states it in this vocabulary's own words. A
+			// value from outside it means the enum has become something else,
+			// and its exemption no longer describes it.
+			for value := range values {
+				if !wholeVocabulary[value] {
+					t.Errorf("the contract enum %s is rostered as %s, yet carries %q, which %s does not admit",
+						enum, part, value, theProfileVocabulary)
+				}
+			}
+			continue
+		}
+		var missing []string
+		for _, value := range admitted {
+			if !values[value] {
+				missing = append(missing, value)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			t.Errorf("the contract enum %s omits %s, which %s admits.\n"+
+				"  Consequence: the API refuses the field on the operations using this schema while accepting it elsewhere.\n"+
+				"  Add it to that schema in api/crm.yaml and regenerate.",
+				enum, strings.Join(missing, ", "), theProfileVocabulary)
+		}
+	}
+
+	// A schema that inlines the vocabulary and is not on the roster is the
+	// failure this gate cannot afford: it would simply not be checked. An enum
+	// is taken to be one when it is drawn ENTIRELY from the vocabulary, which
+	// no unrelated enum sharing a word or two ever is.
+	for enum, values := range byType {
+		if _, rostered := profileFieldEnumRoster[enum]; rostered || len(values) == 0 {
+			continue
+		}
+		ownWords := true
+		for value := range values {
+			if !wholeVocabulary[value] {
+				ownWords = false
+				break
+			}
+		}
+		if ownWords {
+			t.Errorf("the contract enum %s is built from %s and is not on this gate's roster, so nothing checks it.\n"+
+				"  Add it to profileFieldEnumRoster — with \"\" if it carries the whole vocabulary, or the reason it carries a part.",
+				enum, theProfileVocabulary)
+		}
+	}
+}
+
+// profileFieldEnumRoster names every generated enum built from this
+// vocabulary, and says whether it carries all of it or a stated part.
+//
+// Named, not inferred, and the two rejected alternatives are why. "Most of the
+// values" excludes the two required-field enums, which carry three of nineteen
+// and are perfectly correct — a real subject leaving the census with nothing
+// failing is this gate's own defect. "Every value is a vocabulary member"
+// looks tighter and is worse: an enum whose value is CORRUPTED stops matching
+// and drops out, so the filter absorbs exactly the drift it was meant to
+// report.
+//
+// So the roster is a list, and the census below fails on an enum missing from
+// it. That costs one line when a schema is added and refuses to go green until
+// somebody writes it — which is the trade a list has to earn.
+//
+// gatekit:fixture the contract enums built from this vocabulary, and for each
+// one whether it carries all of it or the part named here
+var profileFieldEnumRoster = map[string]string{
+	"ColdStartFieldField":                 "",
+	"CompanyProfileFieldField":            "",
+	"CompanySiteReadSuggestedChangeField": "",
+	"ProfileFieldKey":                     "",
+
+	"OnboardingCompanyMessageReplyNextRequiredField":       "the required fields alone, which is what the interview asks for next",
+	"OnboardingCompanyMessageReplyRemainingRequiredFields": "the required fields alone, which is what the interview still needs",
+}
+
+// profileFieldEnums reads every generated enum type and its values, so the
+// census can judge the rostered ones and NOTICE an unrostered one.
+//
+// It filters nothing. Selecting by content is what let the two earlier
+// versions of this gate lose a subject: a corrupted value stops looking like
+// the vocabulary, and a filter reading values then removes the enum instead of
+// failing it.
+func profileFieldEnums(t *testing.T, file string) map[string]map[string]bool {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), filepath.Clean(file), nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	byType := map[string]map[string]bool{}
+	for _, node := range parsed.Decls {
+		general, isGeneral := node.(*ast.GenDecl)
+		if !isGeneral || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue || value.Type == nil || len(value.Values) != 1 {
+				continue
+			}
+			typeName, named := value.Type.(*ast.Ident)
+			if !named {
+				continue
+			}
+			literal, isLiteral := value.Values[0].(*ast.BasicLit)
+			if !isLiteral || literal.Kind != token.STRING {
+				continue
+			}
+			unquoted, unquoteErr := strconv.Unquote(literal.Value)
+			if unquoteErr != nil {
+				continue
+			}
+			if byType[typeName.Name] == nil {
+				byType[typeName.Name] = map[string]bool{}
+			}
+			byType[typeName.Name][unquoted] = true
+		}
+	}
+	return byType
 }

--- a/backend/gates/frontendprofilevocabulary_test.go
+++ b/backend/gates/frontendprofilevocabulary_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The browser spells the company-profile vocabulary five more times, and every
+// one of them fails SILENTLY when it falls short.
+//
+// companyprofilevocabulary_test.go holds the Go mirrors against the
+// organization_profile_field CHECK. It cannot read TypeScript, so the five
+// below were unheld — and all five were genuinely missing three fields while
+// that gate stayed green. What each miss does to a person:
+//
+//   - COLD_FIELD_LABELS and PROFILE_FIELD_LABELS both fall back to the raw
+//     column with its underscores spaced out, so a missing entry renders
+//     "legal form" in lower case beside properly named fields.
+//   - LEGAL_IDENTITY_FIELDS groups the fields a section shows; a missing entry
+//     is a field no screen ever offers.
+//   - MANUAL_QUESTIONS is the interview's own list. Adding an i18n key does
+//     NOT add the question, so a missing entry leaves the copy translated in
+//     three locales and rendered nowhere.
+//   - onboardingDraftPayload serializes the answers for the resume checkpoint
+//     and the conversational draft; a missing entry is an answer the reader
+//     gives and is then asked for again with the field blank.
+//
+// Two of those shipped exactly that way. The frontend suite caught the label
+// maps only because a test happened to assert rendered label text, and the
+// interview only because the i18n orphan check noticed keys nothing rendered.
+//
+// It reads the sources with a regexp rather than a TypeScript parser, the same
+// trade frontendminorunits_test.go makes for the same reason: the alternative
+// is a second copy of the vocabulary maintained here, which is the defect this
+// gate exists to catch.
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// profileVocabularyScreens are the browser's mirrors of the vocabulary: the
+// file, the declaration the fields are listed inside, and what a reader loses
+// when one falls short.
+var profileVocabularyScreens = []struct {
+	// file is the source, relative to backend/gates.
+	file string
+	// opens is the text the declaration starts with. The literal that follows
+	// it is what this gate reads.
+	opens string
+	// closes ends that literal.
+	closes string
+	// why states the consequence, so a failure explains itself.
+	why string
+	// omits are fields this mirror may legitimately lack, each with its reason.
+	omits map[string]string
+}{
+	{
+		file:   "../frontend/src/screens/common.tsx",
+		opens:  "const COLD_FIELD_LABELS: Record<string, MessageKey> = {",
+		closes: "};",
+		why:    "the field renders as its own column name with the underscores spaced out",
+	},
+	{
+		file:   "../frontend/src/screens/organizations.tsx",
+		opens:  "const PROFILE_FIELD_LABELS: Record<string, MessageKey> = {",
+		closes: "};",
+		why:    "the company record draws the field as its own column name",
+	},
+	{
+		file:   "../frontend/src/screens/onboarding.tsx",
+		opens:  "export const LEGAL_IDENTITY_FIELDS = [",
+		closes: "] as const;",
+		why:    "no section carries the field, so no screen ever offers it",
+		// This group is the legal block alone; the rest of the vocabulary is
+		// grouped beside it under OFFER_FIELDS, CUSTOMER_FIELDS and
+		// SALES_FIELDS. The union is what must be whole, which the payload
+		// mirror below reads.
+		omits: onlyTheLegalBlockOmits(),
+	},
+	{
+		file:   "../frontend/src/screens/onboarding.tsx",
+		opens:  "export function onboardingDraftPayload(values: CompanyForm) {",
+		closes: "\n}",
+		why:    "the answer is dropped from the saved draft, so a resumed interview asks for it again with the field blank",
+	},
+	{
+		file:   "../frontend/src/screens/onboarding-manual-interview.tsx",
+		opens:  "const MANUAL_QUESTIONS: readonly ManualQuestion[] = [",
+		closes: "\n];",
+		why:    "the interview never asks for the field, however many locales its question is translated into",
+	},
+}
+
+// onlyTheLegalBlockOmits names the fields LEGAL_IDENTITY_FIELDS does not
+// carry, because a sibling group does.
+//
+// Listed rather than derived, and that is a compromise worth stating: the
+// three sibling groups sit in the same file and could be read the same way.
+// They are not, because this gate would then assert only that four lists
+// partition one vocabulary — true of any partition, including one that put
+// the register court under SALES_FIELDS. The union is held by the payload
+// mirror above, which reads every field the interview collects.
+//
+// The one thing this list cannot catch is its own staleness: a field dropped
+// from a sibling group stays exempt here. `frontend/src/screens/onboarding.test.tsx`
+// closes that, comparing the four groups' union against onboardingDraftPayload
+// — so the two together hold what neither holds alone, and the frontend half
+// is the one that fails when a group loses a field.
+func onlyTheLegalBlockOmits() map[string]string {
+	const elsewhere = "grouped under OFFER_FIELDS, CUSTOMER_FIELDS or SALES_FIELDS instead"
+	omits := map[string]string{}
+	for _, field := range []string{
+		"offer_summary", "icp", "value_proposition", "usp",
+		"customer_pains", "desired_outcomes", "buying_center",
+		"buying_intents", "common_objections", "sales_motion",
+	} {
+		omits[field] = elsewhere
+	}
+	return omits
+}
+
+// tsVocabularyField reads a vocabulary member where a mirror can NAME one and
+// mean it: an object key (`register_court:` or `"register_court":`), or a
+// standalone string in an array or property (`"register_court"`).
+//
+// It deliberately does not match a bare identifier anywhere in the text. The
+// first version did, and it read the field name out of the i18n key BESIDE
+// each entry — `register_court: "ob.field.register_court"` — so deleting the
+// whole line left the gate green, which is precisely the failure this gate
+// was written to end. Mutation-check any change here against all five
+// mirrors; a looser pattern passes for the wrong reason.
+//
+// Mutation-check with `go test -count=1`. The sources this reads are not Go
+// files, so the test cache does not notice when one changes and a stale PASS
+// looks exactly like a real one.
+//
+// Two shapes it would read wrongly, neither present in the five mirrors and
+// both worth knowing before adding a sixth:
+//
+//   - A backtick string (“ `register_court` “) is not matched, so an entry
+//     spelled that way reads as absent — a false failure, which is the safe
+//     direction and says so loudly.
+//   - A field name inside a longer string ("Ask about register_court") can
+//     match, so a mirror whose prose quotes a field could keep this gate green
+//     after the real entry is deleted. That is the unsafe direction, and it is
+//     why literalAfter strips comments and why every mirror added here is
+//     mutation-checked entry by entry rather than trusted to the pattern.
+var tsVocabularyField = regexp.MustCompile(`(?m)(?:^|[\s,{[])["']?([a-z][a-z_]*[a-z])["']?\s*(?::|,|$|])`)
+
+// tsVocabularyComment strips comments before the fields are read, so a field
+// NAMED in prose beside the literal cannot stand in for a real entry.
+var tsVocabularyComment = regexp.MustCompile(`(?s)//[^\n]*|/\*.*?\*/`)
+
+func TestTheBrowserSpellsTheWholeProfileVocabulary(t *testing.T) {
+	t.Parallel()
+	admitted := tableCheckSets(t)[theProfileVocabulary]
+	if len(admitted) < 10 {
+		t.Fatalf("only %d value(s) derived for %s — the migration scan has stopped reading it",
+			len(admitted), theProfileVocabulary)
+	}
+
+	for _, mirror := range profileVocabularyScreens {
+		source, err := os.ReadFile(mirror.file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", mirror.file, err)
+		}
+		literal, err := literalAfter(string(source), mirror.opens, mirror.closes)
+		if err != nil {
+			t.Fatalf("%s: %v — this gate is reading a shape that is gone", mirror.file, err)
+		}
+		named := map[string]bool{}
+		for _, match := range tsVocabularyField.FindAllStringSubmatch(literal, -1) {
+			named[match[1]] = true
+		}
+		if len(named) == 0 {
+			t.Errorf("%s: no fields parsed out of %s — a mirror that reads as empty agrees with everything",
+				mirror.file, strings.TrimSuffix(mirror.opens, " = {"))
+			continue
+		}
+
+		var missing []string
+		for _, field := range admitted {
+			if named[field] || mirror.omits[field] != "" {
+				continue
+			}
+			missing = append(missing, field)
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			t.Errorf("%s omits %s, which %s admits.\n"+
+				"  Consequence: %s.\n"+
+				"  Add it there, or take it out of the CHECK if the product does not have it.",
+				mirror.file, strings.Join(missing, ", "), theProfileVocabulary, mirror.why)
+		}
+	}
+}
+
+// literalAfter returns the text between a declaration's opening and the token
+// that closes it.
+func literalAfter(source, opens, closes string) (string, error) {
+	start := indexAfter(source, opens)
+	if start < 0 {
+		return "", errNoSuchDeclaration(opens)
+	}
+	end := indexAfter(source[start:], closes)
+	if end < 0 {
+		return "", errUnterminated(opens)
+	}
+	return tsVocabularyComment.ReplaceAllString(source[start:start+end], " "), nil
+}
+
+type errNoSuchDeclaration string
+
+func (e errNoSuchDeclaration) Error() string {
+	return "no declaration opening with " + string(e)
+}
+
+type errUnterminated string
+
+func (e errUnterminated) Error() string {
+	return "the literal opening with " + string(e) + " is unterminated"
+}

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 26
+	wantFixtureAnnotations = 27
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (39)
+## Parity (40)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -41,6 +41,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendidlebase_test.go` | H3 | The deal board and the server must measure silence from the SAME timestamp, or a card ages differently from the list that filed the deal stalled. |
 | `frontendlaneparity_test.go` | H3 | The frontend gate is spelled once as `make check-fe` and run by CI as three parallel jobs. |
 | `frontendminorunits_test.go` | H3 | The browser and the server must scale money by the SAME table, or the integer they exchange means two different amounts. |
+| `frontendprofilevocabulary_test.go` | H3 | The browser spells the company-profile vocabulary five more times, and every one of them fails SILENTLY when it falls short. |
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |
 | `idempotencymap_test.go` | H3 | The idempotency allowlist as a fitness function: the contract is the authority on which operations promise Idempotency-Key retry safety, and internal/compose's hand-maintained replayableOperations map must mirror it exactly. |


### PR DESCRIPTION
Closes #3032.

## What was wrong

`companyprofilevocabulary_test.go` derives the company-profile vocabulary from the `organization_profile_field` CHECK — the right authority — and then compares it against four hand-listed Go declarations. Two whole classes of mirror sat outside it, and both had already shipped short while the gate stayed green.

## The browser's five mirrors

Each fails silently, and the consequence differs:

- `COLD_FIELD_LABELS` and `PROFILE_FIELD_LABELS` fall back to the raw column with its underscores spaced out, so a missing entry renders `legal form` in lower case beside properly named fields.
- `LEGAL_IDENTITY_FIELDS` groups what a section shows; a missing entry is a field no screen offers.
- `MANUAL_QUESTIONS` is the interview's own list, separate from its i18n keys — so adding copy in three locales does not add the question, and the translated strings render nowhere.
- `onboardingDraftPayload` serializes answers for the resume checkpoint; a missing entry is an answer the reader gives and is asked for again with the field blank.

Two shipped exactly that way. The frontend suite caught the label maps only because a test happened to assert rendered label text, and the interview only because the i18n orphan check noticed keys nothing rendered.

`frontendprofilevocabulary_test.go` reads all five and holds them against the same CHECK — the trade `frontendminorunits_test.go` already makes, for the same reason: the alternative is maintaining a second copy of the vocabulary in the gate, which is the defect being fixed.

## The contract's enums, one at a time

The contract inlines this vocabulary as one enum per schema that names a profile field. The old gate resolved identifiers against all of them flattened together — correct for asking what a Go name stands for, wrong as a check on the enums: a value present in one and missing from another resolves anyway, so a short schema was covered by its siblings. What that costs is a field the API refuses on one endpoint and accepts on the next.

Six enums are now checked separately: four carry the whole vocabulary, two carry the required fields alone.

## Why the roster is a list, which is the interesting part

I wrote two content-based rules first and both failed in the way this PR exists to prevent:

- **"Most of the values"** excludes `OnboardingCompanyMessageReplyNextRequiredField` and its sibling, which carry three of nineteen and are perfectly correct. A real subject leaves the census with nothing failing to say so.
- **"Every value is a vocabulary member"** looks tighter and is worse. An enum whose value gets corrupted stops matching and is *removed by the filter* rather than failed by the check — so the selector absorbs exactly the drift it was meant to report.

Both passed their own mutation tests by dropping the subject instead of failing it. So the roster names the six, and the census fails on any unrostered enum drawn entirely from the vocabulary. That costs one line when a schema is added and refuses to go green until somebody writes it.

The second of those two rules was found by a review pass, not by me — it was in the pushed branch and would have merged.

## Mutation-checked, all of it

Each of the five mirrors emptied one entry at a time; each contract enum shortened; an exempt enum drifted outside the vocabulary; a new unrostered enum planted. Every case fails the gate.

One thing worth knowing, written beside the parser: these gates read `.sql` and `.tsx` rather than Go, so **the test cache does not notice when a source changes**. Verify with `go test -count=1` — my first mutation run reported five false PASSes from cached results.

## Verified

`make check-backend` green, all gates pass, `make craft-static` and `make rls-store-path` clean. The gate-inventory page is regenerated for the new gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #3032. Extends the company-profile vocabulary gate so it holds the browser's five mirrors of the vocabulary and the contract's per-schema enums, both of which were shipping short while the gate stayed green.

- The browser's five mirrors (two label maps, the section grouping, the interview's question list, and the draft serializer) are now read from `.tsx` and held against the same `organization_profile_field` CHECK.
- Six contract enums are checked one at a time; four carry the whole vocabulary and two carry only the required fields. A schema that names a profile field must now be added to the gate's roster, or the gate fails.
- The roster is a named list rather than inferred, because both content-based rules silently dropped a subject instead of failing it.

**Migration / rollout notes**

- These gates read `.sql` and `.tsx` sources, so the Go test cache does not notice when they change. Verify with `go test -count=1`, or a stale PASS looks like a real one.

<sup>Written for commit 4abbaa24a1f1b5c0312579910c191a68c760bbf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure profile fields and vocabulary remain consistent across the database, backend, and frontend.
  * Improved detection and reporting of missing, extra, malformed, or outdated profile definitions.
  * Updated validation coverage to include the latest gate checks.

* **Documentation**
  * Updated the gate inventory and reference counts to reflect the expanded profile consistency checks.
  * Documented the corresponding frontend vocabulary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->