### PR TITLE
Tell a model to look before it reports the work finished

### DIFF
--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -310,35 +310,6 @@ func methodNotFound(req rpcRequest) rpcResponse {
 	}
 }
 
-// initialize answers the handshake era's opening call: the revision this
-// server will speak with THIS client, what it can do, and who it is.
-func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpcError) {
-	var params struct {
-		//nolint:tagliatelle // protocolVersion is the MCP wire member, camelCase by the protocol
-		ProtocolVersion string `json:"protocolVersion"`
-	}
-	// Params is optional on the wire; only unmarshal when the client sent
-	// some, so an omitted field (not malformed JSON) falls through to the
-	// negotiator's absent-value default rather than an error.
-	if len(rawParams) > 0 {
-		if err := json.Unmarshal(rawParams, &params); err != nil {
-			// The decoder's own message names Go types, which is server-side
-			// detail an untrusted client has no use for. It is told what to
-			// send instead.
-			s.log.Warn("mcp: initialize params did not decode", "err", err)
-			return nil, &rpcError{
-				Code:    codeInvalidParams,
-				Message: `invalid params: initialize takes an object whose "protocolVersion" is a string`,
-			}
-		}
-	}
-	return map[string]any{
-		"protocolVersion": negotiateLegacyVersion(params.ProtocolVersion),
-		"capabilities":    s.capabilities(false),
-		"serverInfo":      s.identity(),
-	}, nil
-}
-
 // capabilities is what this server claims it can do — initialize reports it to
 // a handshake client and server/discover to a modern one, and the FEATURE
 // entries are identical in both, because two spellings of one claim is how a

--- a/backend/internal/modules/agents/handshake.go
+++ b/backend/internal/modules/agents/handshake.go
@@ -42,8 +42,23 @@ func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpc
 		// one era only, and the era it was missing from is the one most clients
 		// speak — so the surface's own rule about what a write can leave behind
 		// reached nobody who needed it.
-		"instructions": surfaceInstructions,
+		"instructions": s.instructions(),
 	}, nil
+}
+
+// instructions is the guidance as THIS composition can honour it.
+//
+// The queue sentence names a tool BY NAME, and the queue surface is optional:
+// RegisterApprovalTools registers nothing without an inbox, because "a role
+// with no approvals engine does not advertise a queue it cannot read". Told to
+// call it there, a model would get `method not found` — worse than silence,
+// since one that tried and failed learns the check is broken rather than that
+// there was nothing to check.
+func (s *Dispatcher) instructions() string {
+	if _, served := s.registry.Spec(listApprovalsToolName); !served {
+		return surfaceInstructions
+	}
+	return surfaceInstructions + " " + queueInstruction
 }
 
 // surfaceInstructions is the guidance for the model on the other side of the
@@ -55,19 +70,21 @@ func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpc
 // claim to two generations of client, and two spellings of one claim is how a
 // client ends up told different things by the same server — the reason
 // `capabilities` is shared already.
-//
-// THE LAST SENTENCE IS A REPORTING RULE, and it is here because nothing else
-// reaches. An assistant finished a run of correct writes and reported "nothing
-// pending approval this time" while a drafted reply sat in the queue: the
-// automation that staged it ran in reaction to what the agent had just logged,
-// after every one of its calls had returned. No write envelope can carry that —
-// the row did not exist when the write answered — so the only thing that
-// prevents the false report is the model knowing to look before it makes one.
 const surfaceInstructions = "A governed CRM tool surface. Every call re-authenticates and is bounded by " +
 	"the granting human's own permissions, so a tool may refuse a record this passport cannot " +
 	"reach. Tools that a person must approve say so in their own description; calling one " +
-	"stages the effect for review rather than performing it. " +
-	"A write can also leave a question for a human WITHOUT saying so in its answer — an " +
-	"automation reacting to what you just wrote may draft a reply or stage a change of its own, " +
-	"after your call returned. Before telling anyone the work is finished, call list_approvals " +
-	"and report what is waiting; it needs no approval of its own."
+	"stages the effect for review rather than performing it."
+
+// queueInstruction is the REPORTING RULE, appended where the queue is served.
+//
+// It is here because nothing else reaches. An assistant finished a run of
+// correct writes and reported "nothing pending approval this time" while a
+// drafted reply sat in the queue: the automation that staged it ran in reaction
+// to what the agent had just logged, after every one of its calls had returned.
+// No write envelope can carry that — the row did not exist when the write
+// answered — so the only thing that prevents the false report is the model
+// knowing to look before it makes one.
+const queueInstruction = "A write can also leave a question for a human WITHOUT saying so in its " +
+	"answer — an automation reacting to what you just wrote may draft a reply or stage a change " +
+	"of its own, after your call returned. Before telling anyone the work is finished, call " +
+	"list_approvals and report what is waiting; it needs no approval of its own."

