### PR TITLE
A provider run is audited as the provider it is for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,16 @@ numbers appear here when releases start.
 
 ### Fixed
 
+- **A provider run's audit actor names the provider it is for.** Every run was
+  audited as `connector:surfe`, whichever vendor it actually belonged to,
+  because the workers that execute a run hold a run id and the poll sweep drains
+  many at once — the name could only be a guess, and it was correct only while a
+  CHECK constraint made a second provider impossible. Those constraints are
+  gone, and the claim rows already derived their provenance from the run's own
+  provider, so the audit log and the evidence on the record would have named
+  different vendors for one purchase. The actor is now narrowed to the run's own
+  connector inside the module that reads it.
+
 - **A partial payload took down the whole application.** `settings/maintenance`
   dereferenced a contract-required field on `/admin/job-health`, and the only
   error boundary was app-level, so one card's throw cost the reader the rail and

--- a/backend/gates/connectoractor_test.go
+++ b/backend/gates/connectoractor_test.go
@@ -32,7 +32,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -104,8 +103,21 @@ type writtenActorID struct {
 	id   string
 }
 
-// packageSource parses one directory's non-test Go and indexes the
-// package-level string constants it declares.
+// packageSource parses one directory's non-test Go and indexes every string
+// value it binds to a name — package constants and variables, const-block
+// repetitions, aliases of either, and function-local bindings alike.
+//
+// ALL of them, because the defect this gate exists to stop is a connector name
+// written down, and every one of those shapes is a name with a literal behind
+// it. A package-level const, a `vendor := "connector:surfe"` two lines above
+// the principal, and a const aliasing another const are the same thing at
+// different distances.
+//
+// Names are indexed per PACKAGE, not per scope, so two functions binding the
+// same name to different strings share an entry. That can only produce a false
+// POSITIVE — a literal reported at a site that did not use it — which is a
+// loud failure a reader resolves in a minute. The other direction is the one a
+// census may not have.
 func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]string) {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -113,7 +125,9 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 		t.Fatalf("reading %s: %v", dir, err)
 	}
 	files := map[string]*ast.File{}
-	constants := map[string]string{}
+	// bound is name → expression, resolved to text afterwards so an alias can
+	// name a constant declared later or in another file of the package.
+	bound := map[string]ast.Expr{}
 	for _, entry := range entries {
 		name := entry.Name()
 		path := filepath.ToSlash(filepath.Join(dir, name))
@@ -126,28 +140,69 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 			t.Fatalf("parsing %s: %v", path, err)
 		}
 		files[path] = file
-		for _, decl := range file.Decls {
-			spec, isGen := decl.(*ast.GenDecl)
-			if !isGen || (spec.Tok != token.CONST && spec.Tok != token.VAR) {
+		indexBindings(file, bound)
+	}
+	// A fixpoint, because an alias resolves only once its target has: the
+	// first pass folds the literals, the next folds the names pointing at
+	// them, and so on until nothing new resolves. The bound is what ends a
+	// cycle the compiler would refuse but this reader does not typecheck.
+	constants := map[string]string{}
+	for pass := 0; pass < 8; pass++ {
+		progressed := false
+		for name, expr := range bound {
+			if _, done := constants[name]; done {
 				continue
 			}
-			for _, s := range spec.Specs {
-				value, isValue := s.(*ast.ValueSpec)
-				if !isValue {
-					continue
-				}
-				for i, ident := range value.Names {
-					if i >= len(value.Values) {
-						continue
-					}
-					if text, ok := stringValue(value.Values[i]); ok {
-						constants[ident.Name] = text
-					}
-				}
+			if text, ok := gatekit.StringExpr(expr, constants, gatekit.FoldStrict); ok {
+				constants[name] = text
+				progressed = true
 			}
+		}
+		if !progressed {
+			break
 		}
 	}
 	return files, constants
+}
+
+// indexBindings records every name a file binds to an expression, wherever it
+// binds it.
+func indexBindings(file *ast.File, bound map[string]ast.Expr) {
+	// A const block repeats the previous spec's values when a spec has none:
+	//	const ( vend = "connector:surfe"; alias )
+	// carries the same value, and reading only the specs with values would
+	// miss it.
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.GenDecl:
+			var carried []ast.Expr
+			for _, spec := range node.Specs {
+				value, isValue := spec.(*ast.ValueSpec)
+				if !isValue {
+					continue
+				}
+				values := value.Values
+				if len(values) == 0 {
+					values = carried
+				} else {
+					carried = values
+				}
+				for i, ident := range value.Names {
+					if i < len(values) {
+						bound[ident.Name] = values[i]
+					}
+				}
+			}
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				ident, isIdent := lhs.(*ast.Ident)
+				if isIdent && i < len(node.Rhs) {
+					bound[ident.Name] = node.Rhs[i]
+				}
+			}
+		}
+		return true
+	})
 }
 
 // principalActorIDs names the ids a package's principals are built with.
@@ -156,9 +211,10 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 // provenance writers, in prefix tests and in SQL, and none of those binds an
 // actor. What this is about is who a piece of work is recorded as.
 //
-// An id given as an identifier is FOLDED through the package's own string
-// constants, because a constant is written down rather than read from
-// anywhere: moving the literal one line away does not make it derived.
+// An id given as an identifier is FOLDED through every string the package
+// binds to a name — a const, a var, a const-block repetition, an alias of any
+// of those, or a local two lines up. All of them are a connector name written
+// down, and moving the literal further away does not make it derived.
 //
 // An UNKEYED principal literal is refused outright. This reader matches the
 // field by name, and a positional one sets ID with nothing to match on —
