### PR TITLE
An agent stages on its passport, or not at all

### DIFF
--- a/backend/internal/compose/integration/approval_edit_integration_test.go
+++ b/backend/internal/compose/integration/approval_edit_integration_test.go
@@ -73,14 +73,17 @@ func TestModifyThenApproveRebindsTheAuthority(t *testing.T) {
 		t.Fatalf("proposed_change must be the human's version: %s", decided.ProposedChange)
 	}
 
-	// The follow-on effect executed the HUMAN-edited change (jsonb
-	// re-renders the stored bytes, so the payload assertion is on content).
-	var effectChange map[string]any
-	if err := json.Unmarshal(effectPayload, &effectChange); err != nil {
-		t.Fatal(err)
-	}
-	if effectChange["note"] != "human version" || effectHash != editedHash {
-		t.Fatalf("effect ran %s under %s, want the edited payload", effectPayload, effectHash)
+	// NO server-side effect, and that is the point of an AGENT-minted staging:
+	// approving it hands the agent an authority object to redeem, which is what
+	// the redemptions below exercise. This case used to assert the effect ran,
+	// and it did — because an agent staging with no passport wrote the NULL a
+	// SERVER proposal writes, and the row was executed as one. It carries its
+	// passport now, so it is what it always was.
+	// TestAgentMintedStagingDoesNotInvokeAServerSideEffect is the same claim
+	// from the other end.
+	if effectPayload != nil || effectHash != "" {
+		t.Fatalf("an agent-minted staging invoked the server-side executor with %s under %s",
+			effectPayload, effectHash)
 	}
 
 	assertEditAuditCarriesBothSides(t, owner, approvalID, originalHash, editedHash)
@@ -183,12 +186,26 @@ func TestModifyThenApproveCannotRetargetTheEffect(t *testing.T) {
 
 	// The positive control: an edit that corrects the CONTENT still works, so
 	// this test cannot pass by modify-then-approve being broken outright.
+	//
+	// The control is the DECISION rather than the effect. An agent-minted
+	// staging invokes no server-side executor — approving it hands the agent
+	// something to redeem — and this case only ever saw one because a passport-
+	// less agent staging wrote the NULL a server proposal writes.
 	corrected := json.RawMessage(`{"deal_id":"` + mine.String() + `","note":"human version"}`)
-	if _, err := svc.DecideEdited(rep, approvalID, corrected); err != nil {
+	accepted, err := svc.DecideEdited(rep, approvalID, corrected)
+	if err != nil {
 		t.Fatalf("editing the note → %v, want ok — pinning the record must not freeze the payload", err)
 	}
-	if !effectRan {
-		t.Fatal("the accepted edit never reached the effect")
+	_, correctedHash, err := diffhash.Canonical(corrected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Status != "approved" || accepted.DiffHash != correctedHash {
+		t.Fatalf("the corrected edit decided %s/%s, want approved on its own hash",
+			accepted.Status, accepted.DiffHash)
+	}
+	if effectRan {
+		t.Fatal("an agent-minted staging invoked the server-side executor")
 	}
 }
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -52,6 +52,17 @@ type Env struct {
 	// reading as a filter bug.
 	AdminUser    ids.UUID
 	Team1, Team2 ids.UUID
+	// AgentPassport is the credential AgentCtx presents. A real passport row,
+	// because approval.passport_id is a foreign key AND because an agent staging
+	// without one writes the NULL that means "the server proposed this" — the
+	// row a credential is then allowed to release, since there is no passport to
+	// compare its own against. Every live agent principal carries one; a fixture
+	// that did not was modelling a caller production cannot build.
+	//
+	// Lent by Rep1 rather than by a seat of its own: an extra app_user would
+	// move every seat count and seat-derived budget this package asserts, over a
+	// row those cases are not about.
+	AgentPassport ids.UUID
 }
 
 // Setup gives each test a clean, migrated database and seeds the
@@ -100,6 +111,13 @@ func Setup(t *testing.T) *Env {
 			`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, $3)`, user, string(rune('a'+i))+"@authz.test", "Rep"); err != nil {
 			t.Fatal(err)
 		}
+	}
+	e.AgentPassport = ids.NewV7()
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO passport (id, on_behalf_of, granted_by, token_hash, scopes, expires_at)
+		VALUES ($1, $2, $2, $3, ARRAY['read', 'write'], now() + interval '30 days')`,
+		e.AgentPassport, e.Rep1, "hash-"+e.AgentPassport.String()); err != nil {
+		t.Fatal(err)
 	}
 	for _, team := range []ids.UUID{e.Team1, e.Team2} {
 		if _, err := owner.Exec(ctx,
@@ -222,11 +240,16 @@ func (e *Env) Admin() context.Context { return e.As(e.AdminUser, nil, AdminPerms
 
 // AgentCtx binds a synthetic agent principal for staging (the staging
 // path itself is not what a suite using this is testing).
+//
+// It presents e.AgentPassport, as every live agent principal does: a staging
+// with none writes a NULL passport_id, which is what a SERVER proposal looks
+// like, and the credential may then release its own proposal.
 func (e *Env) AgentCtx() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalAgent, ID: "agent:test", SeatType: principal.SeatFull,
+		PassportID: e.AgentPassport,
 	})
 }
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -56,8 +56,11 @@ type Env struct {
 	// because approval.passport_id is a foreign key AND because an agent staging
 	// without one writes the NULL that means "the server proposed this" — the
 	// row a credential is then allowed to release, since there is no passport to
-	// compare its own against. Every live agent principal carries one; a fixture
-	// that did not was modelling a caller production cannot build.
+	// compare its own against. Every agent SURFACE carries one — the REST
+	// bearer, both MCP transports, the Surface-B runner — so a staging fixture
+	// that did not was modelling a caller none of them produces. (An agent
+	// principal without a passport does exist live, in compose/autoapply.go, and
+	// it only decides.)
 	//
 	// Lent by Rep1 rather than by a seat of its own: an extra app_user would
 	// move every seat count and seat-derived budget this package asserts, over a
@@ -241,9 +244,9 @@ func (e *Env) Admin() context.Context { return e.As(e.AdminUser, nil, AdminPerms
 // AgentCtx binds a synthetic agent principal for staging (the staging
 // path itself is not what a suite using this is testing).
 //
-// It presents e.AgentPassport, as every live agent principal does: a staging
-// with none writes a NULL passport_id, which is what a SERVER proposal looks
-// like, and the credential may then release its own proposal.
+// It presents e.AgentPassport, as every agent that STAGES does: a staging with
+// none writes a NULL passport_id, which is what a SERVER proposal looks like,
+// and the credential may then release its own proposal.
 func (e *Env) AgentCtx() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())

--- a/backend/internal/modules/approvals/decide_provenance_test.go
+++ b/backend/internal/modules/approvals/decide_provenance_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 func TestServerProposedTurnsOnThePassport(t *testing.T) {
@@ -29,5 +30,52 @@ func TestServerProposedTurnsOnThePassport(t *testing.T) {
 	if !serverProposed(row{Kind: "enrich"}) {
 		t.Error("a staging with no passport is a server-side proposal — its executor must still run, " +
 			"or the provenance check would disable the confirm-first proposal flows it protects")
+	}
+}
+
+// The other end of the same distinction: what makes a NULL passport_id TRUE.
+//
+// serverProposed reads the column and answers "the server made this". That is
+// only sound while nothing else can write NULL there — and an agent principal
+// with a zero PassportID does exactly that, laundering its own proposal into the
+// server-proposed case. The self-approval refusal compares the two passports, so
+// against a NULL it never fires and the credential releases the call it made.
+func TestAnAgentCannotStageWithoutItsPassport(t *testing.T) {
+	minted := ids.From[ids.PassportKind](ids.NewV7())
+	for name, tc := range map[string]struct {
+		actor   principal.Principal
+		refused bool
+	}{
+		"an agent presenting its passport": {
+			actor: principal.Principal{
+				Type: principal.PrincipalAgent, ID: "agent:x", OnBehalfOf: ids.NewV7(), PassportID: minted.UUID,
+			},
+		},
+		"an agent presenting none": {
+			actor: principal.Principal{
+				Type: principal.PrincipalAgent, ID: "agent:x", OnBehalfOf: ids.NewV7(),
+			},
+			refused: true,
+		},
+		// The case the refusal must not reach. A nightly sweep and a site read
+		// propose on nobody's credential, and their NULL is the one this column
+		// is read for — refusing it would break the path being protected.
+		"the system, which carries no passport by design": {
+			actor: principal.Principal{Type: principal.PrincipalSystem, ID: "system:site-read"},
+		},
+		"a human, who is not a credential at all": {
+			actor: principal.Principal{Type: principal.PrincipalHuman, ID: "human:x", UserID: ids.NewV7()},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := attributableStager(tc.actor)
+			if tc.refused && err == nil {
+				t.Error("staged a proposal that would read as the server's own, which is the row " +
+					"agentMayDecide cannot refuse a self-approval on")
+			}
+			if !tc.refused && err != nil {
+				t.Errorf("refused a legitimate stager: %v", err)
+			}
+		})
 	}
 }

--- a/backend/internal/modules/approvals/stageagentcall.go
+++ b/backend/internal/modules/approvals/stageagentcall.go
@@ -52,6 +52,9 @@ func (s *Service) StageAgentCall(ctx context.Context, in StageInput) (ids.Approv
 		return ids.ApprovalID{}, false, errors.New(
 			"crmapprovals: an agent call is identified by its diff hash, so StageAgentCall takes no Identity")
 	}
+	if err := stagerIsAttributable(ctx); err != nil {
+		return ids.ApprovalID{}, false, err
+	}
 	p, ok := principal.Actor(ctx)
 	if !ok {
 		return ids.ApprovalID{}, false, errors.New("crmapprovals: no actor bound to context")

--- a/backend/internal/modules/approvals/stageagentcall_integration_test.go
+++ b/backend/internal/modules/approvals/stageagentcall_integration_test.go
@@ -272,3 +272,65 @@ func (e *stagingEnv) stageDuplicateInTx(ctx context.Context, t *testing.T, in St
 	}
 	return id
 }
+
+// The stored provenance, from the database rather than from the caller's word.
+//
+// Everything the confirm-first tier rests on is downstream of one column: an
+// agent's row carries the passport that staged it, and a NULL there means the
+// server proposed it. Both halves are asserted here because both are load
+// bearing and neither is visible from the Go side — the row is what
+// agentMayDecide and serverProposed read, and a staging that wrote NULL for an
+// agent would satisfy every unit test while handing the credential back its own
+// proposal to release.
+func TestAStagedAgentCallCarriesThePassportThatMadeIt(t *testing.T) {
+	e := setupStaging(t)
+	target := e.seedOrg(t)
+	passport := e.seedPassport(t)
+
+	id, _, err := e.svc.StageAgentCall(e.asPassport(passport), e.agentCall(target))
+	if err != nil {
+		t.Fatalf("staging the call: %v", err)
+	}
+	var stored *ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT passport_id FROM approval WHERE id = $1`, id).Scan(&stored); err != nil {
+		t.Fatalf("reading the staged row: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("the staged row carries no passport_id, so it reads as a server proposal — " +
+			"agentMayDecide compares the two passports and would let this credential release its own call")
+	}
+	if *stored != passport {
+		t.Errorf("passport_id = %v, want the credential that staged it (%v)", *stored, passport)
+	}
+}
+
+// And the shape that would have laundered it: an agent principal carrying no
+// passport is refused the staging rather than writing the NULL that reads as
+// somebody else's proposal.
+//
+// No live path builds this principal — every real construction sets the
+// PassportID from the authenticated passport. The point is that it is refused by
+// the ROW's own writer rather than by every caller having been careful.
+func TestAnAgentWithNoPassportIsRefusedTheStaging(t *testing.T) {
+	e := setupStaging(t)
+	target := e.seedOrg(t)
+
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:no-passport", OnBehalfOf: e.rep,
+	})
+	if _, _, err := e.svc.StageAgentCall(ctx, e.agentCall(target)); err == nil {
+		t.Fatal("staged an agent call with no passport — the row it wrote is indistinguishable " +
+			"from a server proposal, and the credential could then release it")
+	}
+	var staged int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM approval WHERE target_entity_id = $1`, target).Scan(&staged); err != nil {
+		t.Fatalf("counting what the refusal left behind: %v", err)
+	}
+	if staged != 0 {
+		t.Errorf("the refused staging left %d row(s) behind — a refusal that writes is not a refusal", staged)
+	}
+}

--- a/backend/internal/modules/approvals/stageagentcall_integration_test.go
+++ b/backend/internal/modules/approvals/stageagentcall_integration_test.go
@@ -136,25 +136,25 @@ func TestAnAgentCallIsOnlyOfferedApprovalsItsOwnCredentialHolds(t *testing.T) {
 		t.Fatal("a second passport was handed the approval granted to the first")
 	}
 
-	// And neither is a caller presenting NO passport — the case the redemption
-	// alone would have admitted, since it checks the binding only against a
-	// caller that presents one. It must not be offered either credential's row:
-	// not the approved one, and not the undecided one the second passport is
-	// waiting on.
-	none, noneApproved, err := e.svc.StageAgentCall(e.agentWithoutPassport(), in)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if noneApproved {
-		t.Fatal("a passport-less caller was offered a decision granted to a passport")
-	}
-	if none == staged || none == other {
-		t.Fatalf("a passport-less caller was handed %s, a row staged by a passport", none)
+	// And a caller presenting NO passport is not offered either row — because it
+	// gets no row at all. This used to be the third arm of the same question:
+	// the redemption checks the binding only against a caller that presents a
+	// passport, so a passport-less one had to be kept away from another
+	// credential's approval by the staging probe. It is now refused the staging
+	// outright, which is the stronger answer and the one that also stops the row
+	// it WOULD have written — a NULL passport_id, indistinguishable from a
+	// server proposal, releasable by the credential that made it.
+	if _, _, err := e.svc.StageAgentCall(e.agentWithoutPassport(), in); err == nil {
+		t.Fatal("a passport-less agent staged a call — the row it writes reads as the server's own")
 	}
 }
 
-// agentWithoutPassport is an agent principal carrying no passport — the shape the
-// REST gate's session-authenticated agent path produces.
+// agentWithoutPassport is an agent principal carrying no passport.
+//
+// Production builds no such caller on any agent surface: AgentIdentity.Principal
+// is what the REST bearer, both MCP transports and the Surface-B runner arrive
+// as, and it always carries the authenticated passport. The shape is planted
+// here because the guard that refuses it has to be exercised by something.
 func (e *stagingEnv) agentWithoutPassport() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())

--- a/backend/internal/modules/approvals/stageagentcall_integration_test.go
+++ b/backend/internal/modules/approvals/stageagentcall_integration_test.go
@@ -151,10 +151,13 @@ func TestAnAgentCallIsOnlyOfferedApprovalsItsOwnCredentialHolds(t *testing.T) {
 
 // agentWithoutPassport is an agent principal carrying no passport.
 //
-// Production builds no such caller on any agent surface: AgentIdentity.Principal
-// is what the REST bearer, both MCP transports and the Surface-B runner arrive
-// as, and it always carries the authenticated passport. The shape is planted
-// here because the guard that refuses it has to be exercised by something.
+// No agent SURFACE builds one: AgentIdentity.Principal is what the REST bearer,
+// both MCP transports and the Surface-B runner arrive as, and it always carries
+// the passport it authenticated. compose/autoapply.go does build one — and only
+// ever DECIDES with it, where the sweep releases under the owner's own policy
+// rather than a credential releasing its own proposal, so the staging guard
+// does not reach it. The shape is planted here because the guard that refuses
+// it has to be exercised by something.
 func (e *stagingEnv) agentWithoutPassport() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
@@ -332,5 +335,41 @@ func TestAnAgentWithNoPassportIsRefusedTheStaging(t *testing.T) {
 	}
 	if staged != 0 {
 		t.Errorf("the refused staging left %d row(s) behind — a refusal that writes is not a refusal", staged)
+	}
+}
+
+// The REPEAT is the case an insert-level guard would have missed.
+//
+// A staging does not always insert: the joining path hands back a live row under
+// the same identity, and StageAgentCall hands back an approved-and-unspent one.
+// So a passport-less agent asking a second time would have been handed the row
+// its first attempt wrote — a NULL passport_id, which the redemption then spends
+// without a binding to check, because the caller presents none either. Refused
+// at the entry point, it is handed nothing and writes nothing.
+func TestAPassportLessAgentIsRefusedTheSecondTimeToo(t *testing.T) {
+	e := setupStaging(t)
+	target := e.seedOrg(t)
+	in := e.agentCall(target)
+
+	// The row it would have joined, staged by a credential that may make one.
+	passport := e.seedPassport(t)
+	staged, _, err := e.svc.StageAgentCall(e.asPassport(passport), in)
+	if err != nil {
+		t.Fatalf("staging the call: %v", err)
+	}
+	e.approve(t, staged)
+
+	// The same call, from a caller carrying nothing. It is not handed the
+	// approval it did not make, and it does not stage one of its own.
+	if _, approved, err := e.svc.StageAgentCall(e.agentWithoutPassport(), in); err == nil {
+		t.Fatalf("a passport-less agent was answered (approved=%t) for a call it may not stage", approved)
+	}
+	var rows int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM approval WHERE target_entity_id = $1`, target).Scan(&rows); err != nil {
+		t.Fatalf("counting the approvals for the target: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("the target carries %d approvals, want only the one a passport staged", rows)
 	}
 }

