### PR TITLE
The lane gate reads code, not prose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,6 +903,10 @@ test-migration-versions:
 ## real Postgres/Redis; real-infra suites carry //go:build integration.
 test-lanes:
 	@./scripts/check-test-lanes.sh
+## check-test-lanes.test.sh runs beside it because the gate reports OK both when
+## it read every file and when its comment stripper read none of them — an awk
+## program that failed to load printed exactly the same line as a clean tree.
+	@bash ./scripts/check-test-lanes.test.sh
 
 ## env-reads — OPS-CFG-2: configuration is read once at the composition root,
 ## never by a package below it (ratcheted via scripts/env-read-waivers.txt;

--- a/scripts/check-test-lanes.sh
+++ b/scripts/check-test-lanes.sh
@@ -19,6 +19,25 @@ cd "$(dirname "$0")/.."
 # port contract); a unit test reaching for them is in the wrong lane.
 real='sql\.Open\("(postgres|pgx)"|pgxpool\.New|pgx\.Connect|os\.Getenv\("MARGINCE_TEST_(DSN|APP_DSN|REDIS)"\)|redis\.ParseURL|redis\.New(Universal)?Client'
 
+# CODE, not prose. The markers above are grepped out of the file's TEXT, and a
+# _test.go that merely NAMES one while explaining something is not opening a
+# connection: "a single pgx.Connect" in a sentence about arithmetic was reported
+# as a violation of a rule that file keeps. The workaround such a gate forces is
+# worse than the miss — an author rewords a true comment to avoid a term, and
+# the next reader learns that naming the thing is what is forbidden.
+#
+# So comments are stripped before the match. String literals are NOT, and that
+# is the line: a DSN in a string is exactly the shape this gate looks for, and a
+# stripper that spared strings would spare the violation.
+# The stripper is its own file: an awk program inlined into a shell string has
+# to survive two levels of quoting, and the version that did not was silently
+# empty — which made this gate print OK over a tree it had not read. A file is
+# read by awk itself, and its own test plants a violation to prove it.
+STRIP_AWK="$(dirname "$0")/lib-strip-go-comments.awk"
+
+# strip_comments prints one file's code with its comments removed.
+strip_comments() { awk -f "$STRIP_AWK" "$1"; }
+
 violations=0
 while IFS= read -r f; do
   # Skip files already in a non-unit lane. Build constraints sit anywhere
@@ -26,9 +45,15 @@ while IFS= read -r f; do
   if sed -n '/^package /q;p' "$f" | grep -qE '^//go:build .*(integration|livesmoke)'; then
     continue
   fi
-  if grep -Eq "$real" "$f"; then
+  code="$(strip_comments "$f")"
+  if printf '%s\n' "$code" | grep -Eq "$real"; then
     echo "VIOLATION (unit test opens real infra — add //go:build integration, or fake the boundary): $f"
-    grep -nE "$real" "$f" | sed 's/^/    /'
+    # Reported against the ORIGINAL line, so the number is the one an author
+    # opens and the text is what they wrote — the stripped copy only decides
+    # WHICH lines are reported.
+    printf '%s\n' "$code" | grep -nE "$real" | cut -d: -f1 | while IFS= read -r ln; do
+      printf '    %s:%s\n' "$ln" "$(sed -n "${ln}p" "$f")"
+    done
     violations=1
   fi
 # Search roots: the backend hand-written Go tree. cli/craft is separate

