### PR TITLE
fix(privacy): a request path reaches a log line with its credential removed

### DIFF
--- a/backend/gates/capabilitypathlog_test.go
+++ b/backend/gates/capabilitypathlog_test.go
@@ -29,21 +29,32 @@ package gates
 // every one of the seven sites, and the next log line inherits it. The rule is
 // that a path becomes a log value only through the redactor.
 //
-// What this cannot see, stated rather than implied. The walk is syntactic, so
-// it catches the shape actually written here and the shape the next author
-// would reach for: the path read inside the argument list of a log call. It
-// does NOT follow a path assigned to a variable first, formatted into a message
-// with fmt.Sprintf, or carried into a helper this walk does not enter. Those
-// launder the value out of the gate's sight, and only a reviewer catches them.
+// Two things are checked, because redacting at every site proves nothing if
+// the list of routes needing redaction is short. The prohibition holds the
+// sites; TestEveryPublicRoutePrefixIsJudgedForCredentials holds the list,
+// reading the public route declarations and requiring each to be redacted or
+// to carry a written reason it is not.
+//
+// What this cannot see, stated rather than implied. The walk is syntactic. It
+// catches a raw path in a log call's arguments, and a helper that returns one
+// (the shape that would otherwise hide a read from the argument walk). It does
+// NOT follow a path assigned to a variable first, concatenated, or formatted
+// through fmt.Sprintf. Those launder the value out of the gate's sight, and
+// only a reviewer catches them.
 
 import (
 	"go/ast"
+	"go/token"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/gatekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 )
+
+const capabilityPathPkg = "github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 
 // The log doors a path must not reach raw. slog's package-level functions and
 // its *Logger methods share these names, so matching the selector name alone
