### PR TITLE
fix(people): main-health's two red gates from the relationship range

### DIFF
--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -61,7 +61,7 @@ func relationshipAnchor(kind string) (object, column string) {
 // a side door around them — a caller could attach a company to a project they
 // cannot write, or archive the last one, through POST /v1/relationships.
 var relationshipKinds = map[string]bool{
-	"employment": true, "deal_stakeholder": true, "project_stakeholder": true,
+	employmentKind: true, "deal_stakeholder": true, "project_stakeholder": true,
 	"partner_of": true, "referred_by": true, "co_sell_with": true,
 	worksWithKind: true,
 }
@@ -169,7 +169,7 @@ func lockPersonForEmployment(ctx context.Context, tx pgx.Tx, id ids.UUID) error 
 	case personID == nil:
 		return nil
 	}
-	return storekit.LockWriteIdentity(ctx, tx, "employment", personID.String())
+	return storekit.LockWriteIdentity(ctx, tx, employmentKind, personID.String())
 }
 
 func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRelationshipInput) (relationshipRow, error) {
@@ -224,7 +224,7 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		// notice period: this row keeps the flag, the incumbent keeps it too, and
 		// uq_rel_current_primary_employer 409s a patch the create path honours.
 		if in.IsCurrentPrimary != nil && *in.IsCurrentPrimary &&
-			current.Kind == "employment" && current.PersonID != nil {
+			current.Kind == employmentKind && current.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
 				WHERE person_id = $1 AND id <> $2 AND `+CurrentPrimarySlotSQL("")+`

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -251,6 +251,7 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// the finder's ScopeClauseFor), never a request body.
 	// Client-supplied edge endpoints — every one probed at the store:
 	"relationship.person_id":                     "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
+	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — the far end of the one person↔person kind (worksWithKind), the same probe every other client-supplied endpoint on this row takes",
 	"relationship.counterparty_org_id":           "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.organization_id":               "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.deal_id":                       "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",


### PR DESCRIPTION
## Summary
main-health's backend gate went red after the recent peer/network relationship features (#3135-#3143) — two unrelated failures in the same test run:

- **`TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed`**: `employmentedge.go`'s `employmentKind` constant claims to be the only spelling of `"employment"`, but `relationship.go` had three raw string literals instead of the constant (the `relationshipKinds` map, the write-identity lock name, and the current-primary-employer comparison). Fixed by using the constant at all three sites.
- **`TestFK_rowScopedTargetsHaveVisibilityDecision`**: `relationship.counterparty_person_id` (the new person↔person `worksWithKind` edge) had no entry in the schema-fitness census. It's already gated — `ensureRelationshipEndpoints` in `relationshipcreate.go` puts it through `auth.EnsureLinkTarget` exactly like every other client-supplied endpoint on the row — this was a missing census entry, not a missing authz gate. Added the classification.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet -tags=integration ./migrations/...` — clean
- [x] `go test -count=1 -run TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed ./gates/...` — passes
- [x] `go test ./internal/modules/people/...` — passes
- [ ] `TestFK_rowScopedTargetsHaveVisibilityDecision` not run locally: `make test-it` hit an unrelated stale `extensions/notes` directory on this machine before reaching the test (pre-existing local residue, not introduced by this change, and not something I'm deleting given a peer session shares this filesystem). Verified instead by reading the gating code directly (`ensureRelationshipEndpoints`) rather than skipping verification — the CI run on a fresh runner isn't affected by the local issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two red gates in main-health's backend caused by the recent peer/network relationship changes.

**Bug Fixes**
- Replaces three raw `"employment"` literals in `relationship.go` with the existing `employmentKind` constant so the claimed-spelling gate passes.
- Adds `relationship.counterparty_person_id` to the schema-fitness census; the authorization already existed via `auth.EnsureLinkTarget`.

<sup>Written for commit d5839c5c6efca8ea4de4baae68f58cb0288393d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in employment relationship handling without changing expected behavior.
  * Added coverage for access-control validation when creating person-to-person relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->