### PR TITLE
fix(approvals): a refusal sticks, on every producer that can run again

### DIFF
--- a/backend/gates/refusalmemory_test.go
+++ b/backend/gates/refusalmemory_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A producer that can be re-triggered remembers what a human refused.
+//
+// `StageUnlessDeclined` refuses to raise a proposal whose identity a human has
+// already rejected. Plain `Stage` does not: `JoinPending` collapses a proposal
+// that is still WAITING, and a rejection is precisely what stops it waiting. So
+// a producer that runs again — a nightly sweep, a connector re-sync, a button a
+// rep can press twice — puts the refused proposal straight back, and back again
+// on every run after that.
+//
+// This is not a hypothesis. Four producers shipped with it: the nightly
+// close-date sweep re-asked every morning, a captured merge came back on every
+// connector cycle, a transcript proposal returned whenever somebody pressed read
+// again, and a rate refresh re-offered a figure an admin had turned down on
+// every click. In each case the rep learns that saying no does not stick, and in
+// the merge case the pressure is toward an action that destroys the distinction
+// between two records.
+//
+// So plain `Stage` is the exception here rather than the default, and an
+// exception has to say which mechanism makes repetition impossible or intended.
+// The waivers below are that record; each names the guard that settles it, in a
+// form a reader can go and check.
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// plainStageCall matches a staging through the engine's memoryless entry point.
+// Anchored on the receiver-and-method shape rather than the bare word, so a
+// mention in prose or a different Stage (files, workflows' own port) does not
+// match.
+var plainStageCall = regexp.MustCompile(`\b\w+\.Stage\(ctx, approvals\.StageInput\{`)
+
+// stageWithoutMemory records, per file, why a plain Stage is right there.
+//
+// Each reason names the MECHANISM rather than restating the intent: "a human
+// presses it" is a trigger shape, and the two entries that rest on that say so
+// plainly instead of implying a guard they do not have.
+var stageWithoutMemory = gatekit.Waive(map[string]string{
+	"internal/compose/coldstart.go": "the only trigger is a person pasting text and pressing the button; " +
+		"re-submitting after a rejection is them deliberately asking again, and refusing that would be the bug",
+
+	"internal/compose/scrape.go": "the triggers are a person clicking read-this-website and the enrich tool at " +
+		"page depth; both are a deliberate ask about one named company",
+
+	"internal/compose/workflows.go": "automation claims its run first — workflow_run's " +
+		"ON CONFLICT (handler, idempotency_key) DO NOTHING gates Apply, and a clock trigger's key is " +
+		"derived from the anchor so re-evaluating an unchanged record folds; a rejection additionally " +
+		"marks the run blocked",
+
+	"internal/compose/captureverdictaccept.go": "the sweep's own backlog query excludes a decided offer " +
+		"(AwaitingReview requires decided_at IS NULL), and ReconcileDeclined closes the ledger row a " +
+		"rejection answered, so the row cannot come back round",
+})
+
+// stageCallFloor is how many plain-Stage call sites the tree holds today. Under-
+// recognition is the one way this gate must not break — a scanner that matches
+// nothing reports PASS over every producer at once — so this is the exact count
+// rather than a margin below it.
+const stageCallFloor = 4
+
+func TestEveryRetriggerableProducerRemembersARefusal(t *testing.T) {
+	t.Parallel()
+	found := 0
+	for path, body := range goSourcesUnder(t, "internal/compose") {
+		for _, line := range strings.Split(body, "\n") {
+			if !plainStageCall.MatchString(line) {
+				continue
+			}
+			found++
+			if stageWithoutMemory.Waived(t, filepath.ToSlash(path)) {
+				continue
+			}
+			t.Errorf("%s stages through Stage, which has no rejection memory:\n  %s\n"+
+				"a producer that can run again puts a refused proposal straight back, and "+
+				"back again every run after. Use StageUnlessDeclined with an Identity naming "+
+				"what makes two of its proposals the same question — or, if repetition here is "+
+				"impossible or intended, waive the file in stageWithoutMemory with the mechanism "+
+				"that settles it.", path, strings.TrimSpace(line))
+		}
+	}
+	if found < stageCallFloor {
+		t.Errorf("found %d plain Stage call(s) and expects at least %d — the scanner is "+
+			"matching less than the tree holds, which reports PASS over producers nobody checked",
+			found, stageCallFloor)
+	}
+	// A waiver that matched nothing describes code that has moved or been fixed,
+	// and left standing it exempts whatever is written there next.
+	stageWithoutMemory.AssertAllMatched(t)
+}

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -10,9 +10,6 @@ package compose
 // imports identity or approvals (ADR-0054 §9).
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -30,7 +27,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
-	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // gmailScopes are the Google scopes a Gmail connection requests: mail read for
@@ -453,32 +449,4 @@ func WithGmailCapture(c GmailConfig, cfg CaptureConfig) Option {
 		// object: ChannelSendCapable is a pool query, not a connector lookup.
 		installSendPreflight(s, pool)
 	}
