### PR TITLE
fix(ai): a vendor that stops answering is a fault, not a five-minute wait

### DIFF
--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -18,6 +18,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -25,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
 // TestReembedReembedsAllLiveEntitiesAndIsResumable seeds 3 people
@@ -167,6 +169,76 @@ func TestReembedReportsAWriteItCouldNotLand(t *testing.T) {
 		t.Fatal("a pass whose embedding writes could not land reported success — nothing records that the corpus was never rebuilt")
 	}
 }
+
+// TestReembedEmbedsEveryEntityPastOneItCannot proves a pass carries on past an
+// entity the provider refuses and still embeds the ones behind it, while
+// reporting the refusal.
+//
+// The defect this holds shut: the loop used to RETURN on the first
+// UpsertEmbedding error, so one transient provider fault — a dropped connection
+// partway through a corpus — ended the whole attempt, and every entity after
+// the bad one stayed on the old binding until a later attempt happened to walk
+// past it. A run has five attempts; a corpus reached the same bad entity in
+// each of them.
+//
+// The refusing embedder fails exactly one person by its text, so the assertion
+// is not "some rows survived" but "the row AFTER the failing one is current".
+func TestReembedEmbedsEveryEntityPastOneItCannot(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+	fake := ai.NewFakeClient()
+	inner := fakeEmbedderNamed(t, fake, "model-partial")
+	identity, _ := inner.EmbedIdentity()
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
+		t.Fatalf("SeedBinding: %v", err)
+	}
+
+	// Three people; the middle one by NAME is what the embedder refuses, so the
+	// two either side of it in any scan order prove the pass did not stop.
+	for _, name := range []string{"Reachable One", "Refused Person", "Reachable Two"} {
+		e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, name)
+	}
+
+	err := e.Store.Reembed(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity},
+		refusingEmbedder{inner: inner, refuseText: "Refused Person"})
+	if err == nil {
+		t.Fatal("a pass that could not embed an entity reported success — the run would stamp an identity over a corpus it never finished")
+	}
+	if !strings.Contains(err.Error(), "Refused") && !strings.Contains(err.Error(), "refusing embedder") {
+		t.Fatalf("the reported fault does not name the entity that failed: %v", err)
+	}
+
+	var current int
+	if scanErr := e.Owner.QueryRow(ctx,
+		`SELECT count(*) FROM embedding em JOIN person p ON p.id = em.entity_id
+		  WHERE em.entity_type = 'person' AND em.model = $1 AND p.full_name LIKE 'Reachable %'`,
+		identity).Scan(&current); scanErr != nil {
+		t.Fatalf("counting embedded people: %v", scanErr)
+	}
+	if current != 2 {
+		t.Fatalf("%d of the 2 embeddable people are current under %s; a pass that stops at the first refusal leaves the ones behind it stale", current, identity)
+	}
+}
+
+// refusingEmbedder embeds everything except one exact input, which it fails the
+// way a provider whose connection dropped does. It delegates rather than
+// answering vectors itself so the rows it DOES write go through the real
+// embedder and are indistinguishable from a healthy pass's.
+type refusingEmbedder struct {
+	inner      search.Embedder
+	refuseText string
+}
+
+func (r refusingEmbedder) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
+	for _, in := range req.Inputs {
+		if strings.Contains(in, r.refuseText) {
+			return model.Embeddings{}, errors.New("refusing embedder: connection reset by peer")
+		}
+	}
+	return r.inner.Embed(ctx, req)
+}
+
+func (r refusingEmbedder) EmbedIdentity() (string, int) { return r.inner.EmbedIdentity() }
 
 // TestReembedIdentityDriftCancelsWithoutTouchingRows proves the
 // entry guard fires — and touches NOTHING — when the embedder compose

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -18,6 +18,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -193,19 +194,23 @@ func TestReembedEmbedsEveryEntityPastOneItCannot(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	// Three people; the middle one by NAME is what the embedder refuses, so the
-	// two either side of it in any scan order prove the pass did not stop.
-	for _, name := range []string{"Reachable One", "Refused Person", "Reachable Two"} {
+	// Three people, and the embedder refuses whichever it is asked for FIRST.
+	// Naming a fixed victim would leave the test at the mercy of scan order:
+	// liveEntitiesOf has no ORDER BY, so a refused row that happened to come
+	// last would let the old stop-at-first-failure code pass this test with
+	// nothing embedded after it. Refusing the first row asked for makes the
+	// two survivors the rows BEHIND the failure in every possible order.
+	for _, name := range []string{"Reachable One", "Reachable Two", "Reachable Three"} {
 		e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, name)
 	}
 
 	err := e.Store.Reembed(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity},
-		refusingEmbedder{inner: inner, refuseText: "Refused Person"})
+		&refusingEmbedder{inner: inner})
 	if err == nil {
 		t.Fatal("a pass that could not embed an entity reported success — the run would stamp an identity over a corpus it never finished")
 	}
-	if !strings.Contains(err.Error(), "Refused") && !strings.Contains(err.Error(), "refusing embedder") {
-		t.Fatalf("the reported fault does not name the entity that failed: %v", err)
+	if !strings.Contains(err.Error(), "refusing embedder") {
+		t.Fatalf("the reported fault does not carry the provider's own reason: %v", err)
 	}
 
 	var current int
@@ -216,29 +221,66 @@ func TestReembedEmbedsEveryEntityPastOneItCannot(t *testing.T) {
 		t.Fatalf("counting embedded people: %v", scanErr)
 	}
 	if current != 2 {
-		t.Fatalf("%d of the 2 embeddable people are current under %s; a pass that stops at the first refusal leaves the ones behind it stale", current, identity)
+		t.Fatalf("%d of the 2 people behind the refused one are current under %s; a pass that stops at the first refusal leaves them stale", current, identity)
 	}
 }
 
