### PR TITLE
fix(person360): the timeline carries the version a write needs

### DIFF
--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -745,3 +745,42 @@ func TestThePerson360TimelineNamesTheTransportThatCarriedAMessage(t *testing.T) 
 		t.Errorf("channel_provider = %q, want telegram", string(*got.ChannelProvider))
 	}
 }
+
+// TestThePerson360TimelineCarriesTheVersionAWriteNeeds is the second
+// instance of the same defect class TestThePerson360TimelineNamesTheTransportThatCarriedAMessage
+// guards: the hand-written SELECT in person360's readActivities dropped a
+// column activities.activityColumns carries, and nothing pointed at the
+// copy. This time it was version — AudienceAction (the Visibility control)
+// sends the row's version as If-Match and refuses to write blind without
+// one, so a row that reaches this page with no version cannot have its
+// audience narrowed from here at all (margince#3249).
+//
+// Same shape as the sibling guard, and for the same reason: a source grep
+// for "version" would pass on a query that selected it into a variable
+// nobody scanned onto the wire row.
+func TestThePerson360TimelineCarriesTheVersionAWriteNeeds(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	mine := e.SeedPerson(t, "Version Carrier", &e.Rep1)
+
+	message := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'message', 'they wrote', '2026-08-01T09:00:00Z', 'inbound', 'manual', 'human:x')`)
+	LinkActivity(t, owner, message, "person", mine)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
+	page, err := personRoomService(e).Assemble(rep, ids.From[ids.PersonKind](mine))
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if page.Activities == nil || len(page.Activities.Data) != 1 {
+		t.Fatalf("the timeline holds %v rows, want the one captured message", page.Activities)
+	}
+	got := page.Activities.Data[0]
+	if got.Version == nil {
+		t.Fatal("the message reached the page with no version; a write against it (narrowing its audience) " +
+			"refuses to go blind and the request never leaves the browser")
+	}
+	if *got.Version != 1 {
+		t.Errorf("version = %d, want 1 for a freshly inserted row", *got.Version)
+	}
+}

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -763,8 +763,8 @@ func TestThePerson360TimelineCarriesTheVersionAWriteNeeds(t *testing.T) {
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Version Carrier", &e.Rep1)
 
-	message := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, 'message', 'they wrote', '2026-08-01T09:00:00Z', 'inbound', 'manual', 'human:x')`)
+	message := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, channel_provider, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'message', 'telegram', 'they wrote', '2026-08-01T09:00:00Z', 'inbound', 'manual', 'human:x')`)
 	LinkActivity(t, owner, message, "person", mine)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -127,11 +127,17 @@ func sectionPage(rows []crmcontracts.Activity, hasMore bool) crmcontracts.PageIn
 // It selects channel_provider, and that is not decoration: since ADR-0107/A158
 // the kind says only that an interaction was a message, so a row without the
 // provider renders as the bare word "message" and a Telegram thread becomes
-// indistinguishable from a unit's. This SELECT is a hand-written sibling of
-// activities.activityColumns, which is exactly how it came to be missing the
-// column for a whole slice — the narrowing added it there and nothing pointed
-// at the copy. TestThePerson360TimelineNamesTheTransportThatCarriedAMessage is
-// the guard that says so out loud.
+// indistinguishable from a unit's. It also selects version, for the same
+// reason and by the same mistake a second time: AudienceAction sends the
+// row's version as If-Match and refuses to write blind without one, so a row
+// missing it cannot have its audience narrowed from this page at all — the
+// request never leaves the browser, and the error names no cause because
+// there was no request to have one (margince#3249). This SELECT is a
+// hand-written sibling of activities.activityColumns, which is exactly how
+// it came to be missing a column for a whole slice, twice.
+// TestThePerson360TimelineNamesTheTransportThatCarriedAMessage and
+// TestThePerson360TimelineCarriesTheVersionAWriteNeeds are the guards that
+// say so out loud.
 func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, extra string) ([]crmcontracts.Activity, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -151,7 +157,7 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT a.id, a.kind, a.channel_provider, a.subject, a.body, a.direction,
 		       a.occurred_at, a.due_at, a.is_done, a.source, a.captured_by, a.created_at,
-		       a.thread_key, a.bulk_mail_attested, a.audience, (%s) AS content_available
+		       a.thread_key, a.bulk_mail_attested, a.audience, a.version, (%s) AS content_available
 		FROM activity a
 		WHERE a.archived_at IS NULL AND %s AND (%s)%s %s
 		ORDER BY a.occurred_at DESC, a.id DESC
@@ -166,16 +172,18 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		var a crmcontracts.Activity
 		var id ids.UUID
 		var audience string
+		var version int64
 		var contentAvailable, bulkMailAttested bool
 		var threadKey *string
 		if err := rows.Scan(&id, &a.Kind, &a.ChannelProvider, &a.Subject, &a.Body,
 			&a.Direction, &a.OccurredAt, &a.DueAt, &a.IsDone, &a.Source, &a.CapturedBy,
-			&a.CreatedAt, &threadKey, &bulkMailAttested, &audience, &contentAvailable); err != nil {
+			&a.CreatedAt, &threadKey, &bulkMailAttested, &audience, &version, &contentAvailable); err != nil {
 			return nil, false, err
 		}
 		a.Id = openapi_types.UUID(id)
 		aud := crmcontracts.ActivityAudience(audience)
 		a.Audience = &aud
+		a.Version = &version
 		// The thread key and the bulk attestation are what lets the record
 		// page fold this page into conversations the way the list's page
 		// folds; the key identifies the message at the provider, so it is


### PR DESCRIPTION
## Summary
Closes margince#3249 (filed by cross-session QC with the exact root cause and a live repro on `e18727a72`).

**Symptom**: the Visibility control ("limit this message to the people on it") fails with "The request failed. No cause reported." from a contact's own timeline, but works from the same message's deal timeline.

**Cause**: `AudienceAction` sends the row's `version` as `If-Match` and refuses to write blind without one. The person page seeds its first timeline page from the 360 composite, and that composite's hand-written `SELECT` in `person360/sectionstimeline.go` — a sibling of `activities.activityColumns` kept in sync by nothing but attention — carries every column but `version`. Deal, company and project timelines read through `activities.ListActivitiesTx`, the shared reader, and are fine; person is the only surface with its own copy. The throw is client-side (`requireVersion`), so no request ever reaches the server, which is why the error names no cause.

**This is the second time this class of defect has hit the same query**: the file's own comment already named `channel_provider` going missing the same way, guarded by `TestThePerson360TimelineNamesTheTransportThatCarriedAMessage`. That guard asserts one specific column, not that the copy stays in sync with the original — it could not and did not catch this one.

## What's here vs. what's filed separately
- Fixed: added `version` to the SELECT and the row scan, and a sibling guard test in the same shape as the existing one (a row-to-payload assertion, not a source grep).
- **Not fixed here**: QC suggested removing the hand-written copy entirely rather than patching around a third instance eventually. That's the right question but a bigger one — `activityColumns` and the scan machinery are unexported, package-internal to `activities`, so reusing them from `person360` means deciding how much of that surface to export. Filing that separately as a design question rather than folding it into this fix.

## Test plan
- [x] `go build ./...` and `go build -tags=integration ./...` — both clean
- [x] `go vet ./internal/compose/person360/...` and `go vet -tags=integration ./internal/compose/integration/...` — both clean
- [x] Checked the new SELECT's 17 columns against the row scan's 17 targets by hand, in order — match
- [ ] Not run against a live database: the same pre-existing stale `extensions/notes` directory noted in recent fixes on this machine blocks `make test-it`, and I'm not clearing shared state to work around it (a peer session shares this filesystem). Relying on CI for the real integration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the person 360 timeline to include the `version` column in its hand-written SELECT, so the Visibility control no longer fails from a contact's timeline. Previously, the timeline omitted `version`, so `AudienceAction` refused to issue the write without an `If-Match` value and the request never left the browser.

- Adds a regression test that verifies the timeline carries the `version` for a freshly inserted message; the test seed includes `channel_provider` per the `kind='message'` constraint.

<sup>Written for commit cc0176c761108fe4f9923bd3729f5ba72c99641b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline activities now include version information, enabling reliable handling of activity updates.
  * Timeline data provides consistent activity metadata for supported actions.

* **Bug Fixes**
  * Improved timeline data handling so activity versions are consistently available.

* **Tests**
  * Added integration coverage confirming timeline activities expose the expected version value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->