### PR TITLE
feat(companies): the connection map is back, under the People tab

### DIFF
--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -606,7 +606,9 @@ describe("company view — consent is per purpose", () => {
       await screen.findByRole("button", { name: /^People/ }),
     );
 
-    await waitFor(() => expect(screen.getByText("Dana Buyer")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Dana Buyer" })).toBeTruthy(),
+    );
     expect(screen.getByText("No consent on file")).toBeTruthy();
     expect(screen.queryByText("May contact")).toBeNull();
   });
@@ -1378,6 +1380,59 @@ describe("company view — naming the buying committee", () => {
     ).toBeTruthy();
   });
 
+  // The connection map keeps a fresh graph copy for a minute, so a save that
+  // changes the committee must re-read it explicitly — otherwise the map
+  // beside the roster shows the pre-save committee until the copy expires.
+  it("re-reads the connection map after a role is saved", async () => {
+    const fetched = stub(
+      view({
+        deals: {
+          data: [
+            { deal_id: "d-1", name: "Pilot", status: "open", stalled: false },
+          ],
+          page: { has_more: false, next_cursor: null },
+          won_lifetime: { amount_minor: 0, currency: "EUR" },
+          lost_count: 0,
+        },
+        people: {
+          data: [
+            {
+              person_id: "p-1",
+              full_name: "Christian Hagemeyer",
+              deal_roles: [],
+              consent: {},
+              strength: {
+                score: 0,
+                bucket: "none",
+                factors: {
+                  recency: 0,
+                  frequency: 0,
+                  reciprocity: 0,
+                  direction: 0,
+                },
+              },
+            },
+          ],
+          page: emptyPage,
+        },
+      }),
+    );
+    renderCompany();
+    await userEvent.click(
+      await screen.findByRole("button", { name: /^People/ }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Set role" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    // One read when the tab drew the map, one after the save invalidated it.
+    await waitFor(() =>
+      expect(fetched.filter((path) => path.endsWith("/graph"))).toHaveLength(2),
+    );
+  });
+
   // A role belongs to a DEAL. With nothing open there is nothing to be a
   // champion of, and offering the verb would invite a write that has no
   // subject.
@@ -1465,7 +1520,9 @@ describe("company view — a buying role names the deal it is on", () => {
       await screen.findByRole("button", { name: /^People/ }),
     );
 
-    await waitFor(() => expect(screen.getByText("Dana Buyer")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Dana Buyer" })).toBeTruthy(),
+    );
     // Both roles read as one quiet line under the name, not as two badges.
     expect(
       screen.getByText("champion · Renewal · champion · New business"),
@@ -1495,7 +1552,9 @@ describe("company view — a buying role names the deal it is on", () => {
       await screen.findByRole("button", { name: /^People/ }),
     );
 
-    await waitFor(() => expect(screen.getByText("Dana Buyer")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Dana Buyer" })).toBeTruthy(),
+    );
     expect(screen.getByText("champion")).toBeTruthy();
   });
 });
@@ -2350,8 +2409,9 @@ describe("company view — the way in to one contact", () => {
       screen.getAllByRole("button", { name: "Route in" })[0],
     );
 
-    await screen.findByText("Mira");
-    expect(screen.getByText("in regular contact")).toBeTruthy();
+    const dialog = await screen.findByRole("dialog");
+    await within(dialog).findByText("Mira");
+    expect(within(dialog).getByText("in regular contact")).toBeTruthy();
     expect(fetched.filter((path) => path.endsWith("/graph"))).toHaveLength(1);
   });
 });

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -520,8 +520,13 @@ function SetRoleAction({
       setOpen(false);
       // The committee reading, the missing-role warning and the row's own
       // chips all come off the 360, so the account is re-read rather than
-      // patched in place.
-      await queryClient.invalidateQueries({ queryKey: ["organization360"] });
+      // patched in place. The connection map reads the new stakeholder edge
+      // through its own query, which now keeps a fresh copy for a minute —
+      // without the invalidation it would show the pre-save committee.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["organization360"] }),
+        queryClient.invalidateQueries({ queryKey: ["organization-graph"] }),
+      ]);
     },
   });
 

