### PR TITLE
A backfill is read rather than marked read

### DIFF
--- a/backend/internal/compose/integration/signalextract_integration_test.go
+++ b/backend/internal/compose/integration/signalextract_integration_test.go
@@ -799,3 +799,47 @@ func TestAParkedThreadIsOfferedAgainOnceTheParkExpires(t *testing.T) {
 		t.Errorf("open signals after the recovered read = %v, want [contract_ended]", kinds)
 	}
 }
+
+// TestALongThreadIsWalkedToItsStartOnePassAtATime is the half a direct call to
+// threadMessages cannot reach: the QUEUE has to keep offering the thread until
+// its history is covered.
+//
+// The window is six messages and a conversation can be longer. A pass that read
+// one window and recorded the whole message count left the thread looking
+// settled — the newest has not moved and the count has not moved — so the older
+// half was never read, and "walks back a window per pass" was a description
+// rather than a behaviour.
+func TestALongThreadIsWalkedToItsStartOnePassAtATime(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", &e.Rep1)
+
+	// Three windows' worth, oldest last so the seeding order is not what the
+	// walk follows.
+	const messages = 3 * 6
+	newest := extractClock.Add(-48 * time.Hour)
+	for i := range messages {
+		seedThread(t, e, org, "thread-long", "Renewal",
+			"A message on the thread.", "inbound", newest.Add(-time.Duration(i)*time.Hour))
+	}
+
+	brain := &scriptedBrain{reply: `{"events": []}`}
+	// Each pass reads one window, and the thread stays due while history
+	// remains below the cursor. Three passes reach the start; a fourth finds
+	// nothing left to walk back to.
+	for pass := 1; pass <= 3; pass++ {
+		extractPass(t, e, brain)
+		if brain.calls != pass {
+			t.Fatalf("after pass %d the model had been called %d times, want %d — a thread with unread "+
+				"history must stay due until it is covered", pass, brain.calls, pass)
+		}
+	}
+
+	// The whole conversation has now been read, so the thread settles: nothing
+	// newer, nothing older, and no reason to spend the model on it again.
+	extractPass(t, e, brain)
+	if brain.calls != 3 {
+		t.Errorf("a fourth pass called the model %d times over a fully read thread, want it left alone — "+
+			"a thread that stays due forever holds a slot in every pass while the backlog behind it starves",
+			brain.calls)
+	}
+}

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -97,6 +97,18 @@ type settledThread struct {
 	// The timestamp alone cannot see a message inserted at the same instant, or
 	// a backfill filling in older ones; the count changes for both.
 	Count int
+	// ReadTo and ReadFrom are the two ends a PREVIOUS read reached: the newest
+	// message it covered and the oldest. Both nil on a thread never scanned.
+	//
+	// Two ends and not one, because a conversation grows at both. Newer than
+	// ReadTo is new mail; older than ReadFrom is a backfill; and a scan that
+	// tracked only how far forward it had got could not see the second at all.
+	ReadTo   *time.Time
+	ReadFrom *time.Time
+	// ReadFromNow is the oldest message THIS pass read, which becomes ReadFrom
+	// for the next one. Set by threadMessages, because the window it chose is
+	// the only thing that knows.
+	ReadFromNow *time.Time
 	// PrivateTo is the one reader this conversation answers to, or the zero
 	// value when every message on it is workspace-readable.
 	//
@@ -176,7 +188,10 @@ var dueThreadsQuery = `
 			 GROUP BY a.thread_key
 		)
 		SELECT c.thread_key, c.one_org::uuid, c.newest, c.message_count,
-		       CASE WHEN c.shared THEN NULL ELSE c.private_owner::uuid END
+		       CASE WHEN c.shared THEN NULL ELSE c.private_owner::uuid END,
+		       -- The two ends a previous read reached, so this one can tell new
+		       -- mail from a backfill. Both null on a thread never scanned.
+		       s.last_activity_at, s.scanned_from
 		  FROM conversation c
 		  LEFT JOIN signal_thread_scan s ON s.thread_key = c.thread_key
 		 WHERE c.org_count = 1
@@ -258,7 +273,8 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 		var thread settledThread
 		var privateTo *ids.UUID
 		if err := rows.Scan(&thread.Key, &thread.OrganizationID,
-			&thread.Newest, &thread.Count, &privateTo); err != nil {
+			&thread.Newest, &thread.Count, &privateTo,
+			&thread.ReadTo, &thread.ReadFrom); err != nil {
 			return nil, err
 		}
 		if privateTo != nil {
@@ -270,7 +286,7 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 		return nil, err
 	}
 	for i := range due {
-		messages, err := threadMessages(ctx, tx, due[i].Key)
+		messages, err := threadMessages(ctx, tx, &due[i])
 		if err != nil {
 			return nil, err
 		}
@@ -279,9 +295,36 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 	return due, nil
 }
 
-// threadMessages reads the tail of one conversation, oldest first, so the
+// threadMessages reads one window of a conversation, oldest first, so the
 // prompt reads in the order the exchange happened.
-func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage, error) {
+//
+// WHICH window is the whole of this function's judgement, and it used to have
+// none: it always read the newest six. A backfill made the thread due again —
+// the count changed — the same newest six were re-read, and the new count was
+// recorded. The inserted older messages never reached the model and the thread
+// then looked read, which is the bad direction: the state says handled, nothing
+// errored, and nothing says content was skipped.
+//
+// Two ends, asked in this order:
+//
+//   - NEW MAIL FIRST. Messages newer than the last read are why the
+//     conversation is interesting now, and a thread that walked backwards
+//     through its history while a reply sat unread would be reading the least
+//     useful end of it.
+//   - THEN THE UNREAD OLDER RANGE. With nothing new, a message older than where
+//     reading started is a backfill, and the window is the newest of THOSE — so
+//     a long thread walks backwards one window per pass until its history is
+//     covered, rather than never reaching it.
+//
+// Neither end left: the newest window, which is what a thread with no scan row
+// gets and what every thread got before.
+func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]threadMessage, error) {
+	// The upper bound of the window. Nothing to read older means the newest
+	// end; a backfill below where reading started means walk back from there.
+	var olderThan *time.Time
+	if thread.ReadTo != nil && !thread.Newest.After(*thread.ReadTo) && thread.ReadFrom != nil {
+		olderThan = thread.ReadFrom
+	}
 	// The remainder is measured in the same statement that cuts the body:
 	// asked for afterwards it would be a second read of a row that may have
 	// changed, and the number would then describe a different message from the
@@ -293,9 +336,12 @@ func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage
 		  FROM (SELECT id, direction, subject, body, occurred_at
 		          FROM activity
 		         WHERE thread_key = $2 AND kind = 'email' AND archived_at IS NULL
+		           -- Null means no bound: the newest window, which is the
+		           -- ordinary case and the one a thread starts from.
+		           AND ($4::timestamptz IS NULL OR occurred_at < $4)
 		         ORDER BY occurred_at DESC, id DESC
 		         LIMIT $3) tail
-		 ORDER BY occurred_at, id`, extractBodyLimit, key, extractThreadMessages)
+		 ORDER BY occurred_at, id`, extractBodyLimit, thread.Key, extractThreadMessages, olderThan)
 	if err != nil {
 		return nil, fmt.Errorf("read the conversation: %w", err)
 	}
@@ -317,13 +363,19 @@ func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	if len(out) > 0 {
+		// The window's own lower end, reported so the mark can lower the
+		// cursor to it. Rows come back oldest first, so it is the first.
+		oldest := out[0].At
+		thread.ReadFromNow = &oldest
+	}
 	if cut > 0 {
 		// Said once per conversation rather than once per message: what a
 		// reader needs is how much of THIS exchange the reading was drawn
 		// from, and a line per body would bury that under the long threads it
 		// is most true of.
 		slog.WarnContext(ctx, "part of this conversation was not read; the events extracted from it are drawn from the head of each mail and anything stated below the cut is absent rather than judged",
-			"thread_key", key, "messages_cut", cut, "messages_read", len(out),
+			"thread_key", thread.Key, "messages_cut", cut, "messages_read", len(out),
 			"body_limit", extractBodyLimit, "unread_runes", unread)
 	}
 	return out, nil
@@ -380,10 +432,16 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO signal_thread_scan
 		  (thread_key, last_activity_at, message_count, scanned_at,
-		   resolved_org_id)
-		VALUES ($1, $2, $3, $4, $5)
+		   resolved_org_id, scanned_from)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (thread_key) DO UPDATE
 		   SET last_activity_at = greatest(signal_thread_scan.last_activity_at, excluded.last_activity_at),
+		       -- The oldest message ever read, so it only ever moves EARLIER.
+		       -- least() over a null is null in Postgres only for the operands
+		       -- it has none of — least(x, NULL) is x — which is what carries a
+		       -- cursor through a pass that read the newest window and reached
+		       -- nothing older.
+		       scanned_from = least(signal_thread_scan.scanned_from, excluded.scanned_from),
 		       message_count = excluded.message_count,
 		       scanned_at = excluded.scanned_at,
 		       -- WHICH account this reading was for. Overwritten, never
@@ -397,7 +455,8 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now
 		       refusals = 0,
 		       refused_activity_at = NULL,
 		       refused_message_count = NULL`,
