### PR TITLE
The recency sentence counts calendar days, like the key it is cached on

### DIFF
--- a/backend/internal/modules/deals/healthreasons.go
+++ b/backend/internal/modules/deals/healthreasons.go
@@ -18,6 +18,8 @@ package deals
 import (
 	"fmt"
 	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 )
 
 // HealthReason is one factor's number and the fact behind it.
@@ -41,16 +43,33 @@ func HealthReasons(h DealHealth, now time.Time) []HealthReason {
 	}
 }
 
+// recencyReason says how long ago the last activity was, BY THE CALENDAR.
+//
+// Not by elapsed hours, and the difference is one a reader can catch the
+// product in. The deal status card is cached on a fingerprint that includes the
+// UTC day, so a sentence whose words change on the elapsed clock changes while
+// the key stands still: last activity at 14:00 on the 20th, a card written at
+// 09:00 on the 22nd says "1 days ago", and at 14:00 that afternoon the sentence
+// is wrong and stays wrong until midnight because nothing has invalidated it.
+//
+// Counting the same way the key does means the wording can only change when the
+// key does. It is also how a reader looking at two dates counts: 23:00 Monday
+// to 01:00 Tuesday is one day, not zero.
+//
+// The SCORE is a separate question and keeps its fractional elapsed count
+// (health.daysBetween). A number that measures how stale a deal is should move
+// continuously; a sentence a reader can check against a timestamp should not
+// move between cache writes.
 func recencyReason(last *time.Time, stalled bool, now time.Time) string {
 	if last == nil {
 		return "No activity has been logged on this deal."
 	}
-	days := int(now.Sub(*last).Hours() / 24)
+	days := elapsed.Days(*last, now)
 	when := fmt.Sprintf("%d days ago", days)
-	switch days {
-	case 0:
+	switch {
+	case days <= 0:
 		when = "today"
-	case 1:
+	case days == 1:
 		when = "yesterday"
 	}
 	if stalled {

--- a/backend/internal/modules/deals/healthreasons_test.go
+++ b/backend/internal/modules/deals/healthreasons_test.go
@@ -4,7 +4,6 @@
 package deals
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
@@ -36,11 +35,14 @@ func TestTheRecencySentenceCountsTheWayTheCacheKeyDoes(t *testing.T) {
 		{"later the same day", time.Date(2026, 8, 20, 23, 0, 0, 0, time.UTC), "today"},
 	} {
 		t.Run(probe.what, func(t *testing.T) {
-			got := recencyReason(&last, false, probe.now)
-			if !strings.Contains(got, probe.want) {
-				t.Errorf("at %s the card says %q, want it to say %q — a sentence a reader can check "+
+			// The WHOLE sentence, not a substring of it: "12 days ago" contains
+			// "2 days ago", so a contains-check passes on an answer that is off
+			// by ten days — which is the class of error this test is about.
+			want := "Last activity " + probe.want + "."
+			if got := recencyReason(&last, false, probe.now); got != want {
+				t.Errorf("at %s the card says %q, want %q — a sentence a reader can check "+
 					"against a timestamp must not move between cache writes",
-					probe.now.Format(time.RFC3339), got, probe.want)
+					probe.now.Format(time.RFC3339), got, want)
 			}
 		})
 	}
@@ -51,9 +53,9 @@ func TestTheRecencySentenceCountsTheWayTheCacheKeyDoes(t *testing.T) {
 // honestly say about an activity that has not happened yet.
 func TestARecordAheadOfTheClockReadsAsToday(t *testing.T) {
 	last := time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)
-	got := recencyReason(&last, false, time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC))
-	if !strings.Contains(got, "today") {
-		t.Errorf("an activity dated ahead of now reads %q, want today", got)
+	const want = "Last activity today."
+	if got := recencyReason(&last, false, time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)); got != want {
+		t.Errorf("an activity dated ahead of now reads %q, want %q", got, want)
 	}
 }
 
@@ -61,8 +63,8 @@ func TestARecordAheadOfTheClockReadsAsToday(t *testing.T) {
 // counted must not lose it.
 func TestAStalledDealSaysSoInTheSameSentence(t *testing.T) {
 	last := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
-	got := recencyReason(&last, true, time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC))
-	if !strings.Contains(got, "21 days ago") || !strings.Contains(got, "stalled") {
-		t.Errorf("a stalled deal's recency reads %q, want the day count and the stalled clause", got)
+	const want = "Last activity 21 days ago — the deal counts as stalled."
+	if got := recencyReason(&last, true, time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)); got != want {
+		t.Errorf("a stalled deal's recency reads %q, want %q", got, want)
 	}
 }

--- a/backend/internal/modules/deals/healthreasons_test.go
+++ b/backend/internal/modules/deals/healthreasons_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTheRecencySentenceCountsTheWayTheCacheKeyDoes is the defect this closes,
+// stated as the reader meets it.
+//
+// The deal status card is cached on a fingerprint that includes the UTC day. A
+// sentence counting ELAPSED hours changes while that key stands still, so the
+// card spends part of a day saying something the records do not support and
+// nothing invalidates it. Counting by the calendar means the words can only
+// change when the key does.
+func TestTheRecencySentenceCountsTheWayTheCacheKeyDoes(t *testing.T) {
+	last := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+	for _, probe := range []struct {
+		what string
+		now  time.Time
+		want string
+	}{
+		// The reported case: two calendar days later, before and after the hour
+		// the elapsed count would tick on. Both are "2 days ago", and that is
+		// the whole point — the sentence must not change between them.
+		{"the morning of the 22nd", time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC), "2 days ago"},
+		{"the same afternoon", time.Date(2026, 8, 22, 14, 0, 0, 0, time.UTC), "2 days ago"},
+		{"that evening", time.Date(2026, 8, 22, 23, 59, 0, 0, time.UTC), "2 days ago"},
+		// A reader looking at two dates counts the calendar, not the clock: an
+		// hour before midnight to an hour after is yesterday, not today.
+		{"an hour after midnight the next day", time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC), "yesterday"},
+		{"later the same day", time.Date(2026, 8, 20, 23, 0, 0, 0, time.UTC), "today"},
+	} {
+		t.Run(probe.what, func(t *testing.T) {
+			got := recencyReason(&last, false, probe.now)
+			if !strings.Contains(got, probe.want) {
+				t.Errorf("at %s the card says %q, want it to say %q — a sentence a reader can check "+
+					"against a timestamp must not move between cache writes",
+					probe.now.Format(time.RFC3339), got, probe.want)
+			}
+		})
+	}
+}
+
+// A clock behind the record — a fixed test clock, a row seeded ahead — reads as
+// today rather than as a negative count. The card has nothing else it could
+// honestly say about an activity that has not happened yet.
+func TestARecordAheadOfTheClockReadsAsToday(t *testing.T) {
+	last := time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)
+	got := recencyReason(&last, false, time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "today") {
+		t.Errorf("an activity dated ahead of now reads %q, want today", got)
+	}
+}
+
+// The stalled clause rides the same sentence, so a change to how the days are
+// counted must not lose it.
+func TestAStalledDealSaysSoInTheSameSentence(t *testing.T) {
+	last := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	got := recencyReason(&last, true, time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "21 days ago") || !strings.Contains(got, "stalled") {
+		t.Errorf("a stalled deal's recency reads %q, want the day count and the stalled clause", got)
+	}
+}


