### PR TITLE
fix(deals): a refused close date is not proposed again tomorrow

### DIFF
--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -57,20 +57,39 @@ func (s closeDateStager) HasPendingCorrection(ctx context.Context, dealID ids.UU
 	return s.svc.HasPendingKind(ctx, deals.CloseDateCorrectionKind, dealID)
 }
 
-// HasRefusedCorrection reads the memory's own record: any rejected correction
-// against this deal.
+// RefusedCloseDate answers the seam's question from the payloads the memory
+// stores.
 //
-// It asks whether ONE was refused rather than which, because its caller is the
-// keep-alive branch and that branch proposes no change to weigh — it re-offers
-// the date the sweep already wrote, which is the date the rep declined to have
-// set. The staging path keeps the finer answer for the branch that does propose
-// a change, where a new standing date is a new question.
-func (s closeDateStager) HasRefusedCorrection(ctx context.Context, dealID ids.UUID) (bool, error) {
+// RejectedChangesFor hands back payloads rather than answering a containment
+// query because only the caller knows what makes two of its proposals the same
+// question. This walks them and lets the probe decide — the judgment is
+// RefusalProbe.SameQuestionAs, in the module that owns close dates, because it
+// is a fact about corrections rather than about staging.
+//
+// The read commits before the caller stages, so it can lose a race to a decision
+// landing in the gap. That costs one extra offer and never an unasked write —
+// what the caller goes on to do is stage, and staging re-checks under its own
+// lock.
+func (s closeDateStager) RefusedCloseDate(ctx context.Context, dealID ids.UUID, proposed deals.RefusalProbe) (bool, error) {
 	refused, err := s.svc.RejectedChangesFor(ctx, deals.CloseDateCorrectionKind, dealID)
 	if err != nil {
 		return false, err
 	}
-	return len(refused) > 0, nil
+	for _, payload := range refused {
+		earlier, err := deals.UnmarshalCloseDateCorrection(payload)
+		if err != nil {
+			// A payload an older version of this stager wrote may not decode
+			// today, and a decision a human made does not expire because the
+			// shape moved. Reading it as "not this one" costs one card they
+			// have seen before; failing the sweep would cost every deal's
+			// date hygiene tonight.
+			continue
+		}
+		if proposed.SameQuestionAs(earlier) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal deals.CloseDateCorrection) error {
@@ -83,19 +102,19 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 		return fmt.Errorf("compose: canonicalize close-date proposal: %w", err)
 	}
 	// The logical identity is the deal AND the date it currently holds — the two
-	// fields that say WHICH correction this is.
+	// fields that say WHICH correction this is, for the purpose of collapsing a
+	// LIVE duplicate.
 	//
-	// It must not carry the PROPOSED date. That one is recomputed against
-	// "today" on every pass, so an identity holding it makes each night's
-	// proposal a different one and the rejection memory recognises nothing: the
-	// rep's "no" comes back as the same question tomorrow morning.
+	// Not the deal alone: a decline is remembered with no expiry, so a deal-only
+	// identity lets one "no" bury every future correction on that deal — the rep
+	// refuses a date, sets their own three weeks later, that one goes stale in
+	// turn, and nobody is ever told. The standing date separates those, being new
+	// exactly when the rep has moved it.
 	//
-	// It must not be the deal ALONE either. A decline is remembered with no
-	// expiry, so a deal-only identity lets one "no" bury every future correction
-	// on that deal — the rep refuses a date, sets their own three weeks later,
-	// that one goes stale in turn, and nobody is ever told. The standing date is
-	// what separates those: unchanged while the rep has not moved it, and new
-	// exactly when they have, which is exactly when the question is a fresh one.
+	// It cannot carry the whole memory by itself, because the sweep writes its
+	// date onto the deal BEFORE staging: what the deal stands at tonight is what
+	// was proposed last night, so a refusal recorded then matches nothing now.
+	// That is what ensureStaged's own refusal check answers.
 	identity, err := json.Marshal(map[string]string{
 		closeDateIdentityDeal:     proposal.DealID.String(),
 		closeDateIdentityStanding: proposal.StandingCloseDate,

--- a/backend/internal/compose/closedate.go
+++ b/backend/internal/compose/closedate.go
@@ -40,8 +40,37 @@ type closeDateStager struct {
 	svc *approvals.Service
 }
 
+// The two payload keys the staging identity is drawn from. Named because the
+// identity and the payload must spell them the same way — canonicalIdentity
+// refuses an identity field the payload does not carry, so a typo in either
+// literal is a staging that fails at runtime rather than at compile time.
+//
+// Deliberately not replayscope's offerDealField, which happens to hold the same
+// text: that one names a URL path segment on the offer routes, and binding an
+// approval payload's shape to a router's would make either one unmovable.
+const (
+	closeDateIdentityDeal     = "deal_id"
+	closeDateIdentityStanding = "standing_close_date"
+)
+
 func (s closeDateStager) HasPendingCorrection(ctx context.Context, dealID ids.UUID) (bool, error) {
 	return s.svc.HasPendingKind(ctx, deals.CloseDateCorrectionKind, dealID)
+}
+
+// HasRefusedCorrection reads the memory's own record: any rejected correction
+// against this deal.
+//
+// It asks whether ONE was refused rather than which, because its caller is the
+// keep-alive branch and that branch proposes no change to weigh — it re-offers
+// the date the sweep already wrote, which is the date the rep declined to have
+// set. The staging path keeps the finer answer for the branch that does propose
+// a change, where a new standing date is a new question.
+func (s closeDateStager) HasRefusedCorrection(ctx context.Context, dealID ids.UUID) (bool, error) {
+	refused, err := s.svc.RejectedChangesFor(ctx, deals.CloseDateCorrectionKind, dealID)
+	if err != nil {
+		return false, err
+	}
+	return len(refused) > 0, nil
 }
 
 func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal deals.CloseDateCorrection) error {
@@ -53,14 +82,37 @@ func (s closeDateStager) StageCorrection(ctx context.Context, dealID ids.UUID, t
 	if err != nil {
 		return fmt.Errorf("compose: canonicalize close-date proposal: %w", err)
 	}
-	_, err = s.svc.Stage(ctx, approvals.StageInput{
+	// The logical identity is the deal AND the date it currently holds — the two
+	// fields that say WHICH correction this is.
+	//
+	// It must not carry the PROPOSED date. That one is recomputed against
+	// "today" on every pass, so an identity holding it makes each night's
+	// proposal a different one and the rejection memory recognises nothing: the
+	// rep's "no" comes back as the same question tomorrow morning.
+	//
+	// It must not be the deal ALONE either. A decline is remembered with no
+	// expiry, so a deal-only identity lets one "no" bury every future correction
+	// on that deal — the rep refuses a date, sets their own three weeks later,
+	// that one goes stale in turn, and nobody is ever told. The standing date is
+	// what separates those: unchanged while the rep has not moved it, and new
+	// exactly when they have, which is exactly when the question is a fresh one.
+	identity, err := json.Marshal(map[string]string{
+		closeDateIdentityDeal:     proposal.DealID.String(),
+		closeDateIdentityStanding: proposal.StandingCloseDate,
+	})
+	if err != nil {
+		return fmt.Errorf("compose: marshal close-date identity: %w", err)
+	}
+	_, _, err = s.svc.StageUnlessDeclined(ctx, approvals.StageInput{
 		Kind:           deals.CloseDateCorrectionKind,
 		ProposedChange: canonical,
 		DiffHash:       hash,
+		Identity:       identity,
 		TargetType:     approvalTargetDeal,
 		TargetID:       dealID,
 		TargetVersion:  &targetVersion,
 		Summary:        summary,
+		JoinPending:    true,
 	})
 	return err
 }

--- a/backend/internal/compose/closedateidentity_test.go
+++ b/backend/internal/compose/closedateidentity_test.go
@@ -48,21 +48,3 @@ func TestTheCloseDateIdentityNamesFieldsThePayloadCarries(t *testing.T) {
 		}
 	}
 }
-
-// A deal holding no date at all still has one identity value.
-//
-// The `missing` flag exists for that deal, and an absent or null key never
-// matches by containment: the proposals raised about it would carry no rejection
-// memory, and the rep would be asked again every night with nothing recording
-// that they had answered.
-func TestADealWithNoCloseDateStillHasAStandingValue(t *testing.T) {
-	t.Parallel()
-	if got := deals.StandingCloseDate(nil); got == "" {
-		t.Fatal("a deal with no close date spells its standing date as empty, " +
-			"which reads as an absent identity field")
-	}
-	held := "2026-08-19"
-	if got := deals.StandingCloseDate(&held); got != held {
-		t.Fatalf("a deal holding %q spells its standing date %q", held, got)
-	}
-}

--- a/backend/internal/compose/closedateidentity_test.go
+++ b/backend/internal/compose/closedateidentity_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The staging identity names fields the payload actually carries.
+//
+// canonicalIdentity refuses an identity field the proposed change does not
+// carry with the same value, so a JSON tag renamed on one side and not the other
+// turns every close-date staging into a runtime error — and it is the NIGHTLY
+// sweep that would discover it, in a worker log, after the change shipped.
+// Marshalling the real struct is what makes this a fact about the payload rather
+// than about two string literals agreeing with each other.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheCloseDateIdentityNamesFieldsThePayloadCarries(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal(deals.CloseDateCorrection{
+		DealID:            ids.From[ids.DealKind](ids.NewV7()),
+		ExpectedCloseDate: "2026-12-01",
+		StandingCloseDate: "2026-08-19",
+		Basis:             "the date has passed",
+	})
+	if err != nil {
+		t.Fatalf("marshalling a correction: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decoding the payload: %v", err)
+	}
+	for _, field := range []string{closeDateIdentityDeal, closeDateIdentityStanding} {
+		value, carried := payload[field]
+		if !carried {
+			t.Errorf("the identity names %q, which CloseDateCorrection does not carry — "+
+				"every staging would fail in the nightly sweep", field)
+			continue
+		}
+		if _, isString := value.(string); !isString {
+			t.Errorf("the identity names %q, which the payload carries as %T — "+
+				"an identity field must be a string", field, value)
+		}
+	}
+}
+
+// A deal holding no date at all still has one identity value.
+//
+// The `missing` flag exists for that deal, and an absent or null key never
+// matches by containment: the proposals raised about it would carry no rejection
+// memory, and the rep would be asked again every night with nothing recording
+// that they had answered.
+func TestADealWithNoCloseDateStillHasAStandingValue(t *testing.T) {
+	t.Parallel()
+	if got := deals.StandingCloseDate(nil); got == "" {
+		t.Fatal("a deal with no close date spells its standing date as empty, " +
+			"which reads as an absent identity field")
+	}
+	held := "2026-08-19"
+	if got := deals.StandingCloseDate(&held); got != held {
+		t.Fatalf("a deal holding %q spells its standing date %q", held, got)
+	}
+}

--- a/backend/internal/compose/closedatememory_integration_test.go
+++ b/backend/internal/compose/closedatememory_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -91,11 +92,12 @@ func TestARejectedCloseDateOnOneDealDoesNotSilenceAnother(t *testing.T) {
 
 // A refusal survives the proposal changing under it.
 //
-// The proposed date is recomputed against "today" on every pass, so it differs
-// from one night to the next while the rep's answer has not. An identity
-// carrying that date would recognise nothing, and the whole-payload diff hash
-// the staging falls back to has the same defect — which is why the memory is
-// keyed on the deal and the date the rep actually holds.
+// The proposed date is recomputed against "today" on every pass, and the sweep
+// writes it to the deal before staging — so on the FLAGGED arm the date and the
+// date the deal stands at both move nightly while the rep's answer has not. An
+// identity carrying either would recognise nothing, and the whole-payload diff
+// hash the staging falls back to has the same defect. A deal standing at a date
+// nobody confirmed is one question however often the guess is recomputed.
 func TestARejectedCloseDateStaysRefusedWhenTheProposalMoves(t *testing.T) {
 	e := setupCloseDate(t)
 	id := e.seedSweepDeal(t, "Moves nightly", e.late, stringp("commit"), intp(-10), 3)
@@ -104,20 +106,29 @@ func TestARejectedCloseDateStaysRefusedWhenTheProposalMoves(t *testing.T) {
 	}
 	e.rejectCorrection(t, id)
 
-	// The deal goes quieter, so the next pass computes a different date from the
-	// same situation. The question is still the one the rep answered.
+	// Age the deal past the stalled threshold so the next pass is FLAGGED rather
+	// than the keep-alive arm, and leave it provisional — which is what it is
+	// after the sweep wrote a date nobody confirmed. The flagged pass recomputes
+	// a different proposed date from the same situation, so this is the arm
+	// where an identity carrying that date would forget the rep's answer.
 	if _, err := e.owner.Exec(context.Background(),
-		`UPDATE activity SET occurred_at = occurred_at - interval '20 days'
-		   WHERE id IN (SELECT activity_id FROM activity_link WHERE deal_id = $1)`,
-		id); err != nil {
-		t.Fatalf("ageing the deal's correspondence: %v", err)
+		`UPDATE deal SET last_activity_at = now() - make_interval(days => $2)
+		  WHERE id = $1`,
+		id, deals.StalledThresholdDays+10); err != nil {
+		t.Fatalf("ageing the deal past the stalled threshold: %v", err)
 	}
+
 	if err := e.sweep(); err != nil {
 		t.Fatal(err)
 	}
 	if got := e.pendingCorrections(t, id); got != 0 {
 		t.Errorf("a moved proposal was staged over a rejection: %d pending — "+
 			"the memory is keyed on something that moves with the calendar", got)
+	}
+	// And the pass really did take the flagged arm, or this proves the same
+	// thing the first test does.
+	if !e.readSwept(t, id).provisional {
+		t.Error("the deal is no longer provisional; the flagged arm did not run")
 	}
 }
 

--- a/backend/internal/compose/closedatememory_integration_test.go
+++ b/backend/internal/compose/closedatememory_integration_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What a rep's "no" means to the nightly close-date sweep.
+//
+// The sweep runs every night over the same deals, so a refusal it does not
+// remember is a question asked again every morning until the rep gives in. The
+// memory is durable and has no expiry, which is why the second half of this file
+// matters as much as the first: an identity drawn too wide would let ONE refusal
+// bury every future correction on that deal, and it would fail silently —
+// proposals simply stop appearing, and nobody can point at when they stopped.
+//
+// SQL, all of it: what the sweep staged, and what the identity matched.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// rejectCorrection turns down the correction standing against one deal.
+func (e *closeDateEnv) rejectCorrection(t *testing.T, dealID ids.UUID) {
+	t.Helper()
+	var approvalID ids.ApprovalID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id FROM approval WHERE kind = 'close_date_correction'
+		   AND target_entity_id = $1 AND status = 'pending'`,
+		dealID).Scan(&approvalID); err != nil {
+		t.Fatalf("no staged correction to reject: %v", err)
+	}
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("rejecting the correction: %v", err)
+	}
+}
+
+// A refused date is not proposed again the next night.
+//
+// The pending check the sweep already had cannot do this: a rejection clears
+// 'pending', so the next pass saw nothing standing and staged the same proposal
+// over again.
+func TestARejectedCloseDateIsNotProposedAgainTomorrow(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Asked once", e.late, stringp("commit"), intp(-10), 3)
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	e.rejectCorrection(t, id)
+
+	// Tomorrow's pass, over a deal whose date the rep has not touched.
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingCorrections(t, id); got != 0 {
+		t.Errorf("after a rejection the next sweep staged %d corrections, want 0 — "+
+			"the rep is being asked the same question again", got)
+	}
+}
+
+// A refusal on one deal says nothing about another.
+//
+// This is how a too-wide identity fails, and it is the failure that hides: the
+// pipeline quietly stops raising corrections and every test about staging still
+// passes, because each one seeds its own deal.
+func TestARejectedCloseDateOnOneDealDoesNotSilenceAnother(t *testing.T) {
+	e := setupCloseDate(t)
+	declined := e.seedSweepDeal(t, "Said no here", e.late, stringp("commit"), intp(-10), 3)
+	other := e.seedSweepDeal(t, "Never asked", e.late, stringp("commit"), intp(-12), 4)
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	e.rejectCorrection(t, declined)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingCorrections(t, declined); got != 0 {
+		t.Errorf("the refused deal was asked again: %d pending", got)
+	}
+	if got := e.pendingCorrections(t, other); got != 1 {
+		t.Errorf("a deal nobody refused has %d pending corrections, want 1 — "+
+			"one rejection has silenced a deal it was never about", got)
+	}
+}
+
+// A refusal survives the proposal changing under it.
+//
+// The proposed date is recomputed against "today" on every pass, so it differs
+// from one night to the next while the rep's answer has not. An identity
+// carrying that date would recognise nothing, and the whole-payload diff hash
+// the staging falls back to has the same defect — which is why the memory is
+// keyed on the deal and the date the rep actually holds.
+func TestARejectedCloseDateStaysRefusedWhenTheProposalMoves(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Moves nightly", e.late, stringp("commit"), intp(-10), 3)
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	e.rejectCorrection(t, id)
+
+	// The deal goes quieter, so the next pass computes a different date from the
+	// same situation. The question is still the one the rep answered.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE activity SET occurred_at = occurred_at - interval '20 days'
+		   WHERE id IN (SELECT activity_id FROM activity_link WHERE deal_id = $1)`,
+		id); err != nil {
+		t.Fatalf("ageing the deal's correspondence: %v", err)
+	}
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingCorrections(t, id); got != 0 {
+		t.Errorf("a moved proposal was staged over a rejection: %d pending — "+
+			"the memory is keyed on something that moves with the calendar", got)
+	}
+}
+
+// A rep who sets their own date is asked again when THAT one goes stale.
+//
+// The other half of the identity, and the reason it is not the deal alone. A
+// refusal is remembered forever, so a deal-only key would mean one "no" ends
+// close-date hygiene on that deal permanently: the rep refuses, sets a date
+// themselves, it slips in turn, and nobody ever tells them.
+func TestANewStandingDateIsCorrectedAgainAfterAnEarlierRefusal(t *testing.T) {
+	e := setupCloseDate(t)
+	id := e.seedSweepDeal(t, "Set it myself", e.late, stringp("commit"), intp(-10), 3)
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	e.rejectCorrection(t, id)
+
+	// The rep puts their own date on the deal, and it is overdue in its turn.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE deal SET expected_close_date = current_date - 4,
+		        close_date_provisional = false
+		  WHERE id = $1`, id); err != nil {
+		t.Fatalf("setting the rep's own date: %v", err)
+	}
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingCorrections(t, id); got != 1 {
+		t.Errorf("a date the rep set themselves went stale and raised %d corrections, want 1 — "+
+			"one refusal has ended close-date hygiene on this deal for good", got)
+	}
+}

--- a/backend/internal/modules/deals/closedateproposal.go
+++ b/backend/internal/modules/deals/closedateproposal.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// What a close-date correction IS, and the seams the composition root fills to
+// raise one: the staged payload a human weighs, the kind it is staged under, and
+// the readers that let the nightly sweep ask the approvals engine what it has
+// already proposed and what a human has already refused.
+//
+// Apart from the sweep that drives it because the shape outlives any one pass —
+// the confirm effect unmarshals this payload, the queue renders it, and the
+// staging identity is drawn from its fields. The sweep is one caller.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// CloseDateCorrectionKind is the approvals staging kind the 🟡/🔻 tiers
+// surface through; its decision grant lives in the approvals module and
+// its confirm effect is injected at the composition root.
+const CloseDateCorrectionKind = "close_date_correction"
+
+// CorrectionStager is the approvals seam the composition root fills
+// (a module never imports a sibling): stage a 🟡 confirm-the-real-date
+// proposal, and ask whether one is already pending so a nightly sweep —
+// whose proposed date moves with "today" — cannot stack duplicates.
+type CorrectionStager interface {
+	HasPendingCorrection(ctx context.Context, dealID ids.UUID) (bool, error)
+	StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal CloseDateCorrection) error
+	// HasRefusedCorrection reports whether a human has already turned down a
+	// correction on this deal.
+	//
+	// The staging path remembers a refusal against the date it was about, which
+	// is what keeps a genuinely NEW question askable. One branch of this sweep
+	// needs the coarser answer: the keep-alive pass asks a rep to confirm the
+	// provisional date the sweep itself wrote, and after a refusal that card
+	// would return every night under a fresh identity — the date it names is the
+	// one the rep just declined to accept. A deal whose rep has said no is not
+	// kept alive; it waits for the deal to move.
+	HasRefusedCorrection(ctx context.Context, dealID ids.UUID) (bool, error)
+}
+
+// QuietReviewReader reads one deal's correspondence UNDER ITS OWNER'S OWN
+// AUTHORITY, and that principal is the whole security argument for the
+// gone-quiet review.
+//
+// The sweep runs as a system principal, which auth.Require passes
+// unconditionally and which no row scope bounds. A counterparty resolved under
+// it is resolvable whoever they are — and the review writes that name into
+// proposed_change, where anyone holding deal:update on the target reads it
+// later. An unbounded read frozen into a stored payload is a disclosure no
+// read-side gate can undo, so the read runs as the person the card is for: the
+// deal's owner, resolved per deal.
+//
+// The composition root fills this because resolving an authority means reading
+// app_user, which this module may not do.
+//
+// Best-effort by contract. A deal with no owner, or one whose owner is no
+// longer live, yields no facts and the review falls back to a reason carrying
+// no name. Absence of authority is denial rather than empty permission, and a
+// deal's date hygiene is not a reason to fail the pass.
+type QuietReviewReader interface {
+	ReadForOwner(ctx context.Context, dealID ids.DealID) (QuietFacts, QuietNames, error)
+}
+
+// CloseDateCorrection is the staged proposed_change payload: everything
+// a human needs to confirm (or edit) the replacement date, and the
+// confirm effect needs to apply it.
+type CloseDateCorrection struct {
+	DealID ids.DealID `json:"deal_id"`
+	// ExpectedCloseDate is the proposed date, date-only wire form.
+	ExpectedCloseDate string          `json:"expected_close_date"`
+	PreviousCloseDate *string         `json:"previous_close_date"`
+	Flags             []CloseDateFlag `json:"flags"`
+	// Basis is the plain-language derivation of the proposed date — the
+	// "no mystery number" duty (P6) applied to a guess.
+	Basis string `json:"basis"`
+	// StandingCloseDate is PreviousCloseDate in the form a staging identity can
+	// be keyed on: never absent, and "none" for a deal holding no date at all.
+	//
+	// It exists beside the nullable field rather than replacing it because a
+	// staging identity must be a string the payload carries with the same value
+	// (canonicalIdentity enforces both), and an absent key never matches. The
+	// card renders the nullable one, which reads as "no previous date" rather
+	// than as the word none.
+	StandingCloseDate string `json:"standing_close_date"`
+}
+
+// StandingCloseDate spells the date a deal currently holds for an identity.
+//
+// A deal with no date at all is a real case — the `missing` flag exists for it —
+// and it must be one value rather than an absent key, or the proposals raised
+// about it carry no rejection memory at all.
+func StandingCloseDate(current *string) string {
+	if current == nil {
+		return "none"
+	}
+	return *current
+}
+
+// UnmarshalCloseDateCorrection decodes a staged (possibly human-edited)
+// proposal back into the typed form the confirm effect applies.
+func UnmarshalCloseDateCorrection(raw json.RawMessage) (CloseDateCorrection, error) {
+	var c CloseDateCorrection
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return CloseDateCorrection{}, fmt.Errorf("close_date_correction payload: %w", err)
+	}
+	if c.DealID.IsZero() {
+		return CloseDateCorrection{}, errors.New("close_date_correction payload names no deal")
+	}
+	if _, err := time.Parse(time.DateOnly, c.ExpectedCloseDate); err != nil {
+		return CloseDateCorrection{}, fmt.Errorf("close_date_correction payload date: %w", err)
+	}
+	return c, nil
+}

--- a/backend/internal/modules/deals/closedateproposal.go
+++ b/backend/internal/modules/deals/closedateproposal.go
@@ -8,9 +8,9 @@ package deals
 // the readers that let the nightly sweep ask the approvals engine what it has
 // already proposed and what a human has already refused.
 //
-// Apart from the sweep that drives it because the shape outlives any one pass —
-// the confirm effect unmarshals this payload, the queue renders it, and the
-// staging identity is drawn from its fields. The sweep is one caller.
+// This lives apart from the sweep because the shape outlives any one pass: the
+// confirm effect unmarshals this payload, the queue renders it, and the staging
+// identity is drawn from its fields. The sweep is one caller of it.
 
 import (
 	"context"
@@ -34,17 +34,18 @@ const CloseDateCorrectionKind = "close_date_correction"
 type CorrectionStager interface {
 	HasPendingCorrection(ctx context.Context, dealID ids.UUID) (bool, error)
 	StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal CloseDateCorrection) error
-	// HasRefusedCorrection reports whether a human has already turned down a
-	// correction on this deal.
+	// RefusedCloseDate reports whether a human has already turned down the
+	// correction this probe describes.
 	//
-	// The staging path remembers a refusal against the date it was about, which
-	// is what keeps a genuinely NEW question askable. One branch of this sweep
-	// needs the coarser answer: the keep-alive pass asks a rep to confirm the
-	// provisional date the sweep itself wrote, and after a refusal that card
-	// would return every night under a fresh identity — the date it names is the
-	// one the rep just declined to accept. A deal whose rep has said no is not
-	// kept alive; it waits for the deal to move.
-	HasRefusedCorrection(ctx context.Context, dealID ids.UUID) (bool, error)
+	// The staging memory cannot answer it alone. The sweep writes its new date
+	// onto the deal BEFORE staging, so the standing date the identity is drawn
+	// from has already moved by the time the proposal is built, and a refusal
+	// recorded last night matches nothing tonight.
+	//
+	// The probe carries the judgment rather than a bare date, because what makes
+	// two corrections the same question belongs to this module and the adapter
+	// only walks the payloads.
+	RefusedCloseDate(ctx context.Context, dealID ids.UUID, proposed RefusalProbe) (bool, error)
 }
 
 // QuietReviewReader reads one deal's correspondence UNDER ITS OWNER'S OWN
@@ -82,25 +83,76 @@ type CloseDateCorrection struct {
 	// Basis is the plain-language derivation of the proposed date — the
 	// "no mystery number" duty (P6) applied to a guess.
 	Basis string `json:"basis"`
-	// StandingCloseDate is PreviousCloseDate in the form a staging identity can
-	// be keyed on: never absent, and "none" for a deal holding no date at all.
+	// StandingCloseDate is the date the REP owns, in the form a staging identity
+	// can be keyed on: never absent, and a sentinel where there is no such date.
 	//
-	// It exists beside the nullable field rather than replacing it because a
-	// staging identity must be a string the payload carries with the same value
-	// (canonicalIdentity enforces both), and an absent key never matches. The
-	// card renders the nullable one, which reads as "no previous date" rather
-	// than as the word none.
+	// It exists beside the nullable PreviousCloseDate rather than replacing it
+	// because a staging identity must be a string the payload carries with the
+	// same value (canonicalIdentity enforces both), and an absent key never
+	// matches. The card renders the nullable one, which reads as "no previous
+	// date" rather than as a sentinel word.
 	StandingCloseDate string `json:"standing_close_date"`
 }
 
-// StandingCloseDate spells the date a deal currently holds for an identity.
+// standingNoDate is a deal holding no close date at all — a real case, the
+// `missing` flag exists for it. A value rather than an absent key, because jsonb
+// containment never matches a key the payload does not carry, so such a deal's
+// proposals would otherwise carry no rejection memory whatever. It cannot
+// collide with a real date: every one of those is formatted YYYY-MM-DD.
+const standingNoDate = "none"
+
+// RefusalProbe is one proposed correction, in the terms that decide whether a
+// human has already answered it.
+type RefusalProbe struct {
+	// Proposed is the date this pass wants to put on the deal.
+	Proposed string
+	// AfterHumanEdit says the deal is standing at a date a person chose, so this
+	// is a question about THEIR date rather than about the machine's own guess.
+	AfterHumanEdit bool
+}
+
+// ProbeFor reads a proposal and the state it was raised from into the question
+// it asks.
+func ProbeFor(proposal CloseDateCorrection, provisional bool) RefusalProbe {
+	return RefusalProbe{Proposed: proposal.ExpectedCloseDate, AfterHumanEdit: !provisional}
+}
+
+// SameQuestionAs reports whether an earlier refused correction already answered
+// this one.
 //
-// A deal with no date at all is a real case — the `missing` flag exists for it —
-// and it must be one value rather than an absent key, or the proposals raised
-// about it carry no rejection memory at all.
+// The date proposed is what a rep actually said no to, and it is stable across
+// nights: the sweep computes it from stage velocity, so a deal whose situation
+// has not changed is offered the same date again. That is the resurrection this
+// memory exists to stop, and matching on the proposed date alone stops it.
+//
+// The second term stops it silencing too much. A rep who refuses a date and then
+// sets their own has changed the question — the deal now stands at a date a
+// person chose, and the sweep's next guess for it can easily be the same
+// computed day. Without this, that guess would read as the refused one and the
+// rep would never hear that their own date had gone stale.
+//
+// What it deliberately does NOT use is the standing date. The sweep writes its
+// date onto the deal before staging, so what a deal stands at tonight is what
+// was proposed last night — every pass would look like a fresh question and
+// nothing would be remembered at all.
+func (p RefusalProbe) SameQuestionAs(earlier CloseDateCorrection) bool {
+	return p.Proposed == earlier.ExpectedCloseDate && !p.AfterHumanEdit
+}
+
+// StandingCloseDate spells, for a staging identity, WHICH date this correction
+// is about: the one the deal holds and the sweep is asking to replace.
+//
+// Not the PROPOSED date, which is recomputed against "today" on every pass — an
+// identity carrying it makes each night a different question and a rep's "no" is
+// forgotten by morning.
+//
+// It does move when the sweep writes its own guess, and that is what the
+// keep-alive branch's separate refusal check exists to cover. Here it is what
+// keeps a date the rep sets themselves askable: a new standing date is a new
+// question, so one refusal cannot end close-date hygiene on a deal for good.
 func StandingCloseDate(current *string) string {
 	if current == nil {
-		return "none"
+		return standingNoDate
 	}
 	return *current
 }

--- a/backend/internal/modules/deals/closedateproposal_test.go
+++ b/backend/internal/modules/deals/closedateproposal_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// When two close-date corrections are the same question.
+//
+// This is the whole of the rejection memory's judgment, and both of its terms
+// were arrived at by watching one fail: matching the proposed date alone
+// silences a rep's own date when the sweep's next guess lands on the same day,
+// and dropping it remembers nothing at all.
+
+import "testing"
+
+func TestWhenTwoCloseDateCorrectionsAreTheSameQuestion(t *testing.T) {
+	t.Parallel()
+	refused := CloseDateCorrection{ExpectedCloseDate: "2026-09-13"}
+
+	// The resurrection this memory exists to stop. The sweep computes its date
+	// from stage velocity, so a deal whose situation has not changed is offered
+	// the same date again — and the rep has answered that already.
+	sameDate := RefusalProbe{Proposed: "2026-09-13", AfterHumanEdit: false}
+	if !sameDate.SameQuestionAs(refused) {
+		t.Error("the same date proposed again reads as a new question; the rep is " +
+			"asked what they already answered")
+	}
+
+	// A different date is a different question, however recently they refused.
+	movedOn := RefusalProbe{Proposed: "2026-11-30", AfterHumanEdit: false}
+	if movedOn.SameQuestionAs(refused) {
+		t.Error("a different proposed date reads as already answered")
+	}
+
+	// The rep set their own date, and it has gone stale in its turn. The sweep's
+	// guess for it can be the very day they refused before — this is the term
+	// that keeps that from ending close-date hygiene on the deal for good.
+	theirOwnDate := RefusalProbe{Proposed: "2026-09-13", AfterHumanEdit: true}
+	if theirOwnDate.SameQuestionAs(refused) {
+		t.Error("a date the rep set themselves is treated as the refused one, so " +
+			"they are never told it went stale")
+	}
+}
+
+func TestProbeForReadsTheProposalAndTheStateItCameFrom(t *testing.T) {
+	t.Parallel()
+	proposal := CloseDateCorrection{ExpectedCloseDate: "2026-09-13"}
+
+	// Provisional means the deal stands at the machine's own guess, so this is
+	// not a question about a date any person chose.
+	if got := ProbeFor(proposal, true); got.AfterHumanEdit {
+		t.Error("a correction on a provisional date reads as being about a rep's own date")
+	}
+	if got := ProbeFor(proposal, false); !got.AfterHumanEdit {
+		t.Error("a correction on a rep's own date reads as being about the machine's guess")
+	}
+	if got := ProbeFor(proposal, false); got.Proposed != proposal.ExpectedCloseDate {
+		t.Errorf("the probe proposes %q, the correction %q", got.Proposed, proposal.ExpectedCloseDate)
+	}
+}
+
+func TestADealWithNoCloseDateStillHasAStandingValue(t *testing.T) {
+	t.Parallel()
+	// A real case — the `missing` flag exists for it — and it needs a value
+	// rather than an absent key, because jsonb containment never matches a key
+	// the payload does not carry.
+	if got := StandingCloseDate(nil); got == "" {
+		t.Error("a deal with no close date stands at the empty string, which reads " +
+			"as an absent identity field and matches nothing")
+	}
+	held := "2026-08-19"
+	if got := StandingCloseDate(&held); got != held {
+		t.Errorf("a deal holding %q stands at %q", held, got)
+	}
+	// And the sentinel cannot be mistaken for a date: every real one is
+	// formatted YYYY-MM-DD.
+	if StandingCloseDate(nil) == held {
+		t.Error("the no-date sentinel collides with a real date")
+	}
+}

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -250,19 +250,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 			// has not confirmed it yet: keep the 🟡 surface alive if the
 			// previous staging expired undecided.
 			//
-			// Undecided, and not REFUSED. A rep who turned this correction down
-			// has answered; re-offering the date they refused is the nightly
-			// nagging the rejection memory exists to end, and the staging's own
-			// memory cannot stop it here because each night's card names a
-			// different date and is therefore a different question to it.
-			refused, err := c.stager.HasRefusedCorrection(ctx, cand.id.UUID)
-			if err != nil {
-				return err
-			}
-			if refused {
-				return nil
-			}
-			return c.ensureStaged(ctx, cand.id, 0, cand.name, CloseDateCorrection{
+			return c.ensureStaged(ctx, cand, 0, CloseDateCorrection{
 				DealID:            cand.id,
 				ExpectedCloseDate: cand.expectedClose.Format(time.DateOnly),
 				PreviousCloseDate: dateString(cand.expectedClose),
@@ -302,7 +290,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 		if err != nil {
 			return err
 		}
-		return c.ensureStaged(ctx, cand.id, version, cand.name, proposal)
+		return c.ensureStaged(ctx, cand, version, proposal)
 
 	case CloseDateActionDowngradeAndReview:
 		notched := forecastDowngrade(category)
@@ -327,7 +315,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 		// date the deal already had — a card with nothing in it to approve.
 		review := proposal
 		review.Basis = c.quietBasis(ctx, cand.id, now, loc)
-		return c.ensureStaged(ctx, cand.id, version, cand.name, review)
+		return c.ensureStaged(ctx, cand, version, review)
 	}
 	return fmt.Errorf("close-date sweep: no executor for action %q", hygiene.Action)
 }
@@ -407,15 +395,33 @@ func (c *CloseDateCorrector) apply(ctx context.Context, cand closeDateCandidate,
 	return version, err
 }
 
-// ensureStaged stages the 🟡 confirm-the-real-date proposal unless one
-// is already pending — the sweep's proposal moves with "today", so an
-// identity check on the exact diff would stack duplicates nightly.
-func (c *CloseDateCorrector) ensureStaged(ctx context.Context, dealID ids.DealID, targetVersion int64, name string, proposal CloseDateCorrection) error {
+// ensureStaged stages the 🟡 confirm-the-real-date proposal unless one is
+// already pending, or the rep has already refused this very date.
+//
+// TWO checks, because they answer different questions and each has a gap the
+// other fills. Pending stops the same live card multiplying. Refused stops a
+// decided one returning — and it is needed HERE, above the staging's own
+// memory, because the sweep writes its new date onto the deal before staging:
+// the standing date the identity is drawn from has already moved by the time
+// the proposal is built, so a refusal recorded last night matches nothing
+// tonight. Comparing the date being PROPOSED is what recognises it.
+//
+// Per date rather than per deal, so one "no" silences the date it was about
+// rather than ending close-date hygiene on that deal for good.
+func (c *CloseDateCorrector) ensureStaged(ctx context.Context, cand closeDateCandidate, targetVersion int64, proposal CloseDateCorrection) error {
+	dealID, name := cand.id, cand.name
 	pending, err := c.stager.HasPendingCorrection(ctx, dealID.UUID)
 	if err != nil {
 		return err
 	}
 	if pending {
+		return nil
+	}
+	refused, err := c.stager.RefusedCloseDate(ctx, dealID.UUID, ProbeFor(proposal, cand.provisional))
+	if err != nil {
+		return err
+	}
+	if refused {
 		return nil
 	}
 	if targetVersion == 0 {

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -18,7 +18,6 @@ package deals
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,73 +35,6 @@ import (
 // closeDateBatch bounds how many deals one workspace pass corrects — a
 // first run against a migrated backlog drains over successive nights.
 const closeDateBatch = 200
-
-// CloseDateCorrectionKind is the approvals staging kind the 🟡/🔻 tiers
-// surface through; its decision grant lives in the approvals module and
-// its confirm effect is injected at the composition root.
-const CloseDateCorrectionKind = "close_date_correction"
-
-// CorrectionStager is the approvals seam the composition root fills
-// (a module never imports a sibling): stage a 🟡 confirm-the-real-date
-// proposal, and ask whether one is already pending so a nightly sweep —
-// whose proposed date moves with "today" — cannot stack duplicates.
-type CorrectionStager interface {
-	HasPendingCorrection(ctx context.Context, dealID ids.UUID) (bool, error)
-	StageCorrection(ctx context.Context, dealID ids.UUID, targetVersion int64, summary string, proposal CloseDateCorrection) error
-}
-
-// QuietReviewReader reads one deal's correspondence UNDER ITS OWNER'S OWN
-// AUTHORITY, and that principal is the whole security argument for the
-// gone-quiet review.
-//
-// The sweep runs as a system principal, which auth.Require passes
-// unconditionally and which no row scope bounds. A counterparty resolved under
-// it is resolvable whoever they are — and the review writes that name into
-// proposed_change, where anyone holding deal:update on the target reads it
-// later. An unbounded read frozen into a stored payload is a disclosure no
-// read-side gate can undo, so the read runs as the person the card is for: the
-// deal's owner, resolved per deal.
-//
-// The composition root fills this because resolving an authority means reading
-// app_user, which this module may not do.
-//
-// Best-effort by contract. A deal with no owner, or one whose owner is no
-// longer live, yields no facts and the review falls back to a reason carrying
-// no name. Absence of authority is denial rather than empty permission, and a
-// deal's date hygiene is not a reason to fail the pass.
-type QuietReviewReader interface {
-	ReadForOwner(ctx context.Context, dealID ids.DealID) (QuietFacts, QuietNames, error)
-}
-
-// CloseDateCorrection is the staged proposed_change payload: everything
-// a human needs to confirm (or edit) the replacement date, and the
-// confirm effect needs to apply it.
-type CloseDateCorrection struct {
-	DealID ids.DealID `json:"deal_id"`
-	// ExpectedCloseDate is the proposed date, date-only wire form.
-	ExpectedCloseDate string          `json:"expected_close_date"`
-	PreviousCloseDate *string         `json:"previous_close_date"`
-	Flags             []CloseDateFlag `json:"flags"`
-	// Basis is the plain-language derivation of the proposed date — the
-	// "no mystery number" duty (P6) applied to a guess.
-	Basis string `json:"basis"`
-}
-
-// UnmarshalCloseDateCorrection decodes a staged (possibly human-edited)
-// proposal back into the typed form the confirm effect applies.
-func UnmarshalCloseDateCorrection(raw json.RawMessage) (CloseDateCorrection, error) {
-	var c CloseDateCorrection
-	if err := json.Unmarshal(raw, &c); err != nil {
-		return CloseDateCorrection{}, fmt.Errorf("close_date_correction payload: %w", err)
-	}
-	if c.DealID.IsZero() {
-		return CloseDateCorrection{}, errors.New("close_date_correction payload names no deal")
-	}
-	if _, err := time.Parse(time.DateOnly, c.ExpectedCloseDate); err != nil {
-		return CloseDateCorrection{}, fmt.Errorf("close_date_correction payload date: %w", err)
-	}
-	return c, nil
-}
 
 // CloseDateCorrector drives the sweep; the worker ticks it nightly.
 type CloseDateCorrector struct {
@@ -317,10 +249,24 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 			// The date itself is clean (the sweep set it), but the human
 			// has not confirmed it yet: keep the 🟡 surface alive if the
 			// previous staging expired undecided.
+			//
+			// Undecided, and not REFUSED. A rep who turned this correction down
+			// has answered; re-offering the date they refused is the nightly
+			// nagging the rejection memory exists to end, and the staging's own
+			// memory cannot stop it here because each night's card names a
+			// different date and is therefore a different question to it.
+			refused, err := c.stager.HasRefusedCorrection(ctx, cand.id.UUID)
+			if err != nil {
+				return err
+			}
+			if refused {
+				return nil
+			}
 			return c.ensureStaged(ctx, cand.id, 0, cand.name, CloseDateCorrection{
 				DealID:            cand.id,
 				ExpectedCloseDate: cand.expectedClose.Format(time.DateOnly),
 				PreviousCloseDate: dateString(cand.expectedClose),
+				StandingCloseDate: StandingCloseDate(dateString(cand.expectedClose)),
 				Basis:             quietHoldingBasis,
 			})
 		}
@@ -331,6 +277,7 @@ func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidat
 		DealID:            cand.id,
 		ExpectedCloseDate: hygiene.ProposedClose.Format(time.DateOnly),
 		PreviousCloseDate: dateString(cand.expectedClose),
+		StandingCloseDate: StandingCloseDate(dateString(cand.expectedClose)),
 		Flags:             hygiene.Flags,
 		Basis:             pacedBasis(max(1, cand.remainingOpen)),
 	}


### PR DESCRIPTION
## The bug

The nightly close-date sweep staged its correction with plain `Stage`. Its only guard was "is one already pending" — and a rejection clears `pending`. So the next night staged the same proposal again, and the night after that. A rep could only end it by giving in.

## The identity

Staging now goes through `StageUnlessDeclined` keyed on the deal and **the date it currently holds**.

Not the proposed date: that is recomputed against "today" on every pass, so an identity carrying it makes each night a different question and the memory recognises nothing.

Not the deal alone either, for the opposite reason. A refusal never expires, so a deal-only key would let one "no" end close-date hygiene on that deal permanently — the rep declines, sets their own date, it slips in turn, and nobody ever tells them.

## The keep-alive branch needed its own answer

When a deal is provisional and unflagged, the sweep re-offers the date **it wrote itself**, to keep the confirm card alive if the last staging expired undecided. Expired, not refused — and it could not tell the difference. After a rejection each night's card names a different date, so the staging's own memory reads it as a fresh question every time.

That branch now asks whether a correction on this deal was refused at all, and holds off if one was. The finer per-date answer stays with the branch that actually proposes a change.

## Payload

`CloseDateCorrection` gains `standing_close_date` beside the nullable `previous_close_date`. An identity field must be a string the payload carries with the same value, and "no date at all" is a real case — the `missing` flag exists for it. The card still renders the nullable one; the new field is not in the display allowlist.

## Verification

Four integration tests against a real database:

- a refused date is not proposed again the next night
- a refusal on one deal does not silence another
- a refusal survives the proposal moving under it
- **a date the rep set themselves is still corrected when it goes stale** — the test for the failure that hides

Mutation-checked in both directions. Keying on the proposed date fails all four. Keying on the deal alone passes three and is caught only by the fourth, which is exactly the point of writing it.

Plus a unit test that marshals the real struct and fails if either JSON tag moves away from the identity constants. Without it the nightly sweep discovers the mismatch, in a worker log, after shipping.

`closedatesweep.go` crossed the 500-line cap, so the proposal shape and its seams move to `closedateproposal.go`.

All local gates green: `check-backend`, `check-fe`, `craft-static`, `rls-store-path`, `no-jurisdiction`, and the nine existing close-date integration tests alongside the four new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly close-date sweep so a date a rep declined is not proposed again the next night. Refusals are remembered against the deal and the date it currently holds, so a rep who sets their own date is still asked again when that one goes stale.

- Staging goes through `StageUnlessDeclined` keyed on the deal and its standing close date.
- A per-pass refusal check compares the proposed date on every arm, since the sweep writes its new date onto the deal before staging and would otherwise outrun the identity; the old deal-wide hold-off in the keep-alive branch is gone.
- `CloseDateCorrection` gains `standing_close_date` for the identity; the card still renders the nullable `previous_close_date`.
- Moved the proposal shape and stager seams into `closedateproposal.go`.
- Added integration tests for refusals persisting across nights and deals, a refusal surviving a moved proposal, and a rep-set date going stale.

<sup>Written for commit 5b3ddf8c3b3a5709b1c38910739308911fb67fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Close-date correction proposals now include the deal’s current standing close date for reliable tracking.
  * Previously refused corrections are remembered and won’t be proposed again unless the deal’s standing date changes.
  * Correction payloads now require valid deal and date information.

* **Bug Fixes**
  * Prevented rejected corrections from resurfacing during later review cycles.
  * Improved separation of correction history between deals and changing proposals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->