### PR TITLE
fix(compose): give TestLeadSLAEscalationLogsOneTaskOnTheLead a notices.Store

### DIFF
--- a/backend/internal/compose/leadsla_integration_test.go
+++ b/backend/internal/compose/leadsla_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/notices"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -53,7 +54,11 @@ func TestLeadSLAEscalationLogsOneTaskOnTheLead(t *testing.T) {
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:test"})
 
-	h := leadSLAEscalation{activities: activities.NewStore(e.DB()), now: func() time.Time { return deadline.Add(time.Hour) }}
+	h := leadSLAEscalation{
+		activities: activities.NewStore(e.DB()),
+		notices:    notices.NewStore(e.DB()),
+		now:        func() time.Time { return deadline.Add(time.Hour) },
+	}
 	eff, err := h.Plan(ctx, ev)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
`main-health`'s integration shards were panicking with a nil-pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
notices.(*Store).Create(0x0, ...) at notices/store.go:67
compose.leadSLAEscalation.Apply(...) at leadsla.go:101
compose.TestLeadSLAEscalationLogsOneTaskOnTheLead(...) at leadsla_integration_test.go:62
```

`leadSLAEscalation` gained a `notices *notices.Store` field in #3173 (the notify half of RC-5's `notify_and_task` default, now that a durable transport exists). Production wiring (`workflows.go:90`) sets it correctly, but this test's own construction of `leadSLAEscalation{}` wasn't updated — a nil pointer, and the test's payload always names an `EscalationTarget`, so `Apply`'s new `notices.Create` call panicked every run.

Fixed by constructing the store the same way `workflows.go` does.

**Not fixed here, filed as #3179 instead:** `notices.Store.Create` has no idempotency key (unlike `activities.LogActivity`'s own `(source_system, source_id)` dedup), so this test's existing two-delivery loop would create two duplicate notice rows — an honest "notice count == 1" assertion would fail today. Fixing that needs a schema change and an API decision for the notices module (what the dedup key is, whether every producer must supply one), not a patch bundled with this crash fix.

## Test plan
- [x] `go build -tags=integration ./...` — clean
- [x] `go vet -tags=integration ./internal/compose/...` — clean
- [x] `craft static` — 0 blocker, 0 major, 0 minor
- [ ] Not run locally: `make test-it` hits the same pre-existing stale `extensions/notes` directory noted in #3149's fix, on a shared machine I'm not touching. Relying on CI for the real integration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nil-pointer panic in `TestLeadSLAEscalationLogsOneTaskOnTheLead` by giving `leadSLAEscalation` the `notices.Store` it now requires, matching production wiring. The test doesn't yet assert on notice rows because `notices.Store.Create` lacks an idempotency key, which would create duplicate notices in the existing two-delivery loop; that's tracked in #3179.

<sup>Written for commit e6951a15ed249c8bff3b4aa63866c88bc84a2813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lead SLA escalation integration coverage to include notices alongside activities.
  * Improved test setup for scenarios involving escalation notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->