### PR TITLE
The eyebrow's one spelling is held by a ratchet, not by prose

### DIFF
--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -578,7 +578,13 @@ a:not([class]):focus-visible {
    11px or 12px and 0.03em or 0.04em, and every copy looked right on its own.
    The tracking reads --tracking-eyebrow, which is the token named for exactly
    this: uppercase this small sets cramped at the default spacing.
-   `Eyebrow` (eyebrow.tsx) renders it with the element the caller means. */
+   `Eyebrow` (eyebrow.tsx) renders it with the element the caller means.
+
+   Held by: eyebrow-one-spelling.test.ts, which is a RATCHET rather than a
+   clean sweep: no sheet may newly restate this, and the sheets that still do
+   are counted and can only shrink. The prose above recounted a consolidation
+   and two more copies then appeared inside the design system itself, because
+   nothing failed when they did. */
 .t-eyebrow {
   font-size: var(--fs-eyebrow);
   font-weight: var(--fw-semibold);

--- a/frontend/src/design-system/eyebrow-one-spelling.test.ts
+++ b/frontend/src/design-system/eyebrow-one-spelling.test.ts
@@ -1,0 +1,206 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// `.t-eyebrow` claims to be THE one spelling of uppercase micro-type, and this
+// is what makes that a claim rather than a recollection.
+//
+// Five sheets used to carry their own copy, at 11px or 12px and 0.03em or
+// 0.04em, and every copy looked right on its own — the consolidation is in
+// base.css's own comment. Two more copies then appeared INSIDE the design
+// system, in the sheet for the workbench chrome, because nothing failed when
+// they did. Prose recounting a past consolidation does not prevent the next
+// one.
+//
+// The rule is not "never write these properties". It is that a rule setting
+// uppercase micro-type sets it by carrying the class, so a size or a tracking
+// can only be changed in the one place that owns them.
+
+const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const stylesheets = join(frontendRoot, "src");
+
+// The sheet that OWNS the eyebrow. Its own declaration is the spelling every
+// other rule is measured against, so it is the one file exempt from the rule.
+const owner = "src/design-system/base.css";
+
+/** Every .css file under src, by path relative to the frontend root. */
+function sheets(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" || entry.name === "dist"
+        ? []
+        : sheets(path);
+    }
+    return entry.name.endsWith(".css") ? [path] : [];
+  });
+}
+
+/**
+ * The property pairs that TOGETHER make uppercase micro-type. A rule carrying
+ * both is setting the eyebrow, whatever it calls itself.
+ *
+ * Both, not either: `text-transform: uppercase` alone is an ordinary choice a
+ * button or a table header may make, and `--fs-eyebrow` alone sizes a caption.
+ * It is the pair that restates what the class owns, which is also why the check
+ * cannot be a grep for one line.
+ */
+const eyebrowSize = "--fs-eyebrow";
+const eyebrowCase = "text-transform: uppercase";
+
+/** One CSS rule: its selector and the declarations inside its braces. */
+type Rule = { selector: string; body: string; line: number };
+
+/**
+ * The rules in one sheet, read by brace-matching rather than by regex over the
+ * whole file — a regex spanning `{...}` cannot tell a rule from the gap between
+ * two, and would read a size in one rule and an uppercase in the next as a
+ * single offence.
+ *
+ * At-rules (`@media`, `@supports`) are descended into rather than skipped: a
+ * copy inside a breakpoint is a copy.
+ */
+function rulesIn(source: string): Rule[] {
+  // Comments go first, with their line breaks kept so a reported line number
+  // still points at the rule. A selector read with the comment above it glued
+  // to its front is not the selector, and a brace inside prose is not a rule.
+  const css = source.replaceAll(/\/\*[\s\S]*?\*\//g, (block) =>
+    block.replaceAll(/[^\n]/g, " "),
+  );
+  const out: Rule[] = [];
+  let depth = 0;
+  let selectorStart = 0;
+  const opens: { selector: string; at: number; line: number }[] = [];
+  for (let i = 0; i < css.length; i++) {
+    if (css[i] === "{") {
+      const selector = css.slice(selectorStart, i).trim();
+      opens.push({
+        selector,
+        at: i + 1,
+        line: css.slice(0, i).split("\n").length,
+      });
+      depth++;
+      selectorStart = i + 1;
+    } else if (css[i] === "}") {
+      const open = opens.pop();
+      depth--;
+      if (open && !open.selector.startsWith("@")) {
+        out.push({
+          selector: open.selector,
+          body: css.slice(open.at, i),
+          line: open.line,
+        });
+      }
+      selectorStart = i + 1;
+    } else if (depth === 0 && css[i] === ";") {
+      selectorStart = i + 1;
+    }
+  }
+  return out;
+}
+
+/**
+ * The sheets that still restate the eyebrow, frozen at the count they carried
+ * when this gate landed. Shrinking is allowed; growing is not, and a sheet that
+ * reaches zero has its line deleted.
+ *
+ * A COUNT PER SHEET rather than a list of lines: a line number moves whenever
+ * anything above it is edited, and a baseline that churns on unrelated changes
+ * is one people learn to regenerate without reading.
+ *
+ * Why a ratchet and not a clean sweep. Twenty-eight of these are onboarding
+ * screens, and converting them is markup work with a visual answer per site —
+ * worth doing, and not something to hide inside a gate landing. What matters
+ * now is that the number can only go down: the two copies that appeared INSIDE
+ * the design system did so because nothing failed when they did.
+ */
+const restated: Record<string, number> = {
+  "src/design-system/composed.css": 1,
+  "src/design-system/margince-workbench.css": 3,
+  "src/screens/backfill.css": 1,
+  "src/screens/company360.css": 1,
+  "src/screens/onboarding-backread.css": 1,
+  "src/screens/onboarding-build-scene.css": 1,
+  "src/screens/onboarding-conversation/conversation.css": 13,
+  "src/screens/onboarding-gate.css": 2,
+  "src/screens/onboarding-live-panel.css": 2,
+  "src/screens/onboarding-payoff.css": 1,
+  "src/screens/onboarding.css": 5,
+  "src/screens/record360/spine.css": 1,
+};
+
+/** Every rule that sets uppercase micro-type itself, by sheet. */
+function restatements(): Record<string, string[]> {
+  const found: Record<string, string[]> = {};
+  for (const path of sheets(stylesheets)) {
+    const where = relative(frontendRoot, path).replaceAll("\\", "/");
+    if (where === owner) {
+      continue;
+    }
+    for (const rule of rulesIn(readFileSync(path, "utf8"))) {
+      // A NESTED rule's body contains its children's, so a parent would be
+      // reported for a child's declarations. Only the rule's own text counts.
+      const own = rule.body.replaceAll(/\{[^{}]*\}/g, "");
+      if (own.includes(eyebrowSize) && own.includes(eyebrowCase)) {
+        found[where] ??= [];
+        found[where].push(`${rule.selector} (line ${rule.line})`);
+      }
+    }
+  }
+  return found;
+}
+
+describe("the eyebrow has one spelling", () => {
+  it("gains no new sheet that sets uppercase micro-type itself", () => {
+    const found = restatements();
+    const arrived = Object.keys(found)
+      .filter((where) => !(where in restated))
+      .sort();
+    expect(
+      arrived,
+      "these sheets set uppercase micro-type themselves instead of carrying " +
+        ".t-eyebrow, which is what let five sheets disagree about its size and " +
+        "tracking. Add the class to the element and delete the properties",
+    ).toEqual([]);
+  });
+
+  it("lets no ratified sheet grow another copy", () => {
+    const found = restatements();
+    const grew = Object.entries(restated)
+      .filter(([where, frozen]) => (found[where]?.length ?? 0) > frozen)
+      .map(
+        ([where, frozen]) =>
+          `${where}: ${found[where]?.length} now, ${frozen} when this was frozen — ` +
+          `${found[where]?.join(", ")}`,
+      );
+    expect(grew, "the baseline only shrinks").toEqual([]);
+  });
+
+  it("reports a sheet that has been cleaned, so the baseline shrinks", () => {
+    const found = restatements();
+    const shrunk = Object.entries(restated)
+      .filter(([where, frozen]) => (found[where]?.length ?? 0) < frozen)
+      .map(
+        ([where, frozen]) =>
+          `${where}: ${found[where]?.length ?? 0} now, ${frozen} in the baseline`,
+      );
+    expect(
+      shrunk,
+      "these sheets carry fewer copies than the baseline records. That is the " +
+        "direction this gate exists to allow — lower the number, or delete the " +
+        "line when it reaches zero",
+    ).toEqual([]);
+  });
+
+  // The gate must be able to SEE an offence, or a clean tree and a broken
+  // reader look identical. The owner's own rule is the offence shape, so
+  // finding it there proves the reader works on the real file.
+  it("reads the owner's own declaration as the shape it hunts", () => {
+    const css = readFileSync(join(frontendRoot, owner), "utf8");
+    const eyebrow = rulesIn(css).find((rule) => rule.selector === ".t-eyebrow");
+    expect(eyebrow, ".t-eyebrow is gone from base.css").toBeDefined();
+    expect(eyebrow?.body).toContain(eyebrowSize);
+    expect(eyebrow?.body).toContain(eyebrowCase);
+  });
+});

