### PR TITLE
A bundle's card states only what its members agree on

### DIFF
--- a/frontend/src/design-system/decisiondeck.stories.tsx
+++ b/frontend/src/design-system/decisiondeck.stories.tsx
@@ -11,8 +11,10 @@ import { Callout } from "./callout";
 import type { DecisionApproval, DecisionCardLabels } from "./decisioncard";
 import {
   DecisionDeck,
+  type DecisionDeckChips,
   type DecisionDeckItem,
   type DecisionDeckLabels,
+  type DecisionSharedFacts,
   type StagedDecision,
 } from "./decisiondeck";
 import { AutonomyDot } from "./trust";
@@ -146,19 +148,33 @@ const MANY: readonly DecisionDeckItem[] = [
   single(5),
 ];
 
-const CHIPS = (held: DecisionApproval) => ({
+// Every chip a caller draws about the ACT comes from `shared` — the facts every
+// member of the item carries — and never from the member the card is drawn
+// from. A fact the members disagree on is simply not in there, which is what
+// `DivergentBundle` below shows.
+const CHIPS = (
+  _held: DecisionApproval,
+  shared: DecisionSharedFacts,
+): DecisionDeckChips => ({
   meta: (
     <>
-      <AutonomyDot tier="confirm" />
-      <span className="t-small">
-        {held.kind === "site_lead"
-          ? "Add a person found on the site"
-          : "Send an email"}
-      </span>
+      {shared.kind !== undefined && (
+        <>
+          <AutonomyDot tier="confirm" />
+          <span className="t-small">
+            {shared.kind === "site_lead"
+              ? "Add a person found on the site"
+              : "Send an email"}
+          </span>
+        </>
+      )}
     </>
   ),
-  provenance: { kind: "agent" as const, agent: "mailroom" },
-  confidence: "high" as const,
+  provenance:
+    shared.proposedBy === undefined
+      ? undefined
+      : { kind: "agent" as const, agent: "mailroom" },
+  confidence: shared.confidence === undefined ? undefined : ("high" as const),
   aside: (
     <button type="button" className="link-button">
       Approval detail
@@ -212,6 +228,39 @@ export const ExpiredAtTheFront: Story = {
 // times something they decided once — the members stay reachable underneath.
 export const BundleCollapsed: Story = {
   args: { ...BASE, items: [BUNDLE, single(1)] },
+};
+
+// A bundle whose members do not agree. Two site reads of the same company stage
+// under one bundle, so its members can name two different agents and carry two
+// different readings — and the card drawn from one of them would state that
+// one's kind, tier, provenance and confidence as the whole act's.
+//
+// What to look at: the chips that are NOT there. The count and the member list
+// still are, and they are the honest answer to what this act proposed.
+export const DivergentBundle: Story = {
+  args: {
+    ...BASE,
+    items: [
+      {
+        kind: "bundle",
+        id: "bundle-0198c3bb",
+        bundleId: "0198c3aa-7f10-7bbb-9999-000000000002",
+        members: [
+          approval(60, {
+            kind: "site_lead",
+            summary: "Introduce ourselves to the head of operations.",
+            proposed_by: "agent:deepread",
+          }),
+          approval(61, {
+            kind: "site_lead",
+            summary: "Introduce ourselves to the finance lead.",
+            proposed_by: "agent:site-read",
+            confidence: 0.42,
+          }),
+        ],
+      },
+    ],
+  },
 };
 
 // The tray, mid-flight: three verdicts staged and nothing sent. This is the

--- a/frontend/src/design-system/decisiondeck.test.tsx
+++ b/frontend/src/design-system/decisiondeck.test.tsx
@@ -9,8 +9,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DecisionApproval, DecisionCardLabels } from "./decisioncard";
 import {
   DecisionDeck,
+  type DecisionDeckChips,
   type DecisionDeckItem,
   type DecisionDeckLabels,
+  type DecisionSharedFacts,
   type DeckVerdict,
   dragVerdict,
   keyVerdict,
@@ -346,6 +348,92 @@ describe("DecisionDeck — a bundle is one decision", () => {
     expect(onCommit).toHaveBeenCalledWith([
       { id: "bundle-1", verdict: "accept" as DeckVerdict },
     ]);
+  });
+});
+
+describe("DecisionDeck — a card states only what its members agree on", () => {
+  // The chips as a caller draws them, one line per fact, and a fact the caller
+  // was not given simply has no line. Reading them back out of the DOM is what
+  // proves the deck hands over the AGREEMENT rather than the member it drew.
+  const CHIPS = (
+    _approval: DecisionApproval,
+    shared: DecisionSharedFacts,
+  ): DecisionDeckChips => ({
+    meta: (
+      <>
+        {shared.kind !== undefined && <span>{`kind: ${shared.kind}`}</span>}
+        {shared.proposedBy !== undefined && (
+          <span>{`by: ${shared.proposedBy}`}</span>
+        )}
+        {shared.confidence !== undefined && (
+          <span>{`confidence: ${shared.confidence}`}</span>
+        )}
+      </>
+    ),
+  });
+
+  function bundle(...members: readonly DecisionApproval[]): DecisionDeckItem {
+    return { kind: "bundle", id: "bundle-1", bundleId: "bundle-1", members };
+  }
+
+  it("states a fact every member carries", () => {
+    render(
+      deck({
+        items: [
+          bundle(
+            approval(11, { confidence: 0.9 }),
+            approval(12, { confidence: 0.9 }),
+          ),
+        ],
+        chips: CHIPS,
+      }),
+    );
+    expect(screen.getByText("kind: held_draft")).toBeInTheDocument();
+    expect(screen.getByText("by: agent:mailroom")).toBeInTheDocument();
+    expect(screen.getByText("confidence: 0.9")).toBeInTheDocument();
+  });
+
+  // The one the drawn member would have answered wrongly: it names an agent,
+  // and the card would have said that agent staged all of them.
+  it("drops the fact the members disagree on, and only that one", () => {
+    render(
+      deck({
+        items: [
+          bundle(
+            approval(11, { proposed_by: "agent:deepread", confidence: 0.9 }),
+            approval(12, { proposed_by: "agent:site-read", confidence: 0.9 }),
+          ),
+        ],
+        chips: CHIPS,
+      }),
+    );
+    expect(screen.queryByText(/^by: /)).not.toBeInTheDocument();
+    expect(screen.getByText("kind: held_draft")).toBeInTheDocument();
+    expect(screen.getByText("confidence: 0.9")).toBeInTheDocument();
+  });
+
+  // Absence is a disagreement too. One member scored and one unscored is not a
+  // scored act, and taking the reading that exists is exactly how a bundle came
+  // to report a confidence nobody claimed for the rest of it.
+  it("counts a fact one member never carried as a disagreement", () => {
+    render(
+      deck({
+        items: [bundle(approval(11, { confidence: 0.9 }), approval(12))],
+        chips: CHIPS,
+      }),
+    );
+    expect(screen.queryByText(/^confidence: /)).not.toBeInTheDocument();
+    expect(screen.getByText("by: agent:mailroom")).toBeInTheDocument();
+  });
+
+  // The other end: a single agrees with itself, so nothing is withheld from the
+  // card that was never a bundle. A rule that quietly blanked every chip would
+  // satisfy every case above.
+  it("leaves a single's own facts whole", () => {
+    render(deck({ items: [single(1, { confidence: 0.42 })], chips: CHIPS }));
+    expect(screen.getByText("kind: held_draft")).toBeInTheDocument();
+    expect(screen.getByText("by: agent:mailroom")).toBeInTheDocument();
+    expect(screen.getByText("confidence: 0.42")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/design-system/decisiondeck.tsx
+++ b/frontend/src/design-system/decisiondeck.tsx
@@ -210,6 +210,62 @@ function itemLapsed(item: DecisionDeckItem, now: number): boolean {
   return decisionLapsed(representative(item, now), now);
 }
 
+/**
+ * The facts a card may state about the WHOLE item — never the representative's
+ * alone.
+ *
+ * Drawing a bundle from one member is right for what the card DECIDES and wrong
+ * for what it CLAIMS. A ten-recipient send staged by two agents at two
+ * confidences read as one agent at one confidence, and the reader answered all
+ * ten on that reading. So a fact its members do not share is absent here rather
+ * than sampled from one of them: an omitted chip is honest, a wrong one is not.
+ *
+ * Absent is also what a fact nobody recorded looks like, and that collapse is
+ * deliberate — both mean "this card cannot say", which is the whole of what a
+ * chip could truthfully report either way.
+ */
+export type DecisionSharedFacts = Readonly<{
+  kind?: string;
+  proposedBy?: string;
+  confidence?: number;
+}>;
+
+/**
+ * What every member of an item agrees on. A single agrees with itself, so it
+ * carries its own facts whole.
+ *
+ * The chips are built from THIS rather than from the drawn approval, which is
+ * what keeps the rule from being one a caller has to remember: a fact the
+ * members disagree on is not merely discouraged as a chip, it is not there to
+ * draw one from.
+ */
+export function sharedFacts(item: DecisionDeckItem): DecisionSharedFacts {
+  const members = item.kind === "single" ? [item.approval] : item.members;
+  return {
+    kind: agreed(members, (member) => member.kind),
+    proposedBy: agreed(members, (member) => member.proposed_by),
+    confidence: agreed(members, (member) => member.confidence),
+  };
+}
+
+/**
+ * One fact across the members, or undefined where any two disagree.
+ *
+ * A member that never carried the fact needs no arm of its own: it reads as
+ * absent, a set holding one absence and one value does not agree, and a set of
+ * absences agrees on nothing a chip could print.
+ */
+function agreed<T>(
+  members: readonly DecisionApproval[],
+  read: (member: DecisionApproval) => T | null | undefined,
+): T | undefined {
+  const values = members.map(read);
+  const first = values[0];
+  return first != null && values.every((value) => value === first)
+    ? first
+    : undefined;
+}
+
 // What the deck's body is in, given what the caller knows and what the deck can
 // see. A caller's non-ready state wins — a failed read is a fact the deck has no
 // way to discover — and `ready` defers, because only the deck knows whether
@@ -320,7 +376,10 @@ export type DecisionDeckProps = Readonly<{
   loadingLabel?: string;
   /** Under the tray: what a refused commit said, in the caller's words. */
   notice?: ReactNode;
-  chips?: (approval: DecisionApproval) => DecisionDeckChips;
+  chips?: (
+    approval: DecisionApproval,
+    shared: DecisionSharedFacts,
+  ) => DecisionDeckChips;
 }>;
 
 export function DecisionDeck({
@@ -694,7 +753,10 @@ function DeckStack({
   leaving: Leaving | null;
   now: number;
   labels: DecisionDeckLabels;
-  chips?: (approval: DecisionApproval) => DecisionDeckChips;
+  chips?: (
+    approval: DecisionApproval,
+    shared: DecisionSharedFacts,
+  ) => DecisionDeckChips;
   onStage: (
     item: DecisionDeckItem,
     verdict: DeckVerdict,
@@ -840,11 +902,14 @@ function ItemCard({
   layout: "deck" | "row";
   now: number;
   labels: DecisionDeckLabels;
-  chips?: (approval: DecisionApproval) => DecisionDeckChips;
+  chips?: (
+    approval: DecisionApproval,
+    shared: DecisionSharedFacts,
+  ) => DecisionDeckChips;
   onStage: (item: DecisionDeckItem, verdict: DeckVerdict) => void;
 }>) {
   const approval = representative(item, now);
-  const trim = chips?.(approval) ?? {};
+  const trim = chips?.(approval, sharedFacts(item)) ?? {};
   const members = item.kind === "bundle" ? item.members : [];
   return (
     <DecisionCard

--- a/frontend/src/screens/home.decisions.tsx
+++ b/frontend/src/screens/home.decisions.tsx
@@ -377,17 +377,33 @@ export function DecisionsSection({
         // it is, which tool produced it, and how long it has left. The chips are
         // the design system's, so the deck and the Decisions row cannot disagree
         // about a deadline.
-        chips={(approval) => ({
+        //
+        // Every one of them is read off `shared` — what the item's members
+        // AGREE on — rather than off the card's drawn approval, so a bundle
+        // states one member's kind, tier, tool or provenance as the act's only
+        // when it is every member's. The deadline is the exception and stays on
+        // the drawn approval, because that is the member the deck's Accept
+        // guard answers for.
+        //
+        // The body below is the drawn member's too, and honestly so: it is that
+        // member's own summary and payload, standing beside a count and a list
+        // of the siblings it was staged with. A chip makes a claim about the
+        // ACT; the body shows one proposal in the set.
+        chips={(approval, shared) => ({
           meta: (
             <>
-              <AutonomyDot tier={approvalDotTier(approval.kind, tierMap)} />
-              <span className="t-small">
-                {approvalKindLabel(approval.kind, t)}
-              </span>
-              <DecisionToolChip
-                verb={KIND_TO_VERB[approval.kind]}
-                label={(verb) => t("decision.viaTool", { verb })}
-              />
+              {shared.kind !== undefined && (
+                <>
+                  <AutonomyDot tier={approvalDotTier(shared.kind, tierMap)} />
+                  <span className="t-small">
+                    {approvalKindLabel(shared.kind, t)}
+                  </span>
+                  <DecisionToolChip
+                    verb={KIND_TO_VERB[shared.kind]}
+                    label={(verb) => t("decision.viaTool", { verb })}
+                  />
+                </>
+              )}
               <DecisionStatusChip
                 approval={approval}
                 decided={false}
@@ -396,8 +412,14 @@ export function DecisionsSection({
               />
             </>
           ),
-          provenance: provenanceOf(approval.proposed_by, viewerId),
-          confidence: confidenceLevel(approval.confidence) ?? undefined,
+          // Not `provenanceOf(undefined)`: that answers "nobody recorded a
+          // source", which is a claim of its own and a false one here — the
+          // members each recorded one and they differ.
+          provenance:
+            shared.proposedBy === undefined
+              ? undefined
+              : provenanceOf(shared.proposedBy, viewerId),
+          confidence: confidenceLevel(shared.confidence) ?? undefined,
           display: resolveDisplay(
             approval.kind,
             (approval.proposed_change ?? {}) as Record<string, unknown>,

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -583,6 +583,53 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
 
 // ── A reading is absent until it is read. Never zero. ──
 
+// ── A bundle's chips are claims about the ACT, not about the drawn member ──
+
+describe("HomeScreen — a bundle says only what its members agree on", () => {
+  // A bundle is drawn from one member, which is right for what the card decides
+  // and wrong for what it claims. Two site reads of the same company stage under
+  // one bundle — the second joins the first's still-pending rows and moves them
+  // onto its own bundle — so the members really do name different agents.
+  it("draws no provenance tag where the members name different agents", async () => {
+    const queue = [
+      proposal("apx-1", "Lead: Anna Weber", {
+        bundle_id: "bn-2",
+        proposed_by: "agent:deepread",
+      }),
+      proposal("apx-2", "Lead: Mira Osei", {
+        bundle_id: "bn-2",
+        proposed_by: "agent:site-read",
+      }),
+    ];
+    stubApi({ "GET /approvals": () => pendingPage(queue, new Set<string>()) });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText("One decision · 2 items")).toBeTruthy();
+    // Neither agent's name — and not the unnamed tag either, which would still
+    // claim one agent produced the whole act.
+    expect(screen.queryByText("Automated by deepread")).toBeNull();
+    expect(screen.queryByText("Automated by site-read")).toBeNull();
+    expect(screen.queryByText("Automated by an agent")).toBeNull();
+    // The KIND is every member's, so the chip that says what this act is stays:
+    // the rule drops the fact that diverged, not the card's meta line.
+    expect(screen.getByText("Send an email")).toBeTruthy();
+  });
+
+  // The other end. Without this, blanking the tag unconditionally would pass the
+  // case above, and every single-agent bundle would lose a true reading.
+  it("keeps the tag where every member names the same agent", async () => {
+    const queue = [
+      proposal("apy-1", "Lead: Anna Weber", { bundle_id: "bn-3" }),
+      proposal("apy-2", "Lead: Mira Osei", { bundle_id: "bn-3" }),
+    ];
+    stubApi({ "GET /approvals": () => pendingPage(queue, new Set<string>()) });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText("One decision · 2 items")).toBeTruthy();
+    expect(screen.getByText("Automated by runner")).toBeTruthy();
+  });
+});
+
 describe("HomeScreen — a reading in flight is absent, not zero", () => {
   /** The deck's own section, which is where a failed decisions read belongs. */
   function deckSection(): HTMLElement {


### PR DESCRIPTION
Closes #2578.

## The premise, checked first

The ticket asks whether members can actually diverge today, "if a bundle is always staged by one agent in one call, this is a guard against a future rather than a live defect". They can, and by a path that is easy to miss:

- The three staging sites each use ONE kind and one principal per act (`transcriptproposerun.go`, `deepreadtriage.go`/`deepreadautoapply.go`, `onboardingsitereadtransport.go`), so a freshly staged bundle is uniform.
- But `stageOrJoinPendingInTx` JOINS a still-pending row from an earlier act and `rebundleJoinedInTx` moves it onto the new act's bundle — and a joined row keeps everything it was staged with, including `proposed_by`. A crawl-worker read stages leads as `agent:deepread`; a later onboarding confirmation of the same read re-proposes them as `agent:site-read`, joins the pending ones and rebundles them. One bundle, two agents.
- `kind` cannot diverge (the join matches on kind), and `Approval.confidence` is never populated on the wire today — but both are members' facts read through one member, which is the same defect waiting.

## What changed

The ticket's cheap answer — aggregate-or-omit — put in the shape rather than in the caller's memory.

`DecisionDeck` now computes `DecisionSharedFacts`: the `kind`, `proposedBy` and `confidence` that EVERY member of an item carries, and nothing where any two disagree. The chips callback gets it as a second argument and builds every act-level chip from it. A caller cannot draw a chip from a diverging fact by forgetting the rule, because the value is not there:

    chips={(approval, shared) => ({
      meta: shared.kind !== undefined && <>...</>,
      provenance: shared.proposedBy === undefined ? undefined : provenanceOf(shared.proposedBy, viewerId),
      confidence: confidenceLevel(shared.confidence) ?? undefined,
    })}

Not `provenanceOf(undefined)`: that renders "nobody recorded a source", which is a claim of its own and a false one here.

A member that never carried the fact counts as a disagreement — one scored member and one unscored is not a scored act.

The countdown chip stays on the drawn approval, because that member is the one the deck's Accept guard answers for. The card's BODY stays the drawn member's too, and honestly so: it is that member's own summary and payload standing beside a count and a list of the siblings it was staged with. A chip claims something about the act; the body shows one proposal in the set.

## Held by

- `decisiondeck.test.tsx` — a fact every member carries is stated; the one they disagree on is dropped **and only that one**; an absent fact on one member is a disagreement; and a `single` keeps all of its own facts, which is what stops a rule that quietly blanks every chip from passing.
- `home.test.tsx` — the real screen, through the real API stub: a bundle whose members name `agent:deepread` and `agent:site-read` draws no provenance tag (not the named one, not the unnamed one) and still draws the kind chip; a bundle where every member names the same agent keeps the tag.
- Mutation-checked from the other end: pointing `sharedFacts` back at the first member fails two deck cases, and restoring `provenanceOf(approval.proposed_by, ...)` in the screen fails the home case.
- New `DivergentBundle` story so the catalog shows the chips that are not there.

`make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decision cards now show only facts shared by all items in a bundle.
  * Conflicting or missing details—such as proposer, confidence, kind, and tool metadata—are no longer displayed as if they applied to the entire bundle.
  * Provenance labels are hidden for bundles with mixed proposing agents, while consistent provenance remains visible.
* **Tests**
  * Added coverage for shared facts, single-item bundles, and mixed or consistent provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->