### PR TITLE
Name the currency a brief's revenue norm is in

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29867,7 +29867,6 @@ components:
         revenue_norm_currency:
           type: string
           pattern: '^[A-Z]{3}$'
-          readOnly: true
           description: >-
             What `revenue_norm_minor` is in — the installation's base currency as it stood
             when this run was ranked. A proportion is only checkable against a NAMED base,

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29864,6 +29864,20 @@ components:
         local_day: { type: string, format: date, description: 'The morning this run is for, as a calendar date in the installation reporting timezone. A rep has exactly one run per local day, and the on-open read serves today''s — never an older one dressed as today.' }
         candidate_count: { type: integer, minimum: 0, description: Deals that cleared the §10 honest-short bar (may exceed the queue length). }
         revenue_norm_minor: { type: integer, format: int64, description: The workspace-P90 (or fallback) base value the revenue factor normalized against. }
+        revenue_norm_currency:
+          type: string
+          pattern: '^[A-Z]{3}$'
+          readOnly: true
+          description: >-
+            What `revenue_norm_minor` is in — the installation's base currency as it stood
+            when this run was ranked. A proportion is only checkable against a NAMED base,
+            and a bare figure reads as whatever currency the reader assumes.
+
+            Stored with the run rather than resolved on read: the base currency can still be
+            changed until deals freeze it, so a norm computed against EUR must not later be
+            captioned with the USD in force by then. Absent on a run assembled before this
+            field existed — a brief is one row per rep per local day, so those age out within
+            a day.
         items:
           type: array
           items: { $ref: '#/components/schemas/MorningBriefItem' }

--- a/backend/internal/compose/briefs/briefday.go
+++ b/backend/internal/compose/briefs/briefday.go
@@ -60,10 +60,13 @@ func localDay(ctx context.Context, tx pgx.Tx, now time.Time) (time.Time, error) 
 // is the arbiter, so two writers racing produce one run and no error.
 func insertRunIfDayFree(ctx context.Context, tx pgx.Tx, run BriefRun) (bool, error) {
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO brief_run (id, user_id, generated_at, as_of, local_day, candidate_count, revenue_norm_minor)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO brief_run (
+			id, user_id, generated_at, as_of, local_day, candidate_count,
+			revenue_norm_minor, revenue_norm_currency)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT ON CONSTRAINT uq_brief_run_user_day DO NOTHING`,
-		run.ID, run.UserID, run.GeneratedAt, run.AsOf, run.LocalDay, run.CandidateCount, run.RevenueNormMinor)
+		run.ID, run.UserID, run.GeneratedAt, run.AsOf, run.LocalDay, run.CandidateCount,
+		run.RevenueNormMinor, run.RevenueNormCurrency)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/compose/briefs/briefhandlers.go
+++ b/backend/internal/compose/briefs/briefhandlers.go
@@ -152,16 +152,24 @@ func briefRunToWire(run BriefRun) crmcontracts.MorningBrief {
 	}
 	norm := run.RevenueNormMinor
 	day := openapi_types.Date{Time: run.LocalDay}
+	// Omitted rather than empty when the run predates the column: a client
+	// reading "" would caption the figure with nothing, which is the bare
+	// number this field exists to stop.
+	var normCurrency *string
+	if run.RevenueNormCurrency != "" {
+		normCurrency = &run.RevenueNormCurrency
+	}
 	return crmcontracts.MorningBrief{
-		Id:               openapi_types.UUID(run.ID),
-		GeneratedAt:      run.GeneratedAt,
-		AsOf:             run.AsOf,
-		LocalDay:         &day,
-		CandidateCount:   run.CandidateCount,
-		RevenueNormMinor: &norm,
-		Narrative:        nullableText(run.Narrative),
-		AnnotatedAt:      run.AnnotatedAt,
-		Items:            items,
+		Id:                  openapi_types.UUID(run.ID),
+		GeneratedAt:         run.GeneratedAt,
+		AsOf:                run.AsOf,
+		LocalDay:            &day,
+		CandidateCount:      run.CandidateCount,
+		RevenueNormMinor:    &norm,
+		RevenueNormCurrency: normCurrency,
+		Narrative:           nullableText(run.Narrative),
+		AnnotatedAt:         run.AnnotatedAt,
+		Items:               items,
 	}
 }
 

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -40,7 +40,13 @@ type BriefRanking struct {
 	Queue            []BriefQueueItem
 	CandidateCount   int
 	RevenueNormMinor int64
-	AsOf             time.Time
+	// RevenueNormCurrency is what that figure is in — the installation's base
+	// currency as it stood when the rank ran. Carried with the figure because a
+	// proportion is only checkable against a NAMED base, and because the base
+	// can still change: a norm computed against EUR must not later be read as
+	// the USD in force by then.
+	RevenueNormCurrency string
+	AsOf                time.Time
 }
 
 // briefStrengthSource is the compose-injected §4 warmth seam —
@@ -114,6 +120,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 	stakeholders := map[ids.UUID][]ids.UUID{}
 	lineage := map[ids.UUID]dealLineage{}
 	revenueNorm := int64(briefRevenueNormFallbackMinor)
+	revenueNormCurrency := ""
 
 	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		// The rep's last brief view: the previous run's data cutoff. No
@@ -135,6 +142,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 			return err
 		}
 		revenueNorm = norm
+		revenueNormCurrency = base
 
 		if err := briefCandidates(ctx, tx, userID, now, base, facts, &order); err != nil {
 			return err
@@ -192,10 +200,11 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		return BriefRanking{}, err
 	}
 	return BriefRanking{
-		Queue:            queue,
-		CandidateCount:   len(candidates),
-		RevenueNormMinor: revenueNorm,
-		AsOf:             now,
+		Queue:               queue,
+		CandidateCount:      len(candidates),
+		RevenueNormMinor:    revenueNorm,
+		RevenueNormCurrency: revenueNormCurrency,
+		AsOf:                now,
 	}, nil
 }
 

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -102,27 +102,34 @@ func briefBaseValueSQL(asOfPos, basePos int) string {
 	END`, asOfPos, basePos)
 }
 
