### PR TITLE
Take the constant the acquaintance edge claims, and classify its new FK

### DIFF
--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -61,7 +61,7 @@ func relationshipAnchor(kind string) (object, column string) {
 // a side door around them — a caller could attach a company to a project they
 // cannot write, or archive the last one, through POST /v1/relationships.
 var relationshipKinds = map[string]bool{
-	"employment": true, "deal_stakeholder": true, "project_stakeholder": true,
+	employmentKind: true, "deal_stakeholder": true, "project_stakeholder": true,
 	"partner_of": true, "referred_by": true, "co_sell_with": true,
 	worksWithKind: true,
 }
@@ -169,7 +169,7 @@ func lockPersonForEmployment(ctx context.Context, tx pgx.Tx, id ids.UUID) error 
 	case personID == nil:
 		return nil
 	}
-	return storekit.LockWriteIdentity(ctx, tx, "employment", personID.String())
+	return storekit.LockWriteIdentity(ctx, tx, employmentKind, personID.String())
 }
 
 func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRelationshipInput) (relationshipRow, error) {
@@ -224,7 +224,7 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		// notice period: this row keeps the flag, the incumbent keeps it too, and
 		// uq_rel_current_primary_employer 409s a patch the create path honours.
 		if in.IsCurrentPrimary != nil && *in.IsCurrentPrimary &&
-			current.Kind == "employment" && current.PersonID != nil {
+			current.Kind == employmentKind && current.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
 				WHERE person_id = $1 AND id <> $2 AND `+CurrentPrimarySlotSQL("")+`

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -252,6 +252,7 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// Client-supplied edge endpoints — every one probed at the store:
 	"relationship.person_id":                     "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.counterparty_org_id":           "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
+	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — ensureRelationshipEndpoints walks the far end of the person-to-person kind exactly as it walks the near one",
 	"relationship.organization_id":               "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.deal_id":                       "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.project_id":                    "gated: auth.EnsureLinkTarget on the project anchor in CreateRelationship (H1)",


### PR DESCRIPTION
`main` has been red since #3140 on two gates. Both findings are true of that change and neither is a gate misfiring.

**`TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed`.** `employmentKind` carries the claim — *"spelled once so the SQL, the audit row and the event delta cannot drift apart"* — and names the test that holds it. `relationship.go` spells `"employment"` raw at three sites: the admitted-kinds map, the write-lock identity, and the current-primary displacement. The three take the constant.

**`TestFK_rowScopedTargetsHaveVisibilityDecision`.** `relationship.counterparty_person_id` is a client-supplied FK onto a row-scoped record, so the census requires an explicit decision. It already has one in the code — `ensureRelationshipEndpoints` walks the far end of the person-to-person kind through `auth.EnsureLinkTarget` exactly as it walks the near one — so the entry records that rather than granting an exception.

`make check-backend` exit 0 · full integration lane 0 skips, 47 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in employment relationship handling.
  - Updated relationship validation to correctly account for visibility permissions when linking people.
  - No user-facing behavior changes beyond more reliable relationship creation and employment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->