### PR TITLE
A worker notices the release moving under it

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -91,6 +91,9 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	if err := compose.AssertInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion); err != nil {
 		return err
 	}
+	// And again on a tick, because the boot check answers once.
+	ctx, stopForReleaseSkew, releaseSkewErr := watchReleaseSkew(ctx, pool, logger)
+	defer stopForReleaseSkew()
 
 	// Before this role does any work, so an operator mistake never leaves a
 	// worker running on a license the api refuses to boot on. The RUNNING
@@ -204,7 +207,22 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	defer started.draining()
 
 	relayUntilSignal(ctx, cfg, pool, rdb, logger, stdout)
-	return nil
+	return releaseSkewRefusal(releaseSkewErr)
+}
+
+// releaseSkewRefusal is why the relay returned: a signal, or the release guard.
+//
+// The relay wakes on either, and only one of them is a fault. A signal leaves
+// the channel empty and the role exits zero; a confirmed release change answers
+// the refusal, so the process exits non-zero into the crash loop the boot guard
+// already produces.
+func releaseSkewRefusal(refused <-chan error) error {
+	select {
+	case err := <-refused:
+		return err
+	default:
+		return nil
+	}
 }
 
 // registerComposedExtensions registers the composed extension set before
@@ -331,4 +349,46 @@ func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Gr
 func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, vault keyvault.Vault, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
 	_, err := compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, posture, config.FromOS)
 	return err
+}
+
+// watchReleaseSkew starts the periodic half of the release guard and hands run
+// what it needs to act on it: a context the watcher can put the role down
+// through, the cancel to release on the ordinary path, and the channel the exit
+// reads.
+//
+// The boot check answers once. Roll only the api and this role keeps the relay,
+// the retention evaluator and the agent runner pointed at a schema and an event
+// contract that are not its own, with nothing logged and nothing crash-looping
+// — the state the guard exists to prevent, reached by a partial deploy rather
+// than a torn pull.
+//
+// The cancel is what turns the watcher's answer into an exit: the lanes and the
+// relay all run on the context returned here, so cancelling it puts the role
+// down the way a signal does, and run returns the refusal afterwards so the
+// process exits NON-ZERO into the crash loop the boot guard already produces.
+//
+// The refusal travels by CHANNEL rather than by a variable the goroutine
+// writes: the send happens before the cancel that lets the relay return, so
+// run's read is ordered after it by the channel rather than by an argument
+// about when the relay wakes.
+//
+// See compose/releasewatch.go for why a single differing read is not enough and
+// why a read failure is not a difference.
+func watchReleaseSkew(
+	ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger,
+) (context.Context, context.CancelFunc, <-chan error) {
+	ctx, stop := context.WithCancel(ctx)
+	skew := compose.WatchInstallationRelease(
+		ctx, pool, logger, buildinfo.ReleaseVersion, compose.ReleaseRecheckInterval)
+	refused := make(chan error, 1)
+	go func() {
+		err, stopping := <-skew
+		if !stopping || err == nil {
+			return
+		}
+		refused <- err
+		logger.Error("release guard: stopping this role", "err", err)
+		stop()
+	}()
+	return ctx, stop, refused
 }