-}
-
-// mergeStager adapts the approvals engine to capture's dedupe seam.
-type mergeStager struct {
-	svc *approvals.Service
-}
-
-func (m mergeStager) StageMerge(ctx context.Context, in capture.MergeProposal) (ids.UUID, error) {
-	digest := sha256.Sum256(in.ProposedChange)
-	// A connector re-syncing the same upstream record hits the same
-	// collision every cycle; an identical pending proposal must absorb
-	// the repeat, not multiply in the inbox.
-	pending, err := m.svc.HasPendingFor(ctx, "merge_records", in.TargetID, hex.EncodeToString(digest[:]))
-	if err != nil {
-		return ids.Nil, err
-	}
-	if pending {
-		return ids.Nil, nil
-	}
-	id, err := m.svc.Stage(ctx, approvals.StageInput{
-		Kind:           "merge_records",
-		ProposedChange: in.ProposedChange,
-		DiffHash:       hex.EncodeToString(digest[:]),
-		TargetType:     in.TargetType,
-		TargetID:       in.TargetID,
-		Summary:        in.Summary,
-	})
-	return id.UUID, err
 }

--- a/backend/internal/compose/capturemerge.go
+++ b/backend/internal/compose/capturemerge.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The approvals edge of capture: a dedupe collision becomes a 🟡 merge proposal
+// a human answers, never an auto-merge.
+//
+// It lives apart from the registry wiring because it is the one place capture
+// meets the approvals engine, and what it has to get right is a question about
+// approvals rather than about capture — which repeats of one collision are the
+// same question, so that a rep who says "these are not the same person" is
+// answered once and not on every sync.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// mergeStager adapts the approvals engine to capture's dedupe seam.
+type mergeStager struct {
+	svc *approvals.Service
+}
+
+// mergeIdentityAddress is the payload key the merge identity is drawn from. The
+// dedupe payload is a marshalled capture.LeadFields, which declares no JSON
+// tags, so the key is the Go field name.
+const mergeIdentityAddress = "Email"
+
+func (m mergeStager) StageMerge(ctx context.Context, in capture.MergeProposal) (ids.UUID, error) {
+	digest := sha256.Sum256(in.ProposedChange)
+	// A connector re-syncing the same upstream record hits the same collision
+	// every cycle, and a rep who says "these are not the same person" must be
+	// answered once rather than every cycle after.
+	//
+	// The identity is the ADDRESS the collision was found on, against a target
+	// that already names the incumbent lead: those two together are the whole of
+	// what a rep answers. Not the whole payload, which is what a diff hash would
+	// key on — a re-sync carrying a corrected title or a newly populated company
+	// name is the same question about the same two records, and a memory keyed on
+	// the payload forgets the refusal the first time any field moves.
+	identity, err := json.Marshal(map[string]string{mergeIdentityAddress: capture.MergeAddress(in.ProposedChange)})
+	if err != nil {
+		return ids.Nil, fmt.Errorf("compose: marshal merge identity: %w", err)
+	}
+	id, _, err := m.svc.StageUnlessDeclined(ctx, approvals.StageInput{
+		Kind:           captureCollisionKind,
+		ProposedChange: in.ProposedChange,
+		DiffHash:       hex.EncodeToString(digest[:]),
+		Identity:       identity,
+		TargetType:     in.TargetType,
+		TargetID:       in.TargetID,
+		Summary:        in.Summary,
+		// JoinPending absorbs the re-sync while a proposal is still waiting,
+		// which is what the pending check here used to do on its own. Identity
+		// staging requires it, and it is the same behaviour by a stronger route:
+		// the join runs under the identity's row lock rather than as a separate
+		// read that a concurrent decision can land between.
+		JoinPending: true,
+	})
+	return id.UUID, err
+}