--- a/frontend/src/screens/connections.tsx
+++ b/frontend/src/screens/connections.tsx
@@ -76,6 +76,12 @@ type RelationKey =
 export function useOrganizationGraph(id: string, enabled = true) {
   return useQuery({
     enabled,
+    // The People tab's card and the per-contact "Route in" modal read the same
+    // graph moments apart; a fresh-enough copy serves both as one read. A
+    // write that changes the graph (setting a buying role) must invalidate
+    // this key explicitly — the minute of freshness would otherwise outlive
+    // the save the user is looking at.
+    staleTime: 60_000,
     queryKey: ["organization-graph", id],
     queryFn: async () => {
       const { data, error } = await api.GET("/organizations/{id}/graph", {

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -104,6 +104,7 @@ import {
   sinceLastVisitFooter,
 } from "./companywork";
 import { ComposeModal, TimelineActions } from "./compose";
+import { ConnectionsCard } from "./connections";
 import {
   CreateAction,
   type CreateField,
@@ -2416,12 +2417,20 @@ function CompanyRecordBody({
           copy stands down while it is open — the same roster twice, side by
           side, is the duplication this page's own rule forbids. */}
       {tab === "people" && (
-        <PeopleCard
-          view={view}
-          writable={orgWritable}
-          orgId={org.id}
-          loading={loading}
-        />
+        <div className="co-panel-stack">
+          <PeopleCard
+            view={view}
+            writable={orgWritable}
+            orgId={org.id}
+            loading={loading}
+          />
+          {/* The connection map under the roster: who here deals with the
+              account, who there is to deal with, and — expanded — the diagram
+              with the contact-to-contact lines. The roster answers "who works
+              there"; this answers "who talks to whom", and the People tab is
+              where a reader asks both. */}
+          <ConnectionsCard orgId={org.id} />
+        </div>
       )}
       {/* Files get the whole column on their own tab, which is what the mockup
           gives them. The grid keeps its compact card for the reader who only


### PR DESCRIPTION
The account connection map (ConnectionsCard: our side / their side, the expandable diagram, the contact-to-contact corresponds_with lines) lost its mount when the standing rail card was replaced by the per-contact Route-in modal. The backend kept computing and shipping the edges; no screen drew them.

This mounts the existing card on the company page's People tab, stacked under the roster — the tab that asks who works there is the tab that asks who talks to whom.

Also in this change:
- `useOrganizationGraph` gains `staleTime: 60_000` so the tab's card and the Route-in modal riding the same query key cost one request (held by the existing one-fetch test).
- The Set-role save now invalidates the graph query too — with the staleTime, the map beside the roster would otherwise show the pre-save committee for up to a minute (Codex review finding). New regression test, mutation-checked: it fails with the invalidation removed.
- Four test queries in company360.test.tsx rescoped by role/dialog because contact names now legitimately render twice on the People tab (roster row + graph node list).

Verified in the browser on an isolated dev stack: the card renders under the roster, 'See it larger' opens the diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the account connection map on the company page's People tab, stacked under the roster. The map lost its mount when the standing rail card was replaced by the per-contact Route-in modal — the backend kept shipping the edges but no screen drew them.

- `useOrganizationGraph` now uses a 60-second `staleTime`, so the tab's card and the Route-in modal share one graph request.
- Setting a buying role now invalidates the graph query as well, so the map doesn't show the pre-save committee for up to a minute.
- Test queries on the People tab were rescoped by role or dialog since contact names now render twice (roster row + graph node list).

<sup>Written for commit 8fd388b0ec5b3f12ae22e1f623ad4daa5624a4fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Connections card to the organization’s People view.
  * Updated the connection map after assigning a buying-committee or deal stakeholder role.

* **Performance**
  * Connection map data is cached for up to 60 seconds, improving load efficiency.

* **Bug Fixes**
  * Ensured company relationship data refreshes consistently after role changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->