### PR TITLE
Refuse a mapping proposal that places some of the file's columns

### DIFF
--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -471,6 +471,8 @@ func (bothDoorsImports) ProfileSource(context.Context, string, string) (crmcontr
 	return crmcontracts.ImportSourceProfile{}, nil
 }
 
+func (bothDoorsImports) DiscardSource(context.Context, string) error { return nil }
+
 func (bothDoorsImports) StageRun(context.Context, crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error) {
 	return crmcontracts.ImportRun{Status: "awaiting_approval"}, nil
 }

--- a/backend/internal/compose/csvimport.go
+++ b/backend/internal/compose/csvimport.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
-	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -107,12 +106,14 @@ func (h importHandlers) discardSource(ctx context.Context, ref string) error {
 	if h.blobs == nil {
 		return fmt.Errorf("this role stores no objects, so it holds no import source: %w", apperrors.ErrConflict)
 	}
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return fmt.Errorf("no workspace is bound to this request: %w", apperrors.ErrPermissionDenied)
-	}
-	if !strings.HasPrefix(ref, blobstore.WorkspaceKey(ids.From[ids.WorkspaceKind](ws), importBlobKind, "")) {
-		return fmt.Errorf("that import source belongs to another workspace: %w", apperrors.ErrPermissionDenied)
+	// The SAME check staging makes, not a prefix of it. A prefix admits a key
+	// with extra segments under this workspace's import namespace, and answers
+	// forbidden — which tells a caller that a reference they were never given
+	// belongs to somebody. ownsSource matches the whole minted key and answers
+	// not-found, and a delete is not the place to start disagreeing with the
+	// read about what a source ref is.
+	if err := h.ownsSource(ctx, ref); err != nil {
+		return err
 	}
 	return h.blobs.Delete(ctx, ref)
 }

--- a/backend/internal/compose/csvimport.go
+++ b/backend/internal/compose/csvimport.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -98,6 +99,22 @@ func (h importHandlers) UploadImportSource(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// discardSource removes a stored import source. Keyed the same way it was
+// written, so a ref from another workspace names a key this one never wrote.
+func (h importHandlers) discardSource(ctx context.Context, ref string) error {
+	if h.blobs == nil {
+		return fmt.Errorf("this role stores no objects, so it holds no import source: %w", apperrors.ErrConflict)
+	}
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return fmt.Errorf("no workspace is bound to this request: %w", apperrors.ErrPermissionDenied)
+	}
+	if !strings.HasPrefix(ref, blobstore.WorkspaceKey(ids.From[ids.WorkspaceKind](ws), importBlobKind, "")) {
+		return fmt.Errorf("that import source belongs to another workspace: %w", apperrors.ErrPermissionDenied)
+	}
+	return h.blobs.Delete(ctx, ref)
 }
 
 // profileAndStore is everything the upload does once it HAS the bytes: read the

--- a/backend/internal/compose/importseam.go
+++ b/backend/internal/compose/importseam.go
@@ -102,6 +102,19 @@ func (i importSeam) ProfileSource(
 	return i.door().profileAndStore(ctx, object, []byte(csv))
 }
 
+// DiscardSource removes a stored source no run will reference. Same grant as
+// storing it: a caller who may create an import run may drop the file they just
+// uploaded for one, and nobody else may reach into the store at all.
+func (i importSeam) DiscardSource(ctx context.Context, ref string) error {
+	if err := auth.Require(ctx, migration.ImportRunObject, principal.ActionCreate); err != nil {
+		return err
+	}
+	if err := i.ready(); err != nil {
+		return err
+	}
+	return i.door().discardSource(ctx, ref)
+}
+
 func (i importSeam) StageRun(
 	ctx context.Context, req crmcontracts.CreateImportRunRequest,
 ) (crmcontracts.ImportRun, error) {

--- a/backend/internal/modules/agents/stubimports_test.go
+++ b/backend/internal/modules/agents/stubimports_test.go
@@ -19,6 +19,8 @@ func (stubImports) ProfileSource(context.Context, string, string) (crmcontracts.
 	return crmcontracts.ImportSourceProfile{}, nil
 }
 
+func (stubImports) DiscardSource(context.Context, string) error { return nil }
+
 func (stubImports) StageRun(context.Context, crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error) {
 	return crmcontracts.ImportRun{Status: awaitingApproval}, nil
 }

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -30,6 +30,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -118,7 +120,7 @@ func (t previewImport) Spec() mcp.ToolSpec {
 			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `","` + importObjectPerson + `"]},
 			"csv":{"type":"string","description":"The file's contents, header row first."},
 			"mapping":{"type":"object","additionalProperties":{"type":"string"},
-			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands."},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make, which it will only make if it can place EVERY column — a file whose headers are spelled the way a human would (\"Company\", \"City\") matches no field by name and is refused with the list, so send a mapping for those. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands."},
 			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
 			  "description":"A record already here: create (default) lands a second and files the pair for review; skip leaves the incumbent. For people an address already held is refused either way — an email is a real key, a company name is not."}},
 			"additionalProperties":false}`),
@@ -165,6 +167,11 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 	for column, field := range args.Mapping {
 		mapping[column] = field
 	}
+	if len(args.Mapping) == 0 {
+		if err := proposalCoversTheFile(profile, mapping); err != nil {
+			return nil, err
+		}
+	}
 
 	req := crmcontracts.CreateImportRunRequest{
 		Connector: crmcontracts.CreateImportRunRequestConnector(importConnectorCSV),
@@ -186,6 +193,62 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 		Columns:  columnNames(profile),
 		Unmapped: unmappedColumns(profile, mapping),
 	})
