### PR TITLE
fix(overlay): an unmeasured budget says so instead of reporting exhaustion

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17999,6 +17999,15 @@ components:
             Free REST capacity derived from our own counts, or the `~unknown`
             sentinel (OVB-PARAM-5) when a share cannot be attributed — never a
             fabricated number (OVB-AC-1).
+        measured:
+          type: boolean
+          description: >-
+            Whether the figures were READ rather than assumed. False on the
+            meter's fail-closed arms — no accounting store reachable, an
+            unconfigured incumbent, a read error — where the bands report the
+            shed a spender must assume, not a measured exhaustion. A surface
+            showing this budget to a human states the difference rather than
+            presenting an accounting outage as quota pressure.
         search:
           $ref: '#/components/schemas/OverlayBudgetSearch'
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21503,6 +21503,9 @@ type OverlayBudget struct {
 	Headroom *string `json:"headroom,omitempty"`
 	Limit    *int64  `json:"limit,omitempty"`
 
+	// Measured Whether the figures were READ rather than assumed. False on the meter's fail-closed arms — no accounting store reachable, an unconfigured incumbent, a read error — where the bands report the shed a spender must assume, not a measured exhaustion. A surface showing this budget to a human states the difference rather than presenting an accounting outage as quota pressure.
+	Measured *bool `json:"measured,omitempty"`
+
 	// Search The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
 	Search *OverlayBudgetSearch `json:"search,omitempty"`
 

--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -229,6 +229,7 @@ func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 	searchConsumed := int64(b.SearchConsumed)
 	searchLimit := int64(b.SearchLimit)
 	searchBand := crmcontracts.OverlayBudgetBand(b.SearchBand)
+	measured := b.Measured
 
 	return crmcontracts.OverlayBudget{
 		Window:   &window,
@@ -236,6 +237,7 @@ func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 		Limit:    &limit,
 		Band:     &band,
 		Headroom: &headroom,
+		Measured: &measured,
 		Sources: &struct {
 			Capture    *int64 `json:"capture,omitempty"`
 			ForceFresh *int64 `json:"force_fresh,omitempty"`

--- a/backend/internal/modules/overlay/handlers_test.go
+++ b/backend/internal/modules/overlay/handlers_test.go
@@ -28,7 +28,8 @@ func budgetI64(p *int64) int64 {
 // window. An absent source (capture here) spent nothing and reads 0.
 func TestBudgetToWireExposesBreakdownHeadroomAndSearch(t *testing.T) {
 	w := budgetToWire(overlaybudget.Budget{
-		Window: "24h", Consumed: 7, Limit: 10, Band: overlaybudget.BandWarn,
+		Measured: true,
+		Window:   "24h", Consumed: 7, Limit: 10, Band: overlaybudget.BandWarn,
 		Headroom: overlaybudget.UnknownHeadroom,
 		Breakdown: map[overlaybudget.Source]int{
 			overlaybudget.SourceForceFresh: 4,
@@ -36,6 +37,14 @@ func TestBudgetToWireExposesBreakdownHeadroomAndSearch(t *testing.T) {
 		},
 		SearchWindow: "1s", SearchConsumed: 2, SearchLimit: 4, SearchBand: overlaybudget.BandOK,
 	})
+	if w.Measured == nil || !*w.Measured {
+		t.Fatalf("a measured snapshot's flag did not reach the wire: %v", w.Measured)
+	}
+	// The honesty half of the same field: a fail-closed snapshot must say it
+	// was assumed, or the client prints the shed as measured exhaustion.
+	if unmeasured := budgetToWire(overlaybudget.Budget{}); unmeasured.Measured == nil || *unmeasured.Measured {
+		t.Fatalf("a fail-closed snapshot's flag did not reach the wire as false: %v", unmeasured.Measured)
+	}
 
 	if w.Headroom == nil || *w.Headroom != overlaybudget.UnknownHeadroom {
 		t.Errorf("headroom = %v, want the %q sentinel (never a number, OVB-AC-1)", w.Headroom, overlaybudget.UnknownHeadroom)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12059,6 +12059,8 @@ export interface components {
             };
             /** @description Free REST capacity derived from our own counts, or the `~unknown` sentinel (OVB-PARAM-5) when a share cannot be attributed — never a fabricated number (OVB-AC-1). */
             headroom?: string;
+            /** @description Whether the figures were READ rather than assumed. False on the meter's fail-closed arms — no accounting store reachable, an unconfigured incumbent, a read error — where the bands report the shed a spender must assume, not a measured exhaustion. A surface showing this budget to a human states the difference rather than presenting an accounting outage as quota pressure. */
+            measured?: boolean;
             search?: components["schemas"]["OverlayBudgetSearch"];
         };
         /** @description The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -763,7 +763,7 @@ export const de = {
   "overlay.budgetLoadFailed": "Das Budget-Fenster konnte nicht geladen werden.",
   "overlay.budgetHeadroom": "Spielraum: {headroom}",
   "overlay.budgetUnmeasured":
-    "Das Aufrufbudget kann gerade nicht gemessen werden — der Zählerspeicher ist nicht erreichbar, Live-Aufrufe pausieren vorsorglich. Das ist kein HubSpot-Quotendruck.",
+    "Das Aufrufbudget kann gerade nicht gemessen werden, Live-Aufrufe pausieren vorsorglich. Das ist kein HubSpot-Quotendruck — der Zähler selbst liefert keine Werte.",
   "overlay.budgetEmpty":
     "Das Altsystem hat für diesen Zeitraum kein Budgetfenster gemeldet.",
   "overlay.budgetSources":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -762,6 +762,8 @@ export const de = {
   "overlay.budgetTitle": "API-Budget",
   "overlay.budgetLoadFailed": "Das Budget-Fenster konnte nicht geladen werden.",
   "overlay.budgetHeadroom": "Spielraum: {headroom}",
+  "overlay.budgetUnmeasured":
+    "Das Aufrufbudget kann gerade nicht gemessen werden — der Zählerspeicher ist nicht erreichbar, Live-Aufrufe pausieren vorsorglich. Das ist kein HubSpot-Quotendruck.",
   "overlay.budgetEmpty":
     "Das Altsystem hat für diesen Zeitraum kein Budgetfenster gemeldet.",
   "overlay.budgetSources":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -791,6 +791,8 @@ export const en = {
   "overlay.budgetTitle": "API budget",
   "overlay.budgetLoadFailed": "Couldn't load the budget window.",
   "overlay.budgetHeadroom": "Headroom: {headroom}",
+  "overlay.budgetUnmeasured":
+    "The call budget cannot be measured right now — the accounting store is unreachable, so live calls are paused as a precaution. This is not HubSpot quota pressure.",
   "overlay.budgetEmpty":
     "The incumbent reported no budget window for this period.",
   "overlay.budgetSources":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -792,7 +792,7 @@ export const en = {
   "overlay.budgetLoadFailed": "Couldn't load the budget window.",
   "overlay.budgetHeadroom": "Headroom: {headroom}",
   "overlay.budgetUnmeasured":
-    "The call budget cannot be measured right now — the accounting store is unreachable, so live calls are paused as a precaution. This is not HubSpot quota pressure.",
+    "The call budget cannot be measured right now, so live calls are paused as a precaution. This is not HubSpot quota pressure — the meter itself is not reporting.",
   "overlay.budgetEmpty":
     "The incumbent reported no budget window for this period.",
   "overlay.budgetSources":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -745,7 +745,7 @@ export const vi = {
   "overlay.budgetLoadFailed": "Không tải được cửa sổ hạn mức.",
   "overlay.budgetHeadroom": "Còn dư: {headroom}",
   "overlay.budgetUnmeasured":
-    "Hiện không đo được hạn mức lệnh gọi — kho đếm không truy cập được, các lệnh gọi trực tiếp tạm dừng để phòng ngừa. Đây không phải áp lực hạn mức HubSpot.",
+    "Hiện không đo được hạn mức lệnh gọi, các lệnh gọi trực tiếp tạm dừng để phòng ngừa. Đây không phải áp lực hạn mức HubSpot — bộ đếm không báo số liệu.",
   "overlay.budgetEmpty":
     "Hệ thống cũ không báo cáo cửa sổ ngân sách nào cho kỳ này.",
   "overlay.budgetSources":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -744,6 +744,8 @@ export const vi = {
   "overlay.budgetTitle": "Hạn mức API",
   "overlay.budgetLoadFailed": "Không tải được cửa sổ hạn mức.",
   "overlay.budgetHeadroom": "Còn dư: {headroom}",
+  "overlay.budgetUnmeasured":
+    "Hiện không đo được hạn mức lệnh gọi — kho đếm không truy cập được, các lệnh gọi trực tiếp tạm dừng để phòng ngừa. Đây không phải áp lực hạn mức HubSpot.",
   "overlay.budgetEmpty":
     "Hệ thống cũ không báo cáo cửa sổ ngân sách nào cho kỳ này.",
   "overlay.budgetSources":

--- a/frontend/src/screens/overlay-health.tsx
+++ b/frontend/src/screens/overlay-health.tsx
@@ -291,7 +291,19 @@ function BudgetPanel({
           state={readingState(query.isPending, query.data ? 1 : 0)}
           emptyLabel={t("overlay.budgetEmpty")}
         >
-          {query.data && <BudgetReading budget={query.data} locale={locale} />}
+          {/* An UNMEASURED snapshot is an accounting outage, not a reading:
+              the meter fails closed (shed, zero consumption) so a spender
+              cannot overspend, and printing those numbers as facts would
+              send an operator chasing HubSpot quota when the thing to fix
+              is our own accounting store. The figures are withheld and the
+              outage named instead. */}
+          {query.data?.measured === false ? (
+            <Callout tone="warn" live="status">
+              {t("overlay.budgetUnmeasured")}
+            </Callout>
+          ) : (
+            query.data && <BudgetReading budget={query.data} locale={locale} />
+          )}
         </SurfaceState>
       )}
     </section>

--- a/frontend/src/screens/overlay-health.tsx
+++ b/frontend/src/screens/overlay-health.tsx
@@ -291,12 +291,9 @@ function BudgetPanel({
           state={readingState(query.isPending, query.data ? 1 : 0)}
           emptyLabel={t("overlay.budgetEmpty")}
         >
-          {/* An UNMEASURED snapshot is an accounting outage, not a reading:
-              the meter fails closed (shed, zero consumption) so a spender
-              cannot overspend, and printing those numbers as facts would
-              send an operator chasing HubSpot quota when the thing to fix
-              is our own accounting store. The figures are withheld and the
-              outage named instead. */}
+          {/* Printing an unmeasured snapshot's numbers as facts would send
+              an operator chasing HubSpot quota when the fault is on our
+              side (the meter's own doc says which arms report false). */}
           {query.data?.measured === false ? (
             <Callout tone="warn" live="status">
               {t("overlay.budgetUnmeasured")}

--- a/frontend/src/screens/overlay.stories.tsx
+++ b/frontend/src/screens/overlay.stories.tsx
@@ -85,6 +85,7 @@ function budgetFixture(band: Budget["band"]): Budget {
     consumed: band === "shed" ? 980 : band === "warn" ? 750 : 100,
     limit: 1000,
     band,
+    measured: true,
     sources: { force_fresh: 20, poller: 700, capture: 30 },
     headroom: band === "shed" ? "0" : "~unknown",
     search: {
@@ -231,6 +232,29 @@ export const BudgetShed: Story = {
       "GET /overlay/connection": () => jsonResponse(activeConnection),
       "GET /overlay/sync-status": () => jsonResponse(freshSyncStatus),
       "GET /overlay/budget": () => jsonResponse(budgetFixture("shed")),
+    });
+    return (
+      <StoryProviders>
+        <OverlayCard />
+      </StoryProviders>
+    );
+  },
+};
+
+// The meter itself not reporting: the figures are withheld and the outage
+// named, instead of the fail-closed shed printing as measured exhaustion.
+export const BudgetUnmeasured: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": admin(),
+      "GET /overlay/connection": () => jsonResponse(activeConnection),
+      "GET /overlay/sync-status": () => jsonResponse(freshSyncStatus),
+      "GET /overlay/budget": () =>
+        jsonResponse({
+          ...budgetFixture("shed"),
+          measured: false,
+          consumed: 0,
+        }),
     });
     return (
       <StoryProviders>

--- a/frontend/src/screens/overlay.test.tsx
+++ b/frontend/src/screens/overlay.test.tsx
@@ -66,6 +66,7 @@ const budgetFixture: Budget = {
   consumed: 120,
   limit: 1000,
   band: "warn",
+  measured: true,
   sources: { force_fresh: 10, poller: 100, capture: 10 },
   headroom: "~unknown",
   search: {
@@ -263,6 +264,30 @@ describe("the overlay card", () => {
     // The server's own `~unknown` sentinel prints verbatim — never a
     // computed substitute.
     expect(screen.getByText(/~unknown/)).toBeTruthy();
+  });
+
+  // An unmeasured snapshot is an accounting outage, not a reading: the
+  // fail-closed shed and its zero consumption must not print as facts, or an
+  // operator debugging our own Redis chases HubSpot quota instead.
+  it("names an accounting outage instead of printing the fail-closed shed as a measured budget", async () => {
+    stubApi({
+      "GET /me": meRoute(OVERLAY_OPERATOR),
+      "GET /overlay/connection": () => jsonResponse(activeConnection),
+      "GET /overlay/sync-status": () => jsonResponse(syncStatusFixture),
+      "GET /overlay/budget": () =>
+        jsonResponse({
+          ...budgetFixture,
+          measured: false,
+          band: "shed",
+          consumed: 0,
+        }),
+    });
+    render(<OverlayCard />);
+    expect(
+      await screen.findByText(/cannot be measured right now/),
+    ).toBeTruthy();
+    expect(screen.queryByText("Shedding load")).toBeNull();
+    expect(screen.queryByText(/0 \/ /)).toBeNull();
   });
 
   it("renders a sync state or budget band this build doesn't recognize as the server's own raw value, not blank or literal 'undefined'", async () => {

--- a/frontend/src/screens/overlay.test.tsx
+++ b/frontend/src/screens/overlay.test.tsx
@@ -287,7 +287,7 @@ describe("the overlay card", () => {
       await screen.findByText(/cannot be measured right now/),
     ).toBeTruthy();
     expect(screen.queryByText("Shedding load")).toBeNull();
-    expect(screen.queryByText(/0 \/ /)).toBeNull();
+    expect(screen.queryByText(/Headroom:/)).toBeNull();
   });
 
   it("renders a sync state or budget band this build doesn't recognize as the server's own raw value, not blank or literal 'undefined'", async () => {


### PR DESCRIPTION
## What

Closes #3138. The OVB meter fails closed — no accounting store, an unconfigured incumbent, an unbound workspace, a read error all answer shed with zero consumption so a spender cannot overspend. `GET /overlay/budget` presented that assumption as a measured reading, so an operator debugging our own Redis outage was sent chasing HubSpot quota.

- The wire gains the meter's own `measured` flag (additive, optional — an older server omits it and the client keeps today's behaviour).
- The admin overlay surface withholds the figures and names the fault class when it is false — without asserting WHICH arm fired, since the wire doesn't say and guessing Redis would recreate the misdirection one step down.
- A genuinely exhausted budget still reads `measured: true` + shed and renders exactly as before; the spending gates never consult the flag.

## Verified

- Go: budgetToWire asserts both halves (measured true travels; a fail-closed zero-value travels as false) beside the OVB-AC-1 family.
- Frontend: the unmeasured state has its test (figures withheld, outage named, no shed badge) and its story; fixtures pin measured: true so the normal stories keep meaning what they show.
- `make check-backend` + `make check-fe` green; adversarial security review: no findings (the flag is less revealing than the shed-with-zero signature the endpoint already emits, and cannot make a real exhaustion ignorable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3138. `GET /overlay/budget` now reports when the meter has no reading instead of presenting a fail-closed shed as measured exhaustion. The wire gains an optional `measured` flag; when false, the admin surface withholds the figures and names the outage without guessing which arm failed. Old servers omit the flag and keep today's behavior, and genuinely exhausted budgets still render exactly as before — the spending gates never consult it.

<sup>Written for commit 96d8791f9467634c15b5b5e35aeaf56445b23245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear budget measurement status to overlay health information.
  * Displays a warning when budget measurements are unavailable and live calls are paused as a precaution.
  * Prevents unmeasured data from appearing as zero usage or showing misleading headroom and load-shedding details.
  * Added English, German, and Vietnamese translations for the new warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->