### PR TITLE
Name this product on the outbound calls where nothing else does

### DIFF
--- a/backend/gates/onesqlliteralreader_test.go
+++ b/backend/gates/onesqlliteralreader_test.go
@@ -127,8 +127,25 @@ func TestEveryCensusOfSQLReadsItAsPostgresReceivesIt(t *testing.T) {
 // gates exist to stop.
 func eachGoFileInTheModule(t *testing.T, visit func(path string, file *ast.File)) {
 	t.Helper()
+	eachGoFileUnder(t, []string{"."}, visit)
+}
+
+// eachGoFileUnder is the same walk over a chosen set of roots, for a census
+// whose subject is not one module: the outbound surfaces reach past this one,
+// and a walk that stopped at its edge would certify a tree it never read.
+func eachGoFileUnder(t *testing.T, roots []string, visit func(path string, file *ast.File)) {
+	t.Helper()
 	fset := token.NewFileSet()
-	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, walkErr error) error {
+	for _, root := range roots {
+		walkGoFilesUnder(t, fset, root, visit)
+	}
+}
+
+func walkGoFilesUnder(
+	t *testing.T, fset *token.FileSet, root string, visit func(path string, file *ast.File),
+) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -150,7 +167,7 @@ func eachGoFileInTheModule(t *testing.T, visit func(path string, file *ast.File)
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("walking the module: %v", err)
+		t.Fatalf("walking %s: %v", root, err)
 	}
 }
 