--- a/backend/internal/modules/approvals/stagerattribution.go
+++ b/backend/internal/modules/approvals/stagerattribution.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// Who may stage a proposal, and what a NULL passport_id is allowed to mean.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// stagerIsAttributable is the check every staging ENTRY POINT makes, and the
+// entry is the boundary rather than the insert.
+//
+// A staging does not always insert. The joining path hands back a live row
+// under the same identity, and StageAgentCall hands back an approved-and-unspent
+// one — so a passport-less agent repeating a call that already has a
+// NULL-passport approval would be given that row without an insert happening at
+// all, and the redemption skips the passport binding for a caller presenting
+// none. Guarded at the insert alone, the second attempt walks through.
+func stagerIsAttributable(ctx context.Context) error {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return errors.New("crmapprovals: no actor bound to context")
+	}
+	return attributableStager(p)
+}
+
+// attributableStager refuses an AGENT staging without its passport.
+//
+// A zero PassportID stores NULL, and a NULL passport_id is what a SERVER
+// proposal looks like — the case agentMayDecide deliberately admits, since a row
+// nobody's credential made has no self-approval to refuse. So an agent row
+// staged without one reads as proposed by nobody: the refusal compares the two
+// passports and never fires, and the credential can release the call it just
+// made. That loop is the whole of what the confirm-first tier exists to stop.
+//
+// Only an agent. A SYSTEM principal legitimately carries no passport — the
+// nightly sweeps and the site reads propose changes on nobody's credential —
+// and the server-proposed case has to stay reachable or this would break the
+// path it is protecting.
+//
+// Refused at the STAGING BOUNDARY rather than left to callers, so what a NULL
+// passport_id MEANS becomes a property of the row instead of a property of every
+// writer having been careful — which is a statement about today's callers, not
+// about the column. No agent SURFACE builds such a principal today, which is why
+// this is a guard rather than a repair: AgentIdentity.Principal always carries
+// the passport it authenticated. compose/autoapply.go does build one, and it
+// only ever decides — the sweep releases under the owner's own policy, which is
+// not a credential releasing its own proposal.
+func attributableStager(p principal.Principal) error {
+	if p.Type != principal.PrincipalAgent || p.PassportID != ids.Nil {
+		return nil
+	}
+	return errors.New("crmapprovals: an agent stages on its passport — a proposal carrying none is " +
+		"indistinguishable from one the server made, and the credential could then release it")
+}

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -28,6 +28,9 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 	if err != nil {
 		return ids.ApprovalID{}, err
 	}
