### PR TITLE
docs: the manual describes the settings pages the product actually has

### DIFF
--- a/backend/internal/modules/knowledge/handbook/settings.md
+++ b/backend/internal/modules/knowledge/handbook/settings.md
@@ -100,9 +100,10 @@ Two cards.
 Invite, change role, deactivate, reactivate. Reading the roster is open to every
 user; managing it is administrators only.
 
-**Teams** — named groups you can share records with. Being in a team grants no
-access on its own: no shipped role is team-scoped, so a team matters when a
-record is shared with it.
+**Teams** — named groups you can share records with. Create one, archive it, and
+open a team to add or remove the users in it. Being in a team grants no access on
+its own: no shipped role is team-scoped, so a team matters when a record is
+shared with it.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md).
 
@@ -116,6 +117,27 @@ What the installation is wired to, as opposed to what one person connected.
   chosen events." Deliveries can be inspected and replayed.
 - **HubSpot mirror** — connecting an existing HubSpot portal in read-and-sync
   mode, and the one-way switch to running natively.
+
+## Extensions
+
+Every extension unit this installation was built with, and what each may reach.
+
+A unit is software composed into the installation at build time, not something
+installed from inside the app — so this page reports what is there rather than
+offering anything to add or remove. Each unit says what it is for, the version it
+declares, and the permission objects it registered.
+
+Those permission objects are the reason the page exists. A unit that owns records
+gates them on names no seeded role has ever heard of, so until somebody grants a
+role read on them, every seat opens the unit's screen and sees nothing. The
+switches here are that grant.
+
+A unit that registers no permission objects — a jurisdiction pack, for instance,
+which only supplies retention policy the core consults — is listed with nothing to
+grant, which is the correct and common answer.
+
+Admin only, and the admin role specifically: Ops administers the rest of this
+half of settings and not this page.
 
 ## Capture
 
@@ -217,10 +239,11 @@ See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
 | Page | Who |
 |---|---|
-| Account, Writing voice, Agents, Connections, Capture activity | every member |
+| Account, Writing voice, Agents, Connections, Capture activity | every user |
 | General, Users & teams, Integrations, Capture, Data model, AI, Knowledge, License, Maintenance | Admin or Ops |
 | Privacy & audit | Admin or Ops; the audit log and privacy inbox inside it are Admin only |
-| Job health, Reset data, member management, extension access | Admin only |
+| Extensions | Admin only — Ops does not reach it |
+| Job health, Reset data, user administration | Admin only |
 
 A few things sit outside the role system entirely and need the Admin role, full
 stop: user administration, privacy erasure, and reading the audit log.

--- a/docs/handbook/settings.md
+++ b/docs/handbook/settings.md
@@ -100,9 +100,10 @@ Two cards.
 Invite, change role, deactivate, reactivate. Reading the roster is open to every
 user; managing it is administrators only.
 
-**Teams** — named groups you can share records with. Being in a team grants no
-access on its own: no shipped role is team-scoped, so a team matters when a
-record is shared with it.
+**Teams** — named groups you can share records with. Create one, archive it, and
+open a team to add or remove the users in it. Being in a team grants no access on
+its own: no shipped role is team-scoped, so a team matters when a record is
+shared with it.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md).
 
@@ -116,6 +117,27 @@ What the installation is wired to, as opposed to what one person connected.
   chosen events." Deliveries can be inspected and replayed.
 - **HubSpot mirror** — connecting an existing HubSpot portal in read-and-sync
   mode, and the one-way switch to running natively.
+
+## Extensions
+
+Every extension unit this installation was built with, and what each may reach.
+
+A unit is software composed into the installation at build time, not something
+installed from inside the app — so this page reports what is there rather than
+offering anything to add or remove. Each unit says what it is for, the version it
+declares, and the permission objects it registered.
+
+Those permission objects are the reason the page exists. A unit that owns records
+gates them on names no seeded role has ever heard of, so until somebody grants a
+role read on them, every seat opens the unit's screen and sees nothing. The
+switches here are that grant.
+
+A unit that registers no permission objects — a jurisdiction pack, for instance,
+which only supplies retention policy the core consults — is listed with nothing to
+grant, which is the correct and common answer.
+
+Admin only, and the admin role specifically: Ops administers the rest of this
+half of settings and not this page.
 
 ## Capture
 
@@ -217,10 +239,11 @@ See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
 | Page | Who |
 |---|---|
