### PR TITLE
A lead answered in time does not breach its SLA

### DIFF
--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -147,14 +147,39 @@ func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, er
 		if err != nil {
 			return fmt.Errorf("select breached leads: %w", err)
 		}
-		breaches, err = collectBreaches(rows)
+		candidates, err := collectBreaches(rows)
 		if err != nil {
 			return err
 		}
-		for _, b := range breaches {
+		// Each candidate is re-checked against the ACTIVITIES before it is
+		// marked. first_response_at is projected by an event subscriber
+		// reacting to activity.captured, so it lags the activity's own commit
+		// by the bus's latency: a reply committed at 11:59 against a 12:00
+		// deadline can still be unprojected when a 12:01 scan runs, and the
+		// lead reads as unanswered because the projection has not caught up
+		// rather than because nobody answered.
+		//
+		// The scan owns the consequence — a breach event, an escalation task,
+		// and a number on somebody's review — so it reads the ground truth
+		// rather than the projection. Where it finds one, it stamps the column
+		// itself: the subscriber's later write is then the replay
+		// recordFirstResponseTx already answers as a no-op.
+		breaches = breaches[:0]
+		for _, b := range candidates {
+			answered, err := answeredBy(ctx, tx, b.LeadID, b.Deadline)
+			if err != nil {
+				return err
+			}
+			if answered != nil {
+				if _, err := recordFirstResponseTx(ctx, tx, b.LeadID, *answered); err != nil {
+					return err
+				}
+				continue
+			}
 			if err := markBreach(ctx, tx, b, now); err != nil {
 				return err
 			}
+			breaches = append(breaches, b)
 		}
 		return nil
 	})
@@ -230,6 +255,24 @@ func (s *Store) RecordLeadFirstResponse(ctx context.Context, leadID ids.LeadID, 
 	}
 	set := false
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		set, err = recordFirstResponseTx(ctx, tx, leadID, at)
+		return err
+	})
+	return set, err
+}
+
+// recordFirstResponseTx is RecordLeadFirstResponse's body, inside a
+// transaction the caller already holds.
+//
+// Two callers, one spelling: the outbox subscriber opens its own transaction
+// for it, and the breach scan calls it while holding the lead row it is about
+// to judge. A second implementation there would be a second answer to "what
+// counts as the first response" and to "when is a stamp a replay", in the one
+// place where getting either wrong marks a lead that was answered.
+func recordFirstResponseTx(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, at time.Time) (bool, error) {
+	set := false
+	err := func() error {
 		// The outbox subscriber that drives this is unbounded, so the probe is a
 		// no-op today; it is here so the write carries its own scope the day a
 		// human-facing caller stamps a first response.
@@ -265,7 +308,7 @@ func (s *Store) RecordLeadFirstResponse(ctx context.Context, leadID ids.LeadID, 
 		return storekit.EmitEvent(ctx, tx, auditID, leadID.UUID, crmcontracts.PublicEventLeadUpdated{
 			ChangedFields: map[string]any{eventKeyDelta: map[string]any{firstResponseColumn: at}},
 		})
-	})
+	}()
 	return set, err
 }
 
@@ -289,4 +332,72 @@ func isFirstResponseActivity(t leadResponseTouch) bool {
 		return true
 	}
 	return t.hadInbound
