### PR TITLE
fix(seed): the dev seed's own records satisfy the rules its verifier states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,14 @@ jobs:
               # lockfile then merely records.
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              # And the root scripts the lane's own targets execute —
+              # check-contract-frontend-drift.sh is a gate this lane is the only
+              # runner of, and phase-timer.sh brackets every leg of it. The whole
+              # directory rather than the two names, the same cut the backend
+              # scope takes: a scope that lists individual files stops covering
+              # the next one, and running this lane on a root-script edit costs
+              # minutes where missing it ships a gate that never ran.
+              - 'scripts/**'
             e2e:
               - 'backend/**'
               - 'frontend/**'
@@ -221,6 +229,16 @@ jobs:
               - 'extensions/**'
               - 'fixtures/**'
               - 'composition/**'
+              # The lane IS these scripts: live-boot seeds through
+              # scripts/seed-dev.sh and proves the boot through
+              # scripts/verify-boot.sh, both reached as make targets. Without
+              # these two entries a PR that changes what the lane does — and
+              # nothing else — skips the only lane that would have run it, so a
+              # seeder or a boot assertion could ship never once executed. The
+              # same claim the frontend scope makes on the Makefile, and the
+              # reason the backend scope carries 'scripts/**' too.
+              - 'scripts/**'
+              - 'Makefile'
             # Everything that can change WHICH packages are in the tree, and
             # therefore which licenses the gate below judges. `**/pnpm-lock.yaml`
             # is globbed on purpose: a Renovate lockfile-only PR is precisely

