### PR TITLE
Ask whether a close date has passed in one place, in one day-zone

### DIFF
--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -13,14 +13,18 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -73,12 +77,20 @@ func quietDealLister(pool *pgxpool.Pool, quietForDays int) agents.SlippingLister
 			admitted[ids.UUID(d.Id)] = true
 		}
 
+		// The INSTALLATION's zone, not the server's. A close date is a calendar
+		// date a human picked, and asking whether it has passed in UTC gives a
+		// different answer from the deal record's own hygiene flag for as long
+		// as the two zones disagree about the day — hours wide, every day, for
+		// any installation not running in UTC.
+		zone, err := installationZone(ctx, pool)
+		if err != nil {
+			return nil, err
+		}
 		now := time.Now().UTC()
-		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 		out := make([]agents.SlippingDeal, 0, len(quiet))
 		seen := map[ids.UUID]bool{}
 		for _, d := range append(quiet, open...) {
-			candidate := slippingCandidate(d, today)
+			candidate := slippingCandidate(d, now, zone)
 			if seen[candidate.DealID] {
 				continue
 			}
@@ -92,10 +104,36 @@ func quietDealLister(pool *pgxpool.Pool, quietForDays int) agents.SlippingLister
 	}
 }
 
+// installationZone loads the zone the installation's days are counted in.
+func installationZone(ctx context.Context, pool *pgxpool.Pool) (*time.Location, error) {
+	var name string
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		var err error
+		name, err = identity.TimezoneOf(ctx, tx)
+		return err
+	}); err != nil {
+		return nil, fmt.Errorf("read the installation's timezone: %w", err)
+	}
+	return zoneNamed(name), nil
+}
+
+// zoneNamed resolves a stored zone name, answering UTC for one Go cannot load.
+//
+// The same fallback the deals module's own date arithmetic makes for a nil
+// zone, so a setting nobody can load cannot make the two surfaces disagree in a
+// NEW way — they are then both wrong about the day in the same direction, which
+// is a different and much smaller problem.
+func zoneNamed(name string) *time.Location {
+	if zone, err := time.LoadLocation(name); err == nil {
+		return zone
+	}
+	return time.UTC
+}
+
 // slippingCandidate carries a deal row across the seam with its risk
 // flags and the fields that evidence them; the tool drops any flag its
 // evidence field cannot ground.
-func slippingCandidate(d crmcontracts.Deal, today time.Time) agents.SlippingDeal {
+func slippingCandidate(d crmcontracts.Deal, now time.Time, zone *time.Location) agents.SlippingDeal {
 	candidate := agents.SlippingDeal{
 		DealID:         ids.UUID(d.Id),
 		Name:           d.Name,
@@ -116,7 +154,10 @@ func slippingCandidate(d crmcontracts.Deal, today time.Time) agents.SlippingDeal
 	if d.ExpectedCloseDate != nil {
 		closeDate := d.ExpectedCloseDate.Time
 		candidate.ExpectedCloseDate = &closeDate
-		candidate.CloseOverdue = closeDate.Before(today)
+		// The deals module's own judgement, not a second one: the flag on the
+		// record and the answer this tool gives are the same question, and two
+		// implementations of it disagree the moment their "today" does.
+		candidate.CloseOverdue = deals.CloseIsOverdue(closeDate, now, zone)
 	}
 	return candidate
 }

--- a/backend/internal/modules/deals/closedate.go
+++ b/backend/internal/modules/deals/closedate.go
@@ -118,8 +118,7 @@ func CloseDateAssessment(in CloseDateInput, now time.Time, workspaceTZ *time.Loc
 		out.Flags = append(out.Flags, CloseDateMissing)
 	} else {
 		expected := dateOnly(*in.ExpectedClose)
-		// Strict <: a deal legitimately closing today is fine.
-		findings.overdue = expected.Before(today)
+		findings.overdue = CloseIsOverdue(*in.ExpectedClose, now, workspaceTZ)
 		if findings.overdue {
 			out.Flags = append(out.Flags, CloseDateOverdue)
 		}
@@ -195,6 +194,21 @@ func proposedCloseDate(today time.Time, remainingOpenStages int, velocityDays fl
 		stages = 1
 	}
 	return today.AddDate(0, 0, int(float64(stages)*velocityDays))
+}
+
+// CloseIsOverdue answers whether an expected close date has passed, and it is
+// the ONE place that comparison is made.
+//
+// A close date is a calendar date a human picked, so "has it passed" is a
+// question about the day it is where they work — the INSTALLATION's zone, not
+// the server's. Asked in UTC by a caller east of it, a date that is yesterday
+// locally is still today, and the same record then reads overdue on the deal
+// and on time in the tool that re-derived it — for the whole working morning,
+// every day.
+//
+// Strict <: a deal legitimately closing today is not late.
+func CloseIsOverdue(expectedClose time.Time, now time.Time, workspaceTZ *time.Location) bool {
+	return dateOnly(expectedClose).Before(dateAt(now, workspaceTZ))
 }
 
 // dateAt reduces an instant to its calendar date in the given zone,

--- a/backend/internal/modules/deals/closedate_test.go
+++ b/backend/internal/modules/deals/closedate_test.go
@@ -219,3 +219,44 @@ func TestCloseDateTodayBucketsInWorkspaceZone(t *testing.T) {
 		t.Errorf("Auckland workspace: flags = %v, want overdue", got.Flags)
 	}
 }
+
+// TestOverdueIsAskedInTheInstallationsZone is the disagreement this seam exists
+// to end.
+//
+// A close date is a calendar date a human picked, so whether it has passed is a
+// question about the day it is where they work. Asked in UTC by a caller east
+// of it, a date that is yesterday locally is still today — and the same record
+// then reads overdue on the deal and on time in whatever re-derived it, for the
+// whole working morning, every day.
+func TestOverdueIsAskedInTheInstallationsZone(t *testing.T) {
+	saigon, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		t.Fatalf("loading the zone: %v", err)
+	}
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("loading the zone: %v", err)
+	}
+	// 22:00 on 23 August UTC is 05:00 on the 24th in Saigon and 15:00 on the
+	// 23rd in Los Angeles: one instant, three different days.
+	now := time.Date(2026, 8, 23, 22, 0, 0, 0, time.UTC)
+	expected := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	if !CloseIsOverdue(expected, now, saigon) {
+		t.Error("a deal expected on the 23rd is not overdue at 05:00 on the 24th in Saigon — " +
+			"the working morning is exactly when a rep asks")
+	}
+	if CloseIsOverdue(expected, now, losAngeles) {
+		t.Error("a deal expected on the 23rd is overdue at 15:00 on the 23rd in Los Angeles")
+	}
+	// UTC is the accidental zone, and it is what a caller gets for asking with
+	// no installation zone at all.
+	if CloseIsOverdue(expected, now, nil) {
+		t.Error("a deal expected on the 23rd is overdue at 22:00 on the 23rd UTC")
+	}
+	// Strict: a deal closing today is not late anywhere.
+	tomorrow := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	if CloseIsOverdue(tomorrow, now, saigon) {
+		t.Error("a deal expected on the 24th is overdue on the 24th in Saigon")
+	}
+}


