### PR TITLE
The gate inventory counts every parity gate

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (42)
+## Parity (43)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
`main` is red: `TestTheGateInventoryPageIsCurrent` reports the page no longer matches the `//gate:kind` declarations in the tree.

Two changes each added a parity gate (#3101's catalog-tier gate and #3102's module-ownership gate) and each regenerated `gate-inventory.md` against its own base. Both regenerations wrote **42 → 43** from the same starting number, so the second to merge left the count at 42 for a tree that now holds 43.

Regenerated. One line.

Worth noting because it will happen again: the page's per-kind counts make any two concurrent gate additions conflict semantically without conflicting textually — each writes the same new number, so git merges them cleanly into a wrong one. Nothing here changes that; the gate catches it on the next run, which is what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Parity gate inventory count from 42 to 43.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->