### PR TITLE
A correction does not outlive the value it corrected

### DIFF
--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -203,6 +203,85 @@ func TestCorrectionLedgerSurvivesRederivation(t *testing.T) {
 	}
 }
 
+// The other direction, which the test above passes without: a correction must
+// not outlive the value it was correcting.
+//
+// The sequence is real and every step of it is an ordinary day. A pass writes a
+// title; a human reads it, disagrees, and records their own; then something
+// writes a newer, better value to the same field — an accepted research claim,
+// a fresh enrichment, an edit through another door — and person_profile_field's
+// updated_at moves. Without a recency check the page keeps serving the human's
+// correction, and the reader is told the current value is one the record does
+// not hold. Asked what somebody's title is, an assistant answers with a value
+// no row carries, which reads as a hallucination and is a data contradiction.
+//
+// Driven against a REAL row rather than the ruling alone, because the ruling is
+// only half the fix: it has to be handed the date the VALUE took its current
+// form, and a reader passing the wrong clock would satisfy every unit case.
+func TestACorrectionDoesNotOutliveTheValueItCorrected(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
+	SeedIDRow(t, owner, `INSERT INTO person_profile_field (id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+		VALUES ($1, '`+mine.String()+`', 'title', 'Business Development Manager',
+		        'Anna Weber, Business Development Manager', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
+	svc := personRoomService(e)
+	personID := ids.From[ids.PersonKind](mine)
+
+	before, err := svc.ProfileFields(rep, personID)
+	if err != nil {
+		t.Fatalf("ProfileFields: %v", err)
+	}
+	corrected := "Head of Business Development"
+	if err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
+		SubjectType: "person", SubjectID: mine, ClaimKind: ai.ClaimProfileField,
+		ClaimPath: *before[0].ClaimKey, Verdict: ai.VerdictCorrected, CorrectedValue: &corrected,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	// The correction stands over the value it was recorded against — the
+	// direction the test above pins, asserted here too so the case below is
+	// known to be testing recency rather than a broken overlay.
+	standing, err := svc.ProfileFields(rep, personID)
+	if err != nil {
+		t.Fatalf("ProfileFields after the correction: %v", err)
+	}
+	if standing[0].Value != corrected {
+		t.Fatalf("the correction did not apply at all (%q), so this case proves nothing", standing[0].Value)
+	}
+
+	// Now a newer answer replaces the value the human was looking at. The
+	// touch trigger moves updated_at; the value is what an accepted research
+	// claim would have written.
+	if _, err := owner.Exec(context.Background(), `UPDATE person_profile_field
+		   SET value = 'Geschaeftsfuehrerin', source = 'research_accept', captured_by = 'user:rep1'
+		 WHERE person_id = $1 AND field = 'title'`, mine); err != nil {
+		t.Fatalf("writing the newer value: %v", err)
+	}
+
+	after, err := svc.ProfileFields(rep, personID)
+	if err != nil {
+		t.Fatalf("ProfileFields after the newer value: %v", err)
+	}
+	if after[0].Value != "Geschaeftsfuehrerin" {
+		t.Errorf("value = %q, want the newer stored answer — the correction outlived the value it was correcting", after[0].Value)
+	}
+	// And the marker goes with it. "corrected" beside a value the human never
+	// wrote says they wrote it.
+	if after[0].Verdict != nil {
+		t.Errorf("verdict marker = %q on a value recorded after it — the page says a human decided about an answer they never saw", *after[0].Verdict)
+	}
+	page, err := svc.Assemble(rep, personID)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if page.ProfileFields == nil || (*page.ProfileFields)[0].Value != "Geschaeftsfuehrerin" {
+		t.Error("the composite read served the stale correction the sidecar dropped")
+	}
+}
+
 // The write is gated on the SUBJECT's own grant. A caller who may read a
 // contact but not edit them cannot overrule what the system says about them.
 func TestCorrectionLedgerRefusesAWriteWithoutTheSubjectsUpdateGrant(t *testing.T) {

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -234,6 +234,15 @@ func TestACorrectionDoesNotOutliveTheValueItCorrected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProfileFields: %v", err)
 	}
+	// The same guards the sibling case above carries. A regression that drops
+	// the seeded row or its claim key should fail here saying so, not panic on
+	// an index or a nil pointer and send the reader to the wrong file.
+	if len(before) != 1 || before[0].Value != "Business Development Manager" {
+		t.Fatalf("seeded field did not read back: %+v", before)
+	}
+	if before[0].ClaimKey == nil || *before[0].ClaimKey == "" {
+		t.Fatal("the field carries no claim key, so nothing could ever correct it")
+	}
 	corrected := "Head of Business Development"
 	if err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
 		SubjectType: "person", SubjectID: mine, ClaimKind: ai.ClaimProfileField,

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -388,15 +388,26 @@ func (s *Service) applyFieldVerdicts(
 		if !found {
 			continue
 		}
-		verdict := crmcontracts.PersonProfileFieldVerdict(v.Verdict)
+		// AGAINST f.CapturedAt, which is this row's updated_at — when the
+		// value took its current form. A human's decision is about the answer
+		// that was in front of them, and something may have replaced it since:
+		// a machine fill cannot (it writes DO NOTHING over a row that exists),
+		// but an accepted research claim replaces the whole row and moves this
+		// date. A verdict older than that is about a value the record no
+		// longer holds, and ai.Verdict.AsOf is where that ruling lives.
+		decision, applies := v.AsOf(f.CapturedAt)
+		if !applies {
+			continue
+		}
+		verdict := crmcontracts.PersonProfileFieldVerdict(decision.Verdict)
 		f.Verdict = &verdict
-		f.VerdictNote = v.Note
-		if v.Verdict == ai.VerdictCorrected && v.CorrectedValue != nil {
+		f.VerdictNote = decision.Note
+		if decision.Verdict == ai.VerdictCorrected && decision.CorrectedValue != nil {
 			// The human's value stands. The captured snippet is left in place
 			// beneath it on purpose — what the machine read is still the
 			// evidence for why it got this wrong, and hiding it would leave the
 			// correction unexplainable.
-			f.Value = *v.CorrectedValue
+			f.Value = *decision.CorrectedValue
 		}
 	}
 	return fields, nil

--- a/backend/internal/modules/ai/feedback.go
+++ b/backend/internal/modules/ai/feedback.go
@@ -26,6 +26,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -94,13 +95,73 @@ func ClaimKey(path string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// Verdict is one recorded human decision.
+// Verdict is one recorded human decision, as the ledger holds it.
+//
+// What the human SAID is reached through AsOf and nowhere else, and the fields
+// carrying it are unexported for that reason. A decision is about the value
+// that was in front of the person who made it; a surface that could read it
+// without saying which version of the value it is asking about would serve a
+// correction over an answer the human never saw. That was a live defect on the
+// 360 page, and unexported fields are what stops it being written again.
 type Verdict struct {
-	ClaimKind      string
-	ClaimKey       string
+	ClaimKind string
+	ClaimKey  string
+
+	// recordedAt is ai_feedback.updated_at — when this decision took its
+	// current form, which the upsert moves on every re-decision. NOT
+	// created_at: a human who changes their mind is looking at whatever is
+	// there now, and dating their new decision from their old one would make
+	// it stale the moment they made it.
+	recordedAt     time.Time
+	verdict        string
+	correctedValue *string
+	note           *string
+}
+
+// Decision is what a human decided about one claim, as it applies to a
+// particular version of the value.
+type Decision struct {
 	Verdict        string
-	CorrectedValue *string
 	Note           *string
+	CorrectedValue *string
+}
+
+// AsOf answers what a human decided about a value last written at valueAt, and
+// whether their decision applies to that value at all.
+//
+// A verdict recorded BEFORE the value it is read against is about something
+// else. The human was looking at an earlier answer and something has replaced
+// it since — an accepted research claim, a fresh enrichment, an edit through
+// another door — so their correction describes a value that is no longer
+// stored. Serving it tells the reader the current value is one the record does
+// not hold.
+//
+// The MARKER goes with it, and that is the half worth stating. Keeping
+// "corrected" beside the newer stored value would say the human wrote that
+// value; keeping "confirmed" would say they had seen it. Both are the same lie
+// one field along, and a reader has no way to tell. What a human once decided
+// is still in the ledger and in audit_log for anyone asking that question; what
+// this answers is the narrower one the page asks — does their decision describe
+// what is on the screen.
+//
+// Equal timestamps STAND. A verdict and the value it is about can be written in
+// one transaction, where both carry the same now(), and refusing that case
+// would suppress a decision at the instant it was made.
+func (v Verdict) AsOf(valueAt time.Time) (Decision, bool) {
+	if v.recordedAt.Before(valueAt) {
+		return Decision{}, false
+	}
+	return Decision{Verdict: v.verdict, Note: v.note, CorrectedValue: v.correctedValue}, true
+}
+
+// NewVerdict builds one. It exists because the fields above are unexported: the
+// store that reads the ledger and the tests that drive the ruling need a way to
+// set them, and a constructor is a door the recency question cannot slip past.
+func NewVerdict(claimKind, claimKey, verdict string, correctedValue, note *string, recordedAt time.Time) Verdict {
+	return Verdict{
+		ClaimKind: claimKind, ClaimKey: claimKey, verdict: verdict,
+		correctedValue: correctedValue, note: note, recordedAt: recordedAt,
+	}
 }
 
 // RecordInput is a human's decision about one claim.
@@ -268,7 +329,10 @@ func (s *FeedbackStore) VerdictsForTx(ctx context.Context, tx pgx.Tx, subjectTyp
 		return nil, err
 	}
 	rows, err := tx.Query(ctx, `
-		SELECT claim_kind, claim_key, verdict, corrected_value, note
+		-- updated_at, not created_at: it is when this decision took its
+		-- CURRENT form, and a reader compares it against when the value took
+		-- its own. See Verdict.AsOf.
+		SELECT claim_kind, claim_key, verdict, corrected_value, note, updated_at
 		  FROM ai_feedback
 		 WHERE subject_type = $1 AND subject_id = $2`, subjectType, subjectID)
 	if err != nil {
@@ -278,11 +342,13 @@ func (s *FeedbackStore) VerdictsForTx(ctx context.Context, tx pgx.Tx, subjectTyp
 
 	out := map[string]Verdict{}
 	for rows.Next() {
-		var v Verdict
-		if err := rows.Scan(&v.ClaimKind, &v.ClaimKey, &v.Verdict, &v.CorrectedValue, &v.Note); err != nil {
+		var claimKind, claimKey, verdict string
+		var correctedValue, note *string
+		var recordedAt time.Time
+		if err := rows.Scan(&claimKind, &claimKey, &verdict, &correctedValue, &note, &recordedAt); err != nil {
 			return nil, fmt.Errorf("ai: reading a recorded verdict: %w", err)
 		}
-		out[VerdictLookupKey(v.ClaimKind, v.ClaimKey)] = v
+		out[VerdictLookupKey(claimKind, claimKey)] = NewVerdict(claimKind, claimKey, verdict, correctedValue, note, recordedAt)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("ai: reading the recorded verdicts: %w", err)

--- a/backend/internal/modules/ai/feedback.go
+++ b/backend/internal/modules/ai/feedback.go
@@ -147,6 +147,16 @@ type Decision struct {
 // Equal timestamps STAND. A verdict and the value it is about can be written in
 // one transaction, where both carry the same now(), and refusing that case
 // would suppress a decision at the instant it was made.
+//
+// WHAT THIS DOES NOT ANSWER, because it is a different question and needs a
+// contract field to answer at all: whether the human was looking at THIS value
+// when they decided. A page rendered on the old value, a newer value landing,
+// and the correction submitted after it leaves a verdict that is newer than the
+// value and still about the older one. Closing that means the client sending
+// the field version it rendered and the ledger storing it, so the comparison
+// becomes an equality rather than an ordering. What this answers is the case
+// where the verdict is demonstrably older — which is the one that survives
+// forever rather than for the length of one page view.
 func (v Verdict) AsOf(valueAt time.Time) (Decision, bool) {
 	if v.recordedAt.Before(valueAt) {
 		return Decision{}, false

--- a/backend/internal/modules/ai/feedback_test.go
+++ b/backend/internal/modules/ai/feedback_test.go
@@ -6,6 +6,7 @@ package ai
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // The key is the claim's PATH, never its value. Keyed on the value, a verdict
@@ -67,5 +68,88 @@ func TestEverySubjectTypeIsAnRBACObject(t *testing.T) {
 	}
 	if feedbackSubjects["activity"] {
 		t.Error("a subject outside the column's CHECK would fail at the constraint rather than at the door")
+	}
+}
+
+// A human's decision is about the value that was in front of them. These are
+// the two directions the ruling needs, and it needs BOTH: an assertion that
+// only a stale verdict is dropped passes just as happily against an overlay
+// that never fires at all, and one that only a current verdict stands passes
+// against an overlay with no recency check — which is the defect this exists
+// for.
+func TestAVerdictAppliesToTheValueItWasRecordedAgainst(t *testing.T) {
+	corrected, note := "VP Sales", "they run the team, not the function"
+	recorded := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	v := NewVerdict(ClaimProfileField, ClaimKey("profile_field:role"),
+		VerdictCorrected, &corrected, &note, recorded)
+
+	for _, tc := range []struct {
+		name    string
+		valueAt time.Time
+		applies bool
+	}{
+		{
+			// The ordinary case: the machine wrote a value, a human read it
+			// and disagreed. Their correction is what the page shows.
+			name:    "a verdict recorded after the value it corrects stands",
+			valueAt: recorded.Add(-time.Hour),
+			applies: true,
+		}, {
+			// The defect. Something replaced the value the human was looking
+			// at — an accepted research claim, a fresh enrichment, an edit
+			// through another door — and their correction now describes a
+			// value the record no longer holds.
+			name:    "a verdict older than the value it corrects does not",
+			valueAt: recorded.Add(time.Hour),
+			applies: false,
+		}, {
+			// A verdict and the value it is about can be written in ONE
+			// transaction, where both carry the same now(). Refusing that
+			// would suppress a decision at the instant it was made.
+			name:    "a verdict recorded in the same instant stands",
+			valueAt: recorded,
+			applies: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, applies := v.AsOf(tc.valueAt)
+			if applies != tc.applies {
+				t.Fatalf("applies = %v, want %v", applies, tc.applies)
+			}
+			if !applies {
+				// The MARKER goes with the value. "corrected" beside a value
+				// the human never wrote says they wrote it, which is the same
+				// lie one field along.
+				if decision.Verdict != "" || decision.CorrectedValue != nil || decision.Note != nil {
+					t.Errorf("a stale verdict still handed back %+v", decision)
+				}
+				return
+			}
+			if decision.Verdict != VerdictCorrected {
+				t.Errorf("verdict = %q, want %q", decision.Verdict, VerdictCorrected)
+			}
+			if decision.CorrectedValue == nil || *decision.CorrectedValue != corrected {
+				t.Errorf("corrected value = %v, want %q", decision.CorrectedValue, corrected)
+			}
+			if decision.Note == nil || *decision.Note != note {
+				t.Errorf("note = %v, want %q", decision.Note, note)
+			}
+		})
+	}
+}
+
+// A verdict with no corrected value — "confirmed", "suppressed" — is dated the
+// same way. The human confirmed an answer; a different answer is not the one
+// they confirmed, and carrying their marker onto it says they saw it.
+func TestAMarkerWithoutACorrectionIsDatedToo(t *testing.T) {
+	recorded := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	v := NewVerdict(ClaimProfileField, ClaimKey("profile_field:role"),
+		VerdictConfirmed, nil, nil, recorded)
+
+	if _, applies := v.AsOf(recorded.Add(-time.Hour)); !applies {
+		t.Error("a confirmation of the value on file was dropped")
+	}
+	if _, applies := v.AsOf(recorded.Add(time.Hour)); applies {
+		t.Error("a confirmation outlived the value it confirmed — the page would say a human had seen an answer they never saw")
 	}
 }


### PR DESCRIPTION
Closes #2773.

`applyFieldVerdicts` replaced a field's value with a human's correction unconditionally — no comparison against when the underlying row last changed. The sequence, every step of it an ordinary day:

1. A pass writes `title = "Business Development Manager"`.
2. A human disagrees and records `corrected` with `"Head of Business Development"`. The page shows it.
3. Something writes a newer, better value to the same field — an accepted research claim, a fresh enrichment, an edit through another door. `person_profile_field.updated_at` moves.
4. **The page still shows the correction.** The reader is told the current value is one the record does not hold.

Asked what somebody's title is, an assistant answers with a value no row carries. That reads as a hallucination and is a data contradiction.

Worth noting the shape is narrower than it looks and no less real: a machine fill *cannot* reach step 3 — it writes under `claimUnanswered`, which is `DO NOTHING` over a row that exists. `replaceOnAcceptance` — a human accepting a research claim — replaces the whole row and moves the date. So the value that outlives the correction is another human's.

## Fixed as an invariant, not at the call site

`ai.Verdict` carried no timestamp of any kind and `VerdictsForTx` selected none, though `ai_feedback.updated_at` has been there all along. Adding the field and a comparison at the one call site would have left the next reader free to forget.

Instead: what a human *said* — the verdict, the note, the corrected value — is now unexported, reachable only through

```go
func (v Verdict) AsOf(valueAt time.Time) (Decision, bool)
```

A surface cannot read a decision without saying which version of the value it is asking about. The defect was a caller forgetting to ask; the type no longer offers that.

## The marker goes with the value

This is the ruling worth arguing with, so it is stated rather than assumed. Keeping `corrected` beside the newer stored value would say the human wrote that value; keeping `confirmed` would say they had seen it. Both are the same lie one field along, and a reader has nothing on screen to tell them otherwise. What a human once decided is still in the ledger and in `audit_log` for anyone asking that question — what the page asks is the narrower one: *does their decision describe what is on the screen*.

Equal timestamps **stand**. A verdict and the value it is about can be written in one transaction carrying the same `now()`, and refusing that would suppress a decision at the instant it was made.

## Both directions, and why the end-to-end case is not redundant

The ticket asks for a planted case each way, because a one-directional assertion passes just as happily against an overlay that never fires. `TestAVerdictAppliesToTheValueItWasRecordedAgainst` covers newer / older / equal, and `TestAMarkerWithoutACorrectionIsDatedToo` covers a verdict with no replacement value.

`TestACorrectionDoesNotOutliveTheValueItCorrected` drives a real row through the service, and asserts the correction applies **before** the newer value lands — so the case is known to be testing recency rather than a dead overlay.

Three mutations, each caught in a different pattern:

| mutation | `SurvivesRederivation` | the new case |
|---|---|---|
| drop the comparison (the defect) | pass | **fail** |
| `AsOf` always refuses | **fail** | **fail** |
| the reader passes a zero clock | pass | **fail** |

The third is the half no unit case can reach: `AsOf` guarantees a caller names *a* version, and the end-to-end case is what holds that it names the *right* one.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` run locally. The integration lane is red on `main` on the unrelated pre-existing `TestFK_rowScopedTargetsHaveVisibilityDecision` (`organization_vat_check.organization_id`, from #3158), which #3167 fixes; every other package passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated profile corrections and confirmations from overriding newer profile values.
  - Ensured only verdicts recorded for the current field version are applied.
  - Preserved corrected values and related metadata when verdicts remain valid.

- **Tests**
  - Added coverage for newer stored values replacing previously corrected values.
  - Added timestamp validation for corrected and non-corrected verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->