--- a/backend/internal/modules/agents/handshake.go
+++ b/backend/internal/modules/agents/handshake.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The opening call, and what the surface says about itself in it.
+//
+// Apart from the dispatcher because the guidance is PROSE, edited as prose, for
+// the reason warnings.go is its own file: these sentences are instructions about
+// a conclusion not to draw, written for a reader that will otherwise draw it,
+// and maintaining them is a different job from the plumbing that carries them.
+
+import "encoding/json"
+
+// initialize answers the handshake era's opening call: the revision this
+// server will speak with THIS client, what it can do, and who it is.
+func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpcError) {
+	var params struct {
+		//nolint:tagliatelle // protocolVersion is the MCP wire member, camelCase by the protocol
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	// Params is optional on the wire; only unmarshal when the client sent
+	// some, so an omitted field (not malformed JSON) falls through to the
+	// negotiator's absent-value default rather than an error.
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			// The decoder's own message names Go types, which is server-side
+			// detail an untrusted client has no use for. It is told what to
+			// send instead.
+			s.log.Warn("mcp: initialize params did not decode", "err", err)
+			return nil, &rpcError{
+				Code:    codeInvalidParams,
+				Message: `invalid params: initialize takes an object whose "protocolVersion" is a string`,
+			}
+		}
+	}
+	return map[string]any{
+		"protocolVersion": negotiateLegacyVersion(params.ProtocolVersion),
+		"capabilities":    s.capabilities(false),
+		"serverInfo":      s.identity(),
+		// The SAME guidance server/discover hands a modern client. It was on
+		// one era only, and the era it was missing from is the one most clients
+		// speak — so the surface's own rule about what a write can leave behind
+		// reached nobody who needed it.
+		"instructions": surfaceInstructions,
+	}, nil
+}
+
+// surfaceInstructions is the guidance for the model on the other side of the
+// client, kept to what is true of EVERY tool: the per-tool text is
+// DescribeForClient's, and a second description of the governance here would be
+// a second answer to the same question.
+//
+// One string for both eras. `initialize` and `server/discover` are the same
+// claim to two generations of client, and two spellings of one claim is how a
+// client ends up told different things by the same server — the reason
+// `capabilities` is shared already.
+//
+// THE LAST SENTENCE IS A REPORTING RULE, and it is here because nothing else
+// reaches. An assistant finished a run of correct writes and reported "nothing
+// pending approval this time" while a drafted reply sat in the queue: the
+// automation that staged it ran in reaction to what the agent had just logged,
+// after every one of its calls had returned. No write envelope can carry that —
+// the row did not exist when the write answered — so the only thing that
+// prevents the false report is the model knowing to look before it makes one.
+const surfaceInstructions = "A governed CRM tool surface. Every call re-authenticates and is bounded by " +
+	"the granting human's own permissions, so a tool may refuse a record this passport cannot " +
+	"reach. Tools that a person must approve say so in their own description; calling one " +
+	"stages the effect for review rather than performing it. " +
+	"A write can also leave a question for a human WITHOUT saying so in its answer — an " +
+	"automation reacting to what you just wrote may draft a reply or stage a change of its own, " +
+	"after your call returned. Before telling anyone the work is finished, call list_approvals " +
+	"and report what is waiting; it needs no approval of its own."

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -355,14 +355,7 @@ func (s *Dispatcher) discover() map[string]any {
 	return map[string]any{
 		"supportedVersions": supportedProtocolVersions(),
 		"capabilities":      s.capabilities(true),
-		// Guidance for the model on the other side of the client, kept to what
-		// is true of every tool: the per-tool text is DescribeForClient's, and
-		// a second description of the governance here would be a second answer
-		// to the same question.
-		"instructions": "A governed CRM tool surface. Every call re-authenticates and is bounded by " +
-			"the granting human's own permissions, so a tool may refuse a record this passport cannot " +
-			"reach. Tools that a person must approve say so in their own description; calling one " +
-			"stages the effect for review rather than performing it.",
+		"instructions":      surfaceInstructions,
 	}
 }
 

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -355,7 +355,7 @@ func (s *Dispatcher) discover() map[string]any {
 	return map[string]any{
 		"supportedVersions": supportedProtocolVersions(),
 		"capabilities":      s.capabilities(true),
-		"instructions":      surfaceInstructions,
+		"instructions":      s.instructions(),
 	}
 }
 

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -437,7 +437,8 @@ func TestDiscoverAdvertisesTheWholeWindowAndTheSameCapabilitiesAsInitialize(t *t
 	}
 }
 
-// The reporting rule, held as prose because prose is what it is.
+// The reporting rule, held as prose because prose is what it is — and held
+// against the composition, because it names a tool that is not always served.
 //
 // An assistant finished a run of correct writes and reported "nothing pending
 // approval this time" while a drafted reply sat in the queue — staged by an
