### PR TITLE
fix(decisions): Reject rejects on one press

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2342,11 +2342,8 @@ export const de = {
   "decision.viaTool": "über {verb}",
   "decision.approveEdited": "Bearbeitet übernehmen",
   "decision.reject": "Ablehnen",
-  "decision.rejectReason": "Begründung",
   "decision.draftSubject": "Betreff",
   "decision.draftBody": "Nachricht",
-  "decision.rejectReasonHint":
-    "Wird mit der Person geteilt, für die dies vorgemerkt wurde.",
   "decision.dismiss": "Schließen",
   "decision.versionSkew":
     "Dieser Datensatz hat sich seit dem Vormerken geändert — bitte neu vormerken.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2362,10 +2362,8 @@ export const en = {
   "decision.viaTool": "via {verb}",
   "decision.approveEdited": "Approve edited",
   "decision.reject": "Reject",
-  "decision.rejectReason": "Reason",
   "decision.draftSubject": "Subject",
   "decision.draftBody": "Message",
-  "decision.rejectReasonHint": "Shared with the person this was staged for.",
   "decision.dismiss": "Dismiss",
   "decision.versionSkew":
     "This record changed since it was staged — re-stage it before deciding.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2322,11 +2322,8 @@ export const vi = {
   "decision.viaTool": "qua {verb}",
   "decision.approveEdited": "Duyệt bản đã sửa",
   "decision.reject": "Từ chối",
-  "decision.rejectReason": "Lý do",
   "decision.draftSubject": "Tiêu đề",
   "decision.draftBody": "Nội dung",
-  "decision.rejectReasonHint":
-    "Người mà mục này được xếp chờ duyệt cho sẽ thấy lý do này.",
   "decision.dismiss": "Bỏ qua",
   "decision.versionSkew":
     "Bản ghi đã thay đổi kể từ khi được xếp chờ duyệt — hãy xếp lại trước khi quyết định.",

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -126,9 +126,8 @@ describe("the offer to put an approved change back", () => {
     vi.stubGlobal("fetch", fetched);
     render(<ApprovalRow approval={closeDateApproval()} />);
 
+    // One press rejects — no confirmation step, no reason form.
     await userEvent.click(screen.getByRole("button", { name: "Reject" }));
-    const confirm = await screen.findAllByRole("button", { name: "Reject" });
-    await userEvent.click(confirm[confirm.length - 1]);
 
     await waitFor(() => expect(rejectCalls(fetched)).toBe(1));
     expect(

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -12,8 +12,7 @@ import {
 } from "../app/autonomy";
 import { ENTITY, isEntityKind } from "../app/entity";
 import { navigate, type Route } from "../app/router";
-import { Button, Card, Field, Textarea } from "../design-system/atoms";
-import { ConfirmModal } from "../design-system/confirmmodal";
+import { Button, Card } from "../design-system/atoms";
 import {
   DecisionCard,
   type DecisionCardLabels,
@@ -194,8 +193,6 @@ export function ApprovalRow({
   const toast = useToast();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<Record<string, string>>({});
-  const [rejecting, setRejecting] = useState(false);
-  const [reason, setReason] = useState("");
   const [detailOpen, setDetailOpen] = useState(false);
   // Only a live pending row with an expiry needs the per-second clock; a
   // read-only decided row (or one without expires_at) never shows a countdown,
@@ -242,7 +239,6 @@ export function ApprovalRow({
     mutationFn: async (input: {
       verdict: "approve" | "reject";
       editedPayload?: Record<string, unknown>;
-      reason?: string;
     }) => {
       const path =
         input.verdict === "approve"
@@ -252,9 +248,6 @@ export function ApprovalRow({
         params: { path: { id: approval.id } },
         ...(input.verdict === "approve" && input.editedPayload
           ? { body: { edited_payload: input.editedPayload } }
-          : {}),
-        ...(input.verdict === "reject"
-          ? { body: { reason: input.reason ?? "" } }
           : {}),
       });
       if (error) {
@@ -316,12 +309,6 @@ export function ApprovalRow({
       editedPayload: { ...change, ...draft },
     });
     setEditing(false);
-  };
-
-  const confirmReject = () => {
-    decide.mutate({ verdict: "reject", reason });
-    setRejecting(false);
-    setReason("");
   };
 
   const reRead = () => {
@@ -392,7 +379,10 @@ export function ApprovalRow({
       // write is in flight, so a press here during it left the reader inside a
       // form they could not leave until the request came back.
       onEdit={strings.length > 0 ? startEdit : undefined}
-      onReject={() => setRejecting(true)}
+      // One press, no reason form: a rejection discards a proposal and changes
+      // no record, so it carries the same weight as Accept and asks nothing
+      // extra. The contract's reason field stays for callers that have one.
+      onReject={() => decide.mutate({ verdict: "reject" })}
       notice={
         <DecideOutcome
           decide={decide}
@@ -402,28 +392,6 @@ export function ApprovalRow({
         />
       }
     >
-      <ConfirmModal
-        open={rejecting}
-        onClose={() => setRejecting(false)}
-        title={t("decision.reject")}
-        confirmLabel={t("decision.reject")}
-        confirmVariant="danger"
-        pending={decide.isPending}
-        onConfirm={confirmReject}
-      >
-        <Field
-          label={t("decision.rejectReason")}
-          hint={t("decision.rejectReasonHint")}
-        >
-          {(control) => (
-            <Textarea
-              {...control}
-              value={reason}
-              onChange={(event) => setReason(event.target.value)}
-            />
-          )}
-        </Field>
-      </ConfirmModal>
       <ApprovalDetailModal
         approvalId={approval.id}
         open={detailOpen}


### PR DESCRIPTION
Pressing Reject on a decision card opened a modal demanding a reason before it would act. A rejection discards a staged proposal and changes no record — the contract itself says so ("discards it; nothing commits") and marks the reason body optional — so the form asked for a justification the product does not need, and the modal was the only confirmation step anywhere on the queue.

Now one press rejects, same weight as Accept.

- `approvalrow.tsx`: the ConfirmModal, reason state and reason wiring are removed; `onReject` mutates directly with no body.
- The two now-dead i18n keys (`decision.rejectReason`, `decision.rejectReasonHint`) are removed from en/de/vi.
- `approvalrow.render.test.tsx`: the reject case drives one press instead of two.

No contract change: `reason` stays optional on `/approvals/{id}/reject` for callers that have one.

`make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejecting a staged decision card now works in one press, matching Accept's weight. Reject previously opened a modal requiring a reason, but rejection discards the proposal without changing any record, so the justification was never needed.

- Removes the `ConfirmModal`, reason state, and reason wiring from `approvalrow.tsx`; `onReject` now mutates directly with no body.
- Deletes the unused `decision.rejectReason` and `decision.rejectReasonHint` i18n keys from en/de/vi.
- Updates `approvalrow.render.test.tsx` to drive a single press instead of two.
- Leaves `reason` optional on `/approvals/{id}/reject`, so callers that send one still work.

<sup>Written for commit 60cc59af57a67d8c3c540baa5a79c4291402f105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Rejections are now submitted immediately with a single click.
  * The rejection reason prompt and confirmation dialog have been removed.
  * Approval workflows continue to support edited submissions.
  * Removed obsolete rejection-related translations in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->