### PR TITLE
A reply can name what it is filed under, beyond its anchor

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24226,6 +24226,31 @@ components:
             The IANA zone name (e.g. `Europe/Berlin`) the human chose `scheduled_at` in.
             Required with `scheduled_at`. A zone NAME, never a numeric offset, which
             would freeze the DST rules of the day it was written (AC-DS-TZ4).
+        also_links:
+          type: array
+          maxItems: 25
+          description: |
+            Records to file this reply under IN ADDITION to the ones it inherits from the
+            message it answers. Omit it and a reply is filed exactly as before.
+
+            ADDED, never substituted, and the name says so: a reply belongs to the same people
+            and the same deal as the conversation it continues, and a caller that could replace
+            that set could quietly detach a thread from the records it is about.
+
+            What it exists for is the link the anchor cannot have. A deal whose project was
+            attached after the conversation started has an anchor with no project link, so every
+            reply in that thread would stay unfiled — the composer says "this will be filed under
+            X" and the sent message carries no link to X. A subject tag brings the customer's
+            REply back to the right project, but only once they answer, and the outbound half is
+            missing from the project's timeline until then.
+
+            Each target is row-scope probed exactly as an account-started send's `links` are, so
+            an id the caller cannot see is refused 404 rather than filed. A link the anchor
+            already carries is collapsed rather than doubled.
+
+            Bounded at 25 for the reason the account-started list is: each probe is its own
+            query, and a message about more records than that is about none of them.
+          items: { $ref: '#/components/schemas/ActivityLinkInput' }
 
     ScheduledSend:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24240,8 +24240,8 @@ components:
             What it exists for is the link the anchor cannot have. A deal whose project was
             attached after the conversation started has an anchor with no project link, so every
             reply in that thread would stay unfiled — the composer says "this will be filed under
-            X" and the sent message carries no link to X. A subject tag brings the customer's
-            REply back to the right project, but only once they answer, and the outbound half is
+            X" and the sent message carries no link to X. A subject tag brings the customer's own
+            reply back to the right project, but only once they answer, and the outbound half is
             missing from the project's timeline until then.
 
             Each target is row-scope probed exactly as an account-started send's `links` are, so

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24250,6 +24250,12 @@ components:
 
             Bounded at 25 for the reason the account-started list is: each probe is its own
             query, and a message about more records than that is about none of them.
+
+            The bound is on the MERGED total, not on this list alone. A reply is refused 422
+            `too_many_links` when the anchor's own links plus these exceed 25 — so a conversation
+            already filed under many records leaves room for fewer additions than the `maxItems`
+            here suggests. The refusal arrives at request time, before consent is asked and
+            before anything is scheduled, so a caller learns it while they can still shorten it.
           items: { $ref: '#/components/schemas/ActivityLinkInput' }
 
     ScheduledSend:

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -818,3 +818,87 @@ func TestTwoTimersFiringTheSameMessageSendItOnce(t *testing.T) {
 		t.Fatalf("two timers produced %d activities, want exactly 1", got-activitiesBefore)
 	}
 }
