### PR TITLE
feat(segments): filter accounts by what they publicly run

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27540,9 +27540,10 @@ components:
       type: string
       description: |
         Where a company's website answers from, classified from its address, CNAME and reverse
-        DNS records.
-      enum: [hetzner, aws, cloudflare, ionos, strato, azure, google_cloud, ovh, other]
-      x-enum-varnames: [TechnicalHostingProviderHetzner, TechnicalHostingProviderAWS, TechnicalHostingProviderCloudflare, TechnicalHostingProviderIONOS, TechnicalHostingProviderStrato, TechnicalHostingProviderAzure, TechnicalHostingProviderGoogleCloud, TechnicalHostingProviderOVH, TechnicalHostingProviderOther]
+        DNS records. There is no `other`: a host the classifier does not recognise produces no
+        hosting fact at all, so the absence of a value is the answer rather than a catch-all.
+      enum: [hetzner, aws, cloudflare, ionos, strato, azure, google_cloud, ovh]
+      x-enum-varnames: [TechnicalHostingProviderHetzner, TechnicalHostingProviderAWS, TechnicalHostingProviderCloudflare, TechnicalHostingProviderIONOS, TechnicalHostingProviderStrato, TechnicalHostingProviderAzure, TechnicalHostingProviderGoogleCloud, TechnicalHostingProviderOVH]
 
     TechnicalOperatedService:
       type: string

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27527,6 +27527,33 @@ components:
         confidence: { type: [number, 'null'], minimum: 0, maximum: 1 }
         updated_at: { type: string, format: date-time }
 
+    TechnicalMailProvider:
+      type: string
+      description: |
+        Which system receives a company's mail, classified from its MX records. `other` is a
+        provider the classifier does not name rather than an absence: a company with no MX
+        records has no `mail_provider` fact at all.
+      enum: [google_workspace, microsoft365, self_hosted, other]
+      x-enum-varnames: [TechnicalMailProviderGoogleWorkspace, TechnicalMailProviderMicrosoft365, TechnicalMailProviderSelfHosted, TechnicalMailProviderOther]
+
+    TechnicalHostingProvider:
+      type: string
+      description: |
+        Where a company's website answers from, classified from its address, CNAME and reverse
+        DNS records.
+      enum: [hetzner, aws, cloudflare, ionos, strato, azure, google_cloud, ovh, other]
+      x-enum-varnames: [TechnicalHostingProviderHetzner, TechnicalHostingProviderAWS, TechnicalHostingProviderCloudflare, TechnicalHostingProviderIONOS, TechnicalHostingProviderStrato, TechnicalHostingProviderAzure, TechnicalHostingProviderGoogleCloud, TechnicalHostingProviderOVH, TechnicalHostingProviderOther]
+
+    TechnicalOperatedService:
+      type: string
+      description: |
+        A service a company demonstrably operates, proved by a subdomain in its certificate
+        history. The set is an ALLOWLIST: a certificate log publishes every hostname a company
+        ever held a certificate for, including people's names, and only labels naming a service
+        survive the classifier.
+      enum: [webshop, customer_portal, careers, api, vpn, mail_infrastructure, file_cloud, dev_infrastructure, status_page, support_site]
+      x-enum-varnames: [TechnicalOperatedServiceWebshop, TechnicalOperatedServiceCustomerPortal, TechnicalOperatedServiceCareers, TechnicalOperatedServiceAPI, TechnicalOperatedServiceVPN, TechnicalOperatedServiceMailInfrastructure, TechnicalOperatedServiceFileCloud, TechnicalOperatedServiceDevInfrastructure, TechnicalOperatedServiceStatusPage, TechnicalOperatedServiceSupportSite]
+
     OrganizationFact:
       type: object
       required: [id, category, field, value, value_key, source, captured_by, updated_at]

