### PR TITLE
The next refresh-review timeout answers instead of being seen

### DIFF
--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -243,7 +243,11 @@ const SELECTABLE = 2;
 //
 // It costs nothing on a green run: onTimeout is called only on the failing
 // path, and what it returns is the error vitest then reports.
-function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
+function diagnose(
+  stub: ReturnType<typeof backend>,
+  card: HTMLElement,
+  awaited: string,
+) {
   return (error: Error): Error => {
     const calls = stub.mock.calls
       .map(([input]) => {
@@ -252,19 +256,25 @@ function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
         return `  ${method} ${new URL(request).pathname}`;
       })
       .join("\n");
-    // The card's own words, trimmed: a rendered error state, a spinner, or an
-    // empty shell each read differently here, and which of the three it is
-    // decides where to look next.
-    const rendered = (document.body.textContent ?? "")
-      .replace(/\s+/g, " ")
-      .trim()
-      .slice(0, 600);
+    // The card's own words: a rendered error state, a spinner, or an empty
+    // shell each read differently here, and which of the three it is decides
+    // where to look next.
+    //
+    // Read off the render's own container rather than document.body, and kept
+    // from BOTH ends rather than trimmed to the first n. The review renders
+    // AFTER the facts and source sections, so a head-only excerpt is exactly
+    // the excerpt that cannot contain the thing being waited for — the heading,
+    // the comparison rows, or the error rendered where they should be. The
+    // middle is what a reader can afford to lose.
+    const rendered = excerpt(
+      (card.textContent ?? "").replace(/\s+/g, " ").trim(),
+    );
     error.message = [
       error.message,
       "",
       `--- ${awaited} never arrived ---`,
       "",
-      `the card rendered: ${rendered || "(nothing)"}`,
+      `the card rendered: ${rendered}`,
       "",
       calls
         ? `the fetch stub was called:\n${calls}`
@@ -272,6 +282,18 @@ function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
     ].join("\n");
     return error;
   };
+}
+
+// excerpt keeps a failure readable without losing the end of the card, which is
+// where everything these waiters wait for renders.
+const EXCERPT_HEAD = 300;
+const EXCERPT_TAIL = 700;
+
+function excerpt(text: string): string {
+  if (text.length <= EXCERPT_HEAD + EXCERPT_TAIL) {
+    return text || "(nothing)";
+  }
+  return `${text.slice(0, EXCERPT_HEAD)} … ${text.slice(-EXCERPT_TAIL)}`;
 }
 
 // Renders the card and drives it to the review step, where the comparison
@@ -282,7 +304,7 @@ async function renderReview() {
   // cannot be asked what it was called with.
   const stub = backend();
   vi.stubGlobal("fetch", stub);
-  render(
+  const { container } = render(
     <Providers>
       <CompanyContextCard />
     </Providers>,
@@ -295,13 +317,19 @@ async function renderReview() {
   const refresh = await screen.findByRole(
     "button",
     { name: "Refresh from website" },
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the refresh button") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the refresh button"),
+    },
   );
   fireEvent.click(refresh);
   await screen.findByRole(
     "heading",
     { name: "Review what changed" },
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the review heading") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the review heading"),
+    },
   );
   // The heading is not the last thing to arrive: the comparison cards commit
   // from the site read that the heading only announces, so waiting on the
@@ -310,7 +338,10 @@ async function renderReview() {
   // test is settled rather than merely started.
   await waitFor(
     () => expect(screen.getAllByRole("checkbox")).toHaveLength(SELECTABLE),
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the comparison rows") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the comparison rows"),
+    },
   );
 }
 

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -221,10 +221,67 @@ const DIALOG_MS = SETTLE_MS * 3;
 // nothing, so neither carries a checkbox.
 const SELECTABLE = 2;
 