+
+// TestAScheduledReplyFilesItselfUnderWhatTheComposerNamed holds the two paths
+// against each other.
+//
+// A scheduled send re-derives its origin at fire, and the anchor's links are
+// exactly the thing that SHOULD be re-derived — a record added to the
+// conversation while the message waited belongs on it. What cannot be
+// re-derived is the record the caller named: nothing at fire knows which one
+// they meant. Frozen at composition and replayed, or a scheduled reply files
+// differently from the immediate one written beside it.
+func TestAScheduledReplyFilesItselfUnderWhatTheComposerNamed(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	// A record the anchor does not carry — the shape a project attached to the
+	// deal after the conversation began takes.
+	org := p.seedCompany(t, "Zephyr Freight")
+
+	var scheduled struct {
+		ID string `json:"id"`
+	}
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
+		"subject": "Monday morning", "body": "Written the night before.",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"scheduled_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+		"also_links":   []AnyMap{{"entity_type": "organization", "entity_id": org.String()}},
+	}, nil, &scheduled)
+	if status != http.StatusCreated {
+		t.Fatalf("scheduling a reply with also_links → %d, want 201", status)
+	}
+	id, err := ids.Parse(scheduled.ID)
+	if err != nil {
+		t.Fatalf("scheduling returned no id: %v", err)
+	}
+
+	p.makeDue(t, id)
+	p.fire(t, id)
+	if !p.sent(t, id) {
+		st, reason := p.scheduledStatus(t, id)
+		t.Fatalf("firing did not send: %q/%q", st, reason)
+	}
+
+	if got := p.countLinks(t, id, "organization", org); got != 1 {
+		t.Errorf("the fired reply is filed under the named company %d times, want once — a scheduled reply "+
+			"must file the way the immediate one written beside it does", got)
+	}
+}
+
+// seedCompany creates a company this workspace's rep can read.
+func (p *preflightEnv) seedCompany(t *testing.T, name string) ids.UUID {
+	t.Helper()
+	var created struct {
+		ID string `json:"id"`
+	}
+	if status := p.Call(t, "POST", "/v1/organizations",
+		AnyMap{"display_name": name}, nil, &created); status != http.StatusCreated {
+		t.Fatalf("seeding %s → %d, want 201", name, status)
+	}
+	id, err := ids.Parse(created.ID)
+	if err != nil {
+		t.Fatalf("the created company has no id: %v", err)
+	}
+	return id
+}
+
+// countLinks counts the activity links a fired scheduled send left on one
+// record. It reads the activity the row released rather than the row itself:
+// the filing is a property of the timeline entry, which is what a reader opens.
+func (p *preflightEnv) countLinks(t *testing.T, scheduledID ids.UUID, entityType string, entity ids.UUID) int {
+	t.Helper()
+	var count int
+	if err := p.DB().Tx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*)
+			  FROM activity_link al
+			  JOIN scheduled_send s ON s.activity_id = al.activity_id
+			 WHERE s.id = $1 AND al.entity_type = $2 AND al.organization_id = $3`,
+			scheduledID, entityType, entity).Scan(&count)
+	}); err != nil {
+		t.Fatalf("counting the fired reply's links: %v", err)
+	}
+	return count
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24269,8 +24269,8 @@ type SendEmailRequest struct {
 	// What it exists for is the link the anchor cannot have. A deal whose project was
 	// attached after the conversation started has an anchor with no project link, so every
 	// reply in that thread would stay unfiled — the composer says "this will be filed under
-	// X" and the sent message carries no link to X. A subject tag brings the customer's
-	// REply back to the right project, but only once they answer, and the outbound half is
+	// X" and the sent message carries no link to X. A subject tag brings the customer's own
+	// reply back to the right project, but only once they answer, and the outbound half is
 	// missing from the project's timeline until then.
 	//
 	// Each target is row-scope probed exactly as an account-started send's `links` are, so

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24259,6 +24259,28 @@ type SendAccountEmailRequest struct {
 
 // SendEmailRequest defines model for SendEmailRequest.
 type SendEmailRequest struct {
+	// AlsoLinks Records to file this reply under IN ADDITION to the ones it inherits from the
+	// message it answers. Omit it and a reply is filed exactly as before.
+	//
+	// ADDED, never substituted, and the name says so: a reply belongs to the same people
+	// and the same deal as the conversation it continues, and a caller that could replace
+	// that set could quietly detach a thread from the records it is about.
+	//
+	// What it exists for is the link the anchor cannot have. A deal whose project was
+	// attached after the conversation started has an anchor with no project link, so every
+	// reply in that thread would stay unfiled — the composer says "this will be filed under
+	// X" and the sent message carries no link to X. A subject tag brings the customer's
+	// REply back to the right project, but only once they answer, and the outbound half is
+	// missing from the project's timeline until then.
+	//
+	// Each target is row-scope probed exactly as an account-started send's `links` are, so
+	// an id the caller cannot see is refused 404 rather than filed. A link the anchor
+	// already carries is collapsed rather than doubled.
+	//
+	// Bounded at 25 for the reason the account-started list is: each probe is its own
+	// query, and a message about more records than that is about none of them.
+	AlsoLinks *[]ActivityLinkInput `json:"also_links,omitempty"`
+
 	// AttachmentIds Files already in the record library to send with this message, named by id
 	// — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so
 	// archiving or superseding one later cannot rewrite what the timeline says a

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24279,6 +24279,12 @@ type SendEmailRequest struct {
 	//
 	// Bounded at 25 for the reason the account-started list is: each probe is its own
 	// query, and a message about more records than that is about none of them.
+	//
+	// The bound is on the MERGED total, not on this list alone. A reply is refused 422
+	// `too_many_links` when the anchor's own links plus these exceed 25 — so a conversation
+	// already filed under many records leaves room for fewer additions than the `maxItems`
+	// here suggests. The refusal arrives at request time, before consent is asked and
+	// before anything is scheduled, so a caller learns it while they can still shorten it.
 	AlsoLinks *[]ActivityLinkInput `json:"also_links,omitempty"`
 
 	// AttachmentIds Files already in the record library to send with this message, named by id

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -262,10 +262,7 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	links := make([]ActivityLinkInput, 0, len(req.Links))
-	for _, l := range req.Links {
-		links = append(links, ActivityLinkInput{EntityType: string(l.EntityType), EntityID: ids.UUID(l.EntityId)})
-	}
+	links := linkInputsOf(&req.Links)
 	if len(links) == 0 {
 		// A message filed under nothing is one nobody finds again, which is
 		// the gap this operation exists to close. The contract says minItems,
@@ -369,7 +366,11 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 		writeStoreErr(w, r, err)
 		return
 	}
-	out, err := h.store.SendOrSchedule(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), sendInputFrom(
+	// The anchor's own links, plus whatever the caller named beyond them. A
+	// reply with none of its own is unchanged, which is every reply that was
+	// sent before this field existed.
+	origin := FromActivity(pathID[ids.ActivityKind](id)).AlsoFiledUnder(linkInputsOf(req.AlsoLinks))
+	out, err := h.store.SendOrSchedule(r.Context(), origin, sendInputFrom(
 		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
 		req.ConsentPurpose, req.DraftRef,
 	), sched, h.consent, h.delivery, h.timer)
@@ -388,6 +389,24 @@ func addressesOf(list *[]openapi_types.Email) []string {
 	out := make([]string, 0, len(*list))
 	for _, addr := range *list {
 		out = append(out, string(addr))
+	}
+	return out
+}
+
+// linkInputsOf converts the contract's link list to the store's, and answers
+// nothing for a list that was never sent.
+//
+// One converter for both send paths: the account-started list the caller must
+// supply, and the reply's optional additions. They were separate spellings of
+// the same three lines, and a difference between them would be a difference in
+// what a record link MEANS on two operations that write the same column.
+func linkInputsOf(list *[]crmcontracts.ActivityLinkInput) []ActivityLinkInput {
+	if list == nil {
+		return nil
+	}
+	out := make([]ActivityLinkInput, 0, len(*list))
+	for _, l := range *list {
+		out = append(out, ActivityLinkInput{EntityType: string(l.EntityType), EntityID: ids.UUID(l.EntityId)})
 	}
 	return out
 }

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -305,6 +305,10 @@ func (s *Store) scheduleSend(
 	if err != nil {
 		return ScheduledSend{}, err
 	}
+	alsoLinks, err := marshalAlsoLinks(origin)
+	if err != nil {
+		return ScheduledSend{}, err
+	}
 
 	row := ScheduledSend{
 		ID:          ids.NewV7(),
@@ -327,12 +331,12 @@ func (s *Store) scheduleSend(
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO scheduled_send
 			  (id, status, scheduled_at, scheduled_tz,
-			   origin_kind, anchor_activity_id, origin_links,
+			   origin_kind, anchor_activity_id, origin_links, also_links,
 			   payload, payload_version, scheduled_by, principal_kind,
 			   agent_actor_id, agent_passport_id, agent_on_behalf_of)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
 			row.ID, row.Status, row.ScheduledAt, row.ScheduledTZ,
-			row.OriginKind, nullableAnchor(origin), originLinks,
+			row.OriginKind, nullableAnchor(origin), originLinks, alsoLinks,
 			payload, payloadVersionCurrent, row.ScheduledBy, principalKind(actor),
 			prov.ActorID, prov.PassportID, prov.OnBehalfOf,
 		); err != nil {
@@ -401,6 +405,30 @@ func nullableAnchor(o SendOrigin) *ids.UUID {
 		return &anchor
 	}
 	return nil
+}
+
+// marshalAlsoLinks freezes the records a REPLY was told to file itself under
+// beyond its anchor's, so a scheduled reply files the way an immediate one
+// does.
+//
+// It is a stored intention rather than something re-derived at fire, and it has
+// to be: the caller named these records at composition time, and there is
+// nothing at fire that could work out which ones they meant. The anchor's own
+// links are still resolved then, against the estate as it stands — a link added
+// to the conversation while the message waited belongs on it.
+//
+// Null when there are none, and null on an account origin, whose whole set is
+// origin_links. A reply that named nothing is every reply sent before the
+// column existed.
+func marshalAlsoLinks(o SendOrigin) ([]byte, error) {
+	if !o.isReply() || len(o.also) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(o.also)
+	if err != nil {
+		return nil, fmt.Errorf("scheduled send: freezing the added record links: %w", err)
+	}
+	return raw, nil
 }
 
 func marshalOriginLinks(o SendOrigin) ([]byte, error) {

--- a/backend/internal/modules/activities/scheduledsendfire.go
+++ b/backend/internal/modules/activities/scheduledsendfire.go
@@ -179,8 +179,12 @@ type claimedSend struct {
 	OriginKind  string
 	Anchor      *ids.UUID
 	OriginLinks []byte
-	Payload     []byte
-	Version     int
+	// AlsoLinks are the records a reply was told to file itself under beyond
+	// its anchor's. Frozen at composition because nothing at fire could work
+	// out which ones the caller meant.
+	AlsoLinks []byte
+	Payload   []byte
+	Version   int
 	// RowVersion is the scheduled row's own optimistic-concurrency version, as
 	// the claim saw it. A caller that acts on this row LATER, outside the claim's
 	// transaction, binds to this so it cannot act on a newer intention.
@@ -205,7 +209,20 @@ func (c claimedSend) replay() (SendOrigin, SendEmailInput, error) {
 		if c.Anchor == nil {
 			return SendOrigin{}, SendEmailInput{}, errors.New("scheduled send: a reply with no anchor")
 		}
-		return FromActivity(ids.ActivityID{UUID: *c.Anchor}), in, nil
+		origin := FromActivity(ids.ActivityID{UUID: *c.Anchor})
+		if len(c.AlsoLinks) == 0 {
+			return origin, in, nil
+		}
+		var also []ActivityLinkInput
+		if err := json.Unmarshal(c.AlsoLinks, &also); err != nil {
+			return SendOrigin{}, SendEmailInput{}, fmt.Errorf(
+				"scheduled send: reading the frozen added record links: %w", err)
+		}
+		// Re-probed at fire by resolve, like every other link on this path: a
+		// record the scheduler could read when they composed may be one they
+		// cannot read now, and a scheduled send runs the whole guard sequence
+		// again for exactly that reason.
+		return origin.AlsoFiledUnder(also), in, nil
 	}
 	var links []ActivityLinkInput
 	if err := json.Unmarshal(c.OriginLinks, &links); err != nil {
@@ -219,7 +236,7 @@ func (c claimedSend) replay() (SendOrigin, SendEmailInput, error) {
 func (s *Store) claimForFire(ctx context.Context, tx pgx.Tx, id ids.UUID) (claimedSend, bool, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT scheduled_at, origin_kind, anchor_activity_id,
-		       origin_links, payload, payload_version, version
+		       origin_links, also_links, payload, payload_version, version
 		  FROM scheduled_send
 		 WHERE id = $1 AND status = 'scheduled'
 		 FOR UPDATE`, id)
