### PR TITLE
A certification fixture's trigger ref is derived from the writer that mints one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ numbers appear here when releases start.
 
 ### Changed
 
+- **A certification fixture's trigger ref is checked against the shape
+  production mints.** The validator accepted any non-empty string, so a corpus
+  scenario could drift arbitrarily far from the runner and stay green: when the
+  ref grew a seat segment, a fixture kept the old two-segment value and nothing
+  failed, because a fixture that describes a different system has no failing
+  assertion to notice. The check is now derived from `AgentSpec.TriggerRef`
+  itself — a reference ref is minted and compared segment for segment — so the
+  day the writer changes shape, every stale fixture fails naming itself.
+
 - **BREAKING (metrics): the sweep gauges no longer carry a `_total` suffix.**
   `margince_sweep_workspaces_total` is now `margince_sweep_workspaces`, and
   `margince_sweep_units_total` is now `margince_sweep_units`. The two `_failed`

--- a/backend/gates/seatfanout_test.go
+++ b/backend/gates/seatfanout_test.go
@@ -28,6 +28,16 @@ package gates
 // cannot stop the next author threading a constant, a zero value, or one seat
 // resolved outside the loop through it — which compiles, reads fine, and
 // restores the workspace-wide behaviour exactly.
+//
+// The obligation belongs to the SEEDING path, which is the only place a ref
+// becomes a row. A caller that mints a ref to read its SHAPE and throws the
+// value away carries no fan-out question at all, and there is one: the
+// certification fixture validator derives what a corpus trigger ref must look
+// like by asking the writer, rather than restating the format a second time.
+// It is named below with its reason. What would make that waiver wrong is the
+// value reaching a job — so the reason says what it is used for, and a reader
+// who finds it doing anything else should delete the entry rather than widen
+// it.
 
 import (
 	"go/ast"
@@ -37,6 +47,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // The two constraints whose key IS the trigger ref. Named here because the
@@ -65,6 +77,9 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 			"caller moved and this gate must move with it")
 	}
 	for _, c := range calls {
+		if mintsAShapeRatherThanAnOccurrence.Waived(t, c.site) {
+			continue
+		}
 		if c.seatArg == "" {
 			t.Errorf("%s: TriggerRef is called without a seat, so every rep in the "+
 				"workspace shares one trigger ref and only the first seeded gets a run", c.pos)
@@ -78,7 +93,16 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 				"workspace", c.pos, c.seatArg)
 		}
 	}
+	mintsAShapeRatherThanAnOccurrence.AssertAllMatched(t)
 }
+
+// mintsAShapeRatherThanAnOccurrence names the calls that build a reference
+// value to COMPARE against, never one to seed with. A seat that varies per
+// iteration is meaningless to them: nothing they produce is inserted, so
+// nothing they produce can collide.
+var mintsAShapeRatherThanAnOccurrence = gatekit.Waive(map[string]string{
+	"internal/compose/certcase_agentlooptrigger.go:mintedSchedulerTriggerRef": "mints a ref from a fixed day and seat so the certification fixture validator can compare a corpus trigger ref's SHAPE against what the writer produces, rather than restating the format; the value is compared and discarded, and never reaches EnqueueJob or a job row",
+})
 
 // TestTheTriggerRefStillCarriesTheWholeUniquenessKey fails when a migration
 // re-keys either constraint away from the trigger ref.
