### PR TITLE
A unit can ask for its own job to run now

### DIFF
--- a/backend/internal/compose/extruntime_test.go
+++ b/backend/internal/compose/extruntime_test.go
@@ -142,7 +142,7 @@ func TestRuntimeIsScopedToTheInvokingUnit(t *testing.T) {
 	for i := range rt.NumMethod() {
 		m := rt.Method(i)
 		for _, named := range stringParams(m.Type) {
-			if !nameableByAMember.Waived(t, named) {
+			if !nameableOnThisSurface.Waived(t, named) {
 				t.Errorf("extension.Runtime.%s takes a %s — a unit name is a string, so this is a parameter "+
 					"through which a handler could ask to be re-scoped", m.Name, named)
 			}
@@ -151,24 +151,29 @@ func TestRuntimeIsScopedToTheInvokingUnit(t *testing.T) {
 	// An exception nothing on the interface reaches any more is a review nobody
 	// asked for: report it rather than letting it read as ratification of a
 	// parameter that has since been removed.
-	nameableByAMember.AssertAllMatched(t)
+	nameableOnThisSurface.AssertAllMatched(t)
 }
 
-// nameableByAMember is the one reviewed exception to the rule above, and it is
-// narrow on purpose: a parameter naming a MEMBER of this installation, never a
-// unit.
+// nameableOnThisSurface is the reviewed exception list to the rule above, and
+// every entry is narrow for the same reason: what it names is something OTHER
+// than a unit, and naming it buys the caller nothing it could not already do.
 //
-// Ingest takes one because a connector poll acts for the member whose
-// credential produced the record, and that member has to be named. What keeps
-// it from being the re-scoping parameter this test refuses is that the name is
-// not TRUSTED: the core checks the member currently holds one of this unit's
-// user-scoped secrets — depositing a credential is the consent act — and then
-// resolves what they may do right now, so naming a colleague buys a unit
-// nothing it could not already do for the members who asked it to.
+// Two classes so far, and they are different questions:
 //
-// A bare string stays refused. The exception is by TYPE, so a future parameter
-// that means something else cannot arrive under it.
-var nameableByAMember = gatekit.Waive(map[string]string{
+//   - a MEMBER of this installation. Ingest takes one because a connector poll
+//     acts for the member whose credential produced the record, and that member
+//     has to be named. The name is not TRUSTED: the core checks the member
+//     currently holds one of this unit's user-scoped secrets — depositing a
+//     credential is the consent act — and then resolves what they may do right
+//     now, so naming a colleague buys a unit nothing.
+//   - a JOB the calling unit declares. SyncNow takes one because a unit with
+//     two jobs has two answers to "run it now". It is resolved against the
+//     declarations of the unit the Runtime was minted for, so a name belonging
+//     to another unit reads as a name belonging to nobody.
+//
+// A bare string stays refused. The exceptions are by TYPE, so a future
+// parameter that means something else cannot arrive under one of them.
+var nameableOnThisSurface = gatekit.Waive(map[string]string{
 	"extension.UserID": "a connector poll acts for the member whose credential produced the record, and that " +
 		"member has to be named — see the reasoning above for why the name is checked rather than trusted",
 	"extension.JobName": "the job a unit asks to run NOW, resolved against the declarations of the unit the " +

--- a/backend/internal/compose/extruntime_test.go
+++ b/backend/internal/compose/extruntime_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/pkg/extension"
@@ -141,12 +142,16 @@ func TestRuntimeIsScopedToTheInvokingUnit(t *testing.T) {
 	for i := range rt.NumMethod() {
 		m := rt.Method(i)
 		for _, named := range stringParams(m.Type) {
-			if !nameableByAMember[named] {
+			if !nameableByAMember.Waived(t, named) {
 				t.Errorf("extension.Runtime.%s takes a %s — a unit name is a string, so this is a parameter "+
 					"through which a handler could ask to be re-scoped", m.Name, named)
 			}
 		}
 	}
+	// An exception nothing on the interface reaches any more is a review nobody
+	// asked for: report it rather than letting it read as ratification of a
+	// parameter that has since been removed.
+	nameableByAMember.AssertAllMatched(t)
 }
 
 // nameableByAMember is the one reviewed exception to the rule above, and it is
@@ -163,7 +168,14 @@ func TestRuntimeIsScopedToTheInvokingUnit(t *testing.T) {
 //
 // A bare string stays refused. The exception is by TYPE, so a future parameter
 // that means something else cannot arrive under it.
-var nameableByAMember = map[string]bool{"extension.UserID": true}
+var nameableByAMember = gatekit.Waive(map[string]string{
+	"extension.UserID": "a connector poll acts for the member whose credential produced the record, and that " +
+		"member has to be named — see the reasoning above for why the name is checked rather than trusted",
+	"extension.JobName": "the job a unit asks to run NOW, resolved against the declarations of the unit the " +
+		"Runtime was minted for. It cannot re-scope anything: a name belonging to another unit reads as a " +
+		"name belonging to nobody, and the workspace the run lands in is the invocation's rather than this " +
+		"parameter's",
+})
 
 // stringParams reports EVERY string-kinded parameter of fn, by type name,
 // descending into a callback parameter (Tx hands the unit a func, and a unit

--- a/backend/internal/compose/extsyncnow.go
+++ b/backend/internal/compose/extsyncnow.go
@@ -29,7 +29,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -74,7 +76,7 @@ func (r *callRuntime) SyncNow(ctx context.Context, job extension.JobName) error 
 		// was added to end, in a new place.
 		return extension.ErrNoUnattendedSeat
 	}
-	inserter, err := jobs.NewInserter(pool, slog.Default())
+	inserter, err := extensionJobInserter(pool)
 	if err != nil {
 		return fmt.Errorf("compose: opening the queue to ask for %s: %w", job, err)
 	}
@@ -136,4 +138,44 @@ func attendedChildOpts(childKind string) (*river.InsertOpts, error) {
 		MaxAttempts: spec.MaxAttempts,
 		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}, nil
+}
+
+// extensionJobInserter answers the one insert-only River client this process
+// asks for an extension's own job through, building it on first use.
+//
+// One per POOL rather than one per call. A River client is a configured,
+// pool-holding object, and everywhere else in this tree exactly one is built at
+// boot and injected (cmd/api/boot.go, cmd/worker/jobrunner.go). This seam
+// cannot take that shape: BindExtensionRuntime is called by every role that
+// serves extension work, and threading an inserter through it would make each
+// of them build one whether or not it ever serves a unit that asks.
+//
+// Memoizing against the bound pool gets the same object with the same lifetime,
+// and re-keys itself if the binding moves — which is a wiring fault
+// BindExtensionRuntime already warns about, and which the tests that rebind
+// legitimately do.
+//
+// The error surfaces at the CALL rather than at the boot, which is where it can
+// be answered: a member is told their sync could not be asked for, instead of a
+// role refusing to start over a capability it may never serve.
+func extensionJobInserter(pool *pgxpool.Pool) (*jobs.Runner, error) {
+	extensionJobQueue.mu.Lock()
+	defer extensionJobQueue.mu.Unlock()
+	if extensionJobQueue.inserter != nil && extensionJobQueue.pool == pool {
+		return extensionJobQueue.inserter, nil
+	}
+	inserter, err := jobs.NewInserter(pool, slog.Default())
+	if err != nil {
+		return nil, err
+	}
+	extensionJobQueue.pool, extensionJobQueue.inserter = pool, inserter
+	return inserter, nil
+}
+
+// extensionJobQueue holds that one client, beside the pool it was built for so
+// a rebound pool cannot be served a client pointing at the previous one.
+var extensionJobQueue struct {
+	mu       sync.Mutex
+	pool     *pgxpool.Pool
+	inserter *jobs.Runner
 }

--- a/backend/internal/compose/extsyncnow.go
+++ b/backend/internal/compose/extsyncnow.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The "do it now" a scheduled connector needs, and the three things it must not
+// become.
+//
+// pkg/extension/syncnow.go carries why the capability exists. This is where the
+// bounds are actual rather than documented, and each one is a property of how
+// the enqueue is CONSTRUCTED rather than a check somebody has to remember:
+//
+//   - THE UNIT'S OWN JOB. The name is resolved against the declarations of the
+//     unit this Runtime was minted for, which the handler has no way to supply
+//     — the same fact that scopes its secrets and its ledger.
+//   - THE CALLER'S OWN TENANT. The workspace is the invocation's, read the way
+//     every other capability reads it, so there is no parameter to get wrong
+//     and no shape in which a unit asks for somebody else's sync.
+//   - ONE RUN, NOT A THOUSAND. Repeated calls coalesce onto the queued row for
+//     the workspace, so a member holding down save gets one tick.
+//
+// And the invariant it leaves alone: what is enqueued is the SAME child kind
+// the clock enqueues, with the same workspace agent seat as its principal. The
+// tick runs unattended, exactly as it always did — what crosses this seam is a
+// request to schedule, never an authority to ingest, so ErrAttendedIngest keeps
+// meaning what it means.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/pkg/extension"
+)
+
+// SyncNow enqueues this unit's own declared job for the calling workspace.
+func (r *callRuntime) SyncNow(ctx context.Context, job extension.JobName) error {
+	ctx, err := r.scoped(ctx)
+	if err != nil {
+		return err
+	}
+	decl, found := declaredJobFor(r.unit, string(job))
+	if !found {
+		// The unit's OWN set, so a name that belongs to another unit reads the
+		// same as one that belongs to nobody: this unit declares no such job.
+		// Answering differently would tell a unit which jobs its neighbours have.
+		return fmt.Errorf("%w: %q", extension.ErrNoSuchJob, job)
+	}
+	// The invocation's own binding, which scoped has already found non-nil —
+	// the same pool every other capability on this Runtime reaches the
+	// installation through, rather than a second lookup that could answer
+	// differently.
+	pool := r.deps.pool
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return database.ErrNoWorkspace
+	}
+	// The SAME actor the clock's dispatch records: the workspace's agent seat,
+	// re-derived at execution rather than carried, so a seat deactivated while
+	// the row waits ends the tick the way it ends a scheduled one.
+	actor, err := extensionJobActor(ctx, pool, ws)
+	if err != nil {
+		return err
+	}
+	if actor.IsZero() {
+		// The same state the fleet dispatch skips a workspace for. Said out
+		// loud here because a caller asked: a screen that reported "checking
+		// now" over a tick that will never run is the failure this capability
+		// was added to end, in a new place.
+		return extension.ErrNoUnattendedSeat
+	}
+	inserter, err := jobs.NewInserter(pool, slog.Default())
+	if err != nil {
+		return fmt.Errorf("compose: opening the queue to ask for %s: %w", job, err)
+	}
+	child := decl.ChildKind()
+	opts, err := attendedChildOpts(child)
+	if err != nil {
+		return err
+	}
+	return inserter.Enqueue(ctx, extJobWorkspaceArgs{JobKind: child, Workspace: ws, Principal: actor}, opts)
+}
+
+// declaredJobFor answers the declaration of one unit's job, and whether the
+// unit declares it at all.
+//
+// Read from the composed set rather than from anything the caller supplies,
+// which is what makes "its own job" a property of construction: the set is what
+// this boot registered, and the unit is the one the Runtime was minted for.
+func declaredJobFor(unit, job string) (extension.JobDeclaration, bool) {
+	for _, served := range servedExtensionJobs() {
+		if string(served.decl.Unit) == unit && served.decl.Job == job {
+			return served.decl, true
+		}
+	}
+	return extension.JobDeclaration{}, false
+}
+
+// attendedChildOpts is how a caller-requested run is enqueued, and it sits
+// between its two neighbours for reasons worth stating rather than inheriting.
+//
+// It is NOT workspaceSweepOpts: that marks the row as one workspace's share of
+// a fleet pass, and the sweep gauges count tagged rows. A run somebody asked
+// for is not a pass the clock made, and tagging it would inflate the coverage
+// reading of a pass that never ran.
+//
+// It is NOT oneOffChildOpts either, and this is the half that matters here.
+// That one deliberately drops active-state uniqueness, because an event's whole
+// claim is that new rows landed and deduplicating against a pass already
+// running would drop exactly the data the event fired about. A human pressing
+// save makes no such claim — they are asking for a check, and a check already
+// queued or running IS the check. So uniqueness stays on, and it is what turns
+// a held-down button into one tick.
+//
+// It RETURNS its refusal where both neighbours panic, and that difference is
+// the call site rather than a change of heart. Those two are reached from boot
+// wiring and from a dispatcher, where a kind whose declaration says something
+// else is a composition fault and a panic is the boot failure it deserves.
+// This one is reached from a unit's handler, inside a member's request: the
+// same fault there would take down the call, or the worker, for a mistake in a
+// declaration nobody in that request can fix.
+func attendedChildOpts(childKind string) (*river.InsertOpts, error) {
+	spec := fanOutChildSpec(childKind)
+	if spec.OptsOwner != jobs.OptsFanOut {
+		return nil, fmt.Errorf(
+			"compose: %s declares an opts_owner other than fan_out, so its queue and attempt cap are not "+
+				"this helper's to set", childKind)
+	}
+	return &river.InsertOpts{
+		Queue:       spec.Queue,
+		MaxAttempts: spec.MaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}, nil
+}

--- a/backend/internal/compose/extsyncnow_integration_test.go
+++ b/backend/internal/compose/extsyncnow_integration_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The half of SyncNow only Postgres can answer: that the row it enqueues is one
+// River accepts, of the kind the clock enqueues, for the caller's workspace —
+// and that a second ask coalesces onto it rather than queueing a second tick.
+//
+// The unit tests hold the bounds (whose job, whose tenant, what the opts say).
+// What they cannot hold is whether the insert LANDS: the args carry a kind, a
+// workspace and a principal, River decides whether that row is well formed, and
+// a shape it rejects would leave every "checking now" a lie.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/pkg/extension"
+)
+
+// syncNowJob is a real composed child kind, because attendedChildOpts reads the
+// declaration table for its queue and attempt cap and a made-up kind panics
+// there rather than answering.
+const syncNowUnit, syncNowJob = "notes", "heartbeat"
+
+func TestSyncNowQueuesTheUnitsOwnTickForTheCallersWorkspace(t *testing.T) {
+	ctx := context.Background()
+	ownerDSN, appDSN := os.Getenv("MARGINCE_TEST_DSN"), os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up`")
+	}
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing the owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := testdb.Reset(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ws := ids.NewV7()
+	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, ws); err != nil {
+		t.Fatal(err)
+	}
+	// The agent seat the tick runs under. Without it SyncNow answers
+	// ErrNoUnattendedSeat, which is the other case this file could assert and
+	// the one the fleet dispatch already skips a workspace for.
+	seat := ids.NewV7()
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO app_user (id, email, display_name, is_agent)
+		 VALUES ($1, $2, 'Agent', true)`, seat, "agent-"+seat.String()+"@sync.test"); err != nil {
+		t.Fatal(err)
+	}
+
+	decl := extension.JobDeclaration{Unit: syncNowUnit, Job: syncNowJob}
+	set := []composedJob{{decl: decl}}
+	before := servedExtensionJobs()
+	setComposedJobs(set)
+	t.Cleanup(func() { setComposedJobs(before) })
+	// The DECLARATION table as well as the served set: attendedChildOpts reads
+	// the child kind's queue and attempt cap out of it, so a test that
+	// registered only the served half would be asking about a kind the job
+	// tier has never heard of.
+	if err := jobs.RegisterComposed(composedJobSpecs(set)); err != nil {
+		t.Fatalf("registering the composed job specs: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := jobs.RegisterComposed(composedJobSpecs(before)); err != nil {
+			t.Errorf("restoring the composed job specs: %v", err)
+		}
+	})
+
+	rt := &callRuntime{
+		unit:    syncNowUnit,
+		live:    true,
+		callCtx: principal.WithWorkspaceID(ctx, ws),
+		deps:    extensionRuntimeBinding{pool: pool},
+	}
+
+	if err := rt.SyncNow(ctx, syncNowJob); err != nil {
+		t.Fatalf("asking for this unit's own tick: %v", err)
+	}
+	if n := queuedTicks(t, owner, decl.ChildKind(), ws); n != 1 {
+		t.Fatalf("queued %d tick(s) of %s, want 1 — the ask enqueued nothing River kept", n, decl.ChildKind())
+	}
+
+	// The member presses save again. The second ask must coalesce: a check
+	// already queued IS the check, and a held-down button must not become a
+	// tick per press.
+	if err := rt.SyncNow(ctx, syncNowJob); err != nil {
+		t.Fatalf("asking a second time: %v", err)
+	}
+	if n := queuedTicks(t, owner, decl.ChildKind(), ws); n != 1 {
+		t.Errorf("queued %d tick(s) after a second ask, want still 1 — a member holding down save "+
+			"enqueues a run per press", n)
+	}
+}
+
+// queuedTicks counts the rows River is holding for one kind and workspace.
+func queuedTicks(t *testing.T, owner *pgx.Conn, kind string, ws ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM river_job
+		  WHERE kind = $1 AND args->>'workspace_id' = $2 AND state IN ('available','scheduled','running','retryable')`,
+		kind, ws.String()).Scan(&n); err != nil {
+		t.Fatalf("counting queued ticks: %v", err)
+	}
+	return n
+}

--- a/backend/internal/compose/extsyncnow_test.go
+++ b/backend/internal/compose/extsyncnow_test.go
@@ -10,6 +10,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -141,11 +142,22 @@ func TestAnAskedForRunCoalescesAndIsNotAFleetPass(t *testing.T) {
 	if !asked.UniqueOpts.ByArgs || len(asked.UniqueOpts.ByState) == 0 {
 		t.Error("an asked-for run does not coalesce: a member holding down save enqueues a tick per press")
 	}
-	// Not a fleet pass. The sweep gauges count tagged rows, and a run somebody
-	// asked for would inflate the coverage reading of a pass that never ran.
+	// Not a fleet pass. The sweep gauges count rows carrying jobs.SweepTag, and
+	// a run somebody asked for would inflate the coverage reading of a pass
+	// that never ran.
+	//
+	// The TAG, by name, rather than a count of tags: a count is silent about
+	// which tags those are, so an asked-for run that later grew a second tag
+	// beside the sweep one would read as different-and-therefore-fine. It is
+	// also what the gauge reads — sweepTagPredicate is `'sweep' = ANY(tags)` —
+	// so this asks the question the gauge asks.
 	fleet := workspaceSweepOpts(child)
-	if len(asked.Tags) != 0 && len(asked.Tags) == len(fleet.Tags) {
-		t.Error("an asked-for run carries the fleet sweep's tag, so the sweep gauges count it as coverage")
+	if !slices.Contains(fleet.Tags, jobs.SweepTag) {
+		t.Fatalf("the fleet sweep's opts carry tags %v, not the %q this test is checking the asked-for run is free of — "+
+			"the marker moved and this assertion is no longer about anything", fleet.Tags, jobs.SweepTag)
+	}
+	if slices.Contains(asked.Tags, jobs.SweepTag) {
+		t.Errorf("an asked-for run carries %q, so the sweep gauges count it as coverage of a pass that never ran", jobs.SweepTag)
 	}
 	// Same queue and attempt cap as every other share of this kind: one
 	// workspace's tick is one workspace's tick however it was asked for.

--- a/backend/internal/compose/extsyncnow_test.go
+++ b/backend/internal/compose/extsyncnow_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// SyncNow's bounds, over the composed set rather than a fake: what makes "the
+// unit's own job and nothing else" true is which declarations this boot
+// registered, so a test that supplied its own would be testing the supply.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/pkg/extension"
+)
+
+// composedJobsForTest installs a two-unit job set for one test and puts the
+// process back the way it found it. The set is boot state; a test that left its
+// own behind would govern every test after it.
+func composedJobsForTest(t *testing.T, decls ...extension.JobDeclaration) {
+	t.Helper()
+	before := servedExtensionJobs()
+	set := make([]composedJob, 0, len(decls))
+	for _, decl := range decls {
+		set = append(set, composedJob{decl: decl})
+	}
+	setComposedJobs(set)
+	t.Cleanup(func() { setComposedJobs(before) })
+}
+
+func jobOf(unit, job string) extension.JobDeclaration {
+	return extension.JobDeclaration{Unit: extension.Name(unit), Job: job}
+}
+
+// wiredRuntime is one unit's per-call Runtime, pinned to a workspace and wired
+// to a pool it never reaches: every case below is refused before the queue, and
+// a pool that answered would be testing the queue rather than the bound.
+func wiredRuntime(unit string) *callRuntime {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	return &callRuntime{
+		unit:    unit,
+		live:    true,
+		callCtx: ctx,
+		deps:    extensionRuntimeBinding{pool: &pgxpool.Pool{}},
+	}
+}
+
+// A unit may ask for its OWN job and for nothing else. Two units declaring a
+// job each is the shape that matters: "alpha asks for beta's job" has to read
+// the same as "alpha asks for a job nobody declares", or the refusal tells a
+// unit what its neighbours have.
+func TestSyncNowReachesOnlyTheInvokingUnitsOwnJobs(t *testing.T) {
+	composedJobsForTest(t, jobOf("alpha", "refresh"), jobOf("beta", "reconcile"))
+
+	for _, probe := range []struct {
+		what string
+		job  string
+	}{
+		{"another unit's job", "reconcile"},
+		{"a job nobody declares", "not_a_job"},
+		{"the empty name", ""},
+	} {
+		t.Run(probe.what, func(t *testing.T) {
+			rt := wiredRuntime("alpha")
+			err := rt.SyncNow(context.Background(), extension.JobName(probe.job))
+			if !errors.Is(err, extension.ErrNoSuchJob) {
+				t.Errorf("err = %v, want ErrNoSuchJob — a unit reaches its own declarations and no others", err)
+			}
+		})
+	}
+}
+
+// And the resolver DOES find a unit's own job, so the test above is about
+// ownership rather than about every name being refused.
+//
+// Asserted on declaredJobFor rather than through SyncNow, because a name that
+// resolves goes on to the queue — and what this states is which declarations
+// the lookup can see, not what happens after it.
+func TestTheJobLookupIsScopedToTheDeclaringUnit(t *testing.T) {
+	composedJobsForTest(t, jobOf("alpha", "refresh"), jobOf("beta", "reconcile"))
+
+	if _, found := declaredJobFor("alpha", "refresh"); !found {
+		t.Error("a unit's own declared job did not resolve")
+	}
+	if _, found := declaredJobFor("beta", "reconcile"); !found {
+		t.Error("the second unit's own declared job did not resolve")
+	}
+	// The pair that matters: each unit's name against the OTHER's job.
+	if _, found := declaredJobFor("alpha", "reconcile"); found {
+		t.Error("alpha resolved beta's job — the lookup is not scoped to the declaring unit")
+	}
+	if _, found := declaredJobFor("beta", "refresh"); found {
+		t.Error("beta resolved alpha's job")
+	}
+}
+
+// A released Runtime asks for nothing. The capability is call-scoped like every
+// other, and a handler that stashed one and pressed save later must not be able
+// to keep the scheduler busy.
+func TestSyncNowFailsClosedAfterTheCallEnds(t *testing.T) {
+	composedJobsForTest(t, jobOf("alpha", "refresh"))
+	rt := wiredRuntime("alpha")
+	rt.release()
+	if err := rt.SyncNow(context.Background(), "refresh"); !errors.Is(err, extension.ErrRuntimeExpired) {
+		t.Errorf("err = %v, want ErrRuntimeExpired", err)
+	}
+}
+
+// The coalescing that turns a held-down save into one tick, asserted on the
+// opts rather than on a queue: it is the uniqueness that does it, and the
+// difference from the two neighbouring helpers is the whole reason this one
+// exists.
+func TestAnAskedForRunCoalescesAndIsNotAFleetPass(t *testing.T) {
+	// A real composed child kind, because fanOutChildSpec reads the
+	// declaration table and a made-up kind would panic rather than answer.
+	kinds := fanOutChildren()
+	if len(kinds) == 0 {
+		t.Fatal("this build declares no fan-out child kinds, so this test would prove nothing")
+	}
+	var child string
+	for kind := range kinds {
+		if fanOutChildSpec(kind).OptsOwner == jobs.OptsFanOut {
+			child = kind
+			break
+		}
+	}
+	if child == "" {
+		t.Fatal("no fan-out-owned child kind in this build")
+	}
+
+	asked, err := attendedChildOpts(child)
+	if err != nil {
+		t.Fatalf("reading the opts for %s: %v", child, err)
+	}
+	if !asked.UniqueOpts.ByArgs || len(asked.UniqueOpts.ByState) == 0 {
+		t.Error("an asked-for run does not coalesce: a member holding down save enqueues a tick per press")
+	}
+	// Not a fleet pass. The sweep gauges count tagged rows, and a run somebody
+	// asked for would inflate the coverage reading of a pass that never ran.
+	fleet := workspaceSweepOpts(child)
+	if len(asked.Tags) != 0 && len(asked.Tags) == len(fleet.Tags) {
+		t.Error("an asked-for run carries the fleet sweep's tag, so the sweep gauges count it as coverage")
+	}
+	// Same queue and attempt cap as every other share of this kind: one
+	// workspace's tick is one workspace's tick however it was asked for.
+	if asked.Queue != fleet.Queue || asked.MaxAttempts != fleet.MaxAttempts {
+		t.Errorf("an asked-for run routes to %s/%d, the clock's to %s/%d — one kind, two routings",
+			asked.Queue, asked.MaxAttempts, fleet.Queue, fleet.MaxAttempts)
+	}
+}

--- a/backend/internal/compose/extsyncnow_test.go
+++ b/backend/internal/compose/extsyncnow_test.go
@@ -166,3 +166,49 @@ func TestAnAskedForRunCoalescesAndIsNotAFleetPass(t *testing.T) {
 			asked.Queue, asked.MaxAttempts, fleet.Queue, fleet.MaxAttempts)
 	}
 }
+
+// TestTheQueueIsOpenedOncePerPoolRatherThanPerAsk holds the memoisation.
+//
+// A River client is a configured, pool-holding object. Building one per ask
+// costs nothing visible in a test and everything under a member holding down
+// save, which is exactly the case this capability exists for — so the property
+// is asserted rather than left to the reading.
+//
+// It is also the property a rebind must NOT keep: a client memoised against a
+// pool that has since been replaced would insert into the previous one, which
+// is the quiet half of the wiring fault BindExtensionRuntime warns about.
+func TestTheQueueIsOpenedOncePerPoolRatherThanPerAsk(t *testing.T) {
+	extensionJobQueue.mu.Lock()
+	// The two FIELDS, not the struct: it carries the mutex, and copying that
+	// is what the whole guard is not.
+	prevPool, prevInserter := extensionJobQueue.pool, extensionJobQueue.inserter
+	extensionJobQueue.pool, extensionJobQueue.inserter = nil, nil
+	extensionJobQueue.mu.Unlock()
+	t.Cleanup(func() {
+		extensionJobQueue.mu.Lock()
+		extensionJobQueue.pool, extensionJobQueue.inserter = prevPool, prevInserter
+		extensionJobQueue.mu.Unlock()
+	})
+
+	// Two distinct non-nil pools. Nothing is dialled: NewInserter builds a
+	// client over the pool's driver and this test never enqueues through it.
+	first, second := &pgxpool.Pool{}, &pgxpool.Pool{}
+	one, err := extensionJobInserter(first)
+	if err != nil {
+		t.Fatalf("opening the queue: %v", err)
+	}
+	again, err := extensionJobInserter(first)
+	if err != nil {
+		t.Fatalf("opening the queue a second time: %v", err)
+	}
+	if one != again {
+		t.Error("a second ask on the same pool built a second River client: every press of save now rebuilds one")
+	}
+	other, err := extensionJobInserter(second)
+	if err != nil {
+		t.Fatalf("opening the queue for a rebound pool: %v", err)
+	}
+	if other == one {
+		t.Error("a rebound pool was served the client built for the previous one, so asked-for runs insert into the wrong pool")
+	}
+}

--- a/backend/pkg/extension/runtime.go
+++ b/backend/pkg/extension/runtime.go
@@ -141,6 +141,11 @@ type Runtime interface {
 	// unattended run is the only one where the member above is the single
 	// authority in play. A unit offering an on-demand sync enqueues its job.
 	Ingest(ctx context.Context, on UserID, rec Record) (Result, error)
+
+	// SyncNow asks this unit's own declared job to run soon for the calling
+	// workspace, and answers when it is QUEUED rather than when it has run.
+	// See syncnow.go for what it promises and what it cannot do.
+	SyncNow(ctx context.Context, job JobName) error
 }
 
 // CallerType is which kind of principal an invocation is running as. It mirrors

--- a/backend/pkg/extension/runtime_test.go
+++ b/backend/pkg/extension/runtime_test.go
@@ -35,6 +35,10 @@ func (r *fakeRuntime) Secrets() Secrets { return r.secrets }
 // answers after release too).
 func (r *fakeRuntime) Caller() Caller { return r.caller }
 
+// SyncNow answers for the seam's shape only: what it means is the composition
+// layer's (compose/extsyncnow.go), which is where its bounds are tested.
+func (r *fakeRuntime) SyncNow(context.Context, JobName) error { return nil }
+
 func (r *fakeRuntime) Tx(ctx context.Context, fn func(context.Context, Tx) error) error {
 	if !r.live {
 		return ErrRuntimeExpired

--- a/backend/pkg/extension/syncnow.go
+++ b/backend/pkg/extension/syncnow.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package extension
+
+// "Do it now", for a unit whose value otherwise arrives on a schedule.
+//
+// ErrAttendedIngest tells a unit what to do when somebody asks for an on-demand
+// sync — "a unit wanting an on-demand sync enqueues its job rather than
+// ingesting inline" — and until this existed there was no way to enqueue one.
+// The sentence described a pattern the surface did not offer, and the refusal
+// it explains had no escape hatch.
+//
+// What that cost is not abstract. A member connects an account, chooses what to
+// capture, presses save, and nothing can happen until the next scheduled tick —
+// a full cadence away, longer once adaptive backoff has engaged. From the
+// outside that is indistinguishable from a broken feature, and the first person
+// it happens to is the rep whose belief in the connector is the whole product.
+//
+// WHY THE OTHER THREE ANSWERS ARE WORSE, since each is the obvious one:
+//
+//   - draining inline on the save is what ErrAttendedIngest refuses, and
+//     correctly: ingress runs on the authority of the member whose credential
+//     produced the record, and a call that ALSO has a caller has two
+//     authorities in play;
+//   - shortening the cadence multiplies a login and a handshake per member,
+//     for every member, to make one member feel responsive — the exact cost
+//     adaptive cadence exists to reduce;
+//   - saying nothing is what shipped.
+//
+// WHAT CROSSES HERE IS A REQUEST TO SCHEDULE, never an authority to ingest. The
+// tick it asks for runs exactly as the clock's does: unattended, under the
+// workspace's own agent seat, with the same grants. So ErrAttendedIngest is
+// untouched — a unit still cannot ingest on a caller's authority, it can only
+// ask for the unattended run sooner.
+//
+// WHAT IT PROMISES is that the job is QUEUED, and nothing about when it runs.
+// That is the honest contract and it is also the useful one: a screen can then
+// say "checking now" truthfully instead of guessing, where a synchronous
+// version would have to hold a request open across a provider handshake it does
+// not control.
+//
+// WHAT IT CANNOT DO, by construction rather than by check:
+//
+//   - reach another unit's job. The name is resolved against the DECLARING
+//     unit's set, which the Runtime knows and the handler cannot supply.
+//   - reach another tenant. The workspace is the invocation's, taken the way
+//     every other capability takes it, so there is no argument to get wrong.
+//   - outrun itself. Repeated calls coalesce onto one queued run for the
+//     workspace, so a member holding down save enqueues one tick, not a
+//     thousand.
+
+import "errors"
+
+// JobName is the name of one of the DECLARING unit's own jobs.
+//
+// A distinct type rather than a string, because on this surface a bare string
+// is the shape a handler could use to ask to be re-scoped, and the seam refuses
+// that parameter class on purpose. This one cannot be that: it is resolved
+// against the declarations of the unit the Runtime was minted for, so a name
+// belonging to another unit reads as a name belonging to nobody.
+type JobName string
+
+// ErrNoSuchJob reports a name that is not one of this unit's declared jobs.
+//
+// A unit may only ask for its OWN, and it names it rather than being given a
+// default: a unit with two jobs has two answers to "run it now", and picking
+// one for it would silently sync the wrong thing on a screen that said it
+// synced the right one.
+var ErrNoSuchJob = errors.New("extension: this unit declares no job by that name")
+
+// ErrNoUnattendedSeat reports a workspace with no agent seat, for which no
+// unattended tick can run at all.
+//
+// It is the same state the scheduled fan-out skips a workspace for, said out
+// loud here because a caller ASKED. A screen reporting "checking now" over a
+// tick that will never run is the failure this capability was added to end,
+// reappearing one layer along.
+var ErrNoUnattendedSeat = errors.New("extension: this workspace has no agent seat, so no unattended tick can run for it")

--- a/extensions/notes/fake_test.go
+++ b/extensions/notes/fake_test.go
@@ -40,8 +40,6 @@ type fakeRuntime struct {
 	// to CallerSystem would make every author assertion in the suite pass over
 	// the one path — the job's — that legitimately has none.
 	caller extension.Caller
-	// syncedNow records the job names the unit asked the core to run now.
-	syncedNow []extension.JobName
 }
 
 func newRuntime() *fakeRuntime {
@@ -383,11 +381,10 @@ func (s *fakeSecrets) DeleteUser(context.Context, extension.UserID, string) erro
 // unit's declarations, so a unit cannot ask for a job it does not own. A fake
 // that accepted any string would let a handler reach for a name that fails at
 // run time and still pass here.
-func (r *fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
+func (*fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
 	if job != declaredJob {
 		return extension.ErrNoSuchJob
 	}
-	r.syncedNow = append(r.syncedNow, job)
 	return nil
 }
 

--- a/extensions/notes/fake_test.go
+++ b/extensions/notes/fake_test.go
@@ -40,6 +40,8 @@ type fakeRuntime struct {
 	// to CallerSystem would make every author assertion in the suite pass over
 	// the one path — the job's — that legitimately has none.
 	caller extension.Caller
+	// syncedNow records the job names the unit asked the core to run now.
+	syncedNow []extension.JobName
 }
 
 func newRuntime() *fakeRuntime {
@@ -375,3 +377,20 @@ func (s *fakeSecrets) PutUser(context.Context, extension.UserID, string, []byte)
 func (s *fakeSecrets) DeleteUser(context.Context, extension.UserID, string) error {
 	return errUserScopeUnused
 }
+
+// SyncNow answers for the one job this unit declares and refuses every other
+// name, which is the core's rule: a name is resolved against the CALLING
+// unit's declarations, so a unit cannot ask for a job it does not own. A fake
+// that accepted any string would let a handler reach for a name that fails at
+// run time and still pass here.
+func (r *fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
+	if job != declaredJob {
+		return extension.ErrNoSuchJob
+	}
+	r.syncedNow = append(r.syncedNow, job)
+	return nil
+}
+
+// declaredJob is the job named in api/jobs.yaml, spelled here so the fake
+// refuses exactly what the core refuses.
+const declaredJob = extension.JobName("heartbeat")

--- a/extensions/relay-probe/fake_test.go
+++ b/extensions/relay-probe/fake_test.go
@@ -48,6 +48,8 @@ type fakeRuntime struct {
 	ingestErr   error
 	ingestFrom  int
 	ingestCalls int
+	// syncedNow records the job names the unit asked the core to run now.
+	syncedNow []extension.JobName
 }
 
 func newRuntime() *fakeRuntime {
@@ -394,3 +396,20 @@ func (t *fakeTx) statementMentioning(tb testing.TB, needle string) (string, []an
 	tb.Fatalf("no statement mentions %q; the handler issued:\n%s", needle, strings.Join(t.statements, "\n---\n"))
 	return "", nil
 }
+
+// SyncNow answers for the one job this unit declares and refuses every other
+// name, which is the core's rule: a name is resolved against the CALLING
+// unit's declarations, so a unit cannot ask for a job it does not own. A fake
+// that accepted any string would let a handler reach for a name that fails at
+// run time and still pass here.
+func (r *fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
+	if job != declaredJob {
+		return extension.ErrNoSuchJob
+	}
+	r.syncedNow = append(r.syncedNow, job)
+	return nil
+}
+
+// declaredJob is the job named in api/jobs.yaml, spelled here so the fake
+// refuses exactly what the core refuses.
+const declaredJob = extension.JobName("poll_inbox")

--- a/extensions/relay-probe/fake_test.go
+++ b/extensions/relay-probe/fake_test.go
@@ -48,8 +48,6 @@ type fakeRuntime struct {
 	ingestErr   error
 	ingestFrom  int
 	ingestCalls int
-	// syncedNow records the job names the unit asked the core to run now.
-	syncedNow []extension.JobName
 }
 
 func newRuntime() *fakeRuntime {
@@ -402,11 +400,10 @@ func (t *fakeTx) statementMentioning(tb testing.TB, needle string) (string, []an
 // unit's declarations, so a unit cannot ask for a job it does not own. A fake
 // that accepted any string would let a handler reach for a name that fails at
 // run time and still pass here.
-func (r *fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
+func (*fakeRuntime) SyncNow(_ context.Context, job extension.JobName) error {
 	if job != declaredJob {
 		return extension.ErrNoSuchJob
 	}
-	r.syncedNow = append(r.syncedNow, job)
 	return nil
 }
 


### PR DESCRIPTION
Closes #1736.

## The gap

`ErrAttendedIngest` tells a unit what to do when somebody asks for an on-demand sync — *"a unit wanting an on-demand sync enqueues its job rather than ingesting inline"* — and until now there was no way to enqueue one. The sentence described a pattern the surface did not offer, and the refusal it explains had no escape hatch.

A member connects an account, chooses what to capture, presses save, and nothing can happen until the next scheduled tick — a full cadence away, longer once adaptive backoff has engaged. From the outside that is indistinguishable from a broken feature.

## What crosses

`Runtime.SyncNow(ctx, job)` is a request to **schedule**, never an authority to ingest. The tick it asks for runs exactly as the clock's does: unattended, under the workspace's own agent seat, with the same grants. `ErrAttendedIngest` is untouched — a unit still cannot ingest on a caller's authority, it can only ask for the unattended run sooner.

It promises the job is **queued**, and nothing about when it runs. A screen can then say "checking now" truthfully instead of guessing, where a synchronous version would have to hold a request open across a provider handshake it does not control.

By construction rather than by check, it cannot:

- **reach another unit's job** — the name is resolved against the *declaring* unit's set, which the `Runtime` knows and the handler cannot supply;
- **reach another tenant** — the workspace is the invocation's, taken the way every other capability takes it, so there is no argument to get wrong;
- **outrun itself** — River `ByArgs`/`ByState` uniqueness coalesces repeated asks onto one queued run, so a member holding down save enqueues one tick, not a thousand.

A workspace with no agent seat is refused with `ErrNoUnattendedSeat` rather than queued. That is the same state the scheduled fan-out silently skips a workspace for, said out loud here because a caller *asked* — a screen reporting "checking now" over a tick that will never run is the failure this capability was added to end, reappearing one layer along.

`JobName` is a distinct type rather than a string: on this surface a bare string is the shape a handler could use to ask to be re-scoped, and the seam refuses that parameter class on purpose.

## Why not the obvious three

- **Draining inline on the save** is what `ErrAttendedIngest` refuses, and correctly: ingress runs on the authority of the member whose credential produced the record, and a call that *also* has a caller has two authorities in play.
- **Shortening the cadence** multiplies a login and a handshake per member, for every member, to make one member feel responsive — the exact cost adaptive cadence exists to reduce.
- **Saying nothing** is what shipped.

## `attendedChildOpts` returns where its neighbours panic

`workspaceSweepOpts` and `oneOffChildOpts` panic on a child kind whose declaration names a different opts owner, and that is right for them: they are reached from boot wiring and from a dispatcher, where such a kind is a composition fault and a panic is the boot failure it deserves. `attendedChildOpts` is reached from a unit's handler, inside a member's request — the same fault there would take down the call, or the worker, for a mistake in a declaration nobody in that request can fix.

## Held from the other end

- `TestSyncNowReachesOnlyTheInvokingUnitsOwnJobs` / `TestTheJobLookupIsScopedToTheDeclaringUnit` — mutation-checked by making the lookup resolve across units; the gate catches it.
- `TestAnAskedForRunCoalescesAndIsNotAFleetPass` — mutation-checked by dropping the uniqueness options; the gate catches it.
- `TestSyncNowFailsClosedAfterTheCallEnds` — a released `Runtime` refuses this capability like every other.
- `TestSyncNowQueuesTheUnitsOwnTickForTheCallersWorkspace` (integration) — the half only Postgres can answer: that the row it enqueues is one River accepts, of the kind the clock enqueues, for the caller's workspace, and that a second ask coalesces onto it.

`nameableByAMember` — the reviewed exception list for string-kinded parameters on `Runtime` — is now a `gatekit.Waive` set with `AssertAllMatched`, so `extension.JobName`'s entry carries its cost and a parameter that is later removed is reported stale rather than reading as standing ratification. Mutation-checked both ways.

The two out-of-tree units' fakes implement `SyncNow` by refusing every name but the one their own `api/jobs.yaml` declares, so a handler reaching for a name that fails at run time cannot pass their suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand synchronization for jobs declared by a runtime within the caller’s workspace.
  * Added clear errors for unknown jobs, invalid workspaces, and unavailable unattended execution capacity.
  * Repeated requests are coalesced to prevent duplicate queued runs.
  * Added public job naming and synchronization error reporting.

* **Bug Fixes**
  * Ensured synchronization respects job ownership, queue settings, execution limits, and runtime lifecycle.

* **Tests**
  * Added unit and integration coverage for validation, queuing, deduplication, cleanup, and workspace scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->