### PR TITLE
fix(ci): resolve the duplicate relationship.counterparty_person_id key

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -253,7 +253,6 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"relationship.person_id":                     "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — the far end of the one person↔person kind (worksWithKind), the same probe every other client-supplied endpoint on this row takes",
 	"relationship.counterparty_org_id":           "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
-	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — ensureRelationshipEndpoints walks the far end of the person-to-person kind exactly as it walks the near one",
 	"relationship.organization_id":               "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.deal_id":                       "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.project_id":                    "gated: auth.EnsureLinkTarget on the project anchor in CreateRelationship (H1)",


### PR DESCRIPTION
## Summary
`main-health`'s backend gate broke completely — a Go compile error, not a test failure, which took down every integration shard along with it:

```
migrations/schema_fitness_integration_test.go:256:2: duplicate key
"relationship.counterparty_person_id" in map literal (typecheck)
```

Two PRs each independently added a census entry for the same column around the same time — mine (#3145) and another, on different lines with different wording, so the line-based merge saw no conflict between them. Go's compiler does not allow a duplicate map key, so the tree the second one landed on never built at all.

Kept the entry with the wider context (names `worksWithKind` and the shared probe every endpoint on the row takes), dropped the duplicate.

## Test plan
- [x] `go build -tags=integration ./migrations/...` — clean
- [x] `go vet -tags=integration ./migrations/...` — clean
- [x] `grep -c counterparty_person_id` confirms exactly one entry now
- [x] `craft static` — 0 blocker, 0 major, 0 minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the backend CI gate by removing a duplicate `relationship.counterparty_person_id` key from the schema fitness test map, which was causing a Go compile error and breaking all integration shards.

Two PRs independently added the same column to the map, but the entries had different wording, so the merge didn't detect the conflict. Go rejects duplicate map keys, so the build failed. The duplicate entry is removed, and the remaining one keeps the broader context.

<sup>Written for commit abee3e41bca55456713688aafa85ab794b950c10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an internal explanatory note from the relationship foreign-key decision record.
  * The existing classification and gating decision remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->