### PR TITLE
cleanup(network): remove the unreachable BucketNone skip in addPeerGroup

### DIFF
--- a/backend/internal/compose/network/persongraphpeer.go
+++ b/backend/internal/compose/network/persongraphpeer.go
@@ -14,7 +14,6 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // The peer arm's budget. Same shape as the direct arm: over-fetch recency-
@@ -38,9 +37,11 @@ const (
 //
 // No grant of its own and so no withheld state: the person read the anchor
 // already required is the only object this arm discloses, and each peer row
-// was filtered through the caller's person row scope at source. A peer whose
-// pair has decayed to the none band is not drawn at all — "they were once on
-// a thread together" is an archive fact, not an acquaintance.
+// was filtered through the caller's person row scope at source. There is no
+// none-band peer to filter: a row only exists here because §4's decay floors
+// at BucketWeak for any real LastInteraction, and a ContactEdge cannot exist
+// without one — "they were once on a thread together" is exactly what made
+// the row, however long ago.
 //
 // Pooled counts only, no receipts, the account arm's disclosure rule: the
 // metadata may be shown where the correspondence behind it may not.
@@ -71,9 +72,6 @@ func (h Reads) addPeerGroup(
 	qualified := 0
 	for _, peer := range peers {
 		score := peer.Edge.StrengthOf(now)
-		if score.Bucket == relstrength.BucketNone {
-			continue
-		}
 		qualified++
 		if shown >= graphPeerCap {
 			continue


### PR DESCRIPTION
## Summary
A cross-session QC pass found `addPeerGroup`'s `if score.Bucket == relstrength.BucketNone { continue }` cannot fire, and flagged it rather than writing a test for it ("a test that would pass either way is worse than no test") — the docstring above it describes this as active filtering ("a peer whose pair has decayed to the none band is not drawn at all"), but the intent had quietly stopped matching the code.

Verified the chain directly:
- `relstrength.bucketFor` never returns `BucketNone` — it floors at `BucketWeak` for any computed strength, including zero.
- `relstrength.Compute` only sets `BucketNone` directly, when `LastInteraction == nil`.
- `ContactEdge.StrengthOf` always passes a non-nil `LastInteraction` (its own `LastAt time.Time` field), and a `ContactEdge` row can't exist without one.

So no row this loop ever sees can score into the none band. Removed the dead guard, rewrote the docstring to state the actual invariant instead of describing a filter that never fires, and let `qualified` increment unconditionally (its effective behavior already, since the removed branch was unreachable).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/compose/network/...` — clean
- [x] `go test ./internal/compose/network/...` — passes
- [x] `craft static` — 0 blocker, 0 major, 0 minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an unreachable branch in `addPeerGroup` and updates its docstring to describe the real invariant.

The `if score.Bucket == relstrength.BucketNone` skip could never fire because `ContactEdge.StrengthOf` always passes a non-nil `LastInteraction`, and the strength calculation floors at `BucketWeak`. The old comment described filtering that didn't happen; the new comment explains why the none band is structurally impossible. No behavior changes.

<sup>Written for commit d764347618fc3d9c90819e31eb0414d95d1bb7b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer graphs now include contacts with historical connections, even when their relationship strength is unavailable or low.
  * Previously omitted peers can now appear in peer graph results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->