### PR TITLE
fix(deals): a save carries what the person changed, and a stakeholder can be seated

### DIFF
--- a/backend/gates/clearablefields_test.go
+++ b/backend/gates/clearablefields_test.go
@@ -42,7 +42,12 @@ var clearableMapsByRecordType = map[string]string{
 	"clearableOrganizationColumns": "organization",
 	"clearableLeadColumns":         "lead",
 	"clearableDealColumns":         "deal",
-	"clearableProjectColumns":      "project",
+	// A clear that writes TWO columns cannot travel in the single-column map,
+	// and a census that read only that map would report a store clearing fewer
+	// fields than it does — under-recognition, the one way this gate must not
+	// break. Both declarations serve the deal, and the walk unions them.
+	"dealClearPairs":          "deal",
+	"clearableProjectColumns": "project",
 }
 
 // storeClearableFields walks the module sources for the clearable-column maps

--- a/backend/internal/compose/clearablefields.go
+++ b/backend/internal/compose/clearablefields.go
@@ -24,6 +24,10 @@ package compose
 //     semantics rather than to the reversal path.
 //   - a deal's amount_minor and currency are absent because money is read as one
 //     field, and a half-cleared pair states an amount in no currency.
+//   - a deal's partner_org_id and partner_attribution are BOTH present and mean
+//     one instruction. deal_partner_attribution_pairing admits no row where one
+//     half survived the other, so forgetting either forgets both, and a reversal
+//     of a partner-add names both halves as null.
 //   - a lead's status and score override are absent because they are lifecycle
 //     positions and a sticky decision, not values.
 //   - a person's full_name and an organization's display_name are absent because
@@ -37,7 +41,10 @@ var clearableFields = map[string][]string{
 		"linkedin_url", "owner_id", "parent_org_id",
 	},
 	"lead": {"title", "company_name", "candidate_org_key", "project_id", "owner_id"},
-	"deal": {"expected_close_date", "forecast_category", "wait_until", "owner_id", "project_id"},
+	"deal": {
+		"expected_close_date", "forecast_category", "wait_until", "owner_id",
+		"organization_id", "project_id", "partner_org_id", "partner_attribution",
+	},
 	"project": {
 		"description", "owner_id", "started_at", "target_end_date", "ended_at",
 	},

