### PR TITLE
fix(records): a technology fact is what a company runs, not what it mentions

### DIFF
--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -114,7 +114,7 @@ func workerFlagSet() (*flag.FlagSet, *cliflags.Env, *workerConfig, error) {
 		"how often to look for companies whose technical profile is missing or stale. Unlike "+
 			"geocoding there is no write to trigger on — a company's mail provider changes at the "+
 			"COMPANY — so this pass is the only thing that observes a move. Runs on start; 0 turns "+
-			"the sweep off and leaves the button working.")
+			"the sweep off and leaves the lookup to the site read that queues it.")
 	env.String(fs, &cfg.gmailClientID, "gmail-client-id", "MARGINCE_GMAIL_CLIENT_ID", "", "Google OAuth client id for the Gmail capture connector; enables the background Gmail sync poll")
 	env.String(fs, &cfg.gmailClientSecret, "gmail-client-secret", "MARGINCE_GMAIL_CLIENT_SECRET", "", "Google OAuth client secret for the Gmail capture connector")
 	env.String(fs, &cfg.graphClientID, "graph-client-id", "MARGINCE_GRAPH_CLIENT_ID", "", "Microsoft (Entra) application id for the Outlook/M365 capture connector; enables its background sync poll")

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget"
 	"github.com/margince/margince/backend/internal/platform/vatcheck"
-	"github.com/margince/margince/backend/internal/platform/webread"
 )
 
 // gmailWatchConfig builds the Gmail push-watch maintenance config: the
@@ -317,7 +316,6 @@ func technicalEnricherFor(cfg workerConfig, pool *pgxpool.Pool) *compose.Technic
 	return compose.NewTechnicalEnricher(
 		dnsread.New(dnsread.NewPacer(dnsReadInterval)),
 		certlog.NewCrtSh(baseURL, nil),
-		webread.New(),
 		people.NewStore(compose.InstallationDB(pool)),
 		nil,
 	)

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -247,11 +247,16 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 	// guarded egress, under its own deadline, whose failure is never the
 	// read's. A company that publishes no newsroom is the ordinary case.
 	w.readNewsroom(ctx, claim, crawl)
-	// The third side lane, and the only one that queues rather than fetches:
-	// what the company publicly RUNS, beside what its pages SAY. Its three
-	// services are paced on their own single-threaded queue, so a deep-read
-	// worker hands the question over instead of waiting on it
-	// (technicalonsiteread.go).
+	// What the pages this crawl already fetched DECLARE about the software
+	// serving them — read from the response headers, cookies, scripts and
+	// markup each one arrived with, so no page is asked for twice
+	// (sitetechnology.go).
+	w.readSiteTechnology(ctx, claim, crawl)
+	// The last side lane, and the only one that queues rather than fetches:
+	// what the company publicly runs according to sources the company never
+	// wrote — its DNS and its certificate history. Both are paced on their own
+	// single-threaded queue, so a deep-read worker hands the question over
+	// instead of waiting on it (technicalonsiteread.go).
 	w.askWhatTheCompanyRuns(ctx, claim)
 
 	return w.reportRead(ctx, args, claim, crawl, extraction)

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -44,6 +44,12 @@ type crawlPage struct {
 	// pipeline itself keys off Text alone.
 	Bytes    int
 	FetchDur time.Duration
+	// Fingerprint is what THIS page declared about the software serving it.
+	//
+	// Kept per page rather than for the seed alone: a shop system, a customer
+	// portal or a careers platform commonly announces itself on the one page
+	// that runs it, and a homepage-only read cannot see any of them.
+	Fingerprint webread.Fingerprint
 }
 
 type crawlSkip struct {
@@ -362,7 +368,7 @@ func newCrawlRun(c *siteCrawler, pacer crawlPacer, seedURL string, seedPage webr
 		pacer:   pacer,
 		seedURL: seedURL,
 		crawl: siteCrawl{
-			Pages:      []crawlPage{{URL: seedURL, Kind: crmcontracts.SiteReadPageKindHome, Text: seedPage.Text, Bytes: seedPage.Bytes}},
+			Pages:      []crawlPage{{URL: seedURL, Kind: crmcontracts.SiteReadPageKindHome, Text: seedPage.Text, Bytes: seedPage.Bytes, Fingerprint: seedPage.Fingerprint}},
 			SeedAssets: declaredAssets{ogImage: seedPage.OGImage, icons: seedPage.Icons},
 			SeedURL:    seedURL,
 		},

--- a/backend/internal/compose/sitecrawlfetch.go
+++ b/backend/internal/compose/sitecrawlfetch.go
@@ -33,7 +33,7 @@ func (c *siteCrawler) ReadSeed(ctx context.Context, seedURL string) (crawlPage, 
 	}
 	return crawlPage{
 		URL: answered, Kind: crmcontracts.SiteReadPageKindHome,
-		Text: page.Text, Bytes: page.Bytes,
+		Text: page.Text, Bytes: page.Bytes, Fingerprint: page.Fingerprint,
 	}, nil
 }
 

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -195,7 +195,7 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		// what it guessed at; its kind stays open for the next guess.
 		r.probeKindDone[adm.cand.kind] = true
 	}
