### PR TITLE
feat(compose): a reply is addressed to the thread's counterparty before drafting

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4655,17 +4655,24 @@ paths:
       operationId: getReplyRecipient
       summary: Who a reply to this message would be addressed to.
       description: |
-        The same resolution `draft_email` uses to address and greet its draft, asked
-        without drafting: a composer can show the recipient when it opens rather than
-        after a model call. Both read one gated statement, so what the reader sees before
-        drafting and what the draft carries are one answer.
+        Asked without drafting, so a composer can show the recipient when it opens
+        rather than after a model call. `address` is resolved by the same reply-address
+        rule the automation reply path uses, so the address offered here is one that
+        path would also compose to.
 
-        The counterparty is read from the message's participants by role — the sender of
-        an inbound message first, then an addressee — falling back to the activity link.
-        Every field may be empty: a message linked to nobody, a person this caller cannot
-        read, or a contact with no live address all answer the empty recipient rather than
-        guessing one. Sending still requires `to` on the send request and gates consent
-        independently; this only saves typing an address the record already holds.
+        `address` and the two name fields answer DIFFERENT questions, and on our own
+        outbound mail they name different people. The names are whoever the message was
+        with — the sender of an inbound message, an addressee on our own outbound. The
+        address must be a COUNTERPARTY: one of this installation's own people, whether
+        by seat or by email domain, is never offered, because a reply composed to a
+        colleague is a message to ourselves.
+
+        Every field may be empty, and empty is an answer rather than a failure: a
+        message linked to nobody, a person this caller cannot read, a contact with no
+        live address, and a thread whose every participant is a colleague all answer
+        empty rather than guessing. Sending still requires `to` on the send request and
+        gates consent independently; this only saves typing an address the record
+        already holds.
       responses:
         '200':
           description: The recipient a reply would go to, with empty fields where unknown.
@@ -24730,8 +24737,11 @@ components:
         address:
           type: string
           description: >-
-            Where the reply is sent — their primary live address. Empty for a contact with
-            no address on record, which the reader fills in themselves.
+            Where the reply is sent: the counterparty's own corresponding address where
+            the thread carries one, else their primary live address. Never one of this
+            installation's own people. Empty when the thread offers none — including a
+            thread whose every participant is a colleague — which the reader fills in
+            themselves.
 
     AccountEmailDraft:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4647,6 +4647,33 @@ paths:
               schema: { $ref: '#/components/schemas/EmailDraft' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /activities/{id}/reply-recipient:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Activities]
+      operationId: getReplyRecipient
+      summary: Who a reply to this message would be addressed to.
+      description: |
+        The same resolution `draft_email` uses to address and greet its draft, asked
+        without drafting: a composer can show the recipient when it opens rather than
+        after a model call. Both read one gated statement, so what the reader sees before
+        drafting and what the draft carries are one answer.
+
+        The counterparty is read from the message's participants by role — the sender of
+        an inbound message first, then an addressee — falling back to the activity link.
+        Every field may be empty: a message linked to nobody, a person this caller cannot
+        read, or a contact with no live address all answer the empty recipient rather than
+        guessing one. Sending still requires `to` on the send request and gates consent
+        independently; this only saves typing an address the record already holds.
+      responses:
+        '200':
+          description: The recipient a reply would go to, with empty fields where unknown.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ReplyRecipient' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /activities/{id}/send-email:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -24681,6 +24708,30 @@ components:
         ai_disclosure: { type: [string, 'null'], readOnly: true, description: 'The machine-readable Art. 50 disclosure line; non-null iff ai_generated=true.' }
         voice_profile_version: { type: [integer, 'null'], readOnly: true, minimum: 1, description: 'The Voice DNA PROFILE version (not a model version) that styled this draft — the "built from your corpus · vN" provenance; null when no ready voice profile shaped it.' }
         draft_ref: { type: [string, 'null'], readOnly: true, description: 'Opaque reference identifying this served voice draft for learning feedback (rejectVoiceDraft); null when no voice profile styled it.' }
+
+    ReplyRecipient:
+      type: object
+      description: |
+        Who a reply to a message is addressed to: one person, resolved from the
+        message's participants by role.
+
+        One person rather than a list. A reply is written to somebody, and a group
+        thread degrades to the most likely counterparty rather than to nobody.
+      required: [full_name, first_name, address]
+      properties:
+        full_name:
+          type: string
+          description: The name as recorded, empty when no readable person is on the message.
+        first_name:
+          type: string
+          description: >-
+            What a greeting uses. Split server-side rather than in a prompt: a model asked
+            to shorten a name shortens "Dr. Anne-Marie Weiß-Konrad" differently every call.
+        address:
+          type: string
+          description: >-
+            Where the reply is sent — their primary live address. Empty for a contact with
+            no address on record, which the reader fills in themselves.
 
     AccountEmailDraft:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4668,11 +4668,23 @@ paths:
         colleague is a message to ourselves.
 
         Every field may be empty, and empty is an answer rather than a failure: a
-        message linked to nobody, a person this caller cannot read, a contact with no
-        live address, and a thread whose every participant is a colleague all answer
-        empty rather than guessing. Sending still requires `to` on the send request and
-        gates consent independently; this only saves typing an address the record
-        already holds.
+        message linked to nobody, a contact with no live address, and a thread whose
+        every participant is a colleague all answer empty rather than guessing.
+
+        The name and the address are withheld on DIFFERENT terms, so a caller may get
+        one without the other. Naming a person reads their record, so a person this
+        caller cannot read is not named. An address recorded on the message itself is
+        on correspondence they can already open, so it is answered whether or not the
+        person behind it is readable — which means the two fields can name two
+        different people, and a client that greets by `full_name` while sending to
+        `address` must not assume they are one.
+
+        A caller without the person read grant is refused outright (403) rather than
+        answered with empty fields; a caller who cannot see the message gets 404,
+        whether it is missing or merely withheld.
+
+        Sending still requires `to` on the send request and gates consent
+        independently; this only saves typing an address the record already holds.
       responses:
         '200':
           description: The recipient a reply would go to, with empty fields where unknown.

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -23,6 +23,9 @@ package compose
 // drift this shape exists to make impossible.
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/activities"
@@ -138,6 +141,10 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 		// nothing but the caller's transaction, so a deployment cannot forget
 		// it and leave an account-started send unable to resolve anyone.
 		WithRecipientDirectory(recipientDirectory{}).
+		// Unconditional for the same reason, and a sharper one: addressing a
+		// reply must skip a co-worker who has no seat, and a deployment that
+		// forgot to wire this would compose replies to its own staff.
+		WithColleagues(colleagueDomains{store: capture.NewOwnDomainStore(InstallationDB(pool))}).
 		WithSendAuthority(send.SendAuthority).
 		WithDraftOutcome(send.DraftOutcome)
 	decisions := s.approvalsHandlers
@@ -252,4 +259,18 @@ func newCommsAdapter(pool *pgxpool.Pool, drafter activities.EmailDrafter, send S
 		timer:         send.ScheduleTimer,
 		own:           capture.NewOwnDomainStore(InstallationDB(pool)),
 	}
+}
+
+// colleagueDomains adapts the own-domain store to the seam the activities
+// handlers take. The module may not import capture, and the reply-address
+// question needs to know who is ours by DOMAIN rather than by seat — a
+// co-worker with no login is still not somebody to compose a reply to.
+type colleagueDomains struct{ store *capture.OwnDomainStore }
+
+func (c colleagueDomains) Covers(ctx context.Context) (func(address string) bool, error) {
+	own, err := c.store.Colleagues(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compose: reading who counts as a colleague: %w", err)
+	}
+	return own.Covers, nil
 }

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -71,6 +71,10 @@ func (stubs) RelinkActivity(w nethttp.ResponseWriter, r *nethttp.Request, id crm
 	httperr.NotImplemented(w, r, "RelinkActivity")
 }
 
