### PR TITLE
A credential the agent has outgrown is its own renewal case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,17 @@ numbers appear here when releases start.
 
 ### Added
 
+- **A standing overnight grant says when the agent has outgrown it.** A grant
+  mints the scopes the agent needed at the moment the rep answered; when the
+  agent later gains a tool needing a wider scope, every already-minted passport
+  is short. Nothing failed — the runner degrades the unfunded tools before the
+  first model step, so the rep's overnight work simply stopped, with no error,
+  no expiry and no prompt, and the grant still reported a usable credential
+  because liveness was all that was checked. `credential_funds_agent` is the
+  second renewal cause, computed at request time from what the build would mint
+  today, and the Settings card now offers renewal on it with copy that says the
+  authority was outgrown rather than that it expired.
+
 - **Foundation (WP0)**: the full core data model as reversible
   migrations — RLS (`ENABLE`+`FORCE`, deny-on-unset) on every tenant
   table, composite same-workspace foreign keys, append-only audit log,

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27047,20 +27047,23 @@ components:
             not expired. Read from the passport at request time, never stored, because it
             changes at a moment nothing writes to the grant. False against `granted` is
             the renewal case: the rep agreed and has nothing to act with.
+        # A grant mints the scopes the agent needed at the moment it was answered, and
+        # nothing renews them: when the agent gains a tool needing a wider scope, every
+        # already-minted passport is short. The run does not fail, it degrades the
+        # unfunded tools away before its first model step — so this is the only place a
+        # rep can be told. Derived per request from what this build would mint today,
+        # never stored, for the same reason credential_usable is not.
         credential_funds_agent:
           type: boolean
           description: |
-            Whether that passport still covers what this agent DOES. A grant mints the
-            scopes the agent needed at the moment it was answered; when the agent later
-            gains a tool needing a wider scope, the passport is short. It is neither
-            revoked nor expired, so `credential_usable` stays true — but the run degrades
-            the unfunded tools away before its first step and the rep's overnight work
-            silently stops.
+            Whether that passport still covers what this agent does. Read at request time
+            and never stored, so it must not be cached across requests.
 
-            Computed at request time from what the build would mint today, never stored.
-            False against `granted` is the SECOND renewal case, and a client must offer
-            renewal on it exactly as it does on the first — the two differ only in what
-            the rep is told went wrong.
+            False against `granted` is the second renewal case, distinct from an expiry:
+            the credential works, and does not reach far enough. A client must offer
+            renewal on it exactly as it does on `credential_usable: false`, and say which
+            of the two happened — a rep sent looking for a lapse that never happened
+            cannot fix anything.
         decided_at:
           type: string
           format: date-time

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27036,7 +27036,7 @@ components:
     MyAgentGrant:
       type: object
       additionalProperties: false
-      required: [spec, state, credential_usable]
+      required: [spec, state, credential_usable, credential_funds_agent]
       properties:
         spec: { $ref: '#/components/schemas/ScheduledAgentName' }
         state: { $ref: '#/components/schemas/MyAgentGrantState' }
@@ -27047,6 +27047,20 @@ components:
             not expired. Read from the passport at request time, never stored, because it
             changes at a moment nothing writes to the grant. False against `granted` is
             the renewal case: the rep agreed and has nothing to act with.
+        credential_funds_agent:
+          type: boolean
+          description: |
+            Whether that passport still covers what this agent DOES. A grant mints the
+            scopes the agent needed at the moment it was answered; when the agent later
+            gains a tool needing a wider scope, the passport is short. It is neither
+            revoked nor expired, so `credential_usable` stays true — but the run degrades
+            the unfunded tools away before its first step and the rep's overnight work
+            silently stops.
+
+            Computed at request time from what the build would mint today, never stored.
+            False against `granted` is the SECOND renewal case, and a client must offer
+            renewal on it exactly as it does on the first — the two differ only in what
+            the rep is told went wrong.
         decided_at:
           type: string
           format: date-time

