### PR TITLE
fix(ci): waive the new_reliability_rating gate scripts/seed-reset.sql trips

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -388,8 +388,15 @@ sonar.issue.ignore.multicriteria.e15.resourceKey=.github/actions/install-claude-
 # `EXECUTE format('DELETE FROM %I', t)`, invisible to this rule's static
 # parser — this is the one place a literal, unconditional DELETE was spelled
 # out instead, and is exactly the shape the rule exists to catch on product
-# code). Scoped to dev/ops tooling only: this script runs against the compose
-# stack's own dev database inside a transaction (BEGIN/COMMIT), requires
-# superuser, and is never invoked against a real installation.
+# code).
+#
+# Its scope is per-FILE, not per-line, same as every other entry above: a
+# second unconditional DELETE added to seed-reset.sql later is hidden by this
+# waiver too. Acceptable only because the whole file is dev/ops tooling that
+# exists to clear tables wholesale — it runs against the compose stack's own
+# dev database, inside a transaction (BEGIN/COMMIT), requires superuser, and
+# is never invoked against a real installation. Confirmed reachable only by a
+# human typing `make seed-reset`: not a dependency of any other Make target,
+# not referenced by any script, not referenced by any workflow.
 sonar.issue.ignore.multicriteria.e16.ruleKey=plsql:DeleteOrUpdateWithoutWhereCheck
 sonar.issue.ignore.multicriteria.e16.resourceKey=scripts/seed-reset.sql

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -181,7 +181,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -380,3 +380,16 @@ sonar.issue.ignore.multicriteria.e14.resourceKey=e2e/llm/check.py
 # against a global install at all).
 sonar.issue.ignore.multicriteria.e15.ruleKey=githubactions:S6505
 sonar.issue.ignore.multicriteria.e15.resourceKey=.github/actions/install-claude-cli/action.yml
+# plsql:DeleteOrUpdateWithoutWhereCheck on scripts/seed-reset.sql's `DELETE FROM
+# event_outbox;` (no WHERE) — deliberate, not a missed one. The script's own
+# comment above the line explains why: event_outbox is one of the tables this
+# reset clears WHOLESALE rather than filtering, the same way the DO block above
+# it clears every other target table (that loop's deletes are dynamic SQL,
+# `EXECUTE format('DELETE FROM %I', t)`, invisible to this rule's static
+# parser — this is the one place a literal, unconditional DELETE was spelled
+# out instead, and is exactly the shape the rule exists to catch on product
+# code). Scoped to dev/ops tooling only: this script runs against the compose
+# stack's own dev database inside a transaction (BEGIN/COMMIT), requires
+# superuser, and is never invoked against a real installation.
+sonar.issue.ignore.multicriteria.e16.ruleKey=plsql:DeleteOrUpdateWithoutWhereCheck
+sonar.issue.ignore.multicriteria.e16.resourceKey=scripts/seed-reset.sql


### PR DESCRIPTION
## Summary
- `sonarcloud quality gate (main)` (the `scheduled` workflow) failed on `new_reliability_rating GT 1 (actual 5)` — one BLOCKER: `plsql:DeleteOrUpdateWithoutWhereCheck` on `scripts/seed-reset.sql:121`, `DELETE FROM event_outbox;` with no WHERE clause.
- Deliberate, not missed: it's one of the tables this dev-only reset script clears wholesale, the same way its earlier `DO` block clears every other target table — those use dynamic SQL (`EXECUTE format('DELETE FROM %I', t)`), invisible to the rule's static parser, so this one literal DELETE is the only instance the rule can see. The script's own comment two lines above already explains why `event_outbox` is cleared this way (it's about the relay's independent polling, not about missing a filter). It runs only against the compose stack's own dev database, inside a transaction, requiring superuser — never against a real installation.
- Waived in `sonar-project.properties` (`e16`), scoped to the one file.

## Test plan
- [x] Confirmed the flagged line and its surrounding comment still match (`scripts/seed-reset.sql:121`)
- [x] Confirmed the two OTHER `DELETE FROM` statements in the same file are not affected by this waiver's scope in a way that matters: one has a real `WHERE NOT EXISTS (...)` clause (correctly unflagged), the other is the dynamic-SQL loop (not flagged, not touched)
- [x] `git status` clean diff, single file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waives the SonarCloud `plsql:DeleteOrUpdateWithoutWhereCheck` rule for `scripts/seed-reset.sql` so the quality gate stops failing on the script's deliberate `DELETE FROM event_outbox;`.

- The DELETE is intentional: the script clears that table wholesale, same as its dynamic-SQL loop clears other tables, and it only runs against the dev database.
- The waiver is scoped to the single file, so every other rule still applies to it.

<sup>Written for commit b3c973da89116d7ddea3830bff618e423582f4da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning rules to recognize an intentional, unfiltered development reset operation.
  * Documented that the waiver applies only to the designated reset script and is restricted to development use.
  * No production behavior or user-facing functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->