@@ -119,6 +143,7 @@ func TestTheTriggerRefStillCarriesTheWholeUniquenessKey(t *testing.T) {
 // the seat.
 type triggerRefCall struct {
 	pos     string
+	site    string
 	seatArg string
 	// fromRangeVar is whether the seat traces to the range variable of a loop
 	// enclosing the call. That is the property the fan-out actually needs: a
@@ -155,8 +180,24 @@ func triggerRefCalls(t *testing.T) []triggerRefCall {
 		// The range variables currently in scope, innermost last. A call is
 		// only per-seat if its seat argument is rooted in one of them.
 		var inScope []string
+		// The function a call sits in, so a waiver names one call site rather
+		// than a whole file. A call outside any function declaration keeps the
+		// empty name, which matches no waiver and so must satisfy the seat rule
+		// on its own — the safe direction for a reader that meets a shape it
+		// was not built for.
+		enclosing := ""
 		var walk func(ast.Node) bool
 		walk = func(n ast.Node) bool {
+			if fn, ok := n.(*ast.FuncDecl); ok {
+				if fn.Body == nil {
+					return false
+				}
+				before := enclosing
+				enclosing = fn.Name.Name
+				ast.Inspect(fn.Body, walk)
+				enclosing = before
+				return false
+			}
 			if rng, ok := n.(*ast.RangeStmt); ok {
 				before := len(inScope)
 				for _, key := range []ast.Expr{rng.Key, rng.Value} {
@@ -176,7 +217,7 @@ func triggerRefCalls(t *testing.T) []triggerRefCall {
 			if !ok || sel.Sel.Name != "TriggerRef" {
 				return true
 			}
-			c := triggerRefCall{pos: fset.Position(call.Pos()).String()}
+			c := triggerRefCall{pos: fset.Position(call.Pos()).String(), site: path + ":" + enclosing}
 			// The seat is the LAST argument: the day names the occurrence and
 			// the seat names whose occurrence it is.
 			if n := len(call.Args); n >= 2 {

--- a/backend/gates/seatfanout_test.go
+++ b/backend/gates/seatfanout_test.go
@@ -76,10 +76,12 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 			"unless it can see the seeding path, so either the scan broke or the " +
 			"caller moved and this gate must move with it")
 	}
+	seeding := 0
 	for _, c := range calls {
 		if mintsAShapeRatherThanAnOccurrence.Waived(t, c.site) {
 			continue
 		}
+		seeding++
 		if c.seatArg == "" {
 			t.Errorf("%s: TriggerRef is called without a seat, so every rep in the "+
 				"workspace shares one trigger ref and only the first seeded gets a run", c.pos)
@@ -92,6 +94,15 @@ func TestEveryScheduledOccurrenceIsNamedForOneSeat(t *testing.T) {
 				"and the uniqueness constraints then admit exactly one run for the whole "+
 				"workspace", c.pos, c.seatArg)
 		}
+	}
+	// A tree where every call is waived validates no seeding path, and the loop
+	// above reports nothing about it — which reads exactly like a tree where
+	// every call is correct. The waiver list is the one thing that can grow
+	// until that is true.
+	if seeding == 0 {
+		t.Errorf("all %d TriggerRef call(s) are waived as shape-readers, so this gate checked no seeding path: "+
+			"either the seeding call moved and this gate must move with it, or a waiver was written for one that "+
+			"does seed", len(calls))
 	}
 	mintsAShapeRatherThanAnOccurrence.AssertAllMatched(t)
 }

--- a/backend/internal/compose/certcase_agentloop.go
+++ b/backend/internal/compose/certcase_agentloop.go
@@ -223,6 +223,9 @@ func refuseUnrunnableAgentJob(f agentLoopFixture) error {
 			"%s: the fixture names no trigger, and every run the scheduler starts is one named occurrence",
 			agentLoopSite)
 	}
+	if err := refuseUnmintableTriggerRef(f.TriggerRef); err != nil {
+		return err
+	}
 	for _, item := range f.Grounding {
 		if strings.TrimSpace(item.TrustTier) == "" {
 			return fmt.Errorf(

--- a/backend/internal/compose/certcase_agentloop_test.go
+++ b/backend/internal/compose/certcase_agentloop_test.go
@@ -47,7 +47,7 @@ const (
 func agentLoopBaseFixture() agentLoopFixture {
 	return agentLoopFixture{
 		Goal:       "Find my open deals and log a follow-up note on the largest one.",
-		TriggerRef: "morning_brief:2026-07-27",
+		TriggerRef: "morning_brief:2026-07-27:d48b383f3e8acec5d620c82b8c9b4202",
 		Grounding: []agentLoopGrounding{
 			{SourceID: agentLoopUserRef, TrustTier: "T1", Content: "owner_id=user_42"},
 			{SourceID: agentLoopDealRef, TrustTier: "T2", Content: agentLoopSeedSnippet},
@@ -365,6 +365,46 @@ func TestAgentLoopCaseRefusesAWindowTheLoopIsNeverHanded(t *testing.T) {
 			fixture:  agentLoopVariant(func(f *agentLoopFixture) { f.TriggerRef = "" }),
 			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
 			want:     "names no trigger",
+		},
+		{
+			name: "a fixture left on the trigger shape production stopped minting",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "morning_brief:2026-07-27"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "has 2 segment(s); the scheduler mints 3",
+		},
+		{
+			name: "a seat digest of the wrong width",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "morning_brief:2026-07-27:d48b383f"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "segment 3 is",
+		},
+		{
+			name: "a date segment that is not a date",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "morning_brief:yesterdayx:d48b383f3e8acec5d620c82b8c9b4202"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "segment 2 is",
+		},
+		{
+			name: "a trigger no writer mints",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "webhook:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e08"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "neither a spec in the agent catalog nor one of the occurrence-driven kinds",
+		},
+		{
+			name: "an occurrence-driven trigger whose occurrence is not an id",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "calendar:tomorrows-standup"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "whose shape is `calendar:<uuid>`",
 		},
 		{
 			name:     "a run offered no tools at all",

--- a/backend/internal/compose/certcase_agentloop_test.go
+++ b/backend/internal/compose/certcase_agentloop_test.go
@@ -391,6 +391,22 @@ func TestAgentLoopCaseRefusesAWindowTheLoopIsNeverHanded(t *testing.T) {
 			want:     "segment 2 is",
 		},
 		{
+			name: "an occurrence-driven kind naming no occurrence",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "calendar"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "whose shape is `calendar:<uuid>`",
+		},
+		{
+			name: "a segment of the right width carrying a character the writer never mints",
+			fixture: agentLoopVariant(func(f *agentLoopFixture) {
+				f.TriggerRef = "morning_brief:2026-07-2!:d48b383f3e8acec5d620c82b8c9b4202"
+			}),
+			expected: agentLoopExpectationJSON(t, agentLoopFinalStep),
+			want:     "segment 2 is",
+		},
+		{
 			name: "a trigger no writer mints",
 			fixture: agentLoopVariant(func(f *agentLoopFixture) {
 				f.TriggerRef = "webhook:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e08"

--- a/backend/internal/compose/certcase_agentlooptrigger.go
+++ b/backend/internal/compose/certcase_agentlooptrigger.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The shape a corpus fixture's trigger ref must have, DERIVED from the writer
+// that mints one in production rather than restated here.
+//
+// The agent_loop corpus is production-shaped on purpose: its whole value is
+// certifying the window the runner actually builds. A fixture whose trigger ref
+// drifts from what the scheduler puts on a job certifies a window nothing
+// builds, and there is no failing assertion when that happens — the suite
+// simply reports PASS about a different system.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/agents/runner"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// occurrenceTriggerKinds are the trigger refs of the form `<kind>:<uuid>` this
+// corpus exercises. They are DECLARED rather than derived, because no
+// production writer mints one yet: the scheduler's specs are the only trigger
+// source this build has, and the corpus reaches ahead of it on purpose — a
+// `calendar:<uuid>` is the confusable shape window.go's triggerProvenance
+// sentence exists to answer, and certifying it before the writer exists is the
+// point of having it here.
+//
+// Whoever adds that writer should delete this map and derive its arm the way
+// the scheduled arm below is derived. Until then this list is the seam, and
+// the reason it is short is that reaching ahead is only honest for a shape
+// somebody has actually argued for.
+var occurrenceTriggerKinds = map[string]string{
+	"manual":   "a run a person started by hand, which the corpus drives because a hand-started turn is the same window with a different name on it",
+	"calendar": "the occurrence-driven shape triggerProvenance names as the confusable one; certifying it before its writer exists is why the corpus carries it",
+}
+
+// refuseUnmintableTriggerRef names a trigger ref no production path could have
+// put on a job.
+//
+// The whole value of this corpus is that it is production-shaped: it certifies
+// the window the runner actually builds. A non-empty check was all this used to
+// do, so a fixture could drift arbitrarily far from production and stay
+// accepted — and one did. When the ref grew a seat segment
+// (`<spec>:<date>` → `<spec>:<date>:<seat digest>`) a fixture kept the old
+// two-segment value and every gate stayed green, because there is no failing
+// assertion when a fixture merely describes a different system. A reviewer
+// reading the diff found it.
+//
+// So the scheduled arm is DERIVED from the writer. AgentSpec.TriggerRef is
+// minted here with a known day and seat, and the fixture is required to have
+// the same segment count and the same per-segment shape as what came back.
+// Nothing in this function restates the format, so the day TriggerRef grows a
+// fourth segment or moves the date, every stale fixture fails naming itself.
+func refuseUnmintableTriggerRef(ref string) error {
+	segments := strings.Split(ref, ":")
+	kind := segments[0]
+	if reason, occurrence := occurrenceTriggerKinds[kind]; occurrence {
+		if parsed, err := ids.Parse(segments[1]); len(segments) != 2 || err != nil || parsed.IsZero() {
+			return fmt.Errorf(
+				"%s: trigger ref %q names the occurrence-driven kind %q (%s), whose shape is `%s:<uuid>` — this one is not",
+				agentLoopSite, ref, kind, reason, kind)
+		}
+		return nil
+	}
+	reference, ok := mintedSchedulerTriggerRef(kind)
+	if !ok {
+		return fmt.Errorf(
+			"%s: trigger ref %q starts with %q, which is neither a spec in the agent catalog nor one of the "+
+				"occurrence-driven kinds this corpus reaches ahead for (%s) — a fixture naming a trigger no writer "+
+				"mints certifies a window the product never builds",
+			agentLoopSite, ref, kind, strings.Join(sortedKeys(occurrenceTriggerKinds), ", "))
+	}
+	return refuseDriftedFrom(reference, ref)
+}
+
+// mintedSchedulerTriggerRef mints what the scheduler would put on a job for the
+// named spec, using a fixed day and seat so the value is the SHAPE and nothing
+// else. It reports false for a name no catalog spec carries.
+func mintedSchedulerTriggerRef(specName string) (string, bool) {
+	for _, spec := range runner.Catalog() {
+		if spec.Name != specName {
+			continue
+		}
+		return spec.TriggerRef(referenceTriggerDay, referenceTriggerSeat), true
+	}
+	return "", false
+}
+
+// referenceTriggerDay and referenceTriggerSeat are arbitrary, and the point is
+// that they are: what is compared is the shape TriggerRef gives them, never
+// these values.
+var (
+	referenceTriggerDay  = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	referenceTriggerSeat = ids.From[ids.UserKind](ids.MustParse("0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e00"))
+)
+
+// refuseDriftedFrom compares a fixture's ref against one production just minted,
+// segment by segment: the same count, and each segment the same length and drawn
+// from the same characters as the minted one's. That is as much as can be said
+// without re-spelling the format here, and it is enough — the drift that shipped
+// was a missing segment, and a digest of the wrong width or a date that is not a
+// date fails the same way.
+func refuseDriftedFrom(minted, ref string) error {
+	want, got := strings.Split(minted, ":"), strings.Split(ref, ":")
+	if len(want) != len(got) {
+		return fmt.Errorf(
+			"%s: trigger ref %q has %d segment(s); the scheduler mints %d for this spec (%q) — a fixture on the old "+
+				"shape certifies a window nothing builds",
+			agentLoopSite, ref, len(got), len(want), minted)
+	}
+	// Segment 0 is the spec name and was matched to find `minted` at all.
+	for i := 1; i < len(want); i++ {
+		if len(got[i]) != len(want[i]) || charactersOf(got[i]) != charactersOf(want[i]) {
+			return fmt.Errorf(
+				"%s: trigger ref %q segment %d is %q; the scheduler mints segments shaped like %q here (%q) — the "+
+					"fixture has drifted from what production puts on a job",
+				agentLoopSite, ref, i+1, got[i], want[i], minted)
+		}
+	}
+	return nil
+}
+
+// charactersOf is the character classes a segment is drawn from, in a settled
+// order. It is deliberately coarse: it separates a date from a digest and a
+// digest from a word, and it does NOT try to be a format, because a format
+// stated here is the second spelling this whole function exists to avoid.
+func charactersOf(segment string) string {
+	var classes []string
+	for _, class := range []struct {
+		name string
+		has  func(rune) bool
+	}{
+		{"digit", func(r rune) bool { return r >= '0' && r <= '9' }},
+		{"hex-letter", func(r rune) bool { return r >= 'a' && r <= 'f' }},
+		{"letter", func(r rune) bool { return (r >= 'g' && r <= 'z') || (r >= 'A' && r <= 'Z') }},
+		{"dash", func(r rune) bool { return r == '-' || r == '_' }},
+	} {
+		if strings.ContainsFunc(segment, class.has) {
+			classes = append(classes, class.name)
+		}
+	}
+	return strings.Join(classes, "+")
+}

--- a/backend/internal/compose/certcase_agentlooptrigger.go
+++ b/backend/internal/compose/certcase_agentlooptrigger.go
@@ -59,7 +59,10 @@ func refuseUnmintableTriggerRef(ref string) error {
 	segments := strings.Split(ref, ":")
 	kind := segments[0]
 	if reason, occurrence := occurrenceTriggerKinds[kind]; occurrence {
-		if parsed, err := ids.Parse(segments[1]); len(segments) != 2 || err != nil || parsed.IsZero() {
+		// The length FIRST: `calendar` with no occurrence behind it is a
+		// fixture somebody wrote by hand, and reading segments[1] to tell them
+		// so would panic instead.
+		if !occurrenceIdentified(segments) {
 			return fmt.Errorf(
 				"%s: trigger ref %q names the occurrence-driven kind %q (%s), whose shape is `%s:<uuid>` — this one is not",
 				agentLoopSite, ref, kind, reason, kind)
@@ -75,6 +78,16 @@ func refuseUnmintableTriggerRef(ref string) error {
 			agentLoopSite, ref, kind, strings.Join(sortedKeys(occurrenceTriggerKinds), ", "))
 	}
 	return refuseDriftedFrom(reference, ref)
+}
+
+// occurrenceIdentified reports whether an occurrence-driven ref names exactly
+// one occurrence, by an id.
+func occurrenceIdentified(segments []string) bool {
+	if len(segments) != 2 {
+		return false
+	}
+	parsed, err := ids.Parse(segments[1])
+	return err == nil && !parsed.IsZero()
 }
 
 // mintedSchedulerTriggerRef mints what the scheduler would put on a job for the
@@ -114,7 +127,9 @@ func refuseDriftedFrom(minted, ref string) error {
 	}
 	// Segment 0 is the spec name and was matched to find `minted` at all.
 	for i := 1; i < len(want); i++ {
-		if len(got[i]) != len(want[i]) || charactersOf(got[i]) != charactersOf(want[i]) {
+		mintedClasses, _ := charactersOf(want[i])
+		fixtureClasses, readable := charactersOf(got[i])
+		if len(got[i]) != len(want[i]) || !readable || fixtureClasses != mintedClasses {
 			return fmt.Errorf(
 				"%s: trigger ref %q segment %d is %q; the scheduler mints segments shaped like %q here (%q) — the "+
 					"fixture has drifted from what production puts on a job",
@@ -125,12 +140,18 @@ func refuseDriftedFrom(minted, ref string) error {
 }
 
 // charactersOf is the character classes a segment is drawn from, in a settled
-// order. It is deliberately coarse: it separates a date from a digest and a
-// digest from a word, and it does NOT try to be a format, because a format
-// stated here is the second spelling this whole function exists to avoid.
-func charactersOf(segment string) string {
-	var classes []string
-	for _, class := range []struct {
+// order, and whether EVERY rune of it fell into one.
+//
+// It is deliberately coarse: it separates a date from a digest and a digest
+// from a word, and it does NOT try to be a format, because a format stated here
+// is the second spelling this whole function exists to avoid.
+//
+// The second return is what stops the coarseness from being a hole. Presence
+// alone would let `2026-01-0!` pass for a date: same width, same classes
+// present, one rune that is neither. A segment carrying a rune no class claims
+// is not the shape the writer mints, whatever else it looks like.
+func charactersOf(segment string) (classes string, readable bool) {
+	named := []struct {
 		name string
 		has  func(rune) bool
 	}{
@@ -138,10 +159,21 @@ func charactersOf(segment string) string {
 		{"hex-letter", func(r rune) bool { return r >= 'a' && r <= 'f' }},
 		{"letter", func(r rune) bool { return (r >= 'g' && r <= 'z') || (r >= 'A' && r <= 'Z') }},
 		{"dash", func(r rune) bool { return r == '-' || r == '_' }},
-	} {
+	}
+	var present []string
+	for _, class := range named {
 		if strings.ContainsFunc(segment, class.has) {
-			classes = append(classes, class.name)
+			present = append(present, class.name)
 		}
 	}
-	return strings.Join(classes, "+")
+	for _, r := range segment {
+		claimed := false
+		for _, class := range named {
+			claimed = claimed || class.has(r)
+		}
+		if !claimed {
+			return strings.Join(present, "+"), false
+		}
+	}
+	return strings.Join(present, "+"), true
 }

--- a/backend/internal/compose/certcase_agentlooptrigger.go
+++ b/backend/internal/compose/certcase_agentlooptrigger.go
@@ -9,8 +9,8 @@ package compose
 // The agent_loop corpus is production-shaped on purpose: its whole value is
 // certifying the window the runner actually builds. A fixture whose trigger ref
 // drifts from what the scheduler puts on a job certifies a window nothing
-// builds, and there is no failing assertion when that happens — the suite
-// simply reports PASS about a different system.
+// builds, and no assertion fails when it does — the suite reports PASS about a
+// different system.
 
 import (
 	"fmt"
@@ -30,9 +30,9 @@ import (
 // point of having it here.
 //
 // Whoever adds that writer should delete this map and derive its arm the way
-// the scheduled arm below is derived. Until then this list is the seam, and
-// the reason it is short is that reaching ahead is only honest for a shape
-// somebody has actually argued for.
+// the scheduled arm below is derived. Until then this list is the seam, and it
+// is short because reaching ahead of production is only honest for a shape
+// somebody has argued for.
 var occurrenceTriggerKinds = map[string]string{
 	"manual":   "a run a person started by hand, which the corpus drives because a hand-started turn is the same window with a different name on it",
 	"calendar": "the occurrence-driven shape triggerProvenance names as the confusable one; certifying it before its writer exists is why the corpus carries it",
@@ -41,20 +41,17 @@ var occurrenceTriggerKinds = map[string]string{
 // refuseUnmintableTriggerRef names a trigger ref no production path could have
 // put on a job.
 //
-// The whole value of this corpus is that it is production-shaped: it certifies
-// the window the runner actually builds. A non-empty check was all this used to
-// do, so a fixture could drift arbitrarily far from production and stay
-// accepted — and one did. When the ref grew a seat segment
-// (`<spec>:<date>` → `<spec>:<date>:<seat digest>`) a fixture kept the old
-// two-segment value and every gate stayed green, because there is no failing
-// assertion when a fixture merely describes a different system. A reviewer
-// reading the diff found it.
+// A fixture on a shape production has stopped minting certifies a window
+// nothing builds, and NOTHING FAILS when that happens: the suite reports PASS
+// about a different system, because a fixture that merely describes one has no
+// wrong answer to give. A non-empty check cannot see that, and neither can a
+// format restated here, which drifts the same way the fixture does.
 //
 // So the scheduled arm is DERIVED from the writer. AgentSpec.TriggerRef is
-// minted here with a known day and seat, and the fixture is required to have
-// the same segment count and the same per-segment shape as what came back.
-// Nothing in this function restates the format, so the day TriggerRef grows a
-// fourth segment or moves the date, every stale fixture fails naming itself.
+// minted with a known day and seat, and the fixture is required to have the
+// same segment count and the same per-segment shape as what came back. Nothing
+// in this function states the format, so the day TriggerRef grows a segment or
+// moves the date, every stale fixture fails naming itself.
 func refuseUnmintableTriggerRef(ref string) error {
 	segments := strings.Split(ref, ":")
 	kind := segments[0]
@@ -114,9 +111,8 @@ var (
 // refuseDriftedFrom compares a fixture's ref against one production just minted,
 // segment by segment: the same count, and each segment the same length and drawn
 // from the same characters as the minted one's. That is as much as can be said
-// without re-spelling the format here, and it is enough — the drift that shipped
-// was a missing segment, and a digest of the wrong width or a date that is not a
-// date fails the same way.
+// without re-spelling the format here, and it is enough: a missing segment, a
+// digest of the wrong width and a date that is not a date all fail on it.
 func refuseDriftedFrom(minted, ref string) error {
 	want, got := strings.Split(minted, ":"), strings.Split(ref, ":")
 	if len(want) != len(got) {

--- a/backend/internal/compose/certcase_agentlooptrigger.go
+++ b/backend/internal/compose/certcase_agentlooptrigger.go
@@ -41,11 +41,11 @@ var occurrenceTriggerKinds = map[string]string{
 // refuseUnmintableTriggerRef names a trigger ref no production path could have
 // put on a job.
 //
-// A fixture on a shape production has stopped minting certifies a window
-// nothing builds, and NOTHING FAILS when that happens: the suite reports PASS
-// about a different system, because a fixture that merely describes one has no
-// wrong answer to give. A non-empty check cannot see that, and neither can a
-// format restated here, which drifts the same way the fixture does.
+// When production stops minting a shape, a fixture still carrying it certifies
+// a window nothing builds — and nothing fails when it does: the suite reports
+// PASS about a different system, because a fixture that merely describes one
+// has no wrong answer to give. A non-empty check cannot see that, and neither
+// can a format restated here, which drifts the same way the fixture does.
 //
 // So the scheduled arm is DERIVED from the writer. AgentSpec.TriggerRef is
 // minted with a known day and seat, and the fixture is required to have the


### PR DESCRIPTION
Closes #2820.

## What was wrong

`refuseUnrunnableAgentJob` validated a fixture's `trigger_ref` with a non-empty check. The agent-loop corpus is production-shaped on purpose — its whole value is certifying the window the runner actually builds — but nothing tied a fixture's ref to what `AgentSpec.TriggerRef` mints, so a fixture could drift arbitrarily far and stay accepted.

Not hypothetical. When the ref grew a seat segment (`<spec>:<date>` → `<spec>:<date>:<seat digest>`), `slipping_is_its_own_question.yaml` kept the old two-segment value and every gate stayed green. This is the under-recognition failure: there is no failing assertion when a fixture simply describes a different system, so a reviewer reading the diff is the only thing that catches it.

## The fix

The scheduled arm is **derived from the writer**, per the issue. `mintedSchedulerTriggerRef` asks `AgentSpec.TriggerRef` for a reference value using a fixed day and seat — the values are arbitrary and the point is that they are, since what is compared is the shape they come back in. `refuseDriftedFrom` then requires the fixture's ref to match segment for segment: the same count, and each segment the same width and drawn from the same character classes.

Nothing in the check restates the format. That is what makes it hold: **the day `TriggerRef` grows a fourth segment or moves the date, every stale fixture fails naming itself.** Verified by growing one — the real corpus then refuses with `the scheduler mints 4`.

The occurrence-driven `<kind>:<uuid>` refs the corpus reaches ahead for (`manual:`, `calendar:`) are **declared with reasons**, because no production writer mints one yet — `calendar:<uuid>` is the confusable shape `window.go`'s `triggerProvenance` sentence exists to answer, and certifying it before its writer exists is why the corpus carries it. The declaration says to delete it and derive that arm the moment a writer appears.

## It found a second one immediately

The unit test's own fixture carried `morning_brief:2026-07-27`. Corrected here.

## Seat fan-out gate

`TestEveryScheduledOccurrenceIsNamedForOneSeat` rightly objects to a `TriggerRef` call with a fixed seat. Its obligation belongs to the **seeding** path — a caller that mints a ref to read its shape and discards it carries no fan-out question, since nothing it produces is inserted and nothing it produces can collide.

The shape-reader is named there with a reason, keyed on `file:function` rather than the file, so the waiver covers one call site and not a package. The gate learned to track the enclosing function to make that key possible. Mutation-checked both ways: the real seeding call given a constant seat still fails, and a stale waiver is reported.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green locally, plus `go test -count=1 ./gates`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for trigger references used in certification fixtures.
  * Certification checks now detect outdated or malformed trigger-reference formats.
  * Added support for explicitly waiving approved reference-only validation calls.

* **Bug Fixes**
  * Agent jobs now reject unsupported, malformed, or unrunnable trigger references.
  * Expanded validation for legacy formats, invalid dates, digest lengths, trigger kinds, and calendar references.

* **Documentation**
  * Added an unreleased changelog entry documenting trigger-reference validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->