### PR TITLE
A first message is composed, not templated

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -143,9 +143,9 @@ tasks:
     execution_mode: interactive
     on_budget_exhausted: degrade
     status: shipped
-    sites: [reply, person, account]
+    sites: [reply, person, account, first]
     company_context: {scopes: [positioning, sales, proof, market], token_budget: 1400}
-    doc: "Three sites, one task: the reply to an activity, the person page's composer, and the company page's first-touch outbound. They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a fourth site; the composers gain theirs when Voice DNA reaches them."
+    doc: "Four sites, one task: the reply to an activity, the person page's composer, the company page's first-touch outbound, and the message that opens a conversation from a stated intent alone (draft_email over MCP, which names records to file under rather than records to write from). They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a site of its own; the composers and the first-message site gain theirs when Voice DNA reaches them."
 
   nl_search:
     ladder: [cheap_cloud, premium]

--- a/backend/internal/compose/aicert/corpus/draft_reply/first_message_from_intent_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/first_message_from_intent_01.yaml
@@ -1,0 +1,56 @@
+name: first_message_from_an_intent_alone
+task: draft_reply
+site: first
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+# The thinnest brief this product sends a model. draft_email over MCP names the
+# records the conversation is FILED under, not records it is written FROM, so
+# what reaches the site is the caller's own sentence and the envelope — no
+# company, no recipient, no history, and nothing to fall back on.
+#
+# It is the case that separates writing from filling in. A model given almost
+# nothing is at its most inventive, and the one thing it must not invent here is
+# the very thing an opening line reaches for: a prior meeting, an earlier email,
+# a name it was never told.
+fixture:
+  output_language: en
+  conversation_state: fresh
+  silence_days: "0"
+  now: 2026-08-11T09:00:00Z
+  sender_name: Anna Krüger
+  sender_email: anna.krueger@example.com
+  intent: Introduce ourselves after meeting at the K5 conference and ask for a short call.
+expect:
+  outcome: accepted
+  answer: written
+  rubric: >
+    This is the first email of a new conversation, written from the stated
+    intent and nothing else. Three things decide the case.
+
+    Nothing invented. The ONLY facts supplied are the sender's name and email,
+    the date, and the caller's sentence: they met at K5 and want a short call. A
+    draft that names a company, a product, a price, a job title, a person's
+    name, a mutual contact, a specific problem, or anything said at K5 beyond
+    "we met" is inventing, and scores at the floor. The recipient's name is not
+    supplied, so a greeting that addresses somebody by name has invented one —
+    "Hello," or an equivalent opening with no name is the correct answer, not a
+    weaker one.
+
+    No claimed history beyond the meeting. The intent names one prior contact —
+    meeting at K5 — and that single fact may be referred to. Everything else is
+    a claim about a conversation that has not happened: "following up on our
+    call", "as discussed", "checking back in", or a reply prefix ("Re:", "AW:")
+    on the subject each claim a thread nobody sent, and score at the floor.
+
+    It does the job asked. The intent asks for two things — introduce, and ask
+    for a short call — and a draft that does neither has not written the message
+    it was briefed to write.
+
+    Full marks for a short English note that says who is writing, refers to the
+    K5 meeting and nothing more about it, asks for the call, carries no sign-off
+    or sender name, and reads as somebody's first message rather than the
+    continuation of one.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aitaskregistry.go
+++ b/backend/internal/compose/aitaskregistry.go
@@ -47,6 +47,7 @@ func NewTaskCensus() (*aitasks.Registry, error) {
 	oneShot(ai.TaskDraftReply, "reply", replyDraftCases{})
 	oneShot(ai.TaskDraftReply, "person", personDraftCases{})
 	oneShot(ai.TaskDraftReply, "account", accountDraftCases{})
+	oneShot(ai.TaskDraftReply, "first", firstDraftCases{})
 	oneShot(ai.TaskBriefRanking, "rank", briefRankingCases{})
 	oneShot(ai.TaskWeeklyReview, "narrative", weeklyNarrativeCases{})
 	oneShot(ai.TaskOfferDraft, "draft", offerDraftCases{})

--- a/backend/internal/compose/certcase_firstdraft.go
+++ b/backend/internal/compose/certcase_firstdraft.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The first-message site's certification case.
+//
+// ADR-0074 requires every shipped site to be declared, registered and certified
+// through its PRODUCTION path, and this site has a prompt of its own — the
+// reply's is not true here, because it names an activity that does not exist.
+// A prompt nobody certifies is a prompt free to change under a record still
+// claiming to describe it, which is the failure the census exists to prevent.
+//
+// The fixture is the DRAFTER'S OWN INPUT, as it is on the two composers: a
+// fixture that does not decode into what the site is handed describes a request
+// this site cannot send, and it is refused at Prepare rather than scored later.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/compose/aitasks"
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// firstDraftSite is the site name, as ai-tasks.yaml declares it.
+const firstDraftSite = "draft_reply/first"
+
+// firstDraftCases serves the message that opens a conversation.
+type firstDraftCases struct{}
+
+func (firstDraftCases) Site() aitasks.Site {
+	return aitasks.Site{
+		Task:    ai.TaskDraftReply,
+		Variant: "first",
+		Kind:    ai.SiteKindOneShot,
+	}
+}
+
+// Prepare reads the fixture as the data block this site carries and refuses a
+// scenario it cannot answer.
+//
+// It reuses refuseUnsendableActivity for the same reason the reply site does:
+// the bound is read back out of the ENCODED block, so a field added to
+// replyActivityData is bounded here on the day it is added. What it additionally
+// refuses is a fixture carrying thread evidence — a subject, a body, or an
+// inbound thread flag — because a first message has none of those in existence,
+// and a scenario supplying them would certify a call the product never makes.
+//
+//nolint:ireturn // PreparedCase IS the seam: one implementation per site behind the one interface the cert lane runs.
+func (firstDraftCases) Prepare(fixture, expected json.RawMessage) (aitasks.PreparedCase, error) {
+	var data replyActivityData
+	if err := json.Unmarshal(fixture, &data); err != nil {
+		return nil, fmt.Errorf("%s: the fixture is not the shape this site takes: %w", firstDraftSite, err)
+	}
+	if err := refuseUnsendableActivity(data); err != nil {
+		return nil, err
+	}
+	for what, supplied := range map[string]string{
+		"a subject being answered": data.Subject,
+		"a body being answered":    data.Body,
+		"an inbound mail thread":   data.Thread,
+	} {
+		if supplied != "" {
+			return nil, fmt.Errorf(
+				"%s: the fixture carries %s (%q), and a first message has none — this site is the one that "+
+					"opens a conversation, so a scenario supplying thread evidence certifies a call the "+
+					"product never makes", firstDraftSite, what, supplied)
+		}
+	}
+	if data.Intent == "" {
+		return nil, fmt.Errorf(
+			"%s: the fixture states no intent, and the intent is the whole of this site's subject material — "+
+				"a scenario without one is asking the model to invent a reason to write", firstDraftSite)
+	}
+	if err := refuseUnanswerableComposerCase(firstDraftSite, expected); err != nil {
+		return nil, err
+	}
+	return &firstDraftCase{data: data}, nil
+}
+
+// firstDraftCase is one first-message request ready to be answered.
+type firstDraftCase struct{ data replyActivityData }
+
+// Run drives the production lane — the same completeChecked, correction loop and
+// validators DraftFirstEmail drives — and records every request it issued.
+//
+// The drafter is built with a brain and nothing else because this path does no
+// I/O at all: unlike the reply, there is no activity to read and no voice signal
+// to record, which is the same property that lets the seam take an intent and
+// nothing else.
+func (c *firstDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
+	recorder := &replyDraftRecorder{completer: completer}
+	_, err := replyDrafter{brain: recorder}.completeChecked(ctx, firstDraftSystem, c.data, nil)
+	trace := aitasks.Trace{Requests: recorder.requests}
+	if recorder.failed != nil {
+		return trace, fmt.Errorf("%s: the model call did not complete: %w", firstDraftSite, recorder.failed)
+	}
+	if err != nil {
+		if recorder.last == "" {
+			return trace, fmt.Errorf("%s: no reply reached the drafter to be measured: %w", firstDraftSite, err)
+		}
+		// The draft the drafter REFUSED, which is what a human would have been
+		// spared: the served answer in that case is the deterministic floor,
+		// and scoring the floor would certify text no model wrote.
+		trace.Output = recorder.last
+		return trace, nil
+	}
+	trace.Output = recorder.served
+	return trace, nil
+}
+
+// Evaluate re-reads the draft with the same validators the served path uses, so
+// the record's verdict is measured rather than inferred from the absence of an
+// error. The rubric measures the prose; what is checked here is that a draft was
+// written at all, and that it is one this product would send.
+func (c *firstDraftCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
+	draft, err := parseReplyDraft(trace.Output)
+	if err != nil {
+		return aitasks.Outcome{Result: aitasks.OutcomeInvalid, Detail: err.Error()}
+	}
+	if err := validateReplyDraft(draft); err != nil {
+		return aitasks.Outcome{Result: aitasks.OutcomeInvalid, Detail: err.Error()}
+	}
+	return aitasks.Outcome{Result: aitasks.OutcomeAccepted}
+}

--- a/backend/internal/compose/certcase_replydraft.go
+++ b/backend/internal/compose/certcase_replydraft.go
@@ -372,9 +372,9 @@ func replyDraftServedRegister(trace aitasks.Trace) (string, error) {
 	}
 	system := trace.Requests[len(trace.Requests)-1].System
 	switch {
-	case strings.HasPrefix(system, replyDraftVoiceSystem):
+	case strings.HasPrefix(system, string(replyDraftVoiceSystem)):
 		return replyDraftRegisterVoiced, nil
-	case strings.HasPrefix(system, replyDraftSystem):
+	case strings.HasPrefix(system, string(replyDraftSystem)):
 		return replyDraftRegisterPlain, nil
 	default:
 		return "", errors.New("compose: the last request is in neither system variant this site sends")

--- a/backend/internal/compose/certcase_replydraft_test.go
+++ b/backend/internal/compose/certcase_replydraft_test.go
@@ -263,7 +263,7 @@ func TestReplyDraftCaseRecordsEveryRequestTheDrafterIssued(t *testing.T) {
 			len(trace.Requests))
 	}
 	voiced, retry, fallback := trace.Requests[0], trace.Requests[1], trace.Requests[2]
-	if !strings.HasPrefix(voiced.System, replyDraftVoiceSystem) {
+	if !strings.HasPrefix(voiced.System, string(replyDraftVoiceSystem)) {
 		t.Errorf("the first request is not in the voice variant: %q", voiced.System)
 	}
 	for _, fragment := range []string{"Voice profile:", "Blunt, never hedges.", "We ship Monday."} {
@@ -274,7 +274,7 @@ func TestReplyDraftCaseRecordsEveryRequestTheDrafterIssued(t *testing.T) {
 	if !strings.Contains(retry.Messages[0].Content, "violated these hard rules") {
 		t.Error("the retry does not tell the model what the last attempt broke")
 	}
-	if !strings.HasPrefix(fallback.System, replyDraftSystem) {
+	if !strings.HasPrefix(fallback.System, string(replyDraftSystem)) {
 		t.Errorf("the fallback is not in the plain variant: %q", fallback.System)
 	}
 	if strings.Contains(fallback.Messages[0].Content, "Voice profile:") {

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -95,11 +95,17 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 
 // DraftAccountEmail composes the first message to a record.
 //
-// There is no thread to read, so the DraftContext is built from what a first
-// message actually is rather than from prior correspondence: BandFresh (this
-// IS the opening), Threaded false (nothing is being answered), and the intent
-// as the topic — the caller's own words for what the message should do, which
-// is the only subject material in existence before a conversation starts.
+// There is no thread to read, so the draft is built from what a first message
+// actually is rather than from prior correspondence: BandFresh (this IS the
+// opening), Threaded false (nothing is being answered), and the intent as the
+// whole of the subject material — the caller's own words for what the message
+// should do, which is all that exists before a conversation starts.
+//
+// It reaches the SAME routed lane the reply path does, one method along
+// (activities.FirstEmailDrafter). It used not to, and the reason was never a
+// decision about first messages: EmailDrafter took an anchor by signature, so a
+// draft with no activity behind it could not be asked for. What a caller got
+// instead was a template to rewrite.
 //
 // It deliberately does NOT resolve a recipient. DraftEmail can ask the store
 // who a thread is with; here the caller names the addressee at send time
@@ -118,12 +124,14 @@ func (c commsAdapter) DraftAccountEmail(
 			"links must name at least one record this conversation is filed under; " +
 				"a first message has no thread to inherit them from")}
 	}
-	// Deterministic only, for now. activities.EmailDrafter (the routed model
-	// lane) takes an anchor by signature — DraftEmail(ctx, anchor, intent) —
-	// so a first message cannot reach it without widening that interface and
-	// the AI task behind it. Deliberately left for its own change: the tool's
-	// value is that a first message can be drafted AT ALL, and the copy says
-	// plainly that the fallback is a short deterministic note.
+	// The routed model lane when the drafter can open a conversation, and the
+	// deterministic floor when it cannot. Which one answers is a property of
+	// the deployment — a role that composed no drafting model binds a drafter
+	// that implements only the reply seam, or none at all — so this branch is
+	// the same one the reply path takes, asked one method along.
+	if first, ok := c.draft.(activities.FirstEmailDrafter); ok {
+		return first.DraftFirstEmail(ctx, intent)
+	}
 	// Topic stays EMPTY, and the intent is passed once. DeterministicEmailDraft
 	// renders Topic into a "following up on …" line AND appends the intent as
 	// its own paragraph (handlers_email.go), so naming both would print the

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -63,6 +63,7 @@ func draftingSurfaces(fence promptfence.Fence) map[string][]string {
 		"replydraftmodel.go": {
 			replyDraftSystemFor(replyDraftSystem, fence),
 			replyDraftSystemFor(replyDraftVoiceSystem, fence),
+			replyDraftSystemFor(firstDraftSystem, fence),
 		},
 		"persondraft/write.go":  {persondraft.SystemPromptFor(fence)},
 		"accountdraft/write.go": {accountdraft.SystemPromptFor(fence)},

--- a/backend/internal/compose/firstdraft.go
+++ b/backend/internal/compose/firstdraft.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Drafting the message that starts a conversation.
+//
+// The reply path has been model-backed since it shipped; the first-message path
+// was not, and the difference was not a decision about first messages — it was
+// that activities.EmailDrafter took an anchor by signature, so a draft with no
+// activity behind it could not reach the routed lane at all. What a caller got
+// instead was their own intent string placed between two fixed lines: a
+// template to rewrite, at the exact moment (a hand shaken at a conference, a
+// reply that has to go out while it is fresh) the product is trying to serve.
+//
+// This is the SAME lane the reply uses — same task, same anti-AI floor, same
+// one critic retry, same Voice DNA — with the evidence a first message actually
+// has. What it does not have is an anchor, and that is what the two differ by:
+// no message being answered, so no subject, no body, no silence to measure, and
+// no activity for a learning signal to hang on.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+)
+
+var _ activities.FirstEmailDrafter = replyDrafter{}
+
+// DraftFirstEmail composes an opening message from the caller's intent.
+//
+// The intent is the whole of the subject material, and that is a bound rather
+// than an oversight: the surfaces that call this name records the message will
+// be FILED under, not records it is written FROM, and reading a company's
+// fields into an opening line would make the draft's content depend on data the
+// approving human is not looking at. A surface that does have the account in
+// front of it drafts through accountdraft, which is grounded in that read.
+//
+// The envelope is resolved from the intent because the intent is the only text
+// in existence — so the draft comes back in the language the request was
+// written in, which is the best available answer and a visible one: a caller
+// who wants German asks in German.
+//
+// A model that is down, over budget or answering nonsense must not cost the
+// caller their draft. The deterministic floor is a real message they can edit,
+// and it is what this path returned before the lane was reachable at all.
+func (d replyDrafter) DraftFirstEmail(ctx context.Context, intent string) (string, string, error) {
+	intent = strings.TrimSpace(intent)
+	// BandFresh, not the band a silence would classify to: this IS the opening,
+	// and there is no last message to count days from. It is what the
+	// deterministic floor below has always rendered, and the two must agree —
+	// a model draft and its fallback describing the correspondence differently
+	// would make which writer answered visible in the prose.
+	state := convstate.State{Band: convstate.BandFresh}
+	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(activities.DraftContext{
+		Band:     state.Band,
+		Threaded: false,
+	}, intent)
+	if d.brain == nil {
+		return fallbackSubject, fallbackBody, nil
+	}
+	data := replyActivityData{
+		Envelope: d.envelope.Resolve(ctx, intent, state),
+		// Threaded is FALSE and the subject and body are empty, which is what
+		// makes this a first message rather than a reply with the evidence
+		// missing: nothing is being answered, so nothing may carry "Re:".
+		Thread: threadFlag(false),
+		Intent: boundedRunes(intent, replyActivityMaxRunes),
+	}
+	// No voice block, which puts this site where the two composers already are:
+	// ai-tasks.yaml records that the reply site alone has a voiced variant, and
+	// the composers gain theirs when Voice DNA reaches them. It is also what
+	// keeps this path free of a learning signal nobody can answer — a rep
+	// rejects a voiced draft through a draft_ref, and this surface returns
+	// text only.
+	draft, err := d.completeChecked(ctx, firstDraftSystem, data, nil)
+	if err != nil {
+		d.logger().WarnContext(ctx, "model first-message draft unavailable; using deterministic draft", "err", err)
+		return fallbackSubject, fallbackBody, nil
+	}
+	return draft.Subject, draft.Body, nil
+}

--- a/backend/internal/compose/firstdraft_test.go
+++ b/backend/internal/compose/firstdraft_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// firstDrafter is a drafter with a brain and an envelope resolver and nothing
+// else: DraftFirstEmail reads no store, which is the property the seam has that
+// the reply seam does not.
+// firstMessageContext is the floor's own reading of a first message.
+//
+// It is a value rather than a literal at each assertion because a test that
+// spelled its own context could assert the WRONG floor and pass: the
+// deterministic renderer answers for any context handed to it, so a fallback
+// test is only about the fallback if it asks for the one the code asks for.
+var firstMessageContext = activities.DraftContext{Band: convstate.BandFresh, Threaded: false}
+
+func firstDrafter(brain completer) replyDrafter {
+	return replyDrafter{brain: brain, envelope: draftfloor.NewResolver()}
+}
+
+// TestAFirstMessageIsComposedRatherThanTemplated is the ticket's own case: an
+// intent placed between two fixed lines is a template the caller must rewrite,
+// and it was what this path returned for every deployment, model or not.
+func TestAFirstMessageIsComposedRatherThanTemplated(t *testing.T) {
+	brain := &replyBrainStub{response: model.Response{
+		Text: `{"subject":"Following up on K5","body":"It was good to meet you at K5 last week."}`,
+	}}
+	intent := "introduce ourselves after meeting at K5"
+
+	subject, body, err := firstDrafter(brain).DraftFirstEmail(context.Background(), intent)
+	if err != nil {
+		t.Fatalf("DraftFirstEmail: %v", err)
+	}
+	if subject != "Following up on K5" || body != "It was good to meet you at K5 last week." {
+		t.Fatalf("the model's draft did not reach the caller: subject=%q body=%q", subject, body)
+	}
+	deterministicSubject, deterministicBody := activities.DeterministicEmailDraft(firstMessageContext, intent)
+	if body == deterministicBody && subject == deterministicSubject {
+		t.Error("the deterministic floor answered while a model was configured, which is the defect this closes")
+	}
+}
+
+// TestAFirstMessageCarriesNoThreadEvidence holds what makes it a first message
+// rather than a reply with its evidence missing.
+//
+// The fields are asserted on the REQUEST rather than on the reply: a subject or
+// a body reaching the lane would be a claim about correspondence that does not
+// exist, and "Re:" on a message nobody sent us is the exact failure the thread
+// flag exists to prevent.
+func TestAFirstMessageCarriesNoThreadEvidence(t *testing.T) {
+	brain := &replyBrainStub{response: model.Response{Text: `{"subject":"Hello","body":"A short note."}`}}
+
+	if _, _, err := firstDrafter(brain).DraftFirstEmail(context.Background(), "ask for a call"); err != nil {
+		t.Fatalf("DraftFirstEmail: %v", err)
+	}
+	if len(brain.request.Messages) != 1 {
+		t.Fatalf("the lane was asked %d messages, want one", len(brain.request.Messages))
+	}
+	sent := brain.request.Messages[0].Content
+	for field, spelling := range map[string]string{
+		"a subject being answered": `"subject"`,
+		"a body being answered":    `"body"`,
+		"an inbound mail thread":   "inbound_mail",
+	} {
+		if strings.Contains(sent, spelling) {
+			t.Errorf("a first message carried %s (%s) into the lane: %s", field, spelling, sent)
+		}
+	}
+	if !strings.Contains(sent, "ask for a call") {
+		t.Errorf("the caller's intent — the whole of the subject material — did not reach the lane: %s", sent)
+	}
+}
+
+// TestAFirstMessageFallsBackToTheFloorRatherThanFailing holds the degrade.
+//
+// A model that is down must not cost the caller their draft: the floor is a
+// real message they can edit, and it is what this path returned before the lane
+// was reachable at all.
+func TestAFirstMessageFallsBackToTheFloorRatherThanFailing(t *testing.T) {
+	intent := "introduce ourselves after meeting at K5"
+	wantSubject, wantBody := activities.DeterministicEmailDraft(firstMessageContext, intent)
+
+	for what, drafter := range map[string]replyDrafter{
+		"no model in this deployment": firstDrafter(nil),
+		"a model that refuses":        firstDrafter(&replyBrainStub{err: errors.New("over budget")}),
+		"a model answering nonsense":  firstDrafter(&replyBrainStub{response: model.Response{Text: "not json"}}),
+	} {
+		t.Run(what, func(t *testing.T) {
+			subject, body, err := drafter.DraftFirstEmail(context.Background(), intent)
+			if err != nil {
+				t.Fatalf("a caller was refused their draft: %v", err)
+			}
+			if subject != wantSubject || body != wantBody {
+				t.Errorf("the floor did not answer: subject=%q body=%q", subject, body)
+			}
+		})
+	}
+}
+
+// replyOnlyDrafter implements the reply seam and nothing else — the shape a
+// deployment binds when it runs no model, and the shape every drafter had
+// before this seam existed.
+type replyOnlyDrafter struct{}
+
+func (replyOnlyDrafter) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
+	return "", "", errors.New("this drafter answers replies only")
+}
+
+// firstSeamDrafter records that the first-message seam was the one asked.
+type firstSeamDrafter struct {
+	replyOnlyDrafter
+	asked string
+}
+
+func (d *firstSeamDrafter) DraftFirstEmail(_ context.Context, intent string) (string, string, error) {
+	d.asked = intent
+	return "Composed", "A message written for this intent.", nil
+}
+
+// TestTheAccountDraftAsksTheFirstMessageSeamWhenTheDrafterHasOne holds the
+// WIRING, which is the half a test of DraftFirstEmail alone cannot see.
+//
+// The defect this closes was never that the lane could not compose — it was
+// that nothing asked it to. A drafter that can open a conversation and an
+// adapter that never calls it reads exactly like the deterministic path it
+// replaced, and every other test here would stay green.
+func TestTheAccountDraftAsksTheFirstMessageSeamWhenTheDrafterHasOne(t *testing.T) {
+	links := []agents.RecordLink{{EntityType: "person", EntityID: ids.NewV7()}}
+	intent := "introduce ourselves after meeting at K5"
+
+	drafter := &firstSeamDrafter{}
+	subject, body, err := commsAdapter{draft: drafter}.DraftAccountEmail(context.Background(), links, intent)
+	if err != nil {
+		t.Fatalf("DraftAccountEmail: %v", err)
+	}
+	if drafter.asked != intent {
+		t.Errorf("the first-message seam was asked %q, want the caller's intent %q", drafter.asked, intent)
+	}
+	if subject != "Composed" || body != "A message written for this intent." {
+		t.Errorf("the composed draft did not reach the caller: subject=%q body=%q", subject, body)
+	}
+
+	// And the floor for a drafter that cannot: a deployment running no model
+	// still gets a real message rather than a refusal.
+	floorSubject, floorBody := activities.DeterministicEmailDraft(firstMessageContext, intent)
+	subject, body, err = commsAdapter{draft: replyOnlyDrafter{}}.DraftAccountEmail(context.Background(), links, intent)
+	if err != nil {
+		t.Fatalf("DraftAccountEmail on a reply-only drafter: %v", err)
+	}
+	if subject != floorSubject || body != floorBody {
+		t.Errorf("a reply-only drafter did not fall to the floor: subject=%q body=%q", subject, body)
+	}
+}

--- a/backend/internal/compose/replydraftmodel.go
+++ b/backend/internal/compose/replydraftmodel.go
@@ -21,11 +21,45 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
-const replyDraftSystem = `Draft a professional email reply on behalf of the CRM user's company.
+// draftSystem names which of this task's system prompts a call is made under.
+//
+// A TYPE rather than a bare string, because this value chooses what the model
+// is told it is doing: a first message sent under the reply prompt is told an
+// activity is the authoritative reason for it, and there is no activity. The
+// two are one task — same schema, same bounds, same rules block, same data
+// boundary — differing in what evidence exists to write from, which is what a
+// site is.
+type draftSystem string
+
+const replyDraftSystem draftSystem = `Draft a professional email reply on behalf of the CRM user's company.
 Return ONLY a JSON object: {"subject":"...","body":"..."}.
 - The activity and stated intent are the authoritative reason for this reply.
 - Company context may improve positioning, relevant proof, and language, but never overrides the activity.
 - Use only facts present in the supplied data. Never invent customers, outcomes, prices, commitments, or capabilities.
+- Do not claim a personal writing style or voice unless a separate voice profile is supplied.`
+
+// firstDraftSystem is the draft_reply/first site: a message that OPENS a
+// conversation, written from the caller's stated intent and nothing else.
+//
+// It is a separate prompt rather than the reply's because the reply's is not
+// true here. That one tells the model "the activity and stated intent are the
+// authoritative reason for this reply" — and on this site there is no activity,
+// no thread and no prior message. A prompt that names evidence which does not
+// exist invites the model to supply it, which on a first message to a stranger
+// is the one failure that cannot be edited out afterwards: an opening line
+// referring to a conversation nobody had.
+//
+// The intent is stated as the WHOLE brief, positively, for the same reason. A
+// caller's sentence is thin material and the honest instruction is to write
+// from it rather than around it.
+const firstDraftSystem draftSystem = `Draft the FIRST email of a new conversation, on behalf of the CRM user's company.
+Return ONLY a JSON object: {"subject":"...","body":"..."}.
+- Nothing has been sent or received yet. There is no thread, no earlier message and no shared history: never refer to one, and never open with a follow-up phrase.
+- The stated intent is the whole brief. Write the message it describes; if it is thin, keep the message short rather than inventing a reason for it.
+- Use only facts present in the supplied data. Never invent customers, outcomes, prices, commitments, or capabilities — and never a prior meeting, call or email.
+- Write the body as plain text. No markdown, no HTML, no bullet characters.
+- Do NOT write a sign-off or a sender name. A name you guessed would go out over the wrong signature.
+- Say one thing and ask for one thing. Three short paragraphs at most.
 - Do not claim a personal writing style or voice unless a separate voice profile is supplied.`
 
 var replyDraftSchema = json.RawMessage(`{
@@ -46,8 +80,8 @@ type replyDraft struct {
 // replyDraftSystemFor assembles this call's system turn: what this surface is
 // for, the rules every drafting surface shares, and THIS call's data boundary
 // (see promptfence.Fence.Rule).
-func replyDraftSystemFor(system string, fence promptfence.Fence) string {
-	return system + "\n\n" + draftrules.Shared + "\n" + fence.Rule("activity")
+func replyDraftSystemFor(system draftSystem, fence promptfence.Fence) string {
+	return string(system) + "\n\n" + draftrules.Shared + "\n" + fence.Rule("activity")
 }
 
 // replyDraftRequest builds the one request a draft call sends, in whichever of
@@ -57,7 +91,7 @@ func replyDraftSystemFor(system string, fence promptfence.Fence) string {
 // same invocation site: same schema, same bounds, same data boundary.
 //
 //promptvoice:exempt the reply is an email sent to a customer under the user's own name, and draftrules carries that user's voice; Margince's register belongs to what it says TO the user, never to what it writes AS them.
-func replyDraftRequest(activity replyActivityData, voiceBlock voiceBlockFor, correction string) (model.Request, error) {
+func replyDraftRequest(site draftSystem, activity replyActivityData, voiceBlock voiceBlockFor, correction string) (model.Request, error) {
 	payload, err := json.Marshal(activity)
 	if err != nil {
 		return model.Request{}, fmt.Errorf("compose: encode reply activity context: %w", err)
@@ -67,7 +101,7 @@ func replyDraftRequest(activity replyActivityData, voiceBlock voiceBlockFor, cor
 	// could not be spelled — and an accident of the encoder is not a boundary:
 	// it goes the moment this block is rendered as text rather than JSON.
 	fence := promptfence.New()
-	system := replyDraftSystem
+	system := site
 	content := fence.Wrap(string(payload))
 	if voiceBlock != nil {
 		system = replyDraftVoiceSystem
@@ -90,12 +124,12 @@ func replyDraftRequest(activity replyActivityData, voiceBlock voiceBlockFor, cor
 }
 
 func (d replyDrafter) complete(ctx context.Context, activity replyActivityData, voiceBlock voiceBlockFor) (replyDraft, error) {
-	return d.completeWith(ctx, activity, voiceBlock, "")
+	return d.completeWith(ctx, replyDraftSystem, activity, voiceBlock, "")
 }
 
 // completeWith is complete plus the correction a retry carries.
-func (d replyDrafter) completeWith(ctx context.Context, activity replyActivityData, voiceBlock voiceBlockFor, correction string) (replyDraft, error) {
-	req, err := replyDraftRequest(activity, voiceBlock, correction)
+func (d replyDrafter) completeWith(ctx context.Context, site draftSystem, activity replyActivityData, voiceBlock voiceBlockFor, correction string) (replyDraft, error) {
+	req, err := replyDraftRequest(site, activity, voiceBlock, correction)
 	if err != nil {
 		return replyDraft{}, err
 	}
@@ -126,10 +160,10 @@ func (d replyDrafter) completeWith(ctx context.Context, activity replyActivityDa
 // The voice block rides along unchanged: it selects the system variant, and the
 // correction rides the user turn, so a plain draft told to fix a phrase stays a
 // plain draft rather than silently becoming a voiced one.
-func (d replyDrafter) completeChecked(ctx context.Context, data replyActivityData, voiceBlock voiceBlockFor) (replyDraft, error) {
+func (d replyDrafter) completeChecked(ctx context.Context, site draftSystem, data replyActivityData, voiceBlock voiceBlockFor) (replyDraft, error) {
 	return draftcore.CorrectOnce(ctx, data.Lang(), data.Band(),
 		func(ctx context.Context, correction string) (replyDraft, error) {
-			return d.completeWith(ctx, data, voiceBlock, correction)
+			return d.completeWith(ctx, site, data, voiceBlock, correction)
 		},
 		// The reply site returns no reasoning: its schema is subject and body
 		// alone, so there is no second channel to judge here.

--- a/backend/internal/compose/replydraftvoice.go
+++ b/backend/internal/compose/replydraftvoice.go
@@ -47,14 +47,14 @@ func (d replyDrafter) loadVoice(ctx context.Context) voiceContext {
 // failure as a rejected learning signal.
 func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data replyActivityData, voice voiceContext) (replyDraft, *int, *string, error) {
 	if !voice.ok {
-		draft, err := d.completeChecked(ctx, data, nil)
+		draft, err := d.completeChecked(ctx, replyDraftSystem, data, nil)
 		return draft, nil, nil, err
 	}
 	block := func(fence promptfence.Fence) string {
 		return voiceDraftPromptBlock(voice.profile.PersonalityMD, voice.version.VoiceProfileMD,
 			ai.VersionExemplars(voice.version), ai.DecodeVersionStats(voice.version), fence)
 	}
-	draft, err := d.completeChecked(ctx, data, block)
+	draft, err := d.completeChecked(ctx, replyDraftSystem, data, block)
 	if err != nil {
 		return replyDraft{}, nil, nil, err
 	}
@@ -80,7 +80,7 @@ func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data 
 		// The voice-styled draft kept tripping the floor: serve the plain
 		// draft instead and let the failure feed the learning panel.
 		d.recordVoiceRejection(ctx, voice, anchor, draft)
-		plain, plainErr := d.completeChecked(ctx, data, nil)
+		plain, plainErr := d.completeChecked(ctx, replyDraftSystem, data, nil)
 		return plain, nil, nil, plainErr
 	}
 	d.recordVoiceDraft(ctx, voice, anchor, draft)
@@ -139,7 +139,7 @@ func (d replyDrafter) recordVoiceRejection(ctx context.Context, voice voiceConte
 
 // replyDraftVoiceSystem replaces the no-voice guard when a profile block is
 // supplied: the profile controls expression, never facts.
-const replyDraftVoiceSystem = `Draft a professional email reply on behalf of the CRM user's company, written in the user's own voice.
+const replyDraftVoiceSystem draftSystem = `Draft a professional email reply on behalf of the CRM user's company, written in the user's own voice.
 Return ONLY a JSON object: {"subject":"...","body":"..."}.
 - The activity and stated intent are the authoritative reason for this reply.
 - The supplied voice profile controls expression — rhythm, vocabulary, directness, structure — never facts.

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -90,6 +90,24 @@ type DraftResult struct {
 	DraftRef *string
 }
 
+// FirstEmailDrafter drafts a message that OPENS a conversation, where
+// EmailDrafter answers one.
+//
+// It is a second method rather than an anchor that may be zero, because the two
+// take different evidence and a nil anchor would let a caller ask the reply
+// path a question it has no answer for. A reply reads the activity it answers —
+// its subject, its body, how long ago it arrived, who sent it. A first message
+// has none of that in existence: the caller's intent is the only subject
+// material there is, and everything else the draft is written from (the
+// language, the clock, who is signing) is server-derived either way.
+//
+// A drafter that implements only EmailDrafter leaves the first-message path on
+// the deterministic floor, which is what a deployment running no model gets on
+// both paths.
+type FirstEmailDrafter interface {
+	DraftFirstEmail(ctx context.Context, intent string) (string, string, error)
+}
+
 // ProvenanceEmailDrafter is the richer drafting seam: same draft, plus the
 // provenance the HTTP response stamps. A drafter that implements it is
 // preferred over the plain EmailDrafter shape; the plain seam stays for

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -24,7 +24,7 @@ const (
 	TaskDealHealth Task = "deal_health"
 	// TaskDocumentExtract is read ONE attached document — a scanned form, an invoice, an order confirmation — for the four deal facts a human may then accept onto the deal (records-depth RD-PARAM-N-3), each carrying the quote it was read from. premium-only BY CONTRACT for site_extract's reason and one of its own: a rung that cannot carry the document is not a degraded answer to this question, it is a different question, so there is no rung to degrade to. no_payload BY CONTRACT: a scanned contract or invoice is exactly the content that must never reach ai_call_payload, whatever the deployment's capture posture says. A reading takes seconds and can fail, so it is a durable record its surface polls (records-depth RD-DDL-4), never work done inside the request that asks for it.
 	TaskDocumentExtract Task = "document_extract"
-	// TaskDraftReply is Three sites, one task: the reply to an activity, the person page's composer, and the company page's first-touch outbound. They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a fourth site; the composers gain theirs when Voice DNA reaches them.
+	// TaskDraftReply is Four sites, one task: the reply to an activity, the person page's composer, the company page's first-touch outbound, and the message that opens a conversation from a stated intent alone (draft_email over MCP, which names records to file under rather than records to write from). They differ in what a draft is grounded IN, and share the rules block every drafting surface writes under (compose/draftrules). The reply site alone has two system variants (voice-enabled and plain), selected per call from the workspace's Voice DNA state — a variant, not a site of its own; the composers and the first-message site gain theirs when Voice DNA reaches them.
 	TaskDraftReply Task = "draft_reply"
 	TaskEnrich     Task = "enrich"
 	// TaskGrowthFit is How well one company fits what we sell. The only site on the company view that must read OUR offering as well as theirs — a fit is a claim about two companies, and judging one against a guess about the other is what the DOSS-AC-13 band cap exists to stop. Our own context is never citable: evidence is target-side only, so a factor drawn from what we sell is labelled an assessment and still cites their records, or the grounding filter drops it (DOSS-AC-6). The band the model proposes is not the band served — the deterministic completeness gate can lower it to `unknown` or cap it at `moderate`, and never raises it.
@@ -79,7 +79,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "30bbf30093d57ed4d15f5bb5a002889e0e49bac09ed3bc6dcd346854b1d7a42f"
+const TaskContractHash = "e4836b8193da6ab93f104e13cfe28eda350e7d2ad8475bdd94877410278b54e4"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -281,6 +281,7 @@ var taskSites = map[Task][]Site{
 		{Name: "reply", Kind: "one_shot"},
 		{Name: "person", Kind: "one_shot"},
 		{Name: "account", Kind: "one_shot"},
+		{Name: "first", Kind: "one_shot"},
 	},
 	TaskEnrich: {
 		{Name: "signature", Kind: "one_shot"},


### PR DESCRIPTION
Addresses the first half of #2371.

## What a caller got

`draft_email` could compose a first message from `links` with no prior thread. Called with `intent: "introduce ourselves after meeting at K5"`, it returned:

> Hello,
>
> introduce ourselves after meeting at K5
>
> Would a short call this week suit you?

The intent placed between two fixed lines. No model involved — a template the caller must rewrite, at the exact moment (a hand shaken at a conference, a note that has to go out while it is fresh) the deck's case 1 is trying to serve. And a first-contact follow-up drafted through MCP exists only in the chat transcript, so closing the conversation loses it.

## Why it was that way

Not a decision about first messages. `activities.EmailDrafter` took an anchor by signature — `DraftEmail(ctx, anchor, intent)` — so a draft with no activity behind it could not reach the routed lane at all. The reply path was model-backed from the day it shipped; the first-message path had no door.

## The seam

```go
type FirstEmailDrafter interface {
	DraftFirstEmail(ctx context.Context, intent string) (string, string, error)
}
```

A second method rather than an anchor that may be zero, because the two take different evidence and a nil anchor would let a caller ask the reply path a question it has no answer for. A reply reads the activity it answers — subject, body, how long ago it arrived, who sent it. A first message has none of that in existence: the caller's intent is the only subject material there is, and everything else the draft is written from (the language, the clock, who is signing) is server-derived either way.

`commsAdapter.DraftAccountEmail` asks for it when the bound drafter has one, and falls to the deterministic floor when it does not — which is what a deployment running no model gets on both paths.

## `draft_reply/first` is a site, not a reuse

Declared in `api/ai-tasks.yaml`, registered in the census, with its own certification case and a corpus scenario.

It has its own system prompt because **the reply's is not true here**. That one tells the model *"the activity and stated intent are the authoritative reason for this reply"* — and on this site there is no activity, no thread and no prior message. A prompt that names evidence which does not exist invites the model to supply it, and on a first message to a stranger an opening line referring to a conversation nobody had is the one failure that cannot be edited out afterwards.

Neither existing composer fits either: `persondraft` opens by the recipient's first name, and `accountdraft` is grounded in the company's own 360 — both read records this caller deliberately does not read. `draft_email`'s links name the records the conversation is **filed under**, not records it is written **from**, and reading a company's fields into an opening line would make the draft's content depend on data the approving human is not looking at.

No voiced variant, which puts this site where the two composers already are (`ai-tasks.yaml` records that the reply site alone has one). It also keeps the path free of a learning signal nobody can answer: a rep rejects a voiced draft through a `draft_ref`, and this surface returns text only — recording one would teach the voice model that every unanswerable draft was accepted.

The prompt is carried as a typed `draftSystem` rather than a bare string, so which prompt a call is made under is a choice the compiler can see.

## Held from the other end

- `TestAFirstMessageIsComposedRatherThanTemplated` — the ticket's own case.
- `TestAFirstMessageCarriesNoThreadEvidence` — asserts on the **request**: no subject, no body, no `inbound_mail` flag reaches the lane, and the intent does. Mutation-checked by flipping the thread flag; the gate catches it.
- `TestTheAccountDraftAsksTheFirstMessageSeamWhenTheDrafterHasOne` — the wiring, which a test of `DraftFirstEmail` alone cannot see. Mutation-checked by deleting the branch in `comms.go`: every other test stays green and this one fails, which is the point.
- `TestAFirstMessageFallsBackToTheFloorRatherThanFailing` — no model, a model that refuses, a model answering nonsense. A caller is never refused their draft.
- `firstDraftCases.Prepare` refuses a fixture carrying thread evidence or no intent — a scenario that supplied either would certify a call the product never makes.
- The existing `draftrules` parity gate now covers the new prompt, so it cannot drop the shared rules block.

## What this does not do

The second half of #2371 — that `draft_email` leaves nothing on the correspondence timeline where `draft_follow_ups_for` returns a `draft_activity_id` — is untouched here. It is a product question rather than a wiring one (should drafting write?), and the MCP tool currently matches the HTTP draft endpoint, which also returns text only. Left on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AI-assisted drafting for first-contact emails based on a sender’s intent.
  - First messages now support model-generated drafts with deterministic fallback when AI generation is unavailable.
  - Added certification coverage for first-message drafting, including safeguards against invented details and reply-style content.
  - Expanded voice-ready drafting support to include first messages.

- **Bug Fixes**
  - Improved consistency when selecting drafting styles and retrying generated responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->