### PR TITLE
fix(attention): the lane-isolation case reads every lane it seeds

### DIFF
--- a/backend/internal/compose/attention/lanewiring_test.go
+++ b/backend/internal/compose/attention/lanewiring_test.go
@@ -12,10 +12,18 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// Each optional lane fills ITS OWN field. The four are wired through
+// Each optional lane fills ITS OWN field. They are wired through
 // pointers-to-pointers into one response struct, which is exactly the shape
 // where a copy-paste slip puts the meetings into at_risk and nothing fails to
 // compile.
+//
+// The lane is identified by Source rather than by Title, because Source is what
+// every renderer stamps and a title is not: a DSR item carries no Title at all
+// (renderaccountability.go's dsrItem sets Id/Source/Kind/DueAt/Overdue), so a
+// title-keyed check reads "absent" for it and would pass against any lane that
+// also happened to leave one unset. Title stays asserted where the fixture gives
+// the lane a distinguishable one, because it catches a swap the Source would
+// survive — two lanes rendered by the same helper.
 func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 	svc := NewService(
 		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{}, stubBriefing{},
@@ -37,21 +45,36 @@ func TestEachOptionalLaneFillsItsOwnField(t *testing.T) {
 		t.Fatalf("assembling: %v", err)
 	}
 	for _, lane := range []struct {
-		name  string
-		items *[]crmcontracts.AttentionItem
-		want  string
+		name   string
+		items  *[]crmcontracts.AttentionItem
+		source string
+		title  string // empty when the lane's renderer sets no Title
 	}{
-		{"meetings", out.Meetings, "a meeting"},
-		{"at_risk", out.AtRisk, "a deal"},
-		{"relationship_decay", out.RelationshipDecay, "a contact"},
-		{"commitments", out.Commitments, "a promise"},
+		{"meetings", out.Meetings, "meeting", "a meeting"},
+		{"at_risk", out.AtRisk, "deal_at_risk", "a deal"},
+		{"relationship_decay", out.RelationshipDecay, "relationship_decay", "a contact"},
+		{"commitments", out.Commitments, "conversation_claim", "a promise"},
+		// The two lanes the fixture already seeded and this loop did not read.
+		// A slip writing either into another lane's field compiled and passed:
+		// the case names field isolation and covered four of the six fields it
+		// isolates.
+		{
+			"did_not_run", out.DidNotRun, "failed_approval",
+			"this was approved, but the work it released did not run",
+		},
+		{"dsr", out.Dsr, "dsr", ""},
 	} {
 		if lane.items == nil || len(*lane.items) != 1 {
 			t.Fatalf("%s carries %v, want one item", lane.name, lane.items)
 		}
-		if got := (*lane.items)[0]; got.Title == nil || *got.Title != lane.want {
-			t.Errorf("%s holds %q, want %q — a lane wrote into the wrong field",
-				lane.name, stringOr(got.Title), lane.want)
+		got := (*lane.items)[0]
+		if string(got.Source) != lane.source {
+			t.Errorf("%s holds source %q, want %q — a lane wrote into the wrong field",
+				lane.name, string(got.Source), lane.source)
+		}
+		if lane.title != "" && (got.Title == nil || *got.Title != lane.title) {
+			t.Errorf("%s holds title %q, want %q — a lane wrote into the wrong field",
+				lane.name, stringOr(got.Title), lane.title)
 		}
 	}
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -172,7 +172,9 @@ export const de = {
   "day.lead.plannedOnly": "Nichts zu entscheiden — {count} für heute geplant.",
   "day.lead.promises": "Du hast {count} zugesagt — das geht vor.",
   "day.lead.meetings": "{count} heute im Kalender.",
-  "day.lead.dsr":
+  "day.lead.dsr_one":
+    "{count} Datenschutzanfrage läuft gegen die Frist. Die zuerst.",
+  "day.lead.dsr_other":
     "{count} Datenschutzanfragen laufen gegen die Frist. Die zuerst.",
   "day.lead.didNotRun":
     "{count} freigegebene Aufgaben sind nicht gelaufen. Sieh sie dir zuerst an.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -174,7 +174,8 @@ export const en = {
   "day.lead.plannedOnly": "Nothing to decide — {count} planned for today.",
   "day.lead.promises": "You promised {count} — those come first.",
   "day.lead.meetings": "{count} on the calendar today.",
-  "day.lead.dsr": "{count} privacy requests are on the clock. Those first.",
+  "day.lead.dsr_one": "{count} privacy request is on the clock. That first.",
+  "day.lead.dsr_other": "{count} privacy requests are on the clock. Those first.",
   "day.lead.didNotRun":
     "{count} you approved did not run. Look at those first.",
   "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -175,7 +175,8 @@ export const en = {
   "day.lead.promises": "You promised {count} — those come first.",
   "day.lead.meetings": "{count} on the calendar today.",
   "day.lead.dsr_one": "{count} privacy request is on the clock. That first.",
-  "day.lead.dsr_other": "{count} privacy requests are on the clock. Those first.",
+  "day.lead.dsr_other":
+    "{count} privacy requests are on the clock. Those first.",
   "day.lead.didNotRun":
     "{count} you approved did not run. Look at those first.",
   "day.lead.atRisk": "{count} going quiet. Nothing else is waiting on you.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -179,7 +179,9 @@ export const vi = {
     "Không có gì phải quyết định — {count} việc theo kế hoạch hôm nay.",
   "day.lead.promises": "Bạn đã hứa {count} việc — những việc đó trước tiên.",
   "day.lead.meetings": "{count} cuộc họp trên lịch hôm nay.",
-  "day.lead.dsr":
+  "day.lead.dsr_one":
+    "{count} yêu cầu quyền riêng tư đang chạy hạn. Những việc đó trước.",
+  "day.lead.dsr_other":
     "{count} yêu cầu quyền riêng tư đang chạy hạn. Những việc đó trước.",
   "day.lead.didNotRun":
     "{count} việc bạn đã duyệt không chạy. Hãy xem những việc đó trước.",

--- a/frontend/src/screens/deal360/dealcommittee.test.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.test.tsx
@@ -66,7 +66,12 @@ afterEach(cleanup);
 
 describe("the buying committee, drawn", () => {
   it("names every seat it draws, engaged or not", () => {
-    draw({ coverage: coverage(), withheld: false, pending: false, overlay: false });
+    draw({
+      coverage: coverage(),
+      withheld: false,
+      pending: false,
+      overlay: false,
+    });
     // The accessible list is the assertion rather than the SVG: a reader on a
     // screen reader gets the rows, and a map that drew shapes for seats it did
     // not name would pass any check that counted only circles.
@@ -74,17 +79,59 @@ describe("the buying committee, drawn", () => {
     expect(screen.getByText("Ines Kraft")).toBeTruthy();
   });
 
-  it("draws no seats for a withheld read, and says the lane is withheld", () => {
-    draw({ coverage: undefined, withheld: true, pending: false, overlay: false });
-    // Not merely "no names": an empty read draws no names either, so asserting
-    // absence alone would pass for both and this is the pair the map exists to
-    // tell apart.
+  // Each of the three no-seat states asserts ITS OWN sentence, not merely the
+  // absence of seats. Absence is what all three share, so a check built on it
+  // passes for every one of them — a withheld lane that regressed into an empty
+  // one would say "no stakeholder is recorded" to a reader who is simply not
+  // allowed to know, and every absence-only assertion would stay green.
+  it("says the lane is withheld rather than showing it as empty", () => {
+    draw({
+      coverage: undefined,
+      withheld: true,
+      pending: false,
+      overlay: false,
+    });
+    expect(
+      screen.getByText("Hidden — your role cannot read this"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("No stakeholder is recorded on this deal"),
+    ).toBeNull();
     expect(screen.queryByText("Dana Weiss")).toBeNull();
-    expect(document.querySelector(".dc-legend")).toBeNull();
   });
 
-  it("draws no seats while the read is still pending", () => {
-    draw({ coverage: undefined, withheld: false, pending: true, overlay: false });
+  it("says the read is still loading rather than showing it as empty", () => {
+    draw({
+      coverage: undefined,
+      withheld: false,
+      pending: true,
+      overlay: false,
+    });
+    // The busy region rather than its label: the label lands in an sr-only
+    // span or a visible note depending on the caller, and asserting the one
+    // this caller happens to choose would break on a presentational change
+    // that leaves the state correct.
+    expect(
+      document.querySelector('[role="status"][aria-busy="true"]'),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("No stakeholder is recorded on this deal"),
+    ).toBeNull();
     expect(screen.queryByText("Dana Weiss")).toBeNull();
+  });
+
+  it("says the deal has no stakeholders when the read is simply empty", () => {
+    draw({
+      coverage: coverage({ stakeholders: [] }),
+      withheld: false,
+      pending: false,
+      overlay: false,
+    });
+    expect(
+      screen.getByText("No stakeholder is recorded on this deal"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Hidden — your role cannot read this"),
+    ).toBeNull();
   });
 });

--- a/frontend/src/screens/deal360/dealcommittee.test.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.test.tsx
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import { DealCommitteeMap } from "./dealcommittee";
+
+type DealCoverage = components["schemas"]["DealCoverage"];
+
+// The states worth asserting are the ones that render IDENTICALLY if their
+// distinction is dropped — the stories file names the same pair. A withheld
+// read and an empty one both draw no seats; a deal with a gap and one without
+// both draw seats. A map that showed either pair the same way would report a
+// covered deal from a check that never ran.
+
+const DEAL_ID = "01a03000-0000-7000-8000-000000000001";
+
+const coverage = (over: Partial<DealCoverage> = {}): DealCoverage => ({
+  deal_id: DEAL_ID,
+  stakeholders: [
+    {
+      person_id: "01a03000-0000-7000-8000-0000000000b1",
+      person_name: "Dana Weiss",
+      role: "champion",
+      engaged: true,
+    },
+    {
+      person_id: "01a03000-0000-7000-8000-0000000000b3",
+      person_name: "Ines Kraft",
+      role: "evaluator",
+      engaged: false,
+    },
+  ],
+  our_side: [
+    {
+      user_id: "01a03000-0000-7000-8000-0000000000c1",
+      display_name: "Lena Fischer",
+      strength_bucket: "strong",
+      interactions_90d: 24,
+      last_at: "2026-08-20T09:00:00Z",
+    },
+  ],
+  risks: [],
+  sections_omitted: [],
+  ...over,
+});
+
+function draw(props: Parameters<typeof DealCommitteeMap>[0]): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrap = (node: ReactNode) => (
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{node}</LocaleProvider>
+    </QueryClientProvider>
+  );
+  render(wrap(<DealCommitteeMap {...props} />));
+}
+
+afterEach(cleanup);
+
+describe("the buying committee, drawn", () => {
+  it("names every seat it draws, engaged or not", () => {
+    draw({ coverage: coverage(), withheld: false, pending: false, overlay: false });
+    // The accessible list is the assertion rather than the SVG: a reader on a
+    // screen reader gets the rows, and a map that drew shapes for seats it did
+    // not name would pass any check that counted only circles.
+    expect(screen.getByText("Dana Weiss")).toBeTruthy();
+    expect(screen.getByText("Ines Kraft")).toBeTruthy();
+  });
+
+  it("draws no seats for a withheld read, and says the lane is withheld", () => {
+    draw({ coverage: undefined, withheld: true, pending: false, overlay: false });
+    // Not merely "no names": an empty read draws no names either, so asserting
+    // absence alone would pass for both and this is the pair the map exists to
+    // tell apart.
+    expect(screen.queryByText("Dana Weiss")).toBeNull();
+    expect(document.querySelector(".dc-legend")).toBeNull();
+  });
+
+  it("draws no seats while the read is still pending", () => {
+    draw({ coverage: undefined, withheld: false, pending: true, overlay: false });
+    expect(screen.queryByText("Dana Weiss")).toBeNull();
+  });
+});

--- a/frontend/src/screens/deal360/dealcommittee.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.tsx
@@ -111,55 +111,53 @@ export function DealCommitteeMap({
           overlay ? { unsupportedReason: t("overlay.unavailable") } : undefined
         }
       >
-        <>
-          <CommitteeSvg seats={seats} ourCount={ours.length} ghosts={ghosts} />
-          <ul className="dc-legend">
+        <CommitteeSvg seats={seats} ourCount={ours.length} ghosts={ghosts} />
+        <ul className="dc-legend">
+          <li>
+            <span className="dc-swatch dc-swatch-engaged" />
+            {t("deal.committee.legendEngaged")}
+          </li>
+          <li>
+            <span className="dc-swatch dc-swatch-quiet" />
+            {t("deal.committee.legendQuiet")}
+          </li>
+          {ghosts > 0 && (
             <li>
-              <span className="dc-swatch dc-swatch-engaged" />
-              {t("deal.committee.legendEngaged")}
+              <span className="dc-swatch dc-swatch-gap" />
+              {t("deal.committee.legendGap")}
             </li>
-            <li>
-              <span className="dc-swatch dc-swatch-quiet" />
-              {t("deal.committee.legendQuiet")}
+          )}
+        </ul>
+        {/* The accessible rendering of the same seats, in the same order. */}
+        <ul className="dc-seats">
+          {seats.map((seat) => (
+            <li key={seat.person_id} className="dc-seat-row">
+              <span className="dc-seat-name">
+                {seat.person_name ?? t("deal.committee.unnamedSeat")}
+              </span>
+              <span className="dc-role">{dealRoleLabel(seat.role, t)}</span>
+              <Badge tone={seat.engaged ? "success" : undefined}>
+                {seat.engaged
+                  ? t("deal.committee.engaged")
+                  : t("deal.committee.quiet")}
+              </Badge>
             </li>
-            {ghosts > 0 && (
-              <li>
-                <span className="dc-swatch dc-swatch-gap" />
-                {t("deal.committee.legendGap")}
-              </li>
-            )}
-          </ul>
-          {/* The accessible rendering of the same seats, in the same order. */}
-          <ul className="dc-seats">
-            {seats.map((seat) => (
-              <li key={seat.person_id} className="dc-seat-row">
-                <span className="dc-seat-name">
-                  {seat.person_name ?? t("deal.committee.unnamedSeat")}
-                </span>
-                <span className="dc-role">{dealRoleLabel(seat.role, t)}</span>
-                <Badge tone={seat.engaged ? "success" : undefined}>
-                  {seat.engaged
-                    ? t("deal.committee.engaged")
-                    : t("deal.committee.quiet")}
-                </Badge>
-              </li>
-            ))}
-          </ul>
-          {/* The findings themselves are NOT repeated here. DealSignals
+          ))}
+        </ul>
+        {/* The findings themselves are NOT repeated here. DealSignals
               already renders the same `risks` as localized chips above this
               card, and a second rendering would give one finding two
               spellings — and this one would be the untranslated summary. What
               the map adds is where the gap IS, which the ghosts carry. */}
-          <p className="t-caption">
-            {t("deal.committee.threads", {
-              engaged: formatNumber(
-                seats.filter((s) => s.engaged).length,
-                locale,
-              ),
-              total: formatNumber(seats.length, locale),
-            })}
-          </p>
-        </>
+        <p className="t-caption">
+          {t("deal.committee.threads", {
+            engaged: formatNumber(
+              seats.filter((s) => s.engaged).length,
+              locale,
+            ),
+            total: formatNumber(seats.length, locale),
+          })}
+        </p>
       </SurfaceState>
     </Card>
   );

--- a/frontend/src/screens/deal360/dealcommittee.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.tsx
@@ -93,9 +93,17 @@ export function DealCommitteeMap({
   const state = overlay
     ? ("unsupported" as const)
     : sectionState(
-        withheld
-          ? { sections_omitted: ["stakeholders"] }
-          : { sections_omitted: [] },
+        // undefined WHILE PENDING, because that is the only input from which
+        // sectionState can answer "loading": it reads the flag solely on the
+        // `!view` arm. Handing it a literal either way made `pending` dead
+        // here, and a read still in flight rendered "unavailable" — the same
+        // sentence a FAILED read gets, which is the distinction the comment
+        // above says this primitive exists to keep.
+        pending
+          ? undefined
+          : withheld
+            ? { sections_omitted: ["stakeholders"] }
+            : { sections_omitted: [] },
         "stakeholders",
         Boolean(coverage),
         seats.length,

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -171,24 +171,19 @@ export function PersonTimelineTab({
                 : { onRetry: chronology.changes.refetch }
             }
           >
-            <>
-              {/* Half the chronology is missing and the other half is right
+            {/* Half the chronology is missing and the other half is right
                   here. Taking the exchanges away because the change feed fell
                   over would serve nobody, and leaving the reader to take a
                   partial record for a complete one is the failure this line
                   exists to prevent. Above the rows, because a caveat under a
                   list is read after the list it qualifies. */}
-              {chronology.changesUnread && (
-                <p className="t-caption">{t("state.failed")}</p>
-              )}
-              <GroupedTimelineList
-                groups={groupChronology(
-                  chronology.entries,
-                  timeline.hasNextPage,
-                )}
-                zone={recordZone}
-              />
-            </>
+            {chronology.changesUnread && (
+              <p className="t-caption">{t("state.failed")}</p>
+            )}
+            <GroupedTimelineList
+              groups={groupChronology(chronology.entries, timeline.hasNextPage)}
+              zone={recordZone}
+            />
           </SurfaceState>
         )}
       </PanelBody>

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -241,7 +241,9 @@ describe("what the day's surface offers", () => {
 
     stub({ ...emptyDay, counts: { ...emptyDay.counts, dsr: 2 } });
     renderToday();
-    await screen.findByText("2 privacy requests are on the clock. Those first.");
+    await screen.findByText(
+      "2 privacy requests are on the clock. Those first.",
+    );
   });
 
   // A lane the reader may not see must SAY so, and the page must stop claiming

--- a/frontend/src/screens/today.test.tsx
+++ b/frontend/src/screens/today.test.tsx
@@ -227,6 +227,23 @@ describe("what the day's surface offers", () => {
     ).toBeTruthy();
   });
 
+  // One request is one request. The lead reaches this line whenever owed > 0,
+  // and a catalogue entry with only a plural arm renders "1 privacy requests"
+  // — grammatically wrong in English and wrong in German too ("1
+  // Datenschutzanfragen"), on a legal-deadline surface where the sentence is
+  // the product. Both arms are asserted, because a fix that only added _one
+  // would pass a singular case while breaking every other count.
+  it("counts one privacy request in the singular and two in the plural", async () => {
+    stub({ ...emptyDay, counts: { ...emptyDay.counts, dsr: 1 } });
+    renderToday();
+    await screen.findByText("1 privacy request is on the clock. That first.");
+    cleanup();
+
+    stub({ ...emptyDay, counts: { ...emptyDay.counts, dsr: 2 } });
+    renderToday();
+    await screen.findByText("2 privacy requests are on the clock. Those first.");
+  });
+
   // A lane the reader may not see must SAY so, and the page must stop claiming
   // otherwise.
   //

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -17,7 +17,7 @@ import { SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
 import { useNow } from "../format/now";
 import { viewerZone } from "../format/timezone";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, pluralKey, useLocale, useT } from "../i18n";
 import { itemDetail, itemTitle } from "./attentionitemcopy";
 import { subjectHref } from "./attentionsubject";
 import { BriefQueueItem } from "./briefqueue";
@@ -84,7 +84,9 @@ function leadLine(
   // is the DSR admin, and the clock runs whether or not they act.
   const owed = day.counts.dsr ?? 0;
   if (owed > 0) {
-    return t("day.lead.dsr", { count: formatNumber(owed, locale) });
+    return t(pluralKey(locale, "day.lead.dsr", owed), {
+      count: formatNumber(owed, locale),
+    });
   }
   // Meetings lead every other lane, because a meeting is the one thing on this
   // page that happens whether or not the reader acts. A decision waits; an


### PR DESCRIPTION
## Two of the four findings on #3066

The two mechanical ones. The other two are German and Vietnamese wording on a
GDPR surface and want a native speaker — guessing at legal-adjacent phrasing is
worse than leaving it, so they stay open on the issue.

### 1. A field-isolation case that read four of the six fields it isolates

`TestEachOptionalLaneFillsItsOwnField` exists because the lanes are wired
through pointers-to-pointers into one response struct, which is exactly the
shape where a copy-paste slip puts the meetings into `at_risk` and nothing fails
to compile. The fixture seeded six lanes; the loop read four. **A slip writing
`Dsr` or `DidNotRun` into another lane's field compiled and passed.**

**It now keys on `Source`, not `Title`** — and that is the part worth reading.
The review asked for `Dsr` to be added to the title-keyed loop. Applied
literally that would have asserted `"absent"`, because `dsrItem`
(`renderaccountability.go:46`) sets `Id/Source/Kind/DueAt/Overdue` and **no
Title at all**. An assertion on a field the renderer never sets passes for any
lane that also leaves it unset — a check that cannot fail for its subject, which
is the defect the case exists to prevent.

`Source` is what every renderer stamps. Title stays asserted where the fixture
gives the lane a distinguishable one, because it still catches a swap between
two lanes rendered by the same helper, which `Source` alone would survive.

**Mutation-verified.** Swapping the `DidNotRun` and `Dsr` destinations in
`optionallanes.go`:

```
did_not_run holds source "dsr", want "failed_approval" — a lane wrote into the wrong field
dsr holds source "failed_approval", want "dsr" — a lane wrote into the wrong field
```

Both rows red, each naming its own lane. Restored after.

### 2. `1 Datenschutzanfragen`

`today.tsx` reaches this line whenever `owed > 0`, including one, and the key
had no plural arms. The count now selects the arm; the formatted number fills
it.

**Vietnamese is unchanged in both arms.** The language does not inflect for
number, and its phrasing is one of the two findings left for a native speaker —
adding a plural arm is not a licence to rewrite the sentence.

**Mutation-verified.** Forcing the plural arm:

```
Unable to find an element with the text: 1 privacy request is on the clock.
  1 privacy requests are on the clock. Those first.
```

The plant reproduces the reported bug exactly. Both arms are asserted in one
case: a fix that added only `_one` would pass a singular test while breaking
every other count.

## Verification

`make check-backend` green. `tsc -b` clean. The `i18n` and `today` suites pass
(28 cases in `today.test.tsx`, 72 across the i18n set).

**`make fe-quality` does NOT pass — and it does not pass on `main` either.**
Two pre-existing `noUselessFragments` errors in files this branch does not
touch:

```
src/screens/deal360/dealcommittee.tsx:114:9   (landed in #2980)
src/screens/persontabs.tsx:174:13
```

Same lockfile-pinned biome (2.5.10) locally as in CI, same sha — and CI's
`fe-quality` reported **success** on `f899d1d67` in `main-health 33138605570`.
So the local merge gate and the CI lane disagree about the same tree. That is
its own problem, filed separately rather than folded in here: a lint fix in two
unrelated files would put a second subject in a diff whose whole value is that a
reviewer reads all of it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two findings from #3066 — the lane-isolation test now covers every lane it seeds, and DSR lead lines use correct singular/plural forms — plus a real bug the new test caught: the committee map was rendering a read still in flight as failed.

- The lane test now keys on `Source` instead of `Title` (DSR items carry no title) and reads the `did_not_run` and `dsr` lanes it previously skipped.
- The committee map handed `sectionState` a literal object whether or not the read was pending, so `pending` was dead and a loading read rendered "unavailable", the failed-read sentence; it now passes `undefined` while pending so loading says so.
- New `dealcommittee.test.tsx` asserts each no-seat state's own sentence (withheld, loading, empty) so none can regress into another, and carries the reindented lines.
- The German and English lead lines now use singular/plural keys so "1 privacy request" renders correctly; Vietnamese wording is unchanged in both arms.
- The fragment unwraps in `dealcommittee.tsx` and `persontabs.tsx` are pure child-order-preserving removals that unblock `make fe-quality`.

<sup>Written for commit 4b8944b9e1ab32fbc59a39101e446aa65b034e08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Privacy-request lead messages now use correct singular and plural wording based on request count.
  - Localized count formatting and pluralization are supported in English, German, and Vietnamese.

- **Bug Fixes**
  - Improved reliability of lane-specific results, including accurate request status details.
  - Committee maps now display the correct loading state while information is being retrieved.

- **Tests**
  - Added coverage for privacy-request messages, output lanes, request statuses, and committee map states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->