-// refusingEmbedder embeds everything except one exact input, which it fails the
-// way a provider whose connection dropped does. It delegates rather than
-// answering vectors itself so the rows it DOES write go through the real
-// embedder and are indistinguishable from a healthy pass's.
-type refusingEmbedder struct {
-	inner      search.Embedder
-	refuseText string
+// TestReembedStopsCallingAProviderThatAnswersNothing proves the pass gives up
+// once failures stop looking like bad rows and start looking like an outage.
+//
+// Without the limit a dead provider costs one call per remaining entity, each
+// waiting out its own timeout, and the run's attempt is spent regardless — so
+// the corpus buys nothing for the hours it spends failing.
+func TestReembedStopsCallingAProviderThatAnswersNothing(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+	fake := ai.NewFakeClient()
+	inner := fakeEmbedderNamed(t, fake, "model-outage")
+	identity, _ := inner.EmbedIdentity()
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
+		t.Fatalf("SeedBinding: %v", err)
+	}
+
+	seeded := search.ReembedConsecutiveFailureLimit + 5
+	for i := range seeded {
+		e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`,
+			fmt.Sprintf("Outage Person %d", i))
+	}
+
+	embedder := &refusingEmbedder{inner: inner, refuseEvery: true}
+	if err := e.Store.Reembed(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, embedder); err == nil {
+		t.Fatal("a pass against a provider answering nothing reported success")
+	}
+	if embedder.calls > search.ReembedConsecutiveFailureLimit {
+		t.Fatalf("the provider was called %d times against a limit of %d; a dead provider is called once per entity",
+			embedder.calls, search.ReembedConsecutiveFailureLimit)
+	}
 }
 
-func (r refusingEmbedder) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
-	for _, in := range req.Inputs {
-		if strings.Contains(in, r.refuseText) {
-			return model.Embeddings{}, errors.New("refusing embedder: connection reset by peer")
-		}
+// refusingEmbedder fails the way a provider whose connection dropped does: its
+// FIRST call by default, or every call when refuseEvery is set. It delegates
+// the calls it does not refuse rather than answering vectors itself, so the
+// rows it writes go through the real embedder and are indistinguishable from a
+// healthy pass's.
+//
+// Refusing by call ORDER rather than by which entity it is asked about is what
+// makes the surviving rows provably the ones BEHIND the failure: the scan has
+// no ORDER BY, so no fixed victim can be relied on to come first.
+type refusingEmbedder struct {
+	inner       search.Embedder
+	refuseEvery bool
+	calls       int
+}
+
+func (r *refusingEmbedder) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
+	r.calls++
+	if r.refuseEvery || r.calls == 1 {
+		return model.Embeddings{}, errors.New("refusing embedder: connection reset by peer")
 	}
 	return r.inner.Embed(ctx, req)
 }
 
-func (r refusingEmbedder) EmbedIdentity() (string, int) { return r.inner.EmbedIdentity() }
+func (r *refusingEmbedder) EmbedIdentity() (string, int) { return r.inner.EmbedIdentity() }
 
 // TestReembedIdentityDriftCancelsWithoutTouchingRows proves the
 // entry guard fires — and touches NOTHING — when the embedder compose

--- a/backend/internal/modules/ai/embedlane.go
+++ b/backend/internal/modules/ai/embedlane.go
@@ -42,8 +42,20 @@ func (r *Router) Embed(ctx context.Context, req model.EmbedRequest) (model.Embed
 		req.Dimensions = b.embedDims
 	}
 
+	// One embedding is one forward pass and answers in about a second, so a
+	// minute of silence is a connection that will not answer rather than a model
+	// still working. Without this the caller waits out requestTimeout — five
+	// minutes, with its database transaction open — and a re-embed pass spends
+	// its River attempts on connections the network already dropped.
+	//
+	// A deadline the caller set EARLIER still wins: WithTimeout only ever
+	// shortens, so a request that is already nearly out of time is not handed a
+	// fresh minute here.
+	embedCtx, cancel := context.WithTimeout(ctx, EmbedCallTimeout)
+	defer cancel()
+
 	start := r.now()
-	res, err := b.embedder.Embed(ctx, req)
+	res, err := b.embedder.Embed(embedCtx, req)
 	trace := Call{Task: TaskEmbeddings, Tier: TierEmbedLane, Kind: callKindEmbedding, CacheOff: r.cacheOff, LatencyMS: r.now().Sub(start).Milliseconds()}
 	if err == nil {
 		// Stamp the SAME token estimate the meter records below onto the

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -9,16 +9,16 @@ import (
 )
 
 // Timeouts bounding one outbound model call. requestTimeout is the ceiling on
-// the whole call; the two below bound the legs that can stall while the ceiling
-// is still far away.
+// the whole call; the rest bound the legs that can stall while the ceiling is
+// still far away.
 //
 // The ceiling alone is not enough, and the difference is not theoretical: a
 // re-embed pass on this tree spent 246 seconds inside a single embedding call
 // on a connection the network had silently dropped, then lost the run's River
-// attempt to a peer reset on the next one. A vendor answers an embedding in
-// under two seconds, so five minutes of silence is never the vendor thinking —
-// it is a connection that will not answer at all, and the sooner the transport
-// says so the sooner the caller retries on a fresh one.
+// attempt to a peer reset on the next one. Five minutes of silence on an
+// embedding is never the vendor thinking — it is a connection that will not
+// answer at all, and the sooner the caller hears so the sooner it retries on a
+// fresh one.
 const (
 	// requestTimeout bounds a single model call. Generous because premium
 	// completions on long context are legitimately slow — a streamed corpus
@@ -26,12 +26,22 @@ const (
 	// contexts tighten it where a caller has a real deadline.
 	requestTimeout = 300 * time.Second
 
-	// responseHeaderTimeout bounds the wait for the response HEADERS only, so a
-	// slow BODY — the streamed extraction requestTimeout is generous for — is
-	// untouched by it. A vendor that has accepted a request and is working sends
-	// its status line long before the tokens; ninety seconds of silence before
-	// the first byte is a dead connection, not a thinking model.
-	responseHeaderTimeout = 90 * time.Second
+	// EmbedCallTimeout bounds ONE embedding call, and is the reason there is no
+	// response-header timeout on the shared transport.
+	//
+	// A header timeout cannot tell the two kinds of call apart. A completion is
+	// sent with stream:false (openai.go's Complete and every adapter beside it),
+	// so the vendor holds its status line until generation FINISHES — a slow
+	// reasoning model legitimately says nothing for minutes, and a header
+	// deadline would cut exactly the call requestTimeout is generous for. An
+	// embedding is the opposite: it is one forward pass, it answers in about a
+	// second, and a minute of silence on one is never the model thinking.
+	//
+	// So the bound lives on the embed lane instead, where the expected duration
+	// is actually known — Router.Embed applies it to every embedding call there
+	// is. The ping below is what protects the completion path, by killing a dead
+	// connection rather than by guessing how long an answer may take.
+	EmbedCallTimeout = 60 * time.Second
 
 	// http2PingAfterIdle asks the HTTP/2 transport to ping a connection that has
 	// gone this long without a frame, and http2PingTimeout is how long the ping
@@ -59,7 +69,6 @@ const (
 // connections crowd out another's.
 func newOutboundClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // net/http's own DefaultTransport is a *http.Transport by construction
-	transport.ResponseHeaderTimeout = responseHeaderTimeout
 	transport.IdleConnTimeout = idleConnTimeout
 	transport.ForceAttemptHTTP2 = true
 	transport.HTTP2 = &http.HTTP2Config{

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"net/http"
+	"time"
+)
+
+// Timeouts bounding one outbound model call. requestTimeout is the ceiling on
+// the whole call; the two below bound the legs that can stall while the ceiling
+// is still far away.
+//
+// The ceiling alone is not enough, and the difference is not theoretical: a
+// re-embed pass on this tree spent 246 seconds inside a single embedding call
+// on a connection the network had silently dropped, then lost the run's River
+// attempt to a peer reset on the next one. A vendor answers an embedding in
+// under two seconds, so five minutes of silence is never the vendor thinking —
+// it is a connection that will not answer at all, and the sooner the transport
+// says so the sooner the caller retries on a fresh one.
+const (
+	// requestTimeout bounds a single model call. Generous because premium
+	// completions on long context are legitimately slow — a streamed corpus
+	// extraction emits ten-thousand-token answers over minutes; per-call
+	// contexts tighten it where a caller has a real deadline.
+	requestTimeout = 300 * time.Second
+
+	// responseHeaderTimeout bounds the wait for the response HEADERS only, so a
+	// slow BODY — the streamed extraction requestTimeout is generous for — is
+	// untouched by it. A vendor that has accepted a request and is working sends
+	// its status line long before the tokens; ninety seconds of silence before
+	// the first byte is a dead connection, not a thinking model.
+	responseHeaderTimeout = 90 * time.Second
+
+	// http2PingAfterIdle asks the HTTP/2 transport to ping a connection that has
+	// gone this long without a frame, and http2PingTimeout is how long the ping
+	// itself may go unanswered before the connection is closed and its in-flight
+	// requests fail. Without these an h2 connection dropped by a NAT or a load
+	// balancer stays in the pool looking healthy, and every request handed to it
+	// waits out requestTimeout. Both vendors this reaches over h2 (Cloudflare
+	// fronts OpenRouter and Anthropic) drop idle connections well inside the
+	// minute.
+	http2PingAfterIdle = 20 * time.Second
+	http2PingTimeout   = 10 * time.Second
+
+	// idleConnTimeout retires a pooled connection that nothing has used for this
+	// long, so a worker between passes reconnects rather than reaching for a
+	// connection the far end has already forgotten.
+	idleConnTimeout = 60 * time.Second
+)
+
+// newOutboundClient is the HTTP client EVERY provider adapter calls a vendor
+// with: one transport shape for all seven, so hardening the outbound path is a
+// change here rather than seven changes that drift.
+//
+// One client per adapter rather than one shared package-level client, because
+// the pool is per-transport and a shared pool would let one vendor's stalled
+// connections crowd out another's.
+func newOutboundClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // net/http's own DefaultTransport is a *http.Transport by construction
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	transport.IdleConnTimeout = idleConnTimeout
+	transport.ForceAttemptHTTP2 = true
+	transport.HTTP2 = &http.HTTP2Config{
+		SendPingTimeout: http2PingAfterIdle,
+		PingTimeout:     http2PingTimeout,
+	}
+	return &http.Client{Timeout: requestTimeout, Transport: transport}
+}

--- a/backend/internal/modules/ai/outboundtransport_test.go
+++ b/backend/internal/modules/ai/outboundtransport_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// TestOutboundClientGivesUpOnAVendorThatNeverAnswers proves a vendor that
+// accepts a connection and then says nothing fails in responseHeaderTimeout
+// rather than holding the caller for the full requestTimeout.
+//
+// This is the shape that cost a re-embed run four of its five attempts: a
+// connection the network had dropped stayed in the pool, and each request handed
+// to it waited out the five-minute ceiling with the caller's database
+// transaction open underneath. The test drives the real client against a server
+// that never writes a header, and asserts the deadline it hits is the header one.
+func TestOutboundClientGivesUpOnAVendorThatNeverAnswers(t *testing.T) {
+	t.Parallel()
+
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-blocked // never writes a status line
+	}))
+	defer srv.Close()
+	defer close(blocked)
+
+	client := newOutboundClient()
+	// The real constant is minutes long, which no test may wait out. Asserting
+	// on the FIELD rather than a real elapsed deadline is what keeps this test
+	// honest and fast: the client under test is the one SelectBrain hands every
+	// adapter, and the timeout is read off it, not restated.
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("the outbound client's transport is %T, so nothing bounds its response headers", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != responseHeaderTimeout {
+		t.Fatalf("ResponseHeaderTimeout is %v, want %v — a vendor that stops answering mid-connection holds the caller for the whole %v ceiling",
+			transport.ResponseHeaderTimeout, responseHeaderTimeout, requestTimeout)
+	}
+	if transport.HTTP2 == nil || transport.HTTP2.SendPingTimeout == 0 {
+		t.Fatal("no HTTP/2 keep-alive ping is configured, so a dropped h2 connection stays in the pool looking healthy")
+	}
+	if transport.IdleConnTimeout != idleConnTimeout {
+		t.Fatalf("IdleConnTimeout is %v, want %v", transport.IdleConnTimeout, idleConnTimeout)
+	}
+
+	// And the bound is real, not only declared: the same transport with the
+	// timeout dialled down to something a test may wait out must actually give
+	// up on this server.
+	fast := transport.Clone()
+	fast.ResponseHeaderTimeout = 100 * time.Millisecond
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	start := time.Now()
+	resp, err := (&http.Client{Transport: fast}).Do(req)
+	if err == nil {
+		//craft:ignore swallowed-errors best-effort close of a body this test never reads — the assertion below is the outcome
+		_ = resp.Body.Close()
+		t.Fatal("a server that never writes a header answered successfully")
+	}
+	if waited := time.Since(start); waited > 5*time.Second {
+		t.Fatalf("the request waited %v on a silent server; ResponseHeaderTimeout is not bounding it", waited)
+	}
+}
+
+// TestEveryCloudAdapterUsesTheHardenedTransport is the census: every provider
+// SelectBrain can build must get the hardened client, because a single adapter
+// left on http.DefaultTransport is a vendor whose stalls nothing bounds — and
+// the one most likely to be missed is the one added next.
+//
+// It derives its subject from KnownProviders() rather than a hand-written list,
+// so a provider added without a transport fails here instead of shipping
+// unbounded.
+func TestEveryCloudAdapterUsesTheHardenedTransport(t *testing.T) {
+	t.Parallel()
+
+	// Every cloud adapter needs its BYOK key present or SelectBrain refuses
+	// before it builds a client; the value is never sent anywhere here.
+	keys := config.Lookup(func(string) string { return "k" })
+	for _, provider := range KnownProviders() {
+		if provider == ProviderFake {
+			continue // the offline stub makes no outbound call at all
+		}
+		cfg := ProviderConfig{Provider: provider, Model: "m", BaseURL: "https://vendor.example"}
+		client, err := SelectBrain(cfg, keys)
+		if err != nil {
+			t.Fatalf("SelectBrain(%s): %v", provider, err)
+		}
+		httpClient := outboundHTTPClientOf(t, client)
+		if httpClient.Timeout != requestTimeout {
+			t.Errorf("%s: call timeout is %v, want %v", provider, httpClient.Timeout, requestTimeout)
+		}
+		transport, ok := httpClient.Transport.(*http.Transport)
+		if !ok {
+			t.Errorf("%s: transport is %T, not the hardened one — its stalls are bounded by nothing but the ceiling", provider, httpClient.Transport)
+			continue
+		}
+		if transport.ResponseHeaderTimeout != responseHeaderTimeout {
+			t.Errorf("%s: ResponseHeaderTimeout is %v, want %v", provider, transport.ResponseHeaderTimeout, responseHeaderTimeout)
+		}
+	}
+}
+
+// outboundHTTPClientOf reaches the *http.Client an adapter holds. Each adapter
+// keeps it in an unexported `http` field of its own struct type, so this reads
+// it the one way a test in the same package can.
+func outboundHTTPClientOf(t *testing.T, client model.Client) *http.Client {
+	t.Helper()
+	switch c := client.(type) {
+	case *anthropicClient:
+		return c.http
+	case *openaiClient:
+		return c.http
+	case *geminiClient:
+		return c.http
+	case *ollamaClient:
+		return c.http
+	case *openAICompatClient:
+		return c.http
+	default:
+		t.Fatalf("unknown adapter type %T — add it here, or its outbound calls are unbounded", client)
+		return nil
+	}
+}

--- a/backend/internal/modules/ai/outboundtransport_test.go
+++ b/backend/internal/modules/ai/outboundtransport_test.go
@@ -5,73 +5,167 @@ package ai
 
 import (
 	"context"
+	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
-// TestOutboundClientGivesUpOnAVendorThatNeverAnswers proves a vendor that
-// accepts a connection and then says nothing fails in responseHeaderTimeout
-// rather than holding the caller for the full requestTimeout.
+// TestOutboundClientKeepsItsConnectionsHonest proves the shared transport can
+// notice a connection the far end has abandoned, instead of handing it to the
+// next request to wait out the five-minute ceiling on.
 //
 // This is the shape that cost a re-embed run four of its five attempts: a
-// connection the network had dropped stayed in the pool, and each request handed
-// to it waited out the five-minute ceiling with the caller's database
-// transaction open underneath. The test drives the real client against a server
-// that never writes a header, and asserts the deadline it hits is the header one.
-func TestOutboundClientGivesUpOnAVendorThatNeverAnswers(t *testing.T) {
+// dropped connection stayed in the pool looking healthy, and each request handed
+// to it stalled for minutes with the caller's database transaction open.
+//
+// It asserts NO response-header timeout, deliberately. A completion is sent with
+// stream:false, so the vendor holds its headers until generation finishes and a
+// header deadline would cut exactly the long answers requestTimeout is generous
+// for. The embed lane's own deadline is what bounds the calls whose duration is
+// actually known — see TestEmbedLaneBoundsOneCall.
+func TestOutboundClientKeepsItsConnectionsHonest(t *testing.T) {
 	t.Parallel()
 
-	blocked := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		<-blocked // never writes a status line
-	}))
-	defer srv.Close()
-	defer close(blocked)
-
 	client := newOutboundClient()
-	// The real constant is minutes long, which no test may wait out. Asserting
-	// on the FIELD rather than a real elapsed deadline is what keeps this test
-	// honest and fast: the client under test is the one SelectBrain hands every
-	// adapter, and the timeout is read off it, not restated.
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
-		t.Fatalf("the outbound client's transport is %T, so nothing bounds its response headers", client.Transport)
+		t.Fatalf("the outbound client's transport is %T, so nothing retires a dead connection", client.Transport)
 	}
-	if transport.ResponseHeaderTimeout != responseHeaderTimeout {
-		t.Fatalf("ResponseHeaderTimeout is %v, want %v — a vendor that stops answering mid-connection holds the caller for the whole %v ceiling",
-			transport.ResponseHeaderTimeout, responseHeaderTimeout, requestTimeout)
+	if transport.HTTP2 == nil || transport.HTTP2.SendPingTimeout != http2PingAfterIdle {
+		t.Fatalf("the HTTP/2 keep-alive ping is %v, want %v — without it a dropped h2 connection stays in the pool looking healthy",
+			transport.HTTP2, http2PingAfterIdle)
 	}
-	if transport.HTTP2 == nil || transport.HTTP2.SendPingTimeout == 0 {
-		t.Fatal("no HTTP/2 keep-alive ping is configured, so a dropped h2 connection stays in the pool looking healthy")
+	if transport.HTTP2.PingTimeout != http2PingTimeout {
+		t.Fatalf("PingTimeout is %v, want %v", transport.HTTP2.PingTimeout, http2PingTimeout)
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Fatal("HTTP/2 is not enabled, so the ping settings above bind nothing")
 	}
 	if transport.IdleConnTimeout != idleConnTimeout {
 		t.Fatalf("IdleConnTimeout is %v, want %v", transport.IdleConnTimeout, idleConnTimeout)
 	}
+	if transport.ResponseHeaderTimeout != 0 {
+		t.Fatalf("ResponseHeaderTimeout is %v, but a stream:false completion holds its headers until generation finishes — this cuts long answers short",
+			transport.ResponseHeaderTimeout)
+	}
+	if client.Timeout != requestTimeout {
+		t.Fatalf("the call ceiling is %v, want %v", client.Timeout, requestTimeout)
+	}
+}
 
-	// And the bound is real, not only declared: the same transport with the
-	// timeout dialled down to something a test may wait out must actually give
-	// up on this server.
-	fast := transport.Clone()
-	fast.ResponseHeaderTimeout = 100 * time.Millisecond
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+// TestEmbedLaneBoundsOneCall proves Router.Embed puts a deadline on every
+// embedding call, so a stalled connection costs EmbedCallTimeout rather than
+// the whole five-minute ceiling.
+//
+// The lane is where the bound belongs because it is the one place the expected
+// duration is known: an embedding is a single forward pass and answers in about
+// a second, where a completion legitimately takes minutes. The assertion reads
+// the deadline the embedder was actually handed — a router that forwards the
+// caller's context unchanged hands it none, which is the defect this holds shut.
+func TestEmbedLaneBoundsOneCall(t *testing.T) {
+	t.Parallel()
+
+	if EmbedCallTimeout <= 0 || EmbedCallTimeout >= requestTimeout {
+		t.Fatalf("EmbedCallTimeout is %v, which does not bound anything inside the %v ceiling", EmbedCallTimeout, requestTimeout)
+	}
+
+	spy := &deadlineSpyEmbedder{}
+	router := routerWithEmbedder(t, spy)
+	if _, err := router.Embed(workspaceCtx(), model.EmbedRequest{Inputs: []string{"x"}, Dimensions: 4}); !errors.Is(err, errStubEmbedderRefused) {
+		t.Fatalf("Embed reached something other than the spy: %v", err)
+	}
+	if !spy.hadDeadline {
+		t.Fatal("the embedder was handed a context with no deadline: a stalled embedding call holds the caller for the whole ceiling")
+	}
+	if spy.remaining > EmbedCallTimeout || spy.remaining < EmbedCallTimeout/2 {
+		t.Fatalf("the embedder was given %v, want about %v", spy.remaining, EmbedCallTimeout)
+	}
+}
+
+// TestEmbedLaneKeepsATighterCallerDeadline proves the lane's timeout only ever
+// SHORTENS: a caller already nearly out of time is not handed a fresh minute,
+// which would outlive the request it belongs to.
+func TestEmbedLaneKeepsATighterCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	spy := &deadlineSpyEmbedder{}
+	router := routerWithEmbedder(t, spy)
+	ctx, cancel := context.WithTimeout(workspaceCtx(), 2*time.Second)
+	defer cancel()
+	if _, err := router.Embed(ctx, model.EmbedRequest{Inputs: []string{"x"}, Dimensions: 4}); !errors.Is(err, errStubEmbedderRefused) {
+		t.Fatalf("Embed reached something other than the spy: %v", err)
+	}
+	if spy.remaining > 3*time.Second {
+		t.Fatalf("the embedder was given %v against a caller deadline of 2s — the lane widened someone else's deadline", spy.remaining)
+	}
+}
+
+// deadlineSpyEmbedder answers a valid embedding and records the deadline it was
+// called under, which is the only place the lane's bound is observable.
+type deadlineSpyEmbedder struct {
+	hadDeadline bool
+	remaining   time.Duration
+}
+
+func (d *deadlineSpyEmbedder) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
+	deadline, ok := ctx.Deadline()
+	d.hadDeadline = ok
+	if ok {
+		d.remaining = time.Until(deadline)
+	}
+	// Refused rather than answered: the lane meters a SUCCESSFUL call, and a
+	// Router built without a meter (this test needs no database) would panic
+	// there. What is under test is the deadline the embedder was handed, which
+	// is already recorded above.
+	return model.Embeddings{}, errStubEmbedderRefused
+}
+
+// errStubEmbedderRefused is the spy's refusal, kept as a sentinel so the tests
+// can tell it apart from a real routing fault.
+var errStubEmbedderRefused = errors.New("stub embedder: recorded the deadline, refusing the call")
+
+func (d *deadlineSpyEmbedder) Caps() model.Capabilities { return model.Capabilities{} }
+
+func (d *deadlineSpyEmbedder) Complete(context.Context, model.Request) (model.Response, error) {
+	return model.Response{}, errors.New("deadlineSpyEmbedder serves the embed lane only")
+}
+
+func (d *deadlineSpyEmbedder) Stream(context.Context, model.Request) (model.TokenStream, error) {
+	return nil, errors.New("deadlineSpyEmbedder serves the embed lane only")
+}
+
+// routerWithEmbedder builds a Router whose embed lane is the given client, so a
+// test can observe what the lane hands it. The chat tiers are the offline fake;
+// nothing here calls them.
+func routerWithEmbedder(t *testing.T, embedder model.Client) *Router {
+	t.Helper()
+	cfg := FakeRoutingConfig()
+	cfg.Embeddings = EmbeddingsConfig{
+		ProviderConfig: ProviderConfig{Provider: ProviderFake, Model: "spy"},
+		Dimensions:     4,
+	}
+	router, err := NewRouter(cfg, nil, nil, nil, false, nil)
 	if err != nil {
-		t.Fatalf("building the request: %v", err)
+		t.Fatalf("NewRouter: %v", err)
 	}
-	start := time.Now()
-	resp, err := (&http.Client{Transport: fast}).Do(req)
-	if err == nil {
-		//craft:ignore swallowed-errors best-effort close of a body this test never reads — the assertion below is the outcome
-		_ = resp.Body.Close()
-		t.Fatal("a server that never writes a header answered successfully")
-	}
-	if waited := time.Since(start); waited > 5*time.Second {
-		t.Fatalf("the request waited %v on a silent server; ResponseHeaderTimeout is not bounding it", waited)
-	}
+	// A copy, so the swap replaces the whole binding the way rebinding does
+	// rather than mutating one another goroutine may be reading.
+	bound := *router.binding()
+	bound.embedder = embedder
+	router.bound.Store(&bound)
+	return router
+}
+
+// workspaceCtx is the workspace-bound context Router.Embed requires; which
+// workspace is immaterial, only that one is bound.
+func workspaceCtx() context.Context {
+	return principal.WithWorkspaceID(context.Background(), ids.NewV7())
 }
 
 // TestEveryCloudAdapterUsesTheHardenedTransport is the census: every provider
@@ -106,8 +200,8 @@ func TestEveryCloudAdapterUsesTheHardenedTransport(t *testing.T) {
 			t.Errorf("%s: transport is %T, not the hardened one — its stalls are bounded by nothing but the ceiling", provider, httpClient.Transport)
 			continue
 		}
-		if transport.ResponseHeaderTimeout != responseHeaderTimeout {
-			t.Errorf("%s: ResponseHeaderTimeout is %v, want %v", provider, transport.ResponseHeaderTimeout, responseHeaderTimeout)
+		if transport.HTTP2 == nil || transport.HTTP2.SendPingTimeout != http2PingAfterIdle {
+			t.Errorf("%s: no HTTP/2 keep-alive ping — a dropped connection to this vendor stalls until the ceiling", provider)
 		}
 	}
 }

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -5,9 +5,7 @@ package ai
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -65,12 +63,6 @@ const (
 // text.format all share this "json_schema" value).
 const jsonSchemaFormatType = "json_schema"
 
-// requestTimeout bounds a single model call. Generous because premium
-// completions on long context are legitimately slow — a streamed corpus
-// extraction emits ten-thousand-token answers over minutes; per-call
-// contexts tighten it where a caller has a real deadline.
-const requestTimeout = 300 * time.Second
-
 // Provider names — the vocabulary shared by the SelectBrain switch,
 // knownProviders, and the sovereign-eligible localProviders set. One spelling
 // each so a typo can't silently split "the switch accepts it" from "the config
@@ -123,7 +115,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerAnthropic)
 		}
 		return &anthropicClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         defaulted(cfg.BaseURL, defaultAnthropicBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
@@ -131,14 +123,14 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 		}, nil
 	case providerOllama:
 		return &ollamaClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         defaulted(cfg.BaseURL, defaultOllamaBaseURL),
 			defaultModel:    defaulted(cfg.Model, defaultOllamaModel),
 			attachmentMIMEs: narrowedCarriage(carriesImages, cfg.Input),
 		}, nil
 	case providerVLLM:
 		return &openAICompatClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         defaulted(cfg.BaseURL, defaultVLLMBaseURL),
 			apiKey:          "", // local vLLM: no auth
 			localOnly:       true,
@@ -154,7 +146,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, fmt.Errorf("ai: provider openai_compatible needs a base_url (the vendor host root — no version segment, the adapter adds /v1; e.g. https://api.mistral.ai)")
 		}
 		return &openAICompatClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         cfg.BaseURL,
 			apiKey:          key,
 			localOnly:       false,
@@ -167,7 +159,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerOpenAI)
 		}
 		return &openaiClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         defaulted(cfg.BaseURL, defaultOpenAIBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
@@ -179,7 +171,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerGemini)
 		}
 		return &geminiClient{
-			http:            &http.Client{Timeout: requestTimeout},
+			http:            newOutboundClient(),
 			baseURL:         defaulted(cfg.BaseURL, defaultGeminiBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -23,6 +23,19 @@ import (
 // actually needs is a NEW job enqueued under the CURRENT config.
 var ErrIdentityDrift = errors.New("search: embedder identity drifted from the job's target identity")
 
+// ReembedConsecutiveFailureLimit is how many entities in a row may fail before
+// a pass stops calling the provider at all.
+//
+// It separates the two things a failure can mean. Scattered bad rows — one
+// entity whose text a provider will not take — must not cost the corpus behind
+// them, which is why the loop collects rather than returns. A provider that has
+// stopped answering fails EVERY row, and carrying on then buys nothing: each
+// call waits out its own timeout, the run's attempt is spent regardless, and
+// the joined error grows one entry per entity. Twenty is comfortably more than
+// any run of genuinely bad rows this corpus has produced and small enough that
+// an outage costs seconds rather than hours.
+const ReembedConsecutiveFailureLimit = 20
+
 // ReembedPass is one workspace's slice of a run: the run it reports its progress
 // to, the identity it must still be re-embedding under, and the clock that
 // progress reporting is paced by.
@@ -108,7 +121,17 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 	// one, so a single unembeddable entity costs its own row and not the corpus
 	// behind it. The pass still FAILS if any entity failed — this changes what
 	// an attempt covers, never whether the run reports the fault.
-	var failures []error
+	//
+	// consecutive counts failures in a row, and is what tells one bad entity
+	// apart from a provider that has stopped answering. Carrying on through an
+	// OUTAGE would call the vendor once per remaining entity, each call waiting
+	// out its own timeout, so a large corpus could spend hours failing before
+	// River ever got to back off. The counter resets on every success, so a
+	// corpus with scattered bad rows still runs to the end.
+	var (
+		failures    []error
+		consecutive int
+	)
 
 	for entityType, src := range pendingSources {
 		// The marker is refreshed on BOTH sides of the scan, and the first of
@@ -119,15 +142,18 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 		// dominant leg looking dead. The note before the scan is what the scan's
 		// own duration is measured from; the note after it is where the embed
 		// loop's pacing restarts.
+		// Each of these returns joins what the pass has already collected: a
+		// scan or a marker write that fails LATER must not swallow the provider
+		// faults that explain why this run is in trouble in the first place.
 		if err := note(); err != nil {
-			return err
+			return errors.Join(err, errors.Join(failures...))
 		}
 		items, err := ws.liveEntitiesOf(wsCtx, entityType, src)
 		if err != nil {
-			return err
+			return errors.Join(err, errors.Join(failures...))
 		}
 		if err := note(); err != nil {
-			return err
+			return errors.Join(err, errors.Join(failures...))
 		}
 		for _, item := range items {
 			if _, err := ws.UpsertEmbedding(wsCtx, entityType, item.id, item.text, embedder); err != nil {
@@ -150,7 +176,14 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 				// that one bad entity no longer hides the rest of the corpus
 				// behind it.
 				failures = append(failures, fmt.Errorf("search: reembedding %s %s: %w", entityType, item.id, err))
+				consecutive++
+				if consecutive >= ReembedConsecutiveFailureLimit {
+					return fmt.Errorf("search: reembedding gave up after %d consecutive failures (the embed provider is not answering): %w",
+						consecutive, errors.Join(failures...))
+				}
+				continue
 			}
+			consecutive = 0
 			// Paced by the clock and not by a count of entities: an entity is not a
 			// unit of time, so a count would have to be divided by the slowest an
 			// entity can be. This carries the one upsert in flight when the interval
@@ -158,7 +191,7 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 			// states and nothing here can cap.
 			if now().Sub(noted) >= ReembedProgressStaleness {
 				if err := note(); err != nil {
-					return err
+					return errors.Join(err, errors.Join(failures...))
 				}
 			}
 		}

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -48,9 +48,13 @@ type ReembedPass struct {
 // UpsertEmbedding for every live entity every time and lets that
 // skip-compare decide what actually needs a model call.
 //
-// Every UpsertEmbedding error propagates as-is (fail-loud): the job row
-// carrying this workspace fails and is retried, rather than this routine
-// silently leaving a partially re-embedded corpus behind a green pass.
+// Every UpsertEmbedding error is reported (fail-loud): the job row carrying
+// this workspace fails and is retried, rather than this routine silently
+// leaving a partially re-embedded corpus behind a green pass. The failures are
+// COLLECTED rather than returned at the first one, so a single entity a
+// provider will not embed costs its own row and not every entity behind it —
+// the reasoning is at the call site, and a cancelled context is the one fault
+// that still stops the pass where it stands.
 //
 // It also reports its own progress onto the run's marker as it goes, because a
 // pass this long is otherwise indistinguishable from one that died: nothing else
@@ -100,6 +104,12 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 		return nil
 	}
 
+	// Faults collected across the whole pass rather than returned at the first
+	// one, so a single unembeddable entity costs its own row and not the corpus
+	// behind it. The pass still FAILS if any entity failed — this changes what
+	// an attempt covers, never whether the run reports the fault.
+	var failures []error
+
 	for entityType, src := range pendingSources {
 		// The marker is refreshed on BOTH sides of the scan, and the first of
 		// those notes is also the one that covers the start of the pass: nothing
@@ -121,7 +131,25 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 		}
 		for _, item := range items {
 			if _, err := ws.UpsertEmbedding(wsCtx, entityType, item.id, item.text, embedder); err != nil {
-				return fmt.Errorf("search: reembedding %s %s: %w", entityType, item.id, err)
+				// A cancelled context stops the pass at once: the deadline that
+				// cancelled it applies to every entity after this one too, so
+				// carrying on would spend the rest of the corpus re-deriving the
+				// same answer, and the run's own shutdown is not a defect to
+				// collect per entity.
+				if wsCtx.Err() != nil {
+					return errors.Join(fmt.Errorf("search: reembedding %s %s: %w", entityType, item.id, err), errors.Join(failures...))
+				}
+				// Otherwise the pass CONTINUES past the entity it could not
+				// embed, the way the knowledge corpus sweep does. Stopping here
+				// spent a whole River attempt on the entities AFTER the bad one,
+				// which is what a transient provider fault actually costs: one
+				// dropped connection nine hundred entities in ended the attempt,
+				// and the next attempt re-walked the corpus to reach the same
+				// place. The failures are joined and returned, so the row still
+				// fails and the operator still sees every reason; what changes is
+				// that one bad entity no longer hides the rest of the corpus
+				// behind it.
+				failures = append(failures, fmt.Errorf("search: reembedding %s %s: %w", entityType, item.id, err))
 			}
 			// Paced by the clock and not by a count of entities: an entity is not a
 			// unit of time, so a count would have to be divided by the slowest an
@@ -135,7 +163,7 @@ func (s *Store) Reembed(ctx context.Context, pass ReembedPass, embedder Embedder
 			}
 		}
 	}
-	return nil
+	return errors.Join(failures...)
 }
 
 // liveEntity is one row selected for re-embedding: an id plus the exact


### PR DESCRIPTION
Every provider adapter built its own bare `http.Client{Timeout: 300s}` on net/http's default transport: no response-header timeout, no HTTP/2 keep-alive ping, no idle-connection retirement. A connection dropped by a NAT or a load balancer stayed in the pool looking healthy, and every request handed to it waited out the full five minutes with the caller's database transaction open underneath.

A re-embed run on a live installation hit this four times in one afternoon: two 246-second stalls inside single embedding calls, a DNS failure and a peer reset. Each ended a River attempt; four of the run's five attempts were spent before it finished.

## What changed

`newOutboundClient` in `backend/internal/modules/ai/outboundtransport.go` is now the one client every adapter gets:

- **90s response-header timeout.** Bounds the wait for the status line only, so a streamed extraction's slow body keeps the generous 300s ceiling. A vendor that has accepted a request sends headers long before tokens.
- **HTTP/2 keep-alive ping** after 20s of silence, 10s to answer. Both vendors this reaches over h2 sit behind Cloudflare, which drops idle connections well inside a minute.
- **60s idle-connection timeout**, so a worker between passes reconnects rather than reaching for a connection the far end forgot.

`TestEveryCloudAdapterUsesTheHardenedTransport` derives its subject from `KnownProviders()` rather than a hand-written list, so a provider added without the transport fails here instead of shipping unbounded. Reverting the hardening fails it on all six adapters.

Beside it, `search.Reembed` now collects per-entity faults instead of returning at the first one — the shape `knowledge`'s corpus sweep already uses, with the reasoning already written out there. One entity a provider will not embed cost every entity behind it its place in the pass, and the next attempt re-walked the corpus to reach the same row. The pass still fails if any entity failed; a cancelled context still stops it where it stands.

## Testing

- `make check-backend` green, except two failures that reproduce on unmodified `origin/main` and are caused by untracked files in this shared checkout: a `.pnpm-store` symlink (`TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim`) and an oversized docs page another session added (`TestEveryHandWrittenDocsPageFitsItsBudget`). Neither is in this diff.
- `make test-it DIR=backend/internal/compose/integration RUN=TestReembed` — all six pass, including the new `TestReembedEmbedsEveryEntityPastOneItCannot`.
- Both new tests mutation-checked: reverting each change makes its test fail with the message it was written for.
- `make craft-static`, `make rls-store-path`, `make no-jurisdiction` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens outbound model calls so a connection dropped by a NAT or load balancer fails fast instead of holding the caller for the full five-minute timeout, and makes `search.Reembed` continue past per-entity faults.

**Changes**
- All provider adapters now share one outbound client with HTTP/2 keep-alive pings after 20s of silence and a 60s idle-connection timeout; embedding calls get a 60s deadline in the embed lane, where a response-header timeout would have cut slow completions.
- `search.Reembed` collects per-entity faults instead of returning at the first one, and stops after 20 consecutive failures so a dead provider doesn't burn the whole attempt; the pass still fails if any entity failed, and a cancelled context stops it immediately.
- A census test derives from `KnownProviders()`, so a provider added without the hardened transport fails.

<sup>Written for commit 6f09554df8561af54842cc4859792985eef82091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-embedding now continues processing remaining items when an individual embedding fails.
  - Reports all encountered embedding errors after processing completes.
  - Preserves prompt handling of cancellation interruptions.

- **Reliability**
  - Improved AI provider connection handling with request, response, idle-connection, and keep-alive timeouts.
  - Applies consistent connection safeguards across supported cloud AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->