### PR TITLE
Two write-posture cases state their own ceiling

### DIFF
--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -243,7 +243,11 @@ const SELECTABLE = 2;
 //
 // It costs nothing on a green run: onTimeout is called only on the failing
 // path, and what it returns is the error vitest then reports.
-function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
+function diagnose(
+  stub: ReturnType<typeof backend>,
+  card: HTMLElement,
+  awaited: string,
+) {
   return (error: Error): Error => {
     const calls = stub.mock.calls
       .map(([input]) => {
@@ -252,19 +256,25 @@ function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
         return `  ${method} ${new URL(request).pathname}`;
       })
       .join("\n");
-    // The card's own words, trimmed: a rendered error state, a spinner, or an
-    // empty shell each read differently here, and which of the three it is
-    // decides where to look next.
-    const rendered = (document.body.textContent ?? "")
-      .replace(/\s+/g, " ")
-      .trim()
-      .slice(0, 600);
+    // The card's own words: a rendered error state, a spinner, or an empty
+    // shell each read differently here, and which of the three it is decides
+    // where to look next.
+    //
+    // Read off the render's own container rather than document.body, and kept
+    // from BOTH ends rather than trimmed to the first n. The review renders
+    // AFTER the facts and source sections, so a head-only excerpt is exactly
+    // the excerpt that cannot contain the thing being waited for — the heading,
+    // the comparison rows, or the error rendered where they should be. The
+    // middle is what a reader can afford to lose.
+    const rendered = excerpt(
+      (card.textContent ?? "").replace(/\s+/g, " ").trim(),
+    );
     error.message = [
       error.message,
       "",
       `--- ${awaited} never arrived ---`,
       "",
-      `the card rendered: ${rendered || "(nothing)"}`,
+      `the card rendered: ${rendered}`,
       "",
       calls
         ? `the fetch stub was called:\n${calls}`
@@ -272,6 +282,18 @@ function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
     ].join("\n");
     return error;
   };
+}
+
+// excerpt keeps a failure readable without losing the end of the card, which is
+// where everything these waiters wait for renders.
+const EXCERPT_HEAD = 300;
+const EXCERPT_TAIL = 700;
+
+function excerpt(text: string): string {
+  if (text.length <= EXCERPT_HEAD + EXCERPT_TAIL) {
+    return text || "(nothing)";
+  }
+  return `${text.slice(0, EXCERPT_HEAD)} … ${text.slice(-EXCERPT_TAIL)}`;
 }
 
 // Renders the card and drives it to the review step, where the comparison
@@ -282,7 +304,7 @@ async function renderReview() {
   // cannot be asked what it was called with.
   const stub = backend();
   vi.stubGlobal("fetch", stub);
-  render(
+  const { container } = render(
     <Providers>
       <CompanyContextCard />
     </Providers>,
@@ -295,13 +317,19 @@ async function renderReview() {
   const refresh = await screen.findByRole(
     "button",
     { name: "Refresh from website" },
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the refresh button") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the refresh button"),
+    },
   );
   fireEvent.click(refresh);
   await screen.findByRole(
     "heading",
     { name: "Review what changed" },
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the review heading") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the review heading"),
+    },
   );
   // The heading is not the last thing to arrive: the comparison cards commit
   // from the site read that the heading only announces, so waiting on the
@@ -310,7 +338,10 @@ async function renderReview() {
   // test is settled rather than merely started.
   await waitFor(
     () => expect(screen.getAllByRole("checkbox")).toHaveLength(SELECTABLE),
-    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the comparison rows") },
+    {
+      timeout: SETTLE_MS,
+      onTimeout: diagnose(stub, container, "the comparison rows"),
+    },
   );
 }
 

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -221,10 +221,67 @@ const DIALOG_MS = SETTLE_MS * 3;
 // nothing, so neither carries a checkbox.
 const SELECTABLE = 2;
 
