### PR TITLE
fix(voice): a candidate can be read before it is chosen, and a running build says so

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5572,7 +5572,23 @@ export const de = {
     "KI-gest\u00fctzte Entw\u00fcrfe; jeder Versand bleibt eine menschliche Entscheidung.",
   "voice.insights.nextBestLabel": "So wird sie besser:",
   "voice.candidate.title":
-    "Eine neue Stimmen-Version (v{n}) wartet auf deine Pr\u00fcfung.",
+    "Eine neue Voice-Version (v{n}) ist fertig — lies sie, bevor du sie verwendest.",
+  "voice.candidate.whatItIs":
+    "Das hat der Build aus deinen Proben gelernt. Sie ist noch nicht im Einsatz: Es wird nichts in dieser Stimme entworfen, bevor du sie auswählst.",
+  "voice.candidate.reviewLabel":
+    "Was diese Version über deinen Schreibstil sagt",
+  "voice.candidate.concernsLabel":
+    "Warum sie auf dich wartet, statt von allein aktiv zu werden",
+  "voice.candidate.applyHint":
+    "Wenn sie sich nach dir liest, verwende sie. Wenn nicht, behalte deine aktuelle Stimme und füge mehr eigene Texte hinzu — der nächste Build lernt aus dem, was in deinem Korpus steht.",
+  "voice.candidate.reason.malformed":
+    "Die Prüfung, die eine neue Stimme bewertet, konnte einige der Beispielentwürfe nicht lesen. Die Bewertung beruht daher auf weniger Beispielen als üblich.",
+  "voice.candidate.reason.lowScore":
+    "Beispielentwürfe in dieser Stimme erreichten {score} im Vergleich zu deinen eigenen Texten — unter den {floor}, die diese Installation verlangt, um eine Stimme selbstständig zu aktivieren.",
+  "voice.candidate.reason.hardFailures":
+    "{n} Formulierungen, die diese Stimme vermeiden soll, sind in den Beispielentwürfen geblieben.",
+  "voice.candidate.reason.rulesRemoved":
+    "{n} Regeln darüber, was zu vermeiden ist, sind gegenüber deiner vorherigen Version weggefallen.",
   "voice.candidate.apply": "Diese Version verwenden",
   "voice.candidate.reject": "Meine aktuelle Stimme behalten",
   "voice.history.label": "Versionen und Lernen",
@@ -5642,6 +5658,8 @@ export const de = {
   "settings.voice.buildsTitle": "Builds",
   "settings.voice.buildRowLabel": "Aus deinen Proben bauen",
   "settings.voice.building": "Baue…",
+  "settings.voice.buildRunning":
+    "Deine Voice DNA wird gerade gebaut — das dauert etwa eine Minute. Du kannst die Seite verlassen, der Build läuft weiter.",
   "settings.voice.rebuild": "Voice DNA neu bauen",
   "settings.voice.buildFirst": "Meine Voice DNA bauen",
   "settings.voice.buildNeedsWords":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5623,7 +5623,22 @@ export const en = {
     "AI-assisted drafts; every send stays a human decision.",
   "voice.insights.nextBestLabel": "To make it better:",
   "voice.candidate.title":
-    "A new voice version (v{n}) is waiting for your review.",
+    "A new voice version (v{n}) is ready — read it before you use it.",
+  "voice.candidate.whatItIs":
+    "This is what the build learned from your samples. It is not in use yet: nothing is drafted in this voice until you choose it.",
+  "voice.candidate.reviewLabel": "What this version says about how you write",
+  "voice.candidate.concernsLabel":
+    "Why it is waiting for you rather than going live on its own",
+  "voice.candidate.applyHint":
+    "If it reads like you, use it. If it does not, keep your current voice and add more of your own writing — the next build learns from what is in your corpus.",
+  "voice.candidate.reason.malformed":
+    "The check that scores a new voice could not read some of the sample drafts, so its score is based on fewer samples than usual.",
+  "voice.candidate.reason.lowScore":
+    "Sample drafts written in this voice scored {score} against your own writing, under the {floor} this installation requires to activate a voice on its own.",
+  "voice.candidate.reason.hardFailures":
+    "{n} phrases this voice is supposed to avoid survived into the sample drafts.",
+  "voice.candidate.reason.rulesRemoved":
+    "{n} rules about what to avoid were dropped compared with your previous version.",
   "voice.candidate.apply": "Use this version",
   "voice.candidate.reject": "Keep my current voice",
   "voice.history.label": "Versions and learning",
@@ -5688,6 +5703,8 @@ export const en = {
   "settings.voice.buildsTitle": "Builds",
   "settings.voice.buildRowLabel": "Build from your samples",
   "settings.voice.building": "Building…",
+  "settings.voice.buildRunning":
+    "Building your voice now — this takes about a minute. You can leave this page; the build keeps running.",
   "settings.voice.rebuild": "Rebuild Voice DNA",
   "settings.voice.buildFirst": "Build my Voice DNA",
   "settings.voice.buildNeedsWords":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5516,7 +5516,21 @@ export const vi = {
     "Bản nháp có AI hỗ trợ; mọi lượt gửi vẫn là quyết định của con người.",
   "voice.insights.nextBestLabel": "Để tốt hơn nữa:",
   "voice.candidate.title":
-    "Một phiên bản giọng văn mới (v{n}) đang chờ bạn rà soát.",
+    "Phiên bản giọng văn mới (v{n}) đã sẵn sàng — hãy đọc trước khi dùng.",
+  "voice.candidate.whatItIs":
+    "Đây là những gì bản dựng học được từ các mẫu của bạn. Nó chưa được sử dụng: không có bản nháp nào viết bằng giọng này cho đến khi bạn chọn nó.",
+  "voice.candidate.reviewLabel": "Phiên bản này nói gì về cách bạn viết",
+  "voice.candidate.concernsLabel": "Vì sao nó chờ bạn thay vì tự kích hoạt",
+  "voice.candidate.applyHint":
+    "Nếu đọc lên giống bạn, hãy dùng nó. Nếu không, hãy giữ giọng hiện tại và thêm văn bản của chính bạn — bản dựng tiếp theo sẽ học từ những gì có trong kho.",
+  "voice.candidate.reason.malformed":
+    "Bước kiểm tra chấm điểm giọng mới không đọc được một số bản nháp mẫu, nên điểm số dựa trên ít mẫu hơn bình thường.",
+  "voice.candidate.reason.lowScore":
+    "Các bản nháp mẫu viết bằng giọng này đạt {score} so với văn bản của chính bạn, dưới mức {floor} mà cài đặt này yêu cầu để tự kích hoạt một giọng.",
+  "voice.candidate.reason.hardFailures":
+    "{n} cụm từ mà giọng này lẽ ra phải tránh vẫn còn trong các bản nháp mẫu.",
+  "voice.candidate.reason.rulesRemoved":
+    "{n} quy tắc về những điều cần tránh đã bị bỏ so với phiên bản trước của bạn.",
   "voice.candidate.apply": "Dùng phiên bản này",
   "voice.candidate.reject": "Giữ giọng văn hiện tại",
   "voice.history.label": "Phiên bản và quá trình học",
@@ -5582,6 +5596,8 @@ export const vi = {
   "settings.voice.buildsTitle": "Bản dựng",
   "settings.voice.buildRowLabel": "Dựng từ mẫu văn của bạn",
   "settings.voice.building": "Đang dựng…",
+  "settings.voice.buildRunning":
+    "Đang xây dựng giọng văn của bạn — mất khoảng một phút. Bạn có thể rời trang này, quá trình vẫn tiếp tục chạy.",
   "settings.voice.rebuild": "Dựng lại Voice DNA",
   "settings.voice.buildFirst": "Xây dựng Voice DNA của tôi",
   "settings.voice.buildNeedsWords":

--- a/frontend/src/screens/voice-candidate.test.tsx
+++ b/frontend/src/screens/voice-candidate.test.tsx
@@ -1,0 +1,174 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { ActiveVoiceInsights } from "./voice-versions";
+
+// The banner asks the owner to accept or reject a voice that will write their
+// mail. Everything that decision needs has to be ON it: what the voice says
+// about them, and why it is waiting rather than activating itself. It shipped
+// with a title, the evaluator's own log sentences, and two buttons — so "Use
+// this version" meant approving writing nobody had seen, and reading it first
+// was impossible.
+
+type VoiceProfileVersion = components["schemas"]["VoiceProfileVersion"];
+
+function candidateVersion(
+  reviewReasons: readonly string[],
+): VoiceProfileVersion {
+  return {
+    id: "v-1",
+    profile_id: "p-1",
+    profile_version: 1,
+    status: "candidate",
+    voice_profile_md: "# Voice DNA",
+    profile_json: {
+      inference: {
+        identity_summary: "Direct, concrete, few adjectives.",
+        thinking_pattern: "State the ask, then the reason, then the deadline.",
+        signature_moves: [{ quote: "Passt das so?", source_id: "s1" }],
+        avoid: ["corporate filler"],
+      },
+      sample_drafts: [{ scenario: "Follow-up", draft: "Moin Stefan, kurz..." }],
+      guidance: { next_best: "Add more sent mail." },
+    },
+    stats_json: { corpus_words: 1200, source_count: 3 },
+    source_hash: "h",
+    source_count: 3,
+    reason: "manual",
+    predecessor_version: null,
+    activation_policy_version: "2",
+    model_provider: "routed",
+    model_name: "claude-haiku-4.5",
+    builder_version: "voicebuilder/1",
+    source: "build",
+    captured_by: "human:x",
+    evaluation: {
+      held_out_prompts: 5,
+      repeats_per_prompt: 3,
+      active_median_voice_score: null,
+      candidate_median_voice_score: 0.56,
+      anti_ai_hard_failures: 0,
+      structured_output_valid: false,
+      corpus_citations_valid: true,
+      identity_word_jaccard: 1,
+      signature_set_jaccard: 1,
+      removed_avoid_rules: 0,
+      removed_register_rules: 0,
+      classification: "material",
+      passed: false,
+    },
+    review_reasons: [...reviewReasons],
+    version: 1,
+    created_at: "2026-08-30T03:42:00Z",
+    updated_at: "2026-08-30T03:42:00Z",
+    archived_at: null,
+    activated_at: null,
+  };
+}
+
+function stub(version: VoiceProfileVersion) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [version],
+            page: { next_cursor: null, has_more: false },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    ),
+  );
+}
+
+function view(ui: ReactNode) {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("reviewing a candidate voice", () => {
+  it("shows the voice itself, so the decision is about something visible", async () => {
+    stub(candidateVersion([]));
+    view(
+      <ActiveVoiceInsights
+        profileId="p-1"
+        canEdit
+        onChanged={() => undefined}
+      />,
+    );
+
+    // What the build actually learned, on the card that asks about it.
+    expect(
+      await screen.findByText(
+        "State the ask, then the reason, then the deadline.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/Direct, concrete/)).toBeTruthy();
+    // And the fact that nothing is written in it yet.
+    expect(screen.getByText(/It is not in use yet/)).toBeTruthy();
+  });
+
+  // The evaluator writes for an operator reading a log. "median voice score
+  // 0.56 is below the 0.60 floor" is not a sentence the person being asked to
+  // decide can act on.
+  it("says why it is waiting in words about the owner's own voice", async () => {
+    stub(
+      candidateVersion([
+        "the model returned malformed drafts during evaluation",
+        "median voice score 0.56 is below the 0.60 floor",
+      ]),
+    );
+    view(
+      <ActiveVoiceInsights
+        profileId="p-1"
+        canEdit
+        onChanged={() => undefined}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/scored 0.56 against your own writing/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/could not read some of the sample drafts/),
+    ).toBeTruthy();
+    // The raw operator sentences are gone from the reader's view.
+    expect(screen.queryByText(/below the 0.60 floor/)).toBeNull();
+    // And the reader is told what each answer means for them.
+    expect(screen.getByText(/If it reads like you, use it/)).toBeTruthy();
+  });
+
+  // A reason nobody can read is bad; a reason nobody can SEE is worse, because
+  // the candidate would then be held back for a cause never stated.
+  it("shows a reason it does not recognize rather than dropping it", async () => {
+    stub(candidateVersion(["some future evaluator sentence"]));
+    view(
+      <ActiveVoiceInsights
+        profileId="p-1"
+        canEdit
+        onChanged={() => undefined}
+      />,
+    );
+
+    expect(
+      await screen.findByText("some future evaluator sentence"),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/voice-dna.test.tsx
+++ b/frontend/src/screens/voice-dna.test.tsx
@@ -396,6 +396,57 @@ describe("a build that fails", () => {
   // stand for a spending cap, an unreadable model answer and a broken
   // provider alike — and it told the reader to "try again", which could not
   // work for the first of those.
+  // A build runs for about a minute behind a poll, and the button carries only
+  // a spinner and a visually-hidden label. A reader looking at the page was
+  // told nothing, so they pressed again — the press is swallowed, but a
+  // control that refuses input without saying why invites the next one.
+  it("says in words that a build is running, and starts only one", async () => {
+    let started = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname.replace(/^\/v1/, "");
+        if (path === "/me") {
+          return jsonResponse(meFixture({ allow: VOICE_EDITOR }));
+        }
+        if (path === "/voice-profiles") {
+          return jsonResponse({ data: [BUILDABLE], page: emptyPage.page });
+        }
+        if (path === "/voice-profiles/vp-1/sources") {
+          return jsonResponse({ data: [SOURCE], summary: SUMMARY });
+        }
+        if (path === "/voice-profiles/vp-1/builds") {
+          started += 1;
+          return jsonResponse({ id: "vb-1", status: "queued" }, 201);
+        }
+        if (path === "/voice-profiles/vp-1/builds/vb-1") {
+          // Never terminal: the build is still running while the reader looks
+          // at the page, which is the state under test.
+          return jsonResponse({ id: "vb-1", status: "running" });
+        }
+        return jsonResponse(emptyPage);
+      }),
+    );
+
+    await pressRebuild();
+
+    const running = await screen.findByText(/Building your voice now/);
+    expect(running).toBeTruthy();
+    // The wait outlives this page, and a reader who does not know that sits
+    // and watches it.
+    expect(running.textContent).toMatch(/leave this page/);
+
+    // The button is not natively disabled — that would drop it out of the tab
+    // order mid-wait — but it announces itself busy and takes no second press.
+    const button = screen.getByRole("button", { name: /Build my Voice DNA/ });
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.hasAttribute("disabled")).toBe(false);
+
+    await userEvent.click(button);
+    await userEvent.click(button);
+    expect(started).toBe(1);
+  });
+
   it("says what the finished build says, not a fixed sentence", async () => {
     const detail =
       "Our AI provider is out of budget, so the build never ran. Your previous version is unchanged.";

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -630,6 +630,24 @@ type BuildOutcome = Readonly<{
   detail?: string | null;
 }>;
 
+// What the status line says at each point in a build's life: running, finished,
+// or never started. Named rather than nested in the JSX because the control
+// around it is already at the complexity ceiling, and a reader asking "what
+// does this line say while it builds?" should find one function that answers.
+function buildStatusLine(
+  t: ReturnType<typeof useT>,
+  running: boolean,
+  outcome: BuildOutcome | null,
+): string {
+  if (running) {
+    return t("settings.voice.buildRunning");
+  }
+  if (outcome) {
+    return buildOutcomeText(t, outcome);
+  }
+  return "";
+}
+
 // What the reader is told a finished build did.
 //
 // The server's own sentence wins whenever it sent one, because only the server
@@ -784,9 +802,17 @@ function BuildControls({
                 about a minute behind a poll, so the reader who started it has
                 looked away — and a live region inserted together with its text
                 is not reliably announced, which would leave the one thing they
-                are waiting for arriving in silence. */}
+                are waiting for arriving in silence.
+                
+                While it runs this says so IN WORDS. The button carries the
+                spinner and a visually-hidden busy label, which is the whole
+                story for a screen reader and none of it for a reader looking
+                at the page: a control that swallows a second press without
+                saying why invites the press again. It also says the wait can
+                be left, because a build outlives this page and a reader who
+                does not know that sits and watches it. */}
             <p className="t-small" role="status">
-              {outcome ? buildOutcomeText(t, outcome) : ""}
+              {buildStatusLine(t, build.isPending, outcome)}
             </p>
             {error && (
               <p className="t-small" role="alert">

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -4,9 +4,9 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
-import { Badge, Button, Card } from "../design-system/atoms";
+import { Badge, Button, Card, Disclosure } from "../design-system/atoms";
 import { formatDate, formatNumber, identifierNumber } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { type Locale, useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { parseVoiceInsights, VoiceInsights } from "./voice-insights";
 import "./voice-dna.css";
@@ -83,8 +83,49 @@ export function ActiveVoiceInsights({
   );
 }
 
+// The evaluator writes its reasons for an operator reading a log, and they
+// reached the owner verbatim: "median voice score 0.56 is below the 0.60 floor"
+// says nothing to the person being asked to decide. Each known shape is stated
+// again in words about THEIR voice and what to do about it.
+//
+// An unrecognized reason is shown as it came rather than dropped: a reason
+// nobody can read is bad, and a reason nobody can SEE is worse — it would let
+// a candidate be held back for a cause the owner is never told.
+function reviewReasonText(
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+  reason: string,
+): string {
+  const lowScore =
+    /median voice score ([\d.]+) is below the ([\d.]+) floor/.exec(reason);
+  if (lowScore) {
+    return t("voice.candidate.reason.lowScore", {
+      score: lowScore[1] ?? "",
+      floor: lowScore[2] ?? "",
+    });
+  }
+  const hardFailures = /^(\d+) anti-AI hard failures survived/.exec(reason);
+  if (hardFailures) {
+    return t("voice.candidate.reason.hardFailures", {
+      n: formatNumber(Number(hardFailures[1] ?? 0), locale),
+    });
+  }
+  const rulesRemoved =
+    /^(\d+) avoid and (\d+) register rules were removed/.exec(reason);
+  if (rulesRemoved) {
+    const dropped = Number(rulesRemoved[1] ?? 0) + Number(rulesRemoved[2] ?? 0);
+    return t("voice.candidate.reason.rulesRemoved", {
+      n: formatNumber(dropped, locale),
+    });
+  }
+  if (reason.includes("malformed drafts during evaluation")) {
+    return t("voice.candidate.reason.malformed");
+  }
+  return reason;
+}
+
 // A candidate never replaces the active voice silently: the owner applies
-// or rejects it, with the evaluator's reasons in view.
+// or rejects it, with the version itself and the evaluator's reasons in view.
 function CandidateBanner({
   profileId,
   candidate,
@@ -97,6 +138,7 @@ function CandidateBanner({
   onChanged: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const [error, setError] = useState<string | null>(null);
   const transition = useMutation({
     mutationFn: async (action: "apply" | "reject") => {
@@ -130,13 +172,32 @@ function CandidateBanner({
           n: identifierNumber(candidate.profile_version),
         })}
       </b>
+      <p className="t-small">{t("voice.candidate.whatItIs")}</p>
+      {/* The decision this card asks for cannot be taken without the thing it
+          is about. It used to show a title, the evaluator's raw sentences and
+          two buttons — so "Use this version" meant approving writing the
+          reader had never seen, and the only way to read it was to apply it
+          first. The version is already in hand here; the same insights view
+          the active voice uses renders it. */}
+      <Disclosure summary={t("voice.candidate.reviewLabel")} open>
+        <VoiceInsights
+          data={parseVoiceInsights(candidate)}
+          profileVersion={candidate.profile_version}
+        />
+      </Disclosure>
       {candidate.review_reasons.length > 0 && (
-        <ul className="vdna-reasons">
-          {candidate.review_reasons.map((reason) => (
-            <li key={reason}>{reason}</li>
-          ))}
-        </ul>
+        <>
+          <p className="t-small vdna-label">
+            {t("voice.candidate.concernsLabel")}
+          </p>
+          <ul className="vdna-reasons">
+            {candidate.review_reasons.map((reason) => (
+              <li key={reason}>{reviewReasonText(t, locale, reason)}</li>
+            ))}
+          </ul>
+        </>
       )}
+      <p className="t-small">{t("voice.candidate.applyHint")}</p>
       {error && (
         <p className="t-small" role="alert">
           {error}


### PR DESCRIPTION
## What was wrong

Reported from the running product: *"I got this now. I have ZERO idea as the user what I should do here. I can press use but cant review? And what do the error messages tell me?"*

The candidate review card rendered a title, the evaluator's raw log sentences, and two buttons:

> A new voice version (v1) is waiting for your review.
> the model returned malformed drafts during evaluation
> median voice score 0.56 is below the 0.60 floor
> **[Use this version]  [Keep my current voice]**

Three separate failures:

1. **Nothing to review.** `voice_profile_md`, `profile_json` and the sample drafts were already loaded in the component and already on the wire — and none of it was rendered. The only way to read the voice was to apply it first.
2. **Messages written for an operator reading a log.** "median voice score 0.56 is below the 0.60 floor" is not a sentence the person being asked to decide can act on.
3. **Nothing said what either button meant**, or the fact that mattered most: the candidate is not in use, so nothing is drafted in that voice until it is chosen.

The component had **no test file at all**, which is how it shipped this way.

Separately, the build status line was empty while a build ran — the button carried a spinner and a visually-hidden busy label, which is the whole story for a screen reader and none of it for a reader looking at the page.

## What changed

- The card renders the candidate through **the same `VoiceInsights` view the active voice uses** — how you think, signature moves with quotes, what the voice avoids, sample drafts. Reused, not reimplemented.
- Each known evaluator reason is restated in words about the owner's voice ("Sample drafts written in this voice scored 0.56 against your own writing, under the 0.60 this installation requires to activate a voice on its own"). An **unrecognized reason is still shown verbatim** — a candidate held back for a cause nobody is told is worse than an unreadable sentence.
- The card says what it is ("not in use yet") and what each answer means.
- The build status line says a build is running and that the page can be left.

## On the button that stays clickable

Also reported: *"I can click again and again during building. Shouldn't the button be disabled?"*

It is already safe — the design-system `Button` swallows clicks while `pending` (`onClick={busy ? swallowWhileBusy : onClick}`) and sets `aria-busy`/`aria-disabled`, so no second build starts. It is deliberately **not** natively disabled: that drops it out of the tab order mid-wait. Verified by test — passing `disabled` and `pending` together returns `aria-busy: null`, i.e. the busy state is lost entirely, which is why the `!build.isPending &&` guard in `BuildControls` is correct and stays. The real gap was that nothing said so in words; that is what changed.

## Verified

- `make check` exit 0, zero failures; `craft static --strict` clean.
- New `voice-candidate.test.tsx` (3 tests) plus a build-running test, all mutation-checked: removing the insights view, restoring the raw reasons, dropping the running message, and letting a second click through each turn their test red.
- Rendered in a browser against a **real candidate row** copied from a running stack — the derived voice, the translated reasons and both buttons all appear.

## Known gap this exposes, not fixed here

Five voice integration tests exist and none of them runs a build to completion: `TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold` asserts `202 queued` and stops. The build itself runs in a river job worker no integration test starts, so the model call, JSON parsing, evaluation and candidate creation are untested. Follow-up work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the voice candidate review card so a version can be read before it is chosen, and the build status line now says in words when a build is running.

- The card renders the candidate through the same `VoiceInsights` view the active voice uses instead of only the evaluator's raw log sentences.
- Known evaluator reasons are restated in plain language about the owner's voice; unrecognized reasons still appear verbatim.
- The card says the version is not in use yet and what each button means.
- The build status line now says a build is running and that the page can be left; the button stays clickable rather than natively disabled so it keeps its place in tab order.

<sup>Written for commit 91143f4b1f4156becbde5fabb2ea47aa965adacf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer review details for candidate Voice DNA versions, including readiness, evaluation concerns, scoring issues, and rule changes.
  * Added an expandable view of learned voice insights with localized guidance for applying a candidate version.
  * Added progress messaging for Voice DNA builds, including background continuation and completion status.
* **Bug Fixes**
  * Prevented duplicate build requests while a Voice DNA build is still running.
  * Preserved unknown review reasons while translating recognized reasons into clear, user-facing language.
* **Localization**
  * Added and expanded English, German, and Vietnamese translations for Voice DNA workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->