--- a/backend/internal/compose/releasewatch.go
+++ b/backend/internal/compose/releasewatch.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The release guard's second half: the one that runs while the role does.
+//
+// AssertInstallationRelease answers at BOOT, which catches the case it was
+// written for — a torn tag pull, where every role is new and every role boots.
+// It cannot catch the other shape: one role restarting alone. Roll only the api
+// and its entrypoint migrates and records the new release; the worker that was
+// already running keeps the outbox relay, the retention evaluator and the agent
+// runner pointed at a schema and an event contract that are not its own,
+// indefinitely, with nothing logged and nothing crash-looping. That is exactly
+// "half of one release beside half of another", which is the state the guard
+// exists to prevent, and the next unrelated restart is when it surfaces.
+//
+// So the record is re-read on a tick, and a confirmed difference stops the
+// process — non-zero, so the orchestrator restarts it into the visible crash
+// loop AssertInstallationRelease already produces. This watcher never decides
+// anything the boot guard would not; it only notices later.
+//
+// TWO RULES MAKE IT SAFE TO RUN, and both are about what it must NOT do.
+//
+// It must not exit on an unreadable record. A momentary database error is not a
+// release change, and a guard that turned one into a process exit would be an
+// outage lever pointed at the deployment it protects — the failure mode strictly
+// worse than the one it prevents. Only a KNOWN difference stops the process; a
+// read that failed is logged and the next tick asks again.
+//
+// It must not turn a rolling api deploy into worker churn. During a rollout, api
+// replicas from two releases are alive at once and each records its own on boot,
+// so the recorded value flaps between them for the length of the rollout. A
+// single differing read is therefore not evidence of anything, and this waits
+// for a run of them. The counter resets on any agreeing read, so a flap can
+// never accumulate across a rollout — it only fires when the record has settled
+// somewhere else.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/buildinfo"
+)
+
+// ReleaseRecheckInterval is how often a running role re-reads the installation's
+// release.
+//
+// Minutes rather than seconds: the event this watches for is a deploy, which no
+// operator measures in seconds, and the cost of noticing it a minute later is
+// one minute of a mixed pair that has already been running since the deploy
+// began. Seconds would buy nothing and add a query per role per second for the
+// life of every process.
+const ReleaseRecheckInterval = time.Minute
+
+// releaseSkewConfirmations is how many consecutive differing reads stop the
+// process.
+//
+// Three, and the number is doing work rather than decorating. One is a flap
+// during a rolling api deploy. The run has to outlast the window in which two
+// api releases are alive — at ReleaseRecheckInterval that is three minutes of a
+// record that never once agrees with this role, which no rollout produces and a
+// completed deploy always does.
+const releaseSkewConfirmations = 3
+
+// WatchInstallationRelease re-reads the installation's recorded release on a
+// tick and answers, exactly once, when it has settled on a different one.
+//
+// The channel carries the refusal AssertInstallationRelease would have given at
+// boot — the same sentence, because it is the same fact reaching an operator at
+// a different moment. It closes with nothing when ctx ends, which is the
+// ordinary shutdown.
+//
+// A role with no comparable release version, or an installation nothing has
+// recorded yet, watches nothing: the boot guard says so in its log once, and a
+// watcher that repeated it every minute would be noise about a state that is
+// not a fault.
+func WatchInstallationRelease(
+	ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, version string, every time.Duration,
+) <-chan error {
+	return watchRelease(ctx, log, version, every, func(ctx context.Context) (string, error) {
+		return recordedRelease(ctx, pool)
+	})
+}
+
+// watchRelease is WatchInstallationRelease over any reader, which is what makes
+// the rules above testable without a deploy: the flap, the read failure and the
+// settled difference are three sequences of answers rather than three
+// installations.
+func watchRelease(
+	ctx context.Context,
+	log *slog.Logger,
+	version string,
+	every time.Duration,
+	read func(context.Context) (string, error),
+) <-chan error {
+	skew := make(chan error, 1)
+	if !buildinfo.Comparable(version) {
+		close(skew)
+		return skew
+	}
+	go func() {
+		defer close(skew)
+		tick := time.NewTicker(every)
+		defer tick.Stop()
+		differing := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+			installation, err := read(ctx)
+			if err != nil {
+				// Not a difference, and deliberately not a reset either: a read
+				// that failed says nothing about the record, so it neither
+				// confirms a skew nor clears one. What it must not do is end the
+				// process.
+				log.Warn("release guard: could not re-read the installation's release", "err", err)
+				continue
+			}
+			if refuseMixedRelease(version, installation) == nil {
+				differing = 0
+				continue
+			}
+			differing++
+			if differing < releaseSkewConfirmations {
+				log.Warn("release guard: the installation's release differs from this role's",
+					"release_version", version, "installation_release", installation,
+					"confirmations", differing, "needed", releaseSkewConfirmations)
+				continue
+			}
+			skew <- fmt.Errorf("the installation's release changed while this role was running: %w",
+				refuseMixedRelease(version, installation))
+			return
+		}
+	}()
+	return skew
+}
+
+// recordedRelease is the read AssertInstallationRelease makes, without the
+// bootstrap logging: a running role has already been told once.
+func recordedRelease(ctx context.Context, pool *pgxpool.Pool) (string, error) {
+	ctx, bootstrapped, err := bootLedgerScope(ctx, pool, "system:release-version")
+	if err != nil {
+		return "", fmt.Errorf("resolving the installation: %w", err)
+	}
+	if !bootstrapped {
+		// Not an error and not a difference: an installation that is not
+		// bootstrapped has recorded nothing, which refuseMixedRelease reads as
+		// nothing to compare.
+		return "", nil
+	}
+	var recorded string
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		version, err := lastObservedRelease(ctx, tx)
+		recorded = version
+		return err
+	}); err != nil {
+		return "", err
+	}
+	return recorded, nil
+}

