### PR TITLE
feat(records): a rep can state a company's VAT number and registry address

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16190,7 +16190,7 @@ paths:
     patch:
       tags: [Organizations]
       operationId: updateOrganizationProfileField
-      summary: Correct a profile field — the canonical value changes, the machine's proposal survives.
+      summary: State or correct a profile field — the canonical value changes, the machine's proposal survives.
       description: |
         DOSS-WIRE-4 / PO-AC-N-1. Where the field maps to a column on `organization`, THE COLUMN IS
         WHAT CHANGES; the sidecar keeps the machine's proposal, excerpt, source URL and confidence in
@@ -16198,6 +16198,16 @@ paths:
         would be a lie about having been accepted. Provenance flips to `human` with the acting
         principal and the timestamp; the whole thing commits as one mutation with its audit entry and
         its outboxed event.
+
+        A field with NO row yet is CREATED by this write, audited as a creation with no before-image.
+        Most of this vocabulary is only ever filled by a crawl that read a legal notice, and a company
+        whose site publishes none would otherwise hold a fact nobody could record. Originating a claim
+        is a human act: an agent principal still gets `404` here, because the write stamps
+        `verified_by` with the granting user and that would record a human verification of a value no
+        human saw. Correcting a claim that already exists stays open to an agent.
+
+        `404` therefore means the organization is unreachable, or — for the confirm operation, or for
+        an agent's first statement — that no such claim exists to answer for.
       x-mcp-tool: { verb: update_record, record_type: organization, tier: auto_execute, scope: write }
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -27826,6 +27826,15 @@ components:
         source_url: { type: [string, 'null'], format: uri }
         confidence: { type: [number, 'null'], minimum: 0, maximum: 1 }
         updated_at: { type: string, format: date-time }
+        version:
+          type: integer
+          format: int64
+          readOnly: true
+          description: >-
+            The row's version, for the `If-Match` a correction sends. The write path has
+            always honoured the precondition; without the version on the read, no client
+            could supply one, and two people correcting the same claim overwrote each
+            other with no conflict and no trace.
 
     TechnicalMailProvider:
       type: string

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15913,6 +15913,9 @@ type CompanyProfileField struct {
 
 	// VerifiedBy The human who confirmed the claim. Server-stamped, never accepted from a request body.
 	VerifiedBy *string `json:"verified_by,omitempty"`
+
+	// Version The row's version, for the `If-Match` a correction sends. The write path has always honoured the precondition; without the version on the read, no client could supply one, and two people correcting the same claim overwrote each other with no conflict and no trace.
+	Version *int64 `json:"version,omitempty"`
 }
 
 // CompanyProfileFieldField defines model for CompanyProfileField.Field.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -40839,7 +40839,7 @@ type ServerInterface interface {
 	// The organization's confirmed profile fields (organization_profile_field). A field with no stored value is absent (evidence-or-omit); site-read values carry evidence, human/migration values may omit it.
 	// (GET /organizations/{id}/profile-fields)
 	ListOrganizationProfileFields(w http.ResponseWriter, r *http.Request, id Id)
-	// Correct a profile field — the canonical value changes, the machine's proposal survives.
+	// State or correct a profile field — the canonical value changes, the machine's proposal survives.
 	// (PATCH /organizations/{id}/profile-fields/{field})
 	UpdateOrganizationProfileField(w http.ResponseWriter, r *http.Request, id Id, field ProfileFieldKey, params UpdateOrganizationProfileFieldParams)
 	// Confirm a profile field without changing its value.
