### PR TITLE
main is red: a company's VAT receipt names a company nobody classified

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -358,8 +358,8 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// (TechnicalDomain, TechnicalLaneState) call auth.EnsureVisible before they
 	// return one. A company the caller cannot see answers ErrNotFound rather
 	// than disclosing that a lookup ever ran on it.
-	// A company's VAT standing (#3158). Client-supplied — it is the company
-	// the reader pressed "check" on — and gated on both sides: RecordVatCheck
+	// A company's VAT standing. Client-supplied — it is the company the
+	// reader pressed "check" on — and gated on both sides: RecordVatCheck
 	// puts it through ensureOrgWritable (auth.EnsureWritableLive) before it
 	// writes, and VatCheckFor through auth.EnsureVisible before it returns one.
 	// A company the caller cannot see answers ErrNotFound rather than

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -358,6 +358,13 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// (TechnicalDomain, TechnicalLaneState) call auth.EnsureVisible before they
 	// return one. A company the caller cannot see answers ErrNotFound rather
 	// than disclosing that a lookup ever ran on it.
+	// A company's VAT standing (#3158). Client-supplied — it is the company
+	// the reader pressed "check" on — and gated on both sides: RecordVatCheck
+	// puts it through ensureOrgWritable (auth.EnsureWritableLive) before it
+	// writes, and VatCheckFor through auth.EnsureVisible before it returns one.
+	// A company the caller cannot see answers ErrNotFound rather than
+	// disclosing that its number was ever checked, or whose it is.
+	"organization_vat_check.organization_id":       "client-supplied and gated: the write goes through auth.EnsureWritableLive and the read through auth.EnsureVisible, so a company the caller cannot see is ErrNotFound rather than a readable VAT receipt",
 	"organization_technical_state.organization_id": "client-supplied and gated: the write goes through auth.EnsureWritableLive and both reads through auth.EnsureVisible, so a company the caller cannot see is ErrNotFound rather than a readable lane ledger",
 	// The retention floor's evidence (A165). Both columns are
 	// SERVER-DERIVED and neither has a writer yet — the table shipped ahead of


### PR DESCRIPTION
`main` is red on the integration lane. `backend/migrations` fails
`TestFK_rowScopedTargetsHaveVisibilityDecision`:

```
FK organization_vat_check.organization_id -> organization has no visibility decision:
a reference to a row-scoped record is a read of it — gate it (auth.EnsureLinkTarget) or classify it here
```

That gate derives the H1 obligation from the live schema rather than from a list: an FK naming a row-scoped business record (person / organization / deal / lead / activity / project) *is* a read of that record, so every such column has to carry an explicit decision. #3158 added `organization_vat_check` and did not classify its `organization_id`.

## The decision

**Client-supplied and gated, on both sides.** The company is what the reader pressed "check" on, so it does arrive from the caller — and both doors probe it before anything happens:

- `RecordVatCheck` → `ensureOrgWritable` → `auth.EnsureWritableLive` (`organization_vat_check.go:189`)
- `VatCheckFor` → `auth.EnsureVisible` (`organization_vat_check.go:283`)

A company the caller cannot see answers `ErrNotFound` rather than disclosing that its number was ever checked, or whose it is.

Nothing here loosens the gate. The entry records a probe that already runs, and the next unclassified FK fails exactly as this one did.

## Worth a separate look

#3158's own integration run (33257607183, created 14:26:24) failed on this test at 14:34. The PR merged at 14:27:07 — before its own required check reported. That is the shape #2504 already describes, and no gate in the tree can close it from inside a pull request.

## Checks

`make check-backend` green. `make test-it DIR=backend/migrations RUN=TestFK_rowScopedTargetsHaveVisibilityDecision` passes; it fails without the entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed an internal issue reference from the VAT-check visibility documentation.
  * No runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->