### PR TITLE
A relink re-checks the version its gate was resolved from

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4315,6 +4315,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Activity' }
         '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
   /activities/relink-thread:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4288,6 +4288,12 @@ paths:
       x-mcp-tool: { verb: relink_activity, record_type: activity, tier: dynamic, tier_resolver: destination_record_type, confirmation_required_when: 'entity_type is project — filing under a project classifies the activity as commercial correspondence, which is write-once and cannot be undone by relinking away', scope: write }
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
+        # Conditions the move on the version the caller read the ACTIVITY at.
+        # A stale one answers 409 `version_skew`. It is also how the agent gate
+        # forwards the version a dynamic tier was resolved from, so an agent
+        # relink admitted on one reading of the record cannot execute against
+        # another.
+        - $ref: '#/components/parameters/IfMatch'
       requestBody:
         required: true
         content:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4315,7 +4315,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Activity' }
         '404': { $ref: '#/components/responses/NotFound' }
-        '409': { $ref: '#/components/responses/Conflict' }
+        '409': { $ref: '#/components/responses/VersionConflict' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
   /activities/relink-thread:

--- a/backend/internal/compose/integration/relinkpin_http_integration_test.go
+++ b/backend/internal/compose/integration/relinkpin_http_integration_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The version a relink was admitted on, re-checked by the write that moves it.
+//
+// A dynamic tier is resolved from a READ, and that read commits before the write
+// it admits. An agent controls both sides of the window, so the verdict is only
+// true of the record as it WAS — auth/admit.go binds the version for exactly
+// this reason, and until #2614 nothing consumed it: RelinkActivityInput carried
+// no version and the batch write compared none, on either door.
+//
+// The pin arrives here as If-Match, which is how the REST gate forwards it
+// (compose/agentgate.go) and how a human's client states the version it read.
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestARelinkIsRefusedWhenTheActivityMovedUnderIt(t *testing.T) {
+	e := apptest.SetupApp(t)
+	apptest.BootstrapWorkspaceSession(t, e, "Relink pin", "pin@fable.test", "Admin")
+	personID, taskID := seedTaskAndTarget(t, e)
+
+	var read struct {
+		Version int64 `json:"version"`
+	}
+	if status := e.Call(t, "GET", "/v1/activities/"+taskID, nil, nil, &read); status != http.StatusOK {
+		t.Fatalf("reading the activity → %d, want 200", status)
+	}
+	if read.Version == 0 {
+		t.Fatal("the activity reports no version, so there is nothing for a pin to mean")
+	}
+
+	// The control: the version it was read at still moves it, so this case
+	// cannot pass by the pin refusing everything.
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink",
+		AnyMap{"entity_type": "person", "entity_id": personID},
+		map[string]string{"If-Match": strconv.FormatInt(read.Version, 10)}, nil); status != http.StatusOK {
+		t.Fatalf("relink on the version it was read at → %d, want 200", status)
+	}
+
+	// Something else moves the activity — which is what an agent's own window
+	// looks like from the outside — and the stale pin loses to the compare
+	// rather than to timing.
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID,
+		AnyMap{"subject": "moved under the relink"}, nil, nil); status != http.StatusOK {
+		t.Fatalf("moving the activity → %d, want 200", status)
+	}
+	var problem struct {
+		Code string `json:"code"`
+	}
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink",
+		AnyMap{"entity_type": "person", "entity_id": personID, "replace_existing_of_type": true},
+		map[string]string{"If-Match": strconv.FormatInt(read.Version, 10)}, &problem); status != http.StatusConflict ||
+		problem.Code != "version_skew" {
+		t.Fatalf("relink on a stale version → %d (%s), want 409 version_skew — the pin the gate bound is what "+
+			"stops a relink running on a verdict about the record as it was", status, problem.Code)
+	}
+}
+
+// A thread and a named set move MANY activities, and one version cannot speak
+// for them. Applied per row a pin would refuse every activity except whichever
+// happened to match, which reads as a partial move nobody asked for — so the
+// batch doors say so rather than dropping it silently.
+func TestABatchRelinkRefusesAVersionPinRatherThanIgnoringIt(t *testing.T) {
+	e := apptest.SetupApp(t)
+	apptest.BootstrapWorkspaceSession(t, e, "Batch pin", "batch@fable.test", "Admin")
+	personID, taskID := seedTaskAndTarget(t, e)
+
+	var read struct {
+		Version int64 `json:"version"`
+	}
+	if status := e.Call(t, "GET", "/v1/activities/"+taskID, nil, nil, &read); status != http.StatusOK {
+		t.Fatalf("reading the activity → %d, want 200", status)
+	}
+	var problem struct {
+		Code string `json:"code"`
+	}
+	if status := e.Call(t, "POST", "/v1/activities/relink-bulk",
+		AnyMap{"activity_ids": []string{taskID}, "entity_type": "person", "entity_id": personID},
+		map[string]string{"If-Match": strconv.FormatInt(read.Version, 10)}, &problem); status != http.StatusUnprocessableEntity {
+		t.Fatalf("a pinned batch relink → %d (%s), want 422 — a version that cannot condition the "+
+			"move must be refused, not ignored", status, problem.Code)
+	}
+}

--- a/backend/internal/compose/integration/relinkpin_http_integration_test.go
+++ b/backend/internal/compose/integration/relinkpin_http_integration_test.go
@@ -86,8 +86,10 @@ func TestABatchRelinkRefusesAVersionPinRatherThanIgnoringIt(t *testing.T) {
 	}
 	if status := e.Call(t, "POST", "/v1/activities/relink-bulk",
 		AnyMap{"activity_ids": []string{taskID}, "entity_type": "person", "entity_id": personID},
-		map[string]string{"If-Match": strconv.FormatInt(read.Version, 10)}, &problem); status != http.StatusUnprocessableEntity {
-		t.Fatalf("a pinned batch relink → %d (%s), want 422 — a version that cannot condition the "+
-			"move must be refused, not ignored", status, problem.Code)
+		map[string]string{"If-Match": strconv.FormatInt(read.Version, 10)}, &problem); status != http.StatusUnprocessableEntity ||
+		problem.Code != "pin_not_supported" {
+		t.Fatalf("a pinned batch relink → %d (%s), want 422 pin_not_supported — a version that cannot "+
+			"condition the move must be refused by NAME, so a client can branch on the reason and an "+
+			"unrelated 422 cannot pass for this one", status, problem.Code)
 	}
 }

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -30,12 +30,14 @@ import (
 type activityRelinker struct{ store *activities.Store }
 
 func (a activityRelinker) RelinkActivity(
-	ctx context.Context, activityID ids.UUID, entityType string, entityID ids.UUID, replaceExistingOfType bool,
+	ctx context.Context, activityID ids.UUID, entityType string, entityID ids.UUID,
+	replaceExistingOfType bool, ifVersion *int64,
 ) (json.RawMessage, error) {
 	out, err := a.store.RelinkActivity(ctx, ids.From[ids.ActivityKind](activityID), activities.RelinkActivityInput{
 		EntityType:            entityType,
 		EntityID:              entityID,
 		ReplaceExistingOfType: replaceExistingOfType,
+		IfVersion:             ifVersion,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -26512,6 +26512,13 @@ type RelinkActivityParams struct {
 	// than half-honouring it, so read this contract, not the client, to know which calls are safe
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+
+	// IfMatch Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+	// the last-seen entity `version`. If the row's current `version` differs, the write is
+	// rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+	// re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+	IfMatch *IfMatch `json:"If-Match,omitempty"`
 }
 
 // RelinkActivityJSONBodyEntityType defines parameters for RelinkActivity.
@@ -44048,6 +44055,25 @@ func (siw *ServerInterfaceWrapper) RelinkActivity(w http.ResponseWriter, r *http
 		}
 
 		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch IfMatch
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "If-Match", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "If-Match", valueList[0], &IfMatch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "If-Match", Err: err})
+			return
+		}
+
+		params.IfMatch = &IfMatch
 
 	}
 