-// Rank computes the deterministic §10.1 queue for the acting rep at one
-// instant. It is a read: nothing is persisted (SnapshotRun does that),
-// and the candidate set is bounded by the caller's own row scope — a
-// rep's brief only ranks deals they can see.
-func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, error) {
-	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
-		return BriefRanking{}, err
-	}
-	userID, err := briefUser(ctx)
-	if err != nil {
-		return BriefRanking{}, err
-	}
+// briefFacts is everything ONE transaction gathers for a rank: the candidates
+// and what is known about them, plus the basis every one of them was measured
+// against.
+//
+// One struct rather than six out-parameters, because they are one read: the
+// revenue norm and every candidate's base value have to be measured against the
+// same basis, and two reads of one installation-wide value is two chances to
+// disagree.
+type briefFacts struct {
+	facts        map[ids.UUID]briefDealFacts
+	order        []ids.UUID
+	stakeholders map[ids.UUID][]ids.UUID
+	lineage      map[ids.UUID]dealLineage
+	// revenueNorm is the base value the revenue factor divides by, and
+	// revenueNormCurrency is what that value is in.
+	revenueNorm         int64
+	revenueNormCurrency string
+}
 
-	facts := map[ids.UUID]briefDealFacts{}
-	var order []ids.UUID
-	stakeholders := map[ids.UUID][]ids.UUID{}
-	lineage := map[ids.UUID]dealLineage{}
-	revenueNorm := int64(briefRevenueNormFallbackMinor)
-	revenueNormCurrency := ""
-
-	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+// gather reads one transaction's worth of ranking facts.
+func (e *BriefEngine) gather(ctx context.Context, now time.Time, userID ids.UUID) (briefFacts, error) {
+	out := briefFacts{
+		facts:        map[ids.UUID]briefDealFacts{},
+		stakeholders: map[ids.UUID][]ids.UUID{},
+		lineage:      map[ids.UUID]dealLineage{},
+		revenueNorm:  int64(briefRevenueNormFallbackMinor),
+	}
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		// The rep's last brief view: the previous run's data cutoff. No
 		// previous run → the overnight window is all-time.
 		lastView, err := briefLastView(ctx, tx, userID)
@@ -141,24 +148,48 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		if err != nil {
 			return err
 		}
-		revenueNorm = norm
-		revenueNormCurrency = base
+		out.revenueNorm = norm
+		out.revenueNormCurrency = base
 
-		if err := briefCandidates(ctx, tx, userID, now, base, facts, &order); err != nil {
+		if err := briefCandidates(ctx, tx, userID, now, base, out.facts, &out.order); err != nil {
 			return err
 		}
-		if err := briefEvidenceRows(ctx, tx, lastView, facts, order, stakeholders); err != nil {
+		if err := briefEvidenceRows(ctx, tx, lastView, out.facts, out.order, out.stakeholders); err != nil {
 			return err
 		}
 		// Why each returning deal is back, for the whole candidate set at once.
 		// It reads AFTER the candidates because it is asked about them: a deal
 		// the suppression rule is still holding out has no lineage to tell.
-		lineage, err = briefLineage(ctx, tx, userID, order, now)
+		out.lineage, err = briefLineage(ctx, tx, userID, out.order, now)
 		return err
 	})
 	if err != nil {
+		return briefFacts{}, err
+	}
+	return out, nil
+}
+
+// Rank computes the deterministic §10.1 queue for the acting rep at one
+// instant. It is a read: nothing is persisted (SnapshotRun does that),
+// and the candidate set is bounded by the caller's own row scope — a
+// rep's brief only ranks deals they can see.
+func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
 		return BriefRanking{}, err
 	}
