### PR TITLE
fix(capture): a booked room is not a guest, and a colleague is never drafted a reply

### DIFF
--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -17,6 +17,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -49,6 +50,10 @@ type commsAdapter struct {
 	// defer, exactly as it does on the HTTP transport: an agent must not be
 	// able to promise a moment nothing will wake at.
 	timer activities.ScheduleTimer
+	// own answers whether an addressee is one of the workspace's own people.
+	// The activities store excludes participants with a seat; a colleague
+	// without one is only recognisable by domain, and that set is capture's.
+	own *capture.OwnDomainStore
 }
 
 var _ agents.Comms = commsAdapter{}
@@ -67,8 +72,25 @@ var _ automation.Comms = commsAdapter{}
 // It asks the store rather than the drafter even when a model drafting lane is
 // wired: who a reply is TO is a fact about the record, and a routed drafter
 // must not be able to change it.
+//
+// A colleague is refused here the way an empty thread is refused by the store.
+// A message whose only addressee is on the workspace's own domain — a stand-up
+// with a colleague who has no seat, a hand-off, a message captured before the
+// domain was registered — has nobody outside the company to answer, and an
+// automation must not compose one for a human to wave through.
 func (c commsAdapter) ReplyAddress(ctx context.Context, anchor ids.UUID) (string, error) {
-	return c.store.ReplyAddressFor(ctx, ids.From[ids.ActivityKind](anchor))
+	to, err := c.store.ReplyAddressFor(ctx, ids.From[ids.ActivityKind](anchor))
+	if err != nil {
+		return "", err
+	}
+	internal, err := c.own.Internal(ctx, to)
+	if err != nil {
+		return "", fmt.Errorf("compose: deciding whether the addressee is a colleague: %w", err)
+	}
+	if internal {
+		return "", &activities.NoReplyAddressError{Colleague: true}
+	}
+	return to, nil
 }
 
 func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (string, string, error) {

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -73,24 +73,18 @@ var _ automation.Comms = commsAdapter{}
 // wired: who a reply is TO is a fact about the record, and a routed drafter
 // must not be able to change it.
 //
-// A colleague is refused here the way an empty thread is refused by the store.
-// A message whose only addressee is on the workspace's own domain — a stand-up
-// with a colleague who has no seat, a hand-off, a message captured before the
-// domain was registered — has nobody outside the company to answer, and an
-// automation must not compose one for a human to wave through.
+// The store is told who counts as a colleague by domain, because it excludes
+// only seats on its own. A message whose every addressee is on the workspace's
+// own domains — a stand-up with a colleague who has no seat, a hand-off, a
+// message captured before the domain was registered — has nobody outside the
+// company to answer, and an automation must not compose one for a human to
+// wave through.
 func (c commsAdapter) ReplyAddress(ctx context.Context, anchor ids.UUID) (string, error) {
-	to, err := c.store.ReplyAddressFor(ctx, ids.From[ids.ActivityKind](anchor))
+	own, err := c.own.Colleagues(ctx)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("compose: reading who counts as a colleague: %w", err)
 	}
-	internal, err := c.own.Internal(ctx, to)
-	if err != nil {
-		return "", fmt.Errorf("compose: deciding whether the addressee is a colleague: %w", err)
-	}
-	if internal {
-		return "", &activities.NoReplyAddressError{Colleague: true}
-	}
-	return to, nil
+	return c.store.ReplyAddressFor(ctx, ids.From[ids.ActivityKind](anchor), own.Covers)
 }
 
 func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (string, string, error) {

--- a/backend/internal/compose/integration/replyaddress_integration_test.go
+++ b/backend/internal/compose/integration/replyaddress_integration_test.go
@@ -60,7 +60,7 @@ func TestAReplyIsAddressedToTheCounterpartyWhoWroteIn(t *testing.T) {
 		replyParty{role: "to", address: "rep@ourcompany.test", ours: true},
 	)
 
-	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor)
+	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor, nil)
 	if err != nil {
 		t.Fatalf("ReplyAddressFor → %v, want the counterparty's address", err)
 	}
@@ -78,7 +78,7 @@ func TestAReplyToOurOwnOutboundGoesToTheAddresseeNotOurselves(t *testing.T) {
 		replyParty{role: "to", address: "anna@example.com"},
 	)
 
