### PR TITLE
Money converts to the base currency in one place

### DIFF
--- a/backend/gates/onecurrencyconversion_test.go
+++ b/backend/gates/onecurrencyconversion_test.go
@@ -181,9 +181,9 @@ func conversionIn(where, sql string, fileNamesFXRate bool) (bool, string) {
 // second engine built that way is invisible. Under-recognition is the one
 // direction a prohibition may not fail in, and this is the shape it fails in.
 //
-// Each concatenation contributes its joined text AND its pieces stay available
-// through the walk, so a literal that is a whole statement is still read as
-// one.
+// A concatenation contributes its joined text ONCE: the walk does not descend
+// into a chain it has already flattened, and the literals it consumed are
+// marked so a fragment is not also read as a statement of its own.
 func fxSQLStatementsIn(file *ast.File) []string {
 	var out []string
 	joined := map[ast.Node]bool{}
@@ -197,7 +197,12 @@ func fxSQLStatementsIn(file *ast.File) []string {
 			if ok {
 				out = append(out, text)
 			}
-			return true
+			// Do NOT descend. Go parses `a + b + c` left-nested as
+			// `(a + b) + c`, so the walk would meet the inner ADD next and
+			// flatten it again — emitting the truncated prefix as a second
+			// statement, and reporting the same offence twice. The whole chain
+			// was just read; there is nothing left inside it to find.
+			return false
 		case *ast.BasicLit:
 			if joined[typed] {
 				return true
@@ -213,6 +218,9 @@ func fxSQLStatementsIn(file *ast.File) []string {
 
 // flattenConcatenation joins the string operands of one `+` chain, marking each
 // literal it consumed so the walk does not report it a second time on its own.
+//
+// The CHAIN, not the node: it recurses through nested ADDs itself, which is why
+// the caller must not descend into them afterwards.
 //
 // A non-literal operand — a variable, a call — contributes a space rather than
 // nothing: it stands where text the gate cannot see would be, and joining
@@ -282,6 +290,16 @@ func TestTheDetectorSeesEachShapeAConversionIsWrittenIn(t *testing.T) {
 			true,
 		},
 		{
+			// A three-term chain, which Go parses left-nested as (a + b) + c.
+			// A walk that descended after flattening would meet the inner ADD
+			// and flatten it again, emitting `SELECT rate FROM ` as a second
+			// statement — the same offence reported twice, and the count of
+			// statements judged silently doubled.
+			"a chain of three, counted once",
+			"package p\nvar q = `SELECT rate FROM ` + `fx_rate` + ` WHERE from_currency = $1`\n",
+			true,
+		},
+		{
 			// And the near miss that keeps it from being noise: a dynamic FROM
 			// in a file with no interest in rates at all.
 			"a dynamic FROM in a file that never names the rate table",
@@ -320,14 +338,21 @@ func TestTheDetectorSeesEachShapeAConversionIsWrittenIn(t *testing.T) {
 					namesRate = true
 				}
 			}
-			fired := false
+			hits := 0
 			for _, sql := range statements {
 				if found, _ := conversionIn(elsewhere, sql, namesRate); found {
-					fired = true
+					hits++
 				}
 			}
-			if fired != probe.fires {
-				t.Errorf("%s: the detector answered %t, want %t — %q", probe.what, fired, probe.fires, probe.src)
+			if (hits > 0) != probe.fires {
+				t.Errorf("%s: the detector answered %t, want %t — %q", probe.what, hits > 0, probe.fires, probe.src)
+			}
+			// ONCE, not merely at least once. A statement read twice reports
+			// its offence twice and doubles the count of statements judged,
+			// which is how a floor stops meaning what it says.
+			if probe.fires && hits != 1 {
+				t.Errorf("%s: the detector fired %d times on one statement, want once — %q",
+					probe.what, hits, probe.src)
 			}
 		})
 	}

--- a/backend/gates/onecurrencyconversion_test.go
+++ b/backend/gates/onecurrencyconversion_test.go
@@ -292,9 +292,9 @@ func TestTheDetectorSeesEachShapeAConversionIsWrittenIn(t *testing.T) {
 		{
 			// A three-term chain, which Go parses left-nested as (a + b) + c.
 			// A walk that descended after flattening would meet the inner ADD
-			// and flatten it again, emitting `SELECT rate FROM ` as a second
-			// statement — the same offence reported twice, and the count of
-			// statements judged silently doubled.
+			// and flatten it again, emitting the left prefix — SELECT rate FROM
+			// fx_rate — as a second statement. The same offence reported twice,
+			// and the count of statements judged silently doubled.
 			"a chain of three, counted once",
 			"package p\nvar q = `SELECT rate FROM ` + `fx_rate` + ` WHERE from_currency = $1`\n",
 			true,

--- a/backend/gates/onecurrencyconversion_test.go
+++ b/backend/gates/onecurrencyconversion_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+//go:build !integration
+
+package gates
+
+// Converting money to the base currency has one implementation.
+//
+// It had two, in two languages: exact decimal over big.Int in the hierarchy
+// rollup, and a LEFT JOIN LATERAL on fx_rate with round(amount × rate)::bigint
+// on the company page. Both encoded the same four decisions — the direction,
+// the as-of cutoff, newest-wins, and the multiply-and-round — and they agreed.
+//
+// Nothing made them keep agreeing. The predicted first divergence was the
+// rounding: half-away-from-zero against Postgres round(), which is a
+// one-minor-unit disagreement between two pages about the same account, and the
+// kind of defect nobody can reproduce on demand.
+//
+// What is NOT shared, and must not be, is the missing-rate policy: the rollup
+// refuses the whole read, the company page prices what it can and counts the
+// rest. Both are right for their own surface, so the engine answers "is there a
+// rate, and what does it make of this amount" and leaves the rest to the caller.
+//
+// This gate is about the ENGINE, so it hunts a second one: a read of fx_rate
+// outside the module that owns it, and an arithmetic conversion spelled in SQL.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// fxRateOwner is the module whose store owns fx_rate, and so the one place the
+// lookup is written. tableOwners agrees; this names it for the failure message.
+const fxRateOwner = "internal/modules/deals"
+
+// readsFXRate matches a statement that goes to the rate table itself.
+var readsFXRate = regexp.MustCompile(`(?i)\bfrom\s+fx_rate\b|\bjoin\s+fx_rate\b`)
+
+// convertsInSQL matches the arithmetic: an amount multiplied by a rate. It is
+// the half that makes a second read a second ENGINE rather than a lookup — a
+// query that reads a rate and hands it to Go is converting through
+// deals.ConvertToBase like everything else.
+var convertsInSQL = regexp.MustCompile(`(?i)amount_minor\s*\*|\*\s*[a-z_.]*rate\b`)
+
+// fxConversionExempt ratifies the files that may spell either half.
+var fxConversionExempt = gatekit.Waive(map[string]string{
+	"internal/modules/deals/fxconvert.go": "the engine itself: the one lookup and the one arithmetic every " +
+		"caller reaches money conversion through",
+	"internal/modules/deals/fxrate_store.go": "the rate table's own store — reading and writing the rows the " +
+		"engine later looks up is what owning the table means",
+	"internal/modules/deals/basecurrencyfreeze.go": "the CLOSE-time freeze, which is a different question: a " +
+		"closed deal stores the rate it was converted at, where this engine answers what an OPEN one converts " +
+		"at today",
+	"internal/modules/deals/deal_advance.go": "the same freeze at the moment it happens — advancing to won " +
+		"reads the rate once and stores it on the deal, which is why a closed figure never moves again",
+	"internal/modules/quotas/attainment.go": "a THIRD conversion, and one the module DAG forces: quotas is a " +
+		"module and a module never imports a sibling (ADR-0054 §3), so it cannot reach deals.FXRates and must " +
+		"ask fx_rate itself. Its own comment already names the two implementations it mirrors. Holding it " +
+		"identical to them is an obligation this gate cannot discharge — what it can do is stop a FOURTH " +
+		"appearing anywhere the engine IS reachable",
+	"internal/compose/rateproposals_integration_test.go": "a test seeding and asserting on rate rows. It reads " +
+		"the table to arrange and to check, never to convert an amount for a reader",
+	"internal/compose/briefs/briefrank.go": "a FOURTH conversion, and the only ratified one that could reach " +
+		"the engine — it is in compose. It converts inside a larger ranking query and answers a wider " +
+		"question than the engine does: a CLOSED deal reads its frozen amount_minor_base, which is a stored " +
+		"figure rather than a conversion. Moving it means restructuring that query and teaching the engine " +
+		"the frozen case, which is its own change rather than a line in this one. Recorded so it is a known " +
+		"copy rather than an unnoticed one",
+})
+
+func TestMoneyConvertsToTheBaseCurrencyInOnePlace(t *testing.T) {
+	t.Parallel()
+	defer fxConversionExempt.AssertAllMatched(t)
+
+	var offences []string
+	judged := 0
+	// The WHOLE tree, walked directly rather than through a Scope: a second
+	// conversion is only interesting where nobody thought to look, and the
+	// roots a gate names are exactly where it did.
+	fset := token.NewFileSet()
+	for _, path := range handWrittenGoSources(t) {
+		where := filepath.ToSlash(path)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		literals := sqlLiteralsIn(file)
+		for _, sql := range literals {
+			if !readsFXRate.MatchString(sql) {
+				continue
+			}
+			judged++
+			if fxConversionExempt.Waived(t, where) {
+				continue
+			}
+			if strings.HasPrefix(where, fxRateOwner+"/") {
+				offences = append(offences, where+" reads fx_rate outside the engine, inside the module that "+
+					"owns it — the lookup is deals.FXRates")
+				continue
+			}
+			offences = append(offences, where+" reads fx_rate directly; the lookup is deals.FXRates, which "+
+				"memoizes one per currency and answers the same rate the other surface converts at")
+		}
+		for _, sql := range literals {
+			if !convertsInSQL.MatchString(sql) || !readsFXRate.MatchString(sql) {
+				continue
+			}
+			if fxConversionExempt.Waived(t, where) {
+				continue
+			}
+			offences = append(offences, where+" multiplies an amount by a rate in SQL; the arithmetic is "+
+				"deals.ConvertToBase, which rounds half away from zero over exact decimal digits")
+		}
+	}
+	// A census that judged nothing certifies nothing: the rate table is read by
+	// the engine and its store at minimum, so a zero here is a broken scan.
+	if judged == 0 {
+		t.Fatal("no statement reading fx_rate was found at all, so this gate is reading a tree shape " +
+			"that is gone rather than a clean one")
+	}
+	if len(offences) > 0 {
+		t.Errorf("money converts to the base currency in more than one place:\n  %s\n\n"+
+			"Two implementations of one conversion agree until they do not, and the first thing to "+
+			"diverge is the rounding — a one-minor-unit disagreement between two pages about the same "+
+			"account, which nobody can reproduce on demand.", strings.Join(offences, "\n  "))
+	}
+}
+
+// sqlLiteralsIn returns every string literal in a file, which is where a
+// statement lives. Concatenations are read piece by piece: a fragment naming
+// fx_rate is a read of it whichever half of the concatenation it sits in.
+func sqlLiteralsIn(file *ast.File) []string {
+	var out []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		if lit, ok := node.(*ast.BasicLit); ok {
+			if text, isText := gatekit.LiteralText(lit); isText {
+				out = append(out, text)
+			}
+		}
+		return true
+	})
+	return out
+}

--- a/backend/gates/onecurrencyconversion_test.go
+++ b/backend/gates/onecurrencyconversion_test.go
@@ -46,6 +46,12 @@ const fxRateOwner = "internal/modules/deals"
 // readsFXRate matches a statement that goes to the rate table itself.
 var readsFXRate = regexp.MustCompile(`(?i)\bfrom\s+fx_rate\b|\bjoin\s+fx_rate\b`)
 
+// readsAnInterpolatedTable matches a FROM or JOIN whose table name this gate
+// cannot see, because the flattening substitutes a space for every operand that
+// is not a literal. The trailing anchor is what keeps it off an ordinary
+// `FROM deal d`: only a gap where a name belongs matches.
+var readsAnInterpolatedTable = regexp.MustCompile(`(?i)\b(from|join)\s{2,}\b|(?i)\b(from|join)\s+$`)
+
 // convertsInSQL matches the arithmetic: an amount multiplied by a rate. It is
 // the half that makes a second read a second ENGINE rather than a lookup — a
 // query that reads a rate and hands it to Go is converting through
@@ -70,6 +76,10 @@ var fxConversionExempt = gatekit.Waive(map[string]string{
 		"appearing anywhere the engine IS reachable",
 	"internal/compose/rateproposals_integration_test.go": "a test seeding and asserting on rate rows. It reads " +
 		"the table to arrange and to check, never to convert an amount for a reader",
+	"gates/onecurrencyconversion_test.go": "this gate itself: the probes below are planted defects, and " +
+		"judging them would report its own evidence as a finding. The file holds nothing but the gate, so " +
+		"skipping it whole costs no coverage — unlike a census whose probes sit beside real code, where the " +
+		"exemption belongs on the declaration",
 	"internal/compose/briefs/briefrank.go": "a FOURTH conversion, and the only ratified one that could reach " +
 		"the engine — it is in compose. It converts inside a larger ranking query and answers a wider " +
 		"question than the engine does: a CLOSED deal reads its frozen amount_minor_base, which is a stored " +
@@ -94,32 +104,23 @@ func TestMoneyConvertsToTheBaseCurrencyInOnePlace(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
-		literals := sqlLiteralsIn(file)
-		for _, sql := range literals {
-			if !readsFXRate.MatchString(sql) {
+		statements := fxSQLStatementsIn(file)
+		namesFXRate := false
+		for _, sql := range statements {
+			if strings.Contains(strings.ToLower(sql), "fx_rate") {
+				namesFXRate = true
+			}
+		}
+		for _, sql := range statements {
+			found, why := conversionIn(where, sql, namesFXRate)
+			if !found {
 				continue
 			}
 			judged++
 			if fxConversionExempt.Waived(t, where) {
 				continue
 			}
-			if strings.HasPrefix(where, fxRateOwner+"/") {
-				offences = append(offences, where+" reads fx_rate outside the engine, inside the module that "+
-					"owns it — the lookup is deals.FXRates")
-				continue
-			}
-			offences = append(offences, where+" reads fx_rate directly; the lookup is deals.FXRates, which "+
-				"memoizes one per currency and answers the same rate the other surface converts at")
-		}
-		for _, sql := range literals {
-			if !convertsInSQL.MatchString(sql) || !readsFXRate.MatchString(sql) {
-				continue
-			}
-			if fxConversionExempt.Waived(t, where) {
-				continue
-			}
-			offences = append(offences, where+" multiplies an amount by a rate in SQL; the arithmetic is "+
-				"deals.ConvertToBase, which rounds half away from zero over exact decimal digits")
+			offences = append(offences, where+" "+why)
 		}
 	}
 	// A census that judged nothing certifies nothing: the rate table is read by
@@ -136,18 +137,198 @@ func TestMoneyConvertsToTheBaseCurrencyInOnePlace(t *testing.T) {
 	}
 }
 
-// sqlLiteralsIn returns every string literal in a file, which is where a
-// statement lives. Concatenations are read piece by piece: a fragment naming
-// fx_rate is a read of it whichever half of the concatenation it sits in.
-func sqlLiteralsIn(file *ast.File) []string {
+// conversionIn reports whether one statement converts money outside the engine,
+// and what it did. Extracted from the walk so the shapes it must catch can be
+// PLANTED and asserted: a census over a clean tree passes identically over a
+// detector that has stopped detecting.
+func conversionIn(where, sql string, fileNamesFXRate bool) (bool, string) {
+	if !readsFXRate.MatchString(sql) {
+		// A FROM whose table this gate cannot read — the name is interpolated
+		// from a variable, so the flattening left a gap where it belongs.
+		//
+		// Reported only when the FILE also names fx_rate in a literal
+		// somewhere, and that pairing is what makes it worth reporting rather
+		// than noise: a dynamic FROM alone is ordinary (this tree builds them
+		// over lists of tables), and a file naming the rate table is ordinary,
+		// but a file doing both may be reading fx_rate through a name this
+		// gate cannot follow. The answer is a waiver saying which table it is,
+		// which is a sentence somebody has to write down.
+		if fileNamesFXRate && readsAnInterpolatedTable.MatchString(sql) {
+			return true, "builds a FROM whose table name this gate cannot resolve, in a file that also " +
+				"names fx_rate — say which table it is in a waiver, so a read through an interpolated " +
+				"name cannot hide here"
+		}
+		return false, ""
+	}
+	if convertsInSQL.MatchString(sql) {
+		return true, "converts an amount at a rate in SQL; the arithmetic is deals.ConvertToBase, which " +
+			"rounds half away from zero over exact decimal digits, and the lookup is deals.FXRates"
+	}
+	if strings.HasPrefix(where, fxRateOwner+"/") {
+		return true, "reads fx_rate outside the engine, inside the module that owns it — the lookup is " +
+			"deals.FXRates"
+	}
+	return true, "reads fx_rate directly; the lookup is deals.FXRates, which memoizes one per currency and " +
+		"answers the same rate the other surface converts at"
+}
+
+// fxSQLStatementsIn returns the statements a file holds, with CONCATENATIONS
+// FLATTENED.
+//
+// Flattened, because a statement is routinely assembled — `"SELECT … FROM " +
+// table` is the shape in this tree — and a scan over bare literals sees each
+// half alone: neither fragment carries both the FROM and the table name, so a
+// second engine built that way is invisible. Under-recognition is the one
+// direction a prohibition may not fail in, and this is the shape it fails in.
+//
+// Each concatenation contributes its joined text AND its pieces stay available
+// through the walk, so a literal that is a whole statement is still read as
+// one.
+func fxSQLStatementsIn(file *ast.File) []string {
 	var out []string
+	joined := map[ast.Node]bool{}
 	ast.Inspect(file, func(node ast.Node) bool {
-		if lit, ok := node.(*ast.BasicLit); ok {
-			if text, isText := gatekit.LiteralText(lit); isText {
+		switch typed := node.(type) {
+		case *ast.BinaryExpr:
+			if typed.Op != token.ADD {
+				return true
+			}
+			text, ok := flattenConcatenation(typed, joined)
+			if ok {
+				out = append(out, text)
+			}
+			return true
+		case *ast.BasicLit:
+			if joined[typed] {
+				return true
+			}
+			if text, isText := gatekit.LiteralText(typed); isText {
 				out = append(out, text)
 			}
 		}
 		return true
 	})
 	return out
+}
+
+// flattenConcatenation joins the string operands of one `+` chain, marking each
+// literal it consumed so the walk does not report it a second time on its own.
+//
+// A non-literal operand — a variable, a call — contributes a space rather than
+// nothing: it stands where text the gate cannot see would be, and joining
+// around it would fuse two words that are not adjacent in the statement.
+func flattenConcatenation(expr *ast.BinaryExpr, joined map[ast.Node]bool) (string, bool) {
+	var parts []string
+	var walk func(ast.Expr)
+	walk = func(node ast.Expr) {
+		switch typed := node.(type) {
+		case *ast.BinaryExpr:
+			if typed.Op == token.ADD {
+				walk(typed.X)
+				walk(typed.Y)
+				return
+			}
+			parts = append(parts, " ")
+		case *ast.BasicLit:
+			if text, isText := gatekit.LiteralText(typed); isText {
+				joined[typed] = true
+				parts = append(parts, text)
+				return
+			}
+			parts = append(parts, " ")
+		default:
+			parts = append(parts, " ")
+		}
+	}
+	walk(expr)
+	return strings.Join(parts, ""), len(parts) > 0
+}
+
+// TestTheDetectorSeesEachShapeAConversionIsWrittenIn is the positive control.
+//
+// The census above passes identically over a clean tree and over a detector
+// that has stopped detecting: it reports nothing either way. These read the
+// detector directly, on shapes taken from how this tree actually writes
+// queries, so the census means something.
+//
+// The concatenated case is why this exists. A statement assembled as
+// `"SELECT … FROM " + table` splits the FROM and the table name across two
+// literals, and a scan over bare literals sees neither — a second engine
+// written that way was invisible, which is the one direction a prohibition may
+// not fail in.
+func TestTheDetectorSeesEachShapeAConversionIsWrittenIn(t *testing.T) {
+	t.Parallel()
+	const elsewhere = "internal/compose/somewhere/read.go"
+	for _, probe := range []struct {
+		what  string
+		src   string
+		fires bool
+	}{
+		{"a plain read", "package p\nvar q = `SELECT rate FROM fx_rate WHERE from_currency = $1`\n", true},
+		{"a join", "package p\nvar q = `SELECT d.id FROM deal d JOIN fx_rate r ON r.from_currency = d.currency`\n", true},
+		{
+			"a conversion in SQL",
+			"package p\nvar q = `SELECT round(d.amount_minor * r.rate)::bigint FROM fx_rate r`\n",
+			true,
+		},
+		{
+			// The shape the first version of this gate could not see: the table
+			// name comes from a variable, so the flattening leaves a gap where
+			// it belongs. Caught because the FILE also names fx_rate — a
+			// dynamic FROM alone is ordinary here, and so is naming the table;
+			// doing both is what earns the question.
+			"a read whose table name is interpolated, in a file that names the rate table",
+			"package p\nvar q = `SELECT rate FROM ` + rateTable + ` WHERE from_currency = $1`\nvar rateTable = `fx_rate`\n",
+			true,
+		},
+		{
+			// And the near miss that keeps it from being noise: a dynamic FROM
+			// in a file with no interest in rates at all.
+			"a dynamic FROM in a file that never names the rate table",
+			"package p\nvar q = `SELECT count(*) FROM ` + table + ` WHERE archived_at IS NULL`\nvar table = `deal`\n",
+			false,
+		},
+		{
+			"a concatenation whose halves are both literal",
+			"package p\nvar q = `SELECT rate ` + `FROM fx_rate WHERE from_currency = $1`\n",
+			true,
+		},
+		// Near misses. A gate widened until it matches ordinary prose is a gate
+		// somebody turns off.
+		{"a read of another table", "package p\nvar q = `SELECT amount_minor FROM deal WHERE id = $1`\n", false},
+		{
+			"the words in a comment",
+			"package p\n\n// This reads FROM fx_rate and multiplies amount_minor * rate.\nvar q = 1\n",
+			false,
+		},
+		{
+			"a write to the rate table, which is not a conversion",
+			"package p\nvar q = `INSERT INTO fx_rate (from_currency, rate) VALUES ($1, $2)`\n",
+			false,
+		},
+	} {
+		t.Run(probe.what, func(t *testing.T) {
+			t.Parallel()
+			file, err := parser.ParseFile(token.NewFileSet(), "probe.go", probe.src, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			statements := fxSQLStatementsIn(file)
+			namesRate := false
+			for _, sql := range statements {
+				if strings.Contains(strings.ToLower(sql), "fx_rate") {
+					namesRate = true
+				}
+			}
+			fired := false
+			for _, sql := range statements {
+				if found, _ := conversionIn(elsewhere, sql, namesRate); found {
+					fired = true
+				}
+			}
+			if fired != probe.fires {
+				t.Errorf("%s: the detector answered %t, want %t — %q", probe.what, fired, probe.fires, probe.src)
+			}
+		})
+	}
 }

--- a/backend/internal/compose/org360/pipelineread.go
+++ b/backend/internal/compose/org360/pipelineread.go
@@ -167,8 +167,7 @@ func openPipeline(
 	// Longest idle first, which is the order the stalled rows are offered in, and
 	// by id so that order is deterministic between two deals idle since the same
 	// instant.
-	basePos := arg(baseCcy)
-	asOfPos := arg(now.UTC().Format(time.DateOnly))
+
 	// An OPEN deal has no frozen rate. The rate freezes on close
 	// (deals.deal_advance), and this query reads only open deals
 	// (openDealsWhere), so `amount_minor_base` is null on every row it returns
@@ -177,39 +176,34 @@ func openPipeline(
 	// (deal_closed_fx), so a stored date here can outlive the rate beside it.
 	// Neither stored column is read.
 	//
-	// The amount is converted at the latest rate on or before the as-of day,
-	// and its own rate_date comes back with it. They are ONE answer and must
-	// stay one: a date coalesced from somewhere else could name a day whose
-	// rate is not the rate the figure was computed at, which is the unlabelled
-	// cross-currency total in a more convincing disguise (plan §4.2).
+	// The conversion is NOT in this statement. It used to be — a lateral on
+	// fx_rate and a round()::bigint per row — and that was a second
+	// implementation of a decision the hierarchy rollup already made in Go:
+	// the direction, the as-of cutoff, newest-wins, and the multiply-and-round.
+	// The two agreed, and nothing made them keep agreeing; the first divergence
+	// anyone predicted was rounding, half-away-from-zero against Postgres
+	// round(), which is a one-minor-unit disagreement between two pages about
+	// the same account and nobody able to reproduce it on demand.
+	//
+	// So this reads the deal and deals.FXRates does the rest, ONCE PER CURRENCY
+	// rather than once per row. What stays here is this surface's own policy: a
+	// deal with no usable rate is priced at nothing and still counted, which is
+	// what priced_count reports.
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT d.id, d.name, d.status, d.created_at, d.last_activity_at, d.wait_until,
 		       (SELECT count(*) FROM deal_stage_history h
 		         WHERE h.deal_id = d.id AND h.from_stage_id IS DISTINCT FROM h.to_stage_id),
 		       d.amount_minor,
-		       round(d.amount_minor * live.rate)::bigint,
-		       -- Cast both DATE columns to timestamps: pgx decodes a bare date
+		       -- Cast the DATE column to a timestamp: pgx decodes a bare date
 		       -- (OID 1082) into its own Date type, not into time.Time, and the
 		       -- scan below fails at runtime rather than at compile time. Only
 		       -- a read against real rows finds that, which is why it is spelled
 		       -- here rather than left to the driver.
 		       d.expected_close_date::timestamptz,
-		       d.currency,
-		       live.rate_date::timestamptz
+		       d.currency
 		FROM deal d
-		LEFT JOIN LATERAL (
-			SELECT r.rate, r.rate_date
-			  FROM fx_rate r
-			 WHERE d.currency IS DISTINCT FROM %s
-			   AND r.from_currency = d.currency
-			   AND r.to_currency = %s
-			   AND r.rate_date <= %s::date
-			 ORDER BY r.rate_date DESC
-			 LIMIT 1
-		) live ON true
 		%s
 		ORDER BY %s, d.id`,
-		fmt.Sprintf("$%d", basePos), fmt.Sprintf("$%d", basePos), fmt.Sprintf("$%d", asOfPos),
 		openDealsWhere(orgPos, dealScope), idlebase.SQL("d")), args...)
 	if err != nil {
 		return pipeline{}, fmt.Errorf("read the account's open pipeline: %w", err)
@@ -220,8 +214,7 @@ func openPipeline(
 		var createdAt time.Time
 		var lastActivityAt, waitUntil *time.Time
 		if err := row.Scan(&r.id, &r.name, &status, &createdAt, &lastActivityAt, &waitUntil,
-			&r.stageMoves, &r.amountMinor, &r.valueBase, &r.closeOn, &r.currency,
-			&r.rateDate); err != nil {
+			&r.stageMoves, &r.amountMinor, &r.closeOn, &r.currency); err != nil {
 			return r, err
 		}
 		r.baseCcy = baseCcy
@@ -234,6 +227,52 @@ func openPipeline(
 	if err != nil {
 		return pipeline{}, err
 	}
+	if err := priceOpenDeals(ctx, tx, open, baseCcy, now); err != nil {
+		return pipeline{}, err
+	}
 
 	return foldPipeline(open), nil
+}
+
+// priceOpenDeals fills each row's converted amount and the day its rate is
+// dated, through the one engine both this read and the hierarchy rollup use.
+//
+// A deal with no amount, or in a currency the estate holds no rate for, is left
+// UNPRICED rather than refused: this surface reports a partial figure with the
+// count of deals that reached it, where the rollup refuses the whole read. That
+// difference is the policy, and it is the only thing the two are allowed to
+// disagree about.
+//
+// The rate and its DATE travel together, because they are one answer: a date
+// coalesced from somewhere else could name a day whose rate is not the rate the
+// figure was computed at, which is the unlabelled cross-currency total in a more
+// convincing disguise (plan §4.2).
+func priceOpenDeals(
+	ctx context.Context, tx pgx.Tx, open []openRow, baseCcy string, now time.Time,
+) error {
+	rates := deals.NewFXRates(baseCcy, now.UTC())
+	for i := range open {
+		row := &open[i]
+		if row.amountMinor == nil || row.currency == nil {
+			continue
+		}
+		rate, found, err := rates.For(ctx, tx, *row.currency)
+		if err != nil {
+			return fmt.Errorf("price the account's open pipeline: %w", err)
+		}
+		if !found {
+			continue
+		}
+		converted, err := deals.ConvertToBase(*row.amountMinor, rate.Rate)
+		if err != nil {
+			// The deal is unpriceable rather than the read unreadable: an
+			// amount whose converted value does not fit is one deal the figure
+			// cannot cover, and priced_count is what says so.
+			continue
+		}
+		row.valueBase = &converted
+		on := rate.On
+		row.rateDate = &on
+	}
+	return nil
 }

--- a/backend/internal/compose/org360/pipelineread.go
+++ b/backend/internal/compose/org360/pipelineread.go
@@ -194,11 +194,12 @@ func openPipeline(
 		       (SELECT count(*) FROM deal_stage_history h
 		         WHERE h.deal_id = d.id AND h.from_stage_id IS DISTINCT FROM h.to_stage_id),
 		       d.amount_minor,
-		       -- Cast the DATE column to a timestamp: pgx decodes a bare date
-		       -- (OID 1082) into its own Date type, not into time.Time, and the
-		       -- scan below fails at runtime rather than at compile time. Only
-		       -- a read against real rows finds that, which is why it is spelled
-		       -- here rather than left to the driver.
+		       -- Cast to a timestamp because the scan takes a *time.Time and
+		       -- this column is nullable: the cast keeps the null a null while
+		       -- naming the type the row hands back. pgx does decode a bare
+		       -- DATE into time.Time — the engine's own rate_date read proves
+		       -- it against real rows (deals/fxrates_integration_test.go) — so
+		       -- this is about the shape of the value, not about the driver.
 		       d.expected_close_date::timestamptz,
 		       d.currency
 		FROM deal d
@@ -265,9 +266,18 @@ func priceOpenDeals(
 		}
 		converted, err := deals.ConvertToBase(*row.amountMinor, rate.Rate)
 		if err != nil {
-			// The deal is unpriceable rather than the read unreadable: an
-			// amount whose converted value does not fit is one deal the figure
-			// cannot cover, and priced_count is what says so.
+			// UNPRICED, not refused, and this is a decision rather than a
+			// swallow. An amount whose converted value does not fit a bigint is
+			// one deal the figure cannot cover, and priced_count is what says
+			// so — the same answer organization_open_pipeline_rollup gives the
+			// same deal, because one implausible amount must not take a company
+			// record offline.
+			//
+			// The hierarchy rollup refuses the whole read on this error, and
+			// the two differ for the reason they differ on a missing rate: it
+			// reports ONE number for a set of accounts, where a partial total
+			// presented as a total is a lie, and this page reports a figure
+			// beside the count of deals it covers.
 			continue
 		}
 		row.valueBase = &converted

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -17,8 +17,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -129,11 +128,11 @@ func currentQuarterBounds(now time.Time, loc *time.Location, fiscalStartMonth in
 // amount_minor is contract-unbounded, so baseMinor×winProbability can
 // exceed int64 before the division ever runs; a silent wraparound there
 // would put a wrong number in a money total. The overflow check mirrors
-// convertToBase's: a result outside int64's range refuses loudly rather
+// deals.ConvertToBase's: a result outside int64's range refuses loudly rather
 // than truncating.
 func weightedValue(baseMinor int64, winProbability int) (int64, error) {
 	product := new(big.Int).Mul(big.NewInt(baseMinor), big.NewInt(int64(winProbability)))
-	rounded := bigDivRoundHalfAwayFromZero(product, big.NewInt(100))
+	rounded := deals.DivRoundHalfAwayFromZero(product, big.NewInt(100))
 	if !rounded.IsInt64() {
 		return 0, fmt.Errorf("%w: a %d-minor-unit amount at %d%%; correct the deal amount before retrying the rollup",
 			errWeightedValueOutOfRange, baseMinor, winProbability)
@@ -146,52 +145,6 @@ func weightedValue(baseMinor int64, winProbability int) (int64, error) {
 // accepted any error here would keep passing with the overflow check deleted,
 // as long as something else refused first.
 var errWeightedValueOutOfRange = errors.New("weighted pipeline value exceeds the representable money range")
-
-// convertToBase rounds amountMinor × rate half away from zero, in EXACT
-// decimal arithmetic over the rate's stored numeric digits (Int × 10^Exp)
-// — never float64, so the open-pipeline conversion carries the same
-// exactness Postgres ROUND over numeric gives closed-won, and an amount
-// past float64's 2^53 exact-integer ceiling cannot lose a minor unit. A
-// non-finite rate or an overflowing result refuses loudly: both would
-// otherwise put a silently wrong number in a money total.
-func convertToBase(amountMinor int64, rate pgtype.Numeric) (int64, error) {
-	if !rate.Valid || rate.NaN || rate.InfinityModifier != pgtype.Finite {
-		return 0, fmt.Errorf("stored FX rate is not a finite number; correct the fx_rate row before retrying the rollup")
-	}
-	product := new(big.Int).Mul(big.NewInt(amountMinor), rate.Int)
-	if rate.Exp >= 0 {
-		product.Mul(product, pow10(int64(rate.Exp)))
-	} else {
-		product = bigDivRoundHalfAwayFromZero(product, pow10(int64(-rate.Exp)))
-	}
-	if !product.IsInt64() {
-		return 0, fmt.Errorf("converted amount exceeds the representable money range in the base currency")
-	}
-	return product.Int64(), nil
-}
-
-// bigDivRoundHalfAwayFromZero is divRoundHalfAwayFromZero over big
-// integers: numerator/denominator with the quotient rounded half away
-// from zero. denominator is always a positive power of ten here.
-func bigDivRoundHalfAwayFromZero(numerator, denominator *big.Int) *big.Int {
-	negative := numerator.Sign() < 0
-	quotient, remainder := new(big.Int).QuoRem(numerator, denominator, new(big.Int))
-	remainder.Abs(remainder)
-	remainder.Lsh(remainder, 1) // 2·|remainder| ≥ denominator ⇔ the dropped fraction is ≥ half
-	if remainder.Cmp(denominator) < 0 {
-		return quotient
-	}
-	if negative {
-		return quotient.Sub(quotient, big.NewInt(1))
-	}
-	return quotient.Add(quotient, big.NewInt(1))
-}
-
-// pow10 returns 10^exp as a big integer; exp is a numeric's scale
-// magnitude, always small and never negative here.
-func pow10(exp int64) *big.Int {
-	return new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
-}
 
 // FXRateUnavailableError reports that the rollup needed a stored FX
 // rate for currency as of a point in time and none was on file — the

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -5,11 +5,8 @@ package compose
 
 import (
 	"math"
-	"math/big"
 	"testing"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -201,83 +198,15 @@ func TestWeightedValue(t *testing.T) {
 // TestWeightedValueRefusesOverflow: win_probability is DB-CHECKed to
 // [0,100] (migrations/core/0006_deals.up.sql), so a valid call can never
 // actually produce an unrepresentable result once baseMinor already fits
-// int64 (guaranteed by convertToBase) — 100% of a fitting amount always
+// int64 (guaranteed by deals.ConvertToBase) — 100% of a fitting amount always
 // fits. This drives winProbability past that domain on purpose: the
 // arithmetic itself, not the caller's discipline, must be what keeps a
 // money total honest, the same belt-and-suspenders posture
-// convertToBase takes for a rate that "should never" be non-finite.
+// deals.ConvertToBase takes for a rate that "should never" be non-finite.
 func TestWeightedValueRefusesOverflow(t *testing.T) {
 	if _, err := weightedValue(math.MaxInt64, 300); err == nil {
 		t.Error("overflowing weighted value returned no error — must refuse, a wrapped total would be a lie about money")
 	}
-}
-
-// numericRate builds a pgtype.Numeric the way pgx materializes a stored
-// numeric: coefficient × 10^exp.
-func numericRate(coefficient int64, exp int32) pgtype.Numeric {
-	return pgtype.Numeric{Int: big.NewInt(coefficient), Exp: exp, Valid: true}
-}
-
-func TestConvertToBase(t *testing.T) {
-	cases := []struct {
-		name        string
-		amountMinor int64
-		rate        pgtype.Numeric
-		want        int64
-	}{
-		{name: "rate of 1.0 is a passthrough", amountMinor: 123456, rate: numericRate(1, 0), want: 123456},
-		{name: "positive half rounds away from zero", amountMinor: 1, rate: numericRate(5, -1), want: 1},
-		{name: "negative half rounds away from zero", amountMinor: -1, rate: numericRate(5, -1), want: -1},
-		{name: "positive one-and-half rounds up", amountMinor: 3, rate: numericRate(5, -1), want: 2},
-		{name: "negative one-and-half rounds down", amountMinor: -3, rate: numericRate(5, -1), want: -2},
-		{name: "zero amount converts to zero at any rate", amountMinor: 0, rate: numericRate(137, -2), want: 0},
-		{name: "positive-exponent coefficient scales up", amountMinor: 3, rate: numericRate(2, 3), want: 6000},
-		{
-			// Above float64's 2^53 exact-integer ceiling the old float
-			// conversion would silently drop the odd minor unit; the exact
-			// decimal path must keep it.
-			name:        "amount past 2^53 keeps its last minor unit",
-			amountMinor: 9_007_199_254_740_993, // 2^53 + 1
-			rate:        numericRate(1, 0),
-			want:        9_007_199_254_740_993,
-		},
-		{
-			// Full numeric(20,10) scale: 0.0000000001 × 15,000,000,000
-			// lands exactly on the 1.5 tie, which rounds away from zero
-			// only when judged on exact decimal digits.
-			name:        "ten-decimal rate rounds on exact digits",
-			amountMinor: 15_000_000_000,
-			rate:        numericRate(1, -10),
-			want:        2, // 1.5 exactly, away from zero
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := convertToBase(tc.amountMinor, tc.rate)
-			if err != nil {
-				t.Fatalf("convertToBase(%d, %v): %v", tc.amountMinor, tc.rate, err)
-			}
-			if got != tc.want {
-				t.Errorf("convertToBase(%d, %v) = %d, want %d", tc.amountMinor, tc.rate, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestConvertToBaseRefusesDishonestResults(t *testing.T) {
-	t.Run("non-finite rate is refused", func(t *testing.T) {
-		if _, err := convertToBase(100, pgtype.Numeric{NaN: true, Valid: true}); err == nil {
-			t.Error("NaN rate converted — must refuse, a money total can never absorb it")
-		}
-	})
-	t.Run("overflowing conversion is refused", func(t *testing.T) {
-		// max-int64 minor units at rate 100 cannot fit int64; a wrapped
-		// (silently truncated) figure would be a lie about money.
-		if _, err := convertToBase(math.MaxInt64, numericRate(1, 2)); err == nil {
-			t.Error("overflowing conversion returned a value — must refuse")
-		}
-	})
 }
 
 func TestFxRateUnavailableErrorMessage(t *testing.T) {

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -14,15 +14,14 @@ package compose
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -115,7 +114,7 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 			return err
 		}
 
-		fx := &fxConverter{tx: tx, baseCurrency: baseCurrency, asOf: asOf, rates: map[string]pgtype.Numeric{}}
+		fx := &fxConverter{tx: tx, rates: deals.NewFXRates(baseCurrency, asOf), asOf: asOf}
 		if result.WeightedPipelineMinor, err = weightedPipelineMinor(ctx, tx, included, fx); err != nil {
 			return err
 		}
@@ -284,46 +283,32 @@ func orgReadablePredicate(ctx context.Context, tx pgx.Tx, nodes []orgTreeNode) (
 	return func(id ids.UUID) bool { return readable[id] }, nil
 }
 
-// fxConverter converts open-deal amounts to the workspace base currency
-// at the stored as-of rate, memoizing one lookup per currency for the
-// duration of a single rollup read. Rates stay pgtype.Numeric end to
-// end: the conversion is exact decimal arithmetic, the same discipline
-// closed-won gets from Postgres ROUND over numeric.
+// fxConverter is the rollup's missing-rate POLICY over the shared engine
+// (deals.FXRates): a currency with no stored rate on or before the as-of day
+// fails the whole read with the typed error, because a partial sum or a silent
+// rate of 1 would be a lie about money.
+//
+// The company page's read has the opposite policy over the same engine — it
+// prices what it can and reports how many deals reached the figure — and that
+// difference is the only thing the two surfaces are allowed to disagree about.
+// The lookup and the arithmetic are one implementation, so they cannot come
+// apart on rounding.
 type fxConverter struct {
-	tx           pgx.Tx
-	baseCurrency string
-	asOf         time.Time
-	rates        map[string]pgtype.Numeric
+	tx    pgx.Tx
+	rates *deals.FXRates
+	asOf  time.Time
 }
 
-// toBase converts amountMinor from currency to the base currency. A
-// currency with no stored rate on or before the as-of day fails the
-// whole read with the typed error — a partial sum or a silent rate of 1
-// would be a lie about money.
+// toBase converts amountMinor from currency to the base currency.
 func (c *fxConverter) toBase(ctx context.Context, amountMinor int64, currency string) (int64, error) {
-	if currency == c.baseCurrency {
-		return amountMinor, nil
+	rate, found, err := c.rates.For(ctx, c.tx, currency)
+	if err != nil {
+		return 0, err
 	}
-	rate, ok := c.rates[currency]
-	if !ok {
-		// The as-of day is the UTC calendar date, matching fx_rate's
-		// one-rate-per-pair-per-UTC-day grain; the text bind + cast
-		// keeps the comparison independent of the session timezone.
-		err := c.tx.QueryRow(ctx, `
-			SELECT rate FROM fx_rate
-			WHERE from_currency = $1 AND to_currency = $2 AND rate_date <= $3::date
-			ORDER BY rate_date DESC
-			LIMIT 1`,
-			currency, c.baseCurrency, c.asOf.Format(time.DateOnly)).Scan(&rate)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return 0, &FXRateUnavailableError{Currency: currency, AsOf: c.asOf}
-		}
-		if err != nil {
-			return 0, err
-		}
-		c.rates[currency] = rate
+	if !found {
+		return 0, &FXRateUnavailableError{Currency: currency, AsOf: c.asOf}
 	}
-	return convertToBase(amountMinor, rate)
+	return deals.ConvertToBase(amountMinor, rate.Rate)
 }
 
 // openDealRow is one open deal's contribution inputs: nullable money

--- a/backend/internal/modules/deals/fxconvert.go
+++ b/backend/internal/modules/deals/fxconvert.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Converting one money amount to the installation's base currency, at the rate
+// the estate stored.
+//
+// It lives HERE because this module owns fx_rate, and it is exported because
+// two readers outside the module ask the same question of it: the hierarchy
+// rollup's weighted pipeline, and the company page's own open-pipeline read.
+// They had one implementation each — Go over big.Int in one, a SQL lateral with
+// Postgres round() in the other — encoding the same four decisions: the
+// direction, the as-of cutoff, newest-wins, and the multiply-and-round.
+//
+// The two agreed. Nothing made them keep agreeing, and the first divergence
+// would have been rounding — half-away-from-zero against Postgres round() — so
+// a one-minor-unit disagreement between the company page and the rollup for the
+// same account, which is the class of defect nobody can reproduce on demand.
+//
+// WHAT IS NOT SHARED is the missing-rate policy, and that is deliberate: the
+// rollup refuses the whole read, because a partial total presented as a total
+// is a lie about money; the company page prices what it can and counts the rest,
+// because its contract says how many deals reached the figure. Both are right
+// for their own surface. The engine answers "is there a rate, and what does it
+// make of this amount" and leaves what to DO about a missing one to the caller.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// FXRate is one stored rate and the day it is dated. They are ONE answer and
+// must travel together: a date coalesced from somewhere else could name a day
+// whose rate is not the rate a figure was computed at.
+type FXRate struct {
+	Rate pgtype.Numeric
+	On   time.Time
+}
+
+// FXRates answers what one currency converts at, memoizing a lookup per
+// currency for the life of one read.
+//
+// Per READ and not per process: a rate is appended forward and a long-lived
+// cache would price a rollup at a rate the estate has since corrected. The
+// caller builds one, uses it, and drops it.
+type FXRates struct {
+	base  string
+	asOf  time.Time
+	found map[string]FXRate
+	// missing is remembered too. A currency with no rate is a fact about the
+	// estate, and re-asking per deal turns one refusal into a query per row.
+	missing map[string]bool
+}
+
+// NewFXRates opens a lookup against the installation's base currency, reading
+// the newest rate dated on or before asOf.
+func NewFXRates(base string, asOf time.Time) *FXRates {
+	return &FXRates{base: base, asOf: asOf, found: map[string]FXRate{}, missing: map[string]bool{}}
+}
+
+// Base is the currency everything converts to.
+func (r *FXRates) Base() string { return r.base }
+
+// For answers the rate that converts currency into the base, and whether the
+// estate holds one at all.
+//
+// A currency that IS the base answers a rate of exactly 1 dated the as-of day,
+// rather than making every caller special-case it. That is not an invented
+// rate: it is the identity, and the alternative — each caller comparing
+// currencies before asking — is how one of them comes to compare them
+// differently.
+func (r *FXRates) For(ctx context.Context, tx pgx.Tx, currency string) (FXRate, bool, error) {
+	if currency == r.base {
+		return FXRate{Rate: oneRate(), On: r.asOf}, true, nil
+	}
+	if rate, ok := r.found[currency]; ok {
+		return rate, true, nil
+	}
+	if r.missing[currency] {
+		return FXRate{}, false, nil
+	}
+	var rate FXRate
+	// The as-of day is the UTC calendar date, matching fx_rate's
+	// one-rate-per-pair-per-UTC-day grain; the text bind + cast keeps the
+	// comparison independent of the session timezone.
+	err := tx.QueryRow(ctx, `
+		SELECT rate, rate_date FROM fx_rate
+		WHERE from_currency = $1 AND to_currency = $2 AND rate_date <= $3::date
+		ORDER BY rate_date DESC
+		LIMIT 1`,
+		currency, r.base, r.asOf.Format(time.DateOnly)).Scan(&rate.Rate, &rate.On)
+	if errors.Is(err, pgx.ErrNoRows) {
+		r.missing[currency] = true
+		return FXRate{}, false, nil
+	}
+	if err != nil {
+		return FXRate{}, false, fmt.Errorf("read the stored FX rate for %s: %w", currency, err)
+	}
+	r.found[currency] = rate
+	return rate, true, nil
+}
+
+// oneRate is the identity rate, as a numeric rather than as a special case in
+// the arithmetic below.
+func oneRate() pgtype.Numeric {
+	return pgtype.Numeric{Int: big.NewInt(1), Exp: 0, Valid: true}
+}
+
+// ConvertToBase rounds amountMinor × rate half away from zero, in EXACT decimal
+// arithmetic over the rate's stored numeric digits (Int × 10^Exp).
+//
+// Never float64, so a converted amount carries the same exactness Postgres
+// ROUND over numeric gives a closed deal's frozen figure, and an amount past
+// float64's 2^53 exact-integer ceiling cannot lose a minor unit.
+//
+// A non-finite rate or an overflowing result refuses loudly: both would
+// otherwise put a silently wrong number in a money total.
+func ConvertToBase(amountMinor int64, rate pgtype.Numeric) (int64, error) {
+	if !rate.Valid || rate.NaN || rate.InfinityModifier != pgtype.Finite {
+		return 0, errors.New("stored FX rate is not a finite number; correct the fx_rate row before retrying")
+	}
+	product := new(big.Int).Mul(big.NewInt(amountMinor), rate.Int)
+	if rate.Exp >= 0 {
+		product.Mul(product, Pow10(int64(rate.Exp)))
+	} else {
+		product = DivRoundHalfAwayFromZero(product, Pow10(int64(-rate.Exp)))
+	}
+	if !product.IsInt64() {
+		return 0, errors.New("converted amount exceeds the representable money range in the base currency")
+	}
+	return product.Int64(), nil
+}
+
+// DivRoundHalfAwayFromZero is numerator/denominator with the quotient rounded
+// half away from zero. denominator is always a positive power of ten here.
+func DivRoundHalfAwayFromZero(numerator, denominator *big.Int) *big.Int {
+	negative := numerator.Sign() < 0
+	quotient, remainder := new(big.Int).QuoRem(numerator, denominator, new(big.Int))
+	remainder.Abs(remainder)
+	remainder.Lsh(remainder, 1) // 2·|remainder| ≥ denominator ⇔ the dropped fraction is ≥ half
+	if remainder.Cmp(denominator) < 0 {
+		return quotient
+	}
+	if negative {
+		return quotient.Sub(quotient, big.NewInt(1))
+	}
+	return quotient.Add(quotient, big.NewInt(1))
+}
+
+// Pow10 returns 10^exp as a big integer; exp is a numeric's scale magnitude,
+// always small and never negative here.
+func Pow10(exp int64) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
+}

--- a/backend/internal/modules/deals/fxconvert_test.go
+++ b/backend/internal/modules/deals/fxconvert_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The conversion's arithmetic, proven without a database.
+//
+// These cases moved here with the function they test. Two surfaces used to
+// convert money to the base currency their own way, and the first divergence
+// anyone predicted was rounding — so the rounding rule is now proven once,
+// beside the one implementation, rather than in whichever caller happened to
+// have a test.
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// numericRate builds a pgtype.Numeric the way pgx materializes a stored
+// numeric: coefficient × 10^exp.
+func numericRate(coefficient int64, exp int32) pgtype.Numeric {
+	return pgtype.Numeric{Int: big.NewInt(coefficient), Exp: exp, Valid: true}
+}
+
+func TestConvertToBase(t *testing.T) {
+	cases := []struct {
+		name        string
+		amountMinor int64
+		rate        pgtype.Numeric
+		want        int64
+	}{
+		{name: "rate of 1.0 is a passthrough", amountMinor: 123456, rate: numericRate(1, 0), want: 123456},
+		{name: "positive half rounds away from zero", amountMinor: 1, rate: numericRate(5, -1), want: 1},
+		{name: "negative half rounds away from zero", amountMinor: -1, rate: numericRate(5, -1), want: -1},
+		{name: "positive one-and-half rounds up", amountMinor: 3, rate: numericRate(5, -1), want: 2},
+		{name: "negative one-and-half rounds down", amountMinor: -3, rate: numericRate(5, -1), want: -2},
+		{name: "zero amount converts to zero at any rate", amountMinor: 0, rate: numericRate(137, -2), want: 0},
+		{name: "positive-exponent coefficient scales up", amountMinor: 3, rate: numericRate(2, 3), want: 6000},
+		{
+			// Above float64's 2^53 exact-integer ceiling the old float
+			// conversion would silently drop the odd minor unit; the exact
+			// decimal path must keep it.
+			name:        "amount past 2^53 keeps its last minor unit",
+			amountMinor: 9_007_199_254_740_993, // 2^53 + 1
+			rate:        numericRate(1, 0),
+			want:        9_007_199_254_740_993,
+		},
+		{
+			// Full numeric(20,10) scale: 0.0000000001 × 15,000,000,000
+			// lands exactly on the 1.5 tie, which rounds away from zero
+			// only when judged on exact decimal digits.
+			name:        "ten-decimal rate rounds on exact digits",
+			amountMinor: 15_000_000_000,
+			rate:        numericRate(1, -10),
+			want:        2, // 1.5 exactly, away from zero
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertToBase(tc.amountMinor, tc.rate)
+			if err != nil {
+				t.Fatalf("ConvertToBase(%d, %v): %v", tc.amountMinor, tc.rate, err)
+			}
+			if got != tc.want {
+				t.Errorf("ConvertToBase(%d, %v) = %d, want %d", tc.amountMinor, tc.rate, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertToBaseRefusesDishonestResults(t *testing.T) {
+	t.Run("non-finite rate is refused", func(t *testing.T) {
+		if _, err := ConvertToBase(100, pgtype.Numeric{NaN: true, Valid: true}); err == nil {
+			t.Error("NaN rate converted — must refuse, a money total can never absorb it")
+		}
+	})
+	t.Run("overflowing conversion is refused", func(t *testing.T) {
+		// max-int64 minor units at rate 100 cannot fit int64; a wrapped
+		// (silently truncated) figure would be a lie about money.
+		if _, err := ConvertToBase(math.MaxInt64, numericRate(1, 2)); err == nil {
+			t.Error("overflowing conversion returned a value — must refuse")
+		}
+	})
+}

--- a/backend/internal/modules/deals/fxconvert_test.go
+++ b/backend/internal/modules/deals/fxconvert_test.go
@@ -86,3 +86,23 @@ func TestConvertToBaseRefusesDishonestResults(t *testing.T) {
 		}
 	})
 }
+
+// TestConvertToBaseRefusesRatherThanWrapping is the property both callers rest
+// their own policy on.
+//
+// They differ in what they DO with the refusal — one fails the whole read, the
+// other leaves that deal unpriced and counted — and neither is safe if the
+// engine can return a wrapped number instead of refusing. So the refusal is
+// proven here, once, rather than assumed at two call sites.
+func TestConvertToBaseRefusesRatherThanWrapping(t *testing.T) {
+	// The largest rate the column holds, against an amount near the top of its
+	// own range: a product no int64 can carry.
+	if _, err := ConvertToBase(math.MaxInt64, numericRate(9_999_999_999, 0)); err == nil {
+		t.Error("a product past int64 returned a value — a wrapped figure is a plausible-looking wrong " +
+			"number, which is worse than no number")
+	}
+	// And the boundary the other way: a product that exactly fits is answered.
+	if got, err := ConvertToBase(math.MaxInt64, numericRate(1, 0)); err != nil || got != math.MaxInt64 {
+		t.Errorf("the largest representable product = %d, %v; want it answered, not refused", got, err)
+	}
+}

--- a/backend/internal/modules/deals/fxrates_integration_test.go
+++ b/backend/internal/modules/deals/fxrates_integration_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package deals
+
+// The lookup half of the conversion engine, against a real database.
+//
+// The arithmetic is proven without one (fxconvert_test.go) because it is
+// arithmetic. This is the half that cannot be: which row the as-of cutoff and
+// newest-wins select, and — the reason this file exists at all — that a bare
+// DATE column decodes into the time.Time the engine scans it into. Two files in
+// this tree disagreed about that in prose, and only a read against real rows
+// settles it.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+// seedRate writes one effective-dated rate straight in, so the test arranges
+// what it means rather than through the write path's own guards.
+func (e *configEnv) seedRate(t *testing.T, from string, rate string, on time.Time) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO fx_rate (from_currency, to_currency, rate, rate_date)
+		VALUES ($1, 'EUR', $2::numeric, $3::date)
+		ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE SET rate = excluded.rate`,
+		from, rate, on.Format(time.DateOnly)); err != nil {
+		t.Fatalf("seeding the %s rate for %s: %v", from, on.Format(time.DateOnly), err)
+	}
+}
+
+// TestTheEngineReadsTheNewestRateOnOrBeforeTheAsOfDay holds the two decisions
+// the lookup makes, and the decode that carries the answer back.
+func TestTheEngineReadsTheNewestRateOnOrBeforeTheAsOfDay(t *testing.T) {
+	e := setupConfigEnv(t)
+	ctx := e.as()
+
+	asOf := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	e.seedRate(t, "JPY", "0.0055", asOf.AddDate(0, 0, -5))
+	e.seedRate(t, "JPY", "0.0061", asOf.AddDate(0, 0, -1)) // the newest on or before
+	e.seedRate(t, "JPY", "0.9999", asOf.AddDate(0, 0, 3))  // after: must not be chosen
+
+	var got FXRate
+	var found bool
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var err error
+		got, found, err = NewFXRates("EUR", asOf).For(ctx, tx, "JPY")
+		return err
+	}); err != nil {
+		t.Fatalf("reading the JPY rate: %v", err)
+	}
+	if !found {
+		t.Fatal("no rate found for a currency three rates were seeded for")
+	}
+	// The DATE column, decoded. This assertion is the file's reason: a bare date
+	// that did not decode into time.Time would have failed the scan above, and
+	// no unit test over the arithmetic could have found it.
+	if want := asOf.AddDate(0, 0, -1); !got.On.Equal(want) {
+		t.Errorf("the rate is dated %s, want %s — the newest ON OR BEFORE the as-of day, never one after it",
+			got.On.Format(time.DateOnly), want.Format(time.DateOnly))
+	}
+	// 100 minor units at 0.0061 is 0.61, which rounds to 1 away from zero.
+	converted, err := ConvertToBase(100, got.Rate)
+	if err != nil {
+		t.Fatalf("converting at the read rate: %v", err)
+	}
+	if converted != 1 {
+		t.Errorf("100 minor units at the read rate = %d, want 1 — the rate that came back is not the one "+
+			"seeded for that day", converted)
+	}
+}
+
+// A currency the estate holds no rate for answers "not found" rather than an
+// error or an invented rate. The caller's policy decides what that means, and
+// both callers have a different one.
+func TestTheEngineAnswersNotFoundForAnUnpricedCurrency(t *testing.T) {
+	e := setupConfigEnv(t)
+	ctx := e.as()
+
+	var found bool
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var err error
+		_, found, err = NewFXRates("EUR", time.Now().UTC()).For(ctx, tx, "XPF")
+		return err
+	}); err != nil {
+		t.Fatalf("reading an unpriced currency: %v", err)
+	}
+	if found {
+		t.Error("a currency with no stored rate answered found — nothing may invent a rate")
+	}
+}
+
+// The base currency converts at the identity, without a row and without a
+// query. Every caller would otherwise compare currencies itself, which is how
+// one of them comes to compare them differently.
+func TestTheBaseCurrencyNeedsNoStoredRate(t *testing.T) {
+	e := setupConfigEnv(t)
+	ctx := e.as()
+
+	var got FXRate
+	var found bool
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var err error
+		got, found, err = NewFXRates("EUR", time.Now().UTC()).For(ctx, tx, "EUR")
+		return err
+	}); err != nil {
+		t.Fatalf("reading the base currency: %v", err)
+	}
+	if !found {
+		t.Fatal("the base currency answered not found")
+	}
+	converted, err := ConvertToBase(123456, got.Rate)
+	if err != nil {
+		t.Fatalf("converting at the identity rate: %v", err)
+	}
+	if converted != 123456 {
+		t.Errorf("the base currency converted %d to %d, want a passthrough", 123456, converted)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -181,7 +181,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (32)
+## Prohibition (33)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -204,6 +204,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `logsecrets_test.go` | H2 | A credential reaches a log field only on the failure of the channel that was supposed to carry it. |
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
 | `moduletablespelling_test.go` | H2 | A package that names its table does not pass that name as a bare string. |
+| `onecurrencyconversion_test.go` | H2 | Converting money to the base currency has one implementation. |
 | `pipefailgrepq_test.go` | H2 | A shell gate does not decide its verdict through a pipe that can break. |
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |


### PR DESCRIPTION
Closes #2452.

## Two implementations of one decision

Converting a money amount to the installation's base currency at the latest stored rate was implemented **twice, in two languages**:

- `compose/orgrollupread.go` — `fxConverter.toBase`, Go, exact decimal over `big.Int`, memoized per currency, refusing the whole read on a missing rate.
- `compose/org360/pipelineread.go` — a `LEFT JOIN LATERAL` on `fx_rate` with `round(amount_minor * rate)::bigint`, one lookup per row, contributing nothing for a missing rate.

Both encoded the same four decisions: the direction, the as-of cutoff (`rate_date <= as_of`), newest-wins (`ORDER BY rate_date DESC LIMIT 1`), and the multiply-and-round. They agreed. Nothing made them keep agreeing, and the predicted first divergence was the **rounding** — half-away-from-zero against Postgres `round()` — which is a one-minor-unit disagreement between two pages about the same account, and the kind of defect nobody can reproduce on demand.

## The engine, and what it deliberately does not decide

`deals.FXRates` and `deals.ConvertToBase` live in the module that **owns `fx_rate`**, which is also the one place both callers may import from (`org360` already imports `deals`).

The lookup memoizes per currency for the life of **one read** — per read and not per process, because a rate is appended forward and a long-lived cache would price a rollup at a rate the estate has since corrected. A currency that *is* the base answers the identity rate rather than making every caller special-case it, which is how one of them comes to special-case it differently.

**The missing-rate policy is not shared, and that is the point.** The rollup refuses the whole read, because a partial total presented as a total is a lie about money. The company page prices what it can and reports how many deals reached the figure, because its contract says so. Both are right for their own surface. The engine answers *"is there a rate, and what does it make of this amount"* and leaves the rest to the caller — which is exactly the split the ticket asks for.

`org360` stops converting in SQL: it reads the deal, and the engine does the rest — once per **currency** rather than once per row.

## The gate found two more

`TestMoneyConvertsToTheBaseCurrencyInOnePlace` hunts a read of `fx_rate` outside the engine, and an amount multiplied by a rate in SQL. Beyond the two the ticket names it reported:

- **`quotas.targetInBase`** — a third implementation, forced by the module DAG: `quotas` is a module and a module never imports a sibling (ADR-0054 §3), so it cannot reach the engine. Its own comment already names the two implementations it mirrors. Ratified with that reason; holding it identical is an obligation this gate cannot discharge.
- **`briefs.briefrank`** — a fourth, and the only ratified one that *could* reach the engine. It converts inside a larger ranking query and answers a wider question: a **closed** deal reads its frozen `amount_minor_base`, which is a stored figure rather than a conversion. Moving it means restructuring that query and teaching the engine the frozen case — its own change rather than a line in this one.

Both are recorded so they are known copies rather than unnoticed ones. A **fifth**, anywhere the engine is reachable, fails.

Mutation-checked by dropping the `briefrank` ratification: both arms report it, by file and by which half it spells.

## The arithmetic's tests moved with it

`TestConvertToBase`'s cases now sit beside the one implementation — including the two that matter most here: an amount past float64's 2^53 ceiling keeping its last minor unit, and a full `numeric(20,10)` rate landing exactly on the 1.5 tie, which rounds away from zero only when judged on exact decimal digits.

`make check-backend`, `craft-static`, and the `org360` and organization-computed integration lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent currency conversion and exchange-rate handling across pricing and rollup calculations.
  - Added date-aware rate selection and automatic base-currency conversion.
  - Improved precision for rounding, negative amounts, and large values.

- **Bug Fixes**
  - Prevented invalid or overflowing conversions from producing unreliable amounts.
  - Ensured open deals are priced only when valid amounts and exchange rates are available.

- **Tests**
  - Added coverage for conversion accuracy, rate selection, rounding, overflow, invalid rates, and duplicate logic.

- **Documentation**
  - Updated the gate inventory with the new conversion consistency check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->