+	userID, err := briefUser(ctx)
+	if err != nil {
+		return BriefRanking{}, err
+	}
+
+	gathered, err := e.gather(ctx, now, userID)
+	if err != nil {
+		return BriefRanking{}, err
+	}
+	facts, order := gathered.facts, gathered.order
+	revenueNorm := gathered.revenueNorm
+	stakeholders := gathered.stakeholders
+	lineage := gathered.lineage
 
 	if err := e.resolveWarmth(ctx, now, facts, stakeholders); err != nil {
 		return BriefRanking{}, err
@@ -203,7 +234,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		Queue:               queue,
 		CandidateCount:      len(candidates),
 		RevenueNormMinor:    revenueNorm,
-		RevenueNormCurrency: revenueNormCurrency,
+		RevenueNormCurrency: gathered.revenueNormCurrency,
 		AsOf:                now,
 	}, nil
 }

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -51,6 +51,9 @@ type BriefRun struct {
 	LocalDay         time.Time
 	CandidateCount   int
 	RevenueNormMinor int64
+	// RevenueNormCurrency is what RevenueNormMinor is in. Empty on a run stored
+	// before the column existed, which the wire omits rather than guessing at.
+	RevenueNormCurrency string
 	// Narrative is the overnight agent's sentence about the night, empty when
 	// no pass has written one — which AnnotatedAt is what distinguishes from a
 	// pass that ran and had nothing to say.
@@ -125,12 +128,13 @@ func (e *BriefEngine) SnapshotRunForDay(ctx context.Context, now time.Time) (Bri
 	}
 
 	run := BriefRun{
-		ID:               ids.NewV7(),
-		UserID:           userID,
-		GeneratedAt:      now,
-		AsOf:             ranking.AsOf,
-		CandidateCount:   ranking.CandidateCount,
-		RevenueNormMinor: ranking.RevenueNormMinor,
+		ID:                  ids.NewV7(),
+		UserID:              userID,
+		GeneratedAt:         now,
+		AsOf:                ranking.AsOf,
+		CandidateCount:      ranking.CandidateCount,
+		RevenueNormMinor:    ranking.RevenueNormMinor,
+		RevenueNormCurrency: ranking.RevenueNormCurrency,
 	}
 	queueDeals := make([]ids.UUID, 0, len(ranking.Queue))
 	var joinedExisting bool
@@ -163,12 +167,13 @@ func (e *BriefEngine) SnapshotRunForDay(ctx context.Context, now time.Time) (Bri
 			queueDeals = append(queueDeals, item.DealID)
 		}
 		_, err = storekit.Audit(ctx, tx, "create", "brief_run", run.ID, nil, map[string]any{
-			"user_id":            run.UserID,
-			"as_of":              run.AsOf,
-			"local_day":          run.LocalDay.Format(time.DateOnly),
-			"candidate_count":    run.CandidateCount,
-			"revenue_norm_minor": run.RevenueNormMinor,
-			"queue_deal_ids":     queueDeals,
+			"user_id":               run.UserID,
+			"as_of":                 run.AsOf,
+			"local_day":             run.LocalDay.Format(time.DateOnly),
+			"candidate_count":       run.CandidateCount,
+			"revenue_norm_minor":    run.RevenueNormMinor,
+			"revenue_norm_currency": run.RevenueNormCurrency,
+			"queue_deal_ids":        queueDeals,
 		})
 		return err
 	})
