### PR TITLE
fix(personresearch): Save refuses an agent seat before the empty-list return

### DIFF
--- a/backend/internal/compose/personresearch/service.go
+++ b/backend/internal/compose/personresearch/service.go
@@ -167,13 +167,18 @@ func wireClaims(claims []persondata.Claim) []crmcontracts.PersonResearchClaim {
 // conversation claim: it has no status, no needs-review and no dismissal,
 // because nobody said it in a conversation we captured.
 func (s *Service) Save(ctx context.Context, personID ids.PersonID, in crmcontracts.SavePersonResearchRequest) (int, error) {
+	// Ahead of the empty-list return: the operation is human-only regardless
+	// of what it would have written, and an agent seat posting an empty list
+	// must see the same refusal a non-empty one gets. Nothing lands from
+	// either path, but "human-only" is a property of the call, not of its
+	// payload.
+	if err := auth.RequireHuman(ctx); err != nil {
+		return 0, err
+	}
 	if len(in.Claims) == 0 {
 		// Saving nothing is not an error — a reader who dismissed every claim
 		// made a decision, and it is the one this surface exists to allow.
 		return 0, nil
-	}
-	if err := auth.RequireHuman(ctx); err != nil {
-		return 0, err
 	}
 	return s.people.SaveResearchClaims(ctx, personID, toClaimInputs(in.Claims))
 }

--- a/backend/internal/compose/personresearch/service_test.go
+++ b/backend/internal/compose/personresearch/service_test.go
@@ -4,8 +4,14 @@
 package personresearch
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/persondata"
 )
 
@@ -34,5 +40,25 @@ func TestAClaimLeftWithNoOpenableSourceIsDropped(t *testing.T) {
 	})
 	if len(claims) != 0 {
 		t.Fatalf("kept %d claims, want none", len(claims))
+	}
+}
+
+// Save is human-only whatever it would have written: an agent posting an
+// EMPTY claims list must see the same refusal a non-empty one gets, not the
+// zero-claims no-op a human gets. A zero-value Service is enough to prove
+// it — the refusal has to land before s.people is ever touched, so a nil
+// store that would panic on the write path is the check that the ordering
+// really is what it claims.
+func TestSaveRefusesAnAgentEvenWithNoClaims(t *testing.T) {
+	agentCtx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:test",
+	})
+	s := &Service{}
+	saved, err := s.Save(agentCtx, ids.From[ids.PersonKind](ids.NewV7()), crmcontracts.SavePersonResearchRequest{})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("Save(agent, no claims) err = %v, want ErrPermissionDenied", err)
+	}
+	if saved != 0 {
+		t.Errorf("Save(agent, no claims) saved = %d, want 0", saved)
 	}
 }


### PR DESCRIPTION
## Summary
Cross-session QC found it while evidencing margince#2934: `personresearch.Service.Save` checked `len(in.Claims) == 0` before `auth.RequireHuman`, so an agent seat posting an empty claims list got `200 {saved: 0}` instead of the human-only refusal a non-empty payload gets. Nothing is written either way — the store call sits after both checks — but the surface is contracted as human-only (`SavePersonResearchRequest`'s own doc), and the refusal wasn't uniform across it.

Reordered so `RequireHuman` runs first.

## Test plan
- [x] Added `TestSaveRefusesAnAgentEvenWithNoClaims` — a zero-value `Service{}` (nil `people` store), agent-principal context, empty claims: asserts `ErrPermissionDenied`. The nil store means the refusal genuinely has to land before the write path is reached, not just before some non-nil call.
- [x] Mutation-checked locally: reverted the reorder, the new test fails (`err = nil, want ErrPermissionDenied`); restored, it passes.
- [x] `go build ./...` — clean
- [x] `go test ./internal/compose/personresearch/...` — all 3 tests pass
- [x] `craft static` — 0 blocker, 0 major, 0 minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `personresearch.Service.Save` so agent seats get the human-only refusal even when they post an empty claims list. Previously an empty list returned `200 {saved: 0}` instead of `ErrPermissionDenied`; now the permission check runs before the empty-list return. Adds a test that uses a nil store to prove the refusal happens before any write path.

<sup>Written for commit 62012adfd2b886c702df764596e2c0f49625a6ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automated callers can no longer save person research data, even when submitting an empty claim list.
  * Authorized human callers retain the existing successful no-op behavior for empty saves.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->