+// diagnose turns a waiter's timeout into an answer instead of another sighting.
+//
+// The refresh-review chain has failed in CI across five PRs, and every
+// occurrence reported the same sentence:
+//
+//	TestingLibraryElementError: Unable to find role="heading" and name "Review what changed"
+//
+// which says the heading is absent and NOTHING about why — whether the POST
+// that starts the read ever landed, whether the GET that fetches it returned,
+// whether the query is still pending, or whether the card rendered an error
+// where the review should be. All of that is already in the fixture: the stub
+// is a vi.fn, so its call log is readable, and the container is rendered.
+//
+// Measurement is why this is the fix rather than a bigger budget: the chain
+// costs about a second and does not move under four times the CPU
+// oversubscription, so a timeout here is a HANG and not a slow settle. Nothing
+// about a busy runner explains ten seconds of work that takes 0.9. A larger
+// SETTLE_MS, a retry or a sleep would each make the next occurrence quieter
+// without making it answerable.
+//
+// It costs nothing on a green run: onTimeout is called only on the failing
+// path, and what it returns is the error vitest then reports.
+function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
+  return (error: Error): Error => {
+    const calls = stub.mock.calls
+      .map(([input]) => {
+        const request = input instanceof Request ? input.url : String(input);
+        const method = input instanceof Request ? input.method : "GET";
+        return `  ${method} ${new URL(request).pathname}`;
+      })
+      .join("\n");
+    // The card's own words, trimmed: a rendered error state, a spinner, or an
+    // empty shell each read differently here, and which of the three it is
+    // decides where to look next.
+    const rendered = (document.body.textContent ?? "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 600);
+    error.message = [
+      error.message,
+      "",
+      `--- ${awaited} never arrived ---`,
+      "",
+      `the card rendered: ${rendered || "(nothing)"}`,
+      "",
+      calls
+        ? `the fetch stub was called:\n${calls}`
+        : "the fetch stub was never called",
+    ].join("\n");
+    return error;
+  };
+}
+
 // Renders the card and drives it to the review step, where the comparison
 // cards live.
 async function renderReview() {
-  vi.stubGlobal("fetch", backend());
+  // The stub is held rather than passed straight to stubGlobal: its call log is
+  // half of what diagnose reports, and a stub nothing kept a reference to
+  // cannot be asked what it was called with.
+  const stub = backend();
+  vi.stubGlobal("fetch", stub);
   render(
     <Providers>
       <CompanyContextCard />
@@ -238,13 +295,13 @@ async function renderReview() {
   const refresh = await screen.findByRole(
     "button",
     { name: "Refresh from website" },
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the refresh button") },
   );
   fireEvent.click(refresh);
   await screen.findByRole(
     "heading",
     { name: "Review what changed" },
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the review heading") },
   );
   // The heading is not the last thing to arrive: the comparison cards commit
   // from the site read that the heading only announces, so waiting on the
@@ -253,7 +310,7 @@ async function renderReview() {
   // test is settled rather than merely started.
   await waitFor(
     () => expect(screen.getAllByRole("checkbox")).toHaveLength(SELECTABLE),
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the comparison rows") },
   );
 }
 


### PR DESCRIPTION
Closes #1747.

## Why this and not a bigger budget

#1747 measured the chain instead of guessing at it, and the numbers rule out the whole family of explanations:

| configuration | "names the field each change checkbox selects" |
|---|---|
| the file alone, idle machine | 930 ms |
| full suite, **40 busy loops (4× oversubscribed)** | **898 ms** |
| full suite + v8 coverage, 16 busy loops | 649 ms |
| all 246 files in one shared process | 36 ms |

The chain costs about a second and **does not move under CPU pressure**. At its worst it spends 9% of its `SETTLE_MS = 10_000` budget. So a timeout there is a **hang, not a slow settle**, and nothing about a busy runner explains ten seconds of work that takes 0.9 under four times the load.

Raising `SETTLE_MS`, adding a retry, or adding a sleep would each make the next occurrence quieter without making it answerable. #613 was right to forbid all three; this PR is the measurement's own conclusion.

## What it does

Every occurrence so far has reported exactly one sentence:

```
TestingLibraryElementError: Unable to find role="heading" and name "Review what changed"
```

which says the heading is absent and nothing about **why** — whether the POST that starts the read ever landed, whether the GET that fetches it returned, whether the query is still pending, or whether the card rendered an error where the review should be.

All of that was already in the fixture. `backend()` is a `vi.fn`, so its call log is readable; the container is rendered. The only thing missing was a reference to the stub — it was passed straight to `stubGlobal` and discarded.

So each of the three waiters in `renderReview` now carries an `onTimeout` that prints the card's rendered text and the stub's calls. It costs nothing on a green run: `onTimeout` runs only on the failing path, and what it returns is the error vitest reports.

## Verified by simulating the hang

The site-read route made to throw, `SETTLE_MS` dropped so it fires quickly:

```
--- the review heading never arrived ---

the card rendered: What Margince knows about your companyKeep the shared business
context behind drafting, offers, search, and governed agents accurate… Company
nameAcmeEdit… (the seeded form, and no review)

the fetch stub was called:
  GET /v1/company/context/capabilities
  GET /v1/me
  GET /v1/company
  POST /v1/company/site-reads
```

Which localises it in one read: **the POST landed and no poll followed**. Against the real failure the same output distinguishes the four candidates immediately — a POST that never landed, a GET that never returned, a query still pending, or an error state rendered where the review should be.

## Verification

- `pnpm exec vitest run src/screens/company-context.test.tsx` — 7 passing
- `make check-fe` — green

## Unblocks

#1717 notes it is blocked on this file being editable, which was blocked on this. I will take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for company context review tests.
  * Timeout reports now include bounded excerpts from the rendered review card, showing both the beginning and end of visible content.
  * Enhanced waiting checks provide clearer context when refresh controls, review headings, or comparison details do not appear as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->