+// diagnose turns a waiter's timeout into an answer instead of another sighting.
+//
+// The refresh-review chain has failed in CI across five PRs, and every
+// occurrence reported the same sentence:
+//
+//	TestingLibraryElementError: Unable to find role="heading" and name "Review what changed"
+//
+// which says the heading is absent and NOTHING about why — whether the POST
+// that starts the read ever landed, whether the GET that fetches it returned,
+// whether the query is still pending, or whether the card rendered an error
+// where the review should be. All of that is already in the fixture: the stub
+// is a vi.fn, so its call log is readable, and the container is rendered.
+//
+// Measurement is why this is the fix rather than a bigger budget: the chain
+// costs about a second and does not move under four times the CPU
+// oversubscription, so a timeout here is a HANG and not a slow settle. Nothing
+// about a busy runner explains ten seconds of work that takes 0.9. A larger
+// SETTLE_MS, a retry or a sleep would each make the next occurrence quieter
+// without making it answerable.
+//
+// It costs nothing on a green run: onTimeout is called only on the failing
+// path, and what it returns is the error vitest then reports.
+function diagnose(stub: ReturnType<typeof backend>, awaited: string) {
+  return (error: Error): Error => {
+    const calls = stub.mock.calls
+      .map(([input]) => {
+        const request = input instanceof Request ? input.url : String(input);
+        const method = input instanceof Request ? input.method : "GET";
+        return `  ${method} ${new URL(request).pathname}`;
+      })
+      .join("\n");
+    // The card's own words, trimmed: a rendered error state, a spinner, or an
+    // empty shell each read differently here, and which of the three it is
+    // decides where to look next.
+    const rendered = (document.body.textContent ?? "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 600);
+    error.message = [
+      error.message,
+      "",
+      `--- ${awaited} never arrived ---`,
+      "",
+      `the card rendered: ${rendered || "(nothing)"}`,
+      "",
+      calls
+        ? `the fetch stub was called:\n${calls}`
+        : "the fetch stub was never called",
+    ].join("\n");
+    return error;
+  };
+}
+
 // Renders the card and drives it to the review step, where the comparison
 // cards live.
 async function renderReview() {
-  vi.stubGlobal("fetch", backend());
+  // The stub is held rather than passed straight to stubGlobal: its call log is
+  // half of what diagnose reports, and a stub nothing kept a reference to
+  // cannot be asked what it was called with.
+  const stub = backend();
+  vi.stubGlobal("fetch", stub);
   render(
     <Providers>
       <CompanyContextCard />
@@ -238,13 +295,13 @@ async function renderReview() {
   const refresh = await screen.findByRole(
     "button",
     { name: "Refresh from website" },
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the refresh button") },
   );
   fireEvent.click(refresh);
   await screen.findByRole(
     "heading",
     { name: "Review what changed" },
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the review heading") },
   );
   // The heading is not the last thing to arrive: the comparison cards commit
   // from the site read that the heading only announces, so waiting on the
@@ -253,7 +310,7 @@ async function renderReview() {
   // test is settled rather than merely started.
   await waitFor(
     () => expect(screen.getAllByRole("checkbox")).toHaveLength(SELECTABLE),
-    { timeout: SETTLE_MS },
+    { timeout: SETTLE_MS, onTimeout: diagnose(stub, "the comparison rows") },
   );
 }
 

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -11,6 +11,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SLOWEST_MEASURED_TEST_MS } from "../../vitest.budget";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { CompanyContextCard } from "./company-context";
@@ -216,6 +217,23 @@ const TEST_MS = SETTLE_MS * 4;
 // ceiling that covers the waiters, not waiters trimmed to fit a ceiling.
 const DIALOG_MS = SETTLE_MS * 3;
 
+// The budget for the two write-posture cases, which drive `renderAs` — one
+// waiter at SETTLE_MS — and then assert about a loaded card.
+//
+// Stated rather than left on the suite default, and that is the whole point of
+// it. These two raised their waiters FILE-WIDE (SETTLE_MS is 10s here, where
+// every other test in the default population sits at 7s or below) and said
+// nothing, so they stayed in the population the suite ceiling is measured over
+// and dragged it up with them: testTimeout was 13437ms rather than 10437ms,
+// and a genuinely stuck test anywhere in the suite took three seconds longer to
+// go red — including the deliberately fast-red cases in this same file.
+//
+// A test that deliberately raises its own waiters owes its own ceiling and then
+// leaves that population. That is what read-conclusion, onboarding-restore,
+// voice-act, integrations-provider and onboarding all do; these two were the
+// exception, and the only ones.
+const POSTURE_TEST_MS = SETTLE_MS + SLOWEST_MEASURED_TEST_MS;
+
 // The fixture's two selectable changes — the `new` and `machine_change` rows.
 // The human_conflict row is decided by radio and the unchanged row offers
 // nothing, so neither carries a checkbox.
@@ -393,29 +411,37 @@ describe("CompanyContextCard write posture", () => {
     });
   }
 
-  it("withholds both writes from a seat that holds none, and says so", async () => {
-    await renderAs(ME_READER);
+  it(
+    "withholds both writes from a seat that holds none, and says so",
+    async () => {
+      await renderAs(ME_READER);
 
-    // The read is granted, so the data is there to read — as the row's own
-    // answer now rather than as the contents of an input.
-    expect(screen.getByText(COMPANY.offer_summary ?? "")).toBeTruthy();
-    // Stated once, at the surface, rather than annotated onto each absent
-    // control.
-    expect(screen.getByText(READ_ONLY)).toBeTruthy();
-    expect(screen.queryByRole("button", { name: EDIT_OFFER })).toBeNull();
-    expect(screen.queryByRole("button", { name: REFRESH })).toBeNull();
-  });
+      // The read is granted, so the data is there to read — as the row's own
+      // answer now rather than as the contents of an input.
+      expect(screen.getByText(COMPANY.offer_summary ?? "")).toBeTruthy();
+      // Stated once, at the surface, rather than annotated onto each absent
+      // control.
+      expect(screen.getByText(READ_ONLY)).toBeTruthy();
+      expect(screen.queryByRole("button", { name: EDIT_OFFER })).toBeNull();
+      expect(screen.queryByRole("button", { name: REFRESH })).toBeNull();
+    },
+    POSTURE_TEST_MS,
+  );
 
-  it("offers both writes to a seat that may author the profile", async () => {
-    await renderAs(ME_EDITOR);
+  it(
+    "offers both writes to a seat that may author the profile",
+    async () => {
+      await renderAs(ME_EDITOR);
 
-    // Without this arm the test above would pass on a card that renders no
-    // buttons for anybody.
-    expect(screen.getByRole("button", { name: EDIT_OFFER })).toBeTruthy();
-    expect(screen.getByRole("button", { name: REFRESH })).toBeTruthy();
-    // A reader who may write is told nothing about a posture they do not have.
-    expect(screen.queryByText(READ_ONLY)).toBeNull();
-  });
+      // Without this arm the test above would pass on a card that renders no
+      // buttons for anybody.
+      expect(screen.getByRole("button", { name: EDIT_OFFER })).toBeTruthy();
+      expect(screen.getByRole("button", { name: REFRESH })).toBeTruthy();
+      // A reader who may write is told nothing about a posture they do not have.
+      expect(screen.queryByText(READ_ONLY)).toBeNull();
+    },
+    POSTURE_TEST_MS,
+  );
 
   // One PUT writes this profile, so there is one form and one Save — and both
   // are behind a row's verb rather than standing on the card. A row states an

--- a/frontend/vitest.budget.ts
+++ b/frontend/vitest.budget.ts
@@ -76,7 +76,7 @@ export const ASYNC_UTIL_TIMEOUT_MS = 1_000;
  * ceiling that test actually runs under, so a suite cannot quietly join this one
  * while spending like the other.
  */
-export const MAX_DEFAULT_WAITER_BUDGET_MS = 10_000;
+export const MAX_DEFAULT_WAITER_BUDGET_MS = 7_000;
 
 /**
  * The slowest single test measured under deliberate load, in milliseconds —


### PR DESCRIPTION
Closes #1717.

**Stacked on #3077** (which closes #1747), because that is the sequencing #1717 itself records: it is *"blocked on this file being editable, which is blocked on"* the refresh-review investigation. #613 is closed and #3077 carries the diagnostic that investigation asked for, so this is now free to land. Retarget to `main` once #3077 merges.

## The defect

`vitest.budget.ts` derives the suite-wide `testTimeout` from the **widest waiter budget among tests that state no ceiling of their own**. That measurement was 10000ms, and both tests setting it were in one file — the two write-posture cases in `company-context.test.tsx`:

- *"withholds both writes from a seat that holds none, and says so"*
- *"offers both writes to a seat that may author the profile"*

They drive `renderAs`, which waits once at that file's own `SETTLE_MS = 10_000`. Every other test in the default population sits at 7000ms or below.

The model the budget file states is that a test which deliberately raises its own waiters **owes its own ceiling and then leaves that population** — which is what `read-conclusion`, `onboarding-restore`, `voice-act`, `integrations-provider` and `onboarding` all do. These two raised their waiters file-wide and stated nothing, so they stayed in the population the global is measured over and dragged it with them.

Everything else paid: `testTimeout` was **13437ms rather than 10437ms**, so a genuinely stuck test anywhere in the suite took three seconds longer to go red — including the deliberately fast-red cases in that same file.

## The change

`POSTURE_TEST_MS = SETTLE_MS + SLOWEST_MEASURED_TEST_MS`, applied to both, in the shape `integrations-provider.test.tsx` already uses. `MAX_DEFAULT_WAITER_BUDGET_MS` drops 10000 → 7000, and the suite ceiling follows to 10437ms.

## The number is measured, not asserted

`scripts/test-budget.test.ts` re-measures the constant on every run against every test's actual waiter budget. Declaring 6000 instead:

```
AssertionError: expected 7000 to be 6000
```

So 7000 is what the tree now contains — the two cases have genuinely left the population, rather than the constant having been edited to match an intention.

## Verification

- `make check-fe` — green: **433 files, 5364 tests**, plus the 36 in the gate suites
- `pnpm exec vitest run scripts/test-budget.test.ts src/screens/company-context.test.tsx` — 13 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)