@@ -237,7 +254,7 @@ func (s *Store) claimForFire(ctx context.Context, tx pgx.Tx, id ids.UUID) (claim
 	}
 	var c claimedSend
 	if err := rows.Scan(&c.ScheduledAt, &c.OriginKind, &c.Anchor,
-		&c.OriginLinks, &c.Payload, &c.Version, &c.RowVersion); err != nil {
+		&c.OriginLinks, &c.AlsoLinks, &c.Payload, &c.Version, &c.RowVersion); err != nil {
 		return claimedSend{}, false, fmt.Errorf("scheduled send: claiming: %w", err)
 	}
 	return c, true, nil

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -39,12 +39,35 @@ type SendOrigin struct {
 	// supplied explicitly because there is no anchor to inherit them from.
 	// Each is row-scope probed at insert by insertActivityLinks.
 	links []ActivityLinkInput
+	// also are records a REPLY is filed under beyond what its anchor carries.
+	//
+	// Added rather than substituted, and that is the whole shape of it: a reply
+	// belongs to the same people and the same deal as the conversation it
+	// continues, so a caller that could replace the inherited set could detach
+	// a thread from the records it is about. What it is for is the link the
+	// anchor cannot have — a deal whose project was attached after the
+	// conversation started leaves every reply in that thread unfiled.
+	//
+	// Ignored on an account origin, which names its whole set in links.
+	also []ActivityLinkInput
 }
 
 // FromActivity is the reply origin: the anchor is read, its threading chain
 // is continued, and the new activity inherits its record links.
 func FromActivity(anchor ids.ActivityID) SendOrigin {
 	return SendOrigin{anchor: anchor}
+}
+
+// AlsoFiledUnder adds records to a reply beyond the ones its anchor carries.
+//
+// A method on the origin rather than a parameter of FromActivity, because it is
+// the uncommon case and every existing caller means "the anchor's own links".
+// It returns a new value: an origin is a description of one send, and a
+// constructor that could be mutated after the fact is one a later reader has to
+// trace to know what was actually filed.
+func (o SendOrigin) AlsoFiledUnder(links []ActivityLinkInput) SendOrigin {
+	o.also = append([]ActivityLinkInput(nil), links...)
+	return o
 }
 
 // FromAccount is the account-started origin: no anchor, a fresh thread