--- a/backend/internal/modules/activities/handlers_lifecycle.go
+++ b/backend/internal/modules/activities/handlers_lifecycle.go
@@ -53,10 +53,18 @@ func (h Handlers) RelinkActivity(w http.ResponseWriter, r *http.Request, id crmc
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	// If-Match is how the REST gate forwards the version an auto-executing
+	// agent call was admitted on (compose/agentgate.go), and how a human's
+	// client states the version it read. Both mean the same thing to the write.
+	ifVersion, ok := httperr.IfMatchVersion(w, r)
+	if !ok {
+		return
+	}
 	activity, err := h.store.RelinkActivity(r.Context(), pathID[ids.ActivityKind](id), RelinkActivityInput{
 		EntityType:            req.EntityType,
 		EntityID:              req.EntityID,
 		ReplaceExistingOfType: req.ReplaceExistingOfType,
+		IfVersion:             ifVersion,
 	})
 	if err != nil {
 		writeStoreErr(w, r, err)
@@ -72,10 +80,18 @@ func (h Handlers) RelinkThread(w http.ResponseWriter, r *http.Request, _ crmcont
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	// Forwarded rather than dropped, so the store can say a version cannot
+	// condition a batch. A header silently ignored is the same failure as a pin
+	// silently ignored, which is what #2614 was about.
+	ifVersion, ok := httperr.IfMatchVersion(w, r)
+	if !ok {
+		return
+	}
 	out, err := h.store.RelinkThread(r.Context(), req.ThreadKey, RelinkActivityInput{
 		EntityType:            string(req.EntityType),
 		EntityID:              ids.UUID(req.EntityId),
 		ReplaceExistingOfType: req.ReplaceExistingOfType != nil && *req.ReplaceExistingOfType,
+		IfVersion:             ifVersion,
 	})
 	if err != nil {
 		writeStoreErr(w, r, err)
@@ -91,6 +107,13 @@ func (h Handlers) RelinkActivities(w http.ResponseWriter, r *http.Request, _ crm
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	// Forwarded for the reason RelinkThread's is: the refusal belongs to the
+	// store, and a header this door quietly dropped would be a pin nobody
+	// applied and nobody was told about.
+	ifVersion, ok := httperr.IfMatchVersion(w, r)
+	if !ok {
+		return
+	}
 	activityIDs := make([]ids.UUID, 0, len(req.ActivityIds))
 	for _, id := range req.ActivityIds {
 		activityIDs = append(activityIDs, ids.UUID(id))
@@ -99,6 +122,7 @@ func (h Handlers) RelinkActivities(w http.ResponseWriter, r *http.Request, _ crm
 		EntityType:            string(req.EntityType),
 		EntityID:              ids.UUID(req.EntityId),
 		ReplaceExistingOfType: req.ReplaceExistingOfType != nil && *req.ReplaceExistingOfType,
+		IfVersion:             ifVersion,
 	})
 	if err != nil {
 		writeStoreErr(w, r, err)

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -209,6 +209,20 @@ type RelinkActivityInput struct {
 	// against the kind vocabulary below), so the id stays untyped (rule 6).
 	EntityID              ids.UUID
 	ReplaceExistingOfType bool
+	// IfVersion is the version the caller read the ACTIVITY at, re-checked
+	// inside the transaction that moves it.
+	//
+	// It is what closes the window a dynamic tier opens: the resolver reads the
+	// activity to decide whether this destination may auto-execute, that read
+	// commits, and the agent controls both sides of the gap — so the verdict is
+	// only true of the record as it WAS. auth/admit.go binds the version it was
+	// resolved from for exactly this, and until it reached here nothing
+	// re-checked it (#2614).
+	//
+	// Only the SINGLE relink carries one. A thread or a named set moves many
+	// activities and one version cannot speak for them, so the batch doors
+	// refuse a pin rather than applying it to whichever row happens to match.
+	IfVersion *int64
 }
 
 func (s *Store) RelinkActivity(ctx context.Context, id ids.ActivityID, in RelinkActivityInput) (crmcontracts.Activity, error) {

--- a/backend/internal/modules/activities/relinkbatch.go
+++ b/backend/internal/modules/activities/relinkbatch.go
@@ -71,6 +71,18 @@ func admitRelink(ctx context.Context, in RelinkActivityInput) (string, error) {
 // readable, so the write arm (auth.EnsureActivityWritable) is what keeps a
 // colleague's correspondence theirs — and in a batch every row is somebody's.
 func relinkActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in RelinkActivityInput, column string) (bool, error) {
+	// THE LOCK COMES FIRST, before the authority check and before the version
+	// compare, because both are answers about the row and both are only true
+	// while it holds still. Checked first and locked after, an ownership change
+	// landing in between leaves a caller writing on a permission they no longer
+	// have, and a version compare passing on a row that has since moved.
+	//
+	// It is taken for every relink rather than only a pinned one: the write
+	// below updates this row, so the lock is acquired either way — this decides
+	// WHEN, and the two checks above are the reason it is now.
+	if _, err := storekit.LockRow(ctx, tx, "activity", id.UUID, storekit.LiveOnly); err != nil {
+		return false, err
+	}
 	if err := auth.EnsureActivityWritable(ctx, tx, id.UUID); err != nil {
 		return false, err
 	}
@@ -132,13 +144,13 @@ func relinkActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in Rel
 }
 
 // relinkMeetsItsPin re-checks the version the caller read the activity at,
-// inside the transaction that moves it.
+// inside the transaction that moves it and under the row lock its caller has
+// already taken.
 //
-// UNDER THE ROW LOCK, taken before the read, for the reason every other guarded
-// write in this module takes it first: two relinks reading the same version
-// concurrently would both pass the compare and the loser would silently
-// overwrite the winner. The lock also holds until commit, so the version cannot
-// move between this check and the write below it.
+// The lock is what makes the compare mean anything: two relinks reading the same
+// version would otherwise both pass it and the loser would silently overwrite
+// the winner, and it holds until commit so the version cannot move between this
+// check and the write below it.
 //
 // No pin is the ordinary case and is not an error: a human's relink through the
 // app conditions on nothing, and a static-tier agent call has nothing to
@@ -146,9 +158,6 @@ func relinkActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in Rel
 func relinkMeetsItsPin(ctx context.Context, tx pgx.Tx, id ids.ActivityID, ifVersion *int64) error {
 	if ifVersion == nil {
 		return nil
-	}
-	if _, err := storekit.LockRow(ctx, tx, "activity", id.UUID, storekit.LiveOnly); err != nil {
-		return err
 	}
 	current, err := readActivity(ctx, tx, id, storekit.LiveOnly)
 	if err != nil {

--- a/backend/internal/modules/activities/relinkbatch.go
+++ b/backend/internal/modules/activities/relinkbatch.go
@@ -74,6 +74,9 @@ func relinkActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in Rel
 	if err := auth.EnsureActivityWritable(ctx, tx, id.UUID); err != nil {
 		return false, err
 	}
+	if err := relinkMeetsItsPin(ctx, tx, id, in.IfVersion); err != nil {
+		return false, err
+	}
 	var displaced []ids.UUID
 	if in.ReplaceExistingOfType {
 		var err error
@@ -128,6 +131,68 @@ func relinkActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in Rel
 	})
 }
 
+// relinkMeetsItsPin re-checks the version the caller read the activity at,
+// inside the transaction that moves it.
+//
+// UNDER THE ROW LOCK, taken before the read, for the reason every other guarded
+// write in this module takes it first: two relinks reading the same version
+// concurrently would both pass the compare and the loser would silently
+// overwrite the winner. The lock also holds until commit, so the version cannot
+// move between this check and the write below it.
+//
+// No pin is the ordinary case and is not an error: a human's relink through the
+// app conditions on nothing, and a static-tier agent call has nothing to
+// condition on either.
+func relinkMeetsItsPin(ctx context.Context, tx pgx.Tx, id ids.ActivityID, ifVersion *int64) error {
+	if ifVersion == nil {
+		return nil
+	}
+	if _, err := storekit.LockRow(ctx, tx, "activity", id.UUID, storekit.LiveOnly); err != nil {
+		return err
+	}
+	current, err := readActivity(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return err
+	}
+	if current.Version == nil || int64(*current.Version) != *ifVersion {
+		return apperrors.ErrVersionSkew
+	}
+	return nil
+}
+
+// refuseBatchPin keeps a version pin off the doors it cannot mean.
+//
+// One version cannot speak for a thread or a named set: applied per row it
+// would refuse every activity except the one that happened to match, which
+// reads as a partial move nobody asked for. The doors that take a pin are the
+// single relink's, and a caller that supplies one here is told so rather than
+// having it quietly dropped — a pin silently ignored is the failure this whole
+// change is about.
+func refuseBatchPin(in RelinkActivityInput) error {
+	if in.IfVersion == nil {
+		return nil
+	}
+	return &BatchPinError{}
+}
+
+// BatchPinError refuses a version pin on a door that moves many activities.
+//
+// A MessageFault rather than a field fault: the pin arrives as an If-Match
+// HEADER, so there is no request field to name, and inventing one would point
+// the caller at an input that is not theirs to change.
+type BatchPinError struct{}
+
+func (e *BatchPinError) Error() string {
+	return "a thread or a named set moves many activities, and one version cannot condition them"
+}
+
+// MessageFault maps this to a 422 carrying the code, so a client can branch on
+// the reason rather than parsing prose.
+func (e *BatchPinError) MessageFault() (code, message string) {
+	return "pin_not_supported", e.Error() +
+		" — drop the If-Match and relink them one at a time to pin a version"
+}
+
 // RelinkThread applies one relink to every non-archived activity carrying
 // threadKey that the caller may write. A row the caller cannot see or cannot
 // write is LEFT, not refused: the caller never named it, so there is nothing
@@ -136,6 +201,9 @@ func (s *Store) RelinkThread(ctx context.Context, threadKey string, in RelinkAct
 	if threadKey == "" {
 		return RelinkBatchResult{}, httperr.Validation("thread_key", "required",
 			"thread_key names the conversation to move; it cannot be blank")
+	}
+	if err := refuseBatchPin(in); err != nil {
+		return RelinkBatchResult{}, err
 	}
 	column, err := admitRelink(ctx, in)
 	if err != nil {
@@ -193,6 +261,9 @@ func (s *Store) RelinkActivities(ctx context.Context, activityIDs []ids.UUID, in
 	if len(activityIDs) == 0 || len(activityIDs) > maxBulkRelink {
 		return RelinkBatchResult{}, httperr.Validation("activity_ids", "out_of_range",
 			fmt.Sprintf("activity_ids names between 1 and %d activities; this request names %d", maxBulkRelink, len(activityIDs)))
+	}
+	if err := refuseBatchPin(in); err != nil {
+		return RelinkBatchResult{}, err
 	}
 	column, err := admitRelink(ctx, in)
 	if err != nil {

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -137,6 +137,7 @@ func NewRelinkActivityCall(records datasource.SystemOfRecordProvider, cmd Relink
 			activity: anchoredRecord{records: records, entityType: datasource.EntityActivity},
 		}, cmd),
 		entityType: cmd.EntityType,
+		pinnable:   true,
 	}
 }
 
@@ -157,19 +158,51 @@ func NewRelinkActivityCall(records datasource.SystemOfRecordProvider, cmd Relink
 type destinationTieredCall struct {
 	GovernedCall
 	entityType string
+	// pinnable says whether ONE version can condition this move. A single
+	// relink's can; a thread's and a named set's cannot, because they move many
+	// activities and a pin applied per row would refuse every one except
+	// whichever happened to match.
+	pinnable bool
 }
 
-// tierInput shows the gate the destination type. Nothing here reads a record:
-// the risk is a property of the KIND of destination, which the arguments
-// already state, so the tier is answered without a second read and without a
-// version to bind — the classification does not turn on the activity's state.
+// tierInput shows the gate the destination type AND the version the activity
+// was read at.
 //
-// The error is structurally always nil and the signature keeps it anyway: this
-// implements dynamicTierCall, whose other implementation resolves a tier from
-// records it must read. Narrowing it here would put the seam's two sides on
-// different shapes for the sake of one call that happens not to need it.
-func (c destinationTieredCall) tierInput(context.Context, json.RawMessage) (mcp.TierResolverInput, error) { //nolint:unparam // the shape is dynamicTierCall's, not this call's
-	return mcp.TierResolverInput{Args: relinkTierArgsFor(c.entityType)}, nil
+// The destination alone decides the TIER — the risk is a property of the kind of
+// record, not of the activity's state. But a dynamic tier that resolves to
+// auto-execute and can name no version is refused by the gate (auth/admit.go),
+// deliberately, because an unpinned write would run unattended. Answering no
+// version therefore raised every REST relink to approval whatever its
+// destination, while the MCP door auto-executed the same operation — two doors
+// disagreeing about one call.
+//
+// The read is the staging path's own (relinkActivityResolver.Subject), reached
+// through the bound call this wraps, so both doors are pinned by the same
+// reading of the same row.
+//
+// A call that cannot be described answers NO version rather than an error, for
+// the reason the MCP door's ResolverInput gives: the gate then raises, which is
+// the safe direction and keeps the resolver's contract that it may only RAISE.
+// A batch — a thread or a named set — answers none either, and cannot: one
+// version cannot speak for many activities, so those doors keep costing a
+// decision, which is the honest answer for a move nothing can fence.
+//
+//nolint:unparam // the shape is dynamicTierCall's, not this call's: the other implementation resolves a tier from records it must read, and narrowing here would put the seam's two sides on different shapes
+func (c destinationTieredCall) tierInput(ctx context.Context, _ json.RawMessage) (mcp.TierResolverInput, error) {
+	resolved := mcp.TierResolverInput{Args: relinkTierArgsFor(c.entityType)}
+	if !c.pinnable {
+		return resolved, nil
+	}
+	info, err := StageSubject(ctx, c.GovernedCall)
+	if err != nil {
+		return resolved, nil //nolint:nilerr // an unreadable record raises to a human, it does not fail the call
+	}
+	// Zero is not a version any write can be conditioned on, so it is left
+	// unreported rather than pinned (dealmove.go says the same).
+	if info.TargetVersion != nil && *info.TargetVersion > 0 {
+		resolved.ObservedVersion = info.TargetVersion
+	}
+	return resolved, nil
 }
 
 // relinkTierArgs is the shape relinkActivityTier reads. It carries the

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -193,16 +193,31 @@ func (c destinationTieredCall) tierInput(ctx context.Context, _ json.RawMessage)
 	if !c.pinnable {
 		return resolved, nil
 	}
-	info, err := StageSubject(ctx, c.GovernedCall)
-	if err != nil {
-		return resolved, nil //nolint:nilerr // an unreadable record raises to a human, it does not fail the call
-	}
-	// Zero is not a version any write can be conditioned on, so it is left
-	// unreported rather than pinned (dealmove.go says the same).
-	if info.TargetVersion != nil && *info.TargetVersion > 0 {
-		resolved.ObservedVersion = info.TargetVersion
-	}
+	resolved.ObservedVersion = observedVersion(ctx, c.GovernedCall)
 	return resolved, nil
+}
+
+// observedVersion is the version a dynamic tier is resolved FROM, read through
+// the call's own staging path so the gate pins the same row the resolver judged.
+//
+// One spelling for both doors. The MCP tool answers the same question in its
+// ResolverInput, and two spellings of "which version did we resolve this from"
+// are free to disagree — which is exactly how the doors came to disagree about
+// this operation in the first place.
+//
+// A record that cannot be described answers NO version rather than an error: the
+// gate then RAISES, which is the safe direction and keeps the resolver's
+// contract that it may only ever raise. Zero is left unreported for the reason
+// dealmove.go gives — it is not a version any write can be conditioned on.
+func observedVersion(ctx context.Context, call GovernedCall) *int64 {
+	info, err := StageSubject(ctx, call)
+	if err != nil {
+		return nil
+	}
+	if info.TargetVersion == nil || *info.TargetVersion <= 0 {
+		return nil
+	}
+	return info.TargetVersion
 }
 
 // relinkTierArgs is the shape relinkActivityTier reads. It carries the

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -225,7 +225,7 @@ func fullRegistry(t *testing.T) *Registry {
 // handler, so a seam that answers nothing is the honest stand-in.
 type inertLifecycle struct{}
 
-func (inertLifecycle) RelinkActivity(context.Context, ids.UUID, string, ids.UUID, bool) (json.RawMessage, error) {
+func (inertLifecycle) RelinkActivity(context.Context, ids.UUID, string, ids.UUID, bool, *int64) (json.RawMessage, error) {
 	return nil, nil
 }
 

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -179,7 +179,7 @@ func (seamProbeRetriever) AssembleContext(context.Context, datasource.EntityRef,
 // them" — the whole point of the probe.
 type seamProbeLifecycle struct{}
 
-func (seamProbeLifecycle) RelinkActivity(context.Context, ids.UUID, string, ids.UUID, bool) (json.RawMessage, error) {
+func (seamProbeLifecycle) RelinkActivity(context.Context, ids.UUID, string, ids.UUID, bool, *int64) (json.RawMessage, error) {
 	return nil, errSeamReached
 }
 

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -160,32 +160,26 @@ func (t relinkActivity) ResolverInput(ctx context.Context, in json.RawMessage) (
 	if err := decodeArgs(in, &args); err != nil {
 		return mcp.TierResolverInput{}, err
 	}
-	resolved := mcp.TierResolverInput{Args: in}
-	info, err := StageSubject(ctx, NewRelinkActivityCall(t.p, RelinkActivityCommand{
-		ActivityID: args.ActivityID, EntityType: args.EntityType, EntityID: args.EntityID,
-	}))
-	if err != nil {
-		// The read failed, or the guards refused. Answering NO VERSION rather
-		// than the error is deliberate: the gate then raises, which keeps the
-		// resolver's contract that it may only ever RAISE, and it fails CLOSED —
-		// an otherwise auto-executable destination costs a decision rather than
-		// running on a state this server could not establish.
-		//
-		// It does not follow that a human sees it. stageRefusedCall calls
-		// StageInfo straight after, which repeats this read: a failure that
-		// persists surfaces as that read's own error rather than as a staged
-		// approval. That is the right answer for a bad id or an out-of-scope
-		// target — the caller gets told what is wrong instead of a card nobody
-		// can act on.
-		return resolved, nil //nolint:nilerr // an unreadable record raises to a human, it does not fail the call
-	}
-	// A record with no version is left unreported rather than pinned at zero,
-	// for the reason dealmove.go states: zero is not a version any write can be
-	// conditioned on.
-	if info.TargetVersion != nil && *info.TargetVersion > 0 {
-		resolved.ObservedVersion = info.TargetVersion
-	}
-	return resolved, nil
+	// The same reading the REST door takes (observedVersion), so both pin the
+	// row the resolver judged rather than two readings free to disagree.
+	//
+	// A read that failed, or guards that refused, answer NO VERSION rather than
+	// the error: the gate then raises, which keeps the resolver's contract that
+	// it may only ever RAISE, and it fails CLOSED — an otherwise auto-executable
+	// destination costs a decision rather than running on a state this server
+	// could not establish.
+	//
+	// It does not follow that a human sees it. stageRefusedCall calls StageInfo
+	// straight after, which repeats this read: a failure that persists surfaces
+	// as that read's own error rather than as a staged approval. That is the
+	// right answer for a bad id or an out-of-scope target — the caller gets told
+	// what is wrong instead of a card nobody can act on.
+	return mcp.TierResolverInput{
+		Args: in,
+		ObservedVersion: observedVersion(ctx, NewRelinkActivityCall(t.p, RelinkActivityCommand{
+			ActivityID: args.ActivityID, EntityType: args.EntityType, EntityID: args.EntityID,
+		})),
+	}, nil
 }
 
 func (t relinkActivity) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -46,7 +46,7 @@ func RegisterLifecycleTools(
 // ActivityRelinker moves an activity's typed link onto a record, idempotently
 // on (activity, entity_type, entity_id).
 type ActivityRelinker interface {
-	RelinkActivity(ctx context.Context, activityID ids.UUID, entityType string, entityID ids.UUID, replaceExistingOfType bool) (json.RawMessage, error)
+	RelinkActivity(ctx context.Context, activityID ids.UUID, entityType string, entityID ids.UUID, replaceExistingOfType bool, ifVersion *int64) (json.RawMessage, error)
 	// RelinkThread is the same move over every writable member of one
 	// conversation; RelinkActivities over a named set. Both answer the
 	// count-and-ids shape rather than a record.
@@ -151,13 +151,10 @@ func (t relinkActivity) StageInfo(ctx context.Context, in json.RawMessage) (Stag
 // The version comes from the same read the staging path already performs
 // (relinkActivityResolver.Subject).
 //
-// What it does NOT yet do is condition the write. The gate binds it
-// (auth/admit.go withAutoExecutePin) so a write can re-check it inside the
-// mutating transaction, but no relink consumes that pin: RelinkActivityInput
-// carries no version and relinkbatch.go compares none, on either door. So this
-// restores the tier the resolver always declared, and the version-skew fence
-// the gate's contract describes is still missing — issue #2614, which has to
-// reach the activities write contract rather than this tool.
+// Handle then CONSUMES that pin (pinForWrite), and relinkbatch.go re-checks it
+// under the row lock, which is the fence the gate's contract describes: an
+// activity that moved between the resolve and the execute loses to the version
+// compare rather than to timing.
 func (t relinkActivity) ResolverInput(ctx context.Context, in json.RawMessage) (mcp.TierResolverInput, error) {
 	var args relinkActivityArgs
 	if err := decodeArgs(in, &args); err != nil {
@@ -201,7 +198,16 @@ func (t relinkActivity) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	}
 	noteEvidence(ctx, datasource.EntityActivity, args.ActivityID)
 	noteEvidence(ctx, datasource.EntityType(args.EntityType), args.EntityID)
-	return t.relinker.RelinkActivity(ctx, args.ActivityID, args.EntityType, args.EntityID, args.ReplaceExistingOfType)
+	// The version the gate resolved this call's tier from, re-checked by the
+	// write. Without it the window ResolverInput describes stays open: the
+	// resolver reads the activity, the gate admits on that reading, and the
+	// agent controls both sides of the gap — so an activity that moved in
+	// between is relinked on a verdict about the record as it was.
+	pin, err := pinForWrite(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return t.relinker.RelinkActivity(ctx, args.ActivityID, args.EntityType, args.EntityID, args.ReplaceExistingOfType, pin)
 }
 
 // --- disqualify_lead (🟡 write) ---

--- a/backend/internal/modules/agents/tools_lifecycle_test.go
+++ b/backend/internal/modules/agents/tools_lifecycle_test.go
@@ -111,12 +111,17 @@ func TestConfirmFirstLifecycleToolsRefuseToStageAMirrorHeldRecord(t *testing.T) 
 	}
 }
 
-type recordingRelinker struct{ entityType string }
+type recordingRelinker struct {
+	entityType string
+	// pin is what the tool handed the write, which is the whole question in
+	// #2614: the gate binds a version and nothing consumed it.
+	pin *int64
+}
 
 func (r *recordingRelinker) RelinkActivity(
-	_ context.Context, _ ids.UUID, entityType string, _ ids.UUID, _ bool,
+	_ context.Context, _ ids.UUID, entityType string, _ ids.UUID, _ bool, ifVersion *int64,
 ) (json.RawMessage, error) {
-	r.entityType = entityType
+	r.entityType, r.pin = entityType, ifVersion
 	return nil, nil
 }
 
@@ -428,4 +433,53 @@ func assertRelinkTierReadsEntityType(t *testing.T, name string, spec mcp.ToolSpe
 	if got := spec.TierResolver(mcp.TierResolverInput{Args: json.RawMessage(`not json`)}); got != mcp.TierConfirmationRequired {
 		t.Errorf("an unparseable body resolved tier %v, want confirmation required", got)
 	}
+}
+
+// The relink CONSUMES the version its gate bound, on both of the paths that
+// bind one.
+//
+// A dynamic tier is resolved from a read that commits before the write it
+// admits, and an agent controls both sides of that window — so the gate binds
+// the version and the write is supposed to re-check it. Nothing did: the tool
+// never asked pinForWrite, and the store had no field to put an answer in
+// (#2614). A relink then executed against whatever the record had become.
+//
+// Two pins, one question. An approved relink carries the version the human
+// released against; an auto-executed one carries the version the tier was
+// resolved from. pinForWrite is where they meet, and this asserts the answer
+// reaches the write rather than stopping at the tool.
+func TestRelinkActivityHandsTheWriteTheVersionItsGateBound(t *testing.T) {
+	relink := func(ctx context.Context, seam *recordingRelinker) {
+		t.Helper()
+		tool := relinkActivity{relinker: seam}
+		args := json.RawMessage(`{"activity_id":"` + ids.NewV7().String() +
+			`","entity_type":"person","entity_id":"` + ids.NewV7().String() + `"}`)
+		if _, err := tool.Handle(ctx, args); err != nil {
+			t.Fatalf("relink: %v", err)
+		}
+	}
+
+	t.Run("the version a human released against", func(t *testing.T) {
+		seam := &recordingRelinker{}
+		released := int64(7)
+		relink(context.WithValue(context.Background(), releasedPinKey{}, released), seam)
+		if seam.pin == nil {
+			t.Fatal("the write was handed no version, so an approval released against one reading of " +
+				"the activity executes against another")
+		}
+		if *seam.pin != released {
+			t.Errorf("the write was pinned at %d, want the released %d", *seam.pin, released)
+		}
+	})
+
+	// And no pin is not an error. A human's relink through the app conditions on
+	// nothing, and a static-tier call has nothing to condition on — a sentinel
+	// here would make the write branch on a case it does not act on.
+	t.Run("no pin at all", func(t *testing.T) {
+		seam := &recordingRelinker{}
+		relink(context.Background(), seam)
+		if seam.pin != nil {
+			t.Errorf("an unpinned relink was conditioned on %d", *seam.pin)
+		}
+	})
 }

--- a/backend/internal/modules/agents/tools_lifecycle_test.go
+++ b/backend/internal/modules/agents/tools_lifecycle_test.go
@@ -444,10 +444,12 @@ func assertRelinkTierReadsEntityType(t *testing.T, name string, spec mcp.ToolSpe
 // never asked pinForWrite, and the store had no field to put an answer in
 // (#2614). A relink then executed against whatever the record had become.
 //
-// Two pins, one question. An approved relink carries the version the human
-// released against; an auto-executed one carries the version the tier was
-// resolved from. pinForWrite is where they meet, and this asserts the answer
-// reaches the write rather than stopping at the tool.
+// The RELEASED pin is what this asserts, and it is the one this package can
+// stage: the admitted pin an auto-execute carries is put in the context by
+// auth's own unexported writer, so only the gate can produce it. pinForWrite is
+// where the two meet and the tool asks it once — what is proven here is that its
+// answer reaches the write rather than stopping at the tool, which is the half
+// that was missing.
 func TestRelinkActivityHandsTheWriteTheVersionItsGateBound(t *testing.T) {
 	relink := func(ctx context.Context, seam *recordingRelinker) {
 		t.Helper()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28247,6 +28247,14 @@ export interface operations {
                  *     to retry blind.
                  */
                 "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
             };
             path: {
                 /** @description Opaque resource id (UUID; ordering semantics are not exposed). */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28288,7 +28288,7 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
-            409: components["responses"]["Conflict"];
+            409: components["responses"]["VersionConflict"];
             422: components["responses"]["ValidationError"];
         };
     };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28288,6 +28288,7 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
             422: components["responses"]["ValidationError"];
         };
     };

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -16,10 +16,16 @@
 // `header:` property beside the spread, because the two would be the same slot
 // written twice and the later one silently wins: a relink that sent its key
 // that way sent no precondition at all.
-export function ifMatch<Also extends Readonly<Record<string, string>> = never>(
-  version: number,
-  also?: Also,
-): { header: Also & { "If-Match": string } } {
+//
+// It cannot carry an `If-Match` of its own, and the TYPE is what says so. The
+// version argument always wins at runtime, so a caller passing one here would
+// compile against a header value the request never sends — the same silent
+// disagreement this parameter exists to remove, one level in.
+export function ifMatch<
+  Also extends Readonly<Record<string, string>> & {
+    "If-Match"?: never;
+  } = never,
+>(version: number, also?: Also): { header: Also & { "If-Match": string } } {
   return {
     header: { ...(also ?? ({} as Also)), "If-Match": String(version) },
   };

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -10,10 +10,19 @@
 // The header spelled as the contract declares it, not as a bag of strings: an
 // endpoint that REQUIRES the precondition takes no widened record, and the
 // error belongs at the call site rather than one cast further in.
-export function ifMatch(version: number): {
-  header: { "If-Match": string };
-} {
-  return { header: { "If-Match": String(version) } };
+//
+// `also` carries the headers an endpoint declares BESIDE the precondition — an
+// idempotency key, today. They belong in this call rather than in a second
+// `header:` property beside the spread, because the two would be the same slot
+// written twice and the later one silently wins: a relink that sent its key
+// that way sent no precondition at all.
+export function ifMatch<Also extends Readonly<Record<string, string>> = never>(
+  version: number,
+  also?: Also,
+): { header: Also & { "If-Match": string } } {
+  return {
+    header: { ...(also ?? ({} as Also)), "If-Match": String(version) },
+  };
 }
 
 // The contract states `version` as an optional field on nearly every entity, so

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2928,6 +2928,8 @@ export const de = {
   "compose.relinkTitle": "Diese Aktivität neu verknüpfen",
   "compose.relinkTarget":
     "Person, Organisation, Deal, Lead oder Projekt suchen",
+  "compose.relinkNoVersion":
+    "Diese Aktivität wurde ohne Version gelesen, daher kann eine Neuverknüpfung nicht sagen, was sie ändert. Öffne sie erneut und versuche es noch einmal.",
   "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",
   "compose.relinkReplaceHint":
     "Ersetzt die bestehende Verknüpfung desselben Typs, statt eine weitere hinzuzufügen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2956,6 +2956,8 @@ export const en = {
   "compose.relinkTitle": "Relink this activity",
   "compose.relinkTarget":
     "Search a person, organization, deal, lead, or project",
+  "compose.relinkNoVersion":
+    "This activity was read without a version, so a relink cannot say what it is changing. Reopen it and try again.",
   "compose.relinkReplace": "Move instead of also-link",
   "compose.relinkReplaceHint":
     "Replaces the existing link of the same type rather than adding another.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2898,6 +2898,8 @@ export const vi = {
     "Mục đích này mang liên kết huỷ đăng ký, nên lượt gửi cho nhiều hơn một người nhận sẽ bị từ chối. Hãy gửi riêng cho từng người, không dùng Cc.",
   "compose.relinkTitle": "Liên kết lại hoạt động này",
   "compose.relinkTarget": "Tìm một người, tổ chức, deal, lead hay dự án",
+  "compose.relinkNoVersion":
+    "Hoạt động này được đọc mà không có phiên bản, nên việc liên kết lại không thể nói rõ nó đang thay đổi gì. Hãy mở lại và thử lần nữa.",
   "compose.relinkReplace": "Chuyển hẳn thay vì liên kết thêm",
   "compose.relinkReplaceHint":
     "Thay liên kết cùng loại đang có thay vì thêm một liên kết nữa.",

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -230,6 +230,10 @@ describe("RelinkModal", () => {
     });
     // Relink is idempotency-keyed (its no-dup-on-replay contract).
     expect(relink?.headers.get("Idempotency-Key")).toBeTruthy();
+    // AND it carries the version this reader saw. The key and the precondition
+    // are one header slot, so a regression that wrote them separately would
+    // send whichever came last — the key alone, silently unconditioned.
+    expect(relink?.headers.get("If-Match")).toBe("4");
   });
 
   it("sends replace_existing_of_type when the move toggle is on", async () => {
@@ -267,6 +271,7 @@ describe("RelinkModal", () => {
       entity_id: "o-2",
       replace_existing_of_type: true,
     });
+    expect(relink?.headers.get("If-Match")).toBe("4");
   });
 
   it("moves the whole conversation through relinkThread when asked", async () => {
@@ -311,6 +316,9 @@ describe("RelinkModal", () => {
       replace_existing_of_type: false,
     });
     expect(thread?.headers.get("Idempotency-Key")).toBeTruthy();
+    // And NO precondition: a thread moves many activities, and one version
+    // cannot condition them — the server refuses a pinned batch by name.
+    expect(thread?.headers.get("If-Match")).toBeNull();
     // The single-activity route is not called on the way.
     expect(sent.find((r) => r.key === "POST /activities/act-1/relink")).toBe(
       undefined,

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -206,6 +206,7 @@ describe("RelinkModal", () => {
     render(
       <RelinkModal
         activityId="act-1"
+        activityVersion={4}
         entityType="person"
         entityId="p-1"
         open
@@ -244,6 +245,7 @@ describe("RelinkModal", () => {
     render(
       <RelinkModal
         activityId="act-1"
+        activityVersion={4}
         entityType="deal"
         entityId="d-1"
         open
@@ -280,6 +282,7 @@ describe("RelinkModal", () => {
     render(
       <RelinkModal
         activityId="act-1"
+        activityVersion={4}
         threadKey="thread:abc"
         entityType="person"
         entityId="p-1"
@@ -319,6 +322,7 @@ describe("RelinkModal", () => {
     render(
       <RelinkModal
         activityId="act-1"
+        activityVersion={4}
         entityType="person"
         entityId="p-1"
         open
@@ -346,6 +350,7 @@ describe("RelinkModal", () => {
     render(
       <RelinkModal
         activityId="act-1"
+        activityVersion={4}
         entityType="deal"
         entityId="d-1"
         open

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -236,6 +236,46 @@ describe("RelinkModal", () => {
     expect(relink?.headers.get("If-Match")).toBe("4");
   });
 
+  // A copy read without a version cannot say what it is changing, so the relink
+  // is refused BY NAME rather than through requireVersion's bare throw — which
+  // reached the reader as the generic "something went wrong", on the very error
+  // path the write leans on to say it did not go through.
+  it("refuses in words when the activity was read without a version", async () => {
+    const onClose = vi.fn();
+    const sent = stubRoutes({
+      "GET /search": () =>
+        jsonResponse({
+          data: [{ type: "deal", id: "d-9", title: "Acme renewal" }],
+          page: { has_more: false },
+        }),
+      "POST /activities/act-1/relink": () => jsonResponse(activity202),
+    });
+    render(
+      <RelinkModal
+        activityId="act-1"
+        activityVersion={null}
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "Acme");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Acme renewal" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Relink" }));
+
+    expect(await screen.findByText(/read without a version/i)).toBeTruthy();
+    // And nothing was sent: a refusal that still wrote would be the
+    // last-write-wins this whole change is about.
+    expect(sent.find((r) => r.key === "POST /activities/act-1/relink")).toBe(
+      undefined,
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("sends replace_existing_of_type when the move toggle is on", async () => {
     const onClose = vi.fn();
     const sent = stubRoutes({

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -130,6 +130,15 @@ function useSearchTargets() {
 // this same association to every message of the conversation the rep may
 // edit, in one transaction — a mis-filed conversation is usually mis-filed
 // whole.
+// What one confirmed relink asks for, read at the moment the reader confirmed
+// it rather than at whichever render the mutation's options were last armed on.
+type RelinkRequest = Readonly<{
+  target: RecordPickerCandidate;
+  version?: number | null;
+  thread: boolean;
+  replace: boolean;
+}>;
+
 export function RelinkModal({
   activityId,
   activityVersion,
@@ -158,14 +167,18 @@ export function RelinkModal({
   const [replace, setReplace] = useState(false);
   const [wholeThread, setWholeThread] = useState(false);
 
-  // The picked target arrives as the mutation's variable: read through this
-  // closure it would be the one from the render before the confirm was
-  // enabled, because react-query re-arms a mutation's options in a passive
-  // effect. The remaining guard is a real path and stays — `kindOf` answers
-  // from the search results, and a target whose remembered kind was lost must
-  // be surfaced rather than relinked to nothing.
+  // What the confirm decided arrives as the mutation's VARIABLE — the picked
+  // target, the version it was picked against, and whether the whole thread was
+  // asked for. Read through this closure each would be the value from the
+  // render before the confirm was enabled, because react-query re-arms a
+  // mutation's options in a passive effect: a version that landed just before
+  // the click would refuse a relink that is perfectly valid, and a toggle
+  // flipped at the same moment would move the wrong set. The remaining guard is
+  // a real path and stays — `kindOf` answers from the search results, and a
+  // target whose remembered kind was lost must be surfaced rather than relinked
+  // to nothing.
   const mutation = useMutation({
-    mutationFn: async (target: RecordPickerCandidate) => {
+    mutationFn: async ({ target, version, thread, replace }: RelinkRequest) => {
       const kind = kindOf(target.id);
       if (!kind) {
         throwProblem({ title: t("compose.relinkTarget") });
@@ -175,10 +188,10 @@ export function RelinkModal({
       // rather than through requireVersion's bare throw: the reader sees the
       // mutation's error, and "something went wrong" is not a thing anyone can
       // act on when the answer is "reopen it and try again".
-      if (!wholeThread && activityVersion == null) {
+      if (!thread && version == null) {
         throwProblem({ title: t("compose.relinkNoVersion") });
       }
-      if (threadKey && wholeThread) {
+      if (threadKey && thread) {
         const { data, error } = await api.POST("/activities/relink-thread", {
           params: { header: { "Idempotency-Key": crypto.randomUUID() } },
           body: {
@@ -202,7 +215,7 @@ export function RelinkModal({
           // The idempotency key travels INSIDE the precondition rather than in
           // a `header:` of its own: they are one slot, and written twice the
           // later wins.
-          ...ifMatch(requireVersion(activityVersion ?? undefined), {
+          ...ifMatch(requireVersion(version ?? undefined), {
             "Idempotency-Key": crypto.randomUUID(),
           }),
           path: { id: activityId },
@@ -236,7 +249,15 @@ export function RelinkModal({
       title={t("compose.relinkTitle")}
       confirmLabel={t("compose.relinkConfirm")}
       confirmDisabled={!target}
-      onConfirm={() => target && mutation.mutate(target)}
+      onConfirm={() =>
+        target &&
+        mutation.mutate({
+          target,
+          version: activityVersion,
+          thread: wholeThread,
+          replace,
+        })
+      }
       pending={mutation.isPending}
       error={mutation.isError ? problemMessageOf(mutation.error, t) : null}
     >

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -133,6 +133,8 @@ function useSearchTargets() {
 // What one confirmed relink asks for, read at the moment the reader confirmed
 // it rather than at whichever render the mutation's options were last armed on.
 type RelinkRequest = Readonly<{
+  activityId: string;
+  threadKey?: string | null;
   target: RecordPickerCandidate;
   version?: number | null;
   thread: boolean;
@@ -167,9 +169,13 @@ export function RelinkModal({
   const [replace, setReplace] = useState(false);
   const [wholeThread, setWholeThread] = useState(false);
 
-  // What the confirm decided arrives as the mutation's VARIABLE — the picked
-  // target, the version it was picked against, and whether the whole thread was
-  // asked for. Read through this closure each would be the value from the
+  // What the confirm decided arrives as the mutation's VARIABLE — ALL of it,
+  // including which activity and which conversation, because a mixture is worse
+  // than either: a fresh `thread` read beside a stale `threadKey` falls through
+  // the thread door into the single relink, where the version guard has already
+  // been skipped on the strength of `thread` being true.
+  //
+  // Read through this closure each would be the value from the
   // render before the confirm was enabled, because react-query re-arms a
   // mutation's options in a passive effect: a version that landed just before
   // the click would refuse a relink that is perfectly valid, and a toggle
@@ -178,7 +184,14 @@ export function RelinkModal({
   // target whose remembered kind was lost must be surfaced rather than relinked
   // to nothing.
   const mutation = useMutation({
-    mutationFn: async ({ target, version, thread, replace }: RelinkRequest) => {
+    mutationFn: async ({
+      activityId,
+      threadKey,
+      target,
+      version,
+      thread,
+      replace,
+    }: RelinkRequest) => {
       const kind = kindOf(target.id);
       if (!kind) {
         throwProblem({ title: t("compose.relinkTarget") });
@@ -252,6 +265,8 @@ export function RelinkModal({
       onConfirm={() =>
         target &&
         mutation.mutate({
+          activityId,
+          threadKey,
           target,
           version: activityVersion,
           thread: wholeThread,

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -132,6 +132,7 @@ function useSearchTargets() {
 // whole.
 export function RelinkModal({
   activityId,
+  activityVersion,
   threadKey,
   entityType,
   entityId,
@@ -139,6 +140,11 @@ export function RelinkModal({
   onClose,
 }: Readonly<{
   activityId: string;
+  // The version the reader's copy of the activity was read at, sent as
+  // If-Match so a relink cannot overwrite a change nobody saw. Absent only
+  // where the caller genuinely has none; the thread door takes no version at
+  // all, since one cannot condition a move across many activities.
+  activityVersion?: number | null;
   threadKey?: string | null;
   entityType: RelinkKind;
   entityId: string;
@@ -179,8 +185,19 @@ export function RelinkModal({
       }
       const { data, error } = await api.POST("/activities/{id}/relink", {
         params: {
+          // The version the reader's copy was read at, so a relink cannot
+          // overwrite a change nobody saw. requireVersion refuses the write
+          // rather than sending it unpinned: unpinned is last-write-wins, and
+          // the mutation's own error path is what tells the reader it did not
+          // go through.
+          //
+          // The idempotency key travels INSIDE the precondition rather than in
+          // a `header:` of its own: they are one slot, and written twice the
+          // later wins.
+          ...ifMatch(requireVersion(activityVersion ?? undefined), {
+            "Idempotency-Key": crypto.randomUUID(),
+          }),
           path: { id: activityId },
-          header: { "Idempotency-Key": crypto.randomUUID() },
         },
         body: {
           entity_type: kind,
@@ -2552,6 +2569,7 @@ export function TimelineActions({
       {relink && (
         <RelinkModal
           activityId={activity.id}
+          activityVersion={activity.version}
           threadKey={activity.thread_key}
           entityType={entityType}
           entityId={entityId}

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -170,6 +170,14 @@ export function RelinkModal({
       if (!kind) {
         throwProblem({ title: t("compose.relinkTarget") });
       }
+      // A relink of ONE activity conditions on the version this reader saw, and
+      // a copy that arrived without one cannot make that claim. Refused by name
+      // rather than through requireVersion's bare throw: the reader sees the
+      // mutation's error, and "something went wrong" is not a thing anyone can
+      // act on when the answer is "reopen it and try again".
+      if (!wholeThread && activityVersion == null) {
+        throwProblem({ title: t("compose.relinkNoVersion") });
+      }
       if (threadKey && wholeThread) {
         const { data, error } = await api.POST("/activities/relink-thread", {
           params: { header: { "Idempotency-Key": crypto.randomUUID() } },


### PR DESCRIPTION
Closes #2614. The ticket's four steps, in its order.

## The window

`auth/admit.go` binds the version a dynamic tier was resolved from, and states why:

> That read commits before the write it admits, and the agent controls both sides of the window, so the answer is only true of the record as it WAS. Binding the version here is what makes the write re-check it inside the transaction that mutates.

Nothing re-checked it for a relink. `RelinkActivityInput` had no version field and `relinkbatch.go` compared none, so the mechanism existed and stopped at the tool.

## 1. The write contract

`RelinkActivityInput.IfVersion`, re-checked **under the row lock taken before the read** — the shape every other guarded write in this module uses, and for its reason: two relinks reading the same version would otherwise both pass the compare and the loser would silently overwrite the winner. The lock is held to commit, so the version cannot move between the check and the write beneath it.

## 2. The MCP door

`relinkActivity.Handle` asks `pinForWrite`, which answers with whichever pin exists — the version a human released against (the approved-project case the ticket names) or the one the tier was resolved from (the auto-executed case). The tool's own doc comment carried the standing caveat that this was missing; it now describes what happens instead.

## 3. The REST door

Two changes, and the second is the one that made the doors disagree.

`RelinkActivity` reads **If-Match**, which is how the REST gate forwards the pin (`compose/agentgate.go`) and how a human's client states the version it read. The parameter is declared in the contract with what it conditions.

`destinationTieredCall.tierInput` now resolves the **observed version** from the staging path's own read. It named none, and a dynamic tier that resolves to auto-execute without one is refused by the gate — so every REST relink was raised to approval whatever its destination, while MCP auto-executed the same operation after #2613. One operation, two doors, different answers.

## The batch doors take no pin, and say so

A thread or a named set moves many activities and one version cannot speak for them: applied per row it would refuse every activity except whichever happened to match, which reads as a partial move nobody asked for. Both doors forward the header so the store can refuse it — a header quietly dropped is the same failure as a pin quietly ignored, which is what this ticket is about.

A `MessageFault`, not a field fault: the pin arrives as a header, so there is no request field to name, and inventing one would point the caller at an input that is not theirs to change.

## Tests

- `TestARelinkIsRefusedWhenTheActivityMovedUnderIt` — the ticket's step 4, over HTTP: relink on the version read (200, the control that stops this passing by refusing everything), then something else moves the activity, then the same pin answers **409 `version_skew`**. Mutation-checked: removing the compare makes it 200.
- `TestABatchRelinkRefusesAVersionPinRatherThanIgnoringIt` — a pinned bulk relink answers 422 rather than moving rows on a condition nobody applied.
- `TestRelinkActivityHandsTheWriteTheVersionItsGateBound` — the MCP door hands the released pin to the write, and hands nothing when there is nothing to hand (a sentinel would make the write branch on a case it does not act on).

`make check-backend` 0 · full integration lane 0 skips, 47 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity relinking now supports version-conditional requests using `If-Match`.
  * Single-activity relinks proceed only when the activity is unchanged since it was read.
  * Relink requests retain support for idempotency keys alongside version checks.
  * Attention feeds and counts now include AI work health and bounce lanes.
* **Bug Fixes**
  * Stale relink requests return `409 version_skew` instead of modifying newer activity data.
  * Invalid or unsupported version pins are rejected before processing.
  * Meetings and calls can no longer be filed against or relinked to organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->