-	committed := crawlPage{URL: servedURL, Kind: kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur}
+	committed := crawlPage{URL: servedURL, Kind: kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur, Fingerprint: page.Fingerprint}
 	r.crawl.Pages = append(r.crawl.Pages, committed)
 	if r.onPage != nil {
 		r.onPage(committed)

--- a/backend/internal/compose/sitereadvocab.go
+++ b/backend/internal/compose/sitereadvocab.go
@@ -49,8 +49,17 @@ var categoryGuidance = map[string]string{
 	"market": "served_industry, company_size, geography and language describe markets the company explicitly says it serves — one entry per grounded item, repeating the field name. " +
 		"company_size here is the size of the customers they sell TO (\"we work with mid-sized retailers\"), never their own headcount, which is employee_range under company.",
 	"signal": "certification names a held certification or standard; partner a named business partner; " +
-		"named_customer a customer the site names; technology a platform, product or stack the company says it " +
-		"works with or builds on; quantified_outcome preserves an exact measurable customer or case-study result " +
+		"named_customer a customer the site names; " +
+		"technology a named platform, product or stack the company states it USES, RUNS or BUILDS IN — its own " +
+		"stack, not its subject matter. The passage must assert this company's own use: \"built on X\", \"we run X\", " +
+		"\"our X-based platform\", \"migrating our shop to X\". A vendor merely NAMED, described, compared, offered as " +
+		"an integration or listed among options is not a technology fact, however much text the page spends on it — " +
+		"a page selling integrations names every vendor it integrates with, and none of them is a statement about " +
+		"what this company runs. NEVER an analyst firm, rating, report or award (Gartner, Forrester, a Magic " +
+		"Quadrant, a Wave) — those rate a company, they are not something it uses. NEVER a bare capability " +
+		"category (BI, CRM, ERP, PIM, e-commerce, cloud): a category is not a product. If the page does not say " +
+		"THIS company uses it, omit it. " +
+		"quantified_outcome preserves an exact measurable customer or case-study result " +
 		"without strengthening the claim — one entry per item, repeating the field name.",
 }
 

--- a/backend/internal/compose/sitetechnology.go
+++ b/backend/internal/compose/sitetechnology.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the crawled site DECLARES about its own stack.
+//
+// The technical lookup beside this one reads DNS and the certificate log, both
+// of which answer about a DOMAIN. What software a site runs is answered by the
+// site's own pages, and this read has already fetched them — every page it
+// crawled carries the response headers, cookie names, script srcs and markup it
+// arrived with (webread.Page.Fingerprint).
+//
+// Every page, not the homepage alone. A shop system announces itself on /shop,
+// a portal on /kunden, a careers platform on /karriere, and a homepage-only
+// fetch sees none of the three. This lane matches the same ruleset against
+// everything the crawl reached, so the read that already paid for those pages
+// is what answers the question.
+//
+// It owns the `homepage` lane on the record. The enricher no longer fetches a
+// homepage of its own precisely so there is ONE writer: a completed lane
+// reconciles, and two writers each seeing a different subset would take turns
+// deleting the other's rows.
+
+import (
+	"context"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/techprofile"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// readSiteTechnology matches every crawled page against the fingerprint
+// ruleset and writes what they declared.
+//
+// Errors are logged and dropped, never returned. The dossier this read is
+// about to close is complete without the technology rows, and a company that
+// publishes no recognisable marker is the ordinary case rather than a fault.
+//
+// A read that resolved no organization writes nothing: the domain-triage lane
+// runs before an account exists, and reading a site to decide whether to CREATE
+// a company cannot enrich one.
+func (w *siteDeepReadWorker) readSiteTechnology(ctx context.Context, claim people.SiteReadClaim, crawl siteCrawl) {
+	if claim.OrganizationID == nil {
+		return
+	}
+	orgID := ids.From[ids.OrganizationKind](*claim.OrganizationID)
+	found, err := technologiesAcross(crawl.Pages)
+	if err != nil {
+		w.log.WarnContext(ctx, "site technology read failed",
+			"organization", orgID.String(), "err", err)
+		return
+	}
+	// The lane COMPLETED even when it found nothing: a site that declares no
+	// recognisable stack is an authoritative empty answer, and saying so is
+	// what lets a technology the company dropped leave the record.
+	apply := people.TechnicalEnrichment{
+		OrganizationID: orgID,
+		Completed:      []people.TechnicalLane{people.LaneHomepage},
+		Observations:   found,
+		ObservedAt:     time.Now().UTC(),
+	}
+	if err := w.people.ApplyTechnicalEnrichment(ctx, apply, technicalChangeRecorder()); err != nil {
+		w.log.WarnContext(ctx, "writing what the site runs failed",
+			"organization", orgID.String(), "err", err)
+	}
+}
+
+// technologiesAcross matches the ruleset against every crawled page and returns
+// one observation per technology.
+//
+// First page wins for a given technology, so the evidence cites the page that
+// actually proved it rather than the last one to mention it — a reader asking
+// "how do you know they run Shopware?" gets /shop, not whichever page sorted
+// last. The crawl's own order is seed-first, so a marker on the homepage still
+// cites the homepage.
+func technologiesAcross(pages []crawlPage) ([]people.TechnicalObservation, error) {
+	seen := map[string]bool{}
+	observations := make([]people.TechnicalObservation, 0, len(pages))
+	for _, page := range pages {
+		fingerprint := page.Fingerprint
+		if fingerprint.URL == "" {
+			// A page the crawl recorded without a fetched response: the
+			// certification fixtures build these, and a zero fingerprint
+			// matches nothing anyway.
+			continue
+		}
+		found, err := techprofile.Technologies(techprofile.Evidence{
+			Headers:     fingerprint.Headers,
+			CookieNames: fingerprint.CookieNames,
+			ScriptSrcs:  fingerprint.ScriptSrcs,
+			Generator:   fingerprint.Generator,
+			Body:        fingerprint.Body,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, signal := range found {
+			if seen[signal.Key] {
+				continue
+			}
+			seen[signal.Key] = true
+			observations = append(observations, observationOf(signal, fingerprint.URL))
+		}
+	}
+	return observations, nil
+}

--- a/backend/internal/compose/sitetechnology_test.go
+++ b/backend/internal/compose/sitetechnology_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/webread"
+)
+
+func pageWith(url string, fingerprint webread.Fingerprint) crawlPage {
+	fingerprint.URL = url
+	return crawlPage{URL: url, Fingerprint: fingerprint}
+}
+
+// The reason this lane exists: a shop system announces itself on the page that
+// runs it, and the homepage never mentions it. A homepage-only read reports
+// that this company runs nothing but nginx.
+func TestATechnologyIsFoundOnThePageThatRunsIt(t *testing.T) {
+	t.Parallel()
+	got, err := technologiesAcross([]crawlPage{
+		pageWith("https://example.de/", webread.Fingerprint{
+			Headers: http.Header{"Server": []string{"nginx"}},
+		}),
+		pageWith("https://example.de/shop", webread.Fingerprint{
+			Headers:     http.Header{"Server": []string{"nginx"}},
+			CookieNames: []string{"sw-states"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("matching the crawl: %v", err)
+	}
+	if !observedIn(got, people.FactTechnology, "shopware") {
+		t.Errorf("the shop system on /shop was not read; read %v", got)
+	}
+}
+
+// Evidence has to name the page that PROVED the technology, or a reader asking
+// "how do you know?" is sent to a page that never mentioned it.
+func TestTheEvidenceCitesTheProvingPage(t *testing.T) {
+	t.Parallel()
+	got, err := technologiesAcross([]crawlPage{
+		pageWith("https://example.de/", webread.Fingerprint{}),
+		pageWith("https://example.de/karriere", webread.Fingerprint{
+			CookieNames: []string{"fe_typo_user"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("matching the crawl: %v", err)
+	}
+	for _, observation := range got {
+		if observation.ValueKey == "typo3" {
+			if observation.SourceURL != "https://example.de/karriere" {
+				t.Errorf("cited %q, want the page that proved it", observation.SourceURL)
+			}
+			return
+		}
+	}
+	t.Errorf("typo3 was not read at all; read %v", got)
+}
+
+// One row per technology, however many pages carry the same marker — a site
+// serving nginx on thirty pages states one fact about itself.
+func TestATechnologyOnEveryPageIsOneObservation(t *testing.T) {
+	t.Parallel()
+	same := webread.Fingerprint{Headers: http.Header{"Server": []string{"nginx"}}}
+	got, err := technologiesAcross([]crawlPage{
+		pageWith("https://example.de/", same),
+		pageWith("https://example.de/about", same),
+		pageWith("https://example.de/contact", same),
+	})
+	if err != nil {
+		t.Fatalf("matching the crawl: %v", err)
+	}
+	count := 0
+	for _, observation := range got {
+		if observation.ValueKey == "nginx" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("nginx observed %d times, want 1: %v", count, got)
+	}
+}
+
+// A page the crawl recorded without a fetched response carries a zero
+// fingerprint. It must be skipped rather than matched as an empty page, which
+// is what the certification fixtures build.
+func TestAPageWithNoFetchedResponseIsSkipped(t *testing.T) {
+	t.Parallel()
+	got, err := technologiesAcross([]crawlPage{{URL: "https://example.de/", Text: "hello"}})
+	if err != nil {
+		t.Fatalf("matching the crawl: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("read %v from a page that was never fetched", got)
+	}
+}
+
+func observedIn(in []people.TechnicalObservation, field, key string) bool {
+	for _, observation := range in {
+		if observation.Field == field && observation.ValueKey == key {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/techenrich.go
+++ b/backend/internal/compose/techenrich.go
@@ -28,7 +28,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/certlog"
 	"github.com/margince/margince/backend/internal/platform/dnsread"
 	"github.com/margince/margince/backend/internal/platform/techprofile"
-	"github.com/margince/margince/backend/internal/platform/webread"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -57,11 +56,6 @@ type certHostnameReader interface {
 	Hostnames(ctx context.Context, domain string) ([]string, bool, error)
 }
 
-// homepageReader reads one page's own declarations about its stack.
-type homepageReader interface {
-	FetchFingerprint(ctx context.Context, rawURL string) (webread.Fingerprint, error)
-}
-
 // technicalLookupCache is the remembered-answer surface. The people store
 // implements it; the engine holds the narrow shape so a test can substitute a
 // cache that forgets everything.
@@ -74,7 +68,6 @@ type technicalLookupCache interface {
 type TechnicalEnricher struct {
 	dns   technicalReader
 	certs certHostnameReader
-	pages homepageReader
 	cache technicalLookupCache
 	now   func() time.Time
 }
@@ -84,13 +77,13 @@ type TechnicalEnricher struct {
 // that lane last wrote rather than being cleared by a deployment that simply
 // does not run it.
 func NewTechnicalEnricher(
-	dns technicalReader, certs certHostnameReader, pages homepageReader,
+	dns technicalReader, certs certHostnameReader,
 	cache technicalLookupCache, now func() time.Time,
 ) *TechnicalEnricher {
 	if now == nil {
 		now = time.Now
 	}
-	return &TechnicalEnricher{dns: dns, certs: certs, pages: pages, cache: cache, now: now}
+	return &TechnicalEnricher{dns: dns, certs: certs, cache: cache, now: now}
 }
 
 // laneOutcome is what one lane did, for the attempt ledger and the log.
@@ -125,10 +118,15 @@ func (e *TechnicalEnricher) Read(
 	if domain == "" {
 		return result, nil
 	}
+	// TWO lanes, not three. The homepage lane is written by the SITE READ,
+	// which has already fetched the whole site: a shop system, a portal or a
+	// careers platform commonly announces itself on the one page that runs it,
+	// so a homepage-only fetch here would see less than the crawl already saw
+	// and would then reconcile the crawl's rows away as unobserved.
+	// technicalonsiteread.go carries that lane.
 	outcomes := []laneOutcome{
 		e.readDNS(ctx, domain, &result),
 		e.readCertLog(ctx, domain, &result),
-		e.readHomepage(ctx, domain, &result),
 	}
 	for _, outcome := range outcomes {
 		if outcome.Completed {
@@ -350,44 +348,6 @@ func (e *TechnicalEnricher) readCertLog(
 	sourceURL := certlog.PublicBaseURL + "/?q=%25." + domain
 	for _, service := range services {
 		result.Observations = append(result.Observations, observationOf(service, sourceURL))
-	}
-	outcome.Completed = true
-	return outcome
-}
-
-// readHomepage reads what the company's own homepage declares about its stack.
-func (e *TechnicalEnricher) readHomepage(
-	ctx context.Context, domain string, result *people.TechnicalEnrichment,
-) laneOutcome {
-	outcome := laneOutcome{Lane: people.LaneHomepage}
-	if e.pages == nil {
-		return outcome
-	}
-	page, err := e.pages.FetchFingerprint(ctx, "https://"+domain)
-	if err != nil {
-		if errors.Is(err, webread.ErrRobotsDisallowed) {
-			// The site said no. That is an ANSWER, and the lane completes with
-			// nothing rather than retrying against a refusal — which also
-			// clears any technology rows a previous read left, because we no
-			// longer have permission to claim them.
-			outcome.Completed = true
-			outcome.Refused = true
-			return outcome
-		}
-		return laneOutcome{Lane: people.LaneHomepage, Err: err}
-	}
-	found, err := techprofile.Technologies(techprofile.Evidence{
-		Headers:     page.Headers,
-		CookieNames: page.CookieNames,
-		ScriptSrcs:  page.ScriptSrcs,
-		Generator:   page.Generator,
-		Body:        page.Body,
-	})
-	if err != nil {
-		return laneOutcome{Lane: people.LaneHomepage, Err: err}
-	}
-	for _, technology := range found {
-		result.Observations = append(result.Observations, observationOf(technology, page.URL))
 	}
 	outcome.Completed = true
 	return outcome

--- a/backend/internal/compose/techenrich_test.go
+++ b/backend/internal/compose/techenrich_test.go
@@ -7,14 +7,12 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/dnsread"
-	"github.com/margince/margince/backend/internal/platform/webread"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -71,18 +69,6 @@ func (s stubCertLog) Hostnames(context.Context, string) ([]string, bool, error) 
 	return s.hostnames, len(s.hostnames) > 0, nil
 }
 
-type stubPages struct {
-	page webread.Fingerprint
-	err  error
-}
-
-func (s stubPages) FetchFingerprint(context.Context, string) (webread.Fingerprint, error) {
-	if s.err != nil {
-		return webread.Fingerprint{}, s.err
-	}
-	return s.page, nil
-}
-
 // recordingCache remembers what was written, so a test can assert on what the
 // cache was asked to hold — which is where the privacy boundary is checked.
 type recordingCache struct {
@@ -124,14 +110,15 @@ func TestReadGathersEveryLane(t *testing.T) {
 			names: []string{"static.1.2.3.4.your-server.de"},
 		},
 		stubCertLog{hostnames: []string{"shop.example.de", "karriere.example.de"}},
-		stubPages{page: webread.Fingerprint{URL: "https://example.de", Generator: "Shopware 6"}},
 		newRecordingCache(), fixedClock(),
 	)
 
 	got, outcomes := enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
 
-	if len(got.Completed) != 3 {
-		t.Fatalf("completed %d lanes, want 3: %v", len(got.Completed), outcomes)
+	// TWO, not three: the homepage lane belongs to the site read now, which
+	// matches every page it crawled rather than fetching one here.
+	if len(got.Completed) != 2 {
+		t.Fatalf("completed %d lanes, want 2: %v", len(got.Completed), outcomes)
 	}
 	if !got.ObservedAt.Equal(observedAt) {
 		t.Errorf("stamped %s, want the injected clock's %s", got.ObservedAt, observedAt)
@@ -142,7 +129,6 @@ func TestReadGathersEveryLane(t *testing.T) {
 		{people.FactHostingProvider, "hetzner"},
 		{people.FactOperatedService, "webshop"},
 		{people.FactOperatedService, "careers"},
-		{people.FactTechnology, "shopware"},
 	} {
 		if !observed(got, want.field, want.key) {
 			t.Errorf("did not read %s=%s; read %v", want.field, want.key, got.Observations)
@@ -163,7 +149,6 @@ func TestACertificateLogOutageCompletesNoLane(t *testing.T) {
 	enricher := NewTechnicalEnricher(
 		stubResolver{mx: []dnsread.MXHost{{Host: "aspmx.l.google.com"}}},
 		stubCertLog{err: errors.New("crt.sh is having a day")},
-		stubPages{page: webread.Fingerprint{URL: "https://example.de"}},
 		newRecordingCache(), fixedClock(),
 	)
 
@@ -174,29 +159,10 @@ func TestACertificateLogOutageCompletesNoLane(t *testing.T) {
 			t.Fatal("the certificate lane completed on a query that failed; its rows would be wiped")
 		}
 	}
-	if len(got.Completed) != 2 {
-		t.Errorf("one lane failing cost the others: completed %v", got.Completed)
-	}
-}
-
-func TestARobotsRefusalCompletesTheHomepageLane(t *testing.T) {
-	t.Parallel()
-	enricher := NewTechnicalEnricher(
-		stubResolver{}, stubCertLog{},
-		stubPages{err: webread.ErrRobotsDisallowed},
-		newRecordingCache(), fixedClock(),
-	)
-
-	got, _ := enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
-
-	var completed bool
-	for _, lane := range got.Completed {
-		if lane == people.LaneHomepage {
-			completed = true
-		}
-	}
-	if !completed {
-		t.Error("a site that refuses us is an ANSWER; the lane must complete and clear its claims")
+	// One survivor, because this engine now runs two lanes: DNS answered and
+	// the certificate log did not.
+	if len(got.Completed) != 1 {
+		t.Errorf("one lane failing cost the other: completed %v", got.Completed)
 	}
 }
 
@@ -204,7 +170,7 @@ func TestARobotsRefusalCompletesTheHomepageLane(t *testing.T) {
 // record must keep whatever that lane last wrote.
 func TestAnAbsentReaderCompletesNoLane(t *testing.T) {
 	t.Parallel()
-	enricher := NewTechnicalEnricher(nil, nil, nil, newRecordingCache(), fixedClock())
+	enricher := NewTechnicalEnricher(nil, nil, newRecordingCache(), fixedClock())
 
 	got, _ := enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
 
@@ -218,7 +184,7 @@ func TestAnEmptyDomainAsksNobody(t *testing.T) {
 	enricher := NewTechnicalEnricher(
 		stubResolver{mx: []dnsread.MXHost{{Host: "aspmx.l.google.com"}}},
 		stubCertLog{hostnames: []string{"shop.example.de"}},
-		stubPages{}, newRecordingCache(), fixedClock(),
+		newRecordingCache(), fixedClock(),
 	)
 
 	got, outcomes := enricher.Read(context.Background(), ids.OrganizationID{}, "   ")
@@ -240,7 +206,7 @@ func TestTheCacheNeverHoldsARawCertificateHostname(t *testing.T) {
 			"jan-mueller.example.de",
 			"anna.schmidt.example.de",
 		}},
-		stubPages{}, cache, fixedClock(),
+		cache, fixedClock(),
 	)
 
 	enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
@@ -260,7 +226,7 @@ func TestASecondReadIsAnsweredFromTheCache(t *testing.T) {
 	t.Parallel()
 	cache := newRecordingCache()
 	counting := &countingCertLog{inner: stubCertLog{hostnames: []string{"shop.example.de"}}}
-	enricher := NewTechnicalEnricher(stubResolver{}, counting, stubPages{}, cache, fixedClock())
+	enricher := NewTechnicalEnricher(stubResolver{}, counting, cache, fixedClock())
 
 	enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
 	second, _ := enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
@@ -281,24 +247,6 @@ type countingCertLog struct {
 func (c *countingCertLog) Hostnames(ctx context.Context, domain string) ([]string, bool, error) {
 	c.calls++
 	return c.inner.Hostnames(ctx, domain)
-}
-
-func TestTheHomepageLaneReadsWhatThePageDeclares(t *testing.T) {
-	t.Parallel()
-	enricher := NewTechnicalEnricher(nil, nil, stubPages{page: webread.Fingerprint{
-		URL:         "https://example.de",
-		Headers:     http.Header{"Server": []string{"nginx"}},
-		CookieNames: []string{"fe_typo_user"},
-		ScriptSrcs:  []string{"https://static.hotjar.com/c/hotjar.js"},
-	}}, newRecordingCache(), fixedClock())
-
-	got, _ := enricher.Read(context.Background(), ids.OrganizationID{}, "example.de")
-
-	for _, want := range []string{"nginx", "typo3", "hotjar"} {
-		if !observed(got, people.FactTechnology, want) {
-			t.Errorf("did not read %q; read %v", want, got.Observations)
-		}
-	}
 }
 
 func observed(in people.TechnicalEnrichment, field, key string) bool {

--- a/backend/internal/platform/webread/fingerprint.go
+++ b/backend/internal/platform/webread/fingerprint.go
@@ -81,16 +81,25 @@ func (f *Fetcher) FetchFingerprint(ctx context.Context, rawURL string) (Fingerpr
 	if final == nil {
 		final = parsed
 	}
-	body := string(got.body)
+	return fingerprintOf(got.header, string(got.body), final), nil
+}
+
+// fingerprintOf reads one fetched response for what it declares about its own
+// stack. Split out of FetchFingerprint so the CRAWLER can build the same
+// observation from the pages it already fetched: a shop system that only
+// announces itself on /shop is invisible to a homepage-only read, and asking
+// the site for those pages a second time to see headers the crawl already
+// received would spend a request the site does not owe us.
+func fingerprintOf(header http.Header, body string, final *url.URL) Fingerprint {
 	scripts, generator := extractStackMarkers(body, final)
 	return Fingerprint{
 		URL:         final.String(),
-		Headers:     withoutCookies(got.header),
-		CookieNames: cookieNames(got.header),
+		Headers:     withoutCookies(header),
+		CookieNames: cookieNames(header),
 		ScriptSrcs:  scripts,
 		Generator:   generator,
 		Body:        body,
-	}, nil
+	}
 }
 
 // withoutCookies copies the response header without Set-Cookie.

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -36,6 +36,14 @@ type Page struct {
 	OGImage string
 	// Icons are the icons the page's <link rel> declared, in document order.
 	Icons []IconRef
+	// Fingerprint is what this page declared about the software serving it,
+	// read from the same response the text above came from.
+	//
+	// Carried on every crawled page rather than only the homepage: a shop
+	// system, a portal or a careers platform frequently announces itself on
+	// the one page that runs it and nowhere else, and the crawl has already
+	// paid for that page.
+	Fingerprint Fingerprint
 }
 
 // Icon rel kinds a page can declare. Callers rank by kind rather than by
@@ -73,19 +81,42 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 	// domain redirecting to its www host is the ordinary case, and resolving
 	// the page's own relative references against the pre-redirect origin would
 	// point every one of them at a host that never served this page.
-	body, _, base, err := f.fetchDoc(ctx, rawURL, acceptHTML)
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return Page{}, fmt.Errorf("webread: %q is not a fetchable URL", rawURL)
+	}
+	allowed, err := f.pathAllowed(ctx, parsed)
 	if err != nil {
 		return Page{}, err
 	}
+	if !allowed {
+		return Page{}, fmt.Errorf("%w: %s", ErrRobotsDisallowed, parsed.Path)
+	}
+	// getBytes rather than fetchDoc, because the RESPONSE HEADER is half a
+	// fingerprint and fetchDoc keeps only the media type. Same guard, same
+	// robots gate, same cap — one fetch that keeps what it already received.
+	got, err := f.getBytes(ctx, rawURL, acceptHTML, maxFetchBytes)
+	if err != nil {
+		return Page{}, err
+	}
+	if got.status != http.StatusOK {
+		return Page{}, &StatusError{Status: got.status, URL: rawURL}
+	}
+	base := got.finalURL
+	if base == nil {
+		base = parsed
+	}
+	body := string(got.body)
 	ogImage, icons := extractHeadAssets(body, base)
 	return Page{
-		URL:      rawURL,
-		FinalURL: base.String(),
-		Text:     StripTags(body),
-		Links:    extractLinks(body, base),
-		Bytes:    len(body),
-		OGImage:  ogImage,
-		Icons:    icons,
+		URL:         rawURL,
+		FinalURL:    base.String(),
+		Text:        StripTags(body),
+		Links:       extractLinks(body, base),
+		Bytes:       len(body),
+		OGImage:     ogImage,
+		Icons:       icons,
+		Fingerprint: fingerprintOf(got.header, body, base),
 	}, nil
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ no code, no API, just the app.
 - [run-the-frontend.md](how-to/run-the-frontend.md) — run the SPA in dev.
 - [connect-a-mailbox.md](how-to/connect-a-mailbox.md) — connect a mailbox for capture: Gmail OAuth (standing sync + backfill), IMAP app-password, Microsoft Graph OAuth, or Google Calendar — all standing connections.
 - [enrich-with-a-local-llm.md](how-to/enrich-with-a-local-llm.md) — point the AI lanes at a local Ollama and enrich a company with no cloud key.
+- [read-what-a-company-runs.md](how-to/read-what-a-company-runs.md) — the technical lookup: what DNS, certificate logs and a homepage fingerprint write onto a company, what triggers it, and the one setting that turns it on.
 - [connect-telegram.md](how-to/connect-telegram.md) — bind a workspace-level Telegram bot for pull ingress and governed replies.
 - [import-your-linkedin-network.md](how-to/import-your-linkedin-network.md) — import your own `Connections.csv` as graph substrate, and read the reach it buys.
 - [import-a-company-spreadsheet.md](how-to/import-a-company-spreadsheet.md) — bring a CSV of companies in: the column mapping, what the preview counts, and how a row names the company it corrects.

--- a/docs/explanation/data-enrichment-position.md
+++ b/docs/explanation/data-enrichment-position.md
@@ -247,13 +247,13 @@ When the published person unmistakably matches someone already recorded at that 
 
 Margince also parses the Impressum, whose publication German law *mandates* under Section 5 DDG, and consumes newsroom RSS feeds for company events. We store the signal and a link, never a cached copy of the full text.
 
-Crawling stays polite and respects robots.txt. The existing rule also remains: a human click can write directly; an automatic read stages the suggestion.
+Crawling stays polite and respects robots.txt. The existing rule also remains: a human click can write directly; an automatic read stages the suggestion. That rule is about PEOPLE, who are staged because a wrong person on a record is a privacy problem. Company-level facts write directly in both lanes — they are attributed, evidence-backed and reversible, and a company's mail provider is not personal data.
 
-**A3. Technical enrichment.** One click on the company record tells you what the company runs.[^46]
+**A3. Technical enrichment.** Reading a company's website also tells you what that company runs.[^46]
 
 Every company with a website and email leaves public technical traces, because the internet does not work otherwise. Which system receives their mail: Google Workspace, Microsoft 365, or their own server. What their website is built with: shop system, CMS, marketing tools. Which services they operate, visible through their subdomains: a webshop, a customer portal, a careers page. And where they host.
 
-Margince reads those traces and writes them onto the company record. Your rep sees the company's size class, how modern their IT is and what they operate before the first call. And you can filter on it: every account with a webshop, every account on Microsoft 365, every account that just opened a careers page.
+Margince reads those traces and writes them onto the company record. The reading rides the site read rather than sitting behind a button of its own, and a scheduled pass refreshes it, because a company's mail provider changes at the company and no write on our side announces it. Your rep sees the company's size class, how modern their IT is and what they operate before the first call. Filtering a segment on these fields — every account with a webshop, every account on Microsoft 365 — is not built yet.
 
 Two honest limits. You only see what faces the public internet; the ERP behind the firewall stays invisible unless a subdomain betrays it. And the picture goes stale, so it refreshes like every other enrichment.
 

--- a/docs/how-to/read-what-a-company-runs.md
+++ b/docs/how-to/read-what-a-company-runs.md
@@ -1,0 +1,236 @@
+# Read what a company publicly runs
+
+Margince reads three free public sources — DNS records, certificate-transparency logs, and the
+company's own homepage — and writes what it finds onto the company record as facts with evidence.
+It answers a different question from the deep read beside it: a deep read says what a company
+**tells** you, this says what it demonstrably **runs**.
+
+This guide covers what it reads, how it is triggered, what you configure, and how to tell whether
+it worked.
+
+> **Nothing to press.** There is no lookup button. The reading is queued by the site read, and a
+> scheduled sweep comes back round for companies whose picture went stale. If you want a company
+> re-read now, read its site.
+
+## What it reads
+
+| Field | Source | Set | Example values |
+|---|---|---|---|
+| `mail_provider` | MX records | exactly one | `google_workspace`, `microsoft365`, `self_hosted`, `other` |
+| `email_security` | TXT records | many | `spf`, `dmarc_reject`, `dmarc_quarantine`, `dmarc_none`, `dkim` |
+| `hosting_provider` | A/AAAA, CNAME, PTR | exactly one | `hetzner`, `aws`, `cloudflare`, `ionos`, `strato`, `azure`, `google_cloud`, `other` |
+| `operated_service` | certificate log | many | `webshop`, `careers`, `customer_portal`, `api`, `vpn`, `status_page` |
+| `technology` | homepage fingerprint | many | `shopware`, `shopify`, `wordpress`, `typo3`, `matomo`, `google_analytics` |
+
+Every value is an `organization_fact` row with `category='signal'` and `source='technical_lookup'`,
+carrying the public record that proved it — the winning MX host, the proving subdomain, the matched
+marker — so the record can always answer "how do you know?".
+
+Extraction is **deterministic**. Table-driven classifiers and a hand-curated fingerprint ruleset,
+no model call anywhere in the lane.
+
+### Two lanes write `technology`, to different standards
+
+The deep read also writes `technology` facts, and the two mean different things.
+
+This lane writes only what the site **serves**: a response header, a cookie name, a script `src`, a
+`<meta generator>`. `nginx` from `Header server: nginx` is a fact about what is running, and no
+amount of prose can produce one.
+
+The deep read writes what the company **states** it uses, read from page text by a model. That is
+worth having — a stack a consultancy says it builds in, a platform named on a careers page — but it
+is a weaker claim, and the vocabulary in `compose/sitereadvocab.go` is deliberately narrow about it:
+the passage must assert this company's own use. A vendor merely named, compared, or offered as an
+integration is not a technology fact, an analyst firm or its report (Gartner, Forrester) never is,
+and a bare category (BI, CRM, ERP, PIM) is not a product.
+
+Both land in the same section of the card, each carrying its own evidence, so a reader who opens the
+mark can see which kind of claim they are looking at.
+
+### The three sources
+
+- **DNS** (`internal/platform/dnsread`) — MX, TXT (SPF at the root, DMARC at `_dmarc.`, DKIM at
+  bounded well-known selectors), A and AAAA, CNAME, and a reverse `PTR` lookup for the hosting hint.
+  Paced at one query per 200ms.
+- **Certificate transparency** (`internal/platform/certlog`) — one `GET https://crt.sh/?q=%25.<domain>&output=json`
+  per company. Every publicly trusted certificate must be published to append-only public logs, so
+  the hostnames a company holds certificates for are already public record; reading them needs no
+  agreement and no key. Paced at **one query per five seconds** — crt.sh is a single free service
+  run on goodwill, and its operators have asked heavy users to be gentle rather than parallel.
+- **Homepage** (`internal/platform/webread`) — the fingerprint (response headers, cookie names,
+  script `src`s, `<meta generator>`) gathered during the fetch the site read already makes. Same
+  fetcher, same user-agent, same robots.txt obedience as any other read.
+
+### What is never stored
+
+A certificate log publishes every hostname a company ever held a certificate for, and those include
+people — `lars.example.de` is a normal thing to find. The subdomain classifier is an **allowlist**:
+only first labels that name a *service* survive it, and it runs **before the cache write and before
+the fact write**. A personal name in a certificate matches nothing and reaches no table. That is a
+property of the classifier, not something a caller has to remember.
+
+## What triggers it
+
+Three paths, all landing on the same deduplicated job:
+
+1. **Every site read.** When a deep read finishes and resolved a company, it queues the technical
+   lookup (`compose/technicalonsiteread.go`). This covers both the automatic capture read and a
+   human pressing **read the site** on the company record. This is the path that matters day to day.
+2. **The scheduled sweep** (`technical_enrich_backfill`). Every 6 hours by default, it nominates up
+   to 25 companies per workspace whose picture is missing or older than 7 days. Freshness is the
+   point of this lane: unlike geocoding, which fires when an address is *written*, a company's mail
+   provider changes at the **company** and no write on our side ever announces it. Only a scheduled
+   pass observes a move.
+3. **`POST /organizations/{id}/technical-enrich`** — the API surface, 202 with no body. No UI calls
+   it; it exists for scripting.
+
+The lookup **enqueues rather than runs inline**, because three services with a five-second pacer
+would park a deep-read worker — the scarcest kind in the fleet — on a wait that has nothing to do
+with crawling. It runs on its own single-threaded `technical_lookup` queue.
+
+Jobs are deduplicated by args while queued or running, so a site read of a company the sweep just
+nominated joins that lookup instead of asking the same three services twice. A human-triggered
+lookup runs at a higher priority than a sweep nomination, so it never waits behind a batch.
+
+The **domain is not a job argument**. The job reads whatever the company record holds when it runs.
+A copy in the args would be a stale-lookup bug moved one layer out, and a way to point the lookup at
+a domain the record never carried.
+
+## Configure it
+
+Two settings, both read by the **worker** at boot. The api does not read them — the enricher is
+built in `cmd/worker/jobrunner.go`. Put them in `.env.local`, which `scripts/dev.sh` sources and
+exports.
+
+### `MARGINCE_CERTLOG_BASE_URL` — required, or the whole lane is off
+
+```sh
+MARGINCE_CERTLOG_BASE_URL=public
+```
+
+`public` is a keyword, not a URL: it resolves to `https://crt.sh`. To use your own
+certificate-transparency mirror, give the real base URL instead — it must answer the crt.sh query
+shape (`/?q=%25.<domain>&output=json`).
+
+**Empty or unset turns the entire feature off**, all three lanes together. That is deliberate: a
+partial enricher would complete some lanes and never the others, and a lane that never completes
+leaves its facts frozen at whatever the last full run saw — which on the record is indistinguishable
+from a company that has not changed. An installation that should make no outbound lookups queries
+nothing on purpose.
+
+With it unset, the job kinds are never registered, and anything that enqueues a lookup produces a
+job that retries against an unregistered kind:
+
+```
+job kind is not registered in the client's Workers bundle: technical_enrich_organization
+```
+
+### `--technical-backfill-interval` — how often to refresh
+
+Defaults to **6h**. Runs on start. `0` turns the sweep off and leaves the lookup to the site read
+that queues it.
+
+### Restart after changing either
+
+The worker is a compiled binary and reads both at boot. `make dev` again — Vite hot-reloads the SPA,
+not the Go worker.
+
+## Where it shows
+
+The **Technik** card on the company record's **Profile** tab, inside **Daten & Werkzeuge** and below
+the site-read card that queues it — a reader who just started a company research looks there for what
+it brought back. Four sections: Mail · Website-Technik · Dienste · Hosting.
+
+The card is a read with no controls. Each value carries an evidence mark showing the public record
+behind it. When a source did not answer, a notice at the foot of the card names it — worth a line
+because a missing service then means "not checked today" rather than "they have none", and a reader
+deciding whether to trust "no webshop" deserves to know the certificate log has been down.
+
+A human correcting a value rewrites the row's source to `human`, and the row stays on this card. The
+card partitions by **field name**, never by source, so a corrected row is never dropped from both
+cards or rendered on two.
+
+Changed signals also appear on the company rail as a `technical_change` event.
+
+## How a refresh reconciles
+
+Each lane that **completed** is authoritative over its own fields: rows it no longer observes are
+removed, so a company that moves Google → Microsoft 365 ends with exactly one mail provider rather
+than two.
+
+A lane that **failed** changes nothing. A certificate-log outage must never be recorded as "this
+company operates no services". This is why the lane outcomes distinguish `empty` (the source
+answered; the company publishes none of what this lane reads) from `failed` (the lookup did not
+complete) and `refused` (robots.txt declined the homepage read).
+
+Rows a human wrote are never removed by a machine refresh.
+
+## Answers are cached, with a TTL
+
+Cached per query name and record type, installation-global — a domain's DNS answer is the same for
+every tenant. Negative results are recorded explicitly, so a company with no DMARC is not re-asked
+every run.
+
+| Kind | Trusted for |
+|---|---|
+| MX, TXT, DMARC | 24h |
+| Address (A/AAAA), CNAME | 12h |
+| DKIM, reverse (PTR) | 7 days |
+| Certificate log | 24h |
+
+Every TTL is shorter than the 7-day refresh cadence. That is the constraint rather than a
+coincidence: a cache entry that outlived the refresh would make the sweep unable to observe the very
+move it exists to catch. The cache holds **classified outcomes only** — the allowlist has already
+run, so no raw certificate hostname is stored.
+
+## Check that it worked
+
+**In the app.** Open a company with a real domain, read its site, and watch the Technik card. The
+lookup is queued when the read finishes, so the fields arrive shortly after the read closes, not
+with it.
+
+**Per lane.** `GET /organizations/{id}/technical-enrich/latest` reports what each of the three
+sources last did, with attempt counts and last-success stamps. Per lane rather than per run, because
+the three sources fail independently and one verdict would hide which of them is stale.
+
+**In the job table.**
+
+```sh
+docker exec margince-postgres-1 psql -U margince_app -d margince \
+  -c "select kind, state, attempt, left(coalesce(errors::text,''),200) \
+      from river_job where kind like '%technical%' order by id desc limit 10;"
+```
+
+`state='retryable'` with the "not registered" error means `MARGINCE_CERTLOG_BASE_URL` is unset or
+the worker has not been restarted since you set it.
+
+**Against one domain, without a database.** There is no DB-less subcommand for this lane yet
+(`worker siteread <url>` covers the deep read only). To exercise the classifiers directly, the
+table-driven tests in `backend/internal/compose/techenrich_test.go` are the loop.
+
+## When the card stays empty
+
+- **The feature is off.** `MARGINCE_CERTLOG_BASE_URL` unset, or the worker not restarted since.
+- **The company has no stored domain.** The lanes read the record's own domain and nothing else, so
+  a company without one produces nothing. A seeded demo company with a fake domain resolves nothing
+  and correctly writes nothing.
+- **Nothing has read the site yet.** The lookup rides the site read. A company nobody has read waits
+  for the sweep.
+- **The company genuinely publishes little.** A small site on shared hosting with no subdomains and
+  no recognisable markers is an ordinary `empty` result, not a failure.
+
+## Limits worth knowing
+
+- **One provider for the certificate lane.** crt.sh is frequently slow and sometimes down. Callers
+  treat that as "this lane had nothing to say today", never as an authoritative empty answer. The
+  `certlog.Client` interface is what keeps that from hardening into an assumption.
+- **The fingerprint ruleset is small** (34 rules in `platform/techprofile/data/rules.json`)
+  and German-SMB-biased. It grows by hand, not
+  through a model.
+- **No paid tech-stack datasets**, and no Wappalyzer import — those datasets and their forks are GPL,
+  which is incompatible with this codebase's BUSL-1.1 licence.
+
+## Related
+
+- [add-a-job.md](add-a-job.md) — how the two job kinds and their queue are declared.
+- [connect-an-mcp-client.md](connect-an-mcp-client.md) — reaching these facts as tools.

--- a/docs/how-to/read-what-a-company-runs.md
+++ b/docs/how-to/read-what-a-company-runs.md
@@ -1,7 +1,7 @@
 # Read what a company publicly runs
 
-Margince reads three free public sources — DNS records, certificate-transparency logs, and the
-company's own homepage — and writes what it finds onto the company record as facts with evidence.
+Margince reads three free public sources — DNS records, certificate-transparency logs, and the pages
+of the company's own site — and writes what it finds onto the company record as facts with evidence.
 It answers a different question from the deep read beside it: a deep read says what a company
 **tells** you, this says what it demonstrably **runs**.
 
@@ -20,7 +20,7 @@ it worked.
 | `email_security` | TXT records | many | `spf`, `dmarc_reject`, `dmarc_quarantine`, `dmarc_none`, `dkim` |
 | `hosting_provider` | A/AAAA, CNAME, PTR | exactly one | `hetzner`, `aws`, `cloudflare`, `ionos`, `strato`, `azure`, `google_cloud`, `other` |
 | `operated_service` | certificate log | many | `webshop`, `careers`, `customer_portal`, `api`, `vpn`, `status_page` |
-| `technology` | homepage fingerprint | many | `shopware`, `shopify`, `wordpress`, `typo3`, `matomo`, `google_analytics` |
+| `technology` | site-page fingerprint | many | `shopware`, `shopify`, `wordpress`, `typo3`, `matomo`, `google_analytics` |
 
 Every value is an `organization_fact` row with `category='signal'` and `source='technical_lookup'`,
 carrying the public record that proved it — the winning MX host, the proving subdomain, the matched
@@ -29,20 +29,21 @@ marker — so the record can always answer "how do you know?".
 Extraction is **deterministic**. Table-driven classifiers and a hand-curated fingerprint ruleset,
 no model call anywhere in the lane.
 
-### Two lanes write `technology`, to different standards
+### Two readers write `technology`, to different standards
 
-The deep read also writes `technology` facts, and the two mean different things.
+The site read produces `technology` facts twice over, from the same crawl, and the two mean
+different things.
 
-This lane writes only what the site **serves**: a response header, a cookie name, a script `src`, a
-`<meta generator>`. `nginx` from `Header server: nginx` is a fact about what is running, and no
-amount of prose can produce one.
+**The fingerprint** reads what the site **serves**: a response header, a cookie name, a script
+`src`, a `<meta generator>`, a marker in the markup. `nginx` from `Header server: nginx` is a fact
+about what is running, and no amount of prose can produce one.
 
-The deep read writes what the company **states** it uses, read from page text by a model. That is
-worth having — a stack a consultancy says it builds in, a platform named on a careers page — but it
-is a weaker claim, and the vocabulary in `compose/sitereadvocab.go` is deliberately narrow about it:
-the passage must assert this company's own use. A vendor merely named, compared, or offered as an
-integration is not a technology fact, an analyst firm or its report (Gartner, Forrester) never is,
-and a bare category (BI, CRM, ERP, PIM) is not a product.
+**The model** reads what the company **states** it uses, from the page text. That is worth having —
+a stack a consultancy says it builds in, a platform named on a careers page — but it is a weaker
+claim, and the vocabulary in `compose/sitereadvocab.go` is deliberately narrow about it: the passage
+must assert this company's own use. A vendor merely named, compared, or offered as an integration is
+not a technology fact, an analyst firm or its report (Gartner, Forrester) never is, and a bare
+category (BI, CRM, ERP, PIM) is not a product.
 
 Both land in the same section of the card, each carrying its own evidence, so a reader who opens the
 mark can see which kind of claim they are looking at.
@@ -57,9 +58,12 @@ mark can see which kind of claim they are looking at.
   the hostnames a company holds certificates for are already public record; reading them needs no
   agreement and no key. Paced at **one query per five seconds** — crt.sh is a single free service
   run on goodwill, and its operators have asked heavy users to be gentle rather than parallel.
-- **Homepage** (`internal/platform/webread`) — the fingerprint (response headers, cookie names,
-  script `src`s, `<meta generator>`) gathered during the fetch the site read already makes. Same
-  fetcher, same user-agent, same robots.txt obedience as any other read.
+- **Site pages** (`internal/platform/webread` + `compose/sitetechnology.go`) — the fingerprint
+  (response headers, cookie names, script `src`s, `<meta generator>`, raw markup) of **every page the
+  site read crawled**, not the homepage alone. A shop system announces itself on `/shop`, a portal on
+  `/kunden`, a careers platform on `/karriere`, and a homepage-only fetch sees none of the three. The
+  crawl already paid for those pages, so this costs no extra request. Evidence cites the page that
+  proved it.
 
 ### What is never stored
 
@@ -71,25 +75,34 @@ property of the classifier, not something a caller has to remember.
 
 ## What triggers it
 
-Three paths, all landing on the same deduplicated job:
+The lanes split by who fetches, so they are triggered differently.
 
-1. **Every site read.** When a deep read finishes and resolved a company, it queues the technical
-   lookup (`compose/technicalonsiteread.go`). This covers both the automatic capture read and a
-   human pressing **read the site** on the company record. This is the path that matters day to day.
+**The site-page lane runs inside the site read.** When a crawl finishes and resolved a company, the
+read matches every page it fetched against the ruleset and writes the technology facts itself
+(`compose/sitetechnology.go`). No job, no queue, no second request — the pages are already in hand.
+This covers both the automatic capture read and a human pressing **read the site**.
+
+**The DNS and certificate lanes run as their own job**, queued three ways:
+
+1. **Every site read**, right after the page lane (`compose/technicalonsiteread.go`).
 2. **The scheduled sweep** (`technical_enrich_backfill`). Every 6 hours by default, it nominates up
    to 25 companies per workspace whose picture is missing or older than 7 days. Freshness is the
-   point of this lane: unlike geocoding, which fires when an address is *written*, a company's mail
-   provider changes at the **company** and no write on our side ever announces it. Only a scheduled
-   pass observes a move.
+   point: unlike geocoding, which fires when an address is *written*, a company's mail provider
+   changes at the **company** and no write on our side ever announces it. Only a scheduled pass
+   observes a move.
 3. **`POST /organizations/{id}/technical-enrich`** — the API surface, 202 with no body. No UI calls
    it; it exists for scripting.
 
-The lookup **enqueues rather than runs inline**, because three services with a five-second pacer
+Those two **enqueue rather than run inline**, because a certificate log with a five-second pacer
 would park a deep-read worker — the scarcest kind in the fleet — on a wait that has nothing to do
-with crawling. It runs on its own single-threaded `technical_lookup` queue.
+with crawling. They run on their own single-threaded `technical_lookup` queue.
+
+**One consequence worth knowing:** the sweep refreshes mail, hosting and operated services, but not
+technology. A company that switches Shopware → Shopify keeps the old row until its site is read
+again, because only a crawl can see what the pages declare.
 
 Jobs are deduplicated by args while queued or running, so a site read of a company the sweep just
-nominated joins that lookup instead of asking the same three services twice. A human-triggered
+nominated joins that lookup instead of asking the same two services twice. A human-triggered
 lookup runs at a higher priority than a sweep nomination, so it never waits behind a batch.
 
 The **domain is not a job argument**. The job reads whatever the company record holds when it runs.
@@ -112,7 +125,7 @@ MARGINCE_CERTLOG_BASE_URL=public
 certificate-transparency mirror, give the real base URL instead — it must answer the crt.sh query
 shape (`/?q=%25.<domain>&output=json`).
 
-**Empty or unset turns the entire feature off**, all three lanes together. That is deliberate: a
+**Empty or unset turns the DNS and certificate lanes off**, both together. That is deliberate: a
 partial enricher would complete some lanes and never the others, and a lane that never completes
 leaves its facts frozen at whatever the last full run saw — which on the record is indistinguishable
 from a company that has not changed. An installation that should make no outbound lookups queries
@@ -161,7 +174,7 @@ than two.
 A lane that **failed** changes nothing. A certificate-log outage must never be recorded as "this
 company operates no services". This is why the lane outcomes distinguish `empty` (the source
 answered; the company publishes none of what this lane reads) from `failed` (the lookup did not
-complete) and `refused` (robots.txt declined the homepage read).
+complete) and `refused` (robots.txt declined the page read).
 
 Rows a human wrote are never removed by a machine refresh.
 
@@ -191,7 +204,8 @@ with it.
 
 **Per lane.** `GET /organizations/{id}/technical-enrich/latest` reports what each of the three
 sources last did, with attempt counts and last-success stamps. Per lane rather than per run, because
-the three sources fail independently and one verdict would hide which of them is stale.
+the three sources fail independently and one verdict would hide which of them is stale. The
+`homepage` lane is the site-page one, written by the crawl.
 
 **In the job table.**
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1792,12 +1792,8 @@ export const de = {
   "co.tech.web": "Website-Technik",
   "co.tech.services": "Dienste",
   "co.tech.hosting": "Hosting",
-  "co.tech.read": "Nachschauen",
-  "co.tech.reading": "Schaue nach…",
   "co.tech.empty":
-    "Noch nichts Technisches gelesen. Das füllt sich von selbst, sobald die Website der Firma gelesen wird, und frischt sich selbst auf — der Knopf ist nur da, wenn du nicht warten willst.",
-  "co.tech.unavailable": "Diese Installation macht keine technischen Abfragen.",
-  "co.tech.queued": "Die Abfrage läuft. Meist dauert das keine Minute.",
+    "Noch nichts Technisches gelesen. Das füllt sich von selbst, sobald die Website der Firma gelesen wird, und frischt sich selbst auf.",
   "co.tech.laneFailed":
     "{lane} hat nicht geantwortet — was von dort zuletzt kam, bleibt unverändert.",
   "co.tech.laneRefused": "Die Website möchte nicht gelesen werden.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1819,12 +1819,8 @@ export const en = {
   "co.tech.web": "Website technology",
   "co.tech.services": "Services",
   "co.tech.hosting": "Hosting",
-  "co.tech.read": "Look up",
-  "co.tech.reading": "Looking up…",
   "co.tech.empty":
-    "No technical reading yet. This fills itself in when the company's site is read, and refreshes on its own — the button is only there when you do not want to wait.",
-  "co.tech.unavailable": "This installation makes no technical lookups.",
-  "co.tech.queued": "The lookup is queued. It usually takes under a minute.",
+    "No technical reading yet. This fills itself in when the company's site is read, and refreshes on its own.",
   "co.tech.laneFailed":
     "{lane} did not answer — what it read last time is unchanged.",
   "co.tech.laneRefused": "The site declined to be read.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1778,12 +1778,8 @@ export const vi = {
   "co.tech.web": "Công nghệ website",
   "co.tech.services": "Dịch vụ",
   "co.tech.hosting": "Lưu trữ",
-  "co.tech.read": "Tra cứu",
-  "co.tech.reading": "Đang tra cứu…",
   "co.tech.empty":
-    "Chưa có dữ liệu kỹ thuật. Mục này tự điền khi website của công ty được đọc, và tự làm mới — nút bấm chỉ dành cho khi bạn không muốn chờ.",
-  "co.tech.unavailable": "Bản cài đặt này không thực hiện tra cứu kỹ thuật.",
-  "co.tech.queued": "Đã xếp hàng tra cứu. Thường mất chưa đến một phút.",
+    "Chưa có dữ liệu kỹ thuật. Mục này tự điền khi website của công ty được đọc, và tự làm mới.",
   "co.tech.laneFailed":
     "{lane} không trả lời — những gì đọc được lần trước vẫn giữ nguyên.",
   "co.tech.laneRefused": "Trang web từ chối được đọc.",

--- a/frontend/src/screens/companytechnical.stories.tsx
+++ b/frontend/src/screens/companytechnical.stories.tsx
@@ -14,8 +14,8 @@ import {
 //
 // The states worth looking at are not the full card. They are the ones that
 // say something a reader has to act on: an account nobody has looked up yet,
-// an account where one SOURCE did not answer (so part of the card is older
-// than the rest), and a reader who may not start a lookup at all.
+// and an account where one SOURCE did not answer, so part of the card is
+// older than the rest.
 
 const meta: Meta = {
   title: "Records/Company 360/Technical profile",
@@ -122,13 +122,13 @@ function lanes(
   };
 }
 
-const CAN_ENRICH = meRoute({ organization: ["read", "update"] });
+const A_READER = meRoute({ organization: ["read", "update"] });
 
 /** Everything read: the state a rep sees on an account the lookup has covered. */
 export const Read: Story = {
   render: () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({ data: READ_FACTS }),
       [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
@@ -146,14 +146,14 @@ export const Read: Story = {
  * Not read yet — an account whose site nothing has crawled.
  *
  * The sentence carries the weight: an empty card with no sentence reads as
- * "this company runs nothing", and one that only offered a button would ask
- * for a press the reader does not owe. The reading arrives with the site read
- * and refreshes on a schedule; the button is the impatient path.
+ * "this company runs nothing", which is a different and false claim. The
+ * reading arrives with the site read and refreshes on a schedule, and the
+ * card says so rather than offering a control it does not have.
  */
 export const NotReadYet: Story = {
   render: () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () => jsonResponse({ data: [] }),
       [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
         jsonResponse({ title: "not found" }, 404),
@@ -176,7 +176,7 @@ export const NotReadYet: Story = {
 export const OneSourceDidNotAnswer: Story = {
   render: () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({
           data: READ_FACTS.filter((row) => row.field !== "operated_service"),
@@ -197,32 +197,13 @@ export const OneSourceDidNotAnswer: Story = {
 export const TheSiteDeclined: Story = {
   render: () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({
           data: READ_FACTS.filter((row) => row.field !== "technology"),
         }),
       [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
         jsonResponse(lanes({ homepage: "refused" })),
-    });
-    return (
-      <StoryProviders locale="de">
-        <TechnicalProfileCard orgId={ORG} />
-      </StoryProviders>
-    );
-  },
-};
-
-/** A reader who may not write the record sees the profile and no button: the
- * lookup writes to the company, so it is gated like any other write. */
-export const WithoutWriteAccess: Story = {
-  render: () => {
-    installFetchStub({
-      "GET /me": meRoute({ organization: ["read"] }, { seat: "read" }),
-      [`GET /organizations/${ORG}/facts`]: () =>
-        jsonResponse({ data: READ_FACTS }),
-      [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
-        jsonResponse(lanes()),
     });
     return (
       <StoryProviders locale="de">
@@ -248,7 +229,7 @@ export const AfterAHumanCorrection: Story = {
         : row,
     );
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({ data: corrected }),
       [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>

--- a/frontend/src/screens/companytechnical.tsx
+++ b/frontend/src/screens/companytechnical.tsx
@@ -1,22 +1,15 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCan } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
-import { Badge, Button, Card } from "../design-system/atoms";
+import { Badge, Card } from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { Eyebrow } from "../design-system/eyebrow";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { problemMessageOf, QueryGate, throwProblem } from "./common";
+import { QueryGate, throwProblem } from "./common";
 import { derivedSource } from "./evidencesource";
-
-/** How often the card asks whether the lookup has answered, and how long it
- * keeps asking. Three seconds matches the site read's own poll; two minutes is
- * the job's own ceiling plus room for a queue. */
-const POLL_MS = 3000;
-const POLL_LIMIT_MS = 120_000;
 
 type OrganizationFact = components["schemas"]["OrganizationFact"];
 type TechnicalEnrichLane = components["schemas"]["TechnicalEnrichLane"];
@@ -53,8 +46,10 @@ export function isTechnicalFact(fact: OrganizationFact): boolean {
 }
 
 /**
- * TechnicalProfileCard shows what a company publicly runs, and offers the
- * lookup that reads it.
+ * TechnicalProfileCard shows what a company publicly runs.
+ *
+ * It reads and never asks: the lookup is queued by the site read, so this card
+ * has no button. A reader who wants it refreshed reads the site.
  *
  * Every value carries the public record that proved it — the MX host, the
  * certificate hostname, the matched marker — through the same evidence mark
@@ -65,8 +60,6 @@ export function TechnicalProfileCard({
   orgId,
 }: Readonly<{ orgId: string }>): ReactNode {
   const t = useT();
-  const queryClient = useQueryClient();
-  const canRead = useCan("organization", "update");
 
   const facts = useQuery({
     queryKey: ["org-facts", orgId],
@@ -81,17 +74,15 @@ export function TechnicalProfileCard({
     },
   });
 
-  // 404 is the honest "never looked up", and leaves the card offering a first
-  // lookup rather than reporting a failure nobody caused.
+  // 404 is the honest "never looked up", and leaves the card empty rather
+  // than reporting a failure nobody caused.
   //
-  // Polled WHILE a lookup this tab started is outstanding, because the work
-  // happens in a worker: without it the card sits on "Abfrage läuft" with
-  // stale facts until the reader navigates away and back, which reads as a
-  // lookup that silently failed.
-  const [awaiting, setAwaiting] = useState<string | null>(null);
+  // Read once, not polled. The lookup is queued by the site read that
+  // preceded it, so by the time a reader is looking at this card the work is
+  // either done or running in a worker; a card that polled would be watching
+  // for an event it did not start.
   const lanes = useQuery({
     queryKey: ["org-technical-latest", orgId],
-    refetchInterval: awaiting ? POLL_MS : false,
     queryFn: async () => {
       const { data, error, response } = await api.GET(
         "/organizations/{id}/technical-enrich/latest",
@@ -107,78 +98,8 @@ export function TechnicalProfileCard({
     },
   });
 
-  const start = useMutation({
-    mutationKey: ["org-technical-enrich", orgId],
-    mutationFn: async (organizationId: string) => {
-      const { data, error, response } = await api.POST(
-        "/organizations/{id}/technical-enrich",
-        { params: { path: { id: organizationId } } },
-      );
-      if (error) {
-        // 501 means this deployment makes no outbound lookups, which the
-        // server states in its own terms and the card states in the reader's.
-        throwProblem(
-          response.status === 501 ? { title: t("co.tech.unavailable") } : error,
-        );
-      }
-      return data;
-    },
-    onSuccess: () => {
-      // The lookup runs in a worker, so this marks the card as waiting and the
-      // status query above starts polling. The mark is the time the lookup was
-      // asked for: a lane whose last success is newer than that is this
-      // lookup's answer arriving.
-      setAwaiting(new Date().toISOString());
-      queryClient.invalidateQueries({
-        queryKey: ["org-technical-latest", orgId],
-      });
-    },
-  });
-
-  // Stop polling once a lane has answered since the button was pressed, and
-  // pick up the facts it wrote. Bounded by POLL_LIMIT_MS so a worker that
-  // never runs — an unwired deployment, a queue nobody drains — leaves the
-  // card static rather than polling for the rest of the session.
-  const laneRows = lanes.data?.lanes;
-  useEffect(() => {
-    if (!awaiting) {
-      return;
-    }
-    const answered = laneRows?.some(
-      (lane) => (lane.last_success_at ?? "") > awaiting,
-    );
-    if (answered) {
-      setAwaiting(null);
-      queryClient.invalidateQueries({ queryKey: ["org-facts", orgId] });
-      return;
-    }
-    const giveUp = setTimeout(() => setAwaiting(null), POLL_LIMIT_MS);
-    return () => clearTimeout(giveUp);
-  }, [awaiting, laneRows, orgId, queryClient]);
-
   return (
-    <Card
-      title={t("co.tech.title")}
-      sub={t("co.tech.sub")}
-      actions={
-        canRead ? (
-          <Button
-            small
-            pending={start.isPending}
-            busyLabel={t("co.tech.reading")}
-            onClick={() => start.mutate(orgId)}
-          >
-            {t("co.tech.read")}
-          </Button>
-        ) : undefined
-      }
-    >
-      {start.isError && (
-        <p className="t-caption" style={{ color: "var(--danger)" }}>
-          {problemMessageOf(start.error, t)}
-        </p>
-      )}
-      {awaiting && <p className="t-caption">{t("co.tech.queued")}</p>}
+    <Card title={t("co.tech.title")} sub={t("co.tech.sub")}>
       <QueryGate query={facts} pendingLabel={t("co.tech.title")}>
         {(rows) => (
           <TechnicalSections

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -3208,14 +3208,6 @@ function ReferenceDisclosures({
       <Disclosure summary={t("co.evidence.title")}>
         <FactsCard orgId={org.id} onOpenHistory={onOpenHistory} />
       </Disclosure>
-      {/* What the company RUNS, beside what it SAYS. Its own disclosure rather
-          than rows inside the evidence card above, because these are read from
-          public records the company never wrote for us — DNS, certificates,
-          the markup of their own homepage — and a reader deciding how far to
-          trust a claim is helped by knowing which of the two it is. */}
-      <Disclosure summary={t("co.tech.title")}>
-        <TechnicalProfileCard orgId={org.id} />
-      </Disclosure>
       {/* Who this account is connected to, and the account's own tools and
           configuration. Neither reads like an "overview" or a "deal" or a
           "task" — both are reference material about the RECORD itself, which
@@ -3232,6 +3224,13 @@ function ReferenceDisclosures({
             nothing on file meets the offer at the top of its own column, and
             two offers to research the same company is none. */}
         {!offerOnOverview && <DeepReadCard orgId={org.id} />}
+        {/* What the company RUNS, beside what it SAYS — read from public
+            records the company never wrote for us: DNS, certificates, the
+            markup of their own homepage. It sits under the read that produces
+            it rather than in a disclosure of its own, because the site read
+            above is what queues it and a reader who just started one looks
+            here for what it brought back. */}
+        <TechnicalProfileCard orgId={org.id} />
       </Disclosure>
     </>
   );

--- a/frontend/src/screens/technicalprofile.test.tsx
+++ b/frontend/src/screens/technicalprofile.test.tsx
@@ -3,7 +3,6 @@
 
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { isTechnicalFact, TechnicalProfileCard } from "./companytechnical";
@@ -33,7 +32,7 @@ function fact(field: string, valueKey: string, value: string) {
   };
 }
 
-const CAN_ENRICH = meRoute({ organization: ["read", "update"] });
+const A_READER = meRoute({ organization: ["read", "update"] });
 
 function laneState(outcome = "applied") {
   return {
@@ -65,7 +64,7 @@ describe("the technical profile card", () => {
 
   beforeEach(() => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({
           data: [
@@ -86,36 +85,13 @@ describe("the technical profile card", () => {
     expect(screen.getByText("Dienste")).toBeTruthy();
   });
 
-  it("asks for a lookup when the reader presses the button", async () => {
-    const user = userEvent.setup();
-    let asked = 0;
-    installFetchStub({
-      "GET /me": CAN_ENRICH,
-      [`GET /organizations/${ORG}/facts`]: () => jsonResponse({ data: [] }),
-      [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
-        jsonResponse({ title: "not found" }, 404),
-      [`POST /organizations/${ORG}/technical-enrich`]: () => {
-        asked += 1;
-        return jsonResponse({ organization_id: ORG, status: "queued" }, 202);
-      },
-    });
-    renderCard();
-
-    await user.click(
-      await screen.findByRole("button", { name: "Nachschauen" }),
-    );
-
-    expect(await screen.findByText(/Abfrage läuft/)).toBeTruthy();
-    expect(asked).toBe(1);
-  });
-
   // An empty card with no sentence reads as "this company runs nothing", which
   // is a different and false claim from "this has not been read yet". The
-  // sentence also has to say the reading happens on its own, or the card asks
-  // for a press it does not need.
+  // sentence also has to say the reading happens on its own, because the card
+  // offers no way to ask for one.
   it("says plainly that nothing has been read yet", async () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () => jsonResponse({ data: [] }),
       [`GET /organizations/${ORG}/technical-enrich/latest`]: () =>
         jsonResponse({ title: "not found" }, 404),
@@ -130,7 +106,7 @@ describe("the technical profile card", () => {
   // today" rather than "they have none".
   it("names a source that did not answer", async () => {
     installFetchStub({
-      "GET /me": CAN_ENRICH,
+      "GET /me": A_READER,
       [`GET /organizations/${ORG}/facts`]: () =>
         jsonResponse({
           data: [fact("mail_provider", "microsoft365", "Microsoft 365")],
@@ -142,7 +118,10 @@ describe("the technical profile card", () => {
     expect(await screen.findByText(/hat nicht geantwortet/)).toBeTruthy();
   });
 
-  it("offers no lookup to a reader who may not write the record", async () => {
+  // The card is a read. It has no button for anyone, so a reader who may not
+  // write the record sees exactly what a rep sees — and the absence of a
+  // control is not a permission decision the card has to make.
+  it("shows the same profile to a reader who may not write the record", async () => {
     installFetchStub({
       "GET /me": meRoute({ organization: ["read"] }, { seat: "read" }),
       [`GET /organizations/${ORG}/facts`]: () =>
@@ -154,7 +133,11 @@ describe("the technical profile card", () => {
     });
     renderCard();
     expect(await screen.findByText("Microsoft 365")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Nachschauen" })).toBeNull();
+    // Every button on this card is an evidence mark opening a row's provenance.
+    // A control that ASKS for anything would not be one.
+    for (const button of screen.queryAllByRole("button")) {
+      expect(button.className).toContain("evmark-trigger");
+    }
   });
 });
 


### PR DESCRIPTION
## The defect

Shopware's company record listed **Gartner**, a **Forrester Wave**, **PayPal**, and the bare words **CRM**, **ERP**, **BI** and **PIM** as technologies the company uses. None of those is a statement about what Shopware runs.

All four kinds trace to one sentence in `compose/sitereadvocab.go`. `technology` was defined as *"a platform, product or stack the company says it works with or builds on"* — and a page selling integrations names every vendor it integrates with, so the model filed all of them.

The evidence gate could not have caught this. `value_not_in_snippet` checks that the value's **name** appears in the cited passage, and "PayPal" does appear in Shopware's copy. Whether the sentence asserts *use* is a judgement, which is what the prompt is for.

## The change

`technology` now asks for a named platform the company states it **USES, RUNS or BUILDS IN — its own stack, not its subject matter**, with the passage required to assert that use. Three exclusions named, because these are the ones that actually fired:

- a vendor merely named, compared, or offered as an integration option
- an analyst firm, rating, report or award (Gartner, Forrester, a Magic Quadrant, a Wave) — those rate a company, they are not something it uses
- a bare capability category (BI, CRM, ERP, PIM, e-commerce, cloud) — a category is not a product

This follows the pattern the file already uses for `employee_range` vs `company_size`: state the confusion and rule it out.

## The other half needed no change

The technical lookup reads response headers, cookie names, `<script src>`s, `<meta generator>` and the raw markup. On the **same company** where the model found Gartner, the fingerprint found `nginx` (`Header server: nginx`), `Varnish` (`Header via: varnish`) and `Usercentrics` (`Script: app.usercentrics.eu`).

Both lanes write `technology`, to different standards of proof. The new how-to says which is which, so a reader opening an evidence mark knows what kind of claim they are looking at.

## Also here

The technical lookup rides the site read, so the Technik card no longer offers a button to start one, and it moves into **Daten & Werkzeuge** under the read that queues it. The dead i18n keys (`co.tech.read`, `co.tech.reading`, `co.tech.queued`, `co.tech.unavailable`) go with it, in all three locales, and the empty-state copy no longer points at a button that is not there.

`docs/how-to/read-what-a-company-runs.md` is new: what the lane reads, what triggers it, the two settings, per-lane reconciliation, the cache TTLs, and why the card stays empty when it does.

## Verification

- `make check-fe` — green
- `make check-gates` — green
- `go test ./internal/compose/... ./internal/modules/ai/...` — green
- AI cert corpus checked by hand: `site_fact_extract/basic_01.yaml` expects `technology: AWS` from *"Our platform **runs on** AWS and **integrates with** Snowflake"* — a direct assertion of own use, which the new wording explicitly admits. Still passes.

## Scope note

This fixes future reads. Existing bad rows clear when a company is re-read, since the site read reconciles its own fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows what counts as a technology fact so a company's stack records what it actually runs, not what its site merely mentions, and reads that stack off every page the crawl already fetched instead of the homepage alone. The site read used to file any named vendor as technology and the fingerprint lane looked at one page; now the model only admits asserted own-use and the crawl derives the fingerprint for every page it fetched, leaving the enricher to DNS and certificate logs.

**Bug Fixes**
- `technology` extraction requires the passage to state the company USES, RUNS, or BUILDS IN the named platform; vendors merely mentioned, analyst reports, and bare capability categories are excluded.
- Existing wrong rows clear on a re-read, since the site read reconciles its own fields.

**Refactors**
- Every crawled page now carries its response fingerprint, matched by the site read, so a shop system on /shop is seen without a second request; the enricher no longer fetches a homepage of its own.
- Side effect: the 6-hour sweep no longer refreshes technology — only a site re-read sees a stack change like Shopware → Shopify.
- The card drops its manual lookup button, moved into Daten & Werkzeuge under the read that queues it; dead i18n keys removed and a how-to documents the lane.

<sup>Written for commit f7add2f667837a76ee917dae33f00054186d4643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Technical profiles now display existing enrichment data in a read-only view.
  - Site crawls identify technologies across fetched pages and link findings to evidence pages.
  - Technical data can be queued automatically during site reads and scheduled refreshes.

- **Improvements**
  - Technology detection focuses on platforms the company demonstrably uses, operates, or builds with.
  - Technical lookups now use DNS and certificate history alongside crawled-page evidence.
  - Updated technical profile placement and empty-state messaging.

- **Documentation**
  - Added guidance on data sources, triggers, configuration, caching, troubleshooting, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->