### PR TITLE
chore(labels): add margince-qc provenance label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -116,6 +116,9 @@
 - name: "fast-track-debt"
   color: "6E5494"
   description: "Shipped fast under time pressure; known issue deferred for team cleanup"
+- name: "margince-qc"
+  color: "0052CC"
+  description: "Found by margince-qc, the UAT acceptance-test repo, while building or running a scenario"
 
 # ---------------------------------------------------------------------------
 # GitHub's own defaults, kept because they are what a drive-by contributor and

--- a/docs/reference/issue-labels.md
+++ b/docs/reference/issue-labels.md
@@ -64,9 +64,12 @@ leaving them off puts unactionable work in somebody's queue:
 
 **Provenance**, additive and independent of the three axes: `bug`,
 `enhancement`, `security`, `capability-gap` (a missing capability, not a defect),
-and `fast-track-debt` (shipped fast under time pressure with the gap recorded
-deliberately). These record *why the issue exists*, which is the one thing
-nobody can reconstruct later — prefer keeping them over tidying them away.
+`fast-track-debt` (shipped fast under time pressure with the gap recorded
+deliberately), and `margince-qc` (found by the `margince-qc` UAT acceptance-test
+repo while building or running a scenario, rather than by a person working in
+this repo directly). These record *why the issue exists*, which is the one
+thing nobody can reconstruct later — prefer keeping them over tidying them
+away.
 
 **`security` is not a way to report a vulnerability.** This repo is public, and
 [SECURITY.md](../../SECURITY.md) is explicit that an exploitable weakness goes to a


### PR DESCRIPTION
## Summary
- Adds `margince-qc` as a new provenance label to `.github/labels.yml` and `docs/reference/issue-labels.md`, following the taxonomy's own documented process for adding a label.
- `margince-qc` is the UAT acceptance-test repo that walks the product as each role's own RBAC; this label lets a reader tell "found while building or running a QC scenario" apart from a defect found some other way — the same distinction `fast-track-debt` and `capability-gap` already make for their own provenance.

Once merged, `scripts/sync-labels.sh` (or a scoped `gh label create`) still needs to run by hand to actually create the label on the live repository, per the script's own documented process (no push-to-main workflow exists for this yet).

## Test plan
- [x] `go test ./gates -run TestEachSectionOfTheReferencePageListsExactlyItsLabels` passes (the label-taxonomy consistency gate)
- [x] Pre-push hook: no changed Go files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `margince-qc` as a new provenance label so issues found by the UAT acceptance-test repo are distinguishable from other defects. After merge, the label still needs to be created on the live repository by running `scripts/sync-labels.sh`.

<sup>Written for commit f30edec7c79db438e85a78e14c498ce4fbdb2b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `margince-qc` label to the documented provenance taxonomy.
  * Clarified that the label identifies findings from acceptance testing.

* **Chores**
  * Added the new blue `margince-qc` label for tracking acceptance-test findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->