@@ -461,10 +462,55 @@ func TestTheSurfaceTellsAModelToLookBeforeItReportsTheWorkFinished(t *testing.T)
 		// And the moment: before telling anyone the work is done.
 		"Before telling anyone the work is finished",
 	} {
-		if !strings.Contains(surfaceInstructions, want) {
-			t.Errorf("the surface instructions no longer say %q:\n%s", want, surfaceInstructions)
+		if !strings.Contains(queueInstruction, want) {
+			t.Errorf("the queue guidance no longer says %q:\n%s", want, queueInstruction)
 		}
 	}
+}
+
+// And it is served only where the queue is. RegisterApprovalTools registers
+// nothing without an inbox — "a role with no approvals engine does not
+// advertise a queue it cannot read" — so a composition without one would be
+// telling a model to call something that answers `method not found`. A model
+// that tried and failed learns the check is broken, which is worse than not
+// being told to check at all.
+func TestTheQueueGuidanceIsServedOnlyWhereTheQueueIs(t *testing.T) {
+	bare := modernDispatcher(t)
+	if strings.Contains(bare.instructions(), queueInstruction) {
+		t.Errorf("a surface with no queue tells a model to call list_approvals:\n%s", bare.instructions())
+	}
+	if !strings.Contains(bare.instructions(), "A governed CRM tool surface") {
+		t.Error("a surface with no queue lost the guidance that is true of every tool")
+	}
+
+	// The same surface with the queue registered the way compose registers it,
+	// so what turns the sentence on is the REGISTRATION rather than a flag this
+	// test set.
+	withQueue := modernDispatcher(t)
+	RegisterApprovalTools(withQueue.registry, stubInbox{})
+	if !strings.Contains(withQueue.instructions(), queueInstruction) {
+		t.Error("a surface serving list_approvals does not tell a model to read it")
+	}
+}
+
+// stubInbox is an ApprovalInbox that is never called: this suite asks what the
+// surface SAYS about the queue, not what the queue answers.
+type stubInbox struct{}
+
+func (stubInbox) ListApprovals(context.Context, ApprovalQuery) (ApprovalPage, error) {
+	return ApprovalPage{}, nil
+}
+
+func (stubInbox) ReadApproval(context.Context, ids.UUID) (StagedApproval, error) {
+	return StagedApproval{}, nil
+}
+
+func (stubInbox) DecideApproval(context.Context, ids.UUID, bool, string) (StagedApproval, error) {
+	return StagedApproval{}, nil
+}
+
+func (stubInbox) DecideApprovalBundle(context.Context, ids.UUID, bool, string) ([]DecidedMember, error) {
+	return nil, nil
 }
 
 // A tool result is not a catalog: it is one caller's answer to one question

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -423,6 +423,48 @@ func TestDiscoverAdvertisesTheWholeWindowAndTheSameCapabilitiesAsInitialize(t *t
 		t.Errorf("discover claims %s and initialize claims %s — one server, one claim",
 			members["capabilities"], fromHandshake)
 	}
