### PR TITLE
fix(e2e-llm): case 6 asserts the finding, not the wording of the translation

### DIFF
--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -40,22 +40,28 @@ must_mention:
 # Criterion 1 needs it to find the accounts without being told which.
   - "Reply|valantic|Körber"
 
-# The note says "im Oktober" and it is wrong.
+# The note says "im Oktober" and it is wrong, and the answer has to notice.
 #
-# A bare /Oktober|October/ cannot express the thing being tested. An answer
-# SHOULD quote the note — it is a real record and hiding it would be its own
-# defect. What must not happen is the model adopting the note's month as its
-# own finding, which is what all three runs of 2026-08-27 did: each cited the
-# email as 18 Sep 2025, quoted the note correctly, and then wrote "the customer
-# raised it clearly in October" in its own voice, with no mention that the two
-# disagree.
+# Two spellings of this assertion have now been tried and both were wrong.
 #
-# So the forbidden shape is October asserted OUTSIDE a quotation: "raised it in
-# October", "flagged it in October", "told us in September/October". The
-# quotation itself is allowed through.
-must_not_mention:
-  - "raised (it|this) (clearly )?in Okt|flagged (it|this) (clearly )?in Okt|told us (clearly )?in (September/)?Okt|complained in Okt"
-  - "raised (it|this) (clearly )?in Octo|flagged (it|this) (clearly )?in Octo|told us (clearly )?in (September/)?Octo|complained in Octo"
+# A bare /Oktober|October/ cannot express the thing being tested: an answer
+# SHOULD quote the note, because it is a real record and hiding it would be its
+# own defect.
+#
+# Forbidding October only OUTSIDE a quotation cannot be spelled either. check.py
+# matches one flat regex over the whole answer and has no idea where a quotation
+# starts, so /raised (it|this) in Octo/ fires on the English translation an
+# answer writes directly under the German it just quoted — which is the correct
+# thing to do. That cost two of three runs on 2026-08-28: both had found the
+# contradiction and said so, and failed on the wording of their own translation.
+#
+# So assert the finding instead of policing the wording. An answer that noticed
+# the disagreement says so, in one of a small number of ways: the dates do not
+# match, the note misremembers, the October conversation is not in the CRM. The
+# three runs of 2026-08-27 — each of which adopted October as its own finding
+# ("the October complaint sat too long", "the complaint sat from October to
+# December") with no mention that the email says September — match none of them.
+  - "disagree|do(es)? not match|contradict|misremember|conflict|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|unrecorded|only logged inbound|no October|by the CRM's own dates|hearsay"
 
 runs: 3
 pass_at: 2

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -61,7 +61,12 @@ must_mention:
 # three runs of 2026-08-27 — each of which adopted October as its own finding
 # ("the October complaint sat too long", "the complaint sat from October to
 # December") with no mention that the email says September — match none of them.
-  - "disagree|do(es)? not match|contradict|misremember|conflict|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|unrecorded|only logged inbound|no October|by the CRM's own dates|hearsay"
+# A bare "conflict" is not in the alternation: "a conflict of interest between
+# the two managers" would earn a green from an answer that never noticed the
+# dates at all, and a scenario that can pass a bad answer is worse than one
+# that fails a good one. It counts only when what conflicts is a date or a
+# record.
+  - "disagree|do(es)? not match|contradict|misremember|(dates?|records?|note|two)[^.]{0,40}conflict|conflict[^.]{0,40}(date|record|note|email)|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|unrecorded|only logged inbound|no October|by the CRM's own dates|hearsay"
 
 runs: 3
 pass_at: 2

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -42,31 +42,42 @@ must_mention:
 
 # The note says "im Oktober" and it is wrong, and the answer has to notice.
 #
-# Two spellings of this assertion have now been tried and both were wrong.
+# This takes BOTH halves, and two earlier spellings each had only one.
 #
-# A bare /Oktober|October/ cannot express the thing being tested: an answer
-# SHOULD quote the note, because it is a real record and hiding it would be its
-# own defect.
+# The first was a `must_not_mention` forbidding October outside a quotation:
+# /raised (it|this) (clearly )?in Octo/ and friends. check.py matches one flat
+# regex over the whole answer and has no idea where a quotation ends, so those
+# fired on the English translation an answer writes directly under the German
+# note it just quoted — which is the right thing for an answer to do. Two of
+# three runs on 2026-08-28 had found the contradiction, said so, and failed on
+# the wording of their own translation.
 #