@@ -92,7 +115,39 @@ func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput,
 	if err != nil {
 		return nil, err
 	}
-	return inheritedLinks(anchor), nil
+	inherited := inheritedLinks(anchor)
+	if len(o.also) == 0 {
+		return inherited, nil
+	}
+	// Probed HERE, before the consent gate, for the reason the account origin's
+	// links are: deferring to the insert would let a caller name a record they
+	// cannot see and still reach a gate that answers about the RECIPIENTS, so
+	// the refusal they got back would disclose whether strangers had consented
+	// — and it would be a 409 where the row-scope answer is 404.
+	if err := s.probeLinkTargets(ctx, o.also); err != nil {
+		return nil, err
+	}
+	return mergedLinks(inherited, o.also), nil
+}
+
+// mergedLinks adds the caller's records to the anchor's, once each.
+//
+// The inherited links come FIRST and keep their order, so the reply's timeline
+// row reads as the conversation's own filing with an addition — not as a set
+// the caller composed. A duplicate is collapsed rather than inserted twice:
+// naming a record the anchor already carries is a caller being explicit about
+// what they expect, which is not an error and not a second link.
+func mergedLinks(inherited, also []ActivityLinkInput) []ActivityLinkInput {
+	seen := make(map[ActivityLinkInput]bool, len(inherited)+len(also))
+	out := make([]ActivityLinkInput, 0, len(inherited)+len(also))
+	for _, link := range append(append([]ActivityLinkInput(nil), inherited...), also...) {
+		if seen[link] {
+			continue
+		}
+		seen[link] = true
+		out = append(out, link)
+	}
+	return out
 }
 
 // lockAnchorLive re-reads the anchor under a row lock inside the writing

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -127,7 +127,18 @@ func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput,
 	if err := s.probeLinkTargets(ctx, o.also); err != nil {
 		return nil, err
 	}