@@ -62,8 +73,8 @@ var logDoors = map[string]bool{
 // package parses without type information, and `x.URL.Path` is the shape in
 // every one of these call sites. A request named something other than `r` is
 // still caught, because the chain and not the identifier is what is matched.
-func rawPathRead(expr ast.Expr) bool {
-	path, ok := expr.(*ast.SelectorExpr)
+func rawPathRead(node ast.Node) bool {
+	path, ok := node.(*ast.SelectorExpr)
 	if !ok || path.Sel.Name != "Path" {
 		return false
 	}
@@ -73,9 +84,19 @@ func rawPathRead(expr ast.Expr) bool {
 
 // logCallLeakingAPath reports the log doors in this file that are handed a raw
 // request path as an argument.
-func logCallLeakingAPath(file *ast.File) []string {
+//
+// A function in this file that RETURNS a raw path counts as the same leak, and
+// is reported at the function rather than at the call. That is the shape the
+// argument walk cannot see: the whole reason one wrapper is trusted is that it
+// hides the read, so a second wrapper hides one just as well.
+func logCallLeakingAPath(file *ast.File, path string) []string {
 	var leaks []string
 	ast.Inspect(file, func(n ast.Node) bool {
+		if fn, ok := n.(*ast.FuncDecl); ok && returnsARawPath(fn) &&
+			!(fn.Name.Name == trustedPathWrapper && path == trustedPathWrapperFile) {
+			leaks = append(leaks, "the helper "+fn.Name.Name+" returns r.URL.Path unredacted")
+			return true
+		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -86,12 +107,31 @@ func logCallLeakingAPath(file *ast.File) []string {
 		}
 		for _, arg := range call.Args {
 			if rawPathRead(arg) {
-				leaks = append(leaks, door.Sel.Name)
+				leaks = append(leaks, "slog "+door.Sel.Name+" is handed r.URL.Path directly")
 			}
 		}
 		return true
 	})
 	return leaks
+}
+
+// returnsARawPath reports a function whose return statement hands back
+// r.URL.Path with nothing done to it.
+func returnsARawPath(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, result := range ret.Results {
+			if rawPathRead(result) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
 }
 
 func TestNoRequestPathReachesALogLineUnredacted(t *testing.T) {
@@ -115,12 +155,12 @@ func TestNoRequestPathReachesALogLineUnredacted(t *testing.T) {
 			continue
 		}
 		judged++
-		for _, door := range logCallLeakingAPath(parsed.File) {
-			t.Errorf("%s: slog %s is handed r.URL.Path directly\n"+
+		for _, leak := range logCallLeakingAPath(parsed.File, parsed.Path) {
+			t.Errorf("%s: %s\n"+
 				"\tA public route can carry a bearer credential in a path segment, so a raw "+
 				"path in a log line can be a working credential wherever logs are read.\n"+
 				"\tPass it through shared/kernel/capabilitypath.Redact, which knows which "+
-				"prefixes carry one.", parsed.Path, door)
+				"prefixes carry one.", parsed.Path, leak)
 		}
 	}
 	// The count is taken AFTER the exclusion. A walk that found only
@@ -142,7 +182,7 @@ func TestNoRequestPathReachesALogLineUnredacted(t *testing.T) {
 func TestTheOneTrustedPathWrapperStillRedacts(t *testing.T) {
 	t.Parallel()
 
-	const wrapper = "internal/platform/httperr/httperr.go"
+	const wrapper = trustedPathWrapperFile
 	body, err := os.ReadFile(wrapper)
 	if err != nil {
 		t.Fatalf("reading the trusted path wrapper: %v", err)
@@ -160,24 +200,129 @@ func TestTheOneTrustedPathWrapperStillRedacts(t *testing.T) {
 	}
 }
 
+// Redacting correctly at every site proves nothing if the list of routes that
+// need it is short: every call still runs, and Redact hands the credential
+// straight back for a route it does not know. So the public prefixes are read
+// off the route declarations themselves — `const public<Name>Prefix = "…"` in
+// compose — and each is accounted for either as redacted or as a deliberate
+// exclusion carrying its reason.
+//
+// This is the half a syntactic walk cannot reach on its own, and the half that
+// fails silently: a new token-in-path route added tomorrow leaks with the
+// prohibition above still green.
+func TestEveryPublicRoutePrefixIsJudgedForCredentials(t *testing.T) {
+	t.Parallel()
+
+	// The public prefixes whose segment is NOT a credential, each with why.
+	// A prefix leaves this map only by joining capabilitypath's list.
+	notCredentials := map[string]string{
+		"/v1/public/booking/": "a booking slug is a public identifier the host hands out; the log needs it to say which page was hit",
+		"/v1/public/rooms/":   "the segment is an operation name (peek, exchange, link-request); a deal room presents a Bearer, never a path token",
+	}
+
+	redacted := make(map[string]bool)
+	for _, prefix := range capabilitypath.CredentialPrefixes() {
+		redacted[prefix] = true
+	}
+
+	declared := publicRoutePrefixes(t)
+	if len(declared) == 0 {
+		t.Fatal("no public route prefix was found in compose, so this parity check judged " +
+			"nothing — the declaration shape changed and this gate now certifies an empty set")
+	}
+	for prefix, where := range declared {
+		reason, excluded := notCredentials[prefix]
+		switch {
+		case redacted[prefix] && excluded:
+			t.Errorf("%s: %q is both redacted and listed as not-a-credential (%q) — one of the two is wrong",
+				where, prefix, reason)
+		case !redacted[prefix] && !excluded:
+			t.Errorf("%s: the public route %q is neither redacted nor accounted for.\n"+
+				"\tIf its next path segment is a bearer credential, add it to credentialPrefixes in "+
+				"shared/kernel/capabilitypath — every log site already calls Redact, and Redact returns "+
+				"an unknown route's credential unchanged.\n"+
+				"\tIf it is a public identifier, say so in notCredentials here with the reason.",
+				where, prefix)
+		}
+	}
+	for prefix := range notCredentials {
+		if _, ok := declared[prefix]; !ok {
+			t.Errorf("notCredentials names %q, which no compose route declares any more — "+
+				"drop the entry rather than leaving a stale exclusion standing", prefix)
+		}
+	}
+}
+
+// publicRoutePrefixes reads the `const public<Name>Prefix = "/v1/public/…"`
+// declarations out of compose, keyed by prefix, valued by where it was found.
+// Derived from the declarations rather than listed here, so a new public route
+// enters this check the moment it exists.
+func publicRoutePrefixes(t *testing.T) map[string]string {
+	t.Helper()
+
+	found := map[string]string{}
+	for _, parsed := range (gatekit.Scope{
+		Roots:   []string{"internal"},
+		Subject: declaresAPublicRoutePrefix,
+	}).Files(t) {
+		for name, value := range publicPrefixConstants(parsed.File) {
+			found[value] = parsed.Path + ": " + name
+		}
+	}
+	return found
+}
+
+// publicPrefixConstants reads this file's `public<Name>Prefix = "/v1/public/…"`
+// declarations, by constant name.
+func publicPrefixConstants(file *ast.File) map[string]string {
+	out := map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
+			return true
+		}
+		name := spec.Names[0].Name
+		if !strings.HasPrefix(name, "public") || !strings.HasSuffix(name, "Prefix") {
+			return true
+		}
+		lit, ok := spec.Values[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil || !strings.HasPrefix(value, "/v1/public/") {
+			return true
+		}
+		out[name] = value
+		return true
+	})
+	return out
+}
+
+func declaresAPublicRoutePrefix(_ string, file *ast.File) bool {
+	return len(publicPrefixConstants(file)) > 0
+}
+
 // fileLogsARequestPath selects the files worth judging: those that both log
 // and read a request path. Selecting on the log door alone would drag in every
 // file that logs anything; selecting on the path alone would drag in every
 // router.
+// A file qualifies on reading a request path ANYWHERE, not only inside a log
+// call's arguments. Requiring the read to sit in the call would let a file drop
+// out of the corpus by moving the read into a helper — which is the shape that
+// hides a leak, so it must select the file IN rather than out.
 func fileLogsARequestPath(_ string, file *ast.File) bool {
 	logs, readsPath := false, false
 	ast.Inspect(file, func(n ast.Node) bool {
+		if rawPathRead(n) {
+			readsPath = true
+		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
 		if door, ok := call.Fun.(*ast.SelectorExpr); ok && logDoors[door.Sel.Name] {
 			logs = true
-		}
-		for _, arg := range call.Args {
-			if rawPathRead(arg) || redactedPathRead(arg) {
-				readsPath = true
-			}
 		}
 		return true
 	})
@@ -189,23 +334,42 @@ func fileLogsARequestPath(_ string, file *ast.File) bool {
 // last leaking file would shrink the corpus to nothing and the empty-sweep
 // guard would fire on a clean tree.
 //
-// Two shapes count. `capabilitypath.Redact(r.URL.Path)` at the call is the
-// direct one. A one-argument wrapper taking the request — httperr's
-// loggedPath(r) — is the other: httperr logs six paths and spelling the
-// redaction out six times invites the seventh to forget, but the wrapper hides
-// the .URL.Path read from this walk.
-func redactedPathRead(expr ast.Expr) bool {
+// Two shapes count, and neither is matched by bare name. `Redact` and
+// `loggedPath` are ordinary identifiers, so an unrelated package defining
+// either — a `loggedPath` that returns the path raw is the obvious one — would
+// be read as already-fixed and leak with this gate green.
+//
+// `capabilitypath.Redact(r.URL.Path)` at the call is the direct shape,
+// resolved through the file's own import of the redactor.
+//
+// The wrapper shape is the other: httperr logs six paths, and spelling the
+// redaction out six times invites the seventh to forget, but a wrapper hides
+// the .URL.Path read from this walk. Exactly ONE wrapper is trusted, and only
+// inside the single file that declares it — trusting the name package-wide, or
+// wherever the redactor happens to be imported, is what lets a second
+// same-named helper borrow the trust. TestTheOneTrustedPathWrapperStillRedacts
+// pins what that one wrapper does.
+const (
+	trustedPathWrapper     = "loggedPath"
+	trustedPathWrapperFile = "internal/platform/httperr/httperr.go"
+)
+
+func redactedPathRead(file *ast.File, path string, expr ast.Expr) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
 		return false
 	}
 	if fn, ok := call.Fun.(*ast.SelectorExpr); ok && fn.Sel.Name == "Redact" {
-		for _, arg := range call.Args {
-			if rawPathRead(arg) {
-				return true
+		qualifier, _ := gatekit.ImportedAs(file, capabilityPathPkg)
+		pkg, isIdent := fn.X.(*ast.Ident)
+		if isIdent && qualifier != "" && pkg.Name == qualifier {
+			for _, arg := range call.Args {
+				if rawPathRead(arg) {
+					return true
+				}
 			}
 		}
 	}
 	fn, ok := call.Fun.(*ast.Ident)
-	return ok && fn.Name == "loggedPath"
+	return ok && fn.Name == trustedPathWrapper && path == trustedPathWrapperFile
 }

--- a/backend/gates/capabilitypathlog_test.go
+++ b/backend/gates/capabilitypathlog_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+//go:build !integration
+
+package gates
+
+// A request path reaches a log line through capabilitypath.Redact, never raw.
+//
+// Some public routes carry a bearer credential in a path segment, because they
+// are reached with no login: the recipient of an email follows a link, and the
+// token in it IS the authorization. The preference centre's token reads and
+// changes a person's consent state; the confirm-details token opens the
+// subject's own record. A log line holding one is a working credential sitting
+// wherever logs go — an ops dashboard, a shipped aggregator, a third-party log
+// service, a support engineer's paste.
+//
+// The access log knew this and redacted. Six other sites did not, and they
+// wrote the same paths: an unhandled error, an infrastructure fault, a withheld
+// error detail, a body that could not be read, and two field-level decode
+// refusals. Any 500 on one of those routes wrote the credential out. The holder
+// of such a URL could trigger it, and so could anyone who could provoke a fault
+// on that path.
+//
+// A PROHIBITION rather than a census, because the failure is a leak by default:
+// `"path", r.URL.Path` is what an author reaches for, it is correct-looking at
+// every one of the seven sites, and the next log line inherits it. The rule is
+// that a path becomes a log value only through the redactor.
+//
+// What this cannot see, stated rather than implied. The walk is syntactic, so
+// it catches the shape actually written here and the shape the next author
+// would reach for: the path read inside the argument list of a log call. It
+// does NOT follow a path assigned to a variable first, formatted into a message
+// with fmt.Sprintf, or carried into a helper this walk does not enter. Those
+// launder the value out of the gate's sight, and only a reviewer catches them.
+
+import (
+	"go/ast"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// The log doors a path must not reach raw. slog's package-level functions and
+// its *Logger methods share these names, so matching the selector name alone
+// covers both — and a name like `Warn` on some unrelated receiver would only
+// ever produce a finding if it were ALSO handed r.URL.Path, which is the
+// defect regardless of who logs it.
+var logDoors = map[string]bool{
+	"Debug": true, "Info": true, "Warn": true, "Error": true,
+	"DebugContext": true, "InfoContext": true, "WarnContext": true, "ErrorContext": true,
+	"Log": true, "LogAttrs": true,
+}
+
+// rawPathRead reports an expression that reads .Path off a *http.Request.
+//
+// Matched on the selector chain rather than on a resolved type: the gates
+// package parses without type information, and `x.URL.Path` is the shape in
+// every one of these call sites. A request named something other than `r` is
+// still caught, because the chain and not the identifier is what is matched.
+func rawPathRead(expr ast.Expr) bool {
+	path, ok := expr.(*ast.SelectorExpr)
+	if !ok || path.Sel.Name != "Path" {
+		return false
+	}
+	url, ok := path.X.(*ast.SelectorExpr)
+	return ok && url.Sel.Name == "URL"
+}
+
+// logCallLeakingAPath reports the log doors in this file that are handed a raw
+// request path as an argument.
+func logCallLeakingAPath(file *ast.File) []string {
+	var leaks []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		door, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !logDoors[door.Sel.Name] {
+			return true
+		}
+		for _, arg := range call.Args {
+			if rawPathRead(arg) {
+				leaks = append(leaks, door.Sel.Name)
+			}
+		}
+		return true
+	})
+	return leaks
+}
+
+func TestNoRequestPathReachesALogLineUnredacted(t *testing.T) {
+	t.Parallel()
+
+	files := gatekit.Scope{
+		Roots: []string{"internal"},
+		// Not extensions/: no unit logs a request path today, and a root that
+		// finds no subject fails this scope rather than passing quietly. An
+		// extension that starts logging one is served by the same rule and
+		// belongs in this list on the day it does.
+		Subject: fileLogsARequestPath,
+	}.Files(t)
+
+	judged := 0
+	for _, parsed := range files {
+		// capabilitypath owns the redaction, and its own test states the paths
+		// it is redacting. Excluded by package rather than by file so a second
+		// file in it is covered without an edit here.
+		if strings.Contains(parsed.Path, "/shared/kernel/capabilitypath/") {
+			continue
+		}
+		judged++
+		for _, door := range logCallLeakingAPath(parsed.File) {
+			t.Errorf("%s: slog %s is handed r.URL.Path directly\n"+
+				"\tA public route can carry a bearer credential in a path segment, so a raw "+
+				"path in a log line can be a working credential wherever logs are read.\n"+
+				"\tPass it through shared/kernel/capabilitypath.Redact, which knows which "+
+				"prefixes carry one.", parsed.Path, door)
+		}
+	}
+	// The count is taken AFTER the exclusion. A walk that found only
+	// capabilitypath itself — or one whose subject test broke and matched
+	// nothing — would otherwise report a swept, successful, empty run, which is
+	// the one way this gate must not fail. Something in this tree logs a
+	// request path: the access log does it on every request.
+	if judged == 0 {
+		t.Fatal("no file outside capabilitypath logs a request path, so this prohibition " +
+			"judged nothing — the walk is broken, or the log doors were renamed and this " +
+			"rule now binds calls nobody makes")
+	}
+}
+
+// Accepting httperr's loggedPath(r) as already-redacted is only sound while
+// loggedPath actually redacts. Nothing else in this walk can see inside it, so
+// the one wrapper this gate trusts is pinned here by name: strip the redaction
+// out of it and every httperr log line leaks with the gate still green.
+func TestTheOneTrustedPathWrapperStillRedacts(t *testing.T) {
+	t.Parallel()
+
+	const wrapper = "internal/platform/httperr/httperr.go"
+	body, err := os.ReadFile(wrapper)
+	if err != nil {
+		t.Fatalf("reading the trusted path wrapper: %v", err)
+	}
+	src := string(body)
+	if !strings.Contains(src, "func loggedPath(r *http.Request) string {") {
+		t.Fatalf("%s no longer declares loggedPath; this gate trusts that name as "+
+			"already-redacted, so either restore it or drop it from redactedPathRead", wrapper)
+	}
+	declaration, _, _ := strings.Cut(src[strings.Index(src, "func loggedPath"):], "\n}")
+	if !strings.Contains(declaration, "capabilitypath.Redact(r.URL.Path)") {
+		t.Errorf("%s: loggedPath no longer passes the path through capabilitypath.Redact, "+
+			"so every httperr log line that calls it writes the raw path while this gate "+
+			"reads them as fixed:\n%s", wrapper, declaration)
+	}
+}
+
+// fileLogsARequestPath selects the files worth judging: those that both log
+// and read a request path. Selecting on the log door alone would drag in every
+// file that logs anything; selecting on the path alone would drag in every
+// router.
+func fileLogsARequestPath(_ string, file *ast.File) bool {
+	logs, readsPath := false, false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if door, ok := call.Fun.(*ast.SelectorExpr); ok && logDoors[door.Sel.Name] {
+			logs = true
+		}
+		for _, arg := range call.Args {
+			if rawPathRead(arg) || redactedPathRead(arg) {
+				readsPath = true
+			}
+		}
+		return true
+	})
+	return logs && readsPath
+}
+
+// redactedPathRead reports a path that already goes through the redactor, so a
+// file that has been fixed STAYS in the gate's corpus. Without this, fixing the
+// last leaking file would shrink the corpus to nothing and the empty-sweep
+// guard would fire on a clean tree.
+//
+// Two shapes count. `capabilitypath.Redact(r.URL.Path)` at the call is the
+// direct one. A one-argument wrapper taking the request — httperr's
+// loggedPath(r) — is the other: httperr logs six paths and spelling the
+// redaction out six times invites the seventh to forget, but the wrapper hides
+// the .URL.Path read from this walk.
+func redactedPathRead(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	if fn, ok := call.Fun.(*ast.SelectorExpr); ok && fn.Sel.Name == "Redact" {
+		for _, arg := range call.Args {
+			if rawPathRead(arg) {
+				return true
+			}
+		}
+	}
+	fn, ok := call.Fun.(*ast.Ident)
+	return ok && fn.Name == "loggedPath"
+}

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -181,22 +181,13 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 			),
 		),
 	)
-	// publicPreferencesPrefix is named here twice on purpose: it is where
-	// the edge reads the capability token OUT of the path, and where the
-	// access log must not write it back.
-	//
-	// publicBookingPrefix is deliberately NOT redacted. Its slug is an
-	// unguessable but PUBLIC identifier — the host hands the URL out, it
-	// resolves to free/busy slots and nothing else, and 0036_booking_page
-	// states the posture outright ("a public identifier, not a credential:
-	// stored plaintext"). Redacting it would cost the access log the one
-	// thing that identifies which booking page was hit, and buy nothing.
-	//
-	// publicConfirmPrefix is redacted for the same reason and more urgently:
-	// its token opens the subject's own record, so a token in a log line is a
-	// readable copy of somebody's personal data sitting in operations.
+	// Which public routes carry a credential in the path — and so must not
+	// have it written to any log — is stated once in
+	// shared/kernel/capabilitypath, not named at each mount. The booking
+	// page's slug is deliberately absent from that list; it is a public
+	// identifier the host hands out, not a credential.
 	mux.Handle("/v1/", httpserver.Correlate(
-		httpserver.AccessLog(log, authH.Middleware(publicEdge), publicPreferencesPrefix, publicConfirmPrefix)))
+		httpserver.AccessLog(log, authH.Middleware(publicEdge))))
 	// The remote MCP connector, mounted as ONE group behind the deployment
 	// gate: the A2 transport, the A2 authorization server (ADR-0013) and
 	// both discovery documents. They belong together because RFC 9728

--- a/backend/internal/modules/deals/handlers.go
+++ b/backend/internal/modules/deals/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
@@ -116,7 +117,7 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 	// log gets the name instead.
 	if constraint, ok := storekit.CheckViolation(err); ok {
 		slog.WarnContext(r.Context(), "a schema rule with no message of its own refused a write",
-			"method", r.Method, "path", r.URL.Path, "constraint", constraint)
+			"method", r.Method, "path", capabilitypath.Redact(r.URL.Path), "constraint", constraint)
 		httperr.Write(w, r, httperr.Validation("body", "value_not_allowed",
 			"a value violates a rule on this record; check the picklist options"))
 		return

--- a/backend/internal/modules/projects/handlers_plumbing.go
+++ b/backend/internal/modules/projects/handlers_plumbing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
@@ -140,7 +141,7 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 	// operator's log gets the name instead.
 	if constraint, ok := storekit.CheckViolation(err); ok {
 		slog.WarnContext(r.Context(), "a schema rule with no message of its own refused a write",
-			"method", r.Method, "path", r.URL.Path, "constraint", constraint)
+			"method", r.Method, "path", capabilitypath.Redact(r.URL.Path), "constraint", constraint)
 		httperr.Write(w, r, httperr.Validation("body", "value_not_allowed",
 			"a value violates a rule on this record; check the picklist options"))
 		return

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 	"github.com/margince/margince/backend/internal/shared/kernel/values"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
@@ -315,12 +316,24 @@ func Classify(err error) (Fault, bool) {
 	return Fault{}, false
 }
 
+// loggedPath is the request path as a log line may carry it: any capability
+// segment replaced, because a /v1/public/* route's token IS its authorization
+// and these error paths run on exactly the requests that have one.
+//
+// The pairs stay literal at each call rather than being assembled here into a
+// spread tail — logsecrets_test.go reads these calls syntactically to prove no
+// credential reaches a log, and a spread it cannot follow is a hole in that
+// proof.
+func loggedPath(r *http.Request) string {
+	return capabilitypath.Redact(r.URL.Path)
+}
+
 // Write maps err onto the wire. Unknown errors become an opaque 500 — the
 // cause is logged server-side, never leaked to the client.
 func Write(w http.ResponseWriter, r *http.Request, err error) {
 	fault, ok := Classify(err)
 	if !ok {
-		slog.ErrorContext(r.Context(), "unhandled error", "method", r.Method, "path", r.URL.Path, "err", err)
+		slog.ErrorContext(r.Context(), "unhandled error", "method", r.Method, "path", loggedPath(r), "err", err)
 		writeProblem(w, problem{Status: http.StatusInternalServerError, Code: "internal"})
 		return
 	}
@@ -330,13 +343,13 @@ func Write(w http.ResponseWriter, r *http.Request, err error) {
 		// is true of both: the caller got a sentence we wrote, and the operator
 		// gets the one the infrastructure wrote.
 		slog.ErrorContext(r.Context(), "infrastructure cause withheld from the caller",
-			"method", r.Method, "path", r.URL.Path, "err", fault.InfraCause)
+			"method", r.Method, "path", loggedPath(r), "err", fault.InfraCause)
 	}
 	// A refusal that masked a library's own sentence still owes the operator
 	// that sentence, exactly as the native body decode logs its unnamed shapes.
 	if withheld := withheldFieldDecodeCause(err); withheld != nil {
 		slog.WarnContext(r.Context(), "unnamed field-decode failure",
-			"method", r.Method, "path", r.URL.Path, "err", withheld)
+			"method", r.Method, "path", loggedPath(r), "err", withheld)
 	}
 	// Fields renders INTO details rather than over it: both are public on
 	// DetailedError, so a handler may legitimately carry extra structured

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -98,7 +98,8 @@ func DecodeOrRefusal(w http.ResponseWriter, r *http.Request, into any) error {
 		// A read that failed mid-body is a transport fact — timed-out sockets
 		// carry host and port — so the caller is told what to do about it and
 		// the operator's half stays in the log.
-		slog.WarnContext(r.Context(), "reading request body", "method", r.Method, "path", r.URL.Path, "err", err)
+		slog.WarnContext(r.Context(), "reading request body",
+			"method", r.Method, "path", loggedPath(r), "err", err)
 		return Validation("body", "malformed_json",
 			"the request body could not be read to the end; resend the request with a complete body")
 	}
@@ -194,14 +195,14 @@ func bodyDecodeRefusal(r *http.Request, raw json.RawMessage, into any, err error
 		detail, withheld := fieldShapeDetail(refusal)
 		if withheld {
 			slog.WarnContext(r.Context(), "unnamed request-body field decode failure",
-				"method", r.Method, "path", r.URL.Path, "field", refusal.Field, "err", err)
+				"method", r.Method, "path", loggedPath(r), "field", refusal.Field, "err", err)
 		}
 		return Validation("body", "malformed_json", detail)
 	}
 	safe, withheld := SafeDecodeError(err)
 	if withheld {
 		slog.WarnContext(r.Context(), "unnamed request-body decode failure",
-			"method", r.Method, "path", r.URL.Path, "err", err)
+			"method", r.Method, "path", loggedPath(r), "err", err)
 	}
 	return Validation("body", "malformed_json", safe.Error())
 }