-# Forbidding October only OUTSIDE a quotation cannot be spelled either. check.py
-# matches one flat regex over the whole answer and has no idea where a quotation
-# starts, so /raised (it|this) in Octo/ fires on the English translation an
-# answer writes directly under the German it just quoted — which is the correct
-# thing to do. That cost two of three runs on 2026-08-28: both had found the
-# contradiction and said so, and failed on the wording of their own translation.
+# Replacing it with a positive assertion alone was worse. It could pass an
+# answer that noticed nothing: a lone "conflict" also appears in "a conflict of
+# interest between the two managers", and a lone "unrecorded" or "hearsay" in
+# sentences that never compare the two dates. Under-recognition is the one
+# direction a scenario must not fail in — it reports PASS and there is no
+# failing assertion to notice.
 #
-# So assert the finding instead of policing the wording. An answer that noticed
-# the disagreement says so, in one of a small number of ways: the dates do not
-# match, the note misremembers, the October conversation is not in the CRM. The
-# three runs of 2026-08-27 — each of which adopted October as its own finding
-# ("the October complaint sat too long", "the complaint sat from October to
-# December") with no mention that the email says September — match none of them.
-# A bare "conflict" is not in the alternation: "a conflict of interest between
-# the two managers" would earn a green from an answer that never noticed the
-# dates at all, and a scenario that can pass a bad answer is worse than one
-# that fails a good one. It counts only when what conflicts is a date or a
-# record.
-  - "disagree|do(es)? not match|contradict|misremember|(dates?|records?|note|two)[^.]{0,40}conflict|conflict[^.]{0,40}(date|record|note|email)|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|unrecorded|only logged inbound|no October|by the CRM's own dates|hearsay"
+# So both, each narrow:
+#
+# must_mention  — the answer states that the record and the note disagree, and
+#                 names WHAT disagrees. No lone word qualifies: "conflict"
+#                 counts only next to a date, record, note or email.
+# must_not_mention — the answer does not go on to adopt October as its own
+#                 conclusion. Every alternative here needs a conclusion verb
+#                 ("the complaint was raised in October"), so translating the
+#                 quoted note ("The customer raised it clearly in October")
+#                 does not trip it. That distinction is the whole fix.
+#
+# Verified in both directions against real transcripts with check.py --check:
+# the three CI runs of 2026-08-28 pass, and the three runs of 2026-08-27 —
+# which adopted October as their own finding ("the October complaint sat too
+# long") with no mention that the email says September — still fail.
+  - "disagree|do(es)? not match|contradict|misremember|(dates?|records?|note|email|two)[^.]{0,40}conflict|conflict[^.]{0,40}(date|record|note|email)|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|only logged inbound|no October|by the CRM's own dates"
+
+must_not_mention:
+  - "the (complaint|escalation|customer)[^.]{0,30}(was|were) raised in Octo|raised in Octo(ber)? before|complaint (came|landed|arrived) in Octo|since Octo(ber)?,? the customer"
 
 runs: 3
 pass_at: 2

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -42,30 +42,34 @@ must_mention:
 
 # The note says "im Oktober" and it is wrong, and the answer has to notice.
 #
-# This needs both halves, because either alone is satisfied by a bad answer.
+# Both halves are needed, because either alone passes a bad answer.
 #
 # must_mention — the answer says the record and the note disagree, and names
-# WHAT disagrees. No lone word qualifies: "conflict" counts only next to a
-# date, record, note or email, because "a conflict of interest between the two
-# managers" would otherwise earn a green from an answer that never compared
-# the dates. Under-recognition is the one direction a scenario must not fail
-# in: it reports PASS and leaves no failing assertion to notice.
+# WHAT disagrees. A lone word does not qualify: "conflict" counts only within
+# a clause of a date, record, note or email, or "a conflict of interest
+# between the two managers" would green an answer that never compared the
+# dates. Under-recognition is the one direction a scenario must not fail in,
+# because it reports PASS and leaves no failing assertion to notice.
 #
-# must_not_mention — the answer does not then adopt October as its own
-# conclusion. Every alternative requires a conclusion verb, so an answer that
-# translates the German note it just quoted ("The customer raised it clearly
-# in October") does not trip it. That is the distinction the assertion turns
-# on: a bare /raised (it|this) in Octo/ cannot draw it, because check.py
-# matches one flat regex over the whole answer and cannot see where a
-# quotation ends.
+# must_not_mention — the answer does not then use October as the date of the
+# complaint in its own voice. check.py matches one flat regex over the whole
+# answer and cannot see where a quotation ends, so this half must not fire on
+# an answer that quotes the German note and translates it — "The customer
+# raised it clearly in October" is a rendering of the record, not a claim.
+# Every alternative therefore needs something the note's own sentence does not
+# say: a noun phrase ("the October complaint"), a verb of complaining, a date
+# range, or an explicit "was raised in October". Both languages, because the
+# note is German and an answer may adopt its month in German.
 #