-	return mergedLinks(inherited, o.also), nil
+	merged := mergedLinks(inherited, o.also)
+	// The bound applies to what will be WRITTEN, not to what the caller named.
+	// probeLinkTargets bounds the additions alone, and an anchor already at the
+	// limit plus one more passes that and then fails inside the staging
+	// transaction — after the consent gate has answered, after the message is
+	// prepared, and on a scheduled send days after the caller could have
+	// shortened anything. The write's own check stays; this one is what makes
+	// the refusal arrive while the sender is still at the keyboard.
+	if len(merged) > maxActivityLinks {
+		return nil, &TooManyLinksError{Count: len(merged)}
+	}
+	return merged, nil
 }
 
 // mergedLinks adds the caller's records to the anchor's, once each.

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -14,6 +14,7 @@ package activities
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -522,5 +523,40 @@ func TestAReplyNamingALinkItsAnchorAlreadyCarriesFilesItOnce(t *testing.T) {
 	}
 	if seen != 1 {
 		t.Errorf("the person is filed %d times, want once", seen)
+	}
+}
+
+// TestAReplyIsRefusedWhenItsAdditionsPushTheAnchorPastTheBound holds the bound
+// against what will be WRITTEN rather than against what the caller named.
+//
+// probeLinkTargets bounds the additions alone, so an anchor already at the
+// limit plus one more passed it and failed inside the staging transaction —
+// after the consent gate had answered, after the message was prepared, and on a
+// scheduled send days after the caller could have shortened anything.
+func TestAReplyIsRefusedWhenItsAdditionsPushTheAnchorPastTheBound(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	for i := 0; i < maxActivityLinks; i++ {
+		e.linkPerson(t, anchor, fmt.Sprintf("Person %d", i))
+	}
+	org := e.seedOrganization(t)
+	gate := &countingConsentGate{}
+	stager := &recordingStager{}
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll),
+		FromActivity(anchor).AlsoFiledUnder([]ActivityLinkInput{{EntityType: "organization", EntityID: org}}),
+		sendInput("transactional"), gate, stager)
+
+	var tooMany *TooManyLinksError
+	if !errors.As(err, &tooMany) {
+		t.Fatalf("a reply whose additions push it past the bound = %v, want a TooManyLinksError", err)
+	}
+	if gate.calls != 0 {
+		t.Errorf("the consent gate answered %d times for a send that cannot be written; the caller is told "+
+			"what to shorten before anyone is asked about consent", gate.calls)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
 	}
 }

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -426,3 +426,101 @@ func TestTheLinkBoundHoldsAtTheWriteItself(t *testing.T) {
 		t.Fatalf("logging an activity with %d links = %v, want a TooManyLinksError", len(links), err)
 	}
 }
+
+// TestAReplyIsFiledUnderTheRecordsItsAnchorCarriesPlusTheOnesTheCallerNames is
+// the gap the field closes.
+//
+// A reply inherits the anchor's links, which is right for the people and the
+// deal a conversation is about — and wrong for a record attached to the deal
+// AFTER the conversation started. A deal whose project was filed later has an
+// anchor with no project link, so every reply in that thread went out unfiled:
+// the composer said "this will be filed under X" and the sent message carried
+// no link to X. The project's timeline was missing the outbound half until the
+// customer answered and a subject tag brought their reply back.
+func TestAReplyIsFiledUnderTheRecordsItsAnchorCarriesPlusTheOnesTheCallerNames(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	inherited := e.linkPerson(t, anchor, "Mara Vogt")
+	// The record the anchor does not carry — the shape a project attached to
+	// the deal after the conversation began takes.
+	late := e.seedOrganization(t)
+
+	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll),
+		FromActivity(anchor).AlsoFiledUnder([]ActivityLinkInput{{EntityType: "organization", EntityID: late}}),
+		sendInput("transactional"), stubConsentGate{}, &recordingStager{})
+	if err != nil {
+		t.Fatalf("reply SendEmail: %v", err)
+	}
+
+	filed := map[string]bool{}
+	if sent.Links != nil {
+		for _, l := range *sent.Links {
+			filed[string(l.EntityType)+"/"+ids.UUID(l.EntityId).String()] = true
+		}
+	}
+	if !filed["person/"+inherited.String()] {
+		t.Errorf("the reply lost a link its anchor carried; filed = %v — naming a record must ADD to the "+
+			"conversation's own filing, never replace it", filed)
+	}
+	if !filed["organization/"+late.String()] {
+		t.Errorf("the reply was not filed under the record the caller named; filed = %v", filed)
+	}
+}
+
+// A named record the caller cannot see must refuse exactly as an
+// account-started send's does, and for the same reason: the probe runs before
+// the consent gate, which answers about the RECIPIENTS — so reaching it would
+// tell a caller who guessed a UUID whether strangers had consented, and would
+// answer 409 where the row-scope verdict is 404.
+func TestAReplyRefusesAnAddedLinkTheCallerCannotSee(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	stager := &recordingStager{}
+	gate := &countingConsentGate{}
+	unseen := ids.NewV7()
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll),
+		FromActivity(anchor).AlsoFiledUnder([]ActivityLinkInput{{EntityType: "organization", EntityID: unseen}}),
+		sendInput("transactional"), gate, stager)
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("a reply naming an invisible record = %v, want ErrNotFound (existence-hiding)", err)
+	}
+	if gate.calls != 0 {
+		t.Fatalf("the consent gate answered %d times for a caller who named a record they cannot see; that answer is about the recipients, not the link", gate.calls)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// Naming a record the anchor already carries is a caller being explicit about
+// what they expect. It is not an error, and it is not a second link — the
+// activity_link unique constraint would refuse the write.
+func TestAReplyNamingALinkItsAnchorAlreadyCarriesFilesItOnce(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	inherited := e.linkPerson(t, anchor, "Mara Vogt")
+
+	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll),
+		FromActivity(anchor).AlsoFiledUnder([]ActivityLinkInput{{EntityType: "person", EntityID: inherited}}),
+		sendInput("transactional"), stubConsentGate{}, &recordingStager{})
+	if err != nil {
+		t.Fatalf("reply SendEmail: %v", err)
+	}
+
+	seen := 0
+	if sent.Links != nil {
+		for _, l := range *sent.Links {
+			if string(l.EntityType) == "person" && ids.UUID(l.EntityId) == inherited {
+				seen++
+			}
+		}
+	}
+	if seen != 1 {
+		t.Errorf("the person is filed %d times, want once", seen)
+	}
+}

