### PR TITLE
The trigger already wrote it

### DIFF
--- a/backend/gates/triggerwrittencolumncases_test.go
+++ b/backend/gates/triggerwrittencolumncases_test.go
@@ -98,6 +98,20 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 			statement: `UPDATE activity SET subject = 'it''s from here', updated_at = now() WHERE id = $1`,
 			writes:    map[string][]string{"activity": {"subject", "updated_at"}},
 		}, {
+			// An apostrophe inside a COMMENT. A scan that meets quotes before
+			// comments opens a run that never closes, marks the statement
+			// unreadable, and reports a valid one — the false-failure
+			// direction, which sends an author to rewrite SQL that is fine.
+			name:      "an apostrophe inside a line comment",
+			statement: "UPDATE activity SET body = NULL, -- it's the owner's row\n updated_at = now() WHERE id = $1",
+			writes:    map[string][]string{"activity": {"body", "updated_at"}},
+		}, {
+			// A semicolon or a clause word inside a BLOCK comment, which
+			// Postgres also lets nest.
+			name:      "a clause word inside a nested block comment",
+			statement: `UPDATE activity SET body = NULL /* from /* the */ report */, updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"activity": {"body", "updated_at"}},
+		}, {
 			// A run that never CLOSES. Swallowed as one span, every assignment
 			// after the open quote is stepped over — so a dead updated_at
 			// behind it goes unseen and the gate passes, which is the

--- a/backend/gates/triggerwrittencolumncases_test.go
+++ b/backend/gates/triggerwrittencolumncases_test.go
@@ -45,6 +45,9 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 		statement string
 		// table -> the columns the reader must report as written.
 		writes map[string][]string
+		// wantUnreadable marks a statement the reader must REFUSE to judge
+		// rather than read as clean.
+		wantUnreadable bool
 	}{
 		{
 			name:      "the plain dead assignment",
@@ -94,6 +97,17 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 			name:      "a doubled quote inside a quoted value",
 			statement: `UPDATE activity SET subject = 'it''s from here', updated_at = now() WHERE id = $1`,
 			writes:    map[string][]string{"activity": {"subject", "updated_at"}},
+		}, {
+			// A run that never CLOSES. Swallowed as one span, every assignment
+			// after the open quote is stepped over — so a dead updated_at
+			// behind it goes unseen and the gate passes, which is the
+			// direction this gate must not fail in. It reaches the reader only
+			// as a PIECE of an assembled statement, so it is reported instead:
+			// the write is judged as unreadable rather than as clean.
+			name:           "an unterminated quoted value",
+			statement:      `UPDATE activity SET subject = 'the closing quote is in another literal, updated_at = now()`,
+			writes:         map[string][]string{"activity": {}},
+			wantUnreadable: true,
 		}, {
 			// Dollar-quoting, where a quote character has no meaning at all.
 			name:      "a dollar-quoted value carrying a clause word",
@@ -175,6 +189,15 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := map[string][]string{}
 			for _, segment := range writeSegments(tc.statement) {
+				if segment.unreadable != tc.wantUnreadable {
+					t.Fatalf("on %s unreadable = %v, want %v", segment.table, segment.unreadable, tc.wantUnreadable)
+				}
+				if segment.unreadable {
+					// Its assignments are not judged: what stands after the
+					// open quote could be anything.
+					got[segment.table] = []string{}
+					continue
+				}
 				got[segment.table] = append(got[segment.table], assignedColumns(segment.assignments)...)
 			}
 			if len(got) != len(tc.writes) {

--- a/backend/gates/triggerwrittencolumncases_test.go
+++ b/backend/gates/triggerwrittencolumncases_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind falsification H2
+
+package gates
+
+// The trigger-written-column reader driven with SYNTHETIC statements, for the
+// reason retainedcolumncases_test.go gives for its own: the tree is supposed to
+// pass, so a reader proven only by "nothing in the tree trips it" is one that
+// keeps passing after it stops working.
+//
+// Every MISSED row below is a shape an earlier version of the reader could not
+// see, each one a dead assignment left standing. Every KEPT row is the opposite
+// failure and matters as much: this gate's finding ends in a DELETION, so a
+// reader that over-recognizes deletes live code. The `version = $3` predicate is
+// the sharpest of those — it is the compare-and-set updateguard_test.go requires
+// on the same statements, and a gate that called it a dead write would send the
+// next author to remove their own concurrency guard.
+//
+// WHAT IS STILL NOT ON THIS LIST, stated because a list that reads as complete
+// is what stops the next author looking:
+//
+//   - A trigger that fires CONDITIONALLY — `BEFORE UPDATE OF a, b` or one with
+//     a `WHEN (…)` predicate — is not read as touching the table at all, so
+//     assignments on it are never called dead. channel_connection has one
+//     today. That is deliberate under-recognition: the finding is a deletion,
+//     and the honest failure direction is to leave live code alone.
+//   - A statement built by fmt.Sprintf or a query builder reaches the reader as
+//     a literal with a hole in it. gatekit.ConcatenatedString folds a `+` chain
+//     and leaves a space where the runtime value was, so the surrounding SQL
+//     still reads; a table or column name that only exists at runtime does not,
+//     and the write is invisible. Nothing in the swept tree does this.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		statement string
+		// table -> the columns the reader must report as written.
+		writes map[string][]string
+	}{
+		{
+			name:      "the plain dead assignment",
+			statement: `UPDATE organization SET display_name = $2, updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"display_name", "updated_at"}},
+		}, {
+			name:      "no spaces around the equals",
+			statement: `UPDATE organization SET display_name=$2, version=version+1 WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"display_name", "version"}},
+		}, {
+			// The shape execute.go writes: UPDATE … FROM with the target
+			// aliased, so every assignment target is qualified.
+			name:      "an aliased target with qualified assignments",
+			statement: `UPDATE provider_connection c SET status = $2, c.updated_at = now() FROM provider_connection was WHERE was.id = c.id`,
+			writes:    map[string][]string{"provider_connection": {"status", "updated_at"}},
+		}, {
+			name:      "the alias spelled with AS",
+			statement: `UPDATE organization AS o SET display_name = $2, updated_at = now() WHERE o.id = $1`,
+			writes:    map[string][]string{"organization": {"display_name", "updated_at"}},
+		}, {
+			// SET is a legal identifier, so an aliasless statement can read as
+			// one whose alias is `SET` — and then the reader finds no
+			// assignment list and reports nothing at all.
+			name:      "a column whose name begins with the word SET",
+			statement: `UPDATE organization SET settlement_at = $2, updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"settlement_at", "updated_at"}},
+		}, {
+			// The upsert arm. A BEFORE UPDATE trigger fires on it exactly as on
+			// a plain UPDATE, and the table it writes is the one the INSERT
+			// named — which is nowhere near the word UPDATE.
+			name: "an ON CONFLICT DO UPDATE arm",
+			statement: `INSERT INTO relationship (project_id, organization_id, role) VALUES ($1, $2, $3) ` +
+				`ON CONFLICT (project_id, organization_id) DO UPDATE SET role = EXCLUDED.role, version = relationship.version + 1 RETURNING id`,
+			writes: map[string][]string{"relationship": {"role", "version"}},
+		}, {
+			// The shape retentionrestricted.go already writes. A lazy regex
+			// ending the SET clause at the first FROM stops INSIDE the
+			// subquery, so every assignment after it — here the dead one —
+			// becomes invisible, and reordering the list turns the check off.
+			name: "an assignment after a subquery carrying its own FROM and WHERE",
+			statement: `UPDATE activity SET redacted_fields = ARRAY(SELECT c FROM unnest(ARRAY['body']) AS c WHERE c IS NOT NULL), ` +
+				`version = version + 1 WHERE id = $1`,
+			writes: map[string][]string{"activity": {"redacted_fields", "version"}},
+		}, {
+			// Two writes in one statement, and only the second is on a
+			// trigger-touched table. Read as one write, the reader either
+			// misses it or attributes it to the wrong table.
+			name: "a CTE that updates two tables",
+			statement: `WITH target AS (SELECT id FROM activity WHERE id = ANY($1) FOR UPDATE), ` +
+				`stripped AS (UPDATE activity a SET subject = NULL, updated_at = now() FROM target t WHERE a.id = t.id) ` +
+				`UPDATE activity_link SET person_id = NULL WHERE activity_id = ANY($1)`,
+			writes: map[string][]string{
+				"activity":      {"subject", "updated_at"},
+				"activity_link": {"person_id"},
+			},
+		}, {
+			// The CAS the same statements are REQUIRED to carry
+			// (updateguard_test.go). Reading a WHERE predicate as an
+			// assignment would report every guarded update in the tree and
+			// send the next author to delete their own guard.
+			name:      "a version compared in the WHERE, not assigned",
+			statement: `UPDATE organization SET display_name = $2 WHERE id = $1 AND version = $3`,
+			writes:    map[string][]string{"organization": {"display_name"}},
+		}, {
+			// Same trap one clause further on.
+			name:      "a trigger column returned, not assigned",
+			statement: `UPDATE signal SET archived_at = now() WHERE id = $1 RETURNING id, updated_at, version`,
+			writes:    map[string][]string{"signal": {"archived_at"}},
+		}, {
+			// And inside a subquery's own predicate, at depth.
+			name:      "a trigger column inside a subquery predicate",
+			statement: `UPDATE organization SET display_name = (SELECT name FROM staging WHERE updated_at = $2) WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"display_name"}},
+		}, {
+			// The assignment list split at PAREN DEPTH ZERO, not on every
+			// comma. A comma inside a call, followed by an equality on a bare
+			// column, reads as a second assignment to a reader that splits
+			// naively — and this gate's finding is a DELETION, so it would send
+			// the next author to remove a live comparison.
+			name:      "a comparison after a comma inside a call",
+			statement: `UPDATE organization SET meta = jsonb_build_object('bumped', version = $3), display_name = $2 WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"meta", "display_name"}},
+		}, {
+			name:      "a longer column that merely starts with a trigger column's name",
+			statement: `UPDATE organization SET updated_at_source = $2 WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"updated_at_source"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := map[string][]string{}
+			for _, segment := range writeSegments(tc.statement) {
+				got[segment.table] = append(got[segment.table], assignedColumns(segment.assignments)...)
+			}
+			if len(got) != len(tc.writes) {
+				t.Fatalf("read %v, want %v", got, tc.writes)
+			}
+			for table, want := range tc.writes {
+				if strings.Join(got[table], ",") != strings.Join(want, ",") {
+					t.Errorf("on %s read %v, want %v", table, got[table], want)
+				}
+			}
+		})
+	}
+}
+
+// The derivation the rulings rest on, driven against the catalog rather than
+// asserted. A table read as touched when it is not turns this gate into a
+// code-deleting one.
+func TestTheTouchedTableDerivationReadsTheCatalog(t *testing.T) {
+	t.Parallel()
+	touched := touchTriggerTables(t)
+
+	// Both arms of triggerWrites reach the tree, or half the table is a claim
+	// nothing exercises.
+	if got := touched["organization"]; !got["updated_at"] || !got["version"] {
+		t.Errorf("organization carries set_updated_at_bump_version and reads as %v", got)
+	}
+	if got := touched["app_user"]; !got["updated_at"] || got["version"] {
+		t.Errorf("app_user carries set_updated_at, which does not bump version, and reads as %v", got)
+	}
+	// A CONDITIONAL touch trigger is not read as touching at all. This is the
+	// under-recognition the gate chooses on purpose, and channel_connection is
+	// the table that has it: its trigger carries `WHEN ((to_jsonb(old.*) -
+	// 'poll_offset') IS DISTINCT FROM …)`, so a poll-offset-only write does not
+	// fire it and an assignment there is not dead.
+	if got := touched["channel_connection"]; got != nil {
+		t.Errorf("channel_connection's touch trigger is WHEN-conditional and must not be read as unconditional; reads as %v", got)
+	}
+	// A table with no touch trigger at all is absent rather than empty, or
+	// every statement in the tree would be judged against nothing.
+	if got := touched["activity_link"]; got != nil {
+		t.Errorf("activity_link has no touch trigger and reads as %v", got)
+	}
+}