+	// And the INSTRUCTIONS, for the same reason and with a sharper edge: they
+	// were on the modern era alone, and the era that carried none is the one
+	// most clients speak. A model reading the handshake was told nothing at all
+	// about what a write can leave behind.
+	fromHandshakeText, err := json.Marshal(handshake["instructions"])
+	if err != nil {
+		t.Fatalf("marshalling the handshake instructions: %v", err)
+	}
+	if string(members["instructions"]) != string(fromHandshakeText) {
+		t.Errorf("discover instructs %s and initialize instructs %s — one server, one guidance",
+			members["instructions"], fromHandshakeText)
+	}
+}
+
+// The reporting rule, held as prose because prose is what it is.
+//
+// An assistant finished a run of correct writes and reported "nothing pending
+// approval this time" while a drafted reply sat in the queue — staged by an
+// automation reacting to what it had just logged, after every one of its calls
+// had returned. No write envelope can carry that row: it did not exist when the
+// write answered. The only thing between the model and the false report is
+// knowing to look, so the surface says it, and this is what keeps it said.
+func TestTheSurfaceTellsAModelToLookBeforeItReportsTheWorkFinished(t *testing.T) {
+	for _, want := range []string{
+		// That a write can leave something behind at all — the premise, and the
+		// one the transcript shows was missing.
+		"leave a question for a human",
+		// And that it can happen AFTER the call answered, which is why reading
+		// the write's own result is not enough.
+		"after your call returned",
+		// The tool that answers it, by name, and that reaching for it costs
+		// nothing — a model that thinks the check needs an approval will skip
+		// it exactly when the queue is not empty.
+		"list_approvals",
+		"needs no approval of its own",
+		// And the moment: before telling anyone the work is done.
+		"Before telling anyone the work is finished",
+	} {
+		if !strings.Contains(surfaceInstructions, want) {
+			t.Errorf("the surface instructions no longer say %q:\n%s", want, surfaceInstructions)
+		}
+	}
 }
 
 // A tool result is not a catalog: it is one caller's answer to one question

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -401,6 +401,11 @@ func TestDiscoverAnswersEveryCallerIdentically(t *testing.T) {
 // revision this server serves and the same capabilities initialize reports.
 func TestDiscoverAdvertisesTheWholeWindowAndTheSameCapabilitiesAsInitialize(t *testing.T) {
 	s := modernDispatcher(t)
+	// WITH the queue served, because that is where the two eras can differ:
+	// the guidance is composed per surface, so a comparison on a composition
+	// that serves no queue compares two copies of the general text and proves
+	// nothing about the sentence that varies.
+	RegisterApprovalTools(s.registry, stubInbox{})
 
 	members := modernRPC(scopedAgentCtx(principal.ScopeRead), t, s, methodDiscover, modernParams(""))
 

--- a/backend/internal/modules/agents/tools_approvals.go
+++ b/backend/internal/modules/agents/tools_approvals.go
@@ -127,6 +127,11 @@ func RegisterApprovalTools(r *Registry, inbox ApprovalInbox) {
 
 // --- list_approvals (🟢 read) ---
 
+// listApprovalsToolName is the queue read's name, spelled here and read by the
+// handshake: the surface tells a model to call it, and must not say so where
+// this registration did not happen.
+const listApprovalsToolName = "list_approvals"
+
 type listApprovalsTool struct{ inbox ApprovalInbox }
 
 type listApprovalsArgs struct {
@@ -138,7 +143,7 @@ type listApprovalsArgs struct {
 
 func (t listApprovalsTool) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
-		Name: "list_approvals", Title: "List what is waiting for a decision", Version: toolVersionV1,
+		Name: listApprovalsToolName, Title: "List what is waiting for a decision", Version: toolVersionV1,
 		Description:   listApprovalsCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "listApprovals",


### PR DESCRIPTION
Closes #2615.

## Why neither of the ticket's two options is the fix

The ticket offers copy on the write tools, or write envelopes that report what they staged — and calls the second more reliable *because it does not depend on the model choosing to make an extra call*.

**It would not have caught this one.** The `held_draft` was staged by an **automation reacting to the meeting the agent had just logged**, after every one of its calls had returned. The approval did not exist when any write answered, so no write envelope could have carried it. Nothing in the result of a write can report a row a later job creates.

Which leaves the thing the ticket dismissed: the model has to know to look. So the surface has to say so — and it turns out it had no way to say anything at all to the client in question.

## The gap that made it unsayable

`server/discover` carries `instructions` — *"Guidance for the model on the other side of the client, kept to what is true of every tool"*. `initialize` carries none. The handshake era is the one most clients speak, so a model arriving through it was told nothing about the surface's governance whatsoever.

One string now, both eras, held by the parity test that already keeps `capabilities` from diverging — `capabilities`' own comment says why: *"two spellings of one claim is how a client ends up told different things by the same server."*

## What it now says

Beyond what it said before, three things the transcript shows were missing:

- a write can leave a question for a human **without saying so in its answer**;
- that can happen **after your call returned** — so reading the write's own result is not enough;
- `list_approvals` answers it and **needs no approval of its own** (a model that thinks the check is itself governed will skip it exactly when the queue is not empty).

And the moment: *before telling anyone the work is finished*.

## Held by

- `TestDiscoverAdvertisesTheWholeWindowAndTheSameCapabilitiesAsInitialize` gains the instructions alongside the capabilities. Mutation-checked: dropping it from `initialize` fails with `discover instructs … and initialize instructs null`.
- `TestTheSurfaceTellsAModelToLookBeforeItReportsTheWorkFinished` holds each of the five clauses as prose, each with the wrong conclusion it prevents written beside it.

The handshake moves to its own file with the constant, for the reason `warnings.go` is its own file: these sentences are instructions about a conclusion not to draw, and editing them is a different job from the plumbing that carries them.

`make check-backend` 0 · full integration lane 0 skips.

## What this does not do

It does not make the report impossible — a model can still ignore guidance. The reliable version is a queue reading the agent cannot miss, and the only honest place for one is a surface the model reads at the END of a run, which this protocol has no notion of. If the false report recurs with the guidance in place, that is the next ticket and it is a protocol-shaped problem rather than a copy-shaped one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized guidance across connection setup and service discovery.
  * Approval-queue instructions now appear only when approval-management features are available.
  * Continued guidance on authorization, approval steps, automation side effects, and verifying pending approvals.

* **Bug Fixes**
  * Removed outdated connection-handshake behavior and messaging that could provide misleading capability information.

* **Tests**
  * Added validation to keep connection and discovery guidance consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->