--- a/backend/gates/laneinputscope_test.go
+++ b/backend/gates/laneinputscope_test.go
@@ -70,6 +70,10 @@ var scriptReference = regexp.MustCompile(`(?:frontend/)?scripts/[\w.-]+\.(?:sh|m
 // `make check-fe`, `make db-up && make migrate`.
 var makeInvocation = regexp.MustCompile(`\bmake\s+([a-z][a-z0-9-]*)`)
 
+// `SHELL := /bin/bash` after a target's colon: an assignment scoped to that
+// target, which names no prerequisite.
+var targetSpecificAssignment = regexp.MustCompile(`^[A-Z][A-Z0-9_]*\s*[:?+]?=`)
+
 // A `NAME=value` word set for the duration of one recipe command.
 var environmentAssignment = regexp.MustCompile(`^[A-Z][A-Z0-9_]*=\S*$`)
 
@@ -185,12 +189,18 @@ func parseRecipes(t *testing.T, path string) (map[string]*recipeTarget, map[stri
 			continue
 		}
 		current = strings.Fields(match[1])
+		// `verify-demo: SHELL := /bin/bash` sets a variable FOR that target; the
+		// words after the colon are an assignment, not prerequisites, and reading
+		// them as edges puts `SHELL`, `:=` and a path into the graph.
+		prerequisites := strings.Fields(expandRefs(match[2], vars))
+		if targetSpecificAssignment.MatchString(match[2]) {
+			prerequisites = nil
+		}
 		for _, name := range current {
 			if targets[name] == nil {
 				targets[name] = &recipeTarget{}
 			}
-			targets[name].pulls = append(targets[name].pulls,
-				strings.Fields(expandRefs(match[2], vars))...)
+			targets[name].pulls = append(targets[name].pulls, prerequisites...)
 		}
 	}
 	return targets, vars
@@ -434,22 +444,38 @@ func TestAScriptReachedOnlyThroughMakeIsStillALaneInput(t *testing.T) {
 	// path appears nowhere in ci.yml. A walk that stopped at the make target
 	// would judge that lane against the Makefile alone and pass it, so at least
 	// one lane must owe a script no step spells out.
-	reached := map[string][]string{}
+	// The EDGE, named: `make seed-dev` runs scripts/seed-dev.sh, `make
+	// verify-boot` runs scripts/verify-boot.sh, and neither path appears in
+	// ci.yml. Both halves are asserted from the Makefile, so this cannot be
+	// satisfied by some unrelated lane happening to reach some unrelated script
+	// — which is what "any lane owes any make-only script" allowed.
+	targets, vars := parseRecipes(t, rootMakefile)
+	for target, script := range map[string]string{
+		"seed-dev":    "scripts/seed-dev.sh",
+		"verify-boot": "scripts/verify-boot.sh",
+	} {
+		found := scriptsUnder(targets, vars, target)
+		if !slices.Contains(found, script) {
+			t.Errorf("the walk from `make %s` does not reach %s, and the Makefile's recipe runs it: found %v.\n"+
+				"A lane whose steps only say `make %s` is then judged against the Makefile alone, which is how a change to that script classified as touching nothing.",
+				target, script, found, target)
+		}
+	}
+
+	// And a lane actually owes one of those scripts without naming it, which is
+	// the property the census depends on.
+	owed := map[string][]string{}
 	for _, lane := range lanes {
 		named := strings.Join(jobCommands(t, workflow, workflow.Jobs[lane.name].Uses, lane.name), "\n")
 		for _, input := range lane.inputs {
 			if input != makefilePath && !strings.Contains(named, input) {
-				reached[lane.name] = append(reached[lane.name], input)
+				owed[lane.name] = append(owed[lane.name], input)
 			}
 		}
 	}
-	if len(reached) > 0 {
-		return
+	if len(owed) == 0 {
+		t.Errorf("no lane owes a script that only its make targets name, and live-boot owes two — the workflow reader stopped following `run: make …` into the Makefile")
 	}
-	targets, vars := parseRecipes(t, rootMakefile)
-	t.Errorf("no lane owes a script that only its make targets name, and one does: `make seed-dev` reaches %s.\n"+
-		"The recipe walk stopped following prerequisites and $(MAKE) delegations, which leaves every lane judged against the Makefile alone.",
-		strings.Join(scriptsUnder(targets, vars, "seed-dev"), ", "))
 }
 
 func TestTheCensusFailsOnAScopeThatOmitsAScriptItsLaneRuns(t *testing.T) {

--- a/backend/gates/laneinputscope_test.go
+++ b/backend/gates/laneinputscope_test.go
@@ -70,6 +70,9 @@ var scriptReference = regexp.MustCompile(`(?:frontend/)?scripts/[\w.-]+\.(?:sh|m
 // `make check-fe`, `make db-up && make migrate`.
 var makeInvocation = regexp.MustCompile(`\bmake\s+([a-z][a-z0-9-]*)`)
 
+// A `NAME=value` word set for the duration of one recipe command.
+var environmentAssignment = regexp.MustCompile(`^[A-Z][A-Z0-9_]*=\S*$`)
+
 // A variable reference in either spelling make accepts.
 var makeReference = regexp.MustCompile(`\$[({]([A-Z][A-Z0-9_]*)[)}]`)
 
@@ -253,9 +256,14 @@ func scriptsUnder(targets map[string]*recipeTarget, vars map[string]string, root
 // delegatedTargets reads the targets a `$(MAKE) a b` line pulls in. A `-C` line
 // is a sub-make into another directory: it runs a different Makefile, so it adds
 // no edge to this graph and its scripts are that directory's own.
+//
+// The environment prefix is stripped first, because `make check` is spelled
+// `@PHASE_TIMER_OWNED=1 $(MAKE) check-backend` — a reader that required the
+// line to OPEN with $(MAKE) followed neither half of the merge gate and judged
+// it against one timer script.
 func delegatedTargets(command string) []string {
 	body, isSubMake := strings.CutPrefix(
-		strings.TrimLeft(strings.TrimPrefix(command, "\t"), " \t@+-"), "$(MAKE)")
+		stripEnvironment(strings.TrimLeft(strings.TrimPrefix(command, "\t"), " \t@+-")), "$(MAKE)")
 	if !isSubMake || strings.Contains(body, " -C ") {
 		return nil
 	}
@@ -267,6 +275,18 @@ func delegatedTargets(command string) []string {
 		targets = append(targets, token)
 	}
 	return targets
+}
+
+// stripEnvironment drops the `NAME=value ` words a recipe sets for the command
+// that follows, which is where a recursive make often begins.
+func stripEnvironment(body string) string {
+	for {
+		first, rest, found := strings.Cut(body, " ")
+		if !found || !environmentAssignment.MatchString(first) {
+			return body
+		}
+		body = strings.TrimLeft(rest, " \t")
+	}
 }
 
 func sorted(set map[string]bool) []string {
@@ -471,6 +491,26 @@ func TestTheCensusFailsOnAScopeThatOmitsAScriptItsLaneRuns(t *testing.T) {
 		if missing := unscoped(lane, narrowed); len(missing) == 0 {
 			t.Errorf("%s: %d root script(s) this lane runs stayed claimed after every 'scripts/…' pattern was removed from its scope %v — the matcher claims paths no pattern covers, so the census cannot fail",
 				lane.name, scripts, lane.scopes)
+		}
+	}
+}
+
+func TestARecursiveMakeBehindAnEnvironmentPrefixIsStillAnEdge(t *testing.T) {
+	t.Parallel()
+
+	// `make check` is spelled `@PHASE_TIMER_OWNED=1 $(MAKE) check-backend`, and a
+	// reader that required the line to open with $(MAKE) followed neither half of
+	// the merge gate — it saw one timer script where two whole trees of gates
+	// hang. The census shape that fails short is the one this file exists to
+	// refuse, so the spelling is a case rather than a comment.
+	for command, want := range map[string][]string{
+		"\t@PHASE_TIMER_OWNED=1 $(MAKE) check-backend":   {"check-backend"},
+		"\tPHASE_TIMER_OWNED=1 $(MAKE) -C backend check": nil,
+		"\t$(MAKE) fe-drift":                             {"fe-drift"},
+		"\t@bash scripts/phase-timer.sh reset":           nil,
+	} {
+		if got := delegatedTargets(command); !slices.Equal(got, want) {
+			t.Errorf("delegatedTargets(%q) = %v, want %v", command, got, want)
 		}
 	}
 }

--- a/backend/gates/laneinputscope_test.go
+++ b/backend/gates/laneinputscope_test.go
@@ -262,31 +262,25 @@ func scriptsUnder(targets map[string]*recipeTarget, vars map[string]string, root
 // line to OPEN with $(MAKE) followed neither half of the merge gate and judged
 // it against one timer script.
 func delegatedTargets(command string) []string {
-	body, isSubMake := strings.CutPrefix(
-		stripEnvironment(strings.TrimLeft(strings.TrimPrefix(command, "\t"), " \t@+-")), "$(MAKE)")
-	if !isSubMake || strings.Contains(body, " -C ") {
+	// Split into words first, because make separates a recipe's words with a tab
+	// as readily as with a space and neither the prefix nor the `-C` is found by
+	// matching a literal " ". A reader that missed one silently dropped a whole
+	// half of the merge gate from the census.
+	words := strings.Fields(strings.TrimLeft(command, " \t@+-"))
+	for len(words) > 0 && environmentAssignment.MatchString(words[0]) {
+		words = words[1:]
+	}
+	if len(words) == 0 || words[0] != "$(MAKE)" || slices.Contains(words, "-C") {
 		return nil
 	}
 	var targets []string
-	for _, token := range strings.Fields(body) {
-		if strings.HasPrefix(token, "-") || strings.ContainsAny(token, "$()") {
+	for _, word := range words[1:] {
+		if strings.HasPrefix(word, "-") || strings.ContainsAny(word, "$()") {
 			continue
 		}
-		targets = append(targets, token)
+		targets = append(targets, word)
 	}
 	return targets
-}
-
-// stripEnvironment drops the `NAME=value ` words a recipe sets for the command
-// that follows, which is where a recursive make often begins.
-func stripEnvironment(body string) string {
-	for {
-		first, rest, found := strings.Cut(body, " ")
-		if !found || !environmentAssignment.MatchString(first) {
-			return body
-		}
-		body = strings.TrimLeft(rest, " \t")
-	}
 }
 
 func sorted(set map[string]bool) []string {

--- a/backend/gates/laneinputscope_test.go
+++ b/backend/gates/laneinputscope_test.go
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H3
+
+package gates
+
+// A path-filtered lane runs on a change to the scripts it EXECUTES.
+//
+// CI classifies a pull request with dorny/paths-filter and gates each lane on
+// one of the resulting scopes. That is a real saving and it has one failure
+// mode: a scope that omits a file the lane runs means an edit to that file
+// alone skips the only lane that would have executed it. The lane reports
+// SKIPPED, the aggregate is content, and the edit ships never once run.
+//
+// It has already happened. `live-boot` is the README quickstart run literally —
+// `make seed-dev` then `make verify-boot` — and the `e2e` scope named
+// backend/, frontend/, infra/, extensions/, fixtures/ and composition/ but
+// neither `scripts/**` nor the Makefile that reaches them. A change to the dev
+// seeder and to the boot proof, which is to say a change to precisely what that
+// lane does, classified as touching nothing the lane cares about. The `frontend`
+// scope had the same hole around check-contract-frontend-drift.sh.
+//
+// So the obligation is derived from what the lanes RUN rather than kept as a
+// list beside them: every root script a filtered job reaches — directly, or
+// through a make target and its prerequisites — must be matched by that job's
+// own scope. A script added to a lane's recipe next month arrives here as a
+// failure instead of as a lane that quietly stopped covering it.
+//
+// WHAT THIS CANNOT SEE, and it is the honest limit of reading a recipe: a
+// script's own dependencies. verify-boot.sh sourcing a helper elsewhere in the
+// tree is invisible here, because following that would mean interpreting shell.
+// The census counts what a lane names.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// The classifier and the lanes it gates live in the merge gate; the
+	// Makefile it invokes is the root one, which is where every `make <target>`
+	// in a workflow resolves.
+	classifierWorkflow = workflowDir + "/ci.yml"
+	rootMakefile       = "../Makefile"
+	// The step that does the classifying, identified by the action it uses
+	// rather than by its name or position.
+	pathsFilterAction = "dorny/paths-filter"
+	// The path every filtered job needs the moment it says `make` at all: the
+	// Makefile is what decides which commands the lane runs.
+	makefilePath = "Makefile"
+)
+
+// A job's guard names the scopes it runs under, e.g.
+// `needs.changes.outputs.e2e == 'true' && …`.
+var scopeGuard = regexp.MustCompile(`needs\.changes\.outputs\.(\w+)`)
+
+// A repository script as a command names it: `./scripts/x.sh`,
+// `bash scripts/x.sh`, `node scripts/x.mjs`, `frontend/scripts/x.sh`.
+var scriptReference = regexp.MustCompile(`(?:frontend/)?scripts/[\w.-]+\.(?:sh|mjs|js|ts)`)
+
+// `make check-fe`, `make db-up && make migrate`.
+var makeInvocation = regexp.MustCompile(`\bmake\s+([a-z][a-z0-9-]*)`)
+
+// A variable reference in either spelling make accepts.
+var makeReference = regexp.MustCompile(`\$[({]([A-Z][A-Z0-9_]*)[)}]`)
+
+// workflowFile is as much of a workflow as this gate reads.
+type workflowFile struct {
+	Jobs map[string]struct {
+		If    string `yaml:"if"`
+		Uses  string `yaml:"uses"`
+		Steps []struct {
+			Uses string `yaml:"uses"`
+			Run  string `yaml:"run"`
+			With struct {
+				Filters string `yaml:"filters"`
+			} `yaml:"with"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+func readWorkflow(t *testing.T, path string) workflowFile {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var parsed workflowFile
+	if err := yaml.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	return parsed
+}
+
+// filterScopes is the classifier's own declaration: scope name to the patterns
+// a path is matched against. The `filters:` input is YAML inside YAML, and its
+// anchors mean one scope can be spelled as another plus extras — which is why
+// the value is flattened rather than read as a flat list.
+func filterScopes(t *testing.T, workflow workflowFile) map[string][]string {
+	t.Helper()
+	for _, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if !strings.Contains(step.Uses, pathsFilterAction) {
+				continue
+			}
+			var declared map[string]yaml.Node
+			if err := yaml.Unmarshal([]byte(step.With.Filters), &declared); err != nil {
+				t.Fatalf("parsing the %s filters: %v", pathsFilterAction, err)
+			}
+			scopes := map[string][]string{}
+			for name, patterns := range declared {
+				scopes[name] = flattenPatterns(&patterns)
+			}
+			return scopes
+		}
+	}
+	t.Fatalf("no step in %s uses %s — the classifier was renamed or removed, and this gate was about to compare nothing", classifierWorkflow, pathsFilterAction)
+	return nil
+}
+
+// flattenPatterns reads a scope's value: a list of patterns, and where one scope
+// is spelled as another plus extras, an ANCHOR standing for that other list.
+// Read as nodes rather than as decoded values so the alias is followed — the
+// `backend` scope is `*backend_db` plus the rulebooks, and a reader that stopped
+// at the alias would judge it against two paths.
+func flattenPatterns(node *yaml.Node) []string {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return []string{node.Value}
+	case yaml.AliasNode:
+		return flattenPatterns(node.Alias)
+	case yaml.SequenceNode:
+		var out []string
+		for _, item := range node.Content {
+			out = append(out, flattenPatterns(item)...)
+		}
+		return out
+	default:
+		// A shape the classifier does not use today. Returning nothing leaves
+		// the scope narrower than it is, which fails loudly against a lane
+		// rather than quietly claiming a path.
+		return nil
+	}
+}
+
+// recipeTarget is one Makefile rule as this gate reads it: what it pulls in and
+// the command lines it runs. parseMakefile next door keeps only WHETHER a target
+// works, because that is all a leg census needs; this one needs the commands
+// themselves, which is the whole question here.
+type recipeTarget struct {
+	pulls   []string
+	recipes []string
+}
+
+func parseRecipes(t *testing.T, path string) (map[string]*recipeTarget, map[string]string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	vars := readLiteralVars(string(body))
+	targets := map[string]*recipeTarget{}
+	var current []string
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, "\t") {
+			for _, name := range current {
+				targets[name].recipes = append(targets[name].recipes, line)
+			}
+			continue
+		}
+		match := makeRuleLine.FindStringSubmatch(line)
+		if strings.HasPrefix(line, "#") || match == nil {
+			continue
+		}
+		current = strings.Fields(match[1])
+		for _, name := range current {
+			if targets[name] == nil {
+				targets[name] = &recipeTarget{}
+			}
+			targets[name].pulls = append(targets[name].pulls,
+				strings.Fields(expandRefs(match[2], vars))...)
+		}
+	}
+	return targets, vars
+}
+
+// expandRefs substitutes every `$(NAME)` this Makefile assigns literally, and
+// leaves the rest STANDING. Blanking an unknown reference is what make itself
+// does, and it is the wrong answer here: `$(MAKE)` is set by make rather than by
+// the file, so expanding it to nothing turned every `$(MAKE) fe-drift` line into
+// a bare word and the walk stopped following delegations — a census reading a
+// smaller graph and reporting a pass, which is the one way it must not break.
+//
+// The honest limit is a script named through a variable built from another
+// variable: the ceiling is a few passes, and the top of this file says so.
+func expandRefs(text string, vars map[string]string) string {
+	for range 5 {
+		next := makeReference.ReplaceAllStringFunc(text, func(ref string) string {
+			name := makeVariable.FindStringSubmatch(ref)
+			if value, ok := vars[nameOf(name)]; ok {
+				return value
+			}
+			return ref
+		})
+		if next == text {
+			return text
+		}
+		text = next
+	}
+	return text
+}
+
+// scriptsUnder walks a make target over its prerequisites and its sub-make
+// delegations, collecting every repository script the recipes name.
+func scriptsUnder(targets map[string]*recipeTarget, vars map[string]string, root string) []string {
+	found := map[string]bool{}
+	seen := map[string]bool{}
+	var walk func(string)
+	walk = func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		target := targets[name]
+		if target == nil {
+			return
+		}
+		next := slices.Clone(target.pulls)
+		for _, recipe := range target.recipes {
+			command := expandRefs(recipe, vars)
+			for _, script := range scriptReference.FindAllString(command, -1) {
+				found[script] = true
+			}
+			next = append(next, delegatedTargets(command)...)
+		}
+		for _, name := range next {
+			walk(name)
+		}
+	}
+	walk(root)
+	return sorted(found)
+}
+
+// delegatedTargets reads the targets a `$(MAKE) a b` line pulls in. A `-C` line
+// is a sub-make into another directory: it runs a different Makefile, so it adds
+// no edge to this graph and its scripts are that directory's own.
+func delegatedTargets(command string) []string {
+	body, isSubMake := strings.CutPrefix(
+		strings.TrimLeft(strings.TrimPrefix(command, "\t"), " \t@+-"), "$(MAKE)")
+	if !isSubMake || strings.Contains(body, " -C ") {
+		return nil
+	}
+	var targets []string
+	for _, token := range strings.Fields(body) {
+		if strings.HasPrefix(token, "-") || strings.ContainsAny(token, "$()") {
+			continue
+		}
+		targets = append(targets, token)
+	}
+	return targets
+}
+
+func sorted(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// filteredLane is one CI job that runs only when the classifier says its scope
+// changed, together with every repository input its steps name.
+type filteredLane struct {
+	name   string
+	scopes []string
+	inputs []string
+}
+
+// filteredLanes reads the merge gate for jobs guarded by a classifier scope. A
+// job that delegates to a reusable lane workflow carries no steps of its own, so
+// the callee's steps are read as the job's.
+func filteredLanes(t *testing.T, workflow workflowFile) []filteredLane {
+	t.Helper()
+	targets, vars := parseRecipes(t, rootMakefile)
+	var lanes []filteredLane
+	for name, job := range workflow.Jobs {
+		guarded := scopeGuard.FindAllStringSubmatch(job.If, -1)
+		if guarded == nil {
+			continue
+		}
+		lane := filteredLane{name: name}
+		for _, match := range guarded {
+			lane.scopes = append(lane.scopes, match[1])
+		}
+		commands := jobCommands(t, workflow, job.Uses, name)
+		inputs := map[string]bool{}
+		for _, command := range commands {
+			for _, script := range scriptReference.FindAllString(command, -1) {
+				inputs[script] = true
+			}
+			for _, invocation := range makeInvocation.FindAllStringSubmatch(command, -1) {
+				inputs[makefilePath] = true
+				for _, script := range scriptsUnder(targets, vars, invocation[1]) {
+					inputs[script] = true
+				}
+			}
+		}
+		lane.inputs = sorted(inputs)
+		lanes = append(lanes, lane)
+	}
+	slices.SortFunc(lanes, func(a, b filteredLane) int { return strings.Compare(a.name, b.name) })
+	return lanes
+}
+
+// jobCommands is every `run:` in the job, following a `uses:` into the reusable
+// lane workflow that holds the steps.
+func jobCommands(t *testing.T, workflow workflowFile, uses, jobName string) []string {
+	t.Helper()
+	var commands []string
+	for _, step := range workflow.Jobs[jobName].Steps {
+		if step.Run != "" {
+			commands = append(commands, step.Run)
+		}
+	}
+	if !strings.HasPrefix(uses, "./") {
+		return commands
+	}
+	lane := readWorkflow(t, filepath.Join("..", strings.TrimPrefix(uses, "./")))
+	for _, job := range lane.Jobs {
+		for _, step := range job.Steps {
+			if step.Run != "" {
+				commands = append(commands, step.Run)
+			}
+		}
+	}
+	return commands
+}
+
+// unscoped answers which of a lane's inputs no scope of its own claims.
+func unscoped(lane filteredLane, scopes map[string][]string) []string {
+	var missing []string
+	for _, input := range lane.inputs {
+		claimed := false
+		for _, scope := range lane.scopes {
+			claimed = claimed || scopeClaims(input, scopes[scope])
+		}
+		if !claimed {
+			missing = append(missing, input)
+		}
+	}
+	return missing
+}
+
+// scopeClaims answers the three pattern shapes the classifier uses: a literal
+// path, a directory tree, and a basename anywhere in the tree. A shape it does
+// not recognise leaves the path unclaimed rather than claimed, because the way
+// this gate must not fail is by reporting a pass over patterns it never read.
+func scopeClaims(path string, patterns []string) bool {
+	for _, pattern := range patterns {
+		pattern = strings.Trim(pattern, "'")
+		switch {
+		case pattern == path:
+			return true
+		case strings.HasSuffix(pattern, "/**") &&
+			strings.HasPrefix(path, strings.TrimSuffix(pattern, "**")):
+			return true
+		case strings.HasPrefix(pattern, "**/") &&
+			(path == strings.TrimPrefix(pattern, "**/") ||
+				strings.HasSuffix(path, strings.TrimPrefix(pattern, "**"))):
+			return true
+		}
+	}
+	return false
+}
+
+func TestEveryFilteredLaneRunsOnAChangeToTheScriptsItExecutes(t *testing.T) {
+	t.Parallel()
+	workflow := readWorkflow(t, classifierWorkflow)
+	scopes := filterScopes(t, workflow)
+	lanes := filteredLanes(t, workflow)
+
+	// A classifier that stopped being recognised, or a workflow whose jobs
+	// stopped being guarded, would leave nothing to judge and report a pass.
+	if len(lanes) == 0 {
+		t.Fatalf("%s has no job guarded by a classifier scope — this census read an empty tree", classifierWorkflow)
+	}
+	if len(scopes) == 0 {
+		t.Fatalf("the %s step declares no scopes — this census had nothing to match against", pathsFilterAction)
+	}
+	for _, lane := range lanes {
+		missing := unscoped(lane, scopes)
+		if len(missing) == 0 {
+			continue
+		}
+		t.Errorf("the %s job runs %s, and its scope %v claims none of them.\n"+
+			"An edit to one of those files alone classifies as touching nothing this lane cares about: "+
+			"the lane reports SKIPPED, the aggregate is content, and the change ships never once executed.\n"+
+			"Add the paths to the scope in %s.",
+			lane.name, strings.Join(missing, ", "), lane.scopes, classifierWorkflow)
+	}
+}
+
+func TestAScriptReachedOnlyThroughMakeIsStillALaneInput(t *testing.T) {
+	t.Parallel()
+	workflow := readWorkflow(t, classifierWorkflow)
+	lanes := filteredLanes(t, workflow)
+
+	// The defect this gate was written for was reached through `make`, not named
+	// in the workflow: live-boot's steps say `make seed-dev` and the seeder's
+	// path appears nowhere in ci.yml. A walk that stopped at the make target
+	// would judge that lane against the Makefile alone and pass it, so at least
+	// one lane must owe a script no step spells out.
+	reached := map[string][]string{}
+	for _, lane := range lanes {
+		named := strings.Join(jobCommands(t, workflow, workflow.Jobs[lane.name].Uses, lane.name), "\n")
+		for _, input := range lane.inputs {
+			if input != makefilePath && !strings.Contains(named, input) {
+				reached[lane.name] = append(reached[lane.name], input)
+			}
+		}
+	}
+	if len(reached) > 0 {
+		return
+	}
+	targets, vars := parseRecipes(t, rootMakefile)
+	t.Errorf("no lane owes a script that only its make targets name, and one does: `make seed-dev` reaches %s.\n"+
+		"The recipe walk stopped following prerequisites and $(MAKE) delegations, which leaves every lane judged against the Makefile alone.",
+		strings.Join(scriptsUnder(targets, vars, "seed-dev"), ", "))
+}
+
+func TestTheCensusFailsOnAScopeThatOmitsAScriptItsLaneRuns(t *testing.T) {
+	t.Parallel()
+	workflow := readWorkflow(t, classifierWorkflow)
+	scopes := filterScopes(t, workflow)
+	lanes := filteredLanes(t, workflow)
+
+	// The gate's own falsification, and the defect it shipped against: take the
+	// live classifier, drop the scripts from one scope, and the lane that runs
+	// them must come back unclaimed. Without this, a matcher that quietly
+	// claimed everything would keep this file green forever.
+	for _, lane := range lanes {
+		narrowed := map[string][]string{}
+		for name, patterns := range scopes {
+			kept := make([]string, 0, len(patterns))
+			for _, pattern := range patterns {
+				if !slices.Contains(lane.scopes, name) || !strings.HasPrefix(pattern, "scripts/") {
+					kept = append(kept, pattern)
+				}
+			}
+			narrowed[name] = kept
+		}
+		scripts := 0
+		for _, input := range lane.inputs {
+			if strings.HasPrefix(input, "scripts/") {
+				scripts++
+			}
+		}
+		if scripts == 0 {
+			continue
+		}
+		if missing := unscoped(lane, narrowed); len(missing) == 0 {
+			t.Errorf("%s: %d root script(s) this lane runs stayed claimed after every 'scripts/…' pattern was removed from its scope %v — the matcher claims paths no pattern covers, so the census cannot fail",
+				lane.name, scripts, lane.scopes)
+		}
+	}
+}
+
+func TestTheRecipeWalkReadsPrerequisitesAndDelegations(t *testing.T) {
+	t.Parallel()
+	targets, vars := parseRecipes(t, rootMakefile)
+
+	// Two edges, both load-bearing, both invisible from a target's own recipe:
+	// `make check` reaches its script gates through prerequisites, and the
+	// frontend legs are pulled in by $(MAKE) lines. A walk that read only the
+	// named target's own commands would find nothing behind either.
+	for _, root := range []string{"check", "check-fe"} {
+		if _, ok := targets[root]; !ok {
+			t.Fatalf("%s declares no %q target — the walk was about to prove nothing", rootMakefile, root)
+		}
+		if scripts := scriptsUnder(targets, vars, root); len(scripts) == 0 {
+			t.Errorf("the walk found no script behind `make %s`, which runs several: %s",
+				root, fmt.Sprint(targets[root].pulls))
+		}
+	}
+}

