### PR TITLE
Say what the list misses, and stop missing two of it

### DIFF
--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -423,6 +423,15 @@ var retentionSweepFiles = []string{
 // the destruction of a retained column in it goes unseen. Quoting is the only
 // escape the split has to understand: a doubled ” inside a string is still
 // inside it, which falls out of the scan without a case of its own.
+//
+// Two Postgres forms it does NOT understand, and does not guess at:
+// dollar-quoting ($$…$$, $tag$…$tag$) and the E” escape, where a backslashed
+// apostrophe leaves the scan believing it has closed a string it has not. Both
+// end with the scan's `quoted` inverted against the truth, and an inverted scan
+// splits INSIDE a string — the exact fragment-with-no-table this function
+// exists to prevent. quotingBeyondTheSplit answers for them at the collection
+// site, so their arrival is a failure naming the literal rather than a green
+// run over a split nobody can trust.
 func sqlStatements(literal string) []string {
 	var out []string
 	quoted := false
@@ -442,6 +451,27 @@ func sqlStatements(literal string) []string {
 		out = append(out, collapsedSQL(trimmed))
 	}
 	return out
+}
+
+// The two literal forms sqlStatements cannot track. $tag$ is matched on the
+// OPENING form alone: a scan that has met the open has already lost, whether or
+// not the close is in the same Go literal.
+var (
+	dollarQuoteRe  = regexp.MustCompile(`\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$`)
+	escapeStringRe = regexp.MustCompile(`(?i)\bE'`)
+)
+
+// quotingBeyondTheSplit names the quoting form in a literal that sqlStatements
+// would mis-scan, or "" when there is none. Nothing in the swept files uses
+// either today; this is the tripwire for the day one does, and it fails CLOSED
+// — the caller reports the literal — because the alternative is a split landing
+// inside a string and a destructive assignment riding out in a fragment that
+// names no table.
+func quotingBeyondTheSplit(literal string) string {
+	if m := dollarQuoteRe.FindString(literal); m != "" {
+		return m
+	}
+	return escapeStringRe.FindString(literal)
 }
 
 // setAssignments returns the assignment list of one UPDATE — what sits between
@@ -582,19 +612,89 @@ func statementDestroying(statements []string, table, column string) string {
 // which is indistinguishable from a statement that really destroys nothing, and
 // that is the shape gate-patterns.md §D says a shape check silently passes.
 //
-// Nothing in the swept files assembles one today. This is the tripwire for the
-// day something does: the answer then is a failure naming the statement, not a
-// green run over a column nobody can see being written.
+// A SET clause is unreadable in two shapes, and reading only the first was the
+// same quiet pass one level in. `UPDATE provider_run SET` — which the sweep
+// really does assemble today, in retentionactions.go, joined to
+// storekit.ScrubProviderRunColumns — leaves NO assignments.
+// `UPDATE activity SET body = NULL, ` + column + ` = NULL` leaves one, so a
+// check asking only "is it empty" reads that as an ordinary statement and the
+// assembled column goes unseen exactly as before. The trailing comma is the
+// tell: an assignment list ending on a separator has an assignment after it
+// that is not in the text.
+//
+// Both answers are read off the literal alone, which is why
+// assembledSweepTargets below reads the concatenation instead: a fragment can
+// also be a COMPLETE statement — `"UPDATE activity SET body = NULL" + more +
+// " WHERE id = $1"` — and no amount of looking at that text says more follows.
+//
+// Neither reports provider_run, and that is the scoping and not an oversight.
+// The caller asks these only of a table registering columns the sweep KEEPS,
+// because the question they serve — "is the KEEPS registration still being
+// checked against this statement" — has no meaning for a table with no such
+// registration. provider_run declares none; its assembly is a named constant a
+// reader can follow, not a column hidden from one.
 func assembledSetTarget(statements []string) string {
 	for _, stmt := range statements {
 		if !updateRe.MatchString(stmt) {
 			continue
 		}
-		if strings.TrimSpace(setAssignments(stmt)) == "" {
+		assignments := strings.TrimSpace(setAssignments(stmt))
+		if assignments == "" || strings.HasSuffix(assignments, ",") {
 			return stmt
 		}
 	}
 	return ""
+}
+
+// assembledSweepTargets returns, per table, a swept SQL literal that is joined
+// to a runtime value — `"UPDATE provider_run SET" + storekit.Scrub…`. The table
+// comes from the literal's own text, which is where the write target is even
+// when the assignments are not.
+//
+// This reads the CONCATENATION, not the string, and that is the whole point.
+// assembledSetTarget can only judge the text it is handed, and a fragment that
+// reads as a finished statement is indistinguishable from one that is; the `+`
+// node is the only place the fact that more follows is written down.
+func assembledSweepTargets(t *testing.T, path string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	text := func(e ast.Expr) (string, bool) {
+		lit, ok := e.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return "", false
+		}
+		unquoted, err := strconv.Unquote(lit.Value)
+		return unquoted, err == nil
+	}
+	out := map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		join, ok := n.(*ast.BinaryExpr)
+		if !ok || join.Op != token.ADD {
+			return true
+		}
+		// One side a literal and the other not. Two literals joined are still
+		// one literal as far as the text is concerned — sqlLiterals reads both
+		// halves — and reporting those would fire on every wrapped statement in
+		// the tree.
+		for _, side := range [2][2]ast.Expr{{join.X, join.Y}, {join.Y, join.X}} {
+			fragment, ok := text(side[0])
+			if !ok {
+				continue
+			}
+			if _, alsoLiteral := text(side[1]); alsoLiteral {
+				continue
+			}
+			for _, table := range sqlWriteTargets(collapsedSQL(fragment)) {
+				out[table] = collapsedSQL(fragment)
+			}
+		}
+		return true
+	})
+	return out
 }
 
 func TestErasureAndSARReachEveryPIITable(t *testing.T) {
@@ -617,8 +717,24 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 	// look inside one statement's SET clause, or a WHERE predicate naming the
 	// column in a neighbouring statement would answer for it.
 	sweepStatements := map[string][]string{}
+	// The sweep statements this gate can only read HALF of, keyed by the table
+	// the readable half names. Collected from the syntax tree rather than the
+	// text, for the reason assembledSweepTargets gives.
+	assembled := map[string]string{}
 	for _, path := range retentionSweepFiles {
+		for table, fragment := range assembledSweepTargets(t, path) {
+			assembled[table] = fragment
+		}
 		for _, lit := range sqlLiterals(t, path) {
+			// Before the split, whether the split can be trusted. A quoting
+			// form the scan cannot track leaves it inverted, and an inverted
+			// scan cuts inside a string — which is the fragment naming no
+			// table that sqlStatements was written to prevent.
+			if form := quotingBeyondTheSplit(lit); form != "" {
+				t.Fatalf("%s carries a `%s` literal, which the statement split cannot track: %q\n"+
+					"the split would cut inside the string and the fragment carrying the assignment would name no table. "+
+					"Teach sqlStatements this form, or keep the statement out of the swept files", path, form, collapsedSQL(lit))
+			}
 			// SPLIT, because the unit both checks below name is the statement
 			// and a literal is not one. Read whole, a literal carrying two
 			// would let the first statement's SET clause answer for the second
@@ -703,10 +819,16 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 		// at all. A SET clause with no column in it is one the gate cannot
 		// judge, and answering "keeps everything" for it is the quiet pass.
 		if len(h.retentionKeeps) > 0 {
-			if assembled := assembledSetTarget(sweepStatements[table]); assembled != "" {
+			unreadable := assembledSetTarget(sweepStatements[table])
+			if unreadable == "" {
+				// The statement can be complete and still be half of one. Only
+				// the `+` says so.
+				unreadable = assembled[table]
+			}
+			if unreadable != "" {
 				missing = append(missing, "the retention sweep writes PII table "+table+
-					" with a SET clause this gate cannot read (`"+assembled+"`) — the column is assembled at runtime, so the"+
-					" columns registered as deliberately KEPT are no longer checked against it. Name the column in the"+
+					" with a statement this gate can only half read (`"+unreadable+"`) — the rest of it is assembled at runtime, so the"+
+					" columns registered as deliberately KEPT are no longer checked against it. Name the columns in the"+
 					" statement, or move the write out of the swept files and register what it does")
 			}
 		}

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -639,11 +639,33 @@ func assembledSetTarget(statements []string) string {
 			continue
 		}
 		assignments := strings.TrimSpace(setAssignments(stmt))
-		if assignments == "" || strings.HasSuffix(assignments, ",") {
+		if assignments == "" || strings.HasSuffix(assignments, ",") || formatVerbRe.MatchString(assignments) {
 			return stmt
 		}
 	}
 	return ""
+}
+
+// formatVerbRe is a fmt verb standing where a column or a value should be.
+// `fmt.Sprintf("UPDATE activity SET %s = NULL", column)` reaches the reader as
+// a literal that looks complete and names a column that is not a column, so
+// neither the empty-clause nor the dangling-comma tell fires — and no `+` node
+// exists for assembledSweepTargets to read either. The verb IS the tell.
+var formatVerbRe = regexp.MustCompile(`%[-+# 0-9.*]*[a-zA-Z]`)
+
+// unreadableWriteOn answers the swept statement on one table that this gate
+// can only half read, or "" when it can read them all.
+//
+// It is a function rather than two lines at the call site because the ANSWER is
+// two answers and dropping either is silent. The text says a fragment is
+// unfinished (assembledSetTarget); the syntax says a finished-looking fragment
+// has more joined onto it (the caller's assembledSweepTargets). A regression
+// that kept only the first would keep passing every case written for it.
+func unreadableWriteOn(statements []string, assembledFragment string) string {
+	if unreadable := assembledSetTarget(statements); unreadable != "" {
+		return unreadable
+	}
+	return assembledFragment
 }
 
 // assembledSweepTargets returns, per table, a swept SQL literal that is joined
@@ -683,6 +705,31 @@ func assembledSweepTargets(t *testing.T, path string) map[string]string {
 	}
 	out := map[string]string{}
 	ast.Inspect(file, func(n ast.Node) bool {
+		// A SQL fragment handed to an ASSEMBLER — fmt.Sprintf, a
+		// strings.Builder's WriteString, strings.Replace — is half a statement
+		// with no `+` node to say so. tx.Exec's own literal is not: the whole
+		// statement is the argument, which is why the call names are listed
+		// rather than "any call".
+		if call, isCall := n.(*ast.CallExpr); isCall && assemblesSQL(call) {
+			// The whole SUBTREE, not the direct arguments: strings.Join takes
+			// its pieces inside a slice literal, and a Sprintf format string
+			// can itself be a join of literals.
+			ast.Inspect(call, func(inner ast.Node) bool {
+				expr, isExpr := inner.(ast.Expr)
+				if !isExpr {
+					return true
+				}
+				fragment, ok := text(expr)
+				if !ok {
+					return true
+				}
+				for _, table := range sqlWriteTargets(collapsedSQL(fragment)) {
+					out[table] = collapsedSQL(fragment)
+				}
+				return true
+			})
+			return true
+		}
 		join, ok := n.(*ast.BinaryExpr)
 		if !ok || join.Op != token.ADD {
 			return true
@@ -706,6 +753,25 @@ func assembledSweepTargets(t *testing.T, path string) map[string]string {
 		return true
 	})
 	return out
+}
+
+// sqlAssemblers are the calls that build a statement out of pieces. Named
+// rather than inferred, because "a literal inside a call" is every statement in
+// the tree: tx.Exec takes the whole thing.
+var sqlAssemblers = map[string]bool{
+	"Sprintf": true, "Sprint": true, "Sprintln": true,
+	"Fprintf": true, "WriteString": true, "Replace": true, "ReplaceAll": true,
+	"Join": true,
+}
+
+func assemblesSQL(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return sqlAssemblers[fn.Sel.Name]
+	case *ast.Ident:
+		return sqlAssemblers[fn.Name]
+	}
+	return false
 }
 
 func TestErasureAndSARReachEveryPIITable(t *testing.T) {
@@ -830,13 +896,7 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 		// at all. A SET clause with no column in it is one the gate cannot
 		// judge, and answering "keeps everything" for it is the quiet pass.
 		if len(h.retentionKeeps) > 0 {
-			unreadable := assembledSetTarget(sweepStatements[table])
-			if unreadable == "" {
-				// The statement can be complete and still be half of one. Only
-				// the `+` says so.
-				unreadable = assembled[table]
-			}
-			if unreadable != "" {
+			if unreadable := unreadableWriteOn(sweepStatements[table], assembled[table]); unreadable != "" {
 				missing = append(missing, "the retention sweep writes PII table "+table+
 					" with a statement this gate can only half read (`"+unreadable+"`) — the rest of it is assembled at runtime, so the"+
 					" columns registered as deliberately KEPT are no longer checked against it. Name the columns in the"+

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -662,7 +662,18 @@ func assembledSweepTargets(t *testing.T, path string) map[string]string {
 	if err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
+	// Parentheses are not part of the expression, and reading them as if they
+	// were fails in BOTH directions: a parenthesized literal on the joined side
+	// hides the fragment, and one on the other side reads as a runtime value
+	// and reports a statement that is entirely in the text.
 	text := func(e ast.Expr) (string, bool) {
+		for {
+			paren, ok := e.(*ast.ParenExpr)
+			if !ok {
+				break
+			}
+			e = paren.X
+		}
 		lit, ok := e.(*ast.BasicLit)
 		if !ok || lit.Kind != token.STRING {
 			return "", false

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -416,12 +416,30 @@ var retentionSweepFiles = []string{
 // literal is not a statement: several in this tree carry two, and a check that
 // read the literal whole would let a second statement's SET clause hide behind
 // the first one's.
+//
+// The split skips SEMICOLONS INSIDE STRINGS, which is the case gate-patterns.md
+// §D names. `SET body = 'a;b', counterparty_email = NULL` splits naively into
+// two fragments, and the second names no table — so sqlWriteTargets drops it and
+// the destruction of a retained column in it goes unseen. Quoting is the only
+// escape the split has to understand: a doubled ” inside a string is still
+// inside it, which falls out of the scan without a case of its own.
 func sqlStatements(literal string) []string {
 	var out []string
-	for _, stmt := range strings.Split(literal, ";") {
-		if strings.TrimSpace(stmt) != "" {
-			out = append(out, collapsedSQL(stmt))
+	quoted := false
+	start := 0
+	for i, r := range literal {
+		switch {
+		case r == '\'':
+			quoted = !quoted
+		case r == ';' && !quoted:
+			if trimmed := strings.TrimSpace(literal[start:i]); trimmed != "" {
+				out = append(out, collapsedSQL(trimmed))
+			}
+			start = i + 1
 		}
+	}
+	if trimmed := strings.TrimSpace(literal[start:]); trimmed != "" {
+		out = append(out, collapsedSQL(trimmed))
 	}
 	return out
 }
@@ -518,6 +536,15 @@ func sweepPurges(statements []string, table string, predicates []string) bool {
 // does not write, so any write to it is the finding, and a DELETE of the row
 // counts because it takes the column with it.
 //
+// WHAT IT CANNOT SEE, and the tripwire that makes that loud. The column is
+// matched as a LITERAL name, so a statement whose SET target is assembled —
+// `"UPDATE activity SET " + column + " = NULL"` — carries no name to match and
+// would pass silently. gate-patterns.md §D names that as the way a shape gate
+// goes green. It cannot be read from a string literal at all, so it is not
+// matched but REPORTED: assembledSetTarget below answers for a swept UPDATE
+// whose SET clause names nothing, and the caller fails on it rather than
+// reading it as a statement that destroys no column.
+//
 // Held by TestTheRetainedColumnCheckSeesEveryDestructiveShape, which plants the
 // shapes an earlier version of this missed rather than trusting that the one
 // statement in the tree passes.
@@ -546,6 +573,30 @@ func statementDestroying(statements []string, table, column string) string {
 	return ""
 }
 
+// assembledSetTarget answers the swept UPDATE whose SET clause names no column,
+// or "" when every one of them does.
+//
+// A statement built by concatenation reaches a gate that reads string literals
+// as its literal half alone — `UPDATE activity SET ` — and the column it writes
+// is never in the text. statementDestroying would answer "destroys nothing",
+// which is indistinguishable from a statement that really destroys nothing, and
+// that is the shape gate-patterns.md §D says a shape check silently passes.
+//
+// Nothing in the swept files assembles one today. This is the tripwire for the
+// day something does: the answer then is a failure naming the statement, not a
+// green run over a column nobody can see being written.
+func assembledSetTarget(statements []string) string {
+	for _, stmt := range statements {
+		if !updateRe.MatchString(stmt) {
+			continue
+		}
+		if strings.TrimSpace(setAssignments(stmt)) == "" {
+			return stmt
+		}
+	}
+	return ""
+}
+
 func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 	t.Parallel()
 	writes := map[string]bool{}
@@ -568,9 +619,18 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 	sweepStatements := map[string][]string{}
 	for _, path := range retentionSweepFiles {
 		for _, lit := range sqlLiterals(t, path) {
-			for _, table := range sqlWriteTargets(lit) {
-				sweeps[table] += " " + collapsedSQL(lit)
-				sweepStatements[table] = append(sweepStatements[table], collapsedSQL(lit))
+			// SPLIT, because the unit both checks below name is the statement
+			// and a literal is not one. Read whole, a literal carrying two
+			// would let the first statement's SET clause answer for the second
+			// — which is what sqlStatements exists to prevent, and it was
+			// reached only by the falsification case: the gate itself passed
+			// the literal, so the shape that case plants was not one the sweep
+			// was actually checked against.
+			for _, stmt := range sqlStatements(lit) {
+				for _, table := range sqlWriteTargets(stmt) {
+					sweeps[table] += " " + stmt
+					sweepStatements[table] = append(sweepStatements[table], stmt)
+				}
 			}
 		}
 	}
@@ -638,6 +698,17 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 		if len(h.retentionKeeps) > 0 && len(sweepStatements[table]) == 0 {
 			missing = append(missing, "PII table "+table+
 				" registers a column the sweep deliberately keeps, but the sweep no longer writes this table at all — the check has nothing to read and is passing vacuously; add the file that holds the sweep's statements to retentionSweepFiles, or drop the registration")
+		}
+		// Before asking what the statements destroy, whether they can be read
+		// at all. A SET clause with no column in it is one the gate cannot
+		// judge, and answering "keeps everything" for it is the quiet pass.
+		if len(h.retentionKeeps) > 0 {
+			if assembled := assembledSetTarget(sweepStatements[table]); assembled != "" {
+				missing = append(missing, "the retention sweep writes PII table "+table+
+					" with a SET clause this gate cannot read (`"+assembled+"`) — the column is assembled at runtime, so the"+
+					" columns registered as deliberately KEPT are no longer checked against it. Name the column in the"+
+					" statement, or move the write out of the swept files and register what it does")
+			}
 		}
 		for _, column := range h.retentionKeeps {
 			if destroyer := statementDestroying(sweepStatements[table], table, column); destroyer != "" {

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -639,19 +639,33 @@ func assembledSetTarget(statements []string) string {
 			continue
 		}
 		assignments := strings.TrimSpace(setAssignments(stmt))
-		if assignments == "" || strings.HasSuffix(assignments, ",") || formatVerbRe.MatchString(assignments) {
+		if assignments == "" || strings.HasSuffix(assignments, ",") || formatVerbTargetRe.MatchString(assignments) {
 			return stmt
 		}
 	}
 	return ""
 }
 
-// formatVerbRe is a fmt verb standing where a column or a value should be.
+// formatVerbTargetRe is a fmt verb standing where a COLUMN should be — at the
+// head of the assignment list or just after a comma, and followed by the `=`
+// that makes it a target.
+//
 // `fmt.Sprintf("UPDATE activity SET %s = NULL", column)` reaches the reader as
 // a literal that looks complete and names a column that is not a column, so
 // neither the empty-clause nor the dangling-comma tell fires — and no `+` node
-// exists for assembledSweepTargets to read either. The verb IS the tell.
-var formatVerbRe = regexp.MustCompile(`%[-+# 0-9.*]*[a-zA-Z]`)
+// exists for assembledSweepTargets to read either. The verb is the tell.
+//
+// The POSITION is what makes it a tell rather than a nuisance. A bare `%` is
+// ordinary SQL text: `SET body = 'template %s'`, `SET query = 'foo%bar'`, a
+// LIKE pattern `'100%'`. Matching those would report a statement that is
+// entirely readable, and this gate's report is an instruction to go rewrite it
+// — a tripwire that fires on correct code is one somebody turns off.
+//
+// What it still reads wrongly, stated rather than implied: a comma AND a verb
+// AND an equals inside one quoted value — `SET body = 'a, %s = b'` — puts a
+// target position inside a string. That is over-recognition on a shape nothing
+// writes, which costs a false finding rather than a missed destruction.
+var formatVerbTargetRe = regexp.MustCompile(`(?:^|,)\s*%[-+# 0-9.*]*[a-z]\s*=`)
 
 // unreadableWriteOn answers the swept statement on one table that this gate
 // can only half read, or "" when it can read them all.

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // piiHandling declares how erasure and SAR must reach a PII table.
@@ -314,7 +316,34 @@ var fromJoinRe = regexp.MustCompile(`(?is)\b(?:from|join)\s+([a-z_][a-z0-9_]*)`)
 var sqlWhitespaceRe = regexp.MustCompile(`\s+`)
 
 func collapsedSQL(literal string) string {
-	return strings.ToLower(strings.TrimSpace(sqlWhitespaceRe.ReplaceAllString(literal, " ")))
+	return strings.ToLower(strings.TrimSpace(sqlWhitespaceRe.ReplaceAllString(withoutComments(literal), " ")))
+}
+
+// withoutComments replaces each comment run with a space, keeping everything
+// else — quoted values included — exactly as written.
+//
+// Before the whitespace collapse, and that ORDER is the whole of it. A line
+// comment ends at its newline; collapsing newlines first turns `SET body =
+// NULL, -- note\n counterparty_email = NULL` into one line where the comment
+// runs to the end of the statement, so every assignment after it disappears and
+// the check reports a clean sweep. The comment is not part of the statement, so
+// it comes out rather than being scanned around later.
+func withoutComments(literal string) string {
+	var out strings.Builder
+	for i := 0; i < len(literal); i++ {
+		skip, _ := gatekit.SQLSpanAt(literal, i)
+		if skip == 0 {
+			out.WriteByte(literal[i])
+			continue
+		}
+		if literal[i] == '-' || literal[i] == '/' {
+			out.WriteByte(' ')
+		} else {
+			out.WriteString(literal[i : i+skip])
+		}
+		i += skip - 1
+	}
+	return out.String()
 }
 
 // sqlLiterals returns every Go string literal in one source file. Both the
@@ -424,28 +453,36 @@ var retentionSweepFiles = []string{
 // escape the split has to understand: a doubled ” inside a string is still
 // inside it, which falls out of the scan without a case of its own.
 //
-// Two Postgres forms it does NOT understand, and does not guess at:
-// dollar-quoting ($$…$$, $tag$…$tag$) and the E” escape, where a backslashed
-// apostrophe leaves the scan believing it has closed a string it has not. Both
-// end with the scan's `quoted` inverted against the truth, and an inverted scan
-// splits INSIDE a string — the exact fragment-with-no-table this function
-// exists to prevent. quotingBeyondTheSplit answers for them at the collection
-// site, so their arrival is a failure naming the literal rather than a green
-// run over a split nobody can trust.
+// The scan is gatekit's, shared with the trigger-written-column census, because
+// "what here is not SQL" is one question: a quoted value, a dollar-quoted body,
+// a line comment and a block comment all carry semicolons that are not
+// separators, and a split landing inside one leaves a fragment naming no table.
+// Comments matter as much as quotes here — `SET body = NULL /* ; */ ,
+// counterparty_email = NULL` splits at the comment's semicolon and the
+// destruction rides out in a fragment sqlWriteTargets drops.
+//
+// ONE form it still does not understand, and does not guess at: the E” escape,
+// where a backslashed apostrophe leaves the scan believing it has closed a
+// string it has not. quotingBeyondTheSplit answers for it at the collection
+// site, so its arrival is a failure naming the literal rather than a green run
+// over a split nobody can trust — and it looks for it OUTSIDE the spans the
+// scan does understand, or an E-string MENTIONED inside a value or a comment
+// would refuse a statement that reads perfectly well.
 func sqlStatements(literal string) []string {
 	var out []string
-	quoted := false
 	start := 0
-	for i, r := range literal {
-		switch {
-		case r == '\'':
-			quoted = !quoted
-		case r == ';' && !quoted:
-			if trimmed := strings.TrimSpace(literal[start:i]); trimmed != "" {
-				out = append(out, collapsedSQL(trimmed))
-			}
-			start = i + 1
+	for i := 0; i < len(literal); i++ {
+		if skip, _ := gatekit.SQLSpanAt(literal, i); skip > 0 {
+			i += skip - 1
+			continue
 		}
+		if literal[i] != ';' {
+			continue
+		}
+		if trimmed := strings.TrimSpace(literal[start:i]); trimmed != "" {
+			out = append(out, collapsedSQL(trimmed))
+		}
+		start = i + 1
 	}
 	if trimmed := strings.TrimSpace(literal[start:]); trimmed != "" {
 		out = append(out, collapsedSQL(trimmed))
@@ -453,25 +490,33 @@ func sqlStatements(literal string) []string {
 	return out
 }
 
-// The two literal forms sqlStatements cannot track. $tag$ is matched on the
-// OPENING form alone: a scan that has met the open has already lost, whether or
-// not the close is in the same Go literal.
-var (
-	dollarQuoteRe  = regexp.MustCompile(`\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$`)
-	escapeStringRe = regexp.MustCompile(`(?i)\bE'`)
-)
+// escapeStringRe is the one form the split cannot track: E'…' takes a
+// BACKSLASH escape, so `E'a\';b'` leaves the scan believing it has closed a
+// string it has not, and an inverted scan splits inside one.
+var escapeStringRe = regexp.MustCompile(`(?i)\bE'`)
 
-// quotingBeyondTheSplit names the quoting form in a literal that sqlStatements
-// would mis-scan, or "" when there is none. Nothing in the swept files uses
-// either today; this is the tripwire for the day one does, and it fails CLOSED
-// — the caller reports the literal — because the alternative is a split landing
-// inside a string and a destructive assignment riding out in a fragment that
-// names no table.
+// quotingBeyondTheSplit names the form in a literal that sqlStatements would
+// mis-scan, or "" when there is none. Nothing in the swept files uses it today;
+// this is the tripwire for the day one does, and it fails CLOSED — the caller
+// reports the literal — because the alternative is a split landing inside a
+// string and a destructive assignment riding out in a fragment that names no
+// table.
+//
+// Looked for OUTSIDE the spans the scan does understand, which is the half a
+// bare regex gets wrong in the expensive direction: `SET body = 'E”s note'` or
+// a comment mentioning one would refuse a statement that is read perfectly
+// well, and a tripwire that fires on correct SQL is one somebody turns off.
 func quotingBeyondTheSplit(literal string) string {
-	if m := dollarQuoteRe.FindString(literal); m != "" {
-		return m
+	for i := 0; i < len(literal); i++ {
+		if skip, _ := gatekit.SQLSpanAt(literal, i); skip > 0 {
+			i += skip - 1
+			continue
+		}
+		if m := escapeStringRe.FindString(literal[i:]); m != "" && strings.HasPrefix(strings.ToLower(literal[i:]), "e'") {
+			return m
+		}
 	}
-	return escapeStringRe.FindString(literal)
+	return ""
 }
 
 // setAssignments returns the assignment list of one UPDATE — what sits between

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -179,7 +179,8 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 			t.Fatalf("write: %v", err)
 		}
-		if got := assembledSweepTargets(t, path); got[table] == "" {
+		got := assembledSweepTargets(t, path)
+		if got[table] == "" {
 			t.Errorf("a statement joined to a runtime value was not reported: %v", got)
 		}
 		// Two literals joined must NOT be reported: sqlLiterals reads both
@@ -192,6 +193,24 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 		}
 		if got := assembledSweepTargets(t, whole); len(got) != 0 {
 			t.Errorf("two literals joined were reported as assembled: %v", got)
+		}
+		// Parentheses are not part of the expression, and a reader that treats
+		// them as one is wrong in both directions: the fragment goes unseen on
+		// the joined side, and on the other side an ordinary statement reads as
+		// half-assembled.
+		parens := filepath.Join(dir, "parens.go")
+		parenSource := "package p\n\nfunc f(extra string) string {\n" +
+			"\treturn (`UPDATE activity SET body = NULL`) + extra\n}\n\n" +
+			"func g() string {\n\treturn `UPDATE person SET note = NULL` + (` WHERE id = $1`)\n}\n"
+		if err := os.WriteFile(parens, []byte(parenSource), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got = assembledSweepTargets(t, parens)
+		if got[table] == "" {
+			t.Errorf("a parenthesized fragment joined to a runtime value was not reported: %v", got)
+		}
+		if got["person"] != "" {
+			t.Errorf("a statement joined to a parenthesized LITERAL was reported as assembled: %v", got)
 		}
 	})
 

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -28,11 +28,22 @@ package gates
 //     stopped making it. Closing that needs call-graph reachability, which no
 //     SQL gate in this tree has; piicoverage_test.go states it at the call site.
 //   - An assembled SET target is not matched, because the column is not in the
-//     text to match. It is REPORTED instead — assembledSetTarget fails on a
-//     swept UPDATE whose SET clause names nothing — and the case below plants
-//     that shape.
+//     text to match. It is REPORTED instead, from two directions: from the TEXT
+//     when the fragment reads as unfinished (assembledSetTarget — no
+//     assignments, or an assignment list ending on a comma), and from the
+//     SYNTAX when it reads as finished but is joined to a runtime value
+//     (assembledSweepTargets). Both shapes are planted below.
+//   - A statement assembled by something other than `+` — fmt.Sprintf, a
+//     strings.Builder, a query builder — is seen by neither: the literal reads
+//     as ordinary and no `+` node says otherwise. Nothing in the swept files
+//     does this today and the gate would pass the day one did; closing it needs
+//     the gate to evaluate the expression rather than read it.
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 	t.Parallel()
@@ -95,6 +106,16 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 			statement: `UPDATE activity SET body = 'a;b', counterparty_email = NULL WHERE id = $1`,
 			destroys:  true,
 		}, {
+			// A DOUBLED quote inside a quoted value, which is how SQL escapes
+			// one. The split has no case for it — parity carries it, since two
+			// toggles leave the scan where it was — and this is what holds that
+			// claim: an escape branch that "skipped" the pair would leave the
+			// scan open, the `;` would read as unquoted, and the destruction
+			// after it would ride out in a fragment naming no table.
+			name:      "a doubled quote and a semicolon in the same value",
+			statement: `UPDATE activity SET body = 'it''s; fine', counterparty_email = NULL WHERE id = $1`,
+			destroys:  true,
+		}, {
 			// The other half of the same trap: a REAL second statement still
 			// has to split, so the fix for the case above must not be "stop
 			// splitting".
@@ -129,6 +150,80 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 		// on every sweep and be turned off.
 		if got := assembledSetTarget([]string{`UPDATE activity SET body = NULL WHERE id = $1`}); got != "" {
 			t.Errorf("an ordinary UPDATE was reported as assembled: %q", got)
+		}
+	})
+
+	// The same shape one assignment in. `"UPDATE activity SET body = NULL, " +
+	// column + " = NULL"` leaves a SET clause that is not empty, so a check
+	// asking only whether it is empty reads it as an ordinary statement — and
+	// the assembled column goes unseen exactly as it did before the tripwire.
+	t.Run("an assembled target behind a static assignment is reported too", func(t *testing.T) {
+		stmt := collapsedSQL(`UPDATE activity SET body = NULL, `)
+		if statementDestroying([]string{stmt}, table, column) != "" {
+			t.Error("a statement with no column in it was read as destroying one")
+		}
+		if assembledSetTarget([]string{stmt}) == "" {
+			t.Error("a SET clause ending on a comma was read as complete — the assignment after the separator " +
+				"is assembled at runtime and the KEEPS registration is no longer checked against it")
+		}
+	})
+
+	// The shape no reading of the TEXT can catch: a fragment that is a whole
+	// statement with more concatenated onto it. Only the `+` node says so,
+	// which is why assembledSweepTargets reads the syntax tree.
+	t.Run("a complete-looking fragment joined to a runtime value is reported", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "sweep.go")
+		source := "package p\n\nfunc f(extra string) string {\n" +
+			"\treturn `UPDATE activity SET body = NULL` + extra + ` WHERE id = $1`\n}\n"
+		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if got := assembledSweepTargets(t, path); got[table] == "" {
+			t.Errorf("a statement joined to a runtime value was not reported: %v", got)
+		}
+		// Two literals joined must NOT be reported: sqlLiterals reads both
+		// halves, so nothing is hidden, and reporting them would fire on every
+		// wrapped statement in the tree and get the tripwire turned off.
+		whole := filepath.Join(dir, "whole.go")
+		wholeSource := "package p\n\nconst q = `UPDATE activity SET body = NULL` + ` WHERE id = $1`\n"
+		if err := os.WriteFile(whole, []byte(wholeSource), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if got := assembledSweepTargets(t, whole); len(got) != 0 {
+			t.Errorf("two literals joined were reported as assembled: %v", got)
+		}
+	})
+
+	// The quoting the split cannot track. Each form ends with the scan's
+	// `quoted` inverted against the truth, so the split cuts inside a string —
+	// and the fragment carrying the destructive assignment names no table. The
+	// gate refuses to read these rather than trusting a scan it has lost.
+	t.Run("quoting the split cannot track is refused, not guessed at", func(t *testing.T) {
+		for _, unreadable := range []string{
+			"UPDATE activity SET body = $$a;b$$, counterparty_email = NULL WHERE id = $1",
+			"UPDATE activity SET body = $tag$a;b$tag$, counterparty_email = NULL WHERE id = $1",
+			`UPDATE activity SET body = E'a\';b', counterparty_email = NULL WHERE id = $1`,
+		} {
+			if quotingBeyondTheSplit(unreadable) == "" {
+				t.Errorf("quoting the split cannot track went unreported: %q", unreadable)
+			}
+			// And it must be refused BEFORE the split, not survive it: read
+			// through, the fragment holding the destruction names no table.
+			if statementDestroying(sqlStatements(unreadable), table, column) != "" {
+				t.Errorf("the split read %q correctly by luck; the refusal above is what this case rests on", unreadable)
+			}
+		}
+		// The ordinary quoting it CAN track is not refused, or the sweep's own
+		// statements would stop being read at all.
+		for _, readable := range []string{
+			`UPDATE activity SET body = 'a;b', counterparty_email = NULL WHERE id = $1`,
+			`UPDATE activity SET body = NULL WHERE id = $1 AND kind = 'note'`,
+			`UPDATE person SET note = 'she said ''no''' WHERE id = $1`,
+		} {
+			if form := quotingBeyondTheSplit(readable); form != "" {
+				t.Errorf("ordinary quoting was refused as %q: %s", form, readable)
+			}
 		}
 	})
 

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -33,11 +33,20 @@ package gates
 //     assignments, or an assignment list ending on a comma), and from the
 //     SYNTAX when it reads as finished but is joined to a runtime value
 //     (assembledSweepTargets). Both shapes are planted below.
-//   - A statement assembled by something other than `+` — fmt.Sprintf, a
-//     strings.Builder, a query builder — is seen by neither: the literal reads
-//     as ordinary and no `+` node says otherwise. Nothing in the swept files
-//     does this today and the gate would pass the day one did; closing it needs
-//     the gate to evaluate the expression rather than read it.
+//   - A statement assembled by something other than `+` is reported from two
+//     directions as well. `fmt.Sprintf("UPDATE activity SET %s = NULL", col)`
+//     leaves a fmt VERB standing where a column should be, which is the text
+//     tell; and a fragment handed to a named assembler — Sprintf, a
+//     strings.Builder's WriteString, strings.Replace, strings.Join — is a half
+//     statement with no `+` node to say so, which is the syntax tell. The
+//     assembler list is a LIST rather than "any call", because a literal inside
+//     a call is every statement in this tree: tx.Exec takes the whole thing.
+//   - What still gets past all four: an assembler this tree does not use, and a
+//     builder that writes the column in a call carrying no SQL literal at all —
+//     `b.WriteString(column)` after `b.WriteString("UPDATE activity SET ")`
+//     IS caught, because the first call carries the fragment, but a builder fed
+//     entirely from variables carries no text to read. Closing that needs the
+//     gate to evaluate the expression rather than read it.
 
 import (
 	"os"
@@ -132,6 +141,16 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The shapes the check cannot MATCH, and therefore REPORTS. Split from the
+// case table above because they ask a different question: the table asks
+// whether a destructive statement is seen, and these ask whether a statement
+// the gate cannot read is refused rather than read as harmless — which is how
+// a shape gate goes quietly green (gate-patterns.md §D).
+func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
+	t.Parallel()
+	const table, column = "activity", "counterparty_email"
 
 	// The shape the check cannot MATCH, and therefore reports. A column
 	// assembled at runtime is not in the literal, so statementDestroying
@@ -211,6 +230,75 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 		}
 		if got["person"] != "" {
 			t.Errorf("a statement joined to a parenthesized LITERAL was reported as assembled: %v", got)
+		}
+	})
+
+	// A fmt verb standing where a column should be. The literal reads as a
+	// finished statement — assignments present, no dangling comma — and no `+`
+	// node exists for the syntax side either, so the verb is the only tell.
+	t.Run("a format verb in the SET clause is reported", func(t *testing.T) {
+		stmt := collapsedSQL(`UPDATE activity SET body = NULL, %s = NULL WHERE id = $1`)
+		if statementDestroying([]string{stmt}, table, column) != "" {
+			t.Error("a statement with no column in it was read as destroying one")
+		}
+		if assembledSetTarget([]string{stmt}) == "" {
+			t.Error("a SET clause naming a fmt verb was read as complete — the column arrives at runtime " +
+				"and the KEEPS registration is no longer checked against it")
+		}
+		// A percent that is not a verb must not fire it, or an ordinary LIKE
+		// pattern would be a finding and the tripwire would get turned off.
+		ordinary := collapsedSQL(`UPDATE activity SET body = NULL WHERE subject LIKE '100%'`)
+		if got := assembledSetTarget([]string{ordinary}); got != "" {
+			t.Errorf("an ordinary statement was reported as assembled: %q", got)
+		}
+	})
+
+	// A fragment handed to an assembler. Sprintf and a builder leave no `+`
+	// node, and the fragment can read as a whole statement.
+	t.Run("a fragment handed to an assembler is reported", func(t *testing.T) {
+		dir := t.TempDir()
+		const head = "package p\n\nfunc f(extra string) string {\n"
+		for _, tc := range []struct{ name, body string }{
+			{"sprintf", "\treturn fmt.Sprintf(`UPDATE activity SET body = NULL, %s = NULL`, extra)\n"},
+			{"join", "\treturn strings.Join([]string{`UPDATE activity SET body = NULL`, extra}, \" \")\n"},
+			{"builder", "\tvar b strings.Builder\n\tb.WriteString(`UPDATE activity SET body = NULL`)\n\tb.WriteString(extra)\n\treturn b.String()\n"},
+			{"replace", "\treturn strings.Replace(`UPDATE activity SET body = NULL`, `NULL`, extra, 1)\n"},
+		} {
+			path := filepath.Join(dir, tc.name+".go")
+			if err := os.WriteFile(path, []byte(head+tc.body+"}\n"), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := assembledSweepTargets(t, path); got[table] == "" {
+				t.Errorf("%s: a fragment handed to an assembler was not reported: %v", tc.name, got)
+			}
+		}
+		// The whole statement passed to a QUERY call is not an assembly, or
+		// every statement in the tree would be a finding.
+		whole := filepath.Join(dir, "exec.go")
+		wholeSource := "package p\n\ntype T interface{ Exec(c C, q string) }\ntype C interface{}\n\nfunc g(tx T, ctx C) { tx.Exec(ctx, `UPDATE activity SET body = NULL WHERE id = $1`) }\n"
+		if err := os.WriteFile(whole, []byte(wholeSource), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if got := assembledSweepTargets(t, whole); len(got) != 0 {
+			t.Errorf("a statement passed whole to a query call was reported as assembled: %v", got)
+		}
+	})
+
+	// The two halves of the report, and the reason it is one function: dropping
+	// either arm is silent, because each answers for shapes the other cannot
+	// see.
+	t.Run("both halves of the unreadable report are consulted", func(t *testing.T) {
+		fromText := []string{collapsedSQL(`UPDATE activity SET `)}
+		if unreadableWriteOn(fromText, "") == "" {
+			t.Error("an unfinished fragment went unreported when the syntax side had nothing to say")
+		}
+		ordinary := []string{collapsedSQL(`UPDATE activity SET body = NULL WHERE id = $1`)}
+		if unreadableWriteOn(ordinary, `update activity set body = null`) == "" {
+			t.Error("a fragment the SYNTAX reported went unreported because the text read it as complete — " +
+				"this is the arm a caller keeping only assembledSetTarget would drop")
+		}
+		if got := unreadableWriteOn(ordinary, ""); got != "" {
+			t.Errorf("an ordinary statement was reported as unreadable: %q", got)
 		}
 	})
 

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -245,11 +245,12 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 			t.Error("a SET clause naming a fmt verb was read as complete — the column arrives at runtime " +
 				"and the KEEPS registration is no longer checked against it")
 		}
-		// A percent that is not a verb must not fire it, or an ordinary LIKE
-		// pattern would be a finding and the tripwire would get turned off.
-		ordinary := collapsedSQL(`UPDATE activity SET body = NULL WHERE subject LIKE '100%'`)
-		if got := assembledSetTarget([]string{ordinary}); got != "" {
-			t.Errorf("an ordinary statement was reported as assembled: %q", got)
+		assertOrdinaryStatementsAreNotReported(t, percentsThatAreNotVerbs...)
+		// And the verb after a static assignment, which is the position an
+		// assembled sweep would really produce.
+		behind := collapsedSQL(`UPDATE activity SET body = NULL, %s = NULL WHERE id = $1`)
+		if assembledSetTarget([]string{behind}) == "" {
+			t.Error("a verb standing where a later column should be was read as complete")
 		}
 	})
 
@@ -364,5 +365,24 @@ func TestDeclaredErasuresMustArriveInOneStatement(t *testing.T) {
 	if oneStatementCarries(apart, declared) {
 		t.Error("two statements each making half the erasure were accepted — a declaration describes one act, and " +
 			"accepting the union lets a dead helper carrying the missing half stand in for the action that stopped making it")
+	}
+}
+
+// percentsThatAreNotVerbs are ordinary SQL texts carrying a `%`. Each is
+// entirely readable, and reporting one would send an author to rewrite a
+// statement that is fine — which is how a tripwire gets turned off.
+var percentsThatAreNotVerbs = []string{
+	`UPDATE activity SET body = 'template %s' WHERE id = $1`,
+	`UPDATE activity SET query = 'foo%bar' WHERE id = $1`,
+	`UPDATE activity SET body = '100% useful' WHERE id = $1`,
+	`UPDATE activity SET body = NULL WHERE subject LIKE '100%'`,
+}
+
+func assertOrdinaryStatementsAreNotReported(t *testing.T, statements ...string) {
+	t.Helper()
+	for _, ordinary := range statements {
+		if got := assembledSetTarget([]string{collapsedSQL(ordinary)}); got != "" {
+			t.Errorf("an ordinary statement was reported as assembled: %q", got)
+		}
 	}
 }

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -259,11 +259,13 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 	// finished statement — assignments present, no dangling comma — and no `+`
 	// node exists for the syntax side either, so the verb is the only tell.
 	t.Run("a format verb in the SET clause is reported", func(t *testing.T) {
-		stmt := collapsedSQL(`UPDATE activity SET body = NULL, %s = NULL WHERE id = $1`)
-		if statementDestroying([]string{stmt}, table, column) != "" {
+		// The HEAD of the list, which is what fmt.Sprintf("UPDATE activity SET
+		// %s = NULL", column) really produces.
+		head := collapsedSQL(`UPDATE activity SET %s = NULL WHERE id = $1`)
+		if statementDestroying([]string{head}, table, column) != "" {
 			t.Error("a statement with no column in it was read as destroying one")
 		}
-		if assembledSetTarget([]string{stmt}) == "" {
+		if assembledSetTarget([]string{head}) == "" {
 			t.Error("a SET clause naming a fmt verb was read as complete — the column arrives at runtime " +
 				"and the KEEPS registration is no longer checked against it")
 		}
@@ -275,9 +277,14 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 		if got := assembledSetTarget([]string{collapsedSQL("UPDATE activity SET body = NULL /* was %s once */ WHERE id = $1")}); got != "" {
 			t.Errorf("a comment mentioning a verb was reported as assembled: %q", got)
 		}
-		// And the verb after a static assignment, which is the position an
-		// assembled sweep would really produce.
+		// And the OTHER position: after a static assignment, where the tell is
+		// the comma before the verb rather than the head of the clause. Two
+		// positions, because the pattern anchors on both and a case for one
+		// leaves the other untested.
 		behind := collapsedSQL(`UPDATE activity SET body = NULL, %s = NULL WHERE id = $1`)
+		if statementDestroying([]string{behind}, table, column) != "" {
+			t.Error("a statement with no column in it was read as destroying one")
+		}
 		if assembledSetTarget([]string{behind}) == "" {
 			t.Error("a verb standing where a later column should be was read as complete")
 		}

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -5,16 +5,32 @@
 
 package gates
 
-// The retained-column check, driven with SYNTHETIC statements rather than the
-// tree — the same reason extensionsqlscopecases_test.go gives for its own
-// cases. The sweep is supposed to pass, so a gate proven only by "the one
+// The retention sweep's two SQL claims, driven with SYNTHETIC statements rather
+// than the tree — the same reason extensionsqlscopecases_test.go gives for its
+// own cases. The sweep is supposed to pass, so a gate proven only by "the one
 // statement in the tree is clean" is one that keeps passing after it stops
 // working.
 //
-// Every MISSED row below is a shape an earlier version of this check could not
+// Two claims, not one, and the file is named for the larger: that the sweep does
+// not write a column registered as KEPT (statementDestroying), and that a
+// declared erasure arrives in ONE statement (oneStatementCarries).
+//
+// Every MISSED row below is a shape an earlier version of the check could not
 // see, each one green while the sweep destroyed the column the declaration
 // exists to protect. Rule 8 asks what shape of the defect a gate cannot see and
 // says to plant that case; this is that list.
+//
+// WHAT IS STILL NOT ON IT, stated because a list that reads as complete is what
+// stops the next author looking:
+//
+//   - A statement satisfies a declaration by EXISTING. A decoy carrying the
+//     whole erasure — a helper nobody calls — answers for an action that has
+//     stopped making it. Closing that needs call-graph reachability, which no
+//     SQL gate in this tree has; piicoverage_test.go states it at the call site.
+//   - An assembled SET target is not matched, because the column is not in the
+//     text to match. It is REPORTED instead — assembledSetTarget fails on a
+//     swept UPDATE whose SET clause names nothing — and the case below plants
+//     that shape.
 
 import "testing"
 
@@ -70,6 +86,22 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 			name:      "a longer column that merely starts with the retained name",
 			statement: `UPDATE activity SET counterparty_email_hash = NULL WHERE id = $1`,
 			destroys:  false,
+		}, {
+			// gate-patterns.md §D's own example. Split naively on `;`, this is
+			// two fragments and the second — `b', counterparty_email = null
+			// where …` — names no table, so sqlWriteTargets drops it and the
+			// destruction rides out inside a string nobody parsed.
+			name:      "a semicolon inside a quoted value",
+			statement: `UPDATE activity SET body = 'a;b', counterparty_email = NULL WHERE id = $1`,
+			destroys:  true,
+		}, {
+			// The other half of the same trap: a REAL second statement still
+			// has to split, so the fix for the case above must not be "stop
+			// splitting".
+			name: "a quoted semicolon and a real one",
+			statement: `UPDATE activity SET body = 'a;b' WHERE id = $1; ` +
+				`UPDATE activity SET counterparty_email = NULL WHERE id = $1`,
+			destroys: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -79,6 +111,26 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 			}
 		})
 	}
+
+	// The shape the check cannot MATCH, and therefore reports. A column
+	// assembled at runtime is not in the literal, so statementDestroying
+	// answers "destroys nothing" — indistinguishable from a statement that
+	// really destroys nothing, which is how a shape gate goes green (§D).
+	t.Run("an assembled SET target is reported rather than read as harmless", func(t *testing.T) {
+		assembled := []string{collapsedSQL(`UPDATE activity SET `)}
+		if statementDestroying(assembled, table, column) != "" {
+			t.Error("a statement with no column in it was read as destroying one")
+		}
+		if assembledSetTarget(assembled) == "" {
+			t.Error("a swept UPDATE whose SET clause names no column was not reported — the column is " +
+				"assembled at runtime and the KEEPS registration is no longer checked against it")
+		}
+		// And an ordinary statement is not reported, or the tripwire would fire
+		// on every sweep and be turned off.
+		if got := assembledSetTarget([]string{`UPDATE activity SET body = NULL WHERE id = $1`}); got != "" {
+			t.Errorf("an ordinary UPDATE was reported as assembled: %q", got)
+		}
+	})
 
 	// Two statements in one Go literal, the second destroying. Read whole, the
 	// first statement's SET clause answers for both.

--- a/backend/gates/retainedcolumncases_test.go
+++ b/backend/gates/retainedcolumncases_test.go
@@ -125,6 +125,28 @@ func TestTheRetainedColumnCheckSeesEveryDestructiveShape(t *testing.T) {
 			statement: `UPDATE activity SET body = 'it''s; fine', counterparty_email = NULL WHERE id = $1`,
 			destroys:  true,
 		}, {
+			// A dollar-quoted value carrying a semicolon. Understood rather
+			// than refused: the scan knows this form, and refusing what it can
+			// read would cost the sweep its own statements.
+			name:      "a semicolon inside a dollar-quoted value",
+			statement: "UPDATE activity SET body = $$a;b$$, counterparty_email = NULL WHERE id = $1",
+			destroys:  true,
+		}, {
+			name:      "a semicolon inside a tagged dollar quote",
+			statement: "UPDATE activity SET body = $tag$a;b$tag$, counterparty_email = NULL WHERE id = $1",
+			destroys:  true,
+		}, {
+			// A semicolon inside a COMMENT. Split there, the fragment carrying
+			// the destruction names no table and the gate passes over exactly
+			// the write it exists to see.
+			name:      "a semicolon inside a block comment",
+			statement: `UPDATE activity SET body = NULL /* ; */, counterparty_email = NULL WHERE id = $1`,
+			destroys:  true,
+		}, {
+			name:      "a semicolon inside a line comment",
+			statement: "UPDATE activity SET body = NULL, -- one; two\n counterparty_email = NULL WHERE id = $1",
+			destroys:  true,
+		}, {
 			// The other half of the same trap: a REAL second statement still
 			// has to split, so the fix for the case above must not be "stop
 			// splitting".
@@ -246,6 +268,13 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 				"and the KEEPS registration is no longer checked against it")
 		}
 		assertOrdinaryStatementsAreNotReported(t, percentsThatAreNotVerbs...)
+		// A comment mentioning a verb is not one. The collapse strips comments
+		// before anything reads the clause, so this never reaches the tell —
+		// which is what has to be true, or an author explaining a statement in
+		// a comment makes the gate report it.
+		if got := assembledSetTarget([]string{collapsedSQL("UPDATE activity SET body = NULL /* was %s once */ WHERE id = $1")}); got != "" {
+			t.Errorf("a comment mentioning a verb was reported as assembled: %q", got)
+		}
 		// And the verb after a static assignment, which is the position an
 		// assembled sweep would really produce.
 		behind := collapsedSQL(`UPDATE activity SET body = NULL, %s = NULL WHERE id = $1`)
@@ -309,8 +338,6 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 	// gate refuses to read these rather than trusting a scan it has lost.
 	t.Run("quoting the split cannot track is refused, not guessed at", func(t *testing.T) {
 		for _, unreadable := range []string{
-			"UPDATE activity SET body = $$a;b$$, counterparty_email = NULL WHERE id = $1",
-			"UPDATE activity SET body = $tag$a;b$tag$, counterparty_email = NULL WHERE id = $1",
 			`UPDATE activity SET body = E'a\';b', counterparty_email = NULL WHERE id = $1`,
 		} {
 			if quotingBeyondTheSplit(unreadable) == "" {
@@ -322,12 +349,18 @@ func TestTheRetainedColumnCheckRefusesWhatItCannotRead(t *testing.T) {
 				t.Errorf("the split read %q correctly by luck; the refusal above is what this case rests on", unreadable)
 			}
 		}
-		// The ordinary quoting it CAN track is not refused, or the sweep's own
-		// statements would stop being read at all.
+		// Everything it CAN track is not refused, or the sweep's own statements
+		// would stop being read at all — and the last two are the expensive
+		// mistake: an E'' MENTIONED inside a value or a comment is not one, and
+		// a tripwire that refuses a statement it reads perfectly well is one
+		// somebody turns off.
 		for _, readable := range []string{
 			`UPDATE activity SET body = 'a;b', counterparty_email = NULL WHERE id = $1`,
 			`UPDATE activity SET body = NULL WHERE id = $1 AND kind = 'note'`,
 			`UPDATE person SET note = 'she said ''no''' WHERE id = $1`,
+			"UPDATE activity SET body = $$a;b$$, counterparty_email = NULL WHERE id = $1",
+			`UPDATE person SET note = 'E''s own note' WHERE id = $1`,
+			"UPDATE person SET note = NULL -- not an E'scape\n WHERE id = $1",
 		} {
 			if form := quotingBeyondTheSplit(readable); form != "" {
 				t.Errorf("ordinary quoting was refused as %q: %s", form, readable)

--- a/backend/internal/shared/gatekit/sqlspans.go
+++ b/backend/internal/shared/gatekit/sqlspans.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gatekit
+
+// Stepping over the parts of a SQL statement that are not SQL.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// dollarTagRe matches a dollar-quote opener at the current position.
+var dollarTagRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$`)
+
+// SQLSpanAt returns the length of the quoted or commented run starting at pos
+// and whether it CLOSED, or 0 when the text there is ordinary SQL.
+//
+// Every census that reads a statement's structure — where a clause ends, where
+// one assignment stops and the next begins, where one statement stops and the
+// next begins — has to step OVER these rather than through them, and each of
+// them fails differently by not doing it:
+//
+//   - a clause word inside a value (`SET body = 'from the report', …`) ends an
+//     assignment list early, hiding every assignment after it;
+//   - a comma inside a value (`'Weber, Anna'`) splits one assignment into two,
+//     and the text after the comma can read as an assignment of its own — so a
+//     column MENTIONED in a sentence becomes a column WRITTEN;
+//   - a semicolon inside a value or a comment splits one statement into two,
+//     and the fragment carrying the destruction names no table.
+//
+// A doubled ” inside a string needs no case of its own: the run ends at the
+// first quote, the next character opens a new run, and that one closes where
+// the real one does. Block comments NEST, which Postgres allows and a naive
+// scan to the first `*/` gets wrong.
+//
+// A run that never closes is reported rather than swallowed, because swallowing
+// it steps over the whole remainder — the under-recognition direction, which
+// arrives as a green run with nothing saying the reader stopped seeing
+// anything. It happens when the closing delimiter is in a piece the reader does
+// not have: `"UPDATE x SET body = '" + v + "'"`. A LINE comment running to the
+// end of the text is closed, not unterminated: that is where a line comment
+// ends.
+func SQLSpanAt(text string, pos int) (length int, closed bool) {
+	switch {
+	case text[pos] == '\'':
+		for i := pos + 1; i < len(text); i++ {
+			if text[i] == '\'' {
+				return i - pos + 1, true
+			}
+		}
+		return len(text) - pos, false
+	case strings.HasPrefix(text[pos:], "--"):
+		if end := strings.IndexByte(text[pos:], '\n'); end >= 0 {
+			return end + 1, true
+		}
+		return len(text) - pos, true
+	case strings.HasPrefix(text[pos:], "/*"):
+		return blockCommentSpan(text, pos)
+	}
+	tag := dollarTagRe.FindString(text[pos:])
+	if tag == "" {
+		return 0, true
+	}
+	if end := strings.Index(text[pos+len(tag):], tag); end >= 0 {
+		return len(tag) + end + len(tag), true
+	}
+	return len(text) - pos, false
+}
+
+// blockCommentSpan measures a /* … */ run, counting nesting the way Postgres
+// reads it: `/* a /* b */ c */` is ONE comment, and a scan stopping at the
+// first `*/` would resume inside it.
+func blockCommentSpan(text string, pos int) (length int, closed bool) {
+	depth := 0
+	for i := pos; i < len(text)-1; i++ {
+		switch {
+		case text[i] == '/' && text[i+1] == '*':
+			depth++
+			i++
+		case text[i] == '*' && text[i+1] == '/':
+			depth--
+			i++
+			if depth == 0 {
+				return i - pos + 1, true
+			}
+		}
+	}
+	return len(text) - pos, false
+}

--- a/backend/internal/shared/gatekit/sqlspans_test.go
+++ b/backend/internal/shared/gatekit/sqlspans_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gatekit
+
+import "testing"
+
+// Every shape a census reading SQL structure has to step over, and every
+// lookalike it must not. Each MISSED row hides the assignments after it from
+// whatever is scanning; each unterminated row is the one that must be reported
+// rather than swallowed, because swallowing steps over the whole remainder and
+// passes green.
+func TestSQLSpanAt(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		text   string
+		pos    int
+		length int
+		closed bool
+	}{
+		{name: "ordinary SQL is not a span", text: "a = 1", pos: 0, length: 0, closed: true},
+		{name: "a quoted value", text: "x = 'a, b' , y", pos: 4, length: 6, closed: true},
+		{
+			// A doubled '' is how SQL escapes one, and it needs no case in the
+			// scan: the first run ends AT the first of the pair, and the second
+			// of the pair opens a run that ends where the real close is. The
+			// two together cover the literal, which is what a caller stepping
+			// span by span sees.
+			name: "a doubled quote is two runs that meet",
+			text: "'it''s'", pos: 0, length: 4, closed: true,
+		},
+		{
+			name: "and the second of the pair closes where the value really ends",
+			text: "'it''s'", pos: 4, length: 3, closed: true,
+		},
+		{name: "an unterminated quote is reported", text: "x = 'never closed", pos: 4, length: 13, closed: false},
+		{name: "a dollar-quoted value", text: "x = $$a;b$$ , y", pos: 4, length: 7, closed: true},
+		{name: "a tagged dollar quote", text: "$tag$ where 'it' $tag$", pos: 0, length: 22, closed: true},
+		{name: "an unterminated dollar quote is reported", text: "$tag$ never closed", pos: 0, length: 18, closed: false},
+		{
+			// A line comment ENDS at the newline; running to the end of the
+			// text is where it ends, not a failure to close.
+			name: "a line comment to the newline", text: "-- it's the owner's row\nx = 1", pos: 0, length: 24, closed: true,
+		},
+		{name: "a line comment to the end of the text", text: "-- it's all", pos: 0, length: 11, closed: true},
+		{name: "a block comment", text: "/* ; */ x", pos: 0, length: 7, closed: true},
+		{
+			// Postgres NESTS these. A scan stopping at the first `*/` resumes
+			// inside the comment and reads its text as SQL.
+			name: "a nested block comment", text: "/* a /* b */ c */ x", pos: 0, length: 17, closed: true,
+		},
+		{name: "an unterminated block comment is reported", text: "/* never closed", pos: 0, length: 15, closed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			length, closed := SQLSpanAt(tc.text, tc.pos)
+			if length != tc.length || closed != tc.closed {
+				t.Errorf("SQLSpanAt(%q, %d) = (%d, %v), want (%d, %v)", tc.text, tc.pos, length, closed, tc.length, tc.closed)
+			}
+		})
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -259,5 +259,5 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobfleetwideshapes_test.go` | H2 | The FleetWide gate's own falsification, kept beside it: every dispatch shape the tree actually uses, proven accepted, and the shapes it exists to reject — a dispatcher doing a tenant's work, and a fan-out built around the chokepoints — proven rejected. |
 | `jobkindgate_test.go` | H2 | The registration gate's own falsification. |
 | `rbacbaselineerafixture_test.go` | H3 | The pre-state the RBAC composition gate replays over must not be hand-editable. |
-| `retainedcolumncases_test.go` | H1 | The retained-column check, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
+| `retainedcolumncases_test.go` | H1 | The retention sweep's two SQL claims, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
 | `updateguardcases_test.go` | H2 | What the concurrency-guard census judges a function on, driven with SYNTHETIC source rather than the tree — the same reason retainedcolumncases\_test.go gives for its own cases. |


### PR DESCRIPTION
Closes #2631.

The file opened by claiming to *be* the rule-8 list — "Rule 8 asks what shape of the defect a gate cannot see and says to plant that case; this is that list." A list that reads as complete is exactly what stops the next author looking, which is the failure `retentionKeeps` and the uniqueness register exist to prevent. So it now names what is still not on it, and the two shapes the ticket found are.

## 1. A `;` inside a quoted value

§D's own example. `SET body = 'a;b', counterparty_email = NULL` split into two fragments; the second named no table, `sqlWriteTargets` dropped it, and the destruction of a retained column rode out inside a string nobody parsed.

The split is quote-aware now. Both halves of the trap are planted, because the fix must not be "stop splitting": the quoted semicolon that must NOT split, and a real one beside it that still must. Mutation-checked — restoring the naive split fails the first.

## …which turned up the larger one

**The gate never called `sqlStatements`.** The collection loop appended whole literals, so the case that plants "a second statement in the same literal" was proving a splitter the sweep was not checked through — the shape was planted against a helper the gate did not use.

The loop splits now, so both the planted case and the ticket's finding land on the path that actually runs.

## 2. An assembled SET target

It cannot be MATCHED: `"UPDATE activity SET " + column + " = NULL"` reaches a literal reader as `UPDATE activity SET `, and the column is not in the text. `statementDestroying` would answer "destroys nothing", which is indistinguishable from a statement that truly destroys nothing — §D's description of how a shape gate goes green.

So it is **reported** rather than matched: `assembledSetTarget` fails on a swept UPDATE whose SET clause names no column, and `statementDestroying`'s doc says what it cannot see and points at the tripwire. Nothing in the swept files assembles one today — this is for the day something does. The case asserts both ends: the assembled statement is reported, and an ordinary UPDATE is not (a tripwire that fires on every sweep is one somebody turns off).

## 3. The file's first sentence

It described only the retained-column half while the file also falsifies `oneStatementCarries`, so the generated inventory cell under-described it. Both claims are named, and the inventory is regenerated.

`make check-backend` 0 · full integration lane 0 skips.

Out of scope as the ticket says: the decoy statement that satisfies a declaration by existing, which needs call-graph reachability — now named in the list rather than only at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL statement handling so semicolons inside quoted text are preserved correctly.
  * Unsupported PostgreSQL dollar-quoted and escape-string literals are now rejected safely.
  * Retention checks now evaluate individual SQL statements, preventing incorrect cross-statement matches.
  * Retention validation detects dynamically assembled update targets, including incomplete, concatenated, parenthesized, and formatted strings.
  * Configured retained columns are flagged when updates cannot be verified, including unreadable assembled writes and common string-building patterns.

* **Documentation**
  * Updated retention validation documentation to describe the SQL claims checked by the gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->