### PR TITLE
fix(today): the quiet lead splits under the complexity ceiling

### DIFF
--- a/frontend/src/screens/today.tsx
+++ b/frontend/src/screens/today.tsx
@@ -146,26 +146,36 @@ function healthLead(day: Attention, t: ReturnType<typeof useT>): string | null {
 // promise due, no meeting. Split from the branches above because those answer
 // "what is being asked of you" and these answer "what is worth knowing anyway",
 // and one function holding both was past the complexity the linter allows.
-function quietLead(
+// The leads for promises the product itself broke, worst first: a decision a
+// rep approved that did not run, and a send the customer never received —
+// both worse news than a drifting deal, because the reader believes the
+// opposite. Null when neither lane holds anything.
+function brokenPromiseLead(
   day: Attention,
   t: ReturnType<typeof useT>,
   locale: Locale,
-): string {
-  // A drifting deal is money leaving on its own — nobody is waiting on the
-  // reader for it, which is exactly why it needs saying.
-  // Above the drifting deals, because it is worse news: a rep already DECIDED
-  // these, was told they worked, and they did not.
+): string | null {
   const failed = day.counts.did_not_run ?? 0;
   if (failed > 0) {
     return t("day.lead.didNotRun", { count: formatNumber(failed, locale) });
   }
-  // A bounced send is a conversation the rep believes is happening and is
-  // not — worse news than a drifting deal, because the customer never heard.
   const undelivered = day.counts.bounces ?? 0;
   if (undelivered > 0) {
     return t(pluralKey(locale, "day.lead.bounces", undelivered), {
       count: formatNumber(undelivered, locale),
     });
+  }
+  return null;
+}
+
+function quietLead(
+  day: Attention,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
+  const broken = brokenPromiseLead(day, t, locale);
+  if (broken) {
+    return broken;
   }
   const drifting = day.counts.at_risk ?? 0;
   if (drifting > 0) {


### PR DESCRIPTION
The automation-lane merge (#3170) left main red on fe-lint: quietLead reached complexity 16. The failed-approval and bounced-send leads move into brokenPromiseLead — the same split healthLead already made — with ordering and copy unchanged; the today suite still passes all 32 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the broken-promise branches out of `quietLead` into `brokenPromiseLead` to fix the `fe-lint` complexity violation the automation-lane merge left on main.

This mirrors the split `healthLead` already made. `brokenPromiseLead` returns null when neither lane holds anything, and `quietLead` falls back to its drifting-deal logic. Ordering and copy are unchanged, so there's no behavior change; the today suite still passes all 32 cases.

<sup>Written for commit 616751dc817dabe68642fab222d156dd8e6b9a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of leads associated with failed runs or bounced sends.
  * Preserved prioritization while ensuring at-risk deals continue to be evaluated appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->