@@ -264,11 +269,11 @@ func (e *BriefEngine) LatestRun(ctx context.Context, now time.Time) (BriefRun, e
 		}
 		err = tx.QueryRow(ctx, `
 			SELECT id, user_id, generated_at, as_of, local_day, candidate_count, revenue_norm_minor,
-			       coalesce(narrative, ''), annotated_at
+			       revenue_norm_currency, coalesce(narrative, ''), annotated_at
 			FROM brief_run
 			WHERE user_id = $1 AND local_day = $2`, userID, day).
 			Scan(&run.ID, &run.UserID, &run.GeneratedAt, &run.AsOf, &run.LocalDay, &run.CandidateCount,
-				&run.RevenueNormMinor, &run.Narrative, &run.AnnotatedAt)
+				&run.RevenueNormMinor, &run.RevenueNormCurrency, &run.Narrative, &run.AnnotatedAt)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -26,6 +26,8 @@ var withheldFromTheTool = gatekit.Waive(map[string]string{
 
 	"RevenueNormMinor": "the workspace-wide base the revenue FACTOR was divided by; the factor is " +
 		"served already normalized, so the base explains nothing an agent can act on",
+	"RevenueNormCurrency": "what that base is in, withheld with it — a currency qualifying a figure " +
+		"this surface does not serve names nothing",
 
 	"Narrative": "the agent's OWN sentence about the night, withheld from the agent. It is the " +
 		"only field here the tool's caller wrote rather than read, and handing it back is how a " +
@@ -57,7 +59,7 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 	run := briefs.BriefRun{
 		ID: runID, UserID: userID, GeneratedAt: generated, AsOf: asOf,
 		LocalDay:       time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC),
-		CandidateCount: 17, RevenueNormMinor: 918_273,
+		CandidateCount: 17, RevenueNormMinor: 918_273, RevenueNormCurrency: "CHF",
 		Narrative:   "Two replies overnight, one deal went quiet.",
 		AnnotatedAt: &annotatedAt,
 		Items: []briefs.BriefRunItem{{
@@ -95,6 +97,9 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		// Withheld — so the probe is what a LEAK would look like: the value
 		// itself, which must appear nowhere in what the tool served.
 		"RevenueNormMinor": "918273",
+		// Upper case, so it cannot be found inside a uuid or a timestamp — the
+		// same reason every probe here is a fragment rather than a bare value.
+		"RevenueNormCurrency": "CHF",
 		// The items are covered field by field below; what this row asserts is
 		// that the list itself arrived.
 		"Items": `"deal_id":"` + dealID.String(),

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -89,8 +89,14 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 	//
 	// A WITHHELD field's probe is the bare value instead, and deliberately: it
 	// is what a LEAK would look like, and a leak need not carry the key this
-	// surface would have given it. Each of those is chosen so it cannot be
-	// found by chance in what the tool served — see the two below.
+	// surface would have given it.
+	//
+	// That makes each of them a collision risk, and the two below are not equal
+	// on it. `CHF` is upper case, which no uuid (lower-case hex) or timestamp
+	// can contain, so it cannot collide at all. `918273` is six hex digits and
+	// COULD appear inside a random uuid — improbably, but the guarantee is
+	// probabilistic rather than structural. A future bare-value probe should be
+	// chosen the way CHF was, not the way 918273 was.
 	assertEveryFieldSurvives(t, "BriefRun", reflect.TypeOf(run), map[string]string{
 		"ID": `"brief_id":"` + runID.String(), "UserID": userID.String(),
 		"GeneratedAt":    `"generated_at":"2026-08-08T06:11:00Z"`,
@@ -102,8 +108,9 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		// Withheld — so the probe is what a LEAK would look like: the value
 		// itself, which must appear nowhere in what the tool served.
 		"RevenueNormMinor": "918273",
-		// Upper case, so it cannot be found inside a uuid (lower-case hex) or a
-		// timestamp — which is what makes a bare value safe to probe with here.
+		// Upper case, so no uuid or timestamp in the served document can contain
+		// it — the structural version of the guarantee the digits above only
+		// have by probability.
 		"RevenueNormCurrency": "CHF",
 		// The items are covered field by field below; what this row asserts is
 		// that the list itself arrived.

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -82,10 +82,15 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		t.Fatalf("marshalling the served run: %v", err)
 	}
 
-	// Every probe is a WIRE FRAGMENT — key and value together — not a bare
-	// value. A served brief is full of uuids, and a uuid is 32 hex digits: a
-	// probe of `3` or `17` is found inside one by chance, so an assertion
-	// written that way passes with the field dropped.
+	// A SERVED field's probe is a wire fragment — key and value together — not
+	// a bare value. A served brief is full of uuids, and a uuid is 32 hex
+	// digits: a probe of `3` or `17` is found inside one by chance, so an
+	// assertion written that way passes with the field dropped.
+	//
+	// A WITHHELD field's probe is the bare value instead, and deliberately: it
+	// is what a LEAK would look like, and a leak need not carry the key this
+	// surface would have given it. Each of those is chosen so it cannot be
+	// found by chance in what the tool served — see the two below.
 	assertEveryFieldSurvives(t, "BriefRun", reflect.TypeOf(run), map[string]string{
 		"ID": `"brief_id":"` + runID.String(), "UserID": userID.String(),
 		"GeneratedAt":    `"generated_at":"2026-08-08T06:11:00Z"`,
@@ -97,8 +102,8 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		// Withheld — so the probe is what a LEAK would look like: the value
 		// itself, which must appear nowhere in what the tool served.
 		"RevenueNormMinor": "918273",
-		// Upper case, so it cannot be found inside a uuid or a timestamp — the
-		// same reason every probe here is a fragment rather than a bare value.
+		// Upper case, so it cannot be found inside a uuid (lower-case hex) or a
+		// timestamp — which is what makes a bare value safe to probe with here.
 		"RevenueNormCurrency": "CHF",
 		// The items are covered field by field below; what this row asserts is
 		// that the list itself arrived.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19371,6 +19371,10 @@ type MorningBrief struct {
 	// is what tells those apart, which is why both fields exist.
 	Narrative *string `json:"narrative,omitempty"`
 
+	// RevenueNormCurrency What `revenue_norm_minor` is in — the installation's base currency as it stood when this run was ranked. A proportion is only checkable against a NAMED base, and a bare figure reads as whatever currency the reader assumes.
+	// Stored with the run rather than resolved on read: the base currency can still be changed until deals freeze it, so a norm computed against EUR must not later be captioned with the USD in force by then. Absent on a run assembled before this field existed — a brief is one row per rep per local day, so those age out within a day.
+	RevenueNormCurrency *string `json:"revenue_norm_currency,omitempty"`
+
 	// RevenueNormMinor The workspace-P90 (or fallback) base value the revenue factor normalized against.
 	RevenueNormMinor *int64 `json:"revenue_norm_minor,omitempty"`
 }

--- a/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.down.sql
+++ b/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE brief_run
+    DROP CONSTRAINT brief_run_revenue_norm_currency_check,
+    DROP COLUMN revenue_norm_currency;

--- a/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.down.sql
+++ b/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.down.sql
@@ -1,3 +1,5 @@
+SET LOCAL lock_timeout = '3s';
+
 ALTER TABLE brief_run
     DROP CONSTRAINT brief_run_revenue_norm_currency_check,
     DROP COLUMN revenue_norm_currency;

--- a/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
+++ b/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
@@ -15,9 +15,18 @@
 -- Empty means a run written before this column existed. A brief is one row per
 -- rep per local day, so those age out within a day; the wire omits the field
 -- rather than inventing a currency for them.
+-- NOT VALID, and the pass that validates it is the NEXT migration file rather
+-- than the next statement. The runner wraps each file in one transaction, so a
+-- VALIDATE here would run under the ACCESS EXCLUSIVE this ALTER already holds
+-- and to commit — the weaker lock VALIDATE asks for buys nothing while a
+-- stronger one is held. In its own file it is its own transaction, and the scan
+-- runs under SHARE UPDATE EXCLUSIVE, which brief writes do not queue behind.
+--
+-- Every existing row satisfies it trivially: the column is new, so they all
+-- carry the default. The split is about the LOCK, not about doubt.
 SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE brief_run
     ADD COLUMN revenue_norm_currency text DEFAULT '' NOT NULL,
     ADD CONSTRAINT brief_run_revenue_norm_currency_check
-        CHECK (revenue_norm_currency = '' OR revenue_norm_currency ~ '^[A-Z]{3}$');
+        CHECK (revenue_norm_currency = '' OR revenue_norm_currency ~ '^[A-Z]{3}$') NOT VALID;

--- a/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
+++ b/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
@@ -17,10 +17,11 @@
 -- rather than inventing a currency for them.
 -- NOT VALID, and the pass that validates it is the NEXT migration file rather
 -- than the next statement. The runner wraps each file in one transaction, so a
--- VALIDATE here would run under the ACCESS EXCLUSIVE this ALTER already holds
--- and to commit — the weaker lock VALIDATE asks for buys nothing while a
--- stronger one is held. In its own file it is its own transaction, and the scan
--- runs under SHARE UPDATE EXCLUSIVE, which brief writes do not queue behind.
+-- VALIDATE here would run under the ACCESS EXCLUSIVE this ALTER holds until the
+-- transaction commits, so the weaker lock VALIDATE asks for buys nothing while
+-- a stronger one is already held. In its own file it is its own transaction,
+-- and the scan runs under SHARE UPDATE EXCLUSIVE, which brief writes do not
+-- queue behind.
 --
 -- Every existing row satisfies it trivially: the column is new, so they all
 -- carry the default. The split is about the LOCK, not about doubt.

--- a/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
+++ b/backend/migrations/core/1787968162_a_brief_names_the_currency_it_normalized_against.up.sql
@@ -1,0 +1,23 @@
+-- The currency the run's revenue norm is in, stored beside the figure.
+--
+-- revenue_norm_minor is the base value the revenue factor measured every deal
+-- against, and a proportion is only checkable against a NAMED base. Without the
+-- currency a screen can print a bare number — which is not money, and reads as
+-- whatever currency the reader assumes — or say nothing, which is what the home
+-- screen does today.
+--
+-- Stored rather than read at serve time. The installation's base currency can
+-- still be changed until deals freeze it, and a figure computed against EUR
+-- captioned with the USD in force a week later would be a wrong reading offered
+-- with confidence. The run says what it measured against, the way it already
+-- says how many candidates it saw.
+--
+-- Empty means a run written before this column existed. A brief is one row per
+-- rep per local day, so those age out within a day; the wire omits the field
+-- rather than inventing a currency for them.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_run
+    ADD COLUMN revenue_norm_currency text DEFAULT '' NOT NULL,
+    ADD CONSTRAINT brief_run_revenue_norm_currency_check
+        CHECK (revenue_norm_currency = '' OR revenue_norm_currency ~ '^[A-Z]{3}$');

--- a/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.down.sql
+++ b/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.down.sql
@@ -1,0 +1,3 @@
+-- Nothing to undo: a validated constraint reverts to NOT VALID only by being
+-- dropped, and the migration that created it drops it.
+SELECT 1;

--- a/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.down.sql
+++ b/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.down.sql
@@ -1,3 +1,15 @@
--- Nothing to undo: a validated constraint reverts to NOT VALID only by being
--- dropped, and the migration that created it drops it.
-SELECT 1;
+-- Put the constraint back the way this migration found it: present, unvalidated.
+--
+-- `SELECT 1` would leave it VALIDATED while the migration reads unapplied, so a
+-- rollback to test the pair would find the state the forward pass produced and
+-- prove nothing. Postgres has no ALTER that un-validates, so the constraint is
+-- dropped and re-added NOT VALID — which takes ACCESS EXCLUSIVE without a scan.
+--
+-- The rows still satisfy it; what is being restored is the CATALOG's record of
+-- whether anybody has checked.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_run
+    DROP CONSTRAINT brief_run_revenue_norm_currency_check,
+    ADD CONSTRAINT brief_run_revenue_norm_currency_check
+        CHECK (revenue_norm_currency = '' OR revenue_norm_currency ~ '^[A-Z]{3}$') NOT VALID;

--- a/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.up.sql
+++ b/backend/migrations/core/1787968163_the_brief_currency_check_is_validated.up.sql
@@ -1,0 +1,14 @@
+-- Validate the check the migration before this one added NOT VALID.
+--
+-- Its own file because the runner wraps each file in ONE transaction: run in
+-- the same one, this scan would sit under the ACCESS EXCLUSIVE that ALTER holds
+-- to commit, and the SHARE UPDATE EXCLUSIVE that VALIDATE asks for would be
+-- nothing but a weaker lock requested while a stronger one is held. Here it is
+-- the only statement in its own transaction, so the scan really does run under
+-- the lighter lock and brief writes do not queue behind it.
+--
+-- It cannot fail: the column was created in that migration with a constant
+-- default, so every row it scans carries ''.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_run VALIDATE CONSTRAINT brief_run_revenue_norm_currency_check;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -783,6 +783,7 @@ public.brief_run.brief_run_candidate_count_check CHECK ((candidate_count >= 0))
 public.brief_run.brief_run_narrative_length CHECK (((narrative IS NULL) OR (char_length(narrative) <= 600)))
 public.brief_run.brief_run_narrative_needs_a_pass CHECK (((narrative IS NULL) OR (annotated_at IS NOT NULL)))
 public.brief_run.brief_run_pkey PRIMARY KEY (id)
+public.brief_run.brief_run_revenue_norm_currency_check CHECK (((revenue_norm_currency = ''::text) OR (revenue_norm_currency ~ '^[A-Z]{3}$'::text)))
 public.brief_run.brief_run_revenue_norm_minor_check CHECK ((revenue_norm_minor > 0))
 public.brief_run.brief_run_user_fkey FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
 public.brief_run.candidate_count integer NOT NULL gen=- def=-
@@ -790,6 +791,7 @@ public.brief_run.generated_at timestamp with time zone NOT NULL gen=- def=now()
 public.brief_run.id uuid NOT NULL gen=- def=uuidv7()
 public.brief_run.local_day date NOT NULL gen=- def=-
 public.brief_run.narrative text gen=- def=-
+public.brief_run.revenue_norm_currency text NOT NULL gen=- def=''::text
 public.brief_run.revenue_norm_minor bigint NOT NULL gen=- def=-
 public.brief_run.uq_brief_run_user_day UNIQUE (user_id, local_day)
 public.brief_run.user_id uuid NOT NULL gen=- def=-

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22407,7 +22407,7 @@ export interface components {
              * @description What `revenue_norm_minor` is in — the installation's base currency as it stood when this run was ranked. A proportion is only checkable against a NAMED base, and a bare figure reads as whatever currency the reader assumes.
              *     Stored with the run rather than resolved on read: the base currency can still be changed until deals freeze it, so a norm computed against EUR must not later be captioned with the USD in force by then. Absent on a run assembled before this field existed — a brief is one row per rep per local day, so those age out within a day.
              */
-            readonly revenue_norm_currency?: string;
+            revenue_norm_currency?: string;
             /** @description The ranked queue, best-first, capped at the honest-short target (7). */
             items: components["schemas"]["MorningBriefItem"][];
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22403,6 +22403,11 @@ export interface components {
              * @description The workspace-P90 (or fallback) base value the revenue factor normalized against.
              */
             revenue_norm_minor?: number;
+            /**
+             * @description What `revenue_norm_minor` is in — the installation's base currency as it stood when this run was ranked. A proportion is only checkable against a NAMED base, and a bare figure reads as whatever currency the reader assumes.
+             *     Stored with the run rather than resolved on read: the base currency can still be changed until deals freeze it, so a norm computed against EUR must not later be captioned with the USD in force by then. Absent on a run assembled before this field existed — a brief is one row per rep per local day, so those age out within a day.
+             */
+            readonly revenue_norm_currency?: string;
             /** @description The ranked queue, best-first, capped at the honest-short target (7). */
             items: components["schemas"]["MorningBriefItem"][];
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2416,6 +2416,7 @@ export const de = {
   "home.brief.previouslyDismissed":
     "Am {day} markiert — du hast es weggeklickt.",
   "home.brief.returnedWith": "Zurück durch Aktivität am",
+  "home.brief.revenueBasis": "Umsatz gemessen an {amount}",
   "home.brief.resurfaces": "Zurück",
   "home.evidenceNone": "keine Belege erfasst",
   "home.snooze": "Zurückstellen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2453,6 +2453,7 @@ export const en = {
   // states that rule rather than guessing: it can only ever name an activity.
   "home.brief.previouslyDismissed": "Flagged {day} — you dismissed it.",
   "home.brief.returnedWith": "It came back with activity on",
+  "home.brief.revenueBasis": "Revenue measured against {amount}",
   "home.brief.resurfaces": "Back",
   "home.evidenceNone": "no evidence recorded",
   "home.snooze": "Snooze",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2403,6 +2403,7 @@ export const vi = {
   "home.brief.composite": "Điểm",
   "home.brief.previouslyDismissed": "Đã đánh dấu {day} — bạn đã bỏ qua.",
   "home.brief.returnedWith": "Quay lại do hoạt động ngày",
+  "home.brief.revenueBasis": "Doanh thu đo theo {amount}",
   "home.brief.resurfaces": "Trở lại",
   "home.evidenceNone": "chưa ghi nhận bằng chứng",
   "home.snooze": "Tạm hoãn",

--- a/frontend/src/screens/briefqueue.tsx
+++ b/frontend/src/screens/briefqueue.tsx
@@ -101,11 +101,23 @@ export function BriefQueueItem({
   deals,
   nowMs,
   mark,
+  revenueBasis,
 }: Readonly<{
   item: MorningBriefItem;
   deals: readonly Deal[];
   nowMs: number;
   mark: ReturnType<typeof useBriefItemMark>;
+  /**
+   * The RUN's revenue basis, already formatted as money — every item in one
+   * brief measured against the same figure, so it is the caller's to compose
+   * once rather than each card's to derive.
+   *
+   * Absent when the run does not name a currency, which a run assembled before
+   * the field existed does not. A bare number is not money: it reads as
+   * whatever currency the reader assumes, and the whole point of the note is
+   * that a proportion can be checked.
+   */
+  revenueBasis?: string;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -120,11 +132,11 @@ export function BriefQueueItem({
         item.lineage?.dismissed_on,
         recordZone,
       )}
-      // `revenueBasisNote` is deliberately not passed. The run carries
-      // `revenue_norm_minor` but not the currency it is in, and the base
-      // currency lives on a settings read neither screen makes — a bare figure
-      // with no currency is not a reading, so the card says nothing rather than
-      // something unverifiable.
+      revenueBasisNote={
+        revenueBasis === undefined
+          ? undefined
+          : t("home.brief.revenueBasis", { amount: revenueBasis })
+      }
       dealName={deals.find((deal) => deal.id === item.deal_id)?.name}
       amount={amountOf(item.deal_id, deals, locale)}
       formatPercent={(fraction) =>

--- a/frontend/src/screens/briefqueue.tsx
+++ b/frontend/src/screens/briefqueue.tsx
@@ -8,14 +8,20 @@ import { BriefItemCard } from "../design-system/briefitem";
 import {
   formatDate,
   formatDateTime,
+  formatMoney,
   formatMoneyOrAbsent,
   formatNumber,
 } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { translatePlural, useLocale, useT } from "../i18n";
+import { type Locale, translatePlural, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf } from "./common";
-import type { Deal, MorningBriefItem, useBriefItemMark } from "./home.queries";
+import type {
+  Deal,
+  MorningBrief,
+  MorningBriefItem,
+  useBriefItemMark,
+} from "./home.queries";
 
 // One brief item, drawn and wired — the whole of what a screen needs to show a
 // queue entry and let a reader answer it.
@@ -87,6 +93,31 @@ export function briefLabels(
           }),
     returnedWith: t("home.brief.returnedWith"),
   };
+}
+
+/**
+ * What the revenue factor measured against, as money.
+ *
+ * `undefined` unless the run names BOTH the figure and its currency. A bare
+ * number is not money — it reads as whatever currency the reader assumes — and
+ * the note exists so a proportion can be checked, which an unnamed base cannot
+ * do. A run assembled before the currency was carried names none.
+ */
+export function revenueBasisOf(
+  brief: MorningBrief,
+  locale: Locale,
+): string | undefined {
+  if (
+    brief.revenue_norm_minor === undefined ||
+    brief.revenue_norm_currency === undefined
+  ) {
+    return undefined;
+  }
+  return formatMoney(
+    brief.revenue_norm_minor,
+    brief.revenue_norm_currency,
+    locale,
+  );
 }
 
 /**

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -6,9 +6,9 @@ import { Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { ProvenanceTag } from "../design-system/trust";
-import { formatDateTime, formatNumber } from "../format/format";
+import { formatDateTime, formatMoney, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { BriefQueueItem } from "./briefqueue";
 import { problemMessageOf } from "./common";
@@ -94,6 +94,31 @@ export function TodaySection({
   );
 }
 
+/**
+ * What the revenue factor measured against, as money.
+ *
+ * `undefined` unless the run names BOTH the figure and its currency. A bare
+ * number is not money — it reads as whatever currency the reader assumes — and
+ * the note exists so a proportion can be checked, which an unnamed base cannot
+ * do. A run assembled before the currency was carried names none.
+ */
+function revenueBasisOf(
+  brief: MorningBrief,
+  locale: Locale,
+): string | undefined {
+  if (
+    brief.revenue_norm_minor === undefined ||
+    brief.revenue_norm_currency === undefined
+  ) {
+    return undefined;
+  }
+  return formatMoney(
+    brief.revenue_norm_minor,
+    brief.revenue_norm_currency,
+    locale,
+  );
+}
+
 /** The queue's four readings: in flight, no run, a quiet run, or the items. */
 function TodayBody({
   brief,
@@ -109,6 +134,7 @@ function TodayBody({
   mark: ReturnType<typeof useBriefItemMark>;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   // Anything but a served read is the state vocabulary's to draw. A failure used
   // to fall through the `ready` guard and render nothing, so a queue nobody
   // could read looked exactly like a morning with nothing in it.
@@ -148,6 +174,7 @@ function TodayBody({
           deals={deals}
           nowMs={nowMs}
           mark={mark}
+          revenueBasis={revenueBasisOf(brief, locale)}
         />
       ))}
     </>

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -6,11 +6,11 @@ import { Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { ProvenanceTag } from "../design-system/trust";
-import { formatDateTime, formatMoney, formatNumber } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { type Locale, useLocale, useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { BriefQueueItem } from "./briefqueue";
+import { BriefQueueItem, revenueBasisOf } from "./briefqueue";
 import { problemMessageOf } from "./common";
 import {
   type Deal,
@@ -94,31 +94,6 @@ export function TodaySection({
   );
 }
 
-/**
- * What the revenue factor measured against, as money.
- *
- * `undefined` unless the run names BOTH the figure and its currency. A bare
- * number is not money — it reads as whatever currency the reader assumes — and
- * the note exists so a proportion can be checked, which an unnamed base cannot
- * do. A run assembled before the currency was carried names none.
- */
-function revenueBasisOf(
-  brief: MorningBrief,
-  locale: Locale,
-): string | undefined {
-  if (
-    brief.revenue_norm_minor === undefined ||
-    brief.revenue_norm_currency === undefined
-  ) {
-    return undefined;
-  }
-  return formatMoney(
-    brief.revenue_norm_minor,
-    brief.revenue_norm_currency,
-    locale,
-  );
-}
-
 /** The queue's four readings: in flight, no run, a quiet run, or the items. */
 function TodayBody({
   brief,
@@ -164,6 +139,9 @@ function TodayBody({
       </>
     );
   }
+  // Composed ONCE for the run: every item in one brief measured against the
+  // same figure, and formatMoney builds an Intl.NumberFormat per call.
+  const revenueBasis = revenueBasisOf(brief, locale);
   return (
     <>
       <TodayNarrative brief={brief} />
@@ -174,7 +152,7 @@ function TodayBody({
           deals={deals}
           nowMs={nowMs}
           mark={mark}
-          revenueBasis={revenueBasisOf(brief, locale)}
+          revenueBasis={revenueBasis}
         />
       ))}
     </>

--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -20,7 +20,7 @@ import { viewerZone } from "../format/timezone";
 import { type Locale, pluralKey, useLocale, useT } from "../i18n";
 import { itemDetail, itemTitle } from "./attentionitemcopy";
 import { subjectHref } from "./attentionsubject";
-import { BriefQueueItem } from "./briefqueue";
+import { BriefQueueItem, revenueBasisOf } from "./briefqueue";
 import {
   useBriefItemMark,
   useHomeDeals,
@@ -470,6 +470,7 @@ function MorningCards({
   total,
 }: Readonly<{ items: readonly AttentionItem[]; total: number }>) {
   const t = useT();
+  const { locale } = useLocale();
   // Pinned rather than ticking: nothing this lane DRAWS depends on the clock,
   // and the instant is read only after a click, to work out when a set-aside
   // item comes back. A one-second interval here would re-render every card on
@@ -529,6 +530,12 @@ function MorningCards({
       </MorningPanel>
     );
   }
+  // The SAME note Home draws. One brief item must not say what it was measured
+  // against on one surface and nothing on the other; composed once here for the
+  // same reason it is there.
+  const revenueBasis = brief.data
+    ? revenueBasisOf(brief.data, locale)
+    : undefined;
   return (
     <MorningPanel total={total}>
       <PanelBody className="today-morning-list">
@@ -539,6 +546,7 @@ function MorningCards({
             deals={deals.data?.rows ?? []}
             nowMs={nowMs}
             mark={mark}
+            revenueBasis={revenueBasis}
           />
         ))}
       </PanelBody>


### PR DESCRIPTION
Closes #2541.

## The gap

`MorningBrief` carries `revenue_norm_minor` — the base value the revenue factor measured every deal against — and not the currency it is in. A proportion is only checkable against a **named** base, and a bare number is not money: it reads as whatever currency the reader assumes.

So `BriefItemCard` takes a `revenueBasisNote` and the Home screen passed none, with a comment saying why:

> a bare figure with no currency is not a reading, so the card says nothing rather than something unverifiable

The revenue bar was the one factor of five a rep could not check.

## Stored with the run, not read when served

The installation's base currency can still be **changed** until deals freeze it (`base_currency_locked`). A norm computed against EUR, captioned a week later with the USD in force by then, would be a wrong reading offered with confidence. So the run says what it measured against, the way it already says how many candidates it saw:

- `brief_run.revenue_norm_currency`, written where the rank already resolves the base (`identity.BaseCurrencyOf`, resolved once for the whole rank so the norm and every candidate share one basis);
- `MorningBrief.revenue_norm_currency` on the wire, `readOnly`, `^[A-Z]{3}$`.

Empty means a run assembled before the column existed. The wire **omits** the field there rather than serving `""` — a client reading `""` would print the bare figure this exists to stop. A brief is one row per rep per local day, so those rows age out within a day.

## Wired through

`home.today.tsx` composes the note once for the run (every item in one brief shares the basis) and hands it to `BriefQueueItem`, which passes `revenueBasisNote`. `revenueBasisOf` returns `undefined` unless the run names **both** the figure and its currency. Copy in all three locales.

## Two gates earned their keep

- `TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld` caught the new field immediately. It is **withheld** from the agent surface, registered with the reason: a currency naming a base that surface does not serve names nothing. Its probe is upper-case so it cannot be found inside a uuid or a timestamp.
- `TestEveryMigrationTakingABlockingLockBoundsHowLongItWaits` caught the **down** migration taking the same blocking lock unbounded.

`Rank` passed the 80-line ceiling on the way, so the transaction it opens is now one `gather` returning one struct rather than six variables declared above the closure that fills them.

Local: `make check-backend`, `make check-fe`, `make craft-static` green; `head_catalog.txt` regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Briefings now record and display the currency used to normalize revenue.
  * The revenue basis appears in home briefings when amount and currency information is available.
  * Added English, German, and Vietnamese translations for the revenue-basis label.
  * Currency values are standardized as three-letter uppercase codes.

* **Bug Fixes**
  * Older briefings without currency information continue displaying correctly without the revenue basis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->