--- a/backend/internal/platform/httpserver/chassis.go
+++ b/backend/internal/platform/httpserver/chassis.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -188,7 +189,7 @@ func RecoverPanics(log *slog.Logger, next http.Handler) http.Handler {
 		defer func() {
 			if rec := recover(); rec != nil {
 				log.ErrorContext(r.Context(), "handler panic",
-					"panic", rec, "method", r.Method, "path", r.URL.Path,
+					"panic", rec, "method", r.Method, "path", capabilitypath.Redact(r.URL.Path),
 					"stack", string(debug.Stack()))
 				httperr.Write(w, r, &httperr.DetailedError{
 					Status: http.StatusInternalServerError, Code: "internal",

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -16,11 +16,11 @@ import (
 	"net/http"
 	"runtime"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -122,52 +122,23 @@ func (h *correlationHandler) WithGroup(name string) slog.Handler {
 // pattern — the access log answers "what did clients ask", the metrics
 // answer "how did routes behave".
 //
-// capabilityPrefixes name the route prefixes whose NEXT path segment is a
-// bearer credential rather than an identifier: the no-login preference
-// centre carries its capability token in the URL, and that token resolves
-// straight to a (workspace, person) consent state. Everyone who can read
-// the log — an ops dashboard, a shipped aggregator, a third-party log SaaS,
-// a support engineer — would otherwise be holding a working credential, so
-// the segment is replaced before the line is written. The composition layer
-// names them for the same reason it names every other thing this chassis
-// observes: the chassis owns the mechanism, never the route vocabulary.
-func AccessLog(log *slog.Logger, next http.Handler, capabilityPrefixes ...string) http.Handler {
+// A path segment that is a bearer credential is redacted before the line is
+// written, by shared/kernel/capabilitypath, which owns both the redaction and
+// the list of routes that carry one. That list does NOT arrive as an argument
+// here: it used to, and five of this function's six mount sites passed
+// nothing, so a mount reached the log unredacted by saying less rather than
+// by saying something wrong.
+func AccessLog(log *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rec, r)
 		log.InfoContext(r.Context(), "http request",
 			"method", r.Method,
-			"path", RedactCapabilitySegment(r.URL.Path, capabilityPrefixes...),
+			"path", capabilitypath.Redact(r.URL.Path),
 			"status", rec.status,
 			"duration_ms", time.Since(start).Milliseconds())
 	})
-}
-
-// redactedSegment stands in for a capability the log must not carry.
-const redactedSegment = "[redacted]"
-
-// RedactCapabilitySegment replaces the ONE path segment that follows a
-// capability prefix and keeps everything around it, so the line still says
-// which route was asked for and what trailed the credential ("…/unsubscribe")
-// without saying which credential was presented. A path that reaches no
-// prefix, or that stops at the prefix with no segment after it, is returned
-// unchanged — there is nothing there to leak.
-func RedactCapabilitySegment(path string, capabilityPrefixes ...string) string {
-	for _, prefix := range capabilityPrefixes {
-		if prefix == "" || !strings.HasPrefix(path, prefix) {
-			continue
-		}
-		rest := strings.TrimPrefix(path, prefix)
-		if rest == "" {
-			continue
-		}
-		if _, trailing, found := strings.Cut(rest, "/"); found {
-			return prefix + redactedSegment + "/" + trailing
-		}
-		return prefix + redactedSegment
-	}
-	return path
 }
 
 // statusRecorder captures the response status for the access log.

--- a/backend/internal/platform/httpserver/observe_test.go
+++ b/backend/internal/platform/httpserver/observe_test.go
@@ -161,10 +161,10 @@ func TestReadyzDependencyFailureStillReturns503RegardlessOfEmbedState(t *testing
 }
 
 // The preference centre's capability token travels in a path segment, and
-// the access log writes the path on every request. These cases pin the
-// redaction from both sides: the credential never reaches the line, and
-// everything an operator reads the log FOR — method, route, trailing verb,
-// ordinary record ids — still does.
+// the access log writes the path on every request. The redaction's own cases
+// live with it in shared/kernel/capabilitypath; what this pins is that the
+// middleware applies it with NO argument from the mount site, because the
+// argument is what five of six mounts used to leave out.
 func TestAccessLogRedactsCapabilityPathSegments(t *testing.T) {
 	const prefix = "/v1/public/preferences/"
 	// Deliberately a sentence rather than a realistic token: the assertion
@@ -173,28 +173,11 @@ func TestAccessLogRedactsCapabilityPathSegments(t *testing.T) {
 	// about forever after.
 	const token = "this-stands-in-for-a-preference-capability-token"
 
-	for _, tc := range []struct {
-		name, path, want string
-	}{
-		{"the token segment itself", prefix + token, prefix + "[redacted]"},
-		{"a trailing verb survives", prefix + token + "/unsubscribe", prefix + "[redacted]/unsubscribe"},
-		{"an unrelated path is untouched", "/v1/deals/018f2a10-0000-7000-8000-000000000001", "/v1/deals/018f2a10-0000-7000-8000-000000000001"},
-		{"the prefix with nothing after it has nothing to hide", prefix, prefix},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := RedactCapabilitySegment(tc.path, prefix); got != tc.want {
-				t.Errorf("RedactCapabilitySegment(%q) = %q, want %q", tc.path, got, tc.want)
-			}
-		})
-	}
-
-	// End to end through the middleware: the emitted line carries the
-	// redacted path and no trace of the token.
 	var buf strings.Builder
 	log := slog.New(slog.NewTextHandler(&buf, nil))
 	handler := AccessLog(log, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}), prefix)
+	}))
 	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, prefix+token, nil))
 
 	line := buf.String()