--- a/backend/internal/compose/releasewatch_test.go
+++ b/backend/internal/compose/releasewatch_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// answers replays one installation's recorded release, tick by tick, so the
+// three sequences that matter are three fixtures rather than three deployments.
+func answers(seq ...answer) (func(context.Context) (string, error), <-chan struct{}) {
+	// Announced rather than timed: a test that slept would be asserting about a
+	// clock, and what it means to say is "after the watcher had read N times it
+	// still had not fired". Buffered generously so a reader never blocks on a
+	// test that has stopped counting.
+	reads := make(chan struct{}, 64)
+	i := 0
+	return func(context.Context) (string, error) {
+		at := seq[len(seq)-1]
+		if i < len(seq) {
+			at = seq[i]
+			i++
+		}
+		// Past the fixture the last entry repeats, which is what a settled
+		// installation looks like.
+		select {
+		case reads <- struct{}{}:
+		default:
+		}
+		return at.recorded, at.err
+	}, reads
+}
+
+// afterReads waits until the watcher has read the record n times, so what
+// follows is a statement about those reads rather than about elapsed time.
+func afterReads(t *testing.T, reads <-chan struct{}, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-reads:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("the watcher stopped reading after %d of %d reads", i, n)
+		}
+	}
+}
+
+type answer struct {
+	recorded string
+	err      error
+}
+
+// quiet keeps a watcher's own logging out of the test output; what is under
+// test is what it does, not what it says.
+func quiet() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// waitFor reads the watcher's answer, or reports that it never came.
+func waitFor(t *testing.T, skew <-chan error, within time.Duration) (error, bool) {
+	t.Helper()
+	select {
+	case err, open := <-skew:
+		return err, open
+	case <-time.After(within):
+		t.Fatal("the watcher neither refused nor closed")
+		return nil, false
+	}
+}
+
+// A record that has SETTLED on another release stops the role.
+func TestASettledDifferenceStopsTheRole(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	read, _ := answers(answer{recorded: "1970.43"})
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Millisecond, read)
+	err, open := waitFor(t, skew, 2*time.Second)
+	if !open || err == nil {
+		t.Fatal("a role running against another release's schema was not stopped")
+	}
+	// The operator reads the same sentence the boot guard gives, because it is
+	// the same fact arriving later.
+	for _, want := range []string{"1970.42", "1970.43", "Deploy every role"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %q: %v", want, err)
+		}
+	}
+}
+
+// A FLAP does not. During a rolling api deploy two releases are alive and each
+// records its own, so the record alternates for the length of the rollout — and
+// a watcher that fired on one differing read would restart every worker in the
+// fleet, repeatedly, for the duration.
+func TestAFlappingRecordDoesNotStopTheRole(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	read, reads := answers(
+		answer{recorded: "1970.43"},
+		answer{recorded: "1970.42"},
+		answer{recorded: "1970.43"},
+		answer{recorded: "1970.42"},
+		answer{recorded: "1970.43"},
+		answer{recorded: "1970.42"},
+	)
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Millisecond, read)
+	// Twice the fixture, which is many more ticks than a confirmation run needs.
+	afterReads(t, reads, 12)
+	select {
+	case err := <-skew:
+		t.Fatalf("a rolling deploy stopped the role: %v", err)
+	default:
+	}
+}
+
+// An UNREADABLE record does not, and this is the rule that matters most: a
+// momentary database error is not a release change, and a guard that exited on
+// one would be an outage lever pointed at the deployment it protects.
+func TestAnUnreadableRecordDoesNotStopTheRole(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	read, reads := answers(answer{err: errors.New("connection refused")})
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Millisecond, read)
+	afterReads(t, reads, 12)
+	select {
+	case err := <-skew:
+		t.Fatalf("a database error stopped the role: %v", err)
+	default:
+	}
+}
+
+// A read failure neither confirms a difference nor clears one: it says nothing
+// about the record. So a difference interrupted by an outage still stops the
+// role once it has been seen enough times.
+func TestAReadFailureNeitherConfirmsNorClearsADifference(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// The sequence ENDS on a read failure, and answers repeats its last entry
+	// forever — so a watcher that cleared the count on a failure can never
+	// reach three and this test discriminates. Ending on the difference
+	// instead, it would reach three from the repeats alone and pass either way.
+	read, _ := answers(
+		answer{recorded: "1970.43"},
+		answer{err: errors.New("connection refused")},
+		answer{recorded: "1970.43"},
+		answer{err: errors.New("connection refused")},
+		answer{recorded: "1970.43"},
+		answer{err: errors.New("connection refused")},
+	)
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Millisecond, read)
+	if err, open := waitFor(t, skew, 2*time.Second); !open || err == nil {
+		t.Fatal("a settled difference interrupted by two read failures did not stop the role")
+	}
+}
+
+// An installation that has recorded nothing is not a difference. A worker can
+// legitimately reach a pre-bootstrap installation, and the boot guard already
+// says so once.
+func TestAnUnrecordedInstallationIsNotADifference(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	read, reads := answers(answer{recorded: ""})
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Millisecond, read)
+	afterReads(t, reads, 12)
+	select {
+	case err := <-skew:
+		t.Fatalf("an unrecorded installation stopped the role: %v", err)
+	default:
+	}
+}
+
+// A binary with no comparable release watches nothing, and says so by closing
+// immediately rather than ticking forever against a comparison it cannot make.
+func TestABinaryWithNoReleaseWatchesNothing(t *testing.T) {
+	skew := watchRelease(context.Background(), quiet(), "", time.Millisecond,
+		func(context.Context) (string, error) {
+			t.Error("a binary with no release read the record")
+			return "1970.43", nil
+		})
+	if err, open := waitFor(t, skew, time.Second); open || err != nil {
+		t.Errorf("the channel answered %v (open=%t), want closed with nothing", err, open)
+	}
+}
+
+// Shutdown closes the channel with nothing, which is how the caller tells an
+// ordinary stop from a refusal.
+func TestShutdownClosesWithNoRefusal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	read, _ := answers(answer{recorded: "1970.42"})
+	skew := watchRelease(ctx, quiet(), "1970.42", time.Hour, read)
+	cancel()
+	if err, open := waitFor(t, skew, time.Second); open || err != nil {
+		t.Errorf("shutdown answered %v (open=%t), want closed with nothing", err, open)
+	}
+}


