### PR TITLE
Ask for a coarse fix — the question is yes or no

### DIFF
--- a/frontend/src/mcp-apps/geo.test.ts
+++ b/frontend/src/mcp-apps/geo.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { classify } from "./geo";
+import { classify, READ_OPTIONS } from "./geo";
 
 /** A stand-in for the browser's error object, which cannot be constructed. */
 function err(code: number, message: string): GeolocationPositionError {
@@ -67,5 +67,28 @@ describe("a refused position", () => {
     expect(classify(err(2, "disabled by permissions policy"))).toBe(
       "position-unavailable",
     );
+  });
+});
+
+// The probe collects less than it is allowed to.
+//
+// What this view produces is whether the frame was ALLOWED to ask, and in whose
+// words when it was not — the refusal branch is the whole of the meaning table
+// it feeds. A network-derived fix answers that identically to a satellite one,
+// so asking for the precise one would obtain maximum-precision coordinates
+// inside a third-party chat host to establish a fact that needs no coordinate,
+// and wake a phone's GNSS radio to do it.
+describe("what the read asks for", () => {
+  it("does not ask for a GPS-grade fix to answer a yes/no question", () => {
+    expect(READ_OPTIONS.enableHighAccuracy).toBe(false);
+  });
+
+  // The other two are the reason the read still terminates and still refreshes:
+  // a bound on the wait, and a bound on how stale a cached answer may be. They
+  // are asserted as PRESENT rather than at a value, since neither number is a
+  // claim this case is making.
+  it("still bounds the wait and the staleness", () => {
+    expect(READ_OPTIONS.timeout).toBeGreaterThan(0);
+    expect(READ_OPTIONS.maximumAge).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/mcp-apps/geo.ts
+++ b/frontend/src/mcp-apps/geo.ts
@@ -31,6 +31,18 @@ const TIMEOUT_MS = 15_000;
 const MAX_AGE_MS = 60_000;
 
 /**
+ * What the read asks the device for. Named rather than inline so the one
+ * decision in it can be asserted: `enableHighAccuracy` stays FALSE, because
+ * the question is whether the frame may ask at all and a coarse fix answers
+ * that identically (readPosition says the rest).
+ */
+export const READ_OPTIONS: Readonly<PositionOptions> = {
+  enableHighAccuracy: false,
+  timeout: TIMEOUT_MS,
+  maximumAge: MAX_AGE_MS,
+};
+
+/**
  * Why a position could not be read, distinguished by what a reader can DO about
  * it. The browser's own numeric codes do not separate the two cases that matter
  * most: a host that never allowed the frame to ask, and a person who was asked
@@ -127,6 +139,15 @@ export function classify(err: GeolocationPositionError): GeoRefusal {
  * permission prompt on the first call. That is the user's decision to make and
  * the reason this is never called on load — a view that asks the moment it
  * renders spends the one prompt it gets before anybody wanted the feature.
+ *
+ * AND IT ASKS FOR THE COARSE FIX. The finding this module exists to produce is
+ * WHETHER the frame was allowed to ask, and if not, in whose words — a
+ * yes/no that a network-derived position answers exactly as well as a
+ * satellite one. `enableHighAccuracy: true` would obtain the most precise
+ * coordinates the device can produce, inside a third-party chat host, to
+ * establish a fact that needs no coordinate at all; on a phone it also wakes
+ * the GNSS radio for it. Least privilege is the default until a view needs
+ * otherwise, and this one does not.
  */
 export function readPosition(): Promise<GeoResult> {
   return new Promise<GeoResult>((resolve) => {
@@ -157,7 +178,7 @@ export function readPosition(): Promise<GeoResult> {
           code: err.code,
           message: err.message,
         }),
-      { enableHighAccuracy: true, timeout: TIMEOUT_MS, maximumAge: MAX_AGE_MS },
+      READ_OPTIONS,
     );
   });
 }


### PR DESCRIPTION
Closes #2626.

`readPosition` asked for `enableHighAccuracy: true`. What the view produces is whether the frame was **allowed to ask**, and in whose words when it was not — `main.ts`'s `MEANING` table is entirely about the refusal branch, and a network-derived fix answers that identically to a satellite one.

So the precise read obtained maximum-precision coordinates, inside a third-party chat host, to establish a fact that needs no coordinate at all — and on a phone woke the GNSS radio for it. The module's own package doc already says least privilege is the default until a view needs otherwise; this one does not.

`enableHighAccuracy: false`, as the ticket suggests. The options move into a named `READ_OPTIONS` so the one decision in them can be asserted rather than living inline where nothing can hold it.

**Not done here**, and the ticket agrees it is a separate question: whether the panel should stop rendering latitude/longitude/accuracy altogether. That is about what the probe REPORTS rather than what it asks for.

**On the lifetime note**: `check_location_support` is still in the tree and still marked TEMPORARY. If it is retired soon this rides out with it, which costs nothing; until then the probe is live and collecting more than it needs.

`make check-fe` exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geolocation request behavior by using coarse accuracy, helping reduce unnecessary precision and improve reliability.
  - Preserved existing timeout and cached-location limits, so location requests continue to return promptly while respecting freshness settings.
- **Tests**
  - Added coverage confirming geolocation requests use the intended accuracy, timeout, and cache parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->