### PR TITLE
A unit dials through the installation's egress policy

### DIFF
--- a/backend/gates/netguardparity_test.go
+++ b/backend/gates/netguardparity_test.go
@@ -24,6 +24,7 @@ package gates
 // and grouped differently on purpose.
 
 import (
+	"net"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/platform/netguard"
@@ -61,4 +62,76 @@ func TestReservedNetsDoesNotHandOutTheGuardsOwnSlice(t *testing.T) {
 	if extension.ReservedNets()[0] == nil {
 		t.Error("a caller mutating the returned slice changed what the next caller sees")
 	}
+}
+
+// The two lists agreeing is not the same as the two DECISIONS agreeing.
+//
+// Each side composes its list with the stdlib predicates — loopback, private,
+// link-local, multicast, unspecified — and that half is written out twice, in
+// two files, in two modules. A list held equal while one side dropped
+// IsPrivate would pass the test above and admit every RFC 1918 address, which
+// is the first thing a member-supplied host resolves to.
+//
+// So this asks both sides about the same addresses instead of comparing their
+// source. The corpus is deliberately one address per REASON a decision can be
+// made — each stdlib predicate, each shape of published range, and the
+// routable controls that stop a side answering "no" to everything.
+func TestThePublishedEgressDecisionMatchesTheGuards(t *testing.T) {
+	t.Parallel()
+	corpus := []string{
+		// The stdlib predicates, one address each.
+		"127.0.0.1", "10.0.0.5", "172.16.0.1", "192.168.1.1",
+		"169.254.169.254", "224.0.0.1", "0.0.0.0",
+		"::1", "fe80::1", "ff02::1", "::",
+		// The published ranges: what the stdlib predicates miss.
+		"100.64.0.1", "192.0.2.1", "198.18.0.1", "255.255.255.255",
+		"64:ff9b::7f00:1", "2002:7f00:1::", "::ffff:0:127.0.0.1",
+		// And the controls. A guard that refused these would pass every
+		// negative case above while refusing the whole internet.
+		"93.184.216.34", "8.8.8.8", "2606:2800:220:1::",
+	}
+	agreed, refused, admitted := 0, 0, 0
+	for _, address := range corpus {
+		ip := net.ParseIP(address)
+		if ip == nil {
+			t.Fatalf("%q is not an address, so this corpus asks about nothing", address)
+		}
+		// The published side is asked through the hook, which is what a unit
+		// actually dials through — the predicate behind it is unexported, and
+		// testing an unexported function would prove less than testing the
+		// thing units reach.
+		refusedByUnit := extension.RefuseNonPublic("tcp", net.JoinHostPort(address, "443"), nil) != nil
+		refusedByCore := !netguard.PublicIP(ip)
+		if refusedByUnit != refusedByCore {
+			t.Errorf("%s: the published surface %s it and the core guard %s — a unit and the core disagree "+
+				"about whether this address is dialable, which is the drift publishing the list was meant to end",
+				address, refusedOrNot(refusedByUnit), refusedOrNot(refusedByCore))
+			continue
+		}
+		agreed++
+		if refusedByUnit {
+			refused++
+		} else {
+			admitted++
+		}
+	}
+	// A corpus that stopped parsing, or a hook that answered nil for
+	// everything, would agree with a guard that did the same.
+	if agreed != len(corpus) {
+		t.Fatalf("%d of %d addresses agreed", agreed, len(corpus))
+	}
+	// Two sides that both answer the same thing to everything agree perfectly
+	// and decide nothing, so the agreement above is only worth something if
+	// both answers were actually given.
+	if refused == 0 || admitted == 0 {
+		t.Fatalf("the corpus produced %d refusals and %d admissions — agreement between two inert guards "+
+			"is not agreement about anything", refused, admitted)
+	}
+}
+
+func refusedOrNot(refused bool) string {
+	if refused {
+		return "refuses"
+	}
+	return "admits"
 }

--- a/backend/gates/unitegress_test.go
+++ b/backend/gates/unitegress_test.go
@@ -41,6 +41,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // unitTrees are where a unit's Go lives. fixtures included: a reference unit is
@@ -54,11 +56,17 @@ var unitTrees = []string{"../extensions", "../fixtures/extensions"}
 // one that admits an address the core refuses is the worse half.
 var reservedCIDRLiteral = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$|^[0-9a-fA-F:]+::?[0-9a-fA-F:]*/\d{1,3}$`)
 
-// publishedEgress are the published names a unit reaches the policy through.
-// A file using one is doing the right thing; the prohibitions below do not
-// apply to it, because a unit that composes its own client AROUND the
-// published hook is exactly the case the surface documents.
+// publishedEgress are the names on the published surface a unit reaches the
+// policy through. A dialer whose Control is one of these is doing what the
+// surface documents — composing its own client around the published hook — and
+// is not reported.
 var publishedEgress = []string{"RefuseNonPublic", "OutboundClient", "OutboundTransport", "ReservedNets"}
+
+// extensionSurface is the import path those names have to come from. Matching
+// the SPELLING alone would accept a unit that declared its own
+// RefuseNonPublic and wired that — which is the copy this gate exists to
+// refuse, under the one name guaranteed not to be reported.
+const extensionSurface = "github.com/margince/margince/backend/pkg/extension"
 
 func TestNoUnitDialsAroundTheInstallationsEgressPolicy(t *testing.T) {
 	t.Parallel()
@@ -100,6 +108,17 @@ func TestNoUnitDialsAroundTheInstallationsEgressPolicy(t *testing.T) {
 // unitEgressOffences names each place one unit file writes its own egress
 // policy.
 func unitEgressOffences(path string, file *ast.File) []string {
+	// The file's own alias for the published surface, so a hook is recognised
+	// by WHERE it comes from rather than by what it is called.
+	surface, dotImported := gatekit.ImportedAs(file, extensionSurface)
+	if dotImported {
+		// A dot-import puts the published names in the file's own scope, where
+		// this cannot tell them from a local declaration of the same name. No
+		// unit does it, and the honest answer is to say so rather than to
+		// guess: reported, so somebody looks.
+		return []string{path + ": dot-imports the published surface, and this gate cannot then tell " +
+			"extension.RefuseNonPublic from a local function of that name — import it qualified"}
+	}
 	var offences []string
 	ast.Inspect(file, func(node ast.Node) bool {
 		if literal, isLiteral := node.(*ast.BasicLit); isLiteral && literal.Kind == token.STRING {
@@ -111,7 +130,7 @@ func unitEgressOffences(path string, file *ast.File) []string {
 			}
 			return true
 		}
-		if dialerControl(node) {
+		if dialerControl(node, surface) {
 			offences = append(offences, path+": wires its own net.Dialer.Control — the guarded dialer is "+
 				"published as extension.OutboundClient (and extension.RefuseNonPublic for a unit that "+
 				"needs its own client settings), so a hand-written hook is a second answer to one question")
@@ -123,7 +142,7 @@ func unitEgressOffences(path string, file *ast.File) []string {
 
 // dialerControl reports a net.Dialer composite literal that sets Control to
 // anything other than the published hook.
-func dialerControl(node ast.Node) bool {
+func dialerControl(node ast.Node, surface string) bool {
 	lit, isLit := node.(*ast.CompositeLit)
 	if !isLit || !isNetDialer(lit.Type) {
 		return false
@@ -137,7 +156,7 @@ func dialerControl(node ast.Node) bool {
 		if !isIdent || key.Name != "Control" {
 			continue
 		}
-		return !namesPublishedEgress(kv.Value)
+		return !namesPublishedEgress(kv.Value, surface)
 	}
 	return false
 }
@@ -152,17 +171,32 @@ func isNetDialer(expr ast.Expr) bool {
 }
 
 // namesPublishedEgress reports whether an expression reaches one of the
-// published names, so a unit wrapping extension.RefuseNonPublic in its own
-// dialer is not reported for doing what the surface tells it to.
-func namesPublishedEgress(expr ast.Expr) bool {
+// published names THROUGH THE PUBLISHED PACKAGE, so a unit wrapping
+// extension.RefuseNonPublic in its own dialer is not reported for doing what
+// the surface tells it to.
+//
+// Qualified, never bare. A unit that declared its own func RefuseNonPublic and
+// wired that would otherwise pass under the one name this gate is guaranteed
+// not to report — the copy, wearing the name of the thing it copies. surface is
+// the file's own alias for the published package, and is empty when the file
+// does not import it at all, in which case nothing here can be reached and
+// every hook is the unit's own.
+func namesPublishedEgress(expr ast.Expr, surface string) bool {
+	if surface == "" {
+		return false
+	}
 	found := false
 	ast.Inspect(expr, func(node ast.Node) bool {
-		ident, isIdent := node.(*ast.Ident)
-		if !isIdent {
+		selector, isSelector := node.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+		pkg, isIdent := selector.X.(*ast.Ident)
+		if !isIdent || pkg.Name != surface {
 			return true
 		}
 		for _, name := range publishedEgress {
-			if ident.Name == name {
+			if selector.Sel.Name == name {
 				found = true
 			}
 		}

--- a/backend/gates/unitegress_test.go
+++ b/backend/gates/unitegress_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+//go:build !integration
+
+package gates
+
+// A unit dials through the installation's egress policy, not through a copy of
+// it.
+//
+// The policy is published — extension.ReservedNets, extension.RefuseNonPublic,
+// extension.OutboundClient — precisely so a unit that fetches a
+// member-supplied URL does not have to write one. What this refuses is the
+// alternative: a unit spelling the reserved ranges itself, or wiring its own
+// net.Dialer.Control.
+//
+// The hazard is not that a copy is written badly. The first one was written
+// well — the same eleven ranges, the same post-resolution hook, reviewed side
+// by side. The hazard is that it stops being equal the moment the core list
+// moves, silently, in a module nothing in this tree compiles against the core.
+// A range added because somebody found a way to name an internal address is
+// then absent from every unit that copied it, and the failure is a worker
+// fetching an address the installation refuses everywhere else.
+//
+// WHAT IT CANNOT SEE, said plainly: a unit that builds the denylist from
+// computed strings, or wires a Control hook through a variable this cannot
+// resolve. Both defeat a static reader by construction. This is a lint against
+// the shape a unit actually writes — the same posture
+// TestUnitSQLAddressesItsOwnTables takes about a unit's SQL, and for the same
+// reason: the wall is elsewhere and this catches the mistake.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// unitTrees are where a unit's Go lives. fixtures included: a reference unit is
+// what an author copies, so a copy of the policy there is the one most likely
+// to be reproduced.
+var unitTrees = []string{"../extensions", "../fixtures/extensions"}
+
+// reservedCIDRLiteral matches a CIDR string. It is the SHAPE rather than the
+// eleven values, because a unit hand-copying the list is as likely to have
+// typed a range the core does not carry — which is a copy either way, and the
+// one that admits an address the core refuses is the worse half.
+var reservedCIDRLiteral = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$|^[0-9a-fA-F:]+::?[0-9a-fA-F:]*/\d{1,3}$`)
+
+// publishedEgress are the published names a unit reaches the policy through.
+// A file using one is doing the right thing; the prohibitions below do not
+// apply to it, because a unit that composes its own client AROUND the
+// published hook is exactly the case the surface documents.
+var publishedEgress = []string{"RefuseNonPublic", "OutboundClient", "OutboundTransport", "ReservedNets"}
+
+func TestNoUnitDialsAroundTheInstallationsEgressPolicy(t *testing.T) {
+	t.Parallel()
+	var offences []string
+	scanned := 0
+	for _, tree := range unitTrees {
+		err := filepath.WalkDir(tree, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			scanned++
+			offences = append(offences, unitEgressOffences(path, file)...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s for a unit's own egress policy: %v", tree, err)
+		}
+	}
+	// A prohibition over an empty corpus prohibits nothing, and this one's
+	// corpus is other modules' source: a moved tree, a renamed fixtures
+	// directory, or a walk that stopped finding .go files all read exactly
+	// like a clean set of units.
+	if scanned < 20 {
+		t.Fatalf("read %d unit source file(s) across %v, and the tree ships more than that: this gate is "+
+			"looking somewhere the units are not", scanned, unitTrees)
+	}
+	for _, offence := range offences {
+		t.Error(offence)
+	}
+}
+
+// unitEgressOffences names each place one unit file writes its own egress
+// policy.
+func unitEgressOffences(path string, file *ast.File) []string {
+	var offences []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		if literal, isLiteral := node.(*ast.BasicLit); isLiteral && literal.Kind == token.STRING {
+			text, err := strconv.Unquote(literal.Value)
+			if err == nil && reservedCIDRLiteral.MatchString(text) {
+				offences = append(offences, path+": spells the network "+text+" itself — the installation's "+
+					"denylist is published as extension.ReservedNets, and a copy stops being equal to it "+
+					"the moment the core list moves, in a module nothing here compiles against the core")
+			}
+			return true
+		}
+		if dialerControl(node) {
+			offences = append(offences, path+": wires its own net.Dialer.Control — the guarded dialer is "+
+				"published as extension.OutboundClient (and extension.RefuseNonPublic for a unit that "+
+				"needs its own client settings), so a hand-written hook is a second answer to one question")
+		}
+		return true
+	})
+	return offences
+}
+
+// dialerControl reports a net.Dialer composite literal that sets Control to
+// anything other than the published hook.
+func dialerControl(node ast.Node) bool {
+	lit, isLit := node.(*ast.CompositeLit)
+	if !isLit || !isNetDialer(lit.Type) {
+		return false
+	}
+	for _, element := range lit.Elts {
+		kv, isKV := element.(*ast.KeyValueExpr)
+		if !isKV {
+			continue
+		}
+		key, isIdent := kv.Key.(*ast.Ident)
+		if !isIdent || key.Name != "Control" {
+			continue
+		}
+		return !namesPublishedEgress(kv.Value)
+	}
+	return false
+}
+
+func isNetDialer(expr ast.Expr) bool {
+	selector, isSelector := expr.(*ast.SelectorExpr)
+	if !isSelector || selector.Sel.Name != "Dialer" {
+		return false
+	}
+	pkg, isIdent := selector.X.(*ast.Ident)
+	return isIdent && pkg.Name == "net"
+}
+
+// namesPublishedEgress reports whether an expression reaches one of the
+// published names, so a unit wrapping extension.RefuseNonPublic in its own
+// dialer is not reported for doing what the surface tells it to.
+func namesPublishedEgress(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		ident, isIdent := node.(*ast.Ident)
+		if !isIdent {
+			return true
+		}
+		for _, name := range publishedEgress {
+			if ident.Name == name {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}

--- a/backend/pkg/extension/netguard.go
+++ b/backend/pkg/extension/netguard.go
@@ -57,6 +57,30 @@ var reservedNets = func() []*net.IPNet {
 	return nets
 }()
 
+// publicIP reports whether ip is a globally routable unicast address — the
+// same question netguard.PublicIP answers for the core, spelled here because a
+// unit may import only pkg/**.
+//
+// The stdlib predicates first and the published list second, in that order and
+// with that content, because the two halves are not interchangeable:
+// IsPrivate covers RFC 1918 and nothing else, and the ranges above are exactly
+// what it misses. Held equal to the core's by
+// TestThePublishedEgressDecisionMatchesTheGuards, which asks both about the
+// same addresses rather than comparing their source.
+func publicIP(ip net.IP) bool {
+	// IsMulticast already covers link-local multicast, so it is not repeated.
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return false
+	}
+	for _, n := range reservedNets {
+		if n.Contains(ip) {
+			return false
+		}
+	}
+	return true
+}
+
 // ReservedNets returns the non-public ranges a unit must refuse to dial, in
 // addition to what net.IP's own predicates already cover (loopback, private,
 // link-local unicast, multicast, unspecified). Use it in a unit that dials a

--- a/backend/pkg/extension/outbound.go
+++ b/backend/pkg/extension/outbound.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+// The client a unit dials its provider through.
+//
+// ReservedNets already publishes WHAT the installation refuses. What every
+// unit then had to write for itself is the part that makes the list do
+// anything: a dialer whose Control hook runs the check AFTER resolution, on
+// the concrete address it is about to connect to. That is a small amount of
+// code and exactly the kind that is wrong in a way nobody notices — a unit
+// that checks the URL's hostname before dialling has written a pre-flight
+// lookup, not a guard, and the attacker who cares controls the DNS between
+// the two.
+//
+// So the guard is DELIVERED rather than described. A unit asks for a client
+// and gets the policy inside it, and a range added to the published list
+// reaches every unit at once instead of every unit that remembered.
+//
+// WHAT IT GUARANTEES: every address the client connects to is checked after
+// resolution, so a hostname that resolves into a reserved range is refused
+// even though its text looked public, and one that REBINDS between the
+// resolution and the connect is refused at the connect.
+//
+// WHAT IT DOES NOT: it is not an allowlist, not a proxy, and not a rate limit.
+// It refuses addresses the installation refuses; the method, the headers, the
+// body and the deadline are the unit's own. Redirects are followed by the
+// stdlib as usual — and are dialled through the same Control, which is the
+// half a hand-written guard most often misses, because the refusal has to
+// happen on the address the redirect names rather than on the one the caller
+// typed.
+//
+// WHAT A UNIT MUST NOT DO is assemble its own. TestNoUnitDialsAroundTheInstallationsEgressPolicy
+// refuses a unit that writes its own denylist or its own dialer control: both
+// are copies that stop being equal to the published list the moment it moves.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// outboundDialTimeout bounds the CONNECT, not the request.
+//
+// A request's own deadline is the caller's business and belongs on its
+// context; what this bounds is the case a context deadline handles badly — a
+// host that accepts nothing and never answers, where without a dial timeout
+// every worker that touches it waits for the platform's own TCP timeout,
+// minutes later. 10s is far longer than any reachable host needs and far
+// shorter than that.
+const outboundDialTimeout = 10 * time.Second
+
+// RefuseNonPublic is a net.Dialer.Control hook that refuses any non-public
+// address. Published for the unit that needs its own client settings — a
+// custom TLS config, a different proxy — and can therefore not use
+// OutboundClient as it stands: wire this as Control on the dialer and the
+// guard is the same one.
+//
+// It runs on the concrete IP the dialer is about to connect to, which is the
+// only place the check holds.
+func RefuseNonPublic(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("extension: unparseable dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// The dialer hands a literal here, always. A name at this point means
+		// the caller wired this hook somewhere it does not belong, and
+		// admitting it would be admitting an unchecked address.
+		return fmt.Errorf("extension: dial address %q is not a literal IP", host)
+	}
+	if !publicIP(ip) {
+		return fmt.Errorf("extension: refusing to dial non-public address %s", host)
+	}
+	return nil
+}
+
+// OutboundTransport answers a transport whose dials the egress policy admits.
+//
+// A fresh one per call, and the reason is connection pooling: a shared
+// transport keeps idle connections, and two units sharing them would share a
+// pool sized for neither. A unit builds one and holds it — the same rule any
+// http.Transport carries — rather than building one per request.
+func OutboundTransport() *http.Transport {
+	transport, _ := http.DefaultTransport.(*http.Transport)
+	guarded := transport.Clone()
+	dialer := &net.Dialer{Timeout: outboundDialTimeout, KeepAlive: 30 * time.Second, Control: RefuseNonPublic}
+	guarded.DialContext = dialer.DialContext
+	return guarded
+}
+
+// OutboundClient answers an http.Client whose dials the egress policy admits.
+//
+// No client Timeout is set, deliberately. A client-wide timeout bounds the
+// whole exchange including the body read, so a unit streaming a large export
+// would have it cut mid-download by a number this package chose. The deadline
+// belongs on the caller's context, where it is the unit's decision and applies
+// to the one request that needs it.
+func OutboundClient() *http.Client {
+	return &http.Client{Transport: OutboundTransport()}
+}

--- a/backend/pkg/extension/outbound.go
+++ b/backend/pkg/extension/outbound.go
@@ -90,6 +90,19 @@ func OutboundTransport() *http.Transport {
 	guarded := transport.Clone()
 	dialer := &net.Dialer{Timeout: outboundDialTimeout, KeepAlive: 30 * time.Second, Control: RefuseNonPublic}
 	guarded.DialContext = dialer.DialContext
+	// NO PROXY, and this is the line that decides whether the guard means
+	// anything. The stdlib default is ProxyFromEnvironment, and a proxy turns
+	// the check inside out: the dial goes to the PROXY's address — public, so
+	// admitted — and the proxy is then asked to CONNECT to the target, which
+	// this side never sees. Every internal address the hook refuses is
+	// reachable that way by any deployment with HTTPS_PROXY set.
+	//
+	// So the clone's inherited proxy is dropped rather than trusted. A
+	// deployment that must egress through a proxy has to enforce the
+	// destination policy AT that proxy, which is the only place that can see
+	// the destination — and is a deployment decision rather than something
+	// this package can make on its behalf.
+	guarded.Proxy = nil
 	return guarded
 }
 

--- a/backend/pkg/extension/outbound_test.go
+++ b/backend/pkg/extension/outbound_test.go
@@ -138,3 +138,21 @@ func TestEachOutboundTransportIsItsOwn(t *testing.T) {
 		t.Error("the guarded transport IS the process default — the guard would be everywhere or nowhere")
 	}
 }