+}
+
+// proposalCoversTheFile refuses a proposal that places some of the file's
+// columns and not others, when the caller sent no mapping of their own.
+//
+// The proposal matches NAMES, and nothing more (migration.SuggestMapping); the
+// timidity is right for the screen, which draws an unplaced column as a blank
+// the person fills. A tool caller has no blanks. Handed a proposal that maps
+// `id` and drops `Company`, `City`, `Country` and `Band`, they get something
+// plausible that validates clean and commits an update with no changed fields
+// — an import that reports success and writes nothing. A partial answer that
+// looks whole is worse than no answer, so this is the refusal that says which
+// columns it could not place and what the object can receive.
+//
+// Only when the caller sent NOTHING. A caller who named even one column has
+// made a choice about the rest, and the result's `unmapped` list reports it.
+func proposalCoversTheFile(profile crmcontracts.ImportSourceProfile, mapping map[string]string) error {
+	unplaced := unmappedColumns(profile, mapping)
+	if len(unplaced) == 0 {
+		return nil
+	}
+	// The vocabulary rides in Guidance, which is NOT bounded. Put in the cause
+	// it is echoed through echoSafe and a long header list cuts the field names
+	// off the end — taking away the one thing the refusal exists to teach,
+	// exactly when the caller most needs it.
+	return &BadArgsError{
+		Cause: fmt.Errorf(
+			"this file's columns %s match no %s field by name, so the proposal would import "+
+				"only %s and leave the rest behind — an import that reports success and "+
+				"changes nothing",
+			strings.Join(quoted(unplaced), ", "), profile.Object,
+			strings.Join(quoted(mappedColumns(mapping)), ", ")),
+		Guidance: fmt.Sprintf("send a mapping that says what each column is. A %s takes: %s",
+			profile.Object, strings.Join(profile.Targets, ", ")),
+	}
+}
+
+// mappedColumns names the columns a mapping does place, sorted so one file
+// always refuses in the same words.
+func mappedColumns(mapping map[string]string) []string {
+	out := make([]string, 0, len(mapping))
+	for column := range mapping {
+		out = append(out, column)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// quoted puts each name in quotes so a header with a space in it reads as one
+// name in the sentence.
+func quoted(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, strconv.Quote(name))
+	}
+	return out
 }
 
 // importConnectorCSV is the connector a pasted file is: the same one the

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -47,6 +46,15 @@ type Imports interface {
 	// ProfileSource stores CSV text and reads back what its columns contain,
 	// with a proposed mapping. The agent-shaped half of uploadImportSource.
 	ProfileSource(ctx context.Context, object, csv string) (crmcontracts.ImportSourceProfile, error)
+	// DiscardSource removes a stored source no run will ever reference.
+	//
+	// The tool path stores the file BEFORE it can know whether the call will
+	// succeed, so a refusal after that point leaves an orphan blob — storage a
+	// caller can spend by repeating a call that fails. importSeam.ProfileSource
+	// hoists the authorization check for exactly that reason; this is the same
+	// concern one step later, where the refusal is about the file's own shape
+	// rather than about who is asking.
+	DiscardSource(ctx context.Context, ref string) error
 	// StageRun validates a mapping against the estate and parks the run for a
 	// human. Writes no domain rows.
 	StageRun(ctx context.Context, req crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error)
@@ -169,7 +177,7 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 	}
 	if len(args.Mapping) == 0 {
 		if err := proposalCoversTheFile(profile, mapping); err != nil {
-			return nil, err
+			return nil, discarding(ctx, t.imports, profile.SourceRef, err)
 		}
 	}
 
@@ -185,7 +193,7 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 	}
 	run, err := t.imports.StageRun(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, discarding(ctx, t.imports, profile.SourceRef, err)
 	}
 	return json.Marshal(ImportPreviewResult{
 		Run:      importRunResult(run),
@@ -193,6 +201,19 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 		Columns:  columnNames(profile),
 		Unmapped: unmappedColumns(profile, mapping),
 	})
+}
+
+// discarding removes the stored source behind a call that is about to fail, and
+// returns the failure unchanged.
+//
+// The refusal is what the caller needs to read, so a failure to clean up cannot
+// replace it: an orphan blob is a cost, and the wrong error is a wrong answer.
+func discarding(ctx context.Context, imports Imports, ref string, cause error) error {
+	if ref != "" {
+		//craft:ignore swallowed-errors the refusal below is the answer; a store that would not delete is a cost to carry, not a reason to report something else
+		_ = imports.DiscardSource(ctx, ref)
+	}
+	return cause
 }
 
 // proposalCoversTheFile refuses a proposal that places some of the file's
