### PR TITLE
fix(ai): a draft that takes a minute is not a broken server

### DIFF
--- a/backend/internal/compose/modelroutedeadline.go
+++ b/backend/internal/compose/modelroutedeadline.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+
+// The routes whose handler calls a model and waits for the answer, matched by
+// the suffix their contract path ends in. A model call runs for tens of
+// seconds — measured on a real installation, a reply draft takes 13 to 45 —
+// and the server's WriteTimeout is 30s for every other endpoint's protection.
+//
+// Suffix rather than a full path because each of these is mounted under an
+// id-bearing prefix (/activities/{id}/draft-email, /organizations/{id}/dossier),
+// and a list of formatted paths would be a second copy of the router that
+// drifts the day a route moves.
+var modelRouteSuffixes = []string{
+	"/draft-email",
+	"/dossier",
+	"/growth-fit",
+}
+
+// extendDeadlineForModelRoutes gives a handler that calls a model long enough
+// to answer, on THAT route only.
+//
+// The server-wide WriteTimeout stays short on purpose: it bounds every
+// endpoint, and a long global deadline lets one slow-reading client hold a
+// connection and its handler goroutine for as long as it likes. Raising it was
+// the first fix attempted here and it weakens the whole surface to help three
+// routes — the same trade the MCP handler already refused
+// (modules/agents/httpmcp.go), which extends its own route and says why.
+//
+// Before this, a draft that took longer than 30s had its connection cut
+// mid-response. The reader saw a 502 from whatever proxy sits in front: a
+// deadline nobody meant to set, reported as a broken server.
+func extendDeadlineForModelRoutes(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !callsAModel(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// A failure here means the handler chain lost Unwrap(): fail loudly
+		// rather than serve a response that dies mid-write, which is the very
+		// symptom this exists to remove.
+		if err := http.NewResponseController(w).SetWriteDeadline(
+			time.Now().Add(ai.RouteWriteDeadline),
+		); err != nil {
+			httperr.Write(w, r, &httperr.DetailedError{
+				Status: http.StatusInternalServerError,
+				Code:   "deadline_not_extendable",
+				Detail: "This server chain cannot extend the response deadline.",
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// callsAModel reports whether this path is one of the slow AI routes.
+func callsAModel(path string) bool {
+	for _, suffix := range modelRouteSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/modelroutedeadline_test.go
+++ b/backend/internal/compose/modelroutedeadline_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// A handler that CALLS a model needs longer to answer than the server's
+// WriteTimeout allows every other endpoint, and it takes that time on its own
+// route rather than from the server.
+//
+// Measured on a real installation, a reply draft runs 13 to 45 seconds and the
+// server-wide WriteTimeout is 30s: the response was cut mid-write and reached
+// the reader as a 502 from the proxy in front. Raising the global bound would
+// have let one slow-reading client hold a connection for as long as it liked,
+// which is the trade the MCP handler already refused.
+func TestOnlyTheModelRoutesTakeTheLongerDeadline(t *testing.T) {
+	// A ResponseController reaches the deadline through the writer; a recorder
+	// does not implement it, so the middleware's refusal path is what a test
+	// without a real server sees. The route DECISION is what is asserted here,
+	// and it is the half that decides which endpoints are exposed.
+	for path, wantsModelTime := range map[string]bool{
+		"/v1/activities/01a0-4cd3/draft-email":   true,
+		"/v1/organizations/01a0-4cd2/dossier":    true,
+		"/v1/organizations/01a0-4cd2/growth-fit": true,
+		"/v1/people":                             false,
+		"/v1/me":                                 false,
+		"/v1/organizations/01a0-4cd2":            false,
+		// A path that merely CONTAINS a slow route's name is not one: the
+		// suffix is the whole match, or a list endpoint beside it inherits a
+		// deadline it has no work for.
+		"/v1/draft-email/history": false,
+	} {
+		if got := callsAModel(path); got != wantsModelTime {
+			t.Errorf("callsAModel(%q) = %v, want %v", path, got, wantsModelTime)
+		}
+	}
+}
+
+// The deadline covers the whole logical call, not one request to the provider:
+// the router may spend its per-call ceiling on every rung of the ladder, and
+// may walk that ladder more than once for a single answer. Sized for one call,
+// a legitimate retry would be cut — the same defect one level down from the
+// server timeout this replaces.
+func TestTheRouteDeadlineCoversTheWholeLadder(t *testing.T) {
+	if ai.RouteWriteDeadline <= ai.CallCeiling {
+		t.Fatalf("route deadline %s must outlast one model call (%s)",
+			ai.RouteWriteDeadline, ai.CallCeiling)
+	}
+	// Two rungs, walked more than once, is the shape the router can produce.
+	if ai.RouteWriteDeadline < 2*ai.CallCeiling {
+		t.Fatalf("route deadline %s cannot cover a ladder that falls back once (%s)",
+			ai.RouteWriteDeadline, 2*ai.CallCeiling)
+	}
+}
+
+// A route with no model behind it is handed straight through — the middleware
+// must not touch the deadline of an ordinary read.
+func TestAnOrdinaryRouteIsUntouched(t *testing.T) {
+	served := false
+	handler := extendDeadlineForModelRoutes(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		served = true
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/me", nil))
+
+	if !served {
+		t.Fatal("an ordinary route is served, deadline untouched")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+}
+
+// And a chain that cannot extend the deadline fails LOUDLY rather than serving
+// a response that dies mid-write, which is the symptom this exists to remove.
+func TestAChainThatCannotExtendSaysSo(t *testing.T) {
+	handler := extendDeadlineForModelRoutes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("drafted"))
+	}))
+
+	recorder := httptest.NewRecorder() // implements no ResponseController hook
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/activities/x/draft-email", nil))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 — a chain that cannot extend must say so", recorder.Code)
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, "deadline_not_extendable") {
+		t.Fatalf("body = %q, want the machine code an operator can act on", body)
+	}
+}

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -186,8 +186,12 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 	// shared/kernel/capabilitypath, not named at each mount. The booking
 	// page's slug is deliberately absent from that list; it is a public
 	// identifier the host hands out, not a credential.
-	mux.Handle("/v1/", httpserver.Correlate(
-		httpserver.AccessLog(log, authH.Middleware(publicEdge))))
+	// extendDeadlineForModelRoutes sits OUTSIDE the handler chain because a
+	// write deadline has to be set before anything starts writing — including
+	// the access log's own wrapper, which is what holds the ResponseWriter the
+	// controller reaches through.
+	mux.Handle("/v1/", extendDeadlineForModelRoutes(httpserver.Correlate(
+		httpserver.AccessLog(log, authH.Middleware(publicEdge)))))
 	// The remote MCP connector, mounted as ONE group behind the deployment
 	// gate: the A2 transport, the A2 authorization server (ADR-0013) and
 	// both discovery documents. They belong together because RFC 9728

--- a/backend/internal/modules/ai/embedlane.go
+++ b/backend/internal/modules/ai/embedlane.go
@@ -44,7 +44,7 @@ func (r *Router) Embed(ctx context.Context, req model.EmbedRequest) (model.Embed
 
 	// One embedding is one forward pass and answers in about a second, so a
 	// minute of silence is a connection that will not answer rather than a model
-	// still working. Without this the caller waits out requestTimeout — five
+	// still working. Without this the caller waits out CallCeiling — five
 	// minutes, with its database transaction open — and a re-embed pass spends
 	// its River attempts on connections the network already dropped.
 	//

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// Timeouts bounding one outbound model call. requestTimeout is the ceiling on
+// Timeouts bounding one outbound model call. CallCeiling is the ceiling on
 // the whole call; the rest bound the legs that can stall while the ceiling is
 // still far away.
 //
@@ -20,11 +20,42 @@ import (
 // answer at all, and the sooner the caller hears so the sooner it retries on a
 // fresh one.
 const (
-	// requestTimeout bounds a single model call. Generous because premium
+	// CallCeiling bounds a single model call. Generous because premium
 	// completions on long context are legitimately slow — a streamed corpus
 	// extraction emits ten-thousand-token answers over minutes; per-call
 	// contexts tighten it where a caller has a real deadline.
-	requestTimeout = 300 * time.Second
+	//
+	// Exported because it is not this package's private business: an HTTP
+	// server that serves a synchronous model call must allow the response
+	// longer than this, or it cuts the connection on an answer the AI layer
+	// was still entitled to wait for. cmd/api reads it for exactly that, and a
+	// test holds the two together.
+	CallCeiling = 300 * time.Second
+
+	// RouteWriteDeadline is how long a handler that CALLS a model may take to
+	// write its response — set on that route alone, never on the server, whose
+	// short WriteTimeout protects every other endpoint from a slow reader.
+	//
+	// Sized for the whole logical call rather than one request: the router may
+	// spend CallCeiling on each rung of the ladder, and CompleteStructured may
+	// walk that ladder more than once for a single answer (the first try, the
+	// schema-invalid retry, the escalation). A deadline covering one call would
+	// cut a legitimate retry — the same defect one level down from the 30s
+	// server timeout that cut these responses in the first place.
+	//
+	// This is the same derivation railLease makes for its own lease; a round
+	// number here would be a guess that happens to look like a decision.
+	RouteWriteDeadline = CallCeiling*maxLadderRungs*maxLadderWalks + writeHeadroom
+
+	// maxLadderRungs is the longest ladder any task binds — cheap_cloud then
+	// premium today. Named rather than counted from a task, because this bound
+	// must hold for every task that reaches these routes.
+	maxLadderRungs = 2
+
+	// writeHeadroom is the work AROUND the model calls that shares the same
+	// response: assembling context, the write shape's transaction, serializing
+	// the answer.
+	writeHeadroom = 30 * time.Second
 
 	// EmbedCallTimeout bounds ONE embedding call, and is the reason there is no
 	// response-header timeout on the shared transport.
@@ -33,7 +64,7 @@ const (
 	// sent with stream:false (openai.go's Complete and every adapter beside it),
 	// so the vendor holds its status line until generation FINISHES — a slow
 	// reasoning model legitimately says nothing for minutes, and a header
-	// deadline would cut exactly the call requestTimeout is generous for. An
+	// deadline would cut exactly the call CallCeiling is generous for. An
 	// embedding is the opposite: it is one forward pass, it answers in about a
 	// second, and a minute of silence on one is never the model thinking.
 	//
@@ -48,7 +79,7 @@ const (
 	// itself may go unanswered before the connection is closed and its in-flight
 	// requests fail. Without these an h2 connection dropped by a NAT or a load
 	// balancer stays in the pool looking healthy, and every request handed to it
-	// waits out requestTimeout. Both vendors this reaches over h2 (Cloudflare
+	// waits out CallCeiling. Both vendors this reaches over h2 (Cloudflare
 	// fronts OpenRouter and Anthropic) drop idle connections well inside the
 	// minute.
 	http2PingAfterIdle = 20 * time.Second
@@ -75,5 +106,5 @@ func newOutboundClient() *http.Client {
 		SendPingTimeout: http2PingAfterIdle,
 		PingTimeout:     http2PingTimeout,
 	}
-	return &http.Client{Timeout: requestTimeout, Transport: transport}
+	return &http.Client{Timeout: CallCeiling, Transport: transport}
 }

--- a/backend/internal/modules/ai/outboundtransport_test.go
+++ b/backend/internal/modules/ai/outboundtransport_test.go
@@ -26,7 +26,7 @@ import (
 //
 // It asserts NO response-header timeout, deliberately. A completion is sent with
 // stream:false, so the vendor holds its headers until generation finishes and a
-// header deadline would cut exactly the long answers requestTimeout is generous
+// header deadline would cut exactly the long answers CallCeiling is generous
 // for. The embed lane's own deadline is what bounds the calls whose duration is
 // actually known — see TestEmbedLaneBoundsOneCall.
 func TestOutboundClientKeepsItsConnectionsHonest(t *testing.T) {
@@ -54,8 +54,8 @@ func TestOutboundClientKeepsItsConnectionsHonest(t *testing.T) {
 		t.Fatalf("ResponseHeaderTimeout is %v, but a stream:false completion holds its headers until generation finishes — this cuts long answers short",
 			transport.ResponseHeaderTimeout)
 	}
-	if client.Timeout != requestTimeout {
-		t.Fatalf("the call ceiling is %v, want %v", client.Timeout, requestTimeout)
+	if client.Timeout != CallCeiling {
+		t.Fatalf("the call ceiling is %v, want %v", client.Timeout, CallCeiling)
 	}
 }
 
@@ -71,8 +71,8 @@ func TestOutboundClientKeepsItsConnectionsHonest(t *testing.T) {
 func TestEmbedLaneBoundsOneCall(t *testing.T) {
 	t.Parallel()
 
-	if EmbedCallTimeout <= 0 || EmbedCallTimeout >= requestTimeout {
-		t.Fatalf("EmbedCallTimeout is %v, which does not bound anything inside the %v ceiling", EmbedCallTimeout, requestTimeout)
+	if EmbedCallTimeout <= 0 || EmbedCallTimeout >= CallCeiling {
+		t.Fatalf("EmbedCallTimeout is %v, which does not bound anything inside the %v ceiling", EmbedCallTimeout, CallCeiling)
 	}
 
 	spy := &deadlineSpyEmbedder{}
@@ -192,8 +192,8 @@ func TestEveryCloudAdapterUsesTheHardenedTransport(t *testing.T) {
 			t.Fatalf("SelectBrain(%s): %v", provider, err)
 		}
 		httpClient := outboundHTTPClientOf(t, client)
-		if httpClient.Timeout != requestTimeout {
-			t.Errorf("%s: call timeout is %v, want %v", provider, httpClient.Timeout, requestTimeout)
+		if httpClient.Timeout != CallCeiling {
+			t.Errorf("%s: call timeout is %v, want %v", provider, httpClient.Timeout, CallCeiling)
 		}
 		transport, ok := httpClient.Transport.(*http.Transport)
 		if !ok {

--- a/backend/internal/modules/ai/railstart.go
+++ b/backend/internal/modules/ai/railstart.go
@@ -61,7 +61,7 @@ type railStarter interface {
 // DERIVED from the bound it must outlast, never chosen. Three factors, and the
 // third is the one an earlier version of this file got wrong:
 //
-//   - requestTimeout caps a SINGLE model call — the http.Client timeout every
+//   - CallCeiling caps a SINGLE model call — the http.Client timeout every
 //     adapter is built with.
 //   - a walk of the ladder may spend that bound on EVERY rung.
 //   - and CompleteStructured walks the ladder up to maxLadderWalks times for one
@@ -89,7 +89,7 @@ func railLease(ladder []Tier) time.Duration {
 		// occurrence stale the instant it appeared.
 		rungs = 1
 	}
-	return requestTimeout*time.Duration(rungs*maxLadderWalks) + traceWriteTimeout
+	return CallCeiling*time.Duration(rungs*maxLadderWalks) + traceWriteTimeout
 }
 
 // announceRailStartOnce opens this logical call's occurrence, at most once.

--- a/backend/internal/modules/ai/railstart_test.go
+++ b/backend/internal/modules/ai/railstart_test.go
@@ -30,7 +30,7 @@ func (c *countingStarter) AnnounceRailStart(_ context.Context, call Call, lease 
 
 // The lease must outlast the work it covers, and the property that makes it a
 // derivation rather than a guess is that it grows with the ladder: a call may
-// spend a full requestTimeout on EVERY rung before the flush that settles it.
+// spend a full CallCeiling on EVERY rung before the flush that settles it.
 //
 // Stated as a strict inequality against the worst case rather than as the
 // formula, so the test fails for a constant. A fixed lease passes any
@@ -46,7 +46,7 @@ func TestTheLeaseOutlastsEveryRungTheLadderCanSpend(t *testing.T) {
 		// the same attempt — so the lease has to cover every walk or a
 		// structured call that legitimately retried renders stalled while it is
 		// still working.
-		worstCase := requestTimeout * time.Duration(rungs*maxLadderWalks)
+		worstCase := CallCeiling * time.Duration(rungs*maxLadderWalks)
 		if got := railLease(ladder); got <= worstCase {
 			t.Errorf("railLease over %d rungs = %s, which does not outlast the %s that %d walks of those rungs can spend — "+
 				"a healthy structured call would render stalled", rungs, got, worstCase, maxLadderWalks)

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { api, RequestTimeoutError } from "./client";
+import { api, REQUEST_TIMEOUT_MS, RequestTimeoutError } from "./client";
 
 // The spec for the client's deadline. The failure it exists for is the one
 // nothing above can see: a request that opens and never answers looks exactly
@@ -11,7 +11,7 @@ import { api, RequestTimeoutError } from "./client";
 // ever reached, and the authenticated shell holds its splash with no error, no
 // retry and no explanation until the reader reloads the page.
 //
-// Fake timers throughout: the deadline is 45 seconds, and a test that waited
+// Fake timers throughout: the deadline is minutes long, and a test that waited
 // for it would be the slowest one in the suite and would still be measuring the
 // runner's mood rather than the client's promise.
 
@@ -47,7 +47,7 @@ describe("the api client's request deadline", () => {
     // about how long this test happened to take.
     read.then(settled, settled);
 
-    await vi.advanceTimersByTimeAsync(44_000);
+    await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS - 1_000);
     expect(settled).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1_000);
@@ -60,7 +60,7 @@ describe("the api client's request deadline", () => {
     const read = api.GET("/me");
     const reason = read.catch((error: unknown) => error);
 
-    await vi.advanceTimersByTimeAsync(45_000);
+    await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS);
     // A stall and a refusal are different facts, and the console line an
     // operator reads has to say which one this was and for which request.
     expect(await reason).toMatchObject({
@@ -83,7 +83,94 @@ describe("the api client's request deadline", () => {
     );
     await api.GET("/me");
     // A timer still armed here would abort a controller nobody is listening to
-    // and keep the page awake for 45 seconds after every answered request.
+    // and keep the page awake for the whole deadline after every answered request.
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("a gateway that gave up on the app behind it", () => {
+  // 502/503/504 come from the PROXY, not the app, so they carry no RFC 7807
+  // body. Every reader of problemDetail then finds no code and falls back to
+  // its own generic sentence — which is how a reply draft that ran 45 seconds
+  // and had its connection cut reached the screen as "The request failed.
+  // Please try again." with nothing in it to act on.
+  it("gives a bodiless 502 a problem body the reader can be told about", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(null, { status: 502, statusText: "Bad Gateway" }),
+      ),
+    );
+
+    const { error, response } = await api.GET("/organizations/{id}/dossier", {
+      params: { path: { id: "01a0-4cd2" } },
+    });
+
+    expect(response.status).toBe(502);
+    expect(error).toMatchObject({
+      code: "gateway_unavailable",
+      status: 502,
+    });
+  });
+
+  // A gateway status the app DID answer keeps its own body: the server's
+  // sentence is always better than one synthesized here.
+  it("leaves a 503 the app itself explained alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ code: "maintenance_mode", detail: "upgrading" }),
+            {
+              status: 503,
+              headers: { "Content-Type": "application/problem+json" },
+            },
+          ),
+      ),
+    );
+
+    const { error } = await api.GET("/organizations/{id}/dossier", {
+      params: { path: { id: "01a0-4cd2" } },
+    });
+
+    expect(error).toMatchObject({ code: "maintenance_mode" });
+  });
+
+  // An ordinary refusal is untouched.
+  it("does not invent a body for a 422", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ code: "validation_error" }), {
+            status: 422,
+            headers: { "Content-Type": "application/problem+json" },
+          }),
+      ),
+    );
+
+    const { error } = await api.GET("/organizations/{id}/dossier", {
+      params: { path: { id: "01a0-4cd2" } },
+    });
+
+    expect(error).toMatchObject({ code: "validation_error" });
+  });
+
+  // The narrowness is the contract, not an accident: surfaces across the app
+  // read a bodiless 5xx as an ordinary server fault — the composer branches on
+  // a bare 501, the connector screens on a bodiless 503 — and telling those
+  // readers "the work may still be running" would be false about a mailer that
+  // is simply not wired.
+  it("leaves a bodiless 502 on an ordinary route alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 502 })),
+    );
+
+    const { error } = await api.GET("/me");
+
+    expect(error).not.toMatchObject({ code: "gateway_unavailable" });
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,13 +38,19 @@ function readerLanguage(): string | undefined {
 
 // How long a request may stay open before this client stops waiting for it.
 //
-// The API's own http.Server carries a 30s WriteTimeout, so no answer this
-// client can legitimately receive takes longer than that; the rest is headroom
-// for whatever sits between the two. Nothing long-lived comes through here —
-// the polling screens issue ordinary short requests on a refetchInterval, and
-// the file uploads call `fetch` directly rather than this client — so there is
-// no request this deadline can cut off mid-answer.
-const REQUEST_TIMEOUT_MS = 45_000;
+// This used to be derived from the API's 30s WriteTimeout — "no answer this
+// client can legitimately receive takes longer than that". That stopped being
+// true: the endpoints that call a model and wait (a reply draft, a dossier, a
+// growth-fit read) run 13 to 45 seconds against a cloud provider, and the
+// server now allows them the AI layer's own ceiling rather than cutting the
+// response at 30s.
+//
+// So this deadline was cutting exactly the answers it was written to be
+// generous towards, and the reader saw a request that failed for no stated
+// reason. It sits above the server's own ceiling now, so the SERVER is what
+// ends a hopeless request — it knows what the work was — and this remains what
+// it was for: the request that opened and will never answer at all.
+export const REQUEST_TIMEOUT_MS = 360_000;
 
 /**
  * A request that opened and never answered.
@@ -78,19 +84,96 @@ export class RequestTimeoutError extends Error {
 // a deadline nothing can exercise is a deadline nobody knows still works.
 async function fetchWithDeadline(request: Request): Promise<Response> {
   const deadline = new AbortController();
+  // The REQUEST's own signal is what React Query aborts when a screen unmounts
+  // or a query is cancelled. Without this the deadline was the only way a call
+  // could end, so navigating away from a 45-second draft left it running and a
+  // manual retry ran a second model call beside the first.
+  if (request.signal.aborted) {
+    deadline.abort(request.signal.reason);
+  } else {
+    request.signal.addEventListener(
+      "abort",
+      () => deadline.abort(request.signal.reason),
+      {
+        once: true,
+      },
+    );
+  }
   const expiry = globalThis.setTimeout(() => {
     deadline.abort(
       new RequestTimeoutError(request.method, request.url, REQUEST_TIMEOUT_MS),
     );
   }, REQUEST_TIMEOUT_MS);
   try {
-    return await globalThis.fetch(request, { signal: deadline.signal });
+    return withGatewayProblem(
+      await globalThis.fetch(request, { signal: deadline.signal }),
+      request.url,
+    );
   } finally {
     // Whatever the outcome. A cleared timer is what keeps a settled request
     // from holding the page awake, and — on a request that failed for its own
     // reasons — from aborting a controller nobody is listening to any more.
     globalThis.clearTimeout(expiry);
   }
+}
+
+// The statuses a PROXY answers with when it gave up on the app behind it,
+// rather than the app refusing something.
+const GATEWAY_STATUSES = new Set([502, 503, 504]);
+
+// The routes whose handler calls a model and waits. Only these get the gateway
+// message below, and the narrowness is the point: a bodiless 5xx from any other
+// endpoint is an ordinary server fault, and the app has surfaces that read it
+// as one — the composer branches on a bare 501, the connector screens on a
+// bodiless 503. Rewriting every one of those to say "the work may still be
+// running" would be false about a mailer that is simply not wired.
+//
+// What makes these three different is duration: a model call runs for tens of
+// seconds, so a proxy giving up on one really does leave work in flight, and
+// really does make a retry a second call rather than a repeat.
+const MODEL_ROUTE_SUFFIXES = ["/draft-email", "/dossier", "/growth-fit"];
+
+/**
+ * Give a proxy's failure ON A SLOW AI ROUTE a problem body, so the reader is
+ * told what happened instead of "the request failed".
+ *
+ * These responses come from the PROXY, not the app, so they carry no RFC 7807
+ * body — `problemDetail` finds no code and the caller falls back to its own
+ * generic sentence. That is how a reply draft that ran 45 seconds and had its
+ * connection cut reached the screen as "The request failed. Please try again."
+ *
+ * Identified by CONTENT TYPE, not an empty body: nginx and Vite both answer
+ * with an HTML error page, so a check for "no body at all" matches almost none
+ * of the real cases. Anything the app itself answered is problem+json and
+ * passes through untouched — the server's own sentence is always better.
+ */
+function withGatewayProblem(response: Response, url: string): Response {
+  if (!GATEWAY_STATUSES.has(response.status) || !callsAModel(url)) {
+    return response;
+  }
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (contentType.includes("application/problem+json")) {
+    return response;
+  }
+  return new Response(
+    JSON.stringify({
+      type: "about:blank",
+      title: "Gateway",
+      status: response.status,
+      code: "gateway_unavailable",
+      detail: "the server did not finish this request",
+    }),
+    {
+      status: response.status,
+      statusText: response.statusText,
+      headers: { "Content-Type": "application/problem+json" },
+    },
+  );
+}
+
+function callsAModel(url: string): boolean {
+  const path = URL.canParse(url) ? new URL(url).pathname : url;
+  return MODEL_ROUTE_SUFFIXES.some((suffix) => path.endsWith(suffix));
 }
 
 export const api = createClient<paths>({

--- a/frontend/src/app/queryclient.ts
+++ b/frontend/src/app/queryclient.ts
@@ -48,6 +48,18 @@ function problemStatusOf(error: unknown): number | null {
   return typeof problem.status === "number" ? problem.status : null;
 }
 
+// The RFC-7807 `code` a failure carries, on the same terms as the status above.
+function problemCodeOf(error: unknown): string | null {
+  if (!(error instanceof ProblemError)) {
+    return null;
+  }
+  const problem = error.problem;
+  if (typeof problem !== "object" || problem === null || !("code" in problem)) {
+    return null;
+  }
+  return typeof problem.code === "string" ? problem.code : null;
+}
+
 // FE-PARAM-2: retry a server error that the server may yet recover from —
 // never a client error, and never a refusal it has already settled.
 export function retryQuery(failureCount: number, error: Error): boolean {
@@ -60,9 +72,17 @@ export function retryQuery(failureCount: number, error: Error): boolean {
   // bug in a query function returns the same failure however often it is
   // asked. The error state that follows offers the reader a retry either way,
   // so nothing is lost but the silent second request.
+  // A gateway that gave up is NOT retried, and this is the one 5xx where a
+  // second request is worse than none: the proxy stopped waiting, but the work
+  // behind it — a model call that legitimately runs the better part of a
+  // minute — is very likely still running. Retrying twice more starts up to
+  // three of them, and the reader is told in the same breath that the first
+  // may still be working. Their own retry is a decision; this one is not.
+  const gaveUpWaiting = problemCodeOf(error) === "gateway_unavailable";
   return (
     status !== null &&
     status >= 500 &&
+    !gaveUpWaiting &&
     !SETTLED_SERVER_REFUSALS.has(status) &&
     failureCount < MAX_RETRIES
   );

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -628,6 +628,8 @@ export const de = {
   "common.error": "Konnten diese Ansicht nicht laden.",
   "common.errorNoCause":
     "Die Anfrage ist fehlgeschlagen. Keine Ursache gemeldet.",
+  "common.gatewayUnavailable":
+    "Der Server hat diese Anfrage nicht rechtzeitig abgeschlossen. Sie läuft möglicherweise noch — warte einen Moment, bevor du es erneut versuchst, sonst läuft dieselbe Arbeit zweimal.",
   "common.permissionDenied":
     "Du hast keine Berechtigung für diese Aktion. Bitte einen Admin oder die Person, die diesen Datensatz mit dir geteilt hat, deinen Zugriff zu erweitern.",
   "common.seatReadOnly":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -634,6 +634,8 @@ export const en = {
   // fetch and a bug in our own code both report in wording nobody authored for
   // a reader, so the screen states the fact it can stand behind and stops.
   "common.errorNoCause": "The request failed. No cause reported.",
+  "common.gatewayUnavailable":
+    "The server did not finish this request in time. It may still be working — wait a moment before trying again, or the same work can run twice.",
   // Every 403 the server codes `permission_denied`, which is two refusals with
   // one name: a role that does not admit the action on this kind of record, and
   // a record the reader holds read-only through a share. Nothing on the wire

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -623,6 +623,8 @@ export const vi = {
   "common.error": "Không tải được màn hình này.",
   "common.errorNoCause":
     "Yêu cầu thất bại. Không có nguyên nhân nào được báo về.",
+  "common.gatewayUnavailable":
+    "Máy chủ chưa hoàn tất yêu cầu này kịp thời. Có thể nó vẫn đang chạy — hãy đợi một lát trước khi thử lại, nếu không cùng một công việc sẽ chạy hai lần.",
   "common.permissionDenied":
     "Bạn không có quyền cho hành động này. Hãy nhờ quản trị viên, hoặc người đã chia sẻ bản ghi này với bạn, mở rộng quyền truy cập của bạn.",
   "common.seatReadOnly":

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -540,6 +540,9 @@ function problemDetail(
   if (t && code === "unsupported_in_overlay_mode") {
     return t("overlay.filterUnsupported");
   }
+  if (t && code === "gateway_unavailable") {
+    return t("common.gatewayUnavailable");
+  }
   if (t && code === "permission_denied") {
     return t("common.permissionDenied");
   }

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -800,6 +800,11 @@ describe("ComposeModal", () => {
   it("shows a draft error on a bodiless non-2xx without crashing the fill", async () => {
     // The old !error success path would fabricate an undefined draft and crash
     // onSuccess reading its fields; a bodiless 502 must surface an error only.
+    //
+    // On THIS route the error says what happened: a draft runs for tens of
+    // seconds, so a proxy giving up on one leaves work in flight, and a retry
+    // is a second model call rather than a repeat. Every other route keeps the
+    // generic sentence — see api/client.test.ts.
     stubRoutes({
       "POST /activities/act-1/draft-email": () => emptyResponse(502),
     });
@@ -817,7 +822,11 @@ describe("ComposeModal", () => {
       screen.getByRole("button", { name: "Draft with AI" }),
     );
 
-    expect(await screen.findByText(/The request failed/i)).toBeTruthy();
+    expect(
+      await screen.findByText(/did not finish this request in time/i),
+    ).toBeTruthy();
+    // And it warns before a retry, because the first call may still be running.
+    expect(screen.getByText(/may still be working/i)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## What was wrong

Pressing **Draft with AI** failed with `502 Bad Gateway`, intermittently, and worked on the third try. From the running installation's log, the same endpoint answering 200:

| attempt | duration |
|---|---|
| 1 | 13.3 s |
| 2 | **45.0 s** |
| 3 | 37.1 s |
| 4 | 24.5 s |

The model is thinking. Two deadlines below that were cutting it:

- **The api's `WriteTimeout` was 30s.** Any longer response had its connection cut mid-write, which reaches the reader as a 502 from the proxy in front — a deadline nobody meant to set, reported as a broken server.
- **The browser gave up at 45s**, and its own comment derived that number from the server's 30s. Every `duration_ms=45010` in the log is the client aborting, not the server.

Meanwhile `ai.CallCeiling` allows **one model call 300 seconds**, deliberately, because "premium completions on long context are legitimately slow". The server contradicted its own AI layer by a factor of ten.

## What changed

**A per-route deadline, not a global one.** The first attempt raised `WriteTimeout` server-wide; the review rejected it, and rightly — a long global bound lets one slow-reading client hold a connection and its handler goroutine. `modules/agents/httpmcp.go` had already refused that exact trade for its own route and says why. So `compose/modelroutedeadline.go` extends the deadline for `/draft-email`, `/dossier` and `/growth-fit` only, and the server keeps its short bound for everything else.

**The deadline is derived, not chosen.** `ai.RouteWriteDeadline` = `CallCeiling × rungs × walks + headroom` — the same derivation `railLease` already makes, whose comment notes a round number "would be a guess that happens to look like a decision." A bound sized for one call would cut a legitimate ladder fallback: the same defect one level down.

**The client deadline now outlives the server's**, so the server — which knows what the work was — is what ends a hopeless request.

**An honest message, only where it is true.** A 502 comes from the proxy and carries no problem body, so every reader fell through to "The request failed." On the three slow routes it now says the server did not finish in time, the work may still be running, and to wait before retrying — a blind retry there is a *second* model call. Scoped to those routes because a bodiless 5xx elsewhere is an ordinary fault: the composer branches on a bare 501, the connector screens on a bodiless 503, and telling those readers the work continues would be false about a mailer that is simply not wired.

**Two more from the review:** the caller's abort signal composes with the deadline, so leaving the page cancels the call instead of leaving it running; and these failures are excluded from automatic retry, which was starting up to three overlapping model calls while the message warned the first might still be working.

## Verified

- `make check` exit 0, zero failures; `craft static --strict` and `rls-store-path` clean.
- Four new middleware tests: only the model routes take the longer deadline, the deadline covers the whole ladder, an ordinary route is untouched, and a chain that cannot extend fails loudly rather than dying mid-write.
- The scoping was caught by the suite, not by me: the first version made **21 tests fail** across the app because it rewrote every bodiless 5xx. Narrowing to the three routes brought that to 1 — a genuine draft-route test asserting the old wording, updated to assert the new message and its retry warning.

## Reviewed

Codex's verdict on the first version was "not safe to ship as-is", with five findings — all addressed: the global timeout is reverted in favour of the per-route deadline; gateway detection keys on content type rather than `body !== null` (a real nginx/Vite 502 sends an HTML page, so the original check would have fired on almost nothing); the ladder is covered rather than one call; the abort signal composes; and the retry exclusion is in.

## Known, not fixed here

A 45-second synchronous draft should be a job the caller polls, the way a voice build already is. This stops it failing; it does not make it fast. The middleware test bounds the deadline deliberately so this cannot quietly become a queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended response windows for long-running AI drafting, dossier, and growth-fit requests.
  - Increased client timeout to six minutes.
  - Added clearer gateway-unavailable error handling and localized messages in English, German, and Vietnamese.
  - Prevented automatic retries when a request may still be processing.

- **Bug Fixes**
  - Preserved caller cancellation behavior, including canceled background requests.
  - Standardized timeout-related gateway responses for supported AI routes.
  - Added safeguards when response deadlines cannot be extended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the intermittent 502 on the slow AI routes (`/draft-email`, `/dossier`, `/growth-fit`). A response that runs 13-45 seconds was being cut by the server's 30s `WriteTimeout`, which the proxy surfaced as a 502 even though the model was still working.

**Bug Fixes**

- Those three routes now get a per-route write deadline derived from the AI call ceiling, while the server's short global timeout still protects every other endpoint.
- The frontend request deadline now outlives the server's, and leaving the page cancels the in-flight call instead of leaving it running.
- A bodiless gateway 5xx on those routes now says the work may still be running and to wait before retrying.
- Those failures are excluded from automatic retry, which was starting up to three overlapping model calls.

<sup>Written for commit cc0ad9ba8481399d8896efcd3217eca7bba8ded5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

