### PR TITLE
fix(voice): a failed build says what actually failed

### DIFF
--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -329,9 +329,9 @@ func anthropicError(resp *http.Response) error {
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
-		return fmt.Errorf("ai: anthropic: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
+		return quotaWrapped(resp, fmt.Errorf("ai: anthropic: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
 	}
-	return fmt.Errorf("ai: anthropic: http %d", resp.StatusCode)
+	return quotaWrapped(resp, fmt.Errorf("ai: anthropic: http %d", resp.StatusCode))
 }
 
 // anthropicStream parses the Messages SSE stream, yielding text deltas.

--- a/backend/internal/modules/ai/budget.go
+++ b/backend/internal/modules/ai/budget.go
@@ -7,15 +7,60 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/retryafter"
 )
 
 // ErrBudgetDeferred identifies a background model call that its durable
 // carrier must resume in the next budget window. The router owns the timing
 // decision but never invents a generic job: the caller already owns the work.
 var ErrBudgetDeferred = errors.New("ai: background task deferred until the next budget window")
+
+// ErrProviderQuota identifies a provider that REFUSED the call because the
+// account behind the key is out of quota or over its spending cap — not a
+// model that answered badly. The two need separate words to the operator:
+// this one is fixed in the provider's billing console and retrying changes
+// nothing until somebody does, while a bad answer is worth another attempt.
+//
+// Every provider client wraps its 429 in this, so a caller classifies by
+// errors.Is rather than by matching a message that differs per vendor.
+var ErrProviderQuota = errors.New("ai: the configured AI provider refused the call: its account is out of budget or over its quota")
+
+// ErrProviderThrottled is the OTHER thing a 429 means: too many calls too
+// quickly, which the same call succeeds at a moment later. Separated from
+// ErrProviderQuota because the two want opposite handling — a throttle is
+// worth escalating past and retrying, an exhausted account is not, and telling
+// an operator to raise a spending limit over a burst limit sends them to a
+// console where nothing is wrong.
+var ErrProviderThrottled = errors.New("ai: the configured AI provider is rate limiting this installation")
+
+// quotaWrapped classifies a provider's 429, which every vendor here uses for
+// both an exhausted account and an ordinary burst limit.
+//
+// Retry-After is what separates them: a throttle names the moment the caller
+// may return, because the provider expects it to. An account over its cap has
+// no such moment to name — nothing changes until a human raises the limit — so
+// a 429 that names no moment is read as the refusal it almost always is.
+// Reading it the wrong way is survivable in one direction only: a throttle
+// mistaken for a refusal costs one abandoned call, while a refusal mistaken
+// for a throttle burns every remaining tier against an account that cannot pay
+// for any of them.
+//
+// The header is read through the kernel's one reader, which knows both RFC
+// 9110 forms and answers zero for a header that is absent, unparseable, or
+// already past — all three of which name no moment to come back at.
+func quotaWrapped(resp *http.Response, err error) error {
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		return err
+	}
+	if retryafter.Of(resp) > 0 {
+		return fmt.Errorf("%w: %w", ErrProviderThrottled, err)
+	}
+	return fmt.Errorf("%w: %w", ErrProviderQuota, err)
+}
 
 // BudgetDeferralError carries the exact retry boundary to a background task's
 // durable carrier. It is returned before a provider attempt or ai_call trace is

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -418,9 +418,9 @@ func geminiError(resp *http.Response) error {
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Status != "" {
-		return fmt.Errorf("ai: gemini: %s: %s (http %d)", apiErr.Error.Status, apiErr.Error.Message, resp.StatusCode)
+		return quotaWrapped(resp, fmt.Errorf("ai: gemini: %s: %s (http %d)", apiErr.Error.Status, apiErr.Error.Message, resp.StatusCode))
 	}
-	return fmt.Errorf("ai: gemini: http %d", resp.StatusCode)
+	return quotaWrapped(resp, fmt.Errorf("ai: gemini: http %d", resp.StatusCode))
 }
 
 // geminiStream reads the :streamGenerateContent?alt=sse stream. There is no

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -343,9 +343,9 @@ func openaiError(resp *http.Response) error {
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
-		return fmt.Errorf("ai: openai: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
+		return quotaWrapped(resp, fmt.Errorf("ai: openai: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
 	}
-	return fmt.Errorf("ai: openai: http %d", resp.StatusCode)
+	return quotaWrapped(resp, fmt.Errorf("ai: openai: http %d", resp.StatusCode))
 }
 
 // openaiTerminalStatus maps a non-completed Responses object to an error: a

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -324,13 +324,13 @@ func openAICompatError(resp *http.Response) error {
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil {
 		if apiErr.Error.Message != "" {
-			return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
+			return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
 		}
 		if apiErr.Message != "" {
-			return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Type, apiErr.Message, resp.StatusCode)
+			return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Type, apiErr.Message, resp.StatusCode))
 		}
 	}
