### PR TITLE
Two things that looked like links and were not

### DIFF
--- a/frontend/src/format/weburl.test.ts
+++ b/frontend/src/format/weburl.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { describe, expect, it } from "vitest";
-import { webUrl } from "./weburl";
+import { linkedinUrl, webUrl } from "./weburl";
 
 // The guard three surfaces share: a company link on a reading chip, a
 // provider's source document in the person drawer, and a custom field holding
@@ -52,5 +52,48 @@ describe("what may become a link", () => {
     // `mailto:` is a real destination and still not a link this guard makes:
     // a surface that wants one asks for it deliberately.
     expect(webUrl("mailto:sofia@example.com")).toBeNull();
+  });
+});
+
+// A link's LABEL is a claim about where it goes. These labels are fixed words
+// ("LinkedIn", "Open profile") rather than the address, and the value behind
+// them can be written by a crawl, a connector or a paste — so the host has to
+// be checked before the word is allowed to stand over an anchor.
+describe("what may be shown as a LinkedIn profile", () => {
+  it("admits the profile hosts LinkedIn actually serves", () => {
+    for (const address of [
+      "https://linkedin.com/in/dana",
+      "https://www.linkedin.com/in/dana",
+      "https://de.linkedin.com/in/dana",
+      "https://lnkd.in/abc123",
+    ]) {
+      expect(linkedinUrl(address)?.href).toBeTruthy();
+    }
+  });
+
+  it("refuses another host under LinkedIn's name", () => {
+    // The phishing shapes: a plain impostor, a lookalike that ENDS in the
+    // right characters without being the right host, and one that merely
+    // contains it.
+    for (const address of [
+      "https://attacker.example/login",
+      "https://notlinkedin.com/in/dana",
+      "https://linkedin.com.attacker.example/in/dana",
+      "https://attacker.example/linkedin.com/in/dana",
+    ]) {
+      expect(linkedinUrl(address)).toBeNull();
+    }
+  });
+
+  it("refuses what webUrl already refuses", () => {
+    // The host check is added to the scheme check, never instead of it.
+    for (const address of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "linkedin.com/in/dana",
+      "",
+    ]) {
+      expect(linkedinUrl(address)).toBeNull();
+    }
   });
 });

--- a/frontend/src/format/weburl.ts
+++ b/frontend/src/format/weburl.ts
@@ -29,3 +29,31 @@ export function webUrl(value: string): URL | null {
     ? parsed
     : null;
 }
