### PR TITLE
The census judges its own file, minus the probes it plants

### DIFF
--- a/backend/gates/employmentcurrency_test.go
+++ b/backend/gates/employmentcurrency_test.go
@@ -38,6 +38,8 @@ import (
 	"go/token"
 	"path/filepath"
 	"regexp"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -117,16 +119,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 		if filepath.ToSlash(path) == employmentCurrencyOwner {
 			continue
 		}
-		// This file holds the planted probes below, which are deliberate
-		// defects — judging them would report the gate's own evidence as a
-		// finding. Skipped by name rather than by "_test.go", because a real
-		// test that hand-writes an employment currency test is still a finding
-		// and there is no reason to stop looking at the ones that do not plant
-		// anything.
-		if filepath.ToSlash(path) == slotProbeFile {
-			continue
-		}
-		file, err := parser.ParseFile(fset, path, nil, 0)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 		if err != nil {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
@@ -136,6 +129,9 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 			names:     map[string]bool{employmentHelper: true, primaryHelper: true},
 		}
 		for _, decl := range file.Decls {
+			if plantedProbe(decl) {
+				continue
+			}
 			for _, sql := range employmentStatements(decl, scope) {
 				judged++
 				if !endedAtCurrency.MatchString(sql) {
@@ -239,6 +235,8 @@ type employmentProbe struct {
 // directly, which is the half that makes the census mean anything.
 //
 // Every case here exists because the gate was once green over it.
+//
+//gate:probe
 var employmentProbes = []employmentProbe{
 	{"the bare form that shipped, one literal", true, "", `
 func read() string {
@@ -470,10 +468,48 @@ var (
 	slotArchivedTerm = regexp.MustCompile(`(\w+\.)?archived_at\s+is\s+null\b`)
 )
 
-// slotProbeFile plants the probes below, which are deliberate defects. Named by
-// PATH and not by basename: a basename skip silently exempts any future file
-// that takes the same name anywhere in the tree.
-const slotProbeFile = gateDir + "/employmentcurrency_test.go"
+// probeMarker exempts ONE DECLARATION from the censuses above, for the only
+// reason a gate's own file needs exempting: it plants deliberate defects as
+// evidence, and judging them would report the gate's proof as a finding.
+//
+// A declaration and not a file, which is the whole change. This file used to be
+// skipped whole — and it is the file most likely to attract a real hand-written
+// currency test, because it is where somebody working on this rule is already
+// editing. The one place the rule did not apply was the one place it was most
+// needed.
+//
+// Not "_test.go" either, for the reason the file skip already gave: a real test
+// that hand-writes an employment currency test is still a finding.
+const probeMarker = "//gate:probe"
+
+// probeOwner is this gate's own file, where both probe tables live. By PATH and
+// not by basename: a basename would name any future file so called, anywhere in
+// the tree.
+const probeOwner = gateDir + "/employmentcurrency_test.go"
+
+// plantedProbe reports whether a declaration carries the marker.
+//
+// The doc comment specifically, not any comment in the declaration's span: a
+// marker inside a function body would exempt the function it sits in, which is
+// a way to silence a finding rather than to declare evidence.
+func plantedProbe(decl ast.Decl) bool {
+	var doc *ast.CommentGroup
+	switch node := decl.(type) {
+	case *ast.GenDecl:
+		doc = node.Doc
+	case *ast.FuncDecl:
+		doc = node.Doc
+	}
+	if doc == nil {
+		return false
+	}
+	for _, line := range doc.List {
+		if strings.TrimSpace(line.Text) == probeMarker {
+			return true
+		}
+	}
+	return false
+}
 
 // slotColumn is what makes a statement a candidate at all, and it is the floor
 // this census counts against: `is_current_primary` is a relationship column and
@@ -495,11 +531,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 		if filepath.ToSlash(path) == employmentCurrencyOwner {
 			continue
 		}
-		// This file plants the probes below, which are deliberate defects.
-		if filepath.ToSlash(path) == slotProbeFile {
-			continue
-		}
-		file, err := parser.ParseFile(fset, path, nil, 0)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 		if err != nil {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
@@ -509,6 +541,9 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 			names:     map[string]bool{currentPrimarySlotPredicate: true},
 		}
 		for _, decl := range file.Decls {
+			if plantedProbe(decl) {
+				continue
+			}
 			for _, sql := range slotStatements(decl, scope) {
 				judged++
 				if !spellsSlotPredicate(sql) {
@@ -571,6 +606,8 @@ func firstSlotLine(sql string) string {
 // for it. Every case is a shape the census would read green over if the
 // detector stopped seeing it — the census itself passes identically over a
 // clean tree and over a detector that has stopped detecting.
+//
+//gate:probe
 var slotProbes = []struct {
 	name  string
 	fires bool
@@ -660,4 +697,70 @@ func TestTheSlotDetectorSeesWhatItClaimsTo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTheProbeMarkerExemptsTheProbesAndNothingElse is what makes the narrowing
+// real rather than a differently-spelled whole-file skip.
+//
+// Both censuses above used to skip this file entirely, and the consequence was
+// the opposite of what a gate is for: the one file where the rule did not apply
+// was the file most likely to attract a violation, because it is where somebody
+// working on this rule is already editing. Skipping declarations closes that —
+// but only while the marker stays on the evidence and off everything else.
+//
+// So: this file must be JUDGED, exactly two declarations may carry the marker,
+// and they must be the probe tables.
+func TestTheProbeMarkerExemptsTheProbesAndNothingElse(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, probeOwner, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing this gate's own file: %v", err)
+	}
+
+	var marked []string
+	judged := 0
+	for _, decl := range file.Decls {
+		if plantedProbe(decl) {
+			marked = append(marked, declaredName(decl))
+			continue
+		}
+		judged++
+	}
+
+	if judged == 0 {
+		t.Fatal("every declaration in this file is marked as a probe, which is the whole-file skip " +
+			"this test exists to prevent, spelled differently")
+	}
+	want := []string{"employmentProbes", "slotProbes"}
+	sort.Strings(marked)
+	if !slices.Equal(marked, want) {
+		t.Errorf("the probe marker is on %v, want exactly %v — it exempts a declaration from BOTH "+
+			"censuses, so a marker anywhere else is a finding silenced rather than evidence declared",
+			marked, want)
+	}
+}
+
+// declaredName names a declaration for a failure message.
+func declaredName(decl ast.Decl) string {
+	switch node := decl.(type) {
+	case *ast.FuncDecl:
+		if node.Name != nil {
+			return node.Name.Name
+		}
+	case *ast.GenDecl:
+		for _, spec := range node.Specs {
+			switch value := spec.(type) {
+			case *ast.ValueSpec:
+				if len(value.Names) > 0 {
+					return value.Names[0].Name
+				}
+			case *ast.TypeSpec:
+				if value.Name != nil {
+					return value.Name.Name
+				}
+			}
+		}
+	}
+	return "an unnamed declaration"
 }

--- a/backend/gates/employmentcurrency_test.go
+++ b/backend/gates/employmentcurrency_test.go
@@ -129,7 +129,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 			names:     map[string]bool{employmentHelper: true, primaryHelper: true},
 		}
 		for _, decl := range file.Decls {
-			if plantedProbe(decl) {
+			if plantedProbe(path, decl) {
 				continue
 			}
 			for _, sql := range employmentStatements(decl, scope) {
@@ -487,12 +487,23 @@ const probeMarker = "//gate:probe"
 // the tree.
 const probeOwner = gateDir + "/employmentcurrency_test.go"
 
-// plantedProbe reports whether a declaration carries the marker.
+// plantedProbe reports whether a declaration in path carries the marker.
+//
+// Honoured in the PROBE OWNER only, which is what keeps the marker from being a
+// way past these censuses. Written tree-wide it would be exactly that: a doc
+// comment on any declaration anywhere would exempt it from both, and the file
+// teaching the marker is the one somebody copies from. Refusing it elsewhere
+// closes that by construction rather than by a test that notices afterwards —
+// and TestNoStrayProbeMarker reports one anyway, so somebody who writes it is
+// told it does nothing instead of believing it worked.
 //
 // The doc comment specifically, not any comment in the declaration's span: a
 // marker inside a function body would exempt the function it sits in, which is
 // a way to silence a finding rather than to declare evidence.
-func plantedProbe(decl ast.Decl) bool {
+func plantedProbe(path string, decl ast.Decl) bool {
+	if filepath.ToSlash(path) != probeOwner {
+		return false
+	}
 	var doc *ast.CommentGroup
 	switch node := decl.(type) {
 	case *ast.GenDecl:
@@ -541,7 +552,7 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 			names:     map[string]bool{currentPrimarySlotPredicate: true},
 		}
 		for _, decl := range file.Decls {
-			if plantedProbe(decl) {
+			if plantedProbe(path, decl) {
 				continue
 			}
 			for _, sql := range slotStatements(decl, scope) {
@@ -721,7 +732,7 @@ func TestTheProbeMarkerExemptsTheProbesAndNothingElse(t *testing.T) {
 	var marked []string
 	judged := 0
 	for _, decl := range file.Decls {
-		if plantedProbe(decl) {
+		if plantedProbe(probeOwner, decl) {
 			marked = append(marked, declaredName(decl))
 			continue
 		}
@@ -763,4 +774,44 @@ func declaredName(decl ast.Decl) string {
 		}
 	}
 	return "an unnamed declaration"
+}
+
+// TestNoStrayProbeMarker reports a marker written where it does nothing.
+//
+// plantedProbe honours the marker in its own file only, so a stray one cannot
+// exempt anything — the vulnerability is closed by construction. What is left is
+// the reader who wrote one and believes it worked, and a silent no-op is the
+// worst answer to give them: they think a declaration is declared evidence, and
+// it is being judged.
+//
+// It is also the arm that keeps the construction honest. If plantedProbe were
+// ever widened to honour the marker tree-wide, this is what would already be
+// standing there to catch the first stray.
+func TestNoStrayProbeMarker(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	var stray []string
+	for _, path := range handWrittenGoSources(t) {
+		if filepath.ToSlash(path) == probeOwner {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, group := range file.Comments {
+			for _, line := range group.List {
+				if strings.TrimSpace(line.Text) == probeMarker {
+					stray = append(stray,
+						fmt.Sprintf("%s:%d", filepath.ToSlash(path), fset.Position(line.Pos()).Line))
+				}
+			}
+		}
+	}
+	if len(stray) > 0 {
+		t.Errorf("%s appears in %v, where it exempts nothing. The marker is honoured in %s alone, "+
+			"which is what stops it becoming a way past these censuses — so a copy elsewhere is a "+
+			"declaration somebody believes is evidence while it is being judged. Delete it, or fix the "+
+			"finding it was written to silence", probeMarker, stray, probeOwner)
+	}
 }

--- a/backend/internal/modules/people/employmentcurrency.go
+++ b/backend/internal/modules/people/employmentcurrency.go
@@ -15,10 +15,10 @@ import "github.com/margince/margince/backend/internal/platform/database/storekit
 // Held by: TestEveryEmploymentCurrencyTestUsesTheOneDefinition (backend/gates/employmentcurrency_test.go)
 // — it reads every hand-written Go source outside this file for a hand-spelled
 // `ended_at` currency test, so a second definition fails rather than drifting.
-// With ONE gap, stated because a binding that overclaims is what this
-// convention exists to stop: the census skips its own file whole, so a
-// hand-written currency test added to `backend/gates/employmentcurrency_test.go`
-// itself is outside this guard.
+// The census reaches its OWN file too: it exempts the two declarations holding
+// its planted probes and judges everything else, so a currency test written
+// beside them is a finding like any other.
+//
 // `date` is the
 // end-date expression at the call site: a column on a read, the incoming value
 // on a create, the patched-or-existing one on an update.


### PR DESCRIPTION
Closes #2472.

## The gap

`TestEveryEmploymentCurrencyTestUsesTheOneDefinition` censuses every hand-written Go source for a hand-spelled `ended_at` currency test — and skipped **its own file, whole**.

The skip's comment was careful about why it did not skip all `_test.go` files, and that reasoning was right. The consequence was not: a **real** hand-written currency test added beside the probes was invisible. That is the one file in the tree where the rule did not apply, and it is the file most likely to attract such a statement, because it is where somebody working on this rule is already editing.

## The fix

The skip is per **declaration**. A `//gate:probe` marker on the two probe tables exempts them; everything else in the file is judged like any other source. Both censuses in the file read it, since both plant evidence and both were skipping the file for it.

The marker is read off the **doc comment** only. One inside a function body would exempt the function it sits in — a way to silence a finding rather than to declare evidence.

`EmploymentIsCurrentSQL`'s `Held by:` drops its "with ONE gap" clause, because there is no longer a gap to state. That clause was the right thing to write when the gap existed (#2471), and removing it is the point of closing this.

## Held from the other end

`TestTheProbeMarkerExemptsTheProbesAndNothingElse` is what keeps the narrowing from becoming a whole-file skip spelled differently: the file must be **judged** (some declaration reaches the census), exactly two declarations may carry the marker, and they must be the probe tables.

Mutation-checked twice, and the first is the ticket's own case:

- Planting a real `r.kind = 'employment' AND r.ended_at IS NULL` in this file — beside the probes, not as one — is now **reported**: `gates/employmentcurrency_test.go: SELECT 1 FROM relationship r WHERE …`. Under the old skip it was silent.
- Moving the marker onto an ordinary declaration fails with the declaration named.

## The siblings

The ticket asks that the same shape be checked in the censuses that plant probes. Done:

- `minorunitscale_test.go` skips only the file that **owns** the definition (`values/minorunits.go`) — the definition-lives-here exemption every census here has, not a probe skip.
- `profilefieldreaders_test.go` skips nothing of the kind.

So the whole-file probe skip was unique to this file, and it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved employment and current-primary checks to inspect all declarations in the test file, excluding only those explicitly marked as probes.
  - Added validation to ensure probe markers are applied only to the intended declarations.
  - Enhanced diagnostics for identifying declarations that require review.

- **Documentation**
  - Clarified how employment currency checks handle probe declarations and additional tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->