### PR TITLE
fix(dev): the worker survives a binding it cannot serve, and a dead one is reported

### DIFF
--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -117,7 +118,13 @@ func modelPathFor(ctx context.Context, cfg ai.RoutingConfig, spec modelPathSpec,
 	for i, candidate := range candidates {
 		modelPath, err := compose.NewModelPath(ctx, candidate.cfg, pool, spec.capturePayloads, log)
 		if err != nil {
-			if i == len(candidates)-1 {
+			// Only an unservable BINDING is worth another candidate. A
+			// database fault from the embed marker is not: no fallback repairs
+			// it, and booting past it would serve the AI surfaces with an
+			// unestablished marker while reporting a storage outage as a
+			// missing credential.
+			var unservable *compose.UnservableBindingError
+			if i == len(candidates)-1 || !errors.As(err, &unservable) {
 				return nil, "", ai.PublicProfile{}, "", err
 			}
 			// Loud: a bound installation quietly serving canned text would be

--- a/backend/cmd/worker/modelwiring.go
+++ b/backend/cmd/worker/modelwiring.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -55,7 +56,12 @@ func selectModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Pool
 		// SAME binding: the cost refresh narrows a provider catalog to the
 		// models this deployment actually calls.
 		path, bound, err := modelPathWithBoundModels(ctx, candidate, pool, spec.capturePayloads, log)
-		if err == nil || i == len(candidates)-1 {
+		// Only an unservable BINDING is worth another candidate. A database
+		// fault from the embed marker is not: no fallback repairs it, and
+		// booting past it would launch a worker whose marker is unestablished
+		// while reporting a storage outage as a missing credential.
+		var unservable *compose.UnservableBindingError
+		if err == nil || i == len(candidates)-1 || !errors.As(err, &unservable) {
 			return path, bound, err
 		}
 		// Loud: a bound installation quietly serving canned text would be the

--- a/backend/cmd/worker/modelwiring.go
+++ b/backend/cmd/worker/modelwiring.go
@@ -35,8 +35,13 @@ func selectModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Pool
 	if err != nil {
 		return compose.ModelPath{}, nil, err
 	}
-	switch {
-	case !cfg.Unconfigured():
+	candidates := modelPathCandidates(cfg, spec.fake)
+	if len(candidates) == 0 {
+		// Neither a binding nor --ai-fake: the runner and the embed lane simply
+		// don't start, and nothing is picked silently.
+		return compose.ModelPath{}, nil, nil
+	}
+	if !cfg.Unconfigured() {
 		// A task whose whole fallback ladder has no bound tier is not a
 		// boot error (a deployment may legitimately not run every
 		// workload), but it must be loud: log it now, not discover it
@@ -44,23 +49,50 @@ func selectModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Pool
 		for _, w := range cfg.UnboundLadderWarnings() {
 			log.Warn(w)
 		}
+	}
+	for i, candidate := range candidates {
 		// The bound model ids travel with the path because they describe the
 		// SAME binding: the cost refresh narrows a provider catalog to the
 		// models this deployment actually calls.
-		return modelPathWithBoundModels(ctx, cfg, pool, spec.capturePayloads, log)
-	case spec.fake:
-		// A real ModelPath over ai.FakeRoutingConfig() rather than
-		// FakeModelPath's direct client wiring: the worker always has a
-		// pool, so --ai-fake safely rides the real Router (tiering, the
-		// budget guardrail, metering, call tracing) with only the
-		// provider swapped for the deterministic fake. capturePayloads
-		// still names the deployment's own posture — cmd/api's
-		// resolveModelPath honors it on this same arm, and two process
-		// roles must never disagree on whether content capture is on.
-		return modelPathWithBoundModels(ctx, ai.FakeRoutingConfig(), pool, spec.capturePayloads, log)
-	default:
-		return compose.ModelPath{}, nil, nil
+		path, bound, err := modelPathWithBoundModels(ctx, candidate, pool, spec.capturePayloads, log)
+		if err == nil || i == len(candidates)-1 {
+			return path, bound, err
+		}
+		// Loud: a bound installation quietly serving canned text would be the
+		// worse of the two failures.
+		log.WarnContext(ctx, "the stored model binding cannot be served, and --ai-fake was requested: falling back to the offline fake for this boot. The runner answers with canned text until the binding resolves — bind a servable model under Settings -> AI, or supply the missing credential",
+			"error", err)
 	}
+	return compose.ModelPath{}, nil, nil
+}
+
+// modelPathCandidates names the bindings this boot may run on, best first. The
+// second entry is a FALLBACK from the first, reached only when the stored
+// binding cannot be built.
+//
+// The fallback is not generosity, and it is why this list exists rather than a
+// switch: a dev stack's bootstrap seeds a cloud binding, the engineer running
+// it may hold no key for that vendor, and refusing the boot costs them every
+// queued job over an AI lane they were not using. A deployment passes no
+// --ai-fake, so it still fails closed on a binding it cannot serve.
+//
+// cmd/api's resolveModelPath resolves the same two candidates on the same
+// condition. The roles must agree: a worker that exits where the api falls back
+// leaves the queue unrun behind an api that looks healthy, which reads as a
+// broken feature rather than an unconfigured stack.
+func modelPathCandidates(cfg ai.RoutingConfig, fake bool) []ai.RoutingConfig {
+	var candidates []ai.RoutingConfig
+	if !cfg.Unconfigured() {
+		candidates = append(candidates, cfg)
+	}
+	if fake {
+		// A real RoutingConfig over the fake provider rather than a direct fake
+		// client: the worker always has a pool, so --ai-fake rides the real
+		// Router (tiering, the budget guardrail, metering, call tracing) with
+		// only the provider swapped.
+		candidates = append(candidates, ai.FakeRoutingConfig())
+	}
+	return candidates
 }
 
 // modelPathWithBoundModels assembles the path and reports which models the SAME

--- a/backend/cmd/worker/modelwiring_test.go
+++ b/backend/cmd/worker/modelwiring_test.go
@@ -9,69 +9,86 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 )
 
+// storedBinding stands in for what an installation has bound: a cloud provider,
+// so it is TELLABLE from the fake. A fixture that used FakeRoutingConfig for
+// both candidates could not see a swapped order or a duplicated fake, which is
+// exactly the defect worth pinning here.
+func storedBinding() ai.RoutingConfig {
+	cloud := ai.ProviderConfig{Provider: "gemini", Model: "gemini-2.5-flash"}
+	return ai.RoutingConfig{
+		Profile: ai.ProfileEUHosted,
+		Tiers: map[ai.Tier]ai.ProviderConfig{
+			ai.TierLocalSmall: cloud,
+			ai.TierCheapCloud: cloud,
+			ai.TierPremium:    cloud,
+		},
+		Embeddings: ai.EmbeddingsConfig{ProviderConfig: cloud},
+	}
+}
+
+// providersOf names each candidate by the provider it would call, which is what
+// makes "the stored binding first, the fake behind it" an assertion rather than
+// a count.
+func providersOf(candidates []ai.RoutingConfig) []string {
+	out := make([]string, 0, len(candidates))
+	for _, cfg := range candidates {
+		out = append(out, cfg.Tiers[ai.TierPremium].Provider)
+	}
+	return out
+}
+
 // A dev stack seeds a cloud binding at bootstrap, and the engineer running it
 // may hold no key for that vendor. The worker used to take the stored binding
-// as its only candidate and exit at boot when it could not be built — while
-// the api, on the same machine and the same flag, fell back and served. The
-// stack then looked healthy and ran no queued job at all, which reads as a
-// broken feature rather than an unconfigured one.
+// as its only candidate and exit at boot when it could not be built — while the
+// api, on the same machine and the same flag, fell back and served. The stack
+// then looked healthy and ran no queued job at all, which reads as a broken
+// feature rather than an unconfigured one.
 func TestAnUnservableBindingFallsBackToTheFakeOnlyWhenItWasAskedFor(t *testing.T) {
-	bound := ai.FakeRoutingConfig()
-	if bound.Unconfigured() {
-		t.Fatal("FakeRoutingConfig is unconfigured, so it cannot stand in for a stored binding here")
-	}
-
 	for _, tc := range []struct {
-		name  string
-		cfg   ai.RoutingConfig
-		fake  bool
-		want  int
-		first string
+		name string
+		cfg  ai.RoutingConfig
+		fake bool
+		want []string
 	}{
 		{
-			name:  "a binding plus --ai-fake keeps the fake as a fallback behind it",
-			cfg:   bound,
-			fake:  true,
-			want:  2,
-			first: "the stored binding",
+			// The ORDER carries the rule: a bound installation tries its own
+			// binding first and reaches the fake only when that cannot be
+			// built, so it never quietly serves canned text while its own
+			// binding works.
+			name: "a binding plus --ai-fake keeps the fake as a fallback BEHIND it",
+			cfg:  storedBinding(),
+			fake: true,
+			want: []string{"gemini", ai.ProviderFake},
 		},
 		{
-			name:  "a binding without --ai-fake has no fallback, so a deployment fails closed",
-			cfg:   bound,
-			fake:  false,
-			want:  1,
-			first: "the stored binding",
+			name: "a binding without --ai-fake has no fallback, so a deployment fails closed",
+			cfg:  storedBinding(),
+			fake: false,
+			want: []string{"gemini"},
 		},
 		{
-			name:  "no binding but --ai-fake runs the fake outright",
-			cfg:   ai.RoutingConfig{},
-			fake:  true,
-			want:  1,
-			first: "the fake",
+			name: "no binding but --ai-fake runs the fake outright",
+			cfg:  ai.RoutingConfig{},
+			fake: true,
+			want: []string{ai.ProviderFake},
 		},
 		{
 			name: "neither leaves nothing to run, and nothing is picked silently",
 			cfg:  ai.RoutingConfig{},
 			fake: false,
-			want: 0,
+			want: nil,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := modelPathCandidates(tc.cfg, tc.fake)
-			if len(got) != tc.want {
-				t.Fatalf("modelPathCandidates gave %d candidate(s), want %d", len(got), tc.want)
+			got := providersOf(modelPathCandidates(tc.cfg, tc.fake))
+			if len(got) != len(tc.want) {
+				t.Fatalf("candidates = %v, want %v", got, tc.want)
 			}
-			if tc.want == 0 {
-				return
-			}
-			// The ORDER carries the rule: the stored binding is tried first and
-			// the fake is only ever the last resort, so a bound installation
-			// never quietly serves canned text while its own binding works.
-			if tc.first == "the stored binding" && got[0].Unconfigured() {
-				t.Error("the first candidate is not the stored binding, so a bound installation would serve the fake")
-			}
-			if tc.want == 2 && len(got) == 2 && got[1].Unconfigured() {
-				t.Error("the fallback candidate is unconfigured, so the fallback cannot serve anything")
+			for i, provider := range tc.want {
+				if got[i] != provider {
+					t.Errorf("candidate %d is %q, want %q (full order %v, want %v)",
+						i, got[i], provider, got, tc.want)
+				}
 			}
 		})
 	}

--- a/backend/cmd/worker/modelwiring_test.go
+++ b/backend/cmd/worker/modelwiring_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// A dev stack seeds a cloud binding at bootstrap, and the engineer running it
+// may hold no key for that vendor. The worker used to take the stored binding
+// as its only candidate and exit at boot when it could not be built — while
+// the api, on the same machine and the same flag, fell back and served. The
+// stack then looked healthy and ran no queued job at all, which reads as a
+// broken feature rather than an unconfigured one.
+func TestAnUnservableBindingFallsBackToTheFakeOnlyWhenItWasAskedFor(t *testing.T) {
+	bound := ai.FakeRoutingConfig()
+	if bound.Unconfigured() {
+		t.Fatal("FakeRoutingConfig is unconfigured, so it cannot stand in for a stored binding here")
+	}
+
+	for _, tc := range []struct {
+		name  string
+		cfg   ai.RoutingConfig
+		fake  bool
+		want  int
+		first string
+	}{
+		{
+			name:  "a binding plus --ai-fake keeps the fake as a fallback behind it",
+			cfg:   bound,
+			fake:  true,
+			want:  2,
+			first: "the stored binding",
+		},
+		{
+			name:  "a binding without --ai-fake has no fallback, so a deployment fails closed",
+			cfg:   bound,
+			fake:  false,
+			want:  1,
+			first: "the stored binding",
+		},
+		{
+			name:  "no binding but --ai-fake runs the fake outright",
+			cfg:   ai.RoutingConfig{},
+			fake:  true,
+			want:  1,
+			first: "the fake",
+		},
+		{
+			name: "neither leaves nothing to run, and nothing is picked silently",
+			cfg:  ai.RoutingConfig{},
+			fake: false,
+			want: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := modelPathCandidates(tc.cfg, tc.fake)
+			if len(got) != tc.want {
+				t.Fatalf("modelPathCandidates gave %d candidate(s), want %d", len(got), tc.want)
+			}
+			if tc.want == 0 {
+				return
+			}
+			// The ORDER carries the rule: the stored binding is tried first and
+			// the fake is only ever the last resort, so a bound installation
+			// never quietly serves canned text while its own binding works.
+			if tc.first == "the stored binding" && got[0].Unconfigured() {
+				t.Error("the first candidate is not the stored binding, so a bound installation would serve the fake")
+			}
+			if tc.want == 2 && len(got) == 2 && got[1].Unconfigured() {
+				t.Error("the fallback candidate is unconfigured, so the fallback cannot serve anything")
+			}
+		})
+	}
+}

--- a/backend/internal/compose/brain.go
+++ b/backend/internal/compose/brain.go
@@ -152,6 +152,21 @@ func (m ModelPath) WithAgentTokenSpend(spend ai.AgentTokenSpender) ModelPath {
 	return m
 }
 
+// UnservableBindingError marks the half of NewModelPath's failures that a
+// DIFFERENT binding could fix: the routing config names a provider this process
+// cannot call, usually because its credential is absent.
+//
+// It exists so a caller offering a fallback can tell the two halves apart. The
+// other half is a database fault from the embed marker, which no fallback
+// repairs — falling back on it launches a process whose marker is unestablished
+// and reports a storage outage as a missing key, sending the operator to look
+// at the wrong thing. Both boot loops (cmd/api, cmd/worker) fall back on this
+// type alone.
+type UnservableBindingError struct{ Cause error }
+
+func (e *UnservableBindingError) Error() string { return e.Cause.Error() }
+func (e *UnservableBindingError) Unwrap() error { return e.Cause }
+
 // NewModelPath builds the production model path from a validated
 // routing config. capturePayloads and log ride straight into the
 // router's ai_call tracing (ai.NewRouter) — the deployment's
@@ -159,7 +174,7 @@ func (m ModelPath) WithAgentTokenSpend(spend ai.AgentTokenSpender) ModelPath {
 func NewModelPath(ctx context.Context, cfg ai.RoutingConfig, pool *pgxpool.Pool, capturePayloads bool, log *slog.Logger) (ModelPath, error) {
 	router, err := ai.NewRouter(cfg, ai.NewMeter(InstallationDB(pool)), NewSeatBudget(pool), ai.NewCallMeter(InstallationDB(pool)).WithLogger(log), capturePayloads, log)
 	if err != nil {
-		return ModelPath{}, err
+		return ModelPath{}, &UnservableBindingError{Cause: err}
 	}
 	if err := seedEmbedBinding(ctx, search.NewStore(InstallationDB(pool)), router, log); err != nil {
 		return ModelPath{}, err

--- a/backend/internal/compose/brain_test.go
+++ b/backend/internal/compose/brain_test.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -69,5 +70,39 @@ func TestModelPathInvalidateCacheForcesAFreshCompletion(t *testing.T) {
 	}
 	if calls := len(fake.Calls()); calls != 2 {
 		t.Fatalf("calls after invalidation = %d, want 2 (the cache must have been dropped)", calls)
+	}
+}
+
+// Both boot loops offer a fallback candidate, and both must offer it for ONE
+// reason only: the binding names a provider this process cannot call. A
+// database fault from the embed marker is not that, and falling back on it
+// would launch a process whose marker is unestablished while telling the
+// operator a credential is missing — sending them to look at the wrong thing
+// while a storage outage stands.
+//
+// A binding whose provider needs a key it does not have is the reachable case
+// here; a nil pool never gets as far as the store, so what this pins is the
+// classification the loops read, not the store failure itself.
+func TestAnUnservableBindingIsTheOnlyFailureAFallbackMayAnswer(t *testing.T) {
+	unkeyed := ai.RoutingConfig{
+		Profile: ai.ProfileEUHosted,
+		Tiers: map[ai.Tier]ai.ProviderConfig{
+			ai.TierPremium: {Provider: "gemini", Model: "gemini-2.5-flash"},
+		},
+	}
+
+	_, err := NewModelPath(context.Background(), unkeyed, nil, false,
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("a binding with no credential built a model path, so the fail-closed rule is gone")
+	}
+	var unservable *UnservableBindingError
+	if !errors.As(err, &unservable) {
+		t.Fatalf("a provider that cannot be called is not marked unservable (%v), so a boot loop "+
+			"cannot tell it from a database fault and will either refuse to fall back or fall "+
+			"back on both", err)
+	}
+	if !errors.Is(err, unservable.Cause) {
+		t.Error("the wrapper hides its cause, so the operator loses the sentence naming what is wrong")
 	}
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -534,8 +534,16 @@ wait_ready() { # url timeout_s — only a 2xx counts as ready (a 401/500/503 is 
 # It is asked because the worker's failure mode is exiting DURING boot — a
 # config it refuses, a provider key it needs, a bus it cannot reach — and the
 # grace period is what separates that from a process that is simply slow to
-# settle. A worker that dies later in the session is a different problem and
-# not one a start-up script can watch for.
+# settle.
+#
+# One sample proves only that the process existed at that instant, so the caller
+# asks TWICE: once with a grace period right after launch, and once with
+# grace_s 0 after the FE readiness probe has spent real time, immediately before
+# the banner claims the worker is running. grace_s 0 skips the loop and takes
+# the single sample below.
+#
+# A worker that dies after that last sample is a different problem, and not one
+# a start-up script can watch for.
 still_running() {
   local pid="$1" grace="$2"
   for _ in $(seq 1 "$grace"); do
@@ -1029,6 +1037,21 @@ up)
   printf 'SLUG=%s\nAPI_PORT=%s\nFE_PORT=%s\nDB=%s\nREDIS_DB=%s\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\nLOG=%s\n' \
     "$slug" "$api_port" "$fe_port" "$db" "$redis_db" "$be_pid" "$fe_pid" "$worker_pid" "$log" >"$state"
   if wait_ready "http://localhost:${fe_port}/" 90; then
+    # Asked AGAIN, because the first check only proved the worker was alive
+    # three seconds in. The FE probe above has since spent real time, and a
+    # worker whose boot fails later — a slow connection, a migration it waits
+    # on — would otherwise be announced as running. This is the last moment
+    # before the banner claims it, so it is the last chance to be honest about
+    # it. A worker that dies after this point is a different problem and not
+    # one a start-up script can watch for.
+    if ! still_running "$worker_pid" 0; then
+      echo "FAIL: $label worker exited during boot — no queued job will ever run" >&2
+      echo "  Its own reason is in the log, under the 'worker' role:" >&2
+      echo "    make dev-logs${slug:+ DEV_SLUG=$slug} ROLE=worker" >&2
+      echo "    ${log}" >&2
+      kill "$be_pid" "$fe_pid" 2>/dev/null || true
+      exit 1
+    fi
     # CONFIRMED up, and only here. This used to be set at the state write above,
     # which is before this probe — so an FE that never came ready left a claim
     # behind holding a port and a Redis database, while the script killed the

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -527,6 +527,24 @@ wait_ready() { # url timeout_s — only a 2xx counts as ready (a 401/500/503 is 
   return 1
 }
 
+# still_running pid grace_s — the readiness check for a process that serves no
+# port. The api and the FE are probed over HTTP; the worker answers nothing, so
+# the only thing that can be asked about it is whether it is still there.
+#
+# It is asked because the worker's failure mode is exiting DURING boot — a
+# config it refuses, a provider key it needs, a bus it cannot reach — and the
+# grace period is what separates that from a process that is simply slow to
+# settle. A worker that dies later in the session is a different problem and
+# not one a start-up script can watch for.
+still_running() {
+  local pid="$1" grace="$2"
+  for _ in $(seq 1 "$grace"); do
+    kill -0 "$pid" 2>/dev/null || return 1
+    sleep 1
+  done
+  kill -0 "$pid" 2>/dev/null
+}
+
 # A stack that outlives the shell that started it is the worst failure mode this
 # script has: an api from an earlier branch keeps answering while Vite serves the
 # code you just wrote, and the app breaks in ways that look exactly like your bug.
@@ -984,6 +1002,21 @@ up)
     --retention-interval 720h \
     "${ai_flag[@]+"${ai_flag[@]}"}" "${worker_gmail_flags[@]+"${worker_gmail_flags[@]}"}" > >(log_as worker) 2>&1 &
   worker_pid=$!
+  # A dead worker is indistinguishable from a broken feature, which is what
+  # makes it expensive: every queue-backed lane still ACCEPTS work, durably and
+  # with no error, and simply never runs it. A record arrives, the row says
+  # waiting, the timeline stays empty, and the obvious readings — a bad
+  # signature, a broken drain, a bug in the pipeline — are all wrong and each
+  # costs an afternoon to rule out. The stack has to say so itself, because the
+  # only visible evidence is a process that is not in the list.
+  if ! still_running "$worker_pid" 3; then
+    echo "FAIL: $label worker exited during boot — no queued job will ever run" >&2
+    echo "  Its own reason is in the log, under the 'worker' role:" >&2
+    echo "    make dev-logs${slug:+ DEV_SLUG=$slug} ROLE=worker" >&2
+    echo "    ${log}" >&2
+    kill "$be_pid" "$fe_pid" 2>/dev/null || true
+    exit 1
+  fi
   if [[ "$gmail_enabled" == "1" ]]; then
     echo "  worker   background relay + Surface-B runner + time-scan + Gmail sync (poll every 30s)"
   else


### PR DESCRIPTION
Closes #3083.

## What was wrong

`make dev` came up with no worker, and said nothing about it.

A dev stack seeds a cloud model binding at bootstrap. The engineer running it may hold no key for that vendor — which is the ordinary case, not an edge one. `cmd/api` already handled that: it tries the stored binding, falls back to the offline fake when `--ai-fake` was passed, and warns loudly. `cmd/worker` took the stored binding as its only candidate and returned the error, so it exited at boot with:

```
worker: ai: tier local_small: ai: provider gemini needs an api key
```

## Why it costs more than a missing process

Every queue-backed lane still **accepted** work — durably, with no error — and ran none of it. A record arrives, the row says waiting, the timeline stays empty. Nothing errored, so nothing appears anywhere: the drain that would land it is a job nobody is running.

The obvious readings are all wrong ones. A bad signature, a broken drain, a bug in the capture pipeline — each is expensive to rule out, and the actual cause is visible only by noticing a process is absent from `ps`.

## The two halves

**The worker resolves the same candidates as the api.** Stored binding first, offline fake second and only behind `--ai-fake`. A deployment passes no such flag, so it still fails closed on a binding it cannot serve — that rule is unchanged and now has a test. The reason the two roles must agree is written where the candidate list is built, because a worker that exits where the api falls back leaves the queue unrun behind an api that looks healthy.

**`make dev` no longer claims a worker it did not get.** The api and the FE are probed over HTTP; the worker serves no port, so what can be asked is whether the process is still there. The failure mode is exiting *during* boot — a config it refuses, a key it needs, a bus it cannot reach — so a short grace period separates that from a slow start. A worker that dies is now a failed `make dev` naming the log to read.

A worker that dies later in a session is a different problem and not one a start-up script can watch for. Said in the code rather than implied.

## Verified on a running stack

Before the fix, in a `DEV_SLUG` stack: `make dev` reported the worker exited, and the log gave the missing-key reason. After: the worker stays up and the same stack drained **251 jobs** on the default queue where it previously ran none, logging the unservable binding as an error each time it retries rather than dying on it.

`still_running` was exercised both directions: a live process reports running, an exited one reports exited.

## Mutation-checked

Restoring the old behaviour — the fake offered only when no binding exists — fails `TestAnUnservableBindingFallsBackToTheFakeOnlyWhenItWasAskedFor` on exactly the case that was broken (a binding plus `--ai-fake` gives one candidate, want two).

## Note on the issue's diagnosis

The issue reported that the worker was started without `--ai-fake` and without the keyvault root key. That is no longer true — both reach it today, the flag on the command line and the key through the environment. The flag alone was not enough, because the worker never reached the arm that uses it. The half the issue called the expensive part ("`make dev` returning success while one of the processes it started has exited") is the half that was still real, and is fixed here.

## Verified

`make check-backend` green (2m54s). `make craft-static`, `make rls-store-path`, `make no-jurisdiction` clean. No frontend files touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`make dev` no longer comes up with a dead worker: the worker now tries the stored model binding and falls back to the offline fake when `--ai-fake` was passed, matching `cmd/api`, so a stack with a cloud binding it can't serve keeps the worker up instead of exiting at boot. `make dev` also now fails when the worker dies during the grace period, naming the log, instead of reporting a healthy stack that silently runs no queued jobs.

- The fallback answers only `UnservableBindingError`s (a router error naming a provider this process can't call); a database fault from the embed marker is not a fallback reason and stays fatal.
- The worker's fallback test now uses a cloud provider as the stored binding so it catches a swapped candidate order, not just a wrong count.
- `make dev` checks the worker twice, once right after launch and again after the frontend readiness probe, immediately before the banner claims it running.
- Deployments still fail closed — without `--ai-fake` the worker exits on an unservable binding; the rule is covered by a new test.
- The worker logs a warning each time it retries the unservable binding while serving canned text.
- Closes #3083.

<sup>Written for commit 84c4795deca8961150d50b9e7846779ad9056d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved model selection prioritizes configured routing.
  - Offline fake-model fallback is available when explicitly enabled and configured provider routing is unavailable.
  - Clear warnings identify unavailable model routing.

- **Bug Fixes**
  - Configuration and database errors are now reported instead of being hidden by fake-model fallback.
  - Development startup detects workers that exit unexpectedly, reports relevant logs, and stops related services when startup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->