### PR DESCRIPTION
Closes #1734.

## The gap

`AssertInstallationRelease` runs once, in `cmd/worker/main.go`, before the lanes start. It catches the case #1705 was filed for — a torn tag pull, where every role is new and every role boots. It cannot catch one role restarting alone:

1. api and worker both at `1970.42`, both running.
2. Roll **only** the api to `1970.43`. Its entrypoint migrates and records `1970.43`.
3. The `1970.42` worker keeps running the outbox relay, the retention evaluator and the agent runner against `1970.43`'s schema and event contract — **indefinitely**, with nothing logged and nothing crash-looping.

That is "half of one release beside half of another", which is the state the guard exists to prevent, reached by a partial deploy rather than a torn pull. The next unrelated restart is when it surfaces.

## The fix

The record is re-read on a tick, and a **confirmed** difference stops the role non-zero, into the visible crash loop `AssertInstallationRelease` already produces. The watcher decides nothing the boot guard would not; it only notices later, and returns the same sentence an operator would have read at boot.

## Two rules make it safe to run, and both are about what it must not do

**It does not exit on an unreadable record.** A momentary database error is not a release change, and a guard that turned one into a process exit would be an outage lever pointed at the deployment it protects — strictly worse than the failure it prevents. Only a known difference stops the process.

**It does not turn a rolling api deploy into worker churn.** During a rollout, api replicas from two releases are alive and each records its own on boot, so the record flaps for the length of the rollout (#1735). One differing read is evidence of nothing. Three consecutive ones are, and **any agreeing read resets the count**, so a flap can never accumulate — it fires only when the record has settled somewhere else.

**A read failure does neither.** It says nothing about the record, so it neither confirms a difference nor clears one.

## Each rule has a test that fails when it is inverted

| mutation | result |
|---|---|
| fire on a single differing read | **caught** — the flapping fixture stops the role |
| treat a read failure as a difference | **caught** — a database error stops the role |
| clear the count on a read failure | **caught** — a difference interrupted by outages never fires |

Seven cases in all, over a fake reader: a settled difference, a flap, an unreadable record, a difference interleaved with failures, an unrecorded installation, a binary with no release, and an ordinary shutdown.

The third mutation initially passed, because the fixture ended on the *difference* and the reader repeats its last answer — so the count reached three from the repeats regardless. It ends on a read failure now, and the comment says why.

## The tests wait on reads, not on a clock

`craft static` blocked the first version for three `time.Sleep`s and it was right: what those tests mean to say is *"after the watcher had read N times it still had not fired"*, which is a statement about the watcher. The fake reader announces each read and the assertions wait on that.

## Verification

- `make check-backend` — green
- `make craft-static` — clean (two helpers extracted from `run`, which my three lines had pushed past the 80-line cap)
- `make test-it DIR=backend/cmd/worker` — green
- `go test -race` on the watcher's suite — clean; the refusal travels by channel, so the send is ordered before the cancel that lets the relay return

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic monitoring to detect confirmed installation release mismatches while a worker is running.
  * Workers now stop with a refusal when a release mismatch persists, helping prevent operation with incompatible releases.
  * Temporary read failures, unrecorded installations, and fluctuating mismatches no longer trigger unnecessary shutdowns.
  * Normal worker shutdowns continue to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->