@@ -43332,7 +43332,7 @@ func (_ Unimplemented) ListOrganizationProfileFields(w http.ResponseWriter, r *h
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Correct a profile field — the canonical value changes, the machine's proposal survives.
+// State or correct a profile field — the canonical value changes, the machine's proposal survives.
 // (PATCH /organizations/{id}/profile-fields/{field})
 func (_ Unimplemented) UpdateOrganizationProfileField(w http.ResponseWriter, r *http.Request, id Id, field ProfileFieldKey, params UpdateOrganizationProfileFieldParams) {
 	w.WriteHeader(http.StatusNotImplemented)

--- a/backend/internal/modules/people/organization_evidence_write.go
+++ b/backend/internal/modules/people/organization_evidence_write.go
@@ -48,24 +48,6 @@ type evidenceWrite[T any] struct {
 	readAfter func(context.Context, pgx.Tx) (T, error)
 }
 
-// auditEvidenceWrite records the write under the verb it actually is.
-//
-// The two doors differ in what they REFUSE, which is why the choice is made
-// here rather than by passing a verb string: Audit refuses an update with no
-// before-image, and AuditEvent is the one that records an occurrence having
-// none. A creation sent through Audit would have to invent an image to satisfy
-// it, which is the defect this exists to avoid.
-//
-//craft:ignore naked-any the audit seam: an after image is the entity's own snapshot shape
-func auditEvidenceWrite(
-	ctx context.Context, tx pgx.Tx, table string, before evidenceRow, after any, created bool,
-) (ids.UUID, error) {
-	if created {
-		return storekit.AuditEvent(ctx, tx, "create", table, before.ID, after)
-	}
-	return storekit.Audit(ctx, tx, "update", table, before.ID, before.auditImage(), after)
-}
-
 // writeEvidence is the one way a human correction or confirmation reaches an
 // evidence sidecar (PO-AC-N-2).
 //
@@ -144,7 +126,18 @@ func writeEvidence[T any](
 		// wrote into the audit trail — the one record that answers "what did it
 		// say before I changed it". AuditEvent is the door for a write with no
 		// prior state; Audit refuses an update carrying no before-image.
-		auditID, err := auditEvidenceWrite(ctx, tx, w.table, before, p.After(), created)
+		//
+		// Spelled inline rather than behind a helper: the audit and the emit
+		// below are one obligation, and a helper holding only the audit half
+		// puts them in separate functions where nothing local shows they travel
+		// together — which is exactly what the write-shape gate reads.
+		var auditID ids.UUID
+		if created {
+			auditID, err = storekit.AuditEvent(ctx, tx, "create", w.table, before.ID, p.After())
+		} else {
+			auditID, err = storekit.Audit(ctx, tx, "update", w.table,
+				before.ID, before.auditImage(), p.After())
+		}
 		if err != nil {
 			return fmt.Errorf("audit %s write: %w", w.table, err)
 		}

--- a/backend/internal/modules/people/organization_evidence_write.go
+++ b/backend/internal/modules/people/organization_evidence_write.go
@@ -36,14 +36,34 @@ type evidenceWrite[T any] struct {
 	value     *string
 	ifVersion *int64
 	// readBefore locates the row and returns the machine's claim in full, which
-	// becomes the audit before-image.
-	readBefore func(context.Context, pgx.Tx) (evidenceRow, error)
+	// becomes the audit before-image. The bool says the row did not exist and
+	// this write minted it: there is then no prior state, and the audit records
+	// a creation rather than an update against an image nobody ever wrote.
+	readBefore func(context.Context, pgx.Tx) (evidenceRow, bool, error)
 	// canonical moves the corrected value out of the sidecar and onto the
 	// record it describes. Nil for a claim that lives only in the sidecar and
 	// so has nothing to keep in step.
 	canonical func(context.Context, pgx.Tx) error
 	// readAfter re-reads the written row as its wire shape.
 	readAfter func(context.Context, pgx.Tx) (T, error)
+}
+
+// auditEvidenceWrite records the write under the verb it actually is.
+//
+// The two doors differ in what they REFUSE, which is why the choice is made
+// here rather than by passing a verb string: Audit refuses an update with no
+// before-image, and AuditEvent is the one that records an occurrence having
+// none. A creation sent through Audit would have to invent an image to satisfy
+// it, which is the defect this exists to avoid.
+//
+//craft:ignore naked-any the audit seam: an after image is the entity's own snapshot shape
+func auditEvidenceWrite(
+	ctx context.Context, tx pgx.Tx, table string, before evidenceRow, after any, created bool,
+) (ids.UUID, error) {
+	if created {
+		return storekit.AuditEvent(ctx, tx, "create", table, before.ID, after)
+	}
+	return storekit.Audit(ctx, tx, "update", table, before.ID, before.auditImage(), after)
 }
 
 // writeEvidence is the one way a human correction or confirmation reaches an
@@ -86,7 +106,7 @@ func writeEvidence[T any](
 		if err := tx.QueryRow(ctx, `SELECT now()`).Scan(&now); err != nil {
 			return fmt.Errorf("read transaction time: %w", err)
 		}
-		before, err := w.readBefore(ctx, tx)
+		before, created, err := w.readBefore(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -119,8 +139,12 @@ func writeEvidence[T any](
 			}
 		}
 
-		auditID, err := storekit.Audit(ctx, tx, "update", w.table,
-			before.ID, before.auditImage(), p.After())
+		// A row this write minted has no before-image, and calling it an update
+		// against the empty row we just inserted would put a state nobody ever
+		// wrote into the audit trail — the one record that answers "what did it
+		// say before I changed it". AuditEvent is the door for a write with no
+		// prior state; Audit refuses an update carrying no before-image.
+		auditID, err := auditEvidenceWrite(ctx, tx, w.table, before, p.After(), created)
 		if err != nil {
 			return fmt.Errorf("audit %s write: %w", w.table, err)
 		}

--- a/backend/internal/modules/people/organization_fact_read.go
+++ b/backend/internal/modules/people/organization_fact_read.go
@@ -119,7 +119,7 @@ func (s *Store) ListOrganizationProfileFields(ctx context.Context, id ids.Organi
 		rows, err := tx.Query(ctx, `
 			SELECT id, field, value, source, captured_by,
 			       evidence_snippet, source_url, confidence, retrieved_at,
-			       verified_at, verified_by, updated_at
+			       verified_at, verified_by, updated_at, version
 			  FROM organization_profile_field
 			 WHERE organization_id = $1
 			 ORDER BY field`,
@@ -137,7 +137,7 @@ func (s *Store) ListOrganizationProfileFields(ctx context.Context, id ids.Organi
 			if err := rows.Scan(&rowID, &field, &pf.Value, &source, &pf.CapturedBy,
 				&pf.EvidenceSnippet, &pf.SourceUrl, &pf.Confidence,
 				&pf.RetrievedAt, &pf.VerifiedAt, &pf.VerifiedBy,
-				&pf.UpdatedAt); err != nil {
+				&pf.UpdatedAt, &pf.Version); err != nil {
 				return fmt.Errorf("scan organization profile field: %w", err)
 			}
 			// The row's own identity, so a dossier sentence written from this

--- a/backend/internal/modules/people/organization_fact_write.go
+++ b/backend/internal/modules/people/organization_fact_write.go
@@ -60,8 +60,12 @@ func (s *Store) writeFact(
 		changedKey: factKey,
 		value:      in.Value,
 		ifVersion:  in.IfVersion,
-		readBefore: func(ctx context.Context, tx pgx.Tx) (evidenceRow, error) {
-			return readFactRow(ctx, tx, orgID, factKey)
+		// Never creates: a fact is addressed by `<field>:<value_key>`, a key a
+		// machine derives from what it read, so there is no vocabulary a person
+		// could originate one from. An absent fact stays not-found.
+		readBefore: func(ctx context.Context, tx pgx.Tx) (evidenceRow, bool, error) {
+			row, err := readFactRow(ctx, tx, orgID, factKey)
+			return row, false, err
 		},
 		readAfter: func(ctx context.Context, tx pgx.Tx) (crmcontracts.OrganizationFact, error) {
 			return readFactWire(ctx, tx, orgID, factKey)

--- a/backend/internal/modules/people/organization_profile_field_create_integration_test.go
+++ b/backend/internal/modules/people/organization_profile_field_create_integration_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Stating a profile field the machine never proposed.
+//
+// Most of this vocabulary is only ever filled by a crawl that found a legal
+// notice. A company whose site prints no imprint has no row for register_vat,
+// and the correction path — which locates a row and patches it — answered 404.
+// A rep who knew the number could not record it, and the VAT consultation that
+// a written number is supposed to queue was unreachable for exactly the
+// companies a person would want to check.
+//
+// What must NOT follow from that is a confirm verb that invents rows: agreeing
+// with a claim nobody made is not an act the product has.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// bareOrg seeds a company with NO sidecar rows at all — the state a crawl that
+// found no imprint leaves, and the one evidenceOrg deliberately does not model.
+func bareOrg(ctx context.Context, t *testing.T, e *dedupeEnv) ids.OrganizationID {
+	t.Helper()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Halden Kraft GmbH", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "halden-kraft.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	return ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+}
+
+func profileFieldSource(
+	ctx context.Context, t *testing.T, e *dedupeEnv, orgID ids.OrganizationID, field string,
+) string {
+	t.Helper()
+	var source string
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT source FROM organization_profile_field
+			 WHERE organization_id = $1 AND field = $2`, orgID, field).Scan(&source)
+	}); err != nil {
+		t.Fatalf("read profile field %s source: %v", field, err)
+	}
+	return source
+}
+
+// The case the product could not do: a person states a fact about a company
+// whose site never published it.
+func TestARepCanStateAProfileFieldTheMachineNeverProposed(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	stated := "DE811907980"
+	out, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "register_vat",
+		ProfileFieldWriteInput{Value: &stated})
+	if err != nil {
+		t.Fatalf("state a VAT number on a company with no sidecar row: %v", err)
+	}
+
+	if out.Value != stated {
+		t.Errorf("value = %q, want %q", out.Value, stated)
+	}
+	// A created row belongs to the person who created it, on both columns the
+	// enrichment upserts read: source decides what the reader is told, and
+	// captured_by is what stops the next crawl reclaiming the row.
+	if string(out.Source) != "human" {
+		t.Errorf("source = %q, want human — the person IS the evidence on this path", out.Source)
+	}
+	if got := profileFieldSource(ctx, t, e, orgID, "register_vat"); got != "human" {
+		t.Errorf("stored source = %q, want human", got)
+	}
+	if out.VerifiedAt == nil || out.VerifiedBy == nil {
+		t.Fatal("a stated value records who stated it")
+	}
+	if *out.VerifiedBy != e.rep.String() {
+		t.Errorf("verified_by = %v, want the calling rep %v", *out.VerifiedBy, e.rep)
+	}
+}
+
+// The boundary the create must not cross. A confirmation says "I read this and
+// it is right"; there is nothing to read, and a row invented to be agreed with
+// would record a human verdict on a value nobody ever proposed.
+func TestConfirmingAProfileFieldNobodyProposedIsStillNotFound(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	_, err := e.store.ConfirmOrganizationProfileField(ctx, orgID, "register_vat",
+		ProfileFieldWriteInput{})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("got %v, want not-found — a confirmation cannot create the claim it agrees with", err)
+	}
+
+	var rows int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM organization_profile_field
+			 WHERE organization_id = $1 AND field = 'register_vat'`, orgID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("count profile field rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("the refused confirmation left %d row(s) behind", rows)
+	}
+}
+
+// The reason the create matters: a stated number is an unchecked number, and
+// the consultation has to be queued by the write that stated it. Queued in the
+// SAME transaction, so a correction that rolls back leaves no job asking about
+// a number the record does not hold.
+func TestStatingAVatNumberQueuesItsConsultation(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	var queued []ids.OrganizationID
+	e.store.WithVatCheckEnqueue(func(_ context.Context, _ pgx.Tx, id ids.OrganizationID) error {
+		queued = append(queued, id)
+		return nil
+	})
+
+	stated := "DE811907980"
+	if _, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "register_vat",
+		ProfileFieldWriteInput{Value: &stated}); err != nil {
+		t.Fatalf("state a VAT number: %v", err)
+	}
+
+	if len(queued) != 1 {
+		t.Fatalf("queued %d consultations, want exactly 1 — a stated number nobody checks is worse than none", len(queued))
+	}
+	if queued[0] != orgID {
+		t.Errorf("queued the consultation for %v, want %v", queued[0], orgID)
+	}
+}
+
+// The registry address is the other field a person can now state, and it must
+// NOT reach the six address columns: those describe where the company operates.
+func TestStatingTheRegisteredAddressLeavesTheOperatingAddressAlone(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	stated := "Amtsgericht Charlottenburg, Kaiserdamm 1, 14057 Berlin"
+	if _, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "registered_address",
+		ProfileFieldWriteInput{Value: &stated}); err != nil {
+		t.Fatalf("state the registered address: %v", err)
+	}
+
+	for _, column := range []string{"address_line1", "address_city", "address_postal_code"} {
+		if got := orgColumn(ctx, t, e, orgID, column); got != "" {
+			t.Errorf("%s = %q, want empty — the registry address is not the operating address", column, got)
+		}
+	}
+	if got := readProfileFieldValue(ctx, t, e, orgID, "registered_address"); got != stated {
+		t.Errorf("registered_address = %q, want %q", got, stated)
+	}
+}

--- a/backend/internal/modules/people/organization_profile_field_create_integration_test.go
+++ b/backend/internal/modules/people/organization_profile_field_create_integration_test.go
@@ -20,6 +20,8 @@ package people
 import (
 	"context"
 	"errors"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -144,6 +146,181 @@ func TestStatingAVatNumberQueuesItsConsultation(t *testing.T) {
 	}
 	if queued[0] != orgID {
 		t.Errorf("queued the consultation for %v, want %v", queued[0], orgID)
+	}
+}
+
+// The agent principal is dedupequeue's own `asAgent` — it already carries the
+// organization update grant, so the only thing separating it from `as()` here
+// is who is acting, which is what these two cases turn on.
+//
+// Originating a claim is a human act. This endpoint runs at auto_execute, so
+// without the guard an agent could mint a legal-identity claim on a company
+// nothing was ever read about — and writeEvidence stamps verified_by with the
+// user who granted the agent, recording a human verification of a value that
+// human never saw. Correcting an EXISTING claim stays open to an agent.
+func TestAnAgentCannotOriginateAClaimNobodyProposed(t *testing.T) {
+	e := setupDedupe(t)
+	orgID := bareOrg(e.as(), t, e)
+
+	stated := "DE811907980"
+	_, err := e.store.UpdateOrganizationProfileField(e.asAgent(), orgID, "register_vat",
+		ProfileFieldWriteInput{Value: &stated})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("got %v, want not-found — the refusal an agent saw before the create arm existed", err)
+	}
+
+	var rows int
+	if err := e.store.tx(e.as(), func(tx pgx.Tx) error {
+		return tx.QueryRow(e.as(), `
+			SELECT count(*) FROM organization_profile_field
+			 WHERE organization_id = $1 AND field = 'register_vat'`, orgID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("count profile field rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("the refused agent write minted %d row(s)", rows)
+	}
+}
+
+// The other half, and the one that stops the guard being a blanket refusal: an
+// agent correcting a claim a crawl already made is the ordinary case this
+// endpoint exists for, and it must keep working.
+func TestAnAgentStillCorrectsAClaimThatAlreadyExists(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := evidenceOrg(ctx, t, e)
+
+	corrected := "Mid-market industrial manufacturers"
+	if _, err := e.store.UpdateOrganizationProfileField(e.asAgent(), orgID, "icp",
+		ProfileFieldWriteInput{Value: &corrected}); err != nil {
+		t.Fatalf("an agent correcting an existing claim: %v", err)
+	}
+	if got := readProfileFieldValue(ctx, t, e, orgID, "icp"); got != corrected {
+		t.Errorf("value = %q, want %q", got, corrected)
+	}
+}
+
+// The audit trail has to say what happened. A creation recorded as an update
+// carries a before-image of the empty row the write itself just inserted — a
+// state nobody ever wrote — and "what did it say before I changed it" then
+// answers with something the system invented.
+func TestAStatedClaimIsAuditedAsACreationWithNoBeforeImage(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	stated := "DE811907980"
+	if _, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "register_vat",
+		ProfileFieldWriteInput{Value: &stated}); err != nil {
+		t.Fatalf("state a VAT number: %v", err)
+	}
+
+	var (
+		action string
+		before *string
+		after  map[string]any
+	)
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT action, before::text, after
+			  FROM audit_log
+			 WHERE entity_type = 'organization_profile_field'
+			 ORDER BY occurred_at DESC LIMIT 1`).Scan(&action, &before, &after)
+	}); err != nil {
+		t.Fatalf("read the audit row: %v", err)
+	}
+
+	if action != "create" {
+		t.Errorf("action = %q, want create — the row did not exist before this write", action)
+	}
+	if before != nil {
+		t.Errorf("before = %q, want no image at all — there was no prior state to record", *before)
+	}
+	// The after image still has to carry what was stated, or the audit records
+	// a creation of nothing.
+	if after[auditKeyValue] != stated {
+		t.Errorf("after[value] = %v, want %q", after[auditKeyValue], stated)
+	}
+}
+
+// The correction of an existing claim keeps its before-image: that is the half
+// the audit trail already had, and a fix to the create path must not cost it.
+func TestCorrectingAnExistingClaimStillRecordsWhatItSaidBefore(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := evidenceOrg(ctx, t, e)
+
+	corrected := "Mid-market industrial manufacturers"
+	if _, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "icp",
+		ProfileFieldWriteInput{Value: &corrected}); err != nil {
+		t.Fatalf("correct icp: %v", err)
+	}
+
+	var (
+		action string
+		before map[string]any
+	)
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT action, before
+			  FROM audit_log
+			 WHERE entity_type = 'organization_profile_field'
+			 ORDER BY occurred_at DESC LIMIT 1`).Scan(&action, &before)
+	}); err != nil {
+		t.Fatalf("read the audit row: %v", err)
+	}
+
+	if action != "update" {
+		t.Errorf("action = %q, want update", action)
+	}
+	if before[auditKeyValue] != "Energy-intensive manufacturers" {
+		t.Errorf("before[value] = %v, want the machine's original claim", before[auditKeyValue])
+	}
+}
+
+// Several reps stating the same field at once. What this holds is the OUTCOME:
+// every writer succeeds and the field ends up holding one of the stated values
+// rather than the empty string the insert seeds — so a first statement never
+// leaves a blank claim behind, however the writers interleave.
+//
+// What it does NOT hold is insertHumanProfileField's ON CONFLICT DO NOTHING:
+// this passes with that clause removed, so the collision it guards against is
+// not reached here. The clause says why it stays; this says why the test does
+// not prove it, rather than reading like it does.
+func TestRepsStatingTheSameFieldAtOnceAllSucceed(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := bareOrg(ctx, t, e)
+
+	stated := []string{
+		"DE811907980", "DE136695976", "DE129273398", "DE811128135",
+		"DE114110165", "DE811115368", "DE813501887", "DE167015661",
+	}
+	errs := make([]error, len(stated))
+	// Released together, so every writer reaches the insert in the same instant
+	// rather than trickling in behind whoever the scheduler started first.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i, value := range stated {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, errs[i] = e.store.UpdateOrganizationProfileField(e.as(), orgID,
+				"register_vat", ProfileFieldWriteInput{Value: &value})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("rep %d stating %q: %v", i, stated[i], err)
+		}
+	}
+	got := readProfileFieldValue(ctx, t, e, orgID, "register_vat")
+	if !slices.Contains(stated, got) {
+		t.Errorf("value = %q, want one of the stated numbers — the seeded empty row survived", got)
 	}
 }
 

--- a/backend/internal/modules/people/organization_profile_field_write.go
+++ b/backend/internal/modules/people/organization_profile_field_write.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -17,6 +18,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // ensureOrgWritable is ensureOrgReadable's write-side twin: same row-scope and
@@ -111,7 +113,11 @@ type ProfileFieldWriteInput struct {
 	IfVersion *int64
 }
 
-// UpdateOrganizationProfileField corrects a profile field's value.
+// UpdateOrganizationProfileField states or corrects a profile field's value.
+//
+// A field with no row yet is created by the same call — see
+// readProfileFieldRowForWrite for why originating a claim is a human act and
+// why the confirm verb does not share the behaviour.
 func (s *Store) UpdateOrganizationProfileField(
 	ctx context.Context, orgID ids.OrganizationID, field string, in ProfileFieldWriteInput,
 ) (crmcontracts.CompanyProfileField, error) {
@@ -146,7 +152,7 @@ func (s *Store) writeProfileField(
 		changedKey: field,
 		value:      in.Value,
 		ifVersion:  in.IfVersion,
-		readBefore: func(ctx context.Context, tx pgx.Tx) (evidenceRow, error) {
+		readBefore: func(ctx context.Context, tx pgx.Tx) (evidenceRow, bool, error) {
 			return readProfileFieldRowForWrite(ctx, tx, orgID, field, in.Value)
 		},
 		readAfter: func(ctx context.Context, tx pgx.Tx) (crmcontracts.CompanyProfileField, error) {
@@ -275,24 +281,55 @@ func writeCanonicalOrgColumn(
 // a human verdict on a value no one ever proposed.
 func readProfileFieldRowForWrite(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, field string, value *string,
-) (evidenceRow, error) {
+) (evidenceRow, bool, error) {
 	row, err := readProfileFieldRow(ctx, tx, orgID, field)
 	if !errors.Is(err, apperrors.ErrNotFound) || value == nil {
-		return row, err
+		return row, false, err
+	}
+	// A person stating a fact for the first time is a human act, and only a
+	// human's. An agent reaching this arm would MINT a legal-identity claim on
+	// a company nothing was ever read about, and writeEvidence then stamps
+	// verified_by with the user who granted the agent — a human verification of
+	// a value that human never saw. Correcting a claim that already exists stays
+	// open to an agent, because there the machine's proposal is what it answers.
+	if err := requireHumanOrigination(ctx); err != nil {
+		return row, false, err
 	}
 	if err := insertHumanProfileField(ctx, tx, orgID, field); err != nil {
-		return row, err
+		return row, false, err
 	}
-	return readProfileFieldRow(ctx, tx, orgID, field)
+	created, err := readProfileFieldRow(ctx, tx, orgID, field)
+	return created, true, err
 }
 
-// insertHumanProfileField creates the empty row a first correction then fills.
+// requireHumanOrigination refuses an agent the arm that creates a claim.
+//
+// The refusal is the pre-existing 404: before this change every write to an
+// absent field answered not-found, so an agent sees exactly what it saw before
+// and no route it relied on changed behaviour.
+func requireHumanOrigination(ctx context.Context) error {
+	actor, ok := principal.Actor(ctx)
+	if !ok || !strings.HasPrefix(actor.ID, principal.HumanIDPrefix) {
+		return apperrors.ErrNotFound
+	}
+	return nil
+}
+
+// insertHumanProfileField creates the empty row a first statement then fills.
 //
 // The value is deliberately NOT written here: writeEvidence's guarded patch is
 // what sets it, so the created row travels the same audit and event path as any
-// other correction and the before-image honestly reads empty. source='human'
-// with no snippet is the same shape the company form writes — on this path the
-// person IS the evidence, which is also what satisfies org_profile_site_evidence.
+// other write to this table. source='human' with no snippet is what satisfies
+// org_profile_site_evidence, which binds only site_read rows.
+//
+// THIS IS NOT writeCompanyFields (companyform.go), which also upserts a human
+// profile-field row, and the two stay apart deliberately. That one writes the
+// INSTALLATION'S OWN company from its form: it sets confidence 1, deletes the
+// row on an empty value, and writes no audit, event or canonical column, because
+// the form owns the whole record and commits its own. This path writes a claim
+// about SOMEONE ELSE'S company, where each field is separately evidenced and
+// separately answerable, so it owes the audit before-image, the event and the
+// VAT consultation that a form save does not.
 func insertHumanProfileField(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, field string,
 ) error {
@@ -300,9 +337,18 @@ func insertHumanProfileField(
 	if err != nil {
 		return err
 	}
-	// ON CONFLICT DO NOTHING rather than a bare INSERT: two corrections racing
-	// on one empty field would otherwise have the loser fail on the unique
-	// index, and both are asking for the same row to exist.
+	// ON CONFLICT DO NOTHING because this write takes no lock that would order
+	// two writers: auth.EnsureWritableLive checks scope and liveness, and
+	// LockSubjectLive — the one that holds the organization's row — is not on
+	// this path. Two statements of the same empty field therefore both reach
+	// the insert, and the loser would fail on uq_org_profile_field; DO NOTHING
+	// lets it fall through to the re-read below and patch the row the winner
+	// created, which is the same row it was asking for.
+	//
+	// NOT held by a test. TestRepsStatingTheSameFieldAtOnceAllSucceed drives
+	// eight concurrent writers and passes with this clause removed, so it does
+	// not prove the clause — the collision window is real but that test does not
+	// reach it. Said plainly rather than left as a claim a reader would trust.
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO organization_profile_field
 		       (organization_id, field, value, source, captured_by)

--- a/backend/internal/modules/people/organization_profile_field_write.go
+++ b/backend/internal/modules/people/organization_profile_field_write.go
@@ -147,7 +147,7 @@ func (s *Store) writeProfileField(
 		value:      in.Value,
 		ifVersion:  in.IfVersion,
 		readBefore: func(ctx context.Context, tx pgx.Tx) (evidenceRow, error) {
-			return readProfileFieldRow(ctx, tx, orgID, field)
+			return readProfileFieldRowForWrite(ctx, tx, orgID, field, in.Value)
 		},
 		readAfter: func(ctx context.Context, tx pgx.Tx) (crmcontracts.CompanyProfileField, error) {
 			return readProfileFieldWire(ctx, tx, orgID, field)
@@ -259,6 +259,61 @@ func writeCanonicalOrgColumn(
 	return recheckOrgNameForDuplicates(ctx, tx, orgID, editor)
 }
 
+// readProfileFieldRowForWrite locates the row a write is about to patch, and
+// for a CORRECTION creates it first when the field has none.
+//
+// A correction is a person stating what the company's VAT number or registry
+// address IS, and most of this vocabulary is never proposed by a machine: a
+// crawl reads a legal notice or it reads nothing, so a rep who knows the number
+// had no way to record it and the field stayed empty forever. Creating here
+// rather than in a second writer keeps one path: the same audit before-image,
+// the same event, and the same canonical hook that queues the VAT consultation.
+//
+// A CONFIRMATION still reads 404 on an absent field, which is why this takes
+// the value rather than a bare flag. Agreeing with a claim nobody made is not
+// an act the product has, and inventing an empty row to agree with would record
+// a human verdict on a value no one ever proposed.
+func readProfileFieldRowForWrite(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, field string, value *string,
+) (evidenceRow, error) {
+	row, err := readProfileFieldRow(ctx, tx, orgID, field)
+	if !errors.Is(err, apperrors.ErrNotFound) || value == nil {
+		return row, err
+	}
+	if err := insertHumanProfileField(ctx, tx, orgID, field); err != nil {
+		return row, err
+	}
+	return readProfileFieldRow(ctx, tx, orgID, field)
+}
+
+// insertHumanProfileField creates the empty row a first correction then fills.
+//
+// The value is deliberately NOT written here: writeEvidence's guarded patch is
+// what sets it, so the created row travels the same audit and event path as any
+// other correction and the before-image honestly reads empty. source='human'
+// with no snippet is the same shape the company form writes — on this path the
+// person IS the evidence, which is also what satisfies org_profile_site_evidence.
+func insertHumanProfileField(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, field string,
+) error {
+	capturedBy, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return err
+	}
+	// ON CONFLICT DO NOTHING rather than a bare INSERT: two corrections racing
+	// on one empty field would otherwise have the loser fail on the unique
+	// index, and both are asking for the same row to exist.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO organization_profile_field
+		       (organization_id, field, value, source, captured_by)
+		VALUES ($1, $2, '', 'human', $3)
+		ON CONFLICT (organization_id, field) DO NOTHING`,
+		orgID, field, capturedBy); err != nil {
+		return fmt.Errorf("create organization profile field: %w", err)
+	}
+	return nil
+}
+
 func readProfileFieldRow(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, field string,
 ) (evidenceRow, error) {
@@ -289,12 +344,12 @@ func readProfileFieldWire(
 	)
 	err := tx.QueryRow(ctx, `
 		SELECT id, field, value, source, captured_by, evidence_snippet, source_url, confidence,
-		       retrieved_at, verified_at, verified_by, updated_at
+		       retrieved_at, verified_at, verified_by, updated_at, version
 		  FROM organization_profile_field
 		 WHERE organization_id = $1 AND field = $2`,
 		orgID, field,
 	).Scan(&rowID, &fieldV, &pf.Value, &srcV, &pf.CapturedBy, &pf.EvidenceSnippet, &pf.SourceUrl,
-		&pf.Confidence, &pf.RetrievedAt, &pf.VerifiedAt, &pf.VerifiedBy, &pf.UpdatedAt)
+		&pf.Confidence, &pf.RetrievedAt, &pf.VerifiedAt, &pf.VerifiedBy, &pf.UpdatedAt, &pf.Version)
 	if err != nil {
 		return pf, fmt.Errorf("re-read organization profile field: %w", err)
 	}

--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -51,10 +51,12 @@ const UNPINNED_WRITES: readonly string[] = [
   "screens/relationships.tsx DELETE /relationships/{id}",
   "screens/contractform.tsx PATCH /contracts/{id}",
   "screens/customfields.tsx PATCH /custom-fields/{id}",
+  // The two FACT writes stay: OrganizationFact carries no version on the wire,
+  // so no caller can pin one. Its sibling, CompanyProfileField, now does — the
+  // profile-field lines that used to sit here are gone because both verbs send
+  // the precondition.
   "screens/evidenceverdict.tsx PATCH /organizations/{id}/facts/{factKey}",
-  "screens/evidenceverdict.tsx PATCH /organizations/{id}/profile-fields/{field}",
   "screens/evidenceverdict.tsx POST /organizations/{id}/facts/{factKey}/confirm",
-  "screens/evidenceverdict.tsx POST /organizations/{id}/profile-fields/{field}/confirm",
   "screens/extension-access.tsx PATCH /roles/{key}/objects/{object}",
   "screens/integrations-provider.tsx PATCH /provider-connections/{provider}",
   "screens/settings.tsx DELETE /stages/{id}",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10860,13 +10860,23 @@ export interface paths {
         options?: never;
         head?: never;
         /**
-         * Correct a profile field — the canonical value changes, the machine's proposal survives.
+         * State or correct a profile field — the canonical value changes, the machine's proposal survives.
          * @description DOSS-WIRE-4 / PO-AC-N-1. Where the field maps to a column on `organization`, THE COLUMN IS
          *     WHAT CHANGES; the sidecar keeps the machine's proposal, excerpt, source URL and confidence in
          *     history rather than overwriting them (PO-AC-N-2). A correction that changed only the sidecar
          *     would be a lie about having been accepted. Provenance flips to `human` with the acting
          *     principal and the timestamp; the whole thing commits as one mutation with its audit entry and
          *     its outboxed event.
+         *
+         *     A field with NO row yet is CREATED by this write, audited as a creation with no before-image.
+         *     Most of this vocabulary is only ever filled by a crawl that read a legal notice, and a company
+         *     whose site publishes none would otherwise hold a fact nobody could record. Originating a claim
+         *     is a human act: an agent principal still gets `404` here, because the write stamps
+         *     `verified_by` with the granting user and that would record a human verification of a value no
+         *     human saw. Correcting a claim that already exists stays open to an agent.
+         *
+         *     `404` therefore means the organization is unreachable, or — for the confirm operation, or for
+         *     an agent's first statement — that no such claim exists to answer for.
          */
         patch: operations["updateOrganizationProfileField"];
         trace?: never;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -20336,6 +20336,11 @@ export interface components {
             confidence?: number | null;
             /** Format: date-time */
             updated_at: string;
+            /**
+             * Format: int64
+             * @description The row's version, for the `If-Match` a correction sends. The write path has always honoured the precondition; without the version on the read, no client could supply one, and two people correcting the same claim overwrote each other with no conflict and no trace.
+             */
+            readonly version?: number;
         };
         /**
          * @description Which system receives a company's mail, classified from its MX records. `other` is a

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2634,6 +2634,8 @@ export const de = {
   "field.addLegalName": "Rechtlichen Namen hinzufügen",
   "field.addIndustry": "Branche hinzufügen",
   "field.addLinkedinUrl": "LinkedIn-URL hinzufügen",
+  "field.addRegisterVat": "USt-IdNr. hinzufügen",
+  "field.addRegisteredAddress": "Registeranschrift hinzufügen",
   "field.addFullName": "Namen hinzufügen",
   "field.addTitle": "Titel hinzufügen",
   "field.addAddressLine1": "Straße und Hausnummer hinzufügen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2663,6 +2663,8 @@ export const en = {
   "field.addLegalName": "Add legal name",
   "field.addIndustry": "Add industry",
   "field.addLinkedinUrl": "Add LinkedIn URL",
+  "field.addRegisterVat": "Add VAT ID",
+  "field.addRegisteredAddress": "Add registered address",
   "field.addFullName": "Add name",
   "field.addTitle": "Add title",
   "field.addAddressLine1": "Add street and number",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2609,6 +2609,8 @@ export const vi = {
   "field.addLegalName": "Thêm tên pháp lý",
   "field.addIndustry": "Thêm ngành",
   "field.addLinkedinUrl": "Thêm URL LinkedIn",
+  "field.addRegisterVat": "Thêm mã số thuế",
+  "field.addRegisteredAddress": "Thêm địa chỉ đăng ký",
   "field.addFullName": "Thêm họ và tên",
   "field.addTitle": "Thêm chức danh",
   "field.addAddressLine1": "Thêm số nhà và tên đường",

--- a/frontend/src/screens/companyraildetails.stories.tsx
+++ b/frontend/src/screens/companyraildetails.stories.tsx
@@ -19,6 +19,7 @@ export default meta;
 
 type Story = StoryObj;
 type Organization = components["schemas"]["Organization"];
+type ProfileField = components["schemas"]["CompanyProfileField"];
 
 const page = { has_more: false, next_cursor: null };
 
@@ -52,7 +53,34 @@ const org: Organization = {
   updated_at: "2026-06-01T08:00:00Z",
 } as unknown as Organization;
 
-function Details({ organization }: Readonly<{ organization: Organization }>) {
+// The two sidecar claims the grid reads, as a crawl that found an imprint
+// leaves them. Stories that want the unstated case pass an empty list.
+const sidecarFields: ProfileField[] = [
+  {
+    id: "pf-vat",
+    field: "register_vat",
+    value: "DE811907980",
+    source: "site_read",
+    captured_by: "agent:deepread",
+    updated_at: "2026-06-01T08:00:00Z",
+  },
+  {
+    id: "pf-addr",
+    field: "registered_address",
+    value: "Kaiserdamm 1, 14057 Berlin",
+    source: "site_read",
+    captured_by: "agent:deepread",
+    updated_at: "2026-06-01T08:00:00Z",
+  },
+];
+
+function Details({
+  organization,
+  profileFields = sidecarFields,
+}: Readonly<{
+  organization: Organization;
+  profileFields?: readonly ProfileField[];
+}>) {
   installFetchStub({
     "GET /me": () =>
       jsonResponse({
@@ -64,6 +92,8 @@ function Details({ organization }: Readonly<{ organization: Organization }>) {
         data: [{ id: "u-1", display_name: "Mira Voss" }],
         page,
       }),
+    "GET /organizations/o-1/profile-fields": () =>
+      jsonResponse({ data: profileFields }),
   });
   return (
     <StoryProviders>
@@ -133,9 +163,19 @@ export const Archived: Story = {
 // `data-empty` attribute of its own, just `render(value)` falling through to
 // `field.unset` as the button's own label, chevron included, because the
 // button is drawn whenever `canEdit` is true regardless of what `value` is.
+// The legal identity nobody has stated: no imprint was found, so the VAT and
+// registry-address rows draw their own invitations. This is the state the two
+// rows exist for — before them a rep who knew the number had nowhere to put it,
+// and the VAT consultation a written number queues was unreachable for exactly
+// the companies a person would want to check.
+export const LegalIdentityUnstated: Story = {
+  render: () => <Details organization={org} profileFields={[]} />,
+};
+
 export const EmptyFields: Story = {
   render: () => (
     <Details
+      profileFields={[]}
       organization={{
         ...org,
         legal_name: null,

--- a/frontend/src/screens/companyraildetails.test.tsx
+++ b/frontend/src/screens/companyraildetails.test.tsx
@@ -2,7 +2,8 @@
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { meFixture } from "../app/mefixture";
@@ -23,6 +24,7 @@ import { DetailsGrid } from "./companyraildetails";
 // shows the reader all six.
 
 type Organization = components["schemas"]["Organization"];
+type ProfileField = components["schemas"]["CompanyProfileField"];
 
 // A COMPLETE Organization, not a cast one: a fixture asserted into the contract
 // type can drop a required field and still compile, so the test would go on
@@ -67,23 +69,61 @@ afterEach(() => {
 // The grant is what makes the rows editable, which is the state the collapse is
 // about: a viewer who may not write sees values, and an empty address draws no
 // invitation to hide in the first place.
-function stub() {
+function stub(
+  profileFields: readonly ProfileField[] = [],
+  answers: { patch?: () => Response } = {},
+) {
+  const calls: { method: string; pathname: string; body: string }[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
       const { pathname } = new URL(request.url);
-      const body = pathname.endsWith("/me")
-        ? meFixture({ allow: { organization: ["read", "update"] } })
-        : {
-            data: [{ id: "u-1", display_name: "Mira Voss" }],
-            page: { has_more: false, next_cursor: null },
-          };
-      return new Response(JSON.stringify(body), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+      calls.push({
+        method: request.method,
+        pathname,
+        // Read here rather than in the assertion: the body stream is consumed
+        // once, and a later read would come back empty.
+        body: request.method === "GET" ? "" : await request.text(),
+      });
+      if (pathname.endsWith("/me")) {
+        return json(meFixture({ allow: { organization: ["read", "update"] } }));
+      }
+      if (pathname.endsWith("/profile-fields")) {
+        return json({ data: profileFields });
+      }
+      if (request.method === "PATCH") {
+        return answers.patch?.() ?? json({});
+      }
+      return json({
+        data: [{ id: "u-1", display_name: "Mira Voss" }],
+        page: { has_more: false, next_cursor: null },
       });
     }),
   );
+  return calls;
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// A sidecar claim as the wire carries it. Complete rather than cast, for the
+// same reason ORG is: a fixture missing a required field still compiles.
+function profileField(
+  field: ProfileField["field"],
+  value: string,
+): ProfileField {
+  return {
+    id: `pf-${field}`,
+    field,
+    value,
+    source: "site_read",
+    captured_by: "agent:deepread",
+    updated_at: "2026-06-01T08:00:00Z",
+  };
 }
 
 function renderGrid(organization: Organization) {
@@ -103,11 +143,110 @@ function renderGrid(organization: Organization) {
 // which is a different rendering of the same record and not the one under test.
 // The industry row is the anchor because it sits outside the disclosure and
 // carries a value in every fixture here.
-async function renderSettledGrid(organization: Organization) {
-  stub();
+async function renderSettledGrid(
+  organization: Organization,
+  profileFields: readonly ProfileField[] = [],
+  answers: { patch?: () => Response } = {},
+) {
+  const calls = stub(profileFields, answers);
   renderGrid(organization);
   await screen.findByRole("button", { name: "Change Industry" });
+  return calls;
 }
+
+// The two legal-identity fields that live only in the evidence sidecar. Before
+// these rows a rep could read a VAT number the crawl had found and could not
+// state one it had missed — and most sites print no imprint at all, so the
+// field a person most often knows was the field they could never record.
+describe("the legal identity a person can state", () => {
+  it("invites a VAT number and a registry address on a record carrying neither", async () => {
+    await renderSettledGrid(ORG);
+
+    // Visible, not merely present: these sit in the identity grid beside the
+    // legal name, never inside the address disclosure, which is closed here.
+    expect(screen.getByText("Add VAT ID")).toBeVisible();
+    expect(screen.getByText("Add registered address")).toBeVisible();
+    expect(screen.getByText("Register / VAT ID")).toBeVisible();
+    expect(screen.getByText("Registered address")).toBeVisible();
+  });
+
+  it("reads back the values the crawl already found", async () => {
+    await renderSettledGrid(ORG, [
+      profileField("register_vat", "DE811907980"),
+      profileField("registered_address", "Kaiserdamm 1, 14057 Berlin"),
+    ]);
+
+    expect(await screen.findByText("DE811907980")).toBeVisible();
+    expect(screen.getByText("Kaiserdamm 1, 14057 Berlin")).toBeVisible();
+    expect(screen.queryByText("Add VAT ID")).toBeNull();
+  });
+
+  it("states a typed VAT number through the profile-field correction", async () => {
+    const user = userEvent.setup();
+    const calls = await renderSettledGrid(ORG);
+
+    await user.click(
+      screen.getByRole("button", { name: "Change Register / VAT ID" }),
+    );
+    await user.type(screen.getByLabelText("Register / VAT ID"), "DE811907980");
+    await user.keyboard("{Enter}");
+
+    // The endpoint matters as much as the value: this is the write that queues
+    // the VAT consultation, and PATCH /organizations/{id} would not.
+    const written = await waitFor(() => {
+      const call = calls.find((one) => one.method === "PATCH");
+      expect(call).toBeDefined();
+      return call;
+    });
+    expect(written?.pathname).toBe(
+      "/v1/organizations/o-1/profile-fields/register_vat",
+    );
+    expect(JSON.parse(written?.body ?? "{}")).toEqual({
+      value: "DE811907980",
+    });
+  });
+
+  // Clearing a stated value is the reader asking to unsay it, and the
+  // correction path has no delete — it writes a value or it refuses. The
+  // server's own `minLength: 1` is what refuses, so the reader is told rather
+  // than left looking at a field that silently kept its old value.
+  it("shows the refusal when a stated value is cleared", async () => {
+    const user = userEvent.setup();
+    await renderSettledGrid(
+      ORG,
+      [profileField("register_vat", "DE811907980")],
+      {
+        patch: () =>
+          new Response(
+            JSON.stringify({
+              type: "about:blank",
+              title: "Validation failed",
+              status: 422,
+              detail: "value must be at least 1 character",
+            }),
+            {
+              status: 422,
+              headers: { "content-type": "application/problem+json" },
+            },
+          ),
+      },
+    );
+    await screen.findByText("DE811907980");
+
+    await user.click(
+      screen.getByRole("button", { name: "Change Register / VAT ID" }),
+    );
+    await user.clear(screen.getByLabelText("Register / VAT ID"));
+    await user.keyboard("{Enter}");
+
+    expect(
+      await screen.findByText("value must be at least 1 character"),
+    ).toBeVisible();
+    // The refused write left the claim standing, so the draft is still there to
+    // correct rather than the row having gone blank under the reader.
+    expect(screen.getByLabelText("Register / VAT ID")).toBeVisible();
+  });
+});
 
 describe("the postal address, behind one line until it has something in it", () => {
   it("holds the six parts behind one line that invites the first of them", async () => {

--- a/frontend/src/screens/companyraildetails.test.tsx
+++ b/frontend/src/screens/companyraildetails.test.tsx
@@ -73,7 +73,12 @@ function stub(
   profileFields: readonly ProfileField[] = [],
   answers: { patch?: () => Response } = {},
 ) {
-  const calls: { method: string; pathname: string; body: string }[] = [];
+  const calls: {
+    method: string;
+    pathname: string;
+    body: string;
+    ifMatch: string | null;
+  }[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
@@ -84,6 +89,7 @@ function stub(
         // Read here rather than in the assertion: the body stream is consumed
         // once, and a later read would come back empty.
         body: request.method === "GET" ? "" : await request.text(),
+        ifMatch: request.headers.get("If-Match"),
       });
       if (pathname.endsWith("/me")) {
         return json(meFixture({ allow: { organization: ["read", "update"] } }));
@@ -123,6 +129,9 @@ function profileField(
     source: "site_read",
     captured_by: "agent:deepread",
     updated_at: "2026-06-01T08:00:00Z",
+    // The version a correction pins. Omitting it would model a row the server
+    // does not send and leave the precondition untested.
+    version: 4,
   };
 }
 
@@ -204,6 +213,33 @@ describe("the legal identity a person can state", () => {
     expect(JSON.parse(written?.body ?? "{}")).toEqual({
       value: "DE811907980",
     });
+    // Nothing to pin: this write CREATES the row, so there is no earlier state
+    // another editor could be overwriting.
+    expect(written?.ifMatch).toBeNull();
+  });
+
+  it("pins the row when correcting a value somebody already stated", async () => {
+    const user = userEvent.setup();
+    const calls = await renderSettledGrid(ORG, [
+      profileField("register_vat", "DE111111111"),
+    ]);
+    await screen.findByText("DE111111111");
+
+    await user.click(
+      screen.getByRole("button", { name: "Change Register / VAT ID" }),
+    );
+    await user.clear(screen.getByLabelText("Register / VAT ID"));
+    await user.type(screen.getByLabelText("Register / VAT ID"), "DE811907980");
+    await user.keyboard("{Enter}");
+
+    // Two people correcting the same number: unpinned, the second silently
+    // replaces a change its author never saw.
+    const written = await waitFor(() => {
+      const call = calls.find((one) => one.method === "PATCH");
+      expect(call).toBeDefined();
+      return call;
+    });
+    expect(written?.ifMatch).toBe("4");
   });
 
   // Clearing a stated value is the reader asking to unsay it, and the

--- a/frontend/src/screens/companyraildetails.tsx
+++ b/frontend/src/screens/companyraildetails.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -19,6 +19,7 @@ import {
   useCompanyReadOnlyReason,
 } from "./companyheader";
 import { SIZE_BAND_OPTIONS } from "./companylookups";
+import { profileFieldsKey, useOrgProfileFields } from "./evidenceverdict";
 
 // The rail's own Details grid (companyrail.tsx's DetailsGrid), split into
 // this file so the rail file stays under the 500-line ceiling: one panel
@@ -492,9 +493,7 @@ function SidecarFieldRow({
     // The record read and the profile-fields read both now describe the write
     // that just landed, and the 360 summarises it.
     await Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: ["org-profile-fields", orgId],
-      }),
+      queryClient.invalidateQueries({ queryKey: profileFieldsKey(orgId) }),
       queryClient.invalidateQueries({ queryKey: ["organization", orgId] }),
       queryClient.invalidateQueries({ queryKey: ["organization360", orgId] }),
     ]);
@@ -520,22 +519,10 @@ function DetailsGridBody({
   const canUpdate = useCan("organization", "update");
   const readOnlyReason = useCompanyReadOnlyReason(organization);
   const patch = useCompanyFieldPatch(organization);
-  // The same key the Overview's own profile-field card registers, so a
-  // correction made here settles that card too rather than leaving the two
-  // surfaces disagreeing about what the record says.
-  const sidecarQuery = useQuery({
-    queryKey: ["org-profile-fields", organization.id],
-    queryFn: async () => {
-      const { data, error } = await api.GET(
-        "/organizations/{id}/profile-fields",
-        { params: { path: { id: organization.id } } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data.data ?? [];
-    },
-  });
+  // The same read the Overview's own profile-field card uses, so a correction
+  // made here settles that card too rather than leaving the two surfaces
+  // disagreeing about what the record says.
+  const sidecarQuery = useOrgProfileFields(organization.id);
   // A read that has not answered yet leaves both rows empty rather than absent:
   // the grid's rule is that every known field draws a row, and a row that
   // appears once its value arrives would make the panel jump under the reader.

--- a/frontend/src/screens/companyraildetails.tsx
+++ b/frontend/src/screens/companyraildetails.tsx
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
 import { useCan } from "../app/capability";
 import { Disclosure } from "../design-system/atoms";
 import { FieldGrid, FieldRow } from "../design-system/fieldgrid";
@@ -24,6 +27,11 @@ import { SIZE_BAND_OPTIONS } from "./companylookups";
 
 type Organization = components["schemas"]["Organization"];
 type OrganizationDomain = NonNullable<Organization["domains"]>[number];
+type ProfileField = components["schemas"]["CompanyProfileField"];
+// The path parameter's own closed vocabulary, taken from the generated contract
+// rather than respelled: a field name this endpoint does not accept is then a
+// compile error here rather than a 422 the reader meets.
+type ProfileFieldKey = components["parameters"]["ProfileFieldKey"];
 // Not `keyof Address`: the wire type carries a `[key: string]: unknown` catch-all
 // alongside its six named parts (schema.d.ts's own escape hatch for a future
 // field), which collapses `keyof` down to bare `string` and loses every part's
@@ -410,6 +418,101 @@ function DescriptionRow({
   );
 }
 
+// The two legal-identity fields that live only in the evidence sidecar: the
+// VAT/tax identifier and the address the company is REGISTERED at.
+//
+// Neither has a column on `organization`, so neither can ride the rows above:
+// they are written through the profile-field correction path instead. That
+// difference is invisible to a reader and should stay so — a rep stating the
+// company's VAT number is doing the same thing as stating its legal name, and
+// the two rows sit together because they are the same kind of fact.
+//
+// `registered_address` is NOT the postal address in the disclosure below. That
+// one is six columns describing where the company OPERATES; this one is the
+// single line a register prints. Collapsing them was never intended, so the
+// labels have to keep them apart.
+const SIDECAR_FIELDS = [
+  {
+    field: "register_vat",
+    labelKey: "co.profileField.register_vat",
+    placeholderKey: "field.addRegisterVat",
+  },
+  {
+    field: "registered_address",
+    labelKey: "co.profileField.registered_address",
+    placeholderKey: "field.addRegisteredAddress",
+  },
+] as const satisfies readonly {
+  field: ProfileFieldKey;
+  labelKey: MessageKey;
+  placeholderKey: MessageKey;
+}[];
+
+// One sidecar field's row. The value comes from the profile-fields read rather
+// than from `organization`, which carries no sidecar claim.
+function SidecarFieldRow({
+  orgId,
+  fields,
+  field,
+  labelKey,
+  placeholderKey,
+  canEdit,
+  readOnlyReason,
+}: Readonly<{
+  orgId: string;
+  fields: readonly ProfileField[];
+  field: ProfileFieldKey;
+  labelKey: MessageKey;
+  placeholderKey: MessageKey;
+  canEdit: boolean;
+  readOnlyReason: string | undefined;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const label = t(labelKey);
+  const current = fields.find((one) => one.field === field);
+  const save = async (next: string) => {
+    const { error } = await api.PATCH(
+      "/organizations/{id}/profile-fields/{field}",
+      {
+        params: {
+          path: { id: orgId, field },
+          // A field nobody has stated yet has no row and so no version to pin:
+          // the write CREATES it, and there is no earlier state to lose. Once
+          // one exists the precondition is what stops two people correcting the
+          // same claim and the second silently replacing the first.
+          ...(current ? ifMatch(requireVersion(current.version)) : {}),
+        },
+        body: { value: next.trim() },
+      },
+    );
+    if (error) {
+      throwProblem(error);
+    }
+    // The record read and the profile-fields read both now describe the write
+    // that just landed, and the 360 summarises it.
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["org-profile-fields", orgId],
+      }),
+      queryClient.invalidateQueries({ queryKey: ["organization", orgId] }),
+      queryClient.invalidateQueries({ queryKey: ["organization360", orgId] }),
+    ]);
+  };
+  return (
+    <FieldRow label={label}>
+      <InlineText
+        label={label}
+        value={current?.value ?? ""}
+        placeholder={t(placeholderKey)}
+        canEdit={canEdit}
+        readOnlyReason={readOnlyReason}
+        onSave={save}
+      />
+    </FieldRow>
+  );
+}
+
 function DetailsGridBody({
   organization,
 }: Readonly<{ organization: Organization }>) {
@@ -417,6 +520,26 @@ function DetailsGridBody({
   const canUpdate = useCan("organization", "update");
   const readOnlyReason = useCompanyReadOnlyReason(organization);
   const patch = useCompanyFieldPatch(organization);
+  // The same key the Overview's own profile-field card registers, so a
+  // correction made here settles that card too rather than leaving the two
+  // surfaces disagreeing about what the record says.
+  const sidecarQuery = useQuery({
+    queryKey: ["org-profile-fields", organization.id],
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        "/organizations/{id}/profile-fields",
+        { params: { path: { id: organization.id } } },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data ?? [];
+    },
+  });
+  // A read that has not answered yet leaves both rows empty rather than absent:
+  // the grid's rule is that every known field draws a row, and a row that
+  // appears once its value arrives would make the panel jump under the reader.
+  const sidecarFields = sidecarQuery.data ?? [];
   const row: DetailsRowProps = {
     organization,
     canEdit: canUpdate && !readOnlyReason,
@@ -448,6 +571,19 @@ function DetailsGridBody({
           values still share one left edge down the whole panel. */}
       <FieldGrid>
         <LegalNameRow {...row} />
+        {/* Beside the legal name, not with the postal address below: a VAT
+            number and a registry address are identity facts about the legal
+            entity, and the address disclosure is where the company operates. */}
+        {SIDECAR_FIELDS.map((sidecar) => (
+          <SidecarFieldRow
+            key={sidecar.field}
+            orgId={organization.id}
+            fields={sidecarFields}
+            canEdit={row.canEdit}
+            readOnlyReason={readOnlyReason}
+            {...sidecar}
+          />
+        ))}
         <OwnerRow organization={organization} />
         <LifecycleRow organization={organization} />
         <DomainRow {...row} />

--- a/frontend/src/screens/evidenceverdict.test.tsx
+++ b/frontend/src/screens/evidenceverdict.test.tsx
@@ -24,12 +24,17 @@ afterEach(() => {
 
 const ORG = "o-1";
 
+// The version is what both verbs pin. A fixture without it models a row the
+// server does not produce, and every read that offers a verdict now returns
+// one — so a test that omitted it would prove the buttons work against a
+// record shaped unlike the real one.
 const field: components["schemas"]["CompanyProfileField"] = {
   field: "industry",
   value: "Fahrzeugbau",
   source: "site_read",
   captured_by: "agent:deepread",
   updated_at: "2026-08-01T09:00:00Z",
+  version: 3,
 };
 
 const fact: components["schemas"]["OrganizationFact"] = {
@@ -46,7 +51,12 @@ const fact: components["schemas"]["OrganizationFact"] = {
 // The calls the component made, so a test can assert the METHOD and the PATH
 // rather than that something happened.
 function recordCalls() {
-  const calls: { method: string; path: string; body?: unknown }[] = [];
+  const calls: {
+    method: string;
+    path: string;
+    body?: unknown;
+    ifMatch: string | null;
+  }[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
@@ -54,6 +64,10 @@ function recordCalls() {
         method: request.method,
         path: new URL(request.url).pathname,
         body: request.body ? await request.clone().json() : undefined,
+        // Both verbs overwrite a row somebody else may have moved, so the
+        // precondition is part of what each call IS — asserted here rather than
+        // left to a reviewer to notice missing.
+        ifMatch: request.headers.get("If-Match"),
       });
       return new Response("{}", {
         status: 200,
@@ -96,6 +110,10 @@ describe("a human's verdict on a machine's claim", () => {
       "/v1/organizations/o-1/profile-fields/industry/confirm",
     );
     expect(calls[0].body).toBeUndefined();
+    // A confirmation is a person agreeing with a value they READ. Unpinned, it
+    // stamps their name on whatever the row says by the time it lands — which
+    // may be a correction they never saw.
+    expect(calls[0].ifMatch).toBe("3");
   });
 
   it("corrects a profile field by sending the new value", async () => {
@@ -118,6 +136,7 @@ describe("a human's verdict on a machine's claim", () => {
     expect(calls[0].method).toBe("PATCH");
     expect(calls[0].path).toBe("/v1/organizations/o-1/profile-fields/industry");
     expect(calls[0].body).toEqual({ value: "Automotive" });
+    expect(calls[0].ifMatch).toBe("3");
   });
 
   it("addresses a single-value fact by its bare-colon key", async () => {

--- a/frontend/src/screens/evidenceverdict.tsx
+++ b/frontend/src/screens/evidenceverdict.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -45,6 +45,36 @@ export type EvidenceClaim = {
   confirmPath: () => Promise<void>;
   correctPath: (value: string) => Promise<void>;
 };
+
+// The one read of a company's profile fields, and the one key everything that
+// writes them invalidates.
+//
+// Two surfaces show these claims — the Overview's own card and the record
+// rail's identity rows — and both write through the same endpoint. Spelled
+// twice, the two would drift the first time either added a `staleTime` or a
+// `select`, and the two surfaces would then disagree about a record they are
+// showing side by side.
+export function useOrgProfileFields(orgId: string) {
+  return useQuery({
+    queryKey: profileFieldsKey(orgId),
+    queryFn: async () => {
+      const { data, error } = await api.GET(
+        "/organizations/{id}/profile-fields",
+        { params: { path: { id: orgId } } },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data ?? [];
+    },
+  });
+}
+
+// React Query matches key segments exactly, so a near-miss spelling invalidates
+// nothing and a surface goes on showing a claim the human already settled.
+export function profileFieldsKey(orgId: string) {
+  return ["org-profile-fields", orgId] as const;
+}
 
 export function profileFieldClaim(
   orgId: string,
@@ -148,9 +178,7 @@ export function EvidenceVerdict({
       // key segments exactly, so a near-miss spelling invalidates nothing and
       // the page keeps offering a verdict on a claim the human already settled.
       queryClient.invalidateQueries({ queryKey: ["organization", orgId] }),
-      queryClient.invalidateQueries({
-        queryKey: ["org-profile-fields", orgId],
-      }),
+      queryClient.invalidateQueries({ queryKey: profileFieldsKey(orgId) }),
       queryClient.invalidateQueries({ queryKey: ["org-facts", orgId] }),
     ]);
   };

--- a/frontend/src/screens/evidenceverdict.tsx
+++ b/frontend/src/screens/evidenceverdict.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
 import { useRecordZone } from "../app/recordzone";
 import { Button, TextInput } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
@@ -57,7 +58,12 @@ export function profileFieldClaim(
     confirmPath: async () => {
       const { error } = await api.POST(
         "/organizations/{id}/profile-fields/{field}/confirm",
-        { params: { path: { id: orgId, field: field.field } } },
+        {
+          params: {
+            path: { id: orgId, field: field.field },
+            ...ifMatch(requireVersion(field.version)),
+          },
+        },
       );
       if (error) {
         throwProblem(error);
@@ -67,7 +73,14 @@ export function profileFieldClaim(
       const { error } = await api.PATCH(
         "/organizations/{id}/profile-fields/{field}",
         {
-          params: { path: { id: orgId, field: field.field } },
+          params: {
+            path: { id: orgId, field: field.field },
+            // Both verbs pin the row they answer for. A confirmation is a human
+            // agreeing with a value they READ, so it is the verb a stale version
+            // damages most: agreeing with a claim that has since been corrected
+            // stamps a person's name on a value they never saw.
+            ...ifMatch(requireVersion(field.version)),
+          },
           body: { value },
         },
       );

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -120,6 +120,7 @@ import {
   EvidenceVerdict,
   factClaim,
   profileFieldClaim,
+  useOrgProfileFields,
 } from "./evidenceverdict";
 import { type FactGroup, factFieldLabelKey, groupFacts } from "./factview";
 import { RecordHistoryTab } from "./history";
@@ -1276,19 +1277,7 @@ function ProfileFieldsCard({
   onOpenHistory,
 }: Readonly<{ orgId: string; onOpenHistory?: () => void }>) {
   const t = useT();
-  const fieldsQuery = useQuery({
-    queryKey: ["org-profile-fields", orgId],
-    queryFn: async () => {
-      const { data, error } = await api.GET(
-        "/organizations/{id}/profile-fields",
-        { params: { path: { id: orgId } } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data.data ?? [];
-    },
-  });
+  const fieldsQuery = useOrgProfileFields(orgId);
 
   return (
     <Card

--- a/frontend/src/screens/personprovider.fixtures.ts
+++ b/frontend/src/screens/personprovider.fixtures.ts
@@ -27,6 +27,10 @@ export const completedProviderRun: components["schemas"]["ProviderRun"] = {
   requested_categories: ["email", "mobile"],
   reservations: [{ pool: "email", reserved_credits: 1, actual_credits: 1 }],
   claims_unwritten: false,
+  // The run bought its values AND they reached the contact's record. A
+  // completed run that is not yet applied is a different state — bought but
+  // not landed — and these stories are all the after picture.
+  applied: true,
   submitted_at: "2026-08-12T09:00:00Z",
   completed_at: "2026-08-12T09:02:00Z",
   safe_status_code: null,


### PR DESCRIPTION
## What was wrong

The company rail draws every known field as a row a person can fill — except the two that live only in the evidence sidecar. A VAT number and a registry address reached a record **only** when a crawl found a legal notice, and most sites publish none. The field a rep most often knows was the one they could never record.

That also made the VAT check unreachable. Writing a VAT number is what queues the EU register consultation, so the check could only ever run on companies whose site already published the number — not the ones somebody would want to verify.

## What changed

**The profile-field correction creates the row when the field has none.** It was update-only and answered 404, so the first statement of a fact always failed. The created row is `source=human` with no snippet — on this path the person is the evidence — and it travels the one write path, so the audit before-image, the event and the canonical hook that queues the VAT consultation are the same as any other correction.

A **confirmation** still reads 404 on an absent field. Agreeing with a claim nobody made is not an act the product has, and inventing a row to agree with would stamp a human verdict on a value no one proposed. `TestConfirmingAProfileFieldNobodyProposedIsStillNotFound` holds that boundary, and it fails when the create fires for both verbs.

**The rail draws both fields beside the legal name**, not in the address disclosure below. A VAT number and a registry address are identity facts about the legal entity; the six address columns describe where the company operates, and collapsing the two was never intended.

## Fixed along the way

`CompanyProfileField` now carries its `version` on the wire. The write path had always honoured `If-Match`, but no read returned a version, so **no client could send one** — two people correcting the same claim overwrote each other with no conflict and no trace. Both callers now pin, and the two profile-field entries leave `UNPINNED_WRITES`. The fact writes stay on that list: `OrganizationFact` carries no version, so nothing can pin those yet.

The existing `evidenceverdict` tests passed whether or not a precondition was sent. They now assert the header, which is what would have caught the gap.

## Testing

- `make check-backend`, `make check-fe`, `make craft-static`, `make rls-store-path` — all green
- `make test-it DIR=backend/internal/modules/people` — full lane green
- Every new test mutation-checked: reverting the create fails three, dropping the confirm guard fails the fourth, removing the rail rows fails four frontend tests

A rep can now open a company, type its VAT number in the Details panel, and the EU register consultation is queued by that write.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a rep record a company's VAT number and registry address, which previously reached a record only when a crawl found a legal notice — most sites publish none. Stating a VAT number now queues the EU register consultation on that same write.

- Stating a field with no row creates it instead of returning 404; a confirmation still 404s on an absent field. Only humans can originate a claim — agents keep the 404 — and a created row is audited as a creation with no before-image.
- Both fields render in the rail beside the legal name, not in the operating-address disclosure.
- Profile-field writes now send the row's version as If-Match, so two people correcting the same claim conflict instead of silently overwriting.

<sup>Written for commit cd41abf17f1e6f60208672cb7ad313178b84bf2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editable VAT ID and registered address fields to company details.
  * Added support for manually adding profile information without suggested values.
  * Added localized labels in English, German, and Vietnamese.
  * Added version tracking to prevent conflicting profile updates.

* **Bug Fixes**
  * Improved validation, missing-field handling, and address separation.
  * Prevented unsupported agent-originated claims.
  * Ensured VAT updates trigger follow-up verification.
  * Prevented outdated updates from overwriting newer information.
  * Improved audit records for created and updated profile information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->