### PR TITLE
Count the duplicates the commit met, not the ones it predicted

### DIFF
--- a/backend/internal/compose/csvimportreport.go
+++ b/backend/internal/compose/csvimportreport.go
@@ -34,7 +34,7 @@ func refinePrediction(ctx context.Context, source *migration.CSVSource, writers 
 		report.Objects[i].Unchanged = p.unchanged
 		report.Objects[i].Skipped = append(report.Objects[i].Skipped, p.skipped...)
 		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
-		report.Objects[i].Duplicates += p.duplicates
+		report.Objects[i].WillDuplicate += p.duplicates
 	}
 	return withPredictedLinks(ctx, source, writers, report, p.absent)
 }

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -231,7 +231,17 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 			out.Disposition.Created += o.WillCreate
 			out.Disposition.Updated += o.WillUpdate
 		}
-		duplicates += o.Duplicates
+		// The commit's own count once there is one, for the same reason
+		// Created replaces WillCreate above: the estate moves between the
+		// preview and the approval — a colleague creates one of the companies,
+		// an earlier run lands it — and a finished report that stated the
+		// prediction would describe what was expected rather than what
+		// happened.
+		if committed {
+			duplicates += o.Duplicated
+		} else {
+			duplicates += o.WillDuplicate
+		}
 		for _, s := range o.Skipped {
 			// The same row skipped by the dry run and again by the commit is
 			// ONE row the human must go fix, named by its line.

--- a/backend/internal/compose/csvwriters.go
+++ b/backend/internal/compose/csvwriters.go
@@ -167,7 +167,19 @@ func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Ro
 	// Not a row this importer has landed before — but the estate may hold the
 	// record anyway, and the run says what to do about that. The check runs on
 	// the commit as well as the dry run so the two cannot disagree.
-	if w.onDuplicate == string(crmcontracts.Skip) {
+	//
+	// It runs on BOTH branches of that decision, and it did not always. Asking
+	// only when the run said "skip" made a duplicate that CREATES invisible to
+	// the commit, so a finished report could only ever repeat the prediction —
+	// and the estate moves between the preview and the approval, which is the
+	// whole reason a duplicate count is worth reading. The cost is one
+	// dedupe query per row this importer has not landed before, which is what
+	// the preview already spends on the same rows.
+	collides, err := w.collidesWithExisting(ctx, row)
+	if err != nil {
+		return migration.EnsureResult{}, err
+	}
+	if collides && w.onDuplicate == string(crmcontracts.Skip) {
 		// discloseOnly, so a collision this caller may not see is answered as no
 		// collision — and the row CREATES.
 		//
@@ -183,15 +195,21 @@ func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Ro
 		// What skipping costs is a disclosure that no merge undoes. It also keeps
 		// the preview and the commit answering alike, since the preview is
 		// disclosure-filtered for the same reason.
-		collides, err := w.collidesWithExisting(ctx, row)
-		if err != nil {
-			return migration.EnsureResult{}, err
-		}
-		if collides {
-			_, skipReason := collisionWordingFor(object)
-			return migration.EnsureResult{Skipped: true, SkipReason: skipReason}, nil
-		}
+		_, skipReason := collisionWordingFor(object)
+		return migration.EnsureResult{Skipped: true, SkipReason: skipReason, Duplicate: true}, nil
 	}
+	created, err := w.create(ctx, object, row)
+	if err != nil {
+		return migration.EnsureResult{}, err
+	}
+	// The flag rides the create rather than replacing it: a duplicate the run
+	// asked to keep IS a created row, and the review queue picks up the pair.
+	created.Duplicate = collides
+	return created, nil
+}
+
+// create lands the row as a new record of its class.
+func (w *csvWriters) create(ctx context.Context, object string, row migration.Row) (migration.EnsureResult, error) {
 	switch object {
 	case migration.ObjectLead:
 		return w.createLead(ctx, row)

--- a/backend/internal/compose/integration/csvimport_integration_test.go
+++ b/backend/internal/compose/integration/csvimport_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path"
+	"strconv"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -865,4 +866,80 @@ func TestCSVImportRefusesAnUnknownDuplicatePolicy(t *testing.T) {
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("an unknown on_duplicate → %d, want 422", status)
 	}
+}
+
+// TestCSVImportCountsTheDuplicatesTheCommitMetNotTheOnesThePreviewPredicted is
+// the case that separates a report from a prediction.
+//
+// The estate moves between the preview and the approval — a colleague creates
+// one of the companies, an earlier run lands it — and a finished report is
+// supposed to describe what happened. Counting only what the dry run saw makes
+// "0 duplicates" a statement about a database that no longer exists, and the
+// person reading it has already approved on the strength of it.
+//
+// The four load-bearing counts are checked either side, because the fix must
+// not disturb them: a duplicate that lands is counted in Created and nowhere
+// else, and `duplicates` sits outside the sum by design.
+func TestCSVImportCountsTheDuplicatesTheCommitMetNotTheOnesThePreviewPredicted(t *testing.T) {
+	e := setupImportApp(t)
+
+	const file = "Company,Industry\nZephyr Freight,logistics\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunWithMapping(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "Industry": "industry"})
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var preview importReportDTO
+	if code := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &preview); code != http.StatusOK {
+		t.Fatalf("preview report → %d, want 200", code)
+	}
+	if preview.Disposition.Duplicates == nil || *preview.Disposition.Duplicates != 0 {
+		t.Fatalf("the preview found %v duplicate(s) against an estate that holds none; "+
+			"this test needs a clean prediction to have something to disagree with later",
+			duplicatesSaid(preview))
+	}
+
+	// A colleague creates the company, after the preview and before the
+	// approval. Directly, the way real ones arrive: the importer's identity map
+	// remembers only rows IT wrote, so this one is invisible to it.
+	if code := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Zephyr Freight", "industry": "logistics"}, nil, nil); code != http.StatusCreated {
+		t.Fatalf("creating the company between preview and approval → %d, want 201", code)
+	}
+
+	if code := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); code != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", code)
+	}
+
+	var final importReportDTO
+	if code := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &final); code != http.StatusOK {
+		t.Fatalf("final report → %d, want 200", code)
+	}
+	if final.Disposition.Duplicates == nil || *final.Disposition.Duplicates != 1 {
+		t.Errorf("the finished run reports %v duplicate(s); the commit met one, and a report that "+
+			"repeats the prediction describes an estate that no longer exists",
+			duplicatesSaid(final))
+	}
+	if got := final.Disposition.Created + final.Disposition.Updated +
+		final.Disposition.Unchanged + final.Disposition.Skipped; got != final.RowsRead {
+		t.Errorf("the finished disposition sums to %d for %d row(s) read; a duplicate is counted in "+
+			"Created and nowhere else, so the four must still sum to rows_read", got, final.RowsRead)
+	}
+	if final.Disposition.Created != 1 {
+		t.Errorf("created = %d, want 1 — the duplicate lands and the review queue picks up the pair",
+			final.Disposition.Created)
+	}
+}
+
+// duplicatesSaid renders the duplicate count for a failure message. The field
+// is a pointer because "not reported" and "none found" are different answers,
+// and %v on it prints an address — which tells a reader of a failed run
+// nothing at all about what the report said.
+func duplicatesSaid(report importReportDTO) string {
+	if report.Disposition.Duplicates == nil {
+		return "no"
+	}
+	return strconv.Itoa(*report.Disposition.Duplicates)
 }