--- a/scripts/check-test-lanes.test.sh
+++ b/scripts/check-test-lanes.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# The lane gate's own test — it gates what the gate READS, not its verdict.
+#
+# check-test-lanes.sh answers about a file's text, and the interesting half of
+# that answer is what it declines to see. A version that reported a comment was
+# shipped: `backend/laneconnbudget_test.go` explained why a term in its
+# arithmetic is what it is, said "a single pgx.Connect" in a sentence, and was
+# reported as opening a connection. The rule was right and the reading was
+# wrong, and what a gate like that produces is not a fix — it is an author
+# rewording a true comment to avoid a term, and the next reader learning that
+# naming the thing is what is forbidden.
+#
+# So each case below is a FILE the gate has to judge, planted in a throwaway
+# tree, and each states the reason it must be judged that way. The two halves
+# are equally load-bearing: a stripper that dropped code would make this gate
+# green over every violation, so every "must be reported" case is as much a
+# test of the stripper as the "must not" ones are.
+#
+# Usage: bash scripts/check-test-lanes.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/check-test-lanes.sh"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+fail() { echo "FAIL: $*" >&2; FAILURES=$((FAILURES + 1)); }
+
+# The gate walks `backend` relative to its own parent, so the fixture tree is
+# built as a whole repository root with the gate copied into it. Copied rather
+# than invoked in place: pointing the real gate at a fixture would have it read
+# this repository's own backend as well, and a violation there would be
+# indistinguishable from the planted one.
+plant() {
+  local name="$1" body="$2"
+  rm -rf "$TMP/repo"
+  mkdir -p "$TMP/repo/scripts" "$TMP/repo/backend"
+  cp "$GATE" "$TMP/repo/scripts/check-test-lanes.sh"
+  cp "$SCRIPT_DIR/lib-strip-go-comments.awk" "$TMP/repo/scripts/"
+  printf '%s\n' "$body" > "$TMP/repo/backend/${name}_test.go"
+}
+
+# reported runs the gate over the planted tree and answers whether it named the
+# file.
+reported() {
+  ! ( cd "$TMP/repo" && ./scripts/check-test-lanes.sh >/dev/null 2>&1 )
+}
+
+# --- must NOT be reported: the marker is prose ------------------------------
+
+plant lineComment 'package x
+
+// db verbs are a single pgx.Connect, and at a handover JOBS of them overlap.
+func TestArithmetic(t *testing.T) {}'
+if reported; then
+  fail "a marker inside a // comment was reported — the gate reads prose as code, which is what forces an author to reword a true sentence"
+fi
+
+plant blockComment 'package x
+
+/*
+Two lines of explanation, one of which says pgxpool.New for a reason.
+*/
+func TestArithmetic(t *testing.T) {}'
+if reported; then
+  fail "a marker inside a /* */ comment was reported"
+fi
+
+plant trailingComment 'package x
+
+func TestArithmetic(t *testing.T) {
+	budget := 24 // the ceiling a pgx.Connect would spend
+	_ = budget
+}'
+if reported; then
+  fail "a marker in a trailing comment was reported"
+fi
+
+# --- must BE reported: the marker is code ----------------------------------
+
+plant realConnect 'package x
+
+func TestOpensAConnection(t *testing.T) {
+	conn, _ := pgx.Connect(ctx, dsn)
+	_ = conn
+}'
+if ! reported; then
+  fail "a real pgx.Connect was NOT reported — the stripper is eating code, and this gate is green over every violation it exists to catch"
+fi
+
+plant realEnv 'package x
+
+func TestReadsTheHarnessDSN(t *testing.T) {
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	_ = dsn
+}'
+if ! reported; then
+  fail "a unit test reaching for MARGINCE_TEST_DSN was NOT reported"
+fi
+
+# A URL inside a string carries `//`, and the marker comes AFTER it ON THE SAME
+# LINE. That ordering is the whole case: a stripper that cuts from the first
+# `//` it sees drops the rest of this line, the marker with it, and the gate
+# reads a file that opens a connection as one that does not. On separate lines
+# the same defect is invisible, which is why they are together here.
+plant urlBeforeMarker 'package x
+
+func TestDialsWithAURL(t *testing.T) {
+	cfg := map[string]string{"docs": "https://example.test/path", "dsn": os.Getenv("MARGINCE_TEST_DSN")}
+	_ = cfg
+}'
+if ! reported; then
+  fail "a marker following a // inside a string literal on the same line was NOT reported — the stripper is cutting at a // it should not have seen"
+fi
+
+# The marker inside a string literal IS the violation's usual shape, so a
+# stripper that spared strings would spare it.
+plant markerInString 'package x
+
+func TestBuildsADSN(t *testing.T) {
+	_ = os.Getenv("MARGINCE_TEST_APP_DSN")
+}'
+if ! reported; then
+  fail "a marker inside a string literal was NOT reported — strings are code here, not prose"
+fi
+
+# --- the lane tag still exempts a file -------------------------------------
+
+plant tagged '//go:build integration
+
+package x
+
+func TestOpensAConnection(t *testing.T) {
+	conn, _ := pgx.Connect(ctx, dsn)
+	_ = conn
+}'
+if reported; then
+  fail "a file carrying //go:build integration was reported — the tag is what the whole rule is stated in terms of"
+fi
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "" >&2
+  echo "$FAILURES case(s) failed." >&2
+  exit 1
+fi
+echo "==> test-lanes census: comments are prose, strings and calls are code (8 cases)"

