### PR TITLE
Take the anchor's row arm on the generic relationship verbs and on enrichment runs

### DIFF
--- a/backend/gates/liveprobelock_test.go
+++ b/backend/gates/liveprobelock_test.go
@@ -55,9 +55,23 @@ const (
 // unlockedLiveWrites ratifies a live-probed writer of an erasure-cleared table
 // that does not hold its subject.
 //
-// Empty, and the map exists so that adding an entry is a visible decision with a
-// reason beside it rather than a silent edit to the walk above.
-var unlockedLiveWrites = gatekit.Waive(map[string]string{})
+// Every entry so far shares one reason, and it is the only reason that makes the
+// residue nil rather than small: the subject is CREATED by the very transaction
+// that writes its children. An Art. 17 erasure races a row it can see, and no
+// other transaction can see this person until this one commits — so there is no
+// window to lose, and a lock would be taken against nobody.
+//
+// These three reach the live probe through the employment edge they attach,
+// which probes the person it hangs on. That edge takes lockPersonForAttach on
+// the same row, for the archive race one level down; the walk does not read it
+// as the subject lock because it deliberately is not one (personattachlock.go
+// says why at length — routing it through the mutation door would answer a
+// product question as a side effect of a concurrency fix).
+var unlockedLiveWrites = gatekit.Waive(map[string]string{
+	"internal/modules/people:Store.QuickCapture":            "quick capture creates the person and its phone in one transaction, then attaches the employer edge whose probe puts this function here. The subject did not exist outside this transaction when the probe ran, so no erasure can be in flight against it",
+	"internal/modules/people:Store.quickCaptureInTx":        "the same capture running inside a caller's transaction, reached only from QuickCapture and creating the same person before writing its socials",
+	"internal/modules/people:Store.CreateFromVCardReviewTx": "a reviewed card accepted into a new person: CreatePersonTx mints the row and its socials, and the employer attach that follows is what reaches the probe. The subject is this transaction's own creation, so there is no concurrent erasure to lose a race to",
+})
 
 func TestALiveProbedWriteOfAHeldRowLocksItsSubject(t *testing.T) {
 	t.Parallel()

--- a/backend/gates/writeauthority_test.go
+++ b/backend/gates/writeauthority_test.go
@@ -125,7 +125,6 @@ var readAuthorityOnAWritePath = gatekit.Waive(map[string]string{
 	// Writes that touch a shareable record's machinery without changing the
 	// record, or anything a share can speak about.
 	"internal/modules/consent:PreferenceTokenForEmail": "mints the unsubscribe capability the outbound message must carry (RFC 8058). The row is the RECIPIENT's own preference-centre credential, not a field of the person and not something a colleague's share grants or withholds; the send that mints it is gated on the activity it creates",
-	"internal/modules/integrations:QueueRun":           "an enrichment BUYS data about a person, which is why its object gate is person:READ by design and not update. The only row it writes is integrations' own run; a provider answer that later lands on a record goes through that record's own apply path, which takes the write-authority probe there",
 
 	// Refusal-disclosure clauses: rendered so a refusal may NAME the rows it
 	// collided with, and only the ones the caller could already read. The

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -80,13 +80,18 @@ func (s *Store) WithSubmitEnqueue(fn EnqueueSubmitFunc) *Store {
 // the step that costs money, and the fingerprint is computed before the
 // duplicate check because the check is defined over it.
 func (s *Store) QueueRun(ctx context.Context, in provider.QueueInput) (provider.Run, error) {
-	// Queueing a run spends the customer's credits on a named person, so it is
-	// gated on seeing that person — the same grant that authorizes reading
-	// them. The object is `person` rather than `integrations` deliberately:
-	// `integrations` governs the CONNECTION (admin/ops configuration), while
-	// buying data about someone is a thing a rep does in the course of their
-	// own work, on records they can already see.
-	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+	// A run does not read a person: it BUYS facts about them and writes those
+	// facts onto their record (people.WriteProviderClaims, audited as
+	// update/person), spending the installation's credits on the way. So the
+	// grant it asks for is the one that authorizes that write. `person` rather
+	// than `integrations` deliberately: `integrations` governs the CONNECTION
+	// (admin/ops configuration), while enriching someone is a thing a rep does
+	// in the course of their own work, on records they may already change.
+	//
+	// Read was the wrong half of the pair, and read_only is what made that
+	// visible — a seat whose entire purpose is that it changes nothing passed
+	// this gate and left provider claims on a person.
+	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return provider.Run{}, err
 	}
 	if s.fence == nil || s.identifiers == nil {
@@ -114,12 +119,19 @@ func (s *Store) QueueRun(ctx context.Context, in provider.QueueInput) (provider.
 	var out provider.Run
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The ROW gate, not just the object gate. auth.Require above answers
-		// "may this role read people at all"; this answers "may this caller
-		// see THIS person". Without it a rep could name any person id and buy
-		// data on a record outside their scope — spending the installation's
-		// credits to create data they are not allowed to look at. Existence-
-		// hiding: an invisible subject answers 404, never 403.
-		if err := auth.EnsureVisible(ctx, tx, "person", uuidOf(&in.PersonID)); err != nil {
+		// "may this role change people at all"; this answers "may this caller
+		// change THIS person". Visibility is not enough and on this table it is
+		// nothing at all: person is an identity table, read by every seat, so
+		// the visibility arm renders TRUE for everyone and a rep could name any
+		// colleague's person id, spend the installation's credits, and land
+		// provider claims on a record outside their write scope.
+		//
+		// Live, because the run's claims are new rows on the subject and
+		// archived means frozen — including a subject an Art. 17 erasure has
+		// just cleared, which a run in flight would otherwise refill.
+		// Existence-hiding survives: an invisible subject still answers 404,
+		// and only a visible-but-not-writable one answers 403.
+		if err := auth.EnsureWritableLive(ctx, tx, "person", uuidOf(&in.PersonID)); err != nil {
 			return err
 		}
 		conn, err := s.admit(ctx, tx, name, in.Trigger)

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -18,6 +18,7 @@ package integrations
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
@@ -36,11 +38,16 @@ type runsEnv struct {
 	store *Store
 	ctx   context.Context
 	ws    ids.UUID
-	// mine is visible to the acting principal; theirs is another rep's
-	// capture-private contact, which no other seat can read.
+	// mine is visible AND writable by the acting principal; theirs is another
+	// rep's capture-private contact, which no other seat can read.
 	mine   ids.PersonID
 	theirs ids.PersonID
-	owner  *pgx.Conn
+	// theirsInBook is the subject the visibility probe could never refuse:
+	// another rep's PROMOTED contact. person is an identity table, so every
+	// seat reads it and only the write arm separates them — which is why a run
+	// gated on visibility was gated on nothing at all.
+	theirsInBook ids.PersonID
+	owner        *pgx.Conn
 	// enqueued counts durable hand-offs, so a test can prove one happened.
 	enqueued int
 	// vault and fake are the store's own instances, exposed so the execution
@@ -74,8 +81,12 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		t.Fatal(err)
 	}
 
-	e := &runsEnv{ws: ids.NewV7(), owner: owner,
-		mine: ids.New[ids.PersonKind](), theirs: ids.New[ids.PersonKind]()}
+	e := &runsEnv{
+		ws: ids.NewV7(), owner: owner,
+		mine:         ids.New[ids.PersonKind](),
+		theirs:       ids.New[ids.PersonKind](),
+		theirsInBook: ids.New[ids.PersonKind](),
+	}
 
 	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, e.ws); err != nil {
 		t.Fatal(err)
@@ -101,7 +112,11 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		id         ids.PersonID
 		owner      *ids.UUID
 		visibility string
-	}{{e.mine, &actor, "workspace"}, {e.theirs, &stranger, "owner"}} {
+	}{
+		{e.mine, &actor, "workspace"},
+		{e.theirs, &stranger, "owner"},
+		{e.theirsInBook, &stranger, "workspace"},
+	} {
 		if _, err := owner.Exec(ctx, `
 			INSERT INTO person (id, owner_id, visibility, full_name, source, captured_by)
 			VALUES ($1, $2, $3, 'Anna Muster', 'manual', 'human:test')`,
@@ -183,7 +198,10 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		Type: principal.PrincipalHuman, ID: "human:" + actor.String(), UserID: actor,
 		Permissions: principal.Permissions{
 			Objects: map[string]principal.ObjectGrant{
-				"person": {Read: true},
+				// Update, not Read: a run does not read the subject, it writes
+				// bought facts onto them. Read alone is the read_only seat, and
+				// what that seat must not do is exactly this.
+				"person": {Read: true, Update: true},
 				// What enrichment COSTS is readable by any seat that may see
 				// the connection — a rep asking "are we out of credits" is
 				// asking about the installation, not about a person.
@@ -231,6 +249,94 @@ func TestQueueRunRefusesASubjectTheCallerCannotSee(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("a visible subject was refused: %v", err)
 	}
+}
+
+// The subject a visibility probe can never refuse. person is an identity table,
+// so its owner arm renders TRUE for every seat: another rep's PROMOTED contact
+// is readable by the whole workspace, and a run gated on EnsureVisible admitted
+// it. The write arm is the only thing that separates two reps on that table, so
+// this is the case the old gate could not see — a rep spending the
+// installation's credits to land provider claims on a colleague's record.
+//
+// ErrPermissionDenied exactly, not "an error": the caller was already told this
+// person is theirs to read, so a 404 here would hide nothing and would send
+// them looking for a record that is plainly in their list.
+func TestQueueRunRefusesASubjectTheCallerMaySeeButNotChange(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+
+	_, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.theirsInBook.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("queueing a run on a colleague's readable contact = %v, want ErrPermissionDenied", err)
+	}
+
+	// Nothing was bought and nothing was held: the refusal lands before the
+	// run row, so no credit is reserved against work nobody authorized.
+	if runs := e.runRows(t, e.theirsInBook); runs != 0 {
+		t.Errorf("%d run rows exist for a subject the caller cannot change", runs)
+	}
+	if e.enqueued != 0 {
+		t.Errorf("%d submit jobs enqueued for a refused run", e.enqueued)
+	}
+
+	// The positive control, and it is not the same as the one above: the caller
+	// may still enrich their OWN person, so the gate narrowed the write scope
+	// rather than closing the feature.
+	if _, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	}); err != nil {
+		t.Fatalf("the caller's own subject was refused: %v", err)
+	}
+}
+
+// The seat whose entire purpose is that it changes nothing. read_only holds
+// person.read and not person.update, and the old object gate asked for read —
+// so the lowest seat in the product could spend the installation's credits and
+// land provider claims on a person. The row arm cannot catch this one: the
+// subject here is the caller's OWN record, and it is the ACTION that is wrong.
+func TestQueueRunRefusesASeatThatMayReadPeopleButNotChangeThem(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+
+	_, err := e.store.QueueRun(e.readOnlyCtx(), provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a read-only seat queued a paid run = %v, want ErrPermissionDenied", err)
+	}
+	if runs := e.runRows(t, e.mine); runs != 0 {
+		t.Errorf("%d run rows exist for a seat that may not change the subject", runs)
+	}
+	if e.enqueued != 0 {
+		t.Errorf("%d submit jobs enqueued for a refused run", e.enqueued)
+	}
+}
+
+// readOnlyCtx is the acting principal with the update grant taken away —
+// the seeded read_only seat's shape, on the same user and workspace, so what
+// separates it from e.ctx is the one grant under test and nothing else.
+func (e *runsEnv) readOnlyCtx() context.Context {
+	actor, ok := principal.Actor(e.ctx)
+	if !ok {
+		panic("the runs environment has no actor to narrow")
+	}
+	actor.Permissions.Objects = map[string]principal.ObjectGrant{
+		"person":       {Read: true},
+		"integrations": {Read: true},
+	}
+	return principal.WithActor(e.ctx, actor)
+}
+
+// runRows counts the provider runs recorded for one subject, which is how each
+// refusal above proves it wrote nothing rather than merely answering an error.
+func (e *runsEnv) runRows(t *testing.T, person ids.PersonID) int {
+	t.Helper()
+	var runs int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM provider_run WHERE person_id = $1`, person).Scan(&runs); err != nil {
+		t.Fatal(err)
+	}
+	return runs
 }
 
 // The defect: pools were locked, checked and inserted in one pass, so a run

--- a/backend/internal/modules/people/edgereverse.go
+++ b/backend/internal/modules/people/edgereverse.go
@@ -59,39 +59,17 @@ func (s *Store) EdgeFactsForReverse(ctx context.Context, tx pgx.Tx, id ids.UUID)
 	if err != nil {
 		return EdgeFacts{}, err
 	}
-	anchor, _ := relationshipAnchor(row.Kind)
-	facts := EdgeFacts{
+	anchor, anchorID, err := anchorIDOf(row)
+	if err != nil {
+		return EdgeFacts{}, err
+	}
+	return EdgeFacts{
 		Kind:     row.Kind,
 		Version:  row.Version,
 		Archived: row.ArchivedAt != nil,
 		Anchor:   anchor,
-	}
-	facts.AnchorID, err = anchorIDOf(row, anchor)
-	if err != nil {
-		return EdgeFacts{}, err
-	}
-	return facts, nil
-}
-
-// anchorIDOf names the record whose authority governs this edge. An edge with no
-// anchor id is a row no kind's shape admits, and answering "writable" about a
-// record that is not there would light a button on a write that cannot happen.
-func anchorIDOf(row relationshipRow, anchor string) (ids.UUID, error) {
-	var id *ids.UUID
-	switch anchor {
-	case anchorPerson:
-		id = untypedPtr(row.PersonID)
-	case anchorDeal:
-		id = untypedPtr(row.DealID)
-	case projectObjectName:
-		id = untypedPtr(row.ProjectID)
-	default:
-		id = untypedPtr(row.OrganizationID)
-	}
-	if id == nil {
-		return ids.UUID{}, fmt.Errorf("people: %s edge %s names no %s to anchor on", row.Kind, row.ID, anchor)
-	}
-	return *id, nil
+		AnchorID: anchorID,
+	}, nil
 }
 
 // RefuseEdgeWrite answers the OBJECT half of the authority the inverse of one

--- a/backend/internal/modules/people/edgereverse_test.go
+++ b/backend/internal/modules/people/edgereverse_test.go
@@ -80,15 +80,23 @@ func TestAnEdgeImageValueOfTheWrongShapeIsAFault(t *testing.T) {
 // hold. A row holding none is a shape no kind admits, and answering "writable"
 // about a record that is not there would light a button on a write that cannot
 // happen.
+//
+// The object comes back with the id rather than being handed in: the caller
+// that names the anchor and the switch that reads it off the row are one
+// answer now, so a caller cannot ask for one kind's anchor and be given
+// another kind's column.
 func TestAnEdgeWithNoAnchorIsAFaultRatherThanAnEmptyAnswer(t *testing.T) {
 	t.Parallel()
-	if _, err := anchorIDOf(relationshipRow{ID: ids.NewV7(), Kind: "employment"}, anchorPerson); err == nil {
+	if _, _, err := anchorIDOf(relationshipRow{ID: ids.NewV7(), Kind: "employment"}); err == nil {
 		t.Error("an employment with no person was given an anchor")
 	}
 	person := ids.From[ids.PersonKind](ids.NewV7())
-	got, err := anchorIDOf(relationshipRow{Kind: "employment", PersonID: &person}, anchorPerson)
+	object, got, err := anchorIDOf(relationshipRow{Kind: "employment", PersonID: &person})
 	if err != nil {
 		t.Fatalf("anchoring an employment on its person: %v", err)
+	}
+	if object != anchorPerson {
+		t.Errorf("anchor object = %q, want %q — an employment annotates its person", object, anchorPerson)
 	}
 	if got != person.UUID {
 		t.Errorf("anchor = %s, want the person the employment names", got)

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -103,6 +103,14 @@ func relationshipAnchorRow(kind string, e relationshipEndpoints) (object string,
 // object it is. An edge with no anchor id is a row no kind's shape admits, and
 // answering about a record that is not there would put an audit row on nothing
 // and light a button on a write that cannot happen.
+//
+// It answers an internal fault where ensureRelationshipAnchorWritable answers
+// RelationshipShapeError on the same nil, and the difference is where the nil
+// CAME FROM rather than two minds about one rule. There the endpoints arrived
+// on a request and the caller can correct them. Here they came off a stored row
+// whose rel_*_shape CHECK already guarantees the anchor endpoint is NOT NULL —
+// so a nil is the database disagreeing with itself, and a refusal telling the
+// caller to fix a field they never sent would send them after the wrong thing.
 func anchorIDOf(row relationshipRow) (object string, id ids.UUID, err error) {
 	object, found := relationshipAnchorRow(row.Kind, row.endpoints())
 	if found == nil {

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -51,15 +51,111 @@ func relationshipAnchor(kind string) (object, column string) {
 	}
 }
 
+// relationshipEndpoints is the set of records an edge hangs on, in the one
+// shape both of its writers already hold: the create input, and the stored row
+// an update or an archive names. It exists so the anchor rule below is asked
+// once for all three verbs — two spellings of "which record does this edge
+// annotate" would drift, and the half that drifted would be an ungated write.
+type relationshipEndpoints struct {
+	person  *ids.PersonID
+	org     *ids.OrganizationID
+	deal    *ids.DealID
+	project *ids.ProjectID
+}
+
+func (r relationshipRow) endpoints() relationshipEndpoints {
+	return relationshipEndpoints{person: r.PersonID, org: r.OrganizationID, deal: r.DealID, project: r.ProjectID}
+}
+
+func (in CreateRelationshipInput) endpoints() relationshipEndpoints {
+	return relationshipEndpoints{person: in.PersonID, org: in.OrganizationID, deal: in.DealID, project: in.ProjectID}
+}
+
+// relationshipAnchorRow names the ROW an edge's authority is taken on: the
+// anchor object of its kind, and the endpoint id identifying the record the
+// edge annotates.
+//
+// This is the ONLY place the four endpoint columns are mapped to their kinds.
+// The gate below, the audit subject and the reversal's edge facts all read the
+// anchor through it, because they used to spell the same switch three times —
+// and a rule about which record an edge belongs to, held in three places, is
+// how the gate came to reason about an anchor the writers had already chosen
+// differently.
+//
+// A nil id means the edge's endpoints do not match its kind; every kind's shape
+// CHECK (migration 0001, rel_*_shape) makes its anchor endpoint NOT NULL, so
+// callers treat it as the fault the database would have answered.
+func relationshipAnchorRow(kind string, e relationshipEndpoints) (object string, id *ids.UUID) {
+	anchor, _ := relationshipAnchor(kind)
+	switch anchor {
+	case anchorPerson:
+		return anchor, untypedPtr(e.person)
+	case anchorDeal:
+		return anchor, untypedPtr(e.deal)
+	case projectObjectName:
+		return anchor, untypedPtr(e.project)
+	default:
+		return anchor, untypedPtr(e.org)
+	}
+}
+
+// anchorIDOf names the record whose authority governs a STORED edge, and the
+// object it is. An edge with no anchor id is a row no kind's shape admits, and
+// answering about a record that is not there would put an audit row on nothing
+// and light a button on a write that cannot happen.
+func anchorIDOf(row relationshipRow) (object string, id ids.UUID, err error) {
+	object, found := relationshipAnchorRow(row.Kind, row.endpoints())
+	if found == nil {
+		return object, ids.UUID{}, fmt.Errorf("people: %s edge %s names no %s to anchor on", row.Kind, row.ID, object)
+	}
+	return object, *found, nil
+}
+
+// ensureRelationshipAnchorWritable is the ROW half of the anchor gate, and the
+// half the generic surface used to leave out.
+//
+// auth.Require(anchor, update) says this seat may change PEOPLE — not that it
+// may change THIS person. Every anchor object is an identity table, read by
+// every seat in the workspace, so the endpoint probe an edge already takes is
+// existence-only for all of them and the write arm is the only thing that
+// scopes the record at all. Without this an ordinary seat could demote another
+// team's primary-employer edge, forge a partner edge on their company, or
+// staff their project, through POST/PATCH/DELETE /v1/relationships — reaching
+// past exactly the authority the dedicated verbs demand (ensureProjectWritable
+// on the stakeholder roster, auth.EnsureWritable in UpdatePerson).
+//
+// Live, not merely visible: an edge is something NEW on the anchor, and
+// archived means frozen.
+//
+// A nil id is an edge whose endpoints do not match its kind. Every kind's shape
+// CHECK makes its anchor endpoint NOT NULL, so that is the fault the database
+// would answer, refused here before the gate can silently not run.
+//
+// Held by: TestEveryGenericRelationshipVerbTakesTheAnchorRowGate
+// (backend/internal/modules/people/relationshipanchorgate_test.go)
+func ensureRelationshipAnchorWritable(
+	ctx context.Context, tx pgx.Tx, kind string, e relationshipEndpoints,
+) error {
+	object, anchorID := relationshipAnchorRow(kind, e)
+	if anchorID == nil {
+		return &RelationshipShapeError{Kind: kind}
+	}
+	return auth.EnsureWritableLive(ctx, tx, object, *anchorID)
+}
+
 // The kinds the GENERIC relationship surface admits.
 //
 // project_company is deliberately absent. A company's place on a project
-// carries two rules this surface cannot keep: the caller needs write authority
-// over the PROJECT ROW, not merely the project.update object grant this file
-// takes, and a project must keep at least one company. Both live on the
-// dedicated endpoints (projectcompany.go), so admitting the kind here would be
-// a side door around them — a caller could attach a company to a project they
-// cannot write, or archive the last one, through POST /v1/relationships.
+// carries a rule this surface cannot keep: a project must keep at least one
+// company, and only the dedicated endpoints (projectcompany.go) count them, so
+// admitting the kind here would let a caller archive the last one through
+// DELETE /v1/relationships.
+//
+// The other rule that used to keep it out — write authority over the project
+// ROW rather than the project.update object grant — is kept for every kind now,
+// by ensureRelationshipAnchorWritable. That is where it belonged: an anchor is
+// an anchor whatever the kind, and stating it per-kind is what let
+// project_stakeholder through the same door this paragraph closed.
 var relationshipKinds = map[string]bool{
 	"employment": true, "deal_stakeholder": true, "project_stakeholder": true,
 	"partner_of": true, "referred_by": true, "co_sell_with": true,
@@ -200,9 +296,14 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		if err := refuseGenericProjectCompany(current.Kind); err != nil {
 			return err
 		}
-		// Same rule as create: editing an edge is editing its anchor.
+		// Same rule as create: editing an edge is editing its anchor, so it
+		// takes both halves of the anchor's authority — the object grant, and
+		// the row.
 		anchorObject, _ := relationshipAnchor(current.Kind)
 		if err := auth.Require(ctx, anchorObject, principal.ActionUpdate); err != nil {
+			return err
+		}
+		if err := ensureRelationshipAnchorWritable(ctx, tx, current.Kind, current.endpoints()); err != nil {
 			return err
 		}
 		if in.IfVersion != nil && *in.IfVersion != current.Version {
@@ -274,7 +375,10 @@ func (s *Store) RefuseArchiveRelationship(ctx context.Context, id ids.UUID) erro
 			return err
 		}
 		anchorObject, _ := relationshipAnchor(current.Kind)
-		return auth.Require(ctx, anchorObject, principal.ActionUpdate)
+		if err := auth.Require(ctx, anchorObject, principal.ActionUpdate); err != nil {
+			return err
+		}
+		return ensureRelationshipAnchorWritable(ctx, tx, current.Kind, current.endpoints())
 	})
 }
 
@@ -310,9 +414,13 @@ func (s *Store) archiveRelationshipWithEvidence(ctx context.Context, id ids.UUID
 		if err := refuseGenericProjectCompany(current.Kind); err != nil {
 			return err
 		}
-		// Same rule as create: removing an edge is editing its anchor.
+		// Same rule as create: removing an edge is editing its anchor, and it
+		// owes the row half for the same reason the other two verbs do.
 		anchorObject, _ := relationshipAnchor(current.Kind)
 		if err := auth.Require(ctx, anchorObject, principal.ActionUpdate); err != nil {
+			return err
+		}
+		if err := ensureRelationshipAnchorWritable(ctx, tx, current.Kind, current.endpoints()); err != nil {
 			return err
 		}
 		p := storekit.NewPatch()

--- a/backend/internal/modules/people/relationshipanchor_integration_test.go
+++ b/backend/internal/modules/people/relationshipanchor_integration_test.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// The generic relationship surface against a real database, because the rule it
+// broke is a SQL predicate and nothing else.
+//
+// An edge annotates its anchor, so writing one writes that record. The surface
+// asked the anchor's OBJECT grant and whether the endpoints were VISIBLE, and on
+// an anchor object visibility decides nothing: person, organization, deal and
+// project are identity tables, so their owner arm renders TRUE for every seat.
+// An ordinary rep could therefore demote another team's real primary employer,
+// forge a partner edge on their company, or staff their project — through
+// POST/PATCH/DELETE /v1/relationships and through the MCP record verbs that
+// reach the same three store methods.
+//
+// Every test here carries a positive control on a record the caller DOES own.
+// A refusal test alone would pass just as happily against a surface that had
+// stopped working altogether.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// edgeAnchorEnv is one workspace holding two reps who share no team, and one record
+// of each anchor kind on either side of the boundary. Both reps hold the same
+// grants: what separates them is row authority alone, which is the whole of what
+// this gate decides.
+type edgeAnchorEnv struct {
+	store *Store
+	owner *pgx.Conn
+	ws    ids.UUID
+	me    ids.UUID
+	them  ids.UUID
+
+	// Mine — owned by the acting rep.
+	myPerson ids.PersonID
+	myOrg    ids.OrganizationID
+
+	// Theirs, and readable: promoted records the other rep owns. These are the
+	// subjects the old gate could not refuse.
+	theirPerson  ids.PersonID
+	theirOrg     ids.OrganizationID
+	theirPartner ids.OrganizationID
+	theirProject ids.ProjectID
+
+	// Theirs and UNreadable: a capture-private contact. It is here to prove the
+	// added gate did not turn an existence-hiding 404 into a 403 that discloses
+	// the record exists.
+	theirHiddenPerson ids.PersonID
+}
+
+func setupEdgeAnchor(t *testing.T) *edgeAnchorEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	// Before anything else touches this database, for the reason the capture
+	// privacy harness gives: testdb.Pool refuses until EnsureSchema has run, and
+	// EnsureSchema rebuilds whenever it cannot prove the database is a fresh
+	// clone, so a seed written first would be dropped rather than reset.
+	if err := testdb.EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	if err := testdb.Reset(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &edgeAnchorEnv{
+		owner: conn, ws: ids.NewV7(), me: ids.NewV7(), them: ids.NewV7(),
+		myPerson: ids.New[ids.PersonKind](), myOrg: ids.New[ids.OrganizationKind](),
+		theirPerson: ids.New[ids.PersonKind](), theirOrg: ids.New[ids.OrganizationKind](),
+		theirPartner: ids.New[ids.OrganizationKind](), theirProject: ids.New[ids.ProjectKind](),
+		theirHiddenPerson: ids.New[ids.PersonKind](),
+	}
+	if _, err := conn.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, e.ws); err != nil {
+		t.Fatal(err)
+	}
+	// No team_membership for either: the reps are on no shared team, so `own`
+	// really is own. A shared team would make every refusal below an admission.
+	for _, u := range []struct {
+		id   ids.UUID
+		name string
+	}{{e.me, "Acting Rep"}, {e.them, "Other Rep"}} {
+		if _, err := conn.Exec(ctx,
+			`INSERT INTO app_user (id, email, display_name, status) VALUES ($1, $2, $3, 'active')`,
+			u.id, "anchor-"+u.id.String()+"@example.test", u.name); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, p := range []struct {
+		id         ids.PersonID
+		owner      ids.UUID
+		visibility string
+	}{
+		{e.myPerson, e.me, "workspace"},
+		{e.theirPerson, e.them, "workspace"},
+		{e.theirHiddenPerson, e.them, "owner"},
+	} {
+		if _, err := conn.Exec(ctx, `
+			INSERT INTO person (id, owner_id, visibility, full_name, source, captured_by)
+			VALUES ($1, $2, $3, 'Anna Muster', 'manual', 'human:seed')`,
+			p.id, p.owner, p.visibility); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, o := range []struct {
+		id    ids.OrganizationID
+		owner ids.UUID
+		name  string
+	}{
+		{e.myOrg, e.me, "My Company"},
+		{e.theirOrg, e.them, "Their Company"},
+		{e.theirPartner, e.them, "Their Partner"},
+	} {
+		if _, err := conn.Exec(ctx, `
+			INSERT INTO organization (id, owner_id, display_name, source, captured_by)
+			VALUES ($1, $2, $3, 'manual', 'human:seed')`,
+			o.id, o.owner, o.name); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO project (id, owner_id, organization_id, name, source, captured_by)
+		VALUES ($1, $2, $3, 'Their Delivery', 'manual', 'human:seed')`,
+		e.theirProject, e.them, e.theirOrg); err != nil {
+		t.Fatal(err)
+	}
+
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
+	return e
+}
+
+// as binds one rep at row_scope=own, holding the ordinary grid a seat that
+// manages relationships carries. Both reps get the identical grant set, so the
+// only thing that ever differs between an admission and a refusal below is who
+// owns the anchor row.
+func (e *edgeAnchorEnv) as(user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"relationship": {Create: true, Read: true, Update: true, Delete: true},
+				"person":       {Create: true, Read: true, Update: true},
+				"organization": {Create: true, Read: true, Update: true},
+				"project":      {Create: true, Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeOwn,
+		},
+	})
+}
+
+// seedEdge writes one edge as the rep who owns its anchor, through the store —
+// so the row under test is the row the product writes, not a shape only this
+// test knows how to make.
+func (e *edgeAnchorEnv) seedEdge(t *testing.T, in CreateRelationshipInput) relationshipRow {
+	t.Helper()
+	row, err := e.store.CreateRelationship(e.as(e.them), in)
+	if err != nil {
+		t.Fatalf("seeding a %s edge as its anchor's owner: %v", in.Kind, err)
+	}
+	return row
+}
+
+// liveAndPrimary reads the two facts a hijacked employment edge would move, so
+// a refusal is checked against the surviving state rather than the error alone.
+func (e *edgeAnchorEnv) liveAndPrimary(t *testing.T, id ids.UUID) (live, primary bool) {
+	t.Helper()
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT archived_at IS NULL, is_current_primary FROM relationship WHERE id = $1`, id,
+	).Scan(&live, &primary); err != nil {
+		t.Fatalf("reading the edge back: %v", err)
+	}
+	return live, primary
+}
+
+// Creating an edge is writing its anchor, so it takes the anchor's row
+// authority — for every kind, not only the two the dedicated verbs cover.
+//
+// ErrPermissionDenied exactly, per anchor object. "Not nil" would be satisfied
+// by a 404 from a scope miss, by a shape refusal, or by the surface being
+// broken, and none of those is the gate under test.
+func TestCreatingAnEdgeTakesTheAnchorsRowAuthority(t *testing.T) {
+	e := setupEdgeAnchor(t)
+	me := e.as(e.me)
+
+	for _, tc := range []struct {
+		anchor string
+		in     CreateRelationshipInput
+	}{
+		{"person", CreateRelationshipInput{
+			Kind: employmentKind, PersonID: &e.theirPerson, OrganizationID: &e.myOrg,
+			IsCurrentPrimary: pointerTo(true), Source: "manual",
+		}},
+		{"project", CreateRelationshipInput{
+			Kind: ProjectStakeholderKind, ProjectID: &e.theirProject, PersonID: &e.myPerson,
+			Role: pointerTo("sponsor"), Source: "manual",
+		}},
+		{"organization", CreateRelationshipInput{
+			Kind: "partner_of", OrganizationID: &e.theirOrg, CounterpartyOrgID: &e.theirPartner,
+			Source: "manual",
+		}},
+	} {
+		_, err := e.store.CreateRelationship(me, tc.in)
+		if !errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("creating a %s edge anchored on another rep's %s = %v, want ErrPermissionDenied",
+				tc.in.Kind, tc.anchor, err)
+		}
+	}
+
+	var edges int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM relationship`).Scan(&edges); err != nil {
+		t.Fatal(err)
+	}
+	if edges != 0 {
+		t.Errorf("%d edges were written by a caller with no authority over any anchor", edges)
+	}
+
+	// The positive control: the same kind, the same surface, the same grants —
+	// on an anchor this rep owns. The gate narrowed the scope; it did not close
+	// the surface.
+	if _, err := e.store.CreateRelationship(me, CreateRelationshipInput{
+		Kind: employmentKind, PersonID: &e.myPerson, OrganizationID: &e.theirOrg,
+		IsCurrentPrimary: pointerTo(true), Source: "manual",
+	}); err != nil {
+		t.Fatalf("an edge on the caller's OWN person was refused: %v", err)
+	}
+}
+
+// Patching and archiving an edge are writes on its anchor too, and the patch is
+// the sharper of the two: it demotes the incumbent primary employer as a side
+// effect, so an ungated patch rewrites who the CRM says somebody works for.
+func TestPatchingAndArchivingAnEdgeTakeTheAnchorsRowAuthority(t *testing.T) {
+	e := setupEdgeAnchor(t)
+	me := e.as(e.me)
+	edge := e.seedEdge(t, CreateRelationshipInput{
+		Kind: employmentKind, PersonID: &e.theirPerson, OrganizationID: &e.theirOrg,
+		IsCurrentPrimary: pointerTo(true), Source: "manual",
+	})
+
+	if _, err := e.store.UpdateRelationship(me, edge.ID, UpdateRelationshipInput{
+		Role: pointerTo("former"),
+	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("patching another rep's employment edge = %v, want ErrPermissionDenied", err)
+	}
+	if _, err := e.store.ArchiveRelationship(me, edge.ID, nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("archiving another rep's employment edge = %v, want ErrPermissionDenied", err)
+	}
+	// The stage-time refusal answers the same way, or an approval could be
+	// staged against a write the store was always going to refuse.
+	if err := e.store.RefuseArchiveRelationship(me, edge.ID); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("the archive's stage-time probe = %v, want ErrPermissionDenied", err)
+	}
+
+	// What the refusal was FOR: the edge is untouched, and this person still
+	// works where they work.
+	live, primary := e.liveAndPrimary(t, edge.ID)
+	if !live || !primary {
+		t.Errorf("edge live=%t primary=%t after three refused writes; want it exactly as its owner left it", live, primary)
+	}
+
+	// Positive control on both verbs, on an anchor the caller owns.
+	mine := e.seedEdgeAsMe(me, t)
+	if _, err := e.store.UpdateRelationship(me, mine.ID, UpdateRelationshipInput{Role: pointerTo("founder")}); err != nil {
+		t.Fatalf("patching an edge on the caller's own person was refused: %v", err)
+	}
+	if _, err := e.store.ArchiveRelationship(me, mine.ID, nil); err != nil {
+		t.Fatalf("archiving an edge on the caller's own person was refused: %v", err)
+	}
+}
+
+// seedEdgeAsMe writes the acting rep's own employment edge, which is the
+// positive control's subject.
+func (e *edgeAnchorEnv) seedEdgeAsMe(me context.Context, t *testing.T) relationshipRow {
+	t.Helper()
+	row, err := e.store.CreateRelationship(me, CreateRelationshipInput{
+		Kind: employmentKind, PersonID: &e.myPerson, OrganizationID: &e.myOrg,
+		IsCurrentPrimary: pointerTo(true), Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding the caller's own edge: %v", err)
+	}
+	return row
+}
+
+// The added arm narrows authority; it must not widen disclosure. A subject the
+// caller cannot SEE at all still answers not-found, because 403 on an invisible
+// record says the record is there.
+func TestAnAnchorTheCallerCannotSeeStillAnswersNotFound(t *testing.T) {
+	e := setupEdgeAnchor(t)
+
+	_, err := e.store.CreateRelationship(e.as(e.me), CreateRelationshipInput{
+		Kind: employmentKind, PersonID: &e.theirHiddenPerson, OrganizationID: &e.myOrg,
+		Source: "manual",
+	})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("anchoring an edge on a capture-private contact = %v, want ErrNotFound — a 403 "+
+			"would confirm the record exists to a caller who may not know it does", err)
+	}
+	if errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Error("the write-authority arm overtook the visibility arm, and existence-hiding is gone")
+	}
+}
+
+// pointerTo is the optional-field spelling this file needs across three types.
+// The package's own `ptr` takes a string only, and widening it would touch every
+// caller of it for the sake of one test file.
+func pointerTo[T any](v T) *T { return &v }

--- a/backend/internal/modules/people/relationshipanchorgate_test.go
+++ b/backend/internal/modules/people/relationshipanchorgate_test.go
@@ -44,10 +44,12 @@ const (
 )
 
 // wantMinimumAnchorAskers is the anti-vacuity floor. Seven functions ask the
-// object half today — three create shapes, the update, the archive, its
-// stage-time refusal and the deal-qualification seat — so a floor of five
-// leaves room for one to be folded away and still fails loudly if the pairing
-// this gate matches on stops being recognisable.
+// object half today, and naming them is the point of stating a number at all:
+// the two create shapes, the update, the archive, the archive's own stage-time
+// refusal, the edge reversal's stage-time refusal, and the stakeholder seat a
+// lead qualification mints. A floor of five leaves room for one to be folded
+// away, and still fails loudly if the pairing this gate matches on stops being
+// recognisable.
 const wantMinimumAnchorAskers = 5
 
 // anchorAskersWithoutTheRowGate ratifies a function that asks the anchor's

--- a/backend/internal/modules/people/relationshipanchorgate_test.go
+++ b/backend/internal/modules/people/relationshipanchorgate_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"go/ast"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// An edge annotates its anchor, so writing one is writing that record — and the
+// anchor's authority is TWO questions, not one. `person.update` says this seat
+// may change people; whether it may change THIS person is the row half, and on
+// an anchor object it is the only half that decides anything: person,
+// organization, deal and project are identity tables, read by every seat in the
+// workspace, so the visibility probe an edge already takes passes for everyone.
+//
+// A verb that asks only the object grant is therefore not narrowly gated, it is
+// ungated — an ordinary seat could demote another team's primary-employer edge
+// or staff their project through POST/PATCH/DELETE /v1/relationships, and
+// nothing else in the path refuses.
+//
+// The population is derived from the pairing rather than listed: a function
+// that resolves an anchor with relationshipAnchor and then calls auth.Require
+// is asking the object half, whatever it is called and wherever it lives. So a
+// verb added tomorrow is judged without anyone remembering this file, and a
+// verb that stops taking the object grant leaves the census the same way it
+// entered it — visibly.
+
+// anchorRowGate is the row half every asker of the object half owes.
+const anchorRowGate = "ensureRelationshipAnchorWritable"
+
+// anchorObjectResolver and anchorObjectGate are the pair that identifies an
+// asker of the object half: the anchor is resolved from the kind, then required
+// as an object grant. Either alone is something else — the audit subject
+// resolves an anchor and gates nothing, and most of the module calls
+// auth.Require about objects that are not anchors.
+const (
+	anchorObjectResolver = "relationshipAnchor"
+	anchorObjectGate     = "Require"
+	anchorObjectPackage  = "auth"
+)
+
+// wantMinimumAnchorAskers is the anti-vacuity floor. Seven functions ask the
+// object half today — three create shapes, the update, the archive, its
+// stage-time refusal and the deal-qualification seat — so a floor of five
+// leaves room for one to be folded away and still fails loudly if the pairing
+// this gate matches on stops being recognisable.
+const wantMinimumAnchorAskers = 5
+
+// anchorAskersWithoutTheRowGate ratifies a function that asks the anchor's
+// object grant and cannot ask its row authority. Each entry says why the row
+// question is unanswerable there, not merely inconvenient.
+var anchorAskersWithoutTheRowGate = gatekit.Waive(map[string]string{
+	"RefuseEdgeWrite":           "the stage-time half of an edge reversal, which is handed a KIND and no edge — so there is no anchor row to probe, and it says so itself: it answers the object half early to keep a button honest, and the write it precedes takes the row half through UpdateRelationship or the archive. Gating here would need an id this signature does not carry",
+	"seatPersonOnQualifiedDeal": "the stakeholder seat a lead qualification mints, whose person AND deal were both created in the very transaction that writes it. No row-scope probe can see either yet, so EnsureWritableLive would refuse every qualification; the authority is the promote's own, taken on the lead before any of the three rows exist",
+})
+
+func TestEveryGenericRelationshipVerbTakesTheAnchorRowGate(t *testing.T) {
+	gated := functionsReachingTheAnchorRowGate(t)
+	askers := 0
+	forEachModuleFunc(t, func(parsed moduleFile, fn *ast.FuncDecl) {
+		if !asksTheAnchorObjectGrant(fn) {
+			return
+		}
+		askers++
+		if callsAnyPackageFunc(fn, gated) || anchorAskersWithoutTheRowGate.Waived(t, fn.Name.Name) {
+			return
+		}
+		t.Errorf("%s in %s resolves an edge's anchor and requires the object grant on it, and never "+
+			"reaches %s.\n\n"+
+			"`<anchor>.update` says the seat may change that KIND of record, not that it may change "+
+			"the one this edge hangs on — and every anchor object is read by the whole workspace, so "+
+			"the visibility probe an edge takes admits every seat. Without the row half any seat "+
+			"holding the ordinary relationship grants rewrites another team's graph and the write "+
+			"succeeds. Take the gate, or ratify the omission in %s with the reason the row question "+
+			"cannot be asked here.",
+			fn.Name.Name, parsed.name, anchorRowGate, "anchorAskersWithoutTheRowGate")
+	})
+	if askers < wantMinimumAnchorAskers {
+		t.Errorf("only %d function(s) were recognised as asking the anchor's object grant, want at "+
+			"least %d — the pairing this gate matches on (%s then %s.%s) no longer describes how the "+
+			"module gates an edge, so it is judging a smaller module than it reports",
+			askers, wantMinimumAnchorAskers, anchorObjectResolver, anchorObjectPackage, anchorObjectGate)
+	}
+	anchorAskersWithoutTheRowGate.AssertAllMatched(t)
+}
+
+// asksTheAnchorObjectGrant reports whether fn resolves an edge's anchor and
+// then requires an object grant — the object half of the anchor gate.
+func asksTheAnchorObjectGrant(fn *ast.FuncDecl) bool {
+	return callsAnyPackageFunc(fn, map[string]bool{anchorObjectResolver: true}) &&
+		callsAny(fn, anchorObjectPackage, map[string]bool{anchorObjectGate: true})
+}
+
+// functionsReachingTheAnchorRowGate names the gate plus every module function
+// that calls it, so a verb whose gate is taken by a writer it delegates to is
+// covered. One hop, not a full call graph: a verb two removes from its own
+// authorization check is worth failing over.
+func functionsReachingTheAnchorRowGate(t *testing.T) map[string]bool {
+	t.Helper()
+	gated := map[string]bool{anchorRowGate: true}
+	forEachModuleFunc(t, func(_ moduleFile, fn *ast.FuncDecl) {
+		if callsAnyPackageFunc(fn, map[string]bool{anchorRowGate: true}) {
+			gated[fn.Name.Name] = true
+		}
+	})
+	return gated
+}
+
+// callsAnyPackageFunc reports whether fn calls any of this package's named
+// functions — a bare identifier call, which is how the module's own writers and
+// gates are reached, or a call on fn's own receiver.
+//
+// Closures count. Both create shapes hand their write to s.tx as a function
+// literal, so a walk that stopped at the first FuncLit would find neither of
+// them reaching the gate their one writer takes.
+func callsAnyPackageFunc(fn *ast.FuncDecl, names map[string]bool) bool {
+	if fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		switch callee := call.Fun.(type) {
+		case *ast.Ident:
+			found = found || names[callee.Name]
+		case *ast.SelectorExpr:
+			// A method on this store's own receiver reads as a call to the
+			// same declaration; anything qualified by a package does not, and
+			// this gate's names are all declared here.
+			if on, isIdent := callee.X.(*ast.Ident); isIdent && on.Name == receiverName(fn) {
+				found = found || names[callee.Sel.Name]
+			}
+		}
+		return !found
+	})
+	return found
+}

