### PR TITLE
Discover the platform packages that write rows

### DIFF
--- a/backend/gates/moduleaudits_test.go
+++ b/backend/gates/moduleaudits_test.go
@@ -52,6 +52,15 @@ var modulesThatWriteNoHistory = gatekit.Waive(map[string]string{
 	// storekit.Audit is judged by this gate under its own module.
 	"internal/platform/database/storekit": "storekit IS the audit writer; the four tables it owns are the ledgers themselves",
 
+	// The job fleet's own queue. river_job is River's operational state — what
+	// is queued, running or retained — and not a record of anything a person
+	// did. Every domain write a job performs is audited by the module that
+	// performs it, under that module's own row; the queue row is the machinery
+	// that got the worker there. The one statement this tree issues against it
+	// is a workspace purge, and what a purge DID to the estate is audited by
+	// the erasure path that ordered it.
+	"internal/platform/jobs": "river_job is the fleet's operational state rather than a record fact — what a job DID is audited by the module that did it, and the purge that deletes these rows is audited by the erasure that ordered it",
+
 	// Per-READER derived state. Every one of these tables carries a user_id and
 	// holds an assembly generated FOR one person — a brief, a dossier, a view
 	// cursor, a dismissal. None is a shared record fact, so none has a record

--- a/backend/gates/moduleaudits_test.go
+++ b/backend/gates/moduleaudits_test.go
@@ -56,9 +56,12 @@ var modulesThatWriteNoHistory = gatekit.Waive(map[string]string{
 	// is queued, running or retained — and not a record of anything a person
 	// did. Every domain write a job performs is audited by the module that
 	// performs it, under that module's own row; the queue row is the machinery
-	// that got the worker there. The one statement this tree issues against it
-	// is a workspace purge, and what a purge DID to the estate is audited by
-	// the erasure path that ordered it.
+	// that got the worker there.
+	//
+	// No count of statements here, deliberately: nothing holds one, so a number
+	// would be a claim that rots the first time somebody adds a write. What the
+	// waiver rests on is the KIND of table, which does not change with how many
+	// statements touch it.
 	"internal/platform/jobs": "river_job is the fleet's operational state rather than a record fact — what a job DID is audited by the module that did it, and the purge that deletes these rows is audited by the erasure that ordered it",
 
 	// Per-READER derived state. Every one of these tables carries a user_id and

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -40,7 +40,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -630,84 +629,6 @@ func tableArgText(arg ast.Expr, consts map[string]string) (string, bool) {
 	}
 }
 
-// platformRoot is the tree the platform writers are DISCOVERED in. Everything
-// under it that writes a row is walked; everything else is not swept in.
-const platformRoot = "internal/platform"
-
-// platformStoreDirs answers every package under internal/platform that writes a
-// row.
-//
-// Derived, not named. Three were named here — settings, extsecrets, keyvault —
-// and the list was demonstrably short: platform/events writes event_outbox and
-// platform/jobs deletes river_job, so neither write was ever compared against
-// the ownership map it is declared in. A hand-kept list of writers is one
-// somebody has to remember to extend, and nothing fails when they do not; that
-// is exactly the hole `vault_secret` sat in until somebody noticed.
-//
-// Widening to the whole of internal/platform would be the other mistake: it
-// would sweep in packages that write no rows and make the gate judge files it
-// has no declaration for. Discovery keeps the set exactly as wide as the
-// writing.
-func platformStoreDirs(t *testing.T) []string {
-	t.Helper()
-	found := map[string]bool{}
-	fset := token.NewFileSet()
-	err := filepath.WalkDir(platformRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
-			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
-			isIntegrationTagged(path) {
-			return err
-		}
-		path = filepath.ToSlash(path)
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			return err
-		}
-		dir := filepath.ToSlash(filepath.Dir(path))
-		if dir == storekitOwned {
-			// The applier itself, not an owner. Its writes name whatever table
-			// the CALLER passes, so judging it as a writer would attribute
-			// every module's versioned write to this one package — and every
-			// one of those is already judged where the table is named.
-			return nil
-		}
-		if writesARow(file) {
-			found[dir] = true
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking %s for row writers: %v", platformRoot, err)
-	}
-	dirs := make([]string, 0, len(found))
-	for dir := range found {
-		dirs = append(dirs, dir)
-	}
-	sort.Strings(dirs)
-	if len(dirs) < platformWriterFloor {
-		t.Fatalf("only %d package(s) under %s were found to write rows, and this gate is pinned "+
-			"at %d: %v\n\nA discovery that stopped finding writers reports a clean tree in the "+
-			"same words as a tree whose writers are all declared.",
-			len(dirs), platformRoot, platformWriterFloor, dirs)
-	}
-	return dirs
-}
-
-// platformWriterFloor is how many row-writing platform packages the discovery
-// found when it replaced the hand-kept list.
-const platformWriterFloor = 5
-
-// writesARow reports whether the file holds a SQL statement that writes one.
-func writesARow(file *ast.File) bool {
-	found := false
-	for _, statement := range gatekit.SQLStatementsOf(file) {
-		if len(sqlWriteTargets(statement)) > 0 {
-			found = true
-		}
-	}
-	return found
-}
-
 // collectTableWrites walks every non-test module/compose source file and
 // records each SQL write target (string literals plus the storekit applier and
 // row-lock table arguments, see storekitTableArg) under its owning directory.
@@ -1010,42 +931,4 @@ const blankOne, deleteOne = ` + "`UPDATE t SET a = NULL`" + `, ` + "`DELETE FROM
 				"is answering one spec per spec rather than per value bound in it", sites[0])
 		}
 	})
