### PR TITLE
fix(ai): a refusal is classified by what the provider said, not by a missing header

### DIFF
--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -329,9 +329,9 @@ func anthropicError(resp *http.Response) error {
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
-		return quotaWrapped(resp, fmt.Errorf("ai: anthropic: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
+		return providerRefusal(resp, "", fmt.Errorf("ai: anthropic: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
 	}
-	return quotaWrapped(resp, fmt.Errorf("ai: anthropic: http %d", resp.StatusCode))
+	return providerRefusal(resp, "", fmt.Errorf("ai: anthropic: http %d", resp.StatusCode))
 }
 
 // anthropicStream parses the Messages SSE stream, yielding text deltas.

--- a/backend/internal/modules/ai/budget.go
+++ b/backend/internal/modules/ai/budget.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -37,29 +38,105 @@ var ErrProviderQuota = errors.New("ai: the configured AI provider refused the ca
 // console where nothing is wrong.
 var ErrProviderThrottled = errors.New("ai: the configured AI provider is rate limiting this installation")
 
-// quotaWrapped classifies a provider's 429, which every vendor here uses for
-// both an exhausted account and an ordinary burst limit.
+// errProviderRefused marks a 429 whose cause the provider did not make out —
+// no limit_source, no recognizable words, no Retry-After. It carries no claim
+// about WHY, only the fact that the model was never reached, which is the part
+// a caller must not get wrong: a refusal reported as a bad model answer sends
+// the operator to audit their own data.
+var errProviderRefused = errors.New("ai: the configured AI provider turned the call away")
+
+// providerRefusal classifies a provider's 429, which every vendor here uses for
+// both an exhausted account and an ordinary burst limit. The two want opposite
+// handling — an account is a human's to fix and every rung above bills to it,
+// a burst clears by itself — and telling an operator the wrong one sends them
+// to a console where nothing is wrong.
 //
-// Retry-After is what separates them: a throttle names the moment the caller
-// may return, because the provider expects it to. An account over its cap has
-// no such moment to name — nothing changes until a human raises the limit — so
-// a 429 that names no moment is read as the refusal it almost always is.
-// Reading it the wrong way is survivable in one direction only: a throttle
-// mistaken for a refusal costs one abandoned call, while a refusal mistaken
-// for a throttle burns every remaining tier against an account that cannot pay
-// for any of them.
+// What decides it is what the provider SAID, in this order:
 //
-// The header is read through the kernel's one reader, which knows both RFC
-// 9110 forms and answers zero for a header that is absent, unparseable, or
-// already past — all three of which name no moment to come back at.
-func quotaWrapped(resp *http.Response, err error) error {
+//  1. limit_source, when a broker names one. "upstream_provider_shared_pool"
+//     is a queue in front of a model, not a balance.
+//  2. The words in the error itself. Every vendor here says "quota", "credit",
+//     "billing" or "spending" for an account and "rate limit" for a burst.
+//  3. Retry-After. A throttle names a moment to come back because the provider
+//     expects the caller to return; an empty account has no such moment.
+//
+// Unclassifiable is a real answer and stays one: the refusal is marked without
+// a cause, so the caller says the provider turned the call away rather than
+// naming a reason invented here. Guessing "out of budget" from a bare 429 is
+// what told an operator with unspent credit to go raise a spending limit.
+//
+// EVERY branch carries errProviderRefused, so "did we reach the model?" is one
+// question with one answer whatever the cause turned out to be. A caller that
+// needs the cause asks for the specific sentinel on top.
+func providerRefusal(resp *http.Response, limitSource string, err error) error {
 	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
 		return err
 	}
-	if retryafter.Of(resp) > 0 {
-		return fmt.Errorf("%w: %w", ErrProviderThrottled, err)
+	refused := fmt.Errorf("%w: %w", errProviderRefused, err)
+	switch refusalKind(limitSource, err.Error(), retryafter.Of(resp)) {
+	case refusalQuota:
+		return fmt.Errorf("%w: %w", ErrProviderQuota, refused)
+	case refusalThrottle:
+		return fmt.Errorf("%w: %w", ErrProviderThrottled, refused)
+	default:
+		return refused
 	}
-	return fmt.Errorf("%w: %w", ErrProviderQuota, err)
+}
+
+// What a 429 turned out to be.
+type refusal int
+
+const (
+	refusalUnknown refusal = iota
+	refusalQuota
+	refusalThrottle
+)
+
+// refusalKind reads a 429 for what it is. Split from providerRefusal so the
+// decision can be stated against text and a header alone, which is how the
+// vendors' real answers are pinned in the tests.
+func refusalKind(limitSource, text string, retryAfter time.Duration) refusal {
+	// A broker names the limit it hit, and a shared pool in front of a model
+	// is a queue rather than a balance.
+	switch {
+	case strings.Contains(limitSource, "shared_pool"), strings.Contains(limitSource, "rate"), strings.Contains(limitSource, "retry"):
+		return refusalThrottle
+	case strings.Contains(limitSource, "credit"), strings.Contains(limitSource, "quota"), strings.Contains(limitSource, "balance"):
+		return refusalQuota
+	}
+	lowered := strings.ToLower(text)
+	// An invitation to come back is asked FIRST, and beats any word about an
+	// account. Gemini spends "quota" on a per-minute limit as freely as on an
+	// exhausted cap, so a message that says both "quota exceeded" and "retry
+	// in 45s" is the retryable one — a vendor does not offer a moment to
+	// return to an account that has nothing left to spend.
+	for _, phrase := range []string{"retry in", "try again in", "retry after", "try again later", "try again shortly", "retry shortly", "temporarily"} {
+		if strings.Contains(lowered, phrase) {
+			return refusalThrottle
+		}
+	}
+	// Then an account, which is the operator's to fix.
+	for _, phrase := range []string{"insufficient_quota", "credit", "billing", "spending", "payment", "spend cap", "exceeded your current quota"} {
+		if strings.Contains(lowered, phrase) {
+			return refusalQuota
+		}
+	}
+	// Then a plain burst limit.
+	for _, phrase := range []string{"rate-limit", "rate limit", "ratelimit", "too many requests", "overloaded"} {
+		if strings.Contains(lowered, phrase) {
+			return refusalThrottle
+		}
+	}
+	// "quota" alone is deliberately NOT here. It is the one word both causes
+	// use, and reading it as an empty account is what told an operator with
+	// unspent credit to go raise a limit. Unclassified is the honest answer.
+	// A moment to come back at is the last signal, and only ever evidence OF a
+	// throttle: an account with nothing left names none, but plenty of throttles
+	// do not name one either, so its absence proves nothing.
+	if retryAfter > 0 {
+		return refusalThrottle
+	}
+	return refusalUnknown
 }
 
 // BudgetDeferralError carries the exact retry boundary to a background task's

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -407,22 +407,6 @@ func geminiSawStop(out geminiResponse) bool {
 	return false
 }
 
-// geminiError surfaces the API's error status and message only, so a logged
-// failure can never echo the request (or the key).
-func geminiError(resp *http.Response) error {
-	var apiErr struct {
-		Error struct {
-			Status  string `json:"status"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Status != "" {
-		return quotaWrapped(resp, fmt.Errorf("ai: gemini: %s: %s (http %d)", apiErr.Error.Status, apiErr.Error.Message, resp.StatusCode))
-	}
-	return quotaWrapped(resp, fmt.Errorf("ai: gemini: http %d", resp.StatusCode))
-}
-
 // geminiStream reads the :streamGenerateContent?alt=sse stream. There is no
 // [DONE] sentinel — the final chunk carries finishReason STOP and then the
 // stream closes; text arrives at candidates[0].content.parts[].text on each

--- a/backend/internal/modules/ai/geminierror.go
+++ b/backend/internal/modules/ai/geminierror.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// How Gemini says no, read for what the caller can do about it. Split from
+// gemini.go because the refusal rules are their own subject: which detail
+// separates an exhausted account from a per-minute limit is a question about
+// Google's error contract, not about how a completion is requested.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// geminiError surfaces the API's error status and message only, so a logged
+// failure can never echo the request (or the key).
+func geminiError(resp *http.Response) error {
+	var apiErr struct {
+		Error struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+			// google.rpc.RetryInfo, present on a limit the caller may come
+			// back from. Gemini spends RESOURCE_EXHAUSTED and the word
+			// "quota" on BOTH an exhausted spending cap and an ordinary
+			// per-minute limit, so the words cannot separate them — this
+			// detail can, because only the retryable one carries it.
+			Details []struct {
+				Type       string `json:"@type"`
+				RetryDelay string `json:"retryDelay"` //nolint:tagliatelle // Google's wire format (camelCase)
+			} `json:"details"`
+		} `json:"error"`
+	}
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Status != "" {
+		limit := ""
+		for _, detail := range apiErr.Error.Details {
+			if strings.Contains(detail.Type, "RetryInfo") && detail.RetryDelay != "" {
+				limit = geminiRetryableLimit
+				break
+			}
+		}
+		return providerRefusal(resp, limit, fmt.Errorf("ai: gemini: %s: %s (http %d)", apiErr.Error.Status, apiErr.Error.Message, resp.StatusCode))
+	}
+	return providerRefusal(resp, "", fmt.Errorf("ai: gemini: http %d", resp.StatusCode))
+}
+
+// geminiRetryableLimit is the limit-source name a RetryInfo detail stands for.
+// Spelled as a rate limit because that is what refusalKind reads it as, and
+// what a delay the vendor is willing to name always means.
+const geminiRetryableLimit = "vendor_rate_limit"

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -343,9 +343,9 @@ func openaiError(resp *http.Response) error {
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
-		return quotaWrapped(resp, fmt.Errorf("ai: openai: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
+		return providerRefusal(resp, "", fmt.Errorf("ai: openai: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
 	}
-	return quotaWrapped(resp, fmt.Errorf("ai: openai: http %d", resp.StatusCode))
+	return providerRefusal(resp, "", fmt.Errorf("ai: openai: http %d", resp.StatusCode))
 }
 
 // openaiTerminalStatus maps a non-completed Responses object to an error: a

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -309,28 +309,88 @@ func (c *openAICompatClient) post(ctx context.Context, path string, payload []by
 // openAICompatError surfaces the vendor's structured error message only —
 // never the raw response body, which may be unstructured HTML/text — so a logged
 // failure can't echo the request or leak provider internals (the anthropic /
-// openai pattern). Two structured shapes exist on this generic wire: OpenAI's
-// nested {"error":{type,message}} and vLLM's top-level {"object":"error",
-// type, message}; a body that can't be read falls back to the HTTP status.
+// openai pattern). Three structured shapes exist on this generic wire: OpenAI's
+// nested {"error":{type,message}}, vLLM's top-level {"object":"error", type,
+// message}, and a broker's {"error":{message,metadata:{raw,provider_name}}};
+// a body that can't be read falls back to the HTTP status.
+//
+// The broker shape is the reason metadata is read at all. A gateway in front of
+// several vendors answers with its OWN message — OpenRouter says "Provider
+// returned error" for everything — and puts the upstream vendor's sentence in
+// metadata.raw. Reading only the outer message produced log lines that named
+// no cause and a build failure the operator could do nothing with.
 func openAICompatError(resp *http.Response) error {
 	var apiErr struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
 		Error   struct {
-			Type    string `json:"type"`
-			Message string `json:"message"`
+			Type     string `json:"type"`
+			Message  string `json:"message"`
+			Metadata struct {
+				Raw          string `json:"raw"`
+				ProviderName string `json:"provider_name"`
+				LimitSource  string `json:"limit_source"`
+			} `json:"metadata"`
 		} `json:"error"`
 	}
 	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil {
-		if apiErr.Error.Message != "" {
-			return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode))
+		if detail := compatErrorDetail(apiErr.Error.Message, apiErr.Error.Metadata.Raw, apiErr.Error.Metadata.ProviderName); detail != "" {
+			return providerRefusal(resp, apiErr.Error.Metadata.LimitSource,
+				fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, detail, resp.StatusCode))
 		}
 		if apiErr.Message != "" {
-			return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Type, apiErr.Message, resp.StatusCode))
+			return providerRefusal(resp, "", fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Type, apiErr.Message, resp.StatusCode))
 		}
 	}
-	return quotaWrapped(resp, fmt.Errorf("ai: openai-compat: http %d", resp.StatusCode))
+	return providerRefusal(resp, "", fmt.Errorf("ai: openai-compat: http %d", resp.StatusCode))
+}
+
+// compatErrorDetail is the sentence worth logging out of a broker's answer.
+//
+// The upstream vendor's own words win when there are any: a broker's outer
+// message is written about ITS call to the vendor, not about the request, so
+// it is the same string whatever went wrong. The vendor is named alongside,
+// because "rate-limited upstream" means nothing without saying whose limit.
+//
+// Both are text a REMOTE party chose, so neither is logged as it arrived.
+// An upstream that echoes a prompt, a URL with a token in it, or its own
+// internals would otherwise write all of it into this installation's logs
+// through a path nothing else guards. Redacted through the same stripper the
+// model payloads use, and capped: a vendor's cause is one sentence, and
+// anything longer is a body that lost its way into a message field.
+func compatErrorDetail(message, upstreamRaw, providerName string) string {
+	upstreamRaw = strings.TrimSpace(upstreamRaw)
+	if upstreamRaw == "" {
+		return safeProviderText(message)
+	}
+	if providerName == "" {
+		return safeProviderText(upstreamRaw)
+	}
+	return safeProviderText(providerName + ": " + upstreamRaw)
+}
+
+// providerTextMax bounds one logged vendor sentence.
+const providerTextMax = 300
+
+// safeProviderText redacts and bounds text a remote provider chose.
+func safeProviderText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	stripped, _, err := NewSecretStripper().Strip(context.Background(), []byte(text))
+	if err != nil {
+		// The stripper could not vouch for it, so none of it is logged: a
+		// vendor sentence is worth having, never at the price of writing an
+		// unexamined remote string into the log.
+		return "(provider detail withheld)"
+	}
+	text = strings.Join(strings.Fields(string(stripped)), " ")
+	if len(text) > providerTextMax {
+		return text[:providerTextMax] + "…"
+	}
+	return text
 }
 
 // openAICompatStream reads the OpenAI-compatible SSE stream: `data: {...}`

--- a/backend/internal/modules/ai/voicebuilder.go
+++ b/backend/internal/modules/ai/voicebuilder.go
@@ -52,7 +52,15 @@ func SafeVoiceBuildFailure(err error) string {
 	// and telling this operator to go raise a spending limit would send them
 	// to a console where nothing is wrong.
 	if errors.Is(err, ErrProviderThrottled) {
-		return "Our AI provider is rate limiting us right now, so the build did not run. Your previous version is unchanged; wait a minute and build again."
+		return "Our AI provider is busy right now and turned the call away, so the build did not run. Your previous version is unchanged; wait a minute and build again."
+	}
+	// A refusal neither sentinel claimed. It still did not reach the model, so
+	// it must not fall through to the message below, which describes an answer
+	// that was received — but nothing here knows WHY, and inventing a cause is
+	// what sent an operator with unspent credit to check their billing. The
+	// honest sentence is that the provider said no.
+	if errors.Is(err, errProviderRefused) {
+		return "Our AI provider turned the call away, so the build never ran. Your previous version is unchanged. Check the provider's status and account, then build again."
 	}
 	text := strings.ToLower(err.Error())
 	switch {

--- a/backend/internal/modules/ai/voicebuilder_test.go
+++ b/backend/internal/modules/ai/voicebuilder_test.go
@@ -242,21 +242,44 @@ func TestSafeVoiceBuildFailureNamesTheCause(t *testing.T) {
 	}
 }
 
-// Every provider ADAPTER marks its own 429 — asserted through the real error
-// functions, not through the helper they share. Testing the helper alone let
-// three of four adapters drop their wrap with the suite still green.
-func TestEveryProviderAdapterMarksAQuotaRefusal(t *testing.T) {
-	// The body each vendor returns, so the adapter takes its structured path
-	// rather than its "could not parse" fallback.
+// Every provider ADAPTER classifies its own 429, asserted through the real
+// error functions rather than the helper they share — testing the helper alone
+// let three of four adapters drop their wrap with the suite still green.
+//
+// The bodies are the ones these vendors actually return.
+func TestEveryProviderAdapterClassifiesItsRefusal(t *testing.T) {
 	adapters := []struct {
-		name string
-		body string
-		read func(*http.Response) error
+		name     string
+		quota    string
+		throttle string
+		read     func(*http.Response) error
 	}{
-		{"gemini", `{"error":{"status":"RESOURCE_EXHAUSTED","message":"cap reached"}}`, geminiError},
-		{"openai", `{"error":{"type":"insufficient_quota","message":"cap reached"}}`, openaiError},
-		{"anthropic", `{"error":{"type":"rate_limit_error","message":"cap reached"}}`, anthropicError},
-		{"openai-compat", `{"error":{"type":"insufficient_quota","message":"cap reached"}}`, openAICompatError},
+		{
+			name:     "gemini",
+			quota:    `{"error":{"status":"RESOURCE_EXHAUSTED","message":"Your project has exceeded its monthly spending cap."}}`,
+			throttle: `{"error":{"status":"RESOURCE_EXHAUSTED","message":"Rate limit exceeded for this model."}}`,
+			read:     geminiError,
+		},
+		{
+			name:     "openai",
+			quota:    `{"error":{"type":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details."}}`,
+			throttle: `{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached for gpt-4o."}}`,
+			read:     openaiError,
+		},
+		{
+			name:     "anthropic",
+			quota:    `{"error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the API."}}`,
+			throttle: `{"error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit."}}`,
+			read:     anthropicError,
+		},
+		{
+			// The broker shape: its OWN message says nothing, and the vendor's
+			// sentence is in metadata.raw. This is the live OpenRouter answer.
+			name:     "openai-compat",
+			quota:    `{"error":{"message":"Provider returned error","metadata":{"provider_name":"Mistral","raw":"Insufficient credits to run this request.","limit_source":"account_credits"}}}`,
+			throttle: `{"error":{"message":"Provider returned error","metadata":{"provider_name":"Mistral","raw":"mistralai/mistral-large-2512 is temporarily rate-limited upstream. Please retry shortly","limit_source":"upstream_provider_shared_pool"}}}`,
+			read:     openAICompatError,
+		},
 	}
 	for _, adapter := range adapters {
 		t.Run(adapter.name, func(t *testing.T) {
@@ -270,35 +293,62 @@ func TestEveryProviderAdapterMarksAQuotaRefusal(t *testing.T) {
 				return adapter.read(resp)
 			}
 
-			// An account with nothing left names no moment to come back at.
-			refusal := read(http.StatusTooManyRequests, adapter.body, "")
-			if !errors.Is(refusal, ErrProviderQuota) {
-				t.Fatalf("a 429 naming no retry moment is a quota refusal: %v", refusal)
+			quota := read(http.StatusTooManyRequests, adapter.quota, "")
+			if !errors.Is(quota, ErrProviderQuota) || errors.Is(quota, ErrProviderThrottled) {
+				t.Fatalf("an account with nothing left is a quota refusal: %v", quota)
 			}
-			if !strings.Contains(SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", refusal)), "out of budget") {
+			if !strings.Contains(SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", quota)), "out of budget") {
 				t.Fatal("the build message names the account, not the model")
 			}
 
-			// A burst limit says when to return, and is not the same failure.
-			throttle := read(http.StatusTooManyRequests, adapter.body, "30")
+			// A burst limit is the opposite answer even though the status is
+			// the same, and it must never send the reader to their billing.
+			throttle := read(http.StatusTooManyRequests, adapter.throttle, "")
 			if !errors.Is(throttle, ErrProviderThrottled) || errors.Is(throttle, ErrProviderQuota) {
-				t.Fatalf("Retry-After marks a throttle, not an empty account: %v", throttle)
+				t.Fatalf("a busy model is a throttle, not an empty account: %v", throttle)
+			}
+			if strings.Contains(SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", throttle)), "out of budget") {
+				t.Fatal("a throttle must not send the reader to a billing console")
 			}
 
-			// A body this adapter cannot parse still classifies by status:
-			// the fallback path is the one a vendor outage actually takes.
+			// A body this adapter cannot read still says the model was never
+			// reached, without inventing which limit was hit.
 			garbled := read(http.StatusTooManyRequests, "<html>gateway</html>", "")
-			if !errors.Is(garbled, ErrProviderQuota) {
-				t.Fatalf("an unparseable 429 body is still a refusal: %v", garbled)
+			if errors.Is(garbled, ErrProviderQuota) || errors.Is(garbled, ErrProviderThrottled) {
+				t.Fatalf("an unreadable body names no cause: %v", garbled)
+			}
+			if message := SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", garbled)); !strings.Contains(message, "turned the call away") {
+				t.Fatalf("an unclassified refusal still says the model never ran: %q", message)
 			}
 
-			// Any other status is an ordinary provider error. Dressing one up
-			// as a billing problem sends an operator to the wrong console.
-			other := read(http.StatusInternalServerError, adapter.body, "")
+			// Any other status is an ordinary provider error.
+			other := read(http.StatusInternalServerError, adapter.quota, "")
 			if errors.Is(other, ErrProviderQuota) || errors.Is(other, ErrProviderThrottled) {
 				t.Fatalf("only a 429 is a quota or throttle answer: %v", other)
 			}
 		})
+	}
+}
+
+// The broker's own message says nothing about the cause; the upstream vendor's
+// sentence and name are what a reader needs, so both reach the log line.
+func TestABrokerRefusalQuotesTheUpstreamVendor(t *testing.T) {
+	body := `{"error":{"message":"Provider returned error","metadata":{"provider_name":"Mistral","raw":"temporarily rate-limited upstream","limit_source":"upstream_provider_shared_pool"}}}`
+	resp := refusalResponse(http.StatusTooManyRequests, body, "")
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("closing the provider response: %v", closeErr)
+		}
+	}()
+
+	err := openAICompatError(resp)
+	for _, want := range []string{"Mistral", "temporarily rate-limited upstream"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the logged failure carries %q: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "Provider returned error") {
+		t.Fatalf("the broker's own placeholder is not the cause: %v", err)
 	}
 }
 
@@ -312,5 +362,71 @@ func refusalResponse(status int, body, retryAfter string) *http.Response {
 		StatusCode: status,
 		Header:     header,
 		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// Gemini spends RESOURCE_EXHAUSTED and the word "quota" on BOTH an exhausted
+// spending cap and an ordinary per-minute limit, so the words cannot separate
+// them. Only the retryable one carries a RetryInfo detail, and reading the
+// words alone is what told an operator with unspent credit to raise a limit.
+func TestGeminiQuotaWordingDoesNotHideARetryableLimit(t *testing.T) {
+	retryable := `{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"You exceeded your current quota. Quota exceeded for metric generate_requests_per_minute.","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"45s"}]}}`
+	exhausted := `{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Your project has exceeded its monthly spending cap. Please go to AI Studio to manage your project spend cap."}}`
+
+	read := func(body string) error {
+		resp := refusalResponse(http.StatusTooManyRequests, body, "")
+		defer func() {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				t.Errorf("closing the provider response: %v", closeErr)
+			}
+		}()
+		return geminiError(resp)
+	}
+
+	perMinute := read(retryable)
+	if !errors.Is(perMinute, ErrProviderThrottled) || errors.Is(perMinute, ErrProviderQuota) {
+		t.Fatalf("a limit the vendor offers a retry delay for is a throttle: %v", perMinute)
+	}
+	if strings.Contains(SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", perMinute)), "out of budget") {
+		t.Fatal("a per-minute limit must not send the reader to a billing console")
+	}
+
+	spendCap := read(exhausted)
+	if !errors.Is(spendCap, ErrProviderQuota) || errors.Is(spendCap, ErrProviderThrottled) {
+		t.Fatalf("a spending cap with no retry offered is an account refusal: %v", spendCap)
+	}
+}
+
+// A vendor's sentence is text a REMOTE party chose. It reaches this
+// installation's logs, so it is redacted and bounded on the way — nothing else
+// guards that path.
+func TestABrokerSentenceIsRedactedAndBoundedBeforeItIsLogged(t *testing.T) {
+	leaky := `{"error":{"message":"Provider returned error","metadata":{"provider_name":"Mistral","raw":"upstream rejected key sk-or-v1-abcdefghijklmnopqrstuvwxyz012345 while calling the model"}}}`
+	resp := refusalResponse(http.StatusTooManyRequests, leaky, "")
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("closing the provider response: %v", closeErr)
+		}
+	}()
+
+	err := openAICompatError(resp)
+	if strings.Contains(err.Error(), "sk-or-v1-abcdefghijklmnopqrstuvwxyz012345") {
+		t.Fatalf("a credential a vendor echoed back must not reach the log: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Mistral") {
+		t.Fatalf("the vendor is still named, so the cause stays readable: %v", err)
+	}
+
+	// A body that lost its way into a message field is truncated rather than
+	// written whole.
+	long := `{"error":{"message":"Provider returned error","metadata":{"provider_name":"X","raw":"` + strings.Repeat("verbose ", 200) + `"}}}`
+	longResp := refusalResponse(http.StatusTooManyRequests, long, "")
+	defer func() {
+		if closeErr := longResp.Body.Close(); closeErr != nil {
+			t.Errorf("closing the provider response: %v", closeErr)
+		}
+	}()
+	if got := len(openAICompatError(longResp).Error()); got > providerTextMax+120 {
+		t.Fatalf("one logged vendor sentence is bounded; got %d characters", got)
 	}
 }


### PR DESCRIPTION
## What was wrong

An operator with **$40 of unspent OpenRouter credit** was told: *"the account behind it is out of budget or over its quota … Raise the limit on the provider account."*

The real 429, from OpenRouter:

```json
{"error":{"message":"Provider returned error","metadata":{
  "provider_name":"Mistral",
  "raw":"mistralai/mistral-large-2512 is temporarily rate-limited upstream. Please retry shortly",
  "limit_source":"upstream_provider_shared_pool"}}}
```

A transient throttle on a shared pool. Two defects turned it into a billing accusation.

**1. The classification guessed from a missing header.** The previous rule read a 429 with no `Retry-After` as an exhausted account. OpenRouter sends none for a throttle, so every one of its throttles read as an empty account.

**2. The provider's own reason was discarded.** OpenRouter's outer message is `"Provider returned error"` for everything; the vendor's real sentence is in `metadata.raw`, which `openAICompatError` never parsed. The logged failure was `ai: openai-compat: :` — an empty cause.

## What changed

**Classification follows what the provider said**, in order: the broker's `limit_source`, then an offered retry, then account wording, then a plain rate limit.

An offered retry is checked **before** account wording on purpose. Gemini spends `RESOURCE_EXHAUSTED` and the word "quota" on a per-minute limit as freely as on an exhausted cap, so a message saying both "quota exceeded" and "retry in 45s" is the retryable one — a vendor does not offer a moment to return to an account with nothing left. The bare word "quota" now decides nothing; Gemini's `RetryInfo` detail settles its case, since only the retryable refusal carries one.

A 429 nothing recognizes is marked refused **without a cause**, so the build says the provider turned the call away rather than blaming the model for an answer it never gave.

**The broker's upstream sentence is parsed and reported**, named with its vendor — and redacted through the existing secret stripper and capped at 300 characters on the way to the log. It is text a remote party chose, reaching this installation's logs through a path nothing else guarded; an upstream echoing a prompt or a credential would otherwise have written all of it there.

Gemini's error handling moves to `geminierror.go` (`gemini.go` was one line over the 500-line cap).

## Verified

- `make check` exit 0; `craft static --strict`, `rls-store-path`, `no-jurisdiction` clean.
- All four adapters tested against their **real** vendor bodies — including the live OpenRouter response captured from a running key — for quota, throttle, unparseable-body and non-429 cases.
- Every guard mutation-checked: removing Gemini's RetryInfo read, and removing the stripper call, each turn their test red.

## Reviewed

Codex found three issues on the first pass, all fixed here: the Gemini quota-wording collision (which would have reintroduced the original bug for Gemini), the unredacted broker text reaching logs, and the 4096-byte body truncation behaviour.

## Not included

The routing config (`config/ai-routing.yaml`) is machine-local and gitignored; the premium tier's binding to a shared-pool model is a separate operational choice, not part of this change.

Still open: [#3195](https://github.com/margince/margince/issues/3195) — a build can fail on malformed model JSON even with a working provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 429 classification so refusals are read from what the provider said, not from a missing `Retry-After` header. An operator with unspent OpenRouter credit was previously told the account was over quota when it was actually a transient upstream throttle.

**Bug Fixes**
- Classifies a 429 by the broker's `limit_source`, then an offered retry, then account wording, then a plain rate limit.
- Checks an offered retry before account wording because Gemini uses "quota" for both a per-minute limit and an exhausted cap; the bare word "quota" no longer decides anything.
- Marks unrecognized 429s as refused without a cause, so callers don't blame the model for an answer it never gave.
- Parses the broker's `metadata.raw` upstream sentence, names it with its vendor, and redacts and caps it at 300 characters before logging.
- Moves Gemini's error handling to `geminierror.go`, leaving `gemini.go` under the file cap.

<sup>Written for commit 07c0614fb86398e0daf91bbbb2f3f8f4b19ec245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider error classification to distinguish quota exhaustion, temporary throttling, and provider-declined requests.
  * Added clearer, more accurate messages when voice generation fails.
  * Correctly identifies retryable rate limits, including cases where provider responses contain conflicting quota information.
  * Preserves useful provider details while removing sensitive content and limiting message length.
  * Improved handling of malformed or incomplete provider error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->