-	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor)
+	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor, nil)
 	if err != nil {
 		t.Fatalf("ReplyAddressFor → %v, want the addressee", err)
 	}
@@ -110,7 +110,7 @@ func TestAParticipantWithNoAddressFallsBackToThePrimaryEmail(t *testing.T) {
 		replyParty{role: "from", person: &person},
 	)
 
-	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor)
+	got, err := e.Activities.ReplyAddressFor(e.Admin(), anchor, nil)
 	if err != nil {
 		t.Fatalf("ReplyAddressFor → %v, want the primary email", err)
 	}
@@ -128,7 +128,7 @@ func TestAThreadWithNoCounterpartyRefusesRatherThanGuessing(t *testing.T) {
 		replyParty{role: "from", address: "rep@ourcompany.test", ours: true},
 	)
 
-	_, err := e.Activities.ReplyAddressFor(e.Admin(), anchor)
+	_, err := e.Activities.ReplyAddressFor(e.Admin(), anchor, nil)
 	var refusal *activities.NoReplyAddressError
 	if !errors.As(err, &refusal) {
 		t.Fatalf("ReplyAddressFor → %v, want NoReplyAddressError", err)

--- a/backend/internal/compose/replyaddresscolleague_integration_test.go
+++ b/backend/internal/compose/replyaddresscolleague_integration_test.go
@@ -50,4 +50,14 @@ func TestAReplyIsNeverAddressedToAColleagueOnTheOwnDomain(t *testing.T) {
 	if err != nil || got != "dana@client.example" {
 		t.Fatalf("ReplyAddress → (%q, %v), want the guest", got, err)
 	}
+
+	// A colleague who ranks first must not hide the guest behind them.
+	anchor := seedMeetingWith(t, e, "dana@client.example")
+	e.WsExec(t, `
+		INSERT INTO activity_participant (id, activity_id, role, address)
+		VALUES ($1, $2, 'to', 'colleague@ourcompany.test')`, ids.NewV7(), anchor)
+	got, err = comms.ReplyAddress(e.Admin(), anchor)
+	if err != nil || got != "dana@client.example" {
+		t.Fatalf("ReplyAddress with a colleague ranked ahead → (%q, %v), want the guest", got, err)
+	}
 }

--- a/backend/internal/compose/replyaddresscolleague_integration_test.go
+++ b/backend/internal/compose/replyaddresscolleague_integration_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// An automation composes replies with no human present to name the addressee,
+// so the adapter has to refuse the one addressee the store cannot recognise as
+// ours: a colleague on the workspace's own domain who holds no seat.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedMeetingWith writes one captured meeting whose only party besides the
+// connected owner is the address given.
+func seedMeetingWith(t *testing.T, e *integration.Env, address string) ids.UUID {
+	t.Helper()
+	activity := integration.SeedIDRow(t, integration.OwnerConn(t), `
+		INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Daily stand-up', now(), 'test', 'human:seed')`)
+	e.WsExec(t, `
+		INSERT INTO activity_participant (id, activity_id, role, user_id, address)
+		VALUES ($1, $2, 'from', $3, 'rep@ourcompany.test')`, ids.NewV7(), activity, e.Rep1)
+	e.WsExec(t, `
+		INSERT INTO activity_participant (id, activity_id, role, address)
+		VALUES ($1, $2, 'attendee', $3)`, ids.NewV7(), activity, address)
+	return activity
+}
+
+func TestAReplyIsNeverAddressedToAColleagueOnTheOwnDomain(t *testing.T) {
+	e := integration.Setup(t)
+	e.WsExec(t, `INSERT INTO workspace_email_domain (domain, source, verified) VALUES ('ourcompany.test', 'admin', true)`)
+	comms := newCommsAdapter(e.Pool, nil, SendPath{})
+
+	_, err := comms.ReplyAddress(e.Admin(), seedMeetingWith(t, e, "colleague@ourcompany.test"))
+	var refusal *activities.NoReplyAddressError
+	if !errors.As(err, &refusal) || !refusal.Colleague {
+		t.Fatalf("ReplyAddress → %v, want the colleague refusal", err)
+	}
+
+	// The admit case: the same meeting with a guest is answered to the guest.
+	got, err := comms.ReplyAddress(e.Admin(), seedMeetingWith(t, e, "dana@client.example"))
+	if err != nil || got != "dana@client.example" {
+		t.Fatalf("ReplyAddress → (%q, %v), want the guest", got, err)
+	}
+}

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -29,6 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
@@ -249,5 +250,6 @@ func newCommsAdapter(pool *pgxpool.Pool, drafter activities.EmailDrafter, send S
 		stager:        send.Delivery,
 		channelStager: send.Delivery,
 		timer:         send.ScheduleTimer,
+		own:           capture.NewOwnDomainStore(InstallationDB(pool)),
 	}
 }