--- a/backend/gates/pipefailgrepq_test.go
+++ b/backend/gates/pipefailgrepq_test.go
@@ -50,8 +50,12 @@ const shellGateDir = "../scripts"
 var shellVariableIntoQuietGrep = regexp.MustCompile(
 	`(?:printf\s+'%s(?:\\n)?'|echo)\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*grep\s+-[A-Za-z]*q`)
 
-// The setting that turns a broken pipe into the pipeline's verdict.
-var pipefailSetting = regexp.MustCompile(`set\s+-[a-z]*o?\s*pipefail|set\s+-[a-z]*euo\s+pipefail`)
+// The setting that turns a broken pipe into the pipeline's verdict — recognised
+// by the word rather than by the flag letters around it. `set -Eeuo pipefail`,
+// `set -e -o pipefail` and `set -o pipefail` are the same setting, and a
+// prohibition that recognised only one spelling would let a script escape it by
+// being written the other way. Nothing but this setting says `pipefail`.
+var pipefailSetting = regexp.MustCompile(`(?m)^\s*set\s+.*\bpipefail\b`)
 
 func TestNoShellGateReadsAVerdictThroughAPipeThatCanBreak(t *testing.T) {
 	t.Parallel()
@@ -87,5 +91,28 @@ func TestNoShellGateReadsAVerdictThroughAPipeThatCanBreak(t *testing.T) {
 	}
 	if judged == 0 {
 		t.Fatalf("no script under %s sets pipefail, which is not a shape this tree has ever had — the setting is spelled some way this gate does not recognise", shellGateDir)
+	}
+}
+
+func TestEverySpellingOfPipefailIsRecognised(t *testing.T) {
+	t.Parallel()
+
+	// One setting, several spellings, and the gate above judges only the scripts
+	// where it is on. A matcher that missed a spelling would leave those scripts
+	// unjudged and say nothing — under-recognition, which is the same defect
+	// class the prohibition itself is about.
+	for setting, want := range map[string]bool{
+		"set -euo pipefail":   true,
+		"set -Eeuo pipefail":  true,
+		"set -e -o pipefail":  true,
+		"set -o pipefail":     true,
+		"\tset -eo pipefail":  true,
+		"set -eu":             false,
+		"# set -euo pipefail": false,
+		"echo 'set pipefail'": false,
+	} {
+		if got := pipefailSetting.MatchString(setting); got != want {
+			t.Errorf("pipefailSetting.MatchString(%q) = %v, want %v", setting, got, want)
+		}
 	}
 }

--- a/backend/gates/pipefailgrepq_test.go
+++ b/backend/gates/pipefailgrepq_test.go
@@ -35,6 +35,7 @@ package gates
 // whole variable's worth of output into a consumer that stops early.
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,11 +45,17 @@ import (
 
 const shellGateDir = "../scripts"
 
-// `printf '%s' "$var" | grep -q…` or `echo "$var" | grep -q…`, which is the
+// `printf '%s' "$var" | grep -q…` or `echo "…$var…" | grep -q…`, which is the
 // shape that broke. A pipe into a `grep` without -q consumes all of its input
 // and does not race.
+//
+// Both quotings of the format string, and a variable ANYWHERE in the operand:
+// `printf "%s"` is the same producer as `printf '%s'`, and `echo "at $sha"`
+// writes just as much into a consumer that stops early. A prohibition that
+// recognised one spelling would be avoidable by using the other, which is not a
+// property a prohibition may have.
 var shellVariableIntoQuietGrep = regexp.MustCompile(
-	`(?:printf\s+'%s(?:\\n)?'|echo)\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*grep\s+-[A-Za-z]*q`)
+	`(?:printf\s+["']%s(?:\\n)?["']|echo)\s+"[^"]*\$\{?[A-Za-z_][A-Za-z0-9_]*\}?[^"]*"\s*\|\s*grep\s+-[A-Za-z]*q`)
 
 // The setting that turns a broken pipe into the pipeline's verdict — recognised
 // by the word rather than by the flag letters around it. `set -Eeuo pipefail`,