+
+// A proxy turns the guard inside out: the dial goes to the proxy's own
+// address, which is public and admitted, and the proxy is then asked to
+// CONNECT to the target this side never sees. The stdlib default the clone
+// inherits is ProxyFromEnvironment, so this is one field away on any
+// deployment with HTTPS_PROXY set.
+func TestTheGuardedTransportRoutesThroughNoProxy(t *testing.T) {
+	if OutboundTransport().Proxy != nil {
+		t.Error("the guarded transport carries a proxy — every address the dial control refuses is " +
+			"reachable through it, because the proxy is what connects to the target and the dial only " +
+			"ever sees the proxy")
+	}
+	// And the inherited default is what it would have been, so this test is
+	// asserting a decision rather than restating a zero value.
+	if base, ok := http.DefaultTransport.(*http.Transport); !ok || base.Proxy == nil {
+		t.Skip("the stdlib default carries no proxy in this build, so nothing was inherited to drop")
+	}
+}

--- a/backend/pkg/extension/outbound_test.go
+++ b/backend/pkg/extension/outbound_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The guard runs where it has to: on the concrete address, at the connect.
+func TestRefuseNonPublicAnswersOnTheAddressItIsAboutToDial(t *testing.T) {
+	for address, public := range map[string]bool{
+		// Routable, and the only class that may be dialed.
+		"93.184.216.34":     true,
+		"2606:2800:220:1::": true,
+		// Loopback, private, link-local — the obvious three.
+		"127.0.0.1":       false,
+		"10.0.0.5":        false,
+		"192.168.1.10":    false,
+		"172.16.4.4":      false,
+		"169.254.169.254": false,
+		"::1":             false,
+		"fe80::1":         false,
+		// The ranges the stdlib predicates miss, and the reason the list of
+		// CIDRs exists at all: each of these reads as ordinary public space to
+		// IsPrivate.
+		"0.0.0.0":              false,
+		"0.1.2.3":              false,
+		"100.64.0.1":           false, // CGNAT
+		"192.0.0.1":            false, // protocol assignment
+		"192.0.2.5":            false, // documentation
+		"198.18.0.1":           false, // benchmarking
+		"198.51.100.5":         false,
+		"203.0.113.5":          false,
+		"240.0.0.1":            false, // reserved
+		"255.255.255.255":      false,
+		"192.88.99.1":          false, // 6to4 relay anycast
+		"2001:db8::1":          false, // documentation
+		"3fff::1":              false, // documentation, the newer range
+		"64:ff9b::a9fe:a9fe":   false, // NAT64 onto the metadata address
+		"64:ff9b:1::a9fe:a9fe": false, // local-use NAT64 onto the same address
+		"2002:7f00:1::1":       false, // 6to4 carrying 127.0.0.1
+		"2001::1":              false, // Teredo, inside the 2001::/23 blanket
+		"100::1":               false, // discard-only
+		"100:0:0:1::1":         false, // dummy prefix
+		"5f00::1":              false, // SRv6 SIDs
+		"fec0::1":              false, // deprecated site-local
+		"::ffff:0:a9fe:a9fe":   false, // IPv4-translated onto the metadata address
+		"::ffff:127.0.0.1":     false, // IPv4-mapped loopback
+	} {
+		address := address
+		t.Run(address, func(t *testing.T) {
+			if net.ParseIP(address) == nil {
+				t.Fatalf("%q is not an address — the fixture is wrong, which would make this row pass for free", address)
+			}
+			err := RefuseNonPublic("tcp", net.JoinHostPort(address, "443"), nil)
+			if public && err != nil {
+				t.Errorf("a routable address was refused: %v", err)
+			}
+			if !public && err == nil {
+				t.Error("dialled, and it must not")
+			}
+		})
+	}
+}
+
+// A hook wired where it does not belong sees a name rather than a literal.
+// Admitting that would be admitting an address nothing checked, so it refuses.
+func TestRefuseNonPublicRefusesAnAddressItCannotRead(t *testing.T) {
+	for _, address := range []string{"example.test:443", "not-an-address", ""} {
+		if err := RefuseNonPublic("tcp", address, nil); err == nil {
+			t.Errorf("%q was admitted, and an address this hook cannot read is one nothing checked", address)
+		}
+	}
+}
+
+// The point of the whole file: a client built here refuses a request to an
+// internal address, through the transport rather than by anything the caller
+// remembered to do.
+func TestTheOutboundClientRefusesAnInternalAddress(t *testing.T) {
+	// A real listener on loopback, so the refusal is the guard's and not a
+	// connection that would have failed anyway.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer server.Close()
+
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := OutboundClient().Do(request)
+	if err == nil {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			t.Errorf("closing the body of a response that should not exist: %v", closeErr)
+		}
+		t.Fatalf("the outbound client reached %s — a unit dialling a member-supplied host would reach the "+
+			"installation's own network", server.URL)
+	}
+	if !strings.Contains(err.Error(), "refusing to dial non-public address") {
+		t.Errorf("the request failed for the wrong reason: %v", err)
+	}
+}
+
+// And it is not refusing everything: a client that never connects would pass
+// the test above while being useless.
+func TestTheOutboundClientStillDialsARoutableAddress(t *testing.T) {
+	// No network in a unit lane, so the proof is the DIALER's decision rather
+	// than a completed request: the control hook is what stands between the
+	// client and the address, and it admits this one.
+	dialer := &net.Dialer{Control: RefuseNonPublic}
+	if dialer.Control == nil {
+		t.Fatal("the published hook is nil")
+	}
+	if err := dialer.Control("tcp", "93.184.216.34:443", nil); err != nil {
+		t.Errorf("a routable address was refused: %v", err)
+	}
+	if OutboundTransport().DialContext == nil {
+		t.Error("the transport dials through the stdlib default, so the guard is not in the path")
+	}
+}
+
+// A fresh transport per call, because a shared one pools connections and two
+// units sharing them would share a pool sized for neither.
+func TestEachOutboundTransportIsItsOwn(t *testing.T) {
+	first, second := OutboundTransport(), OutboundTransport()
+	if first == second {
+		t.Error("two calls answered one transport, so units would share a connection pool")
+	}
+	// And it does not hand out the stdlib's, which nothing else in the process
+	// could then dial through unguarded.
+	if first == http.DefaultTransport {
+		t.Error("the guarded transport IS the process default — the guard would be everywhere or nowhere")
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -177,7 +177,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (29)
+## Prohibition (30)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -209,6 +209,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooktally_test.go` | H1 | A rulebook must not spell out a tally of anything the tree can be asked for. |
 | `technicaldomain_test.go` | H2 | The technical lookup reads the domain the RECORD holds, and nothing else. |
 | `txseamacquire_test.go` | H2 | Code that runs on a caller's `pgx.Tx` acquires no connection of its own. |
+| `unitegress_test.go` | H2 | A unit dials through the installation's egress policy, not through a copy of it. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
 ## Claim (5)

--- a/extensions/relay-probe/client.go
+++ b/extensions/relay-probe/client.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/margince/margince/backend/pkg/extension"
@@ -102,26 +101,26 @@ type client struct {
 // THE GUARD IS THE POINT OF THIS CONSTRUCTOR. base_url is text a member typed:
 // without a control hook, `https://<name-that-resolves-to-169.254.169.254>`
 // makes this installation's own worker fetch its cloud metadata endpoint and
-// hand the answer to whoever asked. The core has exactly this guard
-// (internal/platform/netguard) and a unit cannot import it — the published
-// surface is stdlib-only and reaches nothing under internal, and an extensions/
-// module is its own Go module besides, so not even a fitness test can hold the
-// two side by side. What stands in for that is a table of addresses this
-// package refuses, kept in client_test.go and worth reading as the guard's real
-// definition. Publishing a guarded HTTP client on the tier's own surface is the
-// fix that removes the copy (#1194).
+// hand the answer to whoever asked.
+//
+// The guard is the INSTALLATION'S, reached rather than reproduced:
+// extension.OutboundTransport carries the same denylist the core dials through
+// and runs it after resolution. This unit used to restate the hook and the
+// predicate, with a table of addresses standing in for a fitness function that
+// could not cross the module boundary. It can now: the surface publishes the
+// client, the addresses moved to its own tests, and a gate refuses a unit that
+// writes its own.
 func newClient(base, token string) (*client, error) {
 	parsed, err := parseBaseURL(base)
 	if err != nil {
 		return nil, err
 	}
-	dialer := &net.Dialer{Timeout: requestTimeout, Control: refusePrivate}
 	return &client{
 		base:  parsed,
 		token: token,
 		http: &http.Client{
 			Timeout:   requestTimeout,
-			Transport: &http.Transport{DialContext: dialer.DialContext},
+			Transport: extension.OutboundTransport(),
 			// A redirect is another host, chosen by the provider rather than
 			// by the member — and the guard would still hold for it, which is
 			// exactly why refusing is cheap here. An API that answers a
@@ -170,50 +169,6 @@ func hostOnly(host string) string {
 		return h
 	}
 	return host
-}
-
-// refusePrivate refuses to dial anything that is not a globally routable
-// unicast address, on the CONCRETE address the resolver returned — so a DNS
-// answer pointing at the deployment's own network cannot bypass it, which
-// checking the name could not prevent.
-//
-// It is the core's netguard.RefusePrivate rule, restated because a unit cannot
-// import it (see newClient). TestTheEgressGuardRefusesEveryNonPublicAddress is
-// what holds this copy honest.
-func refusePrivate(_, address string, _ syscall.RawConn) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return fmt.Errorf("relay: the address %q is not host:port", address)
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return fmt.Errorf("relay: %q did not resolve to an address", host)
-	}
-	if !publicIP(ip) {
-		return fmt.Errorf("relay: refusing to dial %s — it is not a public address, and a member-supplied host must not become a probe of this deployment's own network", ip)
-	}
-	return nil
-}
-
-// publicIP reports whether ip is a globally routable unicast address.
-//
-// A CIDR this package cannot parse is treated as MATCHING, which is the safe
-// direction: a typo in the list above makes the guard refuse more, never less.
-func publicIP(ip net.IP) bool {
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
-		ip.IsMulticast() || ip.IsUnspecified() {
-		return false
-	}
-	// The core's own denylist, read from the published surface rather than
-	// restated here. A hand-copy drifts, and a range the core refuses while this
-	// unit admits it is a member-supplied host reaching an internal address —
-	// which is why the surface publishes it and why nothing below is a literal.
-	for _, reserved := range extension.ReservedNets() {
-		if reserved.Contains(ip) {
-			return false
-		}
-	}
-	return true
 }
 
 // providerUser is a Relay account, as both /auth/me and the batch lookup

--- a/extensions/relay-probe/client_test.go
+++ b/extensions/relay-probe/client_test.go
@@ -9,7 +9,6 @@ package relayprobe
 import (
 	"context"
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,76 +16,12 @@ import (
 	"testing"
 )
 
-// The guard's real definition. base_url is text a member typed, so without this
-// a name resolving to a link-local address turns this installation's own worker
-// into a probe of its network — and the answer comes back to whoever asked.
-func TestTheEgressGuardRefusesEveryNonPublicAddress(t *testing.T) {
-	for address, public := range map[string]bool{
-		// Routable, and the only class that may be dialed.
-		"93.184.216.34":     true,
-		"2606:2800:220:1::": true,
-		// Loopback, private, link-local — the obvious three.
-		"127.0.0.1":       false,
-		"10.0.0.5":        false,
-		"192.168.1.10":    false,
-		"172.16.4.4":      false,
-		"169.254.169.254": false,
-		"::1":             false,
-		"fe80::1":         false,
-		// The ranges the stdlib predicates miss, and the reason the list of
-		// CIDRs exists at all: each of these reads as ordinary public space to
-		// IsPrivate.
-		"0.0.0.0":              false,
-		"0.1.2.3":              false,
-		"100.64.0.1":           false, // CGNAT
-		"192.0.0.1":            false, // protocol assignment
-		"192.0.2.5":            false, // documentation
-		"198.18.0.1":           false, // benchmarking
-		"198.51.100.5":         false,
-		"203.0.113.5":          false,
-		"240.0.0.1":            false, // reserved
-		"255.255.255.255":      false,
-		"192.88.99.1":          false, // 6to4 relay anycast
-		"2001:db8::1":          false, // documentation
-		"3fff::1":              false, // documentation, the newer range
-		"64:ff9b::a9fe:a9fe":   false, // NAT64 onto the metadata address
-		"64:ff9b:1::a9fe:a9fe": false, // local-use NAT64 onto the same address
-		"2002:7f00:1::1":       false, // 6to4 carrying 127.0.0.1
-		"2001::1":              false, // Teredo, inside the 2001::/23 blanket
-		"100::1":               false, // discard-only
-		"100:0:0:1::1":         false, // dummy prefix
-		"5f00::1":              false, // SRv6 SIDs
-		"fec0::1":              false, // deprecated site-local
-		"::ffff:0:a9fe:a9fe":   false, // IPv4-translated onto the metadata address
-		"::ffff:127.0.0.1":     false, // IPv4-mapped loopback
-	} {
-		t.Run(address, func(t *testing.T) {
-			ip := net.ParseIP(address)
-			if ip == nil {
-				t.Fatalf("%q is not an address — the fixture is wrong, which would make this row pass for free", address)
-			}
-			if got := publicIP(ip); got != public {
-				t.Errorf("publicIP(%s) = %v, want %v", address, got, public)
-			}
-		})
-	}
-}
-
-// The control hook is what actually runs, on the CONCRETE address the resolver
-// returned — so a DNS answer pointing inward cannot bypass a check made on the
-// name.
-func TestTheDialControlRefusesAResolvedPrivateAddress(t *testing.T) {
-	if err := refusePrivate("tcp", "169.254.169.254:443", nil); err == nil {
-		t.Fatal("the dial control admitted the cloud metadata address")
-	}
-	if err := refusePrivate("tcp", "93.184.216.34:443", nil); err != nil {
-		t.Fatalf("the dial control refused a public address: %v", err)
-	}
-	if err := refusePrivate("tcp", "not-an-address", nil); err == nil {
-		t.Error("the dial control admitted something that is not host:port")
-	}
-}
-
+// What this unit owes about egress is that its PRODUCTION client is wired to
+// the installation's guard — not what that guard decides, which is the
+// surface's own question and is answered in pkg/extension's tests against the
+// full corpus of addresses this unit used to carry, and held equal to the core
+// by TestThePublishedEgressDecisionMatchesTheGuards.
+//
 // The guard is attached by the production constructor, which is the property
 // that matters: a client built the way a poll builds it cannot reach a loopback
 // listener, however the URL was spelled.
@@ -102,9 +37,10 @@ func TestTheProductionClientCannotDialLoopback(t *testing.T) {
 	if err == nil {
 		t.Fatal("the production client reached a loopback host")
 	}
-	// Asserted on the guard's own words rather than on any failure: a name that
-	// did not resolve would fail too, and would prove nothing about the guard.
-	if !strings.Contains(err.Error(), "not a public address") {
+	// Asserted on the PUBLISHED guard's own words rather than on any failure: a
+	// name that did not resolve would fail too and would prove nothing, and a
+	// refusal in this unit's own words would mean the copy came back.
+	if !strings.Contains(err.Error(), "extension: refusing to dial non-public address") {
 		t.Fatalf("err = %v, want the egress guard's refusal", err)
 	}
 }


### PR DESCRIPTION
Closes #1194.

## What was already there, and what was missing

`extension.ReservedNets` already publishes **what** the installation refuses, held equal to `internal/platform/netguard` by `TestPublishedReservedNetsMatchTheGuard`. So the ticket's "eleven CIDRs restated in the unit" is half-solved on `main` — `relay-probe/client.go` reads the ranges from the surface.

What every unit still had to write for itself is the part that makes the list do anything: a dialer whose `Control` hook runs the check **after resolution**, on the concrete address it is about to connect to. That is a small amount of code and exactly the kind that is wrong in a way nobody notices — a check on the URL's hostname is a pre-flight lookup, not a guard, and the attacker who cares controls the DNS between the two.

## What this adds

```go
extension.OutboundClient()    // an *http.Client whose dials the policy admits
extension.OutboundTransport() // for a unit that wants its own client settings
extension.RefuseNonPublic     // the Control hook itself, for a custom dialer
```

Deliberate choices worth a reviewer's eye:

- **No client `Timeout`.** A client-wide timeout bounds the whole exchange including the body read, so a unit streaming a large export would have it cut mid-download by a number this package chose. The deadline belongs on the caller's context. The **dial** is bounded (10s) because a context deadline handles that case badly: a host that accepts nothing leaves every worker waiting for the platform's TCP timeout.
- **A fresh transport per call.** A shared one pools connections, and two units sharing them would share a pool sized for neither. It is also not `http.DefaultTransport` — mutating that would put the guard everywhere or nowhere.
- **Redirects.** The stdlib follows them through the same `Control`, which is the half a hand-written guard most often misses: the refusal has to happen on the address the redirect names, not the one the caller typed.

## The copy is gone

`relay-probe` was the unit the ticket describes. Its `newClient` comment said it plainly — *"Publishing a guarded HTTP client on the tier's own surface is the fix that removes the copy (#1194)"* — and stood in for the missing fitness function with a table of addresses, because one *"could not exist across the module boundary"*.

It can now. So:

- the unit dials through `extension.OutboundTransport()`; `refusePrivate` and `publicIP` are deleted;
- its corpus of ~30 addresses moved to `pkg/extension`'s own tests, where the policy now lives — including the ones that matter most (NAT64 and 6to4 carrying an IPv4 address, IPv4-translated onto the metadata address);
- what the unit still asserts is the property that is genuinely its own: its **production constructor** is wired to the guard, asserted on the published refusal's words so a copy coming back would fail it.

## Two gates, because the list agreeing is not the two decisions agreeing

**`TestThePublishedEgressDecisionMatchesTheGuards`** (parity, extends `netguardparity_test.go`). Each side composes its list with the stdlib predicates — loopback, private, link-local, multicast, unspecified — and that half was written out twice, in two files, in two modules. A list held equal while one side dropped `IsPrivate` passes the existing test and admits every RFC 1918 address, which is the first thing a member-supplied host resolves to. This asks both sides about the same 21 addresses instead of comparing their source, one per *reason* a decision can be made, and fails if either side turns out to be inert.

**`TestNoUnitDialsAroundTheInstallationsEgressPolicy`** (prohibition, new) refuses a unit that spells a reserved CIDR itself or wires its own `net.Dialer.Control`. It scans `extensions/` **and** `fixtures/extensions/` — a reference unit is what an author copies, so a copy of the policy there is the one most likely to be reproduced — and fatals below 20 unit source files, because a prohibition over another module's source reads exactly like a clean tree when the walk stops finding it.

Mutation-checked from the other end:

| mutation | gate | result |
|---|---|---|
| the published side drops `IsPrivate` | decision parity | **caught** — names 10.0.0.5, 172.16.0.1, 192.168.1.1 |
| the published list loses `100.64.0.0/10` | both | **caught** |
| the unit wires its own `Dialer.Control` | prohibition | **caught** |
| the unit spells `169.254.0.0/16` | prohibition | **caught** |

The prohibition gate found the real one on its first run, before any of the above: `relay-probe`'s hand-written control hook.

## Verification

- `make check-backend` — green
- `make -C backend test-extensions` — green (all four unit module lanes)

## Not in scope

The ticket's phrasing suggests a `Runtime` capability. I did not add one: `pkg/extension` can build this itself from its own already-parity-gated list, so a method on `Runtime` would add an interface change every out-of-tree unit has to absorb, and a compose-side binding, in exchange for a per-installation variation that does not exist. If policy ever becomes per-installation, the seam to add is the binding — and these three functions become its default rather than being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guarded outbound HTTP networking for extensions.
  - Blocks connections and redirects to private, loopback, reserved, link-local, multicast, and other non-public addresses.
  - Allows connections to globally routable public addresses.
  - Adds a 10-second connection timeout while preserving caller-controlled request timeouts.
  - Standardizes outbound protection across extension clients.

- **Documentation**
  - Updated the gate inventory to include the new networking protection checks.

- **Tests**
  - Added coverage verifying consistent address decisions and protection against duplicated or bypassed egress rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->