### PR TITLE
fix(projects): the page withholds the write controls the save would refuse

### DIFF
--- a/frontend/e2e/projectmock.ts
+++ b/frontend/e2e/projectmock.ts
@@ -28,6 +28,11 @@ export type MockProject = {
   key: string | null;
   organization_id: string;
   owner_id: string | null;
+  // What the server's write gate would answer for the signed-in caller. The
+  // real API sends it on every project; a mock that leaves it out models a
+  // reader who may not write, and the page then correctly withholds every
+  // write control the specs drive.
+  writable: boolean;
   phase: "initiative" | "pursuing" | "delivering" | "closed";
   closed_reason: string | null;
   description: string | null;

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -202,6 +202,10 @@ export const seededProject: MockProject = {
   key: "BRANDT-FLEET",
   organization_id: "o-brandt",
   owner_id: "u1",
+  // The signed-in seat owns this project, so the server sends writable: true
+  // and the page draws its write controls. Left out, it would read as NOT
+  // writable and the specs would drive controls the page correctly withholds.
+  writable: true,
   phase: "initiative",
   closed_reason: null,
   description: null,

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6872,6 +6872,8 @@ export const de = {
     "Durch das Archivieren verschwindet dieses Projekt aus der aktiven Liste und sein Kürzel wird frei. Dies kann in der Oberfläche nicht rückgängig gemacht werden.",
   "project.archivedReadOnly":
     "Dieses Projekt ist archiviert und nimmt keine Änderungen an.",
+  "project.notYoursToChange":
+    "Dieses Projekt gehört jemand anderem. Bitten Sie den Inhaber um Freigabe, wenn Sie etwas ändern möchten.",
   "project.phaseLabel": "Phase",
   "project.filterPhaseAll": "Alle Phasen",
   "project.viewDelivering": "In Umsetzung",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6873,7 +6873,7 @@ export const de = {
   "project.archivedReadOnly":
     "Dieses Projekt ist archiviert und nimmt keine Änderungen an.",
   "project.notYoursToChange":
-    "Dieses Projekt gehört jemand anderem. Bitten Sie den Inhaber um Freigabe, wenn Sie etwas ändern möchten.",
+    "Sie können dieses Projekt nicht ändern. Bitten Sie den Inhaber um Freigabe oder Ihre Administration um das Recht zum Bearbeiten.",
   "project.phaseLabel": "Phase",
   "project.filterPhaseAll": "Alle Phasen",
   "project.viewDelivering": "In Umsetzung",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6960,6 +6960,8 @@ export const en = {
   "project.archiveConfirm":
     "Archiving removes this project from the live list and frees its key. This cannot be undone from the UI.",
   "project.archivedReadOnly": "This project is archived and takes no changes.",
+  "project.notYoursToChange":
+    "This project belongs to someone else. Ask its owner to share it with you if you need to make changes.",
   "project.phaseLabel": "Phase",
   "project.filterPhaseAll": "All phases",
   "project.viewDelivering": "In delivery",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6961,7 +6961,7 @@ export const en = {
     "Archiving removes this project from the live list and frees its key. This cannot be undone from the UI.",
   "project.archivedReadOnly": "This project is archived and takes no changes.",
   "project.notYoursToChange":
-    "This project belongs to someone else. Ask its owner to share it with you if you need to make changes.",
+    "You cannot change this project. Ask its owner to share it with you, or your administrator for the right to edit it.",
   "project.phaseLabel": "Phase",
   "project.filterPhaseAll": "All phases",
   "project.viewDelivering": "In delivery",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6817,7 +6817,7 @@ export const vi = {
     "Lưu trữ sẽ đưa dự án này ra khỏi danh sách đang hoạt động và giải phóng mã của nó. Không thể hoàn tác từ giao diện.",
   "project.archivedReadOnly": "Dự án này đã lưu trữ và không nhận thay đổi.",
   "project.notYoursToChange":
-    "Dự án này thuộc về người khác. Hãy đề nghị chủ sở hữu chia sẻ nếu bạn cần thay đổi.",
+    "Bạn không thể thay đổi dự án này. Hãy đề nghị chủ sở hữu chia sẻ, hoặc quản trị viên cấp quyền chỉnh sửa.",
   "project.phaseLabel": "Giai đoạn",
   "project.filterPhaseAll": "Mọi giai đoạn",
   "project.viewDelivering": "Đang triển khai",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6816,6 +6816,8 @@ export const vi = {
   "project.archiveConfirm":
     "Lưu trữ sẽ đưa dự án này ra khỏi danh sách đang hoạt động và giải phóng mã của nó. Không thể hoàn tác từ giao diện.",
   "project.archivedReadOnly": "Dự án này đã lưu trữ và không nhận thay đổi.",
+  "project.notYoursToChange":
+    "Dự án này thuộc về người khác. Hãy đề nghị chủ sở hữu chia sẻ nếu bạn cần thay đổi.",
   "project.phaseLabel": "Giai đoạn",
   "project.filterPhaseAll": "Mọi giai đoạn",
   "project.viewDelivering": "Đang triển khai",

--- a/frontend/src/screens/project360.test.tsx
+++ b/frontend/src/screens/project360.test.tsx
@@ -265,9 +265,39 @@ describe("ProjectScreen", () => {
     await screen.findByRole("heading", { name: "CRM rollout" });
 
     // The page says why once, rather than each control failing on its own.
-    expect(
-      screen.getByText(/This project belongs to someone else/),
-    ).toBeTruthy();
+    expect(screen.getByText(/You cannot change this project/)).toBeTruthy();
+
+    // Every verb, not a sample of them: asserting one control would leave the
+    // others free to regress one at a time. New Deal is here because binding a
+    // deal to a project needs write authority OVER the project.
+    for (const label of ["New deal"]) {
+      expect(screen.queryByRole("button", { name: label })).toBeNull();
+    }
+    // Edit is refused in place, and the id it describes itself by must resolve
+    // to the sentence in the band from the FIRST render — a reason minted
+    // inside a menu would name no element until the menu was opened.
+    const edit = screen.getByRole("button", { name: "Edit project" });
+    expect(edit.hasAttribute("disabled")).toBe(true);
+    const reasonId = edit.getAttribute("aria-describedby") ?? "";
+    expect(document.getElementById(reasonId)?.textContent).toMatch(
+      /You cannot change this project/,
+    );
+    // Inside the overflow menu the verbs are refused rather than dropped, so a
+    // reader learns the verb exists and why it is shut. What must NOT happen is
+    // a pressable one: clicking it opens the flow and the save 403s.
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    // Barred is the NATIVE disabled attribute — the design system reserves
+    // aria-disabled for "busy" — and each carries aria-describedby pointing at
+    // the one sentence in the band, so a reader is told why rather than left
+    // with a dead control.
+    for (const label of [/^Archive/, /^Assign/, /^Share/]) {
+      for (const verb of screen.queryAllByRole("button", { name: label })) {
+        expect(
+          `${verb.textContent} disabled=${verb.hasAttribute("disabled")}`,
+        ).toBe(`${verb.textContent} disabled=true`);
+        expect(verb.getAttribute("aria-describedby")).toBeTruthy();
+      }
+    }
 
     // The stepper is the one write control on the page that takes a single
     // click, so it is the one that would have posted before any dialog.
@@ -276,31 +306,22 @@ describe("ProjectScreen", () => {
     expect(posted).toBe(false);
   });
 
-  // An unowned project is nobody's yet, not somebody else's, and the door that
-  // lets a reader take it on has to stay open. Withholding here would be the
-  // fix overshooting into a lock-out.
-  it("keeps the write controls on a project nobody owns", async () => {
-    const user = userEvent.setup();
-    let posted: unknown = null;
+  // A company keeps its controls on an ownerless record because the claim door
+  // is what makes it writable. A project has no such door — ClaimRecord refuses
+  // the type — and the server treats an ownerless row as nobody's to change. So
+  // `writable` is the whole answer here, and an ownerless project the server
+  // says is unwritable is drawn read-only like any other.
+  it("refuses an unowned project the server says this caller cannot write", async () => {
     projectsBackend({
       view: project360({
-        project: project({ owner_id: null, writable: true }),
+        project: project({ owner_id: null, writable: false }),
       }),
-      respond: async (url, method, request) => {
-        if (method === "POST" && url.endsWith("/advance")) {
-          posted = JSON.parse(await request.text());
-          return jsonResponse(project({ phase: "pursuing" }));
-        }
-        return null;
-      },
     });
     render(<ProjectScreen id="pr-1" />);
     await screen.findByRole("heading", { name: "CRM rollout" });
 
-    await user.click(screen.getByTestId("project-step-pursuing"));
-    const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: "Move" }));
-    await waitFor(() => expect(posted).toBeTruthy());
+    expect(screen.getByText(/You cannot change this project/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
   });
 
   // Absent is not "unknown", it is "no": a response from a server too old to
@@ -315,8 +336,6 @@ describe("ProjectScreen", () => {
     render(<ProjectScreen id="pr-1" />);
     await screen.findByRole("heading", { name: "CRM rollout" });
 
-    expect(
-      screen.getByText(/This project belongs to someone else/),
-    ).toBeTruthy();
+    expect(screen.getByText(/You cannot change this project/)).toBeTruthy();
   });
 });

--- a/frontend/src/screens/project360.test.tsx
+++ b/frontend/src/screens/project360.test.tsx
@@ -241,4 +241,82 @@ describe("ProjectScreen", () => {
     await waitFor(() => expect(posted).toBeTruthy());
     expect(posted).toEqual({ to_phase: "pursuing", reason: null });
   });
+
+  // `writable` is what the server's write gate would answer on a mutation. A
+  // reader who may open a project but not change it was offered Edit, Archive,
+  // Assign and the phase stepper, and learned otherwise from a 403 after
+  // filling the form in.
+  it("withholds the write controls on a project this caller may not change", async () => {
+    const user = userEvent.setup();
+    let posted = false;
+    projectsBackend({
+      view: project360({
+        project: project({ owner_id: "u-someone-else", writable: false }),
+      }),
+      respond: async (url, method) => {
+        if (method === "POST" && url.endsWith("/advance")) {
+          posted = true;
+          return jsonResponse(project({ phase: "pursuing" }));
+        }
+        return null;
+      },
+    });
+    render(<ProjectScreen id="pr-1" />);
+    await screen.findByRole("heading", { name: "CRM rollout" });
+
+    // The page says why once, rather than each control failing on its own.
+    expect(
+      screen.getByText(/This project belongs to someone else/),
+    ).toBeTruthy();
+
+    // The stepper is the one write control on the page that takes a single
+    // click, so it is the one that would have posted before any dialog.
+    await user.click(screen.getByTestId("project-step-pursuing"));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(posted).toBe(false);
+  });
+
+  // An unowned project is nobody's yet, not somebody else's, and the door that
+  // lets a reader take it on has to stay open. Withholding here would be the
+  // fix overshooting into a lock-out.
+  it("keeps the write controls on a project nobody owns", async () => {
+    const user = userEvent.setup();
+    let posted: unknown = null;
+    projectsBackend({
+      view: project360({
+        project: project({ owner_id: null, writable: true }),
+      }),
+      respond: async (url, method, request) => {
+        if (method === "POST" && url.endsWith("/advance")) {
+          posted = JSON.parse(await request.text());
+          return jsonResponse(project({ phase: "pursuing" }));
+        }
+        return null;
+      },
+    });
+    render(<ProjectScreen id="pr-1" />);
+    await screen.findByRole("heading", { name: "CRM rollout" });
+
+    await user.click(screen.getByTestId("project-step-pursuing"));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Move" }));
+    await waitFor(() => expect(posted).toBeTruthy());
+  });
+
+  // Absent is not "unknown", it is "no": a response from a server too old to
+  // send the field must fail closed, or the fix is only as good as the oldest
+  // server a client talks to.
+  it("treats a project with no writable field as one it may not change", async () => {
+    const withoutWritable = project({ owner_id: "u-someone-else" });
+    delete (withoutWritable as { writable?: boolean }).writable;
+    projectsBackend({
+      view: project360({ project: withoutWritable }),
+    });
+    render(<ProjectScreen id="pr-1" />);
+    await screen.findByRole("heading", { name: "CRM rollout" });
+
+    expect(
+      screen.getByText(/This project belongs to someone else/),
+    ).toBeTruthy();
+  });
 });

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -95,20 +95,19 @@ export function ProjectScreen({ id }: Readonly<{ id: string }>) {
 function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
   const recordZone = useRecordZone();
   const project = view.project;
-  const archivedReasonId = useId();
+  const readOnlyReasonId = useId();
   const [moveTo, setMoveTo] = useState<ProjectPhase | null>(null);
   const overlay = useSorMode() === "overlay";
   const chronology = useProjectChronology(view, overlay);
-  const refusedByArchive = project.archived_at ? archivedReasonId : undefined;
-  // Every write affordance on this page answers ONE question, so it is asked
-  // once: an archived project takes no changes, and one that belongs to
-  // somebody else takes none from this caller. The stepper and the rail cards
-  // used to ask only the first half, which offered a reader a phase move and a
-  // stakeholder edit the save would refuse.
+  // Every write affordance on this page answers ONE question, asked once: an
+  // archived project takes no changes, and one this caller cannot write takes
+  // none from them. The verbs, the stepper and the rail cards used to ask only
+  // the first half, which offered a reader a phase move and a stakeholder edit
+  // the save would refuse.
   //
-  // Same rule as the verbs, so the page cannot disagree with itself about
-  // whether it is writable — including on an UNOWNED project, where both stay
-  // open because nobody owns it yet.
+  // One answer and one rendered sentence, so the page cannot disagree with
+  // itself about whether the record is writable, and every disabled control
+  // describes itself by pointing at the same explanation.
   const readOnlyReason = useProjectVerbRefusal(project);
   const readOnly = Boolean(readOnlyReason);
   return (
@@ -126,7 +125,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
         <>
           <ProjectActions
             project={project}
-            archivedReasonId={refusedByArchive}
+            refusedReasonId={readOnly ? readOnlyReasonId : undefined}
           />
           <PageAsideToggle />
         </>
@@ -142,13 +141,13 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
           {/* One sentence for why this record takes no changes, whichever
               reason applies, so the stepper below can point at it. */}
           {readOnlyReason && (
-            <p id={archivedReasonId} className="t-caption">
+            <p id={readOnlyReasonId} className="t-caption">
               {readOnlyReason}
             </p>
           )}
           <PhaseStepper
             phase={project.phase}
-            refusedReasonId={readOnly ? archivedReasonId : undefined}
+            refusedReasonId={readOnly ? readOnlyReasonId : undefined}
             pending={false}
             onMove={setMoveTo}
           />
@@ -188,8 +187,14 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
         <ProjectDealsCard
           view={view}
           actions={
+            // New Deal from HERE binds the deal to this project, and binding is
+            // held to project WRITE authority rather than deal permission
+            // alone: winning the deal later advances the project's phase
+            // without re-checking, so `EnsureAttachable` proves the authority
+            // at the moment of attaching. A caller who may read this project
+            // but not write it can still work deals — just not born into it.
             !overlay &&
-            !project.archived_at &&
+            !readOnly &&
             project.organization_id && (
               <NewDealAction
                 orgId={project.organization_id}
@@ -265,7 +270,8 @@ function ProjectSubtitle({ view }: Readonly<{ view: Project360 }>) {
  * with nothing green beside it the eye went there first.
  */
 // useProjectVerbRefusal answers why this project's own verbs — edit, archive,
-// assign, share — are refused, or undefined when they are not.
+// assign, share, the phase stepper, the rail cards — are refused, or undefined
+// when they are not.
 //
 // `writable` is what the server's write gate would answer on a mutation, and
 // the contract asks a client to draw or withhold affordances by it so a reader
@@ -273,36 +279,39 @@ function ProjectSubtitle({ view }: Readonly<{ view: Project360 }>) {
 // a response from a server too old to send the field fails closed.
 //
 // Archived comes first because it is the reason a reader can act on, by
-// restoring the record. An UNOWNED project is not "somebody else's" — nobody
-// owns it yet — so its verbs stay pressable, the same call companies make.
+// restoring the record.
+//
+// Unlike a company, an UNOWNED project is refused rather than left open. The
+// company page keeps its controls on an ownerless record because the claim door
+// is what makes it writable, and shutting the controls would shut the way out.
+// A project has no such door — `ClaimRecord` refuses the type outright — and
+// `writeAuthorityPredicate` treats an ownerless row as nobody's to change. So
+// here `writable` is the whole answer, and second-guessing it would offer
+// controls the save refuses with nothing a reader could do about it.
 function useProjectVerbRefusal(project: Project): string | undefined {
   const t = useT();
   if (project.archived_at) {
     return t("project.archivedReadOnly");
   }
-  if (project.owner_id && !(project.writable ?? false)) {
+  if (!(project.writable ?? false)) {
     return t("project.notYoursToChange");
   }
   return undefined;
 }
 
+// refusedReasonId is the id of the sentence the BAND renders, passed in rather
+// than minted here. The verbs describe themselves by pointing at that one
+// sentence: a second copy inside the OverflowMenu would not exist until the
+// menu was first opened, so the header's Edit control would spend its first
+// render describing itself by an id naming no element at all.
 function ProjectActions({
   project,
-  archivedReasonId,
-}: Readonly<{ project: Project; archivedReasonId?: string }>) {
+  refusedReasonId,
+}: Readonly<{ project: Project; refusedReasonId?: string }>) {
   const t = useT();
   const me = useMe();
   const companies = useCompanyOptions();
   const overlay = useSorMode() === "overlay";
-  // The archived note is already rendered in the band, so an archived project
-  // points its verbs at that sentence rather than printing a second copy. A
-  // project that is simply somebody else's has no such note, so the menu
-  // carries its own.
-  const ownReasonId = useId();
-  const refusedReason = useProjectVerbRefusal(project);
-  const refusedReasonId = refusedReason
-    ? (archivedReasonId ?? ownReasonId)
-    : undefined;
   return (
     <>
       <EditAction<Project>
@@ -333,14 +342,6 @@ function ProjectActions({
         recordKey="project"
       />
       <OverflowMenu label={t("record.moreActions")}>
-        {/* The verbs are refused rather than dropped, so the sentence refusing
-            them travels with them. Only when the band is not already saying it
-            for an archived record. */}
-        {refusedReason && !archivedReasonId && (
-          <p id={ownReasonId} className="t-caption">
-            {refusedReason}
-          </p>
-        )}
         <ArchiveAction
           disabledReasonId={refusedReasonId}
           label={t("project.archive")}

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -93,7 +93,6 @@ export function ProjectScreen({ id }: Readonly<{ id: string }>) {
 }
 
 function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
-  const t = useT();
   const recordZone = useRecordZone();
   const project = view.project;
   const archivedReasonId = useId();
@@ -101,6 +100,17 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
   const overlay = useSorMode() === "overlay";
   const chronology = useProjectChronology(view, overlay);
   const refusedByArchive = project.archived_at ? archivedReasonId : undefined;
+  // Every write affordance on this page answers ONE question, so it is asked
+  // once: an archived project takes no changes, and one that belongs to
+  // somebody else takes none from this caller. The stepper and the rail cards
+  // used to ask only the first half, which offered a reader a phase move and a
+  // stakeholder edit the save would refuse.
+  //
+  // Same rule as the verbs, so the page cannot disagree with itself about
+  // whether it is writable — including on an UNOWNED project, where both stay
+  // open because nobody owns it yet.
+  const readOnlyReason = useProjectVerbRefusal(project);
+  const readOnly = Boolean(readOnlyReason);
   return (
     <RecordView
       name={project.name}
@@ -116,7 +126,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
         <>
           <ProjectActions
             project={project}
-            refusedReasonId={refusedByArchive}
+            archivedReasonId={refusedByArchive}
           />
           <PageAsideToggle />
         </>
@@ -129,14 +139,16 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
       actionsInline
       band={
         <div className="project-band">
-          {project.archived_at && (
+          {/* One sentence for why this record takes no changes, whichever
+              reason applies, so the stepper below can point at it. */}
+          {readOnlyReason && (
             <p id={archivedReasonId} className="t-caption">
-              {t("project.archivedReadOnly")}
+              {readOnlyReason}
             </p>
           )}
           <PhaseStepper
             phase={project.phase}
-            refusedReasonId={refusedByArchive}
+            refusedReasonId={readOnly ? archivedReasonId : undefined}
             pending={false}
             onMove={setMoveTo}
           />
@@ -160,12 +172,12 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
           <ProjectCompanies
             projectId={project.id}
             companies={project.organizations}
-            readOnly={Boolean(project.archived_at)}
+            readOnly={readOnly}
           />
           <StakeholdersCard
             view={view}
             projectId={project.id}
-            readOnly={Boolean(project.archived_at)}
+            readOnly={readOnly}
           />
           <ProjectContractsCard view={view} />
           <ProjectDocumentsCard view={view} />
@@ -252,14 +264,45 @@ function ProjectSubtitle({ view }: Readonly<{ view: Project360 }>) {
  * verb as the loudest control on the page: it draws in the danger colour, and
  * with nothing green beside it the eye went there first.
  */
+// useProjectVerbRefusal answers why this project's own verbs — edit, archive,
+// assign, share — are refused, or undefined when they are not.
+//
+// `writable` is what the server's write gate would answer on a mutation, and
+// the contract asks a client to draw or withhold affordances by it so a reader
+// is never offered a control the save refuses. Absent reads as NOT writable:
+// a response from a server too old to send the field fails closed.
+//
+// Archived comes first because it is the reason a reader can act on, by
+// restoring the record. An UNOWNED project is not "somebody else's" — nobody
+// owns it yet — so its verbs stay pressable, the same call companies make.
+function useProjectVerbRefusal(project: Project): string | undefined {
+  const t = useT();
+  if (project.archived_at) {
+    return t("project.archivedReadOnly");
+  }
+  if (project.owner_id && !(project.writable ?? false)) {
+    return t("project.notYoursToChange");
+  }
+  return undefined;
+}
+
 function ProjectActions({
   project,
-  refusedReasonId,
-}: Readonly<{ project: Project; refusedReasonId?: string }>) {
+  archivedReasonId,
+}: Readonly<{ project: Project; archivedReasonId?: string }>) {
   const t = useT();
   const me = useMe();
   const companies = useCompanyOptions();
   const overlay = useSorMode() === "overlay";
+  // The archived note is already rendered in the band, so an archived project
+  // points its verbs at that sentence rather than printing a second copy. A
+  // project that is simply somebody else's has no such note, so the menu
+  // carries its own.
+  const ownReasonId = useId();
+  const refusedReason = useProjectVerbRefusal(project);
+  const refusedReasonId = refusedReason
+    ? (archivedReasonId ?? ownReasonId)
+    : undefined;
   return (
     <>
       <EditAction<Project>
@@ -290,6 +333,14 @@ function ProjectActions({
         recordKey="project"
       />
       <OverflowMenu label={t("record.moreActions")}>
+        {/* The verbs are refused rather than dropped, so the sentence refusing
+            them travels with them. Only when the band is not already saying it
+            for an archived record. */}
+        {refusedReason && !archivedReasonId && (
+          <p id={ownReasonId} className="t-caption">
+            {refusedReason}
+          </p>
+        )}
         <ArchiveAction
           disabledReasonId={refusedReasonId}
           label={t("project.archive")}

--- a/frontend/src/screens/projects.fixtures.ts
+++ b/frontend/src/screens/projects.fixtures.ts
@@ -19,6 +19,12 @@ export function project(overrides: Partial<Project> = {}): Project {
     key: "ACME-CRM",
     organization_id: ORG.id,
     owner_id: "u-me",
+    // The caller owns this project, so the server sends writable: true. Stated
+    // rather than left out: absent means NOT writable per the contract, so a
+    // fixture that omits it models a reader who may not write — which is a
+    // different record from the one `owner_id: "u-me"` describes, and the
+    // screen would rightly withhold every write control on it.
+    writable: true,
     phase: "initiative",
     description: null,
     started_at: null,


### PR DESCRIPTION
Closes #3092.

## What was wrong

`Project.writable` is a server-computed, per-caller field, and the contract says outright what a client owes it:

> A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse.

`project360.tsx` never read it. Edit, Archive, Assign-to-colleague, Share, the phase stepper, the companies card and the stakeholders card were offered to anyone who could open the page. A reader who may see a project but not change it could open the owner picker, choose a colleague, press Confirm — and learn from a 403 that none of it was ever going to work.

The only gating was `refusedReasonId`, which answers whether the project is ARCHIVED. That is a different question, and it was standing in for this one.

## The shape of the fix

Every write affordance on the page now asks one question in one place, so the page cannot disagree with itself about whether the record is writable. `useProjectVerbRefusal` mirrors `useCompanyVerbRefusal` in `companyheader.tsx` — the same rule, the same order, and the two subtleties that rule already encodes:

- **Archived is reported first**, because it is the reason a reader can act on, by restoring the record.
- **An unowned project keeps its controls.** Nobody owns it yet, so it is not "somebody else's", and the door that lets a reader take it on stays open. Withholding here would be the fix overshooting into a lock-out.

`writable ?? false` is the fail-closed default the contract asks for: a response from a server too old to send the field reads as not writable.

## The fixtures were describing a record the server never sends

Both the unit fixture and the e2e seed set `owner_id` and omitted `writable`. Per the contract that combination means *a project someone owns and this caller may not write* — so with the fix in place they correctly locked the page, and two existing tests failed. That is the fixture being wrong, not the fix: the real API sends the field on every project. Both now send what the server sends, with the reason written beside them.

This is why the e2e lane mattered here. `make check-fe` does not run Playwright, and `projects.spec.ts` drives the create/advance/close flow — it would have gone red on merge.

## What is deliberately NOT gated

**New Deal** still gates on archived alone. Creating a deal is a `deal:create` permission and not a project write; hiding it on a project somebody else owns would take away a verb the caller actually has.

## Three new tests, mutation-checked

- A project this caller may not change: the reason is stated once, and the phase stepper — the one write control that acts on a single click — opens no dialog and posts nothing.
- A project nobody owns: the stepper still opens and still posts, so the claim path is not collateral damage.
- A project with no `writable` field at all: treated as not writable, because absent is "no" and not "unknown".

Removing the `writable` branch fails the first and third and leaves the second passing, which is the split that shows the tests are pinning the rule rather than the shape of the page.

## Verified

`make check-fe` green. `make frontend-e2e` green — 185 passed, including `projects.spec.ts`. Backend untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The project page now withholds its write controls from readers who may open a project but not change it, instead of offering Edit, Archive, Assign, Share, the phase stepper, and the companies and stakeholders cards to everyone and letting the save fail with a 403.

- All write affordances ask one question via `useProjectVerbRefusal`: archived first, then `writable`; absent `writable` reads as not writable, so a response from an older server fails closed.
- Unlike companies, unowned projects are refused too—projects have no claim door, so `writable` is the whole answer.
- `New Deal` is gated with the rest, since binding a deal here requires project write authority.
- The refusal message says the project can't be changed, not that it's someone else's—`writable: false` can also mean the caller's seat lost edit rights.
- Test fixtures and e2e seeds now send `writable`; the previous combination of `owner_id` plus no `writable` modeled a record the server never sends.

Closes #3092.

<sup>Written for commit 3a9b9acddd3332821d2065beee80c55aaf67f4b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects without write permission are now read-only.
  * Edit, archive, sharing, ownership, phase-transition, and new-deal controls are disabled or hidden when access is unavailable.
  * Clear guidance explains that users can request access from the project owner or an administrator.
  * Added and updated English, German, and Vietnamese translations.

* **Tests**
  * Expanded coverage for permitted and restricted project actions, controls, and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->