+
+// The hosts a LinkedIn profile can honestly live on.
+const LINKEDIN_HOSTS = ["linkedin.com", "lnkd.in"];
+
+// Whether a stored profile address may be shown under the word "LinkedIn".
+//
+// A link's LABEL is a claim about where it goes, and these labels are fixed
+// words rather than the address itself. `social` is an open map on the wire and
+// a profile URL can be written by a crawl, a connector or a paste, so without a
+// host check a value of `https://attacker.example/login` renders as a link
+// reading "LinkedIn" inside the product's own chrome — which is a better
+// phishing surface than an email, because the reader already trusts the frame.
+//
+// A refused value is not hidden: the caller keeps the fact and drops the link,
+// the same way `webUrl` leaves an unparseable address as text. The fact that a
+// contact has SOMETHING recorded is still worth showing; the claim that it is
+// LinkedIn is what this withholds.
+export function linkedinUrl(value: string): URL | null {
+  const parsed = webUrl(value);
+  if (!parsed) {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  const onHost = LINKEDIN_HOSTS.some(
+    (allowed) => host === allowed || host.endsWith(`.${allowed}`),
+  );
+  return onHost ? parsed : null;
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1653,6 +1653,7 @@ export const de = {
     "Margince liest Meetings, Mails und Rechnungen auf Zusagen, Blocker und Risiken. Dafür braucht es zuerst mindestens eines davon.",
   "co.signals.empty": "Kein offenes Signal zu diesem Account.",
   "co.signals.openProject": "Projekt öffnen",
+  "co.signals.openSource": "Meldung lesen",
   "chronology.label": "Was im Verlauf angezeigt wird",
   "chronology.activities": "Aktivitäten",
   "chronology.changes": "Änderungen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1681,6 +1681,7 @@ export const en = {
     "Margince reads meetings, mail and invoices for promises, blockers and risks. It needs at least one of those first.",
   "co.signals.empty": "No open signal on this account.",
   "co.signals.openProject": "Open the project",
+  "co.signals.openSource": "Read the announcement",
   "chronology.label": "What to show in the timeline",
   "chronology.activities": "Activities",
   "chronology.changes": "Changes",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1641,6 +1641,7 @@ export const vi = {
     "Margince đọc cuộc họp, email và hóa đơn để tìm lời hứa, vướng mắc và rủi ro. Trước hết cần có ít nhất một trong số đó.",
   "co.signals.empty": "Không có tín hiệu nào đang mở trên tài khoản này.",
   "co.signals.openProject": "Mở dự án",
+  "co.signals.openSource": "Đọc thông báo",
   "chronology.label": "Hiện gì trên timeline",
   "chronology.activities": "Hoạt động",
   "chronology.changes": "Thay đổi",

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -6,6 +6,7 @@ import { routeHash } from "../app/router";
 import { Avatar, Button, Disclosure } from "../design-system/atoms";
 import { AvatarStack } from "../design-system/avatarstack";
 import { EvidenceMark } from "../design-system/evidencemark";
+import { OffsiteLink } from "../design-system/offsitelink";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import {
   type SectionState,
@@ -388,15 +389,40 @@ function PersonRow({ contact }: Readonly<{ contact: Contact }>) {
 }
 
 /**
+ * SourcePageLink opens the page a signal was read off, when it names one.
+ *
+ * The address rides `evidence` rather than a field of its own: a signal cites
+ * its source, and a citation is per-claim. `source_type: "page"` is the one
+ * kind that is a web address — the others point at rows inside this product,
+ * which a reader reaches by other means — so it is the only one linked here.
+ *
+ * Renders nothing when no evidence names a page, which is the ordinary case
+ * for a signal derived from the product's own records.
+ */
+function SourcePageLink({ signal }: Readonly<{ signal: Signal }>) {
+  const t = useT();
+  const page = (signal.evidence ?? []).find(
+    (cited) => cited.source_type === "page" && cited.source_id,
+  );
+  if (!page?.source_id) {
+    return null;
+  }
+  return (
+    <OffsiteLink href={page.source_id} className="co-rowlink co-signal-link">
+      {t("co.signals.openSource")}
+    </OffsiteLink>
+  );
+}
+
+/**
  * SignalsSection reads the account-filtered signals, same endpoint and same
  * withheld/failed handling SignalsCard used. Signals are a separately
  * governed surface, not a 360 section, so this runs its own query rather
  * than reading a slice of `view`.
  *
- * No longer mounted by CompanyRail — signals moved out of the rail to sit
- * beside the account's other readings — but exported rather than deleted so
- * that new home can mount it without a second implementation of the same
- * read.
+ * Not mounted by CompanyRail — signals moved out of the rail to sit beside the
+ * account's other readings, and the company record's overview stack mounts it
+ * there.
  */
 export function SignalsSection({ orgId }: Readonly<{ orgId: string }>) {
   const t = useT();
@@ -464,6 +490,12 @@ export function SignalsSection({ orgId }: Readonly<{ orgId: string }>) {
                   {t("co.signals.openProject")}
                 </a>
               )}
+              {/* The page the claim was read off. A newsroom signal cites the
+                  article rather than copying it, so the headline on this row
+                  is the whole of what we hold — without the address, a reader
+                  who wants the announcement itself has nowhere to go and the
+                  citation proves nothing. */}
+              <SourcePageLink signal={signal} />
             </span>
             <span className="co-row-meta">
               {formatDate(signal.detected_at, locale, recordZone)}

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -18,6 +18,7 @@ import {
   formatMoneyOrAbsent,
   formatNumber,
 } from "../format/format";
+import { webUrl } from "../format/weburl";
 import { useLocale, useT } from "../i18n";
 import { problemCodeOf, throwProblem } from "./common";
 import { NewDealAction } from "./companyactions";
@@ -401,8 +402,18 @@ function PersonRow({ contact }: Readonly<{ contact: Contact }>) {
  */
 function SourcePageLink({ signal }: Readonly<{ signal: Signal }>) {
   const t = useT();
-  const page = (signal.evidence ?? []).find(
-    (cited) => cited.source_type === "page" && cited.source_id,
+  // Array-checked rather than `?? []`: the client validates no response body,
+  // so a server ahead of this tab could send a shape `.find` cannot walk, and
+  // the throw would take the whole account page down over one row's citation.
+  const cited = Array.isArray(signal.evidence) ? signal.evidence : [];
+  // The first citation that is actually reachable, not the first one CLAIMING
+  // to be a page: a malformed address in the first slot would otherwise hide a
+  // good one behind it, and the row would fall silently back to no link.
+  const page = cited.find(
+    (one) =>
+      one?.source_type === "page" &&
+      typeof one.source_id === "string" &&
+      webUrl(one.source_id) !== null,
   );
   if (!page?.source_id) {
     return null;

--- a/frontend/src/screens/companysignals.test.tsx
+++ b/frontend/src/screens/companysignals.test.tsx
@@ -1,0 +1,153 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { SignalsSection } from "./companyrail";
+
+// A newsroom signal CITES its article rather than copying it, so the headline
+// on the row is the whole of what this product holds. Without the address the
+// citation proves nothing and a reader who wants the announcement has nowhere
+// to go — which is what this file exists to keep from happening again.
+//
+// Its own file rather than companyrail.test.tsx's: that one is already past
+// the 1000-line ceiling test files split at.
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function signal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "s-1",
+    kind: "funding",
+    source_channel: "web",
+    resolution_state: "resolved",
+    severity: "info",
+    summary: "Brandt Automotive raises a Series B",
+    evidence: [],
+    status: "open",
+    detected_at: "2026-06-01T08:00:00Z",
+    source: "newsroom",
+    captured_by: "system",
+    created_at: "2026-06-01T08:00:00Z",
+    updated_at: "2026-06-01T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function stubSignals(rows: readonly unknown[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      jsonResponse({
+        data: rows,
+        page: { has_more: false, next_cursor: null },
+      }),
+    ),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("SignalsSection", () => {
+  it("links the page a signal was read off", async () => {
+    stubSignals([
+      signal({
+        evidence: [
+          {
+            snippet: "Brandt Automotive raises a Series B",
+            source_type: "page",
+            source_id: "https://brandt.example/news/series-b",
+          },
+        ],
+      }),
+    ]);
+
+    render(<SignalsSection orgId="o-1" />);
+
+    const link = await screen.findByRole("link", {
+      name: "Read the announcement",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://brandt.example/news/series-b",
+    );
+    // Opened away from the app, and without handing the destination this
+    // record's address in a Referer.
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+  });
+
+  it("offers no source link when nothing was read off a page", async () => {
+    // A signal derived from this product's own records cites a row, not a web
+    // address. An "open the source" link pointing at an internal id would send
+    // a reader nowhere.
+    stubSignals([
+      signal({
+        summary: "Two meetings booked and none held",
+        evidence: [
+          {
+            snippet: "Two meetings booked and none held",
+            source_type: "activity",
+            source_id: "01a04fdf-7a3c-75f6-bdf6-5f868ea3a705",
+          },
+        ],
+      }),
+    ]);
+
+    render(<SignalsSection orgId="o-1" />);
+
+    expect(
+      await screen.findByText("Two meetings booked and none held"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Read the announcement" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the headline as text when the cited address is not a web page", async () => {
+    // A stored value that is not an http(s) URL degrades to no link rather
+    // than to a dead anchor a reader would click.
+    stubSignals([
+      signal({
+        evidence: [
+          {
+            snippet: "Brandt Automotive raises a Series B",
+            source_type: "page",
+            source_id: "javascript:alert(1)",
+          },
+        ],
+      }),
+    ]);
+
+    render(<SignalsSection orgId="o-1" />);
+
+    expect(
+      await screen.findByText("Brandt Automotive raises a Series B"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Read the announcement" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/companysignals.test.tsx
+++ b/frontend/src/screens/companysignals.test.tsx
@@ -94,17 +94,23 @@ describe("SignalsSection", () => {
       "https://brandt.example/news/series-b",
     );
     // Opened away from the app, and without handing the destination this
-    // record's address in a Referer.
+    // record's address in a Referer. Asserted as TOKENS rather than as a
+    // substring: "notnoreferrer" contains "noreferrer" and is not a relation
+    // any browser honours, so a substring check passes a mutation that
+    // restores both window.opener access and the Referer leak.
     expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+    const rel = (link.getAttribute("rel") ?? "").split(/\s+/);
+    expect(rel).toContain("noopener");
+    expect(rel).toContain("noreferrer");
   });
 
-  it("offers no source link when nothing was read off a page", async () => {
-    // A signal derived from this product's own records cites a row, not a web
-    // address. An "open the source" link pointing at an internal id would send
-    // a reader nowhere.
+  it("links only the row whose citation is a page", async () => {
+    // Both rows render together, so "no link here" is proved against a link
+    // that DOES appear in the same pass — otherwise the assertion passes just
+    // as well when the component is deleted outright.
     stubSignals([
       signal({
+        id: "s-internal",
         summary: "Two meetings booked and none held",
         evidence: [
           {
@@ -114,21 +120,80 @@ describe("SignalsSection", () => {
           },
         ],
       }),
+      signal({
+        id: "s-news",
+        summary: "Brandt Automotive raises a Series B",
+        evidence: [
+          {
+            snippet: "Brandt Automotive raises a Series B",
+            source_type: "page",
+            source_id: "https://brandt.example/news/series-b",
+          },
+        ],
+      }),
+    ]);
+
+    render(<SignalsSection orgId="o-1" />);
+
+    // Exactly one link, and it belongs to the row that cited a page.
+    const links = await screen.findAllByRole("link", {
+      name: "Read the announcement",
+    });
+    expect(links).toHaveLength(1);
+    const row = links[0].closest(".co-signal-row");
+    expect(row?.textContent).toContain("Brandt Automotive raises a Series B");
+    expect(row?.textContent).not.toContain("Two meetings booked");
+  });
+
+  it("reaches past a malformed citation to a usable one", async () => {
+    // `.find` stopping at the first entry that merely CLAIMS to be a page
+    // would hide the reachable address behind it, and the row would fall
+    // silently back to no link at all.
+    stubSignals([
+      signal({
+        evidence: [
+          {
+            snippet: "…",
+            source_type: "page",
+            source_id: "javascript:alert(1)",
+          },
+          {
+            snippet: "Brandt Automotive raises a Series B",
+            source_type: "page",
+            source_id: "https://brandt.example/news/series-b",
+          },
+        ],
+      }),
+    ]);
+
+    render(<SignalsSection orgId="o-1" />);
+
+    const link = await screen.findByRole("link", {
+      name: "Read the announcement",
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://brandt.example/news/series-b",
+    );
+  });
+
+  it("survives an evidence shape it cannot walk", async () => {
+    // The client validates no response body, so a server ahead of this tab can
+    // send a shape `.find` would throw on — and a throw here blanks the whole
+    // account page over one row's citation.
+    stubSignals([
+      signal({ summary: "Shape from a newer server", evidence: {} }),
     ]);
 
     render(<SignalsSection orgId="o-1" />);
 
     expect(
-      await screen.findByText("Two meetings booked and none held"),
+      await screen.findByText("Shape from a newer server"),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Read the announcement" }),
-    ).not.toBeInTheDocument();
   });
 
-  it("renders the headline as text when the cited address is not a web page", async () => {
-    // A stored value that is not an http(s) URL degrades to no link rather
-    // than to a dead anchor a reader would click.
+  it("draws no anchor at all when every citation is unusable", async () => {
+    // A scheme that would execute on click never reaches an href, and nothing
+    // is left in its place: an anchor with no destination is worse than none.
     stubSignals([
       signal({
         evidence: [
@@ -146,8 +211,6 @@ describe("SignalsSection", () => {
     expect(
       await screen.findByText("Brandt Automotive raises a Series B"),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Read the announcement" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Read the announcement")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -482,6 +482,11 @@ describe("the contact's LinkedIn on the header", () => {
       "https://www.linkedin.com/in/dana-buyer",
     );
     expect(link.getAttribute("target")).toBe("_blank");
+    // Tokens rather than a substring: "notnoreferrer" contains "noreferrer"
+    // and is not a relation any browser honours.
+    const rel = (link.getAttribute("rel") ?? "").split(/\s+/);
+    expect(rel).toContain("noopener");
+    expect(rel).toContain("noreferrer");
   });
 
   it("says nothing at all when no profile is recorded", async () => {
@@ -503,5 +508,42 @@ describe("the contact's LinkedIn on the header", () => {
     const header = await recordHeader();
     expect(within(header).getByText("LinkedIn")).toBeTruthy();
     expect(within(header).queryByRole("link", { name: "LinkedIn" })).toBe(null);
+  });
+
+  it("refuses to put another host under the word LinkedIn", async () => {
+    // The label is a fixed word, so it is a CLAIM about the destination — and
+    // this value can be written by a crawl or a connector. An arbitrary host
+    // under that word is a phishing link wearing the product's own chrome.
+    mount("overview", {
+      ...view,
+      person: {
+        ...view.person,
+        social: { linkedin: "https://attacker.example/login" },
+      },
+    });
+
+    const header = await recordHeader();
+    // The fact is kept — this contact HAS something recorded — and the claim
+    // that it is LinkedIn is what is withheld.
+    expect(within(header).getByText("LinkedIn")).toBeTruthy();
+    expect(within(header).queryByRole("link", { name: "LinkedIn" })).toBe(null);
+  });
+
+  it("accepts a regional LinkedIn subdomain", async () => {
+    // The check is on the host, not on an exact string: de.linkedin.com is
+    // LinkedIn, and refusing it would drop a working link for half of Europe.
+    mount("overview", {
+      ...view,
+      person: {
+        ...view.person,
+        social: { linkedin: "https://de.linkedin.com/in/dana-buyer" },
+      },
+    });
+
+    const header = await recordHeader();
+    const link = within(header).getByRole("link", { name: "LinkedIn" });
+    expect(link.getAttribute("href")).toBe(
+      "https://de.linkedin.com/in/dana-buyer",
+    );
   });
 });

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -460,3 +460,48 @@ describe("which meeting the brief drawer asks about", () => {
     expect(asked).toEqual(["a-held"]);
   });
 });
+
+// The header's meta strip carries a link ICON beside the word LinkedIn, and for
+// a while carried no link — a reader who saw the chain and clicked it got
+// nothing. An affordance that looks like a link has to be one.
+describe("the contact's LinkedIn on the header", () => {
+  const withLinkedin: Person360 = {
+    ...view,
+    person: {
+      ...view.person,
+      social: { linkedin: "https://www.linkedin.com/in/dana-buyer" },
+    },
+  };
+
+  it("opens the profile it names", async () => {
+    mount("overview", withLinkedin);
+
+    const header = await recordHeader();
+    const link = within(header).getByRole("link", { name: "LinkedIn" });
+    expect(link.getAttribute("href")).toBe(
+      "https://www.linkedin.com/in/dana-buyer",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("says nothing at all when no profile is recorded", async () => {
+    mount("overview");
+
+    const header = await recordHeader();
+    expect(within(header).queryByRole("link", { name: "LinkedIn" })).toBe(null);
+    expect(within(header).queryByText("LinkedIn")).toBe(null);
+  });
+
+  it("falls back to plain text when the recorded value is not a web address", async () => {
+    // `social` is an open map on the wire, so its values are whatever was
+    // written there. A dead anchor is worse than no anchor.
+    mount("overview", {
+      ...view,
+      person: { ...view.person, social: { linkedin: "in/dana-buyer" } },
+    });
+
+    const header = await recordHeader();
+    expect(within(header).getByText("LinkedIn")).toBeTruthy();
+    expect(within(header).queryByRole("link", { name: "LinkedIn" })).toBe(null);
+  });
+});

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -21,6 +21,7 @@ import { IconAction } from "../design-system/iconaction";
 import { OffsiteLink } from "../design-system/offsitelink";
 import { liveProjects } from "../design-system/projectpicker";
 import { RecordTabs } from "../design-system/recordtabs";
+import { linkedinUrl } from "../format/weburl";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
@@ -100,6 +101,30 @@ function composerIntentOf(
 ): string {
   const key = COMPOSER_INTENT_KEYS[prefill?.intent ?? ""];
   return key ? t(key) : "";
+}
+
+/**
+ * ProfileLink is the header's LinkedIn fact: a link when the recorded address
+ * really is LinkedIn, the word alone when it is not.
+ *
+ * The label is the fixed word rather than the address, which makes it a CLAIM
+ * about the destination — and `social` is an open map a crawl or a connector
+ * can write. An arbitrary host under that word is a phishing link wearing the
+ * product's own chrome, so the host is checked before the anchor is drawn. The
+ * fact is kept either way: that this contact has a profile recorded is true
+ * whatever the value turns out to be.
+ */
+function ProfileLink({ href }: Readonly<{ href: string }>) {
+  const t = useT();
+  const label = t("person.page.linkedin");
+  if (!linkedinUrl(href)) {
+    return label;
+  }
+  return (
+    <OffsiteLink href={href} className="pe-meta-link">
+      {label}
+    </OffsiteLink>
+  );
 }
 
 /**
@@ -531,9 +556,7 @@ function PersonIdentityLine({
         {typeof person.social?.linkedin === "string" && (
           <span className="pe-meta-fact">
             <LinkIcon size={13} aria-hidden="true" />
-            <OffsiteLink href={person.social.linkedin} className="pe-meta-link">
-              {t("person.page.linkedin")}
-            </OffsiteLink>
+            <ProfileLink href={person.social.linkedin} />
           </span>
         )}
         {/* The role is what the relationship edge records — never inferred from

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -18,6 +18,7 @@ import { navigate } from "../app/router";
 import { Button, OverflowMenu } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { IconAction } from "../design-system/iconaction";
+import { OffsiteLink } from "../design-system/offsitelink";
 import { liveProjects } from "../design-system/projectpicker";
 import { RecordTabs } from "../design-system/recordtabs";
 import { useT } from "../i18n";
@@ -520,11 +521,19 @@ function PersonIdentityLine({
         {/* `social` is an open map on the wire, so its values are unknown to
             the type system. The fact renders only when there is a string to
             stand behind it — a link with nothing at the end is worse than no
-            link at all. */}
+            link at all.
+
+            It IS a link, because it wears a link's icon: a reader who sees the
+            chain and the word clicks it, and for a while this row answered that
+            click with nothing. OffsiteLink falls back to plain text when the
+            value is not a web address, so a malformed one degrades to what this
+            row used to be rather than to a dead anchor. */}
         {typeof person.social?.linkedin === "string" && (
           <span className="pe-meta-fact">
             <LinkIcon size={13} aria-hidden="true" />
-            {t("person.page.linkedin")}
+            <OffsiteLink href={person.social.linkedin} className="pe-meta-link">
+              {t("person.page.linkedin")}
+            </OffsiteLink>
           </span>
         )}
         {/* The role is what the relationship edge records — never inferred from

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -35,6 +35,7 @@ import {
 import { stable } from "../format/collate";
 import { formatDayMonth, formatNumber, relativeDays } from "../format/format";
 import { normalizeProfileUrl } from "../format/profileurl";
+import { linkedinUrl } from "../format/weburl";
 import {
   type Locale,
   type Translator,
@@ -336,7 +337,13 @@ function LinkedinRow({
             })
           }
         />
-        {linkedin ? (
+        {/* The address itself is shown in the row above, so a reader can
+            always see what is recorded. This VERB claims the destination is a
+            profile, and `social` is an open map a crawl or a connector can
+            write — so an address that is not LinkedIn's gets no verb rather
+            than one that would carry the reader somewhere the label did not
+            promise. */}
+        {linkedin && linkedinUrl(linkedin) ? (
           <OffsiteLink href={linkedin}>
             {t("person.page.openProfile")}
           </OffsiteLink>


### PR DESCRIPTION
Two surfaces stored an address and rendered everything except it. Both were found by auditing the enrichment plan against what a user can actually click.

## A news headline had nowhere to go

A newsroom signal **cites** its article rather than copying it — the headline on the row is the whole of what this product holds, and the announcement lives at the URL the crawl recorded. The row drew the kind, the headline and the date. A reader who wanted the announcement had nowhere to go, and the citation proved nothing.

The address was already on the wire: it rides `evidence` as `source_type: "page"`, with the URL in `source_id`. Only the render was missing, so this needs no contract change.

## The contact header's LinkedIn was not a link

It drew a link **icon** plus the word "LinkedIn" as plain text, with the profile URL sitting in the same component's own props. Somebody who saw the chain clicked it and got nothing.

The comment beside it read *"a link with nothing at the end is worse than no link at all"* — true, and describing what the code did.

## Both use `OffsiteLink`

Which falls back to plain text when the stored value is not a web address. A malformed one degrades to what these rows already were rather than to a dead anchor. That matters here: both values can originate from third-party content — a crawled feed, and an open `social` map on the wire.

## Tests

Neither surface had any. `SignalsSection` had **no test file at all**, so its coverage starts here in its own file rather than in `companyrail.test.tsx`, which is already past the 1000-line ceiling test files split at.

Both fixes were mutation-checked: reverting each makes exactly one new test fail.

## Fixed along the way

A docblock claiming `SignalsSection` is "no longer mounted" — the company record's overview stack has mounted it since it moved out of the rail. A comment saying a component is unused is how the next reader stops looking for its callers.

## Checked in a browser

Against a running stack, with both fixtures written through real API endpoints rather than hand-inserted rows:

- A signal carrying a page citation renders **"Read the announcement"** pointing at the stored URL.
- A contact with a `social.linkedin` renders the header word as a link to that profile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes two link-lookalikes into actual links: a newsroom signal's headline now links to the article it cites, and the contact header's LinkedIn word now links to the profile. Both stored the address already; only the render was missing.

**Bug Fixes**
- A signal citing a page renders "Read the announcement" pointing at the stored URL, and survives evidence that isn't an array or that has an unusable citation before a good one.
- The header's LinkedIn fact opens the profile only when the host is actually LinkedIn's; `linkedinUrl` refuses other hosts so a stored impostor shows as plain text instead of a phishing link. The rail's "Open profile" verb carries the same guard.
- Both surfaces fall back to plain text when the value is not a valid web address.

**Tests**
- Adds the first test coverage for `SignalsSection`, in its own file because `companyrail.test.tsx` is already past the line limit test files split at.
- Covers the LinkedIn link, the no-profile case, the non-web fallback, and reverted-link cases; `rel` is asserted as tokens.
- Corrects a stale docblock claiming `SignalsSection` is no longer mounted; the overview stack mounts it.

<sup>Written for commit 779ef0441525cb0459f177488438f9422726d079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added links from company signals to cited newsroom or source pages.
  * Added clickable LinkedIn links to person profiles when valid LinkedIn addresses are available.
  * Added localized announcement link text in English, German, and Vietnamese.
* **Bug Fixes**
  * Invalid, unsupported, or non-web addresses now remain plain text instead of unusable links.
  * External links now use secure relationship attributes.
* **Tests**
  * Added coverage for valid links, missing links, invalid URLs, supported domains, and malformed evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->