### PR TITLE
feat(compose): a reply names the message it answers, and the recipient it goes to

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2896,6 +2896,11 @@ export const de = {
     "Ihre Voice DNA wird noch aufgebaut. Sie prägt diesen Entwurf schon genauso wie eine fertige — es wird nichts zurückgehalten.",
   "compose.intent": 'Entwurf steuern (optional), z. B. "höfliche Nachfrage"',
   "compose.to": "An",
+  "compose.answering": "Antwort auf „{subject}“ · {when}",
+  "compose.answeringTo": "Antwort an {who} · „{subject}“ · {when}",
+  "compose.answeringNoSubject": "Antwort auf die Nachricht vom {when}",
+  "compose.answeringNothing":
+    "Hier gibt es keine frühere Nachricht — das beginnt einen neuen Verlauf.",
   "compose.cc": "Cc",
   "compose.subject": "Betreff",
   "compose.noGroundableRecipient":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2918,6 +2918,11 @@ export const en = {
     "Your Voice DNA is still being built. It already shapes this draft exactly as a finished one would — nothing is held back.",
   "compose.intent": 'Steer the draft (optional), e.g. "polite follow-up"',
   "compose.to": "To",
+  "compose.answering": "Replying to “{subject}” · {when}",
+  "compose.answeringTo": "Replying to {who} · “{subject}” · {when}",
+  "compose.answeringNoSubject": "Replying to the message of {when}",
+  "compose.answeringNothing":
+    "No earlier message here — this starts a new thread.",
   "compose.cc": "Cc",
   "compose.subject": "Subject",
   "compose.noGroundableRecipient":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2869,6 +2869,11 @@ export const vi = {
   "compose.intent":
     'Định hướng bản nháp (không bắt buộc), ví dụ "thư nhắc lịch sự"',
   "compose.to": "Đến",
+  "compose.answering": "Trả lời “{subject}” · {when}",
+  "compose.answeringTo": "Trả lời {who} · “{subject}” · {when}",
+  "compose.answeringNoSubject": "Trả lời tin nhắn ngày {when}",
+  "compose.answeringNothing":
+    "Chưa có tin nhắn nào trước đó — đây sẽ mở một chuỗi mới.",
   "compose.cc": "Cc",
   "compose.subject": "Tiêu đề",
   "compose.noGroundableRecipient":

--- a/frontend/src/screens/compose.css
+++ b/frontend/src/screens/compose.css
@@ -271,3 +271,11 @@
 .compose-reasons .chips {
   margin: 0;
 }
+
+/* What this message answers, above the recipient it will go to. Meta ink and
+   the small size the rest of the dialog's secondary lines use: it is context
+   for the fields below, not a field of its own. */
+.mw-answering {
+  margin: 0 0 var(--space-2);
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -2188,3 +2188,278 @@ describe("ComposeModal started from an account", () => {
     await waitFor(() => expect(subject().value).toBe("Re: ohne Tag"));
   });
 });
+
+// Opened from a record page, the composer named no conversation: To was empty,
+// Subject was empty, and nothing on screen said what was being answered — so a
+// reader could press "Draft with AI" without knowing who they were writing to
+// or which message they were replying to. Reported from the running product in
+// those words.
+describe("what the composer says it is answering", () => {
+  const latestMail: Activity = {
+    id: "act-latest",
+    kind: "email",
+    subject: "Rechnung GR-2026-0207",
+    occurred_at: "2026-08-02T09:00:00Z",
+    is_done: false,
+    source: "manual",
+    captured_by: "human:u1",
+    created_at: "2026-08-02T09:00:00Z",
+    updated_at: "2026-08-02T09:00:00Z",
+  };
+
+  it("names the record's latest message, and drafts against it", async () => {
+    const sent = stubRoutes({
+      "GET /activities": () =>
+        jsonResponse({
+          data: [latestMail],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "POST /activities/act-latest/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Rechnung",
+          body: "Hallo",
+          to: ["d@x.test"],
+        }),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // The conversation being continued is on screen BEFORE the reader commits
+    // to anything.
+    expect(await screen.findByText(/Rechnung GR-2026-0207/)).toBeTruthy();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    // And the draft answers THAT message: the account-wide draft, which needs
+    // a recipient named first, is not what a reader gets from a record page.
+    await waitFor(() =>
+      expect(
+        sent.some((s) => s.key === "POST /activities/act-latest/draft-email"),
+      ).toBe(true),
+    );
+  });
+
+  // An empty account is not a failure, and must not be reported as one: the
+  // reader is told this starts a new thread rather than left guessing.
+  it("says so when the record has no earlier message", async () => {
+    stubRoutes({
+      "GET /activities": () =>
+        jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(/starts a new thread/i)).toBeTruthy();
+  });
+
+  // Who this is going to, on the line, once it is known. The composer used to
+  // make the reader pick the person, and picking them is what made the consent
+  // purpose an attestation about a named human. The thread supplies the
+  // address now, so the reader has to SEE it before they attest anything.
+  it("names the recipient once the draft has filled it", async () => {
+    stubRoutes({
+      "GET /activities": () =>
+        jsonResponse({
+          data: [latestMail],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "POST /activities/act-latest/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Rechnung",
+          body: "Hallo",
+          to: ["dietmar@valantic.test"],
+        }),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Before the draft the line still answers the first question: WHAT.
+    await screen.findByText(/Rechnung GR-2026-0207/);
+    expect(screen.queryByText(/dietmar@valantic.test/)).toBeNull();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    // And then WHO, in the same sentence the reader is already reading.
+    expect(
+      await screen.findByText(/dietmar@valantic.test.*Rechnung GR-2026-0207/),
+    ).toBeTruthy();
+  });
+
+  // The project narrows through the list's OWN project_id filter. Asking for
+  // entity_type=project returns an empty page rather than an error — verified
+  // against the running API — so the wrong spelling reads as "no earlier
+  // message" for every project on the installation, silently.
+  it("narrows to the selected project through project_id", async () => {
+    const asked: { params?: URLSearchParams } = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input),
+          "https://test.local",
+        );
+        if (url.pathname.endsWith("/activities")) {
+          asked.params = url.searchParams;
+          return jsonResponse({
+            data: [latestMail],
+            page: { next_cursor: null, has_more: false },
+          });
+        }
+        if (url.pathname.endsWith("/consent-purposes")) {
+          return jsonResponse(PURPOSES);
+        }
+        if (url.pathname.endsWith("/voice-profiles")) {
+          return jsonResponse(NO_VOICE_PROFILE);
+        }
+        return jsonResponse({});
+      }),
+    );
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByText(/Rechnung GR-2026-0207/);
+    // The record still scopes the read; a project only narrows it further.
+    expect(asked.params?.get("entity_type")).toBe("organization");
+    expect(asked.params?.get("entity_id")).toBe("org-1");
+    expect(asked.params?.get("kind")).toBe("email");
+    // And no project is selected here, so none is asked for.
+    expect(asked.params?.get("project_id")).toBeNull();
+  });
+
+  // The draft and the SEND must agree on what is being answered. Split, the
+  // draft answers a thread and writes "Re: …" while the send takes the account
+  // path: the message files under the links the body names rather than the
+  // anchor's own, so the person it was actually with gets none of it, and it
+  // leaves as a new RFC chain — an orphan, to a reader who was shown a reply.
+  it("sends against the same message it drafted against", async () => {
+    const sent = stubRoutes({
+      "GET /activities": () =>
+        jsonResponse({
+          data: [latestMail],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "POST /activities/act-latest/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Rechnung",
+          body: "Hallo",
+          to: ["d@x.test"],
+        }),
+      "POST /activities/act-latest/send-email": () => jsonResponse({}, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByText(/Rechnung GR-2026-0207/);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+    await waitFor(() =>
+      expect(
+        sent.some((s) => s.key === "POST /activities/act-latest/draft-email"),
+      ).toBe(true),
+    );
+
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      // The reply path, not POST /emails — which would file under the body's
+      // own links and start a new thread.
+      expect(sent.map((s) => s.key)).toContain(
+        "POST /activities/act-latest/send-email",
+      );
+      expect(sent.map((s) => s.key)).not.toContain("POST /emails");
+    });
+  });
+
+  // A message the reader may DISCOVER but not read is not an anchor: the list
+  // is discover-gated and returns it with its subject and body nulled, while
+  // the draft endpoint is content-gated and answers 404. Anchoring there hides
+  // the account path — the reader's only working route — and leaves them told
+  // they are replying to something the server will not let them answer.
+  it("does not anchor on a message whose content is withheld", async () => {
+    stubRoutes({
+      "GET /activities": () =>
+        jsonResponse({
+          data: [
+            {
+              ...latestMail,
+              subject: null,
+              body: null,
+              content_state: "withheld",
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // It falls back to the account path, which asks the reader to name a
+    // recipient — the honest state, rather than a dead end.
+    expect(await screen.findByText(/starts a new thread/i)).toBeTruthy();
+  });
+
+  // A caller that named the message has already shown it — the page behind the
+  // dialog IS that message — so the line would repeat what the reader opened.
+  it("stays quiet when the caller already named the message", async () => {
+    stubRoutes({
+      "GET /activities/act-1": () => jsonResponse(activity202),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("combobox");
+    expect(screen.queryByText(/Replying to|starts a new thread/i)).toBeNull();
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -446,6 +446,117 @@ function ProjectFiling({
 }
 
 /**
+ * The message this composer should answer, when the caller did not name one.
+ *
+ * Opened from a record page there is no anchor: the dialog asked the reader to
+ * authorise a draft with an empty To, an empty Subject, and nothing on screen
+ * saying what was being replied to. The reader could press "Draft with AI"
+ * without knowing who they were writing to or which message they were
+ * answering — reported from the running product in exactly those words.
+ *
+ * The latest message on the record is the answer, and the PROJECT narrows it:
+ * a reader who has picked a project is working inside that project, so the
+ * conversation to continue is that project's own last message rather than the
+ * account's. Changing the selection changes the answer, which is why this is a
+ * query keyed on both rather than a value read once when the dialog opened.
+ *
+ * `kind: email` because this composer sends mail: the last CALL on an account
+ * is not a message anyone can reply to, and offering it as one would put a
+ * recipient in the To field that the call never had.
+ */
+function useLatestMessage(
+  entityType: RelinkKind,
+  entityId: string,
+  projectId: string,
+  enabled: boolean,
+): { activity?: Activity; settled: boolean } {
+  // A project narrows through the list's OWN project_id filter, not through
+  // entity_type — a project is not one of the entity kinds that filter takes,
+  // and asking for one returns an empty page rather than an error, which reads
+  // as "no earlier message" for every project on the installation.
+  const query = useQuery({
+    queryKey: ["compose-latest-message", entityType, entityId, projectId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/activities", {
+        params: {
+          query: {
+            entity_type: entityType,
+            entity_id: entityId,
+            ...(projectId ? { project_id: projectId } : {}),
+            kind: "email",
+            limit: 1,
+          },
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    enabled,
+  });
+  // A row whose content is WITHHELD is not an anchor. The list is
+  // discover-gated, so a limited-audience message on this account comes back
+  // with its subject and body nulled — and the draft endpoint, which is
+  // content-gated, answers 404 for it. Anchoring there strands the composer:
+  // the account path is hidden because an anchor exists, the draft cannot run,
+  // and the reader is told they are replying to a message the server will not
+  // let them answer. Falling back to the account path is the honest outcome.
+  const newest = query.data?.data?.[0];
+  return {
+    // The list is ordered newest first (occurred_at DESC), so one row is the
+    // latest — asked for as one row rather than fetched and sorted here.
+    activity: newest?.content_state === "withheld" ? undefined : newest,
+    // A read that has not answered, or failed, is not "no message": the
+    // composer says nothing rather than claiming this is a fresh thread.
+    settled: query.isSuccess,
+  };
+}
+
+/**
+ * What the composer says it is answering, or null while it does not yet know.
+ *
+ * A caller that named an activity has already told the reader what they opened
+ * — the message is on the page behind this dialog — so the line is for the
+ * case that had nothing: opened from a record, where the conversation being
+ * continued was decided here and shown nowhere.
+ */
+function answeringSentence(
+  latest: { activity?: Activity; settled: boolean },
+  callerAnchor: string | undefined,
+  recipients: readonly string[],
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+  zone: string,
+): string | null {
+  if (callerAnchor !== undefined || !latest.settled) {
+    return null;
+  }
+  const answering = latest.activity;
+  if (!answering) {
+    return t("compose.answeringNothing");
+  }
+  const when = formatDateTime(answering.occurred_at, locale, zone);
+  const subject = answering.subject?.trim();
+  // WHO, as soon as it is known. The composer used to ask the reader to pick
+  // the person, and picking them is what made the consent purpose beneath an
+  // attestation about a named human. Now the thread supplies the address, so
+  // the line has to name it — a purpose chosen against a recipient the reader
+  // never saw is a weaker attestation than the one this replaced.
+  //
+  // The activity list does not carry the recipient, so this fills in when the
+  // draft does. Before that the line still says what is being answered, which
+  // is the question the reader had first.
+  const who = recipients.join(", ");
+  if (who && subject) {
+    return t("compose.answeringTo", { who, subject, when });
+  }
+  return subject
+    ? t("compose.answering", { subject, when })
+    : t("compose.answeringNoSubject", { when });
+}
+
+/**
  * The project link a reply's own thread already carries, if any.
  *
  * Read from the anchor activity rather than assumed, because the thread is the
@@ -1401,6 +1512,7 @@ function MailOnlyFields({
   subject,
   onSubjectChange,
   rejectionInFlight,
+  answering,
 }: Readonly<{
   intent: string;
   onIntentChange: (next: string) => void;
@@ -1416,6 +1528,9 @@ function MailOnlyFields({
   subject: string;
   onSubjectChange: (next: string) => void;
   rejectionInFlight: boolean;
+  /** What this message answers, in the reader's own words. Null while the
+   * lookup is unsettled — an unanswered read is not "no earlier message". */
+  answering: string | null;
 }>) {
   const t = useT();
   const offer = (
@@ -1438,6 +1553,13 @@ function MailOnlyFields({
         </DraftBand>
       ) : (
         offer
+      )}
+      {/* WHAT is being answered, above the recipient — the first thing a
+          reader looks for and the thing this dialog used to leave out. Opened
+          from a record page it named no conversation at all, so a reader could
+          press "Draft with AI" without knowing who they were writing to. */}
+      {answering !== null && (
+        <p className="t-small mw-answering">{answering}</p>
       )}
       <MailRow label={t("compose.to")}>
         <RecipientField
@@ -2012,8 +2134,39 @@ export function ComposeModal({
   // Whether this composer can ground a draft in an account: an account-started
   // message on a company page, over mail. A channel reply resolves its
   // recipient server-side and has no draft endpoint at all.
+  // What this composer is answering. The caller names it when the reader opened
+  // a specific message; opened from a record page it does not, and the reader
+  // was then asked to authorise a draft against a conversation nothing on
+  // screen identified. The project narrows it, so switching projects switches
+  // the conversation being continued.
+  const latest = useLatestMessage(
+    entityType,
+    entityId,
+    account.grounding.projectId,
+    open && !activityId,
+  );
+  const answering = activityId ?? latest.activity?.id;
+  // The sentence the reader reads. Null while the lookup is unsettled: an
+  // unanswered read is not "no earlier message", and saying so would tell them
+  // this starts a new thread when it may continue one.
+  const answeringLine = answeringSentence(
+    latest,
+    activityId,
+    to,
+    t,
+    locale,
+    zone,
+  );
+
+  // The account-started path: no conversation to continue, so the reader names
+  // the recipient and the draft is grounded in the account itself.
+  //
+  // Keyed on the RESOLVED anchor, not the caller's. A record with earlier mail
+  // has a message to answer, and answering it is what a reader opening the
+  // composer there means — the account path asked them to name a recipient the
+  // thread already knows, in front of a To field the draft would have filled.
   const groundable =
-    !activityId && entityType === "organization" && !isChannelReply;
+    !answering && entityType === "organization" && !isChannelReply;
   // Where this send files, and the subject tag that travels with it. The
   // account path keeps its own picker (it chooses a project rather than
   // inheriting one), so this covers the anchored sends: a reply, and a message
@@ -2030,7 +2183,7 @@ export function ComposeModal({
       : undefined,
   );
   const projectFiling = useProjectFiling({
-    activityId,
+    activityId: answering,
     anchorProjectId: anchorProject.projectId,
     anchorSettled: anchorProject.settled,
     projects: reachableProjects,
@@ -2055,7 +2208,7 @@ export function ComposeModal({
   };
 
   const draft = useDraftMutation({
-    activityId,
+    activityId: answering,
     entityType,
     entityId,
     intent,
@@ -2147,7 +2300,14 @@ export function ComposeModal({
         ...scheduleFields(sendAt),
       };
       const { data, error, response } = await sendFrom({
-        activityId,
+        // The SAME anchor the draft used. Split, these disagree in the worst
+        // possible way: the draft answers a thread and writes "Re: …", and the
+        // send then takes the account path — which files under the links the
+        // body names rather than the anchor's own (the person the mail was
+        // with gets none, so the message is missing from their timeline), and
+        // starts a new RFC message-id chain, so what the reader was shown as a
+        // reply reaches the recipient as an orphan.
+        activityId: answering,
         isChannelReply,
         mail,
         channelBody: { body, consent_purpose: purpose },
@@ -2359,6 +2519,7 @@ export function ComposeModal({
             the draft controls nor the To/Cc/Subject fields apply to it. */}
           {!isChannelReply && (
             <MailOnlyFields
+              answering={answeringLine}
               intent={intent}
               onIntentChange={setIntent}
               draft={draftControl}


### PR DESCRIPTION
## What was wrong

Reported from the running product:

> I can just press draft but I have no idea what I answer and to whom I write. If there is no project it should be the last. If there is a project selected it should be the last in this project.

Opened from a record page, the composer had **no anchor at all**. `companyheader.tsx` passes `entityType`/`entityId` and no `activityId`, so:

- To was empty, Subject was empty, nothing on screen named the conversation
- `groundable = !activityId` was true, and `disabled: groundable && !account.recipientId` meant **the Draft button stayed dead until the reader hand-picked a recipient**

The dialog genuinely did not know what it was answering.

## What changed

It resolves the message to answer — the record's latest email, narrowed to the selected project — names it above the To field, and drafts against it. Because there is now a thread, the recipient comes from it rather than from a picker. The line reads:

> Replying to dietmar@valantic.test - "Rechnung GR-2026-0207" - 2 Aug

With nothing to answer it says so: *"No earlier message here — this starts a new thread."*

## Three defects caught before this shipped

**1. The draft and the send used different anchors.** The draft took the resolved one; the send still took the caller's, which is `undefined` here. A message the reader was shown as a reply would have gone out through the account path — filing under the links the body names rather than the anchor's own, so **the person it was actually with gets no link** and it is missing from their timeline — and starting a fresh RFC message-id chain, reaching the recipient as an orphan. Draft, send and the filing picker now read one anchor.

**2. A content-withheld message became the anchor.** `GET /activities` is discover-gated, so a colleague's limited-audience mail on the same account returns with subject and body nulled. `POST /activities/{id}/draft-email` is content-gated and answers 404 for it — while the account path stayed hidden because an anchor "existed". The composer stranded: no picker, no draft, and the reader told they were replying to something the server would not let them answer. Withheld rows are skipped, so it falls back to the account path.

**3. The project scope used the wrong parameter.** `entity_type=project` is not a value that filter takes — it answers an **empty page rather than an error**, so every project would have read as "no earlier message", silently. Verified against the running API: `entity_type=project` returns `{"data":[]}`, the contract's own `project_id` filter returns the mail. The record still scopes the read; a project only narrows it.

## On the consent attestation

Before, the reader picked the person and then chose a consent purpose for that named human. The thread supplies the address now, so the purpose is attested against a recipient the machine filled in. Nothing unlawful ships — `RequireGrantedForEmails` still refuses an erased or unsubscribed address at send time — but the attestation is weaker unless the reader has seen who. That is why the line names the recipient as soon as the draft supplies it.

## Verified

- `make check` exit 0, zero failures; `craft static --strict` clean.
- Six tests, **each mutation-checked**: reverting the anchor resolution, splitting draft from send, restoring the withheld anchor, and dropping the recipient from the line each turn their test red.
- The project-scope defect was found by querying the running API directly, not by reading the contract.

## Reviewed

The security review confirmed what does **not** break: no cross-tenant anchor (the list runs `ensureNarrowingTargetVisible` under `WithWorkspaceTx`), no prior-message content leaking into an unintended draft (`EnsureActivityContentVisible` answers 404 rather than a blanked row), and the consent gate intact on both send paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opened from a record page, the compose dialog had no conversation to anchor to: To and Subject were empty, and the Draft button stayed disabled until the reader picked a recipient by hand. The composer now resolves the record's latest email — narrowed by the selected project — names that message above the To field, and drafts and sends against it.

- Draft, send, and the filing picker now all read the resolved anchor; before, the send used the caller's empty one and would have filed the reply under the body's own links rather than the anchor's.
- A message with withheld content no longer anchors the reply — the draft endpoint returns 404 for it — and the composer falls back to the account path.
- Project narrowing now goes through the list's own `project_id` filter; `entity_type=project` returns an empty page rather than an error, which silently read as "no earlier message" for every project.
- When the record has no earlier mail, the dialog says "No earlier message here — this starts a new thread."
- The line names the recipient as soon as the draft fills it, so the consent purpose is still attested against a person the reader has seen.

<sup>Written for commit 554f2dc7c4fd4546a9850327ac19572b801f6de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The composer now shows which message a reply addresses, including its subject, recipient, and timestamp.
  * When no earlier message is available, the composer clearly indicates that a new conversation will start.
  * Replies are automatically connected to the relevant conversation and project when applicable.
* **Localization**
  * Added reply-context translations for English, German, and Vietnamese.
* **Bug Fixes**
  * Improved handling of unavailable or withheld messages and prevented duplicate reply-context information when composing from an existing activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->