### PR TITLE
A renewal successor names its own deal

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23016,9 +23016,19 @@ components:
     RenewContractRequest:
       type: object
       required: [title, value_basis]
-      description: The successor's terms. It freezes its own rate and inherits none.
+      description: |
+        The successor's terms. It freezes its own rate and inherits none — the counterparty
+        excepted, which comes from the predecessor because a renewal that changed companies would
+        be a different agreement wearing this one's history.
+
+        `deal_id` and `project_id` are the successor's OWN, exactly as on a create: a renewal is
+        usually won by its own opportunity, so inheriting the predecessor's would attribute the new
+        term to the deal that won the old one. Both must belong to the counterparty the successor
+        inherits, and a caller may not name one it cannot see.
       properties:
         title: { type: string, minLength: 1 }
+        deal_id: { type: [string, 'null'], format: uuid }
+        project_id: { type: [string, 'null'], format: uuid }
         contract_number: { type: [string, 'null'] }
         value_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], minLength: 3, maxLength: 3 }

--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -245,5 +246,106 @@ func TestAnInvisibleContractIsAbsentRatherThanRefused(t *testing.T) {
 
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("a contract outside the caller's scope: err = %v, want ErrNotFound (existence stays hidden)", err)
+	}
+}
+
+// A renewal names its OWN deal, and the successor keeps it.
+//
+// The successor inherits the counterparty and nothing else — the request's own
+// description says so — so a renewal that named no deal was created attached to
+// nothing at all. That is not a cosmetic gap: a contract's PDF reaches a deal
+// room only as an attachment on that room's deal, so a renewed agreement's
+// paperwork was unreachable from the room the renewal is discussed in.
+//
+// Its own deal rather than the predecessor's, because a renewal is usually won
+// by its own opportunity: inheriting would attribute the new term to the deal
+// that won the old one.
+func TestARenewalSuccessorKeepsTheDealItNames(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	org := e.SeedOrg(t, "Acme", nil)
+	pipeline, open, _ := DealFixture(t, e)
+	orgID := ids.From[ids.OrganizationKind](org)
+	renewal, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+		Name: "Acme renewal 2027", PipelineID: pipeline, StageID: open, OrganizationID: &orgID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(renewal.Id))
+
+	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: orgID, Title: "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
+	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	successor, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{
+		Title: "MSA 2027", ValueBasis: contracts.BasisAnnualized, Source: "renewal", DealID: &dealID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("renewing onto the renewal deal: %v", err)
+	}
+	if successor.DealId == nil {
+		t.Fatal("the successor names no deal, so its paperwork can reach no deal room — " +
+			"which is the whole reason the term was renewed against an opportunity")
+	}
+	if ids.UUID(*successor.DealId) != ids.UUID(renewal.Id) {
+		t.Errorf("successor deal = %v, want the deal the renewal named (%v)", *successor.DealId, renewal.Id)
+	}
+	// The counterparty is still the predecessor's, which is the one thing a
+	// renewal does inherit.
+	if ids.UUID(successor.OrganizationId) != org {
+		t.Errorf("successor organization = %v, want the predecessor's (%v)", successor.OrganizationId, org)
+	}
+}
+
+// And it cannot name ANOTHER company's deal. The successor's counterparty comes
+// from the predecessor, so the deal it names is checked against that — the same
+// check a create makes, reached now that a renewal can name one at all.
+func TestARenewalCannotNameAnotherCompanysDeal(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	ours, theirs := e.SeedOrg(t, "Acme", nil), e.SeedOrg(t, "Globex", nil)
+	pipeline, open, _ := DealFixture(t, e)
+	theirOrgID := ids.From[ids.OrganizationKind](theirs)
+	elsewhere, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+		Name: "Globex renewal", PipelineID: pipeline, StageID: open, OrganizationID: &theirOrgID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](ours),
+		Title:          "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
+	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	elsewhereID := ids.From[ids.DealKind](ids.UUID(elsewhere.Id))
+	if _, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{
+		Title: "MSA 2027", ValueBasis: contracts.BasisAnnualized, Source: "renewal", DealID: &elsewhereID,
+	}, nil); err == nil {
+		t.Fatal("renewed Acme's agreement onto Globex's deal — the successor's deal must belong to " +
+			"the counterparty it inherits, or the chain and the opportunity name two different companies")
+	}
+	// And the predecessor is untouched: a refused renewal supersedes nothing.
+	predecessor, err := e.Contracts.GetContract(admin, predecessorID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if predecessor.Status == nil || string(*predecessor.Status) != contracts.StatusActive {
+		t.Errorf("predecessor status = %v after a refused renewal, want it still active", predecessor.Status)
 	}
 }