### PR DESCRIPTION
Closes #2550.

## Two day-zones, one question

| where | `today` | feeds |
|---|---|---|
| `deals/closedate.go` | `dateAt(now, workspaceTZ)` — the **installation's** zone | the deal's `CloseDateOverdue` hygiene flag |
| `compose/slipping.go` | `time.Date(…, time.UTC)` | the `whats_slipping_this_week` tool |

The comparison was identical. The `today` was not.

At `Asia/Ho_Chi_Minh` (UTC+7), 05:00 on 24 August local is 22:00 on the 23rd UTC. A deal expected to close on the **23rd** read **overdue** on the record and **on time** in the tool — same reader, same record, two answers, for the whole working morning, every day. Reversed west of UTC, where the tool flags it before the record does.

## One comparison

The ticket names the shape the rulebook asks for — *the tool calls through to the module's judgement rather than recomputing it* — and that is what this does:

```go
// deals/closedate.go
func CloseIsOverdue(expectedClose time.Time, now time.Time, workspaceTZ *time.Location) bool {
	return dateOnly(expectedClose).Before(dateAt(now, workspaceTZ))
}
```

`CloseDateAssessment` calls it, and `slippingCandidate` calls it instead of re-deriving. There is no second implementation left to drift.

`slipping.go` reads the installation's zone the way every other compose surface does (`identity.TimezoneOf` inside the workspace transaction), and a name Go cannot load falls back to UTC — the same fallback `dateAt` makes for a nil zone, so a broken setting cannot make the two surfaces disagree in a *new* way.

Which zone is correct was not in question: a close date is a calendar date a human picked, so it belongs in the zone they work in. UTC was the accidental one.

## Test

`TestOverdueIsAskedInTheInstallationsZone` pins one instant — 22:00 on 23 August UTC — against three zones that call it three different days:

- Saigon (05:00 on the 24th): overdue
- Los Angeles (15:00 on the 23rd): not overdue
- no zone at all: not overdue, because UTC is what a caller gets for not saying

plus the strict boundary, since a deal closing *today* is not late.

Mutation-checked: forcing the comparison back to UTC fails the Saigon case with the message naming the working morning.

Local: `make check-backend`, `make craft-static` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overdue deal detection now uses the installation’s timezone for accurate calendar-date comparisons.
  * Deals due today are no longer incorrectly marked as overdue.
  * Invalid timezone settings safely fall back to UTC.

* **Tests**
  * Added coverage for overdue-date behavior across multiple timezones and same-day boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->