### PR TITLE
fix(ai): the dev stack binds a broker whose tiers have somewhere to fail over

### DIFF
--- a/backend/internal/modules/ai/pricing.go
+++ b/backend/internal/modules/ai/pricing.go
@@ -220,6 +220,14 @@ func brokerSheetRates(day time.Time) []ModelRate {
 		// sibling; 0 here is "no cache discount", and the uncached input rate
 		// is what a call actually pays.
 		rateOn(day, providerOpenAICompatible, "openai/gpt-oss-120b", 37_000, 170_000, 0, 0),
+		// Anthropic reached through the broker rather than its native adapter.
+		// The ids differ from the native rows above — the broker spells a vendor
+		// prefix and a dotted version where the native API takes a dated snapshot
+		// — so these are separate rows rather than duplicates: a call on this
+		// adapter reports the broker's id, and an id with no row prices as a
+		// visible unpriced count instead of a dollar figure.
+		rateOn(day, providerOpenAICompatible, "anthropic/claude-haiku-4.5", 1_000_000, 5_000_000, 100_000, 1_250_000),
+		rateOn(day, providerOpenAICompatible, "anthropic/claude-sonnet-4.5", 3_000_000, 15_000_000, 300_000, 3_750_000),
 		// Embedding lanes have no output and no cache — only input is nonzero.
 		embedOn(day, providerOpenAICompatible, "mistralai/mistral-embed-2312", 100_000),
 		embedOn(day, providerOpenAICompatible, "baai/bge-m3", 10_000),

--- a/backend/internal/modules/ai/pricing.go
+++ b/backend/internal/modules/ai/pricing.go
@@ -198,8 +198,9 @@ func vendorSheetRates(day time.Time) []ModelRate {
 // per-token prices scaled by 1e12 — on 2026-07-31. Every model the example
 // names is here, the commented jurisdiction alternates included: the file
 // presents them as one-line swaps, and a swap must not silently turn the
-// cost report UNPRICED. No entry publishes a cache-WRITE price, so that
-// column is 0 throughout.
+// cost report UNPRICED. Only the two Anthropic rows publish a cache-WRITE
+// price; that column is 0 for every other entry, which is the vendor
+// declining to charge separately for the write rather than a gap here.
 //
 // These rows are keyed on the GENERIC provider name, because that is what a
 // call on this adapter reports. An operator who points openai_compatible at

--- a/config/margince.dev.yaml
+++ b/config/margince.dev.yaml
@@ -44,10 +44,10 @@ seeds:
   ai_routing:
     profile: eu_hosted          # eu_hosted | sovereign | cloud_frontier
     tiers:
-      local_small: { provider: gemini, model: gemini-3.1-flash-lite }
-      cheap_cloud: { provider: gemini, model: gemini-3.1-flash-lite }
-      premium:     { provider: gemini, model: gemini-3.5-flash }
-      frontier:    { provider: gemini, model: gemini-3.1-pro-preview }
+      local_small: { provider: openai_compatible, model: openai/gpt-oss-120b, base_url: https://openrouter.ai/api }
+      cheap_cloud: { provider: openai_compatible, model: openai/gpt-oss-120b, base_url: https://openrouter.ai/api }
+      premium:     { provider: openai_compatible, model: anthropic/claude-haiku-4.5, base_url: https://openrouter.ai/api }
+      frontier:    { provider: openai_compatible, model: anthropic/claude-sonnet-4.5, base_url: https://openrouter.ai/api }
     embeddings:
       provider: gemini
       model: gemini-embedding-001


### PR DESCRIPTION
## What this fixes

A dev stack's seeded binding pointed every tier at Gemini, and that project hit
its monthly spending cap. Chat and embeddings both answered
`429 RESOURCE_EXHAUSTED`, so every AI lane was dead until someone raised a limit
in a console. This rebinds the seed to OpenRouter.

## Why claude-haiku-4.5 on premium

`mistralai/mistral-large-2512` was the first pick and is the wrong one. Its three
OpenRouter endpoints all route to Mistral's own API, so when that shared pool is
busy every route throttles together and the tier has nowhere to fail over — the
observed error was `"limit_source": "upstream_provider_shared_pool"`, on every
attempt across several minutes. `anthropic/claude-haiku-4.5` answers from four
independent clouds (Bedrock, Anthropic, Azure, Google).

`premium` also serves `site_extract`, whose evidence gate drops any claim whose
quote it cannot match against the page. On a German Impressum fixture with a
compound legal form, two managing directors and a spaced VAT id:

| model | fields correct | quote verbatim |
|---|---|---|
| `anthropic/claude-haiku-4.5` | 4/4 | **4/4** |
| `anthropic/claude-sonnet-4.5` | 4/4 | **4/4** |
| `deepseek/deepseek-v4-flash` | 3/4 | 3/4 (one malformed JSON) |
| `openai/gpt-oss-120b` | 4/4 | **1/4** |

`gpt-oss-120b` quoted the wrong passage three times in four — silently thin site
reads, which is the failure the gate exists to make visible. It stays on the
cheap rungs where nothing asks it to quote; `claude-sonnet-4.5` sits on
`frontier`, which costs nothing until a task ladder selects it.

## Price rows

The generic adapter reports the broker's model id, spelled differently from the
native adapter's dated snapshot (`anthropic/claude-haiku-4.5` vs
`claude-haiku-4-5-20251001`). The existing `providerAnthropic` rows therefore do
not cover these calls, and without new rows the cost report would show them as an
unpriced count. Both rows verified against OpenRouter's catalog, all four columns.

## Embeddings stay on Gemini

Deliberate, and still broken. OpenRouter serves no embedding model, so retrieval
has no rung here to move to — unbinding it would delete the lane rather than
degrade it. Semantic search and `knowledge/ask` stay down until that cap resets
or a local embedder is installed.

## Testing

- `go test ./internal/modules/ai/` passes
- `make craft-static` clean across all four roots
- Verified live: a site read on the running stack served `premium` with
  `anthropic/claude-haiku-4.5`, status ok, without a restart — the routing
  watcher adopts a rebind on its own

Two pre-existing `make check-go` failures are unrelated to this diff and fail
identically with it stashed: a `.pnpm-store` symlink blocking a gate's tree walk,
and `docs/explanation/company-record-page-v2-implementation-plan.md` at 1249
lines over its 620-line budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dev stack's AI routing so chat tiers use OpenRouter instead of Gemini, which had hit its spending cap and returned 429 errors for every lane.

- Rebinds `local_small` and `cheap_cloud` to `openai/gpt-oss-120b`, `premium` to `anthropic/claude-haiku-4.5`, and `frontier` to `anthropic/claude-sonnet-4.5`.
- Chooses `claude-haiku-4.5` for premium because it quoted correctly in 4/4 runs on the `site_extract` fixture, unlike `gpt-oss-120b` which misquoted in 3/4.
- Adds pricing rows for the two Anthropic broker models because their IDs differ from the existing native adapter rows, and corrects the broker sheet comment to note only those rows carry a cache-write price.
- Deliberately keeps embeddings on Gemini since OpenRouter serves no embedding models.

<sup>Written for commit c23e3ee4d9dd7327759a7216ab953af39becb92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pricing support for Anthropic Haiku 4.5 and Sonnet 4.5 models.
  * Updated development AI routing to use OpenAI-compatible models through OpenRouter across all service tiers.
* **Configuration**
  * Preserved the existing embedding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->