--- a/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.up.sql
+++ b/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.up.sql
@@ -13,14 +13,22 @@
 --
 -- ADD ... NOT VALID then VALIDATE, rather than one validated ADD.
 --
--- Stated honestly, because the usual reason does NOT apply here: the runner
--- wraps each migration file in a single transaction (dbmigrate.go), so the locks
--- this takes are held until the file commits either way, and the two-step buys
--- no concurrency it would buy in a hand-run psql session. What it does buy is a
--- shorter ACCESS EXCLUSIVE hold: NOT VALID takes that lock without scanning, and
--- VALIDATE downgrades to SHARE UPDATE EXCLUSIVE for the scan, so readers and
--- writers of audit_log are blocked for a moment rather than for a full pass over
--- the largest table in the schema.
+-- Stated honestly, because the usual reason does NOT apply here and the
+-- correction is worth more than the tidy version: the runner wraps each
+-- migration file in a single transaction (dbmigrate.go's inTx), so ADD
+-- CONSTRAINT's ACCESS EXCLUSIVE is held until the file commits — THROUGH the
+-- VALIDATE. Postgres does not downgrade a lock it already holds, so the split
+-- shortens nothing here.
+--
+-- (This paragraph used to claim it did, and the claim was copied into a later
+-- migration before a review caught it. A wrong sentence about locking is worse
+-- than none: it is the kind a reader trusts because it sounds careful.)
+--
+-- The split is kept anyway, for a reason that survives: the two statements say
+-- what they each do, and a table where the scan is the expensive part wants the
+-- VALIDATE in a migration of its OWN — a second file, which commits separately
+-- and does get the downgrade. Writing it as a pair here is the shape that
+-- change starts from.
 --
 -- The transaction is also what makes this safe to interrupt: a failure at any
 -- statement rolls the whole file back, so audit_log can never be left with no

--- a/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.down.sql
+++ b/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.down.sql
@@ -1,0 +1,7 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE scheduled_send
+    DROP CONSTRAINT IF EXISTS scheduled_send_also_links_shape;
+
+ALTER TABLE scheduled_send
+    DROP COLUMN IF EXISTS also_links;

--- a/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
+++ b/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
@@ -13,21 +13,27 @@ SET LOCAL lock_timeout = '3s';
 ALTER TABLE scheduled_send
     ADD COLUMN also_links jsonb;
 
--- ADD ... NOT VALID then VALIDATE, rather than one validated ADD.
+-- ONE validated ADD, not the NOT VALID + VALIDATE pair the tree uses
+-- elsewhere, and this is the file to say why because the pair looks like the
+-- careful choice.
 --
--- Every existing row has NULL in a column added a statement ago, so the scan can
--- only pass — but Postgres still takes ACCESS EXCLUSIVE for its whole length,
--- and scheduled_send is read and written by the timer that releases messages.
--- NOT VALID takes that lock without scanning; VALIDATE downgrades to SHARE
--- UPDATE EXCLUSIVE for the pass. So a deployment blocks scheduling for a moment
--- rather than for a table scan.
+-- It buys nothing HERE. dbmigrate runs each migration file inside one
+-- transaction (dbmigrate.go's inTx), and Postgres holds ADD CONSTRAINT's ACCESS
+-- EXCLUSIVE until that transaction commits — through the VALIDATE scan. The
+-- two-step shortens the lock only when the ADD commits first and VALIDATE runs
+-- in a LATER transaction, which this runner does not do. Writing the pair here
+-- would have cost a statement and told the next reader something untrue about
+-- what it bought.
 --
--- The runner wraps each file in one transaction (dbmigrate.go), so a failure at
--- either statement rolls both back: the column can never be left without its
--- shape.
+-- The scan itself is cheap for a reason this file can point at: also_links was
+-- added a statement ago, so every existing row holds NULL and satisfies the
+-- constraint. scheduled_send is also small by construction — it holds messages
+-- waiting for their moment, not history.
+--
+-- A table where that arithmetic came out differently would want the validation
+-- in a migration of its own, which is a second file rather than a second
+-- statement.
 ALTER TABLE scheduled_send
     ADD CONSTRAINT scheduled_send_also_links_shape
     CHECK (also_links IS NULL
-           OR (origin_kind = 'reply'::text AND jsonb_typeof(also_links) = 'array'::text)) NOT VALID;
-
-ALTER TABLE scheduled_send VALIDATE CONSTRAINT scheduled_send_also_links_shape;
+           OR (origin_kind = 'reply'::text AND jsonb_typeof(also_links) = 'array'::text));

--- a/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
+++ b/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
@@ -1,0 +1,19 @@
+-- The records a scheduled REPLY was told to file itself under, beyond the ones
+-- it inherits from its anchor.
+--
+-- A separate column rather than a second meaning for origin_links, which on an
+-- account row is the WHOLE set. One column answering two questions depending on
+-- origin_kind is a column a reader has to know the kind to interpret, and the
+-- origin_shape check exists precisely so each kind's columns say what they are.
+--
+-- Null on an account origin, and on a reply that named nothing: a reply with no
+-- additions is every reply sent before this column existed.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE scheduled_send
+    ADD COLUMN also_links jsonb;
+
+ALTER TABLE scheduled_send
+    ADD CONSTRAINT scheduled_send_also_links_shape
+    CHECK (also_links IS NULL
+           OR (origin_kind = 'reply'::text AND jsonb_typeof(also_links) = 'array'::text));

--- a/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
+++ b/backend/migrations/core/1787905100_a_scheduled_reply_keeps_what_it_was_filed_under.up.sql
@@ -13,7 +13,21 @@ SET LOCAL lock_timeout = '3s';
 ALTER TABLE scheduled_send
     ADD COLUMN also_links jsonb;
 
+-- ADD ... NOT VALID then VALIDATE, rather than one validated ADD.
+--
+-- Every existing row has NULL in a column added a statement ago, so the scan can
+-- only pass — but Postgres still takes ACCESS EXCLUSIVE for its whole length,
+-- and scheduled_send is read and written by the timer that releases messages.
+-- NOT VALID takes that lock without scanning; VALIDATE downgrades to SHARE
+-- UPDATE EXCLUSIVE for the pass. So a deployment blocks scheduling for a moment
+-- rather than for a table scan.
+--
+-- The runner wraps each file in one transaction (dbmigrate.go), so a failure at
+-- either statement rolls both back: the column can never be left without its
+-- shape.
 ALTER TABLE scheduled_send
     ADD CONSTRAINT scheduled_send_also_links_shape
     CHECK (also_links IS NULL
-           OR (origin_kind = 'reply'::text AND jsonb_typeof(also_links) = 'array'::text));
+           OR (origin_kind = 'reply'::text AND jsonb_typeof(also_links) = 'array'::text)) NOT VALID;
+
+ALTER TABLE scheduled_send VALIDATE CONSTRAINT scheduled_send_also_links_shape;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3800,6 +3800,7 @@ public.scheduled_send.activity_id uuid gen=- def=-
 public.scheduled_send.agent_actor_id text gen=- def=-
 public.scheduled_send.agent_on_behalf_of uuid gen=- def=-
 public.scheduled_send.agent_passport_id uuid gen=- def=-