--- a/backend/internal/compose/dedupemergememory_integration_test.go
+++ b/backend/internal/compose/dedupemergememory_integration_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What a rep's "no" means to a captured merge proposal.
+//
+// A connector re-syncs the same upstream record every cycle, so it hits the same
+// collision every cycle. The pending check the stager had could absorb the
+// repeat only while a proposal was still waiting — and a rejection is exactly
+// what stops it waiting. So a rep who said "these are not the same person" was
+// asked again on the next sync, and every sync after, until they gave in.
+//
+// Giving in here is destructive: a merge is the one action that removes the
+// distinction between two records.
+//
+// SQL throughout, and the sink's own path: what the connector staged, and what
+// the memory matched.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// mergeEnv drives the real capture sink over one workspace, with the approvals
+// service the composition root gives it.
+type mergeEnv struct {
+	*integration.Env
+	sink *capture.Sink
+	svc  *approvals.Service
+}
+
+func setupMerge(t *testing.T) *mergeEnv {
+	t.Helper()
+	e := integration.Setup(t)
+	svc := approvals.NewService(e.DB())
+	return &mergeEnv{Env: e, sink: capture.NewSink(e.DB()).WithStager(mergeStager{svc: svc}), svc: svc}
+}
+
+// capturedLead runs one upstream record through the sink, exactly as a connector
+// sync does.
+func (e *mergeEnv) capturedLead(t *testing.T, source, sourceID, name, email string) ids.UUID {
+	t.Helper()
+	ref, err := e.sink.Upsert(connectorCtx(e.Env), connector.NormalizedRecord{
+		EntityType: "lead",
+		NaturalKey: connector.NaturalKey{SourceSystem: source, SourceID: sourceID},
+		Fields:     capture.LeadFields{FullName: name, Email: email},
+		Source:     source + ":" + sourceID, CapturedBy: "connector:test",
+	})
+	if err != nil {
+		t.Fatalf("capturing %s/%s: %v", source, sourceID, err)
+	}
+	return ref.ID
+}
+
+// pendingMerges counts the merge proposals standing against one lead.
+func (e *mergeEnv) pendingMerges(t *testing.T, leadID ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM approval WHERE kind = 'merge_records'
+			   AND target_entity_id = $1 AND status = 'pending'`, leadID).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting merge proposals: %v", err)
+	}
+	return n
+}
+
+// rejectMerge turns down the merge proposal standing against one lead.
+func (e *mergeEnv) rejectMerge(t *testing.T, leadID ids.UUID) {
+	t.Helper()
+	var approvalID ids.ApprovalID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM approval WHERE kind = 'merge_records'
+			   AND target_entity_id = $1 AND status = 'pending'`, leadID).Scan(&approvalID)
+	}); err != nil {
+		t.Fatalf("no staged merge to reject: %v", err)
+	}
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	if _, err := e.svc.Decide(human, approvalID, false, nil); err != nil {
+		t.Fatalf("rejecting the merge: %v", err)
+	}
+}
+
+// A refused merge is not proposed again on the next sync.
+//
+// The plain case: the connector re-sends exactly what it sent before. This one
+// is answered by the declined check itself, whose fallback discriminator is the
+// payload's diff hash; the identity earns its place in the test below, where the
+// payload has moved.
+func TestARejectedMergeIsNotProposedAgainOnTheNextSync(t *testing.T) {
+	e := setupMerge(t)
+	incumbent := e.capturedLead(t, "apollo", "a-1", "Dana Dup", "dana@example.test")
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	if got := e.pendingMerges(t, incumbent); got != 1 {
+		t.Fatalf("the first collision staged %d proposals, want 1", got)
+	}
+	e.rejectMerge(t, incumbent)
+
+	// The connector syncs again, and its cursor was stale, so it re-sends the
+	// record it already sent.
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	if got := e.pendingMerges(t, incumbent); got != 0 {
+		t.Errorf("after a rejection the next sync staged %d merge proposals, want 0 — "+
+			"the rep is asked to merge two records they said were different", got)
+	}
+}
+
+// A re-sync whose payload has changed is still the same question.
+//
+// This is the case that needs the IDENTITY, and it is the only one here that
+// does: StageUnlessDeclined falls back to the whole-payload diff hash when no
+// identity is declared, which already answers a byte-identical re-sync. What it
+// cannot answer is an upstream record that gains a title or has its name
+// corrected between one sync and the next — the same two records and the same
+// question, with a different payload. Since provider fields drift constantly,
+// this is the common case rather than the exotic one.
+func TestARejectedMergeStaysRefusedWhenTheCapturedFieldsChange(t *testing.T) {
+	e := setupMerge(t)
+	incumbent := e.capturedLead(t, "apollo", "a-1", "Dana Dup", "dana@example.test")
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	e.rejectMerge(t, incumbent)
+
+	// Upstream fills in a fuller name for the same person at the same address.
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate-Smith", "dana@example.test")
+	if got := e.pendingMerges(t, incumbent); got != 0 {
+		t.Errorf("a re-sync carrying a corrected name staged %d proposals over a "+
+			"rejection, want 0 — the memory is keyed on something that moves", got)
+	}
+}
+
+// A different address against the same lead is a different question.
+//
+// The other half of the key. A refusal is remembered with no expiry, so a
+// target-only key would mean one "no" ends dedupe on that lead permanently: a
+// genuinely new collision on a second address would never be raised.
+func TestADifferentAddressIsStillProposedAfterARefusal(t *testing.T) {
+	e := setupMerge(t)
+	incumbent := e.capturedLead(t, "apollo", "a-1", "Dana Dup", "dana@example.test")
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	e.rejectMerge(t, incumbent)
+
+	// The rep adds that second address to the incumbent themselves, and a
+	// connector then captures a record carrying it.
+	if _, err := integration.OwnerConn(t).Exec(context.Background(),
+		`UPDATE lead SET email = 'dana.new@example.test' WHERE id = $1`, incumbent); err != nil {
+		t.Fatalf("moving the incumbent's address: %v", err)
+	}
+	e.capturedLead(t, "hubspot", "h-10", "Dana Duplicate", "dana.new@example.test")
+	if got := e.pendingMerges(t, incumbent); got != 1 {
+		t.Errorf("a collision on an address nobody refused staged %d proposals, want 1 — "+
+			"one refusal has ended dedupe on this lead for good", got)
+	}
+}
+
+// A refusal on one lead says nothing about another.
+//
+// This is how a too-wide key fails, and it is the failure that hides: dedupe
+// quietly stops raising proposals and every other test still passes, because
+// each one seeds its own lead.
+func TestARejectedMergeOnOneLeadDoesNotSilenceAnother(t *testing.T) {
+	e := setupMerge(t)
+	declined := e.capturedLead(t, "apollo", "a-1", "Dana Dup", "dana@example.test")
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	e.rejectMerge(t, declined)
+
+	other := e.capturedLead(t, "apollo", "a-2", "Sam Sample", "sam@example.test")
+	e.capturedLead(t, "hubspot", "h-11", "Samuel Sample", "sam@example.test")
+	if got := e.pendingMerges(t, other); got != 1 {
+		t.Errorf("a lead nobody refused has %d merge proposals, want 1 — one "+
+			"rejection has silenced a lead it was never about", got)
+	}
+	if got := e.pendingMerges(t, declined); got != 0 {
+		t.Errorf("the refused lead was asked again: %d pending", got)
+	}
+}
+
+// The same address in different capitalisation is one question.
+//
+// Providers do not agree on case, and the collision itself is found with
+// `email = lower($1)` — so two syncs differing only in capitalisation hit the
+// same lead. An identity carrying the raw spelling would read them as two
+// questions and forget a refusal the first time a provider changed its mind
+// about case.
+func TestARejectedMergeStaysRefusedWhenTheAddressCaseChanges(t *testing.T) {
+	e := setupMerge(t)
+	incumbent := e.capturedLead(t, "apollo", "a-1", "Dana Dup", "dana@example.test")
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "dana@example.test")
+	e.rejectMerge(t, incumbent)
+
+	e.capturedLead(t, "hubspot", "h-9", "Dana Duplicate", "  DANA@Example.TEST ")
+	if got := e.pendingMerges(t, incumbent); got != 0 {
+		t.Errorf("the same address in another case staged %d proposals over a "+
+			"rejection, want 0", got)
+	}
+}

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -90,7 +90,18 @@ func stageRateProposal(ctx context.Context, svc *approvals.Service, kind, target
 	}
 	digest := sha256.Sum256(raw)
 	hash := hex.EncodeToString(digest[:])