--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -106,6 +106,29 @@ func TestUnderContractTakesTheEarlierOfTermEndAndCancellation(t *testing.T) {
 	}
 }
 
+// anActiveContract seeds the predecessor every renewal case needs: a live
+// agreement on a named company, activated so it can be renewed at all.
+//
+// Shared because the three cases differ only in what they RENEW INTO — a change
+// to the fixture's status vocabulary or its create shape would otherwise have to
+// be made in three places, and the one that was missed would keep passing until
+// it did not.
+func anActiveContract(t *testing.T, e *Env, org ids.UUID, title string) ids.ContractID {
+	t.Helper()
+	first, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          title, ValueBasis: contracts.BasisTotal, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ids.From[ids.ContractKind](ids.UUID(first.Id))
+	if _, err := e.Contracts.ChangeStatus(e.Admin(), id, contracts.StatusActive, nil); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
 // A renewal creates the successor and supersedes the predecessor in ONE
 // transaction, so an agreement that has run for years reads as a chain rather
 // than a row somebody overwrote.
@@ -114,17 +137,7 @@ func TestRenewalChainsRatherThanOverwrites(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", nil)
 	admin := e.Admin()
 
-	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
-		OrganizationID: ids.From[ids.OrganizationKind](org),
-		Title:          "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
-	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
-		t.Fatal(err)
-	}
+	predecessorID := anActiveContract(t, e, org, "MSA 2026")
 
 	successor, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{
 		Title: "MSA 2027", ValueBasis: contracts.BasisAnnualized, Source: "renewal",
@@ -146,7 +159,7 @@ func TestRenewalChainsRatherThanOverwrites(t *testing.T) {
 	// The successor inherits the counterparty rather than taking one from the
 	// request: a renewal that changed companies would be a different agreement
 	// wearing this one's history.
-	if successor.OrganizationId != first.OrganizationId {
+	if ids.UUID(successor.OrganizationId) != org {
 		t.Error("the successor names a different company than the agreement it renews")
 	}
 }
@@ -274,16 +287,7 @@ func TestARenewalSuccessorKeepsTheDealItNames(t *testing.T) {
 	}
 	dealID := ids.From[ids.DealKind](ids.UUID(renewal.Id))
 
-	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
-		OrganizationID: orgID, Title: "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
-	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
-		t.Fatal(err)
-	}
+	predecessorID := anActiveContract(t, e, org, "MSA 2026")
 
 	successor, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{
 		Title: "MSA 2027", ValueBasis: contracts.BasisAnnualized, Source: "renewal", DealID: &dealID,
@@ -321,17 +325,7 @@ func TestARenewalCannotNameAnotherCompanysDeal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	first, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
-		OrganizationID: ids.From[ids.OrganizationKind](ours),
-		Title:          "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	predecessorID := ids.From[ids.ContractKind](ids.UUID(first.Id))
-	if _, err := e.Contracts.ChangeStatus(admin, predecessorID, contracts.StatusActive, nil); err != nil {
-		t.Fatal(err)
-	}
+	predecessorID := anActiveContract(t, e, ours, "MSA 2026")
 
 	elsewhereID := ids.From[ids.DealKind](ids.UUID(elsewhere.Id))
 	if _, err := e.Contracts.Renew(admin, predecessorID, contracts.CreateContractInput{

--- a/backend/internal/compose/integration/contract_renewal_http_integration_test.go
+++ b/backend/internal/compose/integration/contract_renewal_http_integration_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A renewal names its own deal ON THE WIRE.
+//
+// The store-level case beside this one proves the successor keeps a deal it is
+// handed; this proves the request can hand it one at all. They are different
+// claims and only this one fails when the request field stops being mapped —
+// which is the state the API was in: `RenewContractRequest` had no `deal_id`,
+// so every renewal successor was created attached to nothing, and its PDF was
+// out of reach of the deal room the renewal is discussed in.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestARenewalOverHTTPCarriesTheDealTheRequestNames(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	var org struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/organizations",
+		map[string]any{"display_name": "Acme"}, nil, &org); status != http.StatusCreated {
+		t.Fatalf("creating the counterparty → %d, want 201", status)
+	}
+
+	// The pipeline the installation ships with, so the deal has a stage to sit
+	// in without this case inventing a second answer to what a pipeline is.
+	var pipelines struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Stages []struct {
+				ID       string `json:"id"`
+				Semantic string `json:"semantic"`
+			} `json:"stages"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+		t.Fatalf("reading the pipelines → %d, want 200", status)
+	}
+	if len(pipelines.Data) == 0 || len(pipelines.Data[0].Stages) == 0 {
+		t.Fatal("the installation ships no pipeline with stages, so this case has nowhere to put a deal")
+	}
+	var openStage string
+	for _, stage := range pipelines.Data[0].Stages {
+		if stage.Semantic == "open" {
+			openStage = stage.ID
+			break
+		}
+	}
+	if openStage == "" {
+		t.Fatal("the default pipeline has no open stage")
+	}
+
+	var renewalDeal struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/deals", map[string]any{
+		"name": "Acme renewal 2027", "pipeline_id": pipelines.Data[0].ID,
+		"stage_id": openStage, "organization_id": org.ID,
+	}, nil, &renewalDeal); status != http.StatusCreated {
+		t.Fatalf("creating the renewal deal → %d, want 201", status)
+	}
+
+	var first struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/contracts", map[string]any{
+		"organization_id": org.ID, "title": "MSA 2026", "value_basis": "total",
+	}, nil, &first); status != http.StatusCreated {
+		t.Fatalf("creating the predecessor → %d, want 201", status)
+	}
+	if status := e.Call(t, "POST", "/v1/contracts/"+first.ID+"/status",
+		map[string]any{"status": "active"}, nil, nil); status != http.StatusOK {
+		t.Fatalf("activating the predecessor → %d, want 200", status)
+	}
+
+	var successor struct {
+		ID     string  `json:"id"`
+		DealID *string `json:"deal_id"`
+	}
+	if status := e.Call(t, "POST", "/v1/contracts/"+first.ID+"/renewal", map[string]any{
+		"title": "MSA 2027", "value_basis": "annualized_12m", "deal_id": renewalDeal.ID,
+	}, nil, &successor); status != http.StatusCreated {
+		t.Fatalf("renewing → %d, want 201", status)
+	}
+	if successor.DealID == nil {
+		t.Fatal("the successor came back with no deal_id, so the request field reached nothing — " +
+			"a renewal that declares its opportunity is still created attached to none")
+	}
+	if *successor.DealID != renewalDeal.ID {
+		t.Errorf("successor deal_id = %q, want the deal the request named (%q)", *successor.DealID, renewalDeal.ID)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -23868,13 +23868,22 @@ type RenameCustomFieldRequest struct {
 	Label *string `json:"label,omitempty"`
 }
 
-// RenewContractRequest The successor's terms. It freezes its own rate and inherits none.
+// RenewContractRequest The successor's terms. It freezes its own rate and inherits none — the counterparty
+// excepted, which comes from the predecessor because a renewal that changed companies would
+// be a different agreement wearing this one's history.
+//
+// `deal_id` and `project_id` are the successor's OWN, exactly as on a create: a renewal is
+// usually won by its own opportunity, so inheriting the predecessor's would attribute the new
+// term to the deal that won the old one. Both must belong to the counterparty the successor
+// inherits, and a caller may not name one it cannot see.
 type RenewContractRequest struct {
 	AutoRenew        *bool               `json:"auto_renew,omitempty"`
 	ContractNumber   *string             `json:"contract_number,omitempty"`
 	Currency         *string             `json:"currency,omitempty"`
+	DealId           *openapi_types.UUID `json:"deal_id,omitempty"`
 	EndsOn           *openapi_types.Date `json:"ends_on,omitempty"`
 	NoticePeriodDays *int                `json:"notice_period_days,omitempty"`
+	ProjectId        *openapi_types.UUID `json:"project_id,omitempty"`
 	RenewalOn        *openapi_types.Date `json:"renewal_on,omitempty"`
 	SignedOn         *openapi_types.Date `json:"signed_on,omitempty"`
 	StartsOn         *openapi_types.Date `json:"starts_on,omitempty"`

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -245,6 +245,19 @@ func renewInput(req crmcontracts.RenewContractRequest) CreateContractInput {
 		ValueBasis:     string(req.ValueBasis),
 		Source:         "renewal",
 	}
+	// The work this term came out of, and it is the SUCCESSOR's rather than the
+	// predecessor's. A renewal is usually won by its own opportunity, so
+	// inheriting the old deal would attribute the new term to the one that won
+	// the old — and leaving it unset attaches the agreement to nothing at all,
+	// which is what put a renewed contract's PDF out of reach of every deal
+	// room. createContractTx checks both against the counterparty the successor
+	// inherits, so neither can name another company's record.
+	if req.DealId != nil {
+		in.DealID = &ids.DealID{UUID: ids.UUID(*req.DealId)}
+	}
+	if req.ProjectId != nil {
+		in.ProjectID = &ids.ProjectID{UUID: ids.UUID(*req.ProjectId)}
+	}
 	if req.AutoRenew != nil {
 		in.AutoRenew = *req.AutoRenew
 	}

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -216,12 +216,7 @@ func createInput(req crmcontracts.CreateContractRequest) (CreateContractInput, e
 	if req.ValueBasis != nil {
 		in.ValueBasis = string(*req.ValueBasis)
 	}
-	if req.DealId != nil {
-		in.DealID = &ids.DealID{UUID: ids.UUID(*req.DealId)}
-	}
-	if req.ProjectId != nil {
-		in.ProjectID = &ids.ProjectID{UUID: ids.UUID(*req.ProjectId)}
-	}
+	bindLinks(&in, req.DealId, req.ProjectId)
 	if req.AutoRenew != nil {
 		in.AutoRenew = *req.AutoRenew
 	}
@@ -252,12 +247,7 @@ func renewInput(req crmcontracts.RenewContractRequest) CreateContractInput {
 	// which is what put a renewed contract's PDF out of reach of every deal
 	// room. createContractTx checks both against the counterparty the successor
 	// inherits, so neither can name another company's record.
-	if req.DealId != nil {
-		in.DealID = &ids.DealID{UUID: ids.UUID(*req.DealId)}
-	}
-	if req.ProjectId != nil {
-		in.ProjectID = &ids.ProjectID{UUID: ids.UUID(*req.ProjectId)}
-	}
+	bindLinks(&in, req.DealId, req.ProjectId)
 	if req.AutoRenew != nil {
 		in.AutoRenew = *req.AutoRenew
 	}
@@ -267,6 +257,22 @@ func renewInput(req crmcontracts.RenewContractRequest) CreateContractInput {
 	in.RenewalOn = timePtr(req.RenewalOn)
 	in.SignedOn = timePtr(req.SignedOn)
 	return in
+}
+
+// bindLinks puts a request's optional deal and project onto the store input.
+//
+// One spelling for the create and the renewal alike: they are the same question
+// — which work this agreement came out of — and the store checks both the same
+// way (visible to the caller, and belonging to the contract's own counterparty).
+// Written twice, a change to how a link is bound would reach one door and not
+// the other, and the doors would disagree about the same field.
+func bindLinks(in *CreateContractInput, dealID, projectID *openapi_types.UUID) {
+	if dealID != nil {
+		in.DealID = &ids.DealID{UUID: ids.UUID(*dealID)}
+	}
+	if projectID != nil {
+		in.ProjectID = &ids.ProjectID{UUID: ids.UUID(*projectID)}
+	}
 }
 
 // timePtr converts a wire date into the store's time value.

--- a/backend/tools/seed-demo/contracts.go
+++ b/backend/tools/seed-demo/contracts.go
@@ -332,12 +332,17 @@ func repairSuccessorDeal(c *client, cfg demoConfig, contract demoContract, prede
 		return nil
 	}
 	var successor struct {
-		DealID string `json:"deal_id"`
+		DealID     string  `json:"deal_id"`
+		ArchivedAt *string `json:"archived_at"`
 	}
 	if err := c.get("/v1/contracts/"+predecessor.SupersededByID, nil, &successor); err != nil {
 		return fmt.Errorf("reading successor %s: %w", terms.Ref, err)
 	}
-	if successor.DealID != "" {
+	// An ARCHIVED successor is left alone. A read by id still returns it — the
+	// estate is soft-delete — but a write to it is refused, so a repair here
+	// would fail and take every later phase of the seed with it, over a row
+	// somebody deliberately put away.
+	if successor.ArchivedAt != nil || successor.DealID != "" {
 		return nil
 	}
 	dealID, err := successorDealID(c, cfg, refs, terms)

--- a/backend/tools/seed-demo/contracts.go
+++ b/backend/tools/seed-demo/contracts.go
@@ -165,7 +165,18 @@ func driveContract(c *client, cfg demoConfig, contract demoContract, ids map[str
 	}
 	// A terminal contract is finished with: re-asserting anything on it is
 	// refused, and a re-run must not try.
+	//
+	// Its SUCCESSOR is not finished with, though. A superseded predecessor
+	// means the renewal already happened, so nothing re-enters renewContract —
+	// and the successor is skipped by the drive loop too, because the renewal
+	// owns its row. A deal added to the successor's dataset entry after the
+	// first seed would then never be attached, which is the convergence
+	// ensureContract makes for an ordinary contract and this path owed for a
+	// renewed one.
 	if current == "cancelled" || current == "superseded" || current == "expired" {
+		if current == "superseded" && contract.RenewsInto != "" {
+			return repairSuccessorDeal(c, cfg, contract, refs)
+		}
 		return nil
 	}
 
@@ -225,11 +236,11 @@ func renewContract(c *client, cfg demoConfig, contract demoContract, ids map[str
 	// its PDF is then out of reach of that deal's room, which is the blocker
 	// ensureContract already removes for an ordinary contract.
 	if terms.Deal != "" {
-		dealID, err := dealIDFor(c, cfg, refs, terms.Deal)
+		dealID, err := successorDealID(c, cfg, refs, terms)
 		if err != nil {
-			return fmt.Errorf("contract %s: %w", terms.Ref, err)
+			return err
 		}
-		addIfSet(body, "deal_id", dealID)
+		body["deal_id"] = dealID
 	}
 	addIfSet(body, "contract_number", terms.ContractNumber)
 	if terms.ValueMinor > 0 {
@@ -266,6 +277,61 @@ func renewContract(c *client, cfg demoConfig, contract demoContract, ids map[str
 		if err := c.post("/v1/contracts/"+successorID+"/status", jsonBody{"status": terms.Status}, nil); err != nil {
 			return fmt.Errorf("asserting the successor's status: %w", err)
 		}
+	}
+	return nil
+}
+
+// successorDealID resolves the deal a renewal successor declares, and REFUSES
+// rather than answering nothing.
+//
+// dealIDFor answers ("", nil) for a deal whose company this run did not seed,
+// which reads as "no deal" to a caller that only checks the error. Omitting it
+// would create the successor unattached — the exact defect this path exists to
+// fix — and unlike an ordinary contract nothing comes back to repair it on the
+// same run, because the renewal writes its row once.
+func successorDealID(c *client, cfg demoConfig, refs pipelineRefs, terms demoContract) (string, error) {
+	dealID, err := dealIDFor(c, cfg, refs, terms.Deal)
+	if err != nil {
+		return "", fmt.Errorf("contract %s: %w", terms.Ref, err)
+	}
+	if dealID == "" {
+		return "", fmt.Errorf("contract %s renews into a term that names deal %q, which this run has not seeded — "+
+			"a successor created without it is attached to nothing and its paperwork reaches no deal room",
+			terms.Ref, terms.Deal)
+	}
+	return dealID, nil
+}
+
+// repairSuccessorDeal attaches a successor's declared deal on a LATER run.
+//
+// The same convergence ensureContract performs for an ordinary contract, on the
+// one row it cannot reach: the successor is written by the renewal, so neither
+// the create loop nor the drive loop ever revisits it.
+func repairSuccessorDeal(c *client, cfg demoConfig, contract demoContract, refs pipelineRefs) error {
+	var terms demoContract
+	for _, candidate := range refs.contractsByRef {
+		if candidate.Ref == contract.RenewsInto {
+			terms = candidate
+			break
+		}
+	}
+	if terms.Ref == "" || terms.Deal == "" {
+		return nil
+	}
+	orgID, ok := refs.orgsByDom[strings.ToLower(contract.Company)]
+	if !ok {
+		return nil
+	}
+	successorID, hasDeal, err := findContract(c, orgID, terms.Title)
+	if err != nil || successorID == "" || hasDeal {
+		return err
+	}
+	dealID, err := successorDealID(c, cfg, refs, terms)
+	if err != nil {
+		return err
+	}
+	if err := c.patch("/v1/contracts/"+successorID, jsonBody{"deal_id": dealID}, nil); err != nil {
+		return fmt.Errorf("attaching successor %s to its deal: %w", terms.Ref, err)
 	}
 	return nil
 }

--- a/backend/tools/seed-demo/contracts.go
+++ b/backend/tools/seed-demo/contracts.go
@@ -61,7 +61,7 @@ func seedContracts(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (
 		if successors[contract.Ref] {
 			continue
 		}
-		if err := driveContract(c, contract, ids, refs, mode); err != nil {
+		if err := driveContract(c, cfg, contract, ids, refs, mode); err != nil {
 			return created, fmt.Errorf("contract %s: %w", contract.Ref, err)
 		}
 	}
@@ -151,7 +151,7 @@ func ensureContract(c *client, cfg demoConfig, contract demoContract, refs pipel
 
 // driveContract moves one contract to the state the dataset asks for. Each
 // step is skipped when it is already there, so a re-run changes nothing.
-func driveContract(c *client, contract demoContract, ids map[string]string, refs pipelineRefs, mode runMode) error {
+func driveContract(c *client, cfg demoConfig, contract demoContract, ids map[string]string, refs pipelineRefs, mode runMode) error {
 	if mode == modeDryRun {
 		return nil
 	}
@@ -180,7 +180,7 @@ func driveContract(c *client, contract demoContract, ids map[string]string, refs
 
 	switch {
 	case contract.RenewsInto != "":
-		return renewContract(c, contract, ids, refs)
+		return renewContract(c, cfg, contract, ids, refs)
 	case contract.Cancel != nil:
 		body := jsonBody{
 			"cancellation_notice_on":    refs.date(contract.Cancel.NoticeInDays),
@@ -207,7 +207,7 @@ func driveContract(c *client, contract demoContract, ids map[string]string, refs
 // the renewal replaces: renewing writes its OWN successor row, so the
 // placeholder is archived first and the dataset's second entry is what the
 // renewal is filled from.
-func renewContract(c *client, contract demoContract, ids map[string]string, refs pipelineRefs) error {
+func renewContract(c *client, cfg demoConfig, contract demoContract, ids map[string]string, refs pipelineRefs) error {
 	var terms demoContract
 	for _, candidate := range refs.contractsByRef {
 		if candidate.Ref == contract.RenewsInto {
@@ -219,6 +219,18 @@ func renewContract(c *client, contract demoContract, ids map[string]string, refs
 		return fmt.Errorf("renews_into names %q, which is not in this dataset", contract.RenewsInto)
 	}
 	body := jsonBody{"title": terms.Title, "value_basis": terms.ValueBasis, "auto_renew": terms.AutoRenew}
+	// The successor's OWN deal, from the successor's own dataset entry. A
+	// renewal inherits its counterparty and nothing else, so a successor that
+	// declares a deal and is not sent one is created attached to nothing — and
+	// its PDF is then out of reach of that deal's room, which is the blocker
+	// ensureContract already removes for an ordinary contract.
+	if terms.Deal != "" {
+		dealID, err := dealIDFor(c, cfg, refs, terms.Deal)
+		if err != nil {
+			return fmt.Errorf("contract %s: %w", terms.Ref, err)
+		}
+		addIfSet(body, "deal_id", dealID)
+	}
 	addIfSet(body, "contract_number", terms.ContractNumber)
 	if terms.ValueMinor > 0 {
 		body["value_minor"] = terms.ValueMinor

--- a/backend/tools/seed-demo/contracts.go
+++ b/backend/tools/seed-demo/contracts.go
@@ -175,7 +175,7 @@ func driveContract(c *client, cfg demoConfig, contract demoContract, ids map[str
 	// renewed one.
 	if current == "cancelled" || current == "superseded" || current == "expired" {
 		if current == "superseded" && contract.RenewsInto != "" {
-			return repairSuccessorDeal(c, cfg, contract, refs)
+			return repairSuccessorDeal(c, cfg, contract, id, refs)
 		}
 		return nil
 	}
@@ -307,7 +307,7 @@ func successorDealID(c *client, cfg demoConfig, refs pipelineRefs, terms demoCon
 // The same convergence ensureContract performs for an ordinary contract, on the
 // one row it cannot reach: the successor is written by the renewal, so neither
 // the create loop nor the drive loop ever revisits it.
-func repairSuccessorDeal(c *client, cfg demoConfig, contract demoContract, refs pipelineRefs) error {
+func repairSuccessorDeal(c *client, cfg demoConfig, contract demoContract, predecessorID string, refs pipelineRefs) error {
 	var terms demoContract
 	for _, candidate := range refs.contractsByRef {
 		if candidate.Ref == contract.RenewsInto {
@@ -318,19 +318,33 @@ func repairSuccessorDeal(c *client, cfg demoConfig, contract demoContract, refs 
 	if terms.Ref == "" || terms.Deal == "" {
 		return nil
 	}
-	orgID, ok := refs.orgsByDom[strings.ToLower(contract.Company)]
-	if !ok {
+	// The predecessor NAMES its successor. Looking one up by title on the
+	// account would find whichever contract happens to share the name — two
+	// terms of one agreement legitimately do, and patching the wrong one puts
+	// the deal on a row nobody meant.
+	var predecessor struct {
+		SupersededByID string `json:"superseded_by_id"`
+	}
+	if err := c.get("/v1/contracts/"+predecessorID, nil, &predecessor); err != nil {
+		return fmt.Errorf("reading the superseded contract %s: %w", contract.Ref, err)
+	}
+	if predecessor.SupersededByID == "" {
 		return nil
 	}
-	successorID, hasDeal, err := findContract(c, orgID, terms.Title)
-	if err != nil || successorID == "" || hasDeal {
-		return err
+	var successor struct {
+		DealID string `json:"deal_id"`
+	}
+	if err := c.get("/v1/contracts/"+predecessor.SupersededByID, nil, &successor); err != nil {
+		return fmt.Errorf("reading successor %s: %w", terms.Ref, err)
+	}
+	if successor.DealID != "" {
+		return nil
 	}
 	dealID, err := successorDealID(c, cfg, refs, terms)
 	if err != nil {
 		return err
 	}
-	if err := c.patch("/v1/contracts/"+successorID, jsonBody{"deal_id": dealID}, nil); err != nil {
+	if err := c.patch("/v1/contracts/"+predecessor.SupersededByID, jsonBody{"deal_id": dealID}, nil); err != nil {
 		return fmt.Errorf("attaching successor %s to its deal: %w", terms.Ref, err)
 	}
 	return nil

--- a/backend/tools/seed-demo/generatedpaper.go
+++ b/backend/tools/seed-demo/generatedpaper.go
@@ -70,7 +70,10 @@ func seedGeneratedContracts(c *client, refs pipelineRefs, plan map[string]profil
 			if isGeneratedSuccessor(contracts, contract.Ref) {
 				continue
 			}
-			if err := driveContract(c, contract, ids, local, mode); err != nil {
+			// The same empty config ensureContract is given above, for the same
+			// reason: a generated contract names no deal ref, so a renewal
+			// among them has nothing to resolve one against.
+			if err := driveContract(c, demoConfig{}, contract, ids, local, mode); err != nil {
 				return created, fmt.Errorf("contract for %s: %w", domain, err)
 			}
 		}

--- a/backend/tools/seed-demo/pipeline.go
+++ b/backend/tools/seed-demo/pipeline.go
@@ -441,21 +441,32 @@ func loadLeadsBySource(c *client) (map[string]string, error) {
 	return bySource, nil
 }
 
+// findDeal answers the id of the account's deal with this name, or "" when the
+// account has none.
+//
+// EVERY page, not the first hundred rows. An account with more deals than one
+// page would otherwise report a deal it holds as absent — and a caller that
+// treats "" as "not seeded" then refuses, or attaches nothing, over a record
+// that is right there.
 func findDeal(c *client, name, orgID string) (string, error) {
-	var page struct {
-		Data []struct {
+	found := ""
+	err := c.getAll("/v1/deals", url.Values{"organization_id": {orgID}}, func(raw json.RawMessage) error {
+		var rows []struct {
 			ID   string `json:"id"`
 			Name string `json:"name"`
-		} `json:"data"`
-	}
-	query := url.Values{"organization_id": {orgID}, "limit": {"100"}}
-	if err := c.get("/v1/deals", query, &page); err != nil {
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			if found == "" && strings.EqualFold(row.Name, name) {
+				found = row.ID
+			}
+		}
+		return nil
+	})
+	if err != nil {
 		return "", fmt.Errorf("listing deals for %s: %w", orgID, err)
 	}
-	for _, row := range page.Data {
-		if strings.EqualFold(row.Name, name) {
-			return row.ID, nil
-		}
-	}
-	return "", nil
+	return found, nil
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16239,9 +16239,22 @@ export interface components {
              */
             cancellation_effective_on: string;
         };
-        /** @description The successor's terms. It freezes its own rate and inherits none. */
+        /**
+         * @description The successor's terms. It freezes its own rate and inherits none — the counterparty
+         *     excepted, which comes from the predecessor because a renewal that changed companies would
+         *     be a different agreement wearing this one's history.
+         *
+         *     `deal_id` and `project_id` are the successor's OWN, exactly as on a create: a renewal is
+         *     usually won by its own opportunity, so inheriting the predecessor's would attribute the new
+         *     term to the deal that won the old one. Both must belong to the counterparty the successor
+         *     inherits, and a caller may not name one it cannot see.
+         */
         RenewContractRequest: {
             title: string;
+            /** Format: uuid */
+            deal_id?: string | null;
+            /** Format: uuid */
+            project_id?: string | null;
             contract_number?: string | null;
             /** Format: int64 */
             value_minor?: number | null;


### PR DESCRIPTION
Closes #2600.

## Which of the three fixes, and why

The ticket offers three: add `deal_id` to the renewal request, inherit the predecessor's, or PATCH afterwards. The request's own description settles it —

> The successor's terms. **It freezes its own rate and inherits none.**

— and `Renew` makes exactly one exception, with its reason stated in code: *"The successor inherits the predecessor's counterparty rather than taking one from the request: a renewal that changed companies would be a different agreement wearing this one's history."*

So the deal is one of the successor's own terms. Inheriting would be a modelling claim that is usually false: a renewal is normally won by its **own** opportunity, and attributing the new term to the deal that won the old one is worse than leaving it blank. PATCHing afterwards is two writes and a window where the agreement is attached to nothing.

## The change

`deal_id` and `project_id` on `RenewContractRequest`, mapped in `renewInput`. `project_id` too because a successor that cannot name its project has the identical defect one field over, and leaving it is a gap somebody would file again.

**No new validation.** `Renew` hands the input to `createContractTx`, which already refuses a deal or project the caller cannot see (`ensureLinksVisible`) and one belonging to another company (`ensureLinksShareOrganization`) — and since the successor's organization is the predecessor's, those checks say the right thing for free: a renewal cannot chain into another company's opportunity.

The seed's `renewContract` sends it, resolved from the successor's own dataset entry, the same way `ensureContract` resolves an ordinary contract's. `driveContract` gains the `demoConfig` that needs, and the generated-paper path passes `demoConfig{}` — the same empty config `ensureContract` is already given there, for the same stated reason (a generated contract names no deal ref).

## Tests

- `TestARenewalSuccessorKeepsTheDealItNames` — the store path: the successor carries the named deal, and its counterparty is still the predecessor's.
- `TestARenewalCannotNameAnotherCompanysDeal` — Acme's agreement cannot renew onto Globex's deal, **and the predecessor is still active afterwards**: a refused renewal supersedes nothing.
- `TestARenewalOverHTTPCarriesTheDealTheRequestNames` — the WIRE path, which is the one the seed uses and the one that was actually missing. The store test cannot fail when the request field stops being mapped; this one does. Mutation-checked by deleting the mapping in `renewInput`.

`make check-backend` 0 · full integration lane 0 skips, 47 packages.

## Not verifiable here

The dataset lives outside the repo (`datasets/v1/demo.json`, an operator-supplied root), so the seed half is exercised by the API it now calls rather than against a live entry that is both a renewal successor and declares a deal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contract renewals can specify a deal and project for the successor contract.
  * Successors retain valid deal or project references for the inherited counterparty.
  * Relationship graphs support peer and correspondence connections.
  * Attention dashboards include sync, capture, and AI-work health indicators.

* **Bug Fixes**
  * Invalid cross-organization deal references are rejected without replacing the predecessor contract.
  * Demo-generated renewals correctly preserve valid deal links and avoid unattached successors.
  * Deal matching now works across all available results, rather than only the first page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->