+public.scheduled_send.also_links jsonb gen=- def=-
 public.scheduled_send.anchor_activity_id uuid gen=- def=-
 public.scheduled_send.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.scheduled_send.delivery_id uuid gen=- def=-
@@ -3815,6 +3816,7 @@ public.scheduled_send.scheduled_by uuid NOT NULL gen=- def=-
 public.scheduled_send.scheduled_send_activity_id_fkey FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE RESTRICT
 public.scheduled_send.scheduled_send_agent_on_behalf_of_fkey FOREIGN KEY (agent_on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL
 public.scheduled_send.scheduled_send_agent_provenance_shape CHECK ((((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL)) OR ((agent_actor_id IS NULL) AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))))
+public.scheduled_send.scheduled_send_also_links_shape CHECK (((also_links IS NULL) OR ((origin_kind = 'reply'::text) AND (jsonb_typeof(also_links) = 'array'::text))))
 public.scheduled_send.scheduled_send_anchor_activity_id_fkey FOREIGN KEY (anchor_activity_id) REFERENCES activity(id) ON DELETE CASCADE
 public.scheduled_send.scheduled_send_delivery_id_fkey FOREIGN KEY (delivery_id) REFERENCES comms_outbound(id) ON DELETE RESTRICT
 public.scheduled_send.scheduled_send_held_shape CHECK ((((status = 'held'::text) AND (held_reason IS NOT NULL)) OR ((status <> 'held'::text) AND (held_reason IS NULL))))

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17358,6 +17358,12 @@ export interface components {
              *
              *     Bounded at 25 for the reason the account-started list is: each probe is its own
              *     query, and a message about more records than that is about none of them.
+             *
+             *     The bound is on the MERGED total, not on this list alone. A reply is refused 422
+             *     `too_many_links` when the anchor's own links plus these exceed 25 — so a conversation
+             *     already filed under many records leaves room for fewer additions than the `maxItems`
+             *     here suggests. The refusal arrives at request time, before consent is asked and
+             *     before anything is scheduled, so a caller learns it while they can still shorten it.
              */
             also_links?: components["schemas"]["ActivityLinkInput"][];
         };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17337,6 +17337,29 @@ export interface components {
              *     would freeze the DST rules of the day it was written (AC-DS-TZ4).
              */
             scheduled_tz?: string | null;
+            /**
+             * @description Records to file this reply under IN ADDITION to the ones it inherits from the
+             *     message it answers. Omit it and a reply is filed exactly as before.
+             *
+             *     ADDED, never substituted, and the name says so: a reply belongs to the same people
+             *     and the same deal as the conversation it continues, and a caller that could replace
+             *     that set could quietly detach a thread from the records it is about.
+             *
+             *     What it exists for is the link the anchor cannot have. A deal whose project was
+             *     attached after the conversation started has an anchor with no project link, so every
+             *     reply in that thread would stay unfiled — the composer says "this will be filed under
+             *     X" and the sent message carries no link to X. A subject tag brings the customer's
+             *     REply back to the right project, but only once they answer, and the outbound half is
+             *     missing from the project's timeline until then.
+             *
+             *     Each target is row-scope probed exactly as an account-started send's `links` are, so
+             *     an id the caller cannot see is refused 404 rather than filed. A link the anchor
+             *     already carries is collapsed rather than doubled.
+             *
+             *     Bounded at 25 for the reason the account-started list is: each probe is its own
+             *     query, and a message about more records than that is about none of them.
+             */
+            also_links?: components["schemas"]["ActivityLinkInput"][];
         };
         /**
          * @description One message waiting for its moment (ADR-0104/A155). It is not an activity and not a

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17348,8 +17348,8 @@ export interface components {
              *     What it exists for is the link the anchor cannot have. A deal whose project was
              *     attached after the conversation started has an anchor with no project link, so every
              *     reply in that thread would stay unfiled — the composer says "this will be filed under
-             *     X" and the sent message carries no link to X. A subject tag brings the customer's
-             *     REply back to the right project, but only once they answer, and the outbound half is
+             *     X" and the sent message carries no link to X. A subject tag brings the customer's own
+             *     reply back to the right project, but only once they answer, and the outbound half is
              *     missing from the project's timeline until then.
              *
              *     Each target is row-scope probed exactly as an account-started send's `links` are, so


### PR DESCRIPTION
Closes #2422.

## What was missing

`POST /activities/{id}/send-email` took no links. A reply inherits the record links of the activity it answers, and there was no way for the caller to add one.

That is right for most links — a reply belongs to the same people and the same deal as the message it answers. It is wrong for a record attached to that deal **after** the conversation started. A deal whose project was filed later has an anchor with no project link, so every reply in that thread went out unfiled: the composer said *"this will be filed under X"* and the sent message carried no link to X.

The subject tag does perform the filing — capture reads `[KEY]` back off the inbound copy — but only on the customer's **reply**, once they answer. Until then the project's timeline is missing the outbound half.

## `also_links`

Added to `SendEmailRequest`, optional; omit it and a reply is filed exactly as before.

**Added, never substituted, and the name says so.** A caller that could replace the inherited set could quietly detach a thread from the records it is about, which is a different and much larger power than "file this reply under the project too".

Each target is **row-scope probed in `resolve()`** — before the consent gate — for the same reason the account origin's links are probed there rather than deferred to the insert: the gate answers about the **recipients**, so reaching it would tell a caller who guessed a UUID whether strangers had consented, and would answer 409 where the row-scope verdict is 404. The insert-time probe stays, and still catches a target archived between the two reads.

A link the anchor already carries is collapsed rather than doubled — naming one is a caller being explicit about what they expect, not an error and not a second link (the `activity_link` unique constraint would refuse the write).

Both send paths now convert their link lists through one `linkInputsOf`. They were separate spellings of the same three lines, and a difference between them would be a difference in what a record link *means* on two operations writing the same column.

## Held from the other end

- `TestAReplyIsFiledUnderTheRecordsItsAnchorCarriesPlusTheOnesTheCallerNames` — the ticket's case. Mutation-checked by making the caller's links replace the inherited ones: the test reports the lost link.
- `TestAReplyRefusesAnAddedLinkTheCallerCannotSee` — 404, and the consent gate must not have answered. Mutation-checked by removing the probe: the gate answers once, which is exactly the disclosure the probe order exists to prevent.
- `TestAReplyNamingALinkItsAnchorAlreadyCarriesFilesItOnce` — the collapse.

`make check-backend` and `make check-fe` green; `frontend/src/api/schema.d.ts` regenerated with the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replies can include up to 25 additional record links.
  * Links from the original activity are preserved automatically.
  * Scheduled replies retain their additional links when sent.
  * Duplicate links are removed.

* **Bug Fixes**
  * Added links are validated against account access before sending.
  * Invalid links and replies exceeding the link limit are rejected before delivery processing begins.
  * Link handling is consistent for immediate and scheduled replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->