--- a/backend/gates/onestringfolder_test.go
+++ b/backend/gates/onestringfolder_test.go
@@ -27,7 +27,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -88,10 +87,18 @@ const goFileFloor = 2000
 // conversion are where the two readers gave different answers, and a helper
 // that never descends into either has no answer of its own to give.
 func stringFoldersIn(file *ast.File) []string {
-	syntax := astAlias(file)
-	if syntax == "" {
+	// The file's OWN name for go/ast, resolved rather than assumed. Matched as
+	// the literal `ast` it missed a file that aliases the import; matched as
+	// ANY identifier it read `yaml.Node` as a syntax node, and a walk over a
+	// YAML document is not a second answer to what string a Go expression
+	// holds. gatekit.ImportedAs is the one reader of an import there is.
+	syntax, dotImported := gatekit.ImportedAs(file, "go/ast")
+	if syntax == "" && !dotImported {
 		// A file that does not import go/ast reads no Go syntax.
 		return nil
+	}
+	if dotImported {
+		syntax = "."
 	}
 	var out []string
 	for _, decl := range file.Decls {
@@ -105,28 +112,6 @@ func stringFoldersIn(file *ast.File) []string {
 		out = append(out, "func "+fn.Name.Name)
 	}
 	return out
-}
-
-// astAlias is the local name this file binds go/ast to, or "" if it does not
-// import it.
-//
-// Resolved rather than assumed. Matching the package identifier as the literal
-// `ast` misses a file that aliases the import; matching ANY identifier reads
-// `yaml.Node` as a syntax node, and a walk over a YAML document is not a second
-// answer to what string a Go expression holds. The import is what tells them
-// apart, and the file already carries it.
-func astAlias(file *ast.File) string {
-	for _, spec := range file.Imports {
-		path, err := strconv.Unquote(spec.Path.Value)
-		if err != nil || path != "go/ast" {
-			continue
-		}
-		if spec.Name != nil {
-			return spec.Name.Name
-		}
-		return "ast"
-	}
-	return ""
 }
 
 func takesASyntaxNode(sig *ast.FuncType, syntax string) bool {

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -269,7 +269,13 @@ func bindRequest(built map[string]bool, lhs, rhs []ast.Expr, client string) {
 		return
 	}
 	call, isCall := rhs[0].(*ast.CallExpr)
-	if !isCall || !isRequestConstructor(call, client) {
+	// Only a NewRequest* result. The convenience forms answer a RESPONSE and
+	// send the request inside the call, so binding what they return would let
+	// `resp.Header.Set("User-Agent", …)` — a write to a copy of what came back
+	// — count as naming a request that has already gone anonymously. They stay
+	// in the detection above, where being anonymous by construction is the
+	// whole point.
+	if !isCall || !buildsAnOwnedRequest(call, client) {
 		return
 	}
 	if name, isIdent := lhs[0].(*ast.Ident); isIdent {
@@ -309,6 +315,19 @@ func isDefaultClient(expr ast.Expr, client string) bool {
 	}
 	pkg, isIdent := selector.X.(*ast.Ident)
 	return isIdent && pkg.Name == client
+}
+
+// buildsAnOwnedRequest matches only the constructors that hand BACK a request —
+// the ones whose headers the caller still owns.
+func buildsAnOwnedRequest(call *ast.CallExpr, client string) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		pkg, isIdent := fn.X.(*ast.Ident)
+		return isIdent && pkg.Name == client && strings.HasPrefix(fn.Sel.Name, "NewRequest")
+	case *ast.Ident:
+		return client == "" && strings.HasPrefix(fn.Name, "NewRequest")
+	}
+	return false
 }
 
 // startsARequest names the net/http functions that put a request on the wire.
@@ -420,6 +439,16 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			name: "the shared client's convenience call is one of these too",
 			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
 				"\tresp, _ := http.DefaultClient.Get(\"https://x.test\")\n\t_ = resp\n}\n",
+			want: 1,
+		},
+		{
+			// The response is not the request. A convenience call has already
+			// gone by the time it answers, so writing the agent onto what came
+			// back names nothing.
+			name: "naming the caller on a convenience call's response is not naming it",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\tresp, _ := http.Get(\"https://x.test\")\n" +
+				"\tresp.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -42,6 +42,11 @@ import (
 // because a file's waived builder must not vouch for an anonymous sibling
 // written beside it later.
 var anonymousOutbound = gatekit.Waive(map[string]string{
+	// Past this module. Neither can import internal/platform/outbound — they
+	// are separate Go modules — and neither needs to.
+	"../extensions/openchannel/client.go:func post": "posts a document signed with a secret the RECEIVER issued, over a nonce and a timestamp they check; the signature names the sender to them more exactly than an agent could, and to anyone else the request is unverifiable whatever it claims",
+	"../cli/craft/gate/anthropic.go:func Complete":  "carries the developer's own x-api-key, which is the identity that provider bills and throttles — the same ground as the model providers below",
+
 	// This product's own origin, and the harnesses that drive it.
 	"internal/modules/agents/apps/fetch.go:func Fetch":         "fetches this product's own origin, so the server on the other end is this same process and a name would be it introducing itself to itself",
 	"internal/compose/integration/apptest/appenv.go:func Call": "drives a server the test itself started, in the same process tree, for the length of one test",
@@ -81,7 +86,7 @@ func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
 	t.Parallel()
 	var findings []string
 	builders := 0
-	eachGoFileInTheModule(t, func(path string, file *ast.File) {
+	eachGoFileUnder(t, outboundSurfaceRoots, func(path string, file *ast.File) {
 		if strings.HasSuffix(path, "_test.go") {
 			// A test's outbound call goes to a server the test started.
 			return
@@ -119,6 +124,17 @@ func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
 	}
 }
 
+// outboundSurfaceRoots are the trees that can make an outbound call — the same
+// set the sibling identity gate sweeps.
+//
+// Past this module on purpose. A request built in an extension, in the CLI or
+// on the desktop leaves the same installation and reaches the same operator,
+// and a census that stopped at the backend's edge would have claimed "every
+// outbound request" over trees it never read.
+var outboundSurfaceRoots = []string{
+	".", "../extensions", "../cli", "../desktop", "../fixtures",
+}
+
 // outboundBuilderFloor is what the walk found when this census landed.
 const outboundBuilderFloor = 30
 
@@ -130,8 +146,12 @@ const outboundBuilderFloor = 30
 // and judging the file whole would let the first vouch for the second.
 func anonymousRequestBuildersIn(file *ast.File) []string {
 	var out []string
+	client, dotImported := gatekit.ImportedAs(file, "net/http")
+	if client == "" && !dotImported {
+		return nil
+	}
 	for _, fn := range requestBuildersIn(file) {
-		if setsUserAgent(fn) {
+		if setsUserAgent(fn, requestsBuiltIn(fn.Body, client)) {
 			continue
 		}
 		out = append(out, "func "+fn.Name.Name)
@@ -166,37 +186,32 @@ func requestBuildersIn(file *ast.File) []*ast.FuncDecl {
 func buildsARequest(body *ast.BlockStmt, client string) bool {
 	found := false
 	ast.Inspect(body, func(node ast.Node) bool {
-		call, isCall := node.(*ast.CallExpr)
-		if !isCall {
-			return true
-		}
-		switch fn := call.Fun.(type) {
-		case *ast.SelectorExpr:
-			pkg, isIdent := fn.X.(*ast.Ident)
-			if isIdent && pkg.Name == client && strings.HasPrefix(fn.Sel.Name, "NewRequest") {
-				found = true
-			}
-		case *ast.Ident:
-			// A dot import spells it unqualified.
-			if client == "" && strings.HasPrefix(fn.Name, "NewRequest") {
-				found = true
-			}
+		if call, isCall := node.(*ast.CallExpr); isCall && isRequestConstructor(call, client) {
+			found = true
 		}
 		return !found
 	})
 	return found
 }
 
-// setsUserAgent reports whether the function WRITES the caller's name onto a
-// header it is building.
+// setsUserAgent reports whether the function writes the caller's name onto the
+// REQUEST IT BUILT.
 //
-// The write, not the words. Reading any call that mentions "User-Agent" made
-// `log.Printf("User-Agent missing")` enough to mark a request identified — a
-// census reporting a clean tree over an anonymous call because the code
-// complains about anonymity, which is the silent-absence failure this exists to
-// catch. So it matches a `Set` or `Add` on something whose selector is
-// `.Header`, with the header named as the first argument.
-func setsUserAgent(fn *ast.FuncDecl) bool {
+// Three things have to line up, and each was a way to read a clean tree over an
+// anonymous call.
+//
+// The WRITE, not the words: reading any call that mentions "User-Agent" made
+// `log.Printf("User-Agent missing")` enough — a census passing because the code
+// complains about the very thing it is doing.
+//
+// A HEADER, not any receiver: a `Set` on a map keyed "User-Agent" writes no
+// header at all.
+//
+// And THIS request's header. A function can build an anonymous `req` and set
+// the agent on something else it holds — a response, an outgoing second
+// request, a header it is composing for a different call — and the request it
+// actually sends still carries Go's default.
+func setsUserAgent(fn *ast.FuncDecl, built map[string]bool) bool {
 	found := false
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
@@ -211,6 +226,10 @@ func setsUserAgent(fn *ast.FuncDecl) bool {
 		if !onHeader || header.Sel.Name != "Header" {
 			return true
 		}
+		owner, named := header.X.(*ast.Ident)
+		if !named || !built[owner.Name] {
+			return true
+		}
 		name, isLit := call.Args[0].(*ast.BasicLit)
 		if isLit && name.Kind == token.STRING && strings.EqualFold(gatekit.TextOf(name), "User-Agent") {
 			found = true
@@ -218,6 +237,41 @@ func setsUserAgent(fn *ast.FuncDecl) bool {
 		return !found
 	})
 	return found
+}
+
+// requestsBuiltIn names the identifiers this function assigns an
+// http.NewRequest* result to — the requests whose headers are its own.
+func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
+	built := map[string]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
+			return true
+		}
+		call, isCall := assign.Rhs[0].(*ast.CallExpr)
+		if !isCall || !isRequestConstructor(call, client) {
+			return true
+		}
+		if name, isIdent := assign.Lhs[0].(*ast.Ident); isIdent {
+			built[name.Name] = true
+		}
+		return true
+	})
+	return built
+}
+
+// isRequestConstructor matches http.NewRequest and http.NewRequestWithContext,
+// under whatever name the file imports net/http by.
+func isRequestConstructor(call *ast.CallExpr, client string) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		pkg, isIdent := fn.X.(*ast.Ident)
+		return isIdent && pkg.Name == client && strings.HasPrefix(fn.Sel.Name, "NewRequest")
+	case *ast.Ident:
+		// A dot import spells it unqualified.
+		return client == "" && strings.HasPrefix(fn.Name, "NewRequest")
+	}
+	return false
 }
 
 // The detector, from the other end. A census over an ABSENCE is the easiest
@@ -281,6 +335,16 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			name: "an aliased net/http builds the same request",
 			source: "package p\nimport nethttp \"net/http\"\nfunc call() {\n" +
 				"\treq, _ := nethttp.NewRequest(\"GET\", \"https://x.test\", nil)\n\t_ = req\n}\n",
+			want: 1,
+		},
+		{
+			// THIS request's header, not any header the function holds. A
+			// builder that names the caller on something else it is composing
+			// still sends the request it built with Go's default agent.
+			name: "the agent set on a different header is not this request's",
+			source: "package p\nimport \"net/http\"\nfunc call(out *http.Request) {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\tout.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n\t_ = req\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -38,38 +38,43 @@ import (
 )
 
 // anonymousOutbound registers the request builders that carry no identity, and
-// why each is right to. Every entry is a FILE, because the reason is about what
-// that file talks to.
+// why each is right to. Every entry is one FUNCTION, keyed `path:func name`,
+// because a file's waived builder must not vouch for an anonymous sibling
+// written beside it later.
 var anonymousOutbound = gatekit.Waive(map[string]string{
-	"internal/modules/agents/apps/fetch.go": "fetches this product's own origin, so the server on the other end is this same process and a name would be it introducing itself to itself",
+	// This product's own origin, and the harnesses that drive it.
+	"internal/modules/agents/apps/fetch.go:func Fetch":         "fetches this product's own origin, so the server on the other end is this same process and a name would be it introducing itself to itself",
+	"internal/compose/integration/apptest/appenv.go:func Call": "drives a server the test itself started, in the same process tree, for the length of one test",
+	"internal/compose/integration/apptest/mcp.go:func rpc":     "drives a server the test itself started, in the same process tree, for the length of one test",
+	"tools/seed-demo/apiclient.go:func delete":                 "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/apiclient.go:func get":                    "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/apiclient.go:func patch":                  "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/apiclient.go:func patchGuarded":           "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/apiclient.go:func post":                   "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/apiclient.go:func put":                    "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/documents.go:func upload":                 "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
 
 	// The model providers. Each call carries the customer's own API key, which
 	// is the account the provider bills, rate-limits and revokes; an agent
 	// beside it names software the provider has no lever over.
-	"internal/modules/ai/anthropic.go":    "carries the customer's own provider key, which is the identity that provider bills and throttles",
-	"internal/modules/ai/gemini.go":       "carries the customer's own provider key, which is the identity that provider bills and throttles",
-	"internal/modules/ai/ollama.go":       "reaches a model runner the operator runs themselves, on a host they configured — they already know what is calling it",
-	"internal/modules/ai/openai.go":       "carries the customer's own provider key, which is the identity that provider bills and throttles",
-	"internal/modules/ai/openaicompat.go": "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/anthropic.go:func sendOnce": "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/gemini.go:func post":        "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/ollama.go:func post":        "reaches a model runner the operator runs themselves, on a host they configured — they already know what is calling it",
+	"internal/modules/ai/openai.go:func postRaw":     "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/openaicompat.go:func post":  "carries the customer's own provider key, which is the identity that provider bills and throttles",
 
 	// The capture connectors. Every one of these is an OAuth or token session
 	// the person themselves granted, so the provider knows the grant, the app
 	// it was granted to, and the account it was granted on.
-	"internal/modules/capture/gmail/client.go":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
-	"internal/modules/capture/gmail/send.go":            "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
-	"internal/modules/capture/googleconn/googleconn.go": "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
-	"internal/modules/capture/graph/client.go":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
-	"internal/modules/capture/graph/transport.go":       "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
-	"internal/modules/capture/oauthflow/oauthflow.go":   "exchanges a code against a token endpoint using this app's registered client id, which is the identity that endpoint checks",
-	"internal/modules/capture/telegram/api.go":          "calls a bot API under the bot's own token, and the bot IS the identity there",
-	"internal/modules/capture/telegram/sendfiles.go":    "calls a bot API under the bot's own token, and the bot IS the identity there",
-
-	// Test support and tooling. Both call a server this repository started, so
-	// the operator on the other end is the person who ran them.
-	"internal/compose/integration/apptest/appenv.go": "drives a server the test itself started, in the same process tree, for the length of one test",
-	"internal/compose/integration/apptest/mcp.go":    "drives a server the test itself started, in the same process tree, for the length of one test",
-	"tools/seed-demo/apiclient.go":                   "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
-	"tools/seed-demo/documents.go":                   "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"internal/modules/capture/gmail/client.go:func Watch":           "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/gmail/client.go:func get":             "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/gmail/send.go:func postJSON":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/googleconn/googleconn.go:func Get":    "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/graph/client.go:func GetMIME":         "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/graph/transport.go:func get":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/oauthflow/oauthflow.go:func token":    "exchanges a code against a token endpoint using this app's registered client id, which is the identity that endpoint checks",
+	"internal/modules/capture/telegram/api.go:func request":         "calls a bot API under the bot's own token, and the bot IS the identity there",
+	"internal/modules/capture/telegram/sendfiles.go:func SendFiles": "calls a bot API under the bot's own token, and the bot IS the identity there",
 })
 
 func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
@@ -86,10 +91,16 @@ func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
 		if len(anonymous) == 0 {
 			return
 		}
-		if anonymousOutbound.Waived(t, path) {
-			return
+		for _, fn := range anonymous {
+			// Keyed on the FUNCTION, not the file. A file's waived builder must
+			// not vouch for an anonymous sibling written beside it later, which
+			// is the same reason the census judges per function in the first
+			// place.
+			if anonymousOutbound.Waived(t, path+":"+fn) {
+				continue
+			}
+			findings = append(findings, path+": "+fn)
 		}
-		findings = append(findings, path+": "+strings.Join(anonymous, ", "))
 	})
 	if builders < outboundBuilderFloor {
 		t.Fatalf("the walk found only %d outbound request builder(s), and this census is pinned at "+
@@ -131,59 +142,78 @@ func anonymousRequestBuildersIn(file *ast.File) []string {
 // requestBuildersIn names every function in the file that builds an outbound
 // http.Request.
 func requestBuildersIn(file *ast.File) []*ast.FuncDecl {
+	// The file's OWN name for net/http, resolved rather than assumed. Matched
+	// as the literal `http`, a file importing it under an alias had every
+	// builder in it silently left out of the census — and the floor cannot
+	// catch that, because a smaller count still clears it.
+	client, dotImported := gatekit.ImportedAs(file, "net/http")
+	if client == "" && !dotImported {
+		return nil
+	}
 	var out []*ast.FuncDecl
 	for _, decl := range file.Decls {
 		fn, isFunc := decl.(*ast.FuncDecl)
 		if !isFunc || fn.Body == nil {
 			continue
 		}
-		if buildsARequest(fn.Body) {
+		if buildsARequest(fn.Body, client) {
 			out = append(out, fn)
 		}
 	}
 	return out
 }
 
-func buildsARequest(body *ast.BlockStmt) bool {
+func buildsARequest(body *ast.BlockStmt, client string) bool {
 	found := false
 	ast.Inspect(body, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
 		if !isCall {
 			return true
 		}
-		selector, isSelector := call.Fun.(*ast.SelectorExpr)
-		if !isSelector {
-			return true
-		}
-		pkg, isIdent := selector.X.(*ast.Ident)
-		if !isIdent || pkg.Name != "http" {
-			return true
-		}
-		if strings.HasPrefix(selector.Sel.Name, "NewRequest") {
-			found = true
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkg, isIdent := fn.X.(*ast.Ident)
+			if isIdent && pkg.Name == client && strings.HasPrefix(fn.Sel.Name, "NewRequest") {
+				found = true
+			}
+		case *ast.Ident:
+			// A dot import spells it unqualified.
+			if client == "" && strings.HasPrefix(fn.Name, "NewRequest") {
+				found = true
+			}
 		}
 		return !found
 	})
 	return found
 }
 
-// setsUserAgent reports whether the function names the caller on the request it
-// builds — by the header, or by a transport that carries one for it.
+// setsUserAgent reports whether the function WRITES the caller's name onto a
+// header it is building.
+//
+// The write, not the words. Reading any call that mentions "User-Agent" made
+// `log.Printf("User-Agent missing")` enough to mark a request identified — a
+// census reporting a clean tree over an anonymous call because the code
+// complains about anonymity, which is the silent-absence failure this exists to
+// catch. So it matches a `Set` or `Add` on something whose selector is
+// `.Header`, with the header named as the first argument.
 func setsUserAgent(fn *ast.FuncDecl) bool {
 	found := false
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
-		if !isCall {
+		if !isCall || len(call.Args) < 2 {
 			return true
 		}
-		for _, arg := range call.Args {
-			lit, isLit := arg.(*ast.BasicLit)
-			if !isLit || lit.Kind != token.STRING {
-				continue
-			}
-			if strings.EqualFold(gatekit.TextOf(lit), "User-Agent") {
-				found = true
-			}
+		method, isMethod := call.Fun.(*ast.SelectorExpr)
+		if !isMethod || (method.Sel.Name != "Set" && method.Sel.Name != "Add") {
+			return true
+		}
+		header, onHeader := method.X.(*ast.SelectorExpr)
+		if !onHeader || header.Sel.Name != "Header" {
+			return true
+		}
+		name, isLit := call.Args[0].(*ast.BasicLit)
+		if isLit && name.Kind == token.STRING && strings.EqualFold(gatekit.TextOf(name), "User-Agent") {
+			found = true
 		}
 		return !found
 	})
@@ -227,6 +257,31 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
 				"\treq.Header.Set(\"user-agent\", \"margince-x/1.0\")\n}\n",
 			want: 0,
+		},
+		{
+			// The WORDS are not the write. A builder that complains about
+			// anonymity would otherwise mark itself identified, and the census
+			// would report a clean tree over the very call it exists to find.
+			name: "naming the header without setting it is not naming the caller",
+			source: "package p\nimport (\n\t\"log\"\n\t\"net/http\"\n)\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\tlog.Printf(\"User-Agent missing on %v\", req)\n}\n",
+			want: 1,
+		},
+		{
+			// One waived builder does not cover its neighbour, which is why the
+			// register keys on the function.
+			name: "a header set on something that is not a request header",
+			source: "package p\nimport \"net/http\"\nfunc call(m map[string]string) {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\t_ = req\n\tm[\"User-Agent\"] = \"x\"\n}\n",
+			want: 1,
+		},
+		{
+			name: "an aliased net/http builds the same request",
+			source: "package p\nimport nethttp \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := nethttp.NewRequest(\"GET\", \"https://x.test\", nil)\n\t_ = req\n}\n",
+			want: 1,
 		},
 		{
 			name:   "a function that builds no request",

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -124,8 +124,12 @@ func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
 	}
 }
 
-// outboundSurfaceRoots are the trees that can make an outbound call — the same
-// set the sibling identity gate sweeps.
+// outboundSurfaceRoots are the trees that can make an outbound call: this whole
+// module, and the four the sibling identity gate reaches past it for.
+//
+// Not identical to that gate's set — it names internal, cmd and tools where
+// this walks the module root — and a superset of it, which is the safe
+// direction for a census whose finding is an absence.
 //
 // Past this module on purpose. A request built in an extension, in the CLI or
 // on the desktop leaves the same installation and reaches the same operator,
@@ -151,7 +155,7 @@ func anonymousRequestBuildersIn(file *ast.File) []string {
 		return nil
 	}
 	for _, fn := range requestBuildersIn(file) {
-		if setsUserAgent(fn, requestsBuiltIn(fn.Body, client)) {
+		if everyRequestIsNamed(fn, client) {
 			continue
 		}
 		out = append(out, "func "+fn.Name.Name)
@@ -194,8 +198,53 @@ func buildsARequest(body *ast.BlockStmt, client string) bool {
 	return found
 }
 
-// setsUserAgent reports whether the function writes the caller's name onto the
-// REQUEST IT BUILT.
+// everyRequestIsNamed reports whether EVERY request this function sends carries
+// the caller's name.
+//
+// Every one, not any one. A function that builds two requests and names one
+// sends the other with Go's default agent, and a census satisfied by the first
+// reports a clean tree over the second — which is the same silent absence in a
+// smaller place.
+//
+// A convenience call can never be named: `http.Get` builds and sends inside the
+// call, so there is no request to write a header on. One in a function is
+// therefore final, whatever else that function names.
+func everyRequestIsNamed(fn *ast.FuncDecl, client string) bool {
+	if callsAConvenienceForm(fn.Body, client) {
+		return false
+	}
+	built := requestsBuiltIn(fn.Body, client)
+	if len(built) == 0 {
+		// It sends a request this walk cannot attribute to an identifier — an
+		// inline `http.DefaultClient.Do(mustRequest(…))`, say. Nothing here can
+		// show it named, so it is reported.
+		return false
+	}
+	named := requestsNamedIn(fn.Body, built)
+	for request := range built {
+		if !named[request] {
+			return false
+		}
+	}
+	return true
+}
+
+// callsAConvenienceForm reports whether the function sends through one of the
+// build-and-send helpers, which have nowhere to put a name.
+func callsAConvenienceForm(body *ast.BlockStmt, client string) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if isCall && isRequestConstructor(call, client) && !buildsAnOwnedRequest(call, client) {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// requestsNamedIn names the built requests this function writes a User-Agent
+// onto.
 //
 // Three things have to line up, and each was a way to read a clean tree over an
 // anonymous call.
@@ -207,13 +256,12 @@ func buildsARequest(body *ast.BlockStmt, client string) bool {
 // A HEADER, not any receiver: a `Set` on a map keyed "User-Agent" writes no
 // header at all.
 //
-// And THIS request's header. A function can build an anonymous `req` and set
-// the agent on something else it holds — a response, an outgoing second
-// request, a header it is composing for a different call — and the request it
-// actually sends still carries Go's default.
-func setsUserAgent(fn *ast.FuncDecl, built map[string]bool) bool {
-	found := false
-	ast.Inspect(fn.Body, func(node ast.Node) bool {
+// And a request this function BUILT. Naming the caller on something else it
+// holds — a response, a request passed in — leaves the one it sends carrying
+// Go's default.
+func requestsNamedIn(body *ast.BlockStmt, built map[string]bool) map[string]bool {
+	named := map[string]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
 		if !isCall || len(call.Args) < 2 {
 			return true
@@ -226,17 +274,17 @@ func setsUserAgent(fn *ast.FuncDecl, built map[string]bool) bool {
 		if !onHeader || header.Sel.Name != "Header" {
 			return true
 		}
-		owner, named := header.X.(*ast.Ident)
-		if !named || !built[owner.Name] {
+		owner, isIdent := header.X.(*ast.Ident)
+		if !isIdent || !built[owner.Name] {
 			return true
 		}
 		name, isLit := call.Args[0].(*ast.BasicLit)
 		if isLit && name.Kind == token.STRING && strings.EqualFold(gatekit.TextOf(name), "User-Agent") {
-			found = true
+			named[owner.Name] = true
 		}
-		return !found
+		return true
 	})
-	return found
+	return named
 }
 
 // requestsBuiltIn names the identifiers this function assigns an
@@ -449,6 +497,26 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
 				"\tresp, _ := http.Get(\"https://x.test\")\n" +
 				"\tresp.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n}\n",
+			want: 1,
+		},
+		{
+			// EVERY request, not any one. The second goes out with Go's
+			// default while the first carries a name.
+			name: "one named request does not cover a second in the same function",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n" +
+				"\treq2, _ := http.NewRequest(\"GET\", \"https://y.test\", nil)\n\t_ = req2\n}\n",
+			want: 1,
+		},
+		{
+			// A convenience call can never be named, so one in a function is
+			// final whatever else that function names.
+			name: "a named request does not cover a convenience call beside it",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n" +
+				"\tresp, _ := http.Get(\"https://y.test\")\n\t_ = resp\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -214,6 +214,16 @@ func everyRequestIsNamed(fn *ast.FuncDecl, client string) bool {
 		return false
 	}
 	built := requestsBuiltIn(fn.Body, client)
+	for _, bindings := range built {
+		// One NAME, two requests — a shadow in a nested block, a reassignment
+		// across branches. Naming either would mark the name named and leave
+		// the other unaccounted for, and this walk cannot tell which write
+		// belongs to which binding. Unprovable is reported: a census that
+		// cannot say is not a census that says yes.
+		if bindings > 1 {
+			return false
+		}
+	}
 	if len(built) == 0 {
 		// It sends a request this walk cannot attribute to an identifier — an
 		// inline `http.DefaultClient.Do(mustRequest(…))`, say. Nothing here can
@@ -259,7 +269,7 @@ func callsAConvenienceForm(body *ast.BlockStmt, client string) bool {
 // And a request this function BUILT. Naming the caller on something else it
 // holds — a response, a request passed in — leaves the one it sends carrying
 // Go's default.
-func requestsNamedIn(body *ast.BlockStmt, built map[string]bool) map[string]bool {
+func requestsNamedIn(body *ast.BlockStmt, built map[string]int) map[string]bool {
 	named := map[string]bool{}
 	ast.Inspect(body, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
@@ -275,7 +285,7 @@ func requestsNamedIn(body *ast.BlockStmt, built map[string]bool) map[string]bool
 			return true
 		}
 		owner, isIdent := header.X.(*ast.Ident)
-		if !isIdent || !built[owner.Name] {
+		if !isIdent || built[owner.Name] == 0 {
 			return true
 		}
 		name, isLit := call.Args[0].(*ast.BasicLit)
@@ -287,10 +297,13 @@ func requestsNamedIn(body *ast.BlockStmt, built map[string]bool) map[string]bool
 	return named
 }
 
-// requestsBuiltIn names the identifiers this function assigns an
-// http.NewRequest* result to — the requests whose headers are its own.
-func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
-	built := map[string]bool{}
+// requestsBuiltIn counts, per identifier, how many requests this function binds
+// to it — the requests whose headers are its own.
+//
+// A COUNT rather than a flag, because one name can hold two requests and only
+// one of them need be named for a set keyed by name to look complete.
+func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]int {
+	built := map[string]int{}
 	ast.Inspect(body, func(node ast.Node) bool {
 		switch typed := node.(type) {
 		case *ast.AssignStmt:
@@ -312,7 +325,7 @@ func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
 }
 
 // bindRequest records the identifier a request constructor's result lands in.
-func bindRequest(built map[string]bool, lhs, rhs []ast.Expr, client string) {
+func bindRequest(built map[string]int, lhs, rhs []ast.Expr, client string) {
 	if len(rhs) != 1 || len(lhs) == 0 {
 		return
 	}
@@ -327,7 +340,7 @@ func bindRequest(built map[string]bool, lhs, rhs []ast.Expr, client string) {
 		return
 	}
 	if name, isIdent := lhs[0].(*ast.Ident); isIdent {
-		built[name.Name] = true
+		built[name.Name]++
 	}
 }
 
@@ -517,6 +530,16 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
 				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n" +
 				"\tresp, _ := http.Get(\"https://y.test\")\n\t_ = resp\n}\n",
+			want: 1,
+		},
+		{
+			// One NAME, two requests. Naming either would mark the name named
+			// and leave the other unaccounted for.
+			name: "a name bound to two requests cannot be shown named",
+			source: "package p\nimport \"net/http\"\nfunc call(second bool) {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n" +
+				"\tif second {\n\t\treq, _ = http.NewRequest(\"GET\", \"https://y.test\", nil)\n\t}\n\t_ = req\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every outbound HTTP request either says who is calling, or is registered as
+// deliberately anonymous with the reason.
+//
+// The sibling gate next door (TestNoOutboundIdentityIsWrittenAtItsCallSite)
+// holds the calls that DECLARE something to one spelling. It has nothing to say
+// about a call that declares nothing, and it cannot: a gate over the source can
+// see a wrong header and not an absent one — unless it goes looking, which is
+// what this does.
+//
+// A request with no User-Agent is not anonymous. Go supplies
+// `Go-http-client/1.1`, which names the language runtime and nothing about who
+// is calling or why, and it is what 23 live paths in this tree were sending. A
+// remote operator diagnosing that traffic can block a language or nothing.
+//
+// NOT every call needs a name, and the register is where that is said rather
+// than assumed. A token-authenticated provider API already knows exactly who is
+// calling — the credential says so — and a request to this product's own origin
+// is talking to itself. What the register is for is the DIFFERENCE between a
+// call somebody decided needs no identity and one nobody thought about, which
+// is invisible in the code either way.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// anonymousOutbound registers the request builders that carry no identity, and
+// why each is right to. Every entry is a FILE, because the reason is about what
+// that file talks to.
+var anonymousOutbound = gatekit.Waive(map[string]string{
+	"internal/modules/agents/apps/fetch.go": "fetches this product's own origin, so the server on the other end is this same process and a name would be it introducing itself to itself",
+
+	// The model providers. Each call carries the customer's own API key, which
+	// is the account the provider bills, rate-limits and revokes; an agent
+	// beside it names software the provider has no lever over.
+	"internal/modules/ai/anthropic.go":    "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/gemini.go":       "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/ollama.go":       "reaches a model runner the operator runs themselves, on a host they configured — they already know what is calling it",
+	"internal/modules/ai/openai.go":       "carries the customer's own provider key, which is the identity that provider bills and throttles",
+	"internal/modules/ai/openaicompat.go": "carries the customer's own provider key, which is the identity that provider bills and throttles",
+
+	// The capture connectors. Every one of these is an OAuth or token session
+	// the person themselves granted, so the provider knows the grant, the app
+	// it was granted to, and the account it was granted on.
+	"internal/modules/capture/gmail/client.go":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/gmail/send.go":            "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/googleconn/googleconn.go": "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/graph/client.go":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/graph/transport.go":       "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/oauthflow/oauthflow.go":   "exchanges a code against a token endpoint using this app's registered client id, which is the identity that endpoint checks",
+	"internal/modules/capture/telegram/api.go":          "calls a bot API under the bot's own token, and the bot IS the identity there",
+	"internal/modules/capture/telegram/sendfiles.go":    "calls a bot API under the bot's own token, and the bot IS the identity there",
+
+	// Test support and tooling. Both call a server this repository started, so
+	// the operator on the other end is the person who ran them.
+	"internal/compose/integration/apptest/appenv.go": "drives a server the test itself started, in the same process tree, for the length of one test",
+	"internal/compose/integration/apptest/mcp.go":    "drives a server the test itself started, in the same process tree, for the length of one test",
+	"tools/seed-demo/apiclient.go":                   "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+	"tools/seed-demo/documents.go":                   "seeds a demo estate through this product's own API, run by hand against a deployment the operator chose",
+})
+
+func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
+	t.Parallel()
+	var findings []string
+	builders := 0
+	eachGoFileInTheModule(t, func(path string, file *ast.File) {
+		if strings.HasSuffix(path, "_test.go") {
+			// A test's outbound call goes to a server the test started.
+			return
+		}
+		anonymous := anonymousRequestBuildersIn(file)
+		builders += len(requestBuildersIn(file))
+		if len(anonymous) == 0 {
+			return
+		}
+		if anonymousOutbound.Waived(t, path) {
+			return
+		}
+		findings = append(findings, path+": "+strings.Join(anonymous, ", "))
+	})
+	if builders < outboundBuilderFloor {
+		t.Fatalf("the walk found only %d outbound request builder(s), and this census is pinned at "+
+			"%d — a walk that stopped reaching them reports a clean tree in the same words as a "+
+			"tree with nothing left to fix", builders, outboundBuilderFloor)
+	}
+	anonymousOutbound.AssertAllMatched(t)
+	if len(findings) > 0 {
+		sort.Strings(findings)
+		t.Errorf("%d file(s) build an outbound request that names nobody:\n\t%s\n\n"+
+			"Go then sends `Go-http-client/1.1`, which names the language and not the caller, and "+
+			"an operator reading it can act on a language or on nothing. Set the User-Agent from "+
+			"an identity in internal/platform/outbound, or register the file above with the "+
+			"reason it needs none.",
+			len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+// outboundBuilderFloor is what the walk found when this census landed.
+const outboundBuilderFloor = 30
+
+// anonymousRequestBuildersIn names each function in the file that builds an
+// outbound request and never sets a User-Agent on it.
+//
+// Judged per FUNCTION, because that is the unit a header is set in: a file with
+// one named request and one anonymous one is a file with an anonymous request,
+// and judging the file whole would let the first vouch for the second.
+func anonymousRequestBuildersIn(file *ast.File) []string {
+	var out []string
+	for _, fn := range requestBuildersIn(file) {
+		if setsUserAgent(fn) {
+			continue
+		}
+		out = append(out, "func "+fn.Name.Name)
+	}
+	return out
+}
+
+// requestBuildersIn names every function in the file that builds an outbound
+// http.Request.
+func requestBuildersIn(file *ast.File) []*ast.FuncDecl {
+	var out []*ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil {
+			continue
+		}
+		if buildsARequest(fn.Body) {
+			out = append(out, fn)
+		}
+	}
+	return out
+}
+
+func buildsARequest(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+		pkg, isIdent := selector.X.(*ast.Ident)
+		if !isIdent || pkg.Name != "http" {
+			return true
+		}
+		if strings.HasPrefix(selector.Sel.Name, "NewRequest") {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// setsUserAgent reports whether the function names the caller on the request it
+// builds — by the header, or by a transport that carries one for it.
+func setsUserAgent(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		for _, arg := range call.Args {
+			lit, isLit := arg.(*ast.BasicLit)
+			if !isLit || lit.Kind != token.STRING {
+				continue
+			}
+			if strings.EqualFold(gatekit.TextOf(lit), "User-Agent") {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// The detector, from the other end. A census over an ABSENCE is the easiest
+// kind to have stop working: it reports a clean tree by finding nothing, which
+// is also what it does when it has stopped looking.
+func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name: "a request built and sent with no agent",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n\t_ = req\n}\n",
+			want: 1,
+		},
+		{
+			name: "the context form is the same request",
+			source: "package p\nimport (\n\t\"context\"\n\t\"net/http\"\n)\nfunc call(ctx context.Context) {\n" +
+				"\treq, _ := http.NewRequestWithContext(ctx, \"GET\", \"https://x.test\", nil)\n\t_ = req\n}\n",
+			want: 1,
+		},
+		{
+			name: "a request that names the caller",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n}\n",
+			want: 0,
+		},
+		{
+			// The header's canonical spelling is not the only one Go accepts,
+			// and a census that insisted on it would report a named request.
+			name: "the header is matched however it is cased",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"user-agent\", \"margince-x/1.0\")\n}\n",
+			want: 0,
+		},
+		{
+			name:   "a function that builds no request",
+			source: "package p\nfunc call() string { return \"https://x.test\" }\n",
+			want:   0,
+		},
+		{
+			// Per FUNCTION: a file's named request must not vouch for its
+			// anonymous one.
+			name: "a named request does not cover an anonymous sibling",
+			source: "package p\nimport \"net/http\"\nfunc named() {\n" +
+				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n}\n" +
+				"func bare() {\n\treq, _ := http.NewRequest(\"GET\", \"https://y.test\", nil)\n\t_ = req\n}\n",
+			want: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := parser.ParseFile(token.NewFileSet(), "probe.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			if got := anonymousRequestBuildersIn(parsed); len(got) != tc.want {
+				t.Errorf("the detector found %d anonymous builder(s), want %d: %v", len(got), tc.want, got)
+			}
+		})
+	}
+}

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -244,20 +244,37 @@ func setsUserAgent(fn *ast.FuncDecl, built map[string]bool) bool {
 func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
 	built := map[string]bool{}
 	ast.Inspect(body, func(node ast.Node) bool {
-		assign, isAssign := node.(*ast.AssignStmt)
-		if !isAssign || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
-			return true
-		}
-		call, isCall := assign.Rhs[0].(*ast.CallExpr)
-		if !isCall || !isRequestConstructor(call, client) {
-			return true
-		}
-		if name, isIdent := assign.Lhs[0].(*ast.Ident); isIdent {
-			built[name.Name] = true
+		switch typed := node.(type) {
+		case *ast.AssignStmt:
+			bindRequest(built, typed.Lhs, typed.Rhs, client)
+		case *ast.ValueSpec:
+			// `var req, err = http.NewRequest(…)`. Read as an assignment only,
+			// a function declaring its request this way looked as though it had
+			// built one and never named it — a false finding, which costs a
+			// census its reader as surely as a missed one.
+			names := make([]ast.Expr, 0, len(typed.Names))
+			for _, name := range typed.Names {
+				names = append(names, name)
+			}
+			bindRequest(built, names, typed.Values, client)
 		}
 		return true
 	})
 	return built
+}
+
+// bindRequest records the identifier a request constructor's result lands in.
+func bindRequest(built map[string]bool, lhs, rhs []ast.Expr, client string) {
+	if len(rhs) != 1 || len(lhs) == 0 {
+		return
+	}
+	call, isCall := rhs[0].(*ast.CallExpr)
+	if !isCall || !isRequestConstructor(call, client) {
+		return
+	}
+	if name, isIdent := lhs[0].(*ast.Ident); isIdent {
+		built[name.Name] = true
+	}
 }
 
 // isRequestConstructor matches the ways net/http starts an outbound request,
@@ -265,13 +282,33 @@ func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
 func isRequestConstructor(call *ast.CallExpr, client string) bool {
 	switch fn := call.Fun.(type) {
 	case *ast.SelectorExpr:
-		pkg, isIdent := fn.X.(*ast.Ident)
-		return isIdent && pkg.Name == client && startsARequest(fn.Sel.Name)
+		if pkg, isIdent := fn.X.(*ast.Ident); isIdent && pkg.Name == client {
+			return startsARequest(fn.Sel.Name)
+		}
+		// `http.DefaultClient.Get(…)` — the shared client, which is still one
+		// of these calls and still has nowhere to put a name.
+		return isDefaultClient(fn.X, client) && startsARequest(fn.Sel.Name)
 	case *ast.Ident:
 		// A dot import spells it unqualified.
 		return client == "" && startsARequest(fn.Name)
 	}
 	return false
+}
+
+// isDefaultClient matches net/http's package-level client, by name.
+//
+// A convenience method on a *http.Client VARIABLE is not matched, and cannot be
+// without type information a syntactic census does not have — `c.Get(url)` is
+// indistinguishable here from any other Get. The shared client is the one
+// spelling that is decidable, and it is also the one somebody reaches for when
+// they are not building a request at all.
+func isDefaultClient(expr ast.Expr, client string) bool {
+	selector, isSelector := expr.(*ast.SelectorExpr)
+	if !isSelector || selector.Sel.Name != "DefaultClient" {
+		return false
+	}
+	pkg, isIdent := selector.X.(*ast.Ident)
+	return isIdent && pkg.Name == client
 }
 
 // startsARequest names the net/http functions that put a request on the wire.
@@ -370,6 +407,19 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			name: "a convenience call is a request with nowhere to put a name",
 			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
 				"\tresp, _ := http.Get(\"https://x.test\")\n\t_ = resp\n}\n",
+			want: 1,
+		},
+		{
+			name: "a request declared with var is still this function's",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\tvar req, _ = http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
+				"\treq.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n}\n",
+			want: 0,
+		},
+		{
+			name: "the shared client's convenience call is one of these too",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\tresp, _ := http.DefaultClient.Get(\"https://x.test\")\n\t_ = resp\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -115,11 +115,11 @@ func TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot(t *testing.T) {
 	anonymousOutbound.AssertAllMatched(t)
 	if len(findings) > 0 {
 		sort.Strings(findings)
-		t.Errorf("%d file(s) build an outbound request that names nobody:\n\t%s\n\n"+
+		t.Errorf("%d function(s) build an outbound request that names nobody:\n\t%s\n\n"+
 			"Go then sends `Go-http-client/1.1`, which names the language and not the caller, and "+
 			"an operator reading it can act on a language or on nothing. Set the User-Agent from "+
-			"an identity in internal/platform/outbound, or register the file above with the "+
-			"reason it needs none.",
+			"an identity in internal/platform/outbound, or register the FUNCTION above — the "+
+			"register keys on `path:func name`, so a file-shaped entry matches nothing.",
 			len(findings), strings.Join(findings, "\n\t"))
 	}
 }
@@ -260,16 +260,33 @@ func requestsBuiltIn(body *ast.BlockStmt, client string) map[string]bool {
 	return built
 }
 
-// isRequestConstructor matches http.NewRequest and http.NewRequestWithContext,
-// under whatever name the file imports net/http by.
+// isRequestConstructor matches the ways net/http starts an outbound request,
+// under whatever name the file imports it by.
 func isRequestConstructor(call *ast.CallExpr, client string) bool {
 	switch fn := call.Fun.(type) {
 	case *ast.SelectorExpr:
 		pkg, isIdent := fn.X.(*ast.Ident)
-		return isIdent && pkg.Name == client && strings.HasPrefix(fn.Sel.Name, "NewRequest")
+		return isIdent && pkg.Name == client && startsARequest(fn.Sel.Name)
 	case *ast.Ident:
 		// A dot import spells it unqualified.
-		return client == "" && strings.HasPrefix(fn.Name, "NewRequest")
+		return client == "" && startsARequest(fn.Name)
+	}
+	return false
+}
+
+// startsARequest names the net/http functions that put a request on the wire.
+//
+// The CONVENIENCE forms are here beside NewRequest, and they are the sharper
+// half: http.Get and its siblings build and send in one call, so there is no
+// request to set a header on and the call is anonymous by construction. A
+// census that only knew NewRequest would report a clean tree over one, and its
+// floor could not catch that — a smaller count still clears it.
+func startsARequest(name string) bool {
+	switch {
+	case strings.HasPrefix(name, "NewRequest"):
+		return true
+	case name == "Get", name == "Post", name == "PostForm", name == "Head":
+		return true
 	}
 	return false
 }
@@ -323,8 +340,7 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			want: 1,
 		},
 		{
-			// One waived builder does not cover its neighbour, which is why the
-			// register keys on the function.
+			// A map keyed "User-Agent" writes no header at all.
 			name: "a header set on something that is not a request header",
 			source: "package p\nimport \"net/http\"\nfunc call(m map[string]string) {\n" +
 				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
@@ -345,6 +361,15 @@ func TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn(t *testing.T) {
 			source: "package p\nimport \"net/http\"\nfunc call(out *http.Request) {\n" +
 				"\treq, _ := http.NewRequest(\"GET\", \"https://x.test\", nil)\n" +
 				"\tout.Header.Set(\"User-Agent\", \"margince-x/1.0\")\n\t_ = req\n}\n",
+			want: 1,
+		},
+		{
+			// Built and sent in one call, so there is no request to name the
+			// caller on: anonymous by construction, and the census has to say
+			// so rather than not see it.
+			name: "a convenience call is a request with nowhere to put a name",
+			source: "package p\nimport \"net/http\"\nfunc call() {\n" +
+				"\tresp, _ := http.Get(\"https://x.test\")\n\t_ = resp\n}\n",
 			want: 1,
 		},
 		{

--- a/backend/internal/compose/oidcverify.go
+++ b/backend/internal/compose/oidcverify.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/outbound"
 )
 
 const googleJWKSURL = "https://www.googleapis.com/oauth2/v3/certs"
@@ -246,6 +248,10 @@ func (v *googleOIDCVerifier) fetchJWKS(ctx context.Context) (map[string]*rsa.Pub
 	if err != nil {
 		return nil, time.Time{}, err
 	}
+	// No credential rides on this request — a key set is published for anyone —
+	// so the agent is the only thing the provider's operator can attribute it
+	// by, and it is read on a schedule rather than once.
+	req.Header.Set("User-Agent", outbound.KeySetHeader)
 	resp, err := v.client.Do(req)
 	if err != nil {
 		return nil, time.Time{}, err

--- a/backend/internal/modules/capture/imap/imap.go
+++ b/backend/internal/modules/capture/imap/imap.go
@@ -52,8 +52,19 @@ const (
 
 	// dialTimeout bounds the TLS connect; pullDeadline bounds the whole
 	// select+fetch phase so a wedged or dribbling server cannot hang the
-	// request indefinitely (v2 has no per-command timeout, so we set a
-	// deadline on the underlying connection ourselves).
+	// request indefinitely.
+	//
+	// It is a bound on the PHASE, not on a response. v2 sets its own deadline
+	// before every response read (imapclient's respReadTimeout, 30s in the
+	// pinned beta.8), so no single command can wait longer than that whatever
+	// is set here — what pullDeadline stops is a server that answers every
+	// command just fast enough while the phase never ends.
+	//
+	// And that per-response deadline is the reason nothing else may touch this
+	// connection's deadline: the client reads on ONE goroutine, and a read
+	// deadline firing closes the connection and fails every pending command.
+	// A caller "bounding" one exchange more tightly would be rejecting the
+	// session, not the exchange.
 	dialTimeout  = 15 * time.Second
 	pullDeadline = 90 * time.Second
 

--- a/backend/internal/modules/capture/imap/imap.go
+++ b/backend/internal/modules/capture/imap/imap.go
@@ -50,21 +50,23 @@ const (
 	defaultMaxMessages = 50
 	maxMessagesCap     = 200
 
-	// dialTimeout bounds the TLS connect; pullDeadline bounds the whole
-	// select+fetch phase so a wedged or dribbling server cannot hang the
-	// request indefinitely.
+	// dialTimeout bounds the TLS connect. pullDeadline is set on the connection
+	// before the select+fetch phase, and what it actually bounds is NARROWER
+	// than it reads.
 	//
-	// It is a bound on the PHASE, not on a response. v2 sets its own deadline
-	// before every response read (imapclient's respReadTimeout, 30s in the
-	// pinned beta.8), so no single command can wait longer than that whatever
-	// is set here — what pullDeadline stops is a server that answers every
-	// command just fast enough while the phase never ends.
+	// v2 manages this connection's deadlines itself: it sets its own before
+	// every response read (respReadTimeout, 30s in the pinned beta.8) and
+	// CLEARS it afterwards — readResponse defers setReadTimeout(0), which is
+	// SetReadDeadline(time.Time{}). So the read half of what is armed here is
+	// overridden by the first read and gone after it, and the phase as a whole
+	// is bounded by nothing: a server answering every command inside 30s can
+	// keep a pull alive indefinitely. Bounding the phase needs a timer this
+	// package does not have — filed rather than fixed here.
 	//
-	// And that per-response deadline is the reason nothing else may touch this
-	// connection's deadline: the client reads on ONE goroutine, and a read
-	// deadline firing closes the connection and fails every pending command.
-	// A caller "bounding" one exchange more tightly would be rejecting the
-	// session, not the exchange.
+	// The client owning these deadlines is also why nothing else may set one:
+	// it reads on ONE goroutine, and a read deadline firing closes the
+	// connection and fails every pending command. A caller "bounding" a single
+	// exchange more tightly is rejecting the session, not the exchange.
 	dialTimeout  = 15 * time.Second
 	pullDeadline = 90 * time.Second
 

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -29,6 +29,7 @@ import (
 	"github.com/emersion/go-imap/v2/imapclient"
 
 	"github.com/margince/margince/backend/internal/platform/netguard"
+	"github.com/margince/margince/backend/internal/platform/outbound"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -116,12 +117,32 @@ func dialLogin(ctx context.Context, creds Credentials) (*imapclient.Client, net.
 	//craft:ignore swallowed-errors SetDeadline only errors on a closed conn; we just dialed it, and a failure surfaces as the next read timing out
 	_ = tlsConn.SetDeadline(time.Now().Add(pullDeadline))
 	client := imapclient.New(tlsConn, &imapclient.Options{})
+	announceClient(client)
 	if err := client.Login(creds.Email, creds.Password).Wait(); err != nil {
 		//craft:ignore swallowed-errors best-effort close of a session whose login already failed — the rejection is the error to report
 		_ = client.Close()
 		return nil, nil, ErrLoginRejected
 	}
 	return client, tlsConn, nil
+}
+
+// announceClient sends the RFC 2971 ID, which is how a mailbox provider names
+// this client in their own logs and throttles it by name rather than by guess.
+// Nothing sent it, so every session was anonymous to the provider carrying it.
+//
+// Only when the server advertises the extension, and a refusal is not fatal:
+// an introduction is a courtesy the session does not depend on, and declining
+// to read a person's mail because their provider would not take one would be
+// the wrong trade entirely.
+func announceClient(client *imapclient.Client) {
+	if !client.Caps().Has(imapv2.CapID) {
+		return
+	}
+	//craft:ignore swallowed-errors an introduction the provider refused changes nothing about the session; the mail is still there to read
+	_, _ = client.ID(&imapv2.IDData{
+		Name:    outbound.MailboxProduct,
+		Version: outbound.MailboxVersion,
+	}).Wait()
 }
 
 // authenticateStanding probes the credentials end to end (dial, login,

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -117,7 +117,7 @@ func dialLogin(ctx context.Context, creds Credentials) (*imapclient.Client, net.
 	//craft:ignore swallowed-errors SetDeadline only errors on a closed conn; we just dialed it, and a failure surfaces as the next read timing out
 	_ = tlsConn.SetDeadline(time.Now().Add(pullDeadline))
 	client := imapclient.New(tlsConn, &imapclient.Options{})
-	announceClient(client)
+	announceClient(client, tlsConn)
 	if err := client.Login(creds.Email, creds.Password).Wait(); err != nil {
 		//craft:ignore swallowed-errors best-effort close of a session whose login already failed — the rejection is the error to report
 		_ = client.Close()
@@ -134,16 +134,29 @@ func dialLogin(ctx context.Context, creds Credentials) (*imapclient.Client, net.
 // an introduction is a courtesy the session does not depend on, and declining
 // to read a person's mail because their provider would not take one would be
 // the wrong trade entirely.
-func announceClient(client *imapclient.Client) {
+func announceClient(client *imapclient.Client, conn net.Conn) {
 	if !client.Caps().Has(imapv2.CapID) {
 		return
 	}
+	// Its own deadline, and the session's put back afterwards. The connection
+	// carries ONE deadline for everything after it, so a provider that answers
+	// the introduction slowly would otherwise spend the login's time — and a
+	// courtesy that can fail the login it precedes is worse than no courtesy.
+	//craft:ignore swallowed-errors SetDeadline only errors on a closed conn; we just dialed it, and a failure surfaces as the next read timing out
+	_ = conn.SetDeadline(time.Now().Add(announceDeadline))
 	//craft:ignore swallowed-errors an introduction the provider refused changes nothing about the session; the mail is still there to read
 	_, _ = client.ID(&imapv2.IDData{
 		Name:    outbound.MailboxProduct,
 		Version: outbound.MailboxVersion,
 	}).Wait()
+	//craft:ignore swallowed-errors as above — the login below is what reports a connection that has gone
+	_ = conn.SetDeadline(time.Now().Add(pullDeadline))
 }
+
+// announceDeadline bounds the introduction alone. Short, because nothing waits
+// on it: a provider that will not take an ID in this long is one this session
+// carries on without.
+const announceDeadline = 10 * time.Second
 
 // authenticateStanding probes the credentials end to end (dial, login,
 // close) and returns the normalized bundle as the sealed Auth — the vault

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -117,7 +117,7 @@ func dialLogin(ctx context.Context, creds Credentials) (*imapclient.Client, net.
 	//craft:ignore swallowed-errors SetDeadline only errors on a closed conn; we just dialed it, and a failure surfaces as the next read timing out
 	_ = tlsConn.SetDeadline(time.Now().Add(pullDeadline))
 	client := imapclient.New(tlsConn, &imapclient.Options{})
-	announceClient(client, tlsConn)
+	announceClient(client)
 	if err := client.Login(creds.Email, creds.Password).Wait(); err != nil {
 		//craft:ignore swallowed-errors best-effort close of a session whose login already failed — the rejection is the error to report
 		_ = client.Close()
@@ -134,29 +134,24 @@ func dialLogin(ctx context.Context, creds Credentials) (*imapclient.Client, net.
 // an introduction is a courtesy the session does not depend on, and declining
 // to read a person's mail because their provider would not take one would be
 // the wrong trade entirely.
-func announceClient(client *imapclient.Client, conn net.Conn) {
+func announceClient(client *imapclient.Client) {
 	if !client.Caps().Has(imapv2.CapID) {
 		return
 	}
-	// Its own deadline, and the session's put back afterwards. The connection
-	// carries ONE deadline for everything after it, so a provider that answers
-	// the introduction slowly would otherwise spend the login's time — and a
-	// courtesy that can fail the login it precedes is worse than no courtesy.
-	//craft:ignore swallowed-errors SetDeadline only errors on a closed conn; we just dialed it, and a failure surfaces as the next read timing out
-	_ = conn.SetDeadline(time.Now().Add(announceDeadline))
+	// The exchange is bounded by the CLIENT, which sets its own read timeout
+	// per response, and nothing here touches the connection's deadline.
+	//
+	// A shorter deadline set from out here would not make the introduction
+	// safer, it would make it fatal: this client reads on one goroutine, and a
+	// read deadline firing closes the connection and fails every pending
+	// command — so a provider slow to answer an ID would have its LOGIN
+	// rejected, which is the harm bounding it was supposed to avoid.
 	//craft:ignore swallowed-errors an introduction the provider refused changes nothing about the session; the mail is still there to read
 	_, _ = client.ID(&imapv2.IDData{
 		Name:    outbound.MailboxProduct,
 		Version: outbound.MailboxVersion,
 	}).Wait()
-	//craft:ignore swallowed-errors as above — the login below is what reports a connection that has gone
-	_ = conn.SetDeadline(time.Now().Add(pullDeadline))
 }
-
-// announceDeadline bounds the introduction alone. Short, because nothing waits
-// on it: a provider that will not take an ID in this long is one this session
-// carries on without.
-const announceDeadline = 10 * time.Second
 
 // authenticateStanding probes the credentials end to end (dial, login,
 // close) and returns the normalized bundle as the sealed Auth — the vault

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -210,8 +210,9 @@ func (c *Connector) syncStanding(ctx context.Context, auth connector.Auth, curso
 	// concurrent syncs of different mailboxes must not see each other.
 	st := &syncState{owner: creds.Email, contacts: map[string]struct{}{}}
 	if err := netConn.SetDeadline(time.Now().Add(pullDeadline)); err != nil {
-		// Without the deadline a wedged server could hang this pull
-		// forever — refuse rather than sync unbounded.
+		// Armed for the exchanges before v2 takes the deadline over — see
+		// pullDeadline, which says how much of the phase this really bounds.
+		// A connection that will not take a deadline is not one to sync on.
 		return nil, fmt.Errorf("imap: arming the read deadline: %w", errors.Join(ErrUnreachable, err))
 	}
 

--- a/backend/internal/modules/integrations/surfe/surfe.go
+++ b/backend/internal/modules/integrations/surfe/surfe.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/margince/margince/backend/internal/platform/outbound"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
 
@@ -227,6 +228,10 @@ func (a *Adapter) call(ctx context.Context, cred provider.Credential, method, pa
 	req.Header.Set("Authorization", "Bearer "+string(cred))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	// The key names the customer's account; the agent names the software
+	// calling under it, so an operator throttling one is not throttling the
+	// other.
+	req.Header.Set("User-Agent", outbound.EnrichHeader)
 
 	resp, err := a.client.Do(req)
 	if err != nil {

--- a/backend/internal/modules/overlay/hubspot/client.go
+++ b/backend/internal/modules/overlay/hubspot/client.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/margince/margince/backend/internal/platform/outbound"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -154,6 +155,10 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 		return fmt.Errorf("hubspot: building request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
+	// Their administrator reads this traffic in an audit log beside their own
+	// people's, and "some Go program" is not an answer to "what is writing to
+	// our records".
+	req.Header.Set("User-Agent", outbound.MirrorHeader)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/backend/internal/platform/mailer/mailer.go
+++ b/backend/internal/platform/mailer/mailer.go
@@ -85,8 +85,13 @@ func (s SMTP) Send(ctx context.Context, to, subject, textBody string) error {
 // and differs per installation, which is the whole point. The product token
 // stands in only when the configured sender carries no domain to announce.
 func (s SMTP) helloName() string {
-	if _, domain, found := strings.Cut(s.FromAddress, "@"); found && domain != "" {
-		return domain
+	// The LAST `@`, because a quoted local part may hold one — `"a@b"@x.test`
+	// is a legal address whose domain is `x.test`, and cutting at the first
+	// would announce `b"@x.test`, which is not a name any relay will take.
+	if at := strings.LastIndex(s.FromAddress, "@"); at >= 0 {
+		if domain := strings.TrimSpace(s.FromAddress[at+1:]); domain != "" {
+			return domain
+		}
 	}
 	return outbound.MailProduct
 }

--- a/backend/internal/platform/mailer/mailer.go
+++ b/backend/internal/platform/mailer/mailer.go
@@ -18,6 +18,8 @@ import (
 	"net/smtp"
 	"strings"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/outbound"
 )
 
 // Mailer sends one plain-text transactional message. Implementations
@@ -76,6 +78,19 @@ func (s SMTP) Send(ctx context.Context, to, subject, textBody string) error {
 	return client.Quit()
 }
 
+// helloName is what this installation announces to the relay.
+//
+// The sender's own domain, which is the honest answer and the one the relay is
+// about to see in MAIL FROM anyway — so it needs no configuration of its own
+// and differs per installation, which is the whole point. The product token
+// stands in only when the configured sender carries no domain to announce.
+func (s SMTP) helloName() string {
+	if _, domain, found := strings.Cut(s.FromAddress, "@"); found && domain != "" {
+		return domain
+	}
+	return outbound.MailProduct
+}
+
 // connect dials the relay, bounds the WHOLE exchange with one deadline
 // (a stalling relay must not pin a goroutine and socket per reset
 // request), secures the channel, and authenticates.
@@ -93,6 +108,18 @@ func (s SMTP) connect(ctx context.Context, addr string) (*smtp.Client, error) {
 	if err != nil {
 		closeQuietly(conn)
 		return nil, fmt.Errorf("mailer: relay %s greeting failed: %w", addr, err)
+	}
+	// Announced BEFORE STARTTLS and before AUTH, which is the only place SMTP
+	// takes it: the library re-issues the same name after the upgrade.
+	//
+	// Without this call net/smtp says `localhost`, and every installation says
+	// it identically. That is worse than anonymous — it is a claim, and a false
+	// one, since the mail did not come from the relay's own machine. A relay
+	// operator reads the EHLO name to attribute what they are carrying, and
+	// they cannot attribute a name that is the same for everyone.
+	if err := client.Hello(s.helloName()); err != nil {
+		closeQuietly(client)
+		return nil, fmt.Errorf("mailer: relay %s refused the greeting: %w", addr, err)
 	}
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		if err := client.StartTLS(&tls.Config{ServerName: s.Host, MinVersion: tls.VersionTLS12}); err != nil {

--- a/backend/internal/platform/mailer/mailer_test.go
+++ b/backend/internal/platform/mailer/mailer_test.go
@@ -201,6 +201,23 @@ func TestTheGreetingNamesTheSenderRatherThanLocalhost(t *testing.T) {
 			want: "acme.example",
 		},
 		{
+			// A quoted local part may hold an `@` of its own, and the domain is
+			// what follows the LAST one.
+			name: "a quoted local part does not move the domain",
+			from: `"bounce@internal"@acme.example`,
+			want: "acme.example",
+		},
+		{
+			name: "a trailing space is not part of the name",
+			from: "notifications@acme.example ",
+			want: "acme.example",
+		},
+		{
+			name: "an address ending at the at-sign announces the product",
+			from: "postmaster@",
+			want: outbound.MailProduct,
+		},
+		{
 			// Nothing to announce from, so the product token stands in — still
 			// not a claim about which machine this is.
 			name: "a sender with no domain falls back to the product",

--- a/backend/internal/platform/mailer/mailer_test.go
+++ b/backend/internal/platform/mailer/mailer_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/outbound"
 )
 
 // fakeRelay is a minimal in-process SMTP server on the loopback — the one
@@ -177,5 +179,48 @@ func TestIsLoopbackRecognizesLocalRelaysOnly(t *testing.T) {
 		if got := isLoopback(host); got != want {
 			t.Errorf("isLoopback(%q) = %v, want %v", host, got, want)
 		}
+	}
+}
+
+// TestTheGreetingNamesTheSenderRatherThanLocalhost is what a relay operator
+// reads to attribute the mail they are carrying.
+//
+// Nothing called Hello, so net/smtp announced `localhost` — and every
+// installation announced it identically. That is worse than anonymous: it is a
+// claim, and a false one, since the mail did not come from the relay's own
+// machine.
+func TestTheGreetingNamesTheSenderRatherThanLocalhost(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		want string
+	}{
+		{
+			name: "the sender's own domain, which the relay sees in MAIL FROM anyway",
+			from: "notifications@acme.example",
+			want: "acme.example",
+		},
+		{
+			// Nothing to announce from, so the product token stands in — still
+			// not a claim about which machine this is.
+			name: "a sender with no domain falls back to the product",
+			from: "postmaster",
+			want: outbound.MailProduct,
+		},
+		{
+			name: "an unconfigured sender still announces something",
+			from: "",
+			want: outbound.MailProduct,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (SMTP{FromAddress: tc.from}).helloName(); got != tc.want {
+				t.Errorf("helloName() = %q, want %q", got, tc.want)
+			}
+			if got := (SMTP{FromAddress: tc.from}).helloName(); got == "localhost" {
+				t.Errorf("the greeting still claims to be the relay's own machine")
+			}
+		})
 	}
 }

--- a/backend/internal/platform/mailer/mailer_test.go
+++ b/backend/internal/platform/mailer/mailer_test.go
@@ -232,11 +232,11 @@ func TestTheGreetingNamesTheSenderRatherThanLocalhost(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// The exact value, which is what guards the regression: no `want`
+			// here is "localhost", so pinning the answer pins that too. A
+			// second assertion against the old default could never fire.
 			if got := (SMTP{FromAddress: tc.from}).helloName(); got != tc.want {
 				t.Errorf("helloName() = %q, want %q", got, tc.want)
-			}
-			if got := (SMTP{FromAddress: tc.from}).helloName(); got == "localhost" {
-				t.Errorf("the greeting still claims to be the relay's own machine")
 			}
 		})
 	}

--- a/backend/internal/platform/outbound/useragent.go
+++ b/backend/internal/platform/outbound/useragent.go
@@ -52,4 +52,49 @@ const (
 	// other end most needs to know who is asking.
 	ClientMetadataProduct = "margince-oauth"
 	ClientMetadataHeader  = ClientMetadataProduct + "/" + version
+
+	// KeySetProduct identifies the fetch of an identity provider's public key
+	// set. The request carries no credential — it is a read of a document
+	// published for anyone — so the agent is the ONLY thing the provider's
+	// operator has to attribute it by, and a key set is read on a schedule
+	// rather than once.
+	//
+	// Named for the DOCUMENT rather than for what it is used for. Spelled
+	// around the word "token" it reads as a secret to a scanner, and a
+	// suppression on a public constant is a worse answer than a better name.
+	KeySetProduct = "margince-keyset"
+	KeySetHeader  = KeySetProduct + "/" + version
+
+	// SearchProduct identifies web-search queries. The key names the ACCOUNT,
+	// which is one customer's contract with the provider; the agent names the
+	// software making the calls under it. An operator diagnosing a spike can
+	// act on the second without cancelling the first.
+	SearchProduct = "margince-search"
+	SearchHeader  = SearchProduct + "/" + version
+
+	// EnrichProduct identifies contact-enrichment lookups, for the same reason
+	// as the search token and separately from it: the two run at different
+	// rates against different vendors, and one being throttled must not be the
+	// other's problem.
+	EnrichProduct = "margince-enrich"
+	EnrichHeader  = EnrichProduct + "/" + version
+
+	// MirrorProduct identifies reads and writes against a customer's own CRM
+	// while this product mirrors it. Their administrator sees the traffic in an
+	// audit log beside their people's own, and "some Go program" is not an
+	// answer to "what is writing to our records".
+	MirrorProduct = "margince-mirror"
+	MirrorHeader  = MirrorProduct + "/" + version
+
+	// MailProduct is what an SMTP session announces when the sender's address
+	// carries no domain to announce instead. A relay operator reads the EHLO
+	// name to attribute mail; the library's default is `localhost`, which is
+	// not merely anonymous but a claim, and a false one.
+	MailProduct = "margince-mail"
+
+	// MailboxProduct identifies this product in an IMAP ID exchange (RFC 2971).
+	// A mailbox provider throttles per client, and a client they cannot name is
+	// one they can only throttle by guessing.
+	MailboxProduct = "margince-mailbox"
+	MailboxVersion = version
 )

--- a/backend/internal/platform/websearchhttp/websearchhttp.go
+++ b/backend/internal/platform/websearchhttp/websearchhttp.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/platform/outbound"
 	"github.com/margince/margince/backend/internal/shared/ports/websearch"
 )
 
@@ -122,6 +123,10 @@ func (b *Brave) Search(ctx context.Context, q websearch.Query) ([]websearch.Resu
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Subscription-Token", b.key)
+	// The key names the customer's ACCOUNT; the agent names the software
+	// calling under it. An operator diagnosing a spike can act on the second
+	// without cancelling the first.
+	req.Header.Set("User-Agent", outbound.SearchHeader)
 
 	resp, err := b.client.Do(req)
 	if err != nil {

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -67,7 +67,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 
-## Census (70)
+## Census (71)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -121,6 +121,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `onesqlliteralreader_test.go` | H2 | A census over the censuses: whoever judges this tree's SQL must read it the way Postgres receives it. |
 | `onestringfolder_test.go` | H2 | A census over the censuses: nobody writes a second reader for "what string does this Go expression hold". |
 | `onevoiceversionwriter_test.go` | H2 | voice\_profile\_version and voice\_profile\_delta each have ONE writer. |
+| `outboundanonymity_test.go` | H2 | Every outbound HTTP request either says who is calling, or is registered as deliberately anonymous with the reason. |
 | `parallelgates_test.go` | H3 | Every gate here runs in parallel with the others, and this is what keeps that true as gates are added. |
 | `passportmint_test.go` | H1 | A passport is minted for the session user, and for nobody else. |
 | `personattachlock_test.go` | H2 | A relationship carrying a person is written under that person's row lock. |


### PR DESCRIPTION
Closes #2523.

> Stacked on #3111 (issue #2487) for the shared module walk `eachGoFileInTheModule`. Its commits drop out of this diff once that merges.

## The gap

23 live paths set no `User-Agent`, so Go supplied `Go-http-client/1.1` — a string that names the language runtime and nothing about who is calling or why. An operator diagnosing that traffic can act on a language or on nothing.

The sibling gate (`TestNoOutboundIdentityIsWrittenAtItsCallSite`, from #2519) holds the calls that *declare* something to one spelling. It has nothing to say about a call that declares nothing, and the ticket puts why sharply: **a gate cannot see an absent header** — not unless it goes looking, which is what the new census does.

## Named, where the operator has no other signal

| surface | why it needs one |
|---|---|
| **JWKS** (`oidcverify.go`) | carries **no credential at all** — a key set is published for anyone, so the agent is the only attribution the provider's operator has, and it is read on a schedule |
| **Brave** (`websearchhttp.go`) | the key names the customer's **account**; the agent names the software calling under it, so an operator throttling one is not cancelling the other |
| **Surfe** (`surfe.go`) | same, and separately: the two run at different rates against different vendors |
| **HubSpot** (`overlay/hubspot/client.go`) | their administrator reads this traffic in an audit log beside their own people's, and "some Go program" is not an answer to "what is writing to our records" |

## Not everywhere, and that difference is the deliverable

A token-authenticated provider API already knows exactly who is calling: the credential says so, the OAuth grant says so, the bot's own token *is* the identity. Those calls need no name — what they needed was a **record that somebody decided so**, because "decided" and "never considered" look identical in the code. That register is `anonymousOutbound` in the new census, one entry per file with its reason.

## The two non-HTTP identities

**SMTP announced `localhost`** — not merely anonymous but a claim, and a false one, since the mail did not come from the relay's own machine, and every installation said it identically. It announces **the sender's own domain**: what the relay is about to see in `MAIL FROM` anyway, so it needs no configuration of its own and differs per installation, which was the whole complaint.

**IMAP sent no RFC 2971 `ID`**, so every session was anonymous to the provider carrying it. It introduces itself where the server advertises the extension, and a refusal is not fatal — declining to read a person's mail because their provider would not take an introduction would be the wrong trade entirely.

## The census

`TestEveryOutboundRequestSaysWhoIsCallingOrRegistersWhyNot` judges **per function**, because that is the unit a header is set in: a file with one named request and one anonymous one is a file with an anonymous request, and judging the file whole would let the first vouch for the second. Pinned at 30 builders, because a census over an *absence* is the easiest kind to have quietly stop working.

`TestTheAnonymityCensusSeesEachShapeARequestIsBuiltIn` plants six shapes, including the two that must not fire and the case-insensitive header spelling.

Mutation-checked: removing the Brave agent fails the census naming `func Search`.

## One census row was already stale

`extensions/relay-probe` is no longer in the tree, so that row of the ticket's table has nothing behind it.

## A name changed to avoid a suppression

The key-set token is `margince-keyset`, not `margince-tokenverify`: spelled around "token" it reads as a secret to gosec, and a `nolint` on a public constant is a worse answer than a better name.

Local: `make check-backend`, `make craft-static` green; gate inventory regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent product identification to outbound requests for search, enrichment, CRM, OIDC, and mailbox integrations.
  - IMAP connections now announce supported client details when servers allow it.
  - SMTP connections identify the sending domain during setup, with a product fallback when unavailable.

- **Bug Fixes**
  - Improved outbound request transparency while preserving authentication and synchronization behavior.
  - SMTP greeting failures are handled cleanly before connection setup continues.

- **Documentation**
  - Updated the gate inventory to reflect expanded repository checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->