--- a/scripts/lib-strip-go-comments.awk
+++ b/scripts/lib-strip-go-comments.awk
@@ -1,0 +1,47 @@
+# Strip Go comments, leaving code (and string literals) in place.
+#
+# Character by character with three states, because every shorter version is
+# wrong on the input this gate actually reads: `sed 's|//.*||'` cuts a URL out
+# of a string literal, and any regex that tries to spare strings has to know
+# about escapes, which regexes do not.
+#
+# What it must never do is drop CODE — a stripper that swallowed a real call
+# would turn this gate green over the violation it exists to catch — so a
+# character is only ever dropped while a comment is provably open.
+{
+  line = $0
+  out = ""
+  i = 1
+  n = length(line)
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (block) {
+      if (c == "*" && substr(line, i + 1, 1) == "/") { block = 0; i += 2; continue }
+      i++
+      continue
+    }
+    if (raw) {
+      out = out c
+      if (c == "`") raw = 0
+      i++
+      continue
+    }
+    if (str) {
+      out = out c
+      if (c == "\\") { out = out substr(line, i + 1, 1); i += 2; continue }
+      if (c == quote) str = 0
+      i++
+      continue
+    }
+    if (c == "`") { raw = 1; out = out c; i++; continue }
+    if (c == "\"" || c == "'") { str = 1; quote = c; out = out c; i++; continue }
+    if (c == "/" && substr(line, i + 1, 1) == "/") break
+    if (c == "/" && substr(line, i + 1, 1) == "*") { block = 1; i += 2; continue }
+    out = out c
+    i++
+  }
+  # A raw string spans lines; an interpreted one cannot, so a `str` still open
+  # at end of line is a lexical error in the file rather than state to carry.
+  str = 0
+  print out
+}


### PR DESCRIPTION
Closes #1741.

## The defect

`check-test-lanes.sh` decides whether an untagged `*_test.go` opens real infrastructure by grepping the file's **text** for the constructors only a real connection uses. Comments included. So a file that merely *names* one while explaining something is reported as opening it:

```
VIOLATION (unit test opens real infra — add //go:build integration, or fake the boundary): backend/laneconnbudget_test.go
    111:// db verbs are a single pgx.Connect, and at a handover JOBS of them overlap.
```

That file opens nothing — it reads three configuration files and does arithmetic, and the offending line is a sentence explaining why a term in that arithmetic is what it is.

The rule is right and the reading is wrong, and what a gate like that produces is not a fix: an author rewords a true comment to avoid a term, and the next reader learns that *naming* the thing is what is forbidden.

## The fix

Comments are stripped before the match. **String literals are not**, and that is the line — a DSN in a string is exactly the shape this gate looks for, so a stripper that spared strings would spare the violation.

The stripper is `scripts/lib-strip-go-comments.awk`, a character-by-character state machine over three states (interpreted string, raw string, block comment). Every shorter version is wrong on the input this gate actually reads: `sed 's|//.*||'` cuts a URL out of a string literal, and any regex that tries to spare strings has to know about escapes, which regexes do not.

It is **its own file rather than a shell string**, and that turned out to matter: the inlined version had to survive two levels of quoting, the one that did not was silently empty, and the gate then printed `OK` over a tree it had not read. Its own test caught that within a minute of existing.

Findings are still reported against the **original** line — the number an author opens and the text they wrote. The stripped copy only decides *which* lines are reported.

## Its own test

`scripts/check-test-lanes.test.sh` plants eight files in a throwaway tree and states why each must be judged the way it is. Wired into `make test-lanes` beside the gate, because the gate reports `OK` both when it read every file and when its stripper read none of them.

Must **not** be reported — the marker is prose: a `//` comment, a `/* */` block, a trailing comment.

Must **be** reported — the marker is code: a real `pgx.Connect`; a unit test reaching for `MARGINCE_TEST_DSN`; a marker following a `//` **inside a string literal on the same line**; a marker inside a string literal, which is the violation's usual shape.

And the lane tag still exempts a file, which is what the whole rule is stated in terms of.

The must-be-reported half carries as much weight as the other: a stripper that ate code would make this gate green over every violation it exists to catch, and four of the eight say so.

## Mutation-checked from the other end

| mutation | result |
|---|---|
| the naive `sub(/\/\/.*/, "")` everyone reaches for | **caught** — misses the `/* */` case |
| a stripper that drops everything (fail-open) | **caught** — 4 cases, including *"the stripper is eating code, and this gate is green over every violation it exists to catch"* |
| a stripper that stops tracking string literals | **caught** — the same-line URL case, which is the only shape that discriminates |

The third mutation initially passed, because the URL and the marker were on separate lines and the defect is invisible that way. The fixture now puts them together, and the comment says why.

## Verification

- `make test-lanes` — green, both arms
- `make check-backend` — green
- Planted a real violation in `backend/` and confirmed the report names line 7 with its own text while ignoring the `pgx.Connect` sentence on line 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-lane validation to ignore database and Redis markers found only in Go comments.
  * Continued detecting markers in executable code and string literals.
  * Preserved exemptions for integration-tagged files.

* **Tests**
  * Added automated coverage for comment handling, string literals, environment access, and integration-tagged files.
  * Included the new validation test in the standard test-lane checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->