@@ -214,31 +235,23 @@ func proposalCoversTheFile(profile crmcontracts.ImportSourceProfile, mapping map
 	if len(unplaced) == 0 {
 		return nil
 	}
-	// The vocabulary rides in Guidance, which is NOT bounded. Put in the cause
-	// it is echoed through echoSafe and a long header list cuts the field names
-	// off the end — taking away the one thing the refusal exists to teach,
-	// exactly when the caller most needs it.
+	// Both LISTS ride in Guidance, which is not bounded. The cause is echoed
+	// through echoSafe's 200 bytes, and the fixed prose alone is most of that —
+	// so a list put there is cut off partway through, which on a wide file
+	// means the refusal stops naming the very columns it is about. What is left
+	// in the cause is the sentence that is the same length whatever the file
+	// holds.
 	return &BadArgsError{
 		Cause: fmt.Errorf(
-			"this file's columns %s match no %s field by name, so the proposal would import "+
-				"only %s and leave the rest behind — an import that reports success and "+
-				"changes nothing",
+			"the proposal places %d of this file's %d columns, so importing it would report "+
+				"success and change nothing",
+			len(mapping), len(mapping)+len(unplaced)),
+		Guidance: fmt.Sprintf(
+			"it could not place %s, because they match no %s field by name. Send a mapping "+
+				"that says what each column is. A %s takes: %s",
 			strings.Join(quoted(unplaced), ", "), profile.Object,
-			strings.Join(quoted(mappedColumns(mapping)), ", ")),
-		Guidance: fmt.Sprintf("send a mapping that says what each column is. A %s takes: %s",
 			profile.Object, strings.Join(profile.Targets, ", ")),
 	}
-}
-
-// mappedColumns names the columns a mapping does place, sorted so one file
-// always refuses in the same words.
-func mappedColumns(mapping map[string]string) []string {
-	out := make([]string, 0, len(mapping))
-	for column := range mapping {
-		out = append(out, column)
-	}
-	sort.Strings(out)
-	return out
 }
 
 // quoted puts each name in quotes so a header with a space in it reads as one

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -116,167 +115,6 @@ const (
 // with a person at it.
 const maxImportCSVBytes = 1_000_000
 
-type previewImport struct{ imports Imports }
-
-func (t previewImport) Spec() mcp.ToolSpec {
-	return mcp.ToolSpec{
-		Name: "preview_import", Title: "Preview an import", Version: toolVersionV1,
-		Description:   previewImportCopy.render(),
-		RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute,
-		OpenAPIOp: "createImportRun",
-		InputSchema: schema(`{"type":"object","required":["object","csv"],"properties":{
-			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `","` + importObjectPerson + `"]},
-			"csv":{"type":"string","description":"The file's contents, header row first."},
-			"mapping":{"type":"object","additionalProperties":{"type":"string"},
-			  "description":"Source column name → field name. Omit to accept the proposal this call would make, which it will only make if it can place EVERY column — a file whose headers are spelled the way a human would (\"Company\", \"City\") matches no field by name and is refused with the list, so send a mapping for those. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands."},
-			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
-			  "description":"A record already here: create (default) lands a second and files the pair for review; skip leaves the incumbent. For people an address already held is refused either way — an email is a real key, a company name is not."}},
-			"additionalProperties":false}`),
-		OutputSchema: schemaFor[ImportPreviewResult](),
-	}
-}
-
-func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
-	var args struct {
-		Object      string            `json:"object"`
-		CSV         string            `json:"csv"`
-		Mapping     map[string]string `json:"mapping"`
-		OnDuplicate string            `json:"on_duplicate"`
-	}
-	if err := decodeArgs(in, &args); err != nil {
-		return nil, err
-	}
-	if err := refuseUnimportableObject(args.Object); err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(args.CSV) == "" {
-		return nil, &BadArgsError{Cause: errors.New(
-			"`csv` is empty; send the file's contents with its header row first")}
-	}
-	if len(args.CSV) > maxImportCSVBytes {
-		return nil, &BadArgsError{Cause: fmt.Errorf(
-			"this file is %d bytes and one pasted import takes at most %d; "+
-				"upload it in the web app instead, or split it",
-			len(args.CSV), maxImportCSVBytes)}
-	}
-
-	profile, err := t.imports.ProfileSource(ctx, args.Object, args.CSV)
-	if err != nil {
-		return nil, err
-	}
-	// The caller's mapping wins where it names a column, and the proposal
-	// fills the rest. A caller that sends none gets the proposal whole —
-	// which is honest rather than convenient, because the report says what
-	// each column became and a person reads it before anything commits.
-	mapping := make(map[string]string, len(profile.SuggestedMapping))
-	for column, field := range profile.SuggestedMapping {
-		mapping[column] = field
-	}
-	for column, field := range args.Mapping {
-		mapping[column] = field
-	}
-	if len(args.Mapping) == 0 {
-		if err := proposalCoversTheFile(profile, mapping); err != nil {
-			return nil, discarding(ctx, t.imports, profile.SourceRef, err)
-		}
-	}
-
-	req := crmcontracts.CreateImportRunRequest{
-		Connector: crmcontracts.CreateImportRunRequestConnector(importConnectorCSV),
-		Object:    profile.Object,
-		SourceRef: profile.SourceRef,
-		Mapping:   mapping,
-	}
-	if args.OnDuplicate != "" {
-		policy := crmcontracts.ImportOnDuplicate(args.OnDuplicate)
-		req.OnDuplicate = &policy
-	}
-	run, err := t.imports.StageRun(ctx, req)
-	if err != nil {
-		// NOT discarded. Staging persists its run before it validates, and a
-		// run that failed validation is resumable from its SourceRef — so
-		// deleting the file here would turn a run somebody can fix into one
-		// nobody can. The orphan on this path is the pre-existing cost of a
-		// tool call that stores before it can know, and it is a different
-		// change from this one.
-		return nil, err
-	}
-	return json.Marshal(ImportPreviewResult{
-		Run:      importRunResult(run),
-		Mapping:  mapping,
-		Columns:  columnNames(profile),
-		Unmapped: unmappedColumns(profile, mapping),
-	})
-}
-
-// discarding removes the stored source behind a call that is about to fail, and
-// returns the failure unchanged.
-//
-// Only for a refusal BEFORE anything is staged. Past that point a run exists
-// that references the source and can be resumed from it, and deleting the file
-// would turn a run somebody can fix into one nobody can.
-//
-// The refusal is what the caller needs to read, so a failure to clean up cannot
-// replace it: an orphan blob is a cost, and the wrong error is a wrong answer.
-func discarding(ctx context.Context, imports Imports, ref string, cause error) error {
-	if ref != "" {
-		//craft:ignore swallowed-errors the refusal below is the answer; a store that would not delete is a cost to carry, not a reason to report something else
-		_ = imports.DiscardSource(ctx, ref)
-	}
-	return cause
-}
-
-// proposalCoversTheFile refuses a proposal that places some of the file's
-// columns and not others, when the caller sent no mapping of their own.
-//
-// The proposal matches NAMES, and nothing more (migration.SuggestMapping); the
-// timidity is right for the screen, which draws an unplaced column as a blank
-// the person fills. A tool caller has no blanks. Handed a proposal that maps
-// `id` and drops `Company`, `City`, `Country` and `Band`, they get something
-// plausible that validates clean and commits an update with no changed fields
-// — an import that reports success and writes nothing. A partial answer that
-// looks whole is worse than no answer, so this is the refusal that says which
-// columns it could not place and what the object can receive.
-//
-// Only when the caller named NO column — whether the member was omitted or sent
-// as `{}`, which are the same thing to ask about: a mapping that names nothing
-// is not a choice about the columns, it is the absence of one, and what would
-// be used either way is the proposal. A caller who named even one column HAS
-// made a choice about the rest, and the result's `unmapped` list reports it.
-func proposalCoversTheFile(profile crmcontracts.ImportSourceProfile, mapping map[string]string) error {
-	unplaced := unmappedColumns(profile, mapping)
-	if len(unplaced) == 0 {
-		return nil
-	}
-	// Both LISTS ride in Guidance, which is not bounded. The cause is echoed
-	// through echoSafe's 200 bytes, and the fixed prose alone is most of that —
-	// so a list put there is cut off partway through, which on a wide file
-	// means the refusal stops naming the very columns it is about. What is left
-	// in the cause is the sentence that is the same length whatever the file
-	// holds.
-	return &BadArgsError{
-		Cause: fmt.Errorf(
-			"the proposal places %d of this file's %d columns, so importing it would report "+
-				"success and change nothing",
-			len(mapping), len(mapping)+len(unplaced)),
-		Guidance: fmt.Sprintf(
-			"it could not place %s, because they match no %s field by name. Send a mapping "+
-				"that says what each column is. A %s takes: %s",
-			strings.Join(quoted(unplaced), ", "), profile.Object,
-			profile.Object, strings.Join(profile.Targets, ", ")),
-	}
-}
-
-// quoted puts each name in quotes so a header with a space in it reads as one
-// name in the sentence.
-func quoted(names []string) []string {
-	out := make([]string, 0, len(names))
-	for _, name := range names {
-		out = append(out, strconv.Quote(name))
-	}
-	return out
-}
-
 // importConnectorCSV is the connector a pasted file is: the same one the
 // upload door uses, because it IS the same path — only the way the bytes
 // arrived differs.
@@ -299,32 +137,6 @@ func refuseUnimportableObject(object string) error {
 	}
 	return &BadArgsError{Cause: fmt.Errorf("`object` must be one of %s",
 		strings.Join(importObjectEnum, ", "))}
-}
-
-// columnNames lists what the file actually contains, so a caller that guessed
-// a mapping can see the header it guessed against.
-func columnNames(p crmcontracts.ImportSourceProfile) []string {
-	out := make([]string, 0, len(p.Columns))
-	for _, c := range p.Columns {
-		out = append(out, c.Header)
-	}
-	return out
-}
-
-// unmappedColumns names the columns nothing will read.
-//
-// It is reported rather than refused: a file usually carries columns this
-// product has no field for, and dropping them is the normal outcome. What is
-// not acceptable is dropping them SILENTLY — a caller who mistyped a field
-// name would otherwise see a clean report and a column quietly missing.
-func unmappedColumns(p crmcontracts.ImportSourceProfile, mapping map[string]string) []string {
-	var out []string
-	for _, c := range p.Columns {
-		if field, ok := mapping[c.Header]; !ok || field == "" {
-			out = append(out, c.Header)
-		}
-	}
-	return out
 }
 
 type readImportRun struct{ imports Imports }

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -193,7 +193,13 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 	}
 	run, err := t.imports.StageRun(ctx, req)
 	if err != nil {
-		return nil, discarding(ctx, t.imports, profile.SourceRef, err)
+		// NOT discarded. Staging persists its run before it validates, and a
+		// run that failed validation is resumable from its SourceRef — so
+		// deleting the file here would turn a run somebody can fix into one
+		// nobody can. The orphan on this path is the pre-existing cost of a
+		// tool call that stores before it can know, and it is a different
+		// change from this one.
+		return nil, err
 	}
 	return json.Marshal(ImportPreviewResult{
 		Run:      importRunResult(run),
@@ -205,6 +211,10 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 
 // discarding removes the stored source behind a call that is about to fail, and
 // returns the failure unchanged.
+//
+// Only for a refusal BEFORE anything is staged. Past that point a run exists
+// that references the source and can be resumed from it, and deleting the file
+// would turn a run somebody can fix into one nobody can.
 //
 // The refusal is what the caller needs to read, so a failure to clean up cannot
 // replace it: an orphan blob is a cost, and the wrong error is a wrong answer.

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -228,7 +228,10 @@ func discarding(ctx context.Context, imports Imports, ref string, cause error) e
 // looks whole is worse than no answer, so this is the refusal that says which
 // columns it could not place and what the object can receive.
 //
-// Only when the caller sent NOTHING. A caller who named even one column has
+// Only when the caller named NO column — whether the member was omitted or sent
+// as `{}`, which are the same thing to ask about: a mapping that names nothing
+// is not a choice about the columns, it is the absence of one, and what would
+// be used either way is the proposal. A caller who named even one column HAS
 // made a choice about the rest, and the result's `unmapped` list reports it.
 func proposalCoversTheFile(profile crmcontracts.ImportSourceProfile, mapping map[string]string) error {
 	unplaced := unmappedColumns(profile, mapping)

--- a/backend/internal/modules/agents/tools_import_preview.go
+++ b/backend/internal/modules/agents/tools_import_preview.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Bringing a file in: the half of the import verbs that takes a spreadsheet's
+// bytes and stages a run somebody can approve.
+//
+// Separate from the verbs that READ a staged run and commit it, because this
+// half is where the file is stored before anything can know whether the call
+// will succeed — and every refusal past that point has to decide what becomes
+// of it.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+type previewImport struct{ imports Imports }
+
+func (t previewImport) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "preview_import", Title: "Preview an import", Version: toolVersionV1,
+		Description:   previewImportCopy.render(),
+		RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "createImportRun",
+		InputSchema: schema(`{"type":"object","required":["object","csv"],"properties":{
+			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `","` + importObjectPerson + `"]},
+			"csv":{"type":"string","description":"The file's contents, header row first."},
+			"mapping":{"type":"object","additionalProperties":{"type":"string"},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make, which it will only make if it can place EVERY column — a file whose headers are spelled the way a human would (\"Company\", \"City\") matches no field by name and is refused with the list, so send a mapping for those. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands."},
+			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
+			  "description":"A record already here: create (default) lands a second and files the pair for review; skip leaves the incumbent. For people an address already held is refused either way — an email is a real key, a company name is not."}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[ImportPreviewResult](),
+	}
+}
+
+func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args struct {
+		Object      string            `json:"object"`
+		CSV         string            `json:"csv"`
+		Mapping     map[string]string `json:"mapping"`
+		OnDuplicate string            `json:"on_duplicate"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	if err := refuseUnimportableObject(args.Object); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(args.CSV) == "" {
+		return nil, &BadArgsError{Cause: errors.New(
+			"`csv` is empty; send the file's contents with its header row first")}
+	}
+	if len(args.CSV) > maxImportCSVBytes {
+		return nil, &BadArgsError{Cause: fmt.Errorf(
+			"this file is %d bytes and one pasted import takes at most %d; "+
+				"upload it in the web app instead, or split it",
+			len(args.CSV), maxImportCSVBytes)}
+	}
+
+	profile, err := t.imports.ProfileSource(ctx, args.Object, args.CSV)
+	if err != nil {
+		return nil, err
+	}
+	// The caller's mapping wins where it names a column, and the proposal
+	// fills the rest. A caller that sends none gets the proposal whole —
+	// which is honest rather than convenient, because the report says what
+	// each column became and a person reads it before anything commits.
+	mapping := make(map[string]string, len(profile.SuggestedMapping))
+	for column, field := range profile.SuggestedMapping {
+		mapping[column] = field
+	}
+	for column, field := range args.Mapping {
+		mapping[column] = field
+	}
+	if len(args.Mapping) == 0 {
+		if err := proposalCoversTheFile(profile, mapping); err != nil {
+			return nil, discarding(ctx, t.imports, profile.SourceRef, err)
+		}
+	}
+
+	req := crmcontracts.CreateImportRunRequest{
+		Connector: crmcontracts.CreateImportRunRequestConnector(importConnectorCSV),
+		Object:    profile.Object,
+		SourceRef: profile.SourceRef,
+		Mapping:   mapping,
+	}
+	if args.OnDuplicate != "" {
+		policy := crmcontracts.ImportOnDuplicate(args.OnDuplicate)
+		req.OnDuplicate = &policy
+	}
+	run, err := t.imports.StageRun(ctx, req)
+	if err != nil {
+		// NOT discarded. Staging persists its run before it validates, and a
+		// run that failed validation is resumable from its SourceRef — so
+		// deleting the file here would turn a run somebody can fix into one
+		// nobody can. The orphan on this path is the pre-existing cost of a
+		// tool call that stores before it can know, and it is a different
+		// change from this one.
+		return nil, err
+	}
+	return json.Marshal(ImportPreviewResult{
+		Run:      importRunResult(run),
+		Mapping:  mapping,
+		Columns:  columnNames(profile),
+		Unmapped: unmappedColumns(profile, mapping),
+	})
+}
+
+// discarding removes the stored source behind a call that is about to fail, and
+// returns the failure unchanged.
+//
+// Only for a refusal BEFORE anything is staged. Past that point a run exists
+// that references the source and can be resumed from it, and deleting the file
+// would turn a run somebody can fix into one nobody can.
+//
+// The refusal is what the caller needs to read, so a failure to clean up cannot
+// replace it: an orphan blob is a cost, and the wrong error is a wrong answer.
+func discarding(ctx context.Context, imports Imports, ref string, cause error) error {
+	if ref == "" {
+		return cause
+	}
+	// Detached from the request's cancellation, and bounded on its own. The
+	// caller hanging up between the store and the refusal is exactly when the
+	// file is most certainly unwanted, and a cleanup that took the cancelled
+	// context with it would leave the orphan precisely then — a caller could
+	// spend storage by cancelling.
+	cleanup, done := context.WithTimeout(context.WithoutCancel(ctx), discardTimeout)
+	defer done()
+	//craft:ignore swallowed-errors the refusal below is the answer; a store that would not delete is a cost to carry, not a reason to report something else
+	_ = imports.DiscardSource(cleanup, ref)
+	return cause
+}
+
+// discardTimeout bounds the cleanup. It outlives the request on purpose, and a
+// store that has not answered in this long is not going to.
+const discardTimeout = 10 * time.Second
+
+// proposalCoversTheFile refuses a proposal that places some of the file's
+// columns and not others, when the caller sent no mapping of their own.
+//
+// The proposal matches NAMES, and nothing more (migration.SuggestMapping); the
+// timidity is right for the screen, which draws an unplaced column as a blank
+// the person fills. A tool caller has no blanks. Handed a proposal that maps
+// `id` and drops `Company`, `City`, `Country` and `Band`, they get something
+// plausible that validates clean and commits an update with no changed fields
+// — an import that reports success and writes nothing. A partial answer that
+// looks whole is worse than no answer, so this is the refusal that says which
+// columns it could not place and what the object can receive.
+//
+// Only when the caller named NO column — whether the member was omitted or sent
+// as `{}`, which are the same thing to ask about: a mapping that names nothing
+// is not a choice about the columns, it is the absence of one, and what would
+// be used either way is the proposal. A caller who named even one column HAS
+// made a choice about the rest, and the result's `unmapped` list reports it.
+func proposalCoversTheFile(profile crmcontracts.ImportSourceProfile, mapping map[string]string) error {
+	unplaced := unmappedColumns(profile, mapping)
+	if len(unplaced) == 0 {
+		return nil
+	}
+	// Both LISTS ride in Guidance, which is not bounded. The cause is echoed
+	// through echoSafe's 200 bytes, and the fixed prose alone is most of that —
+	// so a list put there is cut off partway through, which on a wide file
+	// means the refusal stops naming the very columns it is about. What is left
+	// in the cause is the sentence that is the same length whatever the file
+	// holds.
+	return &BadArgsError{
+		Cause: fmt.Errorf(
+			"the proposal places %d of this file's %d columns, so importing it would leave the "+
+				"rest of every row behind and report success",
+			len(mapping), len(mapping)+len(unplaced)),
+		Guidance: fmt.Sprintf(
+			"it could not place %s, because they match no %s field by name. Send a mapping "+
+				"that says what each column is. A %s takes: %s",
+			strings.Join(quoted(unplaced), ", "), profile.Object,
+			profile.Object, strings.Join(profile.Targets, ", ")),
+	}
+}
+
+// quoted puts each name in quotes so a header with a space in it reads as one
+// name in the sentence.
+func quoted(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, strconv.Quote(name))
+	}
+	return out
+}
+
+// columnNames lists what the file actually contains, so a caller that guessed
+// a mapping can see the header it guessed against.
+func columnNames(p crmcontracts.ImportSourceProfile) []string {
+	out := make([]string, 0, len(p.Columns))
+	for _, c := range p.Columns {
+		out = append(out, c.Header)
+	}
+	return out
+}
+
+// unmappedColumns names the columns nothing will read.
+//
+// It is reported rather than refused: a file usually carries columns this
+// product has no field for, and dropping them is the normal outcome. What is
+// not acceptable is dropping them SILENTLY — a caller who mistyped a field
+// name would otherwise see a clean report and a column quietly missing.
+func unmappedColumns(p crmcontracts.ImportSourceProfile, mapping map[string]string) []string {
+	var out []string
+	for _, c := range p.Columns {
+		if field, ok := mapping[c.Header]; !ok || field == "" {
+			out = append(out, c.Header)
+		}
+	}
+	return out
+}

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -129,6 +129,16 @@ type recordingImports struct {
 	columns   []string
 	targets   []string
 	discarded *[]string
+	stageErr  error
+}
+
+func (r recordingImports) StageRun(
+	_ context.Context, _ crmcontracts.CreateImportRunRequest,
+) (crmcontracts.ImportRun, error) {
+	if r.stageErr != nil {
+		return crmcontracts.ImportRun{}, r.stageErr
+	}
+	return crmcontracts.ImportRun{}, nil
 }
 
 func (r recordingImports) DiscardSource(_ context.Context, ref string) error {
@@ -335,5 +345,29 @@ func TestAnEmptyMappingIsTheSameQuestionAsNoMapping(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `"Company"`) {
 		t.Errorf("the refusal does not name the column it could not place:\n%s", err.Error())
+	}
+}
+
+// A staging failure keeps its file, because a run already references it.
+//
+// stageRun persists its run before it validates, and a run that failed
+// validation is resumable from its SourceRef — so discarding here would turn a
+// run somebody can fix into one nobody can. The refusal BEFORE staging is the
+// only one where the file is provably unreferenced.
+func TestAStagingFailureKeepsTheFileItsRunStillNeeds(t *testing.T) {
+	var discarded []string
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"id": "id", "Company": "display_name"},
+		columns:   []string{"id", "Company"},
+		targets:   []string{"display_name", "id"},
+		discarded: &discarded,
+		stageErr:  errors.New("the estate refused this mapping"),
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"id,Company\nx,Acme\n"}`))
+	if err == nil {
+		t.Fatal("a staging failure was reported as success")
+	}
+	if len(discarded) != 0 {
+		t.Errorf("discarded = %v, and a failed run is resumable from that source", discarded)
 	}
 }

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -130,6 +130,7 @@ type recordingImports struct {
 	targets   []string
 	discarded *[]string
 	stageErr  error
+	sawLive   *bool
 }
 
 func (r recordingImports) StageRun(
@@ -141,9 +142,15 @@ func (r recordingImports) StageRun(
 	return crmcontracts.ImportRun{}, nil
 }
 
-func (r recordingImports) DiscardSource(_ context.Context, ref string) error {
+func (r recordingImports) DiscardSource(ctx context.Context, ref string) error {
 	if r.discarded != nil {
 		*r.discarded = append(*r.discarded, ref)
+	}
+	if r.sawLive != nil {
+		// Read INSIDE the call: the cleanup context is cancelled by its own
+		// defer the moment discarding returns, so a context captured for later
+		// inspection always reads cancelled whatever it was during the call.
+		*r.sawLive = ctx.Err() == nil
 	}
 	return nil
 }
@@ -369,5 +376,36 @@ func TestAStagingFailureKeepsTheFileItsRunStillNeeds(t *testing.T) {
 	}
 	if len(discarded) != 0 {
 		t.Errorf("discarded = %v, and a failed run is resumable from that source", discarded)
+	}
+}
+
+// The cleanup survives the caller hanging up.
+//
+// A request cancelled between the store and the refusal is exactly when the
+// file is most certainly unwanted, and a discard that took the cancelled
+// context with it would leave the orphan precisely then — a caller could spend
+// storage by cancelling.
+func TestACancelledPreviewStillTakesItsFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	live := false
+	discarded := []string{}
+	imports := recordingImports{
+		suggested: map[string]string{"id": "id"},
+		columns:   []string{"id", "Company"},
+		targets:   []string{"display_name", "id"},
+		discarded: &discarded,
+		sawLive:   &live,
+	}
+	cancel()
+	if _, err := (previewImport{imports: imports}).Handle(ctx, json.RawMessage(
+		`{"object":"organization","csv":"id,Company\nx,Acme\n"}`)); err == nil {
+		t.Fatal("a partial proposal was accepted")
+	}
+	if len(discarded) != 1 {
+		t.Fatalf("discarded = %v, and the refused call stored a file", discarded)
+	}
+	if !live {
+		t.Error("the discard ran on a cancelled context, so the store would refuse it and the " +
+			"file would outlive the call that stored it")
 	}
 }

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -128,6 +128,14 @@ type recordingImports struct {
 	suggested map[string]string
 	columns   []string
 	targets   []string
+	discarded *[]string
+}
+
+func (r recordingImports) DiscardSource(_ context.Context, ref string) error {
+	if r.discarded != nil {
+		*r.discarded = append(*r.discarded, ref)
+	}
+	return nil
 }
 
 func (r recordingImports) ProfileSource(
@@ -137,6 +145,7 @@ func (r recordingImports) ProfileSource(
 		*r.stored = true
 	}
 	profile := crmcontracts.ImportSourceProfile{
+		SourceRef:        "ws/import-source/stored",
 		Object:           crmcontracts.ImportObject(object),
 		SuggestedMapping: r.suggested,
 		Targets:          r.targets,
@@ -219,6 +228,10 @@ func TestAProposalThatPlacesOnlySomeColumnsIsRefused(t *testing.T) {
 		t.Fatal("a proposal that placed one column of five was accepted")
 	}
 	message := err.Error()
+	// Through BadArgsError.Error(), which bounds the CAUSE at 200 bytes and
+	// leaves the guidance alone. Both lists are what a caller has to read, so
+	// both are on the unbounded side — asserted here through the same rendering
+	// a caller sees rather than off the fields.
 	for _, want := range []string{`"Company"`, `"City"`, `"Country"`, `"Band"`, "display_name", "size_band"} {
 		if !strings.Contains(message, want) {
 			t.Errorf("the refusal %q does not name %s — a caller cannot fix what it is not told", message, want)
@@ -250,5 +263,56 @@ func TestACallersOwnMappingIsNotSecondGuessed(t *testing.T) {
 		`{"object":"organization","csv":"Company,City\nAcme,Essen\n","mapping":{"Company":"display_name"}}`))
 	if err != nil {
 		t.Fatalf("a caller's own partial mapping was refused: %v", err)
+	}
+}
+
+// A refusal after the file is already stored takes the file with it.
+//
+// The tool path stores before it can know the call will succeed, so a refusal
+// past that point leaves an orphan blob — storage a caller can spend by
+// repeating a call that fails. importSeam.ProfileSource hoists its
+// authorization check for exactly that reason; this is the same concern one
+// step later.
+func TestARefusedPreviewDoesNotLeaveItsFileBehind(t *testing.T) {
+	var discarded []string
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"id": "id"},
+		columns:   []string{"id", "Company"},
+		targets:   []string{"display_name", "id"},
+		discarded: &discarded,
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"id,Company\nx,Acme\n"}`))
+	if err == nil {
+		t.Fatal("a partial proposal was accepted")
+	}
+	if len(discarded) != 1 || discarded[0] != "ws/import-source/stored" {
+		t.Errorf("discarded = %v, want the stored source the refused call left behind", discarded)
+	}
+}
+
+// A refusal that names every unplaced column, on a file wide enough that the
+// bounded half of the message could not have carried them.
+//
+// This is the case that moved both lists out of the cause: BadArgsError echoes
+// the cause through 200 bytes, and a dozen headers is well past it — so a
+// message built there stops naming the columns it is about exactly when there
+// are the most of them to name.
+func TestAWideFilesRefusalStillNamesEveryColumn(t *testing.T) {
+	columns := append([]string{"id"},
+		"Company Legal Name", "Trading As", "Street Address", "City", "Postal Code",
+		"Country", "Employee Band", "Annual Revenue", "Primary Website", "Industry Sector")
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"id": "id"},
+		columns:   columns,
+		targets:   []string{"display_name", "id"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"id\nx\n"}`))
+	if err == nil {
+		t.Fatal("a proposal that placed one column of eleven was accepted")
+	}
+	for _, want := range columns[1:] {
+		if !strings.Contains(err.Error(), `"`+want+`"`) {
+			t.Errorf("the refusal does not name %q:\n%s", want, err.Error())
+		}
 	}
 }

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -126,6 +126,8 @@ type recordingImports struct {
 	stubImports
 	stored    *bool
 	suggested map[string]string
+	columns   []string
+	targets   []string
 }
 
 func (r recordingImports) ProfileSource(
@@ -134,10 +136,15 @@ func (r recordingImports) ProfileSource(
 	if r.stored != nil {
 		*r.stored = true
 	}
-	return crmcontracts.ImportSourceProfile{
+	profile := crmcontracts.ImportSourceProfile{
 		Object:           crmcontracts.ImportObject(object),
 		SuggestedMapping: r.suggested,
-	}, nil
+		Targets:          r.targets,
+	}
+	for _, header := range r.columns {
+		profile.Columns = append(profile.Columns, crmcontracts.ImportColumn{Header: header})
+	}
+	return profile, nil
 }
 
 // The approval a person sees says what the import will DO.
@@ -191,4 +198,57 @@ type reportlessImports struct{ stubImports }
 
 func (reportlessImports) ReadReport(context.Context, ids.UUID) (crmcontracts.ImportRunReport, error) {
 	return crmcontracts.ImportRunReport{}, errors.New("the report is gone")
+}
+
+// TestAProposalThatPlacesOnlySomeColumnsIsRefused is the shape a partial
+// proposal fails in.
+//
+// The proposal matches names and nothing more, so a file spelling its columns
+// the way a human would — "Company", "City", "Band" — reaches only `id`. A
+// screen draws the rest as blanks somebody fills; a tool caller sees a mapping
+// that looks like an answer, validates clean, and commits an update with no
+// changed fields. That is an import reporting success and writing nothing.
+func TestAProposalThatPlacesOnlySomeColumnsIsRefused(t *testing.T) {
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"id": "id"},
+		columns:   []string{"id", "Company", "City", "Country", "Band"},
+		targets:   []string{"display_name", "address.city", "address.country", "size_band", "id"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"id,Company,City,Country,Band\nx,Acme,Essen,DE,201-500\n"}`))
+	if err == nil {
+		t.Fatal("a proposal that placed one column of five was accepted")
+	}
+	message := err.Error()
+	for _, want := range []string{`"Company"`, `"City"`, `"Country"`, `"Band"`, "display_name", "size_band"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("the refusal %q does not name %s — a caller cannot fix what it is not told", message, want)
+		}
+	}
+}
+
+// A proposal that places every column is the one case where accepting the
+// proposal whole is honest, and it still goes through.
+func TestAProposalThatPlacesEveryColumnIsAccepted(t *testing.T) {
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"display_name": "display_name", "size_band": "size_band"},
+		columns:   []string{"display_name", "size_band"},
+		targets:   []string{"display_name", "size_band"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"display_name,size_band\nAcme,201-500\n"}`))
+	if err != nil {
+		t.Fatalf("a complete proposal was refused: %v", err)
+	}
+}
+
+// A caller who named even one column has made a choice about the rest, so the
+// refusal does not fire — the result's `unmapped` list is what reports it.
+func TestACallersOwnMappingIsNotSecondGuessed(t *testing.T) {
+	_, err := previewImport{imports: recordingImports{
+		columns: []string{"Company", "City"},
+		targets: []string{"display_name", "address.city"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"Company,City\nAcme,Essen\n","mapping":{"Company":"display_name"}}`))
+	if err != nil {
+		t.Fatalf("a caller's own partial mapping was refused: %v", err)
+	}
 }

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -316,3 +316,24 @@ func TestAWideFilesRefusalStillNamesEveryColumn(t *testing.T) {
 		}
 	}
 }
