### PR TITLE
fix(contract): one vocabulary for a strength band

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18649,7 +18649,7 @@ components:
       required: [score, bucket, factors]
       properties:
         score: { type: integer, minimum: 0, maximum: 100, description: 0..100 composite. }
-        bucket: { type: string, enum: [dormant, weak, warm, strong], description: Coarse band derived from score for display. }
+        bucket: { type: string, enum: [none, weak, moderate, strong], description: Coarse band derived from score for display — the same vocabulary every strength band on the wire uses. }
         factors:
           type: object
           description: The 0..1 sub-scores the composite was built from (the explanation).
@@ -20915,7 +20915,7 @@ components:
             and for a contact whose strength this caller's person scope did not resolve.
         strength_bucket:
           type: [string, 'null']
-          enum: [null, dormant, weak, warm, strong]
+          enum: [null, none, weak, moderate, strong]
           description: The server's band for `strength` — the same vocabulary `RelationshipStrength.bucket` uses. Never re-derived from the score by a client.
         intro_path:
           type: boolean

--- a/backend/internal/compose/accountdraft/input.go
+++ b/backend/internal/compose/accountdraft/input.go
@@ -72,7 +72,7 @@ type RecipientIn struct {
 	FirstName string `json:"first_name"`
 	Title     string `json:"title,omitempty"`
 	Email     string `json:"email,omitempty"`
-	// Bucket is the relationship's own reading (strong/warm/weak/dormant),
+	// Bucket is the relationship's own reading (strong/moderate/weak/none),
 	// which tells the writer how familiar to be. Never a score: a number would
 	// invite the prose to quote it.
 	Bucket string `json:"relationship,omitempty"`

--- a/backend/internal/compose/accountdraft/write_test.go
+++ b/backend/internal/compose/accountdraft/write_test.go
@@ -39,7 +39,7 @@ func sampleInput() Input {
 			Name:      "Sarah Cole",
 			FirstName: "Sarah",
 			Email:     "sarah@glazedfrog.example",
-			Bucket:    "warm",
+			Bucket:    "moderate",
 		},
 		Deal: &DealIn{
 			ID: "019fe7ae-0000-7000-8000-000000000002", Name: "Expansion Phase 2",

--- a/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
+++ b/backend/internal/compose/aicert/corpus/draft_reply/account_en_01.yaml
@@ -25,7 +25,7 @@ fixture:
     first_name: Priya
     title: Head of Operations
     email: p.raman@example.com
-    relationship: warm
+    relationship: moderate
     last_interaction: 2026-07-18T14:30:00Z
   # No currency, and that is deliberate. A deal's amount does not decode from a
   # fixture (AmountMinor is json:"-"), and a currency with no amount makes the
@@ -62,7 +62,7 @@ expect:
     the July conversation in mind — say what it was about rather than referring
     to it — and must not write "just circling back" or "as discussed".
 
-    No internals. The relationship reading ("warm") is steering for the writer,
+    No internals. The relationship reading ("moderate") is steering for the writer,
     not something to say to her. A draft that mentions a relationship strength,
     a score, or anything about other accounts scores at the floor.
 

--- a/backend/internal/compose/integration/strength_http_integration_test.go
+++ b/backend/internal/compose/integration/strength_http_integration_test.go
@@ -77,9 +77,9 @@ func TestPersonStrengthHTTPReconciles(t *testing.T) {
 	}
 
 	switch wire.Bucket {
-	case "dormant", "weak", "warm", "strong":
+	case "none", "weak", "moderate", "strong":
 	default:
-		t.Errorf("bucket = %q, want one of dormant|weak|warm|strong", wire.Bucket)
+		t.Errorf("bucket = %q, want one of none|weak|moderate|strong", wire.Bucket)
 	}
 	if wire.Score < 0 || wire.Score > 100 {
 		t.Fatalf("score = %d, want 0..100", wire.Score)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -6969,20 +6969,20 @@ func (e OrganizationGraphNodeKind) Valid() bool {
 
 // Defines values for OrganizationGraphNodeStrengthBucket.
 const (
-	OrganizationGraphNodeStrengthBucketDormant OrganizationGraphNodeStrengthBucket = "dormant"
-	OrganizationGraphNodeStrengthBucketStrong  OrganizationGraphNodeStrengthBucket = "strong"
-	OrganizationGraphNodeStrengthBucketWarm    OrganizationGraphNodeStrengthBucket = "warm"
-	OrganizationGraphNodeStrengthBucketWeak    OrganizationGraphNodeStrengthBucket = "weak"
+	OrganizationGraphNodeStrengthBucketModerate OrganizationGraphNodeStrengthBucket = "moderate"
+	OrganizationGraphNodeStrengthBucketNone     OrganizationGraphNodeStrengthBucket = "none"
+	OrganizationGraphNodeStrengthBucketStrong   OrganizationGraphNodeStrengthBucket = "strong"
+	OrganizationGraphNodeStrengthBucketWeak     OrganizationGraphNodeStrengthBucket = "weak"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationGraphNodeStrengthBucket enum.
 func (e OrganizationGraphNodeStrengthBucket) Valid() bool {
 	switch e {
-	case OrganizationGraphNodeStrengthBucketDormant:
+	case OrganizationGraphNodeStrengthBucketModerate:
+		return true
+	case OrganizationGraphNodeStrengthBucketNone:
 		return true
 	case OrganizationGraphNodeStrengthBucketStrong:
-		return true
-	case OrganizationGraphNodeStrengthBucketWarm:
 		return true
 	case OrganizationGraphNodeStrengthBucketWeak:
 		return true
@@ -7032,20 +7032,20 @@ func (e OrganizationQuestion) Valid() bool {
 
 // Defines values for OrganizationStrengthBucket.
 const (
-	OrganizationStrengthBucketDormant OrganizationStrengthBucket = "dormant"
-	OrganizationStrengthBucketStrong  OrganizationStrengthBucket = "strong"
-	OrganizationStrengthBucketWarm    OrganizationStrengthBucket = "warm"
-	OrganizationStrengthBucketWeak    OrganizationStrengthBucket = "weak"
+	OrganizationStrengthBucketModerate OrganizationStrengthBucket = "moderate"
+	OrganizationStrengthBucketNone     OrganizationStrengthBucket = "none"
+	OrganizationStrengthBucketStrong   OrganizationStrengthBucket = "strong"
+	OrganizationStrengthBucketWeak     OrganizationStrengthBucket = "weak"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationStrengthBucket enum.
 func (e OrganizationStrengthBucket) Valid() bool {
 	switch e {
-	case OrganizationStrengthBucketDormant:
+	case OrganizationStrengthBucketModerate:
+		return true
+	case OrganizationStrengthBucketNone:
 		return true
 	case OrganizationStrengthBucketStrong:
-		return true
-	case OrganizationStrengthBucketWarm:
 		return true
 	case OrganizationStrengthBucketWeak:
 		return true
@@ -8730,20 +8730,20 @@ func (e RelationshipKind) Valid() bool {
 
 // Defines values for RelationshipStrengthBucket.
 const (
-	RelationshipStrengthBucketDormant RelationshipStrengthBucket = "dormant"
-	RelationshipStrengthBucketStrong  RelationshipStrengthBucket = "strong"
-	RelationshipStrengthBucketWarm    RelationshipStrengthBucket = "warm"
-	RelationshipStrengthBucketWeak    RelationshipStrengthBucket = "weak"
+	RelationshipStrengthBucketModerate RelationshipStrengthBucket = "moderate"
+	RelationshipStrengthBucketNone     RelationshipStrengthBucket = "none"
+	RelationshipStrengthBucketStrong   RelationshipStrengthBucket = "strong"
+	RelationshipStrengthBucketWeak     RelationshipStrengthBucket = "weak"
 )
 
 // Valid indicates whether the value is a known member of the RelationshipStrengthBucket enum.
 func (e RelationshipStrengthBucket) Valid() bool {
 	switch e {
-	case RelationshipStrengthBucketDormant:
+	case RelationshipStrengthBucketModerate:
+		return true
+	case RelationshipStrengthBucketNone:
 		return true
 	case RelationshipStrengthBucketStrong:
-		return true
-	case RelationshipStrengthBucketWarm:
 		return true
 	case RelationshipStrengthBucketWeak:
 		return true
@@ -12015,22 +12015,22 @@ func (e ListOrganizationDocumentsParamsCategory) Valid() bool {
 
 // Defines values for ListOrganizationDocumentsParamsDocState.
 const (
-	Current    ListOrganizationDocumentsParamsDocState = "current"
-	Draft      ListOrganizationDocumentsParamsDocState = "draft"
-	Final      ListOrganizationDocumentsParamsDocState = "final"
-	Superseded ListOrganizationDocumentsParamsDocState = "superseded"
+	ListOrganizationDocumentsParamsDocStateCurrent    ListOrganizationDocumentsParamsDocState = "current"
+	ListOrganizationDocumentsParamsDocStateDraft      ListOrganizationDocumentsParamsDocState = "draft"
+	ListOrganizationDocumentsParamsDocStateFinal      ListOrganizationDocumentsParamsDocState = "final"
+	ListOrganizationDocumentsParamsDocStateSuperseded ListOrganizationDocumentsParamsDocState = "superseded"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationDocumentsParamsDocState enum.
 func (e ListOrganizationDocumentsParamsDocState) Valid() bool {
 	switch e {
-	case Current:
+	case ListOrganizationDocumentsParamsDocStateCurrent:
 		return true
-	case Draft:
+	case ListOrganizationDocumentsParamsDocStateDraft:
 		return true
-	case Final:
+	case ListOrganizationDocumentsParamsDocStateFinal:
 		return true
-	case Superseded:
+	case ListOrganizationDocumentsParamsDocStateSuperseded:
 		return true
 	default:
 		return false
@@ -21321,7 +21321,7 @@ type OrganizationQuestion string
 
 // OrganizationStrength defines model for OrganizationStrength.
 type OrganizationStrength struct {
-	// Bucket Coarse band derived from score for display.
+	// Bucket Coarse band derived from score for display — the same vocabulary every strength band on the wire uses.
 	Bucket OrganizationStrengthBucket `json:"bucket"`
 
 	// ComputedAt When this value was last recomputed (fixed-clock reproducible).
@@ -21359,7 +21359,7 @@ type OrganizationStrength struct {
 	Score int `json:"score"`
 }
 
-// OrganizationStrengthBucket Coarse band derived from score for display.
+// OrganizationStrengthBucket Coarse band derived from score for display — the same vocabulary every strength band on the wire uses.
 type OrganizationStrengthBucket string
 
 // OverlayBudget The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
@@ -23675,7 +23675,7 @@ type RelationshipListResponse struct {
 // interaction set + fixed clock yields a stable value (P6/P12). The `factors` decompose the score and
 // `contributing_activity_ids` are the receipts, so the UI can show its inputs — no mystery number.
 type RelationshipStrength struct {
-	// Bucket Coarse band derived from score for display.
+	// Bucket Coarse band derived from score for display — the same vocabulary every strength band on the wire uses.
 	Bucket RelationshipStrengthBucket `json:"bucket"`
 
 	// ComputedAt When this value was last recomputed (fixed-clock reproducible).
@@ -23705,7 +23705,7 @@ type RelationshipStrength struct {
 	Score int `json:"score"`
 }
 
-// RelationshipStrengthBucket Coarse band derived from score for display.
+// RelationshipStrengthBucket Coarse band derived from score for display — the same vocabulary every strength band on the wire uses.
 type RelationshipStrengthBucket string
 
 // RelinkActivitiesRequest The destination for a named set of activities. Every id must be one the caller can see and

--- a/backend/internal/modules/agents/outputshapes_derive_test.go
+++ b/backend/internal/modules/agents/outputshapes_derive_test.go
@@ -150,7 +150,7 @@ func TestEveryResultTypeSatisfiesTheSchemaDerivedFromIt(t *testing.T) {
 		"AvailabilityResult":   AvailabilityResult{Slots: []FreeSlot{{Start: time.Now().UTC(), End: time.Now().UTC().Add(time.Hour)}}, Truncated: false},
 		"PassthroughEntity":    PassthroughEntityResult{ID: id},
 		"listPipelinesAnswer":  listPipelinesAnswer{Pipelines: []Pipeline{{ID: id, Name: "Sales", IsDefault: true, Stages: []Stage{{ID: id, Name: "Open", Semantic: "open"}}}}},
-		"WhoKnowsAnswer":       WhoKnowsAnswer{PersonID: id, Colleagues: []KnownColleague{{UserID: id, DisplayName: "Ada", StrengthBucket: "warm"}}},
+		"WhoKnowsAnswer":       WhoKnowsAnswer{PersonID: id, Colleagues: []KnownColleague{{UserID: id, DisplayName: "Ada", StrengthBucket: "moderate"}}},
 		"IntroPathAnswer":      IntroPathAnswer{OrganizationID: id, Routes: []IntroRoute{}},
 		"AtRiskReport":         AtRiskReport{Deals: []AtRiskDeal{}, DealsScanned: 4},
 		"DealCoverageAnswer":   DealCoverageAnswer{DealID: id, Stakeholders: []CoverageSeat{}, OurSide: []KnownColleague{}, Risks: []CoverageRisk{}, SectionsOmitted: []string{}},

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -135,19 +135,21 @@ func StrengthToWire(rs RelationshipStrength, now time.Time) crmcontracts.Relatio
 	return wire
 }
 
-// StrengthBucketToWire maps the domain's display bucket onto the contract
-// vocabulary. The domain emits only the four cases below; anything else
-// reads as dormant rather than as a wire value the enum never declared.
+// StrengthBucketToWire types the domain's display bucket for the contract.
+// The two vocabularies are the same words on purpose — the wire enum was
+// aligned to the §4 kernel's — so this switch renames nothing. The input is
+// still a plain string, so a value the kernel never emits reads as none
+// rather than as a wire value the enum never declared.
 func StrengthBucketToWire(bucket string) crmcontracts.RelationshipStrengthBucket {
 	switch bucket {
-	case "weak":
+	case relstrength.BucketWeak:
 		return crmcontracts.RelationshipStrengthBucketWeak
-	case "moderate":
-		return crmcontracts.RelationshipStrengthBucketWarm
-	case "strong":
+	case relstrength.BucketModerate:
+		return crmcontracts.RelationshipStrengthBucketModerate
+	case relstrength.BucketStrong:
 		return crmcontracts.RelationshipStrengthBucketStrong
-	default: // bucketNone
-		return crmcontracts.RelationshipStrengthBucketDormant
+	default:
+		return crmcontracts.RelationshipStrengthBucketNone
 	}
 }
 

--- a/backend/internal/modules/people/strengthwire_test.go
+++ b/backend/internal/modules/people/strengthwire_test.go
@@ -18,13 +18,13 @@ import (
 func TestStrengthBucketToWireCoversTheDomainVocabulary(t *testing.T) {
 	cases := map[string]crmcontracts.RelationshipStrengthBucket{
 		"weak":     crmcontracts.RelationshipStrengthBucketWeak,
-		"moderate": crmcontracts.RelationshipStrengthBucketWarm,
+		"moderate": crmcontracts.RelationshipStrengthBucketModerate,
 		"strong":   crmcontracts.RelationshipStrengthBucketStrong,
-		"none":     crmcontracts.RelationshipStrengthBucketDormant,
+		"none":     crmcontracts.RelationshipStrengthBucketNone,
 		// A value the domain never emits must still land on a declared
 		// enum member — a wire value the contract does not declare is worse
 		// than a conservative one.
-		"something-new": crmcontracts.RelationshipStrengthBucketDormant,
+		"something-new": crmcontracts.RelationshipStrengthBucketNone,
 	}
 	for domain, want := range cases {
 		if got := StrengthBucketToWire(domain); got != want {
@@ -71,7 +71,7 @@ func TestStrengthToWireReportsNoDirectionWithoutInteractions(t *testing.T) {
 	if wire.Factors.Direction != 0 {
 		t.Errorf("factors.direction = %v with no interactions, want 0", wire.Factors.Direction)
 	}
-	if wire.Bucket != crmcontracts.RelationshipStrengthBucketDormant {
-		t.Errorf("bucket = %q, want dormant", wire.Bucket)
+	if wire.Bucket != crmcontracts.RelationshipStrengthBucketNone {
+		t.Errorf("bucket = %q, want none", wire.Bucket)
 	}
 }

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1989,7 +1989,7 @@ export async function mockApi(
     if (path.endsWith("/strength")) {
       return json({
         score: 0,
-        bucket: "dormant",
+        bucket: "none",
         factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
         inbound_90d: 0,
         outbound_90d: 0,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12634,10 +12634,10 @@ export interface components {
             /** @description 0..100 composite. */
             score: number;
             /**
-             * @description Coarse band derived from score for display.
+             * @description Coarse band derived from score for display — the same vocabulary every strength band on the wire uses.
              * @enum {string}
              */
-            bucket: "dormant" | "weak" | "warm" | "strong";
+            bucket: "none" | "weak" | "moderate" | "strong";
             /** @description The 0..1 sub-scores the composite was built from (the explanation). */
             factors: {
                 recency: number;
@@ -14401,7 +14401,7 @@ export interface components {
              * @description The server's band for `strength` — the same vocabulary `RelationshipStrength.bucket` uses. Never re-derived from the score by a client.
              * @enum {string|null}
              */
-            strength_bucket?: null | "dormant" | "weak" | "warm" | "strong";
+            strength_bucket?: null | "none" | "weak" | "moderate" | "strong";
             /**
              * @description This contact is the route in the active signal's warm-intro path proposes.
              *     At most one node carries it, and only when `intro_path` at the top level is

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5007,9 +5007,9 @@ export const de = {
 
   "strength.title": "Beziehungsstärke",
   "strength.score": "Score {score}/100",
-  "strength.bucket.dormant": "Ruhend",
+  "strength.bucket.none": "Ruhend",
   "strength.bucket.weak": "Schwach",
-  "strength.bucket.warm": "Warm",
+  "strength.bucket.moderate": "Warm",
   "strength.bucket.strong": "Stark",
   "strength.factor.recency": "Aktualität",
   "strength.factor.frequency": "Häufigkeit",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5074,9 +5074,9 @@ export const en = {
 
   "strength.title": "Relationship strength",
   "strength.score": "Score {score}/100",
-  "strength.bucket.dormant": "Dormant",
+  "strength.bucket.none": "Dormant",
   "strength.bucket.weak": "Weak",
-  "strength.bucket.warm": "Warm",
+  "strength.bucket.moderate": "Warm",
   "strength.bucket.strong": "Strong",
   "strength.factor.recency": "Recency",
   "strength.factor.frequency": "Frequency",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4967,9 +4967,9 @@ export const vi = {
 
   "strength.title": "Độ bền quan hệ",
   "strength.score": "Điểm {score}/100",
-  "strength.bucket.dormant": "Tạm lắng",
+  "strength.bucket.none": "Tạm lắng",
   "strength.bucket.weak": "Yếu",
-  "strength.bucket.warm": "Thân thiết",
+  "strength.bucket.moderate": "Thân thiết",
   "strength.bucket.strong": "Bền chặt",
   "strength.factor.recency": "Độ gần đây",
   "strength.factor.frequency": "Tần suất",

--- a/frontend/src/screens/company.fixtures.ts
+++ b/frontend/src/screens/company.fixtures.ts
@@ -117,7 +117,7 @@ export const emptyBrief = {
  */
 export const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };

--- a/frontend/src/screens/company360.coverage.test.tsx
+++ b/frontend/src/screens/company360.coverage.test.tsx
@@ -40,7 +40,7 @@ function contact(personId: string, roles: Contact["deal_roles"]): Contact {
   return {
     person_id: personId,
     full_name: `Contact ${personId}`,
-    strength: { score: 0, bucket: "dormant", factors: FACTORS },
+    strength: { score: 0, bucket: "none", factors: FACTORS },
     deal_roles: roles,
     consent: {},
   };

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -585,7 +585,7 @@ describe("company view — consent is per purpose", () => {
               },
               strength: {
                 score: 0,
-                bucket: "dormant",
+                bucket: "none",
                 factors: {
                   recency: 0,
                   frequency: 0,
@@ -1046,7 +1046,7 @@ describe("company view — the citations under a finding", () => {
             consent: {},
             strength: {
               score: 0,
-              bucket: "dormant" as const,
+              bucket: "none" as const,
               factors: {
                 recency: 0,
                 frequency: 0,
@@ -1345,7 +1345,7 @@ describe("company view — naming the buying committee", () => {
               consent: {},
               strength: {
                 score: 0,
-                bucket: "dormant",
+                bucket: "none",
                 factors: {
                   recency: 0,
                   frequency: 0,
@@ -1399,7 +1399,7 @@ describe("company view — naming the buying committee", () => {
               consent: {},
               strength: {
                 score: 0,
-                bucket: "dormant",
+                bucket: "none",
                 factors: {
                   recency: 0,
                   frequency: 0,
@@ -1508,7 +1508,7 @@ describe("company view — a recorded role reaches the screen", () => {
     consent: {},
     strength: {
       score: 0,
-      bucket: "dormant",
+      bucket: "none",
       factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
     },
   };
@@ -1598,7 +1598,7 @@ it("does not offer a role the contact already holds on that deal", async () => {
             consent: {},
             strength: {
               score: 0,
-              bucket: "dormant",
+              bucket: "none",
               factors: {
                 recency: 0,
                 frequency: 0,
@@ -2241,7 +2241,7 @@ describe("company view — the account's own tabs", () => {
               title: "Managing director",
               strength: {
                 score: 0,
-                bucket: "dormant",
+                bucket: "none",
                 factors: {
                   recency: 0,
                   frequency: 0,
@@ -2316,7 +2316,7 @@ describe("company view — the way in to one contact", () => {
             },
             strength: {
               score: 0,
-              bucket: "dormant",
+              bucket: "none",
               factors: {
                 recency: 0,
                 frequency: 0,

--- a/frontend/src/screens/companyheader.stories.tsx
+++ b/frontend/src/screens/companyheader.stories.tsx
@@ -80,7 +80,7 @@ const noWayIn = {
   ...withWayIn,
   strength: {
     score: 0,
-    bucket: "dormant",
+    bucket: "none",
     contact_count: 0,
     contributor_person_id: null,
     factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -633,7 +633,7 @@ describe("CompanyRail", () => {
                 title: "VP Procurement",
                 strength: {
                   score: 40,
-                  bucket: "warm",
+                  bucket: "moderate",
                   factors: {},
                   inbound_90d: 1,
                 },

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -177,7 +177,7 @@ describe("the day's call, and which record it is read from", () => {
   const CONTACT = {
     person_id: "p-1",
     full_name: "Sarah Cole",
-    strength: { score: 40, bucket: "warm" as const, factors: FACTORS },
+    strength: { score: 40, bucket: "moderate" as const, factors: FACTORS },
     deal_roles: [],
     consent: {},
   };

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1798,7 +1798,7 @@ describe("ComposeModal started from an account", () => {
                 full_name: "Sarah Cole",
                 strength: {
                   score: 40,
-                  bucket: "warm",
+                  bucket: "moderate",
                   factors: {
                     recency: 0,
                     frequency: 0,

--- a/frontend/src/screens/connections.stories.tsx
+++ b/frontend/src/screens/connections.stories.tsx
@@ -52,7 +52,7 @@ const populated: Graph = {
       label: "Milan Prohaska",
       detail: "Head of Fleet",
       strength: 41,
-      strength_bucket: "warm",
+      strength_bucket: "moderate",
     }),
     node({
       id: "d-1",

--- a/frontend/src/screens/connections.tsx
+++ b/frontend/src/screens/connections.tsx
@@ -603,7 +603,7 @@ function strengthTone(
   if (bucket === "strong") {
     return "success";
   }
-  if (bucket === "warm") {
+  if (bucket === "moderate") {
     return "accent";
   }
   return undefined;

--- a/frontend/src/screens/coverage.test.ts
+++ b/frontend/src/screens/coverage.test.ts
@@ -12,7 +12,7 @@ function contact(over: Partial<Contact> = {}): Contact {
   return {
     person_id: "p1",
     full_name: "Christian Hagemeyer",
-    strength: { score: 0, bucket: "dormant", factors: FACTORS },
+    strength: { score: 0, bucket: "none", factors: FACTORS },
     deal_roles: [],
     consent: {},
     ...over,
@@ -23,7 +23,7 @@ const withTraffic = (out: number, back: number, over: Partial<Contact> = {}) =>
   contact({
     strength: {
       score: back > 0 ? 40 : 2,
-      bucket: back > 0 ? "warm" : "weak",
+      bucket: back > 0 ? "moderate" : "weak",
       factors: FACTORS,
       outbound_90d: out,
       inbound_90d: back,

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -78,7 +78,7 @@ const emptyPage = { data: [], page: { next_cursor: null } };
 // the Person Overview now fires this GET unconditionally (P-4).
 const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };

--- a/frontend/src/screens/organizations.stories.tsx
+++ b/frontend/src/screens/organizations.stories.tsx
@@ -39,7 +39,7 @@ const org = {
 
 const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };

--- a/frontend/src/screens/people.stories.tsx
+++ b/frontend/src/screens/people.stories.tsx
@@ -37,7 +37,7 @@ const anna = {
 
 const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -160,7 +160,7 @@ describe("ContactsScreen (B-EP09.10a)", () => {
 // catch-all.
 const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };

--- a/frontend/src/screens/strength.stories.tsx
+++ b/frontend/src/screens/strength.stories.tsx
@@ -33,7 +33,7 @@ const strongStrength = {
 
 const dormantStrength = {
   score: 0,
-  bucket: "dormant",
+  bucket: "none",
   factors: { recency: 0, frequency: 0, reciprocity: 0, direction: 0 },
   last_interaction: null,
 };
@@ -52,7 +52,7 @@ export const Strong: Story = {
   },
 };
 
-// A record with no qualifying interactions: bucket:dormant, score:0,
+// A record with no qualifying interactions: bucket:none, score:0,
 // rendered plainly (0% bars, an honest "no interactions yet" caption) —
 // never hidden or dressed up as an error.
 export const Dormant: Story = {

--- a/frontend/src/screens/strength.tsx
+++ b/frontend/src/screens/strength.tsx
@@ -21,7 +21,7 @@ import {
 // and the full recency/frequency/reciprocity/direction factor breakdown that
 // explains it (spec ai-operational-spec.md), plus the receipts (last
 // interaction, 90d in/out counts, contributing-activity count). A record
-// with no qualifying interactions is bucket:dormant, score:0 — that's
+// with no qualifying interactions is bucket:none, score:0 — that's
 // rendered plainly (0% bars, an honest "no interactions yet" caption), never
 // hidden or dressed up as an error.
 
@@ -32,9 +32,9 @@ const BUCKET_TONE: Record<
   "success" | "accent" | "warn" | undefined
 > = {
   strong: "success",
-  warm: "accent",
+  moderate: "accent",
   weak: "warn",
-  dormant: undefined,
+  none: undefined,
 };
 
 async function fetchStrength(
@@ -118,14 +118,14 @@ function StrengthBody({
   const recordZone = useRecordZone();
   // The contract guarantees factors/bucket/score, but a single data-driven
   // card must never crash the whole 360 if a response arrives malformed —
-  // degrade to the honest zero/dormant reading instead (craft T7).
+  // degrade to the honest zero/none reading instead (craft T7).
   const factors = strength.factors ?? {
     recency: 0,
     frequency: 0,
     reciprocity: 0,
     direction: 0,
   };
-  const bucket = strength.bucket ?? "dormant";
+  const bucket = strength.bucket ?? "none";
   const score = strength.score ?? 0;
   const factorRows: Array<{
     key: "recency" | "frequency" | "reciprocity" | "direction";


### PR DESCRIPTION
The §4 kernel emits none|weak|moderate|strong, and the newer wire shapes
(graph edges, network colleagues, relationship changes) pass those words
through. The two oldest shapes — RelationshipStrength.bucket and the graph
node's strength_bucket — translated them to dormant|weak|warm|strong through
StrengthBucketToWire. One band, two spellings on one wire: a client comparing
a node's band to a colleague's band had to know which dialect each field
speaks.

The contract now declares the kernel's vocabulary at both sites and the
translator becomes a typed total switch over the kernel constants — same
words in, same words out, with the same conservative floor: a value the
kernel never emits reads as none rather than as a wire value the enum never
declared.

Display copy is untouched. The strength card still prints Dormant/Warm
(Ruhend/Warm, Tạm lắng/Thân thiết); only the wire word under it changed, so
the screens read exactly as before.

The model-facing account-draft input inherits the new words in its
relationship field. That field is free-text guidance about familiarity, not
a parsed enum, and none/moderate say the same thing to the writer that
dormant/warm did.

Verified: make check-backend, make check-fe (incl. fe-drift), craft static, rls-store-path, no-jurisdiction, and the strength HTTP integration tests against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns strength band vocabulary on the wire so `RelationshipStrength.bucket` and the graph node's `strength_bucket` both use the kernel's `none|weak|moderate|strong` instead of the old `dormant|weak|warm|strong`.

- `StrengthBucketToWire` is now a typed total switch over the kernel constants; a value the kernel never emits reads as `none`.
- Display copy is untouched: the i18n keys were renamed but the rendered labels (Dormant/Warm, etc.) are identical.
- The account-draft relationship input inherits the new words; it is free-text guidance about familiarity, so meaning is unchanged.

<sup>Written for commit 3724aa73ca7ab65581a9f6dc2c9ba354f1712a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated relationship-strength categories across the application to use **None**, **Weak**, **Moderate**, and **Strong**.
  * Contacts without relationship activity, or with unrecognized strength values, now consistently appear as **None**.
  * Updated badges, labels, translations, and relationship-strength displays to reflect the revised categories.

* **Tests**
  * Updated test scenarios and sample data to validate the new relationship-strength vocabulary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->