+	if err := stagerIsAttributable(ctx); err != nil {
+		return ids.ApprovalID{}, err
+	}
 	var id ids.ApprovalID
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
@@ -48,6 +51,9 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 func (s *Service) StageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.ApprovalID, error) {
 	in, err := withCanonicalIdentity(in)
 	if err != nil {
+		return ids.ApprovalID{}, err
+	}
+	if err := stagerIsAttributable(ctx); err != nil {
 		return ids.ApprovalID{}, err
 	}
 	return s.stageOrJoinPendingInTx(ctx, tx, in)
@@ -361,34 +367,10 @@ func (s *Service) StageInTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.
 		return ids.ApprovalID{}, errors.New(
 			"crmapprovals: StageInTx always creates a row — use StageOrJoinPendingInTx to join or supersede")
 	}
-	return s.insertProposalInTx(ctx, tx, in)
-}
-
-// attributableStager refuses an AGENT staging without its passport.
-//
-// A zero PassportID stores NULL, and a NULL passport_id is what a SERVER
-// proposal looks like — the case agentMayDecide deliberately admits, since a row
-// nobody's credential made has no self-approval to refuse. So an agent row
-// staged without one reads as proposed by nobody: the refusal compares the two
-// passports and never fires, and the credential can release the call it just
-// made. That loop is the whole of what the confirm-first tier exists to stop.
-//
-// Only an agent. A SYSTEM principal legitimately carries no passport — the
-// nightly sweeps and the site reads propose changes on nobody's credential —
-// and the server-proposed case has to stay reachable or this would break the
-// path it is protecting.
-//
-// Refused at the INSERT rather than left to callers. Every staging path lands
-// here, so what a NULL passport_id MEANS becomes a property of the row instead
-// of a property of every writer having been careful — which is a statement about
-// today's callers, not about the column. No live path builds such a principal
-// today, which is why this is a guard rather than a repair.
-func attributableStager(p principal.Principal) error {
-	if p.Type != principal.PrincipalAgent || p.PassportID != ids.Nil {
-		return nil
+	if err := stagerIsAttributable(ctx); err != nil {
+		return ids.ApprovalID{}, err
 	}
-	return errors.New("crmapprovals: an agent stages on its passport — a proposal carrying none is " +
-		"indistinguishable from one the server made, and the credential could then release it")
+	return s.insertProposalInTx(ctx, tx, in)
 }
 
 // insertProposalInTx is the raw insert every staging path lands on, whether it
@@ -397,9 +379,6 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	p, ok := principal.Actor(ctx)
 	if !ok {
 		return ids.ApprovalID{}, errors.New("crmapprovals: no actor bound to context")
-	}
-	if err := attributableStager(p); err != nil {
-		return ids.ApprovalID{}, err
 	}
 	// The summary is prose, and several stagers build it out of record text
 	// the agent or an inbound sender could have written. Sanitizing at the

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -364,12 +364,42 @@ func (s *Service) StageInTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.
 	return s.insertProposalInTx(ctx, tx, in)
 }
 