+
+// An explicit `"mapping": {}` is the same question as an omitted one.
+//
+// It names no column, so it is not a choice about the columns — it is the
+// absence of one, and what would be used either way is the proposal. Refused in
+// the same words rather than falling through to the thinner `mapping=empty`,
+// which says a run would import nothing without saying what the file held.
+func TestAnEmptyMappingIsTheSameQuestionAsNoMapping(t *testing.T) {
+	_, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"id": "id"},
+		columns:   []string{"id", "Company"},
+		targets:   []string{"display_name", "id"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"id,Company\nx,Acme\n","mapping":{}}`))
+	if err == nil {
+		t.Fatal("an empty mapping accepted a proposal that placed one column of two")
+	}
+	if !strings.Contains(err.Error(), `"Company"`) {
+		t.Errorf("the refusal does not name the column it could not place:\n%s", err.Error())
+	}
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 59,
-    "tokens": 18721,
+    "tokens": 18776,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 316
+    "mean_tool_tokens": 317
   },
   "agents": [
     {
@@ -75,7 +75,7 @@
     },
     {
       "name": "preview_import",
-      "tokens": 653
+      "tokens": 708
     },
     {
       "name": "update_record",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 59 | 18721 | 78% | — | — | — |
+| _whole served catalog, for scale_ | 59 | 18776 | 78% | — | — | — |
 
 ### `morning_brief`
 
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 316, across 59 served tools.
+Median 275 tokens, mean 317, across 59 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -133,7 +133,7 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 1213 | 3 scenarios |
-| `preview_import` | 653 | — |
+| `preview_import` | 708 | — |
 | `update_record` | 603 | 4 scenarios |
 | `log_activity` | 588 | 1 scenario |
 | `send_account_email` | 545 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 167599,
+    "tool_catalog_bytes": 167819,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 42778,
+    "approx_wire_tokens_total": 42833,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 39998,
-      "input_schema_bytes": 36815,
+      "input_schema_bytes": 37035,
       "output_schema_bytes": 77961,
-      "description_plus_input_schema_bytes": 76813
+      "description_plus_input_schema_bytes": 77033
     }
   },
   "tools": {
@@ -5595,7 +5595,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
+              "description": "Source column name → field name. Omit to accept the proposal this call would make, which it will only make if it can place EVERY column — a file whose headers are spelled the way a human would (\"Company\", \"City\") matches no field by name and is refused with the list, so send a mapping for those. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
               "type": "object"
             },
             "object": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 163.7 KB |
+| Tool catalog | 163.9 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 42778 |
+| Approx. wire tokens | 42833 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,9 +31,9 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 76.1 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 39.1 KB | 23% | Yes, every step |
-| Input schemas | 36.0 KB | 21% | Yes, every step |
+| Input schemas | 36.2 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
-| **Description + input schema** | **75.0 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **75.2 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -93,7 +93,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
-| [`preview_import`](#preview_import) | Preview an import |  |  | 3.9 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 4.2 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
@@ -6183,7 +6183,7 @@ Bring a spreadsheet in: send the CSV as text and this checks every row against t
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
+      "description": "Source column name → field name. Omit to accept the proposal this call would make, which it will only make if it can place EVERY column — a file whose headers are spelled the way a human would (\"Company\", \"City\") matches no field by name and is refused with the list, so send a mapping for those. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add. On a PERSON run, map the company column to \"organization_name\" to link each person to their employer: the company must already be in the CRM, so import companies first, and a name matching none or matching two links nothing while the person still lands.",
       "type": "object"
     },
     "object": {


### PR DESCRIPTION
Closes #2513.

## The defect

`preview_import` with `mapping` omitted, on an organization file spelled the way a human spells one:

```
id,Company,City,Country,Band
<uuid>,Bergmann Antriebstechnik GmbH,Essen,DE,201-500
```

proposed a mapping containing **only** `id`. The run validated clean, `issues` was empty, and committing it would update the matched records with no changed fields — an import that reports success and writes nothing.

The tool's own schema said "Omit to accept the proposal this call would make", which presents the proposal as usable. A proposal that maps one column and discards four is worse than refusing: it is plausible, it validates clean, and its failure is silent.

## The fix

`migration.SuggestMapping` is unchanged. Its timidity — normalized-name matches only — is right for the **screen**, which draws an unplaced column as a blank a person fills. A tool caller has no blanks.

So on the tool path, when the caller sent **no mapping of their own**, a proposal that cannot place every column is refused:

> this file's columns "Company", "City", "Country", "Band" match no organization field by name, so the proposal would import only "id" and leave the rest behind — an import that reports success and changes nothing; send a mapping that says what each column is. An organization takes: display_name, address.city, …

A caller who named even one column has made a choice about the rest, and the result's `unmapped` list already reports it — that path is unchanged.

The tool's `mapping` copy now says what actually happens, so the schema and the behaviour cannot drift.

## One trap the type had already documented

The field vocabulary rides in the error's `Guidance`, not its cause. `BadArgsError.Cause` is echoed through `echoSafe`, and a long header list cut the field names off the end — taking away the one thing the refusal exists to teach, exactly when the caller most needs it. `BadArgsError`'s own doc comment records that this happened before; I reproduced it, and the test that names `display_name` and `size_band` is what caught it.

## Tests

- `TestAProposalThatPlacesOnlySomeColumnsIsRefused` — the ticket's own file. Asserts the refusal names every unplaced column **and** the fields it could have used.
- `TestAProposalThatPlacesEveryColumnIsAccepted` — the one case where accepting the proposal whole is honest still goes through.
- `TestACallersOwnMappingIsNotSecondGuessed` — a caller's partial mapping is not refused.

Mutation-checked: removing the guard leaves the second and third green and fails the first.

`agent-tool-budget` and `mcp-info` regenerated for the schema copy.

Local: `make check-backend`, `make craft-static` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CSV import previews with validation, source profiling, and automatic column mapping.
  - Supports common header variations, company-name corrections, and person-to-organization linking.
  - Incomplete automatic mappings now identify unmapped columns and available target fields.
  - Empty mappings are accepted when all columns can be placed automatically.

- **Bug Fixes**
  - Refused previews now clean up stored import files safely.
  - Import files remain available when staging fails.
  - Source cleanup now enforces consistent access validation.

- **Documentation**
  - Updated published import tool guidance and catalog metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->