### PR TITLE
The DCO gate counts what it read

### DIFF
--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -38,6 +38,38 @@ head="${2:?usage: check-dco.sh <base-sha> <head-sha>}"
 range="${base}..${head}"
 missing=0
 
+# WHAT THE RANGE COVERS, asserted before it is trusted.
+#
+# `git rev-list A..B` does not complain when A is not behind B — it answers with
+# whatever that range happens to mean, which for a base ahead of the head is
+# nothing at all. The loops below then run zero times, `missing` stays 0, and
+# this prints the same clean pass it prints for a fully signed branch. That is
+# the one way a gate must not break: it reads a smaller history, reports PASS,
+# and no assertion fails to say so.
+#
+# Held HERE rather than at each call site, because the required caller is the
+# one that had no guard: main-health.yml asserted its baseline's ancestry and
+# ci.yml — the job the `ci` fan-in makes required — called this bare. A
+# protection that lives in the advisory lane and not the blocking one protects
+# nothing.
+if ! git merge-base --is-ancestor "$base" "$head"; then
+	echo "DCO: ${base} is not an ancestor of ${head} — the range ${range} does not" >&2
+	echo "cover the commits it is meant to judge, and an empty one would read as a" >&2
+	echo "clean pass having examined nothing." >&2
+	exit 1
+fi
+
+# Merges included: this is what the range HOLDS, not what needs a trailer. A
+# range covering only merge commits is a real thing (a merge queue's own head),
+# and reporting it as zero examined would be the same silent pass one step
+# along, so the two counts are kept apart and both are printed.
+present="$(git rev-list "$range" | wc -l | tr -d '[:space:]')"
+if [ "$present" -eq 0 ]; then
+	echo "DCO: the range ${range} holds no commits — this gate would report a clean" >&2
+	echo "pass having read nothing. Check the base and head it was given." >&2
+	exit 1
+fi
+
 signed_off() {
 	git log -1 --format='%B' "$1" | grep -qiE '^Signed-off-by: .+ <.+@.+>'
 }
@@ -92,7 +124,9 @@ attested_by() {
 	done
 }
 
+judged=0
 for sha in $(git rev-list --no-merges "$range"); do
+	judged=$((judged + 1))
 	if signed_off "$sha"; then
 		continue
 	fi
@@ -117,4 +151,8 @@ if [ "$missing" -ne 0 ]; then
 	exit 1
 fi
 
-echo "DCO: all commits in ${range} are signed off"
+# The DENOMINATOR is the point of this line. "All commits are signed off" is
+# what a gate that read nothing says too, and a number cannot be misread that
+# way: a run reporting 0 of 0 says so where a run reporting 12 of 14 says
+# something else.
+echo "DCO: all ${judged} of ${present} commit(s) in ${range} are signed off ($((present - judged)) merge commit(s) need none)"

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -227,6 +227,31 @@ git -C "$repo" merge -q --no-ff --no-verify -m "Merge the side branch" merge-sid
 merged="$(git -C "$repo" rev-parse HEAD)"
 case_is "a merge commit needs no sign-off" "$merge_base" "$merged" 0 "are signed off"
 
+# THE RANGE ITSELF. Every case above hands the gate a range with something in
+# it, so none of them can tell "all these commits are signed" from "there were
+# no commits". That distinction is the one a gate must never lose: it reads a
+# smaller history, prints the same clean pass, and nothing fails to say so.
+#
+# Each of these was a green run before the range was checked.
+
+case_is "an empty range is refused, not passed" "$merged" "$merged" 1 "holds no commits"
+
+# A base that RESOLVES and is not behind the head is the dangerous shape, and it
+# is the one `git rev-list` answers silently: not an error, just nothing. The
+# advisory main-health lane asserted this and the required ci.yml job did not,
+# so the protection lived where it could not block a merge.
+git -C "$repo" checkout -q -b sideways "$base"
+sideways="$(commit_with "a commit on a branch of its own
+
+$signed")"
+case_is "a base that is not an ancestor is refused" "$sideways" "$merged" 1 "not an ancestor"
+
+# And the success line carries its own DENOMINATOR, which is what makes a run
+# that read nothing unable to look like one that read everything.
+git -C "$repo" checkout -q merge-case
+case_is "the pass says how many commits it read" "$merge_base" "$merged" 0 "all 1 of 2 commit(s)"
+case_is "and how many of those needed no trailer" "$merge_base" "$merged" 0 "1 merge commit(s) need none"
+
 if [[ "$failures" -ne 0 ]]; then
 	echo "" >&2
 	echo "$failures DCO gate case(s) failed" >&2


### PR DESCRIPTION
Closes #2781.

`scripts/check-dco.sh` could not tell *"I checked twelve commits and all were signed"* from *"I checked nothing"*. An empty `git rev-list` runs the loop zero times, leaves `missing=0`, and prints the same clean pass — AGENTS.md rule 8's exact shape: it reads a smaller history, reports PASS, and there is no failing assertion to notice.

## Where the guard was, and where it was not

`main-health.yml` — **advisory**, nothing merges on it — asserted its baseline's ancestry and explained this hazard in its own comment. `ci.yml:312` — the job the `ci` fan-in makes **required** — called the script bare.

So the assertion lives in the **script** now. A protection that guards the lane which cannot block a merge, and not the one that can, protects nothing; and putting it at one more call site would leave the next caller to remember.

## What it asserts

**The base is an ancestor of the head.** `git rev-list A..B` does not complain when A is not behind B — it answers with whatever that range means, which for a base ahead of the head is nothing.

**The range holds something.** `base == head` is the plain case.

**The two counts are kept apart.** What the range *holds* and what *needed a trailer* are different numbers, and a range of nothing but merge commits is a real thing — a merge queue's own head — so collapsing them would be the same silent pass one step along.

**The success line carries its denominator.** `DCO: all 12 of 14 commit(s) in <range> are signed off (2 merge commit(s) need none)`. "All commits are signed off" is what a gate that read nothing says too; a number cannot be misread that way.

## One correction to the ticket

`check-dco.sh` is **not** untested. `scripts/test-check-dco.sh` is a thorough suite behind `make test-check-dco` — six cases on the attestation match alone, each, by its own header, *"written as the naive version first and rejected here"*. What it had no case for was the **range**, which is what this adds:

- `an empty range is refused, not passed`
- `a base that is not an ancestor is refused`
- `the pass says how many commits it read` / `and how many of those needed no trailer`

Each was a green run before the change. Mutation-checked: dropping the empty-range refusal, dropping the ancestry assertion, and reverting the success line each fail exactly the case written for it and leave the others passing.

## One thing left undone, and why

`main-health.yml`'s comment still presents its own ancestry check as the reason the hazard is covered, and that sentence is now half the story — the gate asserts it for every caller, and what the workflow adds is the specific advice to move `DCO_MAIN_BASELINE`. I wrote that comment and had to drop it: pushing it needs `workflow` token scope, which this checkout does not have (the same blocker that has #2543 and #2544 waiting). The check itself is unchanged and still correct; only its explanation is now narrower than the truth.

## Checks

`make check-backend` and `make craft-static` green; `make test-check-dco` passes all eleven cases. The gate also runs clean against this branch's own history, reporting `all 5 of 5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for empty and invalid commit ranges.
  * Added clear diagnostics when the selected base commit is not an ancestor of the head.
  * Successful checks now report total commits evaluated and merge commits exempt from sign-off requirements.

* **Tests**
  * Added coverage for empty ranges, disconnected histories, and commit-count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->