--- a/backend/gates/triggerwrittencolumncases_test.go
+++ b/backend/gates/triggerwrittencolumncases_test.go
@@ -56,10 +56,49 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 			writes:    map[string][]string{"organization": {"display_name", "version"}},
 		}, {
 			// The shape execute.go writes: UPDATE … FROM with the target
-			// aliased, so every assignment target is qualified.
-			name:      "an aliased target with qualified assignments",
-			statement: `UPDATE provider_connection c SET status = $2, c.updated_at = now() FROM provider_connection was WHERE was.id = c.id`,
+			// aliased. Its assignments are UNQUALIFIED, because Postgres
+			// requires that on the left of a SET — here and everywhere.
+			name:      "an aliased target",
+			statement: `UPDATE provider_connection c SET status = $2, updated_at = now() FROM provider_connection was WHERE was.id = c.id`,
 			writes:    map[string][]string{"provider_connection": {"status", "updated_at"}},
+		}, {
+			// Tolerance rather than a shape this tree writes: a qualified
+			// target is not legal SQL, and reading it as the column it names
+			// costs nothing while SKIPPING it would go quiet.
+			name:      "a qualified target is read as the column it names",
+			statement: `UPDATE provider_connection c SET c.status = $2, c.updated_at = now() WHERE c.id = $1`,
+			writes:    map[string][]string{"provider_connection": {"status", "updated_at"}},
+		}, {
+			// A clause word inside a VALUE. The assignment list ends at the
+			// literal's own `from` to a scan that does not track quotes, and
+			// everything after it — which is where the dead assignment is —
+			// becomes invisible. Reordering an assignment list is not
+			// something anybody reviews as a schema change.
+			name:      "a clause word inside a quoted value",
+			statement: `UPDATE activity SET subject = 'a note from the report where it began', updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"activity": {"subject", "updated_at"}},
+		}, {
+			// The same trap on the comma, and this one fails in the direction
+			// that costs most. A separator inside a string value is not a
+			// separator; split there, the text after it reads as an assignment
+			// of its own — so a trigger column MENTIONED in a sentence becomes
+			// a trigger column WRITTEN, and this gate's finding is an
+			// instruction to delete something that was never there.
+			name:      "a comma and a trigger column named inside a quoted value",
+			statement: `UPDATE activity SET subject = 'we moved it, updated_at = the field they meant', body = NULL WHERE id = $1`,
+			writes:    map[string][]string{"activity": {"subject", "body"}},
+		}, {
+			// A doubled quote is how SQL escapes one. Parity carries it: the
+			// run ends at the first, a new run opens at the second, and it
+			// closes where the real one does.
+			name:      "a doubled quote inside a quoted value",
+			statement: `UPDATE activity SET subject = 'it''s from here', updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"activity": {"subject", "updated_at"}},
+		}, {
+			// Dollar-quoting, where a quote character has no meaning at all.
+			name:      "a dollar-quoted value carrying a clause word",
+			statement: `UPDATE activity SET subject = $tag$ where it's from $tag$, updated_at = now() WHERE id = $1`,
+			writes:    map[string][]string{"activity": {"subject", "updated_at"}},
 		}, {
 			name:      "the alias spelled with AS",
 			statement: `UPDATE organization AS o SET display_name = $2, updated_at = now() WHERE o.id = $1`,

--- a/backend/gates/triggerwrittencolumncases_test.go
+++ b/backend/gates/triggerwrittencolumncases_test.go
@@ -72,6 +72,21 @@ func TestTheTriggerColumnReaderSeesEveryDeadAssignment(t *testing.T) {
 			statement: `UPDATE provider_connection c SET c.status = $2, c.updated_at = now() WHERE c.id = $1`,
 			writes:    map[string][]string{"provider_connection": {"status", "updated_at"}},
 		}, {
+			// A QUOTED target. Postgres reads `"updated_at"` as the same column
+			// as `updated_at`, and a reader taking only the bare form saw no
+			// assignment at all — the silent direction, and the dead write
+			// stays.
+			name:      "a quoted target",
+			statement: `UPDATE organization SET "display_name" = $2, "updated_at" = now() WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"display_name", "updated_at"}},
+		}, {
+			// And the difference the quotes make. A quoted identifier is
+			// case-SENSITIVE, so this names a different column and folding it
+			// would report a write the statement does not make.
+			name:      "a quoted target in another case is another column",
+			statement: `UPDATE organization SET display_name = $2, "Updated_At" = now() WHERE id = $1`,
+			writes:    map[string][]string{"organization": {"display_name", "Updated_At"}},
+		}, {
 			// A clause word inside a VALUE. The assignment list ends at the
 			// literal's own `from` to a scan that does not track quotes, and
 			// everything after it — which is where the dead assignment is —

--- a/backend/gates/triggerwrittencolumns_test.go
+++ b/backend/gates/triggerwrittencolumns_test.go
@@ -236,9 +236,17 @@ func assignedColumns(assignments string) []string {
 	return out
 }
 
-// assignmentTargetRe reads the column an assignment writes. Anchored at the
-// START of the assignment so `updated_at_source = $1` is not read as a write of
-// `updated_at`.
+// assignmentTargetRe reads the column an assignment writes, bare or QUOTED.
+// Anchored at the START of the assignment so `updated_at_source = $1` is not
+// read as a write of `updated_at`.
+//
+// The quoted form is not decoration: `SET "updated_at" = now()` is the same
+// column to Postgres and was the same dead write, and a reader taking only the
+// bare form saw no assignment at all — which is the silent direction. Its case
+// is different, though, and that difference is real: a quoted identifier is
+// case-SENSITIVE, so `"Updated_At"` is a different column and must not match.
+// The inner text is therefore taken verbatim while a bare name is folded, which
+// is exactly how Postgres reads the two.
 //
 // The optional qualifier is TOLERANCE, not a shape this tree writes: Postgres
 // requires an unqualified column on the left of a SET, in `UPDATE … FROM` as
@@ -246,14 +254,22 @@ func assignedColumns(assignments string) []string {
 // means a statement somebody writes that way is read as the write it was meant
 // to be rather than skipped — and skipping is the failure direction that goes
 // quiet.
-var assignmentTargetRe = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\.)?([a-z_][a-z0-9_]*)\s*=`)
+var assignmentTargetRe = regexp.MustCompile(`(?is)^\s*(?:"?[a-z_][a-z0-9_]*"?\.)?(?:([a-z_][a-z0-9_]*)|"([^"]*)")\s*=`)
 
 func assignmentTarget(assignment string) string {
 	m := assignmentTargetRe.FindStringSubmatch(withoutLeadingComments(assignment))
 	if m == nil {
 		return ""
 	}
-	return strings.ToLower(m[1])
+	if m[1] != "" {
+		// An unquoted identifier is folded to lower case, which is what
+		// Postgres does with it.
+		return strings.ToLower(m[1])
+	}
+	// A quoted one is taken as written: the quotes are what make it
+	// case-sensitive, so folding here would report `"Updated_At"` as a write of
+	// a column that statement does not touch.
+	return m[2]
 }
 
 // touchStatements are the ratified deliberate touches: a statement whose whole

--- a/backend/gates/triggerwrittencolumns_test.go
+++ b/backend/gates/triggerwrittencolumns_test.go
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A statement may not write a column its table's trigger already writes.
+//
+// `set_updated_at` and `set_updated_at_bump_version` are BEFORE UPDATE ... FOR
+// EACH ROW triggers. A BEFORE ROW trigger runs after the statement's SET has
+// been applied to NEW, so it OVERWRITES what the statement assigned: on a
+// trigger-touched table, a statement's own `updated_at = now()` or
+// `version = version + 1` is dead. Not wrong — dead. The same value, assigned
+// twice.
+//
+// Dead code that looks load-bearing is worse than dead code that looks dead,
+// and this shape is the second kind. company.go's manual `version = version + 1`
+// read as a fourth approach to concurrent editing across the organization
+// writers and was counted as one; coldstartprofile.go's overwrite arm carried
+// `updated_at = now()` where its fill arm did not, and the difference read as
+// deliberate. Neither was anything. The file next door already names the
+// hazard in its own words, about a different trigger:
+//
+//	Nothing about geocoding here: a trigger marks the coordinates stale on any
+//	address column that changes, so this writer neither can nor has to
+//	remember. An earlier version did it in this statement — correct, and
+//	something the next address writer would not have known to copy.
+//
+// The one honest exception is a TOUCH: a statement whose only purpose is to be
+// a genuine UPDATE of the row, so the trigger fires and moves the version an
+// approval pinned. It needs an assignment to exist at all, and `updated_at =
+// now()` is the honest one to pick. That shape is recognized rather than
+// trusted — the assignment must be the statement's ONLY assignment — and the
+// site is still registered below with the reason it needs the bump, because
+// "this row must move" is a claim about the product and not about SQL.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// touchTriggerLine reads one trigger out of the head catalog. The CATALOG
+// rather than the migration sources, because the catalog is the schema a
+// database really ends up with — it is dumped from one and gated against one
+// (migrations/headcatalog_integration_test.go), so it already accounts for a
+// trigger created in one migration and dropped in another, which reading the
+// CREATE statements would have to re-derive and could get wrong in the
+// direction of a quiet pass.
+//
+// UNCONDITIONAL BEFORE UPDATE only, and that is the fail-closed half of the
+// pattern. `BEFORE UPDATE OF a, b` fires only when the statement writes one of
+// those columns, and a `WHEN (…)` trigger only when its predicate holds — under
+// either, a statement's own assignment is not always overwritten, so calling it
+// dead would delete a live write. Neither is hypothetical: channel_connection's
+// touch trigger carries `WHEN ((to_jsonb(old.*) - 'poll_offset') IS DISTINCT
+// FROM …)`, so a poll-offset-only write does NOT fire it, and this pattern
+// leaves that table alone. The gate refuses to guess rather than guessing in
+// the direction that deletes code.
+var touchTriggerLine = regexp.MustCompile(
+	`(?i)^public\.([a-z_][a-z0-9_]*)\.[a-z_][a-z0-9_]* CREATE TRIGGER [a-z_][a-z0-9_]* BEFORE UPDATE ON public\.[a-z_][a-z0-9_]* FOR EACH ROW EXECUTE FUNCTION (set_updated_at|set_updated_at_bump_version)\(\)$`)
+
+// The columns each trigger function assigns to NEW, read off 0001_baseline's
+// definitions. Two functions, spelled out rather than parsed: the bodies are in
+// the catalog too, and a parser for plpgsql assignments to buy two entries
+// would be more code than the thing it read.
+//
+// triggerFunctionBodies below is what keeps that from being a claim nobody
+// checks — it fails if either function's body stops matching this table.
+var triggerWrites = map[string][]string{
+	"set_updated_at":              {"updated_at"},
+	"set_updated_at_bump_version": {"updated_at", "version"},
+}
+
+// writeSegment is one write inside a statement: the table, and the assignment
+// list that lands on it. A statement can hold several — a CTE that updates two
+// tables, an upsert whose conflict arm writes the table its INSERT named.
+type writeSegment struct {
+	table       string
+	assignments string
+}
+
+// segmentOpener matches the head of a write: `UPDATE t [AS] [alias] SET`, or
+// the `INSERT INTO t … ON CONFLICT … DO UPDATE SET` whose written table is the
+// one the INSERT named. The upsert arm is not an afterthought — a BEFORE UPDATE
+// trigger fires on the conflict arm exactly as it does on a plain UPDATE, and
+// the tree writes that shape (people/projectcompany.go).
+//
+// The alias is optional and SET is a legal identifier, so `UPDATE t SET x = 1`
+// could read as table `t` with alias `SET` and then find no SET clause. It does
+// not: the alternation is preference-ordered, the alias branch fails on the SET
+// that has to follow it, and the match falls back to the aliasless reading.
+//
+// The upsert arm may not cross a statement separator, or an INSERT and an
+// unrelated later UPDATE would read as one write on the INSERT's table.
+var segmentOpener = regexp.MustCompile(
+	`(?is)\bINSERT\s+INTO\s+([a-z_][a-z0-9_]*)\b[^;]*?\bON\s+CONFLICT\b[^;]*?\bDO\s+UPDATE\s+SET\b` +
+		`|\bUPDATE\s+(?:ONLY\s+)?([a-z_][a-z0-9_]*)(?:\s+(?:AS\s+)?[a-z_][a-z0-9_]*)?\s+SET\b`)
+
+// setClauseEnd ends an assignment list. Matched at PAREN DEPTH ZERO by the
+// scan below rather than with a lazy regex: `SET fields = ARRAY(SELECT c FROM
+// unnest(…) WHERE c IS NOT NULL), version = version + 1` is a shape this tree
+// writes, and a regex ending at the first FROM stops inside that subquery — so
+// every assignment after it becomes invisible and reordering the list, which
+// nobody reviews as a schema change, turns the check off.
+var setClauseEnd = regexp.MustCompile(`(?i)^(from|where|returning)\b`)
+
+// writeSegments pairs every write in a statement with the assignment list that
+// lands on it.
+//
+// It is not gates/piicoverage_test.go's setAssignments, which answers a
+// narrower question for a different census: the first SET clause of a statement
+// that has ALREADY been split, with no table attached. Here the table is half
+// the answer — `activity` and `activity_participant` both carry updated_at and
+// only one of them is trigger-touched — and a statement holding two writes has
+// to be read as two.
+func writeSegments(statement string) []writeSegment {
+	var out []writeSegment
+	for _, loc := range segmentOpener.FindAllStringSubmatchIndex(statement, -1) {
+		table := ""
+		for _, group := range [2]int{1, 2} {
+			if loc[2*group] >= 0 {
+				table = strings.ToLower(statement[loc[2*group]:loc[2*group+1]])
+			}
+		}
+		if table == "" {
+			continue
+		}
+		rest := statement[loc[1]:]
+		depth, end := 0, len(rest)
+		for pos := 0; pos < len(rest); pos++ {
+			switch rest[pos] {
+			case '(':
+				depth++
+			case ')':
+				if depth == 0 {
+					end = pos
+					pos = len(rest)
+					continue
+				}
+				depth--
+			}
+			if depth == 0 && (pos == 0 || !isWordByte(rest[pos-1])) && setClauseEnd.MatchString(rest[pos:]) {
+				end = pos
+				break
+			}
+		}
+		out = append(out, writeSegment{table: table, assignments: strings.TrimSpace(rest[:end])})
+	}
+	return out
+}
+
+func isWordByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// assignedColumns returns the columns an assignment list writes — the targets
+// at paren depth zero, so a column named inside a subquery's own WHERE is not
+// mistaken for one being written.
+func assignedColumns(assignments string) []string {
+	var out []string
+	depth, start := 0, 0
+	for pos := 0; pos <= len(assignments); pos++ {
+		if pos == len(assignments) || (assignments[pos] == ',' && depth == 0) {
+			if column := assignmentTarget(assignments[start:pos]); column != "" {
+				out = append(out, column)
+			}
+			start = pos + 1
+			continue
+		}
+		switch assignments[pos] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+	}
+	return out
+}
+
+// assignmentTargetRe reads the column an assignment writes. Anchored at both
+// ends of the target so `updated_at_source = $1` is not read as a write of
+// `updated_at`, and a qualified target (`c.status = $2`, which UPDATE … FROM
+// allows) is read as the column it names.
+var assignmentTargetRe = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\.)?([a-z_][a-z0-9_]*)\s*=`)
+
+func assignmentTarget(assignment string) string {
+	m := assignmentTargetRe.FindStringSubmatch(assignment)
+	if m == nil {
+		return ""
+	}
+	return strings.ToLower(m[1])
+}
+
+// touchStatements are the ratified deliberate touches: a statement whose whole
+// job is to BE an update, so the trigger fires and moves a version somebody
+// pinned. Keyed by "path:declaration".
+//
+// A touch is recognized by shape as well as registered — the assignment has to
+// be the statement's only one — so an entry here cannot wave through a second
+// dead assignment that arrives in the same function later. What the register
+// adds is the product claim the shape cannot carry: WHY this row has to move.
+var touchStatements = gatekit.Waive(map[string]string{
+	"internal/modules/activities/relinkbatch.go:relinkActivityRow":  "a staged approval pins activity.version, and that pin is the only thing between an approved \"send this body on this conversation\" and the conversation being repointed before the approval redeems; a relink that changes who the activity reaches must move the version the pin re-checks",
+	"internal/modules/capture/sinkproject.go:linkActivityToProject": "the automatic half of the same relink: filing under a project changes who the activity reaches, so it must move the version a staged approval pinned, for the reason the human path gives",
+	"internal/modules/people/linkedinmatchapply.go:touchPerson":     "a LinkedIn handle decision changes what the contact record says without writing a person column, and the contact's own version is what an editor's If-Match is checked against; the row is locked first, so the bump is not a blind write",
+})
+
+// touchTriggerFloor is the smallest number of trigger-touched tables this gate
+// may derive and still be believed. It sits well below the real count because
+// its job is to catch a catalog that stopped being read — a renamed file, a
+// changed dump format — rather than to track the schema.
+const touchTriggerFloor = 40
+
+// judgedWriteFloor is the same alarm one level in: the number of statements
+// this gate reads and finds writing a trigger-touched table. A reader that
+// stops seeing statements produces no findings, which is indistinguishable from
+// a clean tree.
+const judgedWriteFloor = 120
+
+// touchTriggerTables derives, per table, the columns a BEFORE UPDATE touch
+// trigger already writes.
+func touchTriggerTables(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile("migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+	tables := map[string]map[string]bool{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		m := touchTriggerLine.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		columns, known := triggerWrites[strings.ToLower(m[2])]
+		if !known {
+			t.Fatalf("trigger function %s touches tables and this gate does not know what it writes — add it to triggerWrites", m[2])
+		}
+		if tables[m[1]] == nil {
+			tables[m[1]] = map[string]bool{}
+		}
+		for _, column := range columns {
+			tables[m[1]][column] = true
+		}
+	}
+	if len(tables) < touchTriggerFloor {
+		t.Fatalf("derived only %d trigger-touched table(s) from the head catalog and expects at least %d — "+
+			"the catalog reader is broken, not the schema", len(tables), touchTriggerFloor)
+	}
+	return tables
+}
+
+// TestNoStatementWritesAColumnItsTriggerAlreadyWrites is the census.
+func TestNoStatementWritesAColumnItsTriggerAlreadyWrites(t *testing.T) {
+	t.Parallel()
+	defer touchStatements.AssertAllMatched(t)
+	touched := touchTriggerTables(t)
+	judged := 0
+	for _, root := range []string{"internal/modules", "internal/compose", "internal/platform", "internal/shared"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") || isIntegrationTagged(path) {
+				return err
+			}
+			path = filepath.ToSlash(path)
+			file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+			if err != nil {
+				return err
+			}
+			for _, decl := range file.Decls {
+				name := declarationName(decl)
+				for _, statement := range gatekit.SQLStatementsOf(decl) {
+					for _, segment := range writeSegments(statement) {
+						columns := touched[segment.table]
+						if columns == nil {
+							continue
+						}
+						judged++
+						written := assignedColumns(segment.assignments)
+						var dead []string
+						for _, column := range written {
+							if columns[column] {
+								dead = append(dead, column)
+							}
+						}
+						if len(dead) == 0 {
+							continue
+						}
+						// A TOUCH: nothing else is assigned, so the
+						// assignment is not a second answer to a question
+						// the trigger already answers — it is how the
+						// statement exists at all.
+						if len(written) == len(dead) {
+							if touchStatements.Waived(t, path+":"+name) {
+								continue
+							}
+							t.Errorf("%s: %s runs `UPDATE %s SET %s` to fire the touch trigger — that is a real shape, but it has to say what version it is moving and why; ratify it in touchStatements",
+								path, name, segment.table, strings.Join(dead, ", "))
+							continue
+						}
+						t.Errorf("%s: %s assigns %s on %s, which that table's BEFORE UPDATE trigger already writes — the trigger runs after the SET is applied to NEW and overwrites it, so the assignment is dead. Delete it; the next writer of this table would otherwise copy it, or read a sibling statement without it as a deliberate difference",
+							path, name, strings.Join(dead, ", "), segment.table)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if judged < judgedWriteFloor {
+		t.Fatalf("this census read %d write(s) to a trigger-touched table and expects at least %d — "+
+			"the reader has stopped seeing statements rather than the tree having lost them", judged, judgedWriteFloor)
+	}
+}
+
+// declarationName names the declaration a statement was found in, for the
+// message and the register key. Package-level statement tables are as much a
+// site as a function is — aiactivity/store.go holds its upsert in a const.
+func declarationName(decl ast.Decl) string {
+	switch typed := decl.(type) {
+	case *ast.FuncDecl:
+		return typed.Name.Name
+	case *ast.GenDecl:
+		for _, spec := range typed.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if ok && len(value.Names) > 0 {
+				return value.Names[0].Name
+			}
+		}
+	}
+	return "the file"
+}
+
+// TestTheTouchTriggerFunctionsStillWriteWhatThisGateSays holds triggerWrites,
+// which is the one thing above that is asserted rather than derived. A trigger
+// function that stops bumping version — or starts — makes every ruling here
+// wrong in the direction of deleting a live assignment.
+func TestTheTouchTriggerFunctionsStillWriteWhatThisGateSays(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+	catalog := string(raw)
+	for function, columns := range triggerWrites {
+		body := functionBody(catalog, function)
+		if body == "" {
+			t.Fatalf("the head catalog holds no definition of %s, which this gate rules from", function)
+		}
+		for _, column := range []string{"updated_at", "version"} {
+			assigns := strings.Contains(body, "NEW."+column+" =")
+			declared := false
+			for _, c := range columns {
+				declared = declared || c == column
+			}
+			if assigns != declared {
+				t.Errorf("%s %s NEW.%s, and triggerWrites says it %s — every deletion this gate ruled on that column was ruled from the wrong list",
+					function, boolWord(assigns, "assigns", "does not assign"), column,
+					boolWord(declared, "does", "does not"))
+			}
+		}
+	}
+}
+
+func boolWord(b bool, yes, no string) string {
+	if b {
+		return yes
+	}
+	return no
+}
+
+// functionBody returns the body of one function as the catalog holds it: a
+// `public.<name>() secdef=…` header line, the plpgsql block, then a blank line.
+// The parentheses are part of the search or set_updated_at would find
+// set_updated_at_bump_version's header and rule from the wrong body.
+func functionBody(catalog, function string) string {
+	start := strings.Index(catalog, "\npublic."+function+"() ")
+	if start < 0 {
+		return ""
+	}
+	rest := catalog[start+1:]
+	header := strings.Index(rest, "\n")
+	if header < 0 {
+		return ""
+	}
+	body := rest[header+1:]
+	if end := strings.Index(body, "\n\n"); end >= 0 {
+		return body[:end]
+	}
+	return body
+}

--- a/backend/gates/triggerwrittencolumns_test.go
+++ b/backend/gates/triggerwrittencolumns_test.go
@@ -87,6 +87,11 @@ var triggerWrites = map[string][]string{
 type writeSegment struct {
 	table       string
 	assignments string
+	// unreadable marks a segment whose text this gate could not scan — an
+	// unterminated quoted run, which means the statement is assembled and the
+	// piece the reader has is not the whole of it. Its assignments are not
+	// judged: what stands after the open quote could be anything.
+	unreadable bool
 }
 
 // segmentOpener matches the head of a write: `UPDATE t [AS] [alias] SET`, or
@@ -136,9 +141,13 @@ func writeSegments(statement string) []writeSegment {
 			continue
 		}
 		rest := statement[loc[1]:]
-		depth, end := 0, len(rest)
+		depth, end, unreadable := 0, len(rest), false
 		for pos := 0; pos < len(rest); pos++ {
-			if skip := quotedSpanAt(rest, pos); skip > 0 {
+			if skip, closed := quotedSpanAt(rest, pos); skip > 0 {
+				if !closed {
+					unreadable, end = true, pos
+					break
+				}
 				pos += skip - 1
 				continue
 			}
@@ -158,7 +167,9 @@ func writeSegments(statement string) []writeSegment {
 				break
 			}
 		}
-		out = append(out, writeSegment{table: table, assignments: strings.TrimSpace(rest[:end])})
+		out = append(out, writeSegment{
+			table: table, assignments: strings.TrimSpace(rest[:end]), unreadable: unreadable,
+		})
 	}
 	return out
 }
@@ -170,8 +181,8 @@ func isWordByte(b byte) bool {
 // dollarTagRe matches a dollar-quote opener at the current position.
 var dollarTagRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$`)
 
