### PR TITLE
fix(breadcrumb): give the current-page label a floor before it clips

### DIFF
--- a/frontend/src/design-system/breadcrumb.css
+++ b/frontend/src/design-system/breadcrumb.css
@@ -7,6 +7,16 @@
    unchanged on screen. */
 .crumbs {
   min-width: 0;
+  /* The trail owns its own overflow rather than trusting a caller's wrapper
+     to. Without this, the last label's 2ch floor (below) is still painted in
+     full even when the row has no room for it — the ancestors' `flex: none`
+     never yields, so the floored box is pushed past the trail's own right
+     edge and bleeds, uncropped, into whatever sits beside it (measured: the
+     top bar's centred search box, at 1280px — the label was visible but
+     unreachable, sitting under a control that intercepted every hover and
+     click meant for it). Clipping here keeps the bleed inside the primitive
+     that owns the promise, instead of asking every consumer to remember it. */
+  overflow: hidden;
 }
 .crumbs > ol {
   display: flex;

--- a/frontend/src/design-system/breadcrumb.css
+++ b/frontend/src/design-system/breadcrumb.css
@@ -82,9 +82,17 @@
 /* Only the last label clips, and it needs the whole chain to allow it: a flex
    item does not shrink below its content unless it is told it may. The tip
    `useTruncationTooltip` hangs on this element is what carries the rest of the
-   name, on hover and on focus alike. */
+   name, on hover and on focus alike.
+
+   The floor is 2ch, not 0: `min-width: 0` alone has no lower bound, and at a
+   width where the unshrinkable ancestor crumbs already fill the row (measured:
+   1280px in the shell's own top bar), flexbox drove this label to literally
+   0px — past the point `text-overflow: ellipsis` has anything to paint the
+   glyph into, so the current page read as nothing at all rather than as
+   truncated (margince#3122). 2ch is enough room for the ellipsis on its own;
+   it does not promise any of the actual label survives. */
 .crumbs > ol > li:last-child .crumbs-label {
-  min-width: 0;
+  min-width: 2ch;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary
- Improves, but does NOT close, margince#3122 (stays open — see below). Two real, browser-verified fixes to the breadcrumb primitive itself:
  1. `min-width: 2ch` on the current-page label — was `min-width: 0` with no floor, which let it collapse to a literal 0px box (invisible, not even an ellipsis) wherever the ancestor crumbs already filled the row.
  2. `overflow: hidden` on `.crumbs` — without it, the 2ch-floored box painted uncropped past the trail's own edge instead of clipping there (caught by cubic's review of the first commit).
- **Both are correct and both are confirmed working from 1366px up** (cross-session QC pass, real browser, three rounds of measurement including catching and correcting an instrument artifact in Playwright's `hover()` auto-scroll).
- **Neither fixes 1280px, and no floor value in `breadcrumb.css` can.** At that width `.crumbs`'s own grid cell (`.topbar-lead`, one of `topbar.css`'s three `minmax(0, 1fr)`/`auto`/`minmax(0, 1fr)` tracks) is measured at 72px — "Contacts /" alone already fills it. Any min-width on the label just makes content wider than a 72px box: overlapped without clipping, or clipped away with it. There is no room to give within the breadcrumb component; the trail's cell itself is too narrow, and that is a `topbar.css` grid-allocation question (should the search track shrink before the trail does? should the avatar-only right cell yield its unused share?) — a bigger, more visually-iterative call than this PR, left for margince#3122 to track.

## Test plan
- [x] `pnpm vitest run src/design-system/breadcrumb.test.tsx` — 8/8 pass, unchanged (jsdom does no real flex layout, so this class of bug is invisible to it — consistent with why it shipped in the first place)
- [x] `pnpm exec biome check` on the changed file — clean
- [x] Real-browser verification across 1280/1366/1440/1600/1920 (cross-session QC pass) — 1366+ confirmed fixed (ellipsis renders, tooltip reachable by real hover and focus); 1280 confirmed NOT fixed (`crumbs.clientWidth: 72, scrollWidth: 92` — the label is clipped away entirely, no hover target exists for a pointer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the breadcrumb current-page label collapsing to 0px at 1280px (margince#3122) so it now shows an ellipsis and the hover/focus tooltip instead of nothing.

- Sets the label's `min-width` to `2ch`, enough room for the ellipsis glyph alone without promising how much of the label survives.
- Adds `overflow: hidden` on `.crumbs` so the floored label clips at the trail's edge instead of bleeding under the top bar's search box at 1280px.
- The tooltip popup is unaffected because it renders via `createPortal`.
- No unit test added: jsdom does no real flex layout (the 8 existing tests pass unchanged); re-verify visually across 1280/1366/1440/1600/1920 before merge.

<sup>Written for commit b4f9463807fd1acbf638b02cfff20a8eb213878e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breadcrumb truncation so the final label consistently displays an ellipsis when space is limited.
  * Prevented overflowing breadcrumb content from extending beyond its container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

