### PR TITLE
fix(dev): the dev stack embeds through the broker it already pays for

### DIFF
--- a/config/margince.dev.yaml
+++ b/config/margince.dev.yaml
@@ -48,7 +48,18 @@ seeds:
       cheap_cloud: { provider: openai_compatible, model: openai/gpt-oss-120b, base_url: https://openrouter.ai/api }
       premium:     { provider: openai_compatible, model: anthropic/claude-haiku-4.5, base_url: https://openrouter.ai/api }
       frontier:    { provider: openai_compatible, model: anthropic/claude-sonnet-4.5, base_url: https://openrouter.ai/api }
+    # The embed lane rides the SAME broker key as the tiers above, so a dev
+    # stack needs one credential rather than two. It used to bind gemini here,
+    # which meant a fresh clone could not embed anything without a second
+    # provider's key — for nothing else, since every chat tier had already moved
+    # to the broker.
+    #
+    # 1024 is mistral-embed-2312's native width, which is what this provider
+    # requires — on openai_compatible the number is a declaration of what the
+    # model emits rather than a request for a width. Why, once:
+    # docs/how-to/connect-a-cloud-model-provider.md §3.
     embeddings:
-      provider: gemini
-      model: gemini-embedding-001
-      dimensions: 1536
+      provider: openai_compatible
+      model: mistralai/mistral-embed-2312
+      base_url: https://openrouter.ai/api
+      dimensions: 1024

--- a/docs/how-to/connect-a-cloud-model-provider.md
+++ b/docs/how-to/connect-a-cloud-model-provider.md
@@ -91,13 +91,17 @@ tiers:
 ## 3. Bind the embeddings lane separately
 
 The embedding lane is bound apart from the chat tiers so retrieval survives a
-chat-budget exhaustion. The shipped default is **gemini** (`gemini-embedding-001`,
-key from `GEMINI_API_KEY`) so the stack needs no local Ollama:
+chat-budget exhaustion. Bound apart does not mean bound elsewhere: the dev seed
+points it at the same broker the chat tiers use, so a stack needs ONE key rather
+than a second provider's purely for embeddings.
 
 ```yaml
-embeddings: { provider: gemini, model: gemini-embedding-001 }  # the default
-# embeddings: { provider: ollama, model: bge-m3 }              # fully-local alternative
-# embeddings: { provider: fake }                               # offline dev
+# the dev default — same broker and key as the chat tiers
+embeddings: { provider: openai_compatible, model: mistralai/mistral-embed-2312,
+              base_url: https://openrouter.ai/api, dimensions: 1024 }
+# embeddings: { provider: gemini, model: gemini-embedding-001 }  # native adapter, key from GEMINI_API_KEY
+# embeddings: { provider: ollama, model: bge-m3 }                # fully-local alternative
+# embeddings: { provider: fake }                                 # offline dev
 ```
 
 > The retrieval store's column is an unbounded **`vector`**, and `dimensions:`

--- a/docs/how-to/enrich-with-a-local-llm.md
+++ b/docs/how-to/enrich-with-a-local-llm.md
@@ -22,8 +22,9 @@ it too (`ollama pull mistral`) if enrich grounding is weak.
 
 ## 2. Point the AI lanes at Ollama
 
-A dev stack is bound to `gemini` on every tier (`seeds.ai_routing` in
-`config/margince.dev.yaml`), so **enrich needs one rebind**: point `local_small`
+A dev stack is bound to one broker over `openai_compatible` on every tier and on
+the embed lane (`seeds.ai_routing` in `config/margince.dev.yaml`), so **enrich
+needs one rebind**: point `local_small`
 — the first rung of `enrich`'s ladder (`local_small` → `cheap_cloud`) — at Ollama.
 
 On a running stack do it under **Settings → AI**, which takes effect immediately.
@@ -63,9 +64,10 @@ provider, not to leave one cloud tier unkeyed. Note the fake is a fallback: once
 the binding is servable it outranks the flag, so a stack that CAN reach its
 models never answers with canned text.
 
-The shipped default routing binds **gemini** on every tier, so out of the box you
-must either set `GEMINI_API_KEY`, or rebind the tiers you exercise to `ollama`
-(§2) for a fully local, no-key stack:
+The shipped dev routing binds every tier AND the embed lane to one broker over
+the `openai_compatible` adapter, so out of the box you must either set
+`OPENAI_COMPATIBLE_API_KEY`, or rebind the tiers you exercise to `ollama` (§2)
+for a fully local, no-key stack:
 
 ```sh
 make dev   # look for: "dev: the stored model binding serves the cold-start read-back (providers bound by …)"


### PR DESCRIPTION
The dev seed in `config/margince.dev.yaml` bound every chat tier to the broker and left the embed lane on gemini. A fresh clone therefore needed a **second** provider's key to embed anything — for nothing else, since no other lane used it. Without that key the boot printed "the AI lanes answer from the offline fake" and every embedding in the stack was a stub.

## What changed

The embed lane rides the same broker key as the tiers:

```yaml
embeddings:
  provider: openai_compatible
  model: mistralai/mistral-embed-2312
  base_url: https://openrouter.ai/api
  dimensions: 1024
```

`dimensions` must equal the model's native width here — on `openai_compatible` the adapter never sends the field, so the number declares what the model emits rather than requesting a width. The rule itself is stated once, in `docs/how-to/connect-a-cloud-model-provider.md` §3; the config comment points at it rather than restating it.

No script change was needed: `scripts/dev.sh` derives the keys it demands from the providers the seed actually names, so it stops asking for `GEMINI_API_KEY` on its own.

**Two how-to pages described the old binding and are corrected here**, since the same decision spelled in three places drifts until they disagree in front of a new engineer:

- `connect-a-cloud-model-provider.md` called gemini the shipped embed default and told the reader to set `GEMINI_API_KEY`.
- `enrich-with-a-local-llm.md` twice said a dev stack binds gemini on *every tier* — already false before this change, from when the chat tiers moved to the broker.

`config/margince.example.yaml` deliberately stays all-gemini: it illustrates the seed shape for any operator rather than binding this stack, and is internally consistent as written.

## Testing

Verified on a real fresh stack with `GEMINI_API_KEY` unset (`DEV_SLUG=seedcheck make dev-fresh`):

- Boot printed `dev: the stored model binding serves the cold-start read-back (providers bound by config/margince.dev.yaml: openai_compatible)` — previously "answers from the offline fake".
- The bootstrapped `setting` row carries `{"provider": "openai_compatible", "model": "mistralai/mistral-embed-2312", "dimensions": 1024}`.
- `GET /v1/embeddings/reindex/status` reports `openai_compatible/mistralai/mistral-embed-2312@1024`.
- A person created through `POST /v1/people` was embedded end to end and stored at width 1024.

Stack torn down afterwards. `make check-backend` lint clean across all modules; the two gate failures that remain are #3220 and reproduce on unmodified `origin/main`.

Reviewed by the repo's security and craftsmanship reviewers. Security: no findings. Craftsmanship: three findings, all fixed here — the two stale docs above, and a config comment that re-derived a rule the how-to already owns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated development embedding services to use the Mistral embedding model through OpenRouter.
  * Configured a 1024-dimensional embedding size.
  * Aligned embedding connectivity with the existing chat service endpoint.

* **Documentation**
  * Updated cloud provider guidance to describe OpenRouter embeddings and available alternatives.
  * Clarified local Ollama setup requirements, including embedding configuration for fully local deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->