### PR TITLE
main is red: the SLA escalation runs with half its stores

### DIFF
--- a/backend/internal/compose/leadsla.go
+++ b/backend/internal/compose/leadsla.go
@@ -50,6 +50,22 @@ type leadSLAEscalation struct {
 	now        func() time.Time
 }
 
+// newLeadSLAEscalation builds it with every store it needs.
+//
+// A CONSTRUCTOR rather than a struct literal at each site, because the struct
+// grew a dependency and only one of its two sites grew with it: the notify half
+// landed wired in production and nil in the test, which panicked in Apply — a
+// nil store is not a compile error and a partial literal reads exactly like a
+// complete one. Taking the database rather than the stores means the next
+// dependency reaches both callers without either being edited.
+func newLeadSLAEscalation(db *database.DB, now func() time.Time) leadSLAEscalation {
+	return leadSLAEscalation{
+		activities: activities.NewStore(db),
+		notices:    notices.NewStore(db),
+		now:        now,
+	}
+}
+
 func (leadSLAEscalation) Spec() workflow.Spec {
 	return workflow.Spec{
 		Name:    "lead_sla_escalation",

--- a/backend/internal/compose/leadsla_integration_test.go
+++ b/backend/internal/compose/leadsla_integration_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -53,7 +52,11 @@ func TestLeadSLAEscalationLogsOneTaskOnTheLead(t *testing.T) {
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:test"})
 
-	h := leadSLAEscalation{activities: activities.NewStore(e.DB()), now: func() time.Time { return deadline.Add(time.Hour) }}
+	// Built the way production builds it, and that is the point rather than
+	// tidiness: this line used to name the stores it wanted, so when the notify
+	// half was added the handler ran here with a nil notices store and panicked
+	// inside Apply. A constructor both sites call cannot be half-updated.
+	h := newLeadSLAEscalation(e.DB(), func() time.Time { return deadline.Add(time.Hour) })
 	eff, err := h.Plan(ctx, ev)
 	if err != nil {
 		t.Fatal(err)
@@ -78,4 +81,42 @@ func TestLeadSLAEscalationLogsOneTaskOnTheLead(t *testing.T) {
 	if assignee == nil || *assignee != e.Rep1 {
 		t.Errorf("task assignee = %v, want the escalation target %s", assignee, e.Rep1)
 	}
+
+	// The notify half, which nothing here asked about until it panicked. A
+	// breach the escalation names a target for writes that person a durable
+	// line, addressed to THEM: a notice on somebody else's Worklist is worse
+	// than none, because the person who has to act never sees it.
+	var recipients []ids.UUID
+	rows, err := owner.Query(context.Background(),
+		`SELECT recipient_user_id FROM notice WHERE kind = $1 ORDER BY id`, noticeKindLeadSLA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var who ids.UUID
+		if err := rows.Scan(&who); err != nil {
+			t.Fatal(err)
+		}
+		recipients = append(recipients, who)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(recipients) == 0 {
+		t.Fatal("the breach wrote its task and no notice — the escalation target is told nothing")
+	}
+	for _, who := range recipients {
+		if who != e.Rep1 {
+			t.Errorf("notice addressed to %s, want the escalation target %s", who, e.Rep1)
+		}
+	}
+	// NOT asserted: how MANY. The task half is idempotent through its
+	// (source_system, source_id) natural key, which is why the loop above
+	// checks for exactly one; the notice half has no such key, so two
+	// deliveries of one breach write two lines. The port's own contract says
+	// Apply is "idempotent on IdempotencyKey(ev)", so that is a defect rather
+	// than a shape to pin here. Asserting the count either way would freeze an
+	// answer nobody has decided; the decision is what the notice register keys
+	// on, and it belongs with the notices store rather than here.
 }

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -87,7 +87,7 @@ func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter)
 		engine.RegisterSystemWorkflow(handler)
 	}
 	activityStore := activities.NewStore(db)
-	engine.RegisterSystemWorkflow(leadSLAEscalation{activities: activityStore, notices: notices.NewStore(db), now: time.Now})
+	engine.RegisterSystemWorkflow(newLeadSLAEscalation(db, time.Now))
 	for _, handler := range activities.FollowUpWorkflows(activityStore) {
 		engine.RegisterSystemWorkflow(handler)
 	}


### PR DESCRIPTION
`main` is red on the integration lane. `internal/compose` panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
  notices.(*Store).Create(0x0, ...)
  compose.leadSLAEscalation.Apply(...)   leadsla.go:101
  compose.TestLeadSLAEscalationLogsOneTaskOnTheLead   leadsla_integration_test.go:62
```

#3174 gave `leadSLAEscalation` a `notices` store and wired it at `workflows.go:90`. The handler's own test still built the struct by naming the fields it wanted, so it got `notices: nil` — and a nil store is not a compile error.

## The fix

`newLeadSLAEscalation(db, now)`, called by both sites. It takes the **database** rather than the stores, so the next dependency reaches the test without anybody editing it. The failure was not that somebody forgot; it was that a partial struct literal reads exactly like a complete one, in a language that will not say otherwise.

## And the half that was added blind

The test now asks about the notice too: a breach that names an escalation target writes that person a durable line, **addressed to them**. A notice on somebody else's Worklist is worse than none — the person who has to act never sees it, and the one who does cannot.

## What it deliberately does not assert

**How many.** The task half is idempotent through its `(source_system, source_id)` natural key, which is why the loop above it checks for exactly one task after two deliveries. The notice half has no key of any kind, so two deliveries of one breach write two lines.

`workflow.Handler.Apply` is documented as *"Idempotent on `IdempotencyKey(ev)`"*, so that is a defect rather than a shape to pin in this test — filed as #3177, where the decision about what a notice keys on belongs. Asserting the count either way here would freeze an answer nobody has made.

## Checks

`make check-backend` and `make craft-static` green; `make test-it DIR=backend/internal/compose RUN=TestLeadSLAEscalationLogsOneTaskOnTheLead` passes, and panics without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lead SLA escalation setup to ensure required activity and notice handling is consistently available.
  * Duplicate escalation events continue to create only one task for the escalation target.
  * SLA breaches now record notices for the appropriate escalation target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->