-# Both directions are checked against real transcripts with check.py --check:
-# answers that flag the contradiction pass, and answers that adopt October as
-# their own finding ("the October complaint sat too long") fail.
+# Reproduce either half against a transcript with
+#   python3 check.py --check scenarios/case6-ask-the-company.yaml <run.jsonl>
+# The three runs in records/ are answers that adopted October: two are caught
+# by must_not_mention, and the third, which only ever quotes the German, by
+# must_mention.
   - "disagree|do(es)? not match|contradict|misremember|(dates?|records?|note|email|two)[^.]{0,40}conflict|conflict[^.]{0,40}(date|record|note|email)|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|only logged inbound|no October|by the CRM's own dates"
 
 must_not_mention:
-  - "the (complaint|escalation|customer)[^.]{0,30}(was|were) raised in Octo|complaint (came|landed|arrived) in Octo"
+  - "the (?:October|Oktober)\s+(?:complaint|escalation)|(?:complained|escalated)[^.]{0,30}(?:October|Oktober)|(?:beschwert|eskaliert)[^.]{0,30}(?:October|Oktober)|(?:October|Oktober)[^.]{0,30}(?:beschwert|eskaliert)|complaint\s+(?:came|landed|arrived|sat)[^.]{0,25}(?:October|Oktober)|from\s+(?:October|Oktober)\s+to|seit\s+(?:October|Oktober)|(?:was|were|is)\s+raised\s+in\s+(?:October|Oktober)"
 
 runs: 3
 pass_at: 2

--- a/e2e/llm/scenarios/case6-ask-the-company.yaml
+++ b/e2e/llm/scenarios/case6-ask-the-company.yaml
@@ -42,42 +42,30 @@ must_mention:
 
 # The note says "im Oktober" and it is wrong, and the answer has to notice.
 #
-# This takes BOTH halves, and two earlier spellings each had only one.
+# This needs both halves, because either alone is satisfied by a bad answer.
 #
-# The first was a `must_not_mention` forbidding October outside a quotation:
-# /raised (it|this) (clearly )?in Octo/ and friends. check.py matches one flat
-# regex over the whole answer and has no idea where a quotation ends, so those
-# fired on the English translation an answer writes directly under the German
-# note it just quoted — which is the right thing for an answer to do. Two of
-# three runs on 2026-08-28 had found the contradiction, said so, and failed on
-# the wording of their own translation.
+# must_mention — the answer says the record and the note disagree, and names
+# WHAT disagrees. No lone word qualifies: "conflict" counts only next to a
+# date, record, note or email, because "a conflict of interest between the two
+# managers" would otherwise earn a green from an answer that never compared
+# the dates. Under-recognition is the one direction a scenario must not fail
+# in: it reports PASS and leaves no failing assertion to notice.
 #
-# Replacing it with a positive assertion alone was worse. It could pass an
-# answer that noticed nothing: a lone "conflict" also appears in "a conflict of
-# interest between the two managers", and a lone "unrecorded" or "hearsay" in
-# sentences that never compare the two dates. Under-recognition is the one
-# direction a scenario must not fail in — it reports PASS and there is no
-# failing assertion to notice.
+# must_not_mention — the answer does not then adopt October as its own
+# conclusion. Every alternative requires a conclusion verb, so an answer that
+# translates the German note it just quoted ("The customer raised it clearly
+# in October") does not trip it. That is the distinction the assertion turns
+# on: a bare /raised (it|this) in Octo/ cannot draw it, because check.py
+# matches one flat regex over the whole answer and cannot see where a
+# quotation ends.
 #
-# So both, each narrow:
-#
-# must_mention  — the answer states that the record and the note disagree, and
-#                 names WHAT disagrees. No lone word qualifies: "conflict"
-#                 counts only next to a date, record, note or email.
-# must_not_mention — the answer does not go on to adopt October as its own
-#                 conclusion. Every alternative here needs a conclusion verb
-#                 ("the complaint was raised in October"), so translating the
-#                 quoted note ("The customer raised it clearly in October")
-#                 does not trip it. That distinction is the whole fix.
-#
-# Verified in both directions against real transcripts with check.py --check:
-# the three CI runs of 2026-08-28 pass, and the three runs of 2026-08-27 —
-# which adopted October as their own finding ("the October complaint sat too
-# long") with no mention that the email says September — still fail.
+# Both directions are checked against real transcripts with check.py --check:
+# answers that flag the contradiction pass, and answers that adopt October as
+# their own finding ("the October complaint sat too long") fail.
   - "disagree|do(es)? not match|contradict|misremember|(dates?|records?|note|email|two)[^.]{0,40}conflict|conflict[^.]{0,40}(date|record|note|email)|not in the CRM|isn't in the CRM|is not in the CRM|never (written down|logged|recorded)|only logged inbound|no October|by the CRM's own dates"
 
 must_not_mention:
