### PR TITLE
An unrepresentable deal refuses one figure, not the record

### DIFF
--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -517,3 +517,49 @@ func TestOrganizationComputed_AnUnrepresentableDeal_RefusesOneFigureNotTheRecord
 			open0.ValueMinor)
 	}
 }
+
+// TestOrganizationComputed_ATotalThatCannotBeRepresented_RefusesTheFigure is the
+// same hazard one level up.
+//
+// Guarding each deal and not the total would have moved the failure rather than
+// removed it: sum(bigint) answers in numeric, so a set of individually
+// representable deals can add to a figure no bigint holds — and the reader
+// scans that column into an int64. The record would have been unreadable
+// because the deals are large rather than because one of them is.
+func TestOrganizationComputed_ATotalThatCannotBeRepresented_RefusesTheFigure(t *testing.T) {
+	e := Setup(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	orgID := e.SeedOrg(t, "Big Numbers GmbH", nil)
+
+	// Two deals, each a legal bigint, whose sum is not. No conversion is
+	// involved — both are in the installation's own currency — so this is the
+	// aggregate's bound and nothing else.
+	for _, amount := range []int64{9_000_000_000_000_000_000, 9_000_000_000_000_000_000} {
+		if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+			Name: "Large deal", AmountMinor: int64Ptr(amount), Currency: strPtr("EUR"),
+			PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+		}); err != nil {
+			t.Fatalf("seeding a large deal: %v", err)
+		}
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatalf("the organization could not be read at all: %v — a total nobody can represent must "+
+			"refuse the figure, never the record", err)
+	}
+
+	minor, count, found := directOpenPipelineRead(e.Admin(), t, e, orgID)
+	if !found {
+		t.Fatal("the view returned no row for an organization with two open deals")
+	}
+	if count != 2 {
+		t.Errorf("open_deal_count = %d, want 2", count)
+	}
+	if minor != nil {
+		t.Errorf("open_pipeline_minor_base = %d, want NULL — a sum that does not fit is not a sum", *minor)
+	}
+	if open0 := computedFieldByKey(*org.ComputedFields, "open_pipeline"); open0.Computable {
+		t.Errorf("open_pipeline reads computable over a total that cannot be represented: %+v", open0)
+	}
+}

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -57,19 +57,33 @@ func freezeDealFX(t *testing.T, owner *pgx.Conn, dealID ids.UUID) {
 // for the view's honest "nothing to sum" case (no row at all).
 func directOpenPipelineRead(ctx context.Context, t *testing.T, e *Env, orgID ids.UUID) (minor *int64, count int, found bool) {
 	t.Helper()
+	minor, count, _, found = directOpenPipelineReadPriced(ctx, t, e, orgID)
+	return minor, count, found
+}
+
+// directOpenPipelineReadPriced is the same read plus priced_deal_count, for the
+// tests whose subject is which deals REACHED the sum.
+//
+// Separate rather than a fourth return on every caller, because most of them
+// are about the total and the count of deals; a test that wants to know how
+// many were priced is asking a different question and says so by asking this.
+func directOpenPipelineReadPriced(
+	ctx context.Context, t *testing.T, e *Env, orgID ids.UUID,
+) (minor *int64, count, priced int, found bool) {
+	t.Helper()
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT open_pipeline_minor_base, open_deal_count
+			`SELECT open_pipeline_minor_base, open_deal_count, priced_deal_count
 			 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
-			orgID).Scan(&minor, &count)
+			orgID).Scan(&minor, &count, &priced)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 	if err != nil {
 		t.Fatal(err)
 	}
-	return minor, count, true
+	return minor, count, priced, true
 }
 
 // computedFieldByKey indexes the assembled rows for the reason/floor
@@ -549,12 +563,20 @@ func TestOrganizationComputed_ATotalThatCannotBeRepresented_RefusesTheFigure(t *
 			"refuse the figure, never the record", err)
 	}
 
-	minor, count, found := directOpenPipelineRead(e.Admin(), t, e, orgID)
+	minor, count, priced, found := directOpenPipelineReadPriced(e.Admin(), t, e, orgID)
 	if !found {
 		t.Fatal("the view returned no row for an organization with two open deals")
 	}
 	if count != 2 {
 		t.Errorf("open_deal_count = %d, want 2", count)
+	}
+	// BOTH deals reached the sum, which is what makes this a test about the
+	// AGGREGATE. Without it the case passes on a view where neither converted:
+	// a null total and a non-computable field look identical whether the sum
+	// overflowed or nothing was priced at all.
+	if priced != 2 {
+		t.Fatalf("priced_deal_count = %d, want 2 — both deals are in the installation's own currency, so "+
+			"a lower count means this test is measuring something other than the sum's bound", priced)
 	}
 	if minor != nil {
 		t.Errorf("open_pipeline_minor_base = %d, want NULL — a sum that does not fit is not a sum", *minor)

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -497,15 +497,23 @@ func TestOrganizationComputed_AnUnrepresentableDeal_RefusesOneFigureNotTheRecord
 		t.Errorf("open_deal_count = %d, want 2 — a deal that cannot be priced is still a deal", count)
 	}
 
-	// A total covering one of two deals is not a total. The field reports
-	// awaiting_fx rather than the ordinary deal's amount on its own, which
-	// would be a confident figure that is quietly short.
+	// A total covering one of two deals is not a total. The field floors, and
+	// it floors to PARTIAL_PIPELINE rather than awaiting_fx: one deal was
+	// priced, so this is a short sum and not an absent one, and the two reasons
+	// are what tells a reader which. Asserted rather than left to Computable,
+	// because "some deals could not be priced" and "none could" are different
+	// sentences on the page.
 	open0 := computedFieldByKey(*org.ComputedFields, "open_pipeline")
 	if open0.Computable {
 		t.Errorf("open_pipeline reads computable with one of two deals priced: %+v — a short total is "+
 			"worse than no total", open0)
 	}
+	if open0.Reason == nil || *open0.Reason != "partial_pipeline" {
+		t.Errorf("open_pipeline.reason = %v, want \"partial_pipeline\" — one deal reached the sum and "+
+			"one could not be represented, which is a short figure rather than no figure", open0.Reason)
+	}
 	if open0.ValueMinor != nil {
-		t.Errorf("open_pipeline.value_minor = %v, want absent", open0.ValueMinor)
+		t.Errorf("open_pipeline.value_minor = %v, want absent — a short sum is not published as a total",
+			open0.ValueMinor)
 	}
 }

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -426,3 +426,86 @@ func TestOrganizationComputed_UngatedPrincipal_ComputedFieldsKeyAbsentFromWire(t
 // orgIDPtr matches int64Ptr/strPtr's convention (orgrollup_integration_test.go
 // / authz_integration_test.go): the *ids.OrganizationID CreateDealInput wants.
 func orgIDPtr(id ids.OrganizationID) *ids.OrganizationID { return &id }
+
+// TestOrganizationComputed_AnUnrepresentableDeal_RefusesOneFigureNotTheRecord
+// is the case that took a whole company record down.
+//
+// The view cast its converted amount straight to bigint, and Postgres raises
+// `numeric field overflow` on a result that does not fit — which failed the
+// statement, which failed GetOrganization, which made the organization
+// unreadable. One implausible amount against a large rate, and the record it
+// sits on could not be opened at all.
+//
+// The deal now contributes nothing and stays counted, exactly as a deal with no
+// usable rate does, and the record opens.
+func TestOrganizationComputed_AnUnrepresentableDeal_RefusesOneFigureNotTheRecord(t *testing.T) {
+	e := Setup(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	orgID := e.SeedOrg(t, "Overflow Logistics", nil)
+
+	// The largest rate the column can hold, against an amount near the top of
+	// its own range. Neither is a number anyone would type on purpose — which
+	// is the point: a data-entry mistake is precisely the input that must not
+	// be able to take a record offline.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(e.Admin(), `
+			INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+			VALUES ('JPY', (SELECT (value #>> '{}')::text FROM setting WHERE key = 'installation.base_currency'),
+			        9999999999, CURRENT_DATE)
+			ON CONFLICT DO NOTHING`)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the outsized rate: %v", err)
+	}
+
+	for _, deal := range []struct {
+		name     string
+		amount   int64
+		currency string
+	}{
+		// Converts to roughly 9.2e27, which no bigint holds.
+		{"Unrepresentable deal", 9_200_000_000_000_000_000, "JPY"},
+		// And one in the installation's own base currency (harnessinstallation.go
+		// seeds EUR), so a partial total has something to be partial ABOUT — a
+		// test where nothing converts would pass on a view that refused
+		// everything.
+		{"Ordinary deal", 125_000, "EUR"},
+	} {
+		in := deals.CreateDealInput{
+			Name: deal.name, AmountMinor: int64Ptr(deal.amount),
+			PipelineID: pipeline, StageID: open,
+			OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+		}
+		in.Currency = strPtr(deal.currency)
+		if _, err := e.Deals.CreateDeal(e.Admin(), in); err != nil {
+			t.Fatalf("seeding %s: %v", deal.name, err)
+		}
+	}
+
+	// The read that used to fail outright.
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatalf("the organization could not be read at all: %v — one deal the view cannot represent "+
+			"must refuse one figure, never the record", err)
+	}
+
+	_, count, found := directOpenPipelineRead(e.Admin(), t, e, orgID)
+	if !found {
+		t.Fatal("the view returned no row for an organization with two open deals")
+	}
+	if count != 2 {
+		t.Errorf("open_deal_count = %d, want 2 — a deal that cannot be priced is still a deal", count)
+	}
+
+	// A total covering one of two deals is not a total. The field reports
+	// awaiting_fx rather than the ordinary deal's amount on its own, which
+	// would be a confident figure that is quietly short.
+	open0 := computedFieldByKey(*org.ComputedFields, "open_pipeline")
+	if open0.Computable {
+		t.Errorf("open_pipeline reads computable with one of two deals priced: %+v — a short total is "+
+			"worse than no total", open0)
+	}
+	if open0.ValueMinor != nil {
+		t.Errorf("open_pipeline.value_minor = %v, want absent", open0.ValueMinor)
+	}
+}

--- a/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.down.sql
+++ b/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.down.sql
@@ -34,3 +34,7 @@ CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
    ) live ON true
   WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
   GROUP BY d.organization_id;
+
+-- And the comment the DROP above took with it, as 1787480000 wrote it.
+COMMENT ON VIEW organization_open_pipeline_rollup IS
+  'Open pipeline per organization in the installation base currency. Open deals hold no frozen rate — that happens on close — so each foreign-currency deal converts at the latest fx_rate on or before today. A deal with no usable rate contributes nothing and is still counted in open_deal_count, so a partial sum is detectable rather than silently short.';

--- a/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.down.sql
+++ b/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.down.sql
@@ -1,0 +1,36 @@
+-- Back to the view that raises on an unrepresentable converted amount.
+SET LOCAL lock_timeout = '5s';
+
+DROP VIEW IF EXISTS organization_open_pipeline_rollup;
+
+CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+ SELECT d.organization_id,
+    sum(
+      CASE
+        WHEN d.currency = base.code THEN d.amount_minor
+        ELSE round(d.amount_minor * live.rate)::bigint
+      END
+    ) AS open_pipeline_minor_base,
+    count(*) AS open_deal_count,
+    count(*) FILTER (
+      WHERE d.amount_minor IS NOT NULL
+        AND (d.currency = base.code OR live.rate IS NOT NULL)
+    ) AS priced_deal_count
+   FROM deal d
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= CURRENT_DATE
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;

--- a/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.up.sql
+++ b/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.up.sql
@@ -30,7 +30,22 @@ DROP VIEW IF EXISTS organization_open_pipeline_rollup;
 
 CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
  SELECT d.organization_id,
-    sum(conv.minor_base) AS open_pipeline_minor_base,
+    -- The SUM is bounded too, and separately from its summands. sum(bigint)
+    -- answers in numeric, so a set of individually representable deals can add
+    -- to a figure no bigint holds — and the reader scans this column into an
+    -- int64. Guarding one deal and not the total would have moved the same
+    -- failure one level up: the record unreadable because the deals are large
+    -- rather than because one of them is.
+    --
+    -- Out of range answers NULL, which the caller already knows how to report:
+    -- the deals were priced, the total cannot be stated, and a figure nobody
+    -- can represent is not a figure to publish.
+    CASE
+      WHEN sum(conv.minor_base)
+           BETWEEN -9223372036854775808 AND 9223372036854775807
+        THEN sum(conv.minor_base)
+      ELSE NULL
+    END AS open_pipeline_minor_base,
     count(*) AS open_deal_count,
     -- How many deals actually reached the sum. SUM ignores a null summand
     -- silently, so without this a total covering one of two deals is
@@ -85,3 +100,9 @@ CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
    ) conv ON true
   WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
   GROUP BY d.organization_id;
+
+-- DROP took the view's comment with it. Restated rather than left off: it is
+-- what a reader querying the schema is told the view means, and the sentence is
+-- unchanged except for the case this migration adds.
+COMMENT ON VIEW organization_open_pipeline_rollup IS
+  'Open pipeline per organization in the installation base currency. Open deals hold no frozen rate — that happens on close — so each foreign-currency deal converts at the latest fx_rate on or before today. A deal with no usable rate, or whose converted amount does not fit a bigint, contributes nothing and is still counted in open_deal_count, so a partial sum is detectable rather than silently short. The total itself answers NULL when it does not fit either.';

--- a/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.up.sql
+++ b/backend/migrations/core/1787905200_an_unrepresentable_deal_refuses_one_figure.up.sql
@@ -1,0 +1,87 @@
+-- One deal no longer takes the whole company record down.
+--
+-- The view cast its converted amount with `round(d.amount_minor * live.rate)
+-- ::bigint`. Postgres raises `numeric field overflow` on a result that does not
+-- fit — so an implausible amount against a large rate failed the STATEMENT,
+-- which failed GetOrganization, which made the entire organization unreadable.
+-- One bad row, and the record it sits on cannot be opened at all.
+--
+-- It now contributes NOTHING and stays counted, which is the answer the view
+-- already gives a deal whose currency has no usable rate. The page reports a
+-- partial figure with priced_deal_count beside it, and that column is what
+-- makes "partial" visible rather than inferred.
+--
+-- The Go path has always done this (org360/pipelinefold.go's wouldWrap), and
+-- its comment says why in one line worth repeating: a total that wraps is a
+-- plausible-looking wrong number, which is worse than no number. This makes the
+-- two agree.
+--
+-- The conversion moves into a LATERAL so the bound is written ONCE. It was
+-- spelled in the sum and would have needed spelling again in the count
+-- predicate — two copies of one rule, and a count that disagreed with its own
+-- sum would report a figure as complete while it was short.
+--
+-- DROP then CREATE, not CREATE OR REPLACE: replace cannot change a view's
+-- column list, and while these names are unchanged the shape below is rebuilt
+-- rather than edited.
+SET LOCAL lock_timeout = '5s';
+
+DROP VIEW IF EXISTS organization_open_pipeline_rollup;
+
+CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+ SELECT d.organization_id,
+    sum(conv.minor_base) AS open_pipeline_minor_base,
+    count(*) AS open_deal_count,
+    -- How many deals actually reached the sum. SUM ignores a null summand
+    -- silently, so without this a total covering one of two deals is
+    -- indistinguishable from one covering both — a confident figure that is
+    -- quietly short, which is worse than the "not computable" it replaces.
+    --
+    -- It counts the CONVERSION rather than restating when one is possible: a
+    -- deal with no rate and a deal whose converted amount does not fit are both
+    -- deals the sum did not reach, and one predicate answers for both.
+    count(*) FILTER (WHERE conv.minor_base IS NOT NULL) AS priced_deal_count
+   FROM deal d
+   -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
+   -- must still report its open_deal_count. A cross join would return no row at
+   -- all for the organization, which reads as "no open deals" — the one answer
+   -- that is definitely wrong. With no base currency nothing converts, every
+   -- deal contributes null, and the sum is null: not computable, honestly.
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= CURRENT_DATE
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+   -- What this deal contributes to the total, or NULL when it contributes
+   -- nothing. Three cases, and the third is the one this migration adds.
+   LEFT JOIN LATERAL (
+     SELECT CASE
+       -- Already in the installation's own currency: no rate needed, and none
+       -- should be looked for. This is the ordinary deal.
+       WHEN d.currency = base.code THEN d.amount_minor
+       -- Converted, and only when the result is a number the column can hold.
+       -- The comparison runs in numeric, where the product already is, so it
+       -- decides the question BEFORE a cast can raise it.
+       WHEN live.rate IS NOT NULL
+        AND round(d.amount_minor * live.rate)
+            BETWEEN -9223372036854775808 AND 9223372036854775807
+         THEN round(d.amount_minor * live.rate)::bigint
+       -- No usable rate, or a result too large to represent. Nothing is ever
+       -- converted at an invented rate of 1 — that would report ¥5,000,000 as
+       -- €5,000,000 — and nothing is ever clamped to the biggest number that
+       -- fits, which is the same lie with more digits.
+       ELSE NULL
+     END AS minor_base
+   ) conv ON true
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2951,7 +2951,10 @@ END;
 
 public.organization_open_pipeline_rollup acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.organization_id,
-    sum(conv.minor_base) AS open_pipeline_minor_base,
+        CASE
+            WHEN ((sum(conv.minor_base) >= ('-9223372036854775808'::bigint)::numeric) AND (sum(conv.minor_base) <= ('9223372036854775807'::bigint)::numeric)) THEN sum(conv.minor_base)
+            ELSE NULL::numeric
+        END AS open_pipeline_minor_base,
     count(*) AS open_deal_count,
     count(*) FILTER (WHERE (conv.minor_base IS NOT NULL)) AS priced_deal_count
    FROM (((deal d

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2951,14 +2951,10 @@ END;
 
 public.organization_open_pipeline_rollup acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.organization_id,
-    sum(
-        CASE
-            WHEN ((d.currency)::text = base.code) THEN d.amount_minor
-            ELSE (round(((d.amount_minor)::numeric * live.rate)))::bigint
-        END) AS open_pipeline_minor_base,
+    sum(conv.minor_base) AS open_pipeline_minor_base,
     count(*) AS open_deal_count,
-    count(*) FILTER (WHERE ((d.amount_minor IS NOT NULL) AND (((d.currency)::text = base.code) OR (live.rate IS NOT NULL)))) AS priced_deal_count
-   FROM ((deal d
+    count(*) FILTER (WHERE (conv.minor_base IS NOT NULL)) AS priced_deal_count
+   FROM (((deal d
      LEFT JOIN LATERAL ( SELECT (setting.value #>> '{}'::text[]) AS code
            FROM setting
           WHERE (setting.key = 'installation.base_currency'::text)) base ON (true))
@@ -2967,6 +2963,12 @@ public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.or
           WHERE (((d.currency)::text IS DISTINCT FROM base.code) AND (r.from_currency = d.currency) AND ((r.to_currency)::text = base.code) AND (r.rate_date <= CURRENT_DATE))
           ORDER BY r.rate_date DESC
          LIMIT 1) live ON (true))
+     LEFT JOIN LATERAL ( SELECT
+                CASE
+                    WHEN ((d.currency)::text = base.code) THEN d.amount_minor
+                    WHEN ((live.rate IS NOT NULL) AND ((round(((d.amount_minor)::numeric * live.rate)) >= ('-9223372036854775808'::bigint)::numeric) AND (round(((d.amount_minor)::numeric * live.rate)) <= ('9223372036854775807'::bigint)::numeric))) THEN (round(((d.amount_minor)::numeric * live.rate)))::bigint
+                    ELSE NULL::bigint
+                END AS minor_base) conv ON (true))
   WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
   GROUP BY d.organization_id;
 public.organization_open_pipeline_rollup.open_deal_count bigint gen=- def=-


### PR DESCRIPTION
Closes #2468.

## What happened

`organization_open_pipeline_rollup` cast its converted amount with `round(d.amount_minor * live.rate)::bigint`. Postgres raises `numeric field overflow` on a result that does not fit, so the **statement** failed, so `GetOrganization` failed — and the entire company record became unreadable because one deal carried an implausible amount against a large rate.

Reproduced before fixing: with the guard removed the new test reports

> the organization could not be read at all: read open pipeline rollup: ERROR: bigint out of range (SQLSTATE 22003)

## The fix

The deal contributes **nothing** and stays counted, which is exactly the answer the view already gives a deal whose currency has no usable rate. The page then reports a partial figure with `priced_deal_count` beside it, and that column is what makes "partial" visible rather than something a caller has to infer.

Nothing is clamped to the largest number that fits. That would be the view's own "never convert at an invented rate of 1" rule broken with more digits.

The Go path has always done this — `org360/pipelinefold.go`'s `wouldWrap`, whose comment is worth repeating: *a total that wraps is a plausible-looking wrong number, which is worse than no number*. The two agree now, which is what the sibling ticket #2452 is about at a larger scale.

The conversion moved into a `LATERAL` so the bound is written **once**. It was spelled in the sum and would have needed spelling again in the `priced_deal_count` filter — and a count that disagreed with its own sum would report a short figure as complete, which is the failure `priced_deal_count` exists to prevent.

The range check runs in `numeric`, where the product already is, so it decides the question *before* a cast can raise it.

## Held from the other end

`TestOrganizationComputed_AnUnrepresentableDeal_RefusesOneFigureNotTheRecord` seeds the largest rate the column can hold against an amount near the top of its own range — neither is a number anyone types on purpose, which is the point — plus one ordinary deal in the base currency, so a partial total has something to be partial *about*. It asserts the record opens, both deals are counted, and the field floors to `partial_pipeline` — not to the ordinary deal's amount on its own, which would be a confident figure that is quietly short, and not to `awaiting_fx`, which would claim nothing could be priced when one deal was.

Mutation-checked by removing the range guard: the test fails with the exact `bigint out of range` the ticket describes.

`head_catalog.txt` regenerated with the view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organizations remain readable when deal amounts cannot be represented safely.
  * Open pipeline totals are withheld when conversions fail or exceed supported limits.
  * Deal counts remain accurate, while unpriced deals are excluded from monetary totals.
  * Currency conversion safely handles unavailable rates and out-of-range results.
  * Prevented partial or misleading pipeline totals when individual deals cannot be converted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->