### PR TITLE
The move's reason cites a record, like every other sentence

### DIFF
--- a/backend/internal/compose/dealstatus/fold_test.go
+++ b/backend/internal/compose/dealstatus/fold_test.go
@@ -123,7 +123,7 @@ func TestTheModelWritesTheReasonAndNeverTheVerb(t *testing.T) {
 	}
 	written := WrittenStatus{
 		Story:      []WrittenLine{{Text: "It went out.", Evidence: []string{id}}},
-		MoveReason: "the model's reason",
+		MoveReason: WrittenLine{Text: "the model's reason", Evidence: []string{id}},
 	}
 	card := foldWritten(composeDeterministic(f, rules), written, f, rules)
 	if card.Next == nil {
@@ -135,8 +135,12 @@ func TestTheModelWritesTheReasonAndNeverTheVerb(t *testing.T) {
 	if (*card.Next.Arguments)["activity_id"] != id {
 		t.Fatalf("arguments = %v, want the rules' operand", *card.Next.Arguments)
 	}
-	if len(card.Next.Evidence) != 1 {
-		t.Fatalf("evidence = %+v, want the rules' own", card.Next.Evidence)
+	// The evidence is now the REASON's, because the reason on screen is the
+	// model's: a sentence shown beside another sentence's sources is the one
+	// thing a reader following a citation must not meet.
+	if len(card.Next.Evidence) != 1 || card.Next.Evidence[0].ActivityId == nil ||
+		card.Next.Evidence[0].ActivityId.String() != id {
+		t.Fatalf("evidence = %+v, want the record the model's reason cites", card.Next.Evidence)
 	}
 	if card.Next.Reason != "the model's reason" {
 		t.Fatalf("reason = %q, want the model's words", card.Next.Reason)

--- a/backend/internal/compose/dealstatus/grounding.go
+++ b/backend/internal/compose/dealstatus/grounding.go
@@ -46,7 +46,7 @@ func keepSections(parsed replyShape, known, citable map[string]bool) (WrittenSta
 		{"buyer", parsed.Buyer, maxBuyerRows, &out.Buyer},
 		{"verdict", parsed.Verdict.Because, maxBecauseRows, &out.Verdict.Because},
 	} {
-		kept, err := keepGrounded(section.lines, known, citable, section.limit)
+		kept, err := keepGrounded(section.lines, known, citable, section.limit, maxSentenceLen)
 		if err != nil {
 			return WrittenStatus{}, fmt.Errorf("%s: %w", section.name, err)
 		}
@@ -82,7 +82,10 @@ func keepSections(parsed replyShape, known, citable map[string]bool) (WrittenSta
 // line, which this filter drops. So the old shape degrades to the
 // deterministic reason instead of passing the check it predates.
 func keepMoveReason(out *WrittenStatus, parsed replyShape, known, citable map[string]bool) error {
-	kept, err := keepGrounded(parsed.MoveReason, known, citable, 1)
+	// maxMoveReason, not the sentence bound: the reason sits inside the move
+	// block rather than in a section, and it has always been the shorter field.
+	// Routing it through the shared filter must not quietly widen it.
+	kept, err := keepGrounded(parsed.MoveReason, known, citable, 1, maxMoveReason)
 	if err != nil {
 		return fmt.Errorf("move reason: %w", err)
 	}
@@ -92,7 +95,7 @@ func keepMoveReason(out *WrittenStatus, parsed replyShape, known, citable map[st
 		// sentence about the same move rather than a blank line.
 		return nil
 	}
-	out.MoveReason = kept[0].Text
+	out.MoveReason = kept[0]
 	return nil
 }
 
@@ -128,7 +131,7 @@ func (r *replyLines) UnmarshalJSON(raw []byte) error {
 	}
 	var bare string
 	if err := json.Unmarshal(raw, &bare); err != nil {
-		return fmt.Errorf("verdict.because is neither a list of sentences nor a string: %w", err)
+		return fmt.Errorf("a cited-sentence field is neither a list of sentences nor a string: %w", err)
 	}
 	if strings.TrimSpace(bare) == "" {
 		*r = nil
@@ -143,7 +146,7 @@ func (r *replyLines) UnmarshalJSON(raw []byte) error {
 // ungrounded sentence is one bad claim among good ones, while an oversized or
 // id-leaking one says the reply is not the shape the prompt asked for.
 func keepGrounded(
-	lines []replyLine, known, citable map[string]bool, limit int,
+	lines []replyLine, known, citable map[string]bool, limit, maxRunes int,
 ) ([]WrittenLine, error) {
 	out := make([]WrittenLine, 0, len(lines))
 	for _, line := range lines {
@@ -151,7 +154,7 @@ func keepGrounded(
 		if text == "" {
 			continue
 		}
-		if len([]rune(text)) > maxSentenceLen {
+		if len([]rune(text)) > maxRunes {
 			return nil, errors.New("a sentence exceeds the card's bounds")
 		}
 		if err := refuseIDsInReaderText(text, known); err != nil {

--- a/backend/internal/compose/dealstatus/grounding.go
+++ b/backend/internal/compose/dealstatus/grounding.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dealstatus
+
+// The grounding filter: what a reply has to prove before a word of it reaches
+// the reader.
+//
+// One rule, applied to every sentence the card shows — cite a record this deal
+// carries, or do not appear. It lives beside the request rather than inside it
+// because the two answer different questions: model.go asks for prose, and this
+// decides which of it is admissible.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// replyShape is the reply as the prompt asks for it.
+type replyShape struct {
+	Story   []replyLine `json:"story"`
+	Blocker []replyLine `json:"blocker"`
+	Buyer   []replyLine `json:"buyer"`
+	Verdict struct {
+		Standing string     `json:"standing"`
+		Because  replyLines `json:"because"`
+	} `json:"verdict"`
+	MoveReason replyLines `json:"move_reason"`
+}
+
+// keepSections runs the grounding filter over every cited section. Each may
+// come back empty except the story, and an empty one means the records did not
+// support saying anything — which is a section the card omits rather than pads.
+func keepSections(parsed replyShape, known, citable map[string]bool) (WrittenStatus, error) {
+	var out WrittenStatus
+	for _, section := range []struct {
+		name  string
+		lines []replyLine
+		limit int
+		into  *[]WrittenLine
+	}{
+		{"story", parsed.Story, maxStoryRows, &out.Story},
+		{"blocker", parsed.Blocker, maxBlockerRows, &out.Blocker},
+		{"buyer", parsed.Buyer, maxBuyerRows, &out.Buyer},
+		{"verdict", parsed.Verdict.Because, maxBecauseRows, &out.Verdict.Because},
+	} {
+		kept, err := keepGrounded(section.lines, known, citable, section.limit)
+		if err != nil {
+			return WrittenStatus{}, fmt.Errorf("%s: %w", section.name, err)
+		}
+		*section.into = kept
+	}
+	// A call this build does not recognise is dropped rather than shown: the
+	// reader has learned what four words mean, and a fifth teaches them
+	// nothing. The reasoning behind it stays, because it is still grounded.
+	if verdictStandings[parsed.Verdict.Standing] {
+		out.Verdict.Standing = parsed.Verdict.Standing
+	}
+	return out, nil
+}
+
+// keepMoveReason holds the move's reason to the rule every other sentence on
+// this card keeps: cite a record, or do not appear.
+//
+// It used to be the exception, on the reasoning that the reason explains a move
+// the RULES chose, so what it rests on is the move's own evidence. That is true
+// of the MOVE and not of the SENTENCE. What reached the reader was free prose
+// bounded only by length and a no-ids check — the one field on the card a
+// crafted mail body on the deal's timeline, or a model having a bad day, could
+// fill with an invented rationale that still shipped as generated_by=model.
+//
+// An ungrounded reason is DROPPED rather than refused, and that is the
+// difference between this and a section: writtenMove then keeps the
+// deterministic reason the rules already produced, which is a true sentence
+// about the same move. Refusing the whole reply would throw away a card that
+// is otherwise entirely grounded.
+//
+// A reply that answers the older shape — a bare string, from a different
+// provider or a cheaper lane — decodes through replyLines into one UNCITED
+// line, which this filter drops. So the old shape degrades to the
+// deterministic reason instead of passing the check it predates.
+func keepMoveReason(out *WrittenStatus, parsed replyShape, known, citable map[string]bool) error {
+	kept, err := keepGrounded(parsed.MoveReason, known, citable, 1)
+	if err != nil {
+		return fmt.Errorf("move reason: %w", err)
+	}
+	if len(kept) == 0 {
+		// Nothing grounded, so nothing written: writtenMove keeps the
+		// deterministic reason the rules already produced, which is a true
+		// sentence about the same move rather than a blank line.
+		return nil
+	}
+	out.MoveReason = kept[0].Text
+	return nil
+}
+
+// replyLine is one sentence as the reply spells it.
+type replyLine struct {
+	Text     string   `json:"text"`
+	Evidence []string `json:"evidence"`
+}
+
+// replyLines is a list of cited sentences that also accepts a BARE STRING.
+//
+// It has to, and the reason is worth stating because the card spent its whole
+// life without a verdict on account of it. The prompt describes this field
+// twice — once in the shape line as a list, once in prose as "one or two
+// sentences" — and the model followed the prose, returning a string. The
+// decoder refused it, the verdict was dropped, and the card fell back to the
+// deterministic writer EVERY TIME, logging a warning nobody was reading. A
+// reader saw a card with no call and no way to tell that one had been written.
+//
+// The prompt is fixed too, but a prompt is a request and this is the parse. A
+// model can always answer the older shape — a different provider, a cheaper
+// lane, a retry — and losing the whole verdict over a JSON shape is the wrong
+// trade when the sentence itself is right there. A bare string becomes one
+// uncited line: the grounding filter then treats it as any other uncited
+// sentence, so nothing skips the check that matters.
+type replyLines []replyLine
+
+func (r *replyLines) UnmarshalJSON(raw []byte) error {
+	var lines []replyLine
+	if err := json.Unmarshal(raw, &lines); err == nil {
+		*r = lines
+		return nil
+	}
+	var bare string
+	if err := json.Unmarshal(raw, &bare); err != nil {
+		return fmt.Errorf("verdict.because is neither a list of sentences nor a string: %w", err)
+	}
+	if strings.TrimSpace(bare) == "" {
+		*r = nil
+		return nil
+	}
+	*r = replyLines{{Text: bare}}
+	return nil
+}
+
+// keepGrounded drops a sentence whose citations do not resolve, and refuses
+// the whole reply when a sentence breaks a bound. The difference matters: an
+// ungrounded sentence is one bad claim among good ones, while an oversized or
+// id-leaking one says the reply is not the shape the prompt asked for.
+func keepGrounded(
+	lines []replyLine, known, citable map[string]bool, limit int,
+) ([]WrittenLine, error) {
+	out := make([]WrittenLine, 0, len(lines))
+	for _, line := range lines {
+		text := strings.TrimSpace(line.Text)
+		if text == "" {
+			continue
+		}
+		if len([]rune(text)) > maxSentenceLen {
+			return nil, errors.New("a sentence exceeds the card's bounds")
+		}
+		if err := refuseIDsInReaderText(text, known); err != nil {
+			return nil, err
+		}
+		cited := make([]string, 0, len(line.Evidence))
+		for _, id := range line.Evidence {
+			// The deal's own id grounds nothing — every sentence is about this
+			// deal — and it is absent from the citable set for that reason.
+			if citable[id] {
+				cited = append(cited, id)
+			}
+		}
+		// A sentence citing nothing is dropped whole rather than shown
+		// uncited, which is the one thing the grounding rule exists to
+		// prevent.
+		if len(cited) == 0 {
+			continue
+		}
+		out = append(out, WrittenLine{Text: text, Evidence: cited})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// refuseIDsInReaderText refuses a reply that spells a record id where a person
+// reads. An id in reader text is either a leak or filler.
+func refuseIDsInReaderText(text string, known map[string]bool) error {
+	for id := range known {
+		if strings.Contains(text, id) {
+			return errors.New("reply spells a record id in reader text")
+		}
+	}
+	return nil
+}
+
+// knownIDs is every id this input carried — the set reader text must be free
+// of. Being known is not the same as being CITABLE: see citableIDs.
+func knownIDs(in StatusInput) map[string]bool {
+	known := citableIDs(in)
+	known[in.Deal.ID] = true
+	if in.Room != nil {
+		for _, th := range in.Room.Threads {
+			known[th.ID] = true
+		}
+	}
+	return known
+}
+
+// citableIDs is the narrower set a citation may come from: the records the
+// card can render as evidence the reader opens.
+//
+// A Deal Room thread is deliberately absent. The card cites through the
+// activity evidence type, and a thread is not an activity — admitting one
+// would pass the filter and then be dropped when the card is assembled, which
+// costs the sentence its grounding after it had already earned it. The buyer's
+// words still reach the model; they are just cited through the deal's timeline
+// rather than by thread id.
+func citableIDs(in StatusInput) map[string]bool {
+	citable := map[string]bool{}
+	for _, a := range in.Timeline {
+		citable[a.ID] = true
+	}
+	for _, t := range in.OpenTasks {
+		citable[t.ID] = true
+	}
+	return citable
+}

--- a/backend/internal/compose/dealstatus/model.go
+++ b/backend/internal/compose/dealstatus/model.go
@@ -55,16 +55,16 @@ type Completer interface {
 const statusSystem = `You brief a colleague on one sales deal, from a JSON summary of the deal, its timeline, its open tasks and its buyer conversation in a CRM.
 
 Return ONLY a JSON object with these keys:
-{"story":[...],"blocker":[...],"buyer":[...],"verdict":{"standing":"...","because":[...]},"move_reason":"..."}
-Each of "story", "blocker", "buyer" and "verdict.because" is a list of {"text":"...","evidence":["<id>", ...]}.
+{"story":[...],"blocker":[...],"buyer":[...],"verdict":{"standing":"...","because":[...]},"move_reason":[...]}
+Each of "story", "blocker", "buyer", "verdict.because" and "move_reason" is a list of {"text":"...","evidence":["<id>", ...]}.
 
 "story" — what happened and where it leaves things, in the order it happened. Two to four sentences. Start with the thing a reader who has forgotten this deal most needs to know. Name people, dates and what was actually said.
 "blocker" — what is HOLDING THE DEAL UP, named as something somebody can act on: an unsent mail, a question nobody answered, a person who never replied, a decision nobody has asked for. One or two sentences. Return an empty list when nothing is holding it up. "Time has passed" is not a blocker; "she asked for times on 2 June and nobody sent them" is.
 "buyer" — what the buyer wants, read from what they have actually said: what they are optimising for, what they asked for, what they have NOT objected to. One or two sentences. Return an empty list when they have said too little to read honestly. Never guess at a motive the summary does not support.
 "verdict" — your honest call. "standing" is exactly one of: live (moving, with a next step both sides expect), drifting (nothing wrong, nothing happening, it dies of neglect if nobody acts), blocked (something specific is in the way, and you named it in "blocker"), cold (a long silence after real engagement — treat as lost unless something changes). "because" is a LIST of one or two {"text","evidence"} objects saying what the call rests on — the same shape as "story", never a bare string. Be willing to say a deal is cold. A briefing that never delivers bad news is not read twice.
-"move_reason" — one sentence on why the recommended move is the right one now. The move itself is decided elsewhere and given to you in "recommended_move": explain it, never replace it.
+"move_reason" — a LIST of exactly one {"text","evidence"} object saying why the recommended move is the right one now, the same shape as "story". The move itself is decided elsewhere and given to you in "recommended_move": explain it, never replace it. It rests on records like every other sentence, so it cites them.
 
-Every sentence in "story", "blocker", "buyer" and "verdict.because" lists the ids it rests on in its own "evidence", from the summary's "id" fields. Ids belong in "evidence" only — never in any "text", in "move_reason" or in "opening".
+Every sentence lists the ids it rests on in its own "evidence", from the summary's "id" fields. Ids belong in "evidence" only — never in any "text" or in "opening".
 Ground every word in the summary. Never invent a person, a company, a date, a number or an event. If the summary does not say it, do not write it.
 Every timeline entry carries "when": "past" for something that has happened, "scheduled" for something booked and still ahead. A scheduled entry is a plan, never an event — never write that it took place, and never measure silence from it.
 "health" scores four things from 0 to 1, where low is bad: activity_recency, stage_velocity, engagement (how many people are actually talking to us) and commitments (promises we have kept). They are signals to reason from, never facts to state — never write a score, a factor name or the word "health" in the card. A low score tells you where to look in "timeline"; the timeline's dates are what you write.
@@ -278,199 +278,10 @@ func ParseStatus(reply string, in StatusInput) (WrittenStatus, error) {
 	if len(sections.Story) == 0 {
 		return WrittenStatus{}, errors.New("deal status reply tells no story")
 	}
-	if err := keepFreeText(&sections, parsed, known); err != nil {
+	if err := keepMoveReason(&sections, parsed, known, citable); err != nil {
 		return WrittenStatus{}, err
 	}
 	return sections, nil
-}
-
-// replyShape is the reply as the prompt asks for it.
-type replyShape struct {
-	Story   []replyLine `json:"story"`
-	Blocker []replyLine `json:"blocker"`
-	Buyer   []replyLine `json:"buyer"`
-	Verdict struct {
-		Standing string     `json:"standing"`
-		Because  replyLines `json:"because"`
-	} `json:"verdict"`
-	MoveReason string `json:"move_reason"`
-}
-
-// keepSections runs the grounding filter over every cited section. Each may
-// come back empty except the story, and an empty one means the records did not
-// support saying anything — which is a section the card omits rather than pads.
-func keepSections(parsed replyShape, known, citable map[string]bool) (WrittenStatus, error) {
-	var out WrittenStatus
-	for _, section := range []struct {
-		name  string
-		lines []replyLine
-		limit int
-		into  *[]WrittenLine
-	}{
-		{"story", parsed.Story, maxStoryRows, &out.Story},
-		{"blocker", parsed.Blocker, maxBlockerRows, &out.Blocker},
-		{"buyer", parsed.Buyer, maxBuyerRows, &out.Buyer},
-		{"verdict", parsed.Verdict.Because, maxBecauseRows, &out.Verdict.Because},
-	} {
-		kept, err := keepGrounded(section.lines, known, citable, section.limit)
-		if err != nil {
-			return WrittenStatus{}, fmt.Errorf("%s: %w", section.name, err)
-		}
-		*section.into = kept
-	}
-	// A call this build does not recognise is dropped rather than shown: the
-	// reader has learned what four words mean, and a fifth teaches them
-	// nothing. The reasoning behind it stays, because it is still grounded.
-	if verdictStandings[parsed.Verdict.Standing] {
-		out.Verdict.Standing = parsed.Verdict.Standing
-	}
-	return out, nil
-}
-
-// keepFreeText holds the one field that carries no citations of its own: the
-// move's reason.
-//
-// It is uncited deliberately. The reason explains a move the RULES chose from
-// records, so what it rests on is the move's own evidence rather than a
-// citation of its own. It is still bounded and still refused when it spells an
-// id.
-func keepFreeText(out *WrittenStatus, parsed replyShape, known map[string]bool) error {
-	reason := strings.TrimSpace(parsed.MoveReason)
-	if len([]rune(reason)) > maxMoveReason {
-		return errors.New("deal status reply's move reason exceeds the card's bounds")
-	}
-	if err := refuseIDsInReaderText(reason, known); err != nil {
-		return fmt.Errorf("move reason: %w", err)
-	}
-	out.MoveReason = reason
-	return nil
-}
-
-// replyLine is one sentence as the reply spells it.
-type replyLine struct {
-	Text     string   `json:"text"`
-	Evidence []string `json:"evidence"`
-}
-
-// replyLines is a list of cited sentences that also accepts a BARE STRING.
-//
-// It has to, and the reason is worth stating because the card spent its whole
-// life without a verdict on account of it. The prompt describes this field
-// twice — once in the shape line as a list, once in prose as "one or two
-// sentences" — and the model followed the prose, returning a string. The
-// decoder refused it, the verdict was dropped, and the card fell back to the
-// deterministic writer EVERY TIME, logging a warning nobody was reading. A
-// reader saw a card with no call and no way to tell that one had been written.
-//
-// The prompt is fixed too, but a prompt is a request and this is the parse. A
-// model can always answer the older shape — a different provider, a cheaper
-// lane, a retry — and losing the whole verdict over a JSON shape is the wrong
-// trade when the sentence itself is right there. A bare string becomes one
-// uncited line: the grounding filter then treats it as any other uncited
-// sentence, so nothing skips the check that matters.
-type replyLines []replyLine
-
-func (r *replyLines) UnmarshalJSON(raw []byte) error {
-	var lines []replyLine
-	if err := json.Unmarshal(raw, &lines); err == nil {
-		*r = lines
-		return nil
-	}
-	var bare string
-	if err := json.Unmarshal(raw, &bare); err != nil {
-		return fmt.Errorf("verdict.because is neither a list of sentences nor a string: %w", err)
-	}
-	if strings.TrimSpace(bare) == "" {
-		*r = nil
-		return nil
-	}
-	*r = replyLines{{Text: bare}}
-	return nil
-}
-
-// keepGrounded drops a sentence whose citations do not resolve, and refuses
-// the whole reply when a sentence breaks a bound. The difference matters: an
-// ungrounded sentence is one bad claim among good ones, while an oversized or
-// id-leaking one says the reply is not the shape the prompt asked for.
-func keepGrounded(
-	lines []replyLine, known, citable map[string]bool, limit int,
-) ([]WrittenLine, error) {
-	out := make([]WrittenLine, 0, len(lines))
-	for _, line := range lines {
-		text := strings.TrimSpace(line.Text)
-		if text == "" {
-			continue
-		}
-		if len([]rune(text)) > maxSentenceLen {
-			return nil, errors.New("a sentence exceeds the card's bounds")
-		}
-		if err := refuseIDsInReaderText(text, known); err != nil {
-			return nil, err
-		}
-		cited := make([]string, 0, len(line.Evidence))
-		for _, id := range line.Evidence {
-			// The deal's own id grounds nothing — every sentence is about this
-			// deal — and it is absent from the citable set for that reason.
-			if citable[id] {
-				cited = append(cited, id)
-			}
-		}
-		// A sentence citing nothing is dropped whole rather than shown
-		// uncited, which is the one thing the grounding rule exists to
-		// prevent.
-		if len(cited) == 0 {
-			continue
-		}
-		out = append(out, WrittenLine{Text: text, Evidence: cited})
-		if len(out) == limit {
-			break
-		}
-	}
-	return out, nil
-}
-
-// refuseIDsInReaderText refuses a reply that spells a record id where a person
-// reads. An id in reader text is either a leak or filler.
-func refuseIDsInReaderText(text string, known map[string]bool) error {
-	for id := range known {
-		if strings.Contains(text, id) {
-			return errors.New("reply spells a record id in reader text")
-		}
-	}
-	return nil
-}
-
-// knownIDs is every id this input carried — the set reader text must be free
-// of. Being known is not the same as being CITABLE: see citableIDs.
-func knownIDs(in StatusInput) map[string]bool {
-	known := citableIDs(in)
-	known[in.Deal.ID] = true
-	if in.Room != nil {
-		for _, th := range in.Room.Threads {
-			known[th.ID] = true
-		}
-	}
-	return known
-}
-
-// citableIDs is the narrower set a citation may come from: the records the
-// card can render as evidence the reader opens.
-//
-// A Deal Room thread is deliberately absent. The card cites through the
-// activity evidence type, and a thread is not an activity — admitting one
-// would pass the filter and then be dropped when the card is assembled, which
-// costs the sentence its grounding after it had already earned it. The buyer's
-// words still reach the model; they are just cited through the deal's timeline
-// rather than by thread id.
-func citableIDs(in StatusInput) map[string]bool {
-	citable := map[string]bool{}
-	for _, a := range in.Timeline {
-		citable[a.ID] = true
-	}
-	for _, t := range in.OpenTasks {
-		citable[t.ID] = true
-	}
-	return citable
 }
 
 // excerpt bounds one body's contribution, cutting on a rune so a multi-byte

--- a/backend/internal/compose/dealstatus/model.go
+++ b/backend/internal/compose/dealstatus/model.go
@@ -233,7 +233,7 @@ type WrittenStatus struct {
 	Blocker    []WrittenLine
 	Buyer      []WrittenLine
 	Verdict    WrittenVerdict
-	MoveReason string
+	MoveReason WrittenLine
 }
 
 // WrittenVerdict is the call and what it rests on. An empty Standing means the

--- a/backend/internal/compose/dealstatus/model_test.go
+++ b/backend/internal/compose/dealstatus/model_test.go
@@ -78,8 +78,8 @@ func TestAGroundedReplyIsKept(t *testing.T) {
 	if got.Verdict.Standing != "drifting" || len(got.Verdict.Because) != 1 {
 		t.Fatalf("verdict = %+v, want drifting with one grounded reason", got.Verdict)
 	}
-	if got.MoveReason != "Sending it is what the call promised." {
-		t.Fatalf("move reason = %q", got.MoveReason)
+	if got.MoveReason.Text != "Sending it is what the call promised." || len(got.MoveReason.Evidence) != 1 {
+		t.Fatalf("move reason = %+v, want the sentence with the record it cites", got.MoveReason)
 	}
 }
 
@@ -351,8 +351,8 @@ func TestAnUngroundedMoveReasonDoesNotReachTheReader(t *testing.T) {
 			if err != nil {
 				t.Fatalf("a card grounded everywhere else was refused whole: %v", err)
 			}
-			if got.MoveReason != "" {
-				t.Errorf("an ungrounded move reason reached the reader: %q", got.MoveReason)
+			if got.MoveReason.Text != "" {
+				t.Errorf("an ungrounded move reason reached the reader: %q", got.MoveReason.Text)
 			}
 			if len(got.Story) != 1 {
 				t.Errorf("the rest of the card did not survive: story = %+v", got.Story)
@@ -383,10 +383,43 @@ func TestTheOlderMoveReasonShapeDegradesRatherThanPassing(t *testing.T) {
 	if parseErr != nil {
 		t.Fatalf("the older shape was refused whole rather than degraded: %v", parseErr)
 	}
-	if got.MoveReason != "" {
-		t.Errorf("a bare-string move reason passed the grounding check it predates: %q", got.MoveReason)
+	if got.MoveReason.Text != "" {
+		t.Errorf("a bare-string move reason passed the grounding check it predates: %q", got.MoveReason.Text)
 	}
 	if len(got.Story) != 1 {
 		t.Errorf("the rest of the reply did not survive: story = %+v", got.Story)
+	}
+}
+
+// TestTheMoveReasonKeepsItsOwnBound holds the tighter limit through the shared
+// filter.
+//
+// The reason sits inside the move block rather than in a section, and it has
+// always been the shorter field. Routing it through keepGrounded put it behind
+// the sentence bound, which is a third longer — a widening nobody asked for,
+// invisible until a card rendered a paragraph where a sentence belongs.
+func TestTheMoveReasonKeepsItsOwnBound(t *testing.T) {
+	in := inputWithTimeline()
+	story := []map[string]any{line("The offer was promised and never sent.", "act-1")}
+	// Longer than the move's own bound, shorter than a section sentence's.
+	overlong := strings.Repeat("a", maxMoveReason+1)
+	if len(overlong) >= maxSentenceLen {
+		t.Fatalf("the probe is %d runes, which a section would refuse too — it must sit between the two bounds",
+			len(overlong))
+	}
+
+	if _, err := ParseStatus(reply(draft{
+		story:      story,
+		moveReason: []map[string]any{line(overlong, "act-1")},
+	}), in); err == nil {
+		t.Error("a move reason longer than its own bound was accepted")
+	}
+
+	// And the same text IS accepted where the longer bound applies, so the test
+	// is about the move reason's bound rather than about length in general.
+	if _, err := ParseStatus(reply(draft{
+		story: []map[string]any{line(overlong, "act-1")},
+	}), in); err != nil {
+		t.Errorf("a section sentence within its own bound was refused: %v", err)
 	}
 }

--- a/backend/internal/compose/dealstatus/model_test.go
+++ b/backend/internal/compose/dealstatus/model_test.go
@@ -29,7 +29,7 @@ type draft struct {
 	buyer      []map[string]any
 	standing   string
 	because    []map[string]any
-	moveReason string
+	moveReason []map[string]any
 }
 
 func reply(d draft) string {
@@ -61,7 +61,7 @@ func TestAGroundedReplyIsKept(t *testing.T) {
 		buyer:      []map[string]any{line("They asked for the price before anything else.", "act-2")},
 		standing:   "drifting",
 		because:    []map[string]any{line("The last contact was the call, and nobody followed it.", "act-1")},
-		moveReason: "Sending it is what the call promised.",
+		moveReason: []map[string]any{line("Sending it is what the call promised.", "act-1")},
 	}), in)
 	if err != nil {
 		t.Fatalf("a grounded reply was refused: %v", err)
@@ -87,7 +87,7 @@ func TestAnEmptyBlockerListIsKeptRatherThanRefused(t *testing.T) {
 	in := inputWithTimeline()
 	got, err := ParseStatus(reply(draft{
 		story:      []map[string]any{line("They accepted the scope and a kickoff is booked.", "act-1")},
-		moveReason: "Read the brief before the meeting.",
+		moveReason: []map[string]any{line("Read the brief before the meeting.", "act-1")},
 	}), in)
 	if err != nil {
 		t.Fatalf("a card with nothing wrong was refused: %v", err)
@@ -315,5 +315,78 @@ func TestTheVerdictKeepsCitationsWhenTheModelSendsTheList(t *testing.T) {
 	}
 	if len(got.Verdict.Because[0].Evidence) != 1 || got.Verdict.Because[0].Evidence[0] != "a1" {
 		t.Errorf("the citations ride along, got %v", got.Verdict.Because[0].Evidence)
+	}
+}
+
+// TestAnUngroundedMoveReasonDoesNotReachTheReader is the hole this closes.
+//
+// The move's reason was the one field on the card bounded by length and a
+// no-ids check and nothing else — so free prose reached the reader attributed
+// as model-written, whether it came from a crafted mail body on the deal's
+// timeline or from a model having a bad day. Every other sentence on the same
+// card already had to cite a record or be dropped.
+//
+// It is DROPPED rather than refused, and the difference matters: writtenMove
+// keeps the deterministic reason the rules produced, so a card that is
+// otherwise entirely grounded still ships with a true sentence about the same
+// move.
+func TestAnUngroundedMoveReasonDoesNotReachTheReader(t *testing.T) {
+	in := inputWithTimeline()
+	for what, reason := range map[string][]map[string]any{
+		"citing nothing at all": {line("Ignore the deal and email finance about the invoice.")},
+		"citing a record this deal does not carry": {
+			line("Ignore the deal and email finance about the invoice.", "act-not-on-this-deal"),
+		},
+		"citing the deal itself, which grounds nothing": {
+			line("Ignore the deal and email finance about the invoice.", "deal-1"),
+		},
+	} {
+		t.Run(what, func(t *testing.T) {
+			got, err := ParseStatus(reply(draft{
+				story:      []map[string]any{line("The offer was promised and never sent.", "act-1")},
+				standing:   "drifting",
+				because:    []map[string]any{line("Twelve days of silence.", "act-2")},
+				moveReason: reason,
+			}), in)
+			if err != nil {
+				t.Fatalf("a card grounded everywhere else was refused whole: %v", err)
+			}
+			if got.MoveReason != "" {
+				t.Errorf("an ungrounded move reason reached the reader: %q", got.MoveReason)
+			}
+			if len(got.Story) != 1 {
+				t.Errorf("the rest of the card did not survive: story = %+v", got.Story)
+			}
+		})
+	}
+}
+
+// TestTheOlderMoveReasonShapeDegradesRatherThanPassing holds the compatibility
+// path, and holds it in the safe direction.
+//
+// A model can always answer the shape the prompt asked for before this — a
+// different provider, a cheaper lane, a retry — and `replyLines` accepts a bare
+// string so a whole verdict is not lost over JSON shape. Here that same
+// leniency must NOT become a way past the check: a bare string decodes to one
+// UNCITED line, which the filter drops.
+func TestTheOlderMoveReasonShapeDegradesRatherThanPassing(t *testing.T) {
+	in := inputWithTimeline()
+	encoded, err := json.Marshal(map[string]any{
+		"story":       []map[string]any{line("The offer was promised and never sent.", "act-1")},
+		"verdict":     map[string]any{"standing": "drifting"},
+		"move_reason": "Sending it is what the call promised.",
+	})
+	if err != nil {
+		t.Fatalf("encoding the older shape: %v", err)
+	}
+	got, parseErr := ParseStatus(string(encoded), in)
+	if parseErr != nil {
+		t.Fatalf("the older shape was refused whole rather than degraded: %v", parseErr)
+	}
+	if got.MoveReason != "" {
+		t.Errorf("a bare-string move reason passed the grounding check it predates: %q", got.MoveReason)
+	}
+	if len(got.Story) != 1 {
+		t.Errorf("the rest of the reply did not survive: story = %+v", got.Story)
 	}
 }

--- a/backend/internal/compose/dealstatus/move.go
+++ b/backend/internal/compose/dealstatus/move.go
@@ -257,10 +257,22 @@ func lastContactEvidence(f facts) []crmcontracts.DealNextBestActionEvidence {
 	return []crmcontracts.DealNextBestActionEvidence{evidenceOf(last, "Last contact: "+subjectOf(last))}
 }
 
+// evidenceOf points the card at one record. A ZERO timestamp answers nil
+// rather than a date.
+//
+// occurred_at is nullable on the wire because some records genuinely have no
+// moment: an open task with no due date is the case, and taking the address of
+// its zero value renders `0001-01-01T00:00:00Z` — a date no reader can act on
+// and none of them chose. "There is no date" is what nil says, and it is the
+// truth about that row.
 func evidenceOf(a crmcontracts.Activity, text string) crmcontracts.DealNextBestActionEvidence {
 	id := a.Id
-	at := a.OccurredAt
-	return crmcontracts.DealNextBestActionEvidence{Text: text, ActivityId: &id, OccurredAt: &at}
+	out := crmcontracts.DealNextBestActionEvidence{Text: text, ActivityId: &id}
+	if !a.OccurredAt.IsZero() {
+		at := a.OccurredAt
+		out.OccurredAt = &at
+	}
+	return out
 }
 
 // subjectOf names a row for a reader. A withheld row is named by its kind:

--- a/backend/internal/compose/dealstatus/write.go
+++ b/backend/internal/compose/dealstatus/write.go
@@ -149,7 +149,7 @@ func foldWritten(
 	out.Blocker = optionalSection(w.Blocker, f)
 	out.Buyer = optionalSection(w.Buyer, f)
 	out.Verdict = verdictOf(w, f)
-	out.Next = writtenMove(mv, w)
+	out.Next = writtenMove(mv, w, f)
 	return out
 }
 
@@ -186,15 +186,44 @@ func verdictOf(w WrittenStatus, f facts) *crmcontracts.DealStatusCardVerdict {
 // written here would be a fifth surface outside that block: no sender, no
 // recipient, no register, and none of the rules the others learned the hard
 // way. The reader drafts through the composer, which has them.
-func writtenMove(mv crmcontracts.DealStatusCardMove, w WrittenStatus) *crmcontracts.DealStatusCardMove {
+func writtenMove(mv crmcontracts.DealStatusCardMove, w WrittenStatus, f facts) *crmcontracts.DealStatusCardMove {
 	if mv.Action == ActionNone {
 		return nil
 	}
 	written := mv
-	if w.MoveReason != "" {
-		written.Reason = w.MoveReason
+	if w.MoveReason.Text == "" {
+		return &written
 	}
+	// The sentence AND what it rests on. Every other sentence on this card is
+	// shown beside the records it cites; a reason shown beside the rules'
+	// evidence instead would put a model's words next to a different sentence's
+	// sources, which is the one thing a reader following a citation must be
+	// able to trust.
+	//
+	// The rules' evidence stands when the model's citation names a record this
+	// build no longer holds: the sentence is still the model's, but there is
+	// nothing to open, and an empty list beside prose reads as uncited.
+	cited := moveEvidence(w.MoveReason, f)
+	if len(cited) == 0 {
+		return &written
+	}
+	written.Reason = w.MoveReason.Text
+	written.Evidence = cited
 	return &written
+}
+
+// moveEvidence resolves the reason's citations to the card's own evidence
+// shape. A citation naming a row this build no longer holds is dropped, exactly
+// as wire drops one — the filter admitted an id, and only the read here can say
+// whether the record is still there.
+func moveEvidence(reason WrittenLine, f facts) []crmcontracts.DealNextBestActionEvidence {
+	out := make([]crmcontracts.DealNextBestActionEvidence, 0, len(reason.Evidence))
+	for _, id := range reason.Evidence {
+		if a, ok := citedRecord(f, id); ok {
+			out = append(out, evidenceOf(a, subjectOf(a)))
+		}
+	}
+	return out
 }
 
 // wire turns the lane's cited lines into sentences the reader can follow back

--- a/backend/internal/compose/dealstatus/write_test.go
+++ b/backend/internal/compose/dealstatus/write_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dealstatus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestAnUndatedTaskCitesWithNoDateRatherThanTheZeroTime holds what nil means on
+// the wire.
+//
+// An open task with no due date has no moment, and taking the address of its
+// zero value renders `0001-01-01T00:00:00Z` — a date no reader can act on and
+// none of them chose. It reaches the card because a cited record may be a task:
+// the model cites one the way it cites any timeline row, and the reader opens it
+// the same way.
+func TestAnUndatedTaskCitesWithNoDateRatherThanTheZeroTime(t *testing.T) {
+	undated := taskAsActivity(activities.OpenTask{ID: ids.NewV7(), Subject: "Send the scope"})
+	if got := evidenceOf(undated, "Open: Send the scope"); got.OccurredAt != nil {
+		t.Errorf("an undated task cites with occurred_at %v, want none — the card would print a date "+
+			"nobody chose", got.OccurredAt)
+	}
+
+	dated := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	withDate := taskAsActivity(activities.OpenTask{ID: ids.NewV7(), Subject: "Send the scope", DueAt: &dated})
+	got := evidenceOf(withDate, "Open: Send the scope")
+	if got.OccurredAt == nil || !got.OccurredAt.Equal(dated) {
+		t.Errorf("a dated task cites with occurred_at %v, want its due date", got.OccurredAt)
+	}
+}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -107,7 +107,7 @@ internal/compose/costestimate/rules.go#type unitRule
 internal/compose/csvfields.go#const fieldFullName
 internal/compose/datasweep.go#const credentialHandleSuffix
 internal/compose/dbhandle.go#func ProjectsStore
-internal/compose/dealstatus/model.go#func knownIDs
+internal/compose/dealstatus/grounding.go#func knownIDs
 internal/compose/deepread_integration_test.go#func TestDeepReadAttributesItsWritesToTheRequesterTheRowNames
 internal/compose/deploymentsecretseal.go#func resolveSecret
 internal/compose/deploymentsecretseal.go#method vaultBinding.open


### PR DESCRIPTION
Addresses the concrete half of #2418.

## The hole

The Next-move card's `move_reason` was the one field the grounding filter let through **uncited**. It was bounded by length, refused if it spelled a record id, and nothing else — so free prose reached the reader attributed as `generated_by=model`, whether it came from an instruction embedded in a captured mail body on the deal's timeline or from a model having a bad day.

Every sibling sentence on the same card already had to cite a record this deal carries or be dropped whole. `move_reason` was the exception, on the reasoning that the reason explains a move the **rules** chose, so what it rests on is the move's own evidence. That is true of the *move* and not of the *sentence*.

## The fix

`move_reason` is now a cited line, run through the same `keepGrounded` filter as `story`, `blocker`, `buyer` and `verdict.because`.

An ungrounded reason is **dropped rather than refusing the reply**, and that difference is deliberate: `writtenMove` then keeps the deterministic reason the rules already produced, so a card that is otherwise entirely grounded still ships with a true sentence about the same move. Refusing the whole reply would throw away a good card over one field.

A reply that answers the **older shape** — a bare string, from a different provider, a cheaper lane, a retry — decodes through `replyLines` into one *uncited* line and takes the same path. So the leniency that exists to stop a whole verdict being lost over a JSON shape cannot become a way past the check it predates.

`model.go` crossed the 500-line cap on the way, so the filter moved to `grounding.go`. The two halves answer different questions: one asks for prose, the other decides which of it is admissible. `uniquenessclaims.txt` follows `knownIDs` to its new file.

## What this does NOT do

It does not make the filter **extractive**. A sentence still has to *cite* a record rather than *quote* one, so ID-adjacency is still treated as grounding — the larger half of #2418, which reaches `orgbrief` and `meetingbrief` the same way and needs a decision about how strict the span match should be before anyone writes it. Left on the ticket with that analysis; the ticket is labelled `status: needs-decision` for it.

What is closed here is the case that was not a design question: a field on a grounded card that required no evidence at all.

## Held from the other end

- `TestAnUngroundedMoveReasonDoesNotReachTheReader` — three ways to be ungrounded (no citation, a record this deal does not carry, the deal's own id which grounds nothing), each asserting the rest of the card survives.
- `TestTheOlderMoveReasonShapeDegradesRatherThanPassing` — the bare-string compatibility path fails closed.
- Mutation-checked both ways: emptying the citable set drops a reason that should be kept; showing the reason when nothing was kept fails all four cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deal-status responses now include only evidence-backed statements from relevant timeline or task records.
  - Move reasons are accepted only when supported by valid evidence.
  - Responses filter overly long sentences, invalid citations, exposed record IDs, and unknown verdicts.

- **Bug Fixes**
  - Prevented unsupported or sensitive details from appearing in deal-status results.
  - Preserved compatibility with older response formats while filtering ungrounded content.
  - Correctly omit unavailable dates from undated evidence.

- **Tests**
  - Added coverage for valid, invalid, missing, and improperly cited move reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->