### PR TITLE
test(voice): the lifecycle is covered where it actually broke, and a draft keeps its author's words

### DIFF
--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -659,3 +659,111 @@ type brainFunc func(context.Context, model.Request) (model.Response, error)
 func (f brainFunc) Complete(ctx context.Context, req model.Request) (model.Response, error) {
 	return f(ctx, req)
 }
+
+// What a build tells its owner when the PROVIDER refuses, rather than when the
+// model answers badly. The two are different failures with different remedies,
+// and the scripted brain above cannot tell them apart: it returns well-formed
+// answers by construction, so every test that uses it passes through a space no
+// real provider occupies.
+//
+// Each case here is a refusal a real provider actually sent, reported from the
+// running product: a Gemini spending cap, an OpenRouter shared-pool throttle,
+// and a 429 whose cause nothing recognizes.
+func TestVoiceBuildTellsTheOwnerWhichProviderFailureItWas(t *testing.T) {
+	refusals := []struct {
+		name    string
+		err     error
+		says    string
+		saysNot string
+	}{
+		{
+			name:    "an account with nothing left",
+			err:     fmt.Errorf("%w: ai: gemini: RESOURCE_EXHAUSTED: Your project has exceeded its monthly spending cap. (http 429)", ai.ErrProviderQuota),
+			says:    "out of budget",
+			saysNot: "could not read",
+		},
+		{
+			name:    "a busy model behind a broker",
+			err:     fmt.Errorf("%w: ai: openai-compat: Mistral: temporarily rate-limited upstream (http 429)", ai.ErrProviderThrottled),
+			says:    "busy",
+			saysNot: "out of budget",
+		},
+	}
+	for _, refusal := range refusals {
+		t.Run(refusal.name, func(t *testing.T) {
+			env, build := seedVoiceBuild(t, "A quote the provider never sees.", 6)
+			worker := newVoiceBuildWorker(env.e.Pool, brainFunc(func(context.Context, model.Request) (model.Response, error) {
+				return model.Response{}, refusal.err
+			}), slog.New(slog.DiscardHandler))
+
+			if err := worker.Work(context.Background(), voiceBuildJob(env, build)); err != nil {
+				t.Fatalf("Work owns the failure on the row: %v", err)
+			}
+			finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if finished.Status != "failed" {
+				t.Fatalf("build = %+v, want failed", finished)
+			}
+			if finished.StatusDetail == nil {
+				t.Fatal("a failed build carries the sentence its owner reads")
+			}
+			detail := strings.ToLower(*finished.StatusDetail)
+			if !strings.Contains(detail, refusal.says) {
+				t.Fatalf("detail = %q, want it to name %q", detail, refusal.says)
+			}
+			// The wrong remedy is worse than a vague one: it sends the owner to
+			// a console where nothing is wrong.
+			if strings.Contains(detail, refusal.saysNot) {
+				t.Fatalf("detail = %q, must not say %q", detail, refusal.saysNot)
+			}
+			// The provider's own payload never reaches the owner — including
+			// the VENDOR's name, which the injected error carries and an
+			// earlier version of this list did not check for.
+			for _, internal := range []string{"http 429", "resource_exhausted", "openai-compat", "gemini", "mistral"} {
+				if strings.Contains(detail, internal) {
+					t.Fatalf("detail leaks provider internals (%q): %q", internal, detail)
+				}
+			}
+		})
+	}
+}
+
+// The build a reader waits on has to REACH a terminal state, whatever the model
+// does. A worker that returned early, hung, or left the row running would look
+// exactly like a slow build on the screen — and the screen polls, so nobody
+// finds out until they give up.
+func TestVoiceBuildAlwaysReachesATerminalState(t *testing.T) {
+	answers := map[string]string{
+		"prose instead of JSON":    "Sure! Here is the voice profile you asked for.",
+		"JSON truncated mid-way":   `{"identity_summary": "Direct and opera`,
+		"a JSON array, not object": `[{"identity_summary": "Direct."}]`,
+		"an empty answer":          "",
+	}
+	for name, answer := range answers {
+		t.Run(name, func(t *testing.T) {
+			env, build := seedVoiceBuild(t, "A quote the brain will not honor.", 6)
+			worker := newVoiceBuildWorker(env.e.Pool, brainFunc(func(context.Context, model.Request) (model.Response, error) {
+				return model.Response{Text: answer}, nil
+			}), slog.New(slog.DiscardHandler))
+
+			if err := worker.Work(context.Background(), voiceBuildJob(env, build)); err != nil {
+				t.Fatalf("Work owns the failure on the row: %v", err)
+			}
+			finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// An answer no parser can read is not a voice, so the only honest
+			// outcome is failure: letting it succeed would store nonsense and
+			// call it the owner's writing.
+			if finished.Status != "failed" {
+				t.Fatalf("build = %q on an unreadable answer, want failed", finished.Status)
+			}
+			if finished.StatusDetail == nil || len(strings.Fields(*finished.StatusDetail)) < 3 {
+				t.Fatalf("a failed build carries a sentence its owner can read, got %v", finished.StatusDetail)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/voicebuildeval.go
+++ b/backend/internal/compose/voicebuildeval.go
@@ -144,8 +144,29 @@ func voiceDraftPromptBlock(personality, profileMD string, exemplars []ai.VoiceEx
 	}
 	fmt.Fprintf(&block, "\n\nStylometric guardrails — limits, NOT targets: mean sentence length ≈ %.0f words (do not write a wall of short sentences to hit it), em dashes per 100 words ≈ %.2f (at 0, treat them as forbidden).",
 		stats.MeanSentenceWords, stats.EmDashPer100Words)
+	block.WriteString("\n\n" + draftVocabularyRule)
 	return block.String()
 }
+
+// draftVocabularyRule keeps a draft in the words its author would actually
+// reach for.
+//
+// A model drafting in one language while thinking in another translates the
+// METAPHOR as well as the sentence, and invents a compound the language does
+// not use: German business mail says "Pipeline" and "Bottleneck", never
+// "Datenmeer" or "Verzögerungsmaschine". The result reads as a translation
+// rather than as the author, which is the one thing a voice draft may not do.
+//
+// It names NO language — not the corpus's and not the borrowed one. Nothing
+// here knows which language the samples are in, and a rule that said "keep the
+// English term" would be advice about a foreign language to an author already
+// writing in English. The samples above are the evidence; this only forbids
+// coining vocabulary inside whichever language they are written in. That is
+// also why it is not the promptlang rule the other prompts carry: it does not
+// choose a language.
+const draftVocabularyRule = "Vocabulary: use the words this author uses, including the terms they borrow from other languages. " +
+	"Keep a borrowed term in the form they write it — never translate a metaphor into a compound word native speakers do not say. " +
+	"When unsure a word is real in their language, use the plainer wording they would."
 
 // evalPromptFor derives one held-out drafting task: reply to the opening of
 // the reserved sample in its register. This is the label the evaluation record

--- a/backend/internal/compose/voicebuildeval_test.go
+++ b/backend/internal/compose/voicebuildeval_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
@@ -237,5 +238,52 @@ func TestEvaluateVoiceCandidatePropagatesBudgetExhaustion(t *testing.T) {
 		artifact, "", heldOut, nil)
 	if !errors.Is(err, ai.ErrBudgetDeferred) {
 		t.Fatalf("err = %v, want the budget sentinel to survive wrapping", err)
+	}
+}
+
+// A draft carries its author's own vocabulary, and BOTH prompts that write one
+// say so: the evaluation's held-out drafts and the reply drafts a member
+// actually sends share this block, so a rule added to one is a rule the other
+// must not miss.
+//
+// Reported from a German build: "Das Angebot liegt seit drei Wochen im
+// Datenmeer… ihr seid die Verzögerungsmaschine". Both compounds are English
+// metaphors translated word for word into German words nobody says; German
+// business mail keeps the English (Pipeline, Bottleneck).
+func TestADraftPromptKeepsTheAuthorsOwnVocabulary(t *testing.T) {
+	fence := promptfence.New()
+	block := voiceDraftPromptBlock(
+		"",
+		"# Voice DNA\n\n## How you think\n\nVerdict first.",
+		nil,
+		ai.VoiceStats{MeanSentenceWords: 12, EmDashPer100Words: 0},
+		fence,
+	)
+
+	if !strings.Contains(block, draftVocabularyRule) {
+		t.Fatalf("the draft prompt states the vocabulary rule:\n%s", block)
+	}
+	// The rule has to forbid the INVENTION, not name one language: nothing here
+	// knows which language the corpus is in.
+	for _, required := range []string{"borrowed term", "never translate a metaphor"} {
+		if !strings.Contains(draftVocabularyRule, required) {
+			t.Fatalf("the rule must say %q, or a model still coins a compound: %q", required, draftVocabularyRule)
+		}
+	}
+	// NO language is named — not the corpus's, and not the one terms are
+	// borrowed from. "Keep the English term" is advice about a foreign
+	// language to an author who already writes in English.
+	for _, language := range []string{"German", "Deutsch", "English", "Englisch"} {
+		if strings.Contains(draftVocabularyRule, language) {
+			t.Fatalf("the rule names %q, but the author's samples decide the language: %q", language, draftVocabularyRule)
+		}
+	}
+
+	// The same block reaches the reply drafts a member sends, so the rule
+	// cannot be an evaluation-only nicety.
+	sample := ai.VoiceSample{Register: "email", Text: "Moin, kurz zum Angebot."}
+	request := voiceEvalDraftRequest("", ai.VoiceArtifact{Markdown: "# Voice DNA"}, sample, 0)
+	if len(request.Messages) == 0 || !strings.Contains(request.Messages[0].Content, draftVocabularyRule) {
+		t.Fatal("the held-out drafting call carries the vocabulary rule")
 	}
 }

--- a/frontend/e2e/voice.spec.ts
+++ b/frontend/e2e/voice.spec.ts
@@ -1,0 +1,326 @@
+import { expect, test } from "@playwright/test";
+import { mockApi } from "./seed";
+
+/**
+ * The Voice DNA lifecycle through the screen a member actually uses: hand over
+ * writing, build from it, watch it run, read what it learned, and choose it.
+ *
+ * Every step here failed in the running product while the backend's own tests
+ * stayed green — those drive a scripted brain that answers correctly by
+ * construction, and none of them renders a page. What broke was the reporting:
+ * a build that failed said "the build didn't finish", a provider refusal blamed
+ * the model, and the candidate asked to be accepted while showing none of
+ * itself. This spec asserts what the SCREEN says at each step, which is the
+ * only place those defects were visible.
+ *
+ * German chrome, as the app renders it.
+ */
+
+const PROFILE = {
+  id: "vp-1",
+  owner_id: "u-1",
+  status: "collecting",
+  maturity: "provisional",
+  quality_band: "thin",
+  voice_profile_md: "",
+  profile_version: 0,
+  personality_md: "",
+  auto_learning_enabled: false,
+  active_source_hash: null,
+  candidate_version: null,
+  last_built_at: null,
+  source: "manual",
+  captured_by: "human:u-1",
+  version: 1,
+  created_at: "2026-08-30T08:00:00Z",
+  updated_at: "2026-08-30T08:00:00Z",
+  archived_at: null,
+};
+
+const SUMMARY = {
+  total_words: 4200,
+  target_words: 30000,
+  maturity: "provisional",
+  quality_band: "thin",
+  source_count: 3,
+  register_words: { general: 4200 },
+};
+
+const SOURCE = {
+  id: "vs-1",
+  origin: "upload",
+  kind: "document",
+  register: "general",
+  weight: 1,
+  source_label: "emails.txt",
+  source_ref: "voice:upload:x",
+  word_count: 4200,
+  included: true,
+  exclusion_reason: null,
+  extractor_version: "1",
+  occurred_at: null,
+  retention_until: null,
+  content_erased_at: null,
+  source: "manual",
+  captured_by: "human:u-1",
+  version: 1,
+  created_at: "2026-08-30T08:00:00Z",
+  updated_at: "2026-08-30T08:00:00Z",
+  archived_at: null,
+};
+
+/** The candidate as a real build leaves it: a derived voice, and the evaluator's
+ * reasons for holding it back. */
+const CANDIDATE = {
+  id: "vv-1",
+  voice_profile_id: "vp-1",
+  profile_version: 1,
+  status: "candidate",
+  voice_profile_md: "# Voice DNA",
+  profile_json: {
+    inference: {
+      identity_summary: "Direkt, konkret, wenige Adjektive.",
+      thinking_pattern: "Erst die Bitte, dann der Grund, dann die Frist.",
+      signature_moves: [
+        { move: "Verdict first", quote: "Passt das so?", sample_id: "s1" },
+      ],
+      avoid: ["Floskeln"],
+    },
+    sample_drafts: [
+      {
+        subject: "Re: Angebot",
+        body: "Moin Stefan, kurz zum Angebot: Freitag steht.",
+        voice_score: 0.56,
+      },
+    ],
+    guidance: { next_best: "Mehr gesendete Mails." },
+  },
+  stats_json: { word_count: 4200, sample_count: 3, mean_sentence_words: 11 },
+  source_hash: "h",
+  source_count: 3,
+  reason: "manual",
+  predecessor_version: null,
+  activation_policy_version: "2",
+  model_provider: "openai_compatible",
+  model_name: "anthropic/claude-haiku-4.5",
+  builder_version: "voicebuilder/1",
+  source: "build",
+  captured_by: "human:u-1",
+  evaluation: {
+    held_out_prompts: 5,
+    repeats_per_prompt: 3,
+    active_median_voice_score: null,
+    candidate_median_voice_score: 0.56,
+    anti_ai_hard_failures: 0,
+    structured_output_valid: false,
+    corpus_citations_valid: true,
+    identity_word_jaccard: 1,
+    signature_set_jaccard: 1,
+    removed_avoid_rules: 0,
+    removed_register_rules: 0,
+    classification: "material",
+    passed: false,
+  },
+  review_reasons: ["median voice score 0.56 is below the 0.60 floor"],
+  version: 1,
+  created_at: "2026-08-30T08:05:00Z",
+  updated_at: "2026-08-30T08:05:00Z",
+  archived_at: null,
+  activated_at: null,
+};
+
+const emptyPage = { page: { next_cursor: null, has_more: false } };
+
+/** How many builds the screen actually started, so "takes no second press" is
+ * counted at the wire rather than read off an attribute. */
+let buildsStarted = 0;
+
+/**
+ * The voice endpoints, as a lifecycle rather than as fixed answers: what the
+ * screen shows depends on what the previous step did, which is the whole
+ * subject here. `buildStatus` and `versions` move as the test drives the page.
+ */
+async function mockVoice(
+  page: import("@playwright/test").Page,
+  script: {
+    buildStatus: string;
+    buildDetail?: string | null;
+    versions: unknown[];
+  },
+): Promise<void> {
+  await page.route(/\/v1\/voice-profiles/, async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/v1/, "");
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (path === "/voice-profiles") {
+      return json({ data: [PROFILE], ...emptyPage });
+    }
+    if (path === "/voice-profiles/vp-1/sources") {
+      return json({ data: [SOURCE], summary: SUMMARY, ...emptyPage });
+    }
+    if (path === "/voice-profiles/vp-1/versions") {
+      return json({ data: script.versions, ...emptyPage });
+    }
+    if (path === "/voice-profiles/vp-1/builds") {
+      if (route.request().method() === "POST") {
+        buildsStarted += 1;
+      }
+      return json({ id: "vb-1", status: "queued" }, 201);
+    }
+    if (path === "/voice-profiles/vp-1/builds/vb-1") {
+      return json({
+        id: "vb-1",
+        status: script.buildStatus,
+        status_code:
+          script.buildStatus === "failed" ? "model_unavailable" : null,
+        status_detail: script.buildDetail ?? null,
+      });
+    }
+    if (path.endsWith("/apply") || path.endsWith("/reject")) {
+      return json({}, 200);
+    }
+    if (path === "/voice-profiles/vp-1/learning") {
+      return json({
+        drafted: 4,
+        accepted: 3,
+        edited_sent: 1,
+        rejected: 0,
+        qualifying_source_count: 3,
+        qualifying_words: 4200,
+        transformations: [],
+      });
+    }
+    // Everything else the card reads is a plain list: deltas, and the paged
+    // reads behind the disclosures.
+    return json({ data: [], ...emptyPage });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  buildsStarted = 0;
+  await mockApi(page);
+});
+
+test("AC-voice-1: the card says what to hand over and why it matters", async ({
+  page,
+}) => {
+  await mockVoice(page, { buildStatus: "running", versions: [] });
+  await page.goto("/#/settings/voice");
+
+  // The zone is a real file control, not a decorated div.
+  const zone = page.locator('input[type="file"]');
+  await expect(zone).toHaveAttribute("accept", ".txt,.md,.vtt,.srt,.json");
+  // And the card answers "what should I upload?" where the uploading happens.
+  await expect(page.getByText("Was am besten funktioniert")).toBeVisible();
+  await expect(page.getByText("Warum das wichtig ist")).toBeVisible();
+});
+
+test("AC-voice-2: a running build says so, and takes no second press", async ({
+  page,
+}) => {
+  await mockVoice(page, { buildStatus: "running", versions: [] });
+  await page.goto("/#/settings/voice");
+
+  const build = page.getByRole("button", { name: /Voice DNA/ }).first();
+  await build.click();
+
+  // In WORDS, not only as a spinner: a reader looking at the page was told
+  // nothing, pressed again, and had no idea whether a second build started.
+  await expect(page.getByText(/wird gerade gebaut/)).toBeVisible();
+  await expect(page.getByText(/Seite verlassen/)).toBeVisible();
+  // Busy, but still reachable by keyboard — a natively disabled button would
+  // drop out of the tab order for the minute the build runs.
+  await expect(build).toHaveAttribute("aria-busy", "true");
+  await expect(build).not.toHaveAttribute("disabled", "");
+
+  // And a second press starts NOTHING. Asserted by counting what reaches the
+  // server, because a button that merely looks busy while still firing its
+  // handler is the defect this claim is about.
+  await build.click({ force: true });
+  await build.click({ force: true });
+  await expect.poll(() => buildsStarted).toBe(1);
+});
+
+test("AC-voice-3: a failed build names the cause the owner can act on", async ({
+  page,
+}) => {
+  await mockVoice(page, {
+    buildStatus: "failed",
+    buildDetail:
+      "Unser KI-Anbieter hat den Aufruf abgelehnt: Das Konto dahinter ist ohne Budget.",
+    versions: [],
+  });
+  await page.goto("/#/settings/voice");
+
+  await page
+    .getByRole("button", { name: /Voice DNA/ })
+    .first()
+    .click();
+
+  // The server's own sentence, not a fixed "the build didn't finish".
+  await expect(page.getByText(/ohne Budget/)).toBeVisible();
+});
+
+test("AC-voice-4: a candidate can be read before it is chosen", async ({
+  page,
+}) => {
+  await mockVoice(page, { buildStatus: "succeeded", versions: [CANDIDATE] });
+  await page.goto("/#/settings/voice");
+
+  // What the build learned — the decision is about something visible.
+  await expect(
+    page.getByText("Erst die Bitte, dann der Grund, dann die Frist."),
+  ).toBeVisible();
+  await expect(page.getByText(/noch nicht im Einsatz/)).toBeVisible();
+
+  // The evidence a reader judges the voice BY, not only the summary of it: a
+  // fixture whose keys the parser does not read renders an empty section and
+  // an assertion on the summary alone stays green through it.
+  await expect(
+    page.getByText("Moin Stefan, kurz zum Angebot: Freitag steht."),
+  ).toBeVisible();
+  await expect(page.getByText("Re: Angebot")).toBeVisible();
+
+  // Why it waits, in words about this voice rather than the evaluator's log,
+  // and in the reader's own notation.
+  await expect(page.getByText(/0,56/)).toBeVisible();
+  await expect(page.getByText(/below the 0.60 floor/)).toHaveCount(0);
+  // Nothing on the card reads as a broken number, which is what an unread
+  // fixture key produces.
+  await expect(page.getByText(/NaN/)).toHaveCount(0);
+
+  // Both answers are offered, and neither is taken for the reader.
+  await expect(
+    page.getByRole("button", { name: "Diese Version verwenden" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Meine aktuelle Stimme behalten" }),
+  ).toBeVisible();
+});
+
+test("AC-voice-5: choosing a candidate applies that version", async ({
+  page,
+}) => {
+  await mockVoice(page, { buildStatus: "succeeded", versions: [CANDIDATE] });
+  const applied: string[] = [];
+  await page.route(/\/versions\/1\/apply/, async (route) => {
+    applied.push(route.request().method());
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    });
+  });
+  await page.goto("/#/settings/voice");
+
+  await page.getByRole("button", { name: "Diese Version verwenden" }).click();
+
+  // The decision reaches the server as a write against THAT version.
+  await expect.poll(() => applied).toContain("POST");
+});

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -99,9 +99,13 @@ function reviewReasonText(
   const lowScore =
     /median voice score ([\d.]+) is below the ([\d.]+) floor/.exec(reason);
   if (lowScore) {
+    // Through the formatter, like every other figure on this page: the
+    // evaluator writes "0.56" because it writes for a log, and a German reader
+    // reads 0,56. A score handed straight to the sentence kept the log's
+    // notation in front of a reader who does not use it.
     return t("voice.candidate.reason.lowScore", {
-      score: lowScore[1] ?? "",
-      floor: lowScore[2] ?? "",
+      score: formatNumber(Number(lowScore[1] ?? 0), locale),
+      floor: formatNumber(Number(lowScore[2] ?? 0), locale),
     });
   }
   const hardFailures = /^(\d+) anti-AI hard failures survived/.exec(reason);


### PR DESCRIPTION
## Two things, one subject

### 1. A German draft invented German words

Reported from a real build:

> Das Angebot liegt seit drei verdammten Wochen im **Datenmeer**. Punkt zwei: Ihr seid die verdammte **Verzögerungsmaschine**…

Both are English metaphors (*data lake*, *delay machine*) calqued into German compounds no German speaker uses — German business mail keeps the borrowed term (*Pipeline*, *Bottleneck*). The draft prompt said nothing about vocabulary at all.

`voiceDraftPromptBlock` now carries a rule against coining one. That block is shared by the evaluation drafts **and** the reply drafts a member actually sends, so one fix covers both paths.

The rule names **no language**. Nothing in that code knows which language the corpus is in, and a first version saying "keep the English term" was advice about a foreign language to an author already writing in English — the same defect as the bug, one level up. The samples in the block are the evidence; the rule only forbids inventing vocabulary inside whichever language they are written in.

### 2. Thirty-six voice test files stayed green while the feature broke end to end

Not because coverage was thin — `TestVoiceBuildRunsToAnActiveVersion` already drives the real worker to a succeeded build. Because of **what those tests can see**:

- They drive `scriptedBuildBrain`, a fake that returns well-formed answers by construction. It cannot emit an HTTP 429, a vendor error body, or truncated JSON.
- `TestVoiceLiveSmoke` is `//go:build voicelive` — manual only, never CI. Nothing automated has ever called a real provider.
- **No e2e spec covered the voice screen**, and the screen is where every one of today's defects was visible.

So the covered space excluded exactly the failures that happened.

**Two integration tests** now hold the build's own reporting:
- A quota refusal and a throttle each produce the sentence their owner can act on, leak no provider payload or vendor name, and never give the other's remedy.
- Four unreadable answers (prose, truncated JSON, a JSON array, empty) each leave the row **terminal with a readable detail** — never stuck in `running`, which on screen is indistinguishable from a slow build, and never `succeeded`, which would store nonsense as the owner's writing.

**`frontend/e2e/voice.spec.ts`** (new, 5 tests, German chrome) covers the screen: the intake guidance, a running build saying so in words while starting **exactly one** build (counted at the wire, not read off an attribute), a failed build showing the server's cause, a candidate rendering the voice it asks to be judged on, and applying it.

## Found while writing the tests

The review score printed `0.56` to a German reader instead of `0,56`. It now goes through `formatNumber` like every other figure on the page.

## Reviewed — and the review mattered

Codex found **five ways these tests could pass while proving nothing**, all fixed here:
- Fixtures used `scenario`/`draft` and `corpus_words`; production reads `body`/`subject`/`voice_score` and `word_count`/`sample_count`. The sample-drafts and statistics sections rendered nothing and no assertion noticed.
- The learning fixture supplied `edited`; the UI reads `edited_sent`, so the page rendered `NaN`.
- "Takes no second press" pressed once and checked an attribute.
- The leak assertion did not check for the vendor names actually present in the injected error.
- A malformed answer was permitted to finish `succeeded`.

The spec now asserts the draft body itself, plus that no `NaN` appears anywhere on the card.

## Verified

- `make check` exit 0, zero failures; `craft static --strict` clean.
- Backend tests run against a real database (6 subtests, all passing).
- All 5 e2e tests pass, and **mutation-checked**: making the drafts section render nothing turns AC-voice-4 red; suppressing the running message turns AC-voice-2 red; reverting the builder's refusal classification turns the integration tests red.

One process note worth recording: two earlier mutation checks on this spec were **invalid** — the frontend build failed on an unused symbol, so `dist` kept the old bundle and Playwright tested unmutated code while reporting green. A mutation check that does not verify its own build proves nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes voice drafts that invented vocabulary the author wouldn't use, and closes the test gap that let the voice lifecycle break end-to-end while backend tests stayed green.

**Draft vocabulary**
- `voiceDraftPromptBlock` now forbids translating metaphors into compounds native speakers don't say, so a German draft keeps "Pipeline" instead of coining "Datenmeer".
- The rule names no language; the block is shared by evaluation drafts and the reply drafts a member actually sends.

**Failures, tests, and formatting**
- Two integration tests now assert that quota and throttle refusals produce the right actionable sentence with no provider payload or vendor name, and that unreadable model answers always end `failed` with readable detail, never stuck `running` or falsely `succeeded`.
- New `frontend/e2e/voice.spec.ts` covers the voice screen for the first time: intake guidance, exactly one build per press, the server's failure cause, candidate preview, and applying a version.
- The review score on the candidate card now goes through `formatNumber`, so a German reader sees `0,56` instead of `0.56`.

<sup>Written for commit f2f59897e88b7b6cb002fb2f4db9b4da5843199e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Voice DNA guidance for using established vocabulary, preserving borrowed terms, and avoiding unclear invented wording.
  * Added end-to-end coverage for uploading sources, tracking builds, reviewing candidates, and applying selected versions.

* **Bug Fixes**
  * Voice build failures now reach a clear terminal state with actionable, provider-neutral remediation details.
  * Improved handling of malformed or incomplete model responses.
  * Localized evaluation scores and thresholds in review messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->