### PR TITLE
A provider name the contract cannot carry is refused at registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,6 +476,19 @@ numbers appear here when releases start.
 
 ### Fixed
 
+- **A provider name the contract cannot carry is refused at registration.** The
+  API publishes `Provider` as a pattern-constrained string — a pattern rather
+  than an enum, because which providers exist is a deployment fact — and nothing
+  enforced it where a name enters the system: the registry asked only that a
+  name be non-empty and unique, and the database CHECK that pinned it to one
+  vendor is gone. An adapter called `Acme-Data` would have registered, written
+  rows, and been serialized into responses that violate the published schema,
+  with the failure surfacing at a client that validates rather than at the
+  author who chose the name. A gate compares the registry's rule against the
+  contract's own, so the two cannot drift. The same rule now holds at the
+  messaging-transport registry, whose names the contract publishes the same way
+  under `ProviderRef`; three test fixtures were already named with hyphens.
+
 - **A provider run's audit actor names the provider it is for.** Every run was
   audited as `connector:surfe`, whichever vendor it actually belonged to,
   because the workers that execute a run hold a run id and the poll sweep drains

--- a/backend/gates/providername_test.go
+++ b/backend/gates/providername_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The rule a provider name must satisfy is the CONTRACT's, spelled once.
+//
+// `Provider` is published as a pattern-constrained string rather than an enum,
+// because which providers exist is a deployment fact — what this binary
+// composed — and an enum would assert the legal set is identical everywhere.
+// A pattern in a schema is not enforcement, though: the registry admitted any
+// non-empty unique name, so an adapter called `Acme-Data` would register, write
+// rows, and be serialized into a response that violates the published schema.
+//
+// The registry checks it now, against a Go spelling of the same pattern. Two
+// spellings of one rule drift, and this drift would be silent in the direction
+// that matters: a Go pattern LOOSER than the contract admits names the schema
+// refuses, which is the defect the check exists to remove, and it would be
+// invisible until a client validated a response.
+//
+// So the two are compared as text. The contract is parsed rather than
+// pattern-matched: rewriting the schema block-style changes nothing about it,
+// and a regex over the raw file would walk onto another schema's constraints
+// and report a confident wrong answer about a rule it was no longer reading.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// providerNameContract is where the published rule lives.
+const providerNameContract = "api/crm.yaml"
+
+// TestTheProviderNameRuleIsTheContractsOwn is the parity check.
+func TestTheProviderNameRuleIsTheContractsOwn(t *testing.T) {
+	t.Parallel()
+	pattern, maxLength := publishedProviderNameRule(t)
+	if pattern != provider.NamePattern {
+		t.Errorf("the contract publishes provider names as %s and the registry admits %s — a Go pattern looser than "+
+			"the contract registers an adapter whose name the schema refuses, and nothing says so until a client "+
+			"validates a response",
+			pattern, provider.NamePattern)
+	}
+	if maxLength != provider.NameMaxLength {
+		t.Errorf("the contract caps a provider name at %d characters and the registry at %d",
+			maxLength, provider.NameMaxLength)
+	}
+}
+
+// publishedProviderNameRule reads the Provider schema's own constraints.
+func publishedProviderNameRule(t *testing.T) (pattern string, maxLength int) {
+	t.Helper()
+	document, err := os.ReadFile(providerNameContract)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var contract struct {
+		Components struct {
+			// Type is `any`: schemas elsewhere in this document declare
+			// theirs as a LIST, and a reader typed to a string fails on
+			// the whole file rather than on the one schema it is about.
+			Schemas map[string]struct {
+				Type    any    `yaml:"type"`
+				Pattern string `yaml:"pattern"`
+				//nolint:tagliatelle // The key is OpenAPI's, and this reads the document as written.
+				MaxLength int `yaml:"maxLength"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(document, &contract); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	schema, declared := contract.Components.Schemas["Provider"]
+	if !declared {
+		t.Fatal("the contract declares no Provider schema: this gate compares the registry's name rule against " +
+			"that schema's own, so it now certifies nothing")
+	}
+	if schema.Pattern == "" || schema.MaxLength == 0 {
+		t.Fatalf("the Provider schema declares pattern %q and maxLength %d — a rule this gate cannot read is one "+
+			"it cannot hold the registry to, and an empty comparison passes",
+			schema.Pattern, schema.MaxLength)
+	}
+	return schema.Pattern, schema.MaxLength
+}
+
+// TestTheProviderNameRuleAdmitsWhatTheContractDoes is the rule itself,
+// exercised on the shapes an extension author actually reaches for.
+func TestTheProviderNameRuleAdmitsWhatTheContractDoes(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name    string
+		admits  bool
+		because string
+	}{
+		{name: "surfe", admits: true, because: "the shape every name has today"},
+		{name: "acme_data", admits: true, because: "an underscore is how a two-word vendor is spelled"},
+		{name: "vendor2", admits: true, because: "a digit after the first character"},
+		{name: "Acme-Data", admits: false, because: "a capital and a hyphen, the shape the issue names"},
+		{name: "ACME", admits: false, because: "capitals"},
+		{name: "2vendor", admits: false, because: "a leading digit"},
+		{name: "acme data", admits: false, because: "a space"},
+		{name: "acme.data", admits: false, because: "a dot"},
+		{name: "", admits: false, because: "no name at all"},
+		{name: strings.Repeat("a", provider.NameMaxLength), admits: true, because: "exactly the ceiling"},
+		{name: strings.Repeat("a", provider.NameMaxLength+1), admits: false, because: "one over the ceiling"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := provider.ValidName(c.name); got != c.admits {
+				t.Errorf("ValidName(%q) = %v, want %v — %s", c.name, got, c.admits, c.because)
+			}
+		})
+	}
+}

--- a/backend/gates/providername_test.go
+++ b/backend/gates/providername_test.go
@@ -5,20 +5,28 @@
 
 package gates
 
-// The rule a provider name must satisfy is the CONTRACT's, spelled once.
+// The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces
+// that have one.
 //
-// `Provider` is published as a pattern-constrained string rather than an enum,
-// because which providers exist is a deployment fact — what this binary
-// composed — and an enum would assert the legal set is identical everywhere.
-// A pattern in a schema is not enforcement, though: the registry admitted any
-// non-empty unique name, so an adapter called `Acme-Data` would register, write
-// rows, and be serialized into a response that violates the published schema.
+// `Provider` (a licensed data vendor) and `ProviderRef` (a messaging
+// transport) are both published as pattern-constrained strings rather than
+// enums, because which of either exists is a deployment fact — what this binary
+// composed — and an enum would assert the legal set is identical everywhere. A
+// pattern in a schema is not enforcement, though: each registry admitted any
+// non-empty unique name, so one called `Acme-Data` would register, write rows,
+// and be serialized into a response that violates the published schema.
 //
-// The registry checks it now, against a Go spelling of the same pattern. Two
+// Each registry checks its own now, against a Go spelling of the pattern. Two
 // spellings of one rule drift, and this drift would be silent in the direction
 // that matters: a Go pattern LOOSER than the contract admits names the schema
 // refuses, which is the defect the check exists to remove, and it would be
 // invisible until a client validated a response.
+//
+// TWO RULES, not one shared constant, because they are two schemas. The shapes
+// are identical today and a transport is not a data vendor: one of them can
+// gain a character the other must not, and a single constant would carry that
+// change to a surface nobody argued it for. What this gate holds is that each
+// matches ITS OWN schema.
 //
 // So the two are compared as text. The contract is parsed rather than
 // pattern-matched: rewriting the schema block-style changes nothing about it,
@@ -32,30 +40,44 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
 
 // providerNameContract is where the published rule lives.
 const providerNameContract = "api/crm.yaml"
 
-// TestTheProviderNameRuleIsTheContractsOwn is the parity check.
-func TestTheProviderNameRuleIsTheContractsOwn(t *testing.T) {
+// TestEveryRegisteredNameRuleIsTheContractsOwn is the parity check.
+func TestEveryRegisteredNameRuleIsTheContractsOwn(t *testing.T) {
 	t.Parallel()
-	pattern, maxLength := publishedProviderNameRule(t)
-	if pattern != provider.NamePattern {
-		t.Errorf("the contract publishes provider names as %s and the registry admits %s — a Go pattern looser than "+
-			"the contract registers an adapter whose name the schema refuses, and nothing says so until a client "+
-			"validates a response",
-			pattern, provider.NamePattern)
-	}
-	if maxLength != provider.NameMaxLength {
-		t.Errorf("the contract caps a provider name at %d characters and the registry at %d",
-			maxLength, provider.NameMaxLength)
+	for _, rule := range []struct {
+		schema    string
+		what      string
+		pattern   string
+		maxLength int
+	}{
+		{schema: "Provider", what: "a licensed data provider", pattern: provider.NamePattern, maxLength: provider.NameMaxLength},
+		{schema: "ProviderRef", what: "a messaging transport", pattern: connector.NamePattern, maxLength: connector.NameMaxLength},
+	} {
+		t.Run(rule.schema, func(t *testing.T) {
+			t.Parallel()
+			pattern, maxLength := publishedNameRule(t, rule.schema)
+			if pattern != rule.pattern {
+				t.Errorf("the contract publishes %s as %s and its registry admits %s — a Go pattern looser than "+
+					"the contract registers a name the schema refuses, and nothing says so until a client "+
+					"validates a response",
+					rule.what, pattern, rule.pattern)
+			}
+			if maxLength != rule.maxLength {
+				t.Errorf("the contract caps the name of %s at %d characters and its registry at %d",
+					rule.what, maxLength, rule.maxLength)
+			}
+		})
 	}
 }
 
-// publishedProviderNameRule reads the Provider schema's own constraints.
-func publishedProviderNameRule(t *testing.T) (pattern string, maxLength int) {
+// publishedNameRule reads one schema's own constraints.
+func publishedNameRule(t *testing.T, schemaName string) (pattern string, maxLength int) {
 	t.Helper()
 	document, err := os.ReadFile(providerNameContract)
 	if err != nil {
@@ -77,22 +99,23 @@ func publishedProviderNameRule(t *testing.T) (pattern string, maxLength int) {
 	if err := yaml.Unmarshal(document, &contract); err != nil {
 		t.Fatalf("parsing the contract: %v", err)
 	}
-	schema, declared := contract.Components.Schemas["Provider"]
+	schema, declared := contract.Components.Schemas[schemaName]
 	if !declared {
-		t.Fatal("the contract declares no Provider schema: this gate compares the registry's name rule against " +
-			"that schema's own, so it now certifies nothing")
+		t.Fatalf("the contract declares no %s schema: this gate compares a registry's name rule against that "+
+			"schema's own, so it now certifies nothing", schemaName)
 	}
 	if schema.Pattern == "" || schema.MaxLength == 0 {
-		t.Fatalf("the Provider schema declares pattern %q and maxLength %d — a rule this gate cannot read is one "+
-			"it cannot hold the registry to, and an empty comparison passes",
-			schema.Pattern, schema.MaxLength)
+		t.Fatalf("the %s schema declares pattern %q and maxLength %d — a rule this gate cannot read is one it "+
+			"cannot hold a registry to, and an empty comparison passes",
+			schemaName, schema.Pattern, schema.MaxLength)
 	}
 	return schema.Pattern, schema.MaxLength
 }
 
-// TestTheProviderNameRuleAdmitsWhatTheContractDoes is the rule itself,
-// exercised on the shapes an extension author actually reaches for.
-func TestTheProviderNameRuleAdmitsWhatTheContractDoes(t *testing.T) {
+// TestARegisteredNameRuleAdmitsWhatTheContractDoes is the rule itself,
+// exercised on the shapes an extension author actually reaches for. Both
+// spellings are checked, so a change to one is not assumed of the other.
+func TestARegisteredNameRuleAdmitsWhatTheContractDoes(t *testing.T) {
 	t.Parallel()
 	for _, c := range []struct {
 		name    string
@@ -114,7 +137,10 @@ func TestTheProviderNameRuleAdmitsWhatTheContractDoes(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			if got := provider.ValidName(c.name); got != c.admits {
-				t.Errorf("ValidName(%q) = %v, want %v — %s", c.name, got, c.admits, c.because)
+				t.Errorf("provider.ValidName(%q) = %v, want %v — %s", c.name, got, c.admits, c.because)
+			}
+			if got := connector.ValidName(c.name); got != c.admits {
+				t.Errorf("connector.ValidName(%q) = %v, want %v — %s", c.name, got, c.admits, c.because)
 			}
 		})
 	}

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -108,9 +108,15 @@ func (r *Registry) WithProgressPacing(d time.Duration) *Registry {
 // Register adds one connector at composition time.
 func (r *Registry) Register(c connector.Connector) {
 	desc := c.Descriptor()
-	if desc.Name == "" {
+	// The name reaches a client as `ProviderRef`, which the contract publishes
+	// under a pattern. A transport whose name the schema refuses would capture
+	// activities, bind identities and be serialized into responses that fail
+	// validation — for an extension author, a unit that works locally and
+	// breaks for anybody who checks.
+	if !connector.ValidName(desc.Name) {
 		//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
-		panic("capture: registering a connector with no name")
+		panic(fmt.Sprintf("capture: connector name %q is not one the contract can carry (%s, at most %d characters): lower-case letters, digits and underscores, starting with a letter",
+			desc.Name, connector.NamePattern, connector.NameMaxLength))
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/backend/internal/modules/capture/registry_internal_test.go
+++ b/backend/internal/modules/capture/registry_internal_test.go
@@ -5,6 +5,7 @@ package capture
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
@@ -94,13 +95,13 @@ func (f fakeMailConnector) SendEmail(context.Context, connector.Auth, connector.
 // answer, with no second marker to keep in sync.
 func TestChannelProvidersReportsOnlyMessageSenderConnectors(t *testing.T) {
 	r := NewRegistry(nil, nil, nil, nil)
-	r.Register(fakeChannelConnector{name: "fake-channel"})
-	r.Register(fakeMailConnector{name: "fake-mail"})
+	r.Register(fakeChannelConnector{name: "fake_channel"})
+	r.Register(fakeMailConnector{name: "fake_mail"})
 
 	got := r.ChannelProviders()
 
-	if len(got) != 1 || got[0] != "fake-channel" {
-		t.Fatalf("ChannelProviders() = %v, want [fake-channel]", got)
+	if len(got) != 1 || got[0] != "fake_channel" {
+		t.Fatalf("ChannelProviders() = %v, want [fake_channel]", got)
 	}
 }
 
@@ -108,13 +109,13 @@ func TestChannelProvidersReportsOnlyMessageSenderConnectors(t *testing.T) {
 // spurious churn from Go's randomized map iteration order.
 func TestChannelProvidersIsSorted(t *testing.T) {
 	r := NewRegistry(nil, nil, nil, nil)
-	r.Register(fakeChannelConnector{name: "zzz-channel"})
-	r.Register(fakeChannelConnector{name: "aaa-channel"})
+	r.Register(fakeChannelConnector{name: "zzz_channel"})
+	r.Register(fakeChannelConnector{name: "aaa_channel"})
 
 	got := r.ChannelProviders()
 
-	if len(got) != 2 || got[0] != "aaa-channel" || got[1] != "zzz-channel" {
-		t.Fatalf("ChannelProviders() = %v, want sorted [aaa-channel zzz-channel]", got)
+	if len(got) != 2 || got[0] != "aaa_channel" || got[1] != "zzz_channel" {
+		t.Fatalf("ChannelProviders() = %v, want sorted [aaa_channel zzz_channel]", got)
 	}
 }
 
@@ -126,5 +127,35 @@ func TestChannelProvidersOnAnEmptyRegistry(t *testing.T) {
 
 	if got := r.ChannelProviders(); len(got) != 0 {
 		t.Fatalf("ChannelProviders() on an empty registry = %v, want empty", got)
+	}
+}
+
+// TestRegisteringATransportTheContractCannotNameIsRefused holds the other half
+// of the name rule at its own door.
+//
+// A transport name reaches a client as `ProviderRef`, which the contract
+// publishes under a pattern. One the schema refuses would capture activities,
+// bind identities and be serialized into responses that fail validation — an
+// extension unit that works locally and breaks for anybody who checks, with
+// the failure surfacing far from the author who chose the name.
+//
+// A panic rather than an error because registration is composition-time, like
+// its two siblings here: a build that cannot state its own surface should not
+// start.
+func TestRegisteringATransportTheContractCannotNameIsRefused(t *testing.T) {
+	for _, name := range []string{"", "fake-channel", "FakeChannel", "2fake", "fake channel"} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				refusal, refused := recover().(string)
+				if !refused {
+					t.Fatalf("a connector named %q registered, and the contract publishes transport names as %s",
+						name, connector.NamePattern)
+				}
+				if !strings.Contains(refusal, connector.NamePattern) {
+					t.Errorf("the refusal of %q does not say what a legal name looks like: %s", name, refusal)
+				}
+			}()
+			NewRegistry(nil, nil, nil, nil).Register(fakeChannelConnector{name: name})
+		})
 	}
 }

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -38,6 +38,17 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 		if d.Name == "" {
 			return nil, errors.New("integrations: an adapter declared no provider name")
 		}
+		// The name is the discriminator on every row this provider's runs
+		// touch, the provenance on the values they buy, and a field the API
+		// publishes under a pattern. An adapter refused here is one whose
+		// author finds out now, rather than through a client that validates
+		// responses and reports a schema breach far from the cause.
+		if !provider.ValidName(d.Name) {
+			return nil, fmt.Errorf(
+				"integrations: provider name %q is not one the contract can carry (%s, at most %d characters): "+
+					"lower-case letters, digits and underscores, starting with a letter",
+				d.Name, provider.NamePattern, provider.NameMaxLength)
+		}
 		if _, dup := r.adapters[d.Name]; dup {
 			return nil, fmt.Errorf("integrations: provider %q registered twice", d.Name)
 		}

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -35,14 +35,15 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 	r := &Registry{adapters: map[string]provider.Adapter{}}
 	for _, a := range adapters {
 		d := a.Descriptor()
-		if d.Name == "" {
-			return nil, errors.New("integrations: an adapter declared no provider name")
-		}
 		// The name is the discriminator on every row this provider's runs
 		// touch, the provenance on the values they buy, and a field the API
 		// publishes under a pattern. An adapter refused here is one whose
 		// author finds out now, rather than through a client that validates
 		// responses and reports a schema breach far from the cause.
+		//
+		// No name at all goes through the same door: it is one of the names
+		// the contract cannot carry, and a caller who gets a different
+		// sentence for it has to be told the rule twice.
 		if !provider.ValidName(d.Name) {
 			return nil, fmt.Errorf(
 				"integrations: provider name %q is not one the contract can carry (%s, at most %d characters): "+

--- a/backend/internal/modules/integrations/registryname_test.go
+++ b/backend/internal/modules/integrations/registryname_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// A provider name the contract cannot carry is refused where the adapter
+// enters, not where a client validates a response.
+//
+// The name is the discriminator on every row a run touches, the provenance on
+// the values it buys, and a field published under a pattern. Until this check
+// existed, an adapter called `Acme-Data` registered, wrote rows, and was
+// serialized into responses that violate the schema — a build that works
+// locally and breaks for any client that checks, with the failure surfacing
+// far from the author who chose the name.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+func TestARegisteredProviderIsNamedTheWayTheContractPublishesIt(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name      string
+		registers bool
+	}{
+		{name: "surfe", registers: true},
+		{name: "acme_data", registers: true},
+		{name: "Acme-Data", registers: false},
+		{name: "ACME", registers: false},
+		{name: "2vendor", registers: false},
+		{name: strings.Repeat("a", provider.NameMaxLength+1), registers: false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			// The real descriptor with ONLY the name changed: every other
+			// field is one the registry already accepts, so a refusal here is
+			// about the name and nothing else.
+			_, err := NewRegistry(renamed{
+				Adapter: NewOfflineProvider(0, time.Now), name: c.name,
+			})
+			switch {
+			case c.registers && err != nil:
+				t.Errorf("a provider named %q was refused: %v", c.name, err)
+			case !c.registers && err == nil:
+				t.Errorf("a provider named %q registered, and the contract publishes provider names as %s — "+
+					"its rows and its responses would carry a value the schema refuses",
+					c.name, provider.NamePattern)
+			case !c.registers && !strings.Contains(err.Error(), provider.NamePattern):
+				t.Errorf("the refusal of %q does not say what a legal name looks like: %v", c.name, err)
+			}
+		})
+	}
+}
+
+// renamed is the shipped fake wearing a different name.
+//
+// A stub descriptor written here would prove the check runs against a shape
+// nothing ships; this proves it runs against the real one, which is what an
+// extension author's adapter will look like in every respect but its name.
+type renamed struct {
+	provider.Adapter
+	name string
+}
+
+func (r renamed) Descriptor() provider.Descriptor {
+	d := r.Adapter.Descriptor()
+	d.Name = r.name
+	return d
+}

--- a/backend/internal/modules/integrations/registryname_test.go
+++ b/backend/internal/modules/integrations/registryname_test.go
@@ -29,6 +29,9 @@ func TestARegisteredProviderIsNamedTheWayTheContractPublishesIt(t *testing.T) {
 	}{
 		{name: "surfe", registers: true},
 		{name: "acme_data", registers: true},
+		{name: "vendor2", registers: true},
+		{name: strings.Repeat("a", provider.NameMaxLength), registers: true},
+		{name: "", registers: false},
 		{name: "Acme-Data", registers: false},
 		{name: "ACME", registers: false},
 		{name: "2vendor", registers: false},

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -99,7 +99,10 @@ type GrantedScoper interface {
 
 // Descriptor — declared capabilities; ⊆ the granting human's scopes.
 type Descriptor struct {
-	Name     string // stable id: "gmail", "gcal", "hubspot", "coldstart-scrape"
+	// Name is the stable id: "gmail", "gcal", "imap". Lower-case letters,
+	// digits and underscores, starting with a letter — the shape the contract
+	// publishes as ProviderRef, held by ValidName at registration.
+	Name     string
 	Version  string
 	Scopes   []principal.Scope
 	RiskTier mcp.RiskTier // capture/read = auto_execute; any outbound = confirmation_required

--- a/backend/internal/shared/ports/connector/name.go
+++ b/backend/internal/shared/ports/connector/name.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package connector
+
+// What a messaging transport may be called.
+//
+// The name is the discriminator on every activity a transport captures, the
+// `connector:<name>` provenance on what it writes, the key a reply path
+// resolves a recipient through, and a value the API publishes as
+// `ProviderRef` — a pattern-constrained string rather than an enum, because
+// which transports exist is a deployment fact including any extension unit
+// present.
+//
+// A name the pattern refuses reaches a client as a response the schema refuses.
+// So the check belongs where a transport ENTERS the registry: an extension
+// author with an illegal name is told at composition time, rather than through
+// a client that validates and reports a breach far from the cause.
+//
+// SEPARATE from provider.ValidName, which governs licensed DATA providers under
+// the `Provider` schema. The two rules are identical today and are two schemas
+// on purpose: a transport and a data vendor are different things, and one of
+// them can gain a character the other must not.
+//
+// Held by: TestEveryRegisteredNameRuleIsTheContractsOwn
+// (backend/gates/providername_test.go)
+
+import "regexp"
+
+const (
+	// NamePattern is the shape a transport name must have, spelled exactly as
+	// the contract spells it so a gate can compare the two as text.
+	NamePattern = `^[a-z][a-z0-9_]*$`
+	// NameMaxLength is the ceiling the contract publishes.
+	NameMaxLength = 32
+)
+
+// nameRe is NamePattern compiled once.
+var nameRe = regexp.MustCompile(NamePattern)
+
+// ValidName reports whether a name is one the contract can carry.
+func ValidName(name string) bool {
+	return len(name) <= NameMaxLength && nameRe.MatchString(name)
+}

--- a/backend/internal/shared/ports/provider/name.go
+++ b/backend/internal/shared/ports/provider/name.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package provider
+
+// What a provider may be called.
+//
+// The name is not decoration: it is the discriminator on every row a run
+// touches, the `connector:<name>` provenance on the values it buys, and a value
+// the API publishes as a pattern-constrained string. It is a pattern rather
+// than an enum because which providers exist is a deployment fact — what this
+// binary composed — and an enum would assert that the legal set is identical in
+// every installation.
+//
+// Nothing enforced it where a name ENTERS the system. The database CHECK that
+// pinned the value to one provider is gone so a second can exist, and the
+// registry asked only that the name be non-empty and unique — so an adapter
+// called `Acme-Data` or `ACME` would register, write rows, and be serialized
+// into a response that violates the schema the product publishes. The failure
+// surfaces at a client that validates, far from the author who chose the name.
+//
+// Held by: TestTheProviderNameRuleIsTheContractsOwn
+// (backend/gates/providername_test.go)
+
+import "regexp"
+
+const (
+	// NamePattern is the shape a provider name must have, spelled exactly as
+	// the contract spells it so a gate can compare the two as text.
+	NamePattern = `^[a-z][a-z0-9_]*$`
+	// NameMaxLength is the ceiling the contract publishes.
+	NameMaxLength = 32
+)
+
+// nameRe is NamePattern compiled once.
+var nameRe = regexp.MustCompile(NamePattern)
+
+// ValidName reports whether a name is one the contract can carry.
+func ValidName(name string) bool {
+	return len(name) <= NameMaxLength && nameRe.MatchString(name)
+}

--- a/backend/internal/shared/ports/provider/name.go
+++ b/backend/internal/shared/ports/provider/name.go
@@ -12,14 +12,12 @@ package provider
 // binary composed — and an enum would assert that the legal set is identical in
 // every installation.
 //
-// Nothing enforced it where a name ENTERS the system. The database CHECK that
-// pinned the value to one provider is gone so a second can exist, and the
-// registry asked only that the name be non-empty and unique — so an adapter
-// called `Acme-Data` or `ACME` would register, write rows, and be serialized
-// into a response that violates the schema the product publishes. The failure
-// surfaces at a client that validates, far from the author who chose the name.
+// A name the pattern refuses reaches a client as a response the schema refuses,
+// so the check belongs where a name ENTERS the system: an adapter with an
+// illegal name is one whose author is told now, rather than through a client
+// that validates and reports a breach far from the cause.
 //
-// Held by: TestTheProviderNameRuleIsTheContractsOwn
+// Held by: TestEveryRegisteredNameRuleIsTheContractsOwn
 // (backend/gates/providername_test.go)
 
 import "regexp"

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -61,7 +61,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `outboundidentity_test.go` | H1 | A remote operator sees one name for this product and decides about it: blocks it, rate-limits it, allow-lists it, or writes a robots.txt group naming it. |
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
-| `providername_test.go` | H2 | The rule a provider name must satisfy is the CONTRACT's, spelled once. |
+| `providername_test.go` | H2 | The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces that have one. |
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -61,6 +61,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `outboundidentity_test.go` | H1 | A remote operator sees one name for this product and decides about it: blocks it, rate-limits it, allow-lists it, or writes a robots.txt group naming it. |
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
+| `providername_test.go` | H2 | The rule a provider name must satisfy is the CONTRACT's, spelled once. |
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (50)
+## Parity (51)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #2844.

## What was wrong

`Provider` is published as a pattern-constrained string:

```yaml
pattern: '^[a-z][a-z0-9_]*$'
maxLength: 32
```

A pattern rather than an enum, deliberately: which providers exist is a deployment fact — what this binary composed — so an enum would assert the legal set is identical in every installation.

Nothing enforced it where a name **enters** the system. `NewRegistry` asked only that `Descriptor.Name` be non-empty and unique, and the database `CHECK` that pinned the value to one vendor has been dropped so a second can exist. An adapter called `Acme-Data` or `ACME` would register, write rows, and be serialized into responses that violate the schema the product publishes — a build that works locally and breaks for any client that validates, with the failure surfacing far from the author who chose the name.

## The fix

`provider.ValidName` is the rule, spelled once beside the descriptor it governs, and `NewRegistry` refuses a name that fails it with a message saying what a legal one looks like rather than just that this one is not.

## Deriving it from one place

The generated Go carries no pattern, so the rule has to be spelled in Go — which means two spellings of one rule, and they drift. **This drift would be silent in the direction that matters**: a Go pattern *looser* than the contract registers an adapter whose name the schema refuses, which is exactly the defect the check exists to remove, and nothing would say so until a client validated a response.

`TestTheProviderNameRuleIsTheContractsOwn` compares them as text — the Go pattern against the `Provider` schema's `pattern`, and the Go ceiling against its `maxLength` — reading the contract by **parsing** it, not pattern-matching: rewriting the schema block-style changes nothing about it, and a regex over the raw file would walk onto another schema's constraints and report a confident wrong answer about a rule it was no longer reading. It refuses a contract it cannot read the rule out of, since an empty comparison passes.

## Tests

- `TestTheProviderNameRuleAdmitsWhatTheContractDoes` — the shapes an extension author reaches for: an underscore, a trailing digit, the ceiling exactly, one over it, and the `Acme-Data` / `ACME` / `2vendor` / space / dot cases.
- `TestARegisteredProviderIsNamedTheWayTheContractPublishesIt` — renames the **shipped** descriptor rather than writing a stub one, so what the check is proved against is the shape a real adapter has in every respect but its name. It also asserts the refusal names the pattern, so an author is told what to do.

Mutation-checked: loosening the Go pattern fails the parity gate naming both spellings; removing the check from `NewRegistry` fails four of the six registry cases.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent grants can renew when existing credentials no longer cover current tool scopes.
  * Provider runs now use provider-specific audit actors for clearer activity tracking.

* **Bug Fixes**
  * Provider and messaging-transport registration now enforce lowercase names with digits and underscores, beginning with a letter and limited to 32 bytes.
  * Invalid names are rejected with clearer validation feedback.

* **Tests**
  * Expanded coverage for valid, invalid, empty, and boundary-length names.

* **Documentation**
  * Updated the gate inventory and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->