-| Account, Writing voice, Agents, Connections, Capture activity | every member |
+| Account, Writing voice, Agents, Connections, Capture activity | every user |
 | General, Users & teams, Integrations, Capture, Data model, AI, Knowledge, License, Maintenance | Admin or Ops |
 | Privacy & audit | Admin or Ops; the audit log and privacy inbox inside it are Admin only |
-| Job health, Reset data, member management, extension access | Admin only |
+| Extensions | Admin only — Ops does not reach it |
+| Job health, Reset data, user administration | Admin only |
 
 A few things sit outside the role system entirely and need the Admin role, full
 stop: user administration, privacy erasure, and reading the audit log.

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -83,6 +83,12 @@ tier owner's review.
    	}
    }
    ```
+   **`Description` is required.** One sentence, at most 200 characters, saying what the unit is for.
+   The Extensions settings page lists every composed unit by it, and an admin deciding whether to
+   grant a unit's permissions has nothing else to go on — a card headed `de` and nothing more is what
+   this field exists to prevent. An empty or computed one fails `make gen`, not just the boot, so a
+   unit that omits it never reaches a deploy.
+
    **Import only `backend/pkg/**` packages carrying `//margince:extension-surface`** — `pkg/extension`,
    `pkg/extension/jurisdiction` and `pkg/extension/crm` today. Any import of `internal/**`, `cmd/**`, an
    unmarked `pkg` package, the composition module, or a sibling extension fails the arch test (the
@@ -402,7 +408,7 @@ Settings instead, on the page that already holds the kind of credential you aske
 
 | Your declaration | Where the unit is listed | What the page means |
 |---|---|---|
-| `Scope: extension.SecretScopeUser` | Settings → Connections | one member's own account somewhere; nobody else sees it |
+| `Scope: extension.SecretScopeUser` | Settings → Connections | one user's own account somewhere; nobody else sees it |
 | `Scope: extension.SecretScopeWorkspace` | Settings → Integrations | the installation's shared credential, curated by an operator |
 | no `Secrets` at all | nowhere | nothing to manage, so nothing to list; `#/ext/<name>` still routes |
 


### PR DESCRIPTION
Follow-up to #3189. That PR renamed the settings page and added a new one; the manual was left describing the old shape in three places.

## What was stale

**The Extensions page had no section at all.** It is a settings page an admin can open, listed in the sidebar between Integrations and Capture, and the handbook's per-page walkthrough went straight from Integrations to Capture. So the one page whose entire purpose is a decision nobody can make without an explanation — which role may reach an extension's records — was the one page with no explanation.

**The role table omitted it too**, and said "every member" where the product now says user. Extensions gets its own row rather than joining the "Admin or Ops" line, because it is the one admin page Ops cannot reach: the read behind it is `auth.RequireAdmin`, which admits the literal `admin` role only.

**The Teams card was described as fixed.** Membership became editable in #3189; the manual still implied you could only create and archive a team.

**The extension how-to never stated the `Description` rule.** Its example already carried the field, but nothing told an author it is required, how long it may be, or that an omitted one now fails `make gen` rather than waiting for a deploy to fail. Someone following that page would have written a unit that cannot boot and found out late.

## Verification

`make check-backend` green, including `backend/gates` in full — the handbook is embedded in the binary, so `TestTheEmbeddedHandbookMatchesTheDocs` covers both copies staying identical. Both edited pages are within their `docs-page-length` budgets.

Every claim in the new prose was checked against the code rather than written from memory: the sidebar position against `SETTINGS_TABS`, the admin-only gate against `settings.tsx` and `handlers_extensions.go`, and the 200-character cap against `maxDescriptionLength`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The manual now describes the settings pages as they actually exist after the Users & teams rename, and the extension how-to gains the missing `Description` rule.

- Adds a section for the Extensions settings page, covering permission switches and that only the Admin role reaches it.
- Updates the role table to list Extensions separately and uses "user" instead of "member".
- Corrects the Teams card to mention editing membership, not just creating and archiving.
- Documents `Description` as required (≤200 chars) and that omitting it fails `make gen`.

<sup>Written for commit 6d6d43e8dbcefb0c896c41f9bd16c1845d6dcee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded settings guidance for team creation, archiving, membership management, and extension administration.
  * Clarified role terminology and identified Extensions and user administration as Admin-only features.
  * Updated extension creation requirements: descriptions must be non-empty, literal, one sentence, and 200 characters or fewer.
  * Clarified documentation for user-scoped secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->