@@ -195,33 +251,19 @@ func principalActorIDs(t *testing.T, files map[string]*ast.File, constants map[s
 				if key, isIdent := field.Key.(*ast.Ident); !isIdent || key.Name != "ID" {
 					continue
 				}
-				if text, ok := stringValue(field.Value); ok {
+				// FoldStrict: "is this DEFINITELY this string". Anything it
+				// cannot settle — a concatenation with a parameter in it, a
+				// call, a value read from a row — is the shape this gate is
+				// asking for, and reporting a guess about one would be worse
+				// than saying nothing.
+				if text, ok := gatekit.StringExpr(field.Value, constants, gatekit.FoldStrict); ok {
 					out = append(out, writtenActorID{file: path, id: text})
-					continue
 				}
-				if ident, isIdent := field.Value.(*ast.Ident); isIdent {
-					if text, declared := constants[ident.Name]; declared {
-						out = append(out, writtenActorID{file: path, id: text})
-					}
-				}
-				// Anything else — a concatenation, a call, a parameter — is a
-				// value the caller read from somewhere, which is the shape
-				// this gate is asking for.
 			}
 			return true
 		})
 	}
 	return out
-}
-
-// stringValue is the text of a string literal, or false for anything else.
-func stringValue(expr ast.Expr) (string, bool) {
-	lit, isLit := expr.(*ast.BasicLit)
-	if !isLit || lit.Kind != token.STRING {
-		return "", false
-	}
-	text, err := strconv.Unquote(lit.Value)
-	return text, err == nil
 }
 
 // namesAPrincipal reports whether a composite literal builds a principal,