@@ -60,14 +67,37 @@ var pipefailSetting = regexp.MustCompile(`(?m)^\s*set\s+.*\bpipefail\b`)
 func TestNoShellGateReadsAVerdictThroughAPipeThatCanBreak(t *testing.T) {
 	t.Parallel()
 
-	scripts, err := filepath.Glob(filepath.Join(shellGateDir, "*.sh"))
+	// The whole tree, not its top level. `scripts/deploy/` already holds two
+	// entrypoints, and a glob of `*.sh` judged neither — an under-scoped census
+	// reports a pass over the part it read, and the empty-tree guard below
+	// cannot see the difference between "nothing there" and "nothing looked at".
+	var scripts []string
+	err := filepath.WalkDir(shellGateDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && strings.HasSuffix(path, ".sh") {
+			scripts = append(scripts, path)
+		}
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("listing %s: %v", shellGateDir, err)
+		t.Fatalf("walking %s: %v", shellGateDir, err)
 	}
-	// A glob that matched nothing would report a pass over an empty tree, which
-	// is the one way a prohibition must not fail.
 	if len(scripts) == 0 {
 		t.Fatalf("%s holds no *.sh — this prohibition read an empty tree", shellGateDir)
+	}
+	// And it reaches BELOW the top level, which is the scoping the glob got
+	// wrong: a tree with subdirectories that this walk flattens to one level
+	// would pass every assertion below while judging none of them.
+	nested := 0
+	for _, path := range scripts {
+		if strings.Count(filepath.ToSlash(path), "/") > strings.Count(filepath.ToSlash(shellGateDir), "/")+1 {
+			nested++
+		}
+	}
+	if nested == 0 {
+		t.Errorf("the walk found no *.sh below the top level of %s, and scripts/deploy/ holds two — the census is reading one directory where it means the tree", shellGateDir)
 	}
 	judged := 0
 	for _, path := range scripts {
@@ -113,6 +143,27 @@ func TestEverySpellingOfPipefailIsRecognised(t *testing.T) {
 	} {
 		if got := pipefailSetting.MatchString(setting); got != want {
 			t.Errorf("pipefailSetting.MatchString(%q) = %v, want %v", setting, got, want)
+		}
+	}
+}
+
+func TestEverySpellingOfTheBreakablePipeIsRecognised(t *testing.T) {
+	t.Parallel()
+
+	// The shape, not one way of writing it. Each false case is a pipe that does
+	// NOT race: a grep without -q reads its input to the end.
+	for line, want := range map[string]bool{
+		`printf '%s' "$body" | grep -q X`:    true,
+		`printf "%s" "$body" | grep -q X`:    true,
+		`printf '%s\n' "$body" | grep -qF X`: true,
+		`echo "$body" | grep -Eq X`:          true,
+		`echo "at $sha" | grep -q X`:         true,
+		`printf '%s' "$body" | grep X`:       false,
+		`git log -1 | grep -q X`:             false,
+		`printf '%s' "$body" > "$out"`:       false,
+	} {
+		if got := shellVariableIntoQuietGrep.MatchString(line); got != want {
+			t.Errorf("shellVariableIntoQuietGrep.MatchString(%q) = %v, want %v", line, got, want)
 		}
 	}
 }

--- a/backend/gates/pipefailgrepq_test.go
+++ b/backend/gates/pipefailgrepq_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A shell gate does not decide its verdict through a pipe that can break.
+//
+// `printf '%s' "$body" | grep -q PATTERN` under `set -o pipefail` is a RACE.
+// `grep -q` exits the moment it matches, which closes the pipe while printf is
+// still writing; printf then fails with EPIPE, pipefail promotes that to the
+// pipeline's status, and the caller reads a match as no-match. Whether it
+// happens depends on how much the producer had left to write and how fast the
+// consumer exited — so it passes on a laptop and fails on a runner, on the same
+// commit.
+//
+// It cost a merge. `scripts/test-scheduled-report.sh` reported
+//
+//	FAIL: MAIN_SONAR_RESULT has a reporter arm, but main-health's report job
+//	does not run for a failing 'sonar' — the arm is unreachable
+//
+// on a job whose `if:` names that very lane, one line after
+// `printf: write error: Broken pipe`, while the same script was green locally.
+// Ten more sites across the script gates had the same shape.
+//
+// A here-string has no second process and cannot break: `grep -q PATTERN
+// <<<"$body"`. Every one of these scripts is bash, so the spelling is available
+// wherever the shape appears.
+//
+// SCOPE, and why it stops here: only a producer that is the SHELL ITSELF —
+// `printf` or `echo` of a variable — is judged. An external command on the left
+// (`git log … | grep -q`) can also take SIGPIPE, but it is a different fix with
+// a much larger surface, and the shell-side sites are the ones that carry a
+// whole variable's worth of output into a consumer that stops early.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const shellGateDir = "../scripts"
+
+// `printf '%s' "$var" | grep -q…` or `echo "$var" | grep -q…`, which is the
+// shape that broke. A pipe into a `grep` without -q consumes all of its input
+// and does not race.
+var shellVariableIntoQuietGrep = regexp.MustCompile(
+	`(?:printf\s+'%s(?:\\n)?'|echo)\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*grep\s+-[A-Za-z]*q`)
+
+// The setting that turns a broken pipe into the pipeline's verdict.
+var pipefailSetting = regexp.MustCompile(`set\s+-[a-z]*o?\s*pipefail|set\s+-[a-z]*euo\s+pipefail`)
+
+func TestNoShellGateReadsAVerdictThroughAPipeThatCanBreak(t *testing.T) {
+	t.Parallel()
+
+	scripts, err := filepath.Glob(filepath.Join(shellGateDir, "*.sh"))
+	if err != nil {
+		t.Fatalf("listing %s: %v", shellGateDir, err)
+	}
+	// A glob that matched nothing would report a pass over an empty tree, which
+	// is the one way a prohibition must not fail.
+	if len(scripts) == 0 {
+		t.Fatalf("%s holds no *.sh — this prohibition read an empty tree", shellGateDir)
+	}
+	judged := 0
+	for _, path := range scripts {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(body)
+		if !pipefailSetting.MatchString(text) {
+			continue
+		}
+		judged++
+		for number, line := range strings.Split(text, "\n") {
+			if !shellVariableIntoQuietGrep.MatchString(line) {
+				continue
+			}
+			t.Errorf("%s:%d decides a verdict through a pipe that can break under pipefail:\n\t%s\n"+
+				"`grep -q` exits on its first match and the producer then fails with EPIPE, so a match reads as no-match — on some machines and not others. Use a here-string: grep -q… <<<\"$var\".",
+				path, number+1, strings.TrimSpace(line))
+		}
+	}
+	if judged == 0 {
+		t.Fatalf("no script under %s sets pipefail, which is not a shape this tree has ever had — the setting is spelled some way this gate does not recognise", shellGateDir)
+	}
+}

--- a/backend/gates/seedemploymentpredicate_test.go
+++ b/backend/gates/seedemploymentpredicate_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The dev seeder and the boot proof ask "is this person currently employed?" the
+// way the PRODUCT asks it, and they ask it in the same words.
+//
+// Neither is a Go client, so neither can call people.CurrentPrimaryEmploymentSQL:
+// both are shell over the public API, and both therefore hand-spell the rule as
+// a jq predicate. That makes it one invariant with three writers, and the two
+// shell copies are the pair that can drift silently — the seeder deciding a
+// record is already good while the boot proof calls the same record broken, or
+// worse, both agreeing on a weaker rule than the product reads.
+//
+// The weaker rule is the one this repository already shipped: an existence probe
+// (`.data | length > 0`) accepts an ended or secondary employment, and a company
+// page shows neither. So the gate holds two things — that the two scripts spell
+// the predicate identically, and that what they spell still names every column
+// the server's own predicate reads.
+//
+// WHAT THIS CANNOT SEE: whether the jq means what the SQL means. Proving that
+// would need a second implementation of the predicate to compare against, which
+// is the duplicate this gate exists to prevent. It holds the shape — same words
+// in both scripts, over the same columns as the server — and the live proof is
+// scripts/verify-boot.sh failing against a planted ended edge.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+)
+
+// The scripts that spell the rule, and the assignment they spell it in.
+var currentPrimaryPredicateScripts = []string{
+	"../scripts/seed-dev.sh",
+	"../scripts/verify-boot.sh",
+}
+
+var currentPrimaryPredicate = regexp.MustCompile(`(?m)^CURRENT_PRIMARY_JQ='([^']+)'$`)
+
+// The columns the server's predicate reads, which is what the shell copies must
+// still be asking about. Derived from the helper rather than listed, so a rule
+// that grows a third column fails here instead of leaving the seeder behind.
+var employmentCurrencyColumns = []string{"is_current_primary", "ended_at"}
+
+func predicateIn(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	match := currentPrimaryPredicate.FindStringSubmatch(string(body))
+	if match == nil {
+		t.Fatalf("%s spells no CURRENT_PRIMARY_JQ='…' assignment.\n"+
+			"Both scripts ask whether a seeded person is currently employed, and they must ask it in the same words — the copy that drifts is the one that accepts an employment the product does not draw.", path)
+	}
+	return match[1]
+}
+
+func TestTheSeederAndTheBootProofSpellOneEmploymentRule(t *testing.T) {
+	t.Parallel()
+
+	first := predicateIn(t, currentPrimaryPredicateScripts[0])
+	for _, path := range currentPrimaryPredicateScripts[1:] {
+		if other := predicateIn(t, path); other != first {
+			t.Errorf("%s and %s ask whether a person is currently employed in different words:\n\t%s\n\t%s\n"+
+				"One writes the records the other refuses. Land both sides in one change.",
+				currentPrimaryPredicateScripts[0], path, first, other)
+		}
+	}
+}
+
+func TestTheShellPredicateReadsTheColumnsTheServerReads(t *testing.T) {
+	t.Parallel()
+
+	// The server's spelling, and the reason this is derived: an existence probe
+	// over /v1/relationships names NEITHER column and reads as employed anybody
+	// who ever was.
+	server := people.CurrentPrimaryEmploymentSQL("")
+	predicate := predicateIn(t, currentPrimaryPredicateScripts[0])
+	for _, column := range employmentCurrencyColumns {
+		if !strings.Contains(server, column) {
+			t.Fatalf("people.CurrentPrimaryEmploymentSQL no longer reads %q (%s) — the rule moved, and this gate was about to hold the shell copies to a shape the product has stopped using",
+				column, server)
+		}
+		if !strings.Contains(predicate, column) {
+			t.Errorf("the seeder's employment predicate does not read %q, and the server's does (%s):\n\t%s\n"+
+				"A predicate short of a column the product reads accepts a record the product will not draw.",
+				column, server, predicate)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (40)
+## Parity (41)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -57,6 +57,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
+| `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this person currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -179,7 +179,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (31)
+## Prohibition (32)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -202,6 +202,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `logsecrets_test.go` | H2 | A credential reaches a log field only on the failure of the channel that was supposed to carry it. |
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
 | `moduletablespelling_test.go` | H2 | A package that names its table does not pass that name as a bare string. |
+| `pipefailgrepq_test.go` | H2 | A shell gate does not decide its verdict through a pipe that can break. |
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |
 | `publicreferences_test.go` | H1 | This repository is public. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -60,7 +60,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 
-## Census (66)
+## Census (67)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -94,6 +94,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobbinding_test.go` | H2 | workspaceBindFloor guards against a vacuous pass. |
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
+| `laneinputscope_test.go` | H3 | A path-filtered lane runs on a change to the scripts it EXECUTES. |
 | `leadpersonlockorder_test.go` | H2 | ONE lock order over the lead and the person it was promoted into. |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by a pass the merge gate runs, analysed by one that lints, and read by both lint configs or neither. |

--- a/scripts/check-image-pins.sh
+++ b/scripts/check-image-pins.sh
@@ -38,7 +38,7 @@ while IFS= read -r line; do
     ./*) continue ;; # local composite action: versioned with the repo itself
   esac
   ref="${pin##*@}"
-  if [ "$ref" = "$pin" ] || ! echo "$ref" | grep -qE '^([0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$'; then
+  if [ "$ref" = "$pin" ] || ! grep -qE '^([0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$' <<<"$ref"; then
     echo "UNPINNED REF: $line" >&2
     fail=1
   fi
@@ -60,7 +60,7 @@ while IFS= read -r line; do
     \#*) continue ;;                                # commented out — not pulled
   esac
   image=$(echo "$content" | sed 's/.*image:[[:space:]]*//' | cut -d'#' -f1 | tr -d ' "'"'")
-  if ! echo "$image" | grep -qE '@sha256:[0-9a-f]{64}$'; then
+  if ! grep -qE '@sha256:[0-9a-f]{64}$' <<<"$image"; then
     echo "UNPINNED IMAGE (pin as tag@sha256:<digest>): $line" >&2
     fail=1
   fi

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -232,7 +232,7 @@ for dir in "$MIGRATIONS_DIR"/*/; do
       # of a new collision. Without this the gate refuses every repair of the
       # outage it exists to report, and the only way back to a loadable
       # namespace is to bypass the gate.
-      if [ "$(echo "$base_name" | wc -l)" -gt 1 ] && echo "$base_name" | grep -qxF "$name"; then
+      if [ "$(echo "$base_name" | wc -l)" -gt 1 ] && grep -qxF "$name" <<<"$base_name"; then
         echo "note: $ns/$version is claimed twice on $BASE_REF ($(echo "$base_name" | tr '\n' ' ')); this branch keeps '$name' at it — repairing, not colliding"
         continue
       fi

--- a/scripts/check-test-lanes.sh
+++ b/scripts/check-test-lanes.sh
@@ -46,7 +46,7 @@ while IFS= read -r f; do
     continue
   fi
   code="$(strip_comments "$f")"
-  if printf '%s\n' "$code" | grep -Eq "$real"; then
+  if grep -Eq "$real" <<<"$code"; then
     echo "VIOLATION (unit test opens real infra — add //go:build integration, or fake the boundary): $f"
     # Reported against the ORIGINAL line, so the number is the one an author
     # opens and the text is what they wrote — the stripped copy only decides

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -265,18 +265,44 @@ echo "== seed-dev: demo employment =="
 CURRENT_PRIMARY_JQ='.is_current_primary and (.ended_at == null or (.ended_at | tostring) >= $today)'
 TODAY="$(date -u +%F)"
 
-person_id() { # person_id <full-name> — prints the id, empty when absent
-  local name="$1" status
-  status="$(api GET "/people?q=$(url_encode "$name")&limit=50")"
-  [ "$status" = "200" ] || fail "GET /v1/people?q= returned HTTP $status"
-  # Matched on the whole name rather than taken from the first hit: `q` is a
-  # full-text query, so it answers with everything that shares a word.
-  jq -r --arg n "$name" 'first(.data[] | select(.full_name == $n) | .id) // empty' "$workdir/body"
+# The first row of a list that matches, across EVERY page of it.
+#
+# One page was enough while the dev seed was the only thing in the installation.
+# It is not enough on a stack that also carries the demo dataset: `q` is a
+# full-text query, so a page of matches can be all the people who share a word
+# with the one being looked for, and a lookup that reads the first hundred of
+# them reports "absent" for a record that is present. That is the failure a
+# census must never have — it stops finding what it is looking for and says so
+# in the voice of a pass — so the cursor is followed to exhaustion.
+#
+# `select` is a jq filter over ONE row, and any further arguments are handed to
+# jq — a name goes in as `--arg`, never spliced into the filter. `$today` is
+# bound for the callers that ask about employment currency.
+find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
+  local path="$1" select="$2" cursor="" sep status row
+  shift 2
+  while :; do
+    case "$path" in *\?*) sep="&" ;; *) sep="?" ;; esac
+    status="$(api GET "$path${sep}limit=100${cursor:+&cursor=$(url_encode "$cursor")}")"
+    [ "$status" = "200" ] || fail "GET /v1${path} returned HTTP $status"
+    row="$(jq -c --arg today "$TODAY" "$@" "first(.data[] | select($select)) // empty" "$workdir/body")"
+    if [ -n "$row" ]; then
+      printf '%s' "$row"
+      return
+    fi
+    cursor="$(jq -r 'if .page.has_more then (.page.next_cursor // "") else "" end' "$workdir/body")"
+    [ -n "$cursor" ] || return
+  done
 }
 
-status="$(api GET '/organizations?domain=demo.test&limit=50')"
-[ "$status" = "200" ] || fail "GET /v1/organizations?domain= returned HTTP $status"
-org_id="$(jq -r 'first(.data[] | select(.display_name == "Demo GmbH") | .id) // empty' "$workdir/body")"
+person_id() { # person_id <full-name> — prints the id, empty when absent
+  # Matched on the whole name rather than taken from the first hit: `q` is a
+  # full-text query, so it answers with everything that shares a word.
+  find_first "/people?q=$(url_encode "$1")" '.full_name == $name' --arg name "$1" \
+    | jq -r '.id // empty'
+}
+
+org_id="$(find_first '/organizations?domain=demo.test' '.display_name == "Demo GmbH"' | jq -r '.id // empty')"
 [ -n "$org_id" ] || fail "Demo GmbH is not in the installation the seed just wrote to"
 
 # The roles are the demo's own: a company page whose three contacts have no
@@ -294,19 +320,17 @@ org_id="$(jq -r 'first(.data[] | select(.display_name == "Demo GmbH") | .id) // 
 # person is re-hired with a new edge instead, which is also what happened in the
 # story the demo tells.
 employ() { # employ <full-name> <role>
-  local name="$1" role="$2" id status standing rel_id rel_version
+  local name="$1" role="$2" id edges standing rel_id rel_version status
   id="$(person_id "$name")"
   [ -n "$id" ] || fail "$name is not in the installation the seed just wrote to"
-  status="$(api GET "/relationships?kind=employment&person_id=$id&limit=50")"
-  [ "$status" = "200" ] || fail "GET /v1/relationships returned HTTP $status"
-  if jq -e --arg o "$org_id" --arg today "$TODAY" \
-    "any(.data[]; .organization_id == \$o and $CURRENT_PRIMARY_JQ)" "$workdir/body" >/dev/null; then
+  edges="/relationships?kind=employment&person_id=$id"
+  if [ -n "$(find_first "$edges" ".organization_id == \$org and $CURRENT_PRIMARY_JQ" --arg org "$org_id")" ]; then
     echo "  OK: $name already employed at Demo GmbH"
     return
   fi
-  standing="$(jq -c --arg o "$org_id" --arg today "$TODAY" \
-    "first(.data[] | select(.organization_id == \$o and (.ended_at == null or (.ended_at | tostring) >= \$today))) // empty" \
-    "$workdir/body")"
+  standing="$(find_first "$edges" \
+    '.organization_id == $org and (.ended_at == null or (.ended_at | tostring) >= $today)' \
+    --arg org "$org_id")"
   if [ -n "$standing" ]; then
     rel_id="$(printf '%s' "$standing" | jq -r '.id')"
     rel_version="$(printf '%s' "$standing" | jq -r '.version // ""')"

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -66,6 +66,27 @@ api() { # api <method> <path> [json-body] — prints the HTTP status, body lands
     ${data:+--data "$data"} || true
 }
 
+# A query-string value, escaped. The seeded names carry a space and an umlaut,
+# and an unescaped `q=Alice Müller` is a malformed request line rather than a
+# lookup that quietly misses.
+url_encode() { # url_encode <value>
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+# The same request carrying the row version it was read at. A seeder is an
+# automated writer, and the contract discourages those from omitting the
+# precondition: without it a PATCH is last-write-wins, so a re-run racing
+# anything else editing the same account would silently overwrite it.
+api_if_match() { # api_if_match <method> <path> <version> <json-body>
+  local method="$1" path="$2" version="$3" data="$4"
+  curl -sS --max-time 30 -o "$workdir/body" -D "$workdir/headers" -w '%{http_code}' \
+    -X "$method" "$API_BASE/v1$path" \
+    -H 'Content-Type: application/json' \
+    -H "If-Match: $version" \
+    ${SESSION:+--cookie "crm_session=$SESSION"} \
+    --data "$data" || true
+}
+
 # The session cookie is Secure, which curl's jar refuses to replay over
 # plain-http localhost — so pull the token out and send it explicitly.
 capture_session() {
@@ -224,6 +245,76 @@ ensure "person Carol Wagner" /people \
 echo "== seed-dev: demo organization =="
 ensure "organization Demo GmbH" /organizations \
   '{"display_name":"Demo GmbH","domains":[{"domain":"demo.test","is_primary":true}],"source":"seed"}'
+
+# What these records are FOR is being looked at, so they are held to the bar the
+# demo dataset's own verify pass states: every person employed somewhere, every
+# account off `unknown`. Three people who work nowhere show on no company page,
+# and an account left at the default makes "who are our customers?" return
+# everything — which is exactly what `make verify-demo` reports, and it reported
+# it against these four rows rather than against the dataset's.
+#
+# Read back rather than remembered from the create: `ensure` answers 409 on a
+# re-run, and a seeder that only knew the ids it created this time would do half
+# its job on every run after the first.
+echo "== seed-dev: demo employment =="
+
+person_id() { # person_id <full-name> — prints the id, empty when absent
+  local name="$1" status
+  status="$(api GET "/people?q=$(url_encode "$name")&limit=50")"
+  [ "$status" = "200" ] || fail "GET /v1/people?q= returned HTTP $status"
+  # Matched on the whole name rather than taken from the first hit: `q` is a
+  # full-text query, so it answers with everything that shares a word.
+  jq -r --arg n "$name" 'first(.data[] | select(.full_name == $n) | .id) // empty' "$workdir/body"
+}
+
+status="$(api GET '/organizations?domain=demo.test&limit=50')"
+[ "$status" = "200" ] || fail "GET /v1/organizations?domain= returned HTTP $status"
+org_id="$(jq -r 'first(.data[] | select(.display_name == "Demo GmbH") | .id) // empty' "$workdir/body")"
+[ -n "$org_id" ] || fail "Demo GmbH is not in the installation the seed just wrote to"
+
+# The roles are the demo's own: a company page whose three contacts have no
+# titles reads as a page that failed to load them.
+employ() { # employ <full-name> <role>
+  local name="$1" role="$2" id status
+  id="$(person_id "$name")"
+  [ -n "$id" ] || fail "$name is not in the installation the seed just wrote to"
+  status="$(api GET "/relationships?kind=employment&person_id=$id&limit=50")"
+  [ "$status" = "200" ] || fail "GET /v1/relationships returned HTTP $status"
+  if jq -e --arg o "$org_id" 'any(.data[]; .organization_id == $o)' "$workdir/body" >/dev/null; then
+    echo "  OK: $name already employed at Demo GmbH"
+    return
+  fi
+  # `is_current_primary` is left out on purpose: the server makes an employment
+  # primary when the person has no other current one, and stating it here would
+  # be this script deciding something it has not read.
+  ensure "employment $name at Demo GmbH" /relationships \
+    "$(jq -n --arg p "$id" --arg o "$org_id" --arg r "$role" \
+      '{kind:"employment",person_id:$p,organization_id:$o,role:$r,source:"seed"}')"
+}
+
+employ "Alice Müller" "Head of Operations"
+employ "Bob Schmidt" "Procurement Lead"
+employ "Carol Wagner" "Managing Director"
+
+echo "== seed-dev: demo account lifecycle =="
+status="$(api GET "/organizations/$org_id")"
+[ "$status" = "200" ] || fail "GET /v1/organizations/$org_id returned HTTP $status"
+org_lifecycle="$(jq -r '.lifecycle // ""' "$workdir/body")"
+org_version="$(jq -r '.version // ""' "$workdir/body")"
+if [ "$org_lifecycle" = "customer" ]; then
+  echo "  OK: Demo GmbH is already a customer"
+else
+  [ -n "$org_version" ] || fail "GET /v1/organizations/$org_id answered without a version to write against"
+  status="$(api_if_match PATCH "/organizations/$org_id" "$org_version" '{"lifecycle":"customer"}')"
+  case "$status" in
+    200) echo "  OK: Demo GmbH is a customer" ;;
+    *)
+      echo "  response body:" >&2
+      cat "$workdir/body" >&2
+      fail "PATCH /v1/organizations/$org_id (lifecycle) returned HTTP $status"
+      ;;
+  esac
+fi
 
 echo "== seed-dev: demo deals =="
 # Deals have no natural key, so idempotency is a name probe against the

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -299,10 +299,17 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
   done
 }
 
-person_id() { # person_id <full-name> — prints the id, empty when absent
-  # Matched on the whole name rather than taken from the first hit: `q` is a
-  # full-text query, so it answers with everything that shares a word.
-  find_first "/people?q=$(url_encode "$1")" '.full_name == $name' --arg name "$1" \
+# The person, identified the way the seed identifies them: their EMAIL.
+#
+# `q` is full-text over name and title only, so it cannot fetch by address — it
+# narrows, and the email then decides. Two people can share a full name, and
+# taking the first hit would attach an employment to whichever row the query
+# happened to answer with; the address is the natural key the seeded row was
+# created with, so it is the one that says "this is that record".
+person_id() { # person_id <full-name> <email> — prints the id, empty when absent
+  find_first "/people?q=$(url_encode "$1")" \
+    '.full_name == $name and any(.emails[]?; .email == $email)' \
+    --arg name "$1" --arg email "$2" \
     | jq -r '.id // empty'
 }
 
@@ -323,10 +330,10 @@ org_id="$(find_first '/organizations?domain=demo.test' '.display_name == "Demo G
 # no way to un-end one on purpose — a former employment keeps its row — so the
 # person is re-hired with a new edge instead, which is also what happened in the
 # story the demo tells.
-employ() { # employ <full-name> <role>
-  local name="$1" role="$2" id edges standing rel_id rel_version status
-  id="$(person_id "$name")"
-  [ -n "$id" ] || fail "$name is not in the installation the seed just wrote to"
+employ() { # employ <full-name> <email> <role>
+  local name="$1" email="$2" role="$3" id edges standing rel_id rel_version status
+  id="$(person_id "$name" "$email")"
+  [ -n "$id" ] || fail "$name <$email> is not in the installation the seed just wrote to"
   edges="/relationships?kind=employment&person_id=$id"
   if [ -n "$(find_first "$edges" ".organization_id == \$org and $CURRENT_PRIMARY_JQ" --arg org "$org_id")" ]; then
     echo "  OK: $name already employed at Demo GmbH"
@@ -358,9 +365,9 @@ employ() { # employ <full-name> <role>
       '{kind:"employment",person_id:$p,organization_id:$o,role:$r,source:"seed"}')"
 }
 
-employ "Alice Müller" "Head of Operations"
-employ "Bob Schmidt" "Procurement Lead"
-employ "Carol Wagner" "Managing Director"
+employ "Alice Müller" "alice@demo.test" "Head of Operations"
+employ "Bob Schmidt" "bob@demo.test" "Procurement Lead"
+employ "Carol Wagner" "carol@demo.test" "Managing Director"
 
 echo "== seed-dev: demo account lifecycle =="
 status="$(api GET "/organizations/$org_id")"

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -291,7 +291,11 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
       return
     fi
     cursor="$(jq -r 'if .page.has_more then (.page.next_cursor // "") else "" end' "$workdir/body")"
-    [ -n "$cursor" ] || return
+    # Absent is an ANSWER, not a failure: every caller asks "is this here?" and
+    # handles no for itself. A bare `return` here carries the test's own exit
+    # status, which is 1 when the cursor is empty — and under `set -e` that
+    # killed the whole script the first time a lookup legitimately found nothing.
+    [ -n "$cursor" ] || return 0
   done
 }
 

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -258,6 +258,13 @@ ensure "organization Demo GmbH" /organizations \
 # its job on every run after the first.
 echo "== seed-dev: demo employment =="
 
+# The current-primary rule, spelled once here and once in verify-boot.sh because
+# each script is a client of the same API and neither can call the other's shell.
+# `ended_at` is a date and ISO dates compare as strings, so a future end is still
+# current — the same reading the server's own predicate takes.
+CURRENT_PRIMARY_JQ='.is_current_primary and (.ended_at == null or (.ended_at | tostring) >= $today)'
+TODAY="$(date -u +%F)"
+
 person_id() { # person_id <full-name> — prints the id, empty when absent
   local name="$1" status
   status="$(api GET "/people?q=$(url_encode "$name")&limit=50")"
@@ -274,14 +281,45 @@ org_id="$(jq -r 'first(.data[] | select(.display_name == "Demo GmbH") | .id) // 
 
 # The roles are the demo's own: a company page whose three contacts have no
 # titles reads as a page that failed to load them.
+#
+# What counts as employed is the CURRENT PRIMARY edge, which is the one the
+# product reads: a company page, a person card and the enrichment path all ask
+# `is_current_primary AND not ended`, so an ended or secondary row leaves the
+# contact off the very page this seed exists to draw, and an existence probe
+# would call that state seeded and repair nothing.
+#
+# Two repairs, because the two states are not the same fact. A standing edge that
+# merely lost the flag is promoted. An ENDED edge is history, and the API offers
+# no way to un-end one on purpose — a former employment keeps its row — so the
+# person is re-hired with a new edge instead, which is also what happened in the
+# story the demo tells.
 employ() { # employ <full-name> <role>
-  local name="$1" role="$2" id status
+  local name="$1" role="$2" id status standing rel_id rel_version
   id="$(person_id "$name")"
   [ -n "$id" ] || fail "$name is not in the installation the seed just wrote to"
   status="$(api GET "/relationships?kind=employment&person_id=$id&limit=50")"
   [ "$status" = "200" ] || fail "GET /v1/relationships returned HTTP $status"
-  if jq -e --arg o "$org_id" 'any(.data[]; .organization_id == $o)' "$workdir/body" >/dev/null; then
+  if jq -e --arg o "$org_id" --arg today "$TODAY" \
+    "any(.data[]; .organization_id == \$o and $CURRENT_PRIMARY_JQ)" "$workdir/body" >/dev/null; then
     echo "  OK: $name already employed at Demo GmbH"
+    return
+  fi
+  standing="$(jq -c --arg o "$org_id" --arg today "$TODAY" \
+    "first(.data[] | select(.organization_id == \$o and (.ended_at == null or (.ended_at | tostring) >= \$today))) // empty" \
+    "$workdir/body")"
+  if [ -n "$standing" ]; then
+    rel_id="$(printf '%s' "$standing" | jq -r '.id')"
+    rel_version="$(printf '%s' "$standing" | jq -r '.version // ""')"
+    [ -n "$rel_version" ] || fail "GET /v1/relationships answered $name's employment without a version to write against"
+    status="$(api_if_match PATCH "/relationships/$rel_id" "$rel_version" '{"is_current_primary":true}')"
+    case "$status" in
+      200) echo "  OK: $name's employment at Demo GmbH is their primary one again" ;;
+      *)
+        echo "  response body:" >&2
+        cat "$workdir/body" >&2
+        fail "PATCH /v1/relationships/$rel_id returned HTTP $status"
+        ;;
+    esac
     return
   fi
   # `is_current_primary` is left out on purpose: the server makes an employment

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -57,7 +57,7 @@ case_is() {
 		failures=$((failures + 1))
 		return
 	fi
-	if [[ -n "$must_say" ]] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
+	if [[ -n "$must_say" ]] && ! grep -qF -- "$must_say" <<<"$out"; then
 		echo "FAIL: $name — exited $want but never named '$must_say'" >&2
 		printf '%s\n' "$out" >&2
 		failures=$((failures + 1))

--- a/scripts/test-ci-verdict.sh
+++ b/scripts/test-ci-verdict.sh
@@ -26,7 +26,7 @@ case_is() {
 		failures=$((failures + 1))
 		return
 	fi
-	if [[ -n "$must_say" ]] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
+	if [[ -n "$must_say" ]] && ! grep -qF -- "$must_say" <<<"$out"; then
 		echo "FAIL: $name — exited $want but never named '$must_say'" >&2
 		printf '%s\n' "$out" >&2
 		failures=$((failures + 1))

--- a/scripts/test-migration-versions.sh
+++ b/scripts/test-migration-versions.sh
@@ -158,7 +158,7 @@ expect() {
     case_fails=$((case_fails + 1))
     return
   fi
-  if ! printf '%s' "$out" | grep -qF -- "$diagnostic"; then
+  if ! grep -qF -- "$diagnostic" <<<"$out"; then
     printf 'FAIL  %s\n      exit %s was right, but the gate never said %s —\n' \
       "$name" "$rc" "'$diagnostic'" >&2
     printf '      so this case was satisfied by some OTHER outcome than the one it planted\n' >&2

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -208,7 +208,7 @@ expect_health() {
 		failures=$((failures + 1))
 		return
 	fi
-	if [ -n "$suspects" ] && ! printf '%s' "$body" | grep -qF -- "deadbeef"; then
+	if [ -n "$suspects" ] && ! grep -qF -- "deadbeef" <<<"$body"; then
 		echo "FAIL: $name — the issue was filed but the suspect range never reached its body"
 		failures=$((failures + 1))
 		return
@@ -217,7 +217,7 @@ expect_health() {
 	# Without this the no-range cases pass for free: an arm that dropped the
 	# fallback would still file, and "a red lane with no range still files"
 	# would go on reporting ok over a body that says nothing about the window.
-	if [ -z "$suspects" ] && ! printf '%s' "$body" | grep -qF -- "no suspect range was computed"; then
+	if [ -z "$suspects" ] && ! grep -qF -- "no suspect range was computed" <<<"$body"; then
 		echo "FAIL: $name — filed without saying the suspect range is unknown"
 		failures=$((failures + 1))
 		return
@@ -373,11 +373,11 @@ fi
 for lane in $lanes; do
 	# MAIN_UAT_RESULT -> uat
 	job="$(printf '%s' "$lane" | sed -E 's/^MAIN_(.+)_RESULT$/\1/' | tr '[:upper:]' '[:lower:]')"
-	if ! printf '%s' "$report_job" | grep -qE "needs\.${job}\.result == 'failure'"; then
+	if ! grep -qE "needs\.${job}\.result == 'failure'" <<<"$report_job"; then
 		echo "FAIL: $lane has a reporter arm, but main-health's report job does not run for a failing '${job}' — the arm is unreachable"
 		failures=$((failures + 1))
 	fi
-	if ! printf '%s' "$report_job" | grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}"; then
+	if ! grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}" <<<"$report_job"; then
 		echo "FAIL: $lane has a reporter arm, but main-health never passes needs.${job}.result in as $lane"
 		failures=$((failures + 1))
 	fi

--- a/scripts/test-secret-scan.sh
+++ b/scripts/test-secret-scan.sh
@@ -370,7 +370,7 @@ fi
 # reporting a plant that never tripped anything.
 CONTROL="backend/internal/modules/people/person.go"
 TARGETED="$(for i in $(indices); do field "$i" rule; done | LC_ALL=C sort -u)"
-if printf '%s\n' "$TARGETED" | grep -qx "$FOREIGN_RULE"; then
+if grep -qx "$FOREIGN_RULE" <<<"$TARGETED"; then
 	fail "an allowlist now targets $FOREIGN_RULE, which this suite uses as the rule every allowlist is foreign to. Property (a) would stop being tested for it. Pick a different FOREIGN_RULE."
 fi
 for rule in $(printf '%s\n%s\n' "$FOREIGN_RULE" "$TARGETED" | LC_ALL=C sort -u); do

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -98,7 +98,11 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
       return
     fi
     cursor="$(jq -r 'if .page.has_more then (.page.next_cursor // "") else "" end' "$workdir/page.json")"
-    [ -n "$cursor" ] || return
+    # Absent is an ANSWER, not a failure: every caller asks "is this here?" and
+    # handles no for itself. A bare `return` here carries the test's own exit
+    # status, which is 1 when the cursor is empty — and under `set -e` that
+    # killed the whole script the first time a lookup legitimately found nothing.
+    [ -n "$cursor" ] || return 0
   done
 }
 

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -62,6 +62,12 @@ session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
 echo "== verify-boot 2/4: seeded people are visible =="
+# The rule the product reads an employment by, spelled the same way
+# scripts/seed-dev.sh writes it: primary, and not ended. `ended_at` is a date and
+# ISO dates compare as strings, so a future end is still current — the reading
+# the server's own predicate takes.
+CURRENT_PRIMARY_JQ='.is_current_primary and (.ended_at == null or (.ended_at | tostring) >= $today)'
+TODAY="$(date -u +%F)"
 # Looked up by NAME rather than scanned off the first page of /v1/people. The
 # page held 100 rows and the seeded three were on it as long as the dev seed was
 # all that had run — on a stack that also carries the demo dataset they are not,
@@ -97,10 +103,17 @@ while IFS= read -r name; do
     cat "$workdir/people.json" >&2
     fail "seeded person '$name' missing from GET /v1/people — seed absent or stale (make seed-dev)"
   fi
-  # And employed somewhere. A person who works nowhere shows on no company page,
-  # which is the demo dataset's own verify rule ("people work somewhere") — and
-  # the rule these records used to break, so `make verify-demo` could not pass
-  # after `make seed-dev` in the order the runbook prescribes.
+  # And employed somewhere, on the edge the PRODUCT reads. A person who works
+  # nowhere shows on no company page, which is the demo dataset's own verify rule
+  # ("people work somewhere") — and the rule these records used to break, so
+  # `make verify-demo` could not pass after `make seed-dev` in the order the
+  # runbook prescribes.
+  #
+  # The current-primary rule rather than mere existence, and this is STRICTER
+  # than the demo verifier, which counts any employment row: an ended or
+  # secondary edge satisfies that census and still leaves the contact off the
+  # company page, so a boot proof that accepted one would be proving something
+  # nobody can see.
   person_id="$(printf '%s' "$person" | jq -r '.id')"
   rel_status="$(curl -sS --max-time 15 -o "$workdir/employment.json" -w '%{http_code}' \
     "$API_BASE/v1/relationships?kind=employment&person_id=$person_id&limit=50" \
@@ -110,10 +123,12 @@ while IFS= read -r name; do
     cat "$workdir/employment.json" >&2
     fail "GET /v1/relationships returned HTTP $rel_status (expected 200)"
   fi
-  if ! jq -e '.data | length > 0' "$workdir/employment.json" >/dev/null; then
-    fail "seeded person '$name' is employed nowhere — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
+  if ! jq -e --arg today "$TODAY" "any(.data[]; $CURRENT_PRIMARY_JQ)" "$workdir/employment.json" >/dev/null; then
+    echo "  employment rows:" >&2
+    cat "$workdir/employment.json" >&2
+    fail "seeded person '$name' has no current primary employment — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
   fi
-  echo "  OK: found '$name', employed"
+  echo "  OK: found '$name', currently employed"
 done <<< "$seeded_people"
 
 # The other rule the seeded records used to break: an account left on the

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -62,22 +62,100 @@ session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
 echo "== verify-boot 2/4: seeded people are visible =="
-people_status="$(curl -sS --max-time 15 -o "$workdir/people.json" -w '%{http_code}' \
-  "$API_BASE/v1/people?limit=100" \
-  --cookie "crm_session=$session" || true)"
-if [ "$people_status" != "200" ]; then
-  echo "  response body:" >&2
-  cat "$workdir/people.json" >&2
-  fail "GET /v1/people returned HTTP $people_status (expected 200)"
-fi
-for name in "Alice Müller" "Bob Schmidt" "Carol Wagner"; do
-  if ! jq -e --arg n "$name" '.data[] | select(.full_name == $n)' "$workdir/people.json" >/dev/null; then
+# Looked up by NAME rather than scanned off the first page of /v1/people. The
+# page held 100 rows and the seeded three were on it as long as the dev seed was
+# all that had run — on a stack that also carries the demo dataset they are not,
+# and a check that reads a smaller set than it means reports a pass it did not
+# earn. `q` is the API's own full-text lookup, so the read is exact whatever else
+# is in the installation.
+find_person() { # find_person <full-name> — prints the matching row, empty when absent
+  local name="$1" status
+  status="$(curl -sS --max-time 15 -o "$workdir/people.json" -w '%{http_code}' \
+    --get --data-urlencode "q=$name" --data-urlencode "limit=50" \
+    "$API_BASE/v1/people" \
+    --cookie "crm_session=$session" || true)"
+  if [ "$status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/people.json" >&2
+    fail "GET /v1/people?q= returned HTTP $status (expected 200)"
+  fi
+  # Matched on the whole name: `q` answers with everything that shares a word.
+  jq -c --arg n "$name" 'first(.data[] | select(.full_name == $n)) // empty' "$workdir/people.json"
+}
+
+# Read from the seeder rather than listed here, so a record added there is
+# checked the day it is added instead of the day somebody remembers to widen
+# this list. A grep that matched nothing would turn this whole step into a pass,
+# so the count is asserted first.
+seeded_people="$(sed -n 's/^ensure "person \(.*\)" \/people \\$/\1/p' "$REPO_DIR/scripts/seed-dev.sh")"
+[ -n "$seeded_people" ] || fail "found no 'ensure \"person …\" /people' lines in scripts/seed-dev.sh — this step would pass by reading nothing"
+
+while IFS= read -r name; do
+  person="$(find_person "$name")"
+  if [ -z "$person" ]; then
     echo "  full /v1/people response:" >&2
     cat "$workdir/people.json" >&2
     fail "seeded person '$name' missing from GET /v1/people — seed absent or stale (make seed-dev)"
   fi
-  echo "  OK: found '$name'"
-done
+  # And employed somewhere. A person who works nowhere shows on no company page,
+  # which is the demo dataset's own verify rule ("people work somewhere") — and
+  # the rule these records used to break, so `make verify-demo` could not pass
+  # after `make seed-dev` in the order the runbook prescribes.
+  person_id="$(printf '%s' "$person" | jq -r '.id')"
+  rel_status="$(curl -sS --max-time 15 -o "$workdir/employment.json" -w '%{http_code}' \
+    "$API_BASE/v1/relationships?kind=employment&person_id=$person_id&limit=50" \
+    --cookie "crm_session=$session" || true)"
+  if [ "$rel_status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/employment.json" >&2
+    fail "GET /v1/relationships returned HTTP $rel_status (expected 200)"
+  fi
+  if ! jq -e '.data | length > 0' "$workdir/employment.json" >/dev/null; then
+    fail "seeded person '$name' is employed nowhere — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
+  fi
+  echo "  OK: found '$name', employed"
+done <<< "$seeded_people"
+
+# The other rule the seeded records used to break: an account left on the
+# default makes "who are our customers?" answer with everything.
+#
+# Looked up by the DOMAIN the seeder writes, from the seeder's own line, for the
+# same reason the people above are looked up by name: `/v1/organizations` is a
+# page, this installation may carry hundreds of companies from the demo dataset,
+# and a check that reads the first hundred of them is a check that stops finding
+# what it is looking for the day the dataset grows.
+# awk rather than sed: the payload is the line AFTER the one that matches, and
+# the portable sed spelling for that is not the same on both platforms this
+# script runs on.
+seeded_org_bodies="$(awk '
+  /^ensure "organization / { want = 1; next }
+  want { sub(/^  ./, ""); sub(/.$/, ""); print; want = 0 }
+' "$REPO_DIR/scripts/seed-dev.sh")"
+[ -n "$seeded_org_bodies" ] || fail "found no 'ensure \"organization …\" /organizations' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+
+while IFS= read -r body; do
+  org_name="$(printf '%s' "$body" | jq -r '.display_name')"
+  org_domain="$(printf '%s' "$body" | jq -r 'first(.domains[]?.domain) // empty')"
+  [ -n "$org_domain" ] || fail "the seeder creates '$org_name' with no domain, so this check has no way to find it"
+  orgs_status="$(curl -sS --max-time 15 -o "$workdir/orgs.json" -w '%{http_code}' \
+    --get --data-urlencode "domain=$org_domain" --data-urlencode "limit=50" \
+    "$API_BASE/v1/organizations" \
+    --cookie "crm_session=$session" || true)"
+  if [ "$orgs_status" != "200" ]; then
+    echo "  response body:" >&2
+    cat "$workdir/orgs.json" >&2
+    fail "GET /v1/organizations?domain= returned HTTP $orgs_status (expected 200)"
+  fi
+  org="$(jq -c --arg n "$org_name" 'first(.data[] | select(.display_name == $n)) // empty' "$workdir/orgs.json")"
+  if [ -z "$org" ]; then
+    echo "  full /v1/organizations response:" >&2
+    cat "$workdir/orgs.json" >&2
+    fail "seeded account '$org_name' missing from GET /v1/organizations — seed absent or stale (make seed-dev)"
+  fi
+  lifecycle="$(printf '%s' "$org" | jq -r '.lifecycle // "unknown"')"
+  [ "$lifecycle" != "unknown" ] || fail "seeded account '$org_name' is still on the default lifecycle — the demo dataset's verify pass refuses the installation for it"
+  echo "  OK: '$org_name' stands at '$lifecycle'"
+done <<< "$seeded_org_bodies"
 
 echo "== verify-boot 3/4: every composed unit's transport is registered =="
 # The boot proof for the channel registry, and it belongs HERE rather than in a

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -68,25 +68,43 @@ echo "== verify-boot 2/4: seeded people are visible =="
 # the server's own predicate takes.
 CURRENT_PRIMARY_JQ='.is_current_primary and (.ended_at == null or (.ended_at | tostring) >= $today)'
 TODAY="$(date -u +%F)"
-# Looked up by NAME rather than scanned off the first page of /v1/people. The
-# page held 100 rows and the seeded three were on it as long as the dev seed was
-# all that had run — on a stack that also carries the demo dataset they are not,
-# and a check that reads a smaller set than it means reports a pass it did not
-# earn. `q` is the API's own full-text lookup, so the read is exact whatever else
-# is in the installation.
+# Looked up record by record rather than scanned off the first page of a list.
+# The page held 100 rows and the seeded three were on it as long as the dev seed
+# was all that had run — on a stack that also carries the demo dataset they are
+# not, and a check that reads a smaller set than it means reports a pass it did
+# not earn. So every lookup here names its record, and follows the cursor to
+# exhaustion: `q` is a full-text query, and a page of its matches can be all the
+# people who merely share a word with the one being looked for.
+#
+# `select` is a jq filter over ONE row, and any further arguments go to jq — a
+# name is an `--arg`, never spliced into the filter. `$today` is bound for the
+# callers that ask about employment currency.
+find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
+  local path="$1" select="$2" cursor="" status row
+  shift 2
+  while :; do
+    status="$(curl -sS --max-time 15 -o "$workdir/page.json" -w '%{http_code}' \
+      --get --data-urlencode "limit=100" ${cursor:+--data-urlencode "cursor=$cursor"} \
+      "$API_BASE/v1$path" \
+      --cookie "crm_session=$session" || true)"
+    if [ "$status" != "200" ]; then
+      echo "  response body:" >&2
+      cat "$workdir/page.json" >&2
+      fail "GET /v1$path returned HTTP $status (expected 200)"
+    fi
+    row="$(jq -c --arg today "$TODAY" "$@" "first(.data[] | select($select)) // empty" "$workdir/page.json")"
+    if [ -n "$row" ]; then
+      printf '%s' "$row"
+      return
+    fi
+    cursor="$(jq -r 'if .page.has_more then (.page.next_cursor // "") else "" end' "$workdir/page.json")"
+    [ -n "$cursor" ] || return
+  done
+}
+
 find_person() { # find_person <full-name> — prints the matching row, empty when absent
-  local name="$1" status
-  status="$(curl -sS --max-time 15 -o "$workdir/people.json" -w '%{http_code}' \
-    --get --data-urlencode "q=$name" --data-urlencode "limit=50" \
-    "$API_BASE/v1/people" \
-    --cookie "crm_session=$session" || true)"
-  if [ "$status" != "200" ]; then
-    echo "  response body:" >&2
-    cat "$workdir/people.json" >&2
-    fail "GET /v1/people?q= returned HTTP $status (expected 200)"
-  fi
   # Matched on the whole name: `q` answers with everything that shares a word.
-  jq -c --arg n "$name" 'first(.data[] | select(.full_name == $n)) // empty' "$workdir/people.json"
+  find_first "/people?q=$(jq -rn --arg v "$1" '$v|@uri')" '.full_name == $name' --arg name "$1"
 }
 
 # Read from the seeder rather than listed here, so a record added there is
@@ -99,8 +117,6 @@ seeded_people="$(sed -n 's/^ensure "person \(.*\)" \/people \\$/\1/p' "$REPO_DIR
 while IFS= read -r name; do
   person="$(find_person "$name")"
   if [ -z "$person" ]; then
-    echo "  full /v1/people response:" >&2
-    cat "$workdir/people.json" >&2
     fail "seeded person '$name' missing from GET /v1/people — seed absent or stale (make seed-dev)"
   fi
   # And employed somewhere, on the edge the PRODUCT reads. A person who works
@@ -115,17 +131,9 @@ while IFS= read -r name; do
   # company page, so a boot proof that accepted one would be proving something
   # nobody can see.
   person_id="$(printf '%s' "$person" | jq -r '.id')"
-  rel_status="$(curl -sS --max-time 15 -o "$workdir/employment.json" -w '%{http_code}' \
-    "$API_BASE/v1/relationships?kind=employment&person_id=$person_id&limit=50" \
-    --cookie "crm_session=$session" || true)"
-  if [ "$rel_status" != "200" ]; then
-    echo "  response body:" >&2
-    cat "$workdir/employment.json" >&2
-    fail "GET /v1/relationships returned HTTP $rel_status (expected 200)"
-  fi
-  if ! jq -e --arg today "$TODAY" "any(.data[]; $CURRENT_PRIMARY_JQ)" "$workdir/employment.json" >/dev/null; then
-    echo "  employment rows:" >&2
-    cat "$workdir/employment.json" >&2
+  if [ -z "$(find_first "/relationships?kind=employment&person_id=$person_id" "$CURRENT_PRIMARY_JQ")" ]; then
+    echo "  their employment rows:" >&2
+    cat "$workdir/page.json" >&2
     fail "seeded person '$name' has no current primary employment — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
   fi
   echo "  OK: found '$name', currently employed"
@@ -152,19 +160,9 @@ while IFS= read -r body; do
   org_name="$(printf '%s' "$body" | jq -r '.display_name')"
   org_domain="$(printf '%s' "$body" | jq -r 'first(.domains[]?.domain) // empty')"
   [ -n "$org_domain" ] || fail "the seeder creates '$org_name' with no domain, so this check has no way to find it"
-  orgs_status="$(curl -sS --max-time 15 -o "$workdir/orgs.json" -w '%{http_code}' \
-    --get --data-urlencode "domain=$org_domain" --data-urlencode "limit=50" \
-    "$API_BASE/v1/organizations" \
-    --cookie "crm_session=$session" || true)"
-  if [ "$orgs_status" != "200" ]; then
-    echo "  response body:" >&2
-    cat "$workdir/orgs.json" >&2
-    fail "GET /v1/organizations?domain= returned HTTP $orgs_status (expected 200)"
-  fi
-  org="$(jq -c --arg n "$org_name" 'first(.data[] | select(.display_name == $n)) // empty' "$workdir/orgs.json")"
+  org="$(find_first "/organizations?domain=$(jq -rn --arg v "$org_domain" '$v|@uri')" \
+    '.display_name == $name' --arg name "$org_name")"
   if [ -z "$org" ]; then
-    echo "  full /v1/organizations response:" >&2
-    cat "$workdir/orgs.json" >&2
     fail "seeded account '$org_name' missing from GET /v1/organizations — seed absent or stale (make seed-dev)"
   fi
   lifecycle="$(printf '%s' "$org" | jq -r '.lifecycle // "unknown"')"

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -106,22 +106,42 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
   done
 }
 
-find_person() { # find_person <full-name> — prints the matching row, empty when absent
-  # Matched on the whole name: `q` answers with everything that shares a word.
-  find_first "/people?q=$(jq -rn --arg v "$1" '$v|@uri')" '.full_name == $name' --arg name "$1"
+find_person() { # find_person <full-name> <email> — the row, empty when absent
+  # `q` is full-text over name and title only, so the name narrows and the EMAIL
+  # decides. Two people can share a full name, and the address is the key the
+  # seeded row was created with — checking whichever row the query answered with
+  # first would report on somebody else's record and call it this one's.
+  find_first "/people?q=$(jq -rn --arg v "$1" '$v|@uri')" \
+    '.full_name == $name and any(.emails[]?; .email == $email)' \
+    --arg name "$1" --arg email "$2"
 }
 
-# Read from the seeder rather than listed here, so a record added there is
-# checked the day it is added instead of the day somebody remembers to widen
-# this list. A grep that matched nothing would turn this whole step into a pass,
-# so the count is asserted first.
-seeded_people="$(sed -n 's/^ensure "person \(.*\)" \/people \\$/\1/p' "$REPO_DIR/scripts/seed-dev.sh")"
-[ -n "$seeded_people" ] || fail "found no 'ensure \"person …\" /people' lines in scripts/seed-dev.sh — this step would pass by reading nothing"
+# The seeded records, read from the seeder's own payloads rather than listed
+# here, so a record added there is checked the day it is added instead of the day
+# somebody remembers to widen a list. A census that matched nothing would turn
+# the whole step into a pass, so each one is asserted non-empty before it is
+# walked.
+#
+# awk rather than sed: the payload is the line AFTER the one naming the record,
+# and the portable sed spelling for that is not the same on both platforms this
+# script runs on.
+seeded_payloads() { # seeded_payloads <resource> — one JSON body per line
+  awk -v want_prefix="ensure \"$1 " '
+    index($0, want_prefix) == 1 { want = 1; next }
+    want { sub(/^  ./, ""); sub(/.$/, ""); print; want = 0 }
+  ' "$REPO_DIR/scripts/seed-dev.sh"
+}
 
-while IFS= read -r name; do
-  person="$(find_person "$name")"
+seeded_people="$(seeded_payloads person)"
+[ -n "$seeded_people" ] || fail "found no 'ensure \"person …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+
+while IFS= read -r body; do
+  name="$(printf '%s' "$body" | jq -r '.full_name')"
+  email="$(printf '%s' "$body" | jq -r 'first(.emails[]?.email) // empty')"
+  [ -n "$email" ] || fail "the seeder creates '$name' with no email, so this check cannot tell them from a namesake"
+  person="$(find_person "$name" "$email")"
   if [ -z "$person" ]; then
-    fail "seeded person '$name' missing from GET /v1/people — seed absent or stale (make seed-dev)"
+    fail "seeded person '$name' <$email> missing from GET /v1/people — seed absent or stale (make seed-dev)"
   fi
   # And employed somewhere, on the edge the PRODUCT reads. A person who works
   # nowhere shows on no company page, which is the demo dataset's own verify rule
@@ -140,7 +160,7 @@ while IFS= read -r name; do
     cat "$workdir/page.json" >&2
     fail "seeded person '$name' has no current primary employment — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
   fi
-  echo "  OK: found '$name', currently employed"
+  echo "  OK: found '$name' <$email>, currently employed"
 done <<< "$seeded_people"
 
 # The other rule the seeded records used to break: an account left on the
@@ -151,14 +171,14 @@ done <<< "$seeded_people"
 # page, this installation may carry hundreds of companies from the demo dataset,
 # and a check that reads the first hundred of them is a check that stops finding
 # what it is looking for the day the dataset grows.
-# awk rather than sed: the payload is the line AFTER the one that matches, and
-# the portable sed spelling for that is not the same on both platforms this
-# script runs on.
-seeded_org_bodies="$(awk '
-  /^ensure "organization / { want = 1; next }
-  want { sub(/^  ./, ""); sub(/.$/, ""); print; want = 0 }
-' "$REPO_DIR/scripts/seed-dev.sh")"
-[ -n "$seeded_org_bodies" ] || fail "found no 'ensure \"organization …\" /organizations' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+seeded_org_bodies="$(seeded_payloads organization)"
+[ -n "$seeded_org_bodies" ] || fail "found no 'ensure \"organization …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+
+# The stage the seeder actually writes, read from the seeder. "Anything but the
+# default" would accept a stage nobody wrote — a boot proof reads the state the
+# seed produces, not a range of states it might have.
+seeded_lifecycle="$(sed -n 's/.*{"lifecycle":"\([a-z_]*\)"}.*/\1/p' "$REPO_DIR/scripts/seed-dev.sh" | head -1)"
+[ -n "$seeded_lifecycle" ] || fail "scripts/seed-dev.sh writes no {\"lifecycle\":\"…\"} body — this check has no stage to hold the account to"
 
 while IFS= read -r body; do
   org_name="$(printf '%s' "$body" | jq -r '.display_name')"
@@ -170,7 +190,7 @@ while IFS= read -r body; do
     fail "seeded account '$org_name' missing from GET /v1/organizations — seed absent or stale (make seed-dev)"
   fi
   lifecycle="$(printf '%s' "$org" | jq -r '.lifecycle // "unknown"')"
-  [ "$lifecycle" != "unknown" ] || fail "seeded account '$org_name' is still on the default lifecycle — the demo dataset's verify pass refuses the installation for it"
+  [ "$lifecycle" = "$seeded_lifecycle" ] || fail "seeded account '$org_name' stands at '$lifecycle' where the seed writes '$seeded_lifecycle' — an account off the stage it was seeded to answers the wrong question about who the customers are, and the demo dataset's verify pass refuses a default lifecycle outright"
   echo "  OK: '$org_name' stands at '$lifecycle'"
 done <<< "$seeded_org_bodies"
 


### PR DESCRIPTION
`make verify-demo` could not pass after `make seed-dev` in the order the runbook prescribes:

```
verify:        2 rule(s) broken
  people work somewhere        3 employed nowhere (Carol Wagner, Bob Schmidt, Alice Müller)
  accounts have a lifecycle    1 still unknown (Demo GmbH)
```

Both broken rules belong to `scripts/seed-dev.sh`'s own four rows, not to the demo dataset. That matters more than the red verifier: three people who work nowhere show on no company page, and an account left on the default lifecycle makes "who are our customers?" answer with everything. The seeder was drawing a broken installation and the second seeder was the only thing saying so.

## What the seeder now does

Each seeded person is employed at Demo GmbH with a role — a company page whose three contacts have no titles reads as a page that failed to load them — and Demo GmbH moves to `lifecycle: customer` under an `If-Match` precondition, because an automated writer that omits the precondition makes its PATCH last-write-wins.

Records are read back by lookup rather than remembered from the create. `ensure` answers 409 on a re-run, so a seeder that only knew the ids it minted this time would do half its job on every run after the first. `is_current_primary` is deliberately omitted: the server makes an employment primary when the person has no other current one, and stating it here would be the script deciding something it has not read.

Verified live, twice: `make seed-dev` creates the three employments and the lifecycle; a second run prints `already employed` / `already a customer`. `make verify-demo` then reports `OK — every seeded record is owned, employed, linked and staged`.

## Why the gate went into verify-boot

CI's `live-boot` lane runs `make seed-dev` then `make verify-boot`. It does not run `verify-demo`, which needs a dataset CI cannot clone — so a gate placed there would never run, and this defect would come back the next time somebody adds a person to the seeder.

`verify-boot` step 2 now asserts both rules, and derives its census **from `seed-dev.sh` itself** rather than from a list kept here: a record added there is checked the day it is added instead of the day somebody remembers to widen a literal array. Each census is guarded against matching nothing, because a grep that found no lines would turn the whole step into a pass with no failing assertion to notice.

Two lookups changed along the way, and the reason is the same in both cases. The old check scanned the first page of `/v1/people?limit=100`; the seeded three were on it as long as the dev seed was all that had run, and on a stack that also carries the demo dataset they are not. Both people and accounts are now looked up individually — by `q=` and by the account's own `domain=` — so the read is exact whatever else is in the installation.

## Proof that each half can fail

A gate that cannot fail is not a gate, so both were run against a planted defect:

- a fourth person added to the seeder and left unemployed → `FAIL: seeded person 'Dora Planted' is employed nowhere — they show on no company page, and the demo dataset's verify pass refuses the installation for it`, exit 2;
- Demo GmbH PATCHed back to `lifecycle: unknown` → `FAIL: seeded account 'Demo GmbH' is still on the default lifecycle — the demo dataset's verify pass refuses the installation for it`, exit 2.

The first shape of the account check did **not** catch its planted defect — it read page one of `/v1/organizations` and reported OK — which is what sent both lookups to per-record queries.

## The lane that should have caught this was skipped

The first commit here shipped with `live-boot` **SKIPPED** — the lane that runs `make seed-dev` and `make verify-boot`, i.e. the two scripts the commit changes. The `e2e` scope named backend/, frontend/, infra/, extensions/, fixtures/ and composition/, and neither `scripts/**` nor the Makefile that reaches them. A change to precisely what that lane does classified as touching nothing it cares about: the lane reports SKIPPED, the aggregate is content, and the change merges never once executed. The `frontend` scope had the same hole around `check-contract-frontend-drift.sh` and `phase-timer.sh`, which its lane is the only runner of.

Both scopes now carry `scripts/**`, and `e2e` the Makefile. The obligation is derived rather than trusted: `backend/gates/laneinputscope_test.go` reads every job guarded by a classifier scope, follows each `make` target through the root Makefile's prerequisites and `$(MAKE)` delegations, and fails when a script the lane executes is claimed by none of the job's own scopes.

Proven able to fail, three ways:

- reverting the filter edit reports `live-boot` (Makefile, seed-dev.sh, verify-boot.sh) and `frontend` (phase-timer.sh);
- one test strips every `scripts/…` pattern from each lane's scope and requires the finding to come back, so a matcher that claimed everything cannot keep the file green;
- one test requires at least one lane to owe a script no workflow step spells out, because the defect was reachable only through `make`.

It caught itself failing short on the way: expanding an unset `$(MAKE)` to nothing, as make does, turned every delegation line into a bare word and hid eleven scripts behind `fe-quality`. Unknown references are now left standing.

What it cannot see is stated in the file: a script's own dependencies. Following those means interpreting shell.

## Review findings, both under-recognition

**Employed means the edge the product reads.** The first shape of this asked with an existence probe over `/v1/relationships`, which accepts an ENDED or a SECONDARY employment — and the product reads neither: a company page, a person card and the enrichment path all ask `is_current_primary AND not ended`. A contact whose only edge is stale is off the very page this seed exists to draw, and the seeder, finding a row, repaired nothing.

Both scripts now spell the product's rule, and the seeder converges on it two ways, because the two broken states are not the same fact: a standing edge that merely lost the flag is **promoted**, while an ended edge is history — the API offers no way to un-end one on purpose — so the person is **re-hired** with a new edge, which is also what happened in the story the demo tells.

Proven live in both directions: a planted `ended_at` and a planted demotion each fail `verify-boot` naming the person, `make seed-dev` repairs each, a second run converges, and `make verify-demo` stays green. This boot proof is deliberately the stricter of the two — the demo verifier counts any employment row.

The predicate now has two shell writers and no way to share a Go helper across them, so `seedemploymentpredicate_test.go` holds the mirror in both directions: the two scripts must spell it identically, and what they spell must still name every column `people.CurrentPrimaryEmploymentSQL` reads. Proven by drifting one copy.

**The lane census failed short too.** `make check` is spelled `@PHASE_TIMER_OWNED=1 $(MAKE) check-backend`, and a reader that required the line to open with `$(MAKE)` followed neither half of the merge gate. Environment prefixes are stripped before the delegation is read, with the spelling as a test case rather than a comment.

**Every lookup names its record and follows the cursor.** Both scripts read the first page of a list and stopped — enough while the dev seed was the only thing in the installation, and not enough on a stack that also carries the demo dataset: `q` is a full-text query, so a page of matches can be all the people who merely share a word with the one being looked for, and `/v1/relationships` for one person carries their history as well as their current employment. Each script now has one `find_first` that follows `page.next_cursor` to exhaustion, and the person, the account and the employment edge all go through it, with values passed as `--arg` rather than spliced into a filter. Proven by forcing one row per page: at `limit=1` both scripts still find every record, which only a followed cursor can do.

**Tokenised recipe words.** `stripEnvironment` and the `-C` test both matched a literal space, so `FOO=1<TAB>$(MAKE) check-backend` read as no delegation. Words are split before either question is asked, with the tab spellings as cases.

**Not changed, and why:** the review also reported `../scripts/...` in `seedemploymentpredicate_test.go` as unreadable from `backend/gates`. `backend/gates/gates_test.go` chdirs to `backend/` in `TestMain`, which is why every gate in that package spells `../.github/workflows` and `../Makefile` — and the mirror gate demonstrably reads both scripts, since it fails when one is drifted.

## Gates

- `make check` — pass on every commit, and again after the rebase onto main
- `make craft-static` — `PASS — 0 blocker, 0 major, 0 minor`
- `live-boot` in CI — pass on the second push, the first lane run this change ever got
- `make verify-boot` — pass (`found 'Alice Müller', employed` ×3, `'Demo GmbH' stands at 'customer'`)
- `make verify-demo` — pass
- `make seed-dev` twice — pass, converges
- `.githooks/pre-push` — `craft static: no changed Go files — ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved development data setup with complete current primary employment relationships.
  - Organizations are promoted to customer status when appropriate.
  - Added safer handling for concurrent updates and paginated lookups.
  - Validation workflows now run when relevant scripts change.

- **Tests**
  - Enhanced startup verification for seeded people and organizations.
  - Added checks for relationship consistency and workflow coverage.
  - Improved shell validation reliability and failure detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->