### PR TITLE
An account is filterable by its domain

### DIFF
--- a/backend/internal/compose/integration/segmentdomain_integration_test.go
+++ b/backend/internal/compose/integration/segmentdomain_integration_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The domain leaf, against Postgres.
+//
+// Its whole content is SQL a unit test cannot judge: whether the correlated
+// subquery binds to the account it is filtering, and whether the archived
+// predicate inside the wrapper actually excludes a removed domain. Both are
+// invisible to a test that reads the template as a string — a leaf correlating
+// to nothing selects every account and reads as a working filter until somebody
+// notices their segment holds the whole book.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/collections"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedDomain gives an account one domain, live or removed. Written through the
+// owner connection because the filter's subject is the ROW, and what puts it
+// there is not what this test is about.
+func seedDomain(t *testing.T, owner *pgx.Conn, org ids.UUID, domain string, removed bool) {
+	t.Helper()
+	archived := "NULL"
+	if removed {
+		archived = "now()"
+	}
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO organization_domain (organization_id, domain, source, captured_by, archived_at)
+		 VALUES ($1, $2, 'manual', 'human:x', `+archived+`)`, org, domain); err != nil {
+		t.Fatalf("seeding the %s domain: %v", domain, err)
+	}
+}
+
+func TestASegmentSelectsAccountsByTheirDomain(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	store := collections.NewStore(e.DB())
+	// The segment is over ACCOUNTS, so the caller needs the account read the
+	// person-shaped fixture perms do not carry.
+	perms := collectionsPerms()
+	grants := map[string]principal.ObjectGrant{}
+	for object, grant := range perms.Objects {
+		grants[object] = grant
+	}
+	grants["organization"] = principal.ObjectGrant{Create: true, Read: true, Update: true, Delete: true}
+	perms.Objects = grants
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	match := e.SeedOrg(t, "Acme", &e.Rep1)
+	seedDomain(t, owner, match, "acme.test", false)
+	// A second domain on the SAME account: the leaf selects an account holding
+	// AT LEAST the named one, so a company that also runs a product site is
+	// still the account somebody searched for.
+	seedDomain(t, owner, match, "acme-labs.test", false)
+
+	other := e.SeedOrg(t, "Globex", &e.Rep1)
+	seedDomain(t, owner, other, "globex.test", false)
+
+	// The account that USED to be at this domain. It must not be selected: a
+	// removed domain is a fact the account no longer carries.
+	former := e.SeedOrg(t, "Former Acme", &e.Rep1)
+	seedDomain(t, owner, former, "acme.test", true)
+
+	// And one with no domain at all, which the EXISTS must simply not match.
+	bare := e.SeedOrg(t, "No Domain", &e.Rep1)
+
+	created, err := store.CreateList(rep, collections.CreateListInput{
+		Name: "At acme.test", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{"field": "domain", "op": "eq", "value": "acme.test"},
+	})
+	if err != nil {
+		t.Fatalf("a segment on the domain leaf was refused: %v", err)
+	}
+
+	members := map[ids.UUID]bool{}
+	rows, _, err := store.ListMembers(rep, created.ID, 50, "")
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	for _, m := range rows {
+		members[m.EntityID] = true
+	}
+
+	for _, want := range []struct {
+		what string
+		id   ids.UUID
+		in   bool
+	}{
+		{"the account at that domain", match, true},
+		{"an account at another domain", other, false},
+		{"an account whose domain was removed", former, false},
+		{"an account with no domain", bare, false},
+	} {
+		if members[want.id] != want.in {
+			t.Errorf("%s: in segment = %t, want %t", want.what, members[want.id], want.in)
+		}
+	}
+}

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -95,6 +95,10 @@ func tagLinkFor(entity string) storekit.Field {
 // dial — as distinct from ownerTeamField below, the leaf it names.
 const ownerTeamIDField = "owner_team_id"
 
+// domainFilterField is the vocabulary's name for the account's web domain, as
+// distinct from domainField below, the leaf it names.
+const domainFilterField = "domain"
+
 // ownerTeamField selects the records owned by any member of one team: the same
 // rows the `owner_team_id` list parameter answers, reached the way a link leaf
 // can express.
@@ -147,6 +151,30 @@ var relationshipTypeField = storekit.Field{
 	Options: relationshipTypeValues,
 	Link: "EXISTS (SELECT 1 FROM organization_relationship_type rt" +
 		" WHERE rt.organization_id = t.id AND rt.archived_at IS NULL AND %s)",
+}
+
+// domainField is the account's web domain, which is MULTI-VALUED for the same
+// reason its relationship is: a company acquires, rebrands and runs product
+// sites, so an account can carry several and the fact lives in its own table.
+// The leaf selects accounts that hold AT LEAST this one, and says nothing about
+// which is primary — "the account whose domain is acme.com" is the question a
+// segment asks, and a primary-only leaf would answer it wrongly for exactly the
+// accounts that have more than one.
+//
+// Archived rows are excluded inside the wrapper, on the relationship leaf's
+// reasoning: a withdrawn domain is one the account no longer has, and a segment
+// naming it would otherwise keep selecting on a fact somebody deliberately
+// removed.
+//
+// FieldText rather than a picklist: a domain is free text with no enum to
+// compare against, and the column is stored lower-cased (org_domain_norm), so a
+// caller's value matches the stored form only when they spell it the same way.
+// That is the same contract every other text leaf here offers.
+var domainField = storekit.Field{
+	Expr: "od.domain",
+	Type: storekit.FieldText,
+	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
+		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
 }
 
 // customerLink is the EXISTS template a deal's filter reaches its customer
@@ -261,6 +289,7 @@ var segmentEngines = map[string]storekit.Query{
 			// below, so no surface OFFERS it for a new clause.
 			"classification":    {Expr: "t.classification", Type: storekit.FieldPicklist},
 			"relationship_type": relationshipTypeField,
+			domainFilterField:   domainField,
 			tagFilterField:      tagLinkFor("organization"),
 		},
 	},

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -134,49 +134,6 @@ var ownerTeamField = storekit.Field{
 		" AND %s)",
 }
 
-// relationshipTypeField is the account's relationship to us, which is
-// MULTI-VALUED: an account can be a customer and a partner at once, so the fact
-// lives in its own table and this leaf selects accounts that are AT LEAST this.
-//
-// Archived rows are excluded inside the wrapper. A retired relationship is one
-// the account no longer has, and a segment naming it would otherwise keep
-// selecting accounts on a fact somebody deliberately withdrew.
-//
-// A picklist leaf compares text and the engine holds no per-field enum, so a
-// value no row carries selects nothing rather than being refused.
-// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt gates that.
-var relationshipTypeField = storekit.Field{
-	Expr:    "rt.relationship_type",
-	Type:    storekit.FieldPicklist,
-	Options: relationshipTypeValues,
-	Link: "EXISTS (SELECT 1 FROM organization_relationship_type rt" +
-		" WHERE rt.organization_id = t.id AND rt.archived_at IS NULL AND %s)",
-}
-
-// domainField is the account's web domain, which is MULTI-VALUED for the same
-// reason its relationship is: a company acquires, rebrands and runs product
-// sites, so an account can carry several and the fact lives in its own table.
-// The leaf selects accounts that hold AT LEAST this one, and says nothing about
-// which is primary — "the account whose domain is acme.com" is the question a
-// segment asks, and a primary-only leaf would answer it wrongly for exactly the
-// accounts that have more than one.
-//
-// Archived rows are excluded inside the wrapper, on the relationship leaf's
-// reasoning: a withdrawn domain is one the account no longer has, and a segment
-// naming it would otherwise keep selecting on a fact somebody deliberately
-// removed.
-//
-// FieldText rather than a picklist: a domain is free text with no enum to
-// compare against, and the column is stored lower-cased (org_domain_norm), so a
-// caller's value matches the stored form only when they spell it the same way.
-// That is the same contract every other text leaf here offers.
-var domainField = storekit.Field{
-	Expr: "od.domain",
-	Type: storekit.FieldText,
-	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
-		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
-}
-
 // customerLink is the EXISTS template a deal's filter reaches its customer
 // through: one correlated subquery per leaf, on the organization the deal
 // already points at.

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -300,6 +300,27 @@ func TestTheRelationshipLeafExcludesWithdrawnRows(t *testing.T) {
 	}
 }
 
+// An account's domain is multi-valued and a removed one is a fact it no longer
+// carries — the relationship leaf's rule, owed by every leaf that reaches a
+// child table.
+func TestTheDomainLeafExcludesRemovedRows(t *testing.T) {
+	field, ok := segmentEngines["organization"].Fields[domainFilterField]
+	if !ok {
+		t.Fatal("organizations cannot be filtered by domain")
+	}
+	if !strings.Contains(field.Link, "od.archived_at IS NULL") {
+		t.Errorf("the domain leaf keeps selecting on removed domains: %q", field.Link)
+	}
+	if !strings.Contains(field.Link, "od.organization_id = t.id") {
+		t.Errorf("the domain leaf does not correlate to the account: %q", field.Link)
+	}
+	// Text, not a picklist: there is no enum of domains to compare against, and
+	// a picklist leaf with no Options would refuse every value a caller sent.
+	if field.Type != storekit.FieldText {
+		t.Errorf("the domain leaf is typed %v, want text", field.Type)
+	}
+}
+
 // A project is a taggable record (taggable's own CHECK admits it) and its
 // list membership must offer the same filter every other taggable type does.
 func TestProjectIsFilterableByTag(t *testing.T) {

--- a/backend/internal/modules/collections/vocabaccountleaves.go
+++ b/backend/internal/modules/collections/vocabaccountleaves.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+// The account facts that live in their OWN tables.
+//
+// Both leaves here reach a child table through a correlated EXISTS, and both
+// are multi-valued for the same reason: a company is more than one thing at
+// once. It can be a customer and a partner; it can hold the domain it was
+// founded under and the one it rebranded to. A column on `organization` could
+// hold neither honestly, so the fact lives beside the account and the leaf
+// selects accounts that carry AT LEAST the named value.
+//
+// The rule they share, stated once: a WITHDRAWN row is a fact the account no
+// longer has, and the archived predicate lives inside the wrapper so a segment
+// naming it stops selecting on something somebody deliberately removed. A leaf
+// added here inherits that obligation — TestTheRelationshipLeafExcludesWithdrawnRows
+// and TestTheDomainLeafExcludesRemovedRows hold each to it, and to correlating
+// to the account it is filtering rather than to nothing.
+
+import "github.com/margince/margince/backend/internal/platform/database/storekit"
+
+// relationshipTypeField is the account's relationship to us, which is
+// MULTI-VALUED: an account can be a customer and a partner at once, so the fact
+// lives in its own table and this leaf selects accounts that are AT LEAST this.
+//
+// Archived rows are excluded inside the wrapper. A retired relationship is one
+// the account no longer has, and a segment naming it would otherwise keep
+// selecting accounts on a fact somebody deliberately withdrew.
+//
+// A picklist leaf compares text and the engine holds no per-field enum, so a
+// value no row carries selects nothing rather than being refused.
+// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt gates that.
+var relationshipTypeField = storekit.Field{
+	Expr:    "rt.relationship_type",
+	Type:    storekit.FieldPicklist,
+	Options: relationshipTypeValues,
+	Link: "EXISTS (SELECT 1 FROM organization_relationship_type rt" +
+		" WHERE rt.organization_id = t.id AND rt.archived_at IS NULL AND %s)",
+}
+
+// domainField is the account's web domain, which is MULTI-VALUED for the same
+// reason its relationship is: a company acquires, rebrands and runs product
+// sites, so an account can carry several and the fact lives in its own table.
+// The leaf selects accounts that hold AT LEAST this one, and says nothing about
+// which is primary — "the account whose domain is acme.com" is the question a
+// segment asks, and a primary-only leaf would answer it wrongly for exactly the
+// accounts that have more than one.
+//
+// Archived rows are excluded inside the wrapper, on the relationship leaf's
+// reasoning: a withdrawn domain is one the account no longer has, and a segment
+// naming it would otherwise keep selecting on a fact somebody deliberately
+// removed.
+//
+// FieldText rather than a picklist: a domain is free text with no enum to
+// compare against, and the column is stored lower-cased (org_domain_norm), so a
+// caller's value matches the stored form only when they spell it the same way.
+// That is the same contract every other text leaf here offers.
+var domainField = storekit.Field{
+	Expr: "od.domain",
+	Type: storekit.FieldText,
+	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
+		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
+}


### PR DESCRIPTION
Closes #1657.

## What was left

The ticket names three filter leaves the spec's DM-VOCAB table promises and the engine lacked. Measured against `main` today, two of the three have since landed:

| Field | Resource | State on `main` |
|---|---|---|
| `owner_team_id` | people, organizations, leads, deals, projects | **present** — `ownerTeamField`, on all five |
| `relationship_type` | organizations | **present** — `relationshipTypeField` |
| `domain` | organizations | **absent** |

So this closes the remainder. The ticket's design question — whether `owner_team_id` should be shared rather than re-implemented per resource — was answered the way it argued for: one `ownerTeamField` value, reached by all five engines.

## The leaf

`organization_domain` is a child table, so `domain` is a link leaf in the shape `relationship_type` already uses:

```go
var domainField = storekit.Field{
	Expr: "od.domain",
	Type: storekit.FieldText,
	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
}
```

**Multi-valued**, for the reason its neighbour is: a company acquires, rebrands and runs product sites. The leaf selects accounts holding **at least** the named domain and says nothing about which is primary — a primary-only leaf would answer "the account at acme.com" wrongly for exactly the accounts that have more than one.

**Removed domains excluded**, on the relationship leaf's reasoning: a withdrawn fact is one the account no longer carries, and a segment naming it would otherwise keep selecting on something somebody deliberately removed.

**Text, not a picklist.** There is no enum of domains to compare against, and a picklist leaf with no `Options` would refuse every value a caller sent. The column is stored lower-cased (`org_domain_norm`), so a caller's value matches the stored form when they spell it the same way — the same contract every other text leaf offers.

## Proven against Postgres

The leaf's whole content is SQL a unit test cannot judge: whether the correlated subquery binds to the account being filtered, and whether the archived predicate actually excludes a removed domain. A leaf correlating to nothing selects *every* account and reads as a working filter until somebody notices their segment holds the whole book.

`TestASegmentSelectsAccountsByTheirDomain` builds four accounts and asserts membership for each:

| account | expected |
|---|---|
| at `acme.test` (and also `acme-labs.test`) | in |
| at another domain | out |
| whose `acme.test` was removed | out |
| with no domain at all | out |

Mutation-checked from the other end:

| mutation | result |
|---|---|
| drop `od.archived_at IS NULL` | **caught** — "an account whose domain was removed: in segment = true" |
| drop the `od.organization_id = t.id` correlation | **caught** — all three negatives flip to in, which is the failure mode described above |

The unit test alongside pins the three properties readable from the template: the archived predicate, the correlation, and the text type.

## One refactor

`vocab.go` crossed the 500-LOC cap, so the two leaves that reach a child table moved to `vocabaccountleaves.go` — a real concept rather than a slice: the account facts that live in their own tables, with the rule they share stated once instead of twice in two doc comments.

## Verification

- `make check-backend` — green
- `make test-it DIR=backend/internal/compose/integration` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization segment filtering by account domain.
  * Added filtering by relationship type and domain, including support for multiple values.
  * Archived domains and relationship records are excluded from segment results.

* **Bug Fixes**
  * Improved organization and account matching to ensure filters return only relevant active records.

* **Tests**
  * Added coverage for domain filtering, archived records, duplicate domains, and unrelated accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->