--- a/backend/gates/connectoractor_test.go
+++ b/backend/gates/connectoractor_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H1
+
+package gates
+
+// A connector's actor id is DERIVED from the work, never written down.
+//
+// Every value a provider run writes is bought from a vendor rather than typed
+// by anybody, so the audit row names the connector — and WHICH connector is a
+// fact about the run. It was written down instead: `connector:surfe`, bound by
+// the workers that execute a run, correct only while provider_connection,
+// provider_run and person_provider_claim each carried a CHECK pinning them to
+// one provider. Those checks are gone so a second vendor can be connected.
+//
+// A LITERAL IS NOT A BUG UNTIL THERE ARE TWO, which is exactly why it needs a
+// gate: nothing failed while one vendor was the only one, the claim rows had
+// already been made to derive their provenance from the run's own provider, and
+// the disagreement appears for the first time on the first installation to
+// connect a second. An audit entry naming the wrong actor is worse than a
+// missing one, because it reads as authoritative.
+//
+// So: no principal anywhere in the tree may take a `connector:` id from a
+// string literal. Assembling one from a value is how a caller says it read
+// which vendor this is.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// connectorActorPrefix is what a connector's actor id starts with, matching the
+// provenance written onto the rows the same act produces.
+const connectorActorPrefix = "connector:"
+
+// oneOfItsKindForever names the written-down connector ids that are not a
+// vendor at all, and so have nothing to derive from.
+//
+// The rule is about work whose vendor is chosen at RUN TIME. A subsystem that
+// records itself as a connector because its values are not typed by anybody is
+// the same actor on every installation and every pass, and assembling that name
+// from somewhere would be indirection with no second case behind it.
+//
+// What would make an entry here wrong is the thing that made connector:surfe
+// wrong: the name becoming a choice. AssertAllMatched keeps the list honest
+// about existing; a reader who finds one of these selecting among vendors
+// should delete the entry rather than widen it.
+var oneOfItsKindForever = gatekit.Waive(map[string]string{
+	"connector:finance": "the finance mirror's own name, not a vendor's: one ledger sweep per installation, converting the source ledger into the base currency as it writes. There is nothing to read the name from, because there is never more than one",
+})
+
+// TestNoPrincipalNamesAConnectorInAStringLiteral is the census.
+func TestNoPrincipalNamesAConnectorInAStringLiteral(t *testing.T) {
+	t.Parallel()
+	read := 0
+	err := filepath.WalkDir("internal", func(walked string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(walked, ".go") ||
+			strings.HasSuffix(walked, "_test.go") || isIntegrationTagged(walked) {
+			return err
+		}
+		walked = filepath.ToSlash(walked)
+		file, err := parser.ParseFile(token.NewFileSet(), walked, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return err
+		}
+		for _, named := range principalIDsWrittenIn(file) {
+			read++
+			if !strings.HasPrefix(named, connectorActorPrefix) || oneOfItsKindForever.Waived(t, named) {
+				continue
+			}
+			t.Errorf("%s: builds a principal whose id is the literal %q, so every run this actor is bound for is "+
+				"audited as that vendor whichever one it is actually for. Read the provider from the work and "+
+				"assemble the id from it — the rows the same act writes already derive their provenance that way",
+				walked, named)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneOfItsKindForever.AssertAllMatched(t)
+	// A tree where no principal carries a written-down id at all would read
+	// exactly like a clean one. There are several, all of them named after a
+	// job or a subsystem rather than a vendor.
+	if read == 0 {
+		t.Fatal("this census found no principal built with a literal id, and there are several in this tree: " +
+			"the reader has stopped matching rather than the tree having changed, and it cannot tell the difference")
+	}
+}
+
+// principalIDsWrittenIn names the string literals a file assigns to a
+// principal's ID field.
+//
+// It reads the FIELD, not the file's strings: `connector:` appears in
+// provenance writers, in prefix tests and in SQL, and none of those binds an
+// actor. What this is about is who a piece of work is recorded as.
+//
+// The qualifier comes from the file's own import block, so a file that aliases
+// the principal package is read as one that does not.
+func principalIDsWrittenIn(file *ast.File) []string {
+	qualifier, dotImported := gatekit.ImportedAs(file, principalImportPath)
+	if qualifier == "" && !dotImported {
+		return nil
+	}
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, isLit := n.(*ast.CompositeLit)
+		if !isLit || !namesAPrincipal(lit.Type, qualifier, dotImported) {
+			return true
+		}
+		for _, element := range lit.Elts {
+			field, isField := element.(*ast.KeyValueExpr)
+			if !isField {
+				continue
+			}
+			if key, isIdent := field.Key.(*ast.Ident); !isIdent || key.Name != "ID" {
+				continue
+			}
+			value, isBasic := field.Value.(*ast.BasicLit)
+			if !isBasic || value.Kind != token.STRING {
+				// Anything assembled — a concatenation, a call, a variable —
+				// is a value the caller read from somewhere, which is the
+				// shape this gate is asking for.
+				continue
+			}
+			if unquoted, err := strconv.Unquote(value.Value); err == nil {
+				out = append(out, unquoted)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// namesAPrincipal reports whether a composite literal builds a principal,
+// including one taken by address.
+func namesAPrincipal(expr ast.Expr, qualifier string, dotImported bool) bool {
+	if star, isStar := expr.(*ast.StarExpr); isStar {
+		return namesAPrincipal(star.X, qualifier, dotImported)
+	}
+	return isPrincipalType(expr, qualifier, dotImported)
+}

--- a/backend/gates/connectoractor_test.go
+++ b/backend/gates/connectoractor_test.go
@@ -114,10 +114,13 @@ type writtenActorID struct {
 // different distances.
 //
 // Names are indexed per PACKAGE, not per scope, so two functions binding the
-// same name to different strings share an entry. That can only produce a false
-// POSITIVE — a literal reported at a site that did not use it — which is a
-// loud failure a reader resolves in a minute. The other direction is the one a
-// census may not have.
+// same name to different strings share an entry. EVERY binding is kept and a
+// connector value wins the entry, because the alternative is the failure a
+// census may not have: a later `vendor := someProvider` in an unrelated
+// function masking an earlier `vendor := "connector:surfe"`, and the literal
+// disappearing. Keeping the connector value can only report it at a site that
+// did not use it — a loud failure a reader resolves in a minute — where the
+// other direction is silent.
 func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]string) {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -125,9 +128,10 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 		t.Fatalf("reading %s: %v", dir, err)
 	}
 	files := map[string]*ast.File{}
-	// bound is name → expression, resolved to text afterwards so an alias can
-	// name a constant declared later or in another file of the package.
-	bound := map[string]ast.Expr{}
+	// bound is name → every expression bound to it, resolved to text afterwards
+	// so an alias can name a constant declared later or in another file of the
+	// package.
+	bound := map[string][]ast.Expr{}
 	for _, entry := range entries {
 		name := entry.Name()
 		path := filepath.ToSlash(filepath.Join(dir, name))
@@ -142,18 +146,29 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 		files[path] = file
 		indexBindings(file, bound)
 	}
-	// A fixpoint, because an alias resolves only once its target has: the
-	// first pass folds the literals, the next folds the names pointing at
-	// them, and so on until nothing new resolves. The bound is what ends a
-	// cycle the compiler would refuse but this reader does not typecheck.
+	// A fixpoint, because an alias resolves only once its target has: the first
+	// pass folds the literals, the next folds the names pointing at them, and
+	// so on until a pass changes nothing. No pass count — a cap would truncate
+	// a legitimately deep chain and drop its tail out of the census without a
+	// sound, and "nothing changed" already ends both a cycle and a chain.
 	constants := map[string]string{}
-	for pass := 0; pass < 8; pass++ {
+	for {
 		progressed := false
-		for name, expr := range bound {
-			if _, done := constants[name]; done {
-				continue
-			}
-			if text, ok := gatekit.StringExpr(expr, constants, gatekit.FoldStrict); ok {
+		for name, exprs := range bound {
+			for _, expr := range exprs {
+				text, ok := gatekit.StringExpr(expr, constants, gatekit.FoldStrict)
+				if !ok {
+					continue
+				}
+				current, have := constants[name]
+				if have && (current == text || strings.HasPrefix(current, connectorActorPrefix)) {
+					// Already settled, or already holding the value that must
+					// not be masked.
+					continue
+				}
+				if have && !strings.HasPrefix(text, connectorActorPrefix) {
+					continue
+				}
 				constants[name] = text
 				progressed = true
 			}
@@ -167,7 +182,7 @@ func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]s
 
 // indexBindings records every name a file binds to an expression, wherever it
 // binds it.
-func indexBindings(file *ast.File, bound map[string]ast.Expr) {
+func indexBindings(file *ast.File, bound map[string][]ast.Expr) {
 	// A const block repeats the previous spec's values when a spec has none:
 	//	const ( vend = "connector:surfe"; alias )
 	// carries the same value, and reading only the specs with values would
@@ -189,7 +204,7 @@ func indexBindings(file *ast.File, bound map[string]ast.Expr) {
 				}
 				for i, ident := range value.Names {
 					if i < len(values) {
-						bound[ident.Name] = values[i]
+						bound[ident.Name] = append(bound[ident.Name], values[i])
 					}
 				}
 			}
@@ -197,7 +212,7 @@ func indexBindings(file *ast.File, bound map[string]ast.Expr) {
 			for i, lhs := range node.Lhs {
 				ident, isIdent := lhs.(*ast.Ident)
 				if isIdent && i < len(node.Rhs) {
-					bound[ident.Name] = node.Rhs[i]
+					bound[ident.Name] = append(bound[ident.Name], node.Rhs[i])
 				}
 			}
 		}

--- a/backend/gates/connectoractor_test.go
+++ b/backend/gates/connectoractor_test.go
@@ -30,6 +30,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -62,25 +63,25 @@ var oneOfItsKindForever = gatekit.Waive(map[string]string{
 func TestNoPrincipalNamesAConnectorInAStringLiteral(t *testing.T) {
 	t.Parallel()
 	read := 0
-	err := filepath.WalkDir("internal", func(walked string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(walked, ".go") ||
-			strings.HasSuffix(walked, "_test.go") || isIntegrationTagged(walked) {
+	err := filepath.WalkDir("internal", func(dir string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
 			return err
 		}
-		walked = filepath.ToSlash(walked)
-		file, err := parser.ParseFile(token.NewFileSet(), walked, nil, parser.SkipObjectResolution)
-		if err != nil {
-			return err
-		}
-		for _, named := range principalIDsWrittenIn(file) {
+		// A package at a time, because an id can be a const declared in one
+		// file and used in another. Folding those is the whole reason this is
+		// not a per-file walk: a const is written down, not read from
+		// anywhere, so `const vendor = "connector:surfe"` used as an ID is the
+		// same defect one line further away.
+		files, constants := packageSource(t, dir)
+		for _, named := range principalActorIDs(t, files, constants) {
 			read++
-			if !strings.HasPrefix(named, connectorActorPrefix) || oneOfItsKindForever.Waived(t, named) {
+			if !strings.HasPrefix(named.id, connectorActorPrefix) || oneOfItsKindForever.Waived(t, named.id) {
 				continue
 			}
 			t.Errorf("%s: builds a principal whose id is the literal %q, so every run this actor is bound for is "+
 				"audited as that vendor whichever one it is actually for. Read the provider from the work and "+
 				"assemble the id from it — the rows the same act writes already derive their provenance that way",
-				walked, named)
+				named.file, named.id)
 		}
 		return nil
 	})
@@ -97,48 +98,130 @@ func TestNoPrincipalNamesAConnectorInAStringLiteral(t *testing.T) {
 	}
 }
 
-// principalIDsWrittenIn names the string literals a file assigns to a
-// principal's ID field.
+// writtenActorID is one principal id this census could read, and where.
+type writtenActorID struct {
+	file string
+	id   string
+}
+
+// packageSource parses one directory's non-test Go and indexes the
+// package-level string constants it declares.
+func packageSource(t *testing.T, dir string) (map[string]*ast.File, map[string]string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	files := map[string]*ast.File{}
+	constants := map[string]string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.ToSlash(filepath.Join(dir, name))
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") || isIntegrationTagged(path) {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		files[path] = file
+		for _, decl := range file.Decls {
+			spec, isGen := decl.(*ast.GenDecl)
+			if !isGen || (spec.Tok != token.CONST && spec.Tok != token.VAR) {
+				continue
+			}
+			for _, s := range spec.Specs {
+				value, isValue := s.(*ast.ValueSpec)
+				if !isValue {
+					continue
+				}
+				for i, ident := range value.Names {
+					if i >= len(value.Values) {
+						continue
+					}
+					if text, ok := stringValue(value.Values[i]); ok {
+						constants[ident.Name] = text
+					}
+				}
+			}
+		}
+	}
+	return files, constants
+}
+
+// principalActorIDs names the ids a package's principals are built with.
 //
-// It reads the FIELD, not the file's strings: `connector:` appears in
+// It reads the ID FIELD, not the package's strings: `connector:` appears in
 // provenance writers, in prefix tests and in SQL, and none of those binds an
 // actor. What this is about is who a piece of work is recorded as.
 //
-// The qualifier comes from the file's own import block, so a file that aliases
-// the principal package is read as one that does not.
-func principalIDsWrittenIn(file *ast.File) []string {
-	qualifier, dotImported := gatekit.ImportedAs(file, principalImportPath)
-	if qualifier == "" && !dotImported {
-		return nil
-	}
-	var out []string
-	ast.Inspect(file, func(n ast.Node) bool {
-		lit, isLit := n.(*ast.CompositeLit)
-		if !isLit || !namesAPrincipal(lit.Type, qualifier, dotImported) {
+// An id given as an identifier is FOLDED through the package's own string
+// constants, because a constant is written down rather than read from
+// anywhere: moving the literal one line away does not make it derived.
+//
+// An UNKEYED principal literal is refused outright. This reader matches the
+// field by name, and a positional one sets ID with nothing to match on —
+// answering "no id here" about a literal that carries one is the
+// under-recognition a census may not have.
+func principalActorIDs(t *testing.T, files map[string]*ast.File, constants map[string]string) []writtenActorID {
+	t.Helper()
+	var out []writtenActorID
+	for path, file := range files {
+		qualifier, dotImported := gatekit.ImportedAs(file, principalImportPath)
+		if qualifier == "" && !dotImported {
+			continue
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, isLit := n.(*ast.CompositeLit)
+			if !isLit || !namesAPrincipal(lit.Type, qualifier, dotImported) {
+				return true
+			}
+			// Once per literal, not once per element: a positional principal
+			// has as many unkeyed elements as it has fields, and nine copies
+			// of one sentence is not nine findings.
+			if len(lit.Elts) > 0 {
+				if _, keyed := lit.Elts[0].(*ast.KeyValueExpr); !keyed {
+					t.Errorf("%s: builds a principal with unkeyed fields, and this census reads the ID field by "+
+						"name — so an actor id spelled positionally is one it cannot see. Name the fields", path)
+					return true
+				}
+			}
+			for _, element := range lit.Elts {
+				field, isField := element.(*ast.KeyValueExpr)
+				if !isField {
+					continue
+				}
+				if key, isIdent := field.Key.(*ast.Ident); !isIdent || key.Name != "ID" {
+					continue
+				}
+				if text, ok := stringValue(field.Value); ok {
+					out = append(out, writtenActorID{file: path, id: text})
+					continue
+				}
+				if ident, isIdent := field.Value.(*ast.Ident); isIdent {
+					if text, declared := constants[ident.Name]; declared {
+						out = append(out, writtenActorID{file: path, id: text})
+					}
+				}
+				// Anything else — a concatenation, a call, a parameter — is a
+				// value the caller read from somewhere, which is the shape
+				// this gate is asking for.
+			}
 			return true
-		}
-		for _, element := range lit.Elts {
-			field, isField := element.(*ast.KeyValueExpr)
-			if !isField {
-				continue
-			}
-			if key, isIdent := field.Key.(*ast.Ident); !isIdent || key.Name != "ID" {
-				continue
-			}
-			value, isBasic := field.Value.(*ast.BasicLit)
-			if !isBasic || value.Kind != token.STRING {
-				// Anything assembled — a concatenation, a call, a variable —
-				// is a value the caller read from somewhere, which is the
-				// shape this gate is asking for.
-				continue
-			}
-			if unquoted, err := strconv.Unquote(value.Value); err == nil {
-				out = append(out, unquoted)
-			}
-		}
-		return true
-	})
+		})
+	}
 	return out
+}
+
+// stringValue is the text of a string literal, or false for anything else.
+func stringValue(expr ast.Expr) (string, bool) {
+	lit, isLit := expr.(*ast.BasicLit)
+	if !isLit || lit.Kind != token.STRING {
+		return "", false
+	}
+	text, err := strconv.Unquote(lit.Value)
+	return text, err == nil
 }
 
 // namesAPrincipal reports whether a composite literal builds a principal,

--- a/backend/internal/compose/jobs_providerruns.go
+++ b/backend/internal/compose/jobs_providerruns.go
@@ -115,20 +115,25 @@ func (ProviderRunPollSweepArgs) Kind() string { return "provider_run_poll_sweep"
 // tenant work of its own (jobs.FleetWide).
 func (ProviderRunPollSweepArgs) FleetWide() {}
 
-// providerJobActor binds the principal a provider run executes as.
+// providerJobActor binds the principal a provider run STARTS as, plus the
+// correlation id the outbox envelope requires.
 //
-// The connector is the actor because every value these runs write is bought
-// from the provider, not typed by anybody: the claim rows carry
-// `connector:surfe` provenance, and a reader must be able to tell purchased
-// data from a colleague's entry. It also carries a correlation id, which the
-// outbox envelope requires.
+// It names the worker, not a vendor, and that is the whole of what this layer
+// knows: the submit worker holds a run id and the poll sweep drains many runs
+// at once, so a connector named here could only ever be a guess. It used to be
+// one — `connector:surfe`, correct only while a CHECK constraint made a second
+// provider impossible. The store narrows this to the run's own connector the
+// moment it has read which one that is, and every audit row a run writes is
+// written after that.
 //
-// Without this the hand-off refused with "no actor bound to context" and every
-// polled run stayed in_progress forever — the run was paid for, the provider
-// had answered, and the values reached nobody.
+// This binding is still load-bearing, for the reason it was added: without an
+// actor the hand-off refused with "no actor bound to context" and every polled
+// run stayed in_progress forever — paid for, answered, and reaching nobody. It
+// is the floor under a path that reaches a gated write before it has resolved a
+// provider, and it is deliberately a name no reader can mistake for a vendor.
 func providerJobActor(ctx context.Context) context.Context {
 	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalSystem, ID: "connector:surfe",
+		Type: principal.PrincipalSystem, ID: "provider_run_worker",
 	})
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }

--- a/backend/internal/modules/integrations/execute.go
+++ b/backend/internal/modules/integrations/execute.go
@@ -93,6 +93,9 @@ func (s *Store) ExecuteSubmit(ctx context.Context, runID string) error {
 	if err != nil {
 		return err
 	}
+	// From here on the run acts as ITS OWN connector. Everything below writes
+	// audit, and the worker that called in could only name a vendor it guessed.
+	ctx = actingForProvider(ctx, name)
 	adapter, err := s.registry.Adapter(name)
 	if err != nil {
 		return fmt.Errorf("integrations: run %s names a provider this build does not carry: %w", runID, err)

--- a/backend/internal/modules/integrations/execute_integration_test.go
+++ b/backend/internal/modules/integrations/execute_integration_test.go
@@ -47,7 +47,7 @@ func sealCredential(t *testing.T, e *runsEnv) {
 	}
 	if _, err := e.owner.Exec(ctx, `
 		UPDATE provider_connection SET credential_ref = $1, execution_epoch = execution_epoch + 1
-		 WHERE provider = 'surfe'`, string(ref)); err != nil {
+		 WHERE provider = $2`, string(ref), e.provider); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -55,7 +55,7 @@ func sealCredential(t *testing.T, e *runsEnv) {
 func queueFor(t *testing.T, e *runsEnv, personID string) provider.Run {
 	t.Helper()
 	run, err := e.store.QueueRun(e.ctx, provider.QueueInput{
-		PersonID: personID, Provider: "surfe", Trigger: provider.TriggerManual,
+		PersonID: personID, Provider: e.provider, Trigger: provider.TriggerManual,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -512,5 +512,62 @@ func TestARefusalAuditsTheConnectionStatusItChangedFrom(t *testing.T) {
 	}
 	if after["status"] != "rate_limited" || after["safe_status_code"] != "provider_rate_limited" {
 		t.Errorf("audit after = %+v, want status rate_limited and safe_status_code provider_rate_limited", after)
+	}
+}
+
+// TestARunAuditsTheProviderItIsFor is the actor, derived rather than assumed.
+//
+// The workers that execute a run hold a run id — the poll sweep drains many at
+// once — so a principal bound out there can only name a vendor it guessed. It
+// guessed the one provider that could exist while a CHECK constraint pinned
+// provider_connection, provider_run and person_provider_claim to a single name.
+// Those checks are gone, and the claim rows already derive their provenance
+// from the run's own provider: a guessed audit actor and a derived claim row
+// name different vendors for one purchase, and the entry that reads as
+// authoritative is the wrong one.
+//
+// The environment is deliberately NOT surfe, because a fixture carrying the one
+// name cannot tell a derived answer from a constant that happens to match.
+func TestARunAuditsTheProviderItIsFor(t *testing.T) {
+	// The credential is refused, because that is the submission outcome whose
+	// settlement writes an audit row: the connection's status changes, and the
+	// row says who observed it.
+	e := setupRuns(t, runsConfig{provider: "otherco", subjectLastName: "InvalidCredentials"})
+	sealCredential(t, e)
+	run := queueFor(t, e, e.mine.String())
+
+	if err := e.store.ExecuteSubmit(e.ctx, run.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var actors []string
+	rows, err := e.owner.Query(context.Background(), `
+		SELECT DISTINCT actor_id FROM audit_log
+		 WHERE entity_type = 'provider_connection'
+		   AND after->>'provider' = 'otherco'
+		 ORDER BY actor_id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var actor string
+		if err := rows.Scan(&actor); err != nil {
+			t.Fatal(err)
+		}
+		actors = append(actors, actor)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(actors) == 0 {
+		t.Fatal("the refused submission wrote no audit row, so this test asserted nothing about who acted")
+	}
+	for _, actor := range actors {
+		if actor != "connector:otherco" {
+			t.Errorf("an audit row for otherco's connection names %q as the actor — the claim rows on a record "+
+				"derive their provenance from the run's own provider, so the log and the evidence would disagree "+
+				"about who acted for this vendor", actor)
+		}
 	}
 }

--- a/backend/internal/modules/integrations/execute_integration_test.go
+++ b/backend/internal/modules/integrations/execute_integration_test.go
@@ -533,6 +533,7 @@ func TestARunAuditsTheProviderItIsFor(t *testing.T) {
 	// settlement writes an audit row: the connection's status changes, and the
 	// row says who observed it.
 	e := setupRuns(t, runsConfig{provider: "otherco", subjectLastName: "InvalidCredentials"})
+	want := "connector:" + e.provider
 	sealCredential(t, e)
 	run := queueFor(t, e, e.mine.String())
 
@@ -544,8 +545,8 @@ func TestARunAuditsTheProviderItIsFor(t *testing.T) {
 	rows, err := e.owner.Query(context.Background(), `
 		SELECT DISTINCT actor_id FROM audit_log
 		 WHERE entity_type = 'provider_connection'
-		   AND after->>'provider' = 'otherco'
-		 ORDER BY actor_id`)
+		   AND after->>'provider' = $1
+		 ORDER BY actor_id`, e.provider)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,10 +565,10 @@ func TestARunAuditsTheProviderItIsFor(t *testing.T) {
 		t.Fatal("the refused submission wrote no audit row, so this test asserted nothing about who acted")
 	}
 	for _, actor := range actors {
-		if actor != "connector:otherco" {
-			t.Errorf("an audit row for otherco's connection names %q as the actor — the claim rows on a record "+
+		if actor != want {
+			t.Errorf("an audit row for %s's connection names %q as the actor, want %q — the claim rows on a record "+
 				"derive their provenance from the run's own provider, so the log and the evidence would disagree "+
-				"about who acted for this vendor", actor)
+				"about who acted for this vendor", e.provider, actor, want)
 		}
 	}
 }

--- a/backend/internal/modules/integrations/handoff.go
+++ b/backend/internal/modules/integrations/handoff.go
@@ -147,6 +147,9 @@ func (s *Store) recoverClaims(ctx context.Context, runID string) error {
 	if err != nil {
 		return err
 	}
+	// The run acts as its own connector from here: the sweep that called in
+	// drains many runs at once and cannot name any one of their vendors.
+	ctx = actingForProvider(ctx, name)
 	adapter, err := s.registry.Adapter(name)
 	if err != nil {
 		return fmt.Errorf("integrations: run %s names a provider this build does not carry: %w", runID, err)

--- a/backend/internal/modules/integrations/offline.go
+++ b/backend/internal/modules/integrations/offline.go
@@ -44,6 +44,11 @@ type OfflineProvider struct {
 	// a run in the dev stack never left in_progress.
 	polls sync.Map
 	now   func() time.Time
+	// name is the vendor this fake stands in for. Almost always the one real
+	// adapter's, because the fake exists to exercise the same cost table and
+	// cascade; a caller renames it to prove a claim about WHICH provider a run
+	// belongs to, which no single-provider fixture can distinguish.
+	name string
 }
 
 // NewOfflineProvider builds the fake. pollsBeforeDone of 0 completes on the
@@ -53,7 +58,20 @@ func NewOfflineProvider(pollsBeforeDone int, now func() time.Time) *OfflineProvi
 	return &OfflineProvider{
 		pollsBeforeDone: pollsBeforeDone,
 		now:             now,
+		name:            "surfe",
 	}
+}
+
+// Named is this fake standing in for a different vendor.
+//
+// Every provider-run seam is keyed on the run's own provider — the claim rows'
+// provenance, the audit actor, the connection lock — and a fixture carrying one
+// name proves none of that: the value under test is also the only value there
+// is. This is what lets a test tell "derived from the run" from "hard-coded to
+// the provider that used to be the only one".
+func (p *OfflineProvider) Named(name string) *OfflineProvider {
+	p.name = name
+	return p
 }
 
 // Calls reports how many times this provider was asked to do anything
@@ -66,7 +84,7 @@ func (p *OfflineProvider) Calls() int64 { return p.calls.Load() }
 // pricing pass every test.
 func (p *OfflineProvider) Descriptor() provider.Descriptor {
 	return provider.Descriptor{
-		Name:        "surfe",
+		Name:        p.name,
 		Transport:   provider.TransportPolled,
 		Billing:     provider.BillingPerSuccessfulResult,
 		CreditPools: []provider.Pool{"email", "mobile"},

--- a/backend/internal/modules/integrations/poll.go
+++ b/backend/internal/modules/integrations/poll.go
@@ -139,6 +139,9 @@ func (s *Store) pollOne(ctx context.Context, runID string) error {
 	if err != nil {
 		return err
 	}
+	// The run acts as its own connector from here: the sweep that called in
+	// drains many runs at once and cannot name any one of their vendors.
+	ctx = actingForProvider(ctx, name)
 	adapter, err := s.registry.Adapter(name)
 	if err != nil {
 		return fmt.Errorf("integrations: run %s names a provider this build does not carry: %w", runID, err)

--- a/backend/internal/modules/integrations/runactor.go
+++ b/backend/internal/modules/integrations/runactor.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// Who a provider run acts as, derived from the run.
+//
+// The connector is the actor because every value these runs write is BOUGHT
+// from the provider rather than typed by anybody: a reader of a record has to
+// be able to tell purchased data from a colleague's entry, and the audit row is
+// where they read it.
+//
+// WHICH connector is a fact about the run, and only this module can resolve it.
+// The workers that execute a run know a run id — the poll sweep drains many at
+// once — so a principal bound out there can only ever name a vendor it guessed.
+// It guessed the one provider that could exist while `provider_connection`,
+// `provider_run` and `person_provider_claim` each carried a CHECK pinning them
+// to a single name. Those checks are gone so a second provider can be
+// connected, and a guess is now a wrong answer: the claim rows derive their
+// provenance from the run's own provider, so the audit log and the evidence on
+// the record would name different vendors for one purchase.
+//
+// An audit entry naming the wrong actor is worse than a missing one, because it
+// reads as authoritative.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// connectorActorPrefix is what a connector's actor id is spelled with, matching
+// the provenance people.WriteProviderClaims writes onto the claim rows. One act
+// leaves two rows, and a reader joining them has to see one name.
+const connectorActorPrefix = "connector:"
+
+// actingForProvider narrows the acting principal to the connector this run
+// belongs to, and stamps a correlation id if the caller has not.
+//
+// It REPLACES whatever the worker bound. The worker's principal exists so an
+// RBAC-gated write is never attempted with no actor at all; it cannot name a
+// vendor, and this is the first point in the run where one is known.
+func actingForProvider(ctx context.Context, name string) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: connectorActorPrefix + name,
+	})
+	if _, stamped := principal.CorrelationID(ctx); stamped {
+		return ctx
+	}
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -48,6 +48,9 @@ type runsEnv struct {
 	// gated on visibility was gated on nothing at all.
 	theirsInBook ids.PersonID
 	owner        *pgx.Conn
+	// provider is the vendor this environment's connection and adapter are
+	// for, so a test can name it without restating the fixture's choice.
+	provider string
 	// enqueued counts durable hand-offs, so a test can prove one happened.
 	enqueued int
 	// vault and fake are the store's own instances, exposed so the execution
@@ -133,10 +136,10 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 	if err := owner.QueryRow(ctx, `
 		INSERT INTO provider_connection
 		       (id, provider, status, mode, preset, categories, daily_run_limit)
-		VALUES ($1, 'surfe', 'connected', 'automatic_on_create', 'full',
+		VALUES ($1, $2, 'connected', 'automatic_on_create', 'full',
 		        ARRAY['professional_email','mobile'], NULL)
 		ON CONFLICT (provider) DO UPDATE SET status = 'connected'
-		RETURNING id`, ids.NewV7()).Scan(&connID); err != nil {
+		RETURNING id`, ids.NewV7(), cfg.providerOf()).Scan(&connID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx,
@@ -167,7 +170,8 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 	// would go on writing into the database the NEXT test just reset.
 	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 
-	e.fake = NewOfflineProvider(0, time.Now)
+	e.provider = cfg.providerOf()
+	e.fake = NewOfflineProvider(0, time.Now).Named(e.provider)
 	reg, err := NewRegistry(e.fake)
 	if err != nil {
 		t.Fatal(err)
@@ -184,7 +188,9 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		},
 		nil,
 		func(context.Context, pgx.Tx, string) (provider.PersonIdentifiers, error) {
-			return provider.PersonIdentifiers{FirstName: "Anna", LastName: "Muster", CompanyName: "Example"}, nil
+			return provider.PersonIdentifiers{
+				FirstName: "Anna", LastName: cfg.subjectOf(), CompanyName: "Example",
+			}, nil
 		},
 	)
 	if !cfg.withoutEnqueue {
@@ -219,6 +225,31 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 type runsConfig struct {
 	ceilings       map[string]int
 	withoutEnqueue bool
+	// subjectLastName picks the fake's scenario, which it reads out of the
+	// subject's name. Empty means Muster, which succeeds.
+	subjectLastName string
+	// provider names the vendor this environment's connection and adapter are
+	// for. Empty means surfe, which is what almost every test wants; a test
+	// asserting that something is derived FROM the run sets it, because a
+	// fixture carrying one name cannot tell derivation from a hard-coded
+	// constant that happens to match.
+	provider string
+}
+
+// subjectOf is the last name the fake is asked about.
+func (c runsConfig) subjectOf() string {
+	if c.subjectLastName == "" {
+		return "Muster"
+	}
+	return c.subjectLastName
+}
+
+// providerOf is the vendor an environment runs as.
+func (c runsConfig) providerOf() string {
+	if c.provider == "" {
+		return "surfe"
+	}
+	return c.provider
 }
 
 // The defect: QueueRun checked the role grant but never the row scope, so a

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -194,12 +194,13 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (39)
+## Prohibition (40)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
+| `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |
 | `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |
 | `dealforecastmovement_test.go` | H2 | A deal row changes through one door, and that door records the forecast. |


### PR DESCRIPTION
Closes #2843.

## What was wrong

`providerJobActor` bound every provider run's principal to the literal `connector:surfe`, whichever provider the run was actually for. Both the submit worker and the poll worker used it.

The claim rows were already correct — `people.WriteProviderClaims` derives `captured_by` as `'connector:' || provider` from the run's own provider. Only the **audit actor** was wrong, so with a second provider connected the audit log and the evidence on the record would name different vendors for one purchase. An audit entry that names the wrong actor is worse than a missing one, because it reads as authoritative.

## Why the fix is where it is

The workers cannot know. The submit worker holds a run id; the poll sweep drains many runs at once. A principal bound out there can only ever name a vendor it guessed — and it guessed the one provider that could exist while `provider_connection`, `provider_run` and `person_provider_claim` each carried a `CHECK` pinning them to a single name. Those constraints have been dropped.

The store already resolves the provider before it does anything else with a run, at all three entry points (`ExecuteSubmit`, `pollOne`, `recoverClaims`), so it narrows the actor there — `actingForProvider`, in `integrations`, spelling the id with the same `connector:` prefix the claim rows carry, so a reader joining the two sees one name.

Compose keeps binding a principal, for the reason it was added: without an actor the hand-off refused with "no actor bound to context" and every polled run stayed `in_progress` forever, paid for and reaching nobody. It now names the **worker** rather than a vendor, so it cannot be mistaken for one if a path ever reaches a gated write before resolving a provider.

## What holds it

**`TestNoPrincipalNamesAConnectorInAStringLiteral`** — no principal anywhere in the tree may take a `connector:` id from a string literal. This needs a gate rather than just a fix: a literal is not a bug until there are two, nothing failed while one vendor was the only one, and the disagreement appears for the first time on the first installation to connect a second. The census reads the ID **field** rather than the file's strings (`connector:` also appears in provenance writers, prefix tests and SQL, none of which binds an actor), and resolves the principal package through `gatekit.ImportedAs` so an alias reads the same.

`connector:finance` is waived with its reason: it is the finance mirror's own name, not a vendor's — one ledger sweep per installation, with nothing to read a name from. `AssertAllMatched` keeps that honest.

**`TestARunAuditsTheProviderItIsFor`** — drives a run for a vendor that is deliberately **not** `surfe`, because a fixture carrying the one name cannot tell a derived answer from a constant that happens to match it. That required teaching the offline fake to stand in for another vendor (`Named`) and the runs fixture to seed its connection for it.

Mutation-checked: restoring the hard-coded actor at either layer fails the integration test naming the wrong actor, and writing a literal into `actingForProvider` fails the gate.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider-run activity now uses the correct provider-specific connector identity for audit records.
  - Multi-provider integration runs can be configured and tracked independently.
  - Offline providers can be assigned custom provider names.

- **Bug Fixes**
  - Improved attribution for integration actions, polling, claim handoffs, submissions, and refusal events.
  - Removed provider-specific constraints that could prevent valid connector configurations.

- **Documentation**
  - Updated the changelog and gate inventory to reflect the new connector attribution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->