### PR TITLE
main is red: a technology lane that changed nothing announces nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,16 @@ numbers appear here when releases start.
 
 ### Fixed
 
+- **A technology lane announces an update only when something moved.** A
+  completed lane is worth an audit row whatever it found — it is what says when
+  the record was last looked at, and what lets a technology the company dropped
+  leave — but it emitted `organization.updated` even when nothing appeared,
+  moved or went. Both shapes are common: most companies' sites declare nothing
+  this build recognises, and most that do declare the same thing they declared
+  yesterday. Between them the lane produced a no-op event on nearly every read,
+  which every subscriber had to learn to ignore. A lane that REMOVES a stale
+  fact still announces, because that is a change.
+
 - **A refusal the server has settled is asked once, not three times.** The
   retry policy retried every status at or above 500, which swept in `501 Not
   Implemented` — a final answer, not a failure the server may recover from. An

--- a/backend/internal/modules/people/organizationtechnical.go
+++ b/backend/internal/modules/people/organizationtechnical.go
@@ -260,6 +260,20 @@ func (s *Store) auditTechnicalEnrichment(
 	if err != nil {
 		return fmt.Errorf("audit technical enrichment: %w", err)
 	}
+	// THE AUDIT ROW ALWAYS, THE EVENT ONLY ON A CHANGE. A lane that completed
+	// having found nothing is worth recording — it is what says when the record
+	// was last looked at, and it is what lets a technology the company dropped
+	// leave. It is not an UPDATE: nothing was written, nothing was removed, and
+	// organization.updated announcing an empty delta tells every subscriber a
+	// record moved when it did not.
+	//
+	// That is not a rare shape. Most companies' sites declare no technology this
+	// build recognises, so before this the homepage lane emitted a no-op event
+	// for nearly every site read in the installation, and each subscriber had to
+	// learn to ignore it.
+	if len(written) == 0 && len(removed) == 0 {
+		return nil
+	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, in.OrganizationID.UUID,
 		crmcontracts.PublicEventOrganizationUpdated{
 			ChangedFields: map[string]any{

--- a/backend/internal/modules/people/organizationtechnical.go
+++ b/backend/internal/modules/people/organizationtechnical.go
@@ -260,18 +260,23 @@ func (s *Store) auditTechnicalEnrichment(
 	if err != nil {
 		return fmt.Errorf("audit technical enrichment: %w", err)
 	}
-	// THE AUDIT ROW ALWAYS, THE EVENT ONLY ON A CHANGE. A lane that completed
-	// having found nothing is worth recording — it is what says when the record
-	// was last looked at, and it is what lets a technology the company dropped
-	// leave. It is not an UPDATE: nothing was written, nothing was removed, and
-	// organization.updated announcing an empty delta tells every subscriber a
-	// record moved when it did not.
+	// THE AUDIT ROW ALWAYS, THE EVENT ONLY ON A CHANGE. A lane that completed is
+	// worth recording whatever it found: it is what says when the record was
+	// last looked at, and it is what lets a technology the company dropped
+	// leave. Whether anything MOVED is a different question, and
+	// organization.updated is the answer to that one — announcing it over an
+	// unchanged record tells every subscriber a record moved when it did not.
 	//
-	// That is not a rare shape. Most companies' sites declare no technology this
-	// build recognises, so before this the homepage lane emitted a no-op event
-	// for nearly every site read in the installation, and each subscriber had to
-	// learn to ignore it.
-	if len(written) == 0 && len(removed) == 0 {
+	// `changes` rather than `written`: an upsert reports a re-observed fact as
+	// written, so a nightly lane over a company whose stack has not moved would
+	// still announce one. technicalChanges is what actually moved — appeared,
+	// moved, or gone — so a removal still announces and a refresh does not.
+	//
+	// Neither shape is rare. Most companies' sites declare no technology this
+	// build recognises, and most that do declare the same one they declared
+	// yesterday: between them the lane emitted a no-op event on nearly every
+	// read in an installation, and each subscriber had to learn to ignore it.
+	if len(changes) == 0 {
 		return nil
 	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, in.OrganizationID.UUID,

--- a/backend/internal/modules/people/technicalenrich_integration_test.go
+++ b/backend/internal/modules/people/technicalenrich_integration_test.go
@@ -291,6 +291,21 @@ func TestACompletedLaneWithNothingClearsItsRows(t *testing.T) {
 	if held := technicalFactsOf(ctx, t, e, orgID); len(held[FactOperatedService]) != 0 {
 		t.Errorf("the record still claims %v after the source answered that there is none", held)
 	}
+	// A technology LEAVING is a change, and the one a rep most wants to hear
+	// about: the arrival announced, and so must the departure. Both events, not
+	// one — the guard on the empty delta must not swallow this.
+	var events int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM event_outbox
+			 WHERE envelope->>'type' = 'organization.updated'
+			   AND envelope->'entity'->>'id' = $1::text`, orgID.String()).Scan(&events)
+	}); err != nil {
+		t.Fatalf("read back the events: %v", err)
+	}
+	if events != 2 {
+		t.Errorf("%d organization.updated events for an arrival and a departure, want 2 — a technology leaving is a change", events)
+	}
 }
 
 // TestEveryTechnicalWriteCommitsItsAuditAndItsEvent holds the write shape.
@@ -377,6 +392,55 @@ func TestALaneThatChangedNothingRecordsItAndAnnouncesNothing(t *testing.T) {
 	}
 	if events != 0 {
 		t.Errorf("the lane announced %d organization.updated events having changed nothing — a subscriber acting on one finds an identical record", events)
+	}
+}
+
+// TestARefreshThatFoundTheSameStackAnnouncesNothing is the same rule on the
+// other common shape.
+//
+// A lane re-reading a company whose stack has not moved UPSERTS every fact it
+// found, so the write count is not zero — but nothing appeared, moved or went.
+// Most companies that declare a recognisable technology declare the same one
+// they declared yesterday, so this is the nightly case, not an edge.
+func TestARefreshThatFoundTheSameStackAnnouncesNothing(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := seedTechnicalOrg(ctx, t, e, "Gleichstand GmbH", "gleichstand.de")
+
+	read := TechnicalEnrichment{
+		OrganizationID: orgID,
+		Completed:      []TechnicalLane{LaneDNS},
+		Observations:   []TechnicalObservation{observation(FactMailProvider, "microsoft365", "Microsoft 365")},
+		ObservedAt:     technicalObservedAt,
+	}
+	if err := e.store.ApplyTechnicalEnrichment(ctx, read, nil); err != nil {
+		t.Fatalf("apply the first reading: %v", err)
+	}
+	// The SAME answer again, which is what a nightly lane produces.
+	if err := e.store.ApplyTechnicalEnrichment(ctx, read, nil); err != nil {
+		t.Fatalf("apply the refresh: %v", err)
+	}
+
+	var audits, events int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, `
+			SELECT count(*) FROM audit_log
+			 WHERE entity_type = 'organization' AND entity_id = $1
+			   AND evidence->>'source' = $2`, orgID, companySourceTechnical).Scan(&audits); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM event_outbox
+			 WHERE envelope->>'type' = 'organization.updated'
+			   AND envelope->'entity'->>'id' = $1::text`, orgID.String()).Scan(&events)
+	}); err != nil {
+		t.Fatalf("read back the trail: %v", err)
+	}
+	if audits != 2 {
+		t.Errorf("the two lanes left %d audit rows, want 2: each one looked, and when it looked is the record", audits)
+	}
+	if events != 1 {
+		t.Errorf("%d organization.updated events for one arrival and one refresh, want 1 — the refresh moved nothing", events)
 	}
 }
 

--- a/backend/internal/modules/people/technicalenrich_integration_test.go
+++ b/backend/internal/modules/people/technicalenrich_integration_test.go
@@ -331,6 +331,55 @@ func TestEveryTechnicalWriteCommitsItsAuditAndItsEvent(t *testing.T) {
 	}
 }
 
+// TestALaneThatChangedNothingRecordsItAndAnnouncesNothing is the other half of
+// the write shape.
+//
+// A lane that completed having found nothing is worth an AUDIT row: it is what
+// says when the record was last looked at, and it is what lets a technology the
+// company dropped leave. It is not an update. Nothing was written, nothing was
+// removed, and `organization.updated` announcing an empty delta tells every
+// subscriber a record moved when it did not.
+//
+// Most companies' sites declare no technology this build recognises, so the
+// homepage lane hit this shape on nearly every site read in an installation —
+// a no-op event each time, which every subscriber had to learn to ignore.
+func TestALaneThatChangedNothingRecordsItAndAnnouncesNothing(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := seedTechnicalOrg(ctx, t, e, "Leerlauf GmbH", "leerlauf.de")
+
+	empty := TechnicalEnrichment{
+		OrganizationID: orgID,
+		Completed:      []TechnicalLane{LaneHomepage},
+		ObservedAt:     technicalObservedAt,
+	}
+	if err := e.store.ApplyTechnicalEnrichment(ctx, empty, nil); err != nil {
+		t.Fatalf("apply the empty reading: %v", err)
+	}
+
+	var audits, events int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, `
+			SELECT count(*) FROM audit_log
+			 WHERE entity_type = 'organization' AND entity_id = $1
+			   AND evidence->>'source' = $2`, orgID, companySourceTechnical).Scan(&audits); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM event_outbox
+			 WHERE envelope->>'type' = 'organization.updated'
+			   AND envelope->'entity'->>'id' = $1::text`, orgID.String()).Scan(&events)
+	}); err != nil {
+		t.Fatalf("read back the trail: %v", err)
+	}
+	if audits != 1 {
+		t.Errorf("the lane left %d audit rows, want 1: a completed lane is worth recording even when it found nothing", audits)
+	}
+	if events != 0 {
+		t.Errorf("the lane announced %d organization.updated events having changed nothing — a subscriber acting on one finds an identical record", events)
+	}
+}
+
 // TestATechnicalFactMustNameWhatProvedIt holds the evidence obligation the DDL
 // carries, and it is the product promise in constraint form: a rep asking "how
 // do you know they run Microsoft 365?" is owed the MX host.

--- a/backend/internal/modules/people/technicalenrich_integration_test.go
+++ b/backend/internal/modules/people/technicalenrich_integration_test.go
@@ -416,8 +416,13 @@ func TestARefreshThatFoundTheSameStackAnnouncesNothing(t *testing.T) {
 	if err := e.store.ApplyTechnicalEnrichment(ctx, read, nil); err != nil {
 		t.Fatalf("apply the first reading: %v", err)
 	}
-	// The SAME answer again, which is what a nightly lane produces.
-	if err := e.store.ApplyTechnicalEnrichment(ctx, read, nil); err != nil {
+	// The same ANSWER, read at a later time — which is what a nightly lane
+	// produces. ObservedAt advances, so the rows' retrieval metadata moves and
+	// nothing about the technology does: reapplying the identical struct would
+	// leave retrieved_at untouched and never exercise that.
+	refresh := read
+	refresh.ObservedAt = read.ObservedAt.Add(24 * time.Hour)
+	if err := e.store.ApplyTechnicalEnrichment(ctx, refresh, nil); err != nil {
 		t.Fatalf("apply the refresh: %v", err)
 	}
 
@@ -441,6 +446,21 @@ func TestARefreshThatFoundTheSameStackAnnouncesNothing(t *testing.T) {
 	}
 	if events != 1 {
 		t.Errorf("%d organization.updated events for one arrival and one refresh, want 1 — the refresh moved nothing", events)
+	}
+	// And the refresh DID land: the rows carry the later reading, so what this
+	// test proves is that metadata moving is not an update, rather than that
+	// the second lane did nothing at all.
+	var retrievedAt time.Time
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT max(retrieved_at) FROM organization_fact
+			 WHERE organization_id = $1 AND field = $2`, orgID, FactMailProvider).Scan(&retrievedAt)
+	}); err != nil {
+		t.Fatalf("read back the retrieval time: %v", err)
+	}
+	if !retrievedAt.Equal(refresh.ObservedAt) {
+		t.Errorf("retrieved_at is %s, want the refresh's %s — the second lane did not land, so the silence above proves nothing",
+			retrievedAt, refresh.ObservedAt)
 	}
 }
 