--- a/backend/internal/shared/kernel/capabilitypath/capabilitypath.go
+++ b/backend/internal/shared/kernel/capabilitypath/capabilitypath.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package capabilitypath answers one question for every log site in the
+// tree: what may this request path say once it is written down?
+//
+// Some public routes carry a bearer credential in a path segment, because
+// they are reached with no login at all — the recipient of an email follows
+// a link and the token in it IS the authorization. Anyone who can read a log
+// line holding one of those paths therefore holds a working credential: an
+// ops dashboard, a shipped aggregator, a third-party log service, a support
+// engineer reading a paste.
+//
+// This package sits in shared/ rather than beside the access log because
+// BOTH sides of the request need it and they cannot import each other:
+// platform/httpserver writes the access log, platform/httperr writes the
+// error logs, and httpserver already imports httperr. Whoever logs a path
+// reaches this package instead of reaching each other.
+//
+// The prefix list lives HERE, next to the redaction, rather than travelling
+// as an argument from the composition layer. That is the whole point: a list
+// a caller passes is a list a caller forgets, and the access log has six
+// mount sites of which one remembered.
+package capabilitypath
+
+import "strings"
+
+// redacted stands in for a capability the log must not carry.
+const redacted = "[redacted]"
+
+// credentialPrefixes name the route prefixes whose NEXT path segment is a
+// bearer credential rather than an identifier.
+//
+// A route belongs here when possession of the segment grants access. It does
+// NOT belong here merely for being unguessable: the public booking page
+// (/v1/public/booking/) carries a slug the host hands out deliberately, which
+// resolves to free/busy slots and nothing else, and redacting it would cost
+// the access log the only thing naming which booking page was hit while
+// buying nothing.
+var credentialPrefixes = []string{
+	// The preference centre: the token resolves straight to a
+	// (workspace, person) consent state and can change it.
+	"/v1/public/preferences/",
+	// The confirm-details link: the token opens the subject's own record,
+	// so a token in a log line is a readable copy of somebody's personal
+	// data sitting in operations.
+	"/v1/public/confirm/",
+}
+
+// Redact replaces the ONE path segment that follows a credential prefix and
+// keeps everything around it, so the line still says which route was asked
+// for and what trailed the credential ("…/unsubscribe") without saying which
+// credential was presented. A path that reaches no prefix, or that stops at
+// the prefix with no segment after it, is returned unchanged — there is
+// nothing there to leak.
+func Redact(path string) string {
+	for _, prefix := range credentialPrefixes {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(path, prefix)
+		if rest == "" {
+			continue
+		}
+		if _, trailing, found := strings.Cut(rest, "/"); found {
+			return prefix + redacted + "/" + trailing
+		}
+		return prefix + redacted
+	}
+	return path
+}
+
+// CredentialPrefixes returns the prefixes carrying a credential segment. It
+// exists so a gate can assert that every route mounted under a
+// credential-bearing prefix is one this package knows about, rather than the
+// list being a copy somebody keeps in step by hand.
+func CredentialPrefixes() []string {
+	out := make([]string, len(credentialPrefixes))
+	copy(out, credentialPrefixes)
+	return out
+}