-// quotedSpanAt returns the length of the quoted run starting at pos, or 0 when
-// nothing is quoted there.
+// quotedSpanAt returns the length of the quoted run starting at pos and whether
+// it CLOSED, or 0 when nothing is quoted there.
 //
 // The scans that read a SET clause have to step OVER these rather than through
 // them. `SET body = 'from the report', updated_at = now()` ends the assignment
@@ -185,23 +196,31 @@ var dollarTagRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$`)
 // run that closes where the real one does. Dollar-quoting is matched on its
 // OPENING tag and closed on the same tag, which is what makes $tag$…'…$tag$
 // readable at all.
-func quotedSpanAt(text string, pos int) int {
+//
+// A run that never CLOSES is reported rather than swallowed, and that matters in
+// the direction this gate must not fail. Reading the remainder as one quoted
+// span steps over every assignment after it, so a dead updated_at behind an
+// unterminated value goes unseen and the gate passes — under-recognition
+// arriving as a green run. It happens on a statement whose closing quote is in
+// a piece the reader does not have: `"UPDATE x SET body = '" + v + "'"`, which
+// is assembly this gate has no detector for.
+func quotedSpanAt(text string, pos int) (length int, closed bool) {
 	if text[pos] == '\'' {
 		for i := pos + 1; i < len(text); i++ {
 			if text[i] == '\'' {
-				return i - pos + 1
+				return i - pos + 1, true
 			}
 		}
-		return len(text) - pos
+		return len(text) - pos, false
 	}
 	tag := dollarTagRe.FindString(text[pos:])
 	if tag == "" {
-		return 0
+		return 0, true
 	}
 	if end := strings.Index(text[pos+len(tag):], tag); end >= 0 {
-		return len(tag) + end + len(tag)
+		return len(tag) + end + len(tag), true
 	}
-	return len(text) - pos
+	return len(text) - pos, false
 }
 
 // assignedColumns returns the columns an assignment list writes — the targets
@@ -216,7 +235,7 @@ func assignedColumns(assignments string) []string {
 			// quotedSpanAt gives: `SET body = 'a, b', updated_at = now()`
 			// otherwise splits into fragments neither of which is an
 			// assignment, and the dead one after it is lost.
-			if skip := quotedSpanAt(assignments, pos); skip > 0 {
+			if skip, _ := quotedSpanAt(assignments, pos); skip > 0 {
 				pos += skip - 1
 				continue
 			}
@@ -342,6 +361,11 @@ func TestNoStatementWritesAColumnItsTriggerAlreadyWrites(t *testing.T) {
 							continue
 						}
 						judged++
+						if segment.unreadable {
+							t.Errorf("%s: %s writes %s with a statement carrying an unterminated quoted value (`%s`) — the text this gate has is a PIECE of a statement assembled at runtime, so what it assigns after the open quote cannot be read at all. Name the columns in one literal, or move the write where a reader can see it whole",
+								path, name, segment.table, segment.assignments)
+							continue
+						}
 						written := assignedColumns(segment.assignments)
 						var dead []string
 						for _, column := range written {

--- a/backend/gates/triggerwrittencolumns_test.go
+++ b/backend/gates/triggerwrittencolumns_test.go
@@ -143,7 +143,7 @@ func writeSegments(statement string) []writeSegment {
 		rest := statement[loc[1]:]
 		depth, end, unreadable := 0, len(rest), false
 		for pos := 0; pos < len(rest); pos++ {
-			if skip, closed := quotedSpanAt(rest, pos); skip > 0 {
+			if skip, closed := gatekit.SQLSpanAt(rest, pos); skip > 0 {
 				if !closed {
 					unreadable, end = true, pos
 					break
@@ -178,49 +178,28 @@ func isWordByte(b byte) bool {
 	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
-// dollarTagRe matches a dollar-quote opener at the current position.
-var dollarTagRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$`)
-
-// quotedSpanAt returns the length of the quoted run starting at pos and whether
-// it CLOSED, or 0 when nothing is quoted there.
+// withoutLeadingComments drops the comments an assignment can begin with.
 //