+func (stubs) GetReplyRecipient(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+	httperr.NotImplemented(w, r, "GetReplyRecipient")
+}
+
 func (stubs) SendEmail(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.SendEmailParams) {
 	httperr.NotImplemented(w, r, "SendEmail")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24748,7 +24748,7 @@ type ReplaceChannelTokenRequest struct {
 // One person rather than a list. A reply is written to somebody, and a group
 // thread degrades to the most likely counterparty rather than to nobody.
 type ReplyRecipient struct {
-	// Address Where the reply is sent — their primary live address. Empty for a contact with no address on record, which the reader fills in themselves.
+	// Address Where the reply is sent: the counterparty's own corresponding address where the thread carries one, else their primary live address. Never one of this installation's own people. Empty when the thread offers none — including a thread whose every participant is a colleague — which the reader fills in themselves.
 	Address string `json:"address"`
 
 	// FirstName What a greeting uses. Split server-side rather than in a prompt: a model asked to shorten a name shortens "Dr. Anne-Marie Weiß-Konrad" differently every call.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24742,6 +24742,22 @@ type ReplaceChannelTokenRequest struct {
 	BotToken string `json:"botToken"`
 }
 
+// ReplyRecipient Who a reply to a message is addressed to: one person, resolved from the
+// message's participants by role.
+//
+// One person rather than a list. A reply is written to somebody, and a group
+// thread degrades to the most likely counterparty rather than to nobody.
+type ReplyRecipient struct {
+	// Address Where the reply is sent — their primary live address. Empty for a contact with no address on record, which the reader fills in themselves.
+	Address string `json:"address"`
+
+	// FirstName What a greeting uses. Split server-side rather than in a prompt: a model asked to shorten a name shortens "Dr. Anne-Marie Weiß-Konrad" differently every call.
+	FirstName string `json:"first_name"`
+
+	// FullName The name as recorded, empty when no readable person is on the message.
+	FullName string `json:"full_name"`
+}
+
 // ReportDerivation The "Explain This Number" resolution (features/03 §1.3): a plain-language definition of
 // the exact filter+group+aggregate plus the underlying source rows, which reconcile
 // exactly to the explained aggregate (AC-X1).
@@ -39936,6 +39952,9 @@ type ServerInterface interface {
 	// Re-associate a captured activity to a chosen deal/entity (idempotent, source-preserving).
 	// (POST /activities/{id}/relink)
 	RelinkActivity(w http.ResponseWriter, r *http.Request, id Id, params RelinkActivityParams)
+	// Who a reply to this message would be addressed to.
+	// (GET /activities/{id}/reply-recipient)
+	GetReplyRecipient(w http.ResponseWriter, r *http.Request, id Id)
 	// Send a (possibly edited) email draft — runs directly, consent-gated.
 	// (POST /activities/{id}/send-email)
 	SendEmail(w http.ResponseWriter, r *http.Request, id Id, params SendEmailParams)
@@ -41523,6 +41542,12 @@ func (_ Unimplemented) ReadActivityPipelineTrace(w http.ResponseWriter, r *http.
 // Re-associate a captured activity to a chosen deal/entity (idempotent, source-preserving).
 // (POST /activities/{id}/relink)
 func (_ Unimplemented) RelinkActivity(w http.ResponseWriter, r *http.Request, id Id, params RelinkActivityParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Who a reply to this message would be addressed to.
+// (GET /activities/{id}/reply-recipient)
+func (_ Unimplemented) GetReplyRecipient(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -45325,6 +45350,40 @@ func (siw *ServerInterfaceWrapper) RelinkActivity(w http.ResponseWriter, r *http
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RelinkActivity(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetReplyRecipient operation middleware
+func (siw *ServerInterfaceWrapper) GetReplyRecipient(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReplyRecipient(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -67407,6 +67466,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/activities/{id}/relink", wrapper.RelinkActivity)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/activities/{id}/reply-recipient", wrapper.GetReplyRecipient)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/activities/{id}/send-email", wrapper.SendEmail)

--- a/backend/internal/modules/activities/handlers.go
+++ b/backend/internal/modules/activities/handlers.go
@@ -46,6 +46,28 @@ type Handlers struct {
 	// (OPS-CFG-12), injected by WithUploadLimit. Zero refuses every upload,
 	// which is the honest reading of "nobody has said" for a bound.
 	uploadLimit int64
+	// colleagues names the addresses that are ours by DOMAIN rather than by
+	// seat, so addressing a reply can skip a co-worker who has no login. The
+	// domains live in capture, which this module may not import, so compose
+	// injects the reader (WithColleagues).
+	//
+	// Nil answers no address rather than an unfiltered one: a reply addressed
+	// to a colleague is the defect ReplyAddressFor exists to prevent, and a
+	// deployment that has not wired this cannot tell one from a counterparty.
+	colleagues ColleagueDomains
+}
+
+// ColleagueDomains reports whether an address belongs to this installation's
+// own people. It is the same reader the automation reply path uses, so the two
+// surfaces cannot disagree about who counts as a colleague.
+type ColleagueDomains interface {
+	Covers(ctx context.Context) (func(address string) bool, error)
+}
+
+// WithColleagues wires the own-domain reader that addressing a reply needs.
+func (h Handlers) WithColleagues(domains ColleagueDomains) Handlers {
+	h.colleagues = domains
+	return h
 }
 
 // EmailDrafter prepares a reply for an existing activity without sending it.

--- a/backend/internal/modules/activities/handlers.go
+++ b/backend/internal/modules/activities/handlers.go
@@ -58,8 +58,11 @@ type Handlers struct {
 }
 
 // ColleagueDomains reports whether an address belongs to this installation's
-// own people. It is the same reader the automation reply path uses, so the two
-// surfaces cannot disagree about who counts as a colleague.
+// own people — by registered email domain, which is how a co-worker with no
+// login is recognised at all.
+//
+// The predicate it returns is what ReplyAddressFor walks its candidates past,
+// so what this answers decides who a composed reply may go to.
 type ColleagueDomains interface {
 	Covers(ctx context.Context) (func(address string) bool, error)
 }

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -5,6 +5,8 @@ package activities
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -138,7 +140,7 @@ func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontr
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.EmailDraft{
 		Subject:             result.Subject,
 		Body:                result.Body,
-		To:                  h.replyAddresses(ctx, ids.UUID(id)),
+		To:                  h.replyAddresses(ctx, ids.From[ids.ActivityKind](ids.UUID(id))),
 		InReplyToActivityId: &replyTo,
 		AiGenerated:         &result.AIGenerated,
 		AiDisclosure:        result.AIDisclosure,
@@ -150,8 +152,22 @@ func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontr
 // GetReplyRecipient answers who a reply to this message would go to, without
 // drafting one. A composer opening on a thread shows the recipient straight
 // away rather than after a model call that takes tens of seconds.
+//
+// The name and the address come from two resolvers because they answer two
+// questions. The greeting names whoever the message was WITH; the address must
+// be a counterparty and never one of our own, so on our own outbound mail the
+// sender we greet is us and the address we answer is the addressee's.
+// ReplyAddressFor owns that distinction, and this asks it rather than keeping
+// a second opinion about who may be written to.
 func (h Handlers) GetReplyRecipient(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
-	recipient, err := h.store.ReplyRecipientFor(r.Context(), ids.From[ids.ActivityKind](ids.UUID(id)))
+	ctx := r.Context()
+	anchor := ids.From[ids.ActivityKind](ids.UUID(id))
+	recipient, err := h.store.ReplyRecipientFor(ctx, anchor)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	address, err := h.replyAddress(ctx, anchor)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -159,28 +175,54 @@ func (h Handlers) GetReplyRecipient(w http.ResponseWriter, r *http.Request, id c
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReplyRecipient{
 		FullName:  recipient.FullName,
 		FirstName: recipient.FirstName,
-		Address:   recipient.Address,
+		Address:   address,
 	})
 }
 
-// replyAddresses names where a reply to this anchor is sent, or nil.
+// replyAddress is the counterparty address for this anchor, empty when the
+// thread carries none to answer.
 //
-// It resolves through the same gated statement that names the person the
-// draft GREETS, so the address on the response and the name in the body are
-// one person rather than two answers. A caller whose scope withholds the
-// person gets neither.
+// A thread with nobody outside the company to write to is an ANSWER, not a
+// fault: ReplyAddressFor refuses it as NoReplyAddressError, and a composer
+// that shows an empty field there is telling the truth. Every other failure
+// is the caller's to see.
+func (h Handlers) replyAddress(ctx context.Context, anchor ids.ActivityID) (string, error) {
+	if h.colleagues == nil {
+		return "", nil
+	}
+	covers, err := h.colleagues.Covers(ctx)
+	if err != nil {
+		return "", err
+	}
+	address, err := h.store.ReplyAddressFor(ctx, anchor, covers)
+	var none *NoReplyAddressError
+	if errors.As(err, &none) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return address, nil
+}
+
+// replyAddresses names where a draft's reply is sent, or nil.
 //
-// Nil on any failure and on a person with no live address: drafting is the
-// caller's request and addressing is a convenience on top of it, so a draft
-// that cannot name its recipient is still served with the field left for the
-// reader to fill. The send path re-resolves and gates independently — this
-// only saves typing an address the record already holds.
-func (h Handlers) replyAddresses(ctx context.Context, anchor ids.UUID) *[]openapi_types.Email {
-	recipient, err := h.store.ReplyRecipientFor(ctx, ids.From[ids.ActivityKind](anchor))
-	if err != nil || recipient.Address == "" {
+// Nil on any failure: drafting is the caller's request and addressing is a
+// convenience on top of it, so a draft whose recipient cannot be resolved is
+// still served with the field left for the reader to fill. The reason is
+// logged rather than swallowed — a permission failure and a thread with no
+// counterparty produce the same empty field, and only the log tells them
+// apart afterwards.
+func (h Handlers) replyAddresses(ctx context.Context, anchor ids.ActivityID) *[]openapi_types.Email {
+	address, err := h.replyAddress(ctx, anchor)
+	if err != nil {
+		slog.WarnContext(ctx, "reply address unavailable; drafting without a recipient", "err", err)
 		return nil
 	}
-	return &[]openapi_types.Email{openapi_types.Email(recipient.Address)}
+	if address == "" {
+		return nil
+	}
+	return &[]openapi_types.Email{openapi_types.Email(address)}
 }
 
 func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error) {

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -127,7 +127,8 @@ func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontr
 	if req.Intent != nil {
 		intent = *req.Intent
 	}
-	result, err := h.prepareEmailDraft(r.Context(), ids.UUID(id), intent)
+	ctx := r.Context()
+	result, err := h.prepareEmailDraft(ctx, ids.UUID(id), intent)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -137,12 +138,49 @@ func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontr
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.EmailDraft{
 		Subject:             result.Subject,
 		Body:                result.Body,
+		To:                  h.replyAddresses(ctx, ids.UUID(id)),
 		InReplyToActivityId: &replyTo,
 		AiGenerated:         &result.AIGenerated,
 		AiDisclosure:        result.AIDisclosure,
 		VoiceProfileVersion: result.VoiceProfileVersion,
 		DraftRef:            result.DraftRef,
 	})
+}
+
+// GetReplyRecipient answers who a reply to this message would go to, without
+// drafting one. A composer opening on a thread shows the recipient straight
+// away rather than after a model call that takes tens of seconds.
+func (h Handlers) GetReplyRecipient(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	recipient, err := h.store.ReplyRecipientFor(r.Context(), ids.From[ids.ActivityKind](ids.UUID(id)))
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReplyRecipient{
+		FullName:  recipient.FullName,
+		FirstName: recipient.FirstName,
+		Address:   recipient.Address,
+	})
+}
+
+// replyAddresses names where a reply to this anchor is sent, or nil.
+//
+// It resolves through the same gated statement that names the person the
+// draft GREETS, so the address on the response and the name in the body are
+// one person rather than two answers. A caller whose scope withholds the
+// person gets neither.
+//
+// Nil on any failure and on a person with no live address: drafting is the
+// caller's request and addressing is a convenience on top of it, so a draft
+// that cannot name its recipient is still served with the field left for the
+// reader to fill. The send path re-resolves and gates independently — this
+// only saves typing an address the record already holds.
+func (h Handlers) replyAddresses(ctx context.Context, anchor ids.UUID) *[]openapi_types.Email {
+	recipient, err := h.store.ReplyRecipientFor(ctx, ids.From[ids.ActivityKind](anchor))
+	if err != nil || recipient.Address == "" {
+		return nil
+	}
+	return &[]openapi_types.Email{openapi_types.Email(recipient.Address)}
 }
 
 func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error) {

--- a/backend/internal/modules/activities/replyrecipient.go
+++ b/backend/internal/modules/activities/replyrecipient.go
@@ -28,7 +28,7 @@ import (
 
 // ReplyRecipient is who a reply to an activity is addressed to.
 //
-// Both fields may be empty, and that is an answer rather than a failure: an
+// Every field may be empty, and that is an answer rather than a failure: an
 // activity linked to no person, or to one this caller cannot read, leaves the
 // drafter with no name — and a draft that opens "Hallo," is correct there,
 // where one that guesses is not.
@@ -39,6 +39,14 @@ type ReplyRecipient struct {
 	// the prompt: a model asked to shorten a name will shorten
 	// "Dr. Anne-Marie Weiß-Konrad" differently on every call.
 	FirstName string
+	// Address is where a reply is sent, resolved in the SAME gated statement
+	// as the name. Two statements would let a caller who may greet a person
+	// be refused their address, or the reverse — and a composer that shows a
+	// name it cannot write to states a recipient the send will reject.
+	//
+	// Empty is the ordinary answer for a person with no live address on
+	// record, which a reader fills in themselves.
+	Address string
 }
 
 // ReplyRecipientFor names the person a reply to this activity is written to.
@@ -95,8 +103,13 @@ func (s *Store) ReplyRecipientFor(ctx context.Context, id ids.ActivityID) (Reply
 		// Rank: the sender of an inbound message is who we are answering, then
 		// a "to" recipient (our own outbound, where the addressee is the
 		// counterparty), then anyone else on it, then the bare link.
+		// The address is a LATERAL rather than a join: a person with three
+		// live addresses would otherwise multiply the counterparty row and
+		// let ORDER BY pick the ranking's winner by which address sorted
+		// first. Primary first, then the record's own order, so the address
+		// shown is the one the person page calls their address.
 		q := `
-			SELECT p.full_name, coalesce(p.first_name, '')
+			SELECT p.full_name, coalesce(p.first_name, ''), coalesce(e.email, '')
 			  FROM person p
 			  JOIN (
 			       SELECT person_id,
@@ -109,13 +122,20 @@ func (s *Store) ReplyRecipientFor(ctx context.Context, id ids.ActivityID) (Reply
 			         FROM activity_link
 			        WHERE activity_id = $1 AND person_id IS NOT NULL
 			  ) c ON c.person_id = p.id
+			  LEFT JOIN LATERAL (
+			       SELECT email
+			         FROM person_email
+			        WHERE person_id = p.id AND archived_at IS NULL
+			        ORDER BY is_primary DESC, position, id
+			        LIMIT 1
+			  ) e ON true
 			 WHERE p.archived_at IS NULL`
 		if scope != "" {
 			q += ` AND (` + scope + `)`
 		}
 		q += ` ORDER BY c.rank, c.created_at, c.id LIMIT 1`
 
-		err = tx.QueryRow(ctx, q, args...).Scan(&out.FullName, &out.FirstName)
+		err = tx.QueryRow(ctx, q, args...).Scan(&out.FullName, &out.FirstName, &out.Address)
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Linked to nobody, or to a person out of scope. Both mean no
 			// name, which the floor renders as an unnamed greeting rather

--- a/backend/internal/modules/activities/replyrecipient.go
+++ b/backend/internal/modules/activities/replyrecipient.go
@@ -28,7 +28,7 @@ import (
 
 // ReplyRecipient is who a reply to an activity is addressed to.
 //
-// Every field may be empty, and that is an answer rather than a failure: an
+// Both fields may be empty, and that is an answer rather than a failure: an
 // activity linked to no person, or to one this caller cannot read, leaves the
 // drafter with no name — and a draft that opens "Hallo," is correct there,
 // where one that guesses is not.
@@ -39,14 +39,6 @@ type ReplyRecipient struct {
 	// the prompt: a model asked to shorten a name will shorten
 	// "Dr. Anne-Marie Weiß-Konrad" differently on every call.
 	FirstName string
-	// Address is where a reply is sent, resolved in the SAME gated statement
-	// as the name. Two statements would let a caller who may greet a person
-	// be refused their address, or the reverse — and a composer that shows a
-	// name it cannot write to states a recipient the send will reject.
-	//
-	// Empty is the ordinary answer for a person with no live address on
-	// record, which a reader fills in themselves.
-	Address string
 }
 
 // ReplyRecipientFor names the person a reply to this activity is written to.
@@ -103,13 +95,8 @@ func (s *Store) ReplyRecipientFor(ctx context.Context, id ids.ActivityID) (Reply
 		// Rank: the sender of an inbound message is who we are answering, then
 		// a "to" recipient (our own outbound, where the addressee is the
 		// counterparty), then anyone else on it, then the bare link.
-		// The address is a LATERAL rather than a join: a person with three
-		// live addresses would otherwise multiply the counterparty row and
-		// let ORDER BY pick the ranking's winner by which address sorted
-		// first. Primary first, then the record's own order, so the address
-		// shown is the one the person page calls their address.
 		q := `
-			SELECT p.full_name, coalesce(p.first_name, ''), coalesce(e.email, '')
+			SELECT p.full_name, coalesce(p.first_name, '')
 			  FROM person p
 			  JOIN (
 			       SELECT person_id,
@@ -122,20 +109,13 @@ func (s *Store) ReplyRecipientFor(ctx context.Context, id ids.ActivityID) (Reply
 			         FROM activity_link
 			        WHERE activity_id = $1 AND person_id IS NOT NULL
 			  ) c ON c.person_id = p.id
-			  LEFT JOIN LATERAL (
-			       SELECT email
-			         FROM person_email
-			        WHERE person_id = p.id AND archived_at IS NULL
-			        ORDER BY is_primary DESC, position, id
-			        LIMIT 1
-			  ) e ON true
 			 WHERE p.archived_at IS NULL`
 		if scope != "" {
 			q += ` AND (` + scope + `)`
 		}
 		q += ` ORDER BY c.rank, c.created_at, c.id LIMIT 1`
 
-		err = tx.QueryRow(ctx, q, args...).Scan(&out.FullName, &out.FirstName, &out.Address)
+		err = tx.QueryRow(ctx, q, args...).Scan(&out.FullName, &out.FirstName)
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Linked to nobody, or to a person out of scope. Both mean no
 			// name, which the floor renders as an unnamed greeting rather

--- a/backend/internal/modules/activities/replyrecipient_integration_test.go
+++ b/backend/internal/modules/activities/replyrecipient_integration_test.go
@@ -37,13 +37,16 @@ func (d ourDomain) Covers(context.Context) (func(string) bool, error) {
 	}, nil
 }
 
-// seedPersonEmail gives a person one address, the way capture records one.
-func (e *sendEnv) seedPersonEmail(t *testing.T, person ids.UUID, email string, primary bool, position int) {
+// seedPersonEmail gives a person their one primary address, the way capture
+// records one. Which of SEVERAL addresses wins is ReplyAddressFor's own
+// question and is covered where that resolver lives; what these cases vary is
+// WHOSE address is offered.
+func (e *sendEnv) seedPersonEmail(t *testing.T, person ids.UUID, email string) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
 		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'manual', 'human:x')`,
-		person, email, primary, position); err != nil {
+		VALUES ($1, $2, true, 0, 'manual', 'human:x')`,
+		person, email); err != nil {
 		t.Fatalf("seeding the person address: %v", err)
 	}
 }
@@ -119,11 +122,11 @@ func TestAReplyIsAddressedToTheSenderOfTheMessageItAnswers(t *testing.T) {
 	// wrong person: only the role ranking can put the sender ahead of them.
 	// Seeded the other way round, this passes with no ranking at all.
 	copied := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
+	e.seedPersonEmail(t, copied, "anne@buyer.test")
 	e.participate(t, anchor, copied, "cc", nil)
 
 	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test")
 	e.participate(t, anchor, sender, "from", nil)
 
 	got := recipientOf(e.as(principal.RowScopeAll), t,
@@ -148,11 +151,11 @@ func TestOurOwnSenderIsNeverTheAddressOnOurOutboundMail(t *testing.T) {
 	// an @demo.test address instead, this passes with the seat filter deleted
 	// and proves nothing about it.
 	us := e.linkPerson(t, anchor, "Sofia Meier")
-	e.seedPersonEmail(t, us, "sofia.private@gmail.test", true, 0)
+	e.seedPersonEmail(t, us, "sofia.private@gmail.test")
 	e.participate(t, anchor, us, "from", &e.rep)
 
 	buyer := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, buyer, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, buyer, "dietmar@buyer.test")
 	e.participate(t, anchor, buyer, "to", nil)
 
 	got := recipientOf(e.as(principal.RowScopeAll), t,
@@ -178,7 +181,7 @@ func TestAColleagueWithoutASeatIsNotAddressable(t *testing.T) {
 	// A co-worker on our own domain who has NO login, so no user_id marks
 	// them as ours. Only the domain predicate can tell.
 	coworker := e.linkPerson(t, anchor, "Jonas Weber")
-	e.seedPersonEmail(t, coworker, "jonas@demo.test", true, 0)
+	e.seedPersonEmail(t, coworker, "jonas@demo.test")
 	e.participate(t, anchor, coworker, "from", nil)
 
 	got := recipientOf(e.as(principal.RowScopeAll), t,
@@ -192,7 +195,7 @@ func TestAnUnwiredColleagueReaderOffersNoAddressRatherThanAnUnfilteredOne(t *tes
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 	coworker := e.linkPerson(t, anchor, "Jonas Weber")
-	e.seedPersonEmail(t, coworker, "jonas@demo.test", true, 0)
+	e.seedPersonEmail(t, coworker, "jonas@demo.test")
 	e.participate(t, anchor, coworker, "from", nil)
 
 	// Nil reader: a deployment that has not wired the own-domain store cannot
@@ -209,10 +212,10 @@ func TestTheDraftCarriesTheAddressTheRecipientEndpointNames(t *testing.T) {
 	anchor := e.seedAnchor(t, "", "")
 
 	us := e.linkPerson(t, anchor, "Sofia Meier")
-	e.seedPersonEmail(t, us, "sofia.private@gmail.test", true, 0)
+	e.seedPersonEmail(t, us, "sofia.private@gmail.test")
 	e.participate(t, anchor, us, "from", &e.rep)
 	buyer := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, buyer, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, buyer, "dietmar@buyer.test")
 	e.participate(t, anchor, buyer, "to", nil)
 
 	h := e.handlers(ourDomain{suffix: "@demo.test"})
@@ -242,7 +245,7 @@ func TestAnArchivedAddressIsNotOfferedAsTheRecipient(t *testing.T) {
 	anchor := e.seedAnchor(t, "", "")
 
 	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, sender, "gone@buyer.test", true, 0)
+	e.seedPersonEmail(t, sender, "gone@buyer.test")
 	if _, err := e.owner.Exec(context.Background(),
 		`UPDATE person_email SET archived_at = now() WHERE person_id = $1`, sender); err != nil {
 		t.Fatalf("archiving the address: %v", err)
@@ -270,11 +273,11 @@ func TestAnErasedPersonYieldsNeitherNameNorAddress(t *testing.T) {
 	// A readable contact keeps the CONVERSATION reachable, so this exercises
 	// the person filter rather than the activity gate refusing outright.
 	readable := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedPersonEmail(t, readable, "anne@buyer.test", true, 0)
+	e.seedPersonEmail(t, readable, "anne@buyer.test")
 	e.participate(t, anchor, readable, "cc", nil)
 
 	erased := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, erased, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, erased, "dietmar@buyer.test")
 	e.participate(t, anchor, erased, "from", nil)
 	// Art. 17 erasure archives the person in place, leaving the activity and
 	// its participant row behind. The reply must not go on naming or writing
@@ -304,7 +307,7 @@ func TestAPrivatelyCapturedContactStaysWithheldOnAReachableConversation(t *testi
 	// activity is unreachable outright and this would pass on the outer
 	// refusal, never exercising capture privacy at all.
 	readable := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedPersonEmail(t, readable, "anne@buyer.test", true, 0)
+	e.seedPersonEmail(t, readable, "anne@buyer.test")
 	e.participate(t, anchor, readable, "cc", nil)
 
 	private := ids.NewV7()
@@ -314,7 +317,7 @@ func TestAPrivatelyCapturedContactStaysWithheldOnAReachableConversation(t *testi
 		private, e.other); err != nil {
 		t.Fatalf("seeding the owner-private person: %v", err)
 	}
-	e.seedPersonEmail(t, private, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, private, "dietmar@buyer.test")
 	// The private contact is the SENDER, so the role ranking wants them: only
 	// the capture-privacy arm can keep their address off this reply.
 	e.participate(t, anchor, private, "from", nil)
@@ -338,7 +341,7 @@ func TestAddressingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test")
 	e.participate(t, anchor, sender, "from", nil)
 
 	// A seat that may read the conversation and not the people on it. Neither

--- a/backend/internal/modules/activities/replyrecipient_integration_test.go
+++ b/backend/internal/modules/activities/replyrecipient_integration_test.go
@@ -366,3 +366,49 @@ func TestAddressingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
 		t.Errorf("reply-recipient answered 200 to a caller with no person read grant: %s", rec.Body.String())
 	}
 }
+
+func TestAWithheldContactIsStillAnsweredAtTheAddressTheyWroteFrom(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// Privately captured by somebody else, so the person row is unreadable —
+	// and the message they wrote carries the address they wrote FROM, which is
+	// on the activity this caller already reached rather than on the person.
+	private := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
+		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
+		private, e.other); err != nil {
+		t.Fatalf("seeding the owner-private person: %v", err)
+	}
+	e.seedPersonEmail(t, private, "dietmar@buyer.test")
+	readable := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, readable, "anne@buyer.test")
+	e.participate(t, anchor, readable, "cc", nil)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO activity_participant (activity_id, person_id, role, address)
+		VALUES ($1, $2, 'from', 'dietmar@buyer.test')`, anchor, private); err != nil {
+		t.Fatalf("stamping the corresponding address: %v", err)
+	}
+
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+
+	// The address is answered even though the person is not readable, and that
+	// is the honest outcome rather than a leak: it is on the message this
+	// caller can already open, and withholding it would refuse a reply to
+	// correspondence they are looking at.
+	if got.Address != "dietmar@buyer.test" {
+		t.Errorf("address = %q, want the address on the message itself", got.Address)
+	}
+	// The NAME cannot come from the withheld person, so it falls through to
+	// the readable contact — the two fields name two different people here.
+	// Worth pinning: a reader who assumed they were one person would greet
+	// the colleague and mail the sender.
+	if got.FullName != "Anne Wiegert" {
+		t.Errorf("full name = %q, want the readable Anne Wiegert — the withheld person cannot be named", got.FullName)
+	}
+	if got.FullName == "Dietmar Rietsch" {
+		t.Error("the withheld person was named through the drafting door")
+	}
+}

--- a/backend/internal/modules/activities/replyrecipient_integration_test.go
+++ b/backend/internal/modules/activities/replyrecipient_integration_test.go
@@ -5,27 +5,37 @@
 
 package activities
 
-// Naming who a reply goes TO, over a real migrated Postgres.
+// Addressing a reply from the HTTP surface, over a real migrated Postgres.
 //
-// The composer cannot send without a recipient — `to` is required on
-// send-email — so an unresolved address is not a cosmetic gap: it is a reply
-// the reader must address by hand against a record that already holds the
-// answer. These cases pin the resolution the draft response carries.
+// Sending REQUIRES `to`, so an unresolved address is not a cosmetic gap: it is
+// a reply the reader must address by hand against a thread that already names
+// the person. These cases drive the two handlers that answer it — the draft
+// response and the recipient endpoint — because what they must agree on is WHO
+// may be written to, and that is a different question from who a draft greets.
 
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
+
+// ourDomain answers the colleague question the way the own-domain store does
+// for a workspace that has registered one domain.
+type ourDomain struct{ suffix string }
+
+func (d ourDomain) Covers(context.Context) (func(string) bool, error) {
+	return func(address string) bool {
+		return len(address) > len(d.suffix) &&
+			address[len(address)-len(d.suffix):] == d.suffix
+	}, nil
+}
 
 // seedPersonEmail gives a person one address, the way capture records one.
 func (e *sendEnv) seedPersonEmail(t *testing.T, person ids.UUID, email string, primary bool, position int) {
@@ -38,98 +48,192 @@ func (e *sendEnv) seedPersonEmail(t *testing.T, person ids.UUID, email string, p
 	}
 }
 
-// seedFirstName fills the split name capture records alongside the full one.
-func (e *sendEnv) seedFirstName(t *testing.T, person ids.UUID, first string) {
+// participate stamps one participant role on the anchor. A participant that
+// carries a user_id is one of OUR OWN people, which is the difference between
+// a reply and a message to ourselves.
+func (e *sendEnv) participate(t *testing.T, anchor ids.ActivityID, person ids.UUID, role string, seat *ids.UUID) {
 	t.Helper()
-	if _, err := e.owner.Exec(context.Background(),
-		`UPDATE person SET first_name = $2 WHERE id = $1`, person, first); err != nil {
-		t.Fatalf("seeding the first name: %v", err)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO activity_participant (activity_id, person_id, role, user_id)
+		VALUES ($1, $2, $3, $4)`, anchor, person, role, seat); err != nil {
+		t.Fatalf("stamping the %s participant: %v", role, err)
 	}
 }
 
-// participate stamps one participant role on the anchor.
-func (e *sendEnv) participate(t *testing.T, anchor ids.ActivityID, person ids.UUID, role string) {
-	t.Helper()
-	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity_participant (activity_id, person_id, role)
-		VALUES ($1, $2, $3)`, anchor, person, role); err != nil {
-		t.Fatalf("stamping the %s participant: %v", role, err)
+// handlers is the module's HTTP surface with the colleague reader wired, which
+// is how compose builds it. A nil reader is a different case with its own test.
+func (e *sendEnv) handlers(colleagues ColleagueDomains) Handlers {
+	h := Handlers{store: NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))}
+	if colleagues != nil {
+		h = h.WithColleagues(colleagues)
 	}
+	return h
+}
+
+// recipientOf drives GET /activities/{id}/reply-recipient and decodes it.
+func recipientOf(ctx context.Context, t *testing.T, h Handlers, anchor ids.ActivityID) crmcontracts.ReplyRecipient {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.GetReplyRecipient(rec,
+		httptest.NewRequest(http.MethodGet, "/v1/activities/x/reply-recipient", nil).WithContext(ctx),
+		crmcontracts.Id(anchor.UUID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reply-recipient answered %d, want 200", rec.Code)
+	}
+	var out crmcontracts.ReplyRecipient
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decoding the recipient: %v", err)
+	}
+	return out
+}
+
+// draftedTo drives POST /activities/{id}/draft-email and returns its `to`.
+func draftedTo(ctx context.Context, t *testing.T, h Handlers, anchor ids.ActivityID) []string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.DraftEmail(rec,
+		httptest.NewRequest(http.MethodPost, "/v1/activities/x/draft-email", nil).WithContext(ctx),
+		crmcontracts.Id(anchor.UUID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft-email answered %d, want 200", rec.Code)
+	}
+	var draft crmcontracts.EmailDraft
+	if err := json.Unmarshal(rec.Body.Bytes(), &draft); err != nil {
+		t.Fatalf("decoding the draft: %v", err)
+	}
+	if draft.To == nil {
+		return nil
+	}
+	out := make([]string, 0, len(*draft.To))
+	for _, address := range *draft.To {
+		out = append(out, string(address))
+	}
+	return out
 }
 
 func TestAReplyIsAddressedToTheSenderOfTheMessageItAnswers(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 
-	// The copied colleague is stamped FIRST, so insertion order favours the
+	// The copied contact is stamped FIRST, so insertion order favours the
 	// wrong person: only the role ranking can put the sender ahead of them.
 	// Seeded the other way round, this passes with no ranking at all.
 	copied := e.linkPerson(t, anchor, "Anne Wiegert")
 	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
-	e.participate(t, anchor, copied, "cc")
+	e.participate(t, anchor, copied, "cc", nil)
 
 	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
 	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
-	e.participate(t, anchor, sender, "from")
+	e.participate(t, anchor, sender, "from", nil)
 
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
-	}
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
 	if got.Address != "dietmar@buyer.test" {
-		t.Errorf("address = %q, want the sender's dietmar@buyer.test — a reply addressed to a copied colleague answers the wrong person", got.Address)
+		t.Errorf("address = %q, want the sender's dietmar@buyer.test — a reply addressed to a copied contact answers the wrong person", got.Address)
 	}
 	if got.FullName != "Dietmar Rietsch" {
 		t.Errorf("full name = %q, want Dietmar Rietsch", got.FullName)
 	}
 }
 
-func TestTheAddressAndTheGreetedNameAreOnePerson(t *testing.T) {
+func TestOurOwnSenderIsNeverTheAddressOnOurOutboundMail(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 
-	// Copied colleague first, so the ranking rather than insertion order has
-	// to be what picks the pair the assertion reads.
-	copied := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedFirstName(t, copied, "Anne")
-	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
-	e.participate(t, anchor, copied, "cc")
+	// OUR rep wrote it, and their address is on file as a contact — the shape
+	// that turns a `from`-first ranking into a message to ourselves.
+	//
+	// Their address is deliberately OFF our own domain, so the colleague
+	// predicate cannot catch them and only the seat exclusion can. Given them
+	// an @demo.test address instead, this passes with the seat filter deleted
+	// and proves nothing about it.
+	us := e.linkPerson(t, anchor, "Sofia Meier")
+	e.seedPersonEmail(t, us, "sofia.private@gmail.test", true, 0)
+	e.participate(t, anchor, us, "from", &e.rep)
 
-	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedFirstName(t, sender, "Dietmar")
-	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
-	e.participate(t, anchor, sender, "from")
+	buyer := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, buyer, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, buyer, "to", nil)
 
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+	if got.Address == "sofia.private@gmail.test" {
+		t.Fatal("the reply is addressed to our own sender — this composes a message to ourselves")
 	}
-	// The failure this guards is a draft greeting one person by name and
-	// addressed to another's mailbox — which reads as correct on screen and
-	// is wrong in the reader's sent folder.
-	if got.FirstName != "Dietmar" || got.Address != "dietmar@buyer.test" {
-		t.Errorf("greeted %q but addressed %q — the name and the address must be one person",
-			got.FirstName, got.Address)
+	if got.Address != "dietmar@buyer.test" {
+		t.Errorf("address = %q, want the counterparty dietmar@buyer.test", got.Address)
+	}
+	// The GREETING still names the sender, and that is correct rather than a
+	// mismatch: the two fields answer different questions, and only the
+	// address is constrained to a counterparty.
+	if got.FullName != "Sofia Meier" {
+		t.Errorf("full name = %q, want the greeted sender Sofia Meier", got.FullName)
 	}
 }
 
-func TestAPersonWithSeveralAddressesIsAnsweredAtTheirPrimary(t *testing.T) {
+func TestAColleagueWithoutASeatIsNotAddressable(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 
-	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	// Written non-primary first, so a resolution that took whatever the
-	// table handed back would pick the wrong one.
-	e.seedPersonEmail(t, sender, "old@buyer.test", false, 0)
-	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 1)
-	e.participate(t, anchor, sender, "from")
+	// A co-worker on our own domain who has NO login, so no user_id marks
+	// them as ours. Only the domain predicate can tell.
+	coworker := e.linkPerson(t, anchor, "Jonas Weber")
+	e.seedPersonEmail(t, coworker, "jonas@demo.test", true, 0)
+	e.participate(t, anchor, coworker, "from", nil)
 
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+	if got.Address != "" {
+		t.Errorf("address = %q, want empty — a thread with only colleagues on it has nobody outside the company to answer", got.Address)
 	}
-	if got.Address != "dietmar@buyer.test" {
-		t.Errorf("address = %q, want the primary dietmar@buyer.test", got.Address)
+}
+
+func TestAnUnwiredColleagueReaderOffersNoAddressRatherThanAnUnfilteredOne(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	coworker := e.linkPerson(t, anchor, "Jonas Weber")
+	e.seedPersonEmail(t, coworker, "jonas@demo.test", true, 0)
+	e.participate(t, anchor, coworker, "from", nil)
+
+	// Nil reader: a deployment that has not wired the own-domain store cannot
+	// tell a colleague from a counterparty, so it offers nobody rather than
+	// offering everybody.
+	got := recipientOf(e.as(principal.RowScopeAll), t, e.handlers(nil), anchor)
+	if got.Address != "" {
+		t.Errorf("address = %q, want empty — an unwired colleague reader must fail closed", got.Address)
+	}
+}
+
+func TestTheDraftCarriesTheAddressTheRecipientEndpointNames(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	us := e.linkPerson(t, anchor, "Sofia Meier")
+	e.seedPersonEmail(t, us, "sofia.private@gmail.test", true, 0)
+	e.participate(t, anchor, us, "from", &e.rep)
+	buyer := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, buyer, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, buyer, "to", nil)
+
+	h := e.handlers(ourDomain{suffix: "@demo.test"})
+	ctx := e.as(principal.RowScopeAll)
+
+	// The composer shows one address on open and the draft fills another in
+	// tens of seconds later; a reader watching the first be replaced by the
+	// second cannot tell which one sends. The anchor is our OWN outbound, so
+	// a surface that skipped the counterparty rule would answer our own rep
+	// here rather than agreeing with the other by accident.
+	shown := recipientOf(ctx, t, h, anchor).Address
+	drafted := draftedTo(ctx, t, h, anchor)
+
+	if len(drafted) != 1 {
+		t.Fatalf("the draft carried %d recipients, want exactly one", len(drafted))
+	}
+	if drafted[0] != shown {
+		t.Errorf("shown %q but drafted %q — one thread must have one recipient", shown, drafted[0])
+	}
+	if shown != "dietmar@buyer.test" {
+		t.Errorf("both named %q, want the counterparty dietmar@buyer.test", shown)
 	}
 }
 
@@ -143,15 +247,14 @@ func TestAnArchivedAddressIsNotOfferedAsTheRecipient(t *testing.T) {
 		`UPDATE person_email SET archived_at = now() WHERE person_id = $1`, sender); err != nil {
 		t.Fatalf("archiving the address: %v", err)
 	}
-	e.participate(t, anchor, sender, "from")
+	e.participate(t, anchor, sender, "from", nil)
 
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
-	}
-	// Empty is the answer here, not the archived address: the reader fills
-	// one in. Offering a retired mailbox sends the reply nowhere and reads
-	// as though the system knew where it was going.
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+
+	// Empty is the answer here, not the archived address: the reader fills one
+	// in. Offering a retired mailbox sends the reply nowhere and reads as
+	// though the system knew where it was going.
 	if got.Address != "" {
 		t.Errorf("address = %q, want empty — an archived address is not somewhere to write", got.Address)
 	}
@@ -164,37 +267,83 @@ func TestAnErasedPersonYieldsNeitherNameNorAddress(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 
-	person := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, person, "dietmar@buyer.test", true, 0)
-	e.participate(t, anchor, person, "from")
+	// A readable contact keeps the CONVERSATION reachable, so this exercises
+	// the person filter rather than the activity gate refusing outright.
+	readable := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, readable, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, readable, "cc", nil)
+
+	erased := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, erased, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, erased, "from", nil)
 	// Art. 17 erasure archives the person in place, leaving the activity and
 	// its participant row behind. The reply must not go on naming or writing
 	// to them.
 	if _, err := e.owner.Exec(context.Background(),
-		`UPDATE person SET archived_at = now() WHERE id = $1`, person); err != nil {
+		`UPDATE person SET archived_at = now() WHERE id = $1`, erased); err != nil {
 		t.Fatalf("archiving the person: %v", err)
 	}
 
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
-	}
-	if got.Address != "" || got.FullName != "" {
-		t.Errorf("got name %q address %q, want both empty for an erased person",
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+	if got.Address == "dietmar@buyer.test" || got.FullName == "Dietmar Rietsch" {
+		t.Fatalf("got name %q address %q — an erased person is still being answered",
 			got.FullName, got.Address)
+	}
+	if got.Address != "anne@buyer.test" {
+		t.Errorf("address = %q, want the readable anne@buyer.test", got.Address)
 	}
 }
 
-func TestDraftingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
+func TestAPrivatelyCapturedContactStaysWithheldOnAReachableConversation(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// A readable contact makes the CONVERSATION reachable, so the activity
+	// gate admits and the person gate is what has to hold. Without them the
+	// activity is unreachable outright and this would pass on the outer
+	// refusal, never exercising capture privacy at all.
+	readable := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, readable, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, readable, "cc", nil)
+
+	private := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
+		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
+		private, e.other); err != nil {
+		t.Fatalf("seeding the owner-private person: %v", err)
+	}
+	e.seedPersonEmail(t, private, "dietmar@buyer.test", true, 0)
+	// The private contact is the SENDER, so the role ranking wants them: only
+	// the capture-privacy arm can keep their address off this reply.
+	e.participate(t, anchor, private, "from", nil)
+
+	// RowScopeAll: the widest seat there is, so admitting here would mean the
+	// address is reachable by everyone rather than by its owner.
+	got := recipientOf(e.as(principal.RowScopeAll), t,
+		e.handlers(ourDomain{suffix: "@demo.test"}), anchor)
+	if got.Address == "dietmar@buyer.test" || got.FullName == "Dietmar Rietsch" {
+		t.Fatalf("got name %q address %q — the privately captured sender leaked through the drafting door",
+			got.FullName, got.Address)
+	}
+	// It degrades to the contact it MAY name rather than to nothing: the reply
+	// is still addressable, just not to the withheld one.
+	if got.Address != "anne@buyer.test" {
+		t.Errorf("address = %q, want the readable anne@buyer.test", got.Address)
+	}
+}
+
+func TestAddressingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedAnchor(t, "", "")
 	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
 	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
-	e.participate(t, anchor, sender, "from")
+	e.participate(t, anchor, sender, "from", nil)
 
-	// A seat that may read the conversation and not the people on it. The
-	// address must not reach them through the drafting door that the people
-	// surface closes.
+	// A seat that may read the conversation and not the people on it. Neither
+	// the name nor the address may reach them through the drafting door that
+	// the people surface closes.
 	ctx := principal.WithCorrelationID(
 		principal.WithWorkspaceID(context.Background(), e.ws), ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{
@@ -206,144 +355,11 @@ func TestDraftingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
 		},
 	})
 
-	if _, err := e.store(nil).ReplyRecipientFor(ctx, anchor); err == nil {
-		t.Error("ReplyRecipientFor returned a recipient to a caller with no person read grant")
-	}
-}
-
-// TestTheRecipientEndpointAndTheDraftNameOneAddress holds the seam this
-// endpoint exists to keep honest. The composer shows a recipient when it
-// opens and a draft fills one in tens of seconds later; if those two ever
-// resolved differently, the reader would watch the address they were shown
-// be replaced by another, with nothing saying which is the one that sends.
-func TestTheRecipientEndpointAndTheDraftNameOneAddress(t *testing.T) {
-	e := setupSend(t)
-	anchor := e.seedAnchor(t, "", "")
-
-	copied := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
-	e.participate(t, anchor, copied, "cc")
-	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
-	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
-	e.participate(t, anchor, sender, "from")
-
-	handlers := Handlers{store: NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))}
-	ctx := e.as(principal.RowScopeAll)
-
-	shown := httptest.NewRecorder()
-	handlers.GetReplyRecipient(shown,
+	rec := httptest.NewRecorder()
+	e.handlers(ourDomain{suffix: "@demo.test"}).GetReplyRecipient(rec,
 		httptest.NewRequest(http.MethodGet, "/v1/activities/x/reply-recipient", nil).WithContext(ctx),
 		crmcontracts.Id(anchor.UUID))
-	if shown.Code != http.StatusOK {
-		t.Fatalf("reply-recipient answered %d, want 200", shown.Code)
-	}
-	var recipient crmcontracts.ReplyRecipient
-	if err := json.Unmarshal(shown.Body.Bytes(), &recipient); err != nil {
-		t.Fatalf("decoding the recipient: %v", err)
-	}
-
-	// The drafter is nil here, so the draft runs the deterministic floor —
-	// which is the point: the address must not depend on a model answering.
-	drafted := httptest.NewRecorder()
-	handlers.DraftEmail(drafted,
-		httptest.NewRequest(http.MethodPost, "/v1/activities/x/draft-email", nil).WithContext(ctx),
-		crmcontracts.Id(anchor.UUID))
-	if drafted.Code != http.StatusOK {
-		t.Fatalf("draft-email answered %d, want 200", drafted.Code)
-	}
-	var draft crmcontracts.EmailDraft
-	if err := json.Unmarshal(drafted.Body.Bytes(), &draft); err != nil {
-		t.Fatalf("decoding the draft: %v", err)
-	}
-
-	if draft.To == nil || len(*draft.To) == 0 {
-		t.Fatal("the draft carried no recipient — a reply the reader must address by hand")
-	}
-	if got := string((*draft.To)[0]); got != recipient.Address {
-		t.Errorf("shown %q but drafted %q — one thread must have one recipient",
-			recipient.Address, got)
-	}
-	if recipient.Address != "dietmar@buyer.test" {
-		t.Errorf("both named %q, want the sender dietmar@buyer.test", recipient.Address)
-	}
-}
-
-func TestAnOwnerPrivateContactIsNotAddressableByAColleague(t *testing.T) {
-	e := setupSend(t)
-	anchor := e.seedAnchor(t, "", "")
-
-	// Captured privately by somebody else. Capture privacy binds even an
-	// unbounded seat, so this is not a row-scope case: neither the address
-	// nor the name may reach a colleague through the drafting door.
-	person := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
-		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
-		person, e.other); err != nil {
-		t.Fatalf("seeding the owner-private person: %v", err)
-	}
-	e.seedPersonEmail(t, person, "dietmar@buyer.test", true, 0)
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, person_id)
-		 VALUES ($1, 'person', $2)`, anchor, person); err != nil {
-		t.Fatalf("linking the private person: %v", err)
-	}
-	e.participate(t, anchor, person, "from")
-
-	// RowScopeAll: the widest seat there is, so admitting here would mean the
-	// address is reachable by everyone rather than by its owner.
-	//
-	// The refusal lands on the ACTIVITY rather than the person: a conversation
-	// whose only linked record is privately captured is not reachable at all,
-	// so the caller is told the message does not exist rather than that its
-	// counterparty is withheld. Both halves are the same protection, and this
-	// asserts the outer one because it is the one that fires.
-	_, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if !errors.Is(err, apperrors.ErrNotFound) {
-		t.Errorf("err = %v, want ErrNotFound — a privately captured contact must not be addressable, and existence must stay hidden", err)
-	}
-}
-
-func TestAnOwnerPrivateContactStaysWithheldOnAReachableConversation(t *testing.T) {
-	e := setupSend(t)
-	anchor := e.seedAnchor(t, "", "")
-
-	// A colleague on the thread makes the conversation reachable, so the
-	// activity gate admits and the PERSON gate is what has to hold. Without
-	// this case the capture-privacy arm is never exercised: the case above
-	// passes on the activity refusal alone.
-	colleague := e.linkPerson(t, anchor, "Anne Wiegert")
-	e.seedPersonEmail(t, colleague, "anne@buyer.test", true, 0)
-	e.participate(t, anchor, colleague, "cc")
-
-	private := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
-		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
-		private, e.other); err != nil {
-		t.Fatalf("seeding the owner-private person: %v", err)
-	}
-	e.seedPersonEmail(t, private, "dietmar@buyer.test", true, 0)
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, person_id)
-		 VALUES ($1, 'person', $2)`, anchor, private); err != nil {
-		t.Fatalf("linking the private person: %v", err)
-	}
-	// The private contact is the SENDER, so the role ranking wants them: only
-	// the capture-privacy arm can keep their address off this reply.
-	e.participate(t, anchor, private, "from")
-
-	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
-	if err != nil {
-		t.Fatalf("ReplyRecipientFor: %v", err)
-	}
-	if got.Address == "dietmar@buyer.test" || got.FullName == "Dietmar Rietsch" {
-		t.Fatalf("got name %q address %q — the privately captured sender leaked through the drafting door",
-			got.FullName, got.Address)
-	}
-	// It degrades to the colleague it MAY name rather than to nothing: the
-	// reply is still addressable, just not to the withheld contact.
-	if got.Address != "anne@buyer.test" {
-		t.Errorf("address = %q, want the readable colleague anne@buyer.test", got.Address)
+	if rec.Code == http.StatusOK {
+		t.Errorf("reply-recipient answered 200 to a caller with no person read grant: %s", rec.Body.String())
 	}
 }

--- a/backend/internal/modules/activities/replyrecipient_integration_test.go
+++ b/backend/internal/modules/activities/replyrecipient_integration_test.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// Naming who a reply goes TO, over a real migrated Postgres.
+//
+// The composer cannot send without a recipient — `to` is required on
+// send-email — so an unresolved address is not a cosmetic gap: it is a reply
+// the reader must address by hand against a record that already holds the
+// answer. These cases pin the resolution the draft response carries.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedPersonEmail gives a person one address, the way capture records one.
+func (e *sendEnv) seedPersonEmail(t *testing.T, person ids.UUID, email string, primary bool, position int) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
+		VALUES ($1, $2, $3, $4, 'manual', 'human:x')`,
+		person, email, primary, position); err != nil {
+		t.Fatalf("seeding the person address: %v", err)
+	}
+}
+
+// seedFirstName fills the split name capture records alongside the full one.
+func (e *sendEnv) seedFirstName(t *testing.T, person ids.UUID, first string) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE person SET first_name = $2 WHERE id = $1`, person, first); err != nil {
+		t.Fatalf("seeding the first name: %v", err)
+	}
+}
+
+// participate stamps one participant role on the anchor.
+func (e *sendEnv) participate(t *testing.T, anchor ids.ActivityID, person ids.UUID, role string) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO activity_participant (activity_id, person_id, role)
+		VALUES ($1, $2, $3)`, anchor, person, role); err != nil {
+		t.Fatalf("stamping the %s participant: %v", role, err)
+	}
+}
+
+func TestAReplyIsAddressedToTheSenderOfTheMessageItAnswers(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// The copied colleague is stamped FIRST, so insertion order favours the
+	// wrong person: only the role ranking can put the sender ahead of them.
+	// Seeded the other way round, this passes with no ranking at all.
+	copied := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, copied, "cc")
+
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, sender, "from")
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	if got.Address != "dietmar@buyer.test" {
+		t.Errorf("address = %q, want the sender's dietmar@buyer.test — a reply addressed to a copied colleague answers the wrong person", got.Address)
+	}
+	if got.FullName != "Dietmar Rietsch" {
+		t.Errorf("full name = %q, want Dietmar Rietsch", got.FullName)
+	}
+}
+
+func TestTheAddressAndTheGreetedNameAreOnePerson(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// Copied colleague first, so the ranking rather than insertion order has
+	// to be what picks the pair the assertion reads.
+	copied := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedFirstName(t, copied, "Anne")
+	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, copied, "cc")
+
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedFirstName(t, sender, "Dietmar")
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, sender, "from")
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	// The failure this guards is a draft greeting one person by name and
+	// addressed to another's mailbox — which reads as correct on screen and
+	// is wrong in the reader's sent folder.
+	if got.FirstName != "Dietmar" || got.Address != "dietmar@buyer.test" {
+		t.Errorf("greeted %q but addressed %q — the name and the address must be one person",
+			got.FirstName, got.Address)
+	}
+}
+
+func TestAPersonWithSeveralAddressesIsAnsweredAtTheirPrimary(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	// Written non-primary first, so a resolution that took whatever the
+	// table handed back would pick the wrong one.
+	e.seedPersonEmail(t, sender, "old@buyer.test", false, 0)
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 1)
+	e.participate(t, anchor, sender, "from")
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	if got.Address != "dietmar@buyer.test" {
+		t.Errorf("address = %q, want the primary dietmar@buyer.test", got.Address)
+	}
+}
+
+func TestAnArchivedAddressIsNotOfferedAsTheRecipient(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, sender, "gone@buyer.test", true, 0)
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE person_email SET archived_at = now() WHERE person_id = $1`, sender); err != nil {
+		t.Fatalf("archiving the address: %v", err)
+	}
+	e.participate(t, anchor, sender, "from")
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	// Empty is the answer here, not the archived address: the reader fills
+	// one in. Offering a retired mailbox sends the reply nowhere and reads
+	// as though the system knew where it was going.
+	if got.Address != "" {
+		t.Errorf("address = %q, want empty — an archived address is not somewhere to write", got.Address)
+	}
+	if got.FullName != "Dietmar Rietsch" {
+		t.Errorf("full name = %q, want the name to survive an unusable address", got.FullName)
+	}
+}
+
+func TestAnErasedPersonYieldsNeitherNameNorAddress(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	person := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, person, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, person, "from")
+	// Art. 17 erasure archives the person in place, leaving the activity and
+	// its participant row behind. The reply must not go on naming or writing
+	// to them.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE person SET archived_at = now() WHERE id = $1`, person); err != nil {
+		t.Fatalf("archiving the person: %v", err)
+	}
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	if got.Address != "" || got.FullName != "" {
+		t.Errorf("got name %q address %q, want both empty for an erased person",
+			got.FullName, got.Address)
+	}
+}
+
+func TestDraftingRefusesACallerWithoutThePersonReadGrant(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, sender, "from")
+
+	// A seat that may read the conversation and not the people on it. The
+	// address must not reach them through the drafting door that the people
+	// surface closes.
+	ctx := principal.WithCorrelationID(
+		principal.WithWorkspaceID(context.Background(), e.ws), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  map[string]principal.ObjectGrant{"activity": {Read: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+
+	if _, err := e.store(nil).ReplyRecipientFor(ctx, anchor); err == nil {
+		t.Error("ReplyRecipientFor returned a recipient to a caller with no person read grant")
+	}
+}
+
+// TestTheRecipientEndpointAndTheDraftNameOneAddress holds the seam this
+// endpoint exists to keep honest. The composer shows a recipient when it
+// opens and a draft fills one in tens of seconds later; if those two ever
+// resolved differently, the reader would watch the address they were shown
+// be replaced by another, with nothing saying which is the one that sends.
+func TestTheRecipientEndpointAndTheDraftNameOneAddress(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	copied := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, copied, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, copied, "cc")
+	sender := e.linkPerson(t, anchor, "Dietmar Rietsch")
+	e.seedPersonEmail(t, sender, "dietmar@buyer.test", true, 0)
+	e.participate(t, anchor, sender, "from")
+
+	handlers := Handlers{store: NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))}
+	ctx := e.as(principal.RowScopeAll)
+
+	shown := httptest.NewRecorder()
+	handlers.GetReplyRecipient(shown,
+		httptest.NewRequest(http.MethodGet, "/v1/activities/x/reply-recipient", nil).WithContext(ctx),
+		crmcontracts.Id(anchor.UUID))
+	if shown.Code != http.StatusOK {
+		t.Fatalf("reply-recipient answered %d, want 200", shown.Code)
+	}
+	var recipient crmcontracts.ReplyRecipient
+	if err := json.Unmarshal(shown.Body.Bytes(), &recipient); err != nil {
+		t.Fatalf("decoding the recipient: %v", err)
+	}
+
+	// The drafter is nil here, so the draft runs the deterministic floor —
+	// which is the point: the address must not depend on a model answering.
+	drafted := httptest.NewRecorder()
+	handlers.DraftEmail(drafted,
+		httptest.NewRequest(http.MethodPost, "/v1/activities/x/draft-email", nil).WithContext(ctx),
+		crmcontracts.Id(anchor.UUID))
+	if drafted.Code != http.StatusOK {
+		t.Fatalf("draft-email answered %d, want 200", drafted.Code)
+	}
+	var draft crmcontracts.EmailDraft
+	if err := json.Unmarshal(drafted.Body.Bytes(), &draft); err != nil {
+		t.Fatalf("decoding the draft: %v", err)
+	}
+
+	if draft.To == nil || len(*draft.To) == 0 {
+		t.Fatal("the draft carried no recipient — a reply the reader must address by hand")
+	}
+	if got := string((*draft.To)[0]); got != recipient.Address {
+		t.Errorf("shown %q but drafted %q — one thread must have one recipient",
+			recipient.Address, got)
+	}
+	if recipient.Address != "dietmar@buyer.test" {
+		t.Errorf("both named %q, want the sender dietmar@buyer.test", recipient.Address)
+	}
+}