--- a/backend/internal/shared/kernel/capabilitypath/capabilitypath_test.go
+++ b/backend/internal/shared/kernel/capabilitypath/capabilitypath_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capabilitypath
+
+import (
+	"strings"
+	"testing"
+)
+
+// These cases pin the redaction from both sides: the credential never
+// survives, and everything an operator reads a log FOR — route, trailing
+// verb, ordinary record ids — still does.
+func TestRedactHidesTheCredentialAndKeepsTheRoute(t *testing.T) {
+	// Deliberately a sentence rather than a realistic token: the assertion
+	// is that this segment does not reach the line, and a fixture that LOOKS
+	// like a credential is one every secret scanner has to be told about
+	// forever after.
+	const token = "this-stands-in-for-a-capability-token"
+
+	for _, tc := range []struct {
+		name, path, want string
+	}{
+		{
+			"the preference token segment itself",
+			"/v1/public/preferences/" + token,
+			"/v1/public/preferences/[redacted]",
+		},
+		{
+			"a trailing verb survives",
+			"/v1/public/preferences/" + token + "/unsubscribe",
+			"/v1/public/preferences/[redacted]/unsubscribe",
+		},
+		{
+			"the confirm token opens a record, so it goes too",
+			"/v1/public/confirm/" + token,
+			"/v1/public/confirm/[redacted]",
+		},
+		{
+			"an unrelated path is untouched",
+			"/v1/deals/018f2a10-0000-7000-8000-000000000001",
+			"/v1/deals/018f2a10-0000-7000-8000-000000000001",
+		},
+		{
+			"the prefix with nothing after it has nothing to hide",
+			"/v1/public/preferences/",
+			"/v1/public/preferences/",
+		},
+		{
+			// The booking slug is a public identifier the host hands out, not
+			// a credential. Redacting it would cost the log the one thing
+			// naming which booking page was hit and buy nothing.
+			"a public booking slug is deliberately kept",
+			"/v1/public/booking/acme-discovery-call",
+			"/v1/public/booking/acme-discovery-call",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Redact(tc.path); got != tc.want {
+				t.Errorf("Redact(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every prefix must end in a slash, or Redact eats the wrong segment: a
+// prefix of "/v1/public/confirm" would match "/v1/public/confirmation/x" and
+// redact a route that carries no credential at all.
+func TestEveryCredentialPrefixEndsInASlash(t *testing.T) {
+	for _, prefix := range CredentialPrefixes() {
+		if !strings.HasSuffix(prefix, "/") {
+			t.Errorf("credential prefix %q does not end in a slash, so it matches sibling routes by prefix", prefix)
+		}
+	}
+}
+
+// The exported list is what a gate reads to check the routes; handing out
+// the backing array would let a caller empty the redaction for the whole
+// process.
+func TestCredentialPrefixesCannotBeMutatedByItsCaller(t *testing.T) {
+	got := CredentialPrefixes()
+	if len(got) == 0 {
+		t.Fatal("no credential prefixes are declared, so nothing is ever redacted")
+	}
+	got[0] = "/nonsense/"
+
+	if CredentialPrefixes()[0] == "/nonsense/" {
+		t.Error("a caller's write reached the package's own list")
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -190,11 +190,12 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (34)
+## Prohibition (35)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
+| `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
 | `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |
 | `dealforecastmovement_test.go` | H2 | A deal row changes through one door, and that door records the forecast. |


### PR DESCRIPTION
Closes #2981.

## The leak

Public no-login routes carry a bearer credential in a path segment: the recipient of an email follows a link, and the token in it IS the authorization. The preference token reads and changes a person's consent state. The confirm token opens the subject's own record.

`httpserver.AccessLog` knew this and redacted the segment. Nine other log sites wrote the same paths raw:

- `httperr.go` — unhandled error, infrastructure fault, withheld error detail
- `wire.go` — unreadable body, and two field-level decode refusals
- `chassis.go` — the handler panic
- `deals/handlers.go` and `projects/handlers_plumbing.go` — a constraint refusal each

Any fault on one of those routes wrote a working credential into operations, where an ops dashboard, a shipped aggregator, a third-party log service or a support engineer's paste would hold it. Triggerable by whoever holds such a URL, and by anyone who can provoke a fault on that path.

The issue named five sites. The gate found nine, including the panic handler.

## Why a new package rather than a call to the existing redactor

`RedactCapabilitySegment` lived in `platform/httpserver`, which already imports `platform/httperr` — so the error-log sites could not reach it. Both now reach `shared/kernel/capabilitypath`, which sits below them and owns the redaction together with the list of routes that need it.

**The prefix list no longer travels as an argument.** That is the substance of the change, not a tidy-up: `AccessLog` took the prefixes variadically, and five of its six mount sites passed none. A mount leaked by saying less rather than by saying something wrong, which is the failure mode a required argument cannot produce and an optional one invites. Moving the list next to the redaction removes the chance to forget it.

`/v1/public/booking/` stays deliberately absent from that list. Its slug is a public identifier the host hands out; it resolves to free/busy slots and nothing else, and redacting it would cost the access log the one thing naming which page was hit. That decision is now stated where the list is, with a test case pinning it.

## The gate

`capabilitypathlog_test.go` is a prohibition: no `r.URL.Path` reaches a log call directly. It is what found `chassis.go`, `deals/handlers.go` and `projects/handlers_plumbing.go` — three sites reading the report alone did not.

Two things about its own honesty:

- A fixed file has to STAY in the corpus. If `redactedPathRead` only matched raw reads, fixing the last leak would empty the corpus and the empty-sweep guard would fire on a clean tree.
- It trusts one wrapper (`httperr.loggedPath`) by name, because six log lines in one file spelling the redaction out six times invites the seventh to forget. That trust is a hole, so `TestTheOneTrustedPathWrapperStillRedacts` pins that the wrapper still redacts — strip it and every `httperr` line leaks while the walk reads them as fixed.

The scope is `internal` only. No extension logs a request path today, and a root that finds no subject fails this scope rather than passing quietly.

## An existing gate pushed back, and it was right

The first version assembled `"method", "path"` into a slice and spread it at each call. `logsecrets_test.go` refused all six: a spread tail cannot be followed syntactically, so it blinds the gate that proves no credential reaches a log. The pairs are passed literally now, and only the redacted string comes from a helper.

## Mutation-checked

Four mutations, each failing the intended gate:

1. Raw `r.URL.Path` restored at a fixed site → prohibition fails, names the file.
2. A NEW file added with a raw path in a log call → prohibition fails.
3. A prefix corrupted in the credential list → the redactor's own test fails on the confirm case.
4. `loggedPath` stripped of its redaction → the wrapper test fails and prints the body.

## Verified

`make check-backend` green (3m28s). `make craft-static`, `make rls-store-path`, `make no-jurisdiction` all clean. No frontend files touched. The gate inventory page is regenerated by its own generator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops request credentials from leaking into log lines when public routes fault. Only the access log redacted `/v1/public/preferences/` and `/v1/public/confirm/` path tokens before; eight other log sites wrote them raw on errors, leaving working bearer credentials wherever logs go. All log sites now route paths through the shared `capabilitypath.Redact`, and a new gate blocks raw paths from any log call.

**Notable changes**
- Moves redaction and the credential-prefix list into `shared/kernel/capabilitypath`, reachable by both `httpserver` and `httperr`.
- `AccessLog` no longer takes prefixes as arguments, since five of its six mounts passed none.
- Adds `capabilitypathlog_test.go`, which fails any log call handed a raw path and reads the public route prefixes from `compose` to flag a new token-in-path route the day it exists.
- Keeps `/v1/public/booking/` unredacted deliberately; its slug is a public identifier, not a credential.
- Breaking change: `AccessLog`'s signature changed and `RedactCapabilitySegment` is removed; both are internal-only.

<sup>Written for commit 294703bad1b0a61266be0896e5c81ef75012bc8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Sensitive credentials in request URLs are now consistently redacted from access, error, warning, and panic logs.
  - Public route identifiers remain visible where appropriate.

- **Bug Fixes**
  - Prevented accidental exposure of credential-bearing URL segments across request logging.

- **Tests**
  - Added automated checks covering credential redaction and public route coverage.

- **Documentation**
  - Updated the gate inventory to include the new logging protection check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->