--- a/backend/internal/compose/integration/dealpartnerattribution_integration_test.go
+++ b/backend/internal/compose/integration/dealpartnerattribution_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -142,5 +143,176 @@ func TestDeletingAPartnerOrganizationDetachesItsDealsIntact(t *testing.T) {
 	if got.PartnerOrgId != nil || got.PartnerAttribution != nil {
 		t.Errorf("deal kept partner %v / attribution %v after its partner was deleted; both halves leave together",
 			got.PartnerOrgId, got.PartnerAttribution)
+	}
+}
+
+// The clear surface names the pair ONCE, as `partner_org_id`, and forgetting the
+// partner forgets what they did. Routed through the single-column clear path
+// instead, this write would set one half and earn the constraint violation the
+// test above proves is really there.
+func TestForgettingADealsPartnerForgetsItsClaimToo(t *testing.T) {
+	e := Setup(t)
+	deal, _ := seedDealWithPartner(t, e)
+
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		Clear: []string{"partner_org_id"},
+	}); err != nil {
+		t.Fatalf("clearing the deal's partner: %v", err)
+	}
+
+	got, err := e.Deals.GetDeal(e.Admin(), deal, 0)
+	if err != nil {
+		t.Fatalf("reading the deal back: %v", err)
+	}
+	if got.PartnerOrgId != nil || got.PartnerAttribution != nil {
+		t.Errorf("deal kept partner %v / attribution %v; both halves leave together",
+			got.PartnerOrgId, got.PartnerAttribution)
+	}
+}
+
+func TestForgettingThePartnerWhileClaimingSomethingOfThemIsRefused(t *testing.T) {
+	e := Setup(t)
+	deal, _ := seedDealWithPartner(t, e)
+	influenced := "influenced"
+
+	_, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		Clear:              []string{"partner_org_id"},
+		PartnerAttribution: &influenced,
+	})
+
+	var unpaired *deals.PartnerAttributionUnpairedError
+	if !errors.As(err, &unpaired) {
+		t.Fatalf("error = %v, want PartnerAttributionUnpairedError — the request forgets the partner the claim describes", err)
+	}
+}
+
+// Naming the claim forgets the whole pair, because there is no state where a
+// deal carries a partner it claims nothing about. A restore reverting a
+// partner-add names both halves as null, and refusing either would leave that
+// reversal impossible to express.
+func TestNamingTheClaimForgetsTheWholePair(t *testing.T) {
+	e := Setup(t)
+	deal, _ := seedDealWithPartner(t, e)
+
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		Clear: []string{"partner_attribution"},
+	}); err != nil {
+		t.Fatalf("clearing the deal's claim about its partner: %v", err)
+	}
+
+	got, err := e.Deals.GetDeal(e.Admin(), deal, 0)
+	if err != nil {
+		t.Fatalf("reading the deal back: %v", err)
+	}
+	if got.PartnerOrgId != nil || got.PartnerAttribution != nil {
+		t.Errorf("deal kept partner %v / attribution %v; both halves leave together",
+			got.PartnerOrgId, got.PartnerAttribution)
+	}
+}
+
+// Forgetting a link is a write ABOUT the record it points at, so it carries the
+// permission naming that record would. Without this a rep who was not shown the
+// deal's partner — masked_fields says so — could still destroy the attribution a
+// commission accrues on.
+func TestForgettingAPartnerTheReaderCannotSeeIsRefused(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	partnerOrg := e.SeedPartnerOrg(t, "Northgate Partners", nil, &e.Rep3)
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Northgate rollout", pipeline, open, &e.Rep1))
+	partnerID := orgIDOf(partnerOrg)
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		PartnerOrganizationID: &partnerID,
+	}); err != nil {
+		t.Fatalf("linking the deal to its partner: %v", err)
+	}
+	e.MakeCapturePrivate(t, "organization", partnerOrg, e.Rep3)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	_, err := e.Deals.UpdateDeal(rep, deal, deals.UpdateDealInput{
+		Clear: []string{"partner_org_id"},
+	})
+
+	if err == nil {
+		t.Fatal("a reader who cannot open the partner cleared it; that is a write about an organization they may not name")
+	}
+	// Not-found rather than forbidden: existence stays hidden, which is what
+	// EnsureLinkTarget answers on the set path too.
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("error = %v, want ErrNotFound", err)
+	}
+	// Read off the ROW, not through the store: the same masking that withholds
+	// this partner from the rep withholds it from any reader whose scope cannot
+	// reach the capture-private organization, so a store read here cannot tell a
+	// surviving link from a cleared one.
+	partner, claim := partnerPairOnTheRow(t, e, deal)
+	if partner == nil || claim == nil {
+		t.Errorf("refused clear still moved the pair: partner %v / attribution %v", partner, claim)
+	}
+}
+
+// partnerPairOnTheRow reads both halves straight off the deal row.
+func partnerPairOnTheRow(t *testing.T, e *Env, deal ids.DealID) (partner, claim *string) {
+	t.Helper()
+	if err := e.DB().Tx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT partner_org_id::text, partner_attribution FROM deal WHERE id = $1`,
+			deal).Scan(&partner, &claim)
+	}); err != nil {
+		t.Fatalf("reading the deal's partner pair off the row: %v", err)
+	}
+	return partner, claim
+}
+
+// The company arm of the same rule.
+func TestForgettingACompanyTheReaderCannotSeeIsRefused(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	org := e.SeedOrg(t, "Meridian Labs", &e.Rep3)
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Meridian renewal", pipeline, open, &e.Rep1))
+	orgID := orgIDOf(org)
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		OrganizationID: &orgID,
+	}); err != nil {
+		t.Fatalf("linking the deal to its company: %v", err)
+	}
+	e.MakeCapturePrivate(t, "organization", org, e.Rep3)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	_, err := e.Deals.UpdateDeal(rep, deal, deals.UpdateDealInput{
+		Clear: []string{"organization_id"},
+	})
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("error = %v, want ErrNotFound — the company is one this reader was never shown", err)
+	}
+}
+
+// A deal without a company is an ordinary deal — the column is nullable and a
+// deal is created without one — so the nullability crm.yaml declares has to be
+// reachable. It was not: the edit form offers unsetting the company, and the
+// store refused the null it sent.
+func TestADealCanBeUnlinkedFromItsCompany(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Kestrel renewal", pipeline, open, &e.Rep1))
+	org := orgIDOf(e.SeedOrg(t, "Kestrel Foods", nil))
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		OrganizationID: &org,
+	}); err != nil {
+		t.Fatalf("linking the deal to its company: %v", err)
+	}
+
+	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
+		Clear: []string{"organization_id"},
+	}); err != nil {
+		t.Fatalf("unlinking the deal from its company: %v", err)
+	}
+
+	got, err := e.Deals.GetDeal(e.Admin(), deal, 0)
+	if err != nil {
+		t.Fatalf("reading the deal back: %v", err)
+	}
+	if got.OrganizationId != nil {
+		t.Errorf("organization_id = %v, want nil", got.OrganizationId)
 	}
 }

--- a/backend/internal/modules/deals/clearable.go
+++ b/backend/internal/modules/deals/clearable.go
@@ -3,21 +3,31 @@
 
 package deals
 
-// Which of a deal's fields a restore can set back to NOTHING.
+// Which of a deal's fields a caller may set back to NOTHING.
 //
 // Its own file because "which fields this store can clear" is a question a
 // reader asks whole, and answering it means reading one place rather than
 // hunting through the writer. Applying a clear is storekit's.
 
 import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// clearableDealColumns names the wire fields a deal restore may set to NULL,
+// clearableDealColumns names the wire fields whose clear writes ONE column,
 // with literal column names. amount_minor and currency are absent: money is
 // read as one field, and a half-cleared pair states an amount in no currency.
 // status and the close-date flags belong to the advance path.
+//
+// The partner fields are absent because their clear writes TWO columns — see
+// dealClearPairs, which owns the pair.
 //
 //nolint:goconst // wire field names against column names, each its own vocabulary — see clearablePersonColumns
 func clearableDealColumns(current crmcontracts.Deal) map[string]storekit.Clearable {
@@ -26,6 +36,97 @@ func clearableDealColumns(current crmcontracts.Deal) map[string]storekit.Clearab
 		"forecast_category":   {Column: "forecast_category", Current: current.ForecastCategory},
 		"wait_until":          {Column: "wait_until", Current: current.WaitUntil},
 		"owner_id":            {Column: "owner_id", Current: current.OwnerId},
+		"organization_id":     {Column: "organization_id", Current: current.OrganizationId},
 		"project_id":          {Column: "project_id", Current: current.ProjectId},
 	}
+}
+
+// dealClearPairs names the wire fields whose clear writes BOTH halves of a
+// two-column fact, keyed by every name a caller may reach it under.
+//
+// The partner and what that partner did are one fact:
+// deal_partner_attribution_pairing rejects a row where one half survived the
+// other, so there is no state in which a deal names a partner it claims nothing
+// about. Both names therefore mean the same instruction — forget the partner and
+// the claim together — rather than one of them being refused with advice to send
+// the other. A restore reverting a partner-add names both halves as null, and
+// refusing either would leave that reversal impossible to express.
+//
+// Routing these through clearableDealColumns instead would set a single column
+// and earn a constraint violation from the database rather than a decision from
+// the store.
+func dealClearPairs(current crmcontracts.Deal) map[string][]storekit.Clearable {
+	partner := []storekit.Clearable{
+		{Column: "partner_org_id", Current: current.PartnerOrgId},
+		{Column: "partner_attribution", Current: current.PartnerAttribution},
+	}
+	return map[string][]storekit.Clearable{
+		"partner_org_id":      partner,
+		"partner_attribution": partner,
+	}
+}
+
+// splitDealClears applies every paired clear the caller named and returns the
+// rest for storekit.ApplyClears, plus whether the partner pair was among them.
+//
+// The flag travels because the partner's own writer has to know: a request that
+// forgets the partner while naming a claim about them has nobody left to
+// attribute it to, and that is a refusal rather than a race between two writes
+// to the same column.
+func splitDealClears(p *storekit.Patch, fields []string, current crmcontracts.Deal) (rest []string, clearedPartner bool) {
+	pairs := dealClearPairs(current)
+	rest = make([]string, 0, len(fields))
+	for _, field := range fields {
+		pair, paired := pairs[field]
+		if !paired {
+			rest = append(rest, field)
+			continue
+		}
+		clearedPartner = true
+		for _, half := range pair {
+			p.Set(half.Column, half.Current, nil)
+		}
+	}
+	return rest, clearedPartner
+}
+
+// ensureClearedLinksVisible refuses to forget a link to a record the caller
+// could not open.
+//
+// The read path withholds a deal's organization and partner from a reader whose
+// row scope cannot reach them (unreadableReferences), and the write path refuses
+// to SET either to a target they cannot see. Between the two sat this hole: a
+// reader told "you may not see which company this is" could still detach it, and
+// with the partner they could destroy the attribution a commission accrues on —
+// a write about an organization they were not allowed to name.
+//
+// A miss reads as not-found, which is what EnsureLinkTarget already answers, so
+// existence stays hidden.
+//
+// project_id is deliberately absent. ATTACHING a project needs write authority
+// because winning the deal advances that project's phase and writes its history;
+// detaching advances nothing and discloses nothing, so the asymmetry is the rule
+// rather than a gap in it.
+func ensureClearedLinksVisible(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, cleared []string) error {
+	for _, field := range cleared {
+		var target *openapi_types.UUID
+		switch field {
+		case filterOrganizationID:
+			target = current.OrganizationId
+		// Either name reaches the pair, and the permission is the partner's
+		// either way: the claim is a statement about that organization.
+		case filterPartnerOrgID, partnerAttributionField:
+			target = current.PartnerOrgId
+		default:
+			continue
+		}
+		// Nothing there to forget, so nobody's record is being written about.
+		if target == nil {
+			continue
+		}
+		if err := auth.EnsureLinkTarget(ctx, tx, "organization", ids.UUID(*target)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -96,7 +96,17 @@ func moved[T comparable](current, supplied *T) bool {
 // visible under the caller's row scope before it lands in the patch.
 func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, in UpdateDealInput) (*storekit.Patch, error) {
 	p := storekit.NewPatch()
-	if err := storekit.ApplyClears(p, in.Clear, clearableDealColumns(current)); err != nil {
+	// FORGETTING a link is a write about the record it points at, so it needs
+	// the same permission naming that record would — the same rule the
+	// re-attribution branch below already states, and the reason it cannot wait
+	// until after the patch is built.
+	if err := ensureClearedLinksVisible(ctx, tx, current, in.Clear); err != nil {
+		return nil, err
+	}
+	// A paired clear leaves the generic path because it writes two columns, not
+	// one (dealClearPairs); everything else in the list is a plain column.
+	clears, clearPartner := splitDealClears(p, in.Clear, current)
+	if err := storekit.ApplyClears(p, clears, clearableDealColumns(current)); err != nil {
 		return nil, err
 	}
 	if in.Name != nil {
@@ -113,7 +123,7 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 	if moved(current.Currency, in.Currency) {
 		p.Set(currencyField, current.Currency, *in.Currency)
 	}
-	if err := applyDealLinkPatches(ctx, tx, current, in, p,
+	if err := applyDealLinkPatches(ctx, tx, current, in, p, clearPartner,
 		s.installation.EnsurePartner, s.ensureProjectAttachable); err != nil {
 		return nil, err
 	}
@@ -159,7 +169,7 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 // is what stands in for it. A visibility-only gate here would let any seat
 // attach any project in the workspace and then force it into `delivering`.
 func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
-	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
+	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch, clearPartner bool,
 	ensurePartner EnsurePartner, ensureProjectAttachable EnsureProjectAttachable,
 ) error {
 	if in.OrganizationID != nil {
@@ -177,7 +187,7 @@ func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
 		}
 		p.Set("project_id", current.ProjectId, *in.ProjectID)
 	}
-	return applyPartnerAttributionPatch(ctx, tx, current, in, p, ensurePartner)
+	return applyPartnerAttributionPatch(ctx, tx, current, in, p, clearPartner, ensurePartner)
 }
 
 // applyPartnerAttributionPatch writes the partner link and what that partner
@@ -192,9 +202,20 @@ func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
 // worse than saying no. Re-attributing a deal that already names a partner
 // leaves the link alone and moves only the claim.
 func applyPartnerAttributionPatch(ctx context.Context, tx pgx.Tx,
-	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
+	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch, clearPartner bool,
 	ensurePartner EnsurePartner,
 ) error {
+	if clearPartner {
+		// A request that forgets the partner while naming what they did has
+		// nobody left to attribute it to, which is the refusal an attribution
+		// standing alone already earns.
+		if in.PartnerAttribution != nil {
+			return &PartnerAttributionUnpairedError{}
+		}
+		p.Set("partner_org_id", current.PartnerOrgId, nil)
+		p.Set("partner_attribution", current.PartnerAttribution, nil)
+		return nil
+	}
 	if in.PartnerAttribution != nil {
 		if err := validPartnerAttribution(*in.PartnerAttribution); err != nil {
 			return err

--- a/backend/internal/modules/deals/partner_attribution_test.go
+++ b/backend/internal/modules/deals/partner_attribution_test.go
@@ -137,7 +137,7 @@ func TestAttributionWithoutAPartnerIsRefused(t *testing.T) {
 	sourced := attributionSourced
 	in := UpdateDealInput{PartnerAttribution: &sourced}
 
-	err := applyPartnerAttributionPatch(t.Context(), nil, crmcontracts.Deal{}, in, p, unreachablePartnerCheck(t))
+	err := applyPartnerAttributionPatch(t.Context(), nil, crmcontracts.Deal{}, in, p, false, unreachablePartnerCheck(t))
 
 	var unpaired *PartnerAttributionUnpairedError
 	if !errors.As(err, &unpaired) {
@@ -159,7 +159,7 @@ func TestAnUnknownAttributionIsRefusedBeforeTheDatabaseSeesIt(t *testing.T) {
 	// does not depend on a transaction being present.
 	in := UpdateDealInput{PartnerAttribution: &bogus}
 
-	err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), in, p, unreachablePartnerCheck(t))
+	err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), in, p, false, unreachablePartnerCheck(t))
 
 	var invalid *PartnerAttributionValueError
 	if !errors.As(err, &invalid) {
@@ -176,7 +176,7 @@ func TestAnUnknownAttributionIsRefusedBeforeTheDatabaseSeesIt(t *testing.T) {
 func TestTouchingNeitherHalfLeavesThePairAlone(t *testing.T) {
 	p := storekit.NewPatch()
 
-	if err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), UpdateDealInput{}, p, unreachablePartnerCheck(t)); err != nil {
+	if err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), UpdateDealInput{}, p, false, unreachablePartnerCheck(t)); err != nil {
 		t.Fatalf("an update naming neither half: %v", err)
 	}
 	if len(p.After()) != 0 {
@@ -299,5 +299,101 @@ func TestAWithheldPartnerTakesItsAttributionWithIt(t *testing.T) {
 	}
 	if d.PartnerOrgId != nil {
 		t.Error("the partner link survived its own mask")
+	}
+}
+
+// The clear surface names the pair once. A deal edited back to having no
+// partner writes both columns in the same patch, because the CHECK admits no
+// row where one half survived the other.
+func TestForgettingThePartnerForgetsWhatTheyDid(t *testing.T) {
+	p := storekit.NewPatch()
+	current := dealNamingPartner(attributionSourced)
+
+	if err := applyPartnerAttributionPatch(t.Context(), nil, current, UpdateDealInput{}, p, true, unreachablePartnerCheck(t)); err != nil {
+		t.Fatalf("clearing the partner: %v", err)
+	}
+	for _, column := range []string{filterPartnerOrgID, partnerAttributionField} {
+		value, set := p.After()[column]
+		if !set {
+			t.Errorf("%s never reached the patch; the pairing CHECK rejects a row where only one half was forgotten", column)
+			continue
+		}
+		if value != nil {
+			t.Errorf("%s = %v, want nil", column, value)
+		}
+	}
+	// The audit image is the only record of what was forgotten once the write
+	// lands, so it carries what the row held rather than the nil it now holds.
+	if p.Before()[partnerAttributionField] != current.PartnerAttribution {
+		t.Errorf("before[%s] = %v, want the claim the row carried", partnerAttributionField, p.Before()[partnerAttributionField])
+	}
+}
+
+func TestForgettingThePartnerWhileNamingItsClaimIsRefused(t *testing.T) {
+	p := storekit.NewPatch()
+	sourced := attributionSourced
+	in := UpdateDealInput{PartnerAttribution: &sourced}
+
+	err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionInfluenced), in, p, true, unreachablePartnerCheck(t))
+
+	var unpaired *PartnerAttributionUnpairedError
+	if !errors.As(err, &unpaired) {
+		t.Fatalf("error = %v, want PartnerAttributionUnpairedError — the request forgets the partner the claim describes", err)
+	}
+	if len(p.After()) != 0 {
+		t.Errorf("patch wrote %v; a refused request must leave the pair alone", p.After())
+	}
+}
+
+// splitDealClears is what keeps the pair off the single-column path. A list that
+// still carried partner_org_id into ApplyClears would set one column and earn a
+// constraint violation from the database rather than a decision from the store.
+func TestThePairedClearLeavesTheSingleColumnPath(t *testing.T) {
+	p := storekit.NewPatch()
+	current := dealNamingPartner(attributionSourced)
+
+	rest, partner := splitDealClears(p,
+		[]string{"wait_until", filterPartnerOrgID, filterOrganizationID}, current)
+
+	if !partner {
+		t.Error("the partner clear was not recognised")
+	}
+	if len(rest) != 2 || rest[0] != "wait_until" || rest[1] != filterOrganizationID {
+		t.Errorf("rest = %v, want the two plain columns in order", rest)
+	}
+	for _, column := range []string{filterPartnerOrgID, partnerAttributionField} {
+		if _, stillGeneric := clearableDealColumns(current)[column]; stillGeneric {
+			t.Errorf("%s is in the single-column map; ApplyClears would set one half of the pair", column)
+		}
+	}
+}
+
+// Either name reaches the whole fact. The pairing CHECK admits no row where one
+// half survived, so there is no state for one name to mean on its own — and a
+// restore reverting a partner-add names both halves as null.
+func TestEitherHalfsNameForgetsTheWholePair(t *testing.T) {
+	for _, named := range []string{filterPartnerOrgID, partnerAttributionField} {
+		t.Run(named, func(t *testing.T) {
+			p := storekit.NewPatch()
+
+			if _, partner := splitDealClears(p, []string{named}, dealNamingPartner(attributionSourced)); !partner {
+				t.Fatalf("clearing %s was not recognised as forgetting the partner", named)
+			}
+			for _, column := range []string{filterPartnerOrgID, partnerAttributionField} {
+				value, set := p.After()[column]
+				if !set || value != nil {
+					t.Errorf("after[%s] = %v (set=%v), want nil", column, value, set)
+				}
+			}
+		})
+	}
+}
+
+// A deal without a company is an ordinary deal — the column is nullable and a
+// deal is created without one — so the contract's nullable organization_id must
+// actually be reachable.
+func TestADealsCompanyCanBeForgotten(t *testing.T) {
+	if _, clearable := clearableDealColumns(crmcontracts.Deal{})[filterOrganizationID]; !clearable {
+		t.Error("organization_id cannot be cleared; the edit form offers unsetting the company and would earn a 422")
 	}
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -532,9 +532,9 @@ export const de = {
   "partner.stage.noFit": "Keine Passung",
 
   "rel.add": "Beziehung hinzufügen",
-  "rel.addStakeholder": "Stakeholder hinzufügen",
-  "rel.dealStakeholders": "Stakeholder",
-  "rel.dealStakeholdersEmpty": "Für diesen Deal ist kein Stakeholder erfasst",
+  "rel.addStakeholder": "Beteiligten hinzufügen",
+  "rel.dealStakeholders": "Beteiligte",
+  "rel.dealStakeholdersEmpty": "Für diesen Deal ist niemand erfasst",
   "rel.kind": "Art",
   "rel.saveDone": "Beziehung gespeichert",
   "rel.role": "Rolle",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -532,6 +532,9 @@ export const de = {
   "partner.stage.noFit": "Keine Passung",
 
   "rel.add": "Beziehung hinzufügen",
+  "rel.addStakeholder": "Stakeholder hinzufügen",
+  "rel.dealStakeholders": "Stakeholder",
+  "rel.dealStakeholdersEmpty": "Für diesen Deal ist kein Stakeholder erfasst",
   "rel.kind": "Art",
   "rel.saveDone": "Beziehung gespeichert",
   "rel.role": "Rolle",
@@ -6894,6 +6897,14 @@ export const de = {
   "project.stakeholders.title": "Beteiligte",
   "project.stakeholders.empty":
     "Noch niemand ist an diesem Projekt beteiligt. Beteiligte sind Personen mit einer Rolle hier — Sponsor, Projektleitung, Champion.",
+  "project.stakeholders.add": "Beteiligten hinzufügen",
+  "project.stakeholders.addHint":
+    "Eine Rolle pro Person. Wer schon an diesem Projekt beteiligt ist, wechselt auf die hier gewählte Rolle.",
+  "project.stakeholders.searchLabel": "Personen nach Namen suchen",
+  "project.stakeholders.removeTitle": "Diese Person vom Projekt nehmen?",
+  "project.stakeholders.removeConfirm":
+    "{name} ist dann nicht mehr an diesem Projekt beteiligt. Die Aktivitäten bleiben erhalten.",
+  "project.stakeholders.removeOne": "{name} vom Projekt nehmen",
   "project.role.sponsor": "Sponsor",
   "project.role.project_lead": "Projektleitung",
   "project.role.delivery_lead": "Umsetzungsleitung",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -545,6 +545,9 @@ export const en = {
   "partner.stage.noFit": "No fit",
 
   "rel.add": "Add relationship",
+  "rel.addStakeholder": "Add stakeholder",
+  "rel.dealStakeholders": "Stakeholders",
+  "rel.dealStakeholdersEmpty": "No stakeholder is recorded on this deal",
   "rel.kind": "Kind",
   "rel.saveDone": "Relationship saved",
   "rel.role": "Role",
@@ -6982,6 +6985,14 @@ export const en = {
   "project.stakeholders.title": "Stakeholders",
   "project.stakeholders.empty":
     "Nobody is seated on this project yet. A stakeholder is a person with a role here — a sponsor, a project lead, a champion.",
+  "project.stakeholders.add": "Add stakeholder",
+  "project.stakeholders.addHint":
+    "One seat per person. Naming somebody already on this project moves them to the role you pick here.",
+  "project.stakeholders.searchLabel": "Search people by name",
+  "project.stakeholders.removeTitle": "Take this person off the project?",
+  "project.stakeholders.removeConfirm":
+    "{name} stops being a stakeholder on this project. Their activity stays where it is.",
+  "project.stakeholders.removeOne": "Take {name} off the project",
   "project.role.sponsor": "Sponsor",
   "project.role.project_lead": "Project lead",
   "project.role.delivery_lead": "Delivery lead",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -535,6 +535,10 @@ export const vi = {
   "partner.stage.noFit": "Không phù hợp",
 
   "rel.add": "Thêm quan hệ",
+  "rel.addStakeholder": "Thêm người liên quan",
+  "rel.dealStakeholders": "Người liên quan",
+  "rel.dealStakeholdersEmpty":
+    "Chưa ghi nhận người liên quan nào cho giao dịch này",
   "rel.kind": "Loại",
   "rel.saveDone": "Đã lưu mối quan hệ",
   "rel.role": "Vai trò",
@@ -6837,6 +6841,14 @@ export const vi = {
   "project.stakeholders.title": "Các bên liên quan",
   "project.stakeholders.empty":
     "Chưa ai có vai trò trong dự án này. Bên liên quan là người giữ một vai trò ở đây — nhà tài trợ, trưởng dự án, người ủng hộ.",
+  "project.stakeholders.add": "Thêm bên liên quan",
+  "project.stakeholders.addHint":
+    "Mỗi người một vai trò. Chọn lại người đã có trong dự án sẽ đổi họ sang vai trò bạn chọn ở đây.",
+  "project.stakeholders.searchLabel": "Tìm người theo tên",
+  "project.stakeholders.removeTitle": "Đưa người này ra khỏi dự án?",
+  "project.stakeholders.removeConfirm":
+    "{name} sẽ không còn là bên liên quan của dự án này. Hoạt động đã ghi nhận vẫn giữ nguyên.",
+  "project.stakeholders.removeOne": "Đưa {name} ra khỏi dự án",
   "project.role.sponsor": "Nhà tài trợ",
   "project.role.project_lead": "Trưởng dự án",
   "project.role.delivery_lead": "Trưởng triển khai",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -535,10 +535,10 @@ export const vi = {
   "partner.stage.noFit": "Không phù hợp",
 
   "rel.add": "Thêm quan hệ",
-  "rel.addStakeholder": "Thêm người liên quan",
-  "rel.dealStakeholders": "Người liên quan",
+  "rel.addStakeholder": "Thêm bên liên quan",
+  "rel.dealStakeholders": "Các bên liên quan",
   "rel.dealStakeholdersEmpty":
-    "Chưa ghi nhận người liên quan nào cho giao dịch này",
+    "Chưa ghi nhận bên liên quan nào cho giao dịch này",
   "rel.kind": "Loại",
   "rel.saveDone": "Đã lưu mối quan hệ",
   "rel.role": "Vai trò",

--- a/frontend/src/screens/activitykeys.ts
+++ b/frontend/src/screens/activitykeys.ts
@@ -78,8 +78,19 @@ export function derivedRecordKeys(
   return derived ? [derived] : [];
 }
 
+// A deal's COVERAGE is written from its stakeholder edges: the rail's seats,
+// the committee map and the risk chips all read GET /deals/{id}/coverage, and
+// every one of them is stale the moment a seat is added, re-roled or removed.
+// Keyed per deal by the reader (dealCoverageKey); named here as the prefix,
+// because a writer usually knows only that SOME deal's edges moved — a
+// stakeholder is seated from the person's page as readily as from the deal's.
+export const DEAL_COVERAGE_KEY: QueryKey = ["deal-coverage"];
+
 const DERIVED_FROM_RECORD: Record<string, (id: string) => QueryKey> = {
   deal: (id) => DEAL_STATUS_KEY(id),
+  // Keyed on the relationship's own id nowhere: what goes stale is the deal the
+  // edge names, and the edit form knows only the edge. The prefix covers it.
+  relationship: () => DEAL_COVERAGE_KEY,
 };
 
 // A task is also a row in the standing work queue, which is keyed per workspace

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -563,7 +563,11 @@ function CompanyEditAction({
           },
           body: {
             ...mapOrgUpdate(values, rows ?? {}, org.domains),
-            ...cf.toBody(values),
+            // A DIFF, like the core half above. recordSlice is what the form
+            // prefilled from, so it is what "unchanged" is measured against —
+            // a snapshot here sends `null` for every empty custom field, which
+            // the API reads as an instruction to clear a column nobody touched.
+            ...cf.toPatch(values, cf.recordSlice(org)),
           },
         });
         if (error) {

--- a/frontend/src/screens/customfields.card.test.tsx
+++ b/frontend/src/screens/customfields.card.test.tsx
@@ -19,6 +19,7 @@ vi.mock("./customfields.form", async (importOriginal) => {
       formFields: [],
       recordSlice: () => ({}),
       toBody: () => ({}),
+      toPatch: () => ({}),
     }),
   };
 });

--- a/frontend/src/screens/customfields.form.render.test.tsx
+++ b/frontend/src/screens/customfields.form.render.test.tsx
@@ -14,6 +14,7 @@ import type { CreateField } from "./create";
 import {
   type CustomField,
   customFieldsToBody,
+  customFieldsToPatch,
   customFieldToFormField,
 } from "./customfields.form";
 import { EditAction } from "./edit";
@@ -107,6 +108,48 @@ describe("custom fields on the record edit form", () => {
     const submitted = update.mock.calls[0][0];
     expect(customFieldsToBody(submitted, [ceilingCf])).toEqual({
       cf_budget_ceiling: 2000,
+    });
+  });
+
+  // The reported defect, in the half of the body the core diff does not reach:
+  // an empty custom field coerces to null, the API reads a top-level null as
+  // "forget this column", and no cf_* column is clearable — so one empty field
+  // refused every save of the record, naming a field nobody had touched.
+  it("says nothing about an empty custom field the person never touched", async () => {
+    const update = vi.fn(async (_values: Record<string, unknown>) => ({
+      id: "d1",
+    }));
+    const seeded = { id: "d1", version: 2, name: "Globex" };
+    render(
+      <EditAction
+        label="Edit"
+        fields={[
+          coreField,
+          divider,
+          customFieldToFormField(ceilingCf, { yes: "Yes", no: "No" }),
+        ]}
+        // The deal carries no value for the field, which is the ordinary state
+        // of a field somebody added to the workspace last week.
+        record={seeded}
+        update={update}
+        invalidate="deals"
+        recordKey="deal"
+        savedMessage="Saved."
+      />,
+    );
+    await userEvent.click(screen.getByTestId("edit-record"));
+    const name = screen.getByLabelText(/Deal name/) as HTMLInputElement;
+    await userEvent.clear(name);
+    await userEvent.type(name, "Globex Renewal");
+    await userEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    const submitted = update.mock.calls[0][0];
+    expect(customFieldsToPatch(submitted, seeded, [ceilingCf])).toEqual({});
+    // What the snapshot would have sent, and why it earned a 422: the same
+    // save, one function apart.
+    expect(customFieldsToBody(submitted, [ceilingCf])).toEqual({
+      cf_budget_ceiling: null,
     });
   });
 

--- a/frontend/src/screens/customfields.form.test.ts
+++ b/frontend/src/screens/customfields.form.test.ts
@@ -284,6 +284,44 @@ describe("customFieldsToPatch", () => {
     expect(body.cf_priority).toBeNull();
   });
 
+  // The prefill converts a currency column's minor units to major; the diff has
+  // to read the stored value the same way or it reports every currency field as
+  // edited on every save, and rewrites a figure nobody touched.
+  it("reads a currency field in the major units the control shows", () => {
+    const budget = cf({
+      id: "cf-4",
+      column_name: "cf_budget",
+      type: "currency",
+      currency: "EUR",
+    });
+
+    expect(
+      customFieldsToPatch({ cf_budget: "12.5" }, { cf_budget: 1250 }, [budget]),
+    ).toEqual({});
+    // And a real edit still travels, back in minor units.
+    expect(
+      customFieldsToPatch({ cf_budget: "20" }, { cf_budget: 1250 }, [budget]),
+    ).toEqual({ cf_budget: 2000 });
+  });
+
+  // A currency whose scale is not two digits: a dong has none, so 1250 VND is
+  // 1250 major, not 12.5. A hard-coded hundred here reports it as edited and
+  // then writes a hundredfold figure on the next real save.
+  it("reads a currency field at its own scale", () => {
+    const dong = cf({
+      id: "cf-5",
+      column_name: "cf_budget_vnd",
+      type: "currency",
+      currency: "VND",
+    });
+
+    expect(
+      customFieldsToPatch({ cf_budget_vnd: "1250" }, { cf_budget_vnd: 1250 }, [
+        dong,
+      ]),
+    ).toEqual({});
+  });
+
   // A record read carries a number or a boolean where the form holds a string.
   // Comparing the two spellings directly reports every such field as moved on
   // every save, which is the defect again with an extra step.

--- a/frontend/src/screens/customfields.form.test.ts
+++ b/frontend/src/screens/customfields.form.test.ts
@@ -6,6 +6,7 @@ import {
   customFieldHref,
   customFieldsRecordSlice,
   customFieldsToBody,
+  customFieldsToPatch,
   customFieldToFormField,
 } from "./customfields.form";
 
@@ -233,5 +234,66 @@ describe("customFieldHref", () => {
     ]) {
       expect(customFieldHref(value)).toBeNull();
     }
+  });
+});
+
+// An UPDATE body carries only what the person moved. customFieldsToBody is a
+// snapshot, which is right for a create and wrong here: an empty field coerces
+// to null, the API reads a top-level null as "forget this column", and no cf_*
+// column is clearable — so one empty custom field refused every save of the
+// record, naming a field nobody had touched.
+describe("customFieldsToPatch", () => {
+  const priority = cf({ column_name: "cf_priority", type: "text" });
+  const renewal = cf({
+    id: "cf-2",
+    column_name: "cf_renewal",
+    type: "date",
+  });
+  const fields = [priority, renewal];
+
+  it("says nothing about a field the person left alone", () => {
+    const seeded = { cf_priority: "", cf_renewal: "2026-09-01" };
+
+    const body = customFieldsToPatch({ ...seeded }, seeded, fields);
+
+    expect(body).toEqual({});
+  });
+
+  // The reported defect, in the half of the body the core diff does not reach.
+  it("does not resubmit an empty field as an instruction to clear it", () => {
+    const seeded = { cf_priority: "", cf_renewal: "" };
+
+    const body = customFieldsToPatch(
+      { ...seeded, cf_renewal: "2026-09-01" },
+      seeded,
+      fields,
+    );
+
+    expect(Object.keys(body)).toEqual(["cf_renewal"]);
+    expect(body.cf_renewal).toBe("2026-09-01");
+  });
+
+  it("still carries a blank over a stored value, which is a real edit", () => {
+    const body = customFieldsToPatch(
+      { cf_priority: "", cf_renewal: "2026-09-01" },
+      { cf_priority: "high", cf_renewal: "2026-09-01" },
+      fields,
+    );
+
+    expect(Object.keys(body)).toEqual(["cf_priority"]);
+    expect(body.cf_priority).toBeNull();
+  });
+
+  // A record read carries a number or a boolean where the form holds a string.
+  // Comparing the two spellings directly reports every such field as moved on
+  // every save, which is the defect again with an extra step.
+  it("reads a non-string stored value in the form's own spelling", () => {
+    const count = cf({ id: "cf-3", column_name: "cf_count", type: "number" });
+
+    const body = customFieldsToPatch({ cf_count: "12" }, { cf_count: 12 }, [
+      count,
+    ]);
+
+    expect(body).toEqual({});
   });
 });

--- a/frontend/src/screens/customfields.form.ts
+++ b/frontend/src/screens/customfields.form.ts
@@ -124,6 +124,46 @@ export function customFieldsToBody(
   return body;
 }
 
+/**
+ * The write-body slice as a DIFF against the record the form opened on.
+ *
+ * `customFieldsToBody` is the right shape for a CREATE, where every field is
+ * being stated for the first time. On an UPDATE it is not: an empty field
+ * coerces to `null`, the API reads a top-level null as *forget this column*
+ * (httperr.ClearedFields), and no `cf_*` column is clearable — so a full
+ * snapshot refused every save of any record with an empty custom field, naming
+ * a field the person had not touched. That is the same defect the core fields
+ * had, in the other half of the same body.
+ *
+ * Compared on the FORM's own strings, the way the core diff is: a control left
+ * alone holds exactly what it was seeded with, and the stored shape (minor
+ * units, a boolean, a trimmed string) is derived from that string afterwards.
+ *
+ * A blank over a stored value is still a change and still travels as null. The
+ * API refuses that today — no catalog column is clearable — which is a real gap
+ * and a different one: it is about what the custom-field contract can express,
+ * not about a form sending fields nobody edited.
+ */
+export function customFieldsToPatch(
+  values: Record<string, unknown>,
+  seeded: Record<string, unknown>,
+  fields: CustomField[],
+): Record<string, unknown> {
+  const spelled = (source: Record<string, unknown>, key: string) => {
+    const raw = source[key];
+    return raw == null ? "" : String(raw).trim();
+  };
+  const body: Record<string, unknown> = {};
+  for (const field of fields) {
+    const column = field.column_name;
+    if (spelled(values, column) === spelled(seeded, column)) {
+      continue;
+    }
+    body[column] = coerceWrite(field, spelled(values, column));
+  }
+  return body;
+}
+
 // One field's display string for the read-only 360, or null when the record
 // carries no value (evidence-or-omit: an empty field is absent, never guessed).
 export function customFieldDisplay(
@@ -184,6 +224,13 @@ export type ObjectCustomFields = {
   formFields: CreateField[];
   recordSlice: (record: Record<string, unknown>) => Record<string, unknown>;
   toBody: (values: Record<string, unknown>) => Record<string, unknown>;
+  // The same slice as a diff, for an EDIT. `seeded` is the record the form
+  // opened on — `recordSlice`'s own output, which is what the form prefilled
+  // from, so the two cannot disagree about what "unchanged" means.
+  toPatch: (
+    values: Record<string, unknown>,
+    seeded: Record<string, unknown>,
+  ) => Record<string, unknown>;
 };
 
 const EMPTY_CUSTOM_FIELDS: CustomField[] = [];
@@ -231,5 +278,6 @@ export function useObjectCustomFields(object: CfObject): ObjectCustomFields {
     formFields,
     recordSlice: (record) => customFieldsRecordSlice(record, fields),
     toBody: (values) => customFieldsToBody(values, fields),
+    toPatch: (values, seeded) => customFieldsToPatch(values, seeded, fields),
   };
 }

--- a/frontend/src/screens/customfields.form.ts
+++ b/frontend/src/screens/customfields.form.ts
@@ -34,18 +34,10 @@ export function customFieldToFormField(
     case "date":
       return { ...base, type: "date" };
     case "currency":
-      // Stored as bigint minor units; the form edits major units, at the scale
-      // THIS field's own currency carries. The catalog holds that code
-      // (CF-T06) — the same one the renderer below formats with — so a
-      // hard-coded hundred here made the form and the display disagree for
-      // every currency that is not two-decimal.
       return {
         ...base,
         type: "number",
-        toInput: (raw) =>
-          raw == null || raw === ""
-            ? ""
-            : String(toMajorUnits(Number(raw), field.currency ?? "")),
+        toInput: (raw) => customFieldFormValue(field, raw),
       };
     case "picklist":
       return {
@@ -72,6 +64,35 @@ export function customFieldToFormField(
 
 // Coerce one field's form string to its stored value. Empty → null so a cleared
 // field actually clears the column.
+/**
+ * One stored value in the FORM's spelling — the string the control is prefilled
+ * with, and therefore the string an unchanged control still holds.
+ *
+ * The currency case is the reason this is a function rather than a
+ * `String(...)`: the column is bigint MINOR units and the form edits MAJOR
+ * units, at the scale this field's own currency carries. The catalog holds that
+ * code (CF-T06) — the same one the renderer formats with — so a hard-coded
+ * hundred here made the form and the display disagree for every currency that
+ * is not two-decimal.
+ *
+ * The prefill (`toInput`) and the diff (`customFieldsToPatch`) both read it, so
+ * they cannot disagree about what a value looks like on screen. They did: the
+ * diff compared a submitted "12.5" against a stored 1250 and reported every
+ * currency field as edited on every save.
+ */
+export function customFieldFormValue(
+  field: CustomField,
+  stored: unknown,
+): string {
+  if (stored == null || stored === "") {
+    return "";
+  }
+  if (field.type === "currency") {
+    return String(toMajorUnits(Number(stored), field.currency ?? ""));
+  }
+  return String(stored).trim();
+}
+
 function coerceWrite(field: CustomField, raw: string): unknown {
   const value = raw.trim();
   if (value === "") {
@@ -149,17 +170,17 @@ export function customFieldsToPatch(
   seeded: Record<string, unknown>,
   fields: CustomField[],
 ): Record<string, unknown> {
-  const spelled = (source: Record<string, unknown>, key: string) => {
-    const raw = source[key];
-    return raw == null ? "" : String(raw).trim();
-  };
   const body: Record<string, unknown> = {};
   for (const field of fields) {
     const column = field.column_name;
-    if (spelled(values, column) === spelled(seeded, column)) {
+    // The submitted value is already a form string; the stored one is put into
+    // the same spelling first, which is what the control was prefilled with.
+    const submitted =
+      values[column] == null ? "" : String(values[column]).trim();
+    if (submitted === customFieldFormValue(field, seeded[column])) {
       continue;
     }
-    body[column] = coerceWrite(field, spelled(values, column));
+    body[column] = coerceWrite(field, submitted);
   }
   return body;
 }

--- a/frontend/src/screens/deal360/usedealcoverage.tsx
+++ b/frontend/src/screens/deal360/usedealcoverage.tsx
@@ -19,13 +19,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
+import { DEAL_COVERAGE_KEY } from "../activitykeys";
 import { throwProblem } from "../common";
 
 type DealCoverage = components["schemas"]["DealCoverage"];
 
-/** The cache key every coverage reader shares. */
+/**
+ * The cache key every coverage reader shares.
+ *
+ * Built on the prefix the WRITERS name (activitykeys.DEAL_COVERAGE_KEY): a
+ * stakeholder edge is created from the person's page as readily as from the
+ * deal's, so the writer usually knows only that some deal's seats moved and
+ * drops the prefix. Two spellings of it would leave the map on this page
+ * confidently stale.
+ */
 export function dealCoverageKey(dealId: string) {
-  return ["deal-coverage", dealId] as const;
+  return [...DEAL_COVERAGE_KEY, dealId] as const;
 }
 
 /**

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -527,27 +527,75 @@ function stubBackend(
 }
 
 describe("mapDealUpdate", () => {
-  it("rebuilds amount_minor from major units and nulls blanks", () => {
-    const body = mapDealUpdate({
-      name: "Fleet retrofit",
-      amount: "2120",
-      currency: "EUR",
-      organization_id: "",
-      owner_id: "u-me",
-      partner_org_id: "",
-      forecast_category: "commit",
-      expected_close_date: "2026-09-01",
-      wait_until: "",
-    });
-    expect(body.name).toBe("Fleet retrofit");
+  // The form's controls as a person who changed nothing left them. Every value
+  // here is exactly what dealEditRecord seeded, so a key reaching the body is
+  // the form reporting a change nobody made.
+  const untouched = {
+    name: "Fleet retrofit",
+    amount: "2120",
+    currency: "EUR",
+    owner_id: "u-me",
+    organization_id: "",
+    partner_org_id: "",
+    partner_attribution: "",
+    forecast_category: "",
+    expected_close_date: "",
+    wait_until: "",
+    project_id: "",
+  };
+
+  it("rebuilds amount_minor from major units for the fields the person moved", () => {
+    const body = mapDealUpdate(
+      {
+        ...untouched,
+        amount: "2120",
+        currency: "EUR",
+        owner_id: "u-me",
+        forecast_category: "commit",
+        expected_close_date: "2026-09-01",
+      },
+      { ...untouched, amount: "", currency: "", owner_id: "" },
+    );
     expect(body.amount_minor).toBe(212_000);
     expect(body.currency).toBe("EUR");
-    expect(body.organization_id).toBeNull();
     expect(body.owner_id).toBe("u-me");
-    expect(body.partner_org_id).toBeNull();
     expect(body.forecast_category).toBe("commit");
     expect(body.expected_close_date).toBe("2026-09-01");
-    expect(body.wait_until).toBeNull();
+    // Named nowhere in the edit, so named nowhere in the body.
+    expect("name" in body).toBe(false);
+    expect("wait_until" in body).toBe(false);
+  });
+
+  // The reported defect. The body used to carry every field on every save, so a
+  // deal with no company resubmitted `organization_id: null` — and the API,
+  // correctly, refused to clear a field the person never touched. On an
+  // installation with no partners the refusal named `partner_attribution`, a
+  // field the form does not even render.
+  it("sends nothing at all when the person changed nothing", () => {
+    const body = mapDealUpdate(untouched, untouched);
+
+    expect(Object.keys(body)).toEqual([]);
+  });
+
+  it("names only the field the person moved, on a deal missing every optional value", () => {
+    const bare = {
+      name: "Any Deal",
+      amount: "",
+      currency: "",
+      owner_id: "",
+      organization_id: "",
+      partner_org_id: "",
+      partner_attribution: "",
+      forecast_category: "",
+      expected_close_date: "",
+      wait_until: "",
+      project_id: "",
+    };
+
+    const body = mapDealUpdate({ ...bare, name: "Renamed" }, bare);
+
+    expect(Object.keys(body)).toEqual(["name"]);
+    expect(body.name).toBe("Renamed");
   });
 
   // A withheld reference arrives as null with masked_fields naming it —
@@ -558,18 +606,65 @@ describe("mapDealUpdate", () => {
   it("does not clear a partner it was never allowed to see", () => {
     const body = mapDealUpdate(
       { name: "Fleet retrofit", partner_org_id: "", partner_attribution: "" },
+      {
+        name: "Fleet retrofit",
+        partner_org_id: "p-1",
+        partner_attribution: "sourced",
+      },
       ["partner_org_id"],
     );
     expect("partner_org_id" in body).toBe(false);
     // The attribution is withheld WITH its partner, so it goes too — returning
     // half the pair would decide what a partner nobody could see is owed.
     expect("partner_attribution" in body).toBe(false);
-    expect(body.name).toBe("Fleet retrofit");
   });
 
   it("still clears a partner the reader could see and chose to remove", () => {
-    const body = mapDealUpdate({ name: "x", partner_org_id: "" }, []);
+    const body = mapDealUpdate(
+      { ...untouched, partner_org_id: "" },
+      { ...untouched, partner_org_id: "p-1", partner_attribution: "sourced" },
+    );
     expect(body.partner_org_id).toBeNull();
+    // The claim goes with the partner, server-side, as one fact. Naming its own
+    // null here would state a claim with nobody left to attribute it to, which
+    // is the one shape the API refuses.
+    expect("partner_attribution" in body).toBe(false);
+  });
+
+  // The scale is part of the amount: amount_minor is denominated in the
+  // currency's OWN minor units, so a currency moving alone re-denominates the
+  // figure the row holds. 10000 JPY re-saved as EUR is €100, and the fx freeze
+  // and the forecast history then record that as the price.
+  it("re-sends the figure at the new scale when only the currency moved", () => {
+    const priced = { ...untouched, amount: "10000", currency: "JPY" };
+
+    const body = mapDealUpdate({ ...priced, currency: "EUR" }, priced);
+
+    expect(body.currency).toBe("EUR");
+    expect(body.amount_minor).toBe(1_000_000);
+  });
+
+  // Naming a currency on a deal with no figure is half a money value, and the
+  // server's own pair refusal says so better than an amount this form invents.
+  it("invents no figure when a currency is named on an unpriced deal", () => {
+    const bare = { ...untouched, amount: "", currency: "" };
+
+    const body = mapDealUpdate({ ...bare, currency: "EUR" }, bare);
+
+    expect(Object.keys(body)).toEqual(["currency"]);
+  });
+
+  it("moves the claim alone when the partner stays put", () => {
+    const body = mapDealUpdate(
+      {
+        ...untouched,
+        partner_org_id: "p-1",
+        partner_attribution: "influenced",
+      },
+      { ...untouched, partner_org_id: "p-1", partner_attribution: "sourced" },
+    );
+    expect(Object.keys(body)).toEqual(["partner_attribution"]);
+    expect(body.partner_attribution).toBe("influenced");
   });
 });
 
@@ -1587,10 +1682,14 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     expect(screen.getByText("via")).toBeTruthy();
   });
 
-  // A form omits nothing the record already carries. The partner picker offers
-  // one capped page of partners, so a deal's own partner can be missing from
-  // it — and a select whose stored value is not an option shows blank, which
-  // on save clears the partner and the commission attribution with it.
+  // A form offers nothing the record already carries as a blank. The partner
+  // picker offers one capped page of partners, so a deal's own partner can be
+  // missing from it — and a select whose stored value is not an option shows
+  // blank, which the patch then reads as the person having chosen "Unset" and
+  // sends as a real null, clearing the partner and its commission attribution.
+  //
+  // The save says nothing about the partner at all, which is what makes it
+  // safe: omitted means unchanged.
   it("keeps a partner the picker cannot reach, rather than clearing it on save", async () => {
     const user = userEvent.setup();
     const patches: { body: unknown }[] = [];
@@ -1614,12 +1713,9 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(patches.length).toBe(1));
-    const body = patches[0].body as {
-      partner_org_id: string | null;
-      partner_attribution: string | null;
-    };
-    expect(body.partner_org_id).toBe("p-offpage");
-    expect(body.partner_attribution).toBe("sourced");
+    const body = patches[0].body as Record<string, unknown>;
+    expect("partner_org_id" in body).toBe(false);
+    expect("partner_attribution" in body).toBe(false);
   });
 
   // Same guarantee when the partner list never arrives at all — a failed or
@@ -1651,12 +1747,9 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(patches.length).toBe(1));
-    const body = patches[0].body as {
-      partner_org_id: string | null;
-      partner_attribution: string | null;
-    };
-    expect(body.partner_org_id).toBe("p-offpage");
-    expect(body.partner_attribution).toBe("influenced");
+    const body = patches[0].body as Record<string, unknown>;
+    expect("partner_org_id" in body).toBe(false);
+    expect("partner_attribution" in body).toBe(false);
   });
 
   // The facts run together without a separator: three adjacent spans in a

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -126,6 +126,7 @@ import {
 import { LogActivity } from "./logactivity";
 import type { Project } from "./projects.form";
 import { invalidateRecord } from "./recordwritekeys";
+import { RelationshipsTab } from "./relationships";
 import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import { ShareAction } from "./share";
 import { groupChronology } from "./timelinegroups";
@@ -502,6 +503,9 @@ type CreateDealRequest = components["schemas"]["CreateDealRequest"];
 // keeping it inline made a component that already draws badges, an edit dialog
 // and an archive verb carry a twentieth concern.
 //
+// It is also the patch's BASELINE (mapDealUpdate), so a field this function
+// misreads becomes a field every save reports as changed.
+//
 // Every absent value becomes "" rather than a default. A currency the FORM
 // chose is a currency the SAVE writes, so seeding one made an unpriced deal
 // acquire it the moment a reader edited its name — and since amount and
@@ -583,11 +587,23 @@ function forecastCategory(v: string): UpdateDealRequest["forecast_category"] {
 }
 
 /**
- * The edit form's values as a deal patch.
+ * The edit form's values as a deal patch — a DIFF, not a snapshot.
  *
- * A blank scalar clears the field on the wire (explicit null); a set value
- * trims through. `amount` arrives in major units from the form, the wire is
- * minor units (deal creation applies the same conversion above).
+ * `seeded` is the record the form opened on (`dealEditRecord`). A key appears
+ * only where the form's value differs from it, and that is the whole point: the
+ * body used to carry every field on every save, so a deal missing a value the
+ * form does not even RENDER — `partner_attribution` on an installation with no
+ * partners — resubmitted `null` as a real instruction to clear it. The API reads
+ * an explicit null as "forget this" and refused, correctly, naming a field the
+ * person had never seen. Nothing the person did not touch travels now.
+ *
+ * A blank over a stored value is still a change, and still travels as null: the
+ * pickers offer "Unset" in words, so clearing a company or a partner is a
+ * choice somebody made rather than a gap in what the form knows.
+ *
+ * `amount` arrives in major units from the form and the wire is minor units
+ * (deal creation applies the same conversion above). The two money halves are
+ * compared as the form spells them, because that is where the person's edit is.
  *
  * `masked` names the fields THIS reader was not shown. A withheld reference
  * arrives as null with `masked_fields` naming it — deliberately, so a reader
@@ -598,28 +614,81 @@ function forecastCategory(v: string): UpdateDealRequest["forecast_category"] {
  */
 export function mapDealUpdate(
   values: Record<string, unknown>,
+  seeded: Record<string, unknown> = {},
   masked: readonly string[] = [],
 ): UpdateDealRequest {
   const str = (v: unknown) => (typeof v === "string" ? v.trim() : "");
-  const amount = str(values.amount);
-  const owner = str(values.owner_id);
-  const forecast = str(values.forecast_category);
   const currency = str(values.currency);
-  const patch: UpdateDealRequest = {
-    name: str(values.name) || undefined,
-    amount_minor: amount ? toMinorUnits(Number(amount), currency) : null,
-    currency: currency || undefined,
-    organization_id: str(values.organization_id) || null,
-    owner_id: owner || null,
-    partner_org_id: str(values.partner_org_id) || null,
-    partner_attribution: partnerAttribution(str(values.partner_attribution)),
-    forecast_category: forecastCategory(forecast),
-    expected_close_date: str(values.expected_close_date) || null,
-    wait_until: str(values.wait_until) || null,
-    // Resolved by the screen before mapping: the "new project" answer has
-    // already become an id by the time the patch is built.
-    project_id: str(values.project_id) || null,
-  };
+  const amount = str(values.amount);
+  const patch: UpdateDealRequest = {};
+  // One reading of "the person moved this field", over the form's own spelling
+  // of the value rather than the wire's: a select left alone holds exactly the
+  // string it was seeded with, and the wire shape (minor units, a narrowed
+  // vocabulary) is derived from that string afterwards.
+  //
+  // The wire key and the form key are named together at every call, because the
+  // one place this can go wrong is a field compared under one name and sent
+  // under another — which sends an untouched field, or swallows a real edit.
+  const moved = (formKey: string) =>
+    str(values[formKey]) !== str(seeded[formKey]);
+  function onMove<K extends keyof UpdateDealRequest>(
+    formKey: string,
+    wireKey: K,
+    value: () => UpdateDealRequest[K],
+  ) {
+    if (moved(formKey)) {
+      patch[wireKey] = value();
+    }
+  }
+  // A required field: an emptied name is a form the person has not finished,
+  // not an instruction to erase the deal's name.
+  onMove("name", "name", () => str(values.name) || undefined);
+  // The money pair travels together whenever either half moves, because the
+  // SCALE is part of the amount: amount_minor is denominated in the currency's
+  // own minor units — a dong has none, a dinar has three — so a currency moving
+  // alone re-denominates the figure the row already holds. 10000 JPY re-saved as
+  // EUR became 10000 minor EUR, which is €100, and the fx freeze and the
+  // forecast history then recorded that as the price.
+  //
+  // The exception is a deal with no figure at all: naming a currency there is
+  // half a money value, and the server's own pair refusal says so better than an
+  // amount_minor this form would have to invent.
+  if (moved("amount") || (moved("currency") && amount)) {
+    patch.amount_minor = amount ? toMinorUnits(Number(amount), currency) : null;
+  }
+  onMove("currency", "currency", () => currency || undefined);
+  onMove(
+    "organization_id",
+    "organization_id",
+    () => str(values.organization_id) || null,
+  );
+  onMove("owner_id", "owner_id", () => str(values.owner_id) || null);
+  onMove(
+    "partner_org_id",
+    "partner_org_id",
+    () => str(values.partner_org_id) || null,
+  );
+  // Only alongside a partner. Clearing the partner clears what they did with
+  // it — the two are one fact, stored under one CHECK — so sending the
+  // attribution's own null beside it would name a claim with nobody left to
+  // attribute it to, which the API refuses.
+  if (str(values.partner_org_id)) {
+    onMove("partner_attribution", "partner_attribution", () =>
+      partnerAttribution(str(values.partner_attribution)),
+    );
+  }
+  onMove("forecast_category", "forecast_category", () =>
+    forecastCategory(str(values.forecast_category)),
+  );
+  onMove(
+    "expected_close_date",
+    "expected_close_date",
+    () => str(values.expected_close_date) || null,
+  );
+  onMove("wait_until", "wait_until", () => str(values.wait_until) || null);
+  // Resolved by the screen before mapping: the "new project" answer has
+  // already become an id by the time the patch is built.
+  onMove("project_id", "project_id", () => str(values.project_id) || null);
   return withoutMasked(patch, masked);
 }
 
@@ -2732,6 +2801,52 @@ function editProjectFields(
   );
 }
 
+// The two people surfaces under the deal's overview.
+//
+// The seats are in the RAIL as context — who these people are. The map is in
+// the column because it is a working surface: it draws how the deal is threaded
+// and where the cover is missing, which is what a reader acts on.
+//
+// The stakeholders panel is where a seat is ADDED, changed and removed. The
+// rail's seats and the map both read the coverage view, which carries no
+// relationship id and so can carry no verb — a deal's stakeholders were
+// readable on three surfaces and writable on none of them, reachable only from
+// whichever person happened to already be linked. It is the generic
+// relationships panel under a deal scope, not a second one: create, edit and
+// remove have one implementation for every kind.
+//
+// Named rather than inlined so DealScreen's render callback stays under the
+// complexity ceiling.
+function DealPeoplePanels({
+  dealId,
+  coverage,
+  overlay,
+}: Readonly<{
+  dealId: string;
+  coverage: ReturnType<typeof useDealCoverage>;
+  overlay: boolean;
+}>) {
+  return (
+    <>
+      <div style={{ marginTop: "var(--space-4)" }}>
+        <DealCommitteeMap
+          coverage={coverage.coverage}
+          withheld={coverage.withheld}
+          pending={coverage.pending}
+          overlay={overlay}
+        />
+      </div>
+      {/* Out in overlay mode, where the deal is a mirror with no native row for
+          a relationship to point at. */}
+      {!overlay && (
+        <div style={{ marginTop: "var(--space-4)" }}>
+          <RelationshipsTab scope={{ deal_id: dealId }} />
+        </div>
+      )}
+    </>
+  );
+}
+
 // This deal's VERBS — split out of DealScreen's render so the record-view
 // callback stays readably small. An archived deal is read-only (no
 // edit/archive/advance path exists server-side for a non-live row), so its
@@ -2808,6 +2923,11 @@ function DealActions({
   const currentProject = deal.project_id
     ? { id: deal.project_id, label: projectById.name ?? deal.project_id }
     : undefined;
+  // What the form OPENS on, named once because two things need the same answer:
+  // the form seeds its controls from it, and the patch is a diff against it.
+  // Two spellings of "the record as the form read it" would drift, and the one
+  // that drifts decides whether an untouched field is sent as a change.
+  const seeded = { ...dealEditRecord(deal), ...cf.recordSlice(deal) };
   return (
     <>
       <EditAction<Deal>
@@ -2837,7 +2957,7 @@ function DealActions({
           }),
           ...cf.formFields,
         ]}
-        record={{ ...dealEditRecord(deal), ...cf.recordSlice(deal) }}
+        record={seeded}
         update={async (values) => {
           // The company the form SUBMITS, not the one the deal had: a
           // project started here belongs to the company the save names.
@@ -2855,9 +2975,14 @@ function DealActions({
             body: {
               ...mapDealUpdate(
                 { ...values, project_id: projectId ?? "" },
+                seeded,
                 masked,
               ),
-              ...cf.toBody(values),
+              // The other half of the same body, diffed the same way and
+              // against the same baseline. A snapshot here reproduced the
+              // reported defect exactly: `cf_*` columns are clearable through
+              // no path, so one empty custom field refused every save.
+              ...cf.toPatch(values, seeded),
             },
           });
           if (error) {
@@ -3637,19 +3762,12 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   }}
                 />
               )}
-              {/* The seats are in the rail as CONTEXT — who these people are.
-                  The map is in the column because it is a working surface: it
-                  draws how the deal is threaded and where the cover is
-                  missing, which is what a reader acts on. */}
               {tab === "overview" && (
-                <div style={{ marginTop: "var(--space-4)" }}>
-                  <DealCommitteeMap
-                    coverage={coverageRead.coverage}
-                    withheld={coverageRead.withheld}
-                    pending={coverageRead.pending}
-                    overlay={overlay}
-                  />
-                </div>
+                <DealPeoplePanels
+                  dealId={deal.id}
+                  coverage={coverageRead}
+                  overlay={overlay}
+                />
               )}
               {tab === "files" && !overlay && <DealFiles dealId={deal.id} />}
               {tab === "files" && overlay && <OverlayUnavailable />}

--- a/frontend/src/screens/dealstakeholders.test.tsx
+++ b/frontend/src/screens/dealstakeholders.test.tsx
@@ -1,0 +1,238 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocaleProvider } from "../i18n";
+import { RelationshipsTab } from "./relationships";
+
+// A deal's stakeholders were readable on three surfaces — the rail's seats, the
+// committee map, the coverage findings — and writable on none: the edge was
+// creatable only from the PERSON's side, so seating a champion meant knowing
+// which contact to open first. This is the generic relationships panel under a
+// deal scope, which is what keeps create/edit/remove at one implementation.
+
+const DEAL = "01a02e25-a5ac-7099-8099-581cbf001a99";
+const PERSON = "01a02be9-2293-75d2-9dd2-3027d9b63dc2";
+
+const stakeholder = {
+  id: "rel-1",
+  kind: "deal_stakeholder",
+  deal_id: DEAL,
+  person_id: PERSON,
+  role: "champion",
+  is_current_primary: false,
+  source: "manual",
+  captured_by: "human:u-1",
+  version: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Every request the panel makes. `seats` is what the deal_id list read answers,
+// so the same stub serves the empty deal and the seated one.
+function stubFetch(
+  seats: unknown[],
+  onPost: (body: unknown) => void = () => {},
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const { method, url } = request;
+      if (method === "POST") {
+        onPost(JSON.parse(await request.text()));
+        return json({ ...stakeholder, id: "rel-new" }, 201);
+      }
+      if (url.includes("/relationships")) {
+        // The panel must ask by deal, not by person: a person_id read would
+        // answer with a different deal's seats.
+        expect(url).toContain(`deal_id=${DEAL}`);
+        return json({ data: seats, page: { next_cursor: null } });
+      }
+      // The by-id read first: EntityRef resolves the far end that way, and the
+      // list branch below would answer it with a page.
+      if (url.includes(`/people/${PERSON}`)) {
+        return json({ id: PERSON, full_name: "Mai Trần" });
+      }
+      if (url.includes("/people")) {
+        return json({
+          data: [{ id: PERSON, full_name: "Mai Trần" }],
+          page: { next_cursor: null },
+        });
+      }
+      return json({ data: [], page: { next_cursor: null } });
+    }),
+  );
+}
+
+function renderPanel() {
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider>
+        <RelationshipsTab scope={{ deal_id: DEAL }} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The search debounces 250ms. Fake timers are armed BEFORE anything types, and
+// userEvent is told to advance them, because switching them on afterwards leaves
+// the already-scheduled timeout on the real clock: the test then waits out 250ms
+// of wall time on a queue it shares with every other jsdom file, which is the
+// flake family the frontend rulebook names rather than a wait at all.
+function setup() {
+  return userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+}
+
+function settleSearch() {
+  act(() => {
+    vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+  });
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+beforeEach(() => {
+  // shouldAdvanceTime, so the fake clock still ticks on its own: react-query's
+  // own scheduling and testing-library's waiters run on timers too, and a clock
+  // frozen until this file advances it hangs them rather than speeding them up.
+  vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 5 });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("the stakeholders on a deal", () => {
+  it("says what it is, in the word the rest of the product uses", async () => {
+    stubFetch([stakeholder]);
+    renderPanel();
+
+    expect(await screen.findByText("Stakeholders")).toBeTruthy();
+    // "People & companies" is the person and company panel's heading, and it
+    // sends a reader on a deal looking for a control this page does not have.
+    expect(screen.queryByText("People & companies")).toBeNull();
+  });
+
+  // A deal anchors one kind, so a Kind column repeats one badge down every row
+  // and a Kind picker asks a question with a single answer.
+  it("drops the kind column and the kind picker on a single-kind scope", async () => {
+    const user = setup();
+    stubFetch([stakeholder]);
+    renderPanel();
+
+    await screen.findByTestId("remove-relationship");
+    expect(screen.queryByText("Deal stakeholder")).toBeNull();
+    await user.click(screen.getByTestId("add-relationship"));
+    expect(
+      within(screen.getByRole("dialog")).queryByLabelText("Kind"),
+    ).toBeNull();
+  });
+
+  it("seats a person on THIS deal, naming both ends", async () => {
+    const user = setup();
+    const posted: unknown[] = [];
+    stubFetch([], (body) => posted.push(body));
+    renderPanel();
+
+    await user.click(await screen.findByTestId("add-relationship"));
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(dialog.getByLabelText("Role"), "economic_buyer");
+    await user.type(dialog.getByPlaceholderText("Search…"), "mai");
+    settleSearch();
+    await user.click(await dialog.findByRole("button", { name: "Mai Trần" }));
+    await user.click(screen.getByTestId("add-relationship-submit"));
+
+    await waitFor(() => expect(posted.length).toBe(1));
+    expect(posted[0]).toMatchObject({
+      kind: "deal_stakeholder",
+      deal_id: DEAL,
+      person_id: PERSON,
+      role: "economic_buyer",
+      source: "manual",
+    });
+    // The deal is the anchor, so no organization travels: an endpoint shape the
+    // rel_*_shape CHECKs refuse earns a 422 rather than a row.
+    expect(posted[0]).not.toHaveProperty("organization_id");
+  });
+
+  it("says nobody is on the deal rather than nothing at all", async () => {
+    stubFetch([]);
+    renderPanel();
+
+    expect(
+      await screen.findByText("No stakeholder is recorded on this deal"),
+    ).toBeTruthy();
+  });
+
+  // The committee map sits directly above this panel and the rail's seats beside
+  // it; all three read GET /deals/{id}/coverage. Seating a champion filled this
+  // table while the map one panel up still said the champion was missing.
+  it("drops the coverage the map and the rail seats read", async () => {
+    const user = setup();
+    stubFetch([]);
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const dropped: unknown[] = [];
+    client.invalidateQueries = ((filters: { queryKey?: unknown }) => {
+      dropped.push(filters?.queryKey);
+      return Promise.resolve();
+    }) as typeof client.invalidateQueries;
+    render(
+      <QueryClientProvider client={client}>
+        <LocaleProvider>
+          <RelationshipsTab scope={{ deal_id: DEAL }} />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+
+    await user.click(await screen.findByTestId("add-relationship"));
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(dialog.getByPlaceholderText("Search…"), "mai");
+    settleSearch();
+    await user.click(await dialog.findByRole("button", { name: "Mai Trần" }));
+    await user.click(screen.getByTestId("add-relationship-submit"));
+
+    await waitFor(() =>
+      expect(dropped).toEqual(
+        expect.arrayContaining([["relationships"], ["deal-coverage"]]),
+      ),
+    );
+  });
+
+  // The verbs are the whole point of adding this panel: the coverage view the
+  // other three surfaces read carries no relationship id, so it can carry no
+  // verb.
+  it("offers edit and remove on a seat that is already there", async () => {
+    stubFetch([stakeholder]);
+    renderPanel();
+
+    // Waited on the ROW, not the heading: the card draws its title before the
+    // list read settles, so a heading is no evidence the seat arrived.
+    expect(await screen.findByTestId("remove-relationship")).toBeTruthy();
+    expect(screen.getByTestId("edit-record")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1431,7 +1431,10 @@ function LeadActions({
             },
             body: {
               ...mapLeadUpdate(values),
-              ...cf.toBody(values),
+              // A diff against what the form prefilled from: a snapshot sends
+              // `null` for every empty custom field, and the API reads that as
+              // clearing a column nobody touched.
+              ...cf.toPatch(values, cf.recordSlice(lead)),
             },
           });
           if (error) {

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -595,7 +595,11 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
                       },
                       body: {
                         ...mapPersonUpdate(values),
-                        ...cf.toBody(values),
+                        // A diff against what the form prefilled from: a
+                        // snapshot sends `null` for every empty custom field,
+                        // and the API reads that as clearing a column nobody
+                        // touched.
+                        ...cf.toPatch(values, cf.recordSlice(person)),
                       },
                     });
                     if (error) {

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -148,7 +148,11 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
             companies={project.organizations}
             readOnly={Boolean(project.archived_at)}
           />
-          <StakeholdersCard view={view} />
+          <StakeholdersCard
+            view={view}
+            projectId={project.id}
+            readOnly={Boolean(project.archived_at)}
+          />
           <ProjectContractsCard view={view} />
           <ProjectDocumentsCard view={view} />
           <PhaseHistoryCard view={view} />

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -24,7 +24,11 @@ import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { EntityRef } from "./entityref";
 import { isProjectPhase, PHASE_LABEL } from "./projects.form";
-import { dealRoleLabel } from "./record360";
+import {
+  AddProjectStakeholder,
+  RemoveProjectStakeholder,
+} from "./projectstakeholders";
+import { projectRoleLabel } from "./record360";
 
 // The project page's sections, each drawn from ONE composite read
 // (GET /projects/{id}/360). Every card below answers the same three questions
@@ -96,26 +100,6 @@ export function stateOf(
     return present ? (count === 0 ? "empty" : "ready") : "unavailable";
   }
   return sectionState(view, section, present, count);
-}
-
-// The delivery roles a project adds to the deal-stakeholder vocabulary. The
-// five deal roles fall through to the company page's own labels, so one word
-// names a champion on a deal and on the project it became.
-const PROJECT_ROLE_LABELS: Record<string, MessageKey> = {
-  sponsor: "project.role.sponsor",
-  project_lead: "project.role.project_lead",
-  delivery_lead: "project.role.delivery_lead",
-  subject_matter_expert: "project.role.subject_matter_expert",
-};
-
-export function projectRoleLabel(
-  role: string,
-  t: (key: MessageKey) => string,
-): string {
-  const key = Object.hasOwn(PROJECT_ROLE_LABELS, role)
-    ? PROJECT_ROLE_LABELS[role]
-    : undefined;
-  return key ? t(key) : dealRoleLabel(role, t);
 }
 
 function phaseWord(phase: string, t: (key: MessageKey) => string): string {
@@ -245,10 +229,27 @@ function ProjectDealRow({
   );
 }
 
-/** The people seated on the project, each with the seat they hold. */
+/**
+ * The people seated on the project, each with the seat they hold — and the
+ * verbs that put them there.
+ *
+ * The verbs ride `titleAction`, which `SectionPanel` draws only on a section
+ * that is ready or empty. That is deliberate rather than incidental: a reader
+ * whose grant withheld the seats is told so, and offering them an Add button
+ * over a list they were not allowed to read would invite a write against
+ * records they cannot see.
+ */
 export function StakeholdersCard({
   view,
-}: Readonly<{ view: Project360 | undefined }>) {
+  projectId,
+  readOnly,
+}: Readonly<{
+  view: Project360 | undefined;
+  projectId: string;
+  // An archived project is read-only: the endpoints refuse a write against a
+  // non-live row, so a verb here could only ever fail.
+  readOnly?: boolean;
+}>) {
   const t = useT();
   const seats = view?.stakeholders?.data ?? [];
   const state = stateOf(
@@ -257,29 +258,47 @@ export function StakeholdersCard({
     Boolean(view?.stakeholders),
     seats.length,
   );
+  const writable = !readOnly && (state === "ready" || state === "empty");
   return (
     <SectionPanel
       title={t("project.stakeholders.title")}
       state={state}
       emptyLabel={t("project.stakeholders.empty")}
+      titleAction={
+        writable ? <AddProjectStakeholder projectId={projectId} /> : undefined
+      }
     >
       {seats.map((seat) => (
-        <StakeholderRow key={seat.relationship_id} seat={seat} />
+        <StakeholderRow
+          key={seat.relationship_id}
+          seat={seat}
+          projectId={projectId}
+          writable={writable}
+        />
       ))}
     </SectionPanel>
   );
 }
 
-function StakeholderRow({ seat }: Readonly<{ seat: Stakeholder }>) {
+function StakeholderRow({
+  seat,
+  projectId,
+  writable,
+}: Readonly<{ seat: Stakeholder; projectId: string; writable: boolean }>) {
   const t = useT();
   return (
     <PanelRow className="project-row">
       <EntityRef kind="person" id={seat.person_id} name={seat.person_name} />
-      {seat.role && (
-        <span className="project-row-meta">
-          <Badge quiet>{projectRoleLabel(seat.role, t)}</Badge>
-        </span>
-      )}
+      <span className="project-row-meta">
+        {seat.role && <Badge quiet>{projectRoleLabel(seat.role, t)}</Badge>}
+        {writable && (
+          <RemoveProjectStakeholder
+            projectId={projectId}
+            personId={seat.person_id}
+            personName={seat.person_name}
+          />
+        )}
+      </span>
     </PanelRow>
   );
 }

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import type { ReactNode } from "react";
+import { type ReactNode, useRef } from "react";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
@@ -259,13 +259,22 @@ export function StakeholdersCard({
     seats.length,
   );
   const writable = !readOnly && (state === "ready" || state === "empty");
+  // Where focus goes after a removal. The row holding the Remove button is gone
+  // by then, and focus restored to a node that has unmounted leaves a keyboard
+  // reader on document.body — so it lands on the panel's own Add control, which
+  // survives every removal and is rendered exactly when a Remove button is.
+  const addVerb = useRef<HTMLDivElement>(null);
   return (
     <SectionPanel
       title={t("project.stakeholders.title")}
       state={state}
       emptyLabel={t("project.stakeholders.empty")}
       titleAction={
-        writable ? <AddProjectStakeholder projectId={projectId} /> : undefined
+        writable ? (
+          <div ref={addVerb}>
+            <AddProjectStakeholder projectId={projectId} />
+          </div>
+        ) : undefined
       }
     >
       {seats.map((seat) => (
@@ -274,6 +283,9 @@ export function StakeholdersCard({
           seat={seat}
           projectId={projectId}
           writable={writable}
+          returnFocusTo={() =>
+            addVerb.current?.querySelector<HTMLElement>("button") ?? null
+          }
         />
       ))}
     </SectionPanel>
@@ -284,7 +296,13 @@ function StakeholderRow({
   seat,
   projectId,
   writable,
-}: Readonly<{ seat: Stakeholder; projectId: string; writable: boolean }>) {
+  returnFocusTo,
+}: Readonly<{
+  seat: Stakeholder;
+  projectId: string;
+  writable: boolean;
+  returnFocusTo: () => HTMLElement | null;
+}>) {
   const t = useT();
   return (
     <PanelRow className="project-row">
@@ -296,6 +314,7 @@ function StakeholderRow({
             projectId={projectId}
             personId={seat.person_id}
             personName={seat.person_name}
+            returnFocusTo={returnFocusTo}
           />
         )}
       </span>

--- a/frontend/src/screens/projectstakeholders.stories.tsx
+++ b/frontend/src/screens/projectstakeholders.stories.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  AddProjectStakeholder,
+  RemoveProjectStakeholder,
+} from "./projectstakeholders";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The verbs on the project page's stakeholders card, drawn on their own so both
+// dialogs can be read in either theme without the surrounding 360 read.
+const meta: Meta = {
+  title: "Records/ProjectStakeholders",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function stubPeople() {
+  installFetchStub({
+    "GET /people": () =>
+      jsonResponse({
+        data: [
+          { id: "p-1", full_name: "Mai Trần" },
+          { id: "p-2", full_name: "Jonas Weber" },
+        ],
+        page: { next_cursor: null, has_more: false },
+      }),
+  });
+}
+
+export const Add: Story = {
+  render: () => {
+    stubPeople();
+    return (
+      <StoryProviders>
+        <AddProjectStakeholder projectId="pr-1" />
+      </StoryProviders>
+    );
+  },
+};
+
+export const Remove: Story = {
+  render: () => {
+    stubPeople();
+    return (
+      <StoryProviders>
+        <RemoveProjectStakeholder
+          projectId="pr-1"
+          personId="p-1"
+          personName="Mai Trần"
+        />
+      </StoryProviders>
+    );
+  },
+};
+
+// A seat whose person the reader may not read. The seat still counts, and is
+// still removable, so the dialog names it as withheld rather than borrowing a
+// name it was never given.
+export const RemoveWithheldPerson: Story = {
+  render: () => {
+    stubPeople();
+    return (
+      <StoryProviders>
+        <RemoveProjectStakeholder
+          projectId="pr-1"
+          personId="p-9"
+          personName={null}
+        />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/projectstakeholders.test.tsx
+++ b/frontend/src/screens/projectstakeholders.test.tsx
@@ -185,6 +185,24 @@ describe("the stakeholders on a project", () => {
     expect(writes[0].url).toContain(`/projects/${PROJECT}/stakeholders/${MAI}`);
   });
 
+  // A successful removal unmounts the row the Remove button sits in, so focus
+  // restored to the trigger lands on a detached node and drops a keyboard reader
+  // on document.body. It goes to the panel's Add control, which survives every
+  // removal and is on screen exactly when a Remove button is.
+  it("leaves focus on a control that survives the removal", async () => {
+    const user = setup();
+    stubFetch(() => {});
+    renderCard();
+
+    await user.click(screen.getByTestId("remove-project-stakeholder"));
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(
+      screen.getByTestId("add-project-stakeholder"),
+    );
+  });
+
   // WITHHELD IS NOT EMPTY. A reader whose grant refused the seats is told so,
   // and offering them a verb over a list they were not allowed to read invites
   // a write against records they cannot see.

--- a/frontend/src/screens/projectstakeholders.test.tsx
+++ b/frontend/src/screens/projectstakeholders.test.tsx
@@ -1,0 +1,293 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LocaleProvider } from "../i18n";
+import { StakeholdersCard } from "./projectsections";
+
+// A project's stakeholders were readable and nothing more: the card listed a
+// name and a role, and the only way to seat or unseat anybody was the endpoint
+// itself. These specs hold the two verbs, and — the half that is easy to lose —
+// hold them ABSENT on a card whose seats the reader's grant withheld.
+
+const PROJECT = "01a02e25-a5ac-7099-8099-581cbf001a99";
+const MAI = "01a02be9-2293-75d2-9dd2-3027d9b63dc2";
+
+type Seats = {
+  relationship_id: string;
+  person_id: string;
+  person_name: string | null;
+  role: string | null;
+}[];
+
+function view(seats: Seats, omitted: string[] = []) {
+  return {
+    stakeholders: { data: seats, page: { next_cursor: null, has_more: false } },
+    sections_omitted: omitted,
+  } as unknown as Parameters<typeof StakeholdersCard>[0]["view"];
+}
+
+function withheldView() {
+  return {
+    sections_omitted: ["stakeholders"],
+  } as unknown as Parameters<typeof StakeholdersCard>[0]["view"];
+}
+
+const mai: Seats = [
+  {
+    relationship_id: "rel-1",
+    person_id: MAI,
+    person_name: "Mai Trần",
+    role: "sponsor",
+  },
+];
+
+function renderCard(
+  over: Partial<Parameters<typeof StakeholdersCard>[0]> = {},
+) {
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider>
+        <StakeholdersCard view={view(mai)} projectId={PROJECT} {...over} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// Every request the card makes, with the people search answering one name so a
+// pick is reachable without a real transport.
+function stubFetch(
+  onWrite: (call: { method: string; url: string; body: unknown }) => void,
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const { method, url } = request;
+      if (method !== "GET") {
+        onWrite({
+          method,
+          url,
+          body: request.body ? JSON.parse(await request.text()) : null,
+        });
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/people")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ id: MAI, full_name: "Mai Trần" }],
+            page: { next_cursor: null, has_more: false },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ data: [], page: { next_cursor: null } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }),
+  );
+}
+
+// The picker debounces 250ms. Fake timers are armed BEFORE anything types, and
+// userEvent is told to advance them, because switching them on afterwards leaves
+// the already-scheduled timeout on the real clock: the test then waits out 250ms
+// of wall time on a queue it shares with every other jsdom file, which is the
+// flake family the frontend rulebook names rather than a wait at all.
+const SEARCH_DEBOUNCE_MS = 250;
+
+function setup() {
+  return userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+}
+
+function settleSearch() {
+  act(() => {
+    vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+  });
+}
+
+// Nothing auto-unmounts here (no global cleanup in the vitest setup), and a
+// second card in the document turns every getByTestId into "found multiple".
+beforeEach(() => {
+  // shouldAdvanceTime, so the fake clock still ticks on its own: react-query's
+  // own scheduling and testing-library's waiters run on timers too, and a clock
+  // frozen until this file advances it hangs them rather than speeding them up.
+  vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 5 });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("the stakeholders on a project", () => {
+  it("seats a person in the role the reader picked", async () => {
+    const user = setup();
+    const writes: { method: string; url: string; body: unknown }[] = [];
+    stubFetch((call) => writes.push(call));
+    renderCard();
+
+    await user.click(screen.getByTestId("add-project-stakeholder"));
+    // Scoped to the dialog: the card's own row carries a button with this
+    // person's name too, and picking the row navigates away instead.
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(
+      dialog.getByPlaceholderText("Search people by name"),
+      "mai",
+    );
+    settleSearch();
+    await user.click(await dialog.findByRole("button", { name: "Mai Trần" }));
+    await user.click(dialog.getByLabelText("Role"));
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "Delivery lead",
+      }),
+    );
+    await user.click(dialog.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(writes.length).toBe(1));
+    expect(writes[0].method).toBe("PUT");
+    expect(writes[0].url).toContain(`/projects/${PROJECT}/stakeholders`);
+    expect(writes[0].body).toEqual({
+      person_id: MAI,
+      role: "delivery_lead",
+    });
+  });
+
+  it("takes a person off the project by their own id, behind a confirm", async () => {
+    const user = setup();
+    const writes: { method: string; url: string; body: unknown }[] = [];
+    stubFetch((call) => writes.push(call));
+    renderCard();
+
+    await user.click(screen.getByTestId("remove-project-stakeholder"));
+    // Two steps on purpose: the endpoint archives the edge and the card offers
+    // no way back, so the first click must not be the write.
+    expect(writes.length).toBe(0);
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(writes.length).toBe(1));
+    expect(writes[0].method).toBe("DELETE");
+    expect(writes[0].url).toContain(`/projects/${PROJECT}/stakeholders/${MAI}`);
+  });
+
+  // WITHHELD IS NOT EMPTY. A reader whose grant refused the seats is told so,
+  // and offering them a verb over a list they were not allowed to read invites
+  // a write against records they cannot see.
+  it("offers no verb at all on seats the reader's grant withheld", () => {
+    stubFetch(() => {
+      throw new Error("a withheld card must not write");
+    });
+    renderCard({ view: withheldView() });
+
+    expect(screen.queryByTestId("add-project-stakeholder")).toBeNull();
+    expect(screen.queryByTestId("remove-project-stakeholder")).toBeNull();
+  });
+
+  it("offers no verb on an archived project", () => {
+    stubFetch(() => {
+      throw new Error("an archived project must not write");
+    });
+    renderCard({ readOnly: true });
+
+    expect(screen.queryByTestId("add-project-stakeholder")).toBeNull();
+    expect(screen.queryByTestId("remove-project-stakeholder")).toBeNull();
+  });
+
+  // A refused write stays on screen in the server's own words. A dialog that
+  // closed on a 422 would report a seat nobody has.
+  it("keeps the dialog open carrying a refused write's reason", async () => {
+    const user = setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        if (request.method !== "GET") {
+          return new Response(
+            JSON.stringify({
+              type: "about:blank",
+              title: "Unprocessable Entity",
+              detail: "this person is archived",
+            }),
+            {
+              status: 422,
+              headers: { "content-type": "application/problem+json" },
+            },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: [{ id: MAI, full_name: "Mai Trần" }],
+            page: { next_cursor: null },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+    renderCard();
+
+    await user.click(screen.getByTestId("remove-project-stakeholder"));
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(await screen.findByText(/this person is archived/)).toBeTruthy();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("keeps the seating dialog open on a refused write, and cancels clean", async () => {
+    const user = setup();
+    const writes: { method: string; url: string; body: unknown }[] = [];
+    stubFetch((call) => {
+      writes.push(call);
+      throw new Error("this person is not on any company here");
+    });
+    renderCard();
+
+    await user.click(screen.getByTestId("add-project-stakeholder"));
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(
+      dialog.getByPlaceholderText("Search people by name"),
+      "mai",
+    );
+    settleSearch();
+    await user.click(await dialog.findByRole("button", { name: "Mai Trần" }));
+    await user.click(dialog.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(writes.length).toBe(1));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    // Cancel drops the pick as well as the dialog: a re-opened form holding
+    // somebody the reader had abandoned is a write waiting to be made by
+    // accident.
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await user.click(screen.getByTestId("add-project-stakeholder"));
+    expect(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Save" }),
+    ).toBeDisabled();
+  });
+
+  // The empty card is where a person seats the FIRST stakeholder, so the verb
+  // has to survive an empty list — the state that reads most like "nothing to
+  // do here".
+  it("offers the add verb on a project with nobody on it yet", () => {
+    stubFetch(() => {
+      throw new Error("rendering must not write");
+    });
+    renderCard({ view: view([]) });
+
+    expect(screen.getByTestId("add-project-stakeholder")).toBeTruthy();
+    expect(screen.queryByTestId("remove-project-stakeholder")).toBeNull();
+  });
+});

--- a/frontend/src/screens/projectstakeholders.tsx
+++ b/frontend/src/screens/projectstakeholders.tsx
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The verbs on a project's stakeholders card.
+//
+// The card read the seats and offered nothing: a person putting a sponsor on a
+// project, or taking a departed one off, had no control anywhere in the app and
+// had to reach the endpoint through an agent tool. The read was on three
+// surfaces and the write on none.
+//
+// They live here rather than beside the generic relationships panel because the
+// contract puts them on the project's OWN endpoints — /projects/{id}/stakeholders
+// — which is also why `project_stakeholder` is the one stakeholder kind that
+// panel does not create. The endpoint carries two rules the generic surface
+// cannot: write authority over the project row, and one seat per person.
+//
+// That last rule is what makes a role CHANGE the same act as an add: the PUT is
+// idempotent per person, so naming somebody already seated re-roles them rather
+// than seating them twice, and the dialog says so.
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Button, Field } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import {
+  RecordPicker,
+  type RecordPickerCandidate,
+} from "../design-system/recordpicker";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import { problemMessageOf, throwProblem } from "./common";
+import { projectRoleLabel } from "./record360";
+
+type SetProjectStakeholderRequest =
+  components["schemas"]["SetProjectStakeholderRequest"];
+type ProjectStakeholderRole = SetProjectStakeholderRequest["role"];
+
+// Every seat the contract admits, in the order it declares them: the five deal
+// roles a project inherits, then the four a body of work running past close
+// needs. Typed as the request's own role, so a role the contract drops stops
+// compiling here rather than earning a 422 in front of a reader.
+const PROJECT_STAKEHOLDER_ROLES: readonly ProjectStakeholderRole[] = [
+  "champion",
+  "economic_buyer",
+  "blocker",
+  "influencer",
+  "user",
+  "sponsor",
+  "project_lead",
+  "delivery_lead",
+  "subject_matter_expert",
+];
+
+// The one key the project page reads under (project360.tsx). A guess here
+// leaves the card showing the state before the write.
+function invalidateProject(
+  queryClient: ReturnType<typeof useQueryClient>,
+  projectId: string,
+) {
+  queryClient.invalidateQueries({ queryKey: ["project", projectId, "360"] });
+}
+
+async function searchPeople(query: string): Promise<RecordPickerCandidate[]> {
+  const { data, error } = await api.GET("/people", {
+    params: { query: { q: query, limit: 10 } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.map((person) => ({
+    id: person.id,
+    name: person.full_name,
+  }));
+}
+
+/**
+ * Seat somebody on the project, or move somebody already seated to another
+ * role — one dialog, because the endpoint makes them one write.
+ */
+export function AddProjectStakeholder({
+  projectId,
+}: Readonly<{ projectId: string }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [person, setPerson] = useState<RecordPickerCandidate | null>(null);
+  const [role, setRole] = useState<ProjectStakeholderRole>(
+    PROJECT_STAKEHOLDER_ROLES[0],
+  );
+
+  // The pick and the role arrive as the mutation's VARIABLES rather than
+  // through this closure: react-query re-arms a mutation's options in a passive
+  // effect, so a submit landing between the commit that enables the button and
+  // that effect runs the previous render's function — where nobody had been
+  // picked yet.
+  const seat = useMutation({
+    mutationFn: async (chosen: {
+      personId: string;
+      role: ProjectStakeholderRole;
+    }) => {
+      const { error } = await api.PUT("/projects/{id}/stakeholders", {
+        params: { path: { id: projectId } },
+        body: { person_id: chosen.personId, role: chosen.role },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      invalidateProject(queryClient, projectId);
+      close();
+    },
+  });
+
+  function close() {
+    setOpen(false);
+    setPerson(null);
+    setRole(PROJECT_STAKEHOLDER_ROLES[0]);
+    seat.reset();
+  }
+
+  return (
+    <>
+      <Button
+        small
+        onClick={() => setOpen(true)}
+        data-testid="add-project-stakeholder"
+      >
+        {t("project.stakeholders.add")}
+      </Button>
+      <ConfirmModal
+        open={open}
+        onClose={close}
+        title={t("project.stakeholders.add")}
+        confirmLabel={t("record.save")}
+        confirmDisabled={person === null}
+        onConfirm={() => {
+          if (person) {
+            seat.mutate({ personId: person.id, role });
+          }
+        }}
+        pending={seat.isPending}
+        error={seat.isError ? problemMessageOf(seat.error, t) : null}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+          }}
+        >
+          {/* Says what a second seating does before anybody tries it: the same
+              person named again is a re-role, not a duplicate row. */}
+          <p className="t-caption">{t("project.stakeholders.addHint")}</p>
+          <RecordPicker
+            label={t("project.stakeholders.searchLabel")}
+            searchTargets={searchPeople}
+            onPick={setPerson}
+            selected={person}
+            disabled={seat.isPending}
+          />
+          <Field label={t("rel.role")}>
+            {(control) => (
+              <Select
+                {...control}
+                value={role}
+                onChange={(value) => {
+                  if (isStakeholderRole(value)) {
+                    setRole(value);
+                  }
+                }}
+                options={PROJECT_STAKEHOLDER_ROLES.map((value) => ({
+                  value,
+                  label: projectRoleLabel(value, t),
+                }))}
+              />
+            )}
+          </Field>
+        </div>
+      </ConfirmModal>
+    </>
+  );
+}
+
+// The Select hands back a bare string, and the request's role is a closed
+// vocabulary — narrowing here is what keeps the body typed without an
+// assertion.
+function isStakeholderRole(value: string): value is ProjectStakeholderRole {
+  return PROJECT_STAKEHOLDER_ROLES.some((role) => role === value);
+}
+
+/**
+ * Take a person off the project.
+ *
+ * Two steps, like every other remove on a record page: the endpoint archives
+ * the edge, and the card gives no way back.
+ */
+export function RemoveProjectStakeholder({
+  projectId,
+  personId,
+  personName,
+}: Readonly<{
+  projectId: string;
+  personId: string;
+  // Absent when the caller may not read that person — the seat is still
+  // reported, and still removable, so the dialog names the seat rather than
+  // pretending to a name it was not given.
+  personName: string | null | undefined;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const detach = useMutation({
+    mutationFn: async (person: string) => {
+      const { error } = await api.DELETE(
+        "/projects/{id}/stakeholders/{person_id}",
+        { params: { path: { id: projectId, person_id: person } } },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      invalidateProject(queryClient, projectId);
+      setOpen(false);
+    },
+  });
+
+  return (
+    <>
+      <Button
+        small
+        variant="danger"
+        onClick={() => setOpen(true)}
+        data-testid="remove-project-stakeholder"
+        aria-label={t("project.stakeholders.removeOne", {
+          name: personName ?? t("coverage.seatWithheld"),
+        })}
+      >
+        {t("rel.remove")}
+      </Button>
+      <ConfirmModal
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          detach.reset();
+        }}
+        title={t("project.stakeholders.removeTitle")}
+        confirmLabel={t("rel.remove")}
+        confirmVariant="danger"
+        onConfirm={() => detach.mutate(personId)}
+        pending={detach.isPending}
+        error={detach.isError ? problemMessageOf(detach.error, t) : null}
+      >
+        <p>
+          {t("project.stakeholders.removeConfirm", {
+            name: personName ?? t("coverage.seatWithheld"),
+          })}
+        </p>
+      </ConfirmModal>
+    </>
+  );
+}

--- a/frontend/src/screens/projectstakeholders.tsx
+++ b/frontend/src/screens/projectstakeholders.tsx
@@ -202,6 +202,7 @@ export function RemoveProjectStakeholder({
   projectId,
   personId,
   personName,
+  returnFocusTo,
 }: Readonly<{
   projectId: string;
   personId: string;
@@ -209,6 +210,12 @@ export function RemoveProjectStakeholder({
   // reported, and still removable, so the dialog names the seat rather than
   // pretending to a name it was not given.
   personName: string | null | undefined;
+  // Where focus lands once the dialog closes. A successful removal unmounts the
+  // row this button sits in, so restoring focus to the trigger would hand a
+  // keyboard reader a detached node and drop them on document.body. The card
+  // names a surviving element — the same rule ProjectLinks keeps for its own
+  // detach, one card up the page.
+  returnFocusTo?: () => HTMLElement | null;
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -252,6 +259,7 @@ export function RemoveProjectStakeholder({
         title={t("project.stakeholders.removeTitle")}
         confirmLabel={t("rel.remove")}
         confirmVariant="danger"
+        returnFocusTo={returnFocusTo}
         onConfirm={() => detach.mutate(personId)}
         pending={detach.isPending}
         error={detach.isError ? problemMessageOf(detach.error, t) : null}

--- a/frontend/src/screens/record360/index.ts
+++ b/frontend/src/screens/record360/index.ts
@@ -17,7 +17,12 @@ export {
   WrittenBy,
   type WrittenByWriter,
 } from "./citations";
-export { dealRoleLabel, signalKindLabel, signalTone } from "./labels";
+export {
+  dealRoleLabel,
+  projectRoleLabel,
+  signalKindLabel,
+  signalTone,
+} from "./labels";
 export {
   incompleteGraph,
   OverlayFallback,

--- a/frontend/src/screens/record360/labels.tsx
+++ b/frontend/src/screens/record360/labels.tsx
@@ -89,3 +89,31 @@ export function dealRoleLabel(role: string, t: (key: MessageKey) => string) {
     : undefined;
   return key ? t(key) : role.replace(/_/g, " ");
 }
+
+// The delivery roles a project adds to the deal-stakeholder vocabulary. The
+// five deal roles fall through to their own labels below, so one word names a
+// champion on a deal and on the project it became.
+const PROJECT_ROLE_LABELS: Record<string, MessageKey> = {
+  sponsor: "project.role.sponsor",
+  project_lead: "project.role.project_lead",
+  delivery_lead: "project.role.delivery_lead",
+  subject_matter_expert: "project.role.subject_matter_expert",
+};
+
+/**
+ * projectRoleLabel names a stakeholder's seat on a project.
+ *
+ * Beside dealRoleLabel because it IS dealRoleLabel plus four words: the project
+ * vocabulary is the deal one with the delivery roles added, and the card that
+ * draws a seat and the dialog that offers one must not each keep their own copy
+ * of that list.
+ */
+export function projectRoleLabel(
+  role: string,
+  t: (key: MessageKey) => string,
+): string {
+  const key = Object.hasOwn(PROJECT_ROLE_LABELS, role)
+    ? PROJECT_ROLE_LABELS[role]
+    : undefined;
+  return key ? t(key) : dealRoleLabel(role, t);
+}

--- a/frontend/src/screens/relationships.stories.tsx
+++ b/frontend/src/screens/relationships.stories.tsx
@@ -73,3 +73,53 @@ export const Empty: Story = {
     );
   },
 };
+
+const stakeholderRel = {
+  ...employmentRel,
+  id: "rel-3",
+  kind: "deal_stakeholder",
+  deal_id: "d-1",
+  organization_id: null,
+  role: "champion",
+  is_current_primary: false,
+};
+
+// The same panel under a deal scope: one kind, so the Kind column and the Kind
+// picker both go — a column repeating one badge down every row, and a question
+// with a single answer.
+export const DealStakeholders: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /relationships": () =>
+        jsonResponse({
+          data: [
+            stakeholderRel,
+            { ...stakeholderRel, id: "rel-4", role: "economic_buyer" },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <RelationshipsTab scope={{ deal_id: "d-1" }} />
+      </StoryProviders>
+    );
+  },
+};
+
+export const DealStakeholdersEmpty: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /relationships": () =>
+        jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <RelationshipsTab scope={{ deal_id: "d-1" }} />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/relationships.test.tsx
+++ b/frontend/src/screens/relationships.test.tsx
@@ -18,6 +18,7 @@ type Relationship = components["schemas"]["Relationship"];
 
 const personScope: RelationshipScope = { person_id: "p-1" };
 const orgScope: RelationshipScope = { organization_id: "o-1" };
+const dealScope: RelationshipScope = { deal_id: "d-1" };
 
 function baseRel(over: Partial<Relationship>): Relationship {
   return {
@@ -38,6 +39,15 @@ describe("edgeOptions — creatable kinds per scope", () => {
     expect(edgeOptions(personScope)).toEqual([
       { kind: "employment", entity: "organization", field: "organization_id" },
       { kind: "deal_stakeholder", entity: "deal", field: "deal_id" },
+    ]);
+  });
+
+  // A deal had no scope of its own, so a stakeholder was creatable only from
+  // the PERSON's side: adding a champion meant knowing which contact to open
+  // first, and a deal nobody had linked from a contact page had no way in.
+  it("a deal anchors its stakeholders and nothing else", () => {
+    expect(edgeOptions(dealScope)).toEqual([
+      { kind: "deal_stakeholder", entity: "person", field: "person_id" },
     ]);
   });
 
@@ -86,6 +96,25 @@ describe("counterpartyRef — the other end of an existing edge, typed for Entit
       kind: "deal",
       id: "d-1",
     });
+  });
+
+  // From the deal, the far end is the PERSON — the deal is the anchor, not the
+  // counterparty, so returning the deal here would point every row at the page
+  // the reader is already on.
+  it("a stakeholder edge resolves to the person when the deal is the scope", () => {
+    const rel = baseRel({
+      kind: "deal_stakeholder",
+      deal_id: "d-1",
+      person_id: "p-1",
+    });
+    expect(counterpartyRef(rel, dealScope)).toEqual({
+      kind: "person",
+      id: "p-1",
+    });
+  });
+
+  it("names no far end for a deal edge that carries no person", () => {
+    expect(counterpartyRef(baseRel({ deal_id: "d-1" }), dealScope)).toBeNull();
   });
 
   it("an org↔org edge resolves to the counterparty org from the anchor side", () => {

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -22,6 +22,7 @@ import {
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { DEAL_COVERAGE_KEY } from "./activitykeys";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import type { CreateField } from "./create";
 import { EditAction } from "./edit";
@@ -41,9 +42,16 @@ type RelationshipKind = Relationship["kind"];
 
 // Which 360 this tab is rendered from — fixes which side of the edge is
 // "this record" and which is the picked "other side".
+//
+// A deal is a scope of its own, not a counterparty of somebody else's: a
+// deal_stakeholder edge was creatable only from the PERSON's side, so adding a
+// champion to a deal meant knowing which person to open first, and a deal
+// nobody had thought to name from a contact page had no stakeholder surface at
+// all. `GET /relationships` filters on deal_id for exactly this reading.
 export type RelationshipScope =
   | { person_id: string }
-  | { organization_id: string };
+  | { organization_id: string }
+  | { deal_id: string };
 
 const KIND_LABELS: Record<RelationshipKind, MessageKey> = {
   employment: "rel.kind.employment",
@@ -69,16 +77,55 @@ const SEARCH_DEBOUNCE_MS = 250;
 function scopeQuery(scope: RelationshipScope): {
   person_id?: string;
   organization_id?: string;
+  deal_id?: string;
 } {
-  return "person_id" in scope
-    ? { person_id: scope.person_id }
-    : { organization_id: scope.organization_id };
+  if ("person_id" in scope) {
+    return { person_id: scope.person_id };
+  }
+  if ("deal_id" in scope) {
+    return { deal_id: scope.deal_id };
+  }
+  return { organization_id: scope.organization_id };
 }
 
 function scopeQueryKey(scope: RelationshipScope): [string, string, string] {
-  return "person_id" in scope
-    ? ["relationships", "person", scope.person_id]
-    : ["relationships", "organization", scope.organization_id];
+  if ("person_id" in scope) {
+    return ["relationships", "person", scope.person_id];
+  }
+  if ("deal_id" in scope) {
+    return ["relationships", "deal", scope.deal_id];
+  }
+  return ["relationships", "organization", scope.organization_id];
+}
+
+// The words this panel uses on the record it is rendered from, and whether that
+// record anchors a single kind.
+//
+// A deal anchors only deal_stakeholder, so it says "stakeholder" where a
+// person's page says "relationship": the generic word sends a reader looking for
+// a control the deal page does not have, and a Kind picker holding one option —
+// or a Kind column repeating one badge down every row — asks a question with a
+// single answer.
+function scopeCopy(scope: RelationshipScope): {
+  title: MessageKey;
+  add: MessageKey;
+  empty: MessageKey;
+  singleKind: boolean;
+} {
+  if ("deal_id" in scope) {
+    return {
+      title: "rel.dealStakeholders",
+      add: "rel.addStakeholder",
+      empty: "rel.dealStakeholdersEmpty",
+      singleKind: true,
+    };
+  }
+  return {
+    title: "tab.relationships",
+    add: "rel.add",
+    empty: "rel.empty",
+    singleKind: false,
+  };
 }
 
 async function fetchRelationships(
@@ -105,6 +152,11 @@ export function counterpartyRef(
   rel: Relationship,
   scope: RelationshipScope,
 ): { kind: EntityKind; id: string } | null {
+  // From a deal, every edge is a person: deal_stakeholder is the only kind the
+  // deal_id filter can return (rel_*_shape, migration 0007).
+  if ("deal_id" in scope) {
+    return rel.person_id ? { kind: "person", id: rel.person_id } : null;
+  }
   if ("person_id" in scope) {
     if (rel.deal_id) {
       return { kind: "deal", id: rel.deal_id };
@@ -217,6 +269,11 @@ export type EdgeOption = {
 // (→person) and the three org↔org kinds (→counterparty org). Offering the
 // rest would only earn an endpoint-shape 422.
 export function edgeOptions(scope: RelationshipScope): EdgeOption[] {
+  // A deal anchors its stakeholders and nothing else — employment is a fact
+  // about a person and a company, and the org↔org kinds name no deal.
+  if ("deal_id" in scope) {
+    return [{ kind: "deal_stakeholder", entity: "person", field: "person_id" }];
+  }
   if ("person_id" in scope) {
     return [
       { kind: "employment", entity: "organization", field: "organization_id" },
@@ -261,6 +318,30 @@ export function endpointBody(
   }
 }
 
+/**
+ * Every cached read a relationship write staleifies, invalidated in one place.
+ *
+ * `["relationships"]` is this panel's own list. A deal_stakeholder edge also
+ * feeds the deal's coverage — the rail's seats, the committee map and the risk
+ * chips all read `GET /deals/{id}/coverage`, and the map sits directly above
+ * this panel on the deal page. Without this, seating a champion filled the table
+ * while the map one panel up still said the champion was missing.
+ *
+ * The whole coverage prefix rather than one deal's: a stakeholder can be seated
+ * from the PERSON's page too, where the deal being changed is the picked target
+ * rather than the scope, and a page that knows only "some deal moved" cannot
+ * name which key to drop.
+ */
+function invalidateAfterEdge(
+  queryClient: ReturnType<typeof useQueryClient>,
+  touchesADeal: boolean,
+) {
+  queryClient.invalidateQueries({ queryKey: ["relationships"] });
+  if (touchesADeal) {
+    queryClient.invalidateQueries({ queryKey: DEAL_COVERAGE_KEY });
+  }
+}
+
 // The "add relationship" affordance: kind + role + start date, plus the
 // other-side target picker (mirrors merge.tsx's debounced search-and-pick —
 // the source of the edge is fixed by scope, so there is no "exclude self"
@@ -272,6 +353,7 @@ function AddRelationshipAction({
   const queryClient = useQueryClient();
   const headingId = useId();
   const options = edgeOptions(scope);
+  const copy = scopeCopy(scope);
   const [open, setOpen] = useState(false);
   const [kind, setKind] = useState<CreatableRelationshipKind>(options[0].kind);
   const [role, setRole] = useState("");
@@ -319,23 +401,31 @@ function AddRelationshipAction({
     };
   }, [open, term, entity]);
 
-  // The picked target arrives as the mutation's variable, not through this
-  // closure: react-query re-arms a mutation's options in a passive effect, so a
-  // submit landing between the commit that enables the button and that effect
-  // runs the previous render's function — where nothing had been picked yet.
+  // EVERY answer the form holds arrives as the mutation's variable, not through
+  // this closure: react-query re-arms a mutation's options in a passive effect,
+  // so a submit landing between the commit that enables the button and that
+  // effect runs the previous render's function. The target alone used to travel,
+  // which left the kind, the role and the start date one render behind — a write
+  // stating choices nobody had made yet.
   const mutation = useMutation({
-    mutationFn: async (target: Candidate) => {
+    mutationFn: async (chosen: {
+      target: Candidate;
+      kind: CreatableRelationshipKind;
+      field: EdgeOption["field"];
+      role: string;
+      startedAt: string;
+    }) => {
       const body: CreateRelationshipRequest = {
-        kind,
-        role: role.trim() || undefined,
-        started_at: startedAt || undefined,
+        kind: chosen.kind,
+        role: chosen.role.trim() || undefined,
+        started_at: chosen.startedAt || undefined,
         source: "manual",
         // Not sent at all. This form offers every relationship kind and no
         // primary control, so `false` here was a literal rather than anybody's
         // decision — and for an employment it silently blocked the server's own
         // rule that a person's only current job is their current primary one.
         ...scopeQuery(scope),
-        ...endpointBody(endpoint.field, target.id),
+        ...endpointBody(chosen.field, chosen.target.id),
       };
       const { data, error } = await api.POST("/relationships", { body });
       if (error) {
@@ -343,8 +433,8 @@ function AddRelationshipAction({
       }
       return data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["relationships"] });
+    onSuccess: (created) => {
+      invalidateAfterEdge(queryClient, created.deal_id != null);
       close();
     },
   });
@@ -378,29 +468,31 @@ function AddRelationshipAction({
         onClick={() => setOpen(true)}
         data-testid="add-relationship"
       >
-        {t("rel.add")}
+        {t(copy.add)}
       </Button>
       <Modal open={open} onClose={close} labelledBy={headingId}>
         <h2 id={headingId} className="t-h2" style={{ marginBottom: 12 }}>
-          {t("rel.add")}
+          {t(copy.add)}
         </h2>
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <Field label={t("rel.kind")}>
-            {(control) => (
-              <Select
-                {...control}
-                value={kind}
-                onChange={(value) => {
-                  const kinds = options.map((o) => o.kind);
-                  if (isOption(value, kinds)) selectKind(value);
-                }}
-                options={options.map((option) => ({
-                  value: option.kind,
-                  label: t(KIND_LABELS[option.kind]),
-                }))}
-              />
-            )}
-          </Field>
+          {!copy.singleKind && (
+            <Field label={t("rel.kind")}>
+              {(control) => (
+                <Select
+                  {...control}
+                  value={kind}
+                  onChange={(value) => {
+                    const kinds = options.map((o) => o.kind);
+                    if (isOption(value, kinds)) selectKind(value);
+                  }}
+                  options={options.map((option) => ({
+                    value: option.kind,
+                    label: t(KIND_LABELS[option.kind]),
+                  }))}
+                />
+              )}
+            </Field>
+          )}
           <Field label={t("rel.role")}>
             {(control) => (
               <TextInput
@@ -469,7 +561,16 @@ function AddRelationshipAction({
               small
               variant="primary"
               disabled={!target || mutation.isPending}
-              onClick={() => target && mutation.mutate(target)}
+              onClick={() =>
+                target &&
+                mutation.mutate({
+                  target,
+                  kind,
+                  field: endpoint.field,
+                  role,
+                  startedAt,
+                })
+              }
               data-testid="add-relationship-submit"
             >
               {t("create.save")}
@@ -507,6 +608,7 @@ export function RelationshipsTab({
   const t = useT();
   const queryClient = useQueryClient();
   const headingId = useId();
+  const copy = scopeCopy(scope);
   const query = useQuery({
     queryKey: scopeQueryKey(scope),
     queryFn: () => fetchRelationships(scope),
@@ -514,44 +616,50 @@ export function RelationshipsTab({
 
   // Two-step confirm, mirroring ArchiveAction (archive.tsx) — Remove is a
   // hard DELETE with no restore path, so it never fires from a single click.
-  const [removing, setRemoving] = useState<string | null>(null);
+  // The ROW, not its id: what the write invalidates depends on whether the edge
+  // names a deal, and an id alone cannot answer that.
+  const [removing, setRemoving] = useState<Relationship | null>(null);
 
   const remove = useMutation({
-    mutationFn: async (id: string) => {
+    mutationFn: async (doomed: Relationship) => {
       const { data, error } = await api.DELETE("/relationships/{id}", {
-        params: { path: { id } },
+        params: { path: { id: doomed.id } },
       });
       if (error) {
         throwProblem(error);
       }
       return data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["relationships"] });
+    onSuccess: (_removed, doomed) => {
+      invalidateAfterEdge(queryClient, doomed.deal_id != null);
       setRemoving(null);
     },
   });
 
   return (
     <Card
-      title={t("tab.relationships")}
+      title={t(copy.title)}
       actions={<AddRelationshipAction scope={scope} />}
     >
       <QueryGate query={query}>
         {(rows) =>
           rows.length === 0 ? (
-            <EmptyState>{t("rel.empty")}</EmptyState>
+            <EmptyState>{t(copy.empty)}</EmptyState>
           ) : (
             <DataTable
-              label={t("tab.relationships")}
+              label={t(copy.title)}
               columns={[
-                {
-                  key: "kind",
-                  header: t("rel.kind"),
-                  render: (rel: Relationship) => (
-                    <Badge>{t(KIND_LABELS[rel.kind])}</Badge>
-                  ),
-                },
+                ...(copy.singleKind
+                  ? []
+                  : [
+                      {
+                        key: "kind",
+                        header: t("rel.kind"),
+                        render: (rel: Relationship) => (
+                          <Badge>{t(KIND_LABELS[rel.kind])}</Badge>
+                        ),
+                      },
+                    ]),
                 {
                   key: "role",
                   header: t("rel.role"),
@@ -616,7 +724,7 @@ export function RelationshipsTab({
                       <Button
                         small
                         variant="danger"
-                        onClick={() => setRemoving(rel.id)}
+                        onClick={() => setRemoving(rel)}
                         data-testid="remove-relationship"
                       >
                         {t("rel.remove")}


### PR DESCRIPTION
## Two QC findings, both about a surface that could read a fact but not write it

### 1. Edit deal refused a save nobody had asked for

The edit form submitted a fixed payload on every save, so every optional field
the deal lacked a value for travelled as an explicit JSON `null`. The API reads
a top-level null as *forget this field* (`httperr.ClearedFields` →
`storekit.ApplyClears`) and refused, correctly, naming a field the person had
never seen — `partner_attribution` is not a control the form renders at all on
an installation with no partners.

**Frontend.** `mapDealUpdate` is now a diff against the record the form opened
on (`dealEditRecord`, named once as `seeded` so the baseline and the controls
cannot drift). A key appears only where the form's value differs from it.
Nothing the person did not touch travels.

**Backend.** With the noise gone, the only null left on the wire is a deliberate
one — the company and partner pickers offer "Unset" in words — so the two
columns that refused it now honour the nullability `crm.yaml` already declares.
`organization_id` joins `clearableDealColumns`. The partner pair gets ONE name
on the clear surface, `partner_org_id`, because
`deal_partner_attribution_pairing` stores the partner and what they did as one
fact: forgetting the partner forgets the claim, and a request that forgets the
partner while naming a claim earns the unpaired refusal it already earned.
`partner_attribution` stays clearable through neither path — a deal that names a
partner always says something about them.

### 2. A deal's and a project's stakeholders had no write control

`deal_stakeholder` was creatable only from the **person's** side, so seating a
champion meant knowing which contact to open first, and a deal nobody had linked
from a contact page had no way in at all. `project_stakeholder` had none.

**Deals.** `RelationshipScope` gained a `{ deal_id }` arm — `GET /relationships`
already filters on it — so the existing relationships panel serves the deal
page unchanged: create, edit and remove keep one implementation for every kind.
A deal anchors one kind, so the panel drops its Kind column and Kind picker
there and says "Stakeholders" rather than "People & companies".

**Projects.** The stakeholders card gained add and remove against
`PUT /projects/{id}/stakeholders` and `DELETE …/{person_id}` — the write path
the contract reserves for the kind, and the reason it is absent from the generic
create surface. The PUT is idempotent per person, so naming somebody already
seated re-roles them; the dialog says so. The verbs ride `titleAction`, which
`SectionPanel` draws only on a ready or empty section, so a reader whose grant
withheld the seats is told so rather than offered a write over records they
cannot see.

`projectRoleLabel` moved into the `record360` label kit beside the
`dealRoleLabel` it falls through to, so the card that draws a seat and the
dialog that offers one read one list.

### Fixed along the way

Nothing else — the two findings were the scope.

### Known remaining refusal, not in this change

Blanking a deal's **amount** still earns `amount_minor cannot be set to null on
this record`. That is unchanged behaviour, deliberately absent from the clear
surface (`clearable.go`: money is read as one field), and unpricing a deal —
particularly a closed one, whose frozen FX rate would outlive the figure it
converted — is a product question rather than a wiring one. Filed separately.

### Tests

- `partner_attribution_test.go`: the paired clear writes both columns with the
  audit image the row held; the pair-with-a-claim conflict is refused; the
  partner clear leaves the single-column path; `organization_id` is clearable
  and the attribution is not. All four watched failing against the unfixed tree.
- `dealpartnerattribution_integration_test.go`: the same four through the real
  writer against a real database, plus a deal unlinked from its company.
- `deals.test.tsx`: an untouched form sends an empty body; a bare deal renamed
  sends only `name`; the claim moves alone when the partner stays; a partner the
  picker cannot reach is not mentioned at all rather than resubmitted.
- `relationships.test.tsx`: the deal scope's creatable kinds and far end.
- `dealstakeholders.test.tsx`, `projectstakeholders.test.tsx`: both new
  surfaces, including the withheld and archived cases where the verb must be
  absent — each watched failing with the guard removed.

### What the review pass changed

Two reviewers went over the diff. Five findings were real and are fixed here:

- **The reported defect still reproduced.** `mapDealUpdate` became a diff while
  `cf.toBody(values)` beside it stayed a full snapshot, sending `null` for every
  empty custom field. In any workspace with a deal custom field the 422 was the
  QC report byte for byte, naming `cf_priority` instead of `partner_attribution`.
  `customFieldsToPatch` is the other half of the same diff, and all four edit
  surfaces use it — the deal, the lead, the person and the company forms carried
  the same bug.
- **A currency moving alone re-denominated the price.** `amount_minor` is in the
  currency's own minor units, so re-saving 10000 JPY as EUR wrote €100 — and the
  fx freeze and the forecast history then recorded that as the figure. The pair
  travels whenever either half moves.
- **Forgetting a link skipped the gate that naming one carries.** A reader shown
  `masked_fields: [partner_org_id]` could still clear it, destroying the
  attribution a commission accrues on. `ensureClearedLinksVisible` mirrors the
  set path's `auth.EnsureLinkTarget` on both reference arms.
- **The census could have failed short.** `dealClearPairs` is a literal-keyed map
  the clearable-fields gate reads, so a clear that writes two columns cannot be
  invisible to the gate that holds the store and the reversal path equal.
- **The committee map went stale.** It sits directly above the new panel and
  reads the coverage view; `DEAL_COVERAGE_KEY` now has one spelling, dropped by
  any edge write that names a deal.

### Known gaps, filed rather than fixed

Both are unchanged behaviour, and both are decisions rather than wiring:

1. Blanking a deal's amount, and clearing a custom field's value, are refused —
   money is deliberately unclearable, and no `cf_*` column is clearable at all.
2. `EditAction` recomputes its diff baseline and `If-Match` version per render
   while prefilling only when the dialog opens, so a refetch landing mid-edit
   defeats the optimistic-concurrency guard. It affects every record type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two deal-editing defects: edit forms now submit only the fields a person changed (untouched optionals no longer travel as `null` and get refused), and deals and projects can now seat and unseat stakeholders from their own pages instead of only from a person's record.

**Edit saves are now diffs**

- Deal, lead, person, and company edit forms submit only fields whose values changed, so untouched optional fields no longer travel as `null` and get refused.
- Currency custom fields diff in the units their controls show, so a stored 1250 displayed as "12.5" is never reported as edited.
- `amount_minor` and `currency` travel together, so a currency change cannot re-denominate the price.
- `organization_id` is now clearable, and clearing a deal's partner clears its attribution with it since the two store as one fact.
- Clearing a link now requires the same permission that naming it does; masked fields can no longer be cleared underneath a reader.

**Stakeholder seating**

- The deal page's existing relationships panel now handles deals, so champions can be added, re-roled, and removed without opening a person's record first.
- The project page's stakeholders card gained add and remove against the project's own endpoints; adding somebody already seated re-roles them.
- Removing a stakeholder restores focus to the panel's Add control, and the German and Vietnamese deal-stakeholder labels now match the wording used elsewhere in those locales.
- Role labels for projects moved next to the deal labels so the card and its dialog read from one list, and the coverage cache key is shared so seat changes invalidate it everywhere.

<sup>Written for commit 679efb8857717484156177cf63d1b3924ac11677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stakeholder management for deals and projects, including search, role assignment, reassignments, removals, confirmations, and localized labels.
  - Deal pages now display relationship information and support person stakeholder relationships.
  - Added English, German, and Vietnamese translations for stakeholder workflows.

- **Bug Fixes**
  - Deal partner and attribution fields are cleared together safely, with improved authorization and visibility checks.
  - Editing records no longer clears untouched custom fields.
  - Deal updates now submit only changed values, preserving existing data during partial edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->