### PR TITLE
ci(changes): the diff classifier asks for the grant its API read needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # paths-filter asks the API for the pull request's file list. Reading that
+      # needs no grant while the repository is public, which is the only reason
+      # this job has run without it; the grant is what the step actually
+      # requires, and without it the classifier fails closed — which on a pull
+      # request skips every gated job and still renders a green `ci`.
+      pull-requests: read
     outputs:
       # Diff-scoping is honest for author feedback and dishonest as a merge
       # verdict: on a push, a commit matching no scope skipped every gate and


### PR DESCRIPTION
`dorny/paths-filter` asks the API for the pull request's file list. That read
currently succeeds without any `pull-requests` grant, but only because this
repository is public — public pull-request metadata is readable by a token
holding nothing but `contents: read`. The grant was never declared, so the job
has been relying on visibility rather than on permission.

Declaring it costs nothing here and makes the job state what it actually needs.

## Why it is worth fixing rather than leaving latent

When the classifier fails, it fails closed: no filter outputs, so every gated job
is skipped. On a pull request `ci-verdict.sh` admits a skip by design —
`admissible="success skipped"` — because diff-scoping legitimately skips whole
areas. The result is a green `ci` on a run where nothing was gated.

The merge queue is unaffected: it sets `admissible="success"` and refuses a skip,
which is exactly the split `ci-verdict.sh` documents. So `main` was never at
risk. What the pull-request lane can do is report green while having run nothing,
and this diff removes one way of reaching that state.

## Not addressed here

`changes` is not in the `ci` aggregate's `needs:` list, so a failure there is
invisible to the verdict regardless of cause. That is a broader question about
whether the classifier belongs in the aggregate, and it deserves its own change
rather than riding along with a permissions line.

## Verification

`ci-doc-parity`, `test-laneorder`, `test-ci-verdict` and `make-target-parity` all
pass — the four gates that parse this file. The diff is a single permissions
block, with no Go or frontend surface, so I did not run the full `make check`
locally; this PR's own pipeline covers it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration permissions to reliably detect changed files in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->