-}
-
-// TestThePlatformWritersAreDiscoveredRatherThanRemembered is the derivation,
-// from the other end.
-//
-// Three platform packages were named here by hand, and the list was short by
-// two: platform/events writes event_outbox and platform/jobs deletes river_job,
-// so neither write was ever compared against the ownership map it is declared
-// in. A hand-kept list of writers is one somebody has to remember to extend,
-// and nothing failed when they did not.
-func TestThePlatformWritersAreDiscoveredRatherThanRemembered(t *testing.T) {
-	t.Parallel()
-	found := map[string]bool{}
-	for _, dir := range platformStoreDirs(t) {
-		found[dir] = true
-	}
-	// The three that were named, and the two that were not.
-	for _, dir := range []string{
-		settingsStoreDir, extSecretsStoreDir, keyVaultStoreDir,
-		"internal/platform/events", jobsStoreDir,
-	} {
-		if !found[dir] {
-			t.Errorf("%s writes rows and the discovery did not find it", dir)
-		}
-	}
-	// And the applier is NOT one: its writes name whatever table the caller
-	// passes, so counting it would attribute every module's versioned write to
-	// one package.
-	if found[storekitOwned] {
-		t.Errorf("%s was discovered as a writer; it is the mechanism every writer goes through",
-			storekitOwned)
-	}
-	// A package that writes no rows stays outside. Widening to the whole of
-	// internal/platform would make the gate judge files it has no declaration
-	// for, which is the other way to get this wrong.
-	if found["internal/platform/blobstore"] {
-		t.Error("internal/platform/blobstore writes no rows and was swept in anyway")
-	}
 }

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -40,6 +40,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -77,6 +78,11 @@ const extSecretsStoreDir = "internal/platform/extsecrets"
 // would sweep in files this gate has not judged. Deriving it instead is
 // https://github.com/margince/margince/issues/2554.
 const keyVaultStoreDir = "internal/platform/keyvault"
+
+// jobsStoreDir runs the River fleet, and is where river_job is written from —
+// discovered by platformStoreDirs rather than named here; the constant exists
+// so tableOwners can point at it in one spelling.
+const jobsStoreDir = "internal/platform/jobs"
 
 // tableOwners maps every core-migration table to the ONE module whose store
 // owns its writes (module doc.go "Tables owned" declarations, kept in sync).
@@ -438,6 +444,11 @@ var tableOwners = map[string]string{
 	// tenant.
 	"vault_secret": keyVaultStoreDir,
 
+	// River's own queue table. Owned by the package that runs the fleet, which
+	// is the only one that writes it directly: the client library writes the
+	// rest, and a purge is the one statement this tree issues against it.
+	"river_job": jobsStoreDir,
+
 	// platform, storekit: the audit+outbox pair has ONE sanctioned writer, and
 	// the shared field-provenance layer (B-E02.12) is spelled once next to it.
 	// system_log is the non-entity operational ledger written through
@@ -619,6 +630,84 @@ func tableArgText(arg ast.Expr, consts map[string]string) (string, bool) {
 	}
 }
 