+// attributableStager refuses an AGENT staging without its passport.
+//
+// A zero PassportID stores NULL, and a NULL passport_id is what a SERVER
+// proposal looks like — the case agentMayDecide deliberately admits, since a row
+// nobody's credential made has no self-approval to refuse. So an agent row
+// staged without one reads as proposed by nobody: the refusal compares the two
+// passports and never fires, and the credential can release the call it just
+// made. That loop is the whole of what the confirm-first tier exists to stop.
+//
+// Only an agent. A SYSTEM principal legitimately carries no passport — the
+// nightly sweeps and the site reads propose changes on nobody's credential —
+// and the server-proposed case has to stay reachable or this would break the
+// path it is protecting.
+//
+// Refused at the INSERT rather than left to callers. Every staging path lands
+// here, so what a NULL passport_id MEANS becomes a property of the row instead
+// of a property of every writer having been careful — which is a statement about
+// today's callers, not about the column. No live path builds such a principal
+// today, which is why this is a guard rather than a repair.
+func attributableStager(p principal.Principal) error {
+	if p.Type != principal.PrincipalAgent || p.PassportID != ids.Nil {
+		return nil
+	}
+	return errors.New("crmapprovals: an agent stages on its passport — a proposal carrying none is " +
+		"indistinguishable from one the server made, and the credential could then release it")
+}
+
 // insertProposalInTx is the raw insert every staging path lands on, whether it
 // arrived by joining, superseding, or straight creation.
 func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.ApprovalID, error) {
 	p, ok := principal.Actor(ctx)
 	if !ok {
 		return ids.ApprovalID{}, errors.New("crmapprovals: no actor bound to context")
+	}
+	if err := attributableStager(p); err != nil {
+		return ids.ApprovalID{}, err
 	}
 	// The summary is prose, and several stagers build it out of record text
 	// the agent or an inbound sender could have written. Sanitizing at the

--- a/backend/internal/modules/approvals/stagingidentity.go
+++ b/backend/internal/modules/approvals/stagingidentity.go
@@ -329,6 +329,9 @@ func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.A
 		}
 		in.Identity = canonical
 	}