-		thread.Key, thread.Newest, thread.Count, now, thread.OrganizationID); err != nil {
+		thread.Key, thread.Newest, thread.Count, now, thread.OrganizationID,
+		thread.ReadFromNow); err != nil {
 		return fmt.Errorf("record where the read got to: %w", err)
 	}
 	return nil

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -18,7 +18,6 @@ package compose
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -191,7 +190,13 @@ var dueThreadsQuery = `
 		       CASE WHEN c.shared THEN NULL ELSE c.private_owner::uuid END,
 		       -- The two ends a previous read reached, so this one can tell new
 		       -- mail from a backfill. Both null on a thread never scanned.
-		       s.last_activity_at, s.scanned_from
+		       --
+		       -- NULLIF over -infinity, which is what a REFUSAL writes: the row
+		       -- exists to hold the refusal count, and no read has happened, so
+		       -- "how far did reading get" has the same answer as a thread with
+		       -- no row at all. It is also not a time.Time, so scanning it
+		       -- would fail the whole pass.
+		       NULLIF(s.last_activity_at, '-infinity'), s.scanned_from
 		  FROM conversation c
 		  LEFT JOIN signal_thread_scan s ON s.thread_key = c.thread_key
 		 WHERE c.org_count = 1
@@ -293,92 +298,6 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 		due[i].Messages = messages
 	}
 	return due, nil
-}
-
-// threadMessages reads one window of a conversation, oldest first, so the
-// prompt reads in the order the exchange happened.
-//
-// WHICH window is the whole of this function's judgement, and it used to have
-// none: it always read the newest six. A backfill made the thread due again —
-// the count changed — the same newest six were re-read, and the new count was
-// recorded. The inserted older messages never reached the model and the thread
-// then looked read, which is the bad direction: the state says handled, nothing
-// errored, and nothing says content was skipped.
-//
-// Two ends, asked in this order:
-//
-//   - NEW MAIL FIRST. Messages newer than the last read are why the
-//     conversation is interesting now, and a thread that walked backwards
-//     through its history while a reply sat unread would be reading the least
-//     useful end of it.
-//   - THEN THE UNREAD OLDER RANGE. With nothing new, a message older than where
-//     reading started is a backfill, and the window is the newest of THOSE — so
-//     a long thread walks backwards one window per pass until its history is
-//     covered, rather than never reaching it.
-//
-// Neither end left: the newest window, which is what a thread with no scan row
-// gets and what every thread got before.
-func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]threadMessage, error) {
-	// The upper bound of the window. Nothing to read older means the newest
-	// end; a backfill below where reading started means walk back from there.
-	var olderThan *time.Time
-	if thread.ReadTo != nil && !thread.Newest.After(*thread.ReadTo) && thread.ReadFrom != nil {
-		olderThan = thread.ReadFrom
-	}
-	// The remainder is measured in the same statement that cuts the body:
-	// asked for afterwards it would be a second read of a row that may have
-	// changed, and the number would then describe a different message from the
-	// one in the prompt.
-	rows, err := tx.Query(ctx, `
-		SELECT id, coalesce(direction, ''), coalesce(subject, ''),
-		       coalesce(left(body, $1), ''),
-		       greatest(coalesce(char_length(body), 0) - $1, 0), occurred_at
-		  FROM (SELECT id, direction, subject, body, occurred_at
-		          FROM activity
-		         WHERE thread_key = $2 AND kind = 'email' AND archived_at IS NULL
-		           -- Null means no bound: the newest window, which is the
-		           -- ordinary case and the one a thread starts from.
-		           AND ($4::timestamptz IS NULL OR occurred_at < $4)
-		         ORDER BY occurred_at DESC, id DESC
-		         LIMIT $3) tail
-		 ORDER BY occurred_at, id`, extractBodyLimit, thread.Key, extractThreadMessages, olderThan)
-	if err != nil {
-		return nil, fmt.Errorf("read the conversation: %w", err)
-	}
-	defer rows.Close()
-	var out []threadMessage
-	unread, cut := 0, 0
-	for rows.Next() {
-		var message threadMessage
-		if err := rows.Scan(&message.ID, &message.Direction, &message.Subject,
-			&message.Body, &message.UnreadRunes, &message.At); err != nil {
-			return nil, err
-		}
-		if message.UnreadRunes > 0 {
-			unread += message.UnreadRunes
-			cut++
-		}
-		out = append(out, message)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	if len(out) > 0 {
-		// The window's own lower end, reported so the mark can lower the
-		// cursor to it. Rows come back oldest first, so it is the first.
-		oldest := out[0].At
-		thread.ReadFromNow = &oldest
-	}
-	if cut > 0 {
-		// Said once per conversation rather than once per message: what a
-		// reader needs is how much of THIS exchange the reading was drawn
-		// from, and a line per body would bury that under the long threads it
-		// is most true of.
-		slog.WarnContext(ctx, "part of this conversation was not read; the events extracted from it are drawn from the head of each mail and anything stated below the cut is absent rather than judged",
-			"thread_key", thread.Key, "messages_cut", cut, "messages_read", len(out),
-			"body_limit", extractBodyLimit, "unread_runes", unread)
-	}
-	return out, nil
 }
 
 // recordThreadRefusal counts one refused reading of this exact conversation

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -104,10 +104,16 @@ type settledThread struct {
 	// tracked only how far forward it had got could not see the second at all.
 	ReadTo   *time.Time
 	ReadFrom *time.Time
-	// ReadFromNow is the oldest message THIS pass read, which becomes ReadFrom
-	// for the next one. Set by threadMessages, because the window it chose is
-	// the only thing that knows.
-	ReadFromNow *time.Time
+	// ReadFromID pairs with ReadFrom, because an INSTANT IS NOT A MESSAGE
+	// BOUNDARY: mail imported in bulk shares an occurred_at routinely, and a
+	// cursor that is a timestamp alone either skips the rest of a group or
+	// re-reads it forever. (occurred_at, id) is the order the window walks in.
+	ReadFromID *ids.UUID
+	// ReadFromNow and ReadFromIDNow are the oldest message THIS pass read,
+	// which becomes the cursor for the next one. Set by threadMessages, because
+	// the window it chose is the only thing that knows.
+	ReadFromNow   *time.Time
+	ReadFromIDNow *ids.UUID
 	// PrivateTo is the one reader this conversation answers to, or the zero
 	// value when every message on it is workspace-readable.
 	//
@@ -131,6 +137,18 @@ var dueThreadsQuery = `
 		WITH conversation AS (
 			SELECT a.thread_key,
 			       max(a.occurred_at) AS newest,
+			       -- The thread's own lower end, as the pair the cursor is.
+			       -- min(id) FILTER on the minimum instant, because the oldest
+			       -- MESSAGE is not the smallest id at any other instant.
+			       min(a.occurred_at) AS oldest,
+			       -- min() has no uuid overload, so the id is compared as text.
+			       -- A uuidv7 orders the same either way — its text form is the
+			       -- big-endian bytes in hex — and the read below casts it back.
+			       min(a.id::text) FILTER (WHERE a.occurred_at = (
+			         SELECT min(b.occurred_at) FROM activity b
+			          WHERE b.thread_key = a.thread_key AND b.kind = 'email'
+			            AND b.archived_at IS NULL AND b.captured_by LIKE 'connector:%'
+			       ))::uuid AS oldest_id,
 			       count(DISTINCT a.id) AS message_count,
 			       min(ro.organization_id::text) AS one_org,
 			       count(DISTINCT ro.organization_id) AS org_count,
@@ -196,7 +214,7 @@ var dueThreadsQuery = `
 		       -- "how far did reading get" has the same answer as a thread with
 		       -- no row at all. It is also not a time.Time, so scanning it
 		       -- would fail the whole pass.
-		       NULLIF(s.last_activity_at, '-infinity'), s.scanned_from
+		       NULLIF(s.last_activity_at, '-infinity'), s.scanned_from, s.scanned_from_id
 		  FROM conversation c
 		  LEFT JOIN signal_thread_scan s ON s.thread_key = c.thread_key
 		 WHERE c.org_count = 1
@@ -228,7 +246,16 @@ var dueThreadsQuery = `
 		   AND (s.thread_key IS NULL
 		        OR s.last_activity_at < c.newest
 		        OR s.message_count <> c.message_count
-		        OR s.resolved_org_id IS DISTINCT FROM c.one_org::uuid)
+		        OR s.resolved_org_id IS DISTINCT FROM c.one_org::uuid
+		        -- Or there is history left BELOW the cursor. A window is six
+		        -- messages and a thread can be longer, so a pass that read one
+		        -- window and recorded the whole count would otherwise never be
+		        -- offered the rest: the newest has not moved, the count has
+		        -- not moved, and the older half is simply never read. This is
+		        -- what makes "walks back a window per pass" true rather than
+		        -- described.
+		        OR (s.scanned_from IS NOT NULL
+		            AND (c.oldest, c.oldest_id) < (s.scanned_from, s.scanned_from_id)))
 		 ORDER BY c.newest DESC
 		 LIMIT $2`
 
@@ -279,7 +306,7 @@ func dueThreads(ctx context.Context, tx pgx.Tx, now time.Time, limit int) ([]set
 		var privateTo *ids.UUID
 		if err := rows.Scan(&thread.Key, &thread.OrganizationID,
 			&thread.Newest, &thread.Count, &privateTo,
-			&thread.ReadTo, &thread.ReadFrom); err != nil {
+			&thread.ReadTo, &thread.ReadFrom, &thread.ReadFromID); err != nil {
 			return nil, err
 		}
 		if privateTo != nil {
@@ -351,8 +378,8 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO signal_thread_scan
 		  (thread_key, last_activity_at, message_count, scanned_at,
-		   resolved_org_id, scanned_from)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		   resolved_org_id, scanned_from, scanned_from_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (thread_key) DO UPDATE
 		   SET last_activity_at = greatest(signal_thread_scan.last_activity_at, excluded.last_activity_at),
 		       -- The oldest message ever read, so it only ever moves EARLIER.
@@ -360,7 +387,23 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now
 		       -- it has none of — least(x, NULL) is x — which is what carries a
 		       -- cursor through a pass that read the newest window and reached
 		       -- nothing older.
-		       scanned_from = least(signal_thread_scan.scanned_from, excluded.scanned_from),
+		       -- The pair moves together, and only EARLIER. A window that read
+		       -- nothing older than the cursor leaves it where it was, which is
+		       -- what carries it through a pass that read the newest end.
+		       scanned_from_id = CASE
+		         WHEN excluded.scanned_from IS NULL THEN signal_thread_scan.scanned_from_id
+		         WHEN signal_thread_scan.scanned_from IS NULL THEN excluded.scanned_from_id
+		         WHEN (excluded.scanned_from, excluded.scanned_from_id)
+		            < (signal_thread_scan.scanned_from, signal_thread_scan.scanned_from_id)
+		           THEN excluded.scanned_from_id
+		         ELSE signal_thread_scan.scanned_from_id END,
+		       scanned_from = CASE
+		         WHEN excluded.scanned_from IS NULL THEN signal_thread_scan.scanned_from
+		         WHEN signal_thread_scan.scanned_from IS NULL THEN excluded.scanned_from
+		         WHEN (excluded.scanned_from, excluded.scanned_from_id)
+		            < (signal_thread_scan.scanned_from, signal_thread_scan.scanned_from_id)
+		           THEN excluded.scanned_from
+		         ELSE signal_thread_scan.scanned_from END,
 		       message_count = excluded.message_count,
 		       scanned_at = excluded.scanned_at,
 		       -- WHICH account this reading was for. Overwritten, never
@@ -375,7 +418,7 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now
 		       refused_activity_at = NULL,
 		       refused_message_count = NULL`,
 		thread.Key, thread.Newest, thread.Count, now, thread.OrganizationID,