+// platformRoot is the tree the platform writers are DISCOVERED in. Everything
+// under it that writes a row is walked; everything else is not swept in.
+const platformRoot = "internal/platform"
+
+// platformStoreDirs answers every package under internal/platform that writes a
+// row.
+//
+// Derived, not named. Three were named here — settings, extsecrets, keyvault —
+// and the list was demonstrably short: platform/events writes event_outbox and
+// platform/jobs deletes river_job, so neither write was ever compared against
+// the ownership map it is declared in. A hand-kept list of writers is one
+// somebody has to remember to extend, and nothing fails when they do not; that
+// is exactly the hole `vault_secret` sat in until somebody noticed.
+//
+// Widening to the whole of internal/platform would be the other mistake: it
+// would sweep in packages that write no rows and make the gate judge files it
+// has no declaration for. Discovery keeps the set exactly as wide as the
+// writing.
+func platformStoreDirs(t *testing.T) []string {
+	t.Helper()
+	found := map[string]bool{}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(platformRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
+			isIntegrationTagged(path) {
+			return err
+		}
+		path = filepath.ToSlash(path)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		dir := filepath.ToSlash(filepath.Dir(path))
+		if dir == storekitOwned {
+			// The applier itself, not an owner. Its writes name whatever table
+			// the CALLER passes, so judging it as a writer would attribute
+			// every module's versioned write to this one package — and every
+			// one of those is already judged where the table is named.
+			return nil
+		}
+		if writesARow(file) {
+			found[dir] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s for row writers: %v", platformRoot, err)
+	}
+	dirs := make([]string, 0, len(found))
+	for dir := range found {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	if len(dirs) < platformWriterFloor {
+		t.Fatalf("only %d package(s) under %s were found to write rows, and this gate is pinned "+
+			"at %d: %v\n\nA discovery that stopped finding writers reports a clean tree in the "+
+			"same words as a tree whose writers are all declared.",
+			len(dirs), platformRoot, platformWriterFloor, dirs)
+	}
+	return dirs
+}
+
+// platformWriterFloor is how many row-writing platform packages the discovery
+// found when it replaced the hand-kept list.
+const platformWriterFloor = 5
+
+// writesARow reports whether the file holds a SQL statement that writes one.
+func writesARow(file *ast.File) bool {
+	found := false
+	for _, statement := range gatekit.SQLStatementsOf(file) {
+		if len(sqlWriteTargets(statement)) > 0 {
+			found = true
+		}
+	}
+	return found
+}
+
 // collectTableWrites walks every non-test module/compose source file and
 // records each SQL write target (string literals plus the storekit applier and
 // row-lock table arguments, see storekitTableArg) under its owning directory.
@@ -631,7 +720,7 @@ func collectTableWrites(t *testing.T) map[string][]tableWrite {
 	// versioned writes in it. The floor is what tells those two apart.
 	storekitWrites := 0
 	fset := token.NewFileSet()
-	roots := []string{"internal/modules", "internal/compose", settingsStoreDir, extSecretsStoreDir, keyVaultStoreDir}
+	roots := append([]string{"internal/modules", "internal/compose"}, platformStoreDirs(t)...)
 	consts := stringConstsByPackage(t, fset, roots)
 	for _, root := range roots {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -921,4 +1010,42 @@ const blankOne, deleteOne = ` + "`UPDATE t SET a = NULL`" + `, ` + "`DELETE FROM
 				"is answering one spec per spec rather than per value bound in it", sites[0])
 		}
 	})
