### PR TITLE
The reset response records its own divergence

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -444,7 +444,24 @@ paths:
                   description: Must equal the organization name exactly.
       responses:
         '200':
-          description: Installation reset to first-boot state.
+          description: >
+            Installation reset to first-boot state.
+
+            Five of these fields — `jobs_deleted`, `streams_purged`, `cache_keys_deleted`,
+            `objects_deleted` and `drain_timed_out` — exist here and not in the retired upstream
+            copy of this contract, and that is deliberate rather than drift anyone should
+            reconcile away. A reset clears the job queue, the event bus, the Redis counters and
+            the object bytes, and an operator who is told only how many table rows went has no way
+            to tell "nothing to delete" from "this build cannot tell you". This file is the
+            authority and the build follows it; the note is here so the next reader meets the
+            divergence rather than re-deriving it.
+
+            The schema is inline rather than a `$ref`, so oapi-codegen synthesizes no Go type and
+            the hand-written `resetDataResponse` is the only Go-side wire shape. What keeps the
+            two together is `gates/resetwireshape_test.go`, which derives both sides — this
+            `required` list and the struct's json tags — so a field added to one and forgotten in
+            the other fails there rather than shipping a 200 body missing a key every client is
+            told is required.
           content:
             application/json:
               schema:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -455,13 +455,15 @@ paths:
             to tell "nothing to delete" from "this build cannot tell you". This file is the
             authority and the build follows it; the note is here so the next reader meets the
             divergence rather than re-deriving it.
-
-            The schema is inline rather than a `$ref`, so oapi-codegen synthesizes no Go type and
-            the hand-written `resetDataResponse` is the only Go-side wire shape. What keeps the
-            two together is `gates/resetwireshape_test.go`, which derives both sides — this
-            `required` list and the struct's json tags — so a field added to one and forgotten in
-            the other fails there rather than shipping a 200 body missing a key every client is
-            told is required.
+          # A YAML comment and not part of the description above: this is for whoever EDITS the
+          # schema, and a description renders in client-facing docs.
+          #
+          # The schema is inline rather than a $ref, so oapi-codegen synthesizes no Go type for it
+          # and the hand-written resetDataResponse is the only Go-side wire shape. What keeps the
+          # two together is gates/resetwireshape_test.go, which derives both sides — this required
+          # list and the struct's json tags — so a field added to one and forgotten in the other
+          # fails there rather than shipping a 200 body missing a key every client is told is
+          # required.
           content:
             application/json:
               schema:

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23743,7 +23743,6 @@ export interface operations {
             /**
              * @description Installation reset to first-boot state.
              *     Five of these fields — `jobs_deleted`, `streams_purged`, `cache_keys_deleted`, `objects_deleted` and `drain_timed_out` — exist here and not in the retired upstream copy of this contract, and that is deliberate rather than drift anyone should reconcile away. A reset clears the job queue, the event bus, the Redis counters and the object bytes, and an operator who is told only how many table rows went has no way to tell "nothing to delete" from "this build cannot tell you". This file is the authority and the build follows it; the note is here so the next reader meets the divergence rather than re-deriving it.
-             *     The schema is inline rather than a `$ref`, so oapi-codegen synthesizes no Go type and the hand-written `resetDataResponse` is the only Go-side wire shape. What keeps the two together is `gates/resetwireshape_test.go`, which derives both sides — this `required` list and the struct's json tags — so a field added to one and forgotten in the other fails there rather than shipping a 200 body missing a key every client is told is required.
              */
             200: {
                 headers: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23740,7 +23740,11 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Installation reset to first-boot state. */
+            /**
+             * @description Installation reset to first-boot state.
+             *     Five of these fields — `jobs_deleted`, `streams_purged`, `cache_keys_deleted`, `objects_deleted` and `drain_timed_out` — exist here and not in the retired upstream copy of this contract, and that is deliberate rather than drift anyone should reconcile away. A reset clears the job queue, the event bus, the Redis counters and the object bytes, and an operator who is told only how many table rows went has no way to tell "nothing to delete" from "this build cannot tell you". This file is the authority and the build follows it; the note is here so the next reader meets the divergence rather than re-deriving it.
+             *     The schema is inline rather than a `$ref`, so oapi-codegen synthesizes no Go type and the hand-written `resetDataResponse` is the only Go-side wire shape. What keeps the two together is `gates/resetwireshape_test.go`, which derives both sides — this `required` list and the struct's json tags — so a field added to one and forgotten in the other fails there rather than shipping a 200 body missing a key every client is told is required.
+             */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Closes #2475.

## What the ticket asks for

`resetData`'s 200 body declares five fields the retired upstream copy of this contract does not: `jobs_deleted`, `streams_purged`, `cache_keys_deleted`, `objects_deleted`, `drain_timed_out`.

Nothing in this tree is wrong. `backend/api/crm.yaml` is the authority and the build follows it, so this is deliberate — and the ticket says so, and asks only that the divergence be **visible rather than folklore**.

Folklore is what a ticket becomes once it is closed, so the note now lives where the next reader will meet it: on the response itself.

## What it says

- The five fields are deliberate, with the reason. A reset clears the job queue, the event bus, the Redis counters and the object bytes — and an operator told only how many table rows went cannot tell *"nothing to delete"* from *"this build cannot tell you"*.
- This file is the authority and the divergence is not something to reconcile away — which is the failure mode a future reader comparing the two specs would otherwise be one step from.
- The schema is inline rather than a `$ref`, so oapi-codegen synthesizes no Go type and `resetDataResponse` is the only Go-side wire shape — with a pointer at `gates/resetwireshape_test.go`, which derives both sides and is the only thing keeping them together.

That last part is the piece most worth having in the file: someone adding a field here has no generated type to fail them, and the gate that does is not otherwise discoverable from this end.

No behaviour changes. `make check-backend` and `make check-fe` green; contract artifacts regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the installation reset endpoint documentation.
  * Clarified the conditions associated with the first-boot state.
  * Improved the description of the endpoint’s reset behavior and response contract.
  * Kept the API documentation focused on information relevant to integrating with and using the endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->