--- a/backend/internal/modules/activities/replyrecipient_integration_test.go
+++ b/backend/internal/modules/activities/replyrecipient_integration_test.go
@@ -15,12 +15,14 @@ package activities
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -263,5 +265,85 @@ func TestTheRecipientEndpointAndTheDraftNameOneAddress(t *testing.T) {
 	}
 	if recipient.Address != "dietmar@buyer.test" {
 		t.Errorf("both named %q, want the sender dietmar@buyer.test", recipient.Address)
+	}
+}
+
+func TestAnOwnerPrivateContactIsNotAddressableByAColleague(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// Captured privately by somebody else. Capture privacy binds even an
+	// unbounded seat, so this is not a row-scope case: neither the address
+	// nor the name may reach a colleague through the drafting door.
+	person := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
+		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
+		person, e.other); err != nil {
+		t.Fatalf("seeding the owner-private person: %v", err)
+	}
+	e.seedPersonEmail(t, person, "dietmar@buyer.test", true, 0)
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO activity_link (activity_id, entity_type, person_id)
+		 VALUES ($1, 'person', $2)`, anchor, person); err != nil {
+		t.Fatalf("linking the private person: %v", err)
+	}
+	e.participate(t, anchor, person, "from")
+
+	// RowScopeAll: the widest seat there is, so admitting here would mean the
+	// address is reachable by everyone rather than by its owner.
+	//
+	// The refusal lands on the ACTIVITY rather than the person: a conversation
+	// whose only linked record is privately captured is not reachable at all,
+	// so the caller is told the message does not exist rather than that its
+	// counterparty is withheld. Both halves are the same protection, and this
+	// asserts the outer one because it is the one that fires.
+	_, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound — a privately captured contact must not be addressable, and existence must stay hidden", err)
+	}
+}
+
+func TestAnOwnerPrivateContactStaysWithheldOnAReachableConversation(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+
+	// A colleague on the thread makes the conversation reachable, so the
+	// activity gate admits and the PERSON gate is what has to hold. Without
+	// this case the capture-privacy arm is never exercised: the case above
+	// passes on the activity refusal alone.
+	colleague := e.linkPerson(t, anchor, "Anne Wiegert")
+	e.seedPersonEmail(t, colleague, "anne@buyer.test", true, 0)
+	e.participate(t, anchor, colleague, "cc")
+
+	private := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, owner_id, visibility, source, captured_by)
+		 VALUES ($1, 'Dietmar Rietsch', $2, 'owner', 'manual', 'human:x')`,
+		private, e.other); err != nil {
+		t.Fatalf("seeding the owner-private person: %v", err)
+	}
+	e.seedPersonEmail(t, private, "dietmar@buyer.test", true, 0)
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO activity_link (activity_id, entity_type, person_id)
+		 VALUES ($1, 'person', $2)`, anchor, private); err != nil {
+		t.Fatalf("linking the private person: %v", err)
+	}
+	// The private contact is the SENDER, so the role ranking wants them: only
+	// the capture-privacy arm can keep their address off this reply.
+	e.participate(t, anchor, private, "from")
+
+	got, err := e.store(nil).ReplyRecipientFor(e.as(principal.RowScopeAll), anchor)
+	if err != nil {
+		t.Fatalf("ReplyRecipientFor: %v", err)
+	}
+	if got.Address == "dietmar@buyer.test" || got.FullName == "Dietmar Rietsch" {
+		t.Fatalf("got name %q address %q — the privately captured sender leaked through the drafting door",
+			got.FullName, got.Address)
+	}
+	// It degrades to the colleague it MAY name rather than to nothing: the
+	// reply is still addressable, just not to the withheld contact.
+	if got.Address != "anne@buyer.test" {
+		t.Errorf("address = %q, want the readable colleague anne@buyer.test", got.Address)
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3091,17 +3091,24 @@ export interface paths {
         };
         /**
          * Who a reply to this message would be addressed to.
-         * @description The same resolution `draft_email` uses to address and greet its draft, asked
-         *     without drafting: a composer can show the recipient when it opens rather than
-         *     after a model call. Both read one gated statement, so what the reader sees before
-         *     drafting and what the draft carries are one answer.
+         * @description Asked without drafting, so a composer can show the recipient when it opens
+         *     rather than after a model call. `address` is resolved by the same reply-address
+         *     rule the automation reply path uses, so the address offered here is one that
+         *     path would also compose to.
          *
-         *     The counterparty is read from the message's participants by role — the sender of
-         *     an inbound message first, then an addressee — falling back to the activity link.
-         *     Every field may be empty: a message linked to nobody, a person this caller cannot
-         *     read, or a contact with no live address all answer the empty recipient rather than
-         *     guessing one. Sending still requires `to` on the send request and gates consent
-         *     independently; this only saves typing an address the record already holds.
+         *     `address` and the two name fields answer DIFFERENT questions, and on our own
+         *     outbound mail they name different people. The names are whoever the message was
+         *     with — the sender of an inbound message, an addressee on our own outbound. The
+         *     address must be a COUNTERPARTY: one of this installation's own people, whether
+         *     by seat or by email domain, is never offered, because a reply composed to a
+         *     colleague is a message to ourselves.
+         *
+         *     Every field may be empty, and empty is an answer rather than a failure: a
+         *     message linked to nobody, a person this caller cannot read, a contact with no
+         *     live address, and a thread whose every participant is a colleague all answer
+         *     empty rather than guessing. Sending still requires `to` on the send request and
+         *     gates consent independently; this only saves typing an address the record
+         *     already holds.
          */
         get: operations["getReplyRecipient"];
         put?: never;
@@ -17724,7 +17731,7 @@ export interface components {
             full_name: string;
             /** @description What a greeting uses. Split server-side rather than in a prompt: a model asked to shorten a name shortens "Dr. Anne-Marie Weiß-Konrad" differently every call. */
             first_name: string;
-            /** @description Where the reply is sent — their primary live address. Empty for a contact with no address on record, which the reader fills in themselves. */
+            /** @description Where the reply is sent: the counterparty's own corresponding address where the thread carries one, else their primary live address. Never one of this installation's own people. Empty when the thread offers none — including a thread whose every participant is a colleague — which the reader fills in themselves. */
             address: string;
         };
         /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3079,6 +3079,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/activities/{id}/reply-recipient": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Who a reply to this message would be addressed to.
+         * @description The same resolution `draft_email` uses to address and greet its draft, asked
+         *     without drafting: a composer can show the recipient when it opens rather than
+         *     after a model call. Both read one gated statement, so what the reader sees before
+         *     drafting and what the draft carries are one answer.
+         *
+         *     The counterparty is read from the message's participants by role — the sender of
+         *     an inbound message first, then an addressee — falling back to the activity link.
+         *     Every field may be empty: a message linked to nobody, a person this caller cannot
+         *     read, or a contact with no live address all answer the empty recipient rather than
+         *     guessing one. Sending still requires `to` on the send request and gates consent
+         *     independently; this only saves typing an address the record already holds.
+         */
+        get: operations["getReplyRecipient"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/activities/{id}/send-email": {
         parameters: {
             query?: never;
@@ -17680,6 +17713,21 @@ export interface components {
             readonly draft_ref: string | null;
         };
         /**
+         * @description Who a reply to a message is addressed to: one person, resolved from the
+         *     message's participants by role.
+         *
+         *     One person rather than a list. A reply is written to somebody, and a group
+         *     thread degrades to the most likely counterparty rather than to nobody.
+         */
+        ReplyRecipient: {
+            /** @description The name as recorded, empty when no readable person is on the message. */
+            full_name: string;
+            /** @description What a greeting uses. Split server-side rather than in a prompt: a model asked to shorten a name shortens "Dr. Anne-Marie Weiß-Konrad" differently every call. */
+            first_name: string;
+            /** @description Where the reply is sent — their primary live address. Empty for a contact with no address on record, which the reader fills in themselves. */
+            address: string;
+        };
+        /**
          * @description A draft written from an account's records, and what it was written from
          *     (ADR-0087/A132). Never sent by drafting; send via `POST /emails`.
          *
@@ -29458,6 +29506,30 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EmailDraft"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getReplyRecipient: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The recipient a reply would go to, with empty fields where unknown. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplyRecipient"];
                 };
             };
             404: components["responses"]["NotFound"];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3104,11 +3104,23 @@ export interface paths {
          *     colleague is a message to ourselves.
          *
          *     Every field may be empty, and empty is an answer rather than a failure: a
-         *     message linked to nobody, a person this caller cannot read, a contact with no
-         *     live address, and a thread whose every participant is a colleague all answer
-         *     empty rather than guessing. Sending still requires `to` on the send request and
-         *     gates consent independently; this only saves typing an address the record
-         *     already holds.
+         *     message linked to nobody, a contact with no live address, and a thread whose
+         *     every participant is a colleague all answer empty rather than guessing.
+         *
+         *     The name and the address are withheld on DIFFERENT terms, so a caller may get
+         *     one without the other. Naming a person reads their record, so a person this
+         *     caller cannot read is not named. An address recorded on the message itself is
+         *     on correspondence they can already open, so it is answered whether or not the
+         *     person behind it is readable — which means the two fields can name two
+         *     different people, and a client that greets by `full_name` while sending to
+         *     `address` must not assume they are one.
+         *
+         *     A caller without the person read grant is refused outright (403) rather than
+         *     answered with empty fields; a caller who cannot see the message gets 404,
+         *     whether it is missing or merely withheld.
+         *
+         *     Sending still requires `to` on the send request and gates consent
+         *     independently; this only saves typing an address the record already holds.
          */
         get: operations["getReplyRecipient"];
         put?: never;

--- a/frontend/src/screens/compose-recipient.test.tsx
+++ b/frontend/src/screens/compose-recipient.test.tsx
@@ -148,9 +148,17 @@ describe("ComposeModal recipient", () => {
     expect(screen.queryByText("dietmar@buyer.test")).toBeNull();
   });
 
-  it("keeps the recipient the reader typed", async () => {
-    // Answers slowly enough that the reader types first, which is the race
-    // this guards: a prefill landing after them must not replace their choice.
+  it("sends only to the address the reader typed, when they typed it first", async () => {
+    // RecipientField holds typed text in its OWN state until Enter, so `to`
+    // is still empty mid-word. A prefill landing in that window would be
+    // added, the reader's own address added on commit, and the reply sent to
+    // somebody they never chose.
+    //
+    // Two things prevent that and this asserts the OUTCOME rather than either
+    // mechanism: the first keystroke stops the offer (onEditing), and the
+    // fill itself never replaces a non-empty field. Neither alone is provable
+    // from here — with one removed the other still holds the outcome — so
+    // what is pinned is the field's final contents, which is what sends.
     let release: (() => void) | undefined;
     const held = new Promise<void>((resolve) => {
       release = resolve;
@@ -173,10 +181,44 @@ describe("ComposeModal recipient", () => {
 
     const user = userEvent.setup();
     const to = await screen.findByLabelText("To");
-    await user.type(to, "someone.else@buyer.test{Enter}");
+    // Typed but deliberately NOT committed — no Enter, no blur.
+    await user.type(to, "someone.else@buyer.test");
     release?.();
 
+    // Commit what was typed, the way a reader does, and assert the field
+    // holds ONLY their address. Asserting the absence mid-word would pass on
+    // a render that simply had not happened yet.
+    await user.keyboard("{Enter}");
     expect(await screen.findByText("someone.else@buyer.test")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText("dietmar@buyer.test")).toBeNull();
+    });
+  });
+
+  it("lets the reader remove the prefilled recipient and have it stay gone", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    expect(await screen.findByText("dietmar@buyer.test")).toBeTruthy();
+    await user.click(
+      screen.getByRole("button", { name: /dietmar@buyer.test/ }),
+    );
+
+    // Offering it again on the next render would make the field impossible to
+    // clear: the reader deletes it, the effect sees an empty field, and puts
+    // the same address straight back.
     await waitFor(() => {
       expect(screen.queryByText("dietmar@buyer.test")).toBeNull();
     });

--- a/frontend/src/screens/compose-recipient.test.tsx
+++ b/frontend/src/screens/compose-recipient.test.tsx
@@ -1,0 +1,184 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+
+// Who the composer says a reply goes to, before a draft is asked for.
+//
+// Sending REQUIRES a recipient, so an empty To field is not a missing
+// nicety: it is a reply the reader must address by hand against a thread
+// that already names the person. These tests assert what stands in the
+// field on open, and that a reader's own typing survives it.
+
+type Sent = { key: string; body: unknown };
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+const THREAD_RECIPIENT = {
+  full_name: "Dietmar Rietsch",
+  first_name: "Dietmar",
+  address: "dietmar@buyer.test",
+};
+
+function stubRoutes(
+  overrides: Record<string, () => Response | Promise<Response>> = {},
+) {
+  const sent: Sent[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      sent.push({ key, body });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ComposeModal recipient", () => {
+  it("addresses the reply to the thread's counterparty on open", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // No click first: the address stands there before any drafting, which is
+    // the whole difference from filling it out of the draft response.
+    expect(await screen.findByText("dietmar@buyer.test")).toBeTruthy();
+  });
+
+  it("leaves the field empty for a contact with no address on record", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse({
+          full_name: "Dietmar Rietsch",
+          first_name: "Dietmar",
+          address: "",
+        }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // The composer settles without inventing one. Rendering the empty string
+    // as a chip would put an unsendable recipient in front of the reader.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Draft with AI" }),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText("dietmar@buyer.test")).toBeNull();
+  });
+
+  it("keeps the recipient the reader typed", async () => {
+    // Answers slowly enough that the reader types first, which is the race
+    // this guards: a prefill landing after them must not replace their choice.
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": async () => {
+        await held;
+        return jsonResponse(THREAD_RECIPIENT);
+      },
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const to = await screen.findByLabelText("To");
+    await user.type(to, "someone.else@buyer.test{Enter}");
+    release?.();
+
+    expect(await screen.findByText("someone.else@buyer.test")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText("dietmar@buyer.test")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -514,6 +514,37 @@ function useLatestMessage(
 }
 
 /**
+ * Who a reply to this anchor goes to, resolved without drafting.
+ *
+ * Sending REQUIRES `to`, so an empty field is not a convenience gap: it is a
+ * reply the reader must address by hand against a record that already holds
+ * the answer. The server ranks the message's participants — its sender before
+ * anyone copied on it — and this asks that same resolution the draft uses, so
+ * what the composer shows on open and what a draft fills in cannot disagree.
+ *
+ * Undefined while unsettled and for a contact with no address on record. The
+ * caller only ever fills an EMPTY field from it, so a reader who typed their
+ * own recipient keeps it.
+ */
+function useReplyRecipient(anchor: string | undefined): string | undefined {
+  const query = useQuery({
+    queryKey: ["compose-reply-recipient", anchor],
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        "/activities/{id}/reply-recipient",
+        { params: { path: { id: anchor ?? "" } } },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    enabled: anchor !== undefined,
+  });
+  return query.data?.address === "" ? undefined : query.data?.address;
+}
+
+/**
  * What the composer says it is answering, or null while it does not yet know.
  *
  * A caller that named an activity has already told the reader what they opened
@@ -2146,6 +2177,20 @@ export function ComposeModal({
     open && !activityId,
   );
   const answering = activityId ?? latest.activity?.id;
+  // Addressing the reply before a draft is asked for. A channel reply resolves
+  // its recipient server-side and shows no To field, so it asks nothing.
+  const threadRecipient = useReplyRecipient(
+    open && !isChannelReply ? answering : undefined,
+  );
+  // Fills an EMPTY field only, and only while nothing drafted stands there:
+  // a reader who typed their own recipient, or a draft that named one, both
+  // outrank the thread's default.
+  useEffect(() => {
+    if (threadRecipient === undefined || to.length > 0) {
+      return;
+    }
+    setTo([threadRecipient]);
+  }, [threadRecipient, to.length]);
   // The sentence the reader reads. Null while the lookup is unsettled: an
   // unanswered read is not "no earlier message", and saying so would tell them
   // this starts a new thread when it may continue one.

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -872,10 +872,16 @@ function RecipientField({
   label,
   values,
   onChange,
+  onEditing,
 }: Readonly<{
   label: string;
   values: string[];
   onChange: (next: string[]) => void;
+  // Called the first time the reader types here. The committed values do not
+  // say this: text sits in `draft` until Enter or blur, so a field the reader
+  // is halfway through filling looks exactly like an untouched empty one to
+  // anyone reading `values`.
+  onEditing?: () => void;
 }>) {
   const t = useT();
   const [draft, setDraft] = useState("");
@@ -910,7 +916,10 @@ function RecipientField({
         type="email"
         aria-label={label}
         value={draft}
-        onChange={(event) => setDraft(event.target.value)}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          onEditing?.();
+        }}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === ",") {
             event.preventDefault();
@@ -1538,6 +1547,7 @@ function MailOnlyFields({
   reasons,
   to,
   onToChange,
+  onToEditing,
   cc,
   onCcChange,
   subject,
@@ -1554,6 +1564,8 @@ function MailOnlyFields({
   reasons: components["schemas"]["AccountDraftReason"][];
   to: string[];
   onToChange: (next: string[]) => void;
+  /** The reader has started typing a recipient, before any is committed. */
+  onToEditing: () => void;
   cc: string[];
   onCcChange: (next: string[]) => void;
   subject: string;
@@ -1597,6 +1609,7 @@ function MailOnlyFields({
           label={t("compose.to")}
           values={to}
           onChange={onToChange}
+          onEditing={onToEditing}
         />
       </MailRow>
       <MailRow label={t("compose.cc")}>
@@ -2182,15 +2195,34 @@ export function ComposeModal({
   const threadRecipient = useReplyRecipient(
     open && !isChannelReply ? answering : undefined,
   );
-  // Fills an EMPTY field only, and only while nothing drafted stands there:
-  // a reader who typed their own recipient, or a draft that named one, both
-  // outrank the thread's default.
+  // Offered ONCE, when the lookup first answers, and never again.
+  //
+  // Keyed on the recipient rather than on the field being empty, because an
+  // empty field is not the same as an untouched one. `to` stays empty while
+  // RecipientField holds text the reader has typed but not yet committed, so
+  // a lookup landing mid-word would add the thread's address and then the
+  // reader's — sending the reply to somebody they never chose. It is also
+  // empty again after they DELETE the prefill, and re-adding what they just
+  // removed makes the field impossible to clear.
+  //
+  // The ref, not state: this decides whether to offer at all, so re-rendering
+  // on it would be a render caused by the thing it is trying not to do twice.
+  const offered = useRef(false);
+  // The reader has taken the field over. Set on the first keystroke, which is
+  // the only signal there is — the committed values stay empty until they
+  // press Enter.
+  const stopOfferingRecipient = useCallback(() => {
+    offered.current = true;
+  }, []);
   useEffect(() => {
-    if (threadRecipient === undefined || to.length > 0) {
+    if (threadRecipient === undefined || offered.current) {
       return;
     }
-    setTo([threadRecipient]);
-  }, [threadRecipient, to.length]);
+    offered.current = true;
+    // A draft that named its own recipient, or a reader who committed one
+    // before the lookup answered, both outrank the thread's default.
+    setTo((current) => (current.length > 0 ? current : [threadRecipient]));
+  }, [threadRecipient]);
   // The sentence the reader reads. Null while the lookup is unsettled: an
   // unanswered read is not "no earlier message", and saying so would tell them
   // this starts a new thread when it may continue one.
@@ -2574,6 +2606,7 @@ export function ComposeModal({
               reasons={account.reasoning}
               to={to}
               onToChange={setTo}
+              onToEditing={stopOfferingRecipient}
               cc={cc}
               onCcChange={setCc}
               subject={subject}


### PR DESCRIPTION
## What was wrong

Sending an email **requires** `to` — it is a required field on
`POST /activities/{id}/send-email`. The reply draft handler never set one.
`EmailDraft` has carried a `to` field in the contract all along; the reply path
built its response with subject, body and the reply anchor and left it out.

So the composer's To field was empty when it opened **and** still empty after
the draft returned, and the client code that applies `drafted.to` was dead on
this path. Every reply had to be addressed by hand against a thread that
already named the person.

## What changed

Both callers resolve the address through `ReplyAddressFor`, which already owned
this question. It excludes participants carrying a seat and walks the remaining
candidates past a colleague-by-domain predicate, so neither a rep with a login
nor a co-worker without one can be offered as the person to answer.

- `POST /activities/{id}/draft-email` fills its contract's own `to` field.
  Failure degrades to no recipient rather than failing the draft — a draft with
  an unaddressed field is still a usable draft — and the reason is logged, so a
  permission failure and a thread with no counterparty are told apart afterwards.
- `GET /activities/{id}/reply-recipient` (new) asks the same question without a
  model call, which is what lets the composer show the recipient when it opens
  instead of forty seconds later. Here a refusal surfaces, because a caller who
  asked for exactly this deserves the answer.

The colleague predicate reads `capture`, which `activities` may not import, so
compose injects it (`WithColleagues`) and wires it **unconditionally** — a
deployment that forgot would compose replies to its own staff. An unwired
reader offers nobody rather than everybody.

The composer prefills an **empty** To field only, so a reader who typed their
own recipient — or a draft that named one — keeps it.

### The name and the address are two answers, deliberately

On our own outbound mail they name different people, and that is correct rather
than drift. The greeting names whoever the message was *with*; the address must
be a **counterparty**. The contract says so where an earlier revision of this
branch claimed the two were one answer.

## What an earlier revision of this branch got wrong

The first version taught `ReplyRecipientFor` to resolve an address. That was a
second implementation of a question `ReplyAddressFor` already owned, and that
function's doc comment says outright why its ranking must not be reused for
addressing: on outbound mail the `from` participant is us, so a `from`-first
rank answers with our own address and mails ourselves. It also reached an
`activity_link` arm `ReplyAddressFor` deliberately does not read, so a thread
with links but no participants would have prefilled an address the automation
path refuses as unresolvable.

`ReplyRecipientFor` is now byte-identical to `main` — the second implementation
is fully withdrawn.

## What it does not change

Consent is untouched. Send still requires an explicit purpose and gates every
recipient against it; this only saves typing an address the record already
holds. A channel reply resolves its recipient server-side and asks nothing.
A first message still deliberately resolves no recipient — it has no thread to
inherit one from.

## Tests

Nine integration cases over real Postgres, plus three frontend cases. They
drive the two **handlers** rather than the store, because what the surfaces
must agree on is who may be written to.

Fixtures are built so they cannot pass for the wrong reason:

- The ranking cases seed the copied contact **first**, so insertion order
  favours the wrong person and only the role ranking can correct it.
- The mail-ourselves case gives our own rep an address **off** our domain, so
  the colleague predicate cannot catch them and only the seat exclusion can.
  With an on-domain address it passes with the seat filter deleted — which is
  what the first version of that test did.
- The capture-privacy case puts a readable contact on the thread so the
  activity gate admits, making the person gate the thing under test, and makes
  the private contact the **sender** so the ranking actively wants them.

Mutation-verified: deleting the seat exclusion, dropping the colleague
predicate, neutralizing the person scope clause, and removing the client
prefill each turn a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically fills the reply recipient when composing email replies.
  * Resolves the appropriate counterparty address while excluding internal colleagues and the sender’s own addresses.
  * Applies the same recipient resolution to drafted emails.
  * Documents recipient details, visibility rules, and authorization behavior.
* **Bug Fixes**
  * Preserves manually entered recipients, including when lookup is delayed.
  * Safely handles unavailable, archived, private, or unauthorized recipients by leaving the address blank.
  * Keeps drafted recipients consistent with the reply-recipient result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->