--- a/backend/internal/modules/activities/replyaddress.go
+++ b/backend/internal/modules/activities/replyaddress.go
@@ -20,8 +20,8 @@ package activities
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -79,7 +79,14 @@ func (e *NoReplyAddressError) FieldFault() (field, code, message string) {
 // declines to model, and answering all of them is a different product decision
 // from answering the counterparty — this addresses the most likely one and a
 // human sees it before anything sends.
-func (s *Store) ReplyAddressFor(ctx context.Context, id ids.ActivityID) (string, error) {
+//
+// colleague names the addresses that are ours by domain rather than by seat —
+// a co-worker without a login. The candidates are walked in rank order and
+// the first one that is not a colleague is the answer, so a stand-up with a
+// colleague AND a guest is answered to the guest whatever the header order.
+// A nil predicate treats nobody as a colleague. When every candidate is one,
+// the refusal says so.
+func (s *Store) ReplyAddressFor(ctx context.Context, id ids.ActivityID, colleague func(address string) bool) (string, error) {
 	// Reaching a person's address is a person read, exactly as reaching their
 	// name is: a caller who may read activities but not people must not be told
 	// through this door what the people surface withholds.
@@ -150,27 +157,46 @@ func (s *Store) ReplyAddressFor(ctx context.Context, id ids.ActivityID) (string,
 		}
 		q += `
 			) ranked
-			 ORDER BY rank, source, primary_first DESC, position, created_at, id, addr
-			 LIMIT 1`
+			 ORDER BY rank, source, primary_first DESC, position, created_at, id, addr`
 
-		err = tx.QueryRow(ctx, q, args...).Scan(&address)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return &NoReplyAddressError{}
-		}
+		rows, err := tx.Query(ctx, q, args...)
 		if err != nil {
 			return fmt.Errorf("resolve the address a reply answers: %w", err)
 		}
-		return nil
+		defer rows.Close()
+		address, err = firstOutside(rows, colleague)
+		return err
 	})
 	if err != nil {
 		return "", err
 	}
-	if address == "" {
-		// Belt and braces against a row that satisfies the predicate with
-		// whitespace: an empty addressee reaches the send's own refusal, but it
-		// would arrive there as "no recipients" rather than as the honest
-		// answer that this thread has no counterparty to answer.
-		return "", &NoReplyAddressError{}
-	}
 	return address, nil
+}
+
+// firstOutside walks the ranked candidates and answers the first that is not
+// a colleague. No candidate at all is the plain refusal; candidates that are
+// all colleagues is the refusal that names why.
+func firstOutside(rows pgx.Rows, colleague func(address string) bool) (string, error) {
+	sawColleague := false
+	for rows.Next() {
+		var address string
+		if err := rows.Scan(&address); err != nil {
+			return "", fmt.Errorf("resolve the address a reply answers: %w", err)
+		}
+		// A row that satisfies the predicate with whitespace is no addressee:
+		// it would reach the send as "no recipients" rather than as the honest
+		// answer that this thread has no counterparty to answer.
+		if strings.TrimSpace(address) == "" {
+			continue
+		}
+		if colleague != nil && colleague(address) {
+			sawColleague = true
+			continue
+		}
+		return address, nil
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("resolve the address a reply answers: %w", err)
+	}
+	return "", &NoReplyAddressError{Colleague: sawColleague}
 }

--- a/backend/internal/modules/activities/replyaddress.go
+++ b/backend/internal/modules/activities/replyaddress.go
@@ -38,9 +38,20 @@ import (
 // a manually logged call, or a thread whose participants were never captured.
 // An automation instance pointed at such a record is misconfigured, and the
 // operator can act on that.
-type NoReplyAddressError struct{}
+//
+// Colleague marks the other way a thread can have nobody to answer: the only
+// addressee left is on the workspace's own domain. The store cannot tell that
+// (the own-domain set is capture's), so the caller that can sets it, and the
+// refusal reads the same to everyone that handles this error.
+type NoReplyAddressError struct {
+	Colleague bool
+}
 
 func (e *NoReplyAddressError) Error() string {
+	if e.Colleague {
+		return "the message being replied to is with a colleague on the workspace's own domain; " +
+			"a reply is composed only to a counterparty outside it"
+	}
 	return "the message being replied to records no counterparty address to answer; " +
 		"a reply can only be composed for a thread that carries one"
 }

--- a/backend/internal/modules/capture/gcal/event.go
+++ b/backend/internal/modules/capture/gcal/event.go
@@ -49,9 +49,30 @@ type eventDateTime struct {
 }
 
 // eventActor is one organizer/attendee: the email is all this mapping needs to
-// resolve the counterparty and the internal-vs-external classification.
+// resolve the counterparty and the internal-vs-external classification, plus
+// Google's resource flag, which marks a booked room or device rather than a
+// person.
 type eventActor struct {
-	Email string `json:"email"`
+	Email    string `json:"email"`
+	Resource bool   `json:"resource"`
+}
+
+// roomResourceDomain is where Google Calendar homes every booked room and
+// device. An event stored before the resource flag was read carries the
+// address alone, so the domain is recognised as well as the flag.
+const roomResourceDomain = "resource.calendar.google.com"
+
+// isRoom reports whether this attendee is a booked room or device rather than
+// a person. A room is not a party to a meeting: it cannot be a counterparty,
+// it cannot be answered, and — the case that matters — it is on no
+// workspace's own domain, so counting it would make every all-colleague
+// meeting held in a booked room look like it had an outside guest.
+func (a eventActor) isRoom() bool {
+	if a.Resource {
+		return true
+	}
+	dom := domainOf(a.Email)
+	return dom == roomResourceDomain || strings.HasSuffix(dom, "."+roomResourceDomain)
 }
 
 // meeting is the pure, classified result of reading one calendar event against
@@ -145,6 +166,9 @@ func meetingParties(ev rawEvent, ownerLower string) []connector.MessageParticipa
 	}
 	add(ev.Organizer.Email, connector.ParticipantRoleOrganizer)
 	for _, a := range ev.Attendees {
+		if a.isRoom() {
+			continue
+		}
 		add(a.Email, connector.ParticipantRoleAttendee)
 	}
 
@@ -221,11 +245,11 @@ func (m meeting) ToRecord(connectorName string, raw []byte) connector.Normalized
 // attendees whose domain differs from the owner's — the external signal behind
 // the all-internal skip. An attendee with no parseable domain is treated as
 // external (unknown ≠ internal): capturing a possibly-external touch beats
-// silently dropping it.
+// silently dropping it. A booked room is not an attendee at all.
 func classifyAttendees(attendees []eventActor, ownerDom string) (emails []string, external int) {
 	for _, a := range attendees {
 		email := strings.TrimSpace(a.Email)
-		if email == "" {
+		if email == "" || a.isRoom() {
 			continue
 		}
 		emails = append(emails, email)
@@ -323,6 +347,9 @@ func eventAddresses(ev rawEvent, owner string) []string {
 	}
 	add(ev.Organizer.Email)
 	for _, a := range ev.Attendees {
+		if a.isRoom() {
+			continue
+		}
 		add(a.Email)
 	}
 	add(owner)

--- a/backend/internal/modules/capture/gcal/event_test.go
+++ b/backend/internal/modules/capture/gcal/event_test.go
@@ -251,3 +251,62 @@ func mustRecord(t *testing.T, raw []byte) connector.NormalizedRecord {
 	t.Helper()
 	return mustParse(t, raw).ToRecord("gcal", raw)
 }
+
+// roomEventJSON is eventJSON with one booked room on the attendee list: the
+// address Google homes every room under, carrying the resource flag when
+// flagged is set and only the address otherwise.
+func roomEventJSON(t *testing.T, id string, flagged bool, attendees ...string) []byte {
+	t.Helper()
+	att := make([]map[string]any, 0, len(attendees)+1)
+	for _, a := range attendees {
+		att = append(att, map[string]any{"email": a})
+	}
+	att = append(att, map[string]any{
+		"email":    "c_1888abc@resource.calendar.google.com",
+		"resource": flagged,
+	})
+	b, err := json.Marshal(map[string]any{
+		"id":        id,
+		"status":    "confirmed",
+		"summary":   "Daily stand-up",
+		"start":     map[string]string{"dateTime": "2026-07-16T09:00:00Z"},
+		"organizer": map[string]string{"email": gcalOwner},
+		"attendees": att,
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return b
+}
+
+// The room a colleagues-only meeting was booked in is not an outside guest.
+// Before this held, every stand-up held in a meeting room was captured as a
+// customer touch and drafted a recap to a colleague.
+func TestABookedRoomDoesNotMakeAColleaguesOnlyMeetingExternal(t *testing.T) {
+	for _, flagged := range []bool{true, false} {
+		raw := roomEventJSON(t, "evt-room", flagged, gcalOwner, "peer@myco.com")
+		reason, skip := mustParse(t, raw).SkipReason()
+		if !skip || reason != "no party outside the owner's domain" {
+			t.Errorf("resource flag %v: got (%q, skip=%v), want the owner-domain floor to drop it", flagged, reason, skip)
+		}
+	}
+}
+
+// The room is not a party at all: it is neither an address the writer judges
+// internal-vs-external over nor a participant on the interaction graph.
+func TestABookedRoomIsNeitherAnAddressNorAParticipant(t *testing.T) {
+	raw := roomEventJSON(t, "evt-room-2", true, gcalOwner, "client@acme.com")
+	rec := mustParse(t, raw).ToRecord("gcal", raw)
+	wantAddresses := []string{gcalOwner, "client@acme.com"}
+	if !slices.Equal(rec.Addresses, wantAddresses) {
+		t.Errorf("Addresses = %v, want %v", rec.Addresses, wantAddresses)
+	}
+	for _, p := range rec.Participants {
+		if strings.HasSuffix(p.Email, "resource.calendar.google.com") {
+			t.Errorf("participants list the room %q", p.Email)
+		}
+	}
+	if len(rec.Participants) != 1 || rec.Participants[0].Email != "client@acme.com" {
+		t.Errorf("Participants = %+v, want the one guest", rec.Participants)
+	}
+}

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -96,6 +96,34 @@ func (s *OwnDomainStore) List(ctx context.Context) (OwnDomainList, error) {
 	return out, err
 }
 
+// Internal reports whether an address belongs to the workspace itself: a
+// colleague rather than a counterparty. It reads the registered set the same
+// way contact creation does — every registered domain, verified or not, plus
+// the company's own — because the question here is whether to answer
+// somebody, and declining to draft a reply to a colleague is safe on the
+// weaker evidence. A workspace with no domain registered has no colleagues
+// this can name, so the answer is false rather than a guess.
+//
+// Gated as a person read, not a settings read: whether somebody is a
+// colleague is a fact about them, asked by a caller who already holds their
+// address, and the same grant that let them reach the address answers it. A
+// rep composing a reply holds no settings authority and must not need one.
+func (s *OwnDomainStore) Internal(ctx context.Context, address string) (bool, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return false, err
+	}
+	var internal bool
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		own, err := ownDomainsTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		internal = own.Covers(address)
+		return nil
+	})
+	return internal, err
+}
+
 // Add registers a domain as the workspace's own, verified.
 //
 // An administrator entering a domain IS the human vouching for it — there is no

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -96,32 +96,29 @@ func (s *OwnDomainStore) List(ctx context.Context) (OwnDomainList, error) {
 	return out, err
 }
 
-// Internal reports whether an address belongs to the workspace itself: a
-// colleague rather than a counterparty. It reads the registered set the same
-// way contact creation does — every registered domain, verified or not, plus
-// the company's own — because the question here is whether to answer
-// somebody, and declining to draft a reply to a colleague is safe on the
-// weaker evidence. A workspace with no domain registered has no colleagues
-// this can name, so the answer is false rather than a guess.
+// Colleagues answers which addresses belong to the workspace itself, so a
+// caller composing a reply can tell a co-worker without a seat from a
+// counterparty. It reads the TRUSTED set — domains an administrator vouched
+// for plus the company's own — and not the mailbox-seeded candidates: a
+// contractor who connects a mailbox at a customer must not turn that whole
+// customer into colleagues nobody may answer. A workspace with nothing
+// registered has no colleagues this can name.
 //
 // Gated as a person read, not a settings read: whether somebody is a
 // colleague is a fact about them, asked by a caller who already holds their
 // address, and the same grant that let them reach the address answers it. A
 // rep composing a reply holds no settings authority and must not need one.
-func (s *OwnDomainStore) Internal(ctx context.Context, address string) (bool, error) {
+func (s *OwnDomainStore) Colleagues(ctx context.Context) (InternalDomains, error) {
 	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
-		return false, err
+		return InternalDomains{}, err
 	}
-	var internal bool
+	var own InternalDomains
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		own, err := ownDomainsTx(ctx, tx)
-		if err != nil {
-			return err
-		}
-		internal = own.Covers(address)
-		return nil
+		var err error
+		own, err = trustedOwnDomainsTx(ctx, tx)
+		return err
 	})
-	return internal, err
+	return own, err
 }
 
 // Add registers a domain as the workspace's own, verified.

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -33,6 +33,7 @@ func adminOwnDomainContext(ctx context.Context, ws ids.UUID) context.Context {
 			RoleKeys: []string{"admin"},
 			Objects: map[string]principal.ObjectGrant{
 				"capture_settings": {Read: true, Update: true},
+				"person":           {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},
@@ -311,5 +312,33 @@ func assertOwnDomainAudited(ctx context.Context, t *testing.T, db *database.DB, 
 	}
 	if rows != 1 {
 		t.Errorf("audit rows for %s %s = %d, want exactly 1 — audit_log is the only record this write leaves", want.action, want.domain, rows)
+	}
+}
+
+// Whether an address is one of ours is read off every registered domain, the
+// company's own included, and off nothing when none is registered.
+func TestInternalRecognisesTheRegisteredDomainsAndNothingElse(t *testing.T) {
+	ctx, db := ownDomainWorkspace(t)
+	store := capture.NewOwnDomainStore(db)
+
+	internal, err := store.Internal(ctx, "peer@acme.com")
+	if err != nil || internal {
+		t.Fatalf("Internal before any registration = (%v, %v), want false: nobody is a colleague yet", internal, err)
+	}
+	if _, err := store.Add(ctx, "acme.com"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	for address, want := range map[string]bool{
+		"peer@acme.com":      true,
+		"Peer@Mail.ACME.com": true,
+		"dana@client.io":     false,
+	} {
+		internal, err := store.Internal(ctx, address)
+		if err != nil {
+			t.Fatalf("Internal(%q): %v", address, err)
+		}
+		if internal != want {
+			t.Errorf("Internal(%q) = %v, want %v", address, internal, want)
+		}
 	}
 }

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -315,30 +315,36 @@ func assertOwnDomainAudited(ctx context.Context, t *testing.T, db *database.DB, 
 	}
 }
 
-// Whether an address is one of ours is read off every registered domain, the
-// company's own included, and off nothing when none is registered.
-func TestInternalRecognisesTheRegisteredDomainsAndNothingElse(t *testing.T) {
+// Which addresses are ours is read off the trusted domains — an
+// administrator's and the company's own — and off nothing when none is
+// registered. A mailbox-seeded candidate that nobody vouched for is not one.
+func TestColleaguesAreTheTrustedDomainsAndNothingElse(t *testing.T) {
 	ctx, db := ownDomainWorkspace(t)
 	store := capture.NewOwnDomainStore(db)
 
-	internal, err := store.Internal(ctx, "peer@acme.com")
-	if err != nil || internal {
-		t.Fatalf("Internal before any registration = (%v, %v), want false: nobody is a colleague yet", internal, err)
+	own, err := store.Colleagues(ctx)
+	if err != nil || own.Covers("peer@acme.com") {
+		t.Fatalf("Colleagues before any registration covers peer@acme.com (%v): nobody is a colleague yet", err)
+	}
+	if _, err := db.Pool().Exec(ctx, `INSERT INTO workspace_email_domain (domain, source, verified)
+		VALUES ('customer.io', 'mailbox', false)`); err != nil {
+		t.Fatalf("seeding an unverified mailbox domain: %v", err)
 	}
 	if _, err := store.Add(ctx, "acme.com"); err != nil {
 		t.Fatalf("Add: %v", err)
+	}
+	own, err = store.Colleagues(ctx)
+	if err != nil {
+		t.Fatalf("Colleagues: %v", err)
 	}
 	for address, want := range map[string]bool{
 		"peer@acme.com":      true,
 		"Peer@Mail.ACME.com": true,
 		"dana@client.io":     false,
+		"rep@customer.io":    false,
 	} {
-		internal, err := store.Internal(ctx, address)
-		if err != nil {
-			t.Fatalf("Internal(%q): %v", address, err)
-		}
-		if internal != want {
-			t.Errorf("Internal(%q) = %v, want %v", address, internal, want)
+		if got := own.Covers(address); got != want {
+			t.Errorf("Covers(%q) = %v, want %v", address, got, want)
 		}
 	}
 }

--- a/docs/explanation/ingress-gate-and-auto-capture.md
+++ b/docs/explanation/ingress-gate-and-auto-capture.md
@@ -141,6 +141,11 @@ Steps, in order:
 > kept. An empty address list therefore does not *skip* the check, it *disables* it, and internal
 > chatter gets stored. `Counterparty.Domain` behaves the same way: if it is missing, the suppression
 > rules below read the message as "keep".
+>
+> The list names people, not things. A booked meeting room or device on a calendar event
+> (`…@resource.calendar.google.com`, or an attendee Google flags as a resource) is left out by the
+> calendar connector: it is on nobody's own domain, so counting it would turn every colleagues-only
+> meeting held in a room into a customer touch.
 
 ## 3. The tier ladder: create a contact or not?
 


### PR DESCRIPTION
## What was wrong

The "Waiting on you" deck filled with "Review a drafted email" cards addressed to colleagues: recaps of the internal daily stand-up.

Two things let that happen:

1. The stand-up is booked in a Google meeting room. The room attendee (`…@resource.calendar.google.com`) is on no own domain, so both the connector's owner-domain floor and the sink's internal-only drop saw an outside party and stored the meeting.
2. The seeded post-meeting recap automation drafts a reply to any captured meeting. Nothing on the drafting side asked whether the addressee is one of our own people.

## What changed

- `capture/gcal`: an attendee Google flags as a resource, or homed under `resource.calendar.google.com`, is not a party. It is left out of the addresses the internal decision runs over, the external count, and the participants.
- `compose.commsAdapter.ReplyAddress` refuses an addressee on the workspace's own domains with `activities.NoReplyAddressError{Colleague: true}`. New reader `capture.OwnDomainStore.Internal`, gated as a person read. The nightly follow-up reconciler handles the same error class already and falls back to its task proposal.
- Doc note in `docs/explanation/ingress-gate-and-auto-capture.md`.

## Tests

- gcal: a colleagues-only meeting with a room is dropped (flag and address forms); the room is neither an address nor a participant. Mutation-checked: disabling the room rule fails both.
- capture integration: `Internal` recognises registered domains and subdomains, and nothing before registration.
- compose integration: the reply address refuses a colleague and admits a guest on the same meeting shape.

Existing pending held-draft cards are not touched; they need rejecting or a reseed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes colleagues-only stand-ups held in a Google meeting room being captured as customer touches, and stops the recap automation from drafting replies to colleagues.

**Bug Fixes**

- Google room attendees (the resource flag or the `resource.calendar.google.com` domain) are no longer treated as meeting parties; they're excluded from addresses, external counts, and participants.
- `ReplyAddress` refuses addressees on the workspace's trusted own domains — admin-vouched or the company's own, not mailbox-seeded — returning `NoReplyAddressError{Colleague: true}`; the nightly follow-up reconciler already falls back to its task proposal on this error.
- A colleague ranked first no longer hides a guest: the first non-colleague candidate is answered.
- Docs updated in `docs/explanation/ingress-gate-and-auto-capture.md`.
- Existing pending held-draft cards are not touched; they need rejection or a reseed.

<sup>Written for commit 934563fd9980747ec86330356e1a12ef294f075d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented replies from being addressed to colleagues on the workspace’s internal domains.
  * Improved handling when no valid external recipient is available.
  * Excluded calendar rooms and devices from meeting participants, contacts, and captured addresses.
  * Preserved external attendees in captured meeting details.

* **Documentation**
  * Clarified that calendar rooms and devices are excluded from captured addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->