--- a/backend/internal/modules/migration/engine.go
+++ b/backend/internal/modules/migration/engine.go
@@ -76,6 +76,16 @@ type EnsureResult struct {
 	Unchanged  bool
 	Skipped    bool
 	SkipReason string
+	// Duplicate marks a row that named a record the estate ALREADY held and
+	// that this importer had not landed before. It is not an outcome — the row
+	// is also Created, or Skipped when the run asked for that — which is why it
+	// is a flag beside them rather than a fifth case.
+	//
+	// It is answered on the commit for the reason the preview answers it: the
+	// estate moves between the two. A colleague creates one of the companies,
+	// or an earlier run lands it, and a finished report carrying only the
+	// prediction states a duplicate count that was true when the preview ran.
+	Duplicate bool
 	// Disclosure names a lossy-but-disclosed mapping decision (e.g. a
 	// deal materialized onto the default pipeline because the source
 	// stage identity did not resolve).
@@ -138,11 +148,24 @@ type ObjectReport struct {
 	// warning exists so a person approving "create 3" is not surprised by a
 	// duplicate afterwards.
 	Collisions []SkippedRow `json:"collisions,omitempty"`
-	// Duplicates counts rows naming a record the estate already holds. It
-	// overlaps the other counts by design — each duplicate is also in Created
-	// or in Skipped — so it is never added to them.
-	Duplicates  int      `json:"duplicates,omitempty"`
-	Disclosures []string `json:"disclosures,omitempty"`
+	// WillDuplicate and Duplicated count rows naming a record the estate
+	// already holds: what the PREVIEW predicted, and what the COMMIT observed.
+	// Both overlap the other counts by design — each is also in Created or in
+	// Skipped — so neither is ever added to them.
+	//
+	// Two fields for the reason WillCreate and Created are two fields, and the
+	// merge is why it has to be. A run's stored report is the dry run's folded
+	// together with every commit attempt's, and the two walk the SAME rows: one
+	// field would report a file with one duplicate as having two the moment it
+	// was approved. Each attempt writes only its own, so addition stays honest
+	// across a resume, where the checkpoint does guarantee disjoint rows.
+	//
+	// WillDuplicate keeps the `duplicates` tag it was written under. The name
+	// is what changed, not the field: a report stored before the commit learned
+	// to count still decodes into the half it actually described.
+	WillDuplicate int      `json:"duplicates,omitempty"`
+	Duplicated    int      `json:"duplicated,omitempty"`
+	Disclosures   []string `json:"disclosures,omitempty"`
 }
 
 // Report is the run (or dry-run) outcome: per-object dispositions plus
@@ -363,6 +386,12 @@ func (or *ObjectReport) record(externalID string, res EnsureResult) {
 	default:
 		or.Updated++
 	}
+	if res.Duplicate {
+		// Counted beside the outcome rather than instead of it: this row is
+		// already in Created or in Skipped above, and the four load-bearing
+		// counts must keep summing to the rows read.
+		or.Duplicated++
+	}
 	if res.Disclosure != "" {
 		or.Disclosures = append(or.Disclosures, res.Disclosure)
 	}
@@ -440,7 +469,8 @@ func (r Report) mergedWith(next Report) Report {
 		into.MirrorCount = or.MirrorCount
 		into.Skipped = append(into.Skipped, or.Skipped...)
 		into.Collisions = append(into.Collisions, or.Collisions...)
-		into.Duplicates += or.Duplicates
+		into.WillDuplicate += or.WillDuplicate
+		into.Duplicated += or.Duplicated
 		into.Disclosures = append(into.Disclosures, or.Disclosures...)
 	}
 	return out

--- a/backend/internal/modules/migration/engine_test.go
+++ b/backend/internal/modules/migration/engine_test.go
@@ -125,8 +125,12 @@ func (f *fakeSource) Associations(context.Context) ([]Assoc, error) { return f.a
 // that crash land the record first, which is the process death this
 // whole seam exists for.
 type fakeWriters struct {
-	landed          map[string]bool // object+"/"+ext — the native row exists
-	mapped          map[string]bool // …and the identity map knows it
+	landed map[string]bool // object+"/"+ext — the native row exists
+	mapped map[string]bool // …and the identity map knows it
+	// duplicates names the external ids the estate ALREADY holds under some
+	// other identity — a company created by hand, or by an earlier run — which
+	// the real writer answers with a dedupe read per row it has not landed.
+	duplicates      map[string]bool
 	ensured         []string
 	assocs          []Assoc
 	calls           int
@@ -137,7 +141,7 @@ type fakeWriters struct {
 
 // newFakeWriters starts with nothing landed and nothing mapped.
 func newFakeWriters() *fakeWriters {
-	return &fakeWriters{landed: map[string]bool{}, mapped: map[string]bool{}}
+	return &fakeWriters{landed: map[string]bool{}, mapped: map[string]bool{}, duplicates: map[string]bool{}}
 }
 
 func (w *fakeWriters) Exists(_ context.Context, object, ext string) (bool, error) {
@@ -174,7 +178,10 @@ func (w *fakeWriters) Ensure(_ context.Context, object string, row Row) (EnsureR
 	w.landed[key] = true
 	w.mapped[key] = true
 	w.ensured = append(w.ensured, key)
-	return EnsureResult{Created: true}, nil
+	// The flag rides the create, as it does in the real writer: a duplicate the
+	// run kept IS a created row, and counting it as an outcome of its own would
+	// break the sum the disposition table rests on.
+	return EnsureResult{Created: true, Duplicate: w.duplicates[row.ExternalID]}, nil
 }
 
 func (w *fakeWriters) Associate(_ context.Context, a Assoc) (AssocResult, error) {
@@ -624,5 +631,60 @@ func TestEveryRunStoreEntryPointIsGateChecked(t *testing.T) {
 		if !checked[name] {
 			t.Errorf("RunStore.%s is an exported entry point with no line in the ungranted-role table", name)
 		}
+	}
+}
+
+// TestAResumedRunCountsEveryDuplicateItMetAndCountsEachOnce holds the arithmetic
+// a resume rests on.
+//
+// A run's stored report is every attempt's folded together, so a count that is
+// written by more than one of them has to be written over DISJOINT rows or it
+// double-reports. The checkpoint guarantees exactly that for what the commit
+// observes — no attempt walks a row a previous one finished — which is why the
+// observed count adds and the PREDICTED one is a separate field: the dry run
+// walks all the rows again, and one field would report a file with two
+// duplicates as having four the moment it was approved.
+func TestAResumedRunCountsEveryDuplicateItMetAndCountsEachOnce(t *testing.T) {
+	src := twoObjectSource()
+	w := newFakeWriters()
+	// One duplicate either side of the crash, so a merge that dropped a leg and
+	// a merge that double-counted one are different answers from the truth.
+	w.duplicates["org-1"] = true
+	w.duplicates["p-3"] = true
+	w.failAt = 3 // crash on person/p-1, after both organizations landed
+	runs := newFakeRuns()
+	// What the dry run predicted, recorded before the commit ever ran. It must
+	// not be added to what the attempts observe.
+	runs.run.Report = &Report{Objects: []ObjectReport{
+		{Object: "organization", WillDuplicate: 1},
+		{Object: "person", WillDuplicate: 1},
+	}}
+	e := &Engine{runs: runs, w: w}
+
+	if _, err := e.Run(context.Background(), RunID{}, src); err == nil {
+		t.Fatal("Run must surface the injected crash")
+	}
+	runs.run.Status = StatusRunning
+	w.failAt = 0
+	if _, err := e.Run(context.Background(), RunID{}, src); err != nil {
+		t.Fatalf("resumed Run: %v", err)
+	}
+
+	stored := runs.run.Report
+	if stored == nil {
+		t.Fatal("a completed run must record a report")
+	}
+	observed, predicted := 0, 0
+	for _, or := range stored.Objects {
+		observed += or.Duplicated
+		predicted += or.WillDuplicate
+	}
+	if observed != 2 {
+		t.Errorf("the resumed run recorded %d duplicate(s) met; it met two — one before the crash and one "+
+			"after — and a report that lost either describes a leg that did not happen", observed)
+	}
+	if predicted != 2 {
+		t.Errorf("the prediction now reads %d; the dry run predicted two and no attempt may add to it, "+
+			"or an approval turns a file's duplicates into twice as many", predicted)
 	}
 }


### PR DESCRIPTION
Closes #2388.

## What was wrong

`ImportRunDisposition.duplicates` was populated during preview refinement and never recomputed. `Engine.record` accumulated created/updated/skipped from each `EnsureResult` and never touched the duplicate count, so a completed or resumed run carried the figure the dry run produced.

The estate moves between the preview and the approval — a colleague creates one of the companies, an earlier run lands it — so a finished report stated a count that was true of a database that no longer exists. And the person reading it has already approved on the strength of it.

## The two-field split

`ObjectReport` now carries the pair the rest of the struct already uses:

| predicted | observed |
|---|---|
| `WillCreate` | `Created` |
| `WillUpdate` | `Updated` |
| **`WillDuplicate`** | **`Duplicated`** |

Two fields rather than one, and the merge is why it has to be. A run's stored report is the dry run's folded together with every commit attempt's, and the two walk the **same rows** — a single field would report a file with one duplicate as having two the moment it was approved. Each attempt writes only its own, so addition stays honest across a resume, where the checkpoint *does* guarantee disjoint rows. (This is the same reason `mergedWith` already replaces edges rather than adding them.)

`WillDuplicate` keeps the `duplicates` JSON tag it was written under. The name is what changed, not the field: a report stored before the commit learned to count still decodes into the half it actually described.

The wire layer picks between them on the `committed` flag it already computes for `Created`/`WillCreate`.

## The writer had to be asked

`EnsureResult` gained a `Duplicate` flag — not an outcome, a flag beside one, because the row is also `Created` (or `Skipped` when the run asked for that).

The writer previously ran `collidesWithExisting` **only** when `on_duplicate` was `skip`. So a duplicate that creates was invisible to the commit, and no amount of accounting downstream could have recovered it. It now runs on both branches.

The cost is one dedupe read per row this importer has not landed before. That is what the preview already spends on the same rows, so the commit is not doing anything the run has not already paid for once — and it is what makes the report describe the run.

## Held from the other end

- `TestCSVImportCountsTheDuplicatesTheCommitMetNotTheOnesThePreviewPredicted` (integration) — previews clean against an empty estate, a company is then created **between the preview and the approval**, and the finished report must say 1. Mutation-checked by restoring the old single-source reporting: the test fails.
- `TestAResumedRunCountsEveryDuplicateItMetAndCountsEachOnce` — a duplicate either side of an injected crash, with a dry-run prediction already stored. Mutation-checked twice: writing both counts into one field reports the prediction as 4 (the double-count this split exists to prevent) and the observation as 0; making the merge replace instead of add loses the pre-crash leg.
- Both tests assert the four load-bearing counts still sum to `rows_read`, because a duplicate is counted in `Created` or in `Skipped` and nowhere else.

One drive-by: the existing duplicate assertions printed `*int` with `%v`, so a failing run reported a pointer address. They now say the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection and reporting during CSV imports.
  * Preview results now distinguish predicted duplicates from duplicates encountered during approval.
  * Final import reports accurately include duplicates detected while committing records.
  * Duplicate counts remain accurate when an import resumes after interruption.
  * Duplicate handling is now consistent across supported import modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->