-		thread.ReadFromNow); err != nil {
+		thread.ReadFromNow, thread.ReadFromIDNow); err != nil {
 		return fmt.Errorf("record where the read got to: %w", err)
 	}
 	return nil

--- a/backend/internal/compose/signalextractwindow.go
+++ b/backend/internal/compose/signalextractwindow.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // threadMessages reads one window of a conversation, oldest first, so the
@@ -47,10 +49,11 @@ func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]th
 	// The upper bound of the window. Nothing to read older means the newest
 	// end; a backfill below where reading started means walk back from there.
 	var olderThan *time.Time
+	var olderThanID *ids.UUID
 	if thread.ReadTo != nil && !thread.Newest.After(*thread.ReadTo) && thread.ReadFrom != nil {
-		olderThan = thread.ReadFrom
+		olderThan, olderThanID = thread.ReadFrom, thread.ReadFromID
 	}
-	messages, err := threadWindow(ctx, tx, thread.Key, olderThan)
+	messages, err := threadWindow(ctx, tx, thread.Key, olderThan, olderThanID)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +63,7 @@ func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]th
 	// window every time. Both fall back to the newest window, which is where
 	// the new content is.
 	if len(messages) == 0 && olderThan != nil {
-		messages, err = threadWindow(ctx, tx, thread.Key, nil)
+		messages, err = threadWindow(ctx, tx, thread.Key, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -70,7 +73,9 @@ func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]th
 
 // threadWindow reads one window, oldest first. olderThan bounds it above; nil
 // is the newest end.
-func threadWindow(ctx context.Context, tx pgx.Tx, key string, olderThan *time.Time) ([]threadMessage, error) {
+func threadWindow(
+	ctx context.Context, tx pgx.Tx, key string, olderThan *time.Time, olderThanID *ids.UUID,
+) ([]threadMessage, error) {
 	// The remainder is measured in the same statement that cuts the body:
 	// asked for afterwards it would be a second read of a row that may have
 	// changed, and the number would then describe a different message from the
@@ -84,10 +89,16 @@ func threadWindow(ctx context.Context, tx pgx.Tx, key string, olderThan *time.Ti
 		         WHERE thread_key = $2 AND kind = 'email' AND archived_at IS NULL
 		           -- Null means no bound: the newest window, which is the
 		           -- ordinary case and the one a thread starts from.
-		           AND ($4::timestamptz IS NULL OR occurred_at < $4)
+		           --
+		           -- A TUPLE, not a timestamp. Mail imported in bulk shares an
+		           -- occurred_at routinely, so comparing the instant alone would
+		           -- drop the rest of that group unread — or, made inclusive,
+		           -- re-read it every pass and never get past it.
+		           AND ($4::timestamptz IS NULL
+		                OR (occurred_at, id) < ($4, $5::uuid))
 		         ORDER BY occurred_at DESC, id DESC
 		         LIMIT $3) tail
-		 ORDER BY occurred_at, id`, extractBodyLimit, key, extractThreadMessages, olderThan)
+		 ORDER BY occurred_at, id`, extractBodyLimit, key, extractThreadMessages, olderThan, olderThanID)
 	if err != nil {
 		return nil, fmt.Errorf("read the conversation: %w", err)
 	}
@@ -116,9 +127,10 @@ func threadWindow(ctx context.Context, tx pgx.Tx, key string, olderThan *time.Ti
 func finishThreadWindow(ctx context.Context, thread *settledThread, out []threadMessage) []threadMessage {
 	if len(out) > 0 {
 		// The window's own lower end, so the mark can lower the cursor to it.
-		// Rows come back oldest first, so it is the first.
-		oldest := out[0].At
-		thread.ReadFromNow = &oldest
+		// Rows come back oldest first, so it is the first — and both halves of
+		// the pair travel, because either alone is not a boundary.
+		oldest, oldestID := out[0].At, out[0].ID
+		thread.ReadFromNow, thread.ReadFromIDNow = &oldest, &oldestID
 	}
 	unread, cut := 0, 0
 	for _, message := range out {

--- a/backend/internal/compose/signalextractwindow.go
+++ b/backend/internal/compose/signalextractwindow.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Which part of a conversation one read looks at.
+//
+// Separate from the pass that decides WHICH conversations are due, because the
+// two answer different questions and the second one grew a judgement: the read
+// used to take the newest six messages and nothing else, and a backfill was
+// therefore marked read without being read. What that judgement is, and the
+// order it asks its two questions in, is the whole of this file.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// threadMessages reads one window of a conversation, oldest first, so the
+// prompt reads in the order the exchange happened.
+//
+// WHICH window is the whole of this function's judgement, and it used to have
+// none: it always read the newest six. A backfill made the thread due again —
+// the count changed — the same newest six were re-read, and the new count was
+// recorded. The inserted older messages never reached the model and the thread
+// then looked read, which is the bad direction: the state says handled, nothing
+// errored, and nothing says content was skipped.
+//
+// Two ends, asked in this order:
+//
+//   - NEW MAIL FIRST. Messages newer than the last read are why the
+//     conversation is interesting now, and a thread that walked backwards
+//     through its history while a reply sat unread would be reading the least
+//     useful end of it.
+//   - THEN THE UNREAD OLDER RANGE. With nothing new, a message older than where
+//     reading started is a backfill, and the window is the newest of THOSE — so
+//     a long thread walks backwards one window per pass until its history is
+//     covered, rather than never reaching it.
+//
+// Neither end left: the newest window, which is what a thread with no scan row
+// gets and what every thread got before.
+func threadMessages(ctx context.Context, tx pgx.Tx, thread *settledThread) ([]threadMessage, error) {
+	// The upper bound of the window. Nothing to read older means the newest
+	// end; a backfill below where reading started means walk back from there.
+	var olderThan *time.Time
+	if thread.ReadTo != nil && !thread.Newest.After(*thread.ReadTo) && thread.ReadFrom != nil {
+		olderThan = thread.ReadFrom
+	}
+	messages, err := threadWindow(ctx, tx, thread.Key, olderThan)
+	if err != nil {
+		return nil, err
+	}
+	// Nothing older LEFT is not the same as nothing to read. A thread grows at
+	// the same instant as its newest message — the count moves and the clock
+	// does not — and one whose history is fully covered has an empty older
+	// window every time. Both fall back to the newest window, which is where
+	// the new content is.
+	if len(messages) == 0 && olderThan != nil {
+		messages, err = threadWindow(ctx, tx, thread.Key, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return finishThreadWindow(ctx, thread, messages), nil
+}
+
+// threadWindow reads one window, oldest first. olderThan bounds it above; nil
+// is the newest end.
+func threadWindow(ctx context.Context, tx pgx.Tx, key string, olderThan *time.Time) ([]threadMessage, error) {
+	// The remainder is measured in the same statement that cuts the body:
+	// asked for afterwards it would be a second read of a row that may have
+	// changed, and the number would then describe a different message from the
+	// one in the prompt.
+	rows, err := tx.Query(ctx, `
+		SELECT id, coalesce(direction, ''), coalesce(subject, ''),
+		       coalesce(left(body, $1), ''),
+		       greatest(coalesce(char_length(body), 0) - $1, 0), occurred_at
+		  FROM (SELECT id, direction, subject, body, occurred_at
+		          FROM activity
+		         WHERE thread_key = $2 AND kind = 'email' AND archived_at IS NULL
+		           -- Null means no bound: the newest window, which is the
+		           -- ordinary case and the one a thread starts from.
+		           AND ($4::timestamptz IS NULL OR occurred_at < $4)
+		         ORDER BY occurred_at DESC, id DESC
+		         LIMIT $3) tail
+		 ORDER BY occurred_at, id`, extractBodyLimit, key, extractThreadMessages, olderThan)
+	if err != nil {
+		return nil, fmt.Errorf("read the conversation: %w", err)
+	}
+	defer rows.Close()
+	var out []threadMessage
+	for rows.Next() {
+		var message threadMessage
+		if err := rows.Scan(&message.ID, &message.Direction, &message.Subject,
+			&message.Body, &message.UnreadRunes, &message.At); err != nil {
+			return nil, err
+		}
+		out = append(out, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// finishThreadWindow records where the window started and reports what the
+// body limit cut, once the window is settled.
+//
+// After the fallback and not inside the read, because both are about the
+// messages that actually reach the prompt: a cursor set from a window that was
+// then discarded would move the reading backwards past text nobody saw.
+func finishThreadWindow(ctx context.Context, thread *settledThread, out []threadMessage) []threadMessage {
+	if len(out) > 0 {
+		// The window's own lower end, so the mark can lower the cursor to it.
+		// Rows come back oldest first, so it is the first.
+		oldest := out[0].At
+		thread.ReadFromNow = &oldest
+	}
+	unread, cut := 0, 0
+	for _, message := range out {
+		if message.UnreadRunes > 0 {
+			unread += message.UnreadRunes
+			cut++
+		}
+	}
+	if cut > 0 {
+		// Said once per conversation rather than once per message: what a
+		// reader needs is how much of THIS exchange the reading was drawn
+		// from, and a line per body would bury that under the long threads it
+		// is most true of.
+		slog.WarnContext(ctx, "part of this conversation was not read; the events extracted from it are drawn from the head of each mail and anything stated below the cut is absent rather than judged",
+			"thread_key", thread.Key, "messages_cut", cut, "messages_read", len(out),
+			"body_limit", extractBodyLimit, "unread_runes", unread)
+	}
+	return out
+}

--- a/backend/internal/compose/threadexcerpt_integration_test.go
+++ b/backend/internal/compose/threadexcerpt_integration_test.go
@@ -125,7 +125,7 @@ func TestABackfillIsReadRatherThanMarkedRead(t *testing.T) {
 	// the same six.
 	second := settledThread{
 		Key: key, Newest: base.Add(7 * time.Hour), Count: 11,
-		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest,
+		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest, ReadFromID: first.ReadFromIDNow,
 	}
 	read(t, e, &second)
 	if len(second.Messages) == 0 {
@@ -165,7 +165,7 @@ func TestNewMailIsReadBeforeTheOlderRange(t *testing.T) {
 
 	second := settledThread{
 		Key: key, Newest: reply, Count: 9,
-		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest,
+		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest, ReadFromID: first.ReadFromIDNow,
 	}
 	read(t, e, &second)
 	newest := second.Messages[len(second.Messages)-1].At
@@ -239,11 +239,61 @@ func TestNothingOlderLeftFallsBackToTheNewestWindow(t *testing.T) {
 
 	second := settledThread{
 		Key: key, Newest: at, Count: 2,
-		ReadTo: timePtr(at), ReadFrom: &firstOldest,
+		ReadTo: timePtr(at), ReadFrom: &firstOldest, ReadFromID: first.ReadFromIDNow,
 	}
 	read(t, e, &second)
 	if len(second.Messages) != 2 {
 		t.Errorf("the read took %d messages, want both — with nothing older left the window is the newest "+
 			"end, and a read that takes nothing never reaches the model at all", len(second.Messages))
+	}
+}
+
+// TestAWindowOfMessagesAtOneInstantIsNotSplit holds the half a timestamp
+// cannot: an instant is not a message boundary.
+//
+// Mail imported in bulk shares an occurred_at routinely. A cursor that is a
+// timestamp alone either drops the rest of that group unread — which is the
+// defect this change exists to fix, at a smaller scale — or, made inclusive,
+// re-reads it every pass and never gets past it.
+func TestAWindowOfMessagesAtOneInstantIsNotSplit(t *testing.T) {
+	e := integration.Setup(t)
+	key := "sameclock-" + ids.NewV7().String()
+
+	// More messages at ONE instant than a window holds.
+	at := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	const group = extractThreadMessages + 3
+	for range group {
+		seedThreadMailAt(t, e, key, at)
+	}
+
+	first := settledThread{Key: key, Newest: at, Count: group}
+	read(t, e, &first)
+	if len(first.Messages) != extractThreadMessages {
+		t.Fatalf("the first read took %d messages, want the window of %d",
+			len(first.Messages), extractThreadMessages)
+	}
+
+	// Nothing is newer, and the rest of the group is below the cursor — which
+	// is only expressible as a pair, since every one of them shares its instant.
+	second := settledThread{
+		Key: key, Newest: at, Count: group,
+		ReadTo: timePtr(at), ReadFrom: first.ReadFromNow, ReadFromID: first.ReadFromIDNow,
+	}
+	read(t, e, &second)
+
+	read1 := map[string]bool{}
+	for _, message := range first.Messages {
+		read1[message.ID.String()] = true
+	}
+	fresh := 0
+	for _, message := range second.Messages {
+		if !read1[message.ID.String()] {
+			fresh++
+		}
+	}
+	if fresh != group-extractThreadMessages {
+		t.Errorf("the second read brought %d messages the first had not seen, want %d — a group sharing "+
+			"one instant is walked through by (occurred_at, id), never split by the instant alone",
+			fresh, group-extractThreadMessages)
 	}
 }

--- a/backend/internal/compose/threadexcerpt_integration_test.go
+++ b/backend/internal/compose/threadexcerpt_integration_test.go
@@ -208,3 +208,42 @@ func read(t *testing.T, e *integration.Env, thread *settledThread) {
 		t.Fatalf("reading the conversation: %v", err)
 	}
 }
+
+// TestNothingOlderLeftFallsBackToTheNewestWindow holds the case the cursor got
+// wrong first.
+//
+// "Nothing NEWER than the last read" is not "nothing to read". A conversation
+// grows at the same instant as its newest message — the count moves and the
+// clock does not, which is the whole reason signal_thread_scan records a count
+// — and a thread whose history is fully covered has an empty older window every
+// pass. Sending either backwards reads nothing and the model is never called,
+// which is the defect this change exists to fix, reintroduced at the other end.
+func TestNothingOlderLeftFallsBackToTheNewestWindow(t *testing.T) {
+	e := integration.Setup(t)
+	key := "sameinstant-" + ids.NewV7().String()
+
+	at := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	seedThreadMailAt(t, e, key, at)
+
+	first := settledThread{Key: key, Newest: at, Count: 1}
+	read(t, e, &first)
+	if len(first.Messages) != 1 {
+		t.Fatalf("the first read took %d messages, want the one on the thread", len(first.Messages))
+	}
+	firstOldest := *first.ReadFromNow
+
+	// A second message at the SAME instant: the thread grew and the clock did
+	// not, so nothing is newer than what was read and nothing is older than
+	// where reading started.
+	seedThreadMailAt(t, e, key, at)
+
+	second := settledThread{
+		Key: key, Newest: at, Count: 2,
+		ReadTo: timePtr(at), ReadFrom: &firstOldest,
+	}
+	read(t, e, &second)
+	if len(second.Messages) != 2 {
+		t.Errorf("the read took %d messages, want both — with nothing older left the window is the newest "+
+			"end, and a read that takes nothing never reaches the model at all", len(second.Messages))
+	}
+}

--- a/backend/internal/compose/threadexcerpt_integration_test.go
+++ b/backend/internal/compose/threadexcerpt_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -59,7 +60,7 @@ func TestAThreadReportsHowMuchOfItselfWasNotRead(t *testing.T) {
 	var messages []threadMessage
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var err error
-		messages, err = threadMessages(context.Background(), tx, key)
+		messages, err = threadMessages(context.Background(), tx, &settledThread{Key: key})
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -82,5 +83,128 @@ func TestAThreadReportsHowMuchOfItselfWasNotRead(t *testing.T) {
 		t.Errorf("the truncated mail reported %d runes unread, want %d — the limit alone cannot say "+
 			"what was lost, because a body one rune over and one far over arrive identically",
 			messages[1].UnreadRunes, over)
+	}
+}
+
+// TestABackfillIsReadRatherThanMarkedRead is the defect this closes.
+//
+// The read always took the newest six messages. A backfill changes the message
+// count, so the thread becomes due again — the same newest six are re-read, and
+// the new count is recorded. The inserted older messages never reach the model
+// and the thread now looks read: the state says handled, nothing errored, and
+// nothing says content was skipped.
+func TestABackfillIsReadRatherThanMarkedRead(t *testing.T) {
+	e := integration.Setup(t)
+	key := "backfill-" + ids.NewV7().String()
+
+	// A thread longer than one window, so the newest six do not cover it.
+	base := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	for i := range 8 {
+		seedThreadMailAt(t, e, key, base.Add(time.Duration(i)*time.Hour))
+	}
+
+	// The first read: the newest window, and the cursor it leaves behind.
+	first := settledThread{Key: key, Newest: base.Add(7 * time.Hour), Count: 8}
+	read(t, e, &first)
+	if len(first.Messages) != extractThreadMessages {
+		t.Fatalf("the first read took %d messages, want the window of %d",
+			len(first.Messages), extractThreadMessages)
+	}
+	if first.ReadFromNow == nil {
+		t.Fatal("the first read recorded no cursor, so nothing tells the next one where it started")
+	}
+	firstOldest := *first.ReadFromNow
+
+	// Now a backfill: three messages older than anything the thread held.
+	for i := range 3 {
+		seedThreadMailAt(t, e, key, base.Add(-time.Duration(i+1)*time.Hour))
+	}
+
+	// The thread is due again — the count moved — and nothing is NEWER than
+	// what was read, so the window must walk backwards rather than re-reading
+	// the same six.
+	second := settledThread{
+		Key: key, Newest: base.Add(7 * time.Hour), Count: 11,
+		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest,
+	}
+	read(t, e, &second)
+	if len(second.Messages) == 0 {
+		t.Fatal("the second read took nothing, so a backfilled message is never sent to the model")
+	}
+	for _, message := range second.Messages {
+		if !message.At.Before(firstOldest) {
+			t.Errorf("the second read took a message at %s, which the first read had already covered "+
+				"(it started at %s) — the window did not move", message.At, firstOldest)
+		}
+	}
+	// And it reached the backfill specifically, not merely something older.
+	if oldest := second.Messages[0].At; !oldest.Before(base) {
+		t.Errorf("the oldest message read was %s, and the backfill sits before %s — the window walked "+
+			"back but not far enough to reach it", oldest, base)
+	}
+}
+
+// New mail outranks a backfill: a reply nobody has read is why the conversation
+// is interesting now, and a thread walking backwards through its history while
+// that sits there would be reading its least useful end.
+func TestNewMailIsReadBeforeTheOlderRange(t *testing.T) {
+	e := integration.Setup(t)
+	key := "newmail-" + ids.NewV7().String()
+
+	base := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	for i := range 8 {
+		seedThreadMailAt(t, e, key, base.Add(time.Duration(i)*time.Hour))
+	}
+	first := settledThread{Key: key, Newest: base.Add(7 * time.Hour), Count: 8}
+	read(t, e, &first)
+	firstOldest := *first.ReadFromNow
+
+	// A reply arrives, and older messages remain unread below the cursor.
+	reply := base.Add(20 * time.Hour)
+	seedThreadMailAt(t, e, key, reply)
+
+	second := settledThread{
+		Key: key, Newest: reply, Count: 9,
+		ReadTo: timePtr(base.Add(7 * time.Hour)), ReadFrom: &firstOldest,
+	}
+	read(t, e, &second)
+	newest := second.Messages[len(second.Messages)-1].At
+	if !newest.Equal(reply) {
+		t.Errorf("the window ends at %s, want the new message at %s — a thread with unread mail must "+
+			"read that before walking back through its history", newest, reply)
+	}
+}
+
+func timePtr(at time.Time) *time.Time { return &at }
+
+// seedThreadMailAt places one message on a thread at an exact instant, which is
+// what a window test needs: the ordering IS the subject, and "minutes ago"
+// cannot express a backfill below everything already there.
+func seedThreadMailAt(t *testing.T, e *integration.Env, threadKey string, at time.Time) {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, thread_key, occurred_at,
+			                      source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'a subject', 'a body', 'inbound', $2, $3,
+			        'gmail', $4, 'gmail:seed', 'connector:gmail')`,
+			id, threadKey, at, id.String())
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a message at %s: %v", at, err)
+	}
+}
+
+// read runs one window read in a transaction, filling the thread's messages and
+// its cursor the way the pass does.
+func read(t *testing.T, e *integration.Env, thread *settledThread) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		messages, err := threadMessages(context.Background(), tx, thread)
+		thread.Messages = messages
+		return err
+	}); err != nil {
+		t.Fatalf("reading the conversation: %v", err)
 	}
 }

--- a/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.down.sql
+++ b/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.down.sql
@@ -1,0 +1,4 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE signal_thread_scan
+    DROP COLUMN IF EXISTS scanned_from;

--- a/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.down.sql
+++ b/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.down.sql
@@ -1,4 +1,8 @@
 SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE signal_thread_scan
-    DROP COLUMN IF EXISTS scanned_from;
+    DROP CONSTRAINT IF EXISTS signal_thread_scan_scanned_from_shape;
+
+ALTER TABLE signal_thread_scan
+    DROP COLUMN IF EXISTS scanned_from,
+    DROP COLUMN IF EXISTS scanned_from_id;

--- a/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
+++ b/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
@@ -29,6 +29,14 @@ ALTER TABLE signal_thread_scan
     ADD COLUMN scanned_from timestamptz,
     ADD COLUMN scanned_from_id uuid;
 
+-- One validated ADD, not NOT VALID + a later VALIDATE. The pair shortens the
+-- ACCESS EXCLUSIVE hold only when the ADD COMMITS FIRST and the VALIDATE runs in
+-- a later transaction: dbmigrate runs each file inside one (dbmigrate.go's
+-- inTx), so Postgres holds that lock through the scan either way.
+--
+-- And the scan is not the cost here. Both columns were added a statement ago, so
+-- every existing row holds NULL in both and satisfies the check trivially;
+-- signal_thread_scan holds one row per conversation being scanned, not history.
 ALTER TABLE signal_thread_scan
     ADD CONSTRAINT signal_thread_scan_scanned_from_shape
     CHECK ((scanned_from IS NULL) = (scanned_from_id IS NULL));

--- a/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
+++ b/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
@@ -1,0 +1,24 @@
+-- Where a thread's reading STARTED, so a backfill is read rather than skipped.
+--
+-- The scan recorded only how far forward it had got: the newest message's
+-- instant and the thread's message count. A backfill changes the count, so the
+-- thread becomes due again — and the read then looks at the same newest six
+-- messages, finds nothing new, and records the new count. The inserted older
+-- messages never reach the model, and the thread now looks read.
+--
+-- That is the bad direction: the state says handled, nothing errored, and there
+-- is no signal that content was skipped.
+--
+-- scanned_from is the OLDEST message a read has covered. With it the two ends
+-- of the conversation are both known, so "unread" has an answer at either end:
+-- newer than last_activity_at is new mail, older than scanned_from is a
+-- backfill, and a thread walks backwards a window at a time until neither
+-- remains.
+--
+-- NULL on every existing row, which reads as "the start is not known yet". The
+-- read treats that as the newest window, which is exactly what it did before —
+-- so no thread changes behaviour until it is next scanned.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE signal_thread_scan
+    ADD COLUMN scanned_from timestamptz;

--- a/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
+++ b/backend/migrations/core/1787905300_a_backfill_is_read_rather_than_marked_read.up.sql
@@ -20,5 +20,15 @@
 -- so no thread changes behaviour until it is next scanned.
 SET LOCAL lock_timeout = '3s';
 
+-- The id travels with the instant, because an instant is not a message
+-- boundary. Mail imported in bulk shares an occurred_at routinely, and a cursor
+-- that is a timestamp alone either skips the rest of a group or re-reads it
+-- forever. (occurred_at, id) is the order the read already walks in, so the
+-- pair is the cursor and the comparison is a tuple.
 ALTER TABLE signal_thread_scan
-    ADD COLUMN scanned_from timestamptz;
+    ADD COLUMN scanned_from timestamptz,
+    ADD COLUMN scanned_from_id uuid;
+
+ALTER TABLE signal_thread_scan
+    ADD CONSTRAINT signal_thread_scan_scanned_from_shape
+    CHECK ((scanned_from IS NULL) = (scanned_from_id IS NULL));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3957,6 +3957,7 @@ public.signal_thread_scan.refused_activity_at timestamp with time zone gen=- def
 public.signal_thread_scan.refused_message_count integer gen=- def=-
 public.signal_thread_scan.resolved_org_id uuid gen=- def=-
 public.signal_thread_scan.scanned_at timestamp with time zone NOT NULL gen=- def=now()
+public.signal_thread_scan.scanned_from timestamp with time zone gen=- def=-
 public.signal_thread_scan.signal_thread_scan_pkey PRIMARY KEY (thread_key)
 public.signal_thread_scan.signal_thread_scan_resolved_org_fkey FOREIGN KEY (resolved_org_id) REFERENCES organization(id) ON DELETE SET NULL (resolved_org_id)
 public.signal_thread_scan.thread_key text NOT NULL gen=- def=-

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3958,8 +3958,10 @@ public.signal_thread_scan.refused_message_count integer gen=- def=-
 public.signal_thread_scan.resolved_org_id uuid gen=- def=-
 public.signal_thread_scan.scanned_at timestamp with time zone NOT NULL gen=- def=now()
 public.signal_thread_scan.scanned_from timestamp with time zone gen=- def=-
+public.signal_thread_scan.scanned_from_id uuid gen=- def=-
 public.signal_thread_scan.signal_thread_scan_pkey PRIMARY KEY (thread_key)
 public.signal_thread_scan.signal_thread_scan_resolved_org_fkey FOREIGN KEY (resolved_org_id) REFERENCES organization(id) ON DELETE SET NULL (resolved_org_id)
+public.signal_thread_scan.signal_thread_scan_scanned_from_shape CHECK (((scanned_from IS NULL) = (scanned_from_id IS NULL)))
 public.signal_thread_scan.thread_key text NOT NULL gen=- def=-
 public.signal_thread_scan_pkey CREATE UNIQUE INDEX signal_thread_scan_pkey ON public.signal_thread_scan USING btree (thread_key)
 public.signing_key acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (42)
+## Parity (43)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #2474.

## The defect

`threadMessages` always read the **newest six** messages of a conversation.

`signal_thread_scan` notices a backfill because the message count changes, so the thread becomes due again — but the window it re-reads is the same newest six, and `markThreadScanned` then records the new count. The inserted older messages are never sent to the model, **and the thread now looks read.**

That is the bad direction: the state says handled, nothing errored, and there is no signal that content was skipped.

## Why widening the tail was never the answer

The ticket says it, and it is worth keeping: widening by the count delta fixes short threads only. On a long thread the backfilled messages sit far outside any bounded window measured from the newest end — no tail length reaches them.

## The cursor

The scan tracked only how far **forward** it had got: the newest message's instant and the count. It now also records `scanned_from`, the **oldest** message a read has covered. With both ends known, "unread" has an answer at either: newer than `last_activity_at` is new mail, older than `scanned_from` is a backfill.

The window is chosen in that order, and the order is the design:

1. **New mail first.** A reply nobody has read is why the conversation is interesting now. A thread walking backwards through its history while that sits there would be reading its least useful end.
2. **Then the unread older range.** With nothing new, the window is the newest messages *below* the cursor — so a long thread walks back one window per pass until its history is covered.
3. **Neither left → the newest window**, which is what a thread with no scan row gets and what every thread got before.

`scanned_from` only ever moves earlier (`least()` on conflict), and it is NULL on every existing row — which reads as "the start is not known yet" and selects case 3. **No thread changes behaviour until it is next scanned.**

## Held from the other end

- `TestABackfillIsReadRatherThanMarkedRead` — an 8-message thread read once, then 3 messages backfilled below everything it held. The second read must take messages the first did not, and must reach past the original start into the backfill itself.
- `TestNewMailIsReadBeforeTheOlderRange` — the same thread with a reply *and* unread history. The window must end at the reply.

Mutation-checked by removing the cursor: the second read takes the same messages again and the test reports them by timestamp — the reported defect, reproduced.

The tests seed at exact instants rather than "minutes ago", because the ordering *is* the subject and a relative offset cannot express a message below everything already there.

`head_catalog.txt` regenerated with the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conversation-window extraction for email threads, prioritizing newer messages and progressively backfilling older history.
  - Long conversations are processed across multiple windows until their history is fully covered.
  - Thread views fall back to the newest available messages when no older history remains.

- **Bug Fixes**
  - Prevented messages sharing timestamps from being skipped, reread, or split across windows.
  - Improved historical cursor tracking and handling of truncated content.

- **Documentation**
  - Updated the Parity gate inventory count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->