--- a/backend/internal/modules/people/relationshipcreate.go
+++ b/backend/internal/modules/people/relationshipcreate.go
@@ -130,6 +130,13 @@ func writeRelationshipInTx(
 	if err := ensureRelationshipEndpoints(ctx, tx, in); err != nil {
 		return out, err
 	}
+	// The endpoint probe above answered which records the caller may SEE. This
+	// answers the narrower question the write owes on the one record the edge
+	// annotates: may they CHANGE it. Both entry points funnel through here, so
+	// the gate is taken once for the transaction-borrowing shape as well.
+	if err := ensureRelationshipAnchorWritable(ctx, tx, in.Kind, in.endpoints()); err != nil {
+		return out, err
+	}
 	// Both rules below read the person's OTHER employments and then write
 	// against what they read, so they are one unit per person or they are a
 	// race: two concurrent unmarked employments at different companies would

--- a/backend/internal/modules/people/relationshipimage.go
+++ b/backend/internal/modules/people/relationshipimage.go
@@ -21,7 +21,6 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/events"
-	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // relationshipFieldImage is the edge as its own fields: every column
@@ -74,17 +73,13 @@ func emitRelationshipChange(ctx context.Context, tx pgx.Tx, action string, befor
 func emitRelationshipChangeWithEvidence(ctx context.Context, tx pgx.Tx, action string,
 	before map[string]any, rel relationshipRow, evidence map[string]any,
 ) error {
-	anchorObject, _ := relationshipAnchor(rel.Kind)
-	var anchorID ids.UUID
-	switch anchorObject {
-	case anchorPerson:
-		anchorID = rel.PersonID.UUID
-	case anchorDeal:
-		anchorID = rel.DealID.UUID
-	case projectObjectName:
-		anchorID = rel.ProjectID.UUID
-	default:
-		anchorID = rel.OrganizationID.UUID
+	// Through the shared resolver, which answers with an error rather than a
+	// nil dereference: this used to read the endpoint pointer the kind implied
+	// straight off the row, and a kind whose shape did not hold would panic
+	// here instead of refusing.
+	anchorObject, anchorID, err := anchorIDOf(rel)
+	if err != nil {
+		return err
 	}
 	after := relationshipIdentityImage(rel)
 	if !storekit.AbsentImage(before) {


### PR DESCRIPTION
## What

Two row-level authorization gates asked the wrong question. In both the object grant was taken and the row arm was not — and on the tables involved the row arm is the only one that narrows anything.

**The generic relationship surface.** An edge annotates its anchor, so writing one writes that record, and the anchor's authority is two questions. `CreateRelationship`, `UpdateRelationship` and the archive asked the anchor's object grant plus an endpoint *visibility* probe. Person, organization, deal and project are identity tables, so their owner arm renders TRUE for every seat: visibility settled nothing, and the row arm was never asked. The dedicated verbs do take it — `ensureProjectWritable` on the stakeholder roster, `EnsureWritable` in `UpdatePerson` — so the generic surface reached past authority its own siblings demand.

**Enrichment runs.** `QueueRun` spends credits to buy facts about a person and writes them onto that person's record (`person_provider_claim`, audited as `update/person`). It admitted on `person:READ` plus `EnsureVisible`. A run is a write, so it owes the write grant and the write arm.

## Why

The invariant, stated once: **an edge's anchor, and an enrichment subject, are records being changed — so both halves of that record's authority apply, the object grant and the row arm.**

On the generic surface the rule had been stated per-kind, which is how it came to cover one kind and not its neighbour: `relationshipKinds` keeps `project_company` out partly for this reason, and `project_stakeholder` sat inside the same door. It is now one gate for every kind, at the one writer all three verbs funnel through.

Nothing downstream compensated for the enrichment gap. The queued run executes with no further RBAC gate by design, and `people.WriteProviderClaims` takes no probe of its own, so queue time is where the authority has to be decided. The waiver covering `QueueRun` in `writeauthority_test.go` asserted otherwise — that a provider answer lands through "that record's own apply path, which takes the write-authority probe there". That path takes none, so the waiver is deleted rather than reworded.

Related: the anchor-id switch existed in three copies — the gate, the audit subject, and the reversal's edge facts. Those copies are what let the gate reason about an anchor the writers had already chosen differently, so they are collapsed onto one resolver, which also removes a nil dereference the audit path could reach.

### Behaviour changes

Worth reading first; these are the changes most likely to surprise someone downstream.

- Creating, patching or archiving an edge whose anchor is outside the caller's write scope answers **403** where it used to succeed. An anchor the caller cannot see at all still answers **404** — the visibility arm runs first, so existence-hiding is unchanged, and there is a test for exactly that.
- An edge whose anchor endpoint is absent answers the shape refusal the `rel_*_shape` CHECK would have given, one step earlier.
- A seat without `person:update` answers **403** on an enrichment run where it used to get **202**.
- The enrichment probe is `Live`, so an archived or erased subject is refused rather than refilled by a run already in flight.
- The automatic enrichment trigger is unaffected: it runs as the system principal, unbounded at both gates.

## How verified

`TestEveryGenericRelationshipVerbTakesTheAnchorRowGate` derives its population from the pairing rather than listing verbs — a function that resolves an anchor and then requires the object grant owes the row gate — so a verb added later is judged without anyone remembering the file. Removing the gate makes it fail; that was checked, not assumed.

Every refusal test was run against the unfixed code and fails there, so none of them passes vacuously. Each carries a positive control on a record the caller does own, so a surface that had stopped working entirely would not read as green.

Two existing gates caught this work, and both are addressed in-branch: the stale `QueueRun` waiver above, and `TestALiveProbedWriteOfAHeldRowLocksItsSubject` — the new live probe pulls three in-transaction person creators into it, ratified in `unlockedLiveWrites` because their subject is created by the very transaction that writes its children, so there is no erasure to race.

Ran green locally: `craft static --strict` (the pre-push hook, diff-scoped over 11 changed Go files), both golangci configs on the touched packages, `check-rls-store-path`, `check-no-jurisdiction`, and the `people`, `integrations` and `compose/integration` integration lanes against real Postgres.

**What I could not run, and why.** This was developed on a Windows checkout with `core.autocrlf=true`, where every byte-comparing gate fails on untouched files — the license-header gate reports 4438 files, `.tool-versions` "does not pin golang 1.26.6" while containing exactly that, and snapshot tests whose `got` and `want` render identically. `make check` additionally needs `rsync` and a `gitleaks` build that do not exist on this platform, and `go-arch-lint` emits ~9200 notices here on `main` as well.

So instead of claiming a green `make check`, I ran the Go merge gate in a fresh LF worktree and compared it against a second worktree checked out at `origin/main`. **The failure sets are identical** — the same 9 unit tests, 3 packages and one `unused` lint finding, all pre-existing and Windows-specific (`blobstore` filesystem tests, the setup-token file, a helper used only behind a non-Windows build tag). No new failures from this branch. The Go-side architecture rules are covered by `gates/arch_test.go` and depguard, which do pass.

CI is the authority on the boxes I have left unticked below.

- [ ] `make check` is green — cannot run on this platform; see above for what was run instead and how it was baselined against `origin/main`
- [x] `make test-integration` is green — the three affected packages (`people`, `integrations`, `compose/integration`) against real Postgres, not the full parallel lane
- [x] `make craft-static` reports no new blockers — `craft static --strict` diff-scoped, 0 blocker / 0 major / 0 minor
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

The whole diff is AI-assisted: written by Claude Code (Opus 5) working from a triaged finding set, under my direction and my accountability. That includes the production changes, the derived gate, the integration tests, and this description.

What the model was made to prove rather than assert: each refusal test was run against the unfixed code to confirm it reproduces, the new gate was checked by deleting the fix and watching it fail, and the "pre-existing failure" claims above were established by diffing two worktrees rather than by judgement. I have reviewed the diff and can explain it.

Deliberately not included here: the reproduction. This repository is public and [SECURITY.md](/SECURITY.md) asks that a finding not be described publicly before a fix ships, so the commit messages and this description state the invariant being restored rather than how to exercise the gap. The tests carry the detail, and they ship alongside the code that refuses.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. Commits are signed off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two row-authorization gaps: generic relationship verbs and enrichment runs now gate on the row write authority of the record they change, not just the object grant and visibility. An edge annotates its anchor and a run writes facts onto its subject, so both halves of that record's authority apply; on identity tables visibility admits every seat, so the old gates let any seat with the object grant write records it did not own.

**Behavior changes**

- Creating, patching, or archiving an edge whose anchor is outside the caller's write scope now answers 403 where it used to succeed; an anchor the caller cannot see still answers 404.
- Enrichment runs now require `person:update`; a seat without it answers 403 instead of 202.
- The enrichment probe is live, so archived or erased subjects are refused rather than refilled by a run in flight; the automatic trigger is unaffected.
- The anchor-id switch existed in three copies and is now one resolver, which also removes a nil dereference the audit path could reach.

<sup>Written for commit c8a10419910523802de14d5ad5a0ea6583a19b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