-// The scans that read a SET clause have to step OVER these rather than through
-// them. `SET body = 'from the report', updated_at = now()` ends the assignment
-// list at the literal's own `from` otherwise — and everything after it, which
-// is where the dead assignment is, becomes invisible. That is under-recognition
-// arriving as a green run, and reordering an assignment list is not something
-// anybody reviews as a schema change.
-//
-// A doubled ” inside a string needs no case of its own: the run ends at the
-// first quote, the next character is the second quote, and the scan opens a new
-// run that closes where the real one does. Dollar-quoting is matched on its
-// OPENING tag and closed on the same tag, which is what makes $tag$…'…$tag$
-// readable at all.
-//
-// A run that never CLOSES is reported rather than swallowed, and that matters in
-// the direction this gate must not fail. Reading the remainder as one quoted
-// span steps over every assignment after it, so a dead updated_at behind an
-// unterminated value goes unseen and the gate passes — under-recognition
-// arriving as a green run. It happens on a statement whose closing quote is in
-// a piece the reader does not have: `"UPDATE x SET body = '" + v + "'"`, which
-// is assembly this gate has no detector for.
-func quotedSpanAt(text string, pos int) (length int, closed bool) {
-	if text[pos] == '\'' {
-		for i := pos + 1; i < len(text); i++ {
-			if text[i] == '\'' {
-				return i - pos + 1, true
-			}
+// The target is matched ANCHORED, so `SET a = 1, -- why\n b = 2` leaves the
+// second item starting with the comment and reading as no assignment at all —
+// which loses the assignment after it, silently. The comment is not part of the
+// assignment, so it comes off before the match rather than being allowed for
+// inside the pattern.
+func withoutLeadingComments(assignment string) string {
+	for pos := 0; pos < len(assignment); {
+		if assignment[pos] == ' ' || assignment[pos] == '\t' || assignment[pos] == '\n' || assignment[pos] == '\r' {
+			pos++
+			continue
 		}
-		return len(text) - pos, false
+		skip, _ := gatekit.SQLSpanAt(assignment, pos)
+		// A quoted run is not a comment and not a target either; stopping here
+		// leaves the anchored match to refuse it, which is the right answer.
+		if skip == 0 || assignment[pos] == '\'' || assignment[pos] == '$' {
+			return assignment[pos:]
+		}
+		pos += skip
 	}
-	tag := dollarTagRe.FindString(text[pos:])
-	if tag == "" {
-		return 0, true
-	}
-	if end := strings.Index(text[pos+len(tag):], tag); end >= 0 {
-		return len(tag) + end + len(tag), true
-	}
-	return len(text) - pos, false
+	return ""
 }
 
 // assignedColumns returns the columns an assignment list writes — the targets
@@ -232,10 +211,10 @@ func assignedColumns(assignments string) []string {
 	for pos := 0; pos <= len(assignments); pos++ {
 		if pos < len(assignments) {
 			// A comma inside a string value is not a separator, for the reason
-			// quotedSpanAt gives: `SET body = 'a, b', updated_at = now()`
+			// the shared scan gives: `SET body = 'a, b', updated_at = now()`
 			// otherwise splits into fragments neither of which is an
 			// assignment, and the dead one after it is lost.
-			if skip, _ := quotedSpanAt(assignments, pos); skip > 0 {
+			if skip, _ := gatekit.SQLSpanAt(assignments, pos); skip > 0 {
 				pos += skip - 1
 				continue
 			}
@@ -270,7 +249,7 @@ func assignedColumns(assignments string) []string {
 var assignmentTargetRe = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\.)?([a-z_][a-z0-9_]*)\s*=`)
 
 func assignmentTarget(assignment string) string {
-	m := assignmentTargetRe.FindStringSubmatch(assignment)
+	m := assignmentTargetRe.FindStringSubmatch(withoutLeadingComments(assignment))
 	if m == nil {
 		return ""
 	}

--- a/backend/gates/triggerwrittencolumns_test.go
+++ b/backend/gates/triggerwrittencolumns_test.go
@@ -138,6 +138,10 @@ func writeSegments(statement string) []writeSegment {
 		rest := statement[loc[1]:]
 		depth, end := 0, len(rest)
 		for pos := 0; pos < len(rest); pos++ {
+			if skip := quotedSpanAt(rest, pos); skip > 0 {
+				pos += skip - 1
+				continue
+			}
 			switch rest[pos] {
 			case '(':
 				depth++
@@ -163,6 +167,43 @@ func isWordByte(b byte) bool {
 	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
+// dollarTagRe matches a dollar-quote opener at the current position.
+var dollarTagRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$`)
+
+// quotedSpanAt returns the length of the quoted run starting at pos, or 0 when
+// nothing is quoted there.
+//
+// The scans that read a SET clause have to step OVER these rather than through
+// them. `SET body = 'from the report', updated_at = now()` ends the assignment
+// list at the literal's own `from` otherwise — and everything after it, which
+// is where the dead assignment is, becomes invisible. That is under-recognition
+// arriving as a green run, and reordering an assignment list is not something
+// anybody reviews as a schema change.
+//
+// A doubled ” inside a string needs no case of its own: the run ends at the
+// first quote, the next character is the second quote, and the scan opens a new
+// run that closes where the real one does. Dollar-quoting is matched on its
+// OPENING tag and closed on the same tag, which is what makes $tag$…'…$tag$
+// readable at all.
+func quotedSpanAt(text string, pos int) int {
+	if text[pos] == '\'' {
+		for i := pos + 1; i < len(text); i++ {
+			if text[i] == '\'' {
+				return i - pos + 1
+			}
+		}
+		return len(text) - pos
+	}
+	tag := dollarTagRe.FindString(text[pos:])
+	if tag == "" {
+		return 0
+	}
+	if end := strings.Index(text[pos+len(tag):], tag); end >= 0 {
+		return len(tag) + end + len(tag)
+	}
+	return len(text) - pos
+}
+
 // assignedColumns returns the columns an assignment list writes — the targets
 // at paren depth zero, so a column named inside a subquery's own WHERE is not
 // mistaken for one being written.
@@ -170,6 +211,16 @@ func assignedColumns(assignments string) []string {
 	var out []string
 	depth, start := 0, 0
 	for pos := 0; pos <= len(assignments); pos++ {
+		if pos < len(assignments) {
+			// A comma inside a string value is not a separator, for the reason
+			// quotedSpanAt gives: `SET body = 'a, b', updated_at = now()`
+			// otherwise splits into fragments neither of which is an
+			// assignment, and the dead one after it is lost.
+			if skip := quotedSpanAt(assignments, pos); skip > 0 {
+				pos += skip - 1
+				continue
+			}
+		}
 		if pos == len(assignments) || (assignments[pos] == ',' && depth == 0) {
 			if column := assignmentTarget(assignments[start:pos]); column != "" {
 				out = append(out, column)
@@ -187,10 +238,16 @@ func assignedColumns(assignments string) []string {
 	return out
 }
 
-// assignmentTargetRe reads the column an assignment writes. Anchored at both
-// ends of the target so `updated_at_source = $1` is not read as a write of
-// `updated_at`, and a qualified target (`c.status = $2`, which UPDATE … FROM
-// allows) is read as the column it names.
+// assignmentTargetRe reads the column an assignment writes. Anchored at the
+// START of the assignment so `updated_at_source = $1` is not read as a write of
+// `updated_at`.
+//
+// The optional qualifier is TOLERANCE, not a shape this tree writes: Postgres
+// requires an unqualified column on the left of a SET, in `UPDATE … FROM` as
+// much as anywhere else. Accepting `c.updated_at = now()` costs nothing and
+// means a statement somebody writes that way is read as the write it was meant
+// to be rather than skipped — and skipping is the failure direction that goes
+// quiet.
 var assignmentTargetRe = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\.)?([a-z_][a-z0-9_]*)\s*=`)
 
 func assignmentTarget(assignment string) string {
@@ -370,6 +427,54 @@ func TestTheTouchTriggerFunctionsStillWriteWhatThisGateSays(t *testing.T) {
 					boolWord(declared, "does", "does not"))
 			}
 		}
+	}
+}
+
+// TestNothingInGoTurnsOffTheTouchTrigger holds the OTHER half of every ruling
+// here: that the trigger actually fires when a swept statement runs.
+//
+// set_updated_at_bump_version has an early return — it writes nothing while
+// margince.last_activity_move is 'on' — so a statement executing under that
+// setting keeps its own assignment, and calling it dead would delete a live
+// write. The setting is turned on and off inside the last-activity trigger
+// functions themselves, around the UPDATE they make, and nothing in Go touches
+// it. That is the proof the rulings rest on, and this is what fails the day it
+// stops being true.
+func TestNothingInGoTurnsOffTheTouchTrigger(t *testing.T) {
+	t.Parallel()
+	const guc = "margince.last_activity_move"
+	found := 0
+	for _, root := range []string{"internal", "cmd", "tools"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return err
+			}
+			raw, err := os.ReadFile(path) // #nosec G304 -- a *.go path from walking this repository's own tree
+			if err != nil {
+				return err
+			}
+			if strings.Contains(string(raw), guc) {
+				found++
+				t.Errorf("%s names %s, which suppresses the touch trigger — every assignment this gate ruled dead is live inside that scope. Either the statement keeps its own updated_at/version and is waived here, or the GUC goes back to being the trigger functions' own",
+					filepath.ToSlash(path), guc)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// And the setting still exists where it is supposed to, or this test is
+	// reading for a string nothing uses and passing for the wrong reason.
+	raw, err := os.ReadFile("migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+	if !strings.Contains(string(raw), guc) {
+		t.Fatalf("the head catalog no longer names %s at all — the early return this test is about has moved or gone, and the reasoning above has to be redone rather than assumed", guc)
+	}
+	if found > 0 {
+		t.Logf("%d Go source(s) name the setting", found)
 	}
 }
 

--- a/backend/internal/modules/activities/capturenoise.go
+++ b/backend/internal/modules/activities/capturenoise.go
@@ -58,7 +58,7 @@ func (s *Store) HideCapturedNoiseTx(ctx context.Context, tx pgx.Tx, activityIDs 
 		return 0, nil
 	}
 	rows, err := tx.Query(ctx, `
-		UPDATE activity SET archived_at = now(), updated_at = now()
+		UPDATE activity SET archived_at = now()
 		 WHERE id = ANY($1) AND archived_at IS NULL
 		RETURNING id`, activityIDs)
 	if err != nil {
@@ -128,7 +128,7 @@ func (s *Store) RedactCapturedNoiseTx(ctx context.Context, tx pgx.Tx, activityID
 		   FOR UPDATE
 		), stripped AS (
 		  UPDATE activity a
-		     SET subject = NULL, body = NULL, raw = NULL, updated_at = now()
+		     SET subject = NULL, body = NULL, raw = NULL
 		    FROM target t
 		   WHERE a.id = t.id AND t.had_content
 		)

--- a/backend/internal/modules/activities/messageidentity.go
+++ b/backend/internal/modules/activities/messageidentity.go
@@ -456,8 +456,7 @@ func archiveAbsorbedEcho(ctx context.Context, tx pgx.Tx, survivorID, echoID ids.
 		UPDATE activity
 		   SET source_system = NULL,
 		       source_id     = NULL,
-		       archived_at   = coalesce(archived_at, now()),
-		       updated_at    = now()
+		       archived_at   = coalesce(archived_at, now())
 		 WHERE id = $1 AND source_id = $2`, echoID, stamped)
 	if err != nil {
 		return fmt.Errorf("activities: archiving the absorbed echo: %w", err)

--- a/backend/internal/modules/aiactivity/store.go
+++ b/backend/internal/modules/aiactivity/store.go
@@ -105,8 +105,7 @@ ON CONFLICT (source, occurrence_key) DO UPDATE SET
   quantity = EXCLUDED.quantity, quantity_unit = EXCLUDED.quantity_unit,
   degrade_reason = EXCLUDED.degrade_reason, summary = EXCLUDED.summary,
   last_event_id = EXCLUDED.last_event_id,
-  seq = nextval('ai_task_run_seq'),
-  updated_at = now()
+  seq = nextval('ai_task_run_seq')
 WHERE (EXCLUDED.attempt, ai_task_run_state_rank(EXCLUDED.state))
     > (ai_task_run.attempt, ai_task_run_state_rank(ai_task_run.state))
 RETURNING seq`
@@ -196,8 +195,7 @@ UPDATE ai_task_run
        finished_at = now(),
        stale_after = NULL,
        degrade_reason = $2,
-       seq = nextval('ai_task_run_seq'),
-       updated_at = now()
+       seq = nextval('ai_task_run_seq')
  WHERE source = 'ai_router'
    AND state IN ('queued','running')
    AND stale_after IS NOT NULL

--- a/backend/internal/modules/identity/userlocale.go
+++ b/backend/internal/modules/identity/userlocale.go
@@ -78,7 +78,7 @@ func (s *Service) SaveMyLocale(ctx context.Context, locale string) (Seat, error)
 			return nil
 		}
 		if _, err := tx.Exec(ctx,
-			`UPDATE app_user SET locale = $2, updated_at = now()
+			`UPDATE app_user SET locale = $2
 			  WHERE id = $1 AND archived_at IS NULL`, human, locale); err != nil {
 			return err
 		}

--- a/backend/internal/modules/integrations/execute.go
+++ b/backend/internal/modules/integrations/execute.go
@@ -184,7 +184,7 @@ func (s *Store) leaseForSubmit(ctx context.Context, tx pgx.Tx, name, runID strin
 	}
 	if _, err := tx.Exec(ctx, `
 		UPDATE provider_run SET state = 'submitting', inflight_at = now(),
-		       submitted_at = now(), updated_at = now()
+		       submitted_at = now()
 		 WHERE id = $1`, runID); err != nil {
 		return none, false, fmt.Errorf("integrations: marking the run in flight: %w", err)
 	}
@@ -220,7 +220,7 @@ func (s *Store) frozenRequest(ctx context.Context, tx pgx.Tx, name, person, corr
 // nothing anyone paid for is being released.
 func (s *Store) cancelWithdrawn(ctx context.Context, tx pgx.Tx, runID string) error {
 	if _, err := tx.Exec(ctx, `
-		UPDATE provider_run SET state = 'cancelled', completed_at = now(), updated_at = now()
+		UPDATE provider_run SET state = 'cancelled', completed_at = now()
 		 WHERE id = $1`, runID); err != nil {
 		return fmt.Errorf("integrations: cancelling the withdrawn run: %w", err)
 	}
@@ -333,7 +333,7 @@ func (s *Store) recordSubmission(ctx context.Context, tx pgx.Tx, desc provider.D
 	switch sub.Outcome {
 	case provider.OutcomeAccepted:
 		if _, err := tx.Exec(ctx, `
-			UPDATE provider_run SET state = 'in_progress', provider_job_id = $2, updated_at = now()
+			UPDATE provider_run SET state = 'in_progress', provider_job_id = $2
 			 WHERE id = $1`, runID, sub.ProviderJobID); err != nil {
 			return fmt.Errorf("integrations: recording the accepted submission: %w", err)
 		}
@@ -376,7 +376,7 @@ func (s *Store) lockRunState(ctx context.Context, tx pgx.Tx, runID string) (stri
 func (s *Store) parkUnknown(ctx context.Context, tx pgx.Tx, runID, safeCode string) error {
 	if _, err := tx.Exec(ctx, `
 		UPDATE provider_run SET state = 'submission_unknown', completed_at = now(),
-		       last_safe_status_code = $2, updated_at = now()
+		       last_safe_status_code = $2
 		 WHERE id = $1`, runID, safeCode); err != nil {
 		return fmt.Errorf("integrations: parking the unknown submission: %w", err)
 	}
@@ -408,7 +408,7 @@ func (s *Store) recordRefusal(ctx context.Context, tx pgx.Tx, desc provider.Desc
 	}
 	if _, err := tx.Exec(ctx, `
 		UPDATE provider_run SET state = 'failed', completed_at = now(), inflight_at = NULL,
-		       last_safe_status_code = $2, updated_at = now()
+		       last_safe_status_code = $2
 		 WHERE id = $1`, runID, safeCode); err != nil {
 		return fmt.Errorf("integrations: recording the refusal: %w", err)
 	}
@@ -433,7 +433,7 @@ func (s *Store) writeStatusThrough(ctx context.Context, tx pgx.Tx, name, status,
 	// image is the only way to read what the two columns held — and what they
 	// held is the whole question an operator brings to this row.
 	err := tx.QueryRow(ctx, `
-		UPDATE provider_connection c SET status = $2, last_safe_status_code = $3, updated_at = now()
+		UPDATE provider_connection c SET status = $2, last_safe_status_code = $3
 		  FROM provider_connection was
 		 WHERE was.id = c.id AND c.provider = $1 AND c.status <> $2
 		 RETURNING c.id::text, was.status, was.last_safe_status_code`,

--- a/backend/internal/modules/integrations/handoff.go
+++ b/backend/internal/modules/integrations/handoff.go
@@ -110,7 +110,7 @@ func (s *Store) writeClaimsInline(ctx context.Context, tx pgx.Tx, runID, personI
 	// Cleared with the write: a crash after the claims commit but before a
 	// separate clear would merely re-run an idempotent upsert.
 	if _, err := tx.Exec(ctx, `
-		UPDATE provider_run SET next_attempt_at = NULL, updated_at = now()
+		UPDATE provider_run SET next_attempt_at = NULL
 		 WHERE id = $1`, runID); err != nil {
 		return fmt.Errorf("integrations: clearing the claims-pending marker: %w", err)
 	}
@@ -122,7 +122,7 @@ func (s *Store) writeClaimsInline(ctx context.Context, tx pgx.Tx, runID, personI
 // reached the subject.
 func (s *Store) discardClaims(ctx context.Context, tx pgx.Tx, runID string) error {
 	if _, err := tx.Exec(ctx, `
-		UPDATE provider_run SET claims_unwritten = true, next_attempt_at = NULL, updated_at = now()
+		UPDATE provider_run SET claims_unwritten = true, next_attempt_at = NULL
 		 WHERE id = $1`, runID); err != nil {
 		return fmt.Errorf("integrations: recording the discarded claims: %w", err)
 	}
@@ -185,7 +185,7 @@ func (s *Store) recoverClaims(ctx context.Context, runID string) error {
 func (s *Store) bumpClaimAttempt(ctx context.Context, tx pgx.Tx, runID string) (bool, error) {
 	var attempts int
 	if err := tx.QueryRow(ctx, `
-		UPDATE provider_run SET attempt_count = attempt_count + 1, updated_at = now()
+		UPDATE provider_run SET attempt_count = attempt_count + 1
 		 WHERE id = $1 RETURNING attempt_count`, runID).Scan(&attempts); err != nil {
 		return false, fmt.Errorf("integrations: advancing the hand-off ladder: %w", err)
 	}

--- a/backend/internal/modules/integrations/poll.go
+++ b/backend/internal/modules/integrations/poll.go
@@ -65,7 +65,7 @@ func (s *Store) expireDeadInflight(ctx context.Context) error {
 		if _, err := tx.Exec(ctx, `
 			UPDATE provider_run
 			   SET state = 'submission_unknown', completed_at = now(),
-			       last_safe_status_code = 'submission_expired', updated_at = now()
+			       last_safe_status_code = 'submission_expired'
 			 WHERE state = 'submitting' AND inflight_at < now() - $1::interval`,
 			inflightExpiry.String()); err != nil {
 			return fmt.Errorf("integrations: expiring dead in-flight submissions: %w", err)
@@ -76,7 +76,7 @@ func (s *Store) expireDeadInflight(ctx context.Context) error {
 		if _, err := tx.Exec(ctx, `
 			UPDATE provider_run
 			   SET state = 'submission_unknown', completed_at = now(),
-			       last_safe_status_code = 'poll_expired', updated_at = now()
+			       last_safe_status_code = 'poll_expired'
 			 WHERE state = 'in_progress' AND submitted_at < now() - $1::interval`,
 			pollExpiry.String()); err != nil {
 			return fmt.Errorf("integrations: expiring unresolvable in-progress runs: %w", err)
@@ -261,7 +261,7 @@ func (s *Store) terminalize(ctx context.Context, tx pgx.Tx, desc provider.Descri
 	case provider.OutcomeCompleted:
 		if _, err := tx.Exec(ctx, `
 			UPDATE provider_run SET state = 'completed', completed_at = now(),
-			       next_attempt_at = now(), inflight_at = NULL, updated_at = now()
+			       next_attempt_at = now(), inflight_at = NULL
 			 WHERE id = $1`, runID); err != nil {
 			return fmt.Errorf("integrations: recording the completed run: %w", err)
 		}
@@ -275,7 +275,7 @@ func (s *Store) terminalize(ctx context.Context, tx pgx.Tx, desc provider.Descri
 	case provider.OutcomeNoMatch:
 		if _, err := tx.Exec(ctx, `
 			UPDATE provider_run SET state = 'no_match', completed_at = now(),
-			       last_safe_status_code = $2, inflight_at = NULL, updated_at = now()
+			       last_safe_status_code = $2, inflight_at = NULL
 			 WHERE id = $1`, runID, status.SafeStatusCode); err != nil {
 			return fmt.Errorf("integrations: recording the no-match run: %w", err)
 		}
@@ -293,7 +293,7 @@ func (s *Store) terminalize(ctx context.Context, tx pgx.Tx, desc provider.Descri
 		return s.recordRefusal(ctx, tx, desc, name, runID, status.Outcome, status.SafeStatusCode)
 	}
 	if _, err := tx.Exec(ctx, `
-		UPDATE provider_connection SET last_used_at = now(), updated_at = now()
+		UPDATE provider_connection SET last_used_at = now()
 		 WHERE provider = $1`, name); err != nil {
 		return fmt.Errorf("integrations: stamping the connection's last use: %w", err)
 	}

--- a/backend/internal/modules/people/coldstartcolumn.go
+++ b/backend/internal/modules/people/coldstartcolumn.go
@@ -23,13 +23,13 @@ func writeOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, co
 		return applyUnclaimedOrgColumn(ctx, tx, orgID, column, value)
 	}
 	queries := map[string]string{
-		columnLegalName: `UPDATE organization SET legal_name = $2, updated_at = now()
+		columnLegalName: `UPDATE organization SET legal_name = $2
 			WHERE id = $1 AND legal_name IS DISTINCT FROM $2`,
-		columnIndustry: `UPDATE organization SET industry = $2, updated_at = now()
+		columnIndustry: `UPDATE organization SET industry = $2
 			WHERE id = $1 AND industry IS DISTINCT FROM $2`,
-		columnAddress: `UPDATE organization SET address_line1 = $2, updated_at = now()
+		columnAddress: `UPDATE organization SET address_line1 = $2
 			WHERE id = $1 AND address_line1 IS DISTINCT FROM $2`,
-		columnDescription: `UPDATE organization SET description = $2, updated_at = now()
+		columnDescription: `UPDATE organization SET description = $2
 			WHERE id = $1 AND description IS DISTINCT FROM $2
 			AND ($2::text IS NULL OR length($2) <= 500)`,
 	}

--- a/backend/internal/modules/people/company.go
+++ b/backend/internal/modules/people/company.go
@@ -375,7 +375,7 @@ func resolveOrCreateAnchor(ctx context.Context, tx pgx.Tx, displayName, by strin
 		return anchorTarget{}, err
 	}
 	tag, err := tx.Exec(ctx,
-		`UPDATE organization SET display_name = $2, version = version + 1
+		`UPDATE organization SET display_name = $2
 		 WHERE id = $1 AND display_name IS DISTINCT FROM $2`,
 		orgID, displayName)
 	if err != nil {

--- a/backend/internal/modules/people/ensurenamefill.go
+++ b/backend/internal/modules/people/ensurenamefill.go
@@ -80,8 +80,7 @@ func fillMissingPersonName(ctx context.Context, tx pgx.Tx, personID ids.PersonID
 		   SET first_name = $2,
 		       last_name  = $3,
 		       full_name  = CASE WHEN full_name = $2 OR full_name = $3
-		                         THEN $4 ELSE full_name END,
-		       updated_at = now()
+		                         THEN $4 ELSE full_name END
 		 WHERE id = $1
 		   AND first_name IS NULL AND last_name IS NULL
 		RETURNING full_name`,

--- a/backend/internal/modules/people/organizationlifecycle.go
+++ b/backend/internal/modules/people/organizationlifecycle.go
@@ -69,7 +69,7 @@ func (s *Store) SetOrganizationLifecycleTx(
 		return false, nil
 	}
 	tag, err := tx.Exec(ctx, `
-		UPDATE organization SET lifecycle = $2, updated_at = now(), version = version + 1
+		UPDATE organization SET lifecycle = $2
 		 WHERE id = $1 AND lifecycle = $3`, orgID, to, from)
 	if err != nil {
 		return false, fmt.Errorf("people: moving the account's stage: %w", err)

--- a/backend/internal/modules/people/projectcompany.go
+++ b/backend/internal/modules/people/projectcompany.go
@@ -249,7 +249,7 @@ func setCompanyRoleTx(
 		 VALUES ('`+ProjectCompanyKind+`', $1, $2, $3, $4, $5)
 		 ON CONFLICT (project_id, organization_id)
 		   WHERE kind = '`+ProjectCompanyKind+`' AND archived_at IS NULL
-		   DO UPDATE SET role = EXCLUDED.role, version = relationship.version + 1, updated_at = now()
+		   DO UPDATE SET role = EXCLUDED.role
 		 RETURNING `+relationshipColumns+`, (SELECT was.role FROM was), xmax = 0`,
 		projectID, organizationID, role, projectCompanySource, by)
 	row, err := scanRelationshipWithPrior(scan, &priorRole, &inserted)
@@ -345,7 +345,7 @@ func (s *Store) RemoveProjectCompany(ctx context.Context, projectID ids.ProjectI
 			return &CompanyHasDealsOnProjectError{Deals: stranded}
 		}
 		row, err := scanRelationship(tx.QueryRow(ctx,
-			`UPDATE relationship SET archived_at = now(), version = version + 1, updated_at = now()
+			`UPDATE relationship SET archived_at = now()
 			  WHERE kind = $1 AND project_id = $2 AND organization_id = $3 AND archived_at IS NULL
 			  RETURNING `+relationshipColumns,
 			ProjectCompanyKind, projectID, organizationID))

--- a/backend/internal/modules/privacy/erasuredealroom.go
+++ b/backend/internal/modules/privacy/erasuredealroom.go
@@ -91,8 +91,7 @@ func anonymizeDealRoomSeats(ctx context.Context, tx pgx.Tx, emails []string) ([]
 	rows, err := tx.Query(ctx, `
 		UPDATE deal_room_participant
 		   SET full_name = $1, email = $2,
-		       revoked_at = coalesce(revoked_at, now()),
-		       updated_at = now()
+		       revoked_at = coalesce(revoked_at, now())
 		 WHERE email = ANY($3)
 		RETURNING id`, erasedName, erasedEmail, emails)
 	if err != nil {

--- a/backend/internal/modules/signals/audiencerescope.go
+++ b/backend/internal/modules/signals/audiencerescope.go
@@ -77,7 +77,7 @@ func NarrowDerivedForActivity(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 	if owner != nil {
 		if err := apply("narrowing extraction signals", `
 			UPDATE signal
-			   SET visibility = 'owner', owner_id = $2, updated_at = now(), version = version + 1
+			   SET visibility = 'owner', owner_id = $2
 			 WHERE source = 'signal-scan' AND visibility = 'workspace' AND archived_at IS NULL
 			   AND `+cites+`
 			RETURNING id`,
@@ -90,7 +90,7 @@ func NarrowDerivedForActivity(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 		// message: the summary now mixes two people's limited correspondence.
 		if err := apply("archiving cross-owner extraction signals", `
 			UPDATE signal
-			   SET archived_at = now(), updated_at = now(), version = version + 1
+			   SET archived_at = now()
 			 WHERE source = 'signal-scan' AND visibility = 'owner' AND owner_id <> $2 AND archived_at IS NULL
 			   AND `+cites+`
 			RETURNING id`,
@@ -103,7 +103,7 @@ func NarrowDerivedForActivity(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 	}
 	if err := apply("archiving ownerless extraction signals", `
 		UPDATE signal
-		   SET archived_at = now(), updated_at = now(), version = version + 1
+		   SET archived_at = now()
 		 WHERE source = 'signal-scan' AND archived_at IS NULL
 		   AND `+cites+`
 		RETURNING id`,

--- a/backend/internal/modules/signals/derived.go
+++ b/backend/internal/modules/signals/derived.go
@@ -253,7 +253,7 @@ func AcknowledgeTx(ctx context.Context, tx pgx.Tx, signalID ids.UUID) (bool, err
 	// left 'open' behind, the update matches nothing, and the false below says
 	// their judgement stands.
 	tag, err := tx.Exec(ctx, `
-		UPDATE signal SET status = 'acknowledged', version = version + 1, updated_at = now()
+		UPDATE signal SET status = 'acknowledged'
 		 WHERE id = $1 AND status = 'open' AND archived_at IS NULL`, signalID)
 	if err != nil {
 		return false, fmt.Errorf("acknowledge the signal: %w", err)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -192,7 +192,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (35)
+## Prohibition (36)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -228,6 +228,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooktally_test.go` | H1 | A rulebook must not spell out a tally of anything the tree can be asked for. |
 | `technicaldomain_test.go` | H2 | The technical lookup reads the domain the RECORD holds, and nothing else. |
 | `transactionopeners_test.go` | H2 | One function in the database package turns a pool into a transaction, and every seam the package publishes routes through it. |
+| `triggerwrittencolumns_test.go` | H2 | A statement may not write a column its table's trigger already writes. |
 | `txseamacquire_test.go` | H2 | Code that runs on a caller's `pgx.Tx` acquires no connection of its own. |
 | `unitegress_test.go` | H2 | A unit dials through the installation's egress policy, not through a copy of it. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
@@ -251,7 +252,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooklength_test.go` | H3 | A rulebook is read in full by every session and, for its Craftsmanship section, by every gate prompt — so its length is a running cost rather than a matter of taste. |
 | `workflowtimeouts_test.go` | H3 | Every workflow job carries a wall-clock ceiling. |
 
-## Falsification (6)
+## Falsification (7)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -260,4 +261,5 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobkindgate_test.go` | H2 | The registration gate's own falsification. |
 | `rbacbaselineerafixture_test.go` | H3 | The pre-state the RBAC composition gate replays over must not be hand-editable. |
 | `retainedcolumncases_test.go` | H1 | The retention sweep's two SQL claims, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
+| `triggerwrittencolumncases_test.go` | H2 | The trigger-written-column reader driven with SYNTHETIC statements, for the reason retainedcolumncases\_test.go gives for its own: the tree is supposed to pass, so a reader proven only by "nothing in the tree trips it" is one that keeps passing after it stops working. |
 | `updateguardcases_test.go` | H2 | What the concurrency-guard census judges a function on, driven with SYNTHETIC source rather than the tree — the same reason retainedcolumncases\_test.go gives for its own cases. |


### PR DESCRIPTION
Closes #2761.

A `BEFORE UPDATE ... FOR EACH ROW` trigger runs *after* the statement's `SET` has been applied to `NEW`, so it overwrites what the statement assigned. On the 64 tables carrying `set_updated_at` or `set_updated_at_bump_version`, a statement's own `updated_at = now()` or `version = version + 1` is dead — not wrong, dead: the same value, assigned twice.

## Why it is worth a gate and not a grep

Dead code that looks load-bearing is worse than dead code that looks dead, and both instances the ticket found are the second kind:

- `company.go`'s `version = version + 1` was counted as a fourth disagreeing approach to concurrent editing across the organization writers. It was not an approach at all.
- `coldstartcolumn.go`'s overwrite statements carried `updated_at = now()` where their sibling fill statements did not, and the difference read as deliberate.

The file next door already writes the sentence, about a different trigger: *"an earlier version did it in this statement — correct, and something the next address writer would not have known to copy."* Nothing enforced it.

## The gate

`backend/gates/triggerwrittencolumns_test.go` (`//gate:kind prohibition H2`). Trigger-touched tables are derived from `migrations/testdata/head_catalog.txt` — the dumped head schema rather than the `CREATE TRIGGER` lines, so a trigger created in one migration and dropped in another is already accounted for instead of having to be re-derived. Statements are read with `gatekit.SQLStatementsIn`, so a concatenated statement is one statement.

Three rulings worth reading before changing it:

**It refuses to rule on a conditional trigger.** `BEFORE UPDATE OF a, b` fires only when the statement writes one of those columns; a `WHEN (…)` trigger only when its predicate holds. Under either, the assignment is not always overwritten. `channel_connection` carries `WHEN ((to_jsonb(old.*) - 'poll_offset') IS DISTINCT FROM …)` today. The finding here ends in a **deletion**, so the gate under-recognizes rather than deleting live code.

**A touch is a real shape.** Three statements exist only to *be* an update, so the trigger fires and moves the `activity.version` (or `person.version`) a staged approval pinned. They need an assignment to exist at all. That is recognized rather than trusted — the assignment must be the statement's **only** one — and the site is still registered with the reason the row has to move, because "this must bump" is a claim about the product, not about SQL. A waived site that gains a second dead assignment fails (mutation-checked).

**It reads the `ON CONFLICT` arm.** A `BEFORE UPDATE` trigger fires on an upsert's conflict arm exactly as on a plain `UPDATE`, and the table it writes is the one the `INSERT` named — nowhere near the word `UPDATE`. `projectcompany.go` writes that shape.

`triggerWrites` (the two functions → the columns they assign) is the one thing asserted rather than derived, so `TestTheTouchTriggerFunctionsStillWriteWhatThisGateSays` reads both bodies out of the catalog and fails if either stops matching — every deletion below was ruled from that table.

## The falsification cases

`backend/gates/triggerwrittencolumncases_test.go`. Every MISSED row is a shape an earlier reader could not see. Every KEPT row is the opposite failure and matters as much, because the finding is a deletion — the sharpest being `WHERE … AND version = $3`, the compare-and-set `updateguard_test.go` **requires** on these same statements. A gate that read it as a dead write would send the next author to delete their own concurrency guard.

Mutation-checked from six directions: putting one assignment back in the tree, a lazy SET-clause terminator, a depth-blind assignment split, dropping the `ON CONFLICT` branch, unanchoring the assignment target, and giving a waived touch a second assignment. Each fails the cases that exist for it and nothing else.

The cases file also states what still gets past the reader: a statement built by `fmt.Sprintf` or a query builder, where the table or column only exists at runtime.

## The sweep

41 assignments in 15 files. Nothing else changes — every deleted assignment wrote the value its trigger writes one instruction later.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` run locally. The integration lane is red on `main` on an unrelated pre-existing failure — `TestFK_rowScopedTargetsHaveVisibilityDecision` on `organization_vat_check.organization_id`, from #3158 — which #3167 fixes; every other package passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary record updates across activities, identities, locales, integrations, organization details, relationships, privacy data, and signal states.
  * Preserved status, audit, event, archival, and sequencing behavior while avoiding unrelated timestamp or version changes.
  * Prevented redundant organization version changes during name updates.
  * Improved safeguards against conflicting database updates and trigger-related data inconsistencies.

* **Tests**
  * Added coverage for trigger interactions and SQL updates across varied write patterns, comments, aliases, nested queries, and incomplete statements.

* **Documentation**
  * Updated the gate inventory with expanded validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->