--- a/frontend/src/design-system/margince-workbench.css
+++ b/frontend/src/design-system/margince-workbench.css
@@ -159,14 +159,11 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  /* --textMeta, not --textTertiary: tokens.css names Meta the AA floor for
-     everything under 13px, and every label in this chrome is 9-11px. */
-  color: var(--textMeta);
+  /* The type is .t-eyebrow's, carried by the element rather than restated here.
+     Only the face is set: this chrome runs on the body font where the shared
+     class is agnostic, and the colour it brings (--textMeta) is the AA floor
+     tokens.css names for everything under 13px, which every label here is. */
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 /* The hairline that makes five stops one rail. Drawn, not marked up: a
@@ -256,14 +253,12 @@
   min-width: 0;
 }
 
+/* The type is .t-eyebrow's, carried by the element rather than restated here:
+   this is the same uppercase micro-label the token exists for, and a sheet that
+   respelled it is how five of them came to disagree at 11px and 12px. */
 .mw-identity span {
   display: block;
-  color: var(--textMeta);
   font-family: var(--f-body);
-  font-size: var(--fs-eyebrow);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
 }
 
 .mw-identity h1 {

--- a/frontend/src/design-system/margince-workbench.test.tsx
+++ b/frontend/src/design-system/margince-workbench.test.tsx
@@ -138,9 +138,9 @@ describe("the step rail", () => {
     expect(rail.querySelector("button")).toBeNull();
     expect(rail.querySelector("a")).toBeNull();
     expect(stops.map((stop) => stop.className)).toEqual([
-      "mw-step is-done",
-      "mw-step is-now",
-      "mw-step is-todo",
+      "mw-step t-eyebrow is-done",
+      "mw-step t-eyebrow is-now",
+      "mw-step t-eyebrow is-todo",
     ]);
   });
 

--- a/frontend/src/design-system/margince-workbench.tsx
+++ b/frontend/src/design-system/margince-workbench.tsx
@@ -116,7 +116,7 @@ export function MarginceWorkbench({
         className="mw-core"
       />
       <div className="mw-identity">
-        <span>{eyebrow}</span>
+        <span className="t-eyebrow">{eyebrow}</span>
         <h1>{title}</h1>
         <p>
           <i data-state={state} aria-hidden /> {status}
@@ -237,7 +237,7 @@ function StepRail({ steps }: Readonly<{ steps: readonly WorkbenchStep[] }>) {
       {steps.map((step, index) => (
         <li
           key={step.label}
-          className={`mw-step is-${step.state}`}
+          className={`mw-step t-eyebrow is-${step.state}`}
           aria-current={step.state === "now" ? "step" : undefined}
         >
           <b aria-hidden>{ordinalNumber(index + 1)}</b>


### PR DESCRIPTION
Closes #2444 (item 4, the last one still open — see the comment on the ticket for the other five).

## The claim and what happened to it

`.t-eyebrow` says it is **THE one spelling of uppercase micro-type**, and its comment recounts the consolidation: five sheets used to carry their own copy, at 11px or 12px and 0.03em or 0.04em, and every copy looked right on its own.

Nothing held it. Two more copies then appeared **inside the design system itself** — `.mw-step` and `.mw-identity span` in the workbench sheet — because nothing failed when they did. That is the pattern the ticket names across all six items: *the docblock recounts a past consolidation as history and treats the retelling as enforcement.*

## What changed

Those two carry the class now and keep only the face this chrome sets, which the shared class is agnostic about. One of the four properties they were restating — `--tracking-eyebrow` — is the token named for exactly this problem, so a sheet restating it is a sheet that can drift from it.

The gate is a **ratchet**, and that is a deliberate choice rather than a shortcut. Thirty-two rules across the tree still set uppercase micro-type themselves, twenty-eight of them onboarding screens. Each is markup work with a visual answer per site — worth doing, and not something to land inside a gate. So:

- **A new sheet fails.** That is the case that produced this ticket.
- **A ratified sheet may not grow another copy.**
- **A sheet that has been cleaned is reported**, so the baseline follows the work down instead of standing after it is done. A ratchet that only ever refuses is one whose number stops meaning anything.

Counted **per sheet** rather than by line: a line number moves whenever anything above it is edited, and a baseline that churns on unrelated changes is one people learn to regenerate without reading.

The claim in `base.css` now names the gate and says what it holds — a ratchet, not a clean tree — so the next reader is not told something stronger than what is true.

## Held from the other end

- Mutation-checked both directions: restoring one copy to `.mw-identity span` fails the growth arm with the count; dropping a new sheet in fails the arrival arm by name.
- A fourth arm reads `.t-eyebrow`'s own declaration and asserts it matches the shape being hunted — a clean tree and a broken reader look identical otherwise, and this gate's reader is a CSS brace-matcher rather than a regex, so it is worth proving on the real file.
- The parser strips comments first (keeping line breaks so reported lines stay right) and descends into `@media`, because a copy inside a breakpoint is a copy. It ignores nested children's declarations so a parent is not reported for them.

`make check-fe` green.

The remaining 28 screen sites are recorded in the baseline and worth their own change; I have filed nothing for them here, so say the word if you would like a ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized eyebrow labels across the workbench with consistent typography and color styling.
  - Updated identity and step-rail labels to use the shared eyebrow appearance.

- **Bug Fixes**
  - Removed duplicate styling that could cause inconsistent eyebrow formatting.

- **Tests**
  - Added regression coverage to prevent duplicate eyebrow styling from being introduced in future changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->