### PR TITLE
A form field can follow the form's own answers

### DIFF
--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
-import { type ReactNode, useId, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { navigate, type Route, type Screen } from "../app/router";
 import {
   Button,
@@ -127,6 +127,41 @@ export type CreateField = {
    */
   optionsFor?: (values: Record<string, string>) => CreateFieldOption[];
 };
+
+/**
+ * Publishes a form's live answers to a caller that asked for them.
+ *
+ * `optionsFor` covers the dependent field whose narrowing the browser can do
+ * for itself: it is a pure function of the values, so it can only filter a
+ * list the parent already fetched. It cannot RE-READ, and some narrowings are
+ * questions only the server can answer — which projects a company may be
+ * filed under is decided by relationship rows, and a project list row carries
+ * only its anchor company, so nothing in the browser can compute membership.
+ * This is the seam for that: the parent watches the values, runs its own
+ * query, and hands the narrowed list back as ordinary options.
+ *
+ * From an EFFECT rather than from the setter, because values are set from two
+ * places. The reader typing is one; the seed that runs during the closed→open
+ * transition is the other, and it runs during render — where calling a
+ * parent's setState is exactly what React refuses. Publishing from the setter
+ * would miss it, and the answers a form OPENS with are the first thing a
+ * dependent query needs.
+ *
+ * The dependency is the values object alone. It is a new identity only when
+ * they change, which is precisely when a caller wants to hear; adding the
+ * callback would republish on every render for the callers most likely to
+ * pass an inline one.
+ */
+export function usePublishedValues(
+  values: Record<string, string>,
+  publish?: (values: Record<string, string>) => void,
+): void {
+  const latest = useRef(publish);
+  latest.current = publish;
+  useEffect(() => {
+    latest.current?.(values);
+  }, [values]);
+}
 
 /** A field's choices right now: the dependent list when it has one. */
 export function fieldOptions(
@@ -328,10 +363,15 @@ export function CreateAction<Created extends { id: string }>({
   aboutId,
   keepOpen = false,
   onCreated,
+  onValuesChange,
   testId,
 }: Readonly<{
   label: string;
   fields: CreateField[];
+  // The form's live answers, for a screen whose field list depends on them —
+  // a dependent picker whose options only the server can narrow. See
+  // usePublishedValues.
+  onValuesChange?: (values: Record<string, string>) => void;
   create: (values: Record<string, string>, rows?: FormRows) => Promise<Created>;
   invalidate: string;
   screen: Screen;
@@ -406,6 +446,7 @@ export function CreateAction<Created extends { id: string }>({
         existing={existing}
         resolveExisting={resolveExisting}
         resetToken={saved}
+        onValuesChange={onValuesChange}
         onSubmit={(values, rows) =>
           mutation.mutate({ values, rows: rows ?? {} })
         }
@@ -849,6 +890,7 @@ export function CreateRecordModal({
   existing,
   resolveExisting,
   onSubmit,
+  onValuesChange,
   resetToken = 0,
 }: Readonly<{
   open: boolean;
@@ -860,6 +902,9 @@ export function CreateRecordModal({
   existing?: { id: string; code: string } | null;
   resolveExisting?: (code: string, id: string) => Route;
   onSubmit: (values: Record<string, string>, rows?: FormRows) => void;
+  // The form's live answers, published so a caller can drive a SERVER read
+  // from them. See the note on the shared publisher below.
+  onValuesChange?: (values: Record<string, string>) => void;
   // Emptying the form WITHOUT closing it, for a modal that stays open to take
   // the next record. The caller bumps this after a save it kept open, and the
   // seeding below treats it exactly like a fresh open. A number rather than a
@@ -882,6 +927,7 @@ export function CreateRecordModal({
   // Starts false, not `open`: a modal mounted already open still has to seed.
   const [seededOpen, setSeededOpen] = useState(false);
   const [seededReset, setSeededReset] = useState(resetToken);
+  usePublishedValues(values, onValuesChange);
   const reopened = open !== seededOpen;
   const cleared = open && resetToken !== seededReset;
   if (reopened || cleared) {

--- a/frontend/src/screens/dealproject.test.tsx
+++ b/frontend/src/screens/dealproject.test.tsx
@@ -96,6 +96,11 @@ function dealBackend(opts: {
   // What an advance answers; null for the default success.
   onAdvance?: () => Response | null;
   companies?: { id: string; display_name: string }[];
+  // Which companies the server would match each project for, by project id.
+  // A project is worked by several companies and a row names only its ANCHOR,
+  // so a fixture that could not say this could not express the case the deal
+  // form exists to serve: the company on a project as a partner.
+  projectCompanies?: Record<string, string[]>;
   // What the deal reads back as once a PATCH has landed.
   afterPatch?: (row: Deal) => Deal;
 }): Call[] {
@@ -168,8 +173,21 @@ function dealBackend(opts: {
         return jsonResponse({ id: "o-1", display_name: "Brandt Automotive" });
       }
       if (pathname.endsWith("/projects")) {
+        // The list endpoint answers about ONE company when asked, which is what
+        // both deal forms now do. It matches ANY of a project's companies, not
+        // just the anchor — the whole reason the narrowing cannot be done in
+        // the browser — so a fixture may name the others through
+        // `projectCompanies`, and falls back to the anchor when it does not.
+        const asked = new URL(url).searchParams.get("organization_id");
+        const rows = (opts.projects ?? []).filter((row) => {
+          if (!asked) {
+            return true;
+          }
+          const on = opts.projectCompanies?.[row.id];
+          return on ? on.includes(asked) : row.organization_id === asked;
+        });
         return jsonResponse({
-          data: opts.projects ?? [],
+          data: rows,
           page: { next_cursor: null, has_more: false },
         });
       }
@@ -259,6 +277,53 @@ describe("the deal form's project picker", () => {
     expect(writes[0].url.endsWith("/projects")).toBe(true);
     expect(writes[1].url.endsWith("/deals")).toBe(true);
     expect(writes[1].body).toMatchObject({ project_id: "pr-born" });
+  });
+
+  // The case the create form could not serve at all, and the reason
+  // `optionsFor` was not enough: the newly chosen company is on the project as
+  // a PARTNER, so nothing on a project row says it belongs. Filtering a fetched
+  // page in the browser can only ever match the anchor, and the answer has to
+  // come from a re-read the form's own answers drive.
+  it("repopulates the picker from the server when the form names a different company", async () => {
+    const user = userEvent.setup();
+    dealBackend({
+      projects: [
+        project({ id: "pr-1", name: "CRM rollout" }),
+        // Anchored at a THIRD company. Nothing on this row names o-2.
+        project({
+          id: "pr-joint",
+          name: "Joint rollout",
+          organization_id: "o-customer",
+        }),
+      ],
+      projectCompanies: { "pr-1": ["o-1"], "pr-joint": ["o-customer", "o-2"] },
+      companies: [
+        { id: "o-1", display_name: "Brandt Automotive" },
+        { id: "o-2", display_name: "Other GmbH" },
+      ],
+    });
+    render(<DealsScreen />);
+    await user.click(await screen.findByTestId("new-record"));
+    await pickOption(
+      user,
+      screen.getByLabelText("Company"),
+      "Brandt Automotive",
+    );
+    await user.click(screen.getByLabelText("Project"));
+    expect(screen.getByRole("option", { name: "CRM rollout" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "Joint rollout" })).toBeNull();
+    await user.keyboard("{Escape}");
+
+    // The reader changes their mind mid-form. The picker used to go empty here
+    // and stay empty until the deal was saved and reopened.
+    await pickOption(user, screen.getByLabelText("Company"), "Other GmbH");
+    await user.click(screen.getByLabelText("Project"));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: "Joint rollout" }),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByRole("option", { name: "CRM rollout" })).toBeNull();
   });
 
   it("holds the picker until a company is chosen, and drops a pick the new company does not own", async () => {
@@ -439,9 +504,12 @@ describe("the deal page", () => {
   // PARTNER matched nothing, so the list came back empty on an installation
   // full of projects.
   //
-  // The edit form asks the server for its own company's projects now — the
-  // server matches ANY of a project's companies — and passes narrowedByServer,
-  // which is what stops the second filter from undoing the answer.
+  // BOTH forms ask the server for one company's projects now — the server
+  // matches ANY of a project's companies — and name the company they asked
+  // about, which is what stops a second filter here from undoing the answer.
+  // The create form gets there by following the answers the open form
+  // publishes (CreateAction's onValuesChange), which is the read a pure
+  // `optionsFor` cannot do.
   it("does not re-filter a list the server already narrowed to one company", () => {
     const partnerProject = project({
       id: "pr-1",
@@ -456,7 +524,6 @@ describe("the deal page", () => {
       t,
       [partnerProject],
       undefined,
-      true,
       "o-partner",
     );
     const asked = narrowed.find((field) => field.key === "project_id");
@@ -464,11 +531,13 @@ describe("the deal page", () => {
       asked?.optionsFor?.({ organization_id: "o-partner" }).map((o) => o.label),
     ).toContain("Joint rollout");
 
-    // And the create form, which has no company to ask about and narrows here,
-    // still keeps its own filter: it would otherwise offer every project in the
-    // installation under whichever company was picked.
-    const unnarrowed = dealProjectFields(t, [partnerProject]);
-    const client = unnarrowed.find((field) => field.key === "project_id");
+    // A list read for NO company answers about no company. That is the state
+    // before the form has named one — not a list to filter, which is the
+    // shortcut a project row cannot support: organization_id names only the
+    // CUSTOMER, so filtering on it hides every project this company is on as a
+    // partner, which is the defect above in the other direction.
+    const unread = dealProjectFields(t, [partnerProject]);
+    const client = unread.find((field) => field.key === "project_id");
     expect(
       client
         ?.optionsFor?.({ organization_id: "o-partner" })
@@ -484,15 +553,15 @@ describe("the deal page", () => {
     });
     const t = (key: string) => key;
     // The list was read for o-partner; the reader has since changed the form's
-    // company to o-other. Nothing on a project row says whether o-other is on
-    // this project, so the only honest answer is none — offering the old
-    // company's projects is what lets a save carry a pairing the server
-    // refuses (deal_project_same_org, 422).
+    // company to o-other and the read for it is still in flight. Nothing on a
+    // project row says whether o-other is on this project, so the only honest
+    // answer for that moment is none — offering the old company's projects is
+    // what lets a save carry a pairing the server refuses
+    // (deal_project_same_org, 422).
     const fields = dealProjectFields(
       t,
       [partnerProject],
       { id: "pr-1", label: "Joint rollout" },
-      true,
       "o-partner",
     );
     const asked = fields.find((field) => field.key === "project_id");

--- a/frontend/src/screens/dealproject.tsx
+++ b/frontend/src/screens/dealproject.tsx
@@ -33,28 +33,6 @@ type Deal = components["schemas"]["Deal"];
 export const NEW_PROJECT = "__new_project__";
 
 /**
- * The open projects a deal may be filed under, with the company each belongs
- * to, because the deal form chooses its company in the same dialog and the
- * server refuses a project on another company (422). A closed project is not
- * offered: a deal born into a closed project would reopen nothing.
- */
-// The live projects of ONE company, asked of the server rather than filtered
-// here.
-//
-// A project is worked by several companies now, and `organization_id` names
-// only its CUSTOMER — so filtering a full page of projects on that field in the
-// browser hides every project this company is on as a partner or a
-// subcontractor. The list endpoint matches ANY of a project's companies, which
-// is the question the deal form is actually asking.
-//
-// It also stops paging past the answer: the old read took the first 200
-// projects and filtered them, so an installation with more than 200 offered an
-// empty picker to whichever company sorted last.
-export function useOpenProjects(organizationId?: string): Project[] {
-  return useProjectPage(organizationId, true);
-}
-
-/**
  * The live projects of ONE company, asked of the server, and NOTHING when there
  * is no company to ask about.
  *
@@ -111,19 +89,16 @@ export function dealProjectFields(
   // form shows the value it has rather than a blank picker whose save would
   // clear it.
   current?: { id: string; label: string },
-  // Whether `projects` was already narrowed to one company by the SERVER. The
-  // edit form asks for its deal's company and gets the projects that company is
-  // on, whatever role it holds; the create form has no company until the reader
-  // picks one, so it asks for all of them and narrows here — on the anchor,
-  // which is the only company a list row names. That is a known narrower answer
-  // for the create form, and the honest fix is a per-company read once the form
-  // can report which company is chosen.
-  narrowedByServer = false,
-  // The company `projects` was read for, when the server narrowed it. The form
-  // can change its company while the list stands, and the list is keyed on the
-  // company the record HAD; comparing the two lets the picker go empty rather
-  // than offer the old company's projects under the new one, which the server
-  // refuses (deal_project_same_org, 422).
+  // The company `projects` was read FOR. Both forms now read per company — the
+  // create form follows the answers the open form publishes — so the list is
+  // always the server's answer about one company, and this says which.
+  //
+  // It is still compared against the form's own answer, and the gap it covers
+  // is a render rather than a workaround: the reader changes the company, the
+  // new query is in flight, and for that moment the list on hand is the
+  // previous company's. Offering it would let a save carry a pairing the server
+  // refuses (deal_project_same_org, 422), so the picker holds nothing until the
+  // answer for the company on screen arrives.
   narrowedFor?: string,
 ): CreateField[] {
   return [
@@ -137,16 +112,13 @@ export function dealProjectFields(
           return [];
         }
         // A list the server narrowed is trustworthy only for the company it
-        // was narrowed FOR. Once the form names a different one, this page
-        // answers the wrong question and the honest answer is none: a list row
-        // names only a project's anchor company, so nothing here can tell
-        // which of the new company's projects belong.
-        const stale = narrowedByServer && narrowedFor !== company;
-        const reachable = stale
-          ? []
-          : narrowedByServer
-            ? projects
-            : projects.filter((project) => project.organization_id === company);
+        // was narrowed FOR. While a read for a newly chosen company is in
+        // flight, this page still answers about the previous one, and the
+        // honest answer is none: a list row names only a project's anchor
+        // company, so nothing here can tell which of the new company's
+        // projects belong.
+        const stale = narrowedFor !== company;
+        const reachable = stale ? [] : projects;
         // The NAME alone. The key belongs where a reader needs to recognise it
         // — a subject line, the project's own chip — and a picker of one
         // company's projects is already unambiguous without it.

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -104,7 +104,6 @@ import {
   dealProjectFields,
   resolveDealProject,
   StartDeliveryPrompt,
-  useOpenProjects,
   useProjectsOfCompany,
 } from "./dealproject";
 import { DealRoomAside } from "./dealroom";
@@ -1891,7 +1890,17 @@ export function DealsScreen({
   // The picker asks the server for ONE company's projects, so the form's chosen
   // company is what it is keyed on: a project is worked by several companies,
   // and only the server can say which of them this one is on.
-  const openProjects = useOpenProjects();
+  //
+  // The company comes from the OPEN FORM rather than from anything on this
+  // screen, because there is nothing else it could come from: a create form has
+  // no record, and the reader picks the company inside the same dialog. The
+  // form publishes its answers (CreateAction's onValuesChange) and the query
+  // follows them, which is the read `optionsFor` cannot do — it is a pure
+  // function of the values, so it can only filter a list already fetched, and a
+  // project list row names only its anchor company, so nothing in the browser
+  // can compute which projects a company is on.
+  const [formCompany, setFormCompany] = useState("");
+  const openProjects = useProjectsOfCompany(formCompany || undefined);
 
   const createDeal = async (values: Record<string, string>) => {
     const pipeline = effectivePipeline;
@@ -1990,6 +1999,7 @@ export function DealsScreen({
       screen="deals"
       create={createDeal}
       startOpen={startCreating}
+      onValuesChange={(values) => setFormCompany(values.organization_id ?? "")}
       fields={[
         { key: "name", label: "create.dealName", required: true },
         { key: "amount", label: "create.amount", type: "number" },
@@ -2024,7 +2034,10 @@ export function DealsScreen({
         },
         // The body of work this deal is about, chosen or started here: a
         // project begins during the deal, in its initiative phase.
-        ...dealProjectFields(t, openProjects),
+        // Narrowed BY THE SERVER, for the company the form currently names:
+        // the query above re-reads when the reader changes it, so the picker
+        // repopulates instead of going empty.
+        ...dealProjectFields(t, openProjects, undefined, formCompany),
         // A deal brought by a partner is attributed at birth, not by editing
         // it afterwards: the win that pays them can come before anybody thinks
         // to revisit the record.
@@ -2797,7 +2810,6 @@ function editProjectFields(
     t,
     opts.openProjects,
     opts.currentProject,
-    true,
     opts.company,
   );
 }

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -18,6 +18,7 @@ import {
   type FormRow,
   type FormRows,
   RecordFormBody,
+  usePublishedValues,
 } from "./create";
 
 // The agent rail's WROTE head for an edit, keyed by `recordKey` (agentrail-
@@ -187,6 +188,7 @@ export function EditRecordModal({
   existing,
   resolveExisting,
   onSubmit,
+  onValuesChange,
 }: Readonly<{
   open: boolean;
   onClose: () => void;
@@ -202,9 +204,14 @@ export function EditRecordModal({
   existing?: { id: string; code: string } | null;
   resolveExisting?: (code: string, id: string) => Route;
   onSubmit: (values: Record<string, string>, rows?: FormRows) => void;
+  // The form's live answers, published so a caller can drive a SERVER read
+  // from them — the narrowing optionsFor cannot do, because it is a pure
+  // function of the values. See usePublishedValues (create.tsx).
+  onValuesChange?: (values: Record<string, string>) => void;
 }>) {
   const headingId = useId();
   const [values, setValues] = useState<Record<string, string>>({});
+  usePublishedValues(values, onValuesChange);
   // Repeatable-row fields prefill from the record's current rows (e.g. a
   // company's domains) so an edit starts from the live set rather than blank.
   const [rows, setRows] = useState<FormRows>({});
@@ -277,6 +284,7 @@ export function EditAction<Updated extends { id: string }>({
   resolveExisting,
   disabledReasonId,
   labelled,
+  onValuesChange,
 }: Readonly<{
   label: string;
   /**
@@ -311,6 +319,10 @@ export function EditAction<Updated extends { id: string }>({
   // Symmetric with CreateAction's dedupe link — edit rarely collides, but the
   // API stays uniform for the screens that adopt it.
   resolveExisting?: (code: string, id: string) => Route;
+  // The form's live answers, for a screen whose field list depends on them —
+  // a dependent picker whose options only the server can narrow. See
+  // usePublishedValues (create.tsx).
+  onValuesChange?: (values: Record<string, string>) => void;
 }>) {
   const t = useT();
   const [editing, setEditing] = useState(false);
@@ -376,6 +388,7 @@ export function EditAction<Updated extends { id: string }>({
         }
         existing={existing}
         resolveExisting={resolveExisting}
+        onValuesChange={onValuesChange}
         onSubmit={(values, rows) =>
           mutation.mutate({ values, rows: rows ?? {} })
         }


### PR DESCRIPTION
Closes #2416.

## The wall

`CreateField.optionsFor` is a pure function of the form's current values, so a field whose options depend on another field can only **filter a list the parent already fetched**. It cannot re-read.

That is fine when the full list is small enough to fetch and narrow locally. It breaks when the narrowing is a question only the server can answer, and the deal form's project picker is the live case: which projects a company may be filed under is decided by `relationship` rows of kind `project_company`, and a project list row carries only its **anchor** company — so filtering on `organization_id` in the browser hides every project the company is on as a partner or a subcontractor. Membership is not computable from what the browser holds.

#2413 worked around it by reading for the company the record **has** and refusing to answer once the form named a different one. Correct, and narrow: the picker went empty and stayed empty until the deal was saved and reopened.

## The seam

`CreateRecordModal` and `EditRecordModal` publish their live answers through `onValuesChange`, plumbed through `CreateAction` and `EditAction` so every form built on them has it. The parent watches the values, runs its own query, and hands the narrowed list back as ordinary options.

`usePublishedValues` is the shared publisher, and it publishes from an **effect** rather than from the setter. Values are set from two places: the reader typing, and the seed that runs during the closed→open transition. Publishing from the setter would miss the seed — and the answers a form *opens* with are the first thing a dependent query needs — while publishing during render would be a parent's `setState` inside this component's render, which React refuses. The callback is held in a ref so the dependency is the values object alone: a new identity exactly when they change, which is when a caller wants to hear.

## What that let me delete

The deal create form now reads per company, following the company the open form names. Two consequences:

- **The workaround is gone.** Every caller of `dealProjectFields` hands it a list the server narrowed, so the `narrowedByServer` parameter had nothing left to select and the browser-side anchor filter behind it is deleted. `useOpenProjects` — the fetch-everything-and-filter read — had no callers left and went with it.
- **The staleness check stays, and now covers a render rather than a workaround.** While the read for a newly chosen company is in flight, the list on hand is the previous company's; offering it would let a save carry a pairing the server refuses (`deal_project_same_org`, 422). So the picker holds nothing for that moment, and fills the instant the answer for the company on screen arrives.

## Held from the other end

- `repopulates the picker from the server when the form names a different company` — the case the create form could not serve at all: the newly chosen company is on the project as a **partner**, anchored at a third company, so nothing on the row names it. No amount of client-side filtering can offer it.
- Mutation-checked by deleting the one `onValuesChange` prop on the deal form: three tests fail, including the two that already existed. The wiring is load-bearing rather than decorative.
- The test harness's `/projects` mock now honours `organization_id`, with an optional `projectCompanies` map so a fixture can express the partner case at all — the real endpoint matches **any** of a project's companies, and a fixture row carries only its anchor.

`make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project selections are now filtered by the company selected in the deal form.
  * Project options refresh automatically when the company changes.
  * Current form values update live to support dependent field queries.

* **Bug Fixes**
  * Prevented stale or unrelated projects from appearing while company-specific results are loading.
  * Improved project filtering for partner-company matches and deal editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->