### PR DESCRIPTION
Closes #2431.

## What a reader saw

Last activity at 14:00 on the 20th. A card written at 09:00 on the 22nd says **"Last activity 1 days ago"**. At 14:00 that same afternoon the sentence has become wrong — it is now 2 days — but the UTC day has not turned, so the cache fingerprint has not moved and the card keeps saying "1 days ago" until midnight.

The card's own `since`/`until` wording already counts **calendar** days for exactly this reason. `deals.HealthReasons` did not: `recencyReason` divided elapsed hours by 24, and the deterministic risk section prints that sentence verbatim.

## The fix

Option 1 from the ticket. `recencyReason` counts through `elapsed.Days` — the kernel helper the card's own wording already uses, whose doc comment states this hazard in as many words:

> counting elapsed hours would flip "today" to "yesterday" twenty-four hours after the contact — mid-afternoon, say — while the cache key waits for midnight, and the card would spend the gap saying something the records do not support with nothing to notice.

It is also how a reader looking at two dates counts: 23:00 Monday to 01:00 Tuesday is one day, not zero.

Option 2 — have the card render the age itself — was the alternative, and it costs the card the wording that lives beside the formula for no gain once the module counts correctly.

## The other readers agree

The ticket asks that they be checked. `HealthReasons` has one reader (`dealstatus/write.go`). The neighbouring day counts in the module were examined and left alone, with the line between them now stated in the code:

- `health.daysBetween` is **fractional** and feeds the **score**. A number measuring how stale a deal is should move continuously; only a sentence a reader can check against a timestamp must not move between cache writes.
- `quietreason.quietFor` already counts by the calendar, in a caller-supplied zone, which is right for what it answers.

## Held from the other end

`TestTheRecencySentenceCountsTheWayTheCacheKeyDoes` walks the reported case: the morning of the 22nd, the same afternoon, and that evening must all say "2 days ago" — the point being that the sentence does not change between them. Plus the boundary a calendar count gets right and an elapsed one does not (23:00 → 01:00 is yesterday), a record ahead of the clock reading as today, and the stalled clause surviving.

Mutation-checked by restoring `int(now.Sub(*last).Hours() / 24)`: the test reproduces the reported symptom exactly — `"Last activity yesterday."` at 09:00 on the 22nd where the records say two days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deal recency messages to use calendar days for more accurate wording.
  * Records from today, including future-dated timestamps, are now labeled as “today.”
  * Stalled-deal information remains included in the same recency message.
  * Recency wording is now more consistent with the application’s date-based behavior.

* **Tests**
  * Added coverage for calendar-day calculations, future timestamps, and stalled-deal messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->