### PR TITLE
A refusal the server has settled is asked once, not three times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,15 @@ numbers appear here when releases start.
 
 ### Fixed
 
+- **A refusal the server has settled is asked once, not three times.** The
+  retry policy retried every status at or above 500, which swept in `501 Not
+  Implemented` — a final answer, not a failure the server may recover from. An
+  installation with no embeddings model bound answers 501 to the reindex status
+  by design, so every reader of that surface produced three requests and three
+  console errors for one settled answer, which an operator scanning for a real
+  fault reads first. 501 and 505 are excluded now; their neighbours are still
+  retried.
+
 - **A provider name the contract cannot carry is refused at registration.** The
   API publishes `Provider` as a pattern-constrained string — a pattern rather
   than an enum, because which providers exist is a deployment fact — and nothing

--- a/frontend/src/app/queryclient.test.ts
+++ b/frontend/src/app/queryclient.test.ts
@@ -28,6 +28,23 @@ describe("the query retry policy", () => {
     expect(retryQuery(2, problem(503))).toBe(false);
   });
 
+  it("never retries a refusal the server has settled, however early", () => {
+    // Both are classed as server errors and neither is a failure the server
+    // may recover from: 501 does not support what was asked, 505 will not
+    // speak this version. A build reaches 501 deliberately — httperr answers
+    // it for a surface the contract specifies and this build does not wire —
+    // so a retry here is three requests and three console errors for one
+    // settled answer, read first by an operator looking for a real fault.
+    for (const status of [501, 505]) {
+      expect(retryQuery(0, problem(status)), String(status)).toBe(false);
+    }
+    // And the neighbours are still retried, so the exclusion is these two
+    // rather than a range that swallowed them.
+    for (const status of [500, 502, 503, 504]) {
+      expect(retryQuery(0, problem(status)), String(status)).toBe(true);
+    }
+  });
+
   it("never retries a client error, however early the failure", () => {
     for (const status of [400, 401, 403, 404, 409, 422, 429]) {
       expect(retryQuery(0, problem(status)), String(status)).toBe(false);

--- a/frontend/src/app/queryclient.ts
+++ b/frontend/src/app/queryclient.ts
@@ -18,6 +18,22 @@ const STALE_TIME_MS = 30_000;
 // own fault.
 const MAX_RETRIES = 2;
 
+// The 5xx statuses that are SETTLED rather than failed, and so are not retried.
+//
+// The 4xx/5xx split is the wrong seam for these two. Both are classed as server
+// errors and neither says the server failed trying: 501 says it does not
+// support what was asked, and 505 that it will not speak this version of the
+// protocol. Nothing about asking again changes either within a session, so a
+// retry buys three requests and three console errors where one would do — and
+// an operator reading the console for a real fault reads those first.
+//
+// 501 is not hypothetical here. httperr has a generated 501 path precisely so
+// a surface the contract specifies and this build does not implement refuses
+// cleanly instead of 500ing, which is a state this product reaches on purpose:
+// an installation with no embeddings model bound answers 501 to the reindex
+// status, every time it is asked.
+const SETTLED_SERVER_REFUSALS = new Set([501, 505]);
+
 // The RFC-7807 `status` a failure carries, or null when it carries none. Only
 // a ProblemError holds a server problem body, on the same terms as
 // problemCodeOf: a rejected fetch, or a query function that threw a plain
@@ -32,7 +48,8 @@ function problemStatusOf(error: unknown): number | null {
   return typeof problem.status === "number" ? problem.status : null;
 }
 
-// FE-PARAM-2: retry a server error, never a client error.
+// FE-PARAM-2: retry a server error that the server may yet recover from —
+// never a client error, and never a refusal it has already settled.
 export function retryQuery(failureCount: number, error: Error): boolean {
   const status = problemStatusOf(error);
   // A failure that carries no status is NOT retried, and that stays true now
@@ -43,7 +60,12 @@ export function retryQuery(failureCount: number, error: Error): boolean {
   // bug in a query function returns the same failure however often it is
   // asked. The error state that follows offers the reader a retry either way,
   // so nothing is lost but the silent second request.
-  return status !== null && status >= 500 && failureCount < MAX_RETRIES;
+  return (
+    status !== null &&
+    status >= 500 &&
+    !SETTLED_SERVER_REFUSALS.has(status) &&
+    failureCount < MAX_RETRIES
+  );
 }
 
 // FE-PARAM-4: the ONE place a query failure is reported. This installation


### PR DESCRIPTION
Closes #2906.

## What was wrong

`retryQuery` retried every response at or above 500:

```ts
return status !== null && status >= 500 && failureCount < MAX_RETRIES;
```

`501 Not Implemented` is in that range and is a **final** refusal — the server does not support what was asked, and no amount of asking again changes that within a session. With `MAX_RETRIES = 2`, each one costs three requests and three console errors where one would do.

The file's own header already said this is not what it is for. Among the library defaults this product replaces it lists *"retry a refusal the server has already made final"*. 501 is the case that slipped past it, because the 4xx/5xx split is the wrong seam for a status that is **classed** as a server error and **behaves** like a settled answer.

## Not one endpoint

`httperr` has a generated 501 path precisely so a surface the contract specifies and a build does not implement refuses cleanly rather than 500ing — a state this product reaches on purpose. An installation with no embeddings model bound answers 501 to `GET /embeddings/reindex/status` every time it is asked, and the console fills with three lines per read. Nothing a *reader* sees is wrong; an operator scanning for a real fault reads those first.

## The fix

`SETTLED_SERVER_REFUSALS` — 501 and 505. Both say the server **will not** do this rather than that it failed trying: 501 does not support what was asked, 505 will not speak this version of the protocol.

The test asserts both are refused at failure count zero **and** that 500, 502, 503 and 504 are still retried — so what landed is an exclusion of these two, not a range that swallowed them. Mutation-checked: removing the exclusion fails the case.

## Checks

`make check-fe` and `make check-backend` green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP retry behavior to stop retrying 501 and 505 server responses.
  * Other 5xx server errors remain eligible for retries.
  * Added coverage to verify retry behavior across supported server error statuses.

* **Documentation**
  * Documented the updated HTTP retry behavior in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->