### PR TITLE
fix(identity): the agent seat is Margince's, and says so

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28578,7 +28578,7 @@ components:
       required: [organization_id, cert_status, created_at, updated_at]   # partner_role is nullable (data-model §4.3)
       properties:
         organization_id: { type: string, format: uuid, description: The org this partner record extends (PK = FK). }
-        partner_role: { type: string, enum: [hosting, consulting, strategic], description: Functional role (A44/ADR-0034); implementation + dev are Gradion's turf. }
+        partner_role: { type: string, enum: [hosting, consulting, strategic], description: Functional role (A44/ADR-0034); implementation + dev are Margince's turf. }
         cert_status: { type: string, enum: [applied, certified, suspended] }   # data-model §4.3 CHECK
         margin_tier: { type: [string, 'null'], enum: [null, tier1_15, tier2_20, tier3_25], description: Scenario-C margin tier (business/14-partner-program.md; data-model §4.3 CHECK). }
         gate_metrics: { type: [object, 'null'], additionalProperties: true, description: 'Program gate metrics (certified seats, CSAT, ...).' }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21979,7 +21979,7 @@ type Partner struct {
 	// PartnerFitScoreComputed Retained machine-computed partner-fit value while a Commercial Judgement override is in force.
 	PartnerFitScoreComputed *int `json:"partner_fit_score_computed,omitempty"`
 
-	// PartnerRole Functional role (A44/ADR-0034); implementation + dev are Gradion's turf.
+	// PartnerRole Functional role (A44/ADR-0034); implementation + dev are Margince's turf.
 	PartnerRole *PartnerPartnerRole `json:"partner_role,omitempty"`
 
 	// RelationshipHealth Decimal-as-string 0..1 derived by formulas §16; basis for 30/60/90 partner dormancy flags.
@@ -22002,7 +22002,7 @@ type PartnerCertStatus string
 // PartnerMarginTier Scenario-C margin tier (business/14-partner-program.md; data-model §4.3 CHECK).
 type PartnerMarginTier string
 
-// PartnerPartnerRole Functional role (A44/ADR-0034); implementation + dev are Gradion's turf.
+// PartnerPartnerRole Functional role (A44/ADR-0034); implementation + dev are Margince's turf.
 type PartnerPartnerRole string
 
 // PartnerRelationshipStage defines model for Partner.RelationshipStage.

--- a/backend/internal/modules/identity/agentseat_integration_test.go
+++ b/backend/internal/modules/identity/agentseat_integration_test.go
@@ -111,9 +111,9 @@ func TestBootstrapMintsAnAgentSeatThatCarriesNoAuthorityOfItsOwn(t *testing.T) {
 	if want := agentSeatEmail(slug); seat.email != want {
 		t.Errorf("seat address = %q, want %q (seed-and-fixtures §1.5)", seat.email, want)
 	}
-	if seat.displayName != "Gradion Agent" {
+	if seat.displayName != "Margince Agent" {
 		t.Errorf("seat display name = %q, want %q — it is what a human reads beside a record the "+
-			"runner owns", seat.displayName, "Gradion Agent")
+			"runner owns", seat.displayName, "Margince Agent")
 	}
 	if seat.status != "active" || seat.archived {
 		t.Errorf("seat status = %q, archived = %v; the dispatcher resolves an initiator by "+

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -320,7 +320,7 @@ func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap
 func seedAgentSeat(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, boot BootstrapInput) error {
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO app_user (email, display_name, timezone, is_agent, seat_type, status)
-		 VALUES ($1, 'Gradion Agent', $2, true, 'full', 'active')`,
+		 VALUES ($1, 'Margince Agent', $2, true, 'full', 'active')`,
 		agentSeatEmail(boot.Slug), boot.Timezone); err != nil {
 		return fmt.Errorf("identity: seeding the agent seat: %w", err)
 	}

--- a/backend/internal/modules/identity/ssologin_integration_test.go
+++ b/backend/internal/modules/identity/ssologin_integration_test.go
@@ -188,7 +188,7 @@ func TestResolveFederatedUserRefusesTheAgentSeat(t *testing.T) {
 	agentEmail := "agent@sso-agent-seat.gradion.local"
 	if _, err := conn.Exec(context.Background(),
 		`INSERT INTO app_user (id, email, display_name, is_agent, seat_type, status)
-		 VALUES ($1, $2, 'Gradion Agent', true, 'full', 'active')`,
+		 VALUES ($1, $2, 'Margince Agent', true, 'full', 'active')`,
 		ids.New[ids.UserKind](), agentEmail); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/migrations/core/1788129035_the_agent_seat_is_margince.down.sql
+++ b/backend/migrations/core/1788129035_the_agent_seat_is_margince.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+UPDATE app_user SET display_name = 'Gradion Agent', updated_at = now()
+ WHERE is_agent AND display_name = 'Margince Agent';

--- a/backend/migrations/core/1788129035_the_agent_seat_is_margince.up.sql
+++ b/backend/migrations/core/1788129035_the_agent_seat_is_margince.up.sql
@@ -1,0 +1,16 @@
+-- The seeded agent identity carries the product's name, and the product is
+-- Margince. Every installation seeded before this shows "Gradion Agent" in its
+-- user list, next to a page that says Margince everywhere else.
+--
+-- Scoped to the SEEDED row: an agent seat whose name an operator has already
+-- changed is their text, not ours, and renaming it would be editing somebody's
+-- data to win an argument about vocabulary. `is_agent` alone would be too wide
+-- for the same reason.
+--
+-- The seat's email is deliberately untouched. It is a uniqueness key on a row
+-- that holds no password and receives no mail, the screen no longer prints it,
+-- and rewriting an address to change a word nobody reads is churn with a
+-- collision risk attached.
+SET LOCAL lock_timeout = '3s';
+UPDATE app_user SET display_name = 'Margince Agent', updated_at = now()
+ WHERE is_agent AND display_name = 'Gradion Agent';

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21022,7 +21022,7 @@ export interface components {
              */
             organization_id: string;
             /**
-             * @description Functional role (A44/ADR-0034); implementation + dev are Gradion's turf.
+             * @description Functional role (A44/ADR-0034); implementation + dev are Margince's turf.
              * @enum {string}
              */
             partner_role?: "hosting" | "consulting" | "strategic";

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5207,7 +5207,7 @@ export const de = {
   "cf.refuse.body":
     "Dieser Builder fügt nur einfache Felder zu bestehenden Datensätzen hinzu. Ein neues Objekt, eine Verknüpfung zwischen Objekten oder ein berechneter Roll-up ist eine strukturelle Änderung — sie kommt als geprüfte Änderung an Margince in einer neuen Version, gemacht von Menschen, nicht vom Produkt, das seinen eigenen Code bearbeitet.",
   "cf.refuse.route":
-    "Leite es über den Entwicklungsweg — deine eigenen Entwickler, einen Implementierungspartner oder Gradion-Services.",
+    "Leite es über den Entwicklungsweg — deine eigenen Entwickler, einen Implementierungspartner oder Margince-Services.",
   "cf.confirm": "Bestätigen & Feld hinzufügen",
   "cf.writing": "wird geschrieben…",
   "cf.added":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5264,7 +5264,7 @@ export const en = {
   "cf.refuse.body":
     "This builder adds simple fields to existing records only. A new object, a link between objects, or a calculated roll-up is a structural change — it ships as a reviewed change to Margince in a new version, done by people, not by the product editing its own code.",
   "cf.refuse.route":
-    "Route it through the development path — your own engineers, an implementation partner, or Gradion services.",
+    "Route it through the development path — your own engineers, an implementation partner, or Margince services.",
   "cf.confirm": "Confirm & add field",
   "cf.writing": "writing…",
   "cf.added": 'Field "{label}" added — live on 360, filters, export & API',

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5157,7 +5157,7 @@ export const vi = {
   "cf.refuse.body":
     "Trình dựng này chỉ thêm trường đơn giản vào bản ghi sẵn có. Một đối tượng mới, một liên kết giữa các đối tượng, hay một số tổng hợp tính toán đều là thay đổi cấu trúc — thay đổi đó ra mắt trong một phiên bản mới của Margince sau khi được rà soát, do con người làm, chứ không phải sản phẩm tự sửa mã của chính mình.",
   "cf.refuse.route":
-    "Hãy đưa việc đó qua con đường phát triển — kỹ sư của chính bạn, một đối tác triển khai, hoặc dịch vụ của Gradion.",
+    "Hãy đưa việc đó qua con đường phát triển — kỹ sư của chính bạn, một đối tác triển khai, hoặc dịch vụ của Margince.",
   "cf.confirm": "Xác nhận và thêm trường",
   "cf.writing": "đang ghi…",
   "cf.added":

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -60,7 +60,7 @@ const ROSTER = {
     {
       id: "u-agent",
       email: "agent@acme.gradion.local",
-      display_name: "Gradion Agent",
+      display_name: "Margince Agent",
       status: "active",
       is_agent: true,
       roles: [],
@@ -318,9 +318,11 @@ describe("UsersAdminCard", () => {
     const user = userEvent.setup();
     vi.stubGlobal("fetch", backend([]));
     render(<UsersAdminCard />);
-    await waitFor(() => expect(screen.getByText("Gradion Agent")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText("Margince Agent")).toBeTruthy(),
+    );
 
-    const agent = rowFor("Gradion Agent");
+    const agent = rowFor("Margince Agent");
     expect(within(agent).getByText("Agent")).toBeTruthy();
     // No role control at all, not a disabled one: the seat's authority comes
     // from a passport and the person it names, never from a role of its own. The
@@ -332,7 +334,7 @@ describe("UsersAdminCard", () => {
     // No set-password link: the seat holds no password by construction, which
     // is what makes it a thing that signs in nowhere. Its menu still opens —
     // deactivating the seat is a posture an operator is entitled to take.
-    const agentVerbs = await rowMenu(user, "Gradion Agent");
+    const agentVerbs = await rowMenu(user, "Margince Agent");
     expect(agentVerbs.queryByText(/set-password link/i)).toBeNull();
     expect(agentVerbs.getByText("Deactivate")).toBeTruthy();
 
@@ -354,10 +356,12 @@ describe("UsersAdminCard", () => {
     const user = userEvent.setup();
     vi.stubGlobal("fetch", backend([]));
     render(<UsersAdminCard />);
-    await waitFor(() => expect(screen.getByText("Gradion Agent")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText("Margince Agent")).toBeTruthy(),
+    );
 
     await user.click(
-      (await rowMenu(user, "Gradion Agent")).getByRole("button", {
+      (await rowMenu(user, "Margince Agent")).getByRole("button", {
         name: /deactivate/i,
       }),
     );


### PR DESCRIPTION
The user list showed **"Gradion Agent"** — the product's old name, on a page that says Margince everywhere else.

It is not a leftover an operator can fix themselves. The name is a literal in the bootstrap SQL, so every installation ever seeded carries it, and nothing in the product offers a way to change it.

## What changes

The bootstrap literal becomes `Margince Agent` for new installations, and a migration renames the row for existing ones.

The migration is **scoped to the seeded name**, not to `is_agent`:

```sql
UPDATE app_user SET display_name = 'Margince Agent', updated_at = now()
 WHERE is_agent AND display_name = 'Gradion Agent';
```

An operator who has already renamed their agent seat wrote that text, and overwriting it would be editing somebody's data to win an argument about vocabulary. I tested both halves against a real database — see below.

**The seat's email keeps `gradion.local`.** It is a uniqueness key on a row that holds no password and receives no mail, nothing is ever delivered to it, and rewriting an address nobody reads would be churn with a collision risk attached.

## Two other places said Gradion where they meant the product

- `cf.refuse.route` — the custom-field refusal offering "Gradion services", in all three locales, one line below a sentence that already says Margince.
- `partner_role` in `crm.yaml` — "implementation + dev are Gradion's turf", which API consumers read.

## What is deliberately untouched

The **SPDX copyright headers** name the legal entity, not the product, and the two are not the same thing. The **signature placeholder** (`"Marek Janetzke\nGradion · +49 40 123456"`) is an example of a *user's own* sign-off, not ours.

## Verification

`make check-backend` and `make check-fe` green (5455 frontend tests), `make craft-static` clean, and the migrations + identity integration lanes pass against real Postgres — including `TestMigrations_applyReverseReapply`, so the down migration is exercised too.

The migration itself was tested end to end on a live stack rather than only through tests:

1. Set a seeded seat back to `Gradion Agent` and un-recorded the migration — the shape of an existing installation.
2. Ran `make migrate` → the seat read `Margince Agent`.
3. Set it to `Acme Robot`, un-recorded the migration, ran it again → it stayed `Acme Robot`.

Step 3 is the one that matters: the guard holds, and an operator's own name survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the user list showing "Gradion Agent" — the product's old name — where the page says Margince everywhere else. New installations get the corrected literal from the bootstrap; a migration renames the seat for existing ones.

**Migration**
- Scoped to rows still carrying the seeded name so an operator who already renamed their seat keeps their text.
- Leaves the seat's email as `gradion.local`; it's a uniqueness key on a row that holds no password and receives no mail.

Also fixes two other product-name references: the custom-field refusal in all three locales and the `partner_role` description API consumers read.

<sup>Written for commit c35005e343b41435bdf7bc298c728b335ea04500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the agent seat name to **Margince Agent** across the product.
  * Updated service references in English, German, and Vietnamese guidance to mention **Margince**.
  * Updated partner responsibility information to reflect Margince’s implementation and development role.
  * Existing renamed agent seats remain unchanged during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->