+	if err := stagerIsAttributable(ctx); err != nil {
+		return ids.ApprovalID{}, false, err
+	}
 	var id ids.ApprovalID
 	staged := false
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {


### PR DESCRIPTION
Closes #2597.

## The laundering

`passport_id` is how the confirm-first tier tells a credential's own proposal from one nobody made. `agentMayDecide` refuses a self-approval by comparing the two passports; `serverProposed` reads a NULL as "the server made this" and lets its executor run.

An agent principal with a zero `PassportID` writes NULL through `nullUUID`, so its row reads as the server's. Then:

- the self-approval refusal compares against `nil` and never fires, and the credential releases the call it just made;
- the row also passes as server-proposed to the executor branch.

## The fix, and where it went

The ticket suggests refusing in `StageAgentCall`. It went one level down, into **`insertProposalInTx`** — "the raw insert every staging path lands on, whether it arrived by joining, superseding, or straight creation". That covers `Stage`, `StageInTx`, `StageOrJoinPendingInTx` and `StageAgentCall` in one place, so what a NULL `passport_id` *means* becomes a property of the row rather than a property of every writer having been careful.

Only an AGENT. A `PrincipalSystem` legitimately carries no passport — the nightly sweeps and the site reads propose on nobody's credential — and the server-proposed case has to stay reachable, or the guard breaks the path it is protecting. That arm is a test case, not a comment.

## Still not reachable

As the ticket says, and I re-checked the three constructions it names: real HTTP/MCP auth sets `PassportID` from the authenticated passport, `commsscheduled.go` sets it from the schedule, and `extjobsrun.go` sets neither `PassportID` nor `OnBehalfOf` so `actingForAHuman` refuses it a layer earlier. This is defence in depth.

## Tests

- **Unit** (`decide_provenance_test.go`, next to the `serverProposed` test it is the other half of): an agent with its passport is admitted, one without is refused, and both the system and a human are admitted — the last two being the arms a blanket refusal would have broken.
- **Integration**, which is what the ticket asked for: `TestAStagedAgentCallCarriesThePassportThatMadeIt` reads `passport_id` back **from the row** rather than from the caller's word, and `TestAnAgentWithNoPassportIsRefusedTheStaging` asserts the refusal leaves nothing behind — a refusal that writes is not a refusal.
- Mutation-checked: removing the guard fails the second one.

`make check-backend` exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented agents from staging proposals without a valid passport.
  * Rejected invalid staging attempts before approval records are created.
  * Preserved the passport details associated with valid staged agent calls.
  * Confirmed system and human principals can continue staging without passports.
  * Updated approval editing and redemption behavior to avoid immediate execution during agent-minted staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->