### PR TITLE
A registry nothing builds, gating on a rule that changed

### DIFF
--- a/backend/gates/googleconnectorregistration_test.go
+++ b/backend/gates/googleconnectorregistration_test.go
@@ -93,7 +93,12 @@ func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		for _, built := range googleConnectorsBuiltIn(file) {
+		built, dotImported := googleConnectorsBuiltIn(file)
+		for _, hidden := range dotImported {
+			t.Errorf("%s: dot-imports %s, so a construction in this file reads as a bare New( ) with no package to match on and this census cannot see it. Import it with a qualifier — a reader that cannot see a registration is how the stored app became unreachable while every test passed",
+				walked, hidden)
+		}
+		for _, built := range built {
 			switch {
 			case built.function == googleConnectorRegistrar:
 				inRegistrar[built.connector] = true
@@ -120,6 +125,37 @@ func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
 	}
 }
 
+// TestTheGoogleConnectorCensusFailsClosedOnADotImport proves the arm the tree
+// cannot exercise.
+//
+// A dot import of gmail or gcal into package compose does not compile today —
+// `New` collides with compose's own — so the reader is asked directly, with a
+// planted file. The arm is not dead code for that: the collision is an accident
+// of two names, and a census whose blind spot is only closed by an accident is
+// a census nobody should trust.
+func TestTheGoogleConnectorCensusFailsClosedOnADotImport(t *testing.T) {
+	t.Parallel()
+	const planted = `package compose
+
+import . "github.com/margince/margince/backend/internal/modules/capture/gmail"
+
+func hidden() any { return New(nil, nil) }
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "planted.go", planted, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builds, dotImported := googleConnectorsBuiltIn(file)
+	if len(dotImported) != 1 || !strings.HasSuffix(dotImported[0], "/gmail") {
+		t.Errorf("dot-imported = %v, want the gmail package reported: a construction this reader cannot see must be "+
+			"named, not skipped", dotImported)
+	}
+	if len(builds) != 0 {
+		t.Errorf("builds = %v, want none: there is no qualifier to attribute one to, which is the whole reason the "+
+			"import itself is reported", builds)
+	}
+}
+
 // googleConnectorBuild is one construction and the function it sits in.
 type googleConnectorBuild struct {
 	function  string
@@ -127,39 +163,53 @@ type googleConnectorBuild struct {
 }
 
 // googleConnectorsBuiltIn names the Google connectors a file constructs, with
-// the enclosing function of each. The qualifier comes from the file's own
-// import block rather than from the package's name, so an aliased import is
-// read as the connector it is.
-func googleConnectorsBuiltIn(file *ast.File) []googleConnectorBuild {
+// the enclosing function of each, and separately the governed packages the file
+// dot-imports.
+//
+// The qualifier comes from the file's own import block rather than from the
+// package's name, so an aliased import is read as the connector it is. A DOT
+// import has no qualifier at all — its construction reads as a bare `New(…)`
+// with nothing to match on — so it is reported rather than skipped: a reader
+// that cannot see a registration certifies nothing while reading exactly like
+// a clean one.
+//
+// It walks the WHOLE file, not just function bodies. A package-scope
+// initializer is a construction like any other, and one attributed to package
+// scope can never be the registrar, so it fails — which is the right answer,
+// since a registry built at init time decides reachability the same way.
+func googleConnectorsBuiltIn(file *ast.File) (builds []googleConnectorBuild, dotImported []string) {
 	byQualifier := map[string]string{}
 	for _, importPath := range googleConnectorPackages {
-		// A dot import has no qualifier to match on, and a blank one cannot be
-		// called through at all; ImportedAs reports both as an empty name.
-		if qualifier, _ := gatekit.ImportedAs(file, importPath); qualifier != "" {
+		qualifier, dot := gatekit.ImportedAs(file, importPath)
+		switch {
+		case dot:
+			dotImported = append(dotImported, importPath)
+		case qualifier != "":
 			byQualifier[qualifier] = path.Base(importPath)
 		}
+		// A blank import is neither: it cannot be called through at all.
 	}
 	if len(byQualifier) == 0 {
-		return nil
+		return nil, dotImported
 	}
-	var out []googleConnectorBuild
-	for _, decl := range file.Decls {
-		fn, isFunc := decl.(*ast.FuncDecl)
-		if !isFunc || fn.Body == nil {
-			continue
-		}
-		for _, connector := range googleConnectorsConstructedIn(fn.Body, byQualifier) {
-			out = append(out, googleConnectorBuild{function: functionName(fn), connector: connector})
-		}
-	}
-	return out
-}
-
-// googleConnectorsConstructedIn names the connectors a body builds, sorted so
-// that a function building both reports them in a settled order.
-func googleConnectorsConstructedIn(body *ast.BlockStmt, byQualifier map[string]string) []string {
+	// packageScope is what a construction outside every function declaration is
+	// attributed to. It is spelled as prose rather than as an identifier so that
+	// no function can be named it and inherit the registrar's licence.
+	const packageScope = "(package scope)"
+	enclosing := packageScope
 	seen := map[string]bool{}
-	ast.Inspect(body, func(n ast.Node) bool {
+	var walk func(ast.Node) bool
+	walk = func(n ast.Node) bool {
+		if fn, isFunc := n.(*ast.FuncDecl); isFunc {
+			if fn.Body == nil {
+				return false
+			}
+			before := enclosing
+			enclosing = functionName(fn)
+			ast.Inspect(fn.Body, walk)
+			enclosing = before
+			return false
+		}
 		call, isCall := n.(*ast.CallExpr)
 		if !isCall {
 			return true
@@ -168,17 +218,29 @@ func googleConnectorsConstructedIn(body *ast.BlockStmt, byQualifier map[string]s
 		if !isSel || sel.Sel.Name != "New" {
 			return true
 		}
-		if qualifier, isIdent := sel.X.(*ast.Ident); isIdent && byQualifier[qualifier.Name] != "" {
-			seen[byQualifier[qualifier.Name]] = true
+		qualifier, isIdent := sel.X.(*ast.Ident)
+		if !isIdent || byQualifier[qualifier.Name] == "" {
+			return true
+		}
+		// One entry per function per connector: a registrar building the same
+		// one twice is one decision, and reporting it twice reads as two.
+		key := enclosing + ":" + byQualifier[qualifier.Name]
+		if !seen[key] {
+			seen[key] = true
+			builds = append(builds, googleConnectorBuild{
+				function: enclosing, connector: byQualifier[qualifier.Name],
+			})
 		}
 		return true
-	})
-	var out []string
-	for connector := range seen {
-		out = append(out, connector)
 	}
-	sort.Strings(out)
-	return out
+	ast.Inspect(file, walk)
+	sort.Slice(builds, func(i, j int) bool {
+		if builds[i].function != builds[j].function {
+			return builds[i].function < builds[j].function
+		}
+		return builds[i].connector < builds[j].connector
+	})
+	return builds, dotImported
 }
 
 // functionName spells a method as Receiver.Name, so that two files declaring

--- a/backend/gates/googleconnectorregistration_test.go
+++ b/backend/gates/googleconnectorregistration_test.go
@@ -5,8 +5,9 @@
 
 package gates
 
-// The Google connectors are registered in ONE function, because registering
-// them is a decision about REACHABILITY and that decision has been wrong once.
+// The Google connectors are built for the registry in ONE function, because
+// putting one INTO the registry is a decision about REACHABILITY and that
+// decision has been wrong once.
 //
 // An installation can supply its Google app from either of two places: the pair
 // the deployment composed, or the setting the installation stored through its
@@ -23,18 +24,32 @@ package gates
 // — and both were exactly what somebody wiring up a poller next would have
 // reached for, with tests already passing over the old rule to reassure them.
 // They are gone; this is what stops the third one.
+//
+// The CONSTRUCTION is what this reads, not the Register call it is passed to.
+// A registration can hoist its connector into a local, hand it to a helper, or
+// reach the registry through a chain of them, and a reader that followed the
+// argument would have to be a dataflow analysis to see any of that — one that
+// answers "no Google connector here" for every shape it has not been taught.
+// A construction cannot be hidden the same way: a second registrar has to build
+// the connector somewhere, and that somewhere is a syntactic fact. The price is
+// that a construction which is NOT a registration has to be named below.
 
 import (
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// googleConnectorRegistrar is the one function that may register them.
+// googleConnectorRegistrar is the one function that may build them for the
+// registry.
 //
 // Held by: TestOnlyOneFunctionRegistersTheGoogleConnectors
 // (backend/gates/googleconnectorregistration_test.go) — the census below is
@@ -43,37 +58,49 @@ import (
 const googleConnectorRegistrar = "newCaptureRegistryWithGoogle"
 
 // googleConnectorPackages are the connector constructors whose registration is
-// governed by the reachability rule. graph is deliberately absent: it answers
-// to a Microsoft app with a rule of its own, and folding the two together would
-// be a third spelling of a question neither is asking.
-var googleConnectorPackages = map[string]bool{"gmail": true, "gcal": true}
+// governed by the reachability rule, by import path so that an alias is read
+// the same as the plain name. graph is deliberately absent: it answers to a
+// Microsoft app with a rule of its own, and folding the two together would be a
+// third spelling of a question neither is asking.
+var googleConnectorPackages = []string{
+	"github.com/margince/margince/backend/internal/modules/capture/gmail",
+	"github.com/margince/margince/backend/internal/modules/capture/gcal",
+}
+
+// builtForSomethingOtherThanTheRegistry names the constructions that are a USE
+// rather than an offer. The registry is what the transport reads to decide
+// whether the consent flow may run at all, so a connector built to call a
+// method on it and thrown away carries no reachability decision.
+var builtForSomethingOtherThanTheRegistry = gatekit.Waive(map[string]string{
+	"internal/compose/connectorapp.go:connectorHandlers.gmailApp": "builds a connector to call Authenticate on it and drops it; the registry never sees this one, so it decides nothing about whether Gmail is reachable",
+	"internal/compose/connectorapp.go:connectorHandlers.gcalApp":  "builds a connector to call Authenticate on it and drops it; the registry never sees this one, so it decides nothing about whether Calendar is reachable",
+})
 
 // TestOnlyOneFunctionRegistersTheGoogleConnectors is the census.
 func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
 	t.Parallel()
-	found := 0
-	err := filepath.WalkDir("internal/compose", func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
-			strings.HasSuffix(path, "_test.go") || isIntegrationTagged(path) {
+	// Distinct connectors, not a count: one connector built twice reads as two
+	// registrations, and a census that certified on the total would pass a tree
+	// that had lost Calendar entirely.
+	inRegistrar := map[string]bool{}
+	err := filepath.WalkDir("internal/compose", func(walked string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(walked, ".go") ||
+			strings.HasSuffix(walked, "_test.go") || isIntegrationTagged(walked) {
 			return err
 		}
-		path = filepath.ToSlash(path)
-		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		walked = filepath.ToSlash(walked)
+		file, err := parser.ParseFile(token.NewFileSet(), walked, nil, 0)
 		if err != nil {
 			return err
 		}
-		for _, decl := range file.Decls {
-			fn, isFunc := decl.(*ast.FuncDecl)
-			if !isFunc || fn.Body == nil {
-				continue
-			}
-			for _, connector := range googleConnectorsRegisteredIn(fn) {
-				found++
-				if fn.Name.Name == googleConnectorRegistrar {
-					continue
-				}
-				t.Errorf("%s: %s registers the %s connector — the rule for WHETHER it may be registered lives in %s, and a second place to decide it is how the stored app became unreachable while every test passed. Build the registry through %s and add what this needs to it",
-					path, fn.Name.Name, connector, googleConnectorRegistrar, googleConnectorRegistrar)
+		for _, built := range googleConnectorsBuiltIn(file) {
+			switch {
+			case built.function == googleConnectorRegistrar:
+				inRegistrar[built.connector] = true
+			case builtForSomethingOtherThanTheRegistry.Waived(t, walked+":"+built.function):
+			default:
+				t.Errorf("%s: %s builds the %s connector — the rule for WHETHER it may be registered lives in %s, and a second place to decide it is how the stored app became unreachable while every test passed. Build the registry through %s and add what this needs to it, or name this one in builtForSomethingOtherThanTheRegistry if the registry never sees it",
+					walked, built.function, built.connector, googleConnectorRegistrar, googleConnectorRegistrar)
 			}
 		}
 		return nil
@@ -81,51 +108,58 @@ func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Both connectors, or the reader has stopped seeing registrations rather
+	builtForSomethingOtherThanTheRegistry.AssertAllMatched(t)
+	// Every connector, or the reader has stopped seeing constructions rather
 	// than the tree having lost them — and a census that finds none certifies
 	// nothing while reading exactly like a clean one.
-	if found < len(googleConnectorPackages) {
-		t.Fatalf("this census found %d Google connector registration(s) and expects at least %d — the reader has gone quiet",
-			found, len(googleConnectorPackages))
+	for _, importPath := range googleConnectorPackages {
+		if connector := path.Base(importPath); !inRegistrar[connector] {
+			t.Fatalf("this census did not find the %s connector built in %s — either the registrar has stopped building it or the reader has gone quiet, and it cannot tell the difference",
+				connector, googleConnectorRegistrar)
+		}
 	}
 }
 
-// googleConnectorsRegisteredIn names the Google connectors a function registers.
-//
-// The REGISTRATION is what is judged, not the construction. connectorapp.go
-// builds a gmail.Connector to call Authenticate on it, which is a use rather
-// than an offer: the registry is what the transport reads to decide whether the
-// consent flow may run at all, so putting one INTO it is the act with the
-// reachability question attached.
-func googleConnectorsRegisteredIn(fn *ast.FuncDecl) []string {
-	var out []string
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		call, isCall := n.(*ast.CallExpr)
-		if !isCall {
-			return true
+// googleConnectorBuild is one construction and the function it sits in.
+type googleConnectorBuild struct {
+	function  string
+	connector string
+}
+
+// googleConnectorsBuiltIn names the Google connectors a file constructs, with
+// the enclosing function of each. The qualifier comes from the file's own
+// import block rather than from the package's name, so an aliased import is
+// read as the connector it is.
+func googleConnectorsBuiltIn(file *ast.File) []googleConnectorBuild {
+	byQualifier := map[string]string{}
+	for _, importPath := range googleConnectorPackages {
+		// A dot import has no qualifier to match on, and a blank one cannot be
+		// called through at all; ImportedAs reports both as an empty name.
+		if qualifier, _ := gatekit.ImportedAs(file, importPath); qualifier != "" {
+			byQualifier[qualifier] = path.Base(importPath)
 		}
-		sel, isSel := call.Fun.(*ast.SelectorExpr)
-		if !isSel || sel.Sel.Name != "Register" {
-			return true
+	}
+	if len(byQualifier) == 0 {
+		return nil
+	}
+	var out []googleConnectorBuild
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil {
+			continue
 		}
-		for _, arg := range call.Args {
-			if connector := googleConnectorConstructed(arg); connector != "" {
-				out = append(out, connector)
-			}
+		for _, connector := range googleConnectorsConstructedIn(fn.Body, byQualifier) {
+			out = append(out, googleConnectorBuild{function: functionName(fn), connector: connector})
 		}
-		return true
-	})
+	}
 	return out
 }
 
-// googleConnectorConstructed names the Google connector an expression builds,
-// or "" for anything else. It looks THROUGH the option chain a registration
-// wraps its connector in — `gmail.New(…).WithBounceSink(…)` is still a gmail
-// registration, and a reader that only matched the outermost call would see a
-// method name and pass.
-func googleConnectorConstructed(expr ast.Expr) string {
-	found := ""
-	ast.Inspect(expr, func(n ast.Node) bool {
+// googleConnectorsConstructedIn names the connectors a body builds, sorted so
+// that a function building both reports them in a settled order.
+func googleConnectorsConstructedIn(body *ast.BlockStmt, byQualifier map[string]string) []string {
+	seen := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
 		call, isCall := n.(*ast.CallExpr)
 		if !isCall {
 			return true
@@ -134,10 +168,31 @@ func googleConnectorConstructed(expr ast.Expr) string {
 		if !isSel || sel.Sel.Name != "New" {
 			return true
 		}
-		if pkg, isIdent := sel.X.(*ast.Ident); isIdent && googleConnectorPackages[pkg.Name] {
-			found = pkg.Name
+		if qualifier, isIdent := sel.X.(*ast.Ident); isIdent && byQualifier[qualifier.Name] != "" {
+			seen[byQualifier[qualifier.Name]] = true
 		}
-		return found == ""
+		return true
 	})
-	return found
+	var out []string
+	for connector := range seen {
+		out = append(out, connector)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// functionName spells a method as Receiver.Name, so that two files declaring
+// the same method name on different types cannot share a waiver.
+func functionName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	receiver := fn.Recv.List[0].Type
+	if star, isStar := receiver.(*ast.StarExpr); isStar {
+		receiver = star.X
+	}
+	if ident, isIdent := receiver.(*ast.Ident); isIdent {
+		return ident.Name + "." + fn.Name.Name
+	}
+	return fn.Name.Name
 }

--- a/backend/gates/googleconnectorregistration_test.go
+++ b/backend/gates/googleconnectorregistration_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// The Google connectors are registered in ONE function, because registering
+// them is a decision about REACHABILITY and that decision has been wrong once.
+//
+// An installation can supply its Google app from either of two places: the pair
+// the deployment composed, or the setting the installation stored through its
+// own Settings screen. The registration used to require the first, which made
+// the second unusable rather than merely unread — the transport asks the
+// registry whether a connector exists before it will run the consent flow, so
+// an installation that set its app through Settings was answered with the
+// declared 501 and had no way to connect Gmail at all.
+//
+// That was fixed in newCaptureRegistryWithGoogle, and two OTHER constructors
+// went on carrying the old rule: NewCaptureRegistryWithGmail passed no resolver
+// at all, and GmailPollRegistry returned nothing unless the environment carried
+// the pair. Neither had a production caller, so neither could cause the defect
+// — and both were exactly what somebody wiring up a poller next would have
+// reached for, with tests already passing over the old rule to reassure them.
+// They are gone; this is what stops the third one.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// googleConnectorRegistrar is the one function that may register them.
+//
+// Held by: TestOnlyOneFunctionRegistersTheGoogleConnectors
+// (backend/gates/googleconnectorregistration_test.go) — the census below is
+// what makes this a fact rather than a note, and it fails naming the second
+// function the moment one appears.
+const googleConnectorRegistrar = "newCaptureRegistryWithGoogle"
+
+// googleConnectorPackages are the connector constructors whose registration is
+// governed by the reachability rule. graph is deliberately absent: it answers
+// to a Microsoft app with a rule of its own, and folding the two together would
+// be a third spelling of a question neither is asking.
+var googleConnectorPackages = map[string]bool{"gmail": true, "gcal": true}
+
+// TestOnlyOneFunctionRegistersTheGoogleConnectors is the census.
+func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
+	t.Parallel()
+	found := 0
+	err := filepath.WalkDir("internal/compose", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || isIntegrationTagged(path) {
+			return err
+		}
+		path = filepath.ToSlash(path)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil {
+				continue
+			}
+			for _, connector := range googleConnectorsRegisteredIn(fn) {
+				found++
+				if fn.Name.Name == googleConnectorRegistrar {
+					continue
+				}
+				t.Errorf("%s: %s registers the %s connector — the rule for WHETHER it may be registered lives in %s, and a second place to decide it is how the stored app became unreachable while every test passed. Build the registry through %s and add what this needs to it",
+					path, fn.Name.Name, connector, googleConnectorRegistrar, googleConnectorRegistrar)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both connectors, or the reader has stopped seeing registrations rather
+	// than the tree having lost them — and a census that finds none certifies
+	// nothing while reading exactly like a clean one.
+	if found < len(googleConnectorPackages) {
+		t.Fatalf("this census found %d Google connector registration(s) and expects at least %d — the reader has gone quiet",
+			found, len(googleConnectorPackages))
+	}
+}
+
+// googleConnectorsRegisteredIn names the Google connectors a function registers.
+//
+// The REGISTRATION is what is judged, not the construction. connectorapp.go
+// builds a gmail.Connector to call Authenticate on it, which is a use rather
+// than an offer: the registry is what the transport reads to decide whether the
+// consent flow may run at all, so putting one INTO it is the act with the
+// reachability question attached.
+func googleConnectorsRegisteredIn(fn *ast.FuncDecl) []string {
+	var out []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel || sel.Sel.Name != "Register" {
+			return true
+		}
+		for _, arg := range call.Args {
+			if connector := googleConnectorConstructed(arg); connector != "" {
+				out = append(out, connector)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// googleConnectorConstructed names the Google connector an expression builds,
+// or "" for anything else. It looks THROUGH the option chain a registration
+// wraps its connector in — `gmail.New(…).WithBounceSink(…)` is still a gmail
+// registration, and a reader that only matched the outermost call would see a
+// method name and pass.
+func googleConnectorConstructed(expr ast.Expr) string {
+	found := ""
+	ast.Inspect(expr, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel || sel.Sel.Name != "New" {
+			return true
+		}
+		if pkg, isIdent := sel.X.(*ast.Ident); isIdent && googleConnectorPackages[pkg.Name] {
+			found = pkg.Name
+		}
+		return found == ""
+	})
+	return found
+}

--- a/backend/gates/googleconnectorregistration_test.go
+++ b/backend/gates/googleconnectorregistration_test.go
@@ -156,9 +156,13 @@ func hidden() any { return New(nil, nil) }
 	}
 }
 
-// shadowedIn names the governed qualifiers a file also BINDS: a variable, a
-// parameter, a field, a type or a function of the same name. Reported in a
-// settled order.
+// shadowedIn names the governed qualifiers a file also BINDS IN LEXICAL SCOPE:
+// a variable, a parameter, a result, a range variable, a type, a type parameter
+// or a function of the same name. Reported in a settled order.
+//
+// Struct FIELDS are deliberately absent. A field named gmail is reached as
+// x.gmail and shadows nothing, so reporting one would refuse correct code for a
+// name it was entitled to use.
 func shadowedIn(file *ast.File, byQualifier map[string]string) []string {
 	var found []string
 	seen := map[string]bool{}
@@ -194,6 +198,7 @@ func shadowedIn(file *ast.File, byQualifier map[string]string) []string {
 			note(node.Names...)
 		case *ast.TypeSpec:
 			note(node.Name)
+			fields(node.TypeParams)
 		case *ast.RangeStmt:
 			for _, key := range []ast.Expr{node.Key, node.Value} {
 				if id, isIdent := key.(*ast.Ident); isIdent {
@@ -203,18 +208,81 @@ func shadowedIn(file *ast.File, byQualifier map[string]string) []string {
 		case *ast.FuncDecl:
 			note(node.Name)
 			fields(node.Recv)
+			fields(node.Type.TypeParams)
 			fields(node.Type.Params)
 			fields(node.Type.Results)
 		case *ast.FuncLit:
+			fields(node.Type.TypeParams)
 			fields(node.Type.Params)
 			fields(node.Type.Results)
-		case *ast.StructType:
-			fields(node.Fields)
 		}
 		return true
 	})
 	sort.Strings(found)
 	return found
+}
+
+// TestTheGoogleConnectorCensusFailsClosedOnAShadowedPackage proves the other
+// arm this tree cannot exercise.
+//
+// No file in internal/compose shadows gmail or gcal, and none should — so the
+// reporting arm would otherwise run against nothing and a hole in it would look
+// exactly like a clean sweep. That is the under-recognition failure this census
+// exists to forbid, so the reader is asked directly with a planted file.
+func TestTheGoogleConnectorCensusFailsClosedOnAShadowedPackage(t *testing.T) {
+	t.Parallel()
+	const planted = `package compose
+
+import "github.com/margince/margince/backend/internal/modules/capture/gmail"
+
+type stand struct{}
+
+func (stand) New(a, b any) any { return nil }
+
+func hidden() any {
+	gmail := stand{}
+	return gmail.New(nil, nil)
+}
+
+var _ = gmail.New
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "planted.go", planted, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builds, unreadable := googleConnectorsBuiltIn(file)
+	if len(unreadable) != 1 || !strings.Contains(unreadable[0], "gmail") {
+		t.Errorf("unreadable = %v, want the shadowed gmail reported: a reader that cannot tell a package from a "+
+			"variable must say so", unreadable)
+	}
+	// It still reports the construction, because it cannot tell which one this
+	// is — and reporting one that turns out to be a local is the safe direction
+	// where missing a real one is not.
+	if len(builds) != 1 {
+		t.Errorf("builds = %v, want the construction still reported", builds)
+	}
+}
+
+// TestAStructFieldIsNotAShadowedPackage holds the other side: a field named
+// after a connector package is reached as x.gmail and shadows nothing, so
+// refusing it would reject correct code for a name it was entitled to use.
+func TestAStructFieldIsNotAShadowedPackage(t *testing.T) {
+	t.Parallel()
+	const planted = `package compose
+
+import "github.com/margince/margince/backend/internal/modules/capture/gmail"
+
+type wiring struct{ gmail string }
+
+func used(w wiring) any { return gmail.New(nil, nil) }
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "planted.go", planted, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, unreadable := googleConnectorsBuiltIn(file); len(unreadable) != 0 {
+		t.Errorf("unreadable = %v, want none: a struct field is not a lexical binding", unreadable)
+	}
 }
 
 // googleConnectorBuild is one construction and the function it sits in.

--- a/backend/gates/googleconnectorregistration_test.go
+++ b/backend/gates/googleconnectorregistration_test.go
@@ -93,10 +93,10 @@ func TestOnlyOneFunctionRegistersTheGoogleConnectors(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		built, dotImported := googleConnectorsBuiltIn(file)
-		for _, hidden := range dotImported {
-			t.Errorf("%s: dot-imports %s, so a construction in this file reads as a bare New( ) with no package to match on and this census cannot see it. Import it with a qualifier — a reader that cannot see a registration is how the stored app became unreachable while every test passed",
-				walked, hidden)
+		built, unreadable := googleConnectorsBuiltIn(file)
+		for _, why := range unreadable {
+			t.Errorf("%s: %s. A reader that cannot tell what it is looking at is how the stored app became unreachable while every test passed",
+				walked, why)
 		}
 		for _, built := range built {
 			switch {
@@ -145,15 +145,76 @@ func hidden() any { return New(nil, nil) }
 	if err != nil {
 		t.Fatal(err)
 	}
-	builds, dotImported := googleConnectorsBuiltIn(file)
-	if len(dotImported) != 1 || !strings.HasSuffix(dotImported[0], "/gmail") {
-		t.Errorf("dot-imported = %v, want the gmail package reported: a construction this reader cannot see must be "+
-			"named, not skipped", dotImported)
+	builds, unreadable := googleConnectorsBuiltIn(file)
+	if len(unreadable) != 1 || !strings.Contains(unreadable[0], "/gmail") {
+		t.Errorf("unreadable = %v, want the gmail dot import reported: a construction this reader cannot see must be "+
+			"named, not skipped", unreadable)
 	}
 	if len(builds) != 0 {
 		t.Errorf("builds = %v, want none: there is no qualifier to attribute one to, which is the whole reason the "+
 			"import itself is reported", builds)
 	}
+}
+
+// shadowedIn names the governed qualifiers a file also BINDS: a variable, a
+// parameter, a field, a type or a function of the same name. Reported in a
+// settled order.
+func shadowedIn(file *ast.File, byQualifier map[string]string) []string {
+	var found []string
+	seen := map[string]bool{}
+	note := func(idents ...*ast.Ident) {
+		for _, id := range idents {
+			if id == nil || byQualifier[id.Name] == "" || seen[id.Name] {
+				continue
+			}
+			seen[id.Name] = true
+			found = append(found, id.Name)
+		}
+	}
+	fields := func(list *ast.FieldList) {
+		if list == nil {
+			return
+		}
+		for _, field := range list.List {
+			note(field.Names...)
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.ImportSpec:
+			// The import itself is the binding this census WANTS.
+			return false
+		case *ast.AssignStmt:
+			for _, lhs := range node.Lhs {
+				if id, isIdent := lhs.(*ast.Ident); isIdent {
+					note(id)
+				}
+			}
+		case *ast.ValueSpec:
+			note(node.Names...)
+		case *ast.TypeSpec:
+			note(node.Name)
+		case *ast.RangeStmt:
+			for _, key := range []ast.Expr{node.Key, node.Value} {
+				if id, isIdent := key.(*ast.Ident); isIdent {
+					note(id)
+				}
+			}
+		case *ast.FuncDecl:
+			note(node.Name)
+			fields(node.Recv)
+			fields(node.Type.Params)
+			fields(node.Type.Results)
+		case *ast.FuncLit:
+			fields(node.Type.Params)
+			fields(node.Type.Results)
+		case *ast.StructType:
+			fields(node.Fields)
+		}
+		return true
+	})
+	sort.Strings(found)
+	return found
 }
 
 // googleConnectorBuild is one construction and the function it sits in.
@@ -177,20 +238,32 @@ type googleConnectorBuild struct {
 // initializer is a construction like any other, and one attributed to package
 // scope can never be the registrar, so it fails — which is the right answer,
 // since a registry built at init time decides reachability the same way.
-func googleConnectorsBuiltIn(file *ast.File) (builds []googleConnectorBuild, dotImported []string) {
+func googleConnectorsBuiltIn(file *ast.File) (builds []googleConnectorBuild, unreadable []string) {
 	byQualifier := map[string]string{}
 	for _, importPath := range googleConnectorPackages {
 		qualifier, dot := gatekit.ImportedAs(file, importPath)
 		switch {
 		case dot:
-			dotImported = append(dotImported, importPath)
+			unreadable = append(unreadable, "dot-imports "+importPath+
+				", so a construction in this file reads as a bare New( ) with no package to match on")
 		case qualifier != "":
 			byQualifier[qualifier] = path.Base(importPath)
 		}
 		// A blank import is neither: it cannot be called through at all.
 	}
 	if len(byQualifier) == 0 {
-		return nil, dotImported
+		return nil, unreadable
+	}
+	// A local named after the package SHADOWS it, and this reader matches on
+	// identifier text rather than on resolved bindings. An unrelated New method
+	// on such a variable would satisfy the floor below while the real
+	// registration was missing — the census reporting a connector it never saw.
+	// Rather than resolve lexical scope, the shadowing itself is reported: it
+	// costs nothing today, and the alternative is a reader that answers
+	// confidently about the wrong thing.
+	for _, shadowed := range shadowedIn(file, byQualifier) {
+		unreadable = append(unreadable, "declares something named "+shadowed+
+			", which shadows the imported connector package this census matches on — rename it")
 	}
 	// packageScope is what a construction outside every function declaration is
 	// attributed to. It is spelled as prose rather than as an identifier so that
@@ -240,7 +313,7 @@ func googleConnectorsBuiltIn(file *ast.File) (builds []googleConnectorBuild, dot
 		}
 		return builds[i].connector < builds[j].connector
 	})
-	return builds, dotImported
+	return builds, unreadable
 }
 
 // functionName spells a method as Receiver.Name, so that two files declaring

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -308,15 +308,6 @@ func newGcalOAuth(c GmailConfig) gcal.OAuth {
 	})
 }
 
-// NewCaptureRegistryWithGmail builds the capture registry and, when the Google
-// OAuth app is configured, registers the read-only Google connectors — Gmail
-// and Google Calendar — so Registry.Connect (api) and SyncOnce (worker poller)
-// can resolve each by name. A deployment without the app configured gets a
-// plain registry (both absent by omission). Returns nil only if pool is nil.
-func NewCaptureRegistryWithGmail(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, cfg CaptureConfig) *capture.Registry {
-	return newCaptureRegistryWithGoogle(pool, vault, nil, c, cfg)
-}
-
 // newCaptureRegistryWithGoogle registers the Google connectors where the app
 // can be resolved from EITHER source: the stored setting this installation
 // wrote, or the pair the deployment composed.
@@ -349,17 +340,6 @@ func newCaptureRegistryWithGoogle(
 // declared 501: it looks configured and is not.
 func googleAppReachable(resolve googleAppResolver, c GmailConfig) bool {
 	return resolve != nil || c.canSync()
-}
-
-// GmailPollRegistry returns a Google-registered capture registry for the
-// worker's background poller (Gmail + Calendar), or nil when the Google app is
-// not configured — nil tells NewJobRunner to skip the polls entirely (no
-// connector, no job).
-func GmailPollRegistry(pool *pgxpool.Pool, vault keyvault.Vault, c GmailConfig, cfg CaptureConfig) *capture.Registry {
-	if !c.canSync() {
-		return nil
-	}
-	return NewCaptureRegistryWithGmail(pool, vault, c, cfg)
 }
 
 // CaptureSyncRegistry is the worker's sweep registry: always non-nil —
@@ -443,7 +423,7 @@ func WithGmailCapture(c GmailConfig, cfg CaptureConfig) Option {
 		// here must be the mailbox the check asks about. WithKeyvault already
 		// wired this same call over the plain registry before this option ran;
 		// re-wiring it here is NOT redundant, because this registry is a
-		// different, richer object (NewCaptureRegistryWithGmail) — without this
+		// different, richer object (newCaptureRegistryWithGoogle) — without this
 		// line the mailbox half would keep answering off a registry with no
 		// Gmail connector. The channel half answers identically off either
 		// object: ChannelSendCapable is a pool query, not a connector lookup.

--- a/backend/internal/compose/capture_wiring_test.go
+++ b/backend/internal/compose/capture_wiring_test.go
@@ -8,44 +8,45 @@ package compose
 // all — the composition rules the process roles rely on at boot.
 
 import (
+	"context"
 	"slices"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
 )
 
 func TestCaptureRegistryComposition(t *testing.T) {
 	gmailApp := GmailConfig{ClientID: "id", ClientSecret: "secret"}
 
-	t.Run("a configured gmail app registers the connector", func(t *testing.T) {
-		reg := NewCaptureRegistryWithGmail(nil, nil, gmailApp, CaptureConfig{})
-		names := map[string]bool{}
-		for _, d := range reg.Connectors() {
-			names[d.Name] = true
-		}
-		if !names["gmail"] {
-			t.Fatalf("connectors = %v, want gmail registered", names)
-		}
+	// EITHER source registers, and that is the whole rule. The registration
+	// used to require the deployment's pair, which made the stored app
+	// unusable rather than merely unread: the transport asks the registry
+	// whether a connector exists before it will run the consent flow, so an
+	// installation that set its app through Settings was sent to the declared
+	// 501 with no way to connect Gmail at all.
+	//
+	// Driven through newCaptureRegistryWithGoogle, which is the one
+	// constructor that ships. Two others used to stand in front of it — one
+	// gating on the environment alone — and a case driving those proved the
+	// rule of a function nothing called.
+	stored := func(context.Context) (string, string, bool, error) { return "id", "secret", true, nil }
+
+	t.Run("the deployment's pair registers the connector", func(t *testing.T) {
+		assertRegisters(t, newCaptureRegistryWithGoogle(nil, nil, nil, gmailApp, CaptureConfig{}), "gmail", "gcal")
 	})
 
-	t.Run("an unconfigured app still carries standing imap, never gmail", func(t *testing.T) {
-		reg := NewCaptureRegistryWithGmail(nil, nil, GmailConfig{}, CaptureConfig{})
-		names := map[string]bool{}
-		for _, d := range reg.Connectors() {
-			names[d.Name] = true
-		}
+	t.Run("a stored app registers it with no pair composed", func(t *testing.T) {
+		assertRegisters(t, newCaptureRegistryWithGoogle(nil, nil, stored, GmailConfig{}, CaptureConfig{}), "gmail", "gcal")
+	})
+
+	t.Run("neither source carries standing imap, never gmail", func(t *testing.T) {
+		reg := newCaptureRegistryWithGoogle(nil, nil, nil, GmailConfig{}, CaptureConfig{})
+		names := registered(reg)
 		if names["gmail"] {
-			t.Fatal("gmail must be absent without its OAuth app")
+			t.Fatal("gmail must be absent when neither the stored app nor the deployment's pair can supply one")
 		}
 		if !names["imap"] {
 			t.Fatal("the standing imap connector needs no app and must always register")
-		}
-	})
-
-	t.Run("the poll registry exists only with a syncable app", func(t *testing.T) {
-		if reg := GmailPollRegistry(nil, nil, GmailConfig{}, CaptureConfig{}); reg != nil {
-			t.Fatal("no app configured must mean no poll registry (the job stays absent)")
-		}
-		if reg := GmailPollRegistry(nil, nil, gmailApp, CaptureConfig{}); reg == nil {
-			t.Fatal("a syncable app must yield the poll registry")
 		}
 	})
 
@@ -127,5 +128,26 @@ func TestWithKeyvaultWiresTheSendPreflightWithNoGoogleApp(t *testing.T) {
 	}
 	if authority.grants != s.connectorHandlers.registry {
 		t.Fatal("the pre-flight must read the SAME registry the connect flow writes to, not a second construction")
+	}
+}
+
+// registered names the connectors a registry carries.
+func registered(reg *capture.Registry) map[string]bool {
+	names := map[string]bool{}
+	for _, d := range reg.Connectors() {
+		names[d.Name] = true
+	}
+	return names
+}
+
+// assertRegisters is the shape both reachability arms assert, so neither can
+// drift into checking less than the other.
+func assertRegisters(t *testing.T, reg *capture.Registry, want ...string) {
+	t.Helper()
+	names := registered(reg)
+	for _, name := range want {
+		if !names[name] {
+			t.Errorf("connectors = %v, want %s registered", names, name)
+		}
 	}
 }

--- a/backend/internal/compose/capture_wiring_test.go
+++ b/backend/internal/compose/capture_wiring_test.go
@@ -41,7 +41,7 @@ func TestCaptureRegistryComposition(t *testing.T) {
 
 	t.Run("neither source carries standing imap, never gmail", func(t *testing.T) {
 		reg := newCaptureRegistryWithGoogle(nil, nil, nil, GmailConfig{}, CaptureConfig{})
-		names := registered(reg)
+		names := registeredNames(reg.Connectors())
 		if names["gmail"] {
 			t.Fatal("gmail must be absent when neither the stored app nor the deployment's pair can supply one")
 		}
@@ -131,20 +131,11 @@ func TestWithKeyvaultWiresTheSendPreflightWithNoGoogleApp(t *testing.T) {
 	}
 }
 
-// registered names the connectors a registry carries.
-func registered(reg *capture.Registry) map[string]bool {
-	names := map[string]bool{}
-	for _, d := range reg.Connectors() {
-		names[d.Name] = true
-	}
-	return names
-}
-
 // assertRegisters is the shape both reachability arms assert, so neither can
 // drift into checking less than the other.
 func assertRegisters(t *testing.T, reg *capture.Registry, want ...string) {
 	t.Helper()
-	names := registered(reg)
+	names := registeredNames(reg.Connectors())
 	for _, name := range want {
 		if !names[name] {
 			t.Errorf("connectors = %v, want %s registered", names, name)

--- a/backend/internal/compose/connectors_wiring_test.go
+++ b/backend/internal/compose/connectors_wiring_test.go
@@ -156,15 +156,6 @@ func TestGmailConfigGating(t *testing.T) {
 	}
 }
 
-func TestGmailPollRegistryNilWhenUnconfigured(t *testing.T) {
-	if reg := GmailPollRegistry(nil, nil, GmailConfig{}, CaptureConfig{}); reg != nil {
-		t.Errorf("unconfigured GmailPollRegistry = %v, want nil (poll skipped)", reg)
-	}
-	if reg := GmailPollRegistry(nil, nil, GmailConfig{ClientID: "id", ClientSecret: "sec"}, CaptureConfig{}); reg == nil {
-		t.Error("configured GmailPollRegistry returned nil, want a registry with gmail registered")
-	}
-}
-
 // The stored-app resolver SURVIVES the option order cmd/api uses.
 //
 // It did not. WithKeyvault installed it and WithGmailCapture then replaced the

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -194,7 +194,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (38)
+## Prohibition (39)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -207,6 +207,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensions_arch_test.go` | H2 | Extension-tier fitness functions (ADR-0069 §3): the compiler already walls extensions off from internal/\*\* (their module paths sit outside the backend module), these tests hold the rest of the import contract from the tree — every extension source dir (enabled or fixture) is enrolled the moment it exists. |
 | `flagdefault_test.go` | H2 | No string flag takes its default straight from the environment. |
 | `formulafieldscope_test.go` | H3 | The negative-scope half of the formula-field boundary proof (RD-AC-7): a formula field is a database-GENERATED artifact, never a runtime-authored one, so NO contract operation may accept a writable formula\_sql in its request body — ComputedField.formula\_sql (crm.yaml) is a response-only display field, never echoed back as an editable one. |
+| `googleconnectorregistration_test.go` | H2 | The Google connectors are registered in ONE function, because registering them is a decision about REACHABILITY and that decision has been wrong once. |
 | `guardedversion_test.go` | H2 | A nil version is the request's answer, never the call site's. |
 | `integrationmigrateonce_test.go` | H2 | Migrate-once discipline for everything the integration lane compiles, as a fitness function. |
 | `jobargscontent_test.go` | H2 | Job args carry REFERENCES, never content. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -207,7 +207,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensions_arch_test.go` | H2 | Extension-tier fitness functions (ADR-0069 §3): the compiler already walls extensions off from internal/\*\* (their module paths sit outside the backend module), these tests hold the rest of the import contract from the tree — every extension source dir (enabled or fixture) is enrolled the moment it exists. |
 | `flagdefault_test.go` | H2 | No string flag takes its default straight from the environment. |
 | `formulafieldscope_test.go` | H3 | The negative-scope half of the formula-field boundary proof (RD-AC-7): a formula field is a database-GENERATED artifact, never a runtime-authored one, so NO contract operation may accept a writable formula\_sql in its request body — ComputedField.formula\_sql (crm.yaml) is a response-only display field, never echoed back as an editable one. |
-| `googleconnectorregistration_test.go` | H2 | The Google connectors are registered in ONE function, because registering them is a decision about REACHABILITY and that decision has been wrong once. |
+| `googleconnectorregistration_test.go` | H2 | The Google connectors are built for the registry in ONE function, because putting one INTO the registry is a decision about REACHABILITY and that decision has been wrong once. |
 | `guardedversion_test.go` | H2 | A nil version is the request's answer, never the call site's. |
 | `integrationmigrateonce_test.go` | H2 | Migrate-once discipline for everything the integration lane compiles, as a fitness function. |
 | `jobargscontent_test.go` | H2 | Job args carry REFERENCES, never content. |


### PR DESCRIPTION
Closes #2797.

`compose.GmailPollRegistry` has no production caller — only its own two tests. Two things follow, both as the ticket describes.

**Its doc names a caller that does not call it.** *"nil tells `NewJobRunner` to skip the polls entirely"* — `NewJobRunner` builds its registry through `CaptureSyncRegistry` (`cmd/worker/jobrunner.go:72`).

**Its gate contradicts the registration rule.** Since #2796 the Google connectors register when the app is reachable from **either** the stored setting or the environment. `GmailPollRegistry` still returned nil unless the environment carried the pair.

It cannot cause a defect while nothing calls it. What it can do is be *found*: whoever wires up a poller next reaches for the function whose name says poller, and an installation whose app was set through Settings silently skips its polls — with two green tests over the old rule to reassure them.

## One more than the ticket asked for

`NewCaptureRegistryWithGmail` goes too. It was the only thing `GmailPollRegistry` called, so it is dead the moment that one is; it passes **no resolver**, which is the same environment-only rule one level down; and its doc names callers it does not have either (*"so `Registry.Connect` (api) and `SyncOnce` (worker poller) can resolve each by name"*). Deleting one and leaving the other would leave the trap with a different name.

## The cases moved rather than went

Two of the deleted subtests were about something real — that a configured app registers the connector, and that an unconfigured one still carries standing IMAP. They now drive `newCaptureRegistryWithGoogle`, the constructor that ships, and assert **both** reachability arms.

That is strictly more than they could before. Driving a constructor that passed `nil`, they never exercised the stored app at all — so re-narrowing the rule to `c.canSync()` left them green. It does not now: that mutation fails `a stored app registers it with no pair composed` and names both missing connectors.

## And the shape, not just the instance

`gates/googleconnectorregistration_test.go` refuses a registration of `gmail` or `gcal` outside `newCaptureRegistryWithGoogle`. Registering them **is** the reachability decision, and a second place to decide it is how the stored app became unreachable while every test passed.

It judges the `Register` call rather than the construction — `connectorapp.go` builds a `gmail.Connector` to call `Authenticate` on it, which is a use rather than an offer — and looks *through* the option chain, so a second registration cannot hide behind `.WithBounceSink(...)`. `graph` is deliberately out of scope: it answers to a Microsoft app with a rule of its own, and folding the two together would be a third spelling of a question neither is asking.

Mutation-checked: re-adding `GmailPollRegistry` in either shape (plain, and behind an option chain) fails the census naming the function.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Gmail and Google Calendar connectors now support configuration from stored or deployment-provided credentials.
  * Connector setup behaves consistently when credentials are unavailable or supplied through supported sources.

* **Tests**
  * Expanded coverage for connector registration and credential-source scenarios.
  * Added safeguards to help prevent inconsistent connector setup.

* **Documentation**
  * Updated the gate inventory to reflect the latest connector-registration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->