### PR DESCRIPTION
**`main` is red.** `TestDeepReadCrawlsExtractsAppliesWhatItEvidencedAndFinishesDone` fails on a clean checkout of `73b0ef331`:

```
deepread_integration_test.go:235: 2 organization.updated outbox events after accept, want exactly 1 for the whole delta
```

## What the second event is

Not the accept's. It is the homepage technology lane's, and it carries an empty delta:

```json
{"delta": {"lanes": ["homepage"], "changes": 0, "removed": [], "written": []},
 "source": "technical_lookup"}
```

The site declared no technology this build recognises, `auditTechnicalEnrichment` wrote its audit row, and then announced `organization.updated` about a record nothing had changed.

## Why the audit row stays and the event goes

The lane **completing** with nothing found is worth recording: it is what says when the record was last looked at, and it is what lets a technology the company dropped leave the record — the reconciliation semantics the function's own comment describes. So the audit row is unconditional.

It is not an **update**. Nothing was written and nothing was removed. `organization.updated` announcing that tells every subscriber a record moved when it did not, and a subscriber that acts on one finds an identical record.

And it is not a rare shape: most companies' sites declare nothing this build recognises, so the homepage lane emitted a no-op event on nearly every site read in an installation. Every consumer had to learn to ignore it.

## The fix

The event is emitted only when the reconciliation wrote or removed something.

`TestALaneThatChangedNothingRecordsItAndAnnouncesNothing` holds both halves — the audit row is there, the event is not — and the two existing cases (`TestEveryTechnicalWriteCommitsItsAuditAndItsEvent`, `TestACompletedLaneWithNothingClearsItsRows`) hold that a lane which *did* change still announces. Mutation-checked: removing the guard fails the new case and nothing else.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green locally — including the deep-read case that is currently failing on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed technology enrichment runs no longer generate unnecessary organization update events when no facts are added, changed, or removed.
  * Audit records continue to be created for unchanged runs.
  * Organization update events are still emitted when technology information changes, including when stale facts are removed.
  * Added coverage to verify event behavior for repeated observations and removals.

* **Documentation**
  * Clarified technology enrichment event behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->