-  - "the (complaint|escalation|customer)[^.]{0,30}(was|were) raised in Octo|raised in Octo(ber)? before|complaint (came|landed|arrived) in Octo|since Octo(ber)?,? the customer"
+  - "the (complaint|escalation|customer)[^.]{0,30}(was|were) raised in Octo|complaint (came|landed|arrived) in Octo"
 
 runs: 3
 pass_at: 2


### PR DESCRIPTION
## What was red

The scheduled `use cases, driven by a model (weekly)` lane failed on `case6_ask_the_company`, 1 of 3 runs (needed 2). The other five scenarios passed 3/3.

The product was right in all three runs. The scenario file was wrong.

## Why it failed

`case6-ask-the-company.yaml` held two `must_not_mention` patterns meant to forbid October asserted *outside* a quotation:

```
raised (it|this) (clearly )?in Octo|flagged (it|this) (clearly )?in Octo|...
```

`check.py` matches one flat regex over the whole answer and has no idea where a quotation starts or ends. So the pattern fired on the English translation an answer writes directly under the German note it just quoted — which is the correct thing for an answer to do:

- run 1: `> "Der Kunde hat das im Oktober klar angesprochen..." > *(The customer raised it clearly in October; we reacted too late.)*`
- run 3: `*"Der Kunde hat das im Oktober..."* ("The customer raised this clearly in October; we reacted too late.")`

Both runs then flagged the contradiction explicitly — run 1: "the complaint is dated **18 September** — so by the CRM's own dates, the customer had already said it in writing"; run 3: "the post-mortem itself references an October escalation that isn't in the CRM".

Run 2 passed only by accident of phrasing: it wrote "says the customer raised it", putting two words between `raised` and `it` and breaking the pattern's adjacency.

So the gate was a coin flip on translation wording, not on correctness.

## The change

The scenario now asserts **both halves**, each narrow:

- **`must_mention`** — the answer states that the record and the note disagree, and names *what* disagrees. No lone word qualifies: `conflict` counts only next to a date, record, note or email.
- **`must_not_mention`** — the answer does not go on to adopt October as its own conclusion. Every alternative requires a conclusion verb (`the complaint was raised in October`), so translating the quoted German note does not trip it. That distinction is the whole fix.

An intermediate commit on this branch tried the positive assertion alone. Codex correctly rejected it: a lone `conflict` is satisfied by "a conflict of interest between the two managers", and nothing stopped an answer that acknowledged the clash and still concluded October. Both holes are closed.

## Verified in both directions

Run with the real checker, `check.py --check`, against real transcripts:

| transcript | before | after |
|---|---|---|
| CI 2026-08-28 run 1 | FAIL | **PASS** |
| CI 2026-08-28 run 2 | PASS | **PASS** |
| CI 2026-08-28 run 3 | FAIL | **PASS** |
| local 2026-08-27 run 1 | — | **FAIL** |
| local 2026-08-27 run 2 | — | **FAIL** |
| local 2026-08-27 run 3 | — | **FAIL** |

The 2026-08-27 runs are the ones the file's own comment records as the real defect: each adopted October as its own finding ("the October complaint sat too long", "the complaint sat from October to December") with no mention that the email says September. They still fail, and they fail on the new assertion specifically — so this is a mutation check, not a pattern fitted to the passing runs.

Six adversarial answers are rejected, including both Codex constructed:

- "…prepare for conflict during the handover" (lone `conflict`)
- "…email conflicts with the note. Nevertheless, the complaint was raised in October." (clash acknowledged, October adopted)
- "The October escalation is hearsay from the team."
- "Several unrecorded calls happened; the complaint was raised in October."
- "There was a conflict of interest between the two account managers."
- "The handovers conflict with what the customer expects…"

And six plausible translations of the quoted German note — including the exact strings runs 1 and 3 wrote — do **not** trip the new `must_not_mention`, so the CI regression cannot recur.

`make check-backend` green (exit 0, clean worktree). `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green.

## Not in this PR

The same scheduled run has a second, unrelated red job: `sonarcloud quality gate (main)` failing `new_security_rating GT 1 (actual 3)`. That is main's Sonar state and needs its own look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end validation for complaint and escalation wording in English and German.
  * Improved detection of date ranges and explicit conclusions referring to issues raised in October.
  * Refined contradiction checks to distinguish attributed October statements from unsupported conclusions.
  * Clarified test criteria and expected response behavior, including limitations in pattern-based matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->