### PR TITLE
The tool catalog's tiers are the contract's tiers

### DIFF
--- a/backend/gates/agenttoolcatalogtiers_test.go
+++ b/backend/gates/agenttoolcatalogtiers_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+//go:build !integration
+
+package gates
+
+// The tool catalog's Tier column says what the contract says.
+//
+// docs/reference/agent-tools.md is what somebody deciding whether to hand an
+// agent a passport reads — not agentpolicy_gen.go. It states, per tool, whether
+// the verb RUNS or waits for a human, and it is hand-kept.
+//
+// It drifted the moment a tier annotation changed, and nothing reported it: ten
+// rows disagreed with the contract, eight of them in the dangerous direction —
+// the catalog told a reader that archiving, merging and disqualifying wait for a
+// human when they run immediately. That survived a merge, a review and a day of
+// CI (#2432, #2460).
+//
+// So both sides are DERIVED and compared. agentPolicies is generated from
+// crm.yaml, which means an annotation change binds this page by regeneration
+// rather than by anyone remembering.
+//
+// THE MIXED CASE IS THE POINT, not an exception to skip. create_record and
+// update_record resolve per record type, so no single mark can be right for
+// them: the doc writes 🟢 / 🟡 and the contract carries two tiers under one tool
+// name. A gate that skipped them would be blind to the half of the table most
+// likely to mislead — so a mixed tool must be written mixed, and a tool whose
+// policies agree may not claim to be.
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// catalogPage is the page this gate holds. Relative to the backend module, like
+// every other root a gate here walks.
+const catalogPage = "../docs/reference/agent-tools.md"
+
+// catalogRow reads one table row: the tool in backticks, then the tier cell.
+// The remaining columns are not this gate's subject and are left unread.
+var catalogRow = regexp.MustCompile("^\\|\\s*`([a-z0-9_]+)`\\s*\\|\\s*([^|]+?)\\s*\\|")
+
+// catalogHeader opens the table this gate reads. The page holds a SECOND table
+// of the same row shape — the passport scopes, keyed by scope name — and a scan
+// that took every matching row read `enrich` as tier "1", which is that table's
+// route count. Rows are therefore read only between this header and the blank
+// line that ends its table.
+const catalogHeader = "| Tool | Tier | Scope | Egress | In overlay mode |"
+
+// The marks the page uses, and what each means in the contract's own
+// vocabulary. Spelled here rather than inferred, because the mapping IS the
+// claim being checked: a gate that derived it from the page would agree with
+// whatever the page said.
+const (
+	marksRuns      = "🟢"
+	marksWaits     = "🟡"
+	marksDynamic   = "dynamic"
+	marksBothTiers = "🟢 / 🟡"
+)
+
+// tierMark renders one contract tier as the page writes it.
+func tierMark(tier string) string {
+	switch tier {
+	case "auto_execute":
+		return marksRuns
+	case "confirmation_required":
+		return marksWaits
+	case "dynamic":
+		return marksDynamic
+	default:
+		return ""
+	}
+}
+
+func TestTheToolCatalogsTiersAreTheContractsTiers(t *testing.T) {
+	t.Parallel()
+	// An entry that matched no subject reads as ratification of a verb that has
+	// been listed since — which is the direction this baseline is supposed to
+	// move in, and it must be noticed rather than left standing.
+	defer absentFromTheCatalog.AssertAllMatched(t)
+	page, err := os.ReadFile(catalogPage)
+	if err != nil {
+		t.Fatalf("reading %s: %v", catalogPage, err)
+	}
+
+	documented := map[string]string{}
+	inTable := false
+	for _, line := range strings.Split(string(page), "\n") {
+		if strings.TrimSpace(line) == catalogHeader {
+			inTable = true
+			continue
+		}
+		if !inTable {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			inTable = false
+			continue
+		}
+		if match := catalogRow.FindStringSubmatch(line); match != nil {
+			documented[match[1]] = strings.TrimSpace(match[2])
+		}
+	}
+	if len(documented) == 0 {
+		t.Fatalf("no tool rows parsed out of %s — this gate is reading a table shape that is gone, "+
+			"and an empty census passes exactly like a correct page", catalogPage)
+	}
+
+	declared := compose.AgentToolTiers()
+	if len(declared) == 0 {
+		t.Fatal("the contract declares no tool tiers, so this gate is comparing the page against nothing")
+	}
+
+	compared := 0
+	for _, tool := range catalogToolNames(documented) {
+		tiers, governed := declared[tool]
+		if !governed {
+			// A row the contract declares no tier for. Most of the catalog is
+			// this: a native read tool is registered by the MCP registry and
+			// has no crm.yaml operation, so agentPolicies has nothing to say
+			// about it. Not a finding — this gate holds the tier column
+			// against the contract, and where there is no contract tier there
+			// is nothing to hold it against.
+			continue
+		}
+		compared++
+		if want := markFor(tiers); documented[tool] != want {
+			t.Errorf("%s says %s is %q; the contract says %q. This page is what somebody reads before "+
+				"granting a passport, so a wrong tier here is worse than an absent one",
+				catalogPage, tool, documented[tool], want)
+		}
+	}
+	// A comparison of nothing passes exactly like a correct page. The floor is
+	// far below the real count, so it catches a broken scan rather than a
+	// changing catalog.
+	if compared < 20 {
+		t.Fatalf("only %d row(s) were compared against a contract tier, so this gate covered almost "+
+			"nothing — the table shape or the policy table has moved", compared)
+	}
+
+	var arrived []string
+	for _, tool := range catalogToolNames(declared) {
+		if _, listed := documented[tool]; listed {
+			continue
+		}
+		if absentFromTheCatalog.Waived(t, tool) {
+			continue
+		}
+		arrived = append(arrived, tool)
+	}
+	if len(arrived) > 0 {
+		t.Errorf("the contract declares a tier for %v and %s does not list them. The catalog is the "+
+			"inventory a reader consults before granting a passport, so a governed verb missing from it "+
+			"is a verb whose autonomy nobody can look up", arrived, catalogPage)
+	}
+}
+
+// absentFromTheCatalog ratifies the governed verbs the page did not list when
+// this gate landed. Shrinking is the point; a NEW one fails.
+//
+// A ratchet rather than a sweep, because filling a row in means writing its
+// overlay-mode behaviour — what the verb does when the records live in somebody
+// else's CRM — and that is a per-verb answer read out of the code, not
+// something a gate landing should guess at nineteen times.
+//
+// One reason for all of them, because it is one fact: each is declared in
+// crm.yaml with a tier, the catalog is hand-kept, and none of them was ever
+// added. That is the same drift this gate exists to stop, caught in the other
+// direction.
+var absentFromTheCatalog = gatekit.Waive(map[string]string{
+	"annotate_brief":         catalogNeverListedIt,
+	"apply_tag":              catalogNeverListedIt,
+	"commit_import":          catalogNeverListedIt,
+	"create_task":            catalogNeverListedIt,
+	"decide_approval":        catalogNeverListedIt,
+	"decide_approval_bundle": catalogNeverListedIt,
+	"list_approvals":         catalogNeverListedIt,
+	"list_channel_providers": catalogNeverListedIt,
+	"list_colleagues":        catalogNeverListedIt,
+	"list_tags":              catalogNeverListedIt,
+	"preview_import":         catalogNeverListedIt,
+	"read_approval":          catalogNeverListedIt,
+	"read_import_report":     catalogNeverListedIt,
+	"read_import_run":        catalogNeverListedIt,
+	"read_project_360":       catalogNeverListedIt,
+	"relink_activities":      catalogNeverListedIt,
+	"relink_thread":          catalogNeverListedIt,
+	"remove_tag":             catalogNeverListedIt,
+	"send_account_email":     catalogNeverListedIt,
+})
+
+const catalogNeverListedIt = "declared in crm.yaml with a tier and absent from the hand-kept catalog when " +
+	"this gate landed. Writing its row means answering what the verb does in overlay mode, which is read " +
+	"out of the code per verb — so these are counted rather than guessed at, and the count only falls"
+
+// markFor is how the page must write a tool whose policies carry these tiers.
+//
+// One tier is written as itself. Two are written as the mixed mark, whatever
+// the two are: the page's own legend says the mixed mark means "the tier
+// depends on the record type", which is true of any tool that resolves more
+// than one.
+func markFor(tiers []string) string {
+	marks := map[string]bool{}
+	for _, tier := range tiers {
+		if mark := tierMark(tier); mark != "" {
+			marks[mark] = true
+		}
+	}
+	if len(marks) == 1 {
+		for mark := range marks {
+			return mark
+		}
+	}
+	if marks[marksRuns] && marks[marksWaits] {
+		return marksBothTiers
+	}
+	// Any other combination is a shape the page has no vocabulary for, and
+	// naming it here beats rendering something that looks like a mark.
+	return "an unwritable combination of " + strings.Join(sortedSet(marks), " and ")
+}
+
+func sortedSet(in map[string]bool) []string {
+	out := make([]string, 0, len(in))
+	for key := range in {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// catalogToolNames is the tool names in a table, sorted, so both walks report in
+// a stable order. Generic over the value because the two tables it reads answer
+// different questions with the same key.
+func catalogToolNames[V any](in map[string]V) []string {
+	out := make([]string, 0, len(in))
+	for key := range in {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/gates/agenttoolcatalogtiers_test.go
+++ b/backend/gates/agenttoolcatalogtiers_test.go
@@ -11,17 +11,13 @@ package gates
 //
 // docs/reference/agent-tools.md is what somebody deciding whether to hand an
 // agent a passport reads — not agentpolicy_gen.go. It states, per tool, whether
-// the verb RUNS or waits for a human, and it is hand-kept.
-//
-// It drifted the moment a tier annotation changed, and nothing reported it: ten
-// rows disagreed with the contract, eight of them in the dangerous direction —
-// the catalog told a reader that archiving, merging and disqualifying wait for a
-// human when they run immediately. That survived a merge, a review and a day of
-// CI (#2432, #2460).
+// the verb RUNS or waits for a human, and it is hand-kept. A wrong tier there
+// tells somebody a consequential verb waits for them when it does not, which is
+// worse than telling them nothing.
 //
 // So both sides are DERIVED and compared. agentPolicies is generated from
 // crm.yaml, which means an annotation change binds this page by regeneration
-// rather than by anyone remembering.
+// rather than by anyone remembering to edit it.
 //
 // THE MIXED CASE IS THE POINT, not an exception to skip. create_record and
 // update_record resolve per record type, so no single mark can be right for
@@ -139,9 +135,14 @@ func TestTheToolCatalogsTiersAreTheContractsTiers(t *testing.T) {
 				catalogPage, tool, documented[tool], want)
 		}
 	}
-	// A comparison of nothing passes exactly like a correct page. The floor is
-	// far below the real count, so it catches a broken scan rather than a
-	// changing catalog.
+	// A comparison of nothing passes exactly like a correct page.
+	//
+	// The floor is CLOSE to the real count — twenty-one rows carry a contract
+	// tier today — so it is not a robustness margin and must not be read as
+	// one. It trips when the scan breaks or the governed corpus shrinks, and
+	// either is a thing to look at: the first is this gate reading a table
+	// shape that has moved, the second is verbs leaving the contract's
+	// governance, which is not a change to make quietly.
 	if compared < 20 {
 		t.Fatalf("only %d row(s) were compared against a contract tier, so this gate covered almost "+
 			"nothing — the table shape or the policy table has moved", compared)

--- a/backend/internal/compose/agenttierfloor.go
+++ b/backend/internal/compose/agenttierfloor.go
@@ -18,6 +18,7 @@ package compose
 // tool door by regeneration and not by anyone remembering.
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
@@ -146,3 +147,44 @@ func tierFloor(tool, recordType string) (mcp.RiskTier, bool) {
 // composed api surface passes it; the integration lane is what proves that, since
 // a comment cannot.
 func withContractTierFloor() agents.RegistryOption { return agents.WithTierFloor(tierFloor) }
+
+// AgentToolTiers answers, per tool verb, which contract tiers its operations
+// resolve to — sorted and deduplicated.
+//
+// NOT every registered tool, and the difference is the thing to know before
+// reading its answer: a native read tool is registered by the MCP registry and
+// backs no crm.yaml operation, so agentPolicies holds no tier for it and it is
+// absent here. The subject is what the CONTRACT governs.
+//
+// Exported for one reader — the gate holding docs/reference/agent-tools.md's
+// Tier column against this table — and shaped for the question that page
+// answers rather than for the table's own key. agentPolicies is keyed by ROUTE,
+// because that is what the dispatcher looks a call up by; a catalog row is per
+// TOOL, and a tool reached by several routes may resolve differently on each.
+//
+// Which is the interesting case rather than an inconvenience: create_record and
+// update_record carry one tier for the record types they enumerate and another
+// for the two the contract still declares confirm-first. This answers with
+// both and leaves what to say about it to the caller.
+func AgentToolTiers() map[string][]string {
+	byTool := map[string]map[string]bool{}
+	for _, policy := range agentPolicies {
+		if policy.Tool == "" || policy.Tier == "" {
+			continue
+		}
+		if byTool[policy.Tool] == nil {
+			byTool[policy.Tool] = map[string]bool{}
+		}
+		byTool[policy.Tool][string(policy.Tier)] = true
+	}
+	out := make(map[string][]string, len(byTool))
+	for tool, tiers := range byTool {
+		list := make([]string, 0, len(tiers))
+		for tier := range tiers {
+			list = append(list, tier)
+		}
+		sort.Strings(list)
+		out[tool] = list
+	}
+	return out
+}

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -68,10 +68,10 @@ Columns:
   (`relink_activity`, `relink_thread`, `relink_activities` — the table below
   lists the first) read the destination record type (filing under a project is
   🟡 — it classifies every named activity as commercial correspondence, which is
-  write-once and cannot be undone by relinking away). **🟢 / 🟡** means the tier depends on the record
-  type the call names: 🟢 for the seven the tool enumerates, 🟡 for
-  `custom_field` and `webhook_subscription`, which the contract still declares
-  confirm-first.
+  write-once and cannot be undone by relinking away).
+  **🟢 / 🟡** means the tier depends on the record type the call names: 🟢 for
+  the seven the tool enumerates, 🟡 for `custom_field` and
+  `webhook_subscription`, which the contract still declares confirm-first.
 - Consequential verbs read 🟢 here because ADR-0055 stopped them staging by
   default: a passport carries the granting human's own seat, grants and row
   scope, so a verb it can spend is one its holder could spend unaided, and a

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -62,11 +62,15 @@ have a tool carries `x-agent-access: human-only` instead.
 Columns:
 
 - **Tier** — 🟢 runs immediately; 🟡 refused until a human releases the staged
-  approval; **dynamic** resolves per call from the target stage's semantic
-  (`open` → 🟢, won/lost → 🟡), and may only ever *raise*. **🟢 / 🟡** means the
-  tier depends on the record type the call names: 🟢 for the seven the tool
-  enumerates, 🟡 for `custom_field` and `webhook_subscription`, which the
-  contract still declares confirm-first.
+  approval; **dynamic** resolves per call, from what the call is aimed at, and
+  may only ever *raise*. Two resolvers carry it: the deal pair reads the target
+  stage's semantic (`open` → 🟢, won/lost → 🟡), and the relink pair reads the
+  destination record type (filing under a project is 🟡 — it classifies every
+  named activity as commercial correspondence, which is write-once and cannot be
+  undone by relinking away). **🟢 / 🟡** means the tier depends on the record
+  type the call names: 🟢 for the seven the tool enumerates, 🟡 for
+  `custom_field` and `webhook_subscription`, which the contract still declares
+  confirm-first.
 - Consequential verbs read 🟢 here because ADR-0055 stopped them staging by
   default: a passport carries the granting human's own seat, grants and row
   scope, so a verb it can spend is one its holder could spend unaided, and a
@@ -108,7 +112,7 @@ Columns:
 | `read_brief` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `read_record` | 🟢 | `read` | — | Mirror-backed; result carries `trust_tier: external` |
 | `query_workspace` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
-| `relink_activity` | 🟢 | `write` | — | Runs: a link row is not an SoR record write, so it is available in either mode |
+| `relink_activity` | dynamic | `write` | — | Runs: a link row is not an SoR record write, so it is available in either mode |
 | `resolve_entities` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `run_report` | 🟢 | `read` | — | `unsupported_by_sor` (no incumbent analogue) |
 | `search_context` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -64,10 +64,11 @@ Columns:
 - **Tier** — 🟢 runs immediately; 🟡 refused until a human releases the staged
   approval; **dynamic** resolves per call, from what the call is aimed at, and
   may only ever *raise*. Two resolvers carry it: the deal pair reads the target
-  stage's semantic (`open` → 🟢, won/lost → 🟡), and the relink pair reads the
-  destination record type (filing under a project is 🟡 — it classifies every
-  named activity as commercial correspondence, which is write-once and cannot be
-  undone by relinking away). **🟢 / 🟡** means the tier depends on the record
+  stage's semantic (`open` → 🟢, won/lost → 🟡), and the three relink verbs
+  (`relink_activity`, `relink_thread`, `relink_activities` — the table below
+  lists the first) read the destination record type (filing under a project is
+  🟡 — it classifies every named activity as commercial correspondence, which is
+  write-once and cannot be undone by relinking away). **🟢 / 🟡** means the tier depends on the record
   type the call names: 🟢 for the seven the tool enumerates, 🟡 for
   `custom_field` and `webhook_subscription`, which the contract still declares
   confirm-first.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,10 +15,11 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (41)
+## Parity (42)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
+| `agenttoolcatalogtiers_test.go` | H2 | The tool catalog's Tier column says what the contract says. |
 | `aiactivitycatalogparity_test.go` | H3 | The AI-activity contract must name exactly the work that can reach it, and cap exactly what the read caps. |
 | `airoutingschema_test.go` | H3 | What the EDITOR accepts, checked against what the parser accepts. |
 | `aitaskparity_test.go` | H3 | Every ai\_task an emitter writes into the AI-activity projection must be a task the AI contract declares. |


### PR DESCRIPTION
Closes #2460.

## Why a gate

`docs/reference/agent-tools.md` is what somebody deciding whether to hand an agent a passport reads — not `agentpolicy_gen.go`. It states, per tool, whether the verb **runs** or **waits for a human**, and it is hand-kept.

It drifted the moment a tier annotation changed and nothing reported it: ten rows disagreed, eight of them in the dangerous direction — the catalog told a reader that archiving, merging and disqualifying wait for a human when they run immediately. That survived a merge, a review and a day of CI.

Both sides are derived and compared now. `agentPolicies` is generated from `crm.yaml`, so an annotation change binds this page **by regeneration** rather than by anyone remembering.

## The gate found one the correction missed

`relink_activity` read 🟢 where the contract says `dynamic`. Filing an activity under a project classifies it as commercial correspondence, which is write-once and cannot be undone by relinking away — so that call may resolve to 🟡, and the page said it never would.

Corrected, and the legend widened with it: `dynamic` had been described as the deal pair's stage resolver alone, leaving the relink pair's `destination_record_type` resolver undocumented on a page whose job is to explain exactly that.

## The mixed case

`create_record` and `update_record` resolve per record type, so no single mark can be right for them. The gate holds **both directions**: a tool whose policies carry two tiers must be written 🟢 / 🟡, and one whose policies agree may not claim to be mixed. Skipping them would have been blind to the half of the table most likely to mislead.

## Two boundaries, stated rather than assumed

- **Nineteen governed verbs are absent from the catalog entirely** — `create_task`, `decide_approval`, `send_account_email` and others. They are a **counted baseline that can only shrink**, not a sweep: writing a row means answering what the verb does in overlay mode, which is read out of the code per verb. A *new* one fails.
- **A catalog row the contract declares no tier for is not judged.** Most of the page is that: a native read tool is registered by the MCP registry and backs no `crm.yaml` operation, so `agentPolicies` holds no tier for it. Where there is no contract tier there is nothing to hold the column against — and `AgentToolTiers`'s doc says so at the source, because getting that wrong is what made the first draft of this gate report forty false findings.

## Held from the other end

Mutation-checked on all three arms:

- A tier flipped on `archive_record` → reported, with both values.
- `archive_record`'s row deleted → reported as a governed verb the catalog does not list.
- `create_record`'s 🟢 / 🟡 collapsed to 🟢 → reported.

Plus a floor: fewer than twenty rows compared against a contract tier fails, because a comparison of nothing passes exactly like a correct page. The scan is bounded to the catalog table by its header — the page holds a second table of the same row shape (passport scopes), and a scan that took every matching row read `enrich` as tier "1", which is that table's route count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that dynamic tool approval tiers are determined for each call.
  * Documented destination-type handling for activity relinking, including `relink_activity`, `relink_thread`, and `relink_activities`.
  * Classified `relink_activity` as dynamic rather than always immediate.
  * Preserved documentation for approval behavior when filing items to projects.
  * Updated the gate inventory to include catalog tier validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->