--- a/backend/gates/grantrenewalcauses_test.go
+++ b/backend/gates/grantrenewalcauses_test.go
@@ -55,8 +55,14 @@ func TestEveryRenewalCauseReachesTheCardThatAsksForIt(t *testing.T) {
 		t.Fatalf("reading the settings card: %v", err)
 	}
 	for _, cause := range causes {
-		if !strings.Contains(string(card), cause) {
-			t.Errorf("MyAgentGrant.%s says a rep's standing grant has stopped working, and %s never reads it — "+
+		// The field READ, not the name anywhere in the file. A card that
+		// carried the name in a type annotation, a comment or a dead
+		// expression would satisfy a substring search while ignoring the cause
+		// entirely — the exact silence this gate exists to break.
+		if !strings.Contains(string(card), "grant?."+cause) &&
+			!strings.Contains(string(card), "grant."+cause) {
+			t.Errorf("MyAgentGrant.%s says a rep's standing grant has stopped working, and %s never READS it (no "+
+				"`grant.%[1]s`) — "+
 				"so the run degrades every night and nothing on the surface the rep can act on says why. Branch on "+
 				"it beside the causes already there",
 				cause, grantRenewalCard)

--- a/backend/gates/grantrenewalcauses_test.go
+++ b/backend/gates/grantrenewalcauses_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H1
+
+package gates
+
+// Every reason a standing grant needs renewing must reach the card that asks
+// for it.
+//
+// A rep's overnight grant can stop working in more than one way, and none of
+// them fails a run: the runner DEGRADES an under-funded job before its first
+// model step, which is right for a misconfiguration and invisible from the
+// rep's side. No error, no expiry, no prompt — their overnight work simply
+// stops. The settings card is the only thing that can tell them, so a cause the
+// server computes and the card never reads is a field that reads as meaningful
+// and proves nothing.
+//
+// THE CORPUS IS THE CONTRACT. MyAgentGrant's `credential_*` booleans are what
+// the server says about the credential behind a granted answer, so adding one
+// is how a new cause arrives. The card has to branch on each of them. It may
+// branch on them TOGETHER — a lapsed passport funds nothing, so the two known
+// causes overlap and the card shows the actionable one — but it may not be
+// silent about one.
+//
+// Read from crm.yaml rather than from the generated Go: the field is added to
+// the schema first, and a gate reading the generated side would agree with a
+// tree nobody had regenerated yet.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	grantRenewalContract = "api/crm.yaml"
+	grantRenewalCard     = "../frontend/src/screens/overnight-grant.tsx"
+)
+
+// TestEveryRenewalCauseReachesTheCardThatAsksForIt is the parity check.
+func TestEveryRenewalCauseReachesTheCardThatAsksForIt(t *testing.T) {
+	t.Parallel()
+	causes := credentialFieldsOfMyAgentGrant(t)
+	// Two today: usable, and funds_agent. A reader that found none would report
+	// a clean sweep over a card that branches on nothing.
+	if len(causes) < 2 {
+		t.Fatalf("found %d credential field(s) on MyAgentGrant and expects at least 2 — either the schema lost one "+
+			"or this reader has stopped matching, and it cannot tell the difference: %v", len(causes), causes)
+	}
+	card, err := os.ReadFile(grantRenewalCard)
+	if err != nil {
+		t.Fatalf("reading the settings card: %v", err)
+	}
+	for _, cause := range causes {
+		if !strings.Contains(string(card), cause) {
+			t.Errorf("MyAgentGrant.%s says a rep's standing grant has stopped working, and %s never reads it — "+
+				"so the run degrades every night and nothing on the surface the rep can act on says why. Branch on "+
+				"it beside the causes already there",
+				cause, grantRenewalCard)
+		}
+	}
+}
+
+// credentialFieldsOfMyAgentGrant names the schema's `credential_` booleans.
+//
+// PARSED, not pattern-matched: rewriting the schema block-style changes nothing
+// about the contract, and a regex over the raw file would walk onto a different
+// schema's properties and report a confident wrong answer about a list it was
+// no longer reading.
+func credentialFieldsOfMyAgentGrant(t *testing.T) []string {
+	t.Helper()
+	document, err := os.ReadFile(grantRenewalContract)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var contract struct {
+		Components struct {
+			Schemas map[string]struct {
+				// Type is `any`: a property elsewhere in this document
+				// declares its type as a LIST, and a reader typed to a
+				// string fails on the whole file rather than on the one
+				// schema it is about.
+				Properties map[string]struct {
+					Type any `yaml:"type"`
+				} `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(document, &contract); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	schema, declared := contract.Components.Schemas["MyAgentGrant"]
+	if !declared {
+		t.Fatal("the contract declares no MyAgentGrant schema: this gate reads that schema for the causes a rep " +
+			"can be asked to renew, so it now certifies nothing")
+	}
+	var out []string
+	for name, property := range schema.Properties {
+		if strings.HasPrefix(name, "credential_") && property.Type == any("boolean") {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/backend/gates/grantrenewalcauses_test.go
+++ b/backend/gates/grantrenewalcauses_test.go
@@ -50,17 +50,19 @@ func TestEveryRenewalCauseReachesTheCardThatAsksForIt(t *testing.T) {
 		t.Fatalf("found %d credential field(s) on MyAgentGrant and expects at least 2 — either the schema lost one "+
 			"or this reader has stopped matching, and it cannot tell the difference: %v", len(causes), causes)
 	}
-	card, err := os.ReadFile(grantRenewalCard)
+	source, err := os.ReadFile(grantRenewalCard)
 	if err != nil {
 		t.Fatalf("reading the settings card: %v", err)
 	}
+	card := codeOf(string(source))
 	for _, cause := range causes {
-		// The field READ, not the name anywhere in the file. A card that
-		// carried the name in a type annotation, a comment or a dead
-		// expression would satisfy a substring search while ignoring the cause
-		// entirely — the exact silence this gate exists to break.
-		if !strings.Contains(string(card), "grant?."+cause) &&
-			!strings.Contains(string(card), "grant."+cause) {
+		// The field READ, in CODE. A name in a type annotation satisfies a bare
+		// substring search while the cause goes unshown, which is the exact
+		// silence this gate exists to break; a name in a comment or a string
+		// satisfies it without being a name at all, which is why those are
+		// stripped before the match.
+		if !strings.Contains(card, "grant?."+cause) &&
+			!strings.Contains(card, "grant."+cause) {
 			t.Errorf("MyAgentGrant.%s says a rep's standing grant has stopped working, and %s never READS it (no "+
 				"`grant.%[1]s`) — "+
 				"so the run degrades every night and nothing on the surface the rep can act on says why. Branch on "+
@@ -110,4 +112,57 @@ func credentialFieldsOfMyAgentGrant(t *testing.T) []string {
 		}
 	}
 	return out
+}
+
+// codeOf is the card with its comments and its string and template literals
+// removed, so a match is a read rather than a mention.
+//
+// WHAT IT IS, AND IS NOT. A scanner, not a parser. It separates `grant.x` in an
+// expression from `grant.x` inside a comment or a translation key, which is the
+// difference that made a bare substring search too weak. It does NOT prove the
+// expression is REACHED: a branch left in the file but never rendered still
+// reads as a read. Proving that needs the card's own tests, and it has them —
+// one per renewal cause, asserting the notice a rep actually sees. This gate is
+// the floor under those: it fails when a cause has no branch at all, which is
+// the case a card's tests cannot cover, because nobody writes a test for a
+// notice they did not know to add.
+func codeOf(source string) string {
+	var out strings.Builder
+	for i := 0; i < len(source); i++ {
+		switch {
+		case strings.HasPrefix(source[i:], "//"):
+			end := strings.IndexByte(source[i:], '\n')
+			if end < 0 {
+				return out.String()
+			}
+			i += end
+			out.WriteByte('\n')
+		case strings.HasPrefix(source[i:], "/*"):
+			end := strings.Index(source[i+2:], "*/")
+			if end < 0 {
+				return out.String()
+			}
+			i += 2 + end + 1
+			out.WriteByte(' ')
+		case source[i] == '"' || source[i] == '\'' || source[i] == '`':
+			// A literal runs to its unescaped closing quote. An unterminated
+			// one ends the scan rather than swallowing the rest as code.
+			quote := source[i]
+			j := i + 1
+			for j < len(source) && source[j] != quote {
+				if source[j] == '\\' {
+					j++
+				}
+				j++
+			}
+			if j >= len(source) {
+				return out.String()
+			}
+			i = j
+			out.WriteByte(' ')
+		default:
+			out.WriteByte(source[i])
+		}
+	}
+	return out.String()
 }

--- a/backend/internal/compose/agentgrantseam.go
+++ b/backend/internal/compose/agentgrantseam.go
@@ -40,6 +40,7 @@ func (a agentGrantStore) MyAnswerTx(ctx context.Context, tx pgx.Tx, spec string)
 		State:            grant.State,
 		PassportID:       grant.PassportID,
 		CredentialUsable: grant.CredentialUsable,
+		PassportScopes:   grant.PassportScopes,
 		DecidedAt:        grant.DecidedAt,
 	}, true, nil
 }

--- a/backend/internal/compose/integration/jobfanout/agentgrantapi_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/agentgrantapi_integration_test.go
@@ -72,6 +72,65 @@ func TestGrantingMintsTheRepsOwnCredentialAndNothingWider(t *testing.T) {
 	}
 }
 
+// TestAGrantMintedBeforeTheAgentGrewReportsItselfShort is the case liveness
+// cannot see.
+//
+// The passport is neither revoked nor expired, so `credential_usable` is true —
+// it is perfectly good authority for the job the agent did when the rep
+// answered. What it is not is enough for the job the agent does now. Nothing
+// fails: the runner degrades the unfunded tools before the first model step and
+// the rep's brief is simply not prepared, silently, at 2am. The only thing that
+// can tell them is this field.
+//
+// The passport is narrowed IN PLACE rather than minted narrow, because that is
+// what actually happened: the rows were written by an older build and no
+// migration or renewal path touches them.
+func TestAGrantMintedBeforeTheAgentGrewReportsItselfShort(t *testing.T) {
+	re := setupRunner(t)
+	if status := re.answerGrant(t, true); status != http.StatusOK {
+		t.Fatalf("grant → %d", status)
+	}
+	if _, err := re.Owner.Exec(context.Background(), `
+		UPDATE passport SET scopes = ARRAY['read']
+		 WHERE id = (SELECT passport_id FROM agent_standing_grant
+		              WHERE agent_spec = 'morning_brief')`); err != nil {
+		t.Fatalf("narrowing the credential to what an older build minted: %v", err)
+	}
+
+	var body struct {
+		Data []struct {
+			Spec             string `json:"spec"`
+			State            string `json:"state"`
+			CredentialUsable bool   `json:"credential_usable"`
+			FundsAgent       bool   `json:"credential_funds_agent"`
+		} `json:"data"`
+	}
+	if status := re.Call(t, "GET", "/v1/me/agent-grants", nil, nil, &body); status != http.StatusOK {
+		t.Fatalf("listing the rep's grants → %d", status)
+	}
+	found := false
+	for _, grant := range body.Data {
+		if grant.Spec != "morning_brief" {
+			continue
+		}
+		found = true
+		if grant.State != "granted" {
+			t.Errorf("state = %q, want granted: the rep answered and nothing has changed that", grant.State)
+		}
+		if !grant.CredentialUsable {
+			t.Error("credential_usable is false on a passport that is neither revoked nor expired — " +
+				"reporting an expiry sends the rep looking for a lapse that never happened")
+		}
+		if grant.FundsAgent {
+			t.Error("credential_funds_agent is true on a passport minted before the agent gained a write tool: " +
+				"the run degrades every night and the rep is told nothing is wrong")
+		}
+	}
+	if !found {
+		t.Fatal("the rep's own grant list does not carry morning_brief, so this test asserted nothing")
+	}
+}
+
 func TestWithdrawingEndsTheAuthorityRatherThanTheReference(t *testing.T) {
 	re := setupRunner(t)
 	if status := re.answerGrant(t, true); status != http.StatusOK {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19852,6 +19852,19 @@ type MorningDigestConnectorsStatus string
 
 // MyAgentGrant One rep's standing answer for one scheduled agent.
 type MyAgentGrant struct {
+	// CredentialFundsAgent Whether that passport still covers what this agent DOES. A grant mints the
+	// scopes the agent needed at the moment it was answered; when the agent later
+	// gains a tool needing a wider scope, the passport is short. It is neither
+	// revoked nor expired, so `credential_usable` stays true — but the run degrades
+	// the unfunded tools away before its first step and the rep's overnight work
+	// silently stops.
+	//
+	// Computed at request time from what the build would mint today, never stored.
+	// False against `granted` is the SECOND renewal case, and a client must offer
+	// renewal on it exactly as it does on the first — the two differ only in what
+	// the rep is told went wrong.
+	CredentialFundsAgent bool `json:"credential_funds_agent"`
+
 	// CredentialUsable Whether the passport behind a granted answer is live RIGHT NOW — not revoked,
 	// not expired. Read from the passport at request time, never stored, because it
 	// changes at a moment nothing writes to the grant. False against `granted` is

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19852,17 +19852,14 @@ type MorningDigestConnectorsStatus string
 
 // MyAgentGrant One rep's standing answer for one scheduled agent.
 type MyAgentGrant struct {
-	// CredentialFundsAgent Whether that passport still covers what this agent DOES. A grant mints the
-	// scopes the agent needed at the moment it was answered; when the agent later
-	// gains a tool needing a wider scope, the passport is short. It is neither
-	// revoked nor expired, so `credential_usable` stays true — but the run degrades
-	// the unfunded tools away before its first step and the rep's overnight work
-	// silently stops.
+	// CredentialFundsAgent Whether that passport still covers what this agent does. Read at request time
+	// and never stored, so it must not be cached across requests.
 	//
-	// Computed at request time from what the build would mint today, never stored.
-	// False against `granted` is the SECOND renewal case, and a client must offer
-	// renewal on it exactly as it does on the first — the two differ only in what
-	// the rep is told went wrong.
+	// False against `granted` is the second renewal case, distinct from an expiry:
+	// the credential works, and does not reach far enough. A client must offer
+	// renewal on it exactly as it does on `credential_usable: false`, and say which
+	// of the two happened — a rep sent looking for a lapse that never happened
+	// cannot fix anything.
 	CredentialFundsAgent bool `json:"credential_funds_agent"`
 
 	// CredentialUsable Whether the passport behind a granted answer is live RIGHT NOW — not revoked,

--- a/backend/internal/modules/agents/runner/standinggrant.go
+++ b/backend/internal/modules/agents/runner/standinggrant.go
@@ -66,7 +66,12 @@ type StandingGrant struct {
 	// not expired. Read from the passport rather than stored here, because it
 	// changes at a moment nothing writes to this table.
 	CredentialUsable bool
-	DecidedAt        time.Time
+	// PassportScopes is what the credential was minted with. Reported rather
+	// than judged: this package knows what a passport HOLDS, and the module
+	// that mints them knows what an agent NEEDS. A passport minted before an
+	// agent gained a tool is short, and neither fact alone can say so.
+	PassportScopes []string
+	DecidedAt      time.Time
 }
 
 // Live reports whether this grant can authorize a run right now: the rep said
@@ -134,12 +139,13 @@ func grantForTx(ctx context.Context, tx pgx.Tx, userID ids.UserID, spec string) 
 	// about whether their authority still works.
 	row := tx.QueryRow(ctx, `
 		SELECT g.user_id, g.agent_spec, g.state, g.passport_id, g.decided_at,
-		       coalesce(p.revoked_at IS NULL AND p.expires_at > now(), false)
+		       coalesce(p.revoked_at IS NULL AND p.expires_at > now(), false),
+		       coalesce(p.scopes, '{}')
 		  FROM agent_standing_grant g
 		  LEFT JOIN passport p ON p.id = g.passport_id
 		 WHERE g.user_id = $1 AND g.agent_spec = $2`, userID, spec)
 	switch err := row.Scan(&out.UserID, &out.Spec, &out.State,
-		&out.PassportID, &out.DecidedAt, &out.CredentialUsable); {
+		&out.PassportID, &out.DecidedAt, &out.CredentialUsable, &out.PassportScopes); {
 	case errors.Is(err, pgx.ErrNoRows):
 		return StandingGrant{}, false, nil
 	case err != nil:
@@ -186,7 +192,7 @@ func (s *Store) LiveGrantsFor(ctx context.Context, spec string) ([]StandingGrant
 	var out []StandingGrant
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT g.user_id, g.agent_spec, g.state, g.passport_id, g.decided_at, true
+			SELECT g.user_id, g.agent_spec, g.state, g.passport_id, g.decided_at, true, p.scopes
 			  FROM agent_standing_grant g
 			  JOIN passport p ON p.id = g.passport_id
 			 WHERE g.agent_spec = $1
@@ -207,7 +213,7 @@ func (s *Store) LiveGrantsFor(ctx context.Context, spec string) ([]StandingGrant
 		for rows.Next() {
 			var g StandingGrant
 			if err := rows.Scan(&g.UserID, &g.Spec, &g.State, &g.PassportID,
-				&g.DecidedAt, &g.CredentialUsable); err != nil {
+				&g.DecidedAt, &g.CredentialUsable, &g.PassportScopes); err != nil {
 				return fmt.Errorf("scan a standing grant: %w", err)
 			}
 			out = append(out, g)

--- a/backend/internal/modules/agents/runner/standinggrant.go
+++ b/backend/internal/modules/agents/runner/standinggrant.go
@@ -192,7 +192,7 @@ func (s *Store) LiveGrantsFor(ctx context.Context, spec string) ([]StandingGrant
 	var out []StandingGrant
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT g.user_id, g.agent_spec, g.state, g.passport_id, g.decided_at, true, p.scopes
+			SELECT g.user_id, g.agent_spec, g.state, g.passport_id, g.decided_at, true
 			  FROM agent_standing_grant g
 			  JOIN passport p ON p.id = g.passport_id
 			 WHERE g.agent_spec = $1
@@ -212,8 +212,13 @@ func (s *Store) LiveGrantsFor(ctx context.Context, spec string) ([]StandingGrant
 		defer rows.Close()
 		for rows.Next() {
 			var g StandingGrant
+			// PassportScopes is deliberately not read here. The fan-out asks
+			// whether a credential is live tonight, which the JOIN above has
+			// already decided; whether it still FUNDS the agent is a question
+			// the rep's own card asks, through grantForTx. Pulling the array
+			// for every live grant on every nightly pass would buy nothing.
 			if err := rows.Scan(&g.UserID, &g.Spec, &g.State, &g.PassportID,
-				&g.DecidedAt, &g.CredentialUsable, &g.PassportScopes); err != nil {
+				&g.DecidedAt, &g.CredentialUsable); err != nil {
 				return fmt.Errorf("scan a standing grant: %w", err)
 			}
 			out = append(out, g)

--- a/backend/internal/modules/identity/agentgrantfunding_test.go
+++ b/backend/internal/modules/identity/agentgrantfunding_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// Whether a credential minted at some past moment still covers what its agent
+// does today.
+//
+// This is the half liveness cannot see. A passport neither revoked nor expired
+// is perfectly good authority — for the job the agent did when the rep answered.
+// When the agent gains a tool needing a wider scope, the run does not fail: it
+// degrades the unfunded tools away before the first model step and prepares
+// nothing. No error, no expiry, no prompt, at 2am.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/agentgrant"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestACredentialIsShortWhenItsAgentHasGrownSinceItWasMinted(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name  string
+		spec  string
+		held  []string
+		funds bool
+	}{
+		{
+			name:  "exactly what the build would mint today",
+			spec:  "morning_brief",
+			held:  []string{"read", "write"},
+			funds: true,
+		},
+		{
+			// The shape that shipped: morning_brief was granted {"read"} and
+			// later gained annotate_brief, a write tool.
+			name:  "the scopes the agent needed before it gained a tool",
+			spec:  "morning_brief",
+			held:  []string{"read"},
+			funds: false,
+		},
+		{
+			// Wider is not short. A rep whose passport carries more than this
+			// agent needs is not owed a renewal prompt, and telling them
+			// otherwise sends them to revoke authority that works.
+			name:  "more than the agent needs",
+			spec:  "morning_brief",
+			held:  []string{"read", "write", "admin"},
+			funds: true,
+		},
+		{
+			name:  "nothing at all",
+			spec:  "morning_brief",
+			held:  nil,
+			funds: false,
+		},
+		{
+			// There is no scope list to meet, so "covered" would be a claim
+			// about a requirement nobody in this build can state.
+			name:  "an agent this build cannot spell",
+			spec:  "agent_from_another_deployment",
+			held:  []string{"read", "write", "admin"},
+			funds: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := credentialFundsAgent(c.spec, c.held); got != c.funds {
+				t.Errorf("credentialFundsAgent(%q, %v) = %v, want %v",
+					c.spec, c.held, got, c.funds)
+			}
+		})
+	}
+}
+
+// TestTheRenderedGrantReportsBothRenewalCauses holds the two apart on the wire.
+//
+// A client shows one notice or the other, so a response that conflated them
+// would tell a rep their authority expired when nothing did — sending them to
+// look for a lapse that never happened.
+func TestTheRenderedGrantReportsBothRenewalCauses(t *testing.T) {
+	t.Parallel()
+	passport := ids.From[ids.PassportKind](ids.NewV7())
+	for _, c := range []struct {
+		name       string
+		answer     agentgrant.Answer
+		wantUsable bool
+		wantFunds  bool
+	}{
+		{
+			name: "a live credential that still covers the agent",
+			answer: agentgrant.Answer{
+				State: agentgrant.StateGranted, PassportID: &passport,
+				CredentialUsable: true, PassportScopes: []string{"read", "write"},
+			},
+			wantUsable: true, wantFunds: true,
+		},
+		{
+			name: "a live credential the agent has outgrown",
+			answer: agentgrant.Answer{
+				State: agentgrant.StateGranted, PassportID: &passport,
+				CredentialUsable: true, PassportScopes: []string{"read"},
+			},
+			wantUsable: true, wantFunds: false,
+		},
+		{
+			// A lapsed passport reports no scopes, so it is short as well as
+			// dead. Both are true and the client shows the expiry notice,
+			// because that is the thing the rep can act on.
+			name: "a lapsed credential",
+			answer: agentgrant.Answer{
+				State: agentgrant.StateGranted, PassportID: &passport,
+				CredentialUsable: false, PassportScopes: nil,
+			},
+			wantUsable: false, wantFunds: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			out := renderAgentGrant("morning_brief", c.answer, true)
+			if out.CredentialUsable != c.wantUsable {
+				t.Errorf("credential_usable = %v, want %v", out.CredentialUsable, c.wantUsable)
+			}
+			if out.CredentialFundsAgent != c.wantFunds {
+				t.Errorf("credential_funds_agent = %v, want %v", out.CredentialFundsAgent, c.wantFunds)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/identity/handlers_agentgrants.go
+++ b/backend/internal/modules/identity/handlers_agentgrants.go
@@ -69,6 +69,47 @@ func scopesForAgent(spec string) ([]string, bool) {
 	return scopes, known
 }
 
+// credentialFundsAgent reports whether a passport minted at some past moment
+// still covers what this agent needs today.
+//
+// A standing grant mints the scopes the agent needed AT THAT MOMENT. When the
+// agent later gains a tool that needs a wider scope, every already-minted
+// passport is short — and the run does not fail, it DEGRADES: the runner drops
+// the unfunded tools before the first model step, which is right for a
+// misconfiguration and invisible to the rep. No error, no expiry, no prompt;
+// their overnight work simply stops. Liveness cannot see it, because the
+// passport is neither revoked nor expired. It is perfectly good authority for
+// a job this agent no longer does.
+//
+// The comparison is against what would be MINTED today, not against the tools
+// directly, and that is what makes it derived rather than a second opinion: the
+// mint reads grantScopes, this reads grantScopes, and the gate below holds
+// grantScopes at or above what the agent's tools require. There is one place a
+// requirement can be stated and all three read it.
+//
+// Held by: TestEveryGrantFundsTheToolsItsAgentDeclares
+// (backend/gates/agentgrantscopes_test.go)
+//
+// An agent this build cannot spell funds nothing. There is no scope list to
+// meet, and answering "covered" about a requirement nobody can state would be
+// the silent failure this exists to end.
+func credentialFundsAgent(spec string, held []string) bool {
+	need, known := scopesForAgent(spec)
+	if !known {
+		return false
+	}
+	carried := make(map[string]bool, len(held))
+	for _, scope := range held {
+		carried[scope] = true
+	}
+	for _, scope := range need {
+		if !carried[scope] {
+			return false
+		}
+	}
+	return true
+}
+
 // ListMyAgentGrants implements (GET /me/agent-grants).
 //
 // It enumerates the CATALOG rather than the stored rows, because "never asked"
@@ -223,6 +264,7 @@ func renderAgentGrant(spec string, answer agentgrant.Answer, found bool) crmcont
 		return out
 	}
 	out.CredentialUsable = answer.CredentialUsable
+	out.CredentialFundsAgent = credentialFundsAgent(spec, answer.PassportScopes)
 	decided := answer.DecidedAt
 	out.DecidedAt = &decided
 	switch answer.State {

--- a/backend/internal/platform/agentgrant/agentgrant.go
+++ b/backend/internal/platform/agentgrant/agentgrant.go
@@ -48,7 +48,12 @@ type Answer struct {
 	// copy would say "granted" about a credential that stopped working hours
 	// ago.
 	CredentialUsable bool
-	DecidedAt        time.Time
+	// PassportScopes is what the credential was minted with. The grant table
+	// can say what a passport HOLDS; only the module that mints them knows what
+	// an agent NEEDS, so the comparison belongs on the reader's side of this
+	// port rather than behind it.
+	PassportScopes []string
+	DecidedAt      time.Time
 }
 
 // Store is what the credential-holding module needs from the grant table.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (49)
+## Parity (50)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -47,6 +47,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendprofilevocabulary_test.go` | H3 | The browser spells the company-profile vocabulary five more times, and every one of them fails SILENTLY when it falls short. |
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |
+| `grantrenewalcauses_test.go` | H1 | Every reason a standing grant needs renewing must reach the card that asks for it. |
 | `idempotencymap_test.go` | H3 | The idempotency allowlist as a fitness function: the contract is the authority on which operations promise Idempotency-Key retry safety, and internal/compose's hand-maintained replayableOperations map must mirror it exactly. |
 | `inboundsigningrecipe_test.go` | H3 | The signing scope is ONE invariant spelled on both sides of a wire. |
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -19695,17 +19695,14 @@ export interface components {
              */
             credential_usable: boolean;
             /**
-             * @description Whether that passport still covers what this agent DOES. A grant mints the
-             *     scopes the agent needed at the moment it was answered; when the agent later
-             *     gains a tool needing a wider scope, the passport is short. It is neither
-             *     revoked nor expired, so `credential_usable` stays true — but the run degrades
-             *     the unfunded tools away before its first step and the rep's overnight work
-             *     silently stops.
+             * @description Whether that passport still covers what this agent does. Read at request time
+             *     and never stored, so it must not be cached across requests.
              *
-             *     Computed at request time from what the build would mint today, never stored.
-             *     False against `granted` is the SECOND renewal case, and a client must offer
-             *     renewal on it exactly as it does on the first — the two differ only in what
-             *     the rep is told went wrong.
+             *     False against `granted` is the second renewal case, distinct from an expiry:
+             *     the credential works, and does not reach far enough. A client must offer
+             *     renewal on it exactly as it does on `credential_usable: false`, and say which
+             *     of the two happened — a rep sent looking for a lapse that never happened
+             *     cannot fix anything.
              */
             credential_funds_agent: boolean;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -19695,6 +19695,20 @@ export interface components {
              */
             credential_usable: boolean;
             /**
+             * @description Whether that passport still covers what this agent DOES. A grant mints the
+             *     scopes the agent needed at the moment it was answered; when the agent later
+             *     gains a tool needing a wider scope, the passport is short. It is neither
+             *     revoked nor expired, so `credential_usable` stays true — but the run degrades
+             *     the unfunded tools away before its first step and the rep's overnight work
+             *     silently stops.
+             *
+             *     Computed at request time from what the build would mint today, never stored.
+             *     False against `granted` is the SECOND renewal case, and a client must offer
+             *     renewal on it exactly as it does on the first — the two differ only in what
+             *     the rep is told went wrong.
+             */
+            credential_funds_agent: boolean;
+            /**
              * Format: date-time
              * @description When the rep last answered. Absent when they never were asked.
              */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3914,6 +3914,8 @@ export const de = {
     "Deine Antwort auf die Nacht-Frage konnte nicht gespeichert werden. Alles andere ist verbunden — stelle es unter Einstellungen → Verbindungen ein, sobald du drin bist.",
   "overnightGrant.renew":
     "Du hast zugestimmt, aber die Vollmacht, unter der Margince gearbeitet hat, ist abgelaufen. Schalte die Option aus und wieder ein, um sie zu erneuern — bis dahin wird dein Überblick nicht vorbereitet.",
+  "overnightGrant.renewScope":
+    "Du hast zugestimmt, aber Margince kann inzwischen mehr, und die erteilte Vollmacht deckt die neue Arbeit nicht ab. Schalte die Option aus und wieder ein, um sie zu erweitern — bis dahin wird dein Überblick nicht vorbereitet.",
   "mailSharing.title": "E-Mail-Freigabe",
   "mailSharing.sub":
     "Erfasste E-Mails sind für alle Kolleginnen und Kollegen lesbar, die den Kontakt sehen können. Standardmäßig eingeschaltet — das macht die Pipeline gemeinsam.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3939,6 +3939,8 @@ export const en = {
     "Your answer to the overnight question could not be saved. Everything else is connected — set it under Settings → Connections when you are in.",
   "overnightGrant.renew":
     "You said yes, but the authority Margince was working under has expired. Turn this off and on again to renew it — until then your brief is not being prepared.",
+  "overnightGrant.renewScope":
+    "You said yes, but Margince has learned to do more since, and the authority you gave does not cover the new work. Turn this off and on again to widen it — until then your brief is not being prepared.",
   "mailSharing.title": "Email sharing",
   "mailSharing.sub":
     "Captured mail is readable by every colleague who can see the contact. On by default — it is what makes the pipeline shared.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3873,6 +3873,8 @@ export const vi = {
     "Không lưu được câu trả lời của bạn cho câu hỏi ban đêm. Mọi thứ khác đã được kết nối — hãy đặt lại trong Cài đặt → Kết nối khi bạn vào.",
   "overnightGrant.renew":
     "Bạn đã đồng ý, nhưng quyền mà Margince đang dùng đã hết hạn. Tắt rồi bật lại tùy chọn này để gia hạn — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
+  "overnightGrant.renewScope":
+    "Bạn đã đồng ý, nhưng Margince nay làm được nhiều hơn, và quyền bạn đã cấp không bao gồm phần việc mới. Tắt rồi bật lại tùy chọn này để mở rộng — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
   "mailSharing.title": "Chia sẻ email",
   "mailSharing.sub":
     "Email được thu thập sẽ hiển thị với mọi đồng nghiệp có quyền xem liên hệ. Bật mặc định — đây là điều làm cho pipeline được chia sẻ.",

--- a/frontend/src/screens/overnight-grant.stories.tsx
+++ b/frontend/src/screens/overnight-grant.stories.tsx
@@ -23,9 +23,9 @@ type Story = StoryObj<typeof OvernightGrantCard>;
 function grantsResponse(
   state: "granted" | "declined" | "never_asked",
   credentialUsable = true,
-  // Defaults to true so a story about anything else shows a covered
-  // credential. Omitting it would read as false and put the scope-renewal
-  // notice on every story in this file.
+  // Defaulted, because the field's ABSENCE from the response reads as false
+  // and put the scope-renewal notice on every granted story in this file. A
+  // story about anything else shows a covered credential.
   credentialFundsAgent = true,
 ) {
   return jsonResponse({

--- a/frontend/src/screens/overnight-grant.stories.tsx
+++ b/frontend/src/screens/overnight-grant.stories.tsx
@@ -23,6 +23,10 @@ type Story = StoryObj<typeof OvernightGrantCard>;
 function grantsResponse(
   state: "granted" | "declined" | "never_asked",
   credentialUsable = true,
+  // Defaults to true so a story about anything else shows a covered
+  // credential. Omitting it would read as false and put the scope-renewal
+  // notice on every story in this file.
+  credentialFundsAgent = true,
 ) {
   return jsonResponse({
     data: [
@@ -30,6 +34,7 @@ function grantsResponse(
         spec: "morning_brief",
         state,
         credential_usable: credentialUsable,
+        credential_funds_agent: credentialFundsAgent,
         decided_at: "2026-08-20T06:00:00Z",
       },
     ],
@@ -94,6 +99,22 @@ export const SettingsNeedsRenewal: Story = {
   render: () => {
     installFetchStub({
       "GET /me/agent-grants": () => grantsResponse("granted", false),
+    });
+    return (
+      <StoryProviders>
+        <OvernightGrantCard />
+      </StoryProviders>
+    );
+  },
+};
+
+/** The rep agreed, their credential still works, and the agent has since
+ * learned to do more than it covers. Its own notice: nothing expired, and
+ * telling them it did sends them looking for a lapse that never happened. */
+export const SettingsNeedsWiderAuthority: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me/agent-grants": () => grantsResponse("granted", true, false),
     });
     return (
       <StoryProviders>

--- a/frontend/src/screens/overnight-grant.test.tsx
+++ b/frontend/src/screens/overnight-grant.test.tsx
@@ -118,6 +118,53 @@ it("the settings card shows the stored answer and writes when flipped", async ()
   await waitFor(() => expect(written).toEqual([{ granted: false }]));
 });
 
+it("tells the rep the agent outgrew their authority, not that it lapsed", async () => {
+  installFetchStub({
+    "GET /me/agent-grants": () =>
+      jsonResponse({
+        data: [
+          // Live authority — neither revoked nor expired — for a job this
+          // agent no longer does. The run does not fail; it degrades the
+          // unfunded tools away and prepares nothing, silently, at 2am.
+          {
+            spec: "morning_brief",
+            state: "granted",
+            credential_usable: true,
+            credential_funds_agent: false,
+          },
+        ],
+      }),
+  });
+  render(<OvernightGrantCard />);
+
+  expect(await screen.findByText(en["overnightGrant.renewScope"])).toBeTruthy();
+  // NOT the expiry notice: nothing expired, and telling the rep it did sends
+  // them looking for a lapse that never happened.
+  expect(screen.queryByText(en["overnightGrant.renew"])).toBeNull();
+  expect(screen.queryByText(en["overnightGrant.danger"])).toBeNull();
+});
+
+it("says nothing when the authority still covers the agent", async () => {
+  installFetchStub({
+    "GET /me/agent-grants": () =>
+      jsonResponse({
+        data: [
+          {
+            spec: "morning_brief",
+            state: "granted",
+            credential_usable: true,
+            credential_funds_agent: true,
+          },
+        ],
+      }),
+  });
+  render(<OvernightGrantCard />);
+
+  await screen.findByTestId("overnight-grant-toggle");
+  expect(screen.queryByText(en["overnightGrant.renewScope"])).toBeNull();
+  expect(screen.queryByText(en["overnightGrant.renew"])).toBeNull();
+});
+
 it("tells the rep their authority died rather than that they declined", async () => {
   installFetchStub({
     "GET /me/agent-grants": () =>
@@ -132,8 +179,11 @@ it("tells the rep their authority died rather than that they declined", async ()
 
   expect(await screen.findByText(en["overnightGrant.renew"])).toBeTruthy();
   // NOT the decline warning: they already answered, and showing that would put
-  // a settled question back in front of them.
+  // a settled question back in front of them. And not the scope notice either:
+  // a lapsed passport funds nothing, so BOTH would be true of it and a rep
+  // reading two notices cannot tell which one to act on.
   expect(screen.queryByText(en["overnightGrant.danger"])).toBeNull();
+  expect(screen.queryByText(en["overnightGrant.renewScope"])).toBeNull();
 });
 
 it("says the same thing about the same authority in both places", async () => {

--- a/frontend/src/screens/overnight-grant.tsx
+++ b/frontend/src/screens/overnight-grant.tsx
@@ -217,11 +217,21 @@ export function OvernightGrantCard() {
             const grant = morningBriefGrant(grants);
             const granted = grant?.state === "granted";
             const shown = optimistic ?? granted;
-            // The rep agreed and has nothing to act with: their passport was
-            // revoked or has expired. Reported as its own state rather than as
-            // a decline, because they already answered — asking again would be
-            // putting a settled question back to them.
-            const needsRenewal = granted && !grant?.credential_usable;
+            // The rep agreed and their credential no longer does the job.
+            // Reported as its own state rather than as a decline, because they
+            // already answered — asking again would be putting a settled
+            // question back to them.
+            //
+            // TWO CAUSES, and the rep is owed which one. The passport lapsed —
+            // revoked or expired — or the agent has since gained a tool the
+            // passport was never minted to fund, in which case it is perfectly
+            // live authority for a job this agent no longer does. Neither
+            // fails the run: it degrades, silently, at 2am.
+            const lapsed = granted && !grant?.credential_usable;
+            const outgrown =
+              granted &&
+              grant?.credential_usable === true &&
+              !grant?.credential_funds_agent;
             return (
               <>
                 <SettingList>
@@ -248,7 +258,8 @@ export function OvernightGrantCard() {
                 </SettingList>
                 <GrantNotices
                   showDanger={!shown}
-                  showRenewal={needsRenewal && shown}
+                  showRenewal={lapsed && shown}
+                  showScopeRenewal={outgrown && shown}
                   error={
                     save.isError ? problemMessageOf(save.error, t) : undefined
                   }
@@ -267,14 +278,16 @@ export function OvernightGrantCard() {
 function GrantNotices({
   showDanger,
   showRenewal,
+  showScopeRenewal,
   error,
 }: Readonly<{
   showDanger: boolean;
   showRenewal: boolean;
+  showScopeRenewal: boolean;
   error?: ReactNode;
 }>) {
   const t = useT();
-  if (!showDanger && !showRenewal && error === undefined) {
+  if (!showDanger && !showRenewal && !showScopeRenewal && error === undefined) {
     return null;
   }
   return (
@@ -283,6 +296,11 @@ function GrantNotices({
       {showRenewal && (
         <Callout tone="warn" live="status">
           {t("overnightGrant.renew")}
+        </Callout>
+      )}
+      {showScopeRenewal && (
+        <Callout tone="warn" live="status">
+          {t("overnightGrant.renewScope")}
         </Callout>
       )}
       {error !== undefined && (


### PR DESCRIPTION
Closes #2842.

## What was wrong

A standing overnight grant mints the scopes the agent needed **at that moment**. When the agent later gains a tool requiring a wider scope, every already-minted passport is short — and nothing notices.

The run does not fail. `runner.go` calls `unfundedTools` and **degrades** the whole run before the first model step, which is right for a misconfiguration and invisible from the rep's side: no error, no expiry, no prompt. Their overnight work simply stops, and the grant still reports `credential_usable: true`, because liveness — not revoked, not expired — was the only thing checked. It is perfectly good authority for a job this agent no longer does.

This shipped. `morning_brief` carried `{"read"}` until `annotate_brief` moved its requirement to `{"read", "write"}`. New grants were corrected by the existing gate; live passports were not, and no migration or renewal path would touch them. On any installation where a rep granted before that change, the overnight brief degrades every night.

## The fix, in the three parts the issue asks for

**1. Its own state.** `credential_funds_agent` sits beside `credential_usable` on `MyAgentGrant` — computed at request time, never stored, for the same reason liveness is not stored: it changes when nothing writes to the grant row.

**2. The seam.** The grant read already joins the passport for liveness, so it now also reports what the passport **holds**. Judging that belongs to `identity`, which owns the map a mint reads: `credentialFundsAgent` asks whether the credential covers what this build would mint **today**. That is what makes it derived rather than a second opinion — the mint reads `grantScopes`, this reads `grantScopes`, and `TestEveryGrantFundsTheToolsItsAgentDeclares` holds `grantScopes` at or above what the agent's tools require. One place states a requirement and all three read it.

An agent this build cannot spell funds nothing: there is no scope list to meet, and answering "covered" about a requirement nobody can state is the silent failure this exists to end.

**3. The rep is asked.** The Settings card branches on it, with copy that says the authority was **outgrown** rather than that it expired — a rep sent looking for a lapse that never happened cannot fix anything. The two notices are mutually exclusive: a lapsed passport is short as well as dead, and the card shows the expiry, because that is the actionable one.

## What holds it

- `TestEveryRenewalCauseReachesTheCardThatAsksForIt` (`backend/gates/`) — every `credential_` boolean the contract declares must be read by `overnight-grant.tsx`. A cause the server computes and nothing shows is a field that reads as meaningful and proves nothing, which is why part of this was backed out of the earlier PR. The corpus is the contract, parsed rather than pattern-matched.
- `TestAGrantMintedBeforeTheAgentGrewReportsItselfShort` — narrows a real minted passport in place (which is what actually happened to these rows) and asserts over HTTP that `state=granted`, `credential_usable=true`, `credential_funds_agent=false`.
- Unit tables for the judgement — exact, short, wider-than-needed, empty, unknown agent — and for the rendered response.
- Two card tests: the outgrown notice appears and the expiry one does not, and neither appears when the credential still covers the agent.

Mutation-checked: hard-coding `credential_funds_agent = true` fails the integration test and six unit cases; removing the card branch fails the card test; pointing the card's second branch at the first field fails the parity gate.

## Checks

`make check-backend`, `make check-fe`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) all green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Settings now identifies when overnight authorization no longer covers newly available work.
  - Added a dedicated renewal message explaining that authorization must be toggled off and on to expand its scope.
  - Grant status distinguishes expired, unusable, and insufficient-scope authorizations.
  - Added English, German, and Vietnamese translations for the new messaging.

- **Documentation**
  - Updated the changelog and gate inventory.

- **Tests**
  - Added coverage for scope changes, renewal messaging, and grant-status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->