### PR TITLE
One coverage card, not two, and the dead one had tests

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5085,14 +5085,9 @@ export const de = {
   "network.bucket.weak": "Schwach",
   "network.bucket.moderate": "Mittel",
   "network.bucket.strong": "Stark",
-  "coverage.title": "Abdeckung",
   "coverage.engaged": "Im Austausch",
   "coverage.quiet": "Kein beidseitiger Kontakt",
   "coverage.seatWithheld": "Ein Kontakt, den Sie nicht lesen dürfen",
-  "coverage.clear":
-    "Nichts markiert — dieser Deal besteht alle Abdeckungsprüfungen.",
-  "coverage.withheld":
-    "Abdeckung zurückgehalten — Sie können die Beziehungen dieses Deals nicht lesen, daher wurde keine Prüfung durchgeführt.",
   "coverage.daysSinceTouch": "{days} Tage",
   "coverage.risk.single_threaded_theirs": "Nur ein Kontakt",
   "coverage.risk.single_threaded_ours": "Von einer Person getragen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5143,13 +5143,9 @@ export const en = {
   "network.bucket.weak": "Weak",
   "network.bucket.moderate": "Moderate",
   "network.bucket.strong": "Strong",
-  "coverage.title": "Coverage",
   "coverage.engaged": "Engaged",
   "coverage.quiet": "No two-way contact",
   "coverage.seatWithheld": "A contact you cannot read",
-  "coverage.clear": "Nothing flagged — this deal passes every coverage check.",
-  "coverage.withheld":
-    "Coverage was withheld — you cannot read this deal’s relationships, so no check was run.",
   "coverage.daysSinceTouch": "{days} days",
   "coverage.risk.single_threaded_theirs": "Single-threaded",
   "coverage.risk.single_threaded_ours": "Carried by one colleague",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5035,14 +5035,9 @@ export const vi = {
   "network.bucket.weak": "Yếu",
   "network.bucket.moderate": "Vừa",
   "network.bucket.strong": "Mạnh",
-  "coverage.title": "Độ phủ",
   "coverage.engaged": "Đang trao đổi",
   "coverage.quiet": "Chưa có trao đổi hai chiều",
   "coverage.seatWithheld": "Một liên hệ bạn không thể xem",
-  "coverage.clear":
-    "Không có gì đáng lưu ý — deal này qua mọi kiểm tra độ phủ.",
-  "coverage.withheld":
-    "Độ phủ bị giữ lại — bạn không đọc được quan hệ của deal này, nên chưa kiểm tra gì.",
   "coverage.daysSinceTouch": "{days} ngày",
   "coverage.risk.single_threaded_theirs": "Chỉ một đầu mối",
   "coverage.risk.single_threaded_ours": "Chỉ một đồng nghiệp phụ trách",

--- a/frontend/src/screens/network.css
+++ b/frontend/src/screens/network.css
@@ -1,18 +1,18 @@
-/* The two relationship-graph cards (ADR-0078).
+/* The relationship-graph card (ADR-0078), and the deal rail's seat list, which
+   reads as the same kind of thing and imports this file for it.
 
    Both are lists whose rows carry a name, a band and two numbers. Rendered as
    plain rows rather than a table: there are at most ten of them, and a table
    header would cost more vertical space than the rows it labels. */
 
-/* Both cards stack among the other 360 panels, so they carry the same gap
-   those panels leave — as a token, not a raw pixel count. */
+/* The card stacks among the other 360 panels, so it carries the same gap those
+   panels leave — as a token, not a raw pixel count. */
 .net-card {
   margin-bottom: var(--space-4);
 }
 
 .net-colleagues,
-.net-seats,
-.net-risks {
+.net-seats {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -28,8 +28,7 @@
 }
 
 .net-colleagues li,
-.net-seats li,
-.net-risks li {
+.net-seats li {
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -52,23 +51,4 @@
   color: var(--textContent);
   font: 500 0.875rem / 1.4 var(--f-body);
   overflow-wrap: anywhere;
-}
-
-/* The reason a flag fired. It wraps onto its own line on a narrow card rather
-   than truncating: a risk a rep cannot read the reason for is a red dot. */
-/* --textMeta, not --textMuted: --textMuted is the placeholder-grade ink and
-   measures 1.54:1 on this ground, while tokens.css names --textMeta the
-   canonical AA small-text role. Every line below is prose a reader is meant to
-   READ. */
-.net-risk-why {
-  flex: 1 1 12rem;
-  min-width: 0;
-  color: var(--textMeta);
-  font: 400 0.8125rem / 1.5 var(--f-body);
-}
-
-.net-risk-days {
-  color: var(--textMeta);
-  font-size: 0.8125rem;
-  font-variant-numeric: tabular-nums;
 }

--- a/frontend/src/screens/network.stories.tsx
+++ b/frontend/src/screens/network.stories.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { DealCoverageCard, PersonNetworkCard } from "./network";
+import { PersonNetworkCard } from "./network";
 import {
   installFetchStub,
   jsonResponse,
@@ -10,10 +10,16 @@ import {
   StoryProviders,
 } from "./story-utils";
 
-// The two relationship-graph cards (ADR-0078). Both fetch their own data, so
-// the shared fetch stub carries the fixtures — chosen to show the readings that
-// are easy to get wrong: a never-spoken colleague, a clean deal, and a deal
-// carrying two findings of different severity.
+// The relationship-graph card (ADR-0078). It fetches its own data, so the
+// shared fetch stub carries the fixture — chosen to show the reading that is
+// easy to get wrong: a colleague on the record nobody has ever spoken to.
+//
+// The deal-coverage frames that used to sit beside these are in
+// deal360/dealcommittee.stories.tsx, on the card that actually ships. Its
+// `Withheld` and `Empty` are the pair to open when changing that surface: they
+// differ only in `sections_omitted`, and a reviewer comparing the two frames is
+// the check that no refactor collapses "we could not look" into "nothing is
+// wrong".
 const meta: Meta = {
   title: "Records/Network",
   parameters: { layout: "padded" },
@@ -79,90 +85,6 @@ export const NobodyKnowsThem: Story = {
     return (
       <StoryProviders>
         <PersonNetworkCard id="p-1" />
-      </StoryProviders>
-    );
-  },
-};
-
-// Two findings of different severity: somebody is gone (danger) and the deal
-// has drifted (warning). Rendering both as alarms is how a card stops being
-// read at all.
-export const DealAtRisk: Story = {
-  render: () => {
-    installFetchStub({
-      "GET /me": meRoute({}),
-      "GET /deals/d-1/coverage": () =>
-        jsonResponse({
-          deal_id: "d-1",
-          stakeholders: [],
-          our_side: [],
-          risks: [
-            {
-              kind: "champion_left",
-              summary:
-                "the champion has left the account — the person arguing for this deal no longer works there",
-              person_ids: ["p-9"],
-            },
-            {
-              kind: "going_cold",
-              summary:
-                "no captured touch for 41 days — the deal is open and nobody is talking",
-              days_since_touch: 41,
-            },
-          ],
-        }),
-    });
-    return (
-      <StoryProviders>
-        <DealCoverageCard id="d-1" />
-      </StoryProviders>
-    );
-  },
-};
-
-// Nothing flagged is a RESULT and says so. A blank card is indistinguishable
-// from one that failed to load.
-export const DealClear: Story = {
-  render: () => {
-    installFetchStub({
-      "GET /me": meRoute({}),
-      "GET /deals/d-1/coverage": () =>
-        jsonResponse({
-          deal_id: "d-1",
-          stakeholders: [],
-          our_side: [],
-          risks: [],
-        }),
-    });
-    return (
-      <StoryProviders>
-        <DealCoverageCard id="d-1" />
-      </StoryProviders>
-    );
-  },
-};
-
-// The withheld view, beside the clear one deliberately: the two payloads differ
-// only in `sections_omitted`, and the card MUST NOT render them alike. This is
-// the story to open when changing the card — a reviewer comparing these two
-// frames is the check that no refactor collapses "we could not look" back into
-// "nothing is wrong".
-export const DealCoverageWithheld: Story = {
-  render: () => {
-    installFetchStub({
-      "GET /me": meRoute({}),
-      "GET /deals/d-1/coverage": () =>
-        jsonResponse({
-          deal_id: "d-1",
-          stakeholders: [],
-          our_side: [],
-          risks: [],
-          sections_omitted: ["stakeholders", "our_side", "risks"],
-        }),
-    });
-    return (
-      <StoryProviders>
-        <DealCoverageCard id="d-1" />
       </StoryProviders>
     );
   },

--- a/frontend/src/screens/network.test.tsx
+++ b/frontend/src/screens/network.test.tsx
@@ -11,12 +11,11 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
-import { DealCoverageCard, PersonNetworkCard } from "./network";
+import { PersonNetworkCard } from "./network";
 
-// The two relationship-graph cards. What is worth pinning is not that they
-// render a list — it is the handful of readings that would quietly mislead a
-// rep: an unspoken relationship shown as a zero, a clean deal shown as a blank
-// card, and a server ranking a client re-sorted.
+// The relationship-graph card. What is worth pinning is not that it renders a
+// list — it is the two readings that would quietly mislead a rep: an unspoken
+// relationship shown as a zero, and a server ranking a client re-sorted.
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -129,94 +128,5 @@ describe("PersonNetworkCard", () => {
     expect(
       await screen.findByText(/nobody here has recorded contact/i),
     ).toBeInTheDocument();
-  });
-});
-
-describe("DealCoverageCard", () => {
-  it("renders each finding with the server's own reason, not a client re-wording", async () => {
-    // The summary explains WHY the rule fired. A card that showed only the kind
-    // would be a red dot nobody can act on, and one that re-worded it would let
-    // this surface and the assistant describe the same flag differently.
-    stubRoutes({
-      "/deals/d-1/coverage": {
-        deal_id: "d-1",
-        stakeholders: [],
-        our_side: [],
-        risks: [
-          {
-            kind: "champion_left",
-            summary: "the champion has left the account",
-            person_ids: ["p-9"],
-          },
-          {
-            kind: "going_cold",
-            summary: "no captured touch for 41 days",
-            days_since_touch: 41,
-          },
-        ],
-      },
-    });
-    render(<DealCoverageCard id="d-1" />);
-    expect(await screen.findByText("Champion has left")).toBeInTheDocument();
-    expect(
-      screen.getByText("the champion has left the account"),
-    ).toBeInTheDocument();
-    // The day count is what the 30/60-day views filter on, so it has to reach
-    // the screen rather than living only in the payload.
-    expect(screen.getByText("41 days")).toBeInTheDocument();
-  });
-
-  it("says a clean deal is clean instead of rendering a blank card", async () => {
-    // No findings is a RESULT. A card that rendered nothing is indistinguishable
-    // from one that failed to load, and a manager reads the blank as "unknown".
-    stubRoutes({
-      "/deals/d-1/coverage": {
-        deal_id: "d-1",
-        stakeholders: [],
-        our_side: [],
-        risks: [],
-      },
-    });
-    render(<DealCoverageCard id="d-1" />);
-    expect(
-      await screen.findByText(/passes every coverage check/i),
-    ).toBeInTheDocument();
-  });
-
-  it("says the coverage was withheld rather than that the deal is clean", async () => {
-    // The payload a caller without the relationship grant receives: three
-    // empty arrays and the reason. Rendering the empty risk list would tell a
-    // manager the deal passes every check when no check ran — the wrong
-    // verdict this channel exists to prevent, and the one a blank or clean
-    // card cannot be distinguished from.
-    stubRoutes({
-      "/deals/d-1/coverage": {
-        deal_id: "d-1",
-        stakeholders: [],
-        our_side: [],
-        risks: [],
-        sections_omitted: ["stakeholders", "our_side", "risks"],
-      },
-    });
-    render(<DealCoverageCard id="d-1" />);
-    expect(
-      await screen.findByText(/coverage was withheld/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/passes every coverage check/i),
-    ).not.toBeInTheDocument();
-  });
-
-  it("surfaces a refused read as an error, never as a clean deal", async () => {
-    // A 403 rendered as "nothing flagged" would tell a manager their deal is
-    // healthy when the server declined to say anything at all.
-    stubRoutes({});
-    render(<DealCoverageCard id="d-1" />);
-    expect(
-      await screen.findByRole("listitem").catch(() => null),
-    ).not.toBeTruthy();
-    expect(
-      screen.queryByText(/passes every coverage check/i),
-    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -16,22 +16,24 @@ import {
   useSorMode,
 } from "./common";
 
-// The two relationship-graph cards (ADR-0078).
+// The relationship-graph card (ADR-0078): "who here knows them", the question a
+// rep asks before they write a cold email. It was server-only until it landed —
+// the endpoint shipped and nothing rendered it, so the interaction projection
+// was a fact the product held and never showed anybody.
 //
-// "Who here knows them" answers the question a rep asks before they write a
-// cold email, and the coverage card answers the one their manager asks before
-// the forecast call. Both were server-only until now: the endpoints shipped and
-// nothing rendered them, so the interaction projection was a fact the product
-// held and never showed anybody.
+// The deal COVERAGE card was the other half and is gone. Its seats moved to the
+// deal rail (deal360/dealseats.tsx) when the readings band started counting
+// them, and its findings became chips (dealsignals.tsx) — leaving a card nothing
+// rendered, still carrying its own overlay handling, its own withheld-before-
+// empty ordering and its own copy. Two spellings of one card, and the dead one
+// had passing tests, which is what made it look maintained.
 //
-// Ordering is the answer on both cards and is NOT re-sorted here. The server
-// ranks colleagues by a strength it computes at read; a client that re-ordered
-// them would be a second implementation of the decay formula, and the two would
-// disagree the moment either changed.
+// Ordering is the answer here and is NOT re-sorted. The server ranks colleagues
+// by a strength it computes at read; a client that re-ordered them would be a
+// second implementation of the decay formula, and the two would disagree the
+// moment either changed.
 
 type PersonNetworkColleague = components["schemas"]["PersonNetworkColleague"];
-type DealCoverage = components["schemas"]["DealCoverage"];
-type DealCoverageRisk = components["schemas"]["DealCoverageRisk"];
 
 // The per-user band vocabulary is PO-F-3b's — none/weak/moderate/strong — and
 // deliberately NOT the workspace-wide card's dormant/weak/warm/strong. The two
@@ -47,32 +49,10 @@ const COLLEAGUE_TONE: Record<
   none: undefined,
 };
 
-// Every risk kind is a warning; only the two that mean somebody is gone are
-// rendered as danger. A card where six chips all shout is a card a rep stops
-// reading.
-const RISK_TONE: Record<DealCoverageRisk["kind"], "danger" | "warn"> = {
-  champion_left: "danger",
-  stakeholder_left: "danger",
-  going_cold: "warn",
-  single_threaded_theirs: "warn",
-  single_threaded_ours: "warn",
-  coverage_gap: "warn",
-};
-
 async function fetchPersonNetwork(
   id: string,
 ): Promise<components["schemas"]["PersonNetwork"]> {
   const { data, error } = await api.GET("/people/{id}/network", {
-    params: { path: { id } },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return data;
-}
-
-async function fetchDealCoverage(id: string): Promise<DealCoverage> {
-  const { data, error } = await api.GET("/deals/{id}/coverage", {
     params: { path: { id } },
   });
   if (error) {
@@ -139,71 +119,3 @@ export function PersonNetworkCard({ id }: Readonly<{ id: string }>) {
 }
 
 /** What is wrong with how this deal is covered, and why. */
-export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
-  const t = useT();
-  const { locale } = useLocale();
-  const overlay = useSorMode() === "overlay";
-  const query = useQuery({
-    queryKey: ["deal-coverage", id],
-    queryFn: () => fetchDealCoverage(id),
-    enabled: !overlay,
-  });
-  const risks = query.data?.risks ?? [];
-  // Withheld is checked BEFORE the empty case, and the order is the whole
-  // point: a caller without the relationship grant is served no findings, so
-  // testing the risk list first would render "this deal passes every coverage
-  // check" over a check that never ran. The server says which of the two
-  // happened; the card must not decide for itself.
-  const omitted = query.data?.sections_omitted ?? [];
-  const withheld = omitted.includes("risks");
-
-  return (
-    <Card className="net-card" title={t("coverage.title")}>
-      {overlay && <OverlayUnavailable />}
-      {!overlay && query.isPending && <Skeleton width="60%" />}
-      {!overlay && query.isError && (
-        <EmptyState>{problemMessageOf(query.error, t)}</EmptyState>
-      )}
-      {!overlay && query.isSuccess && withheld && (
-        <EmptyState>{t("coverage.withheld")}</EmptyState>
-      )}
-      {/* No findings is a RESULT, not an empty state. A deal that passes every
-          coverage rule has earned a sentence saying so — a blank card reads as
-          a card that failed to load. */}
-      {!overlay && query.isSuccess && !withheld && risks.length === 0 && (
-        <p className="t-caption">{t("coverage.clear")}</p>
-      )}
-      {/* The SEATS are not here any more. They moved to the deal page's rail
-          (deal360/dealseats.tsx) when the readings band started counting them:
-          a reader was meeting the same two facts three times on one screen —
-          once as a figure, once as a chip in Deal360, once as this list. What
-          stays is the FINDINGS, which is what this card was for.
-
-          The seat list still lives in one place, not two: dealseats.tsx moved
-          the markup rather than rewriting it, and both render `.net-seats`
-          from this sheet. */}
-      {!overlay && risks.length > 0 && (
-        <ul className="net-risks">
-          {risks.map((risk) => (
-            <li key={risk.kind}>
-              <Badge tone={RISK_TONE[risk.kind]}>
-                {t(`coverage.risk.${risk.kind}`)}
-              </Badge>
-              {/* The rule's own explanation, not a client re-wording: the
-                  server names the rule and says why, so a flag on this card
-                  reads identically to the same flag in the assistant. */}
-              <span className="net-risk-why">{risk.summary}</span>
-              {risk.days_since_touch != null && (
-                <span className="t-mono net-risk-days">
-                  {t("coverage.daysSinceTouch", {
-                    days: formatNumber(risk.days_since_touch, locale),
-                  })}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </Card>
-  );
-}


### PR DESCRIPTION
Closes #2640.

`DealCoverageCard` in `frontend/src/screens/network.tsx` was rendered by nothing. Only `network.test.tsx` and `network.stories.tsx` imported it. Its seats moved to the deal rail (`deal360/dealseats.tsx`) when the readings band started counting them, and its findings became chips (`dealsignals.tsx`); what stayed behind was a second spelling of one card, with its own overlay handling, its own withheld-before-empty ordering and its own copy — kept looking maintained by a green test suite and three stories nothing else pointed at.

## What went

The card, `fetchDealCoverage`, the local `RISK_TONE` map (`dealsignals.tsx` has its own, with the tones the shipping surface uses), the `DealCoverage`/`DealCoverageRisk` type aliases, the `.net-risks` / `.net-risk-why` / `.net-risk-days` rules, the `describe("DealCoverageCard")` block, the `DealAtRisk` / `DealClear` / `DealCoverageWithheld` stories, and `coverage.title` / `coverage.clear` / `coverage.withheld` in en, de and vi.

`.net-seats` and `.net-seat-name` stay — `dealseats.tsx` imports this stylesheet for them, and `.net-card` stays with `PersonNetworkCard`.

## The ticket's three checks, answered

**The withheld-before-empty ordering is preserved.** `useDealCoverage` returns `withheld` separately from an empty result, and `DealCommitteeMap` distinguishes the two through `sectionState(… sections_omitted …)`. The *check* on it is preserved too, which matters more: `deal360/dealcommittee.stories.tsx` carries `Withheld` and `Empty` as adjacent frames — the same pair `DealCoverageWithheld` and `DealClear` were here, on the card that ships. The stories header now points a reader at them.

**`coverage.clear` does not survive, and that is a real loss.** "Nothing flagged — this deal passes every coverage check" had no other home: `SignalStrip` (`record360/verdict.tsx:214`) returns `null` when `signals.length === 0`, so a clean deal now says nothing on Deal 360 where this card said a result. I removed the sentence rather than leave it translated three times and rendered nowhere — restoring the reading is a change to `SignalStrip`, on the surface a rep actually opens, not a reason to keep a dead card alive. Worth a follow-up if the empty signal strip reads as a failure to load.

**Nothing else in the coverage namespace was orphaned.** `coverage.daysSinceTouch`, `coverage.risk.*`, `coverage.engaged`, `coverage.quiet` and `coverage.seatWithheld` are still rendered by `dealsignals.tsx` and `dealseats.tsx`. The i18n orphan gate holds this: the three keys I dropped are the three it would have failed on.

## Checks

`make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified the network view to focus on relationship connections.
  * Removed deal coverage cards, risk indicators, and related coverage states.
  * Updated network card documentation and styling to reflect the streamlined experience.
  * Removed unused coverage translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->