### PR TITLE
One entry for one FK — main does not compile with two

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -251,9 +251,8 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// the finder's ScopeClauseFor), never a request body.
 	// Client-supplied edge endpoints — every one probed at the store:
 	"relationship.person_id":                     "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
-	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — the far end of the one person↔person kind (worksWithKind), the same probe every other client-supplied endpoint on this row takes",
+	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — ensureRelationshipEndpoints walks the far end of the one person↔person kind (worksWithKind) exactly as it walks the near one, which is the same probe every other client-supplied endpoint on this row takes",
 	"relationship.counterparty_org_id":           "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
-	"relationship.counterparty_person_id":        "gated: auth.EnsureLinkTarget in CreateRelationship (H1) — ensureRelationshipEndpoints walks the far end of the person-to-person kind exactly as it walks the near one",
 	"relationship.organization_id":               "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.deal_id":                       "gated: auth.EnsureLinkTarget in CreateRelationship (H1)",
 	"relationship.project_id":                    "gated: auth.EnsureLinkTarget on the project anchor in CreateRelationship (H1)",


### PR DESCRIPTION
`main` has not compiled since #3145 and #3144 both landed.

The two fixed the same red gate in parallel — `TestFK_rowScopedTargetsHaveVisibilityDecision` on `relationship.counterparty_person_id`, which #3140 introduced — and each added its own entry to `rowScopedFKDecisions`. A duplicate key in a map literal is a compile error, so the `migrations` test package has not built since: every branch fails the lint step with a typecheck error that names neither PR.

One entry now, keeping what each of them said that the other did not — which kind the far end belongs to (`worksWithKind`), and the function that walks it (`ensureRelationshipEndpoints`).

`make check-backend` exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relationship mapping for person counterparties by consolidating duplicate and conflicting entries.
  * Preserved the existing organization counterparty behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->