### PR TITLE
fix(migrations): one census entry for the counterparty person endpoint

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -253,7 +253,6 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"relationship.person_id":                     "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — the far end of the one person↔person kind (worksWithKind), the same probe every other client-supplied endpoint on this row takes",
 	"relationship.counterparty_org_id":           "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
-	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — ensureRelationshipEndpoints walks the far end of the person-to-person kind exactly as it walks the near one",
 	"relationship.organization_id":               "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.deal_id":                       "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.project_id":                    "gated: auth.EnsureLinkTarget on the project anchor in CreateRelationship (H1)",


### PR DESCRIPTION
Two parallel fixes for the same red gate each added the schema-fitness classification for relationship.counterparty_person_id; the second copy is a duplicate map key, a compile error that failed the migrations package, all six integration shards and the backend gate on main-health run 33252561610. This keeps one entry and changes nothing about the classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicate schema-fitness entry for `relationship.counterparty_person_id` that was a compile error and failed the migrations package, all integration shards, and the backend gate. The classification itself is unchanged.

<sup>Written for commit 88f09c7f2755897dc51a9ed5fb2624f873defef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an outdated internal explanatory comment.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->