-	return fmt.Errorf("ai: openai-compat: http %d", resp.StatusCode)
+	return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: http %d", resp.StatusCode))
 }
 
 // openAICompatStream reads the OpenAI-compatible SSE stream: `data: {...}`

--- a/backend/internal/modules/ai/quota429_test.go
+++ b/backend/internal/modules/ai/quota429_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The whole chain, over a real HTTP response: a provider answering 429 with a
+// spending-cap body must reach the operator as a budget message, not as a
+// claim that the model produced something unusable.
+func TestAQuotaRefusalReachesTheOperatorAsABudgetMessage(t *testing.T) {
+	const capReached = `{"error":{"status":"RESOURCE_EXHAUSTED","message":"Your project has exceeded its monthly spending cap."}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		if _, writeErr := io.WriteString(w, capReached); writeErr != nil {
+			t.Errorf("writing the provider's refusal body: %v", writeErr)
+		}
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("closing the response body: %v", closeErr)
+		}
+	}()
+
+	providerErr := geminiError(resp)
+	if !errors.Is(providerErr, ErrProviderQuota) {
+		t.Fatalf("a 429 from the provider is a quota refusal: %v", providerErr)
+	}
+	message := SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", providerErr))
+	if !strings.Contains(strings.ToLower(message), "out of budget") {
+		t.Fatalf("the operator is told the budget ran out: %q", message)
+	}
+	if strings.Contains(message, "RESOURCE_EXHAUSTED") || strings.Contains(message, "429") {
+		t.Fatalf("the provider's own payload never reaches the operator: %q", message)
+	}
+}

--- a/backend/internal/modules/ai/router_attempts_test.go
+++ b/backend/internal/modules/ai/router_attempts_test.go
@@ -10,8 +10,10 @@ package ai
 // terminal tracing this behavior builds on.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -390,5 +392,83 @@ func TestMetricsCountOneCallPerLogicalCallNotPerAttempt(t *testing.T) {
 	}
 	if strings.Contains(out, `provider="anthropic"`) {
 		t.Fatalf("the non-terminal failed rung must not surface in /metrics at all:\n%s", out)
+	}
+}
+
+// countingClient answers like stubClient and remembers how often it was asked,
+// which is what proves a rung was never reached rather than merely unused.
+// It embeds stubClient so it stays a model.Client as that interface grows.
+type countingClient struct {
+	stubClient
+	calls *int
+}
+
+func (c countingClient) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	*c.calls++
+	return c.stubClient.Complete(ctx, req)
+}
+
+// Every rung bills to the same provider account, so escalating past a quota
+// refusal spends latency to arrive at the same refusal — and the LAST rung's
+// error is the one the caller sees. That is how a spending cap reached an
+// operator as "the model returned something unreadable": the honest refusal
+// below was overwritten by whatever the rung above failed with.
+func TestAQuotaRefusalStopsTheLadderInsteadOfEscalating(t *testing.T) {
+	premiumCalls := 0
+	r := assembleRouter(
+		map[Tier]model.Client{
+			TierCheapCloud: stubClient{err: fmt.Errorf("ai: openai: %w", ErrProviderQuota)},
+			TierPremium: countingClient{
+				stubClient: stubClient{err: errors.New("premium returned something unreadable")},
+				calls:      &premiumCalls,
+			},
+		},
+		nil, ProfileCloudFrontier, stubMeter{}, unlimitedBudget{}, &fakeCallStore{},
+		map[Tier]routeMeta{
+			TierCheapCloud: {provider: "openai", model: "gpt-cheap"},
+			TierPremium:    {provider: "anthropic", model: "claude-premium"},
+		},
+		false, nil,
+	)
+	r.now = func() time.Time { return time.Unix(0, 0) }
+
+	_, _, err := r.serveCompletion(wsCtx(), TaskColdStart, []Tier{TierCheapCloud, TierPremium}, model.Request{})
+
+	if premiumCalls != 0 {
+		t.Fatalf("the rung above was asked %d time(s); an empty account cannot pay for it either", premiumCalls)
+	}
+	if !errors.Is(err, ErrProviderQuota) {
+		t.Fatalf("the caller is told the account refused, not what a later rung did: %v", err)
+	}
+}
+
+// A throttle is the opposite: another tier is another limit, so the ladder
+// keeps walking and a burst on one provider still gets an answer.
+func TestAThrottleStillEscalates(t *testing.T) {
+	premiumCalls := 0
+	r := assembleRouter(
+		map[Tier]model.Client{
+			TierCheapCloud: stubClient{err: fmt.Errorf("ai: openai: %w", ErrProviderThrottled)},
+			TierPremium: countingClient{
+				stubClient: stubClient{resp: model.Response{Text: "premium answer", OutputTokens: 2}},
+				calls:      &premiumCalls,
+			},
+		},
+		nil, ProfileCloudFrontier, stubMeter{}, unlimitedBudget{}, &fakeCallStore{},
+		map[Tier]routeMeta{
+			TierCheapCloud: {provider: "openai", model: "gpt-cheap"},
+			TierPremium:    {provider: "anthropic", model: "claude-premium"},
+		},
+		false, nil,
+	)
+	r.now = func() time.Time { return time.Unix(0, 0) }
+
+	_, info, err := r.serveCompletion(wsCtx(), TaskColdStart, []Tier{TierCheapCloud, TierPremium}, model.Request{})
+
+	if err != nil || info.Tier != TierPremium {
+		t.Fatalf("a rate-limited rung escalates to the next: err=%v tier=%s", err, info.Tier)
+	}
+	if premiumCalls != 1 {
+		t.Fatalf("premium calls = %d, want 1", premiumCalls)
 	}
 }

--- a/backend/internal/modules/ai/tracing.go
+++ b/backend/internal/modules/ai/tracing.go
@@ -147,6 +147,22 @@ func (r *Router) attemptLadder(ctx context.Context, b *binding, lc *logicalCall,
 		out, callErr := b.clients[t].Complete(ctx, req)
 		if callErr != nil {
 			lastErr, lastTier = callErr, t
+			// A refused account is the operator's to fix, and only the rung
+			// that hit it knows so. The walk keeps just `lastErr`, so an
+			// escalation overwrites that refusal with whatever the rung above
+			// failed with — which is exactly how a spending cap reached an
+			// operator as "the model returned something unreadable". Stopping
+			// here keeps the one error they can act on.
+			//
+			// Rungs may be different vendors, so the rung above might well
+			// have answered. That trade is deliberate: a silent fallback bills
+			// a premium provider for every call while the configured cheap one
+			// is unusable and nobody is told. A throttle keeps escalating,
+			// because it clears by itself and names no account to fix.
+			if errors.Is(callErr, ErrProviderQuota) {
+				lc.append(r.traceForFailedRung(b, base, t, callErr, start))
+				break
+			}
 			if i < len(boundRungs)-1 {
 				lc.append(r.traceForFailedRung(b, base, t, callErr, start))
 			}

--- a/backend/internal/modules/ai/voicebuilder.go
+++ b/backend/internal/modules/ai/voicebuilder.go
@@ -40,6 +40,20 @@ func SafeVoiceBuildFailure(err error) string {
 	if err == nil {
 		return "The build failed. Try again."
 	}
+	// Asked FIRST, and by sentinel rather than by message: a provider that
+	// refused on billing never ran the model, so every message below it would
+	// be a claim about an answer nobody received. This was the defect — a
+	// spending cap read to the operator as "the model could not produce a
+	// valid profile", which sent them looking at their writing samples.
+	if errors.Is(err, ErrProviderQuota) {
+		return "Our AI provider refused the call: the account behind it is out of budget or over its quota, so the build never ran. Your previous version is unchanged. Raise the limit on the provider account, then build again."
+	}
+	// A burst limit, not an empty account: the same build succeeds shortly,
+	// and telling this operator to go raise a spending limit would send them
+	// to a console where nothing is wrong.
+	if errors.Is(err, ErrProviderThrottled) {
+		return "Our AI provider is rate limiting us right now, so the build did not run. Your previous version is unchanged; wait a minute and build again."
+	}
 	text := strings.ToLower(err.Error())
 	switch {
 	// Only OUR OWN word-floor message is safe verbatim: match its exact
@@ -51,7 +65,7 @@ func SafeVoiceBuildFailure(err error) string {
 		strings.Contains(text, "not bound"), strings.Contains(text, "unbound"):
 		return "Voice building is unavailable until an AI provider is configured."
 	default:
-		return "The voice model could not produce a valid profile. Your previous version is unchanged; try again."
+		return "The voice model returned something we could not read as a profile. Your previous version is unchanged; try again, and if it keeps failing the model or its configuration is at fault rather than your samples."
 	}
 }
 

--- a/backend/internal/modules/ai/voicebuilder_test.go
+++ b/backend/internal/modules/ai/voicebuilder_test.go
@@ -6,6 +6,10 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -206,5 +210,107 @@ func TestVoicePromptNamesTheValidSampleIDs(t *testing.T) {
 	}
 	if !strings.Contains(brain.prompt, "Valid sample ids: s-email, s-spoken") {
 		t.Fatal("the prompt must enumerate the exact ids the model may cite")
+	}
+}
+
+// The message a failed build shows its operator is the only thing they get, so
+// each cause has to be distinguishable in it. A provider that refused on
+// billing never ran the model, and saying otherwise sent an operator to audit
+// writing samples over a spending cap.
+func TestSafeVoiceBuildFailureNamesTheCause(t *testing.T) {
+	quota := fmt.Errorf("voice build model call: %w: ai: gemini: RESOURCE_EXHAUSTED: spending cap (http 429)", ErrProviderQuota)
+	message := SafeVoiceBuildFailure(quota)
+	if !strings.Contains(strings.ToLower(message), "budget") {
+		t.Fatalf("a provider out of budget says so: %q", message)
+	}
+	if strings.Contains(strings.ToLower(message), "could not produce") {
+		t.Fatalf("the model never ran, so nothing may claim it answered badly: %q", message)
+	}
+
+	// A model that DID answer, unreadably, keeps its own separate wording —
+	// otherwise one message covers two causes again.
+	unreadable := SafeVoiceBuildFailure(errors.New("voice build model call: ai: output rejected by the validator"))
+	if unreadable == message {
+		t.Fatal("a bad model answer and a billing refusal are different failures and read differently")
+	}
+
+	// Nothing leaks the provider's own payload to the operator.
+	for _, leak := range []string{"RESOURCE_EXHAUSTED", "http 429", "gemini"} {
+		if strings.Contains(message, leak) {
+			t.Fatalf("message leaks provider internals (%q): %q", leak, message)
+		}
+	}
+}
+
+// Every provider ADAPTER marks its own 429 — asserted through the real error
+// functions, not through the helper they share. Testing the helper alone let
+// three of four adapters drop their wrap with the suite still green.
+func TestEveryProviderAdapterMarksAQuotaRefusal(t *testing.T) {
+	// The body each vendor returns, so the adapter takes its structured path
+	// rather than its "could not parse" fallback.
+	adapters := []struct {
+		name string
+		body string
+		read func(*http.Response) error
+	}{
+		{"gemini", `{"error":{"status":"RESOURCE_EXHAUSTED","message":"cap reached"}}`, geminiError},
+		{"openai", `{"error":{"type":"insufficient_quota","message":"cap reached"}}`, openaiError},
+		{"anthropic", `{"error":{"type":"rate_limit_error","message":"cap reached"}}`, anthropicError},
+		{"openai-compat", `{"error":{"type":"insufficient_quota","message":"cap reached"}}`, openAICompatError},
+	}
+	for _, adapter := range adapters {
+		t.Run(adapter.name, func(t *testing.T) {
+			read := func(status int, body, retryAfter string) error {
+				resp := refusalResponse(status, body, retryAfter)
+				defer func() {
+					if closeErr := resp.Body.Close(); closeErr != nil {
+						t.Errorf("closing the provider response: %v", closeErr)
+					}
+				}()
+				return adapter.read(resp)
+			}
+
+			// An account with nothing left names no moment to come back at.
+			refusal := read(http.StatusTooManyRequests, adapter.body, "")
+			if !errors.Is(refusal, ErrProviderQuota) {
+				t.Fatalf("a 429 naming no retry moment is a quota refusal: %v", refusal)
+			}
+			if !strings.Contains(SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", refusal)), "out of budget") {
+				t.Fatal("the build message names the account, not the model")
+			}
+
+			// A burst limit says when to return, and is not the same failure.
+			throttle := read(http.StatusTooManyRequests, adapter.body, "30")
+			if !errors.Is(throttle, ErrProviderThrottled) || errors.Is(throttle, ErrProviderQuota) {
+				t.Fatalf("Retry-After marks a throttle, not an empty account: %v", throttle)
+			}
+
+			// A body this adapter cannot parse still classifies by status:
+			// the fallback path is the one a vendor outage actually takes.
+			garbled := read(http.StatusTooManyRequests, "<html>gateway</html>", "")
+			if !errors.Is(garbled, ErrProviderQuota) {
+				t.Fatalf("an unparseable 429 body is still a refusal: %v", garbled)
+			}
+
+			// Any other status is an ordinary provider error. Dressing one up
+			// as a billing problem sends an operator to the wrong console.
+			other := read(http.StatusInternalServerError, adapter.body, "")
+			if errors.Is(other, ErrProviderQuota) || errors.Is(other, ErrProviderThrottled) {
+				t.Fatalf("only a 429 is a quota or throttle answer: %v", other)
+			}
+		})
+	}
+}
+
+// One provider response, as the adapters read it.
+func refusalResponse(status int, body, retryAfter string) *http.Response {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if retryAfter != "" {
+		header.Set("Retry-After", retryAfter)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/frontend/src/screens/voice-dna.test.tsx
+++ b/frontend/src/screens/voice-dna.test.tsx
@@ -390,6 +390,87 @@ describe("a build that fails", () => {
     expect(screen.queryByText(/Cannot read properties/)).toBeNull();
   });
 
+  // The build the reader actually hits: the POST succeeds, the job runs, and
+  // the row comes back `failed` carrying the server's own explanation. That
+  // detail used to be dropped on the floor, leaving one fixed sentence to
+  // stand for a spending cap, an unreadable model answer and a broken
+  // provider alike — and it told the reader to "try again", which could not
+  // work for the first of those.
+  it("says what the finished build says, not a fixed sentence", async () => {
+    const detail =
+      "Our AI provider is out of budget, so the build never ran. Your previous version is unchanged.";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+        if (path === "/me") {
+          return jsonResponse(meFixture({ allow: VOICE_EDITOR }));
+        }
+        if (path === "/voice-profiles") {
+          return jsonResponse({ data: [BUILDABLE], page: emptyPage.page });
+        }
+        if (path === "/voice-profiles/vp-1/sources") {
+          return jsonResponse({ data: [SOURCE], summary: SUMMARY });
+        }
+        if (path === "/voice-profiles/vp-1/builds") {
+          return jsonResponse({ id: "vb-1", status: "queued" }, 201);
+        }
+        if (path === "/voice-profiles/vp-1/builds/vb-1") {
+          return jsonResponse({
+            id: "vb-1",
+            status: "failed",
+            status_code: "model_unavailable",
+            status_detail: detail,
+          });
+        }
+        return jsonResponse(emptyPage);
+      }),
+    );
+
+    await pressRebuild();
+
+    expect(await screen.findByText(detail)).toBeTruthy();
+    // The old catch-all is gone, so a reader is never told to retry something
+    // that cannot succeed until somebody raises a spending limit.
+    expect(screen.queryByText(/The build didn't finish/)).toBeNull();
+  });
+
+  // An older server, or an outcome the server had nothing to add about, still
+  // gets a sentence rather than an empty line.
+  it("falls back to its own wording when the build carries no detail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+        if (path === "/me") {
+          return jsonResponse(meFixture({ allow: VOICE_EDITOR }));
+        }
+        if (path === "/voice-profiles") {
+          return jsonResponse({ data: [BUILDABLE], page: emptyPage.page });
+        }
+        if (path === "/voice-profiles/vp-1/sources") {
+          return jsonResponse({ data: [SOURCE], summary: SUMMARY });
+        }
+        if (path === "/voice-profiles/vp-1/builds") {
+          return jsonResponse({ id: "vb-1", status: "queued" }, 201);
+        }
+        if (path === "/voice-profiles/vp-1/builds/vb-1") {
+          return jsonResponse({
+            id: "vb-1",
+            status: "failed",
+            status_code: null,
+            status_detail: null,
+          });
+        }
+        return jsonResponse(emptyPage);
+      }),
+    );
+
+    await pressRebuild();
+
+    expect(await screen.findByText(/The build didn't finish/)).toBeTruthy();
+  });
+
   it("shows the server's own cause when the server composed one", async () => {
     stubBuild(() =>
       jsonResponse(

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -622,6 +622,31 @@ function SourceRow({
   );
 }
 
+/** How a build ended, and the server's own words about it when it has any. */
+type BuildOutcome = Readonly<{
+  status: "succeeded" | "failed" | "deferred" | "pending";
+  /** `status_detail` from the build row: safe operator guidance, already
+   * written for a reader. Null when the server had nothing to add. */
+  detail?: string | null;
+}>;
+
+// What the reader is told a finished build did.
+//
+// The server's own sentence wins whenever it sent one, because only the server
+// knows WHY — a provider out of budget, a model answer it could not read, a
+// configuration that is missing. The local strings stay as the fallback for an
+// older server, and for the outcomes that carry no detail.
+function buildOutcomeText(
+  t: ReturnType<typeof useT>,
+  outcome: BuildOutcome,
+): string {
+  const detail = outcome.detail?.trim();
+  if (detail) {
+    return detail;
+  }
+  return t(`settings.voice.buildStatus.${outcome.status}`);
+}
+
 // Build creates a durable background build; poll to a terminal state. A slow or
 // budget-deferred build is honestly reported, not spun on forever.
 //
@@ -644,15 +669,17 @@ function BuildControls({
 }>) {
   const t = useT();
   const { locale } = useLocale();
-  const [status, setStatus] = useState<
-    "succeeded" | "failed" | "deferred" | "pending" | null
-  >(null);
+  // The outcome AND what the server said about it. A terminal build carries
+  // `status_detail` — safe operator guidance the server composed for exactly
+  // this moment — and dropping it left one fixed sentence standing in for
+  // every cause: a spending cap, an unreadable model answer and a broken
+  // provider all read as "the build didn't finish", so "try again" was advice
+  // that could not work.
+  const [outcome, setOutcome] = useState<BuildOutcome | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const build = useMutation({
-    mutationFn: async (): Promise<
-      "succeeded" | "failed" | "deferred" | "pending"
-    > => {
+    mutationFn: async (): Promise<BuildOutcome> => {
       const created = await api.POST("/voice-profiles/{id}/builds", {
         params: { path: { id: profile.id } },
         body: { reason: "manual" },
@@ -669,23 +696,27 @@ function BuildControls({
         if (err) {
           throwProblem(err);
         }
+        // Spelled as three comparisons rather than a set lookup: this is what
+        // proves to the compiler that the status is one a BuildOutcome may
+        // hold, so a new server state cannot be passed through untyped.
         if (
           data.status === "succeeded" ||
           data.status === "failed" ||
           data.status === "deferred"
         ) {
-          return data.status;
+          return { status: data.status, detail: data.status_detail };
         }
         await new Promise((resolve) => {
           globalThis.setTimeout(resolve, 1500);
         });
       }
       // Still queued/running after the poll budget — honestly "pending", not
-      // "deferred" (which specifically means the AI budget snoozed it).
-      return "pending";
+      // "deferred" (which specifically means the AI budget snoozed it). There
+      // is no detail to carry: nothing terminal happened to describe.
+      return { status: "pending", detail: null };
     },
-    onSuccess: (finalStatus) => {
-      setStatus(finalStatus);
+    onSuccess: (finalOutcome) => {
+      setOutcome(finalOutcome);
       setError(null);
       onBuilt();
     },
@@ -755,7 +786,7 @@ function BuildControls({
                 is not reliably announced, which would leave the one thing they
                 are waiting for arriving in silence. */}
             <p className="t-small" role="status">
-              {status ? t(`settings.voice.buildStatus.${status}`) : ""}
+              {outcome ? buildOutcomeText(t, outcome) : ""}
             </p>
             {error && (
               <p className="t-small" role="alert">


### PR DESCRIPTION
## What was wrong

Pressing **Build my Voice DNA** showed *"The build didn't finish — try again."* The real cause, from the worker log:

```
ai: gemini: RESOURCE_EXHAUSTED: Your project has exceeded its monthly
spending cap. (http 429)
```

"Try again" was advice that could not work: nothing changes until somebody raises the limit.

Three defects, each hiding the one below it.

**1. The builder asserted something false.** `SafeVoiceBuildFailure` had cases for the word floor and for "no provider configured", and a provider quota refusal fell to a default claiming *"The voice model could not produce a valid profile"* — a statement about an answer that was never received.

**2. The tier ladder escalated past it.** `attemptLadder` kept only `lastErr`, so a cheap-tier quota refusal followed by a premium failure of another kind lost the sentinel entirely, and the generic message came back one tier down.

**3. The UI threw the server's explanation away.** The build poll kept only `data.status`; `status_detail` — safe operator guidance the server composes for exactly this moment, already required by the contract — was discarded, so one fixed string stood for every cause.

## What changed

- `ErrProviderQuota` and `ErrProviderThrottled` split the two things a 429 means. `Retry-After` separates them: a throttle names a moment to return, an exhausted account names none. The header is read through `shared/kernel/retryafter`, the tree's single reader for it.
- All four provider adapters (gemini, openai, anthropic, openai-compat) wrap their own 429, structured and fallback paths alike.
- The ladder stops on a quota refusal and still escalates a throttle. Deliberate trade-off, stated in the code: rungs may be different vendors, so a silent fallback would bill a premium provider for every call while the configured cheap one is unusable and nobody is told.
- The builder names the account or the rate limit; the default case now says the model returned something unreadable rather than claiming it judged a profile.
- The poll carries `status_detail` and the status line prefers it, falling back to the local wording for an older server or an outcome with nothing to add.

## Verified

- `make check` green (exit 0, zero failures); `craft static --strict` and `rls-store-path` clean.
- Every new test mutation-checked: reverting the builder branch, the ladder stop, the frontend detail preference, and the wrap in each of the three non-Gemini adapters each turns its test red.
- Full chain over a real HTTP 429 (`quota429_test.go`): the operator gets the budget message and no provider payload leaks.
- In the browser on a dev stack, the build's own detail now renders in the status line.

## Reviewed

Codex found four issues on the first pass; all fixed here — a missing licence header, the ladder escalation (2 above), quota-versus-throttle conflation, and provider tests that could not catch three adapters regressing.

## Known, filed separately

[#3195](https://github.com/margince/margince/issues/3195) — with a working provider and 1,593 words, a build can still fail because the model returns malformed JSON after retry and escalation. The message is now honest about it; the build still does not complete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes voice build failures so the UI shows the real cause instead of a generic "try again" message. A provider quota refusal (HTTP 429) previously appeared as "The build didn't finish — try again," which could never succeed until someone raised the spending cap.

**Bug Fixes**
- Classifies provider 429s as quota refusals or throttles using the Retry-After header, and wraps them in all four provider adapters.
- Stops the tier ladder from escalating past a quota refusal, so the operator sees the actionable error instead of a later rung's failure; throttles still escalate.
- Carries `status_detail` through the build poll and prefers it in the status line, falling back to local wording when the server sends none.

<sup>Written for commit c746338a5a4a5655b7a71838bb9ff7a99f4848b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI provider quota errors are now distinguished from temporary throttling, preventing unnecessary fallback attempts when usage limits are reached.
  * Voice build failures now provide clearer, actionable messages without exposing provider-specific technical details.
  * Voice build status screens display detailed server-provided failure information when available.
  * Failed builds clearly indicate that the build did not complete and the previous version remains unchanged.
* **Reliability**
  * Temporary provider throttling continues to use fallback providers when available, while quota-related failures stop escalation appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->