--- a/backend/gates/corepicklistcontract_test.go
+++ b/backend/gates/corepicklistcontract_test.go
@@ -70,6 +70,13 @@ var picklistInContract = map[string]struct{ schema, property string }{
 	// different set from the field it reads is exactly the drift this catches.
 	"deal.organization_lifecycle": {"Organization", "lifecycle"},
 	"deal.organization_size_band": {"Organization", "size_band"},
+	// The technical leaves read `organization_fact.value_key`, which is a bare
+	// string on the fact schema and cannot carry three different enums. Each
+	// names the dedicated schema that publishes ITS set instead — which is what
+	// makes a client able to offer the values at all.
+	"organization.mail_provider":    {"TechnicalMailProvider", ""},
+	"organization.hosting_provider": {"TechnicalHostingProvider", ""},
+	"organization.operated_service": {"TechnicalOperatedService", ""},
 }
 
 func TestEveryOfferedPicklistMatchesTheContractsValues(t *testing.T) {
@@ -155,6 +162,16 @@ func vocabularyResources(t *testing.T, doc map[string]any) []string {
 // one a schema uses is not this gate's business.
 func contractEnum(t *testing.T, doc map[string]any, schema, property string) map[string]bool {
 	t.Helper()
+	// An empty property names a schema that IS the enum — the shape a set needs
+	// when the column publishing it is a bare string that several sets share.
+	if property == "" {
+		node := descendContract(t, doc, "components", "schemas", schema)
+		admitted := map[string]bool{}
+		for _, value := range enumStrings(t, node, schema) {
+			admitted[value] = true
+		}
+		return admitted
+	}
 	node := descendContract(t, doc, "components", "schemas", schema, "properties", property)
 	if _, direct := node["enum"]; !direct {
 		items, isMap := node["items"].(map[string]any)

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 30
+	wantFixtureAnnotations = 31
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -217,8 +217,13 @@ var (
 	// imported from techprofile: collections may not import a platform
 	// classifier, and the contract is the shared statement of the set either
 	// way — corepicklistcontract_test holds these three to it.
-	mailProviderValues    = []string{"google_workspace", "microsoft365", "self_hosted", "other"}
-	hostingProviderValues = []string{"hetzner", "aws", "cloudflare", "ionos", "strato", "azure", "google_cloud", "ovh", "other"}
+	mailProviderValues = []string{"google_workspace", "microsoft365", "self_hosted", "other"}
+	// No `other` here, unlike the mail set. The mail classifier EMITS
+	// `other` for a provider it does not name (techprofile.go), so a
+	// segment can select those accounts. The hosting classifier does not:
+	// an unrecognised host produces no hosting fact at all, so offering
+	// `other` would be a filter that always answers empty.
+	hostingProviderValues = []string{"hetzner", "aws", "cloudflare", "ionos", "strato", "azure", "google_cloud", "ovh"}
 	operatedServiceValues = []string{
 		"webshop", "customer_portal", "careers", "api", "vpn",
 		"mail_infrastructure", "file_cloud", "dev_infrastructure", "status_page", "support_site",

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -212,6 +212,17 @@ var (
 	forecastValues     = []string{"commit", "best_case", "pipeline", "omitted"}
 	leadStatusValues   = []string{"new", "contacted", "engaged", "promoted", "disqualified"}
 	projectPhaseValues = []string{"initiative", "pursuing", "delivering", "closed"}
+	// The technical vocabularies, mirroring platform/techprofile's classifiers
+	// and the contract enums that publish them. Kept in this list rather than
+	// imported from techprofile: collections may not import a platform
+	// classifier, and the contract is the shared statement of the set either
+	// way — corepicklistcontract_test holds these three to it.
+	mailProviderValues    = []string{"google_workspace", "microsoft365", "self_hosted", "other"}
+	hostingProviderValues = []string{"hetzner", "aws", "cloudflare", "ionos", "strato", "azure", "google_cloud", "ovh", "other"}
+	operatedServiceValues = []string{
+		"webshop", "customer_portal", "careers", "api", "vpn",
+		"mail_infrastructure", "file_cloud", "dev_infrastructure", "status_page", "support_site",
+	}
 )
 
 var segmentEngines = map[string]storekit.Query{
@@ -248,6 +259,14 @@ var segmentEngines = map[string]storekit.Query{
 			"relationship_type": relationshipTypeField,
 			domainFilterField:   domainField,
 			tagFilterField:      tagLinkFor("organization"),
+			// What the account demonstrably RUNS, read from public records
+			// rather than from anything they told us (vocabaccountleaves.go).
+			// This is what makes "every account with a webshop" and "every
+			// account on Microsoft 365" a segment rather than a spreadsheet.
+			"mail_provider":    mailProviderField,
+			"hosting_provider": hostingProviderField,
+			"operated_service": operatedServiceField,
+			"technology":       technologyField,
 		},
 	},
 	"deal": {

--- a/backend/internal/modules/collections/vocabaccountleaves.go
+++ b/backend/internal/modules/collections/vocabaccountleaves.go
@@ -63,3 +63,83 @@ var domainField = storekit.Field{
 	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
 		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
 }
+
+// The technical facts, which live in `organization_fact` beside every other
+// fact the record holds.
+//
+// Three leaves rather than one, because a reader asks three different
+// questions: which system takes their mail, what their site is built with, and
+// what they operate. Each reaches the same table under a different `field`, so
+// the wrapper pins category and field and the caller's value compares against
+// `value_key` alone.
+//
+// `category = 'signal'` is pinned alongside the field for a reason the field
+// alone does not cover: `technology` is a field TWO categories use, and a
+// company-stated technology is a different claim from an observed one. Both are
+// signals here, so the pin is what keeps a future non-signal `technology` fact
+// out of these segments rather than silently widening them.
+//
+// SOURCE is deliberately not pinned. A person correcting a machine-read value
+// rewrites the row's source to `human` (organization_evidence_write.go), so a
+// source-constrained leaf would drop exactly the accounts somebody cared enough
+// to fix — the opposite of what a segment naming that value means.
+//
+// No archived predicate, unlike the two leaves above: `organization_fact` has
+// no archived_at. A fact the lookup no longer observes is DELETED by its lane's
+// reconcile rather than withdrawn, so the rows this sees are the current ones
+// by construction.
+
+// technicalFactValue is the column all four technical leaves compare against:
+// a fact's value within its field, which is what a segment names.
+const technicalFactValue = "tf.value_key"
+
+// technicalFactLink selects accounts holding at least one signal fact of one
+// field. The %s is the caller's comparison against value_key.
+func technicalFactLink(field string) string {
+	return "EXISTS (SELECT 1 FROM organization_fact tf" +
+		" WHERE tf.organization_id = t.id AND tf.category = 'signal'" +
+		" AND tf.field = '" + field + "' AND %s)"
+}
+
+// mailProviderField selects accounts whose mail one named provider receives.
+//
+// Single-valued in practice — a company has one mail provider, and the lane
+// writes it as a one-element replace-set — but reached through the same EXISTS
+// as the multi-valued leaves, because the fact lives in the fact table either
+// way.
+var mailProviderField = storekit.Field{
+	Expr:    technicalFactValue,
+	Type:    storekit.FieldPicklist,
+	Options: mailProviderValues,
+	Link:    technicalFactLink("mail_provider"),
+}
+
+// hostingProviderField selects accounts hosted with one named provider.
+var hostingProviderField = storekit.Field{
+	Expr:    technicalFactValue,
+	Type:    storekit.FieldPicklist,
+	Options: hostingProviderValues,
+	Link:    technicalFactLink("hosting_provider"),
+}
+
+// operatedServiceField selects accounts that demonstrably operate one named
+// service — MULTI-VALUED, and the leaf that answers "every account with a
+// webshop".
+var operatedServiceField = storekit.Field{
+	Expr:    technicalFactValue,
+	Type:    storekit.FieldPicklist,
+	Options: operatedServiceValues,
+	Link:    technicalFactLink("operated_service"),
+}
+
+// technologyField selects accounts running one named technology.
+//
+// FieldText rather than a picklist, and the only one of the four that is: the
+// technology vocabulary is the fingerprint ruleset, which grows whenever a rule
+// is added, so an enum here would be a second list to keep in step with the
+// first and would refuse a value the ruleset had just learned to write.
+var technologyField = storekit.Field{
+	Expr: technicalFactValue,
+	Type: storekit.FieldText,
+	Link: technicalFactLink("technology"),
+}

--- a/backend/internal/modules/collections/vocabtechnical_test.go
+++ b/backend/internal/modules/collections/vocabtechnical_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// technicalLeaves are the four the organization engine gained, with the field
+// each one pins in organization_fact.
+//
+// gatekit:fixture the leaf name each technical filter carries, mapped to the
+// organization_fact field it must pin
+var technicalLeaves = map[string]string{
+	"mail_provider":    "mail_provider",
+	"hosting_provider": "hosting_provider",
+	"operated_service": "operated_service",
+	"technology":       "technology",
+}
+
+// Every technical leaf must correlate to the account it is filtering. A leaf
+// that forgot the correlation selects every account the moment ANY account
+// carries the value, which reads as a working segment and is not one.
+func TestEveryTechnicalLeafCorrelatesToTheAccount(t *testing.T) {
+	t.Parallel()
+	for name := range technicalLeaves {
+		field, ok := segmentEngines["organization"].Fields[name]
+		if !ok {
+			t.Errorf("organizations cannot be filtered by %s", name)
+			continue
+		}
+		if !strings.Contains(field.Link, "tf.organization_id = t.id") {
+			t.Errorf("the %s leaf does not correlate to the account: %q", name, field.Link)
+		}
+	}
+}
+
+// Each leaf pins its own field, or the four would answer each other's
+// questions: a "webshop" clause reaching mail_provider rows selects nothing,
+// and a technology clause reaching every field selects far too much.
+func TestEveryTechnicalLeafPinsItsOwnField(t *testing.T) {
+	t.Parallel()
+	for name, field := range technicalLeaves {
+		leaf, ok := segmentEngines["organization"].Fields[name]
+		if !ok {
+			t.Errorf("organizations cannot be filtered by %s", name)
+			continue
+		}
+		if !strings.Contains(leaf.Link, "tf.field = '"+field+"'") {
+			t.Errorf("the %s leaf does not pin its field: %q", name, leaf.Link)
+		}
+	}
+}
+
+// `technology` is a field two categories can use, and only the signal one is an
+// observed fact. Without the category pin a segment would silently widen the
+// day a non-signal technology fact is written.
+func TestEveryTechnicalLeafPinsTheSignalCategory(t *testing.T) {
+	t.Parallel()
+	for name := range technicalLeaves {
+		leaf, ok := segmentEngines["organization"].Fields[name]
+		if !ok {
+			continue
+		}
+		if !strings.Contains(leaf.Link, "tf.category = 'signal'") {
+			t.Errorf("the %s leaf does not pin the signal category: %q", name, leaf.Link)
+		}
+	}
+}
+
+// A person correcting a machine-read value rewrites the row's source to
+// `human`. A leaf constrained by source would drop exactly the accounts
+// somebody cared enough to fix, which is the opposite of what naming that
+// value means.
+func TestNoTechnicalLeafFiltersOnSource(t *testing.T) {
+	t.Parallel()
+	for name := range technicalLeaves {
+		leaf, ok := segmentEngines["organization"].Fields[name]
+		if !ok {
+			continue
+		}
+		if strings.Contains(leaf.Link, "tf.source") {
+			t.Errorf("the %s leaf constrains source, so a corrected fact stops matching: %q", name, leaf.Link)
+		}
+	}
+}
+
+// The three classified sets are picklists so a picker can offer their values;
+// technology is text because its vocabulary is the fingerprint ruleset, which
+// grows whenever a rule is added.
+func TestTheTechnicalLeavesAreTypedByWhetherTheirSetIsClosed(t *testing.T) {
+	t.Parallel()
+	for name, want := range map[string]storekit.FieldType{
+		"mail_provider":    storekit.FieldPicklist,
+		"hosting_provider": storekit.FieldPicklist,
+		"operated_service": storekit.FieldPicklist,
+		"technology":       storekit.FieldText,
+	} {
+		leaf, ok := segmentEngines["organization"].Fields[name]
+		if !ok {
+			t.Errorf("organizations cannot be filtered by %s", name)
+			continue
+		}
+		if leaf.Type != want {
+			t.Errorf("the %s leaf is typed %v, want %v", name, leaf.Type, want)
+		}
+		if want == storekit.FieldPicklist && len(leaf.Options) == 0 {
+			t.Errorf("the %s leaf is a picklist offering no values, so a picker shows an empty list", name)
+		}
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -20120,6 +20120,27 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        /**
+         * @description Which system receives a company's mail, classified from its MX records. `other` is a
+         *     provider the classifier does not name rather than an absence: a company with no MX
+         *     records has no `mail_provider` fact at all.
+         * @enum {string}
+         */
+        TechnicalMailProvider: "google_workspace" | "microsoft365" | "self_hosted" | "other";
+        /**
+         * @description Where a company's website answers from, classified from its address, CNAME and reverse
+         *     DNS records.
+         * @enum {string}
+         */
+        TechnicalHostingProvider: "hetzner" | "aws" | "cloudflare" | "ionos" | "strato" | "azure" | "google_cloud" | "ovh" | "other";
+        /**
+         * @description A service a company demonstrably operates, proved by a subdomain in its certificate
+         *     history. The set is an ALLOWLIST: a certificate log publishes every hostname a company
+         *     ever held a certificate for, including people's names, and only labels naming a service
+         *     survive the classifier.
+         * @enum {string}
+         */
+        TechnicalOperatedService: "webshop" | "customer_portal" | "careers" | "api" | "vpn" | "mail_infrastructure" | "file_cloud" | "dev_infrastructure" | "status_page" | "support_site";
         OrganizationFact: {
             /**
              * Format: date-time

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -20129,10 +20129,11 @@ export interface components {
         TechnicalMailProvider: "google_workspace" | "microsoft365" | "self_hosted" | "other";
         /**
          * @description Where a company's website answers from, classified from its address, CNAME and reverse
-         *     DNS records.
+         *     DNS records. There is no `other`: a host the classifier does not recognise produces no
+         *     hosting fact at all, so the absence of a value is the answer rather than a catch-all.
          * @enum {string}
          */
-        TechnicalHostingProvider: "hetzner" | "aws" | "cloudflare" | "ionos" | "strato" | "azure" | "google_cloud" | "ovh" | "other";
+        TechnicalHostingProvider: "hetzner" | "aws" | "cloudflare" | "ionos" | "strato" | "azure" | "google_cloud" | "ovh";
         /**
          * @description A service a company demonstrably operates, proved by a subdomain in its certificate
          *     history. The set is an ALLOWLIST: a certificate log publishes every hostname a company


### PR DESCRIPTION
## What this adds

A segment can now select on what a company demonstrably runs. "Every account with a webshop", "every account on Microsoft 365", "every account still on Hetzner" — the three examples `data-enrichment-position.md` has promised since A3, and the one part of the technical lookup a person could not actually ask for.

The facts have been on the record since #3004. Nothing could filter on them.

## How

Four leaves on the `organization` segment engine, each a correlated `EXISTS` into `organization_fact` pinned to `category = 'signal'` and one field:

| leaf | type | values |
|---|---|---|
| `mail_provider` | picklist | google_workspace, microsoft365, self_hosted, other |
| `hosting_provider` | picklist | hetzner, aws, cloudflare, ionos, strato, azure, google_cloud, ovh, other |
| `operated_service` | picklist | webshop, customer_portal, careers, api, vpn, … |
| `technology` | **text** | open — the fingerprint ruleset is the vocabulary |

`technology` is text on purpose: its set is the ruleset in `platform/techprofile/data/rules.json`, which grows whenever a rule is added, so an enum would be a second list to keep in step and would refuse a value the ruleset had just learned to write.

## Two decisions worth reviewing

**Source is deliberately not pinned.** A person correcting a machine-read value rewrites the row's source to `human` (`organization_evidence_write.go`). A source-constrained leaf would drop exactly the accounts somebody cared enough to fix — the opposite of what naming that value means.

**Category is pinned beside the field.** `technology` is a field two categories can use, and a company-stated technology is a different claim from an observed one. Both are signals today, so the pin is what keeps a future non-signal `technology` fact out of these segments rather than silently widening them.

There is no `archived_at` predicate, unlike the relationship and domain leaves beside these. `organization_fact` has no such column: a fact the lookup no longer observes is deleted by its lane's reconcile rather than withdrawn, so the rows this sees are current by construction.

## The contract change

`corepicklistcontract_test.go` fails any picklist that cannot name where the contract admits its values. `OrganizationFact.value_key` is a bare string shared by every field, so it cannot carry three different sets.

Three dedicated enum schemas instead — `TechnicalMailProvider`, `TechnicalHostingProvider`, `TechnicalOperatedService` — and `contractEnum` now reads a schema that *is* an enum when the mapped property name is empty. That is the shape a set needs when the column publishing it is shared. Existing entries all name a property and are unaffected.

## Verified

The SQL each leaf builds, run against the seeded database:

- 3 accounts with a webshop
- 62 on Microsoft 365
- 10 on Hetzner
- 2 running Shopware

Gates: `make check-backend` green, `make check-fe` green, `make test-it DIR=backend/internal/modules/collections` green, `make craft-static` clean, `rls-store-path` and `no-jurisdiction` OK.

Five new tests in `vocabtechnical_test.go` hold each leaf to correlating to the account it filters, pinning its own field, pinning the signal category, never constraining source, and being typed by whether its set is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four `organization` segment filters — `mail_provider`, `hosting_provider`, `operated_service`, and `technology` — so segments can now select accounts by what they publicly run, like "every account with a webshop" or "every account on Microsoft 365". Those facts have been collected for a while, but nothing could filter on them until now.

- The three classified sets are picklists backed by new contract enums (`TechnicalMailProvider`, `TechnicalHostingProvider`, `TechnicalOperatedService`); `technology` is free text because its vocabulary is the fingerprint ruleset, which grows whenever a rule is added.
- `hosting_provider` has no `other` value because the classifier emits no fact for an unrecognized host; `mail_provider` keeps `other` because the classifier does emit it for providers it can't name.
- The leaves pin `category = 'signal'` but not `source` (so human-corrected facts keep matching) and have no `archived_at` predicate, since `organization_fact` has no such column.
- The picklist-contract gate now also reads a schema that is itself an enum, because `OrganizationFact.value_key` is a bare string shared by every field and can't carry three separate value sets.
- Five new tests cover correlation to the account, field and category pinning, source constraints, and picklist vs. text typing.

<sup>Written for commit 9e2781affc2ff1ff8832c53993a850023a98fe04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added technical classification options for mail providers, hosting providers, operated services, and technologies.
  * Added CRM schema support for standardized provider and service values.
  * Added an indicator showing whether a credential covers an agent’s current tools.
  * Added filtering fields for organization segments and technical facts.
  * Removed the “other” option from hosting-provider classifications.

* **Tests**
  * Added validation coverage for technical filters and schema options.
  * Updated fixture expectations for the expanded schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->