### PR TITLE
Say what a meeting is about where the caller chooses its links

### DIFF
--- a/backend/internal/modules/agents/toollist_test.go
+++ b/backend/internal/modules/agents/toollist_test.go
@@ -53,12 +53,11 @@ func TestAWriteOnlyPassportIsStillOfferedItsOwnIdentity(t *testing.T) {
 // TestTheLinksArgumentSaysWhatAMeetingIsAbout holds the fact that decides
 // whether a logged meeting lands on a timeline anybody reads.
 //
-// Driven from claude.ai, a model logging a meeting after a call linked it to the
-// DEAL only and attached the person and the company afterwards. A meeting is
-// with a person and reaches their company through them, so the transcript sat
-// on no attendee's timeline and the company saw nothing — and the correction was
-// two more writes. The schema is where that is decided, because it is what the
-// caller reads before choosing.
+// A meeting is with a PERSON and reaches their company through them. Linked to
+// the deal alone it sits on no attendee's timeline and the company sees
+// nothing, and putting it right afterwards is a second write. The schema is
+// where that is decided, because it is what the caller reads before choosing —
+// so the copy has to carry the modelling fact, not only the instruction.
 func TestTheLinksArgumentSaysWhatAMeetingIsAbout(t *testing.T) {
 	t.Parallel()
 	schema := string(logActivity{}.Spec().InputSchema)

--- a/backend/internal/modules/agents/toollist_test.go
+++ b/backend/internal/modules/agents/toollist_test.go
@@ -69,8 +69,14 @@ func TestTheLinksArgumentSaysWhatAMeetingIsAbout(t *testing.T) {
 		"with a PERSON",
 		"reaches their company through them",
 		// What a deal-only link actually costs, which is the mistake this copy
-		// exists to stop.
+		// exists to stop — on both sides, because the person's timeline and the
+		// company's are two facts and losing either leaves the copy half true.
 		"no attendee's timeline",
+		"the company sees nothing",
+		// And what doing it in two calls costs instead, including the one
+		// destination that still asks a human.
+		"a second write",
+		"onto a project it asks a human",
 	} {
 		if !strings.Contains(schema, want) {
 			t.Errorf("the links argument no longer says %q:\n%s", want, schema)

--- a/backend/internal/modules/agents/toollist_test.go
+++ b/backend/internal/modules/agents/toollist_test.go
@@ -73,9 +73,10 @@ func TestTheLinksArgumentSaysWhatAMeetingIsAbout(t *testing.T) {
 		"no attendee's timeline",
 		"the company sees nothing",
 		// And what doing it in two calls costs instead, including the one
-		// destination that still asks a human.
+		// destination that still waits on a person — said as what it does to
+		// the link, not only that somebody is asked.
 		"a second write",
-		"onto a project it asks a human",
+		"stages an approval a human must decide before it takes effect",
 	} {
 		if !strings.Contains(schema, want) {
 			t.Errorf("the links argument no longer says %q:\n%s", want, schema)

--- a/backend/internal/modules/agents/toollist_test.go
+++ b/backend/internal/modules/agents/toollist_test.go
@@ -7,6 +7,7 @@ package agents
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -46,5 +47,33 @@ func TestAWriteOnlyPassportIsStillOfferedItsOwnIdentity(t *testing.T) {
 	readOnly := offered(principal.ScopeRead)
 	if slices.Contains(readOnly, "log_activity") {
 		t.Errorf("a read-only passport is offered %v — a write tool must not be among them", readOnly)
+	}
+}
+
+// TestTheLinksArgumentSaysWhatAMeetingIsAbout holds the fact that decides
+// whether a logged meeting lands on a timeline anybody reads.
+//
+// Driven from claude.ai, a model logging a meeting after a call linked it to the
+// DEAL only and attached the person and the company afterwards. A meeting is
+// with a person and reaches their company through them, so the transcript sat
+// on no attendee's timeline and the company saw nothing — and the correction was
+// two more writes. The schema is where that is decided, because it is what the
+// caller reads before choosing.
+func TestTheLinksArgumentSaysWhatAMeetingIsAbout(t *testing.T) {
+	t.Parallel()
+	schema := string(logActivity{}.Spec().InputSchema)
+	for _, want := range []string{
+		// All of them, in this call.
+		"ALL OF THEM in this call",
+		// A meeting is with a PERSON, and the company follows from that.
+		"with a PERSON",
+		"reaches their company through them",
+		// What a deal-only link actually costs, which is the mistake this copy
+		// exists to stop.
+		"no attendee's timeline",
+	} {
+		if !strings.Contains(schema, want) {
+			t.Errorf("the links argument no longer says %q:\n%s", want, schema)
+		}
 	}
 }

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -371,7 +371,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 			"links":{"type":"array","items":{"type":"object","required":["entity_type","entity_id"],"properties":{
 				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
 				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},
-				"description":"Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval."},
+				"description":"Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human."},
 			"source_system":{"type":"string"},"source_id":{"type":"string"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[wireRecord](),

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -371,7 +371,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 			"links":{"type":"array","items":{"type":"object","required":["entity_type","entity_id"],"properties":{
 				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
 				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},
-				"description":"Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human."},
+				"description":"Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Adding a link AFTERWARDS is a second write — and a later link onto a project stages an approval a human must decide before it takes effect."},
 			"source_system":{"type":"string"},"source_id":{"type":"string"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[wireRecord](),

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 59,
-    "tokens": 18813,
+    "tokens": 18830,
     "median_tool_tokens": 275,
     "mean_tool_tokens": 318
   },
@@ -45,9 +45,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2367,
+      "tokens": 2384,
       "percent_of_ceiling": 9,
-      "headroom_tokens": 14633,
+      "headroom_tokens": 14616,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -79,7 +79,7 @@
     },
     {
       "name": "log_activity",
-      "tokens": 625
+      "tokens": 642
     },
     {
       "name": "update_record",

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 59,
-    "tokens": 18776,
+    "tokens": 18813,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 317
+    "mean_tool_tokens": 318
   },
   "agents": [
     {
@@ -45,9 +45,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2330,
+      "tokens": 2367,
       "percent_of_ceiling": 9,
-      "headroom_tokens": 14670,
+      "headroom_tokens": 14633,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -78,12 +78,12 @@
       "tokens": 708
     },
     {
-      "name": "update_record",
-      "tokens": 603
+      "name": "log_activity",
+      "tokens": 625
     },
     {
-      "name": "log_activity",
-      "tokens": 588
+      "name": "update_record",
+      "tokens": 603
     },
     {
       "name": "send_account_email",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2367 | 9% | 14633 | 15 | 8 |
-| _whole served catalog, for scale_ | 59 | 18813 | 78% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2384 | 9% | 14616 | 15 | 8 |
+| _whole served catalog, for scale_ | 59 | 18830 | 78% | — | — | — |
 
 ### `morning_brief`
 
@@ -55,7 +55,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2367 tokens, leaving 14633 of its budget and 21633 tokens of the
+Attaches 7 tools for 2384 tokens, leaving 14616 of its budget and 21616 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -134,7 +134,7 @@ a term in an addition.
 |---|---:|---:|
 | `run_report` | 1213 | 3 scenarios |
 | `preview_import` | 708 | — |
-| `log_activity` | 625 | 1 scenario |
+| `log_activity` | 642 | 1 scenario |
 | `update_record` | 603 | 4 scenarios |
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
-| _whole served catalog, for scale_ | 59 | 18776 | 78% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2367 | 9% | 14633 | 15 | 8 |
+| _whole served catalog, for scale_ | 59 | 18813 | 78% | — | — | — |
 
 ### `morning_brief`
 
@@ -55,7 +55,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2330 tokens, leaving 14670 of its budget and 21670 tokens of the
+Attaches 7 tools for 2367 tokens, leaving 14633 of its budget and 21633 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 317, across 59 served tools.
+Median 275 tokens, mean 318, across 59 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -134,8 +134,8 @@ a term in an addition.
 |---|---:|---:|
 | `run_report` | 1213 | 3 scenarios |
 | `preview_import` | 708 | — |
+| `log_activity` | 625 | 1 scenario |
 | `update_record` | 603 | 4 scenarios |
-| `log_activity` | 588 | 1 scenario |
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |
 | `query_workspace` | 491 | 3 scenarios |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 167819,
+    "tool_catalog_bytes": 167966,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 42833,
+    "approx_wire_tokens_total": 42869,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 39998,
-      "input_schema_bytes": 37035,
+      "input_schema_bytes": 37182,
       "output_schema_bytes": 77961,
-      "description_plus_input_schema_bytes": 77033
+      "description_plus_input_schema_bytes": 77180
     }
   },
   "tools": {
@@ -4657,7 +4657,7 @@
               "type": "string"
             },
             "links": {
-              "description": "Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval.",
+              "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human.",
               "items": {
                 "additionalProperties": false,
                 "properties": {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 167966,
+    "tool_catalog_bytes": 168034,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 42869,
+    "approx_wire_tokens_total": 42886,
     "largest_tool_bytes": 6414,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 39998,
-      "input_schema_bytes": 37182,
+      "input_schema_bytes": 37250,
       "output_schema_bytes": 77961,
-      "description_plus_input_schema_bytes": 77180
+      "description_plus_input_schema_bytes": 77248
     }
   },
   "tools": {
@@ -4657,7 +4657,7 @@
               "type": "string"
             },
             "links": {
-              "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human.",
+              "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Adding a link AFTERWARDS is a second write — and a later link onto a project stages an approval a human must decide before it takes effect.",
               "items": {
                 "additionalProperties": false,
                 "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 164.0 KB |
+| Tool catalog | 164.1 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 42869 |
+| Approx. wire tokens | 42886 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,7 +31,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 76.1 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 39.1 KB | 23% | Yes, every step |
-| Input schemas | 36.3 KB | 22% | Yes, every step |
+| Input schemas | 36.4 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
 | **Description + input schema** | **75.4 KB** | **45%** | **the recurring cost** |
 
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
-| [`log_activity`](#log_activity) | Log an activity |  |  | 3.6 KB |
+| [`log_activity`](#log_activity) | Log an activity |  |  | 3.7 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
@@ -5212,7 +5212,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "links": {
-      "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human.",
+      "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Adding a link AFTERWARDS is a second write — and a later link onto a project stages an approval a human must decide before it takes effect.",
       "items": {
         "additionalProperties": false,
         "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 163.9 KB |
+| Tool catalog | 164.0 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 42833 |
+| Approx. wire tokens | 42869 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,9 +31,9 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 76.1 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 39.1 KB | 23% | Yes, every step |
-| Input schemas | 36.2 KB | 22% | Yes, every step |
+| Input schemas | 36.3 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
-| **Description + input schema** | **75.2 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **75.4 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
-| [`log_activity`](#log_activity) | Log an activity |  |  | 3.4 KB |
+| [`log_activity`](#log_activity) | Log an activity |  |  | 3.6 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
@@ -5212,7 +5212,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "links": {
-      "description": "Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval.",
+      "description": "Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human.",
       "items": {
         "additionalProperties": false,
         "properties": {


### PR DESCRIPTION
Closes #2534.

## What is already fixed, and what is not

The ticket's headline — two spurious approvals for one logged meeting — was fixed by **#2613** (`24d6fdc1d`, 2026-08-25): a relink onto a person, a company or a deal no longer asks a human, because `relinkActivityTier` always said it should not and the dynamic tier was unreachable. That PR also added the first version of this `links` copy.

What #2613 did **not** fix is the modelling mistake that produced the sequence in the first place:

> **a meeting is with a person**, and shows on the company through that person. Because the first call linked only the deal, the meeting landed on the wrong timeline

A meeting linked to the deal alone still sits on no attendee's timeline, and the company still sees nothing. That is not an approval problem; it is the model not knowing what a meeting *is*.

## The change

The `links` description is where that is decided, because the schema is what the caller reads before choosing. It said which records to pass and not what a meeting is:

> Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval.

It now says both, and names the one destination that still asks a human:

> Every record this was about, ALL OF THEM in this call. A meeting is with a PERSON and reaches their company through them, so a meeting linked to the deal alone sits on no attendee's timeline and the company sees nothing. Linking afterwards is a second write, and onto a project it asks a human.

`TestTheLinksArgumentSaysWhatAMeetingIsAbout` pins the four facts, because copy without a test drifts back.

## The other suggestion, and why not

> or refuse a `log_activity` whose `links` name a deal but no person

A note about a deal with no attendee is a real thing to log — a stage change, a decision recorded against the opportunity itself. The refusal would land on legitimate calls in order to stop a likely mistake, where saying the cost at the point of choice does not.

`agent-tool-budget` and `mcp-info` regenerated.

Local: `make check-backend`, `make craft-static` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified meeting activity-linking requirements, including relevant people, companies, deals, and other records.
  * Documented that links added after activity creation are separate writes and that project associations require human approval.
  * Clarified that import previews require explicit mappings for unmatched column headers.
  * Updated tool catalog size and usage metrics.

* **Tests**
  * Added coverage verifying meeting-linking guidance explains required relationships and multi-step linking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->