-	_, err = svc.Stage(ctx, approvals.StageInput{
+	// StageUnlessDeclined rather than Stage, and the difference is a rejection
+	// rather than a duplicate. JoinPending collapses a proposal that is still
+	// waiting; the moment a human turns one down there is no pending row left to
+	// join, so a plain Stage puts the refused figure straight back. And it comes
+	// back on every refresh after that: the diff is computed against the RATE
+	// SHEET, which a rejection does not change, so the same click re-derives the
+	// same proposal from the same source indefinitely.
+	//
+	// The identity was already declared for the join, and it is what makes the
+	// memory precise: a refused $5 stays refused while a genuine move to $6 is
+	// still offered.
+	_, _, err = svc.StageUnlessDeclined(ctx, approvals.StageInput{
 		Kind: kind, ProposedChange: raw, DiffHash: hash,
 		TargetType: targetType, TargetID: ws, Summary: summary,
 		JoinPending: true, Identity: identity,

--- a/backend/internal/compose/transcriptmemory_integration_test.go
+++ b/backend/internal/compose/transcriptmemory_integration_test.go
@@ -145,3 +145,36 @@ func TestAReadingWhoseStepsWereAllAnsweredSaysSo(t *testing.T) {
 		t.Errorf("the run claims %d proposals it did not raise", len(second.ProposalIDs))
 	}
 }
+
+// Two commitments made in one sentence are two proposals, not one.
+//
+// The identity is the transcript's own words, so two steps citing the SAME line
+// carry the same key — and identity staging supersedes a pending twin. If a
+// reading can produce that, one commitment silently replaces the other and the
+// rep never sees it.
+func TestTwoCommitmentsOnOneLineBothReachTheQueue(t *testing.T) {
+	e := setupTranscript(t)
+	both, err := json.Marshal(map[string]any{"proposals": []map[string]any{
+		{
+			"summary": "Send the revised pricing", "owner": "Priya",
+			"source_lines": []int{3}, "confidence": 0.9,
+		},
+		{
+			"summary": "Book the follow-up call", "owner": "Dana",
+			"source_lines": []int{3}, "confidence": 0.9,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("building the model reply: %v", err)
+	}
+	read := e.read(t, cannedBrain{reply: string(both)})
+
+	if got := e.pendingProposals(t); got != 2 {
+		t.Errorf("one line stating two commitments left %d proposals waiting, want 2 — "+
+			"they share a cited quotation, so one has superseded the other and the rep "+
+			"will never see it", got)
+	}
+	if len(read.ProposalIDs) != 2 {
+		t.Errorf("the run recorded %d proposals, want 2", len(read.ProposalIDs))
+	}
+}

--- a/backend/internal/compose/transcriptmemory_integration_test.go
+++ b/backend/internal/compose/transcriptmemory_integration_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What a rep's "no" means when the same transcript is read again.
+//
+// Reading a transcript twice is an ordinary thing to do: a rep re-checks a call,
+// or a colleague opens it. The in-flight uniqueness index only stops a SECOND
+// reading while the first is queued or running, so once a reading finishes
+// another may start — and the model, asked the same question of the same text,
+// says roughly the same thing. Without a memory the refused proposals come
+// straight back, and the rep learns that turning something down does not stick.
+//
+// "Roughly" is what makes the key hard. The summary is the model's prose and the
+// cited line is its citation; both move between readings of one document. The
+// transcript's own words do not, which is what the identity carries.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// reworded is a reading that reaches the same commitment on the same line and
+// says so differently — what a second pass over one transcript actually looks
+// like.
+func reworded(t *testing.T, summary string, line int) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"proposals": []map[string]any{{
+		"summary": summary, "owner": "Priya",
+		"source_lines": []int{line}, "confidence": 0.9,
+	}}})
+	if err != nil {
+		t.Fatalf("building the model reply: %v", err)
+	}
+	return string(raw)
+}
+
+// pendingProposals counts the transcript proposals waiting on this activity.
+func (e *transcriptEnv) pendingProposals(t *testing.T) int {
+	t.Helper()
+	return e.WsCount(t, `SELECT count(*) FROM approval
+		 WHERE kind = 'transcript_proposal' AND status = 'pending'`)
+}
+
+// rejectFirst turns down the proposal a reading staged.
+func (e *transcriptEnv) rejectFirst(t *testing.T, proposalIDs []ids.UUID) {
+	t.Helper()
+	reason := "not a commitment"
+	if len(proposalIDs) == 0 {
+		t.Fatal("the reading staged nothing to reject")
+	}
+	if _, err := e.svc.Decide(e.ctx, ids.From[ids.ApprovalKind](proposalIDs[0]), false, &reason); err != nil {
+		t.Fatalf("rejecting the proposal: %v", err)
+	}
+}
+
+// A refused proposal does not come back when the transcript is read again.
+func TestARejectedTranscriptProposalIsNotStagedAgainOnASecondReading(t *testing.T) {
+	e := setupTranscript(t)
+	first := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	e.rejectFirst(t, first.ProposalIDs)
+
+	second := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	if got := e.pendingProposals(t); got != 0 {
+		t.Errorf("a second reading staged %d proposals over a rejection, want 0 — "+
+			"the rep is shown what they already turned down", got)
+	}
+	if len(second.ProposalIDs) != 0 {
+		t.Errorf("the run recorded %d proposals it did not raise", len(second.ProposalIDs))
+	}
+}
+
+// The same commitment, worded differently, is still the same question.
+//
+// This is the case the identity exists for. The model is not deterministic, so a
+// second reading of one transcript paraphrases: the payload differs, and a
+// memory keyed on the payload's diff hash forgets the refusal immediately.
+func TestARejectedTranscriptProposalStaysRefusedWhenTheModelRewordsIt(t *testing.T) {
+	e := setupTranscript(t)
+	first := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	e.rejectFirst(t, first.ProposalIDs)
+
+	// Same line of the transcript, different words for what it says.
+	e.read(t, cannedBrain{reply: reworded(t, "Priya to send revised pricing by Friday", 3)})
+	if got := e.pendingProposals(t); got != 0 {
+		t.Errorf("a reworded reading of the same line staged %d proposals over a "+
+			"rejection, want 0 — the memory is keyed on the model's prose", got)
+	}
+}
+
+// A commitment from a different part of the transcript is a different question.
+//
+// The other half of the key. A refusal is remembered with no expiry, so a
+// target-only key would mean one "no" ends transcript reading on that activity
+// for good — every later commitment silently suppressed, with nothing to point
+// at.
+func TestADifferentLineIsStillProposedAfterARefusal(t *testing.T) {
+	e := setupTranscript(t)
+	first := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	e.rejectFirst(t, first.ProposalIDs)
+
+	// A different sentence of the same call.
+	e.read(t, cannedBrain{reply: reworded(t, "Dana to review the pricing", 4)})
+	if got := e.pendingProposals(t); got != 1 {
+		t.Errorf("a commitment from a line nobody refused staged %d proposals, want 1 — "+
+			"one refusal has ended transcript reading on this activity for good", got)
+	}
+}
+
+// A second reading does not duplicate a proposal that is still waiting.
+//
+// The pending half, which the producer had no guard for at all: before this,
+// reading twice put two identical cards in front of the rep.
+func TestASecondReadingDoesNotDuplicateAProposalStillWaiting(t *testing.T) {
+	e := setupTranscript(t)
+	e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	if got := e.pendingProposals(t); got != 1 {
+		t.Errorf("two readings left %d proposals waiting, want 1 — the rep is shown "+
+			"the same commitment twice", got)
+	}
+}
+
+// A reading that raises nothing says why.
+//
+// "I read it and everything in it was already put to you" and "I could not read
+// it" are different answers, and a run that finishes silent reads as the second.
+// The run record refuses to let them collapse, which is what caught this.
+func TestAReadingWhoseStepsWereAllAnsweredSaysSo(t *testing.T) {
+	e := setupTranscript(t)
+	first := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	e.rejectFirst(t, first.ProposalIDs)
+
+	second := e.read(t, cannedBrain{reply: groundedReply(t, 3, 0.9)})
+	if second.StatusDetail == nil || *second.StatusDetail == "" {
+		t.Fatal("a reading that raised nothing recorded no reason, so it cannot be " +
+			"told from one that failed")
+	}
+	if len(second.ProposalIDs) != 0 {
+		t.Errorf("the run claims %d proposals it did not raise", len(second.ProposalIDs))
+	}
+}

--- a/backend/internal/compose/transcriptpropose.go
+++ b/backend/internal/compose/transcriptpropose.go
@@ -295,6 +295,22 @@ func aboveFloor(steps []proposedStep) []proposedStep {
 // evidence, quoting the transcript rather than the model's paraphrase of it —
 // the point is to show the human what the text actually says.
 func stepEvidence(step proposedStep, lines []string, activityID ids.ActivityID) approvals.Evidence {
+	return approvals.Evidence{
+		Snippet:     quotedFromTranscript(step, lines),
+		SourceType:  string(recordTypeActivity),
+		SourceID:    activityID.UUID,
+		SourceLines: step.SourceLines,
+	}
+}
+
+// quotedFromTranscript is the transcript's own words behind one step.
+//
+// One function because two readers need the SAME string: the evidence a reader
+// sees, and the proposal's `cited` field, which the rejection memory keys on. A
+// second spelling of the trim would let the two diverge on a long quotation,
+// and the memory would then fail to recognise a refusal that a reader can see
+// is about the same words.
+func quotedFromTranscript(step proposedStep, lines []string) string {
 	quoted := make([]string, 0, len(step.SourceLines))
 	for _, line := range step.SourceLines {
 		quoted = append(quoted, lines[line-1])
@@ -306,12 +322,7 @@ func stepEvidence(step proposedStep, lines []string, activityID ids.ActivityID) 
 		// end in a glyph the transcript does not contain.
 		snippet = strings.ToValidUTF8(snippet[:approvals.MaxEvidenceSnippet], "")
 	}
-	return approvals.Evidence{
-		Snippet:     snippet,
-		SourceType:  string(recordTypeActivity),
-		SourceID:    activityID.UUID,
-		SourceLines: step.SourceLines,
-	}
+	return snippet
 }
 
 // transcriptReadStore is the slice of the activities store this engine drives.

--- a/backend/internal/compose/transcriptproposerun.go
+++ b/backend/internal/compose/transcriptproposerun.go
@@ -68,11 +68,14 @@ type TranscriptStepProposal struct {
 	Cited string `json:"cited"`
 }
 
-// transcriptIdentityCited is the payload key the staging identity is drawn from.
-// It and the struct tag above must spell the same thing — canonicalIdentity
-// refuses an identity field the payload does not carry, so a typo here is a
-// staging that fails when a rep reads a transcript rather than at compile time.
-const transcriptIdentityCited = "cited"
+// The payload keys the staging identity is drawn from. Each must spell exactly
+// what the struct tag above spells — canonicalIdentity refuses an identity field
+// the payload does not carry, so a typo here is a staging that fails when a rep
+// reads a transcript rather than at compile time.
+const (
+	transcriptIdentityCited = "cited"
+	transcriptIdentityOwner = "owner"
+)
 
 // UnmarshalTranscriptStepProposal reads back what was staged.
 func UnmarshalTranscriptStepProposal(raw json.RawMessage) (TranscriptStepProposal, error) {
@@ -209,12 +212,24 @@ func (p *TranscriptProposer) stage(
 		}
 		// A rep can read the same transcript again — the in-flight uniqueness
 		// index covers only a queued or running reading — so a refused step must
-		// not come straight back. The identity is the transcript's own words
-		// behind the step, against a target that already names the activity:
-		// those are what a rep answered, and they are what a second reading has
-		// in common with the first. The model's summary and its line citation
-		// both move between readings, so a diff hash remembers nothing.
-		identity, err := json.Marshal(map[string]string{transcriptIdentityCited: proposal.Cited})
+		// not come straight back. The identity is what the transcript itself
+		// says: the words behind the step, and who it names as promising them.
+		// Both hold still between readings of one document, where the model's
+		// summary and its line citation do not — so a diff hash remembers
+		// nothing.
+		//
+		// The owner is here to tell two commitments in ONE sentence apart. "I'll
+		// send pricing and Dana will book the call" cites one line twice, and on
+		// the quotation alone those are one identity: the second staging would
+		// supersede the first and a rep would see one of the two, with nothing
+		// saying the other existed. The owner is safe to key on for the same
+		// reason the quotation is — it is the party AS THE TRANSCRIPT NAMES
+		// THEM, carved out of the translation rule precisely because a
+		// translated name is a different person.
+		identity, err := json.Marshal(map[string]string{
+			transcriptIdentityCited: proposal.Cited,
+			transcriptIdentityOwner: proposal.Owner,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("compose: marshal transcript step identity: %w", err)
 		}

--- a/backend/internal/compose/transcriptproposerun.go
+++ b/backend/internal/compose/transcriptproposerun.go
@@ -51,7 +51,28 @@ type TranscriptStepProposal struct {
 	Owner       string                         `json:"owner"`
 	SourceLines []int                          `json:"source_lines"`
 	Links       []activities.ActivityLinkInput `json:"links"`
+	// Cited is the transcript's OWN words behind this step, and it is what a
+	// second reading of the same transcript has in common with the first.
+	//
+	// Nothing else here does. Summary and Owner are the model's prose and vary
+	// between readings; SourceLines is the model's citation and can shift by a
+	// line for the same sentence. The transcript is a fixed document, so the
+	// commitment it states is the one thing that holds still — which is what the
+	// rejection memory has to key on for a rep's "no" to survive somebody
+	// pressing read again.
+	//
+	// It duplicates the evidence snippet deliberately. A staging identity must be
+	// a string the PAYLOAD carries with the same value (canonicalIdentity
+	// enforces both), and evidence is a sibling record rather than part of the
+	// proposed change.
+	Cited string `json:"cited"`
 }
+
+// transcriptIdentityCited is the payload key the staging identity is drawn from.
+// It and the struct tag above must spell the same thing — canonicalIdentity
+// refuses an identity field the payload does not carry, so a typo here is a
+// staging that fails when a rep reads a transcript rather than at compile time.
+const transcriptIdentityCited = "cited"
 
 // UnmarshalTranscriptStepProposal reads back what was staged.
 func UnmarshalTranscriptStepProposal(raw json.RawMessage) (TranscriptStepProposal, error) {
@@ -111,11 +132,20 @@ func (p *TranscriptProposer) Read(ctx context.Context, store transcriptReadStore
 	if err != nil {
 		return err
 	}
-	return store.FinishTranscriptRead(ctx, readID, activities.TranscriptReadOutcome{
+	outcome := activities.TranscriptReadOutcome{
 		Status:      activities.TranscriptReadDone,
 		ProposalIDs: staged,
 		LineCount:   len(reading.Lines),
-	})
+	}
+	if len(staged) == 0 {
+		// The reading found commitments and raised none of them: every one was
+		// already answered, either waiting in the queue or turned down before.
+		// That is a real outcome and it needs saying — a run that finishes with
+		// nothing and no reason reads exactly like a broken one, which is the
+		// distinction FinishTranscriptRead refuses to let collapse.
+		outcome.Detail = "every next step this transcript states has already been put to you"
+	}
+	return store.FinishTranscriptRead(ctx, readID, outcome)
 }
 
 // unreadableTranscript separates a refusal a rep can act on from a fault the
@@ -167,6 +197,7 @@ func (p *TranscriptProposer) stage(
 			Owner:       step.Owner,
 			SourceLines: step.SourceLines,
 			Links:       reading.Links,
+			Cited:       quotedFromTranscript(step, reading.Lines),
 		}
 		raw, err := json.Marshal(proposal)
 		if err != nil {
@@ -176,18 +207,37 @@ func (p *TranscriptProposer) stage(
 		if err != nil {
 			return nil, fmt.Errorf("compose: canonicalize transcript step proposal: %w", err)
 		}
-		approvalID, err := p.approval.Stage(ctx, approvals.StageInput{
+		// A rep can read the same transcript again — the in-flight uniqueness
+		// index covers only a queued or running reading — so a refused step must
+		// not come straight back. The identity is the transcript's own words
+		// behind the step, against a target that already names the activity:
+		// those are what a rep answered, and they are what a second reading has
+		// in common with the first. The model's summary and its line citation
+		// both move between readings, so a diff hash remembers nothing.
+		identity, err := json.Marshal(map[string]string{transcriptIdentityCited: proposal.Cited})
+		if err != nil {
+			return nil, fmt.Errorf("compose: marshal transcript step identity: %w", err)
+		}
+		approvalID, staged1, err := p.approval.StageUnlessDeclined(ctx, approvals.StageInput{
 			Kind:           TranscriptProposalKind,
 			ProposedChange: canonical,
 			DiffHash:       hash,
+			Identity:       identity,
 			TargetType:     transcriptTargetType,
 			TargetID:       activityID.UUID,
 			Summary:        step.Summary,
 			Evidence:       []approvals.Evidence{stepEvidence(step, reading.Lines, activityID)},
 			BundleID:       bundleID,
+			JoinPending:    true,
 		})
 		if err != nil {
 			return nil, err
+		}
+		if !staged1 {
+			// Already refused, or already waiting. Either way this reading adds
+			// nothing to the queue, and the run's own record says how many steps
+			// it raised — so a step that was answered before is not counted again.
+			continue
 		}
 		staged = append(staged, approvalID.UUID)
 	}

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -86,6 +86,27 @@ type MergeProposal struct {
 	Summary        string
 }
 
+// MergeAddress reads the address a merge proposal collided on out of its
+// payload, in the normalized form captureLead stores it.
+//
+// It lives here because this module owns what the payload is: the composition
+// root stages the proposal and needs one field of it for the rejection memory's
+// identity, and re-deriving that field there would be a second answer to "what
+// shape is a dedupe payload" sitting in a package that never builds one.
+//
+// An unreadable payload answers the empty string rather than an error. The
+// caller's use is an identity, and an identity that matches nothing costs a
+// duplicate card a rep has seen before; failing the staging would cost the
+// proposal entirely, and a collision nobody is told about is worse than one
+// they are told about twice.
+func MergeAddress(proposedChange json.RawMessage) string {
+	var fields LeadFields
+	if err := json.Unmarshal(proposedChange, &fields); err != nil {
+		return ""
+	}
+	return fields.Email
+}
+
 // NewSink binds the capture sink to the pool its writes run through.
 func NewSink(db *database.DB) *Sink {
 	return &Sink{db: db}

--- a/backend/internal/modules/capture/sinklead.go
+++ b/backend/internal/modules/capture/sinklead.go
@@ -33,10 +33,17 @@ import (
 // (the incumbent's id and the captured fields) for the caller to stage
 // after commit.
 func (s *Sink) captureLead(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord, fields LeadFields) (datasource.EntityRef, *ids.LeadID, json.RawMessage, error) {
-	// Provider payloads carry whitespace; every downstream email
-	// comparison (suppression, dedupe, the DB lower()) assumes a
-	// trimmed address.
-	fields.Email = strings.TrimSpace(fields.Email)
+	// Provider payloads carry whitespace and arbitrary case; every downstream
+	// email comparison (suppression, dedupe, the DB lower()) assumes a trimmed,
+	// lowercased address.
+	//
+	// Lowercased HERE rather than left to the SQL, because the address also
+	// leaves this path in the dedupe payload, and the merge proposal's rejection
+	// memory is keyed on it. Two syncs of one upstream record differing only in
+	// case collide with the same lead — `email = lower($1)` — so an identity
+	// carrying the raw spelling would read them as two questions and forget a
+	// refusal the first time a provider changed its capitalisation.
+	fields.Email = strings.ToLower(strings.TrimSpace(fields.Email))
 	// The A13 resurrection guard: an erased subject's address
 	// refuses re-capture — deletion sticks. The natural key, not
 	// the address, names the skip (the log must not re-store PII).

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -193,7 +193,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (37)
+## Prohibition (38)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -222,6 +222,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |
 | `publicreferences_test.go` | H1 | This repository is public. |
+| `refusalmemory_test.go` | H2 | A producer that can be re-triggered remembers what a human refused. |
 | `requestbodybound_test.go` | H2 | Every JSON request body is bounded in one place. |
 | `retentionscope_test.go` | H2 | retentionScopeBuilder is the fixture whose reach these gates bound, retentionScopeSink is the one call it may feed, and retentionScopeSinkOwner is the package that call must live in. |
 | `rlsclaims_test.go` | H1 | Fitness function over a guarantee this codebase no longer has. |


### PR DESCRIPTION
Three producers put a refused proposal straight back on their next run. A rep's "no" meant nothing to any of them.

`StageUnlessDeclined` refuses to raise a proposal whose identity a human has rejected. Plain `Stage` does not: `JoinPending` collapses a proposal still *waiting*, and a rejection is precisely what stops it waiting. Three producers called the wrong one.

## A captured merge came back on every connector sync

The stager guarded only "is one already pending" — and the comment above that guard names re-sync repetition as the problem it was solving. It solved half of it.

Keyed now on the address the collision was found on, against a target that already names the incumbent lead: those two are what a rep answers. Not the payload's diff hash, because an upstream record gains a title or a corrected name between syncs while the question is unchanged. The address is lowercased where it is captured, since the collision itself is found with `lower()` and two spellings would otherwise read as two questions.

This is the one that worried me most. A merge discards the loser's link rows and cannot be undone, and the queue was pressuring the rep toward it every cycle.

## A transcript proposal came back whenever anybody pressed read again

The in-flight uniqueness index covers only a queued or running reading, and there was no guard of any kind — so a second reading also duplicated what was still waiting.

Keyed on what the transcript itself says: the words behind the step, and who it names as promising them. Both hold still between readings of one document, where the model's summary and its line citation do not.

The owner is in that key because review found a defect I had introduced: on the quotation alone, "I'll send pricing and Dana will book the call" cites one line twice, so the second staging superseded the first and one commitment vanished with nothing saying it had existed. The owner is safe to key on for the same reason the quotation is — it is the party *as the transcript names them*, carved out of the prompt's translation rule precisely because a translated name is a different person. There is a test for the two-in-one-sentence case, and it failed before the fix.

A reading that now raises nothing says so, because "everything here was already put to you" and "I could not read this" are different answers and a silent run reads as the second.

## A rate refresh re-offered a figure an admin had turned down

On every click. The diff is computed against the rate sheet, which a rejection does not change, so the same click re-derived the same proposal forever. Its `Identity` and `JoinPending` were already declared; only the entry point was wrong.

## A gate holds the rule rather than the four instances

A producer under `compose` stages through `StageUnlessDeclined` unless it waives itself with the mechanism that makes repetition impossible or intended. The four standing waivers name a run-claim index, a backlog query that excludes decided offers, and two triggers that are a person deliberately asking again.

## Verification

- `make check-backend` green, `make craft-static` clean.
- The full `internal/compose` integration lane green, plus capture and approvals.
- Mutation-checked, and one result changed what I wrote: reverting the merge identity left four of five tests passing on `StageUnlessDeclined`'s diff-hash fallback, so the test that actually earns the identity is now labelled as the one that does.

## What came out of this PR

A "never ask me about this kind" mute was built here and has been pulled back out. Review found that muting closed the *shared* approval row, so one rep's personal preference removed a proposal from their manager's queue — and the inbox is shared with managers by design. The right shape is a per-reader narrowing where `decidable` already lives, not a row closure, and that is a different change. Filed separately rather than half-landed.

Closes #3200. Closes #3201.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Declined approval proposals are no longer recreated for the same decision, even when source wording changes.
  * Pending proposals are consolidated to prevent duplicates.
  * Capture merge proposals now include stable deduplication and approval handling.
  * Email matching is more consistent, including differences in capitalization and spacing.
  * Transcript-based proposals include cited text and clearer status when all detected steps were already addressed.
  * Multiple commitments referencing the same transcript line are handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->