+}
+
+// answeredBy is the ground truth the breach scan judges on: the earliest
+// genuine first response linked to this lead that happened at or before the
+// deadline, or nil when there is none.
+//
+// It reads the ACTIVITIES rather than lead.first_response_at, because that
+// column is a projection an event subscriber writes and the scan's whole
+// hazard is running in the window before it catches up. What it must not be is
+// a second definition of "genuine response": the touches come back in the same
+// shape the subscriber judges, and isFirstResponseActivity — the §18.1 rule
+// itself — decides each of them.
+//
+// EARLIEST, not any: the stamp this feeds is the first response, and a lead
+// answered twice before its deadline must record the first of the two, exactly
+// as the subscriber does when the bus delivers them out of order.
+func answeredBy(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, deadline time.Time) (*time.Time, error) {
+	touches, err := leadTouchesFor(ctx, tx, leadID, deadline)
+	if err != nil {
+		return nil, err
+	}
+	var earliest *time.Time
+	for _, t := range touches {
+		if !isFirstResponseActivity(t) {
+			continue
+		}
+		if earliest == nil || t.occurredAt.Before(*earliest) {
+			at := t.occurredAt
+			earliest = &at
+		}
+	}
+	return earliest, nil
+}
+
+// leadTouchesFor answers this lead's activities up to the deadline in the shape
+// isFirstResponseActivity reads.
+//
+// The same columns and the same hadInbound sub-select as leadResponseTouches,
+// asked from the other end: that one starts from ONE activity and finds the
+// leads it is linked to, which is what an event subscriber knows; this starts
+// from one LEAD and finds its activities, which is what a scan knows. Neither
+// can be expressed as the other without asking the database for rows its
+// caller has no use for.
+func leadTouchesFor(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, deadline time.Time) ([]leadResponseTouch, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT coalesce(a.direction, ''), a.captured_by, a.occurred_at,
+		       EXISTS (SELECT 1 FROM activity_link li JOIN activity ai ON ai.id = li.activity_id
+		               WHERE li.lead_id = $1 AND ai.direction = 'inbound'
+		                 AND ai.archived_at IS NULL AND `+auth.ActivityAvailableClause("ai")+`
+		                 AND ai.occurred_at < a.occurred_at),
+		       a.kind, coalesce(a.meeting_status, ''), a.source
+		FROM activity_link l JOIN activity a ON a.id = l.activity_id
+		WHERE l.lead_id = $1 AND a.archived_at IS NULL AND a.occurred_at <= $2
+		  AND `+auth.ActivityAvailableClause("a"), leadID, deadline)
+	if err != nil {
+		return nil, fmt.Errorf("read the lead's activities before its deadline: %w", err)
+	}
+	defer rows.Close()
+	var out []leadResponseTouch
+	for rows.Next() {
+		t := leadResponseTouch{lead: leadID}
+		if err := rows.Scan(&t.direction, &t.capturedBy, &t.occurredAt, &t.hadInbound,
+			&t.kind, &t.meetingStatus, &t.source); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
 }

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -282,3 +282,155 @@ func TestFirstResponseKeepsTheEarliestReplyWhateverTheDeliveryOrder(t *testing.T
 		t.Errorf("first_response_at = %v, want the earliest reply %v", got.FirstResponseAt, early)
 	}
 }
+
+// seedLeadActivity links one activity to a lead, exactly as a capture would
+// have committed it — and WITHOUT running the subscriber that projects
+// lead.first_response_at from it. That gap is the whole subject: the scan has
+// to survive the window between the activity's commit and the projection.
+func (e *promoteConsentEnv) seedLeadTouch(t *testing.T, lead ids.LeadID, kind, direction, capturedBy, source string, at time.Time) {
+	t.Helper()
+	id := ids.NewV7()
+	ctx := context.Background()
+	// direction is NULL for a note: the column's CHECK admits inbound and
+	// outbound and nothing else, and a note has neither.
+	var carried *string
+	if direction != "" {
+		carried = &direction
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity (id, kind, subject, direction, occurred_at, source, captured_by)
+		 VALUES ($1, $2, 'Reply', $3, $4, $5, $6)`,
+		id, kind, carried, at, source, capturedBy); err != nil {
+		t.Fatalf("seeding the %s activity: %v", kind, err)
+	}
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO activity_link (activity_id, entity_type, lead_id) VALUES ($1, 'lead', $2)`,
+		id, lead); err != nil {
+		t.Fatalf("linking the activity to the lead: %v", err)
+	}
+}
+
+// A lead answered before its deadline is not breached, even when the scan runs
+// before the projection catches up.
+//
+// lead.first_response_at is written by a subscriber reacting to
+// activity.captured, so it lags the activity's own commit by the bus's
+// latency. An outbound reply committed at 11:59 against a 12:00 deadline can
+// still be unprojected when a 12:01 scan runs — and the scan owns the
+// consequence: a breach event, an escalation task, and a number on somebody's
+// review. Every activity below is committed WITHOUT running the subscriber,
+// which is the window this reproduces.
+func TestTheScanReadsTheActivitiesRatherThanTheProjection(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	started := time.Now().UTC().Add(-DefaultFirstResponseTarget - time.Hour)
+
+	for name, seed := range map[string]func(lead ids.LeadID, deadline time.Time){
+		// A person's outbound reply, one minute inside the deadline: the case
+		// from the report.
+		"a human's outbound reply": func(lead ids.LeadID, deadline time.Time) {
+			e.seedLeadTouch(t, lead, "email", "outbound", "human:"+e.user.String(), "manual", deadline.Add(-time.Minute))
+		},
+		// A note the rep typed into the composer counts too (§18.1) — the
+		// stepper shows the lead as contacted, so it must not go on to breach
+		// as if nobody had answered.
+		"a note a rep logged": func(lead ids.LeadID, deadline time.Time) {
+			e.seedLeadTouch(t, lead, "note", "", "human:"+e.user.String(), "manual", deadline.Add(-time.Minute))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			lead := e.seedLeadCreatedAt(t, name+"@sla.test", started)
+			state, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+			if err != nil {
+				t.Fatalf("read the lead's deadline: %v", err)
+			}
+			if state.SlaDeadlineAt == nil {
+				t.Fatal("the lead has no first-response deadline, so this case tests nothing")
+			}
+			seed(lead, *state.SlaDeadlineAt)
+
+			breaches, err := e.store.ScanLeadSLA(e.ctx, time.Now().UTC())
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			for _, b := range breaches {
+				if b.LeadID == lead {
+					t.Fatal("a lead answered before its deadline was marked breached — the scan read " +
+						"lead.first_response_at, which the subscriber had not projected yet")
+				}
+			}
+			// And the scan stamped the column itself from what it found, so the
+			// subscriber's later write is the replay it already answers as a
+			// no-op rather than a second first response.
+			after, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after.FirstResponseAt == nil {
+				t.Error("the scan found the response and did not record it, so the next scan re-reads " +
+					"every activity on this lead to reach the same answer")
+			}
+			if after.SlaState != nil && *after.SlaState == crmcontracts.LeadSlaStateBreached {
+				t.Error("the lead reads sla_state=breached")
+			}
+		})
+	}
+}
+
+// And the scan still breaches a lead nobody answered: a version that returned
+// "answered" for everything would pass the test above while switching the
+// whole target off.
+func TestTheScanStillBreachesALeadNobodyAnswered(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	lead := e.seedLeadCreatedAt(t, "unanswered@sla.test", time.Now().UTC().Add(-DefaultFirstResponseTarget-time.Hour))
+
+	// An activity that is NOT a first response: an inbound the lead sent, and
+	// an agent's outbound with nothing to respond to (§18.1's anti-pollution
+	// case). Neither may keep the breach away.
+	state, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+	if err != nil || state.SlaDeadlineAt == nil {
+		t.Fatalf("read the lead's deadline: %v (%v)", err, state.SlaDeadlineAt)
+	}
+	e.seedLeadTouch(t, lead, "email", "outbound", "agent:scheduler", "connector", state.SlaDeadlineAt.Add(-time.Minute))
+
+	breaches, err := e.store.ScanLeadSLA(e.ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	found := false
+	for _, b := range breaches {
+		if b.LeadID == lead {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("a lead nobody answered was not breached — an agent's cold outbound is not a first " +
+			"response, and treating it as one turns the whole target off")
+	}
+}
+
+// A reply AFTER the deadline is not an answer in time, and must not rescue the
+// lead from a breach it has already earned.
+func TestALateReplyDoesNotRescueTheLead(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	lead := e.seedLeadCreatedAt(t, "late@sla.test", time.Now().UTC().Add(-DefaultFirstResponseTarget-time.Hour))
+	state, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+	if err != nil || state.SlaDeadlineAt == nil {
+		t.Fatalf("read the lead's deadline: %v (%v)", err, state.SlaDeadlineAt)
+	}
+	e.seedLeadTouch(t, lead, "email", "outbound", "human:"+e.user.String(), "manual", state.SlaDeadlineAt.Add(time.Minute))
+
+	breaches, err := e.store.ScanLeadSLA(e.ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, b := range breaches {
+		if b.LeadID == lead {
+			return
+		}
+	}
+	t.Fatal("a lead answered a minute LATE was not breached — the re-check must be bounded by the " +
+		"deadline, or the target only ever fires for a lead nobody answered at all")
+}


### PR DESCRIPTION
Closes #1671.

## The defect

`ScanLeadSLA` judged `lead.first_response_at`. That column is a **projection**: an event subscriber (`leadslaworkflow.go`) writes it reacting to `activity.captured`, so it lags the activity's own commit by the bus's latency.

An outbound reply committed at 11:59 against a 12:00 deadline can still be unprojected when a 12:01 scan runs. The lead then reads as unanswered — because the projection has not caught up, not because nobody answered — and the scan emits `lead.sla_breached`, creates the escalation task, and puts a number on somebody's review.

The scan owns those consequences, so it reads the ground truth rather than the projection.

## The fix

Each candidate is re-checked against the **activities** before it is marked, inside the transaction that already holds the row from `SELECT … FOR UPDATE SKIP LOCKED`. Where a genuine first response is found at or before the deadline, the scan **stamps the column itself** from that activity — so the subscriber's later write is the replay `recordFirstResponseTx` already answers as a no-op, and the next scan does not re-read every activity on the lead to reach the same answer.

## One rule, not two

The risk in a fix like this is writing a second definition of "genuine response" — in SQL, next to the Go one — and having the scan and the subscriber quietly disagree about who was answered.

So the rule is not restated. `leadTouchesFor` returns the same `leadResponseTouch` shape the subscriber judges, with the same `hadInbound` sub-select, and `isFirstResponseActivity` — the §18.1 rule itself — decides each touch. The two queries differ only in which end they start from, which is what each caller knows: the subscriber starts from one activity and finds its leads; the scan starts from one lead and finds its activities.

`RecordLeadFirstResponse`'s body moved into a tx-scoped `recordFirstResponseTx` for the same reason: the subscriber opens its own transaction for it, the scan calls it holding the row it is about to judge, and a second implementation there would be a second answer to *what counts as the first response* and *when is a stamp a replay* — in the one place where getting either wrong marks a lead that was answered.

## Four integration cases

Every one commits the activity **without running the subscriber**, which is the window being reproduced:

| case | expected |
|---|---|
| a human's outbound reply, one minute inside the deadline | no breach, and `first_response_at` stamped |
| a note a rep logged into the composer (§18.1 counts it) | no breach, and stamped |
| a lead nobody answered — only an agent's cold outbound | **still breaches** |
| a human's reply one minute **late** | **still breaches** |

The last two are what stop the fix from being "answered = true": a version that rescued everything would pass the first two while switching the whole target off, and one whose re-check was unbounded would only ever fire for a lead nobody answered at all.

## Mutation-checked from the other end

| mutation | result |
|---|---|
| skip the re-check (the original behaviour) | **caught** — both answered cases report the false breach in the report's own words |
| widen the deadline bound by a day | **caught** — the late reply rescues the lead, and `TestTheScanStillBreachesALeadNobodyAnswered` keeps passing, so the two cases are independent |

## Verification

- `make check-backend` — green
- `make test-it DIR=backend/internal/modules/people` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lead SLA scans now recognize qualifying replies and notes recorded before the deadline, preventing incorrect breach escalations.
  * Leads without a qualifying response still breach as expected.
  * Responses received after the deadline no longer prevent a breach.

* **Tests**
  * Added coverage for activity-based response detection and deadline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->