+}
+
+// TestThePlatformWritersAreDiscoveredRatherThanRemembered is the derivation,
+// from the other end.
+//
+// Three platform packages were named here by hand, and the list was short by
+// two: platform/events writes event_outbox and platform/jobs deletes river_job,
+// so neither write was ever compared against the ownership map it is declared
+// in. A hand-kept list of writers is one somebody has to remember to extend,
+// and nothing failed when they did not.
+func TestThePlatformWritersAreDiscoveredRatherThanRemembered(t *testing.T) {
+	t.Parallel()
+	found := map[string]bool{}
+	for _, dir := range platformStoreDirs(t) {
+		found[dir] = true
+	}
+	// The three that were named, and the two that were not.
+	for _, dir := range []string{
+		settingsStoreDir, extSecretsStoreDir, keyVaultStoreDir,
+		"internal/platform/events", jobsStoreDir,
+	} {
+		if !found[dir] {
+			t.Errorf("%s writes rows and the discovery did not find it", dir)
+		}
+	}
+	// And the applier is NOT one: its writes name whatever table the caller
+	// passes, so counting it would attribute every module's versioned write to
+	// one package.
+	if found[storekitOwned] {
+		t.Errorf("%s was discovered as a writer; it is the mechanism every writer goes through",
+			storekitOwned)
+	}
+	// A package that writes no rows stays outside. Widening to the whole of
+	// internal/platform would make the gate judge files it has no declaration
+	// for, which is the other way to get this wrong.
+	if found["internal/platform/blobstore"] {
+		t.Error("internal/platform/blobstore writes no rows and was swept in anyway")
+	}
 }

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -52,30 +52,20 @@ import (
 // walked package owns them, so any direct module write needs a waiver.
 const storekitOwned = "internal/platform/database/storekit"
 
-// extSecretsStoreDir is the second platform package this gate walks (after
-// settingsStoreDir): the extension tier's secret namespace owns
-// extension_secret, so leaving it outside the sweep would let a future
-// second writer of that table land unnoticed. Named explicitly, for the
-// same reason settingsStoreDir is — the rest of platform owns no rows, and
-// widening to internal/platform would sweep in files this gate has not
-// judged.
+// extSecretsStoreDir is the extension tier's secret namespace, which owns
+// extension_secret. The constant exists so tableOwners can point at it in one
+// spelling; WHICH platform packages this gate walks is answered by
+// platformStoreDirs, not by a name here.
 const extSecretsStoreDir = "internal/platform/extsecrets"
 
-// keyVaultStoreDir is the third, for the same reason and found the same way: the
-// local key-vault provider owns vault_secret, and until this gate walked it the
-// table had no owner entry at all.
+// keyVaultStoreDir is the local key-vault provider, which owns vault_secret.
+// Until this gate walked it the table had no owner entry at all.
 //
-// What that actually left open, stated narrowly because the wide version is not
-// true: a second writer in internal/modules or internal/compose was already
-// caught, by the no-declared-owner arm below. The unguarded case was a second
-// writer inside a platform package this gate does not walk — and two such
-// packages write rows today (platform/events/relay.go UPDATEs event_outbox,
-// which this map declares; platform/jobs/quiesce.go DELETEs river_job), so the
-// case is live rather than theoretical.
-//
-// The list is named rather than reached by widening to internal/platform, which
-// would sweep in files this gate has not judged. Deriving it instead is
-// https://github.com/margince/margince/issues/2554.
+// What that left open, stated narrowly because the wide version is not true: a
+// second writer in internal/modules or internal/compose was already caught, by
+// the no-declared-owner arm below. The unguarded case was a second writer
+// inside a platform package the gate did not walk — and the hand-kept list of
+// those was short by two, which is what the derivation replaced.
 const keyVaultStoreDir = "internal/platform/keyvault"
 
 // jobsStoreDir runs the River fleet, and is where river_job is written from —

--- a/backend/gates/tableownershipdiscovery_test.go
+++ b/backend/gates/tableownershipdiscovery_test.go
@@ -111,11 +111,21 @@ func writesARow(file *ast.File) bool {
 
 // callsAStorekitApplier reports whether the file reaches a storekit call that
 // carries its table — the second way this gate learns a package writes rows.
+//
+// The SAME shape the walker attributes from, argument count included. Matching
+// a bare method name would declare a writer out of any package holding a method
+// that happens to share one, and the walker would then reach a package with no
+// table to read and fail on its own unreadable-argument arm — a gate failing
+// over a file that writes nothing. And a package that does not import storekit
+// cannot be calling it at all.
 func callsAStorekitApplier(file *ast.File) bool {
+	if imported, _ := gatekit.ImportedAs(file, storekitImportPath); imported == "" {
+		return false
+	}
 	found := false
 	ast.Inspect(file, func(node ast.Node) bool {
 		call, isCall := node.(*ast.CallExpr)
-		if !isCall {
+		if !isCall || len(call.Args) < storekitTableArgArity {
 			return true
 		}
 		if method, isMethod := call.Fun.(*ast.SelectorExpr); isMethod && storekitTableArg[method.Sel.Name] {
@@ -125,6 +135,14 @@ func callsAStorekitApplier(file *ast.File) bool {
 	})
 	return found
 }
+
+// storekitImportPath is the package a storekit-shaped call must come from.
+const storekitImportPath = "github.com/margince/margince/backend/internal/platform/database/storekit"
+
+// storekitTableArgArity is how many arguments such a call carries before its
+// table is at Args[2] — the walker's own guard, so discovery cannot count a
+// call the walk would decline to read.
+const storekitTableArgArity = 4
 
 // TestThePlatformWritersAreDiscoveredRatherThanRemembered is the derivation,
 // from the other end.
@@ -164,6 +182,12 @@ func TestThePlatformWritersAreDiscoveredRatherThanRemembered(t *testing.T) {
 	}
 }
 
+// withStorekit puts a probe in a package that imports storekit, which is what
+// makes a storekit-shaped call a storekit call.
+func withStorekit(body string) string {
+	return "package p\n\nimport \"" + storekitImportPath + "\"\n\n" + body
+}
+
 // The second write shape, from the other end.
 //
 // A package whose only row write goes through a storekit applier holds no
@@ -179,19 +203,35 @@ func TestAStorekitOnlyWriterIsDiscovered(t *testing.T) {
 	}{
 		{
 			name: "an applier call with no SQL in the file",
-			source: "package p\nfunc write(p *storekit.Patch, tx pgx.Tx) error {\n" +
-				"\treturn p.ApplyWithVersion(ctx, tx, \"vault_secret\", id, version)\n}\n",
+			source: withStorekit("func write(p *storekit.Patch, tx pgx.Tx) error {\n" +
+				"\treturn p.ApplyWithVersion(ctx, tx, \"vault_secret\", id, version)\n}\n"),
 			want: true,
 		},
 		{
 			name: "a row lock, which is where ApplyLocked's table is legible",
-			source: "package p\nfunc lock(tx pgx.Tx) error {\n" +
-				"\t_, err := storekit.LockRow(ctx, tx, \"vault_secret\", id)\n\treturn err\n}\n",
+			source: withStorekit("func lock(tx pgx.Tx) error {\n" +
+				"\t_, err := storekit.LockRow(ctx, tx, \"vault_secret\", id)\n\treturn err\n}\n"),
 			want: true,
 		},
 		{
 			name:   "a package that reads and writes nothing",
 			source: "package p\nfunc name() string { return \"vault_secret\" }\n",
+			want:   false,
+		},
+		{
+			// A method that merely shares a name. Counted, this package would
+			// join the walk with no table to read, and the walker would fail on
+			// its own unreadable-argument arm over a file that writes nothing.
+			name: "a same-named method on somebody else's type",
+			source: "package p\ntype cache struct{}\nfunc (c cache) LockRow(a, b, d, e int) {}\n" +
+				"func use(c cache) { c.LockRow(1, 2, 3, 4) }\n",
+			want: false,
+		},
+		{
+			// The walker declines to read a call this short, so discovery must
+			// not count one either — the two have to agree on what a write is.
+			name:   "a storekit-shaped call too short to carry a table",
+			source: withStorekit("func short(p *storekit.Patch) { p.LockRow(ctx, tx) }\n"),
 			want:   false,
 		},
 	}

--- a/backend/gates/tableownershipdiscovery_test.go
+++ b/backend/gates/tableownershipdiscovery_test.go
@@ -118,6 +118,19 @@ func writesARow(file *ast.File) bool {
 // table to read and fail on its own unreadable-argument arm — a gate failing
 // over a file that writes nothing. And a package that does not import storekit
 // cannot be calling it at all.
+//
+// The import is as far as this can be narrowed, and the residual is stated
+// rather than left to be discovered: a file that imports storekit AND declares
+// its own four-argument method under one of these names is counted here on the
+// name alone. Narrowing further by QUALIFIER — checking the selector reaches
+// the storekit identifier — is what the shapes rule out: a third of the tree's
+// applier calls are methods on a `*storekit.Patch` value whose receiver is
+// named by its holder (`p.ApplyGuarded`), so that check would stop recognising
+// them. Between the two, this gate over-recognises: an extra package joins the
+// walk and either attributes nothing or fails LOUDLY on the table it cannot
+// read, where the qualifier check drops real writers SILENTLY and every table
+// they own goes back to being unowned — the direction a census is not allowed
+// to fail in.
 func callsAStorekitApplier(file *ast.File) bool {
 	if imported, _ := gatekit.ImportedAs(file, storekitImportPath); imported == "" {
 		return false
@@ -202,6 +215,10 @@ func TestAStorekitOnlyWriterIsDiscovered(t *testing.T) {
 		want   bool
 	}{
 		{
+			// The applier as a METHOD on a storekit value, which is a third of
+			// the tree's call sites and the reason `callsAStorekitApplier`
+			// cannot narrow to calls that reach the storekit identifier: the
+			// receiver here is named by whoever holds the patch.
 			name: "an applier call with no SQL in the file",
 			source: withStorekit("func write(p *storekit.Patch, tx pgx.Tx) error {\n" +
 				"\treturn p.ApplyWithVersion(ctx, tx, \"vault_secret\", id, version)\n}\n"),

--- a/backend/gates/tableownershipdiscovery_test.go
+++ b/backend/gates/tableownershipdiscovery_test.go
@@ -92,14 +92,37 @@ func platformStoreDirs(t *testing.T) []string {
 // found when it replaced the hand-kept list.
 const platformWriterFloor = 5
 
-// writesARow reports whether the file holds a SQL statement that writes one.
+// writesARow reports whether the file writes one, in either shape the walker
+// judges.
+//
+// Both shapes, because discovery narrower than the walk is discovery that
+// hides a write: a package whose only row write goes through a storekit
+// applier — no inline SQL anywhere in it — would never be walked, and its
+// write never compared against tableOwners. That is the same hole the
+// hand-kept list had, one level in.
 func writesARow(file *ast.File) bool {
-	found := false
 	for _, statement := range gatekit.SQLStatementsOf(file) {
 		if len(sqlWriteTargets(statement)) > 0 {
-			found = true
+			return true
 		}
 	}
+	return callsAStorekitApplier(file)
+}
+
+// callsAStorekitApplier reports whether the file reaches a storekit call that
+// carries its table — the second way this gate learns a package writes rows.
+func callsAStorekitApplier(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		if method, isMethod := call.Fun.(*ast.SelectorExpr); isMethod && storekitTableArg[method.Sel.Name] {
+			found = true
+		}
+		return !found
+	})
 	return found
 }
 
@@ -138,5 +161,50 @@ func TestThePlatformWritersAreDiscoveredRatherThanRemembered(t *testing.T) {
 	// for, which is the other way to get this wrong.
 	if found["internal/platform/blobstore"] {
 		t.Error("internal/platform/blobstore writes no rows and was swept in anyway")
+	}
+}
+
+// The second write shape, from the other end.
+//
+// A package whose only row write goes through a storekit applier holds no
+// inline SQL at all, so a discovery reading literals alone would never walk it
+// — and its write would never be compared against tableOwners. That is the hand
+// -kept list's hole one level in, so the shape is planted rather than assumed.
+func TestAStorekitOnlyWriterIsDiscovered(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{
+			name: "an applier call with no SQL in the file",
+			source: "package p\nfunc write(p *storekit.Patch, tx pgx.Tx) error {\n" +
+				"\treturn p.ApplyWithVersion(ctx, tx, \"vault_secret\", id, version)\n}\n",
+			want: true,
+		},
+		{
+			name: "a row lock, which is where ApplyLocked's table is legible",
+			source: "package p\nfunc lock(tx pgx.Tx) error {\n" +
+				"\t_, err := storekit.LockRow(ctx, tx, \"vault_secret\", id)\n\treturn err\n}\n",
+			want: true,
+		},
+		{
+			name:   "a package that reads and writes nothing",
+			source: "package p\nfunc name() string { return \"vault_secret\" }\n",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := parser.ParseFile(token.NewFileSet(), "probe.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the probe: %v", err)
+			}
+			if got := writesARow(parsed); got != tc.want {
+				t.Errorf("writesARow = %t, want %t", got, tc.want)
+			}
+		})
 	}
 }

--- a/backend/gates/tableownershipdiscovery_test.go
+++ b/backend/gates/tableownershipdiscovery_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// WHICH packages the ownership gate walks, derived rather than remembered.
+//
+// Separate from the judgement next door because it answers a different
+// question. That file asks whether a package writes only what it owns; this one
+// asks who the writers ARE — and the answer used to be a list somebody had to
+// keep, which is the shape a derivation replaces.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// platformRoot is the tree the platform writers are DISCOVERED in. Everything
+// under it that writes a row is walked; everything else is not swept in.
+const platformRoot = "internal/platform"
+
+// platformStoreDirs answers every package under internal/platform that writes a
+// row.
+//
+// Derived, not named. Three were named here — settings, extsecrets, keyvault —
+// and the list was demonstrably short: platform/events writes event_outbox and
+// platform/jobs deletes river_job, so neither write was ever compared against
+// the ownership map it is declared in. A hand-kept list of writers is one
+// somebody has to remember to extend, and nothing fails when they do not; that
+// is exactly the hole `vault_secret` sat in until somebody noticed.
+//
+// Widening to the whole of internal/platform would be the other mistake: it
+// would sweep in packages that write no rows and make the gate judge files it
+// has no declaration for. Discovery keeps the set exactly as wide as the
+// writing.
+func platformStoreDirs(t *testing.T) []string {
+	t.Helper()
+	found := map[string]bool{}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(platformRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
+			isIntegrationTagged(path) {
+			return err
+		}
+		path = filepath.ToSlash(path)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		dir := filepath.ToSlash(filepath.Dir(path))
+		if dir == storekitOwned {
+			// The applier itself, not an owner. Its writes name whatever table
+			// the CALLER passes, so judging it as a writer would attribute
+			// every module's versioned write to this one package — and every
+			// one of those is already judged where the table is named.
+			return nil
+		}
+		if writesARow(file) {
+			found[dir] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s for row writers: %v", platformRoot, err)
+	}
+	dirs := make([]string, 0, len(found))
+	for dir := range found {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	if len(dirs) < platformWriterFloor {
+		t.Fatalf("only %d package(s) under %s were found to write rows, and this gate is pinned "+
+			"at %d: %v\n\nA discovery that stopped finding writers reports a clean tree in the "+
+			"same words as a tree whose writers are all declared.",
+			len(dirs), platformRoot, platformWriterFloor, dirs)
+	}
+	return dirs
+}
+
+// platformWriterFloor is how many row-writing platform packages the discovery
+// found when it replaced the hand-kept list.
+const platformWriterFloor = 5
+
+// writesARow reports whether the file holds a SQL statement that writes one.
+func writesARow(file *ast.File) bool {
+	found := false
+	for _, statement := range gatekit.SQLStatementsOf(file) {
+		if len(sqlWriteTargets(statement)) > 0 {
+			found = true
+		}
+	}
+	return found
+}
+
+// TestThePlatformWritersAreDiscoveredRatherThanRemembered is the derivation,
+// from the other end.
+//
+// Three platform packages were named here by hand, and the list was short by
+// two: platform/events writes event_outbox and platform/jobs deletes river_job,
+// so neither write was ever compared against the ownership map it is declared
+// in. A hand-kept list of writers is one somebody has to remember to extend,
+// and nothing failed when they did not.
+func TestThePlatformWritersAreDiscoveredRatherThanRemembered(t *testing.T) {
+	t.Parallel()
+	found := map[string]bool{}
+	for _, dir := range platformStoreDirs(t) {
+		found[dir] = true
+	}
+	// The three that were named, and the two that were not.
+	for _, dir := range []string{
+		settingsStoreDir, extSecretsStoreDir, keyVaultStoreDir,
+		"internal/platform/events", jobsStoreDir,
+	} {
+		if !found[dir] {
+			t.Errorf("%s writes rows and the discovery did not find it", dir)
+		}
+	}
+	// And the applier is NOT one: its writes name whatever table the caller
+	// passes, so counting it would attribute every module's versioned write to
+	// one package.
+	if found[storekitOwned] {
+		t.Errorf("%s was discovered as a writer; it is the mechanism every writer goes through",
+			storekitOwned)
+	}
+	// A package that writes no rows stays outside. Widening to the whole of
+	// internal/platform would make the gate judge files it has no declaration
+	// for, which is the other way to get this wrong.
+	if found["internal/platform/blobstore"] {
+		t.Error("internal/platform/blobstore writes no rows and was swept in anyway")
+	}
+}

--- a/backend/gates/tableownershipwaivers_test.go
+++ b/backend/gates/tableownershipwaivers_test.go
@@ -16,6 +16,9 @@ import "github.com/margince/margince/backend/internal/shared/gatekit"
 // entry a sibling earned. Every entry carries its rationale inline so the gate
 // is self-contained on a clean checkout.
 var crossStoreWrites = gatekit.Waive(map[string]string{
+	// The relay marks what it shipped, in the transaction that shipped it.
+	"internal/platform/events:event_outbox:relay.go:Relay.relayBatch": "storekit WRITES the outbox row and the relay RETIRES it, which is the whole point of an outbox: the domain write and the publish are separate transactions, and marking published_at in the same transaction as the XADD is what makes a crash re-ship rather than lose. Moving it into storekit would put the shipping half inside the module seam that exists to know nothing about shipping",
+
 	// people's merge/promotion relink rows across aggregates inside their
 	// single transaction — the primary aggregate owns the single-tx
 	// cross-aggregate write, because a merge that could half-commit its

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -139,6 +139,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
+| `tableownershipdiscovery_test.go` | H2 | WHICH packages the ownership gate walks, derived rather than remembered. |
 | `undoreasoncensus_test.go` | H2 | One refusal set, three spellings. |
 | `uniquenessclaimscorpus_test.go` | H2 | WHERE the claim sweep looks, as against what it looks for. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -67,7 +67,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 
-## Census (71)
+## Census (72)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #2554.

## The list was short by two

`tableownership_test.go` walked `internal/modules`, `internal/compose`, and three hand-named platform directories. The ticket's claim, confirmed by deriving the set:

- `internal/platform/events` — `UPDATE event_outbox SET published_at = now() …`. `event_outbox` **is** declared in `tableOwners` (as `storekitOwned`), so this write was simply never compared against that declaration.
- `internal/platform/jobs` — `DELETE FROM river_job`, a table with no owner at all.

A hand-kept list of writers is one somebody has to remember to extend, and nothing fails when they do not. That is the same hole `vault_secret` sat in until #2546.

## Derived, and bounded on both sides

`platformStoreDirs` discovers every package under `internal/platform` holding a row-writing statement. Two things keep it honest:

- **Pinned** at 5. A discovery that stopped finding writers would report a clean tree in exactly the words of a tree whose writers are all declared.
- **Not widened to the whole tree.** Sweeping `internal/platform` wholesale would make the gate judge packages that write nothing and have no declaration to judge them against. Discovery keeps the set exactly as wide as the writing.

`storekit` is excluded, and that is not an exemption: its writes name whatever table the **caller** passes, so counting it would attribute every module's versioned write to one package — and every one of those is already judged where the table is named.

## The cascade, answered rather than assumed

The ticket predicted it, and both entries are written with their reasons:

- **`river_job` → `internal/platform/jobs`**, and `TestEveryTableOwningModuleWritesAnAuditRow` then demanded its history. It is operational state, not a record fact: what a job *did* is audited by the module that did it, and the purge that deletes these rows is audited by the erasure that ordered it.
- **The relay's outbox mark** is ratified in `crossStoreWrites` where it happens. storekit *writes* the row and the relay *retires* it, which is what an outbox is — and marking `published_at` in the transaction that shipped is what makes a crash re-ship rather than lose. Moving it into storekit would put the shipping half inside the seam that exists to know nothing about shipping.

## Tests

`TestThePlatformWritersAreDiscoveredRatherThanRemembered` asserts the discovery finds all three that were named **and** the two that were not, does **not** find storekit, and does **not** sweep in `blobstore`, which writes no rows.

Mutation-checked: restoring the hand-named list fails, because the events waiver then matches nothing — the derivation is load-bearing rather than decorative.

`tableownership_test.go` passed the 1000-line cap on the way, so the discovery is its own file: that gate asks whether a package writes only what it owns, and this asks who the writers are.

Local: `make check-backend`, `make craft-static` green; gate inventory regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated checks for database table ownership and audit coverage.
  * Added discovery tests to identify components that write database records, including direct and managed writes.
  * Expanded coverage for event relay and background job data-handling exceptions.

* **Documentation**
  * Updated the gate inventory to include new ownership and anonymity checks and revised the census count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->