### PR TITLE
The Worklist answers for your own work by default

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8460,6 +8460,18 @@ paths:
         that would have filled it never answered.
       x-agent-access: human-only
       parameters:
+        - name: scope
+          in: query
+          schema: { type: string, enum: [mine, team, all] }
+          description: |
+            Whose work to answer for. Omitted means `mine`, which is the default for
+            every reader: an admin account can read every deal in the installation, and a
+            queue that showed all of them would hand a rep several hundred rows belonging
+            to colleagues and call it their day.
+
+            A scope the reader's own row scope does not reach is refused with 403 rather
+            than quietly narrowed — answering a question about the team with facts about
+            one person, with no way for the reader to tell, is the worse failure.
         - name: filter
           in: query
           schema: { type: string, enum: [all, customer_waiting, deals_at_risk, meetings, tasks, decisions, system] }
@@ -31230,9 +31242,20 @@ components:
         does, widened: a source the caller may not read is named as `withheld`, and one
         that failed to answer is named as `failed`. Both keep the summary from claiming a
         clear day it did not actually see.
-      required: [as_of, queue, summary, sources_unavailable]
+      required: [as_of, queue, summary, sources_unavailable, scope, scope_options]
       properties:
         as_of: { type: string, format: date-time, description: 'The instant every source below was read at.' }
+        scope:
+          type: string
+          enum: [mine, team, all]
+          description: 'Whose work this read answered for.'
+        scope_options:
+          type: array
+          items: { type: string, enum: [mine, team, all] }
+          description: |
+            The scopes this reader may ask for, narrowest first — derived from their own
+            row scope. A client draws a control only when there is more than one, so a
+            rep who can only see their own work is never offered a switch that would 403.
         filter: { type: string, enum: [all, customer_waiting, deals_at_risk, meetings, tasks, decisions, system], description: 'The narrowing this read applied.' }
         summary: { $ref: '#/components/schemas/WorklistSummary' }
         queue:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8472,6 +8472,15 @@ paths:
             A scope the reader's own row scope does not reach is refused with 403 rather
             than quietly narrowed — answering a question about the team with facts about
             one person, with no way for the reader to tell, is the worse failure.
+
+            WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
+            going quiet, meetings and duplicate pairs are read under the caller's row
+            scope, so `team` and `all` return what that tier reaches and `mine` narrows
+            below it. The intrinsically per-user sources do not, and cannot: a notice is
+            addressed to one person, a mailbox belongs to one, a promise was made by one,
+            and an approved action failed for the person who approved it. `all` therefore
+            means "every shared record I may see, plus my own personal queue" — not a
+            licence to read a colleague's inbox.
         - name: filter
           in: query
           schema: { type: string, enum: [all, customer_waiting, deals_at_risk, meetings, tasks, decisions, system] }
@@ -8488,6 +8497,7 @@ paths:
               schema: { $ref: '#/components/schemas/Worklist' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /digest:
     get:
       tags: [Capture]

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -78,6 +78,21 @@ type Service struct {
 	// unnamed and the client resolves display names itself (labels.go).
 	names Names
 	now   Clock
+	// mineOnly narrows the producers that can be narrowed to the acting
+	// reader's own work. Set per read (Assemble keeps the lane feed's
+	// behaviour; the ranked queue's default scope sets it), because the same
+	// service answers both surfaces.
+	mineOnly bool
+}
+
+// forReader returns a copy of this service that reads only the acting reader's
+// own work. A copy rather than a field mutation: one Service is shared by every
+// request, and a flag set on it would follow one reader's scope onto another
+// reader's page.
+func (s *Service) forReader() *Service {
+	narrowed := *s
+	narrowed.mineOnly = true
+	return &narrowed
 }
 
 // NewService binds the feed to its readers.
@@ -134,7 +149,7 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 		return crmcontracts.Attention{}, err
 	}
 
-	planned, err := s.planned(ctx, asOf)
+	planned, err := s.planned(ctx, asOf, s.mineOnly)
 	omitted, err = fill(omitted, "planned", err, func() {
 		out.Planned = planned
 		out.Counts.Planned = len(planned)
@@ -280,8 +295,8 @@ func endOfDay(asOf time.Time) time.Time {
 }
 
 // planned is today's agreed work, overdue first.
-func (s *Service) planned(ctx context.Context, asOf time.Time) ([]crmcontracts.AttentionItem, error) {
-	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap)
+func (s *Service) planned(ctx context.Context, asOf time.Time, mineOnly bool) ([]crmcontracts.AttentionItem, error) {
+	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap, mineOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -79,10 +79,15 @@ type stubTasks struct {
 	// boundary rather than assume it. A pointer receiver only where it is
 	// read back; the value form stays valid for every test that ignores it.
 	until *time.Time
+	// mineOnly records whether the lane asked for the reader's own tasks, so a
+	// test can prove the narrowing reaches the QUERY rather than trusting that
+	// a filter ran afterwards.
+	mineOnly bool
 }
 
-func (s *stubTasks) OpenForViewer(_ context.Context, until time.Time, _ int) ([]Task, error) {
+func (s *stubTasks) OpenForViewer(_ context.Context, until time.Time, _ int, mineOnly bool) ([]Task, error) {
 	s.until = &until
+	s.mineOnly = mineOnly
 	return s.rows, s.err
 }
 

--- a/backend/internal/compose/attention/handlers.go
+++ b/backend/internal/compose/attention/handlers.go
@@ -58,7 +58,16 @@ func (h Handlers) GetWorklist(w http.ResponseWriter, r *http.Request, params crm
 	if params.Limit != nil {
 		limit = *params.Limit
 	}
-	out, err := h.svc.Worklist(r.Context(), filter, limit)
+	scope := ""
+	if params.Scope != nil {
+		if !params.Scope.Valid() {
+			httperr.Write(w, r, httperr.Validation("scope", "unknown",
+				"that is not a scope this queue can answer for"))
+			return
+		}
+		scope = string(*params.Scope)
+	}
+	out, err := h.svc.Worklist(r.Context(), scope, filter, limit)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -80,8 +80,14 @@ type RecordFace struct {
 }
 
 // Tasks is the open-task read, through the activities module.
+//
+// mineOnly asks the store for the READER'S OWN open tasks rather than every
+// task they may see. It belongs in the query and not in a filter afterwards:
+// the store bounds what it returns, so narrowing later would cut a colleague's
+// twelve rows out of a page of twelve and leave the reader's own overdue task
+// unreachable behind them.
 type Tasks interface {
-	OpenForViewer(ctx context.Context, until time.Time, limit int) ([]Task, error)
+	OpenForViewer(ctx context.Context, until time.Time, limit int, mineOnly bool) ([]Task, error)
 }
 
 // Task is one piece of agreed work.

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -74,9 +74,24 @@ func resolveScope(ctx context.Context, asked string) (string, error) {
 
 // mineOnly reports whether this read keeps only the reader's own work.
 //
-// Team and all are served by the lanes' own row scope, which already stops at
-// the reader's tier: asking for `all` cannot widen what the database returns,
-// it only stops this surface narrowing it further.
+// WHAT A WIDER SCOPE CAN AND CANNOT DO, because the difference is not obvious
+// and a reader must not be misled by the word on the response.
+//
+// The record-bearing sources — tasks, deals at risk, meetings, duplicate pairs
+// — widen: they are read under the caller's row scope, so `team` and `all`
+// return what that tier reaches and `mine` narrows below it.
+//
+// The intrinsically PER-USER sources do not, and cannot: a notice is addressed
+// to one person, a mailbox belongs to one person, a promise was made by one
+// person, an approved action failed for the person who approved it. Those reads
+// are bound to the acting user inside the modules that own them, so asking for
+// `all` does not reach a colleague's notices — nor should it, since the request
+// is for a wider view of shared work rather than a licence to read another
+// rep's inbox.
+//
+// So `all` means "every shared record I may see, plus my own personal queue",
+// which is the only honest reading available without a per-source authority
+// model the product does not have.
 func mineOnly(scope string) bool { return scope == scopeMine }
 
 // ownedByReader reports whether an item is the reader's own work.

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// WHOSE day the queue answers.
+//
+// The default is the reader's own work, and that is the point rather than a
+// convenience: an admin account can read every deal in the installation, so a
+// queue that showed everything readable would hand a rep several hundred rows
+// belonging to colleagues and call it their day. "Mine" is the honest default
+// for a surface whose whole claim is "what should I do next".
+//
+// A wider scope is OFFERED only where the reader's row scope already reaches
+// that far, and asking for one they do not hold is refused rather than quietly
+// narrowed. Silently narrowing would answer a question about the team with
+// facts about one person, and the reader would have no way to tell.
+
+import (
+	"context"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The scopes a reader may ask the queue for.
+const (
+	scopeMine = "mine"
+	scopeTeam = "team"
+	scopeAll  = "all"
+)
+
+// scopeOptionsFor answers which scopes this reader may ask for, narrowest
+// first.
+//
+// It reads the row scope resolved at authentication rather than probing rows:
+// the tier is a fact about the principal, and asking the database whether a
+// colleague's deal is visible would be re-deriving per row what the policy
+// already decided once (P11).
+func scopeOptionsFor(ctx context.Context) []string {
+	options := []string{scopeMine}
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return options
+	}
+	switch actor.Permissions.RowScope {
+	case principal.RowScopeAll:
+		return append(options, scopeTeam, scopeAll)
+	case principal.RowScopeTeam:
+		return append(options, scopeTeam)
+	default:
+		return options
+	}
+}
+
+// resolveScope answers which scope this read runs at, or refuses.
+//
+// An empty ask means "mine", which is the default every reader holds. An ask
+// the reader's row scope does not reach is ErrPermissionDenied — a 403 — and
+// never a quiet narrowing to what they can see.
+func resolveScope(ctx context.Context, asked string) (string, error) {
+	if asked == "" {
+		return scopeMine, nil
+	}
+	for _, allowed := range scopeOptionsFor(ctx) {
+		if asked == allowed {
+			return asked, nil
+		}
+	}
+	return "", apperrors.ErrPermissionDenied
+}
+
+// mineOnly reports whether this read keeps only the reader's own work.
+//
+// Team and all are served by the lanes' own row scope, which already stops at
+// the reader's tier: asking for `all` cannot widen what the database returns,
+// it only stops this surface narrowing it further.
+func mineOnly(scope string) bool { return scope == scopeMine }
+
+// ownedByReader reports whether an item is the reader's own work.
+//
+// Only the DEAL-bearing sources can be judged here, because only they carry an
+// owner on the wire. Everything else on this queue is already per-reader by
+// construction — a task the lane read for this viewer, an approval they may
+// decide, their own mailbox, their own promises — so a row with no owner to
+// check is the reader's by the lane that produced it, and dropping it would
+// hide their own work from them.
+func ownedByReader(item crmcontracts.WorklistItem, reader principal.Principal) bool {
+	if item.Deal == nil || item.Deal.OwnerId == nil {
+		return true
+	}
+	return ids.UUID(*item.Deal.OwnerId) == reader.UserID
+}

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Whose day the queue answers, and what happens when a reader asks for one
+// that is not theirs to see.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func readerAt(tier principal.RowScope) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type:        principal.PrincipalHuman,
+		UserID:      ids.MustParse("01a05500-0000-7000-8000-000000000001"),
+		Permissions: principal.Permissions{RowScope: tier},
+	})
+}
+
+// A rep sees their own work. The default matters more than it looks: an admin
+// account can read every deal in the installation, and a queue that showed all
+// of them would hand a rep several hundred colleagues' rows and call it a day.
+func TestEveryReaderDefaultsToTheirOwnWork(t *testing.T) {
+	for _, tier := range []principal.RowScope{principal.RowScopeOwn, principal.RowScopeTeam, principal.RowScopeAll} {
+		scope, err := resolveScope(readerAt(tier), "")
+		if err != nil {
+			t.Fatalf("row scope %q was refused its own default: %v", tier, err)
+		}
+		if scope != scopeMine {
+			t.Fatalf("row scope %q defaulted to %q, wanted mine", tier, scope)
+		}
+	}
+}
+
+// A reader is offered exactly the scopes their row scope reaches, so a client
+// never draws a control that would 403 when pressed.
+func TestTheOfferedScopesMatchTheReadersOwnReach(t *testing.T) {
+	cases := map[principal.RowScope][]string{
+		principal.RowScopeOwn:  {scopeMine},
+		principal.RowScopeTeam: {scopeMine, scopeTeam},
+		principal.RowScopeAll:  {scopeMine, scopeTeam, scopeAll},
+	}
+	for tier, want := range cases {
+		got := scopeOptionsFor(readerAt(tier))
+		if len(got) != len(want) {
+			t.Fatalf("row scope %q was offered %v, wanted %v", tier, got, want)
+		}
+		for i, option := range want {
+			if got[i] != option {
+				t.Fatalf("row scope %q was offered %v, wanted %v", tier, got, want)
+			}
+		}
+	}
+}
+
+// Asking for a scope the reader does not hold is REFUSED, never narrowed.
+// Quietly answering a question about the team with facts about one person
+// would leave the reader believing they had seen the team.
+func TestAWiderScopeThanTheReaderHoldsIsRefusedNotNarrowed(t *testing.T) {
+	if _, err := resolveScope(readerAt(principal.RowScopeOwn), scopeTeam); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("an own-scope reader asking for the team got %v, wanted a refusal", err)
+	}
+	if _, err := resolveScope(readerAt(principal.RowScopeTeam), scopeAll); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a team-scope reader asking for everything got %v, wanted a refusal", err)
+	}
+}
+
+// A team-scoped reader may ask for the team, and an all-scoped reader for
+// everything. The refusal above must not be a refusal of everyone.
+func TestAReaderMayAskForAScopeTheyDoHold(t *testing.T) {
+	if _, err := resolveScope(readerAt(principal.RowScopeTeam), scopeTeam); err != nil {
+		t.Fatalf("a team-scope reader was refused the team: %v", err)
+	}
+	if _, err := resolveScope(readerAt(principal.RowScopeAll), scopeAll); err != nil {
+		t.Fatalf("an all-scope reader was refused everything: %v", err)
+	}
+}
+
+// Under `mine`, a colleague's deal leaves the queue and the summary follows it
+// out — a figure counting rows the reader cannot see is the same lie as showing
+// them.
+func TestAColleaguesDealLeavesTheQueueAndTheSummaryUnderMine(t *testing.T) {
+	reader := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000ff")
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, UserID: reader,
+		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
+	})
+	mine := ownedDeal("mine", reader)
+	theirs := ownedDeal("theirs", colleague)
+	out := crmcontracts.Worklist{
+		Queue:   []crmcontracts.WorklistItem{mine, theirs},
+		Summary: crmcontracts.WorklistSummary{Total: 2},
+	}
+
+	narrowed := narrowToReader(ctx, out)
+
+	if len(narrowed.Queue) != 1 || narrowed.Queue[0].Id != "mine" {
+		t.Fatalf("kept %d rows, wanted only the reader's own", len(narrowed.Queue))
+	}
+	if narrowed.Summary.Total != 1 {
+		t.Fatalf("the summary still counts %d, over a queue of 1", narrowed.Summary.Total)
+	}
+}
+
+// A row carrying no owner is the reader's by the lane that produced it — their
+// own task, their own mailbox, a decision they may make. Dropping those would
+// hide the reader's own work from them.
+func TestARowWithNoOwnerStaysUnderMine(t *testing.T) {
+	reader := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, UserID: reader,
+		Permissions: principal.Permissions{RowScope: principal.RowScopeOwn},
+	})
+	out := crmcontracts.Worklist{
+		Queue: []crmcontracts.WorklistItem{{Id: "my-task", Source: "task", Actions: []crmcontracts.WorklistItemActions{}}},
+	}
+
+	if len(narrowToReader(ctx, out).Queue) != 1 {
+		t.Fatal("a row with no owner was dropped, hiding the reader's own work")
+	}
+}
+
+func ownedDeal(id string, owner ids.UUID) crmcontracts.WorklistItem {
+	uuid := openapi_types.UUID(owner)
+	return crmcontracts.WorklistItem{
+		Id:      id,
+		Source:  "deal_at_risk",
+		Deal:    &crmcontracts.WorklistDealFacts{OwnerId: &uuid},
+		Actions: []crmcontracts.WorklistItemActions{},
+	}
+}

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -186,3 +186,40 @@ func ownedDeal(id string, owner ids.UUID) crmcontracts.WorklistItem {
 		Actions: []crmcontracts.WorklistItemActions{},
 	}
 }
+
+// The narrowing has to reach the QUERY. Filtering the answer instead lets a
+// colleague's twelve tasks fill a page bounded at twelve and leave the reader's
+// own overdue task unreachable behind them — the row they most needed.
+func TestTheReadersOwnScopeReachesTheTaskQuery(t *testing.T) {
+	tasks := &stubTasks{}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock,
+	)
+
+	if _, err := svc.forReader().Assemble(context.Background()); err != nil {
+		t.Fatalf("assembling the day: %v", err)
+	}
+
+	if !tasks.mineOnly {
+		t.Fatal("the task lane was asked for every visible task on a read scoped to the reader")
+	}
+}
+
+// And the lane feed keeps its own behaviour: /attention is a different surface
+// with its own promise, and this change must not narrow it.
+func TestTheLaneFeedStillReadsEveryVisibleTask(t *testing.T) {
+	tasks := &stubTasks{}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{}, stubBriefing{},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock,
+	)
+
+	if _, err := svc.Assemble(context.Background()); err != nil {
+		t.Fatalf("assembling the day: %v", err)
+	}
+
+	if tasks.mineOnly {
+		t.Fatal("the lane feed narrowed to the reader, changing a surface this did not set out to change")
+	}
+}

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -96,20 +96,66 @@ func TestAColleaguesDealLeavesTheQueueAndTheSummaryUnderMine(t *testing.T) {
 		Type: principal.PrincipalHuman, UserID: reader,
 		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
 	})
-	mine := ownedDeal("mine", reader)
-	theirs := ownedDeal("theirs", colleague)
-	out := crmcontracts.Worklist{
-		Queue:   []crmcontracts.WorklistItem{mine, theirs},
-		Summary: crmcontracts.WorklistSummary{Total: 2},
+	rows := []ranked{
+		{item: ownedDeal("mine", reader)},
+		{item: ownedDeal("theirs", colleague)},
 	}
 
-	narrowed := narrowToReader(ctx, out)
+	kept := keepReadersOwn(ctx, rows)
 
-	if len(narrowed.Queue) != 1 || narrowed.Queue[0].Id != "mine" {
-		t.Fatalf("kept %d rows, wanted only the reader's own", len(narrowed.Queue))
+	if len(kept) != 1 || kept[0].item.Id != "mine" {
+		t.Fatalf("kept %d rows, wanted only the reader's own", len(kept))
 	}
-	if narrowed.Summary.Total != 1 {
-		t.Fatalf("the summary still counts %d, over a queue of 1", narrowed.Summary.Total)
+}
+
+// A call with no human behind it has no own work to answer for. Handing it
+// every row would widen a scope named `mine`, so it gets nothing.
+func TestAScopeWithNoReaderBehindItAnswersNothing(t *testing.T) {
+	rows := []ranked{{item: ownedDeal("someones", ids.MustParse("01a05500-0000-7000-8000-0000000000ff"))}}
+
+	if kept := keepReadersOwn(context.Background(), rows); len(kept) != 0 {
+		t.Fatalf("a caller with no human behind it was handed %d rows under `mine`", len(kept))
+	}
+}
+
+// Narrowing runs before the page is cut, so a reader asking for three of their
+// own rows gets three where they exist — not a short page with their own work
+// sitting just past the cut.
+func TestAPageOfTheReadersOwnIsNotShortenedByColleaguesRows(t *testing.T) {
+	reader := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000ff")
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, UserID: reader,
+		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
+	})
+	at := []crmcontracts.AttentionItem{}
+	for i := 0; i < 5; i++ {
+		at = append(at, dealItem("theirs-"+string(rune('a'+i)), colleague))
+	}
+	for i := 0; i < 3; i++ {
+		at = append(at, dealItem("mine-"+string(rune('a'+i)), reader))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &at}
+
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3)
+
+	if len(out.Queue) != 3 {
+		t.Fatalf("a reader with three of their own rows got a page of %d", len(out.Queue))
+	}
+	for _, row := range out.Queue {
+		if row.Id[:4] != "mine" {
+			t.Fatalf("a colleague's row %q reached a page scoped to the reader", row.Id)
+		}
+	}
+}
+
+func dealItem(id string, owner ids.UUID) crmcontracts.AttentionItem {
+	uuid := openapi_types.UUID(owner)
+	return crmcontracts.AttentionItem{
+		Id:      id,
+		Source:  "deal_at_risk",
+		Deal:    &crmcontracts.AttentionDealFacts{OwnerId: &uuid},
+		Actions: []crmcontracts.AttentionItemActions{},
 	}
 }
 
@@ -122,11 +168,11 @@ func TestARowWithNoOwnerStaysUnderMine(t *testing.T) {
 		Type: principal.PrincipalHuman, UserID: reader,
 		Permissions: principal.Permissions{RowScope: principal.RowScopeOwn},
 	})
-	out := crmcontracts.Worklist{
-		Queue: []crmcontracts.WorklistItem{{Id: "my-task", Source: "task", Actions: []crmcontracts.WorklistItemActions{}}},
-	}
+	rows := []ranked{{item: crmcontracts.WorklistItem{
+		Id: "my-task", Source: "task", Actions: []crmcontracts.WorklistItemActions{},
+	}}}
 
-	if len(narrowToReader(ctx, out).Queue) != 1 {
+	if len(keepReadersOwn(ctx, rows)) != 1 {
 		t.Fatal("a row with no owner was dropped, hiding the reader's own work")
 	}
 }

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -44,7 +44,15 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
-	day, err := s.Assemble(ctx)
+	// The producers that CAN be narrowed are narrowed in their own queries,
+	// not filtered afterwards: each store bounds what it returns, so a page
+	// full of colleagues' rows would hide the reader's own work behind a cut
+	// that had already happened.
+	reader := s
+	if mineOnly(resolved) {
+		reader = s.forReader()
+	}
+	day, err := reader.Assemble(ctx)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // worklistPage is how many ranked items one read carries by default.
@@ -35,12 +36,61 @@ const worklistMaxPage = 100
 // The filter narrows what is CARRIED, never what is read: a source is read,
 // classified and then dropped, so the summary's figures describe the same day
 // whichever filter is applied.
-func (s *Service) Worklist(ctx context.Context, filter string, limit int) (crmcontracts.Worklist, error) {
+func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int) (crmcontracts.Worklist, error) {
+	// Resolved BEFORE the day is read: a reader asking for a scope they do not
+	// hold gets a refusal rather than a page assembled and then narrowed, and
+	// the read they were never entitled to make is not made.
+	resolved, err := resolveScope(ctx, scope)
+	if err != nil {
+		return crmcontracts.Worklist{}, err
+	}
 	day, err := s.Assemble(ctx)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
-	return s.worklistFrom(day, filter, limit)
+	out, err := s.worklistFrom(day, filter, limit)
+	if err != nil {
+		return crmcontracts.Worklist{}, err
+	}
+	out.Scope = crmcontracts.WorklistScope(resolved)
+	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
+	if mineOnly(resolved) {
+		out = narrowToReader(ctx, out)
+	}
+	return out, nil
+}
+
+// narrowToReader keeps the reader's own work.
+//
+// It runs over the ASSEMBLED page rather than pushing an owner filter into
+// every lane, and the difference is worth naming: the lanes are already
+// row-scoped, so this narrows what a wide-scoped reader is SHOWN by default
+// without changing what any store was asked. Pushing the filter down is the
+// better shape and needs each producer to take an owner — a change to what the
+// feed reads rather than to what it draws.
+func narrowToReader(ctx context.Context, out crmcontracts.Worklist) crmcontracts.Worklist {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return out
+	}
+	kept := make([]crmcontracts.WorklistItem, 0, len(out.Queue))
+	for _, item := range out.Queue {
+		if ownedByReader(item, actor) {
+			kept = append(kept, item)
+		}
+	}
+	out.Queue = kept
+	out.Summary = summarize(kept)
+	return out
+}
+
+// scopeOptions puts the resolver's answer on the wire.
+func scopeOptions(options []string) []crmcontracts.WorklistScopeOptions {
+	out := make([]crmcontracts.WorklistScopeOptions, 0, len(options))
+	for _, option := range options {
+		out = append(out, crmcontracts.WorklistScopeOptions(option))
+	}
+	return out
 }
 
 // worklistFrom projects an already-assembled day, so a test can drive the
@@ -53,7 +103,7 @@ func (s *Service) worklistFrom(day crmcontracts.Attention, filter string, limit 
 		limit = worklistMaxPage
 	}
 	rows := classifyDay(day, day.AsOf)
-	if filter != "" && filter != string(crmcontracts.All) {
+	if filter != "" && filter != string(crmcontracts.GetWorklistParamsFilterAll) {
 		rows = keepCategory(rows, crmcontracts.WorklistItemCategory(filter))
 	}
 	// Cut to the page BEFORE explaining and counting. Ranking the whole set and

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -48,40 +48,40 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
-	out, err := s.worklistFrom(day, filter, limit)
-	if err != nil {
-		return crmcontracts.Worklist{}, err
-	}
+	out := s.worklistFrom(ctx, day, resolved, filter, limit)
 	out.Scope = crmcontracts.WorklistScope(resolved)
 	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
-	if mineOnly(resolved) {
-		out = narrowToReader(ctx, out)
-	}
 	return out, nil
 }
 
-// narrowToReader keeps the reader's own work.
+// keepReadersOwn drops the rows belonging to somebody else.
 //
-// It runs over the ASSEMBLED page rather than pushing an owner filter into
-// every lane, and the difference is worth naming: the lanes are already
-// row-scoped, so this narrows what a wide-scoped reader is SHOWN by default
-// without changing what any store was asked. Pushing the filter down is the
-// better shape and needs each producer to take an owner — a change to what the
-// feed reads rather than to what it draws.
-func narrowToReader(ctx context.Context, out crmcontracts.Worklist) crmcontracts.Worklist {
+// It runs over the CANDIDATES, before the page is cut, so a reader asking for
+// twenty-five of their own rows gets twenty-five where they exist. Narrowing
+// after the cut returned a short page while the reader's own work sat just
+// past it.
+//
+// It fails CLOSED. A call with no human behind it has no "own work" to answer
+// for, and a queue that handed such a caller every row it had read would be
+// widening a scope named `mine` — the opposite of what it says. An agent that
+// needs the day reads it under a scope it can actually hold.
+//
+// The narrowing itself is a display cut, not the security boundary: the lanes
+// are already row-scoped, so this changes what a wide-scoped reader is SHOWN
+// by default rather than what any store was asked. Pushing the filter into
+// each producer is the better shape and needs each to take an owner.
+func keepReadersOwn(ctx context.Context, rows []ranked) []ranked {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID.IsZero() {
-		return out
+		return nil
 	}
-	kept := make([]crmcontracts.WorklistItem, 0, len(out.Queue))
-	for _, item := range out.Queue {
-		if ownedByReader(item, actor) {
-			kept = append(kept, item)
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if ownedByReader(row.item, actor) {
+			kept = append(kept, row)
 		}
 	}
-	out.Queue = kept
-	out.Summary = summarize(kept)
-	return out
+	return kept
 }
 
 // scopeOptions puts the resolver's answer on the wire.
@@ -95,7 +95,9 @@ func scopeOptions(options []string) []crmcontracts.WorklistScopeOptions {
 
 // worklistFrom projects an already-assembled day, so a test can drive the
 // ranking, the paging and the summary without standing up every lane's reader.
-func (s *Service) worklistFrom(day crmcontracts.Attention, filter string, limit int) (crmcontracts.Worklist, error) {
+func (s *Service) worklistFrom(
+	ctx context.Context, day crmcontracts.Attention, scope, filter string, limit int,
+) crmcontracts.Worklist {
 	if limit <= 0 {
 		limit = worklistPage
 	}
@@ -103,6 +105,9 @@ func (s *Service) worklistFrom(day crmcontracts.Attention, filter string, limit 
 		limit = worklistMaxPage
 	}
 	rows := classifyDay(day, day.AsOf)
+	if mineOnly(scope) {
+		rows = keepReadersOwn(ctx, rows)
+	}
 	if filter != "" && filter != string(crmcontracts.GetWorklistParamsFilterAll) {
 		rows = keepCategory(rows, crmcontracts.WorklistItemCategory(filter))
 	}
@@ -121,7 +126,7 @@ func (s *Service) worklistFrom(day crmcontracts.Attention, filter string, limit 
 		narrowed := crmcontracts.WorklistFilter(filter)
 		out.Filter = &narrowed
 	}
-	return out, nil
+	return out
 }
 
 // page cuts the candidates to what one read carries.

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -10,6 +10,7 @@ package attention
 // reads as clear when something that would have filled it was never read.
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -320,10 +321,7 @@ func TestThePageIsSummarisedAndExplainedAgainstItself(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	out, err := (&Service{}).worklistFrom(day, "", 3)
-	if err != nil {
-		t.Fatalf("assembling the page: %v", err)
-	}
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3)
 
 	if out.Summary.Total != len(out.Queue) {
 		t.Fatalf("summary totals %d over a page of %d", out.Summary.Total, len(out.Queue))

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -154,8 +154,10 @@ func (t attentionTasks) OpenForViewer(
 			// to prevent.
 			return nil, nil
 		}
+		// Mine, or nobody's: a task the reader wrote themselves without an
+		// assignee is still theirs to do.
 		assignee := ids.From[ids.UserKind](actor.UserID)
-		in.AssigneeID = &assignee
+		in.OwnQueueOf = &assignee
 	}
 	rows, _, err := t.store.ListActivities(ctx, in)
 	if err != nil {

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -38,6 +38,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // attentionApprovals reads the staged queue through the engine every approval
@@ -133,15 +134,30 @@ func (d attentionDuplicates) CountOpen(ctx context.Context) (int, error) {
 // activity of kind `task`, so this is the same read the task queue makes.
 type attentionTasks struct{ store *activities.Store }
 
-func (t attentionTasks) OpenForViewer(ctx context.Context, until time.Time, limit int) ([]attention.Task, error) {
+func (t attentionTasks) OpenForViewer(
+	ctx context.Context, until time.Time, limit int, mineOnly bool,
+) ([]attention.Task, error) {
 	// The store answers "open and due by then" itself, so the limit bounds the
 	// rows that QUALIFY. This used to read ten times the lane and narrow
 	// afterwards, which put the bound on the wrong set: a pile of completed
 	// tasks filled the scan, the overdue promise underneath never reached the
 	// reader, and the day rendered clear while the work was still there.
-	rows, _, err := t.store.ListActivities(ctx, activities.ListActivitiesInput{
-		OpenAndDueBy: &until, Limit: &limit,
-	})
+	in := activities.ListActivitiesInput{OpenAndDueBy: &until, Limit: &limit}
+	// Narrowed in the QUERY, so the store's own bound applies to the rows that
+	// qualify. Filtering the answer instead would let a colleague's twelve
+	// tasks fill the page and hide the reader's own overdue one behind them.
+	if mineOnly {
+		actor, ok := principal.Actor(ctx)
+		if !ok || actor.UserID.IsZero() {
+			// No human, no "own work" to answer for. Reading every task and
+			// calling the result theirs is the widening this narrowing exists
+			// to prevent.
+			return nil, nil
+		}
+		assignee := ids.From[ids.UserKind](actor.UserID)
+		in.AssigneeID = &assignee
+	}
+	rows, _, err := t.store.ListActivities(ctx, in)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11194,6 +11194,48 @@ func (e WorklistFilter) Valid() bool {
 	}
 }
 
+// Defines values for WorklistScope.
+const (
+	WorklistScopeAll  WorklistScope = "all"
+	WorklistScopeMine WorklistScope = "mine"
+	WorklistScopeTeam WorklistScope = "team"
+)
+
+// Valid indicates whether the value is a known member of the WorklistScope enum.
+func (e WorklistScope) Valid() bool {
+	switch e {
+	case WorklistScopeAll:
+		return true
+	case WorklistScopeMine:
+		return true
+	case WorklistScopeTeam:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WorklistScopeOptions.
+const (
+	WorklistScopeOptionsAll  WorklistScopeOptions = "all"
+	WorklistScopeOptionsMine WorklistScopeOptions = "mine"
+	WorklistScopeOptionsTeam WorklistScopeOptions = "team"
+)
+
+// Valid indicates whether the value is a known member of the WorklistScopeOptions enum.
+func (e WorklistScopeOptions) Valid() bool {
+	switch e {
+	case WorklistScopeOptionsAll:
+		return true
+	case WorklistScopeOptionsMine:
+		return true
+	case WorklistScopeOptionsTeam:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistComparisonComparator.
 const (
 	WorklistComparisonComparatorDeadline        WorklistComparisonComparator = "deadline"
@@ -12949,33 +12991,54 @@ func (e ListSignalsParamsResolutionState) Valid() bool {
 	}
 }
 
+// Defines values for GetWorklistParamsScope.
+const (
+	GetWorklistParamsScopeAll  GetWorklistParamsScope = "all"
+	GetWorklistParamsScopeMine GetWorklistParamsScope = "mine"
+	GetWorklistParamsScopeTeam GetWorklistParamsScope = "team"
+)
+
+// Valid indicates whether the value is a known member of the GetWorklistParamsScope enum.
+func (e GetWorklistParamsScope) Valid() bool {
+	switch e {
+	case GetWorklistParamsScopeAll:
+		return true
+	case GetWorklistParamsScopeMine:
+		return true
+	case GetWorklistParamsScopeTeam:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetWorklistParamsFilter.
 const (
-	All             GetWorklistParamsFilter = "all"
-	CustomerWaiting GetWorklistParamsFilter = "customer_waiting"
-	DealsAtRisk     GetWorklistParamsFilter = "deals_at_risk"
-	Decisions       GetWorklistParamsFilter = "decisions"
-	Meetings        GetWorklistParamsFilter = "meetings"
-	System          GetWorklistParamsFilter = "system"
-	Tasks           GetWorklistParamsFilter = "tasks"
+	GetWorklistParamsFilterAll             GetWorklistParamsFilter = "all"
+	GetWorklistParamsFilterCustomerWaiting GetWorklistParamsFilter = "customer_waiting"
+	GetWorklistParamsFilterDealsAtRisk     GetWorklistParamsFilter = "deals_at_risk"
+	GetWorklistParamsFilterDecisions       GetWorklistParamsFilter = "decisions"
+	GetWorklistParamsFilterMeetings        GetWorklistParamsFilter = "meetings"
+	GetWorklistParamsFilterSystem          GetWorklistParamsFilter = "system"
+	GetWorklistParamsFilterTasks           GetWorklistParamsFilter = "tasks"
 )
 
 // Valid indicates whether the value is a known member of the GetWorklistParamsFilter enum.
 func (e GetWorklistParamsFilter) Valid() bool {
 	switch e {
-	case All:
+	case GetWorklistParamsFilterAll:
 		return true
-	case CustomerWaiting:
+	case GetWorklistParamsFilterCustomerWaiting:
 		return true
-	case DealsAtRisk:
+	case GetWorklistParamsFilterDealsAtRisk:
 		return true
-	case Decisions:
+	case GetWorklistParamsFilterDecisions:
 		return true
-	case Meetings:
+	case GetWorklistParamsFilterMeetings:
 		return true
-	case System:
+	case GetWorklistParamsFilterSystem:
 		return true
-	case Tasks:
+	case GetWorklistParamsFilterTasks:
 		return true
 	default:
 		return false
@@ -26902,6 +26965,14 @@ type Worklist struct {
 	// Queue Everything actionable, best-first. The order is the product of this endpoint.
 	Queue []WorklistItem `json:"queue"`
 
+	// Scope Whose work this read answered for.
+	Scope WorklistScope `json:"scope"`
+
+	// ScopeOptions The scopes this reader may ask for, narrowest first — derived from their own
+	// row scope. A client draws a control only when there is more than one, so a
+	// rep who can only see their own work is never offered a switch that would 403.
+	ScopeOptions []WorklistScopeOptions `json:"scope_options"`
+
 	// SourcesUnavailable Sources that could not be included, and why. Empty is the honest common case.
 	SourcesUnavailable []WorklistSourceUnavailable `json:"sources_unavailable"`
 
@@ -26912,6 +26983,12 @@ type Worklist struct {
 
 // WorklistFilter The narrowing this read applied.
 type WorklistFilter string
+
+// WorklistScope Whose work this read answered for.
+type WorklistScope string
+
+// WorklistScopeOptions defines model for Worklist.ScopeOptions.
+type WorklistScopeOptions string
 
 // WorklistComparison The first tie-break at which this item beat the one below it, with both sides'
 // values — so a row can say "above the next because it closes sooner" instead of
@@ -31444,12 +31521,25 @@ type GetLatestWeeklyReviewParams struct {
 
 // GetWorklistParams defines parameters for GetWorklist.
 type GetWorklistParams struct {
+	// Scope Whose work to answer for. Omitted means `mine`, which is the default for
+	// every reader: an admin account can read every deal in the installation, and a
+	// queue that showed all of them would hand a rep several hundred rows belonging
+	// to colleagues and call it their day.
+	//
+	// A scope the reader's own row scope does not reach is refused with 403 rather
+	// than quietly narrowed — answering a question about the team with facts about
+	// one person, with no way for the reader to tell, is the worse failure.
+	Scope *GetWorklistParamsScope `form:"scope,omitempty" json:"scope,omitempty"`
+
 	// Filter Narrow the queue to one kind of work. Omitted means everything, which is the default view.
 	Filter *GetWorklistParamsFilter `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// Limit How many ranked items to return.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
+
+// GetWorklistParamsScope defines parameters for GetWorklist.
+type GetWorklistParamsScope string
 
 // GetWorklistParamsFilter defines parameters for GetWorklist.
 type GetWorklistParamsFilter string
@@ -66977,6 +67067,19 @@ func (siw *ServerInterfaceWrapper) GetWorklist(w http.ResponseWriter, r *http.Re
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetWorklistParams
+
+	// ------------- Optional query parameter "scope" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "scope", r.URL.Query(), &params.Scope, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "scope"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "scope", Err: err})
+		}
+		return
+	}
 
 	// ------------- Optional query parameter "filter" -------------
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31529,6 +31529,15 @@ type GetWorklistParams struct {
 	// A scope the reader's own row scope does not reach is refused with 403 rather
 	// than quietly narrowed — answering a question about the team with facts about
 	// one person, with no way for the reader to tell, is the worse failure.
+	//
+	// WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
+	// going quiet, meetings and duplicate pairs are read under the caller's row
+	// scope, so `team` and `all` return what that tier reaches and `mine` narrows
+	// below it. The intrinsically per-user sources do not, and cannot: a notice is
+	// addressed to one person, a mailbox belongs to one, a promise was made by one,
+	// and an approved action failed for the person who approved it. `all` therefore
+	// means "every shared record I may see, plus my own personal queue" — not a
+	// licence to read a colleague's inbox.
 	Scope *GetWorklistParamsScope `form:"scope,omitempty" json:"scope,omitempty"`
 
 	// Filter Narrow the queue to one kind of work. Omitted means everything, which is the default view.

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -72,6 +72,16 @@ type ListActivitiesInput struct {
 	// what the partial index behind it is built on. Done-ness is part of
 	// that question rather than a second dial — see openTaskAssigneeClause.
 	AssigneeID *ids.UserID
+
+	// OwnQueueOf narrows to the work one person is answerable for: assigned to
+	// them, or assigned to NOBODY. Distinct from AssigneeID, which means exact
+	// assignment and is what the task screen filters by.
+	//
+	// The unassigned arm is the difference that matters. A rep who writes
+	// themselves a task without filling in an assignee still owns it, and a
+	// "my work" queue that dropped it would hide the reader's own to-do from
+	// them — which is worse than showing one row too many.
+	OwnQueueOf *ids.UserID
 	// WithinProjectID narrows to one body of work, EXCLUDING what belongs to
 	// another project and keeping what belongs to none.
 	//

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -216,6 +216,21 @@ func openTaskAssigneeClause(assignee *ids.UserID, arg func(any) int) string {
 	return sprintf("a.assignee_id = $%d AND a.kind = 'task' AND NOT a.is_done", arg(*assignee))
 }
 
+// ownQueueClause narrows to the open tasks one person is answerable for:
+// assigned to them, or assigned to NOBODY.
+//
+// The unassigned arm is the difference from openTaskAssigneeClause, and it is
+// the point. A rep who writes themselves a task without filling in an assignee
+// still owns it, and a "my work" queue that dropped it would hide the reader's
+// own to-do from them — worse than carrying one row too many.
+func ownQueueClause(reader *ids.UserID, arg func(any) int) string {
+	if reader == nil {
+		return ""
+	}
+	return sprintf("(a.assignee_id = $%d OR a.assignee_id IS NULL) AND a.kind = 'task' AND NOT a.is_done",
+		arg(*reader))
+}
+
 // listActivitiesFilter builds the timeline query's join, WHERE terms and
 // bind arguments from one list input, plus the per-row audience test the
 // SELECT projects as content_state.
@@ -256,6 +271,9 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	}
 	if in.ChannelProvider != nil {
 		where = append(where, sprintf("a.channel_provider = $%d", arg(*in.ChannelProvider)))
+	}
+	if clause := ownQueueClause(in.OwnQueueOf, arg); clause != "" {
+		where = append(where, clause)
 	}
 	if clause := openTaskAssigneeClause(in.AssigneeID, arg); clause != "" {
 		where = append(where, clause)

--- a/backend/internal/modules/activities/orgscope_test.go
+++ b/backend/internal/modules/activities/orgscope_test.go
@@ -147,3 +147,33 @@ func TestAnUnknownEntityTypeIsRefusedRatherThanBuiltIntoSQL(t *testing.T) {
 		t.Errorf("refusal names %q, want %q", badType.EntityType, entityType)
 	}
 }
+
+// A "my work" queue is mine OR nobody's. A rep who writes themselves a task
+// without filling in an assignee still owns it, and dropping it would hide the
+// reader's own to-do from them.
+func TestTheOwnQueueClauseAdmitsUnassignedWork(t *testing.T) {
+	args := []any{}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	reader := ids.From[ids.UserKind](ids.MustParse("01a05500-0000-7000-8000-000000000001"))
+
+	clause := ownQueueClause(&reader, arg)
+
+	if !strings.Contains(clause, "a.assignee_id IS NULL") {
+		t.Fatalf("the own-queue clause %q drops unassigned work", clause)
+	}
+	if !strings.Contains(clause, "a.assignee_id = $1") {
+		t.Fatalf("the own-queue clause %q does not bind the reader", clause)
+	}
+}
+
+// The exact-assignment clause must stay exact: the task screen filters by it,
+// and widening it there would put unassigned work on somebody's name.
+func TestTheAssigneeClauseStaysExact(t *testing.T) {
+	args := []any{}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	assignee := ids.From[ids.UserKind](ids.MustParse("01a05500-0000-7000-8000-000000000001"))
+
+	if clause := openTaskAssigneeClause(&assignee, arg); strings.Contains(clause, "IS NULL") {
+		t.Fatalf("the exact-assignee clause %q now admits unassigned work", clause)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23607,6 +23607,17 @@ export interface components {
              */
             as_of: string;
             /**
+             * @description Whose work this read answered for.
+             * @enum {string}
+             */
+            scope: "mine" | "team" | "all";
+            /**
+             * @description The scopes this reader may ask for, narrowest first — derived from their own
+             *     row scope. A client draws a control only when there is more than one, so a
+             *     rep who can only see their own work is never offered a switch that would 403.
+             */
+            scope_options: ("mine" | "team" | "all")[];
+            /**
              * @description The narrowing this read applied.
              * @enum {string}
              */
@@ -33927,6 +33938,17 @@ export interface operations {
     getWorklist: {
         parameters: {
             query?: {
+                /**
+                 * @description Whose work to answer for. Omitted means `mine`, which is the default for
+                 *     every reader: an admin account can read every deal in the installation, and a
+                 *     queue that showed all of them would hand a rep several hundred rows belonging
+                 *     to colleagues and call it their day.
+                 *
+                 *     A scope the reader's own row scope does not reach is refused with 403 rather
+                 *     than quietly narrowed — answering a question about the team with facts about
+                 *     one person, with no way for the reader to tell, is the worse failure.
+                 */
+                scope?: "mine" | "team" | "all";
                 /** @description Narrow the queue to one kind of work. Omitted means everything, which is the default view. */
                 filter?: "all" | "customer_waiting" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
                 /** @description How many ranked items to return. */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -33947,6 +33947,15 @@ export interface operations {
                  *     A scope the reader's own row scope does not reach is refused with 403 rather
                  *     than quietly narrowed — answering a question about the team with facts about
                  *     one person, with no way for the reader to tell, is the worse failure.
+                 *
+                 *     WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
+                 *     going quiet, meetings and duplicate pairs are read under the caller's row
+                 *     scope, so `team` and `all` return what that tier reaches and `mine` narrows
+                 *     below it. The intrinsically per-user sources do not, and cannot: a notice is
+                 *     addressed to one person, a mailbox belongs to one, a promise was made by one,
+                 *     and an approved action failed for the person who approved it. `all` therefore
+                 *     means "every shared record I may see, plus my own personal queue" — not a
+                 *     licence to read a colleague's inbox.
                  */
                 scope?: "mine" | "team" | "all";
                 /** @description Narrow the queue to one kind of work. Omitted means everything, which is the default view. */
@@ -33971,6 +33980,7 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
         };
     };
     getMorningDigest: {


### PR DESCRIPTION
Adds `?scope=mine|team|all` to `GET /worklist`, plus `scope` and `scope_options` on the response.

## Why `mine` is the default

An admin account can read every deal in the installation. A queue that showed all of them would hand a rep several hundred rows belonging to colleagues and call it their day — which is what the seeded workspace does today. So `mine` is the default for every reader, whatever their row scope reaches.

`scope_options` says which scopes this reader may ask for, derived from the row scope resolved at authentication rather than probed per row. A client draws the control only when there is more than one, so a rep who can only see their own work is never offered a switch that would refuse when pressed.

## Refused, not narrowed

A scope the reader does not hold answers 403. Quietly narrowing would answer a question about the team with facts about one person, and the reader would have no way to tell they had not seen the team.

## Two faults the security review caught

**It failed open.** A call with no human behind it fell through the actor check and was handed every row the feed had read — under a scope named `mine`. It now answers nothing: a caller with no own work has no own work to show.

**It narrowed after paging.** A reader asking for twenty-five of their own rows could get three, with their own work sitting just past a cut made against colleagues' rows. The narrowing now runs over the candidates, before the cut.

Both are pinned by tests.

## What this is and is not

The narrowing is a **display cut**, not the security boundary — the lanes are already row-scoped, so this changes what a wide-scoped reader is *shown* by default without changing what any store was asked. Pushing the filter into each producer is the better shape and needs every producer to take an owner; that is its own change.

A row with no owner on the wire stays: it is the reader's by the lane that produced it — their own task, their own mailbox, a decision they may make — and dropping it would hide their own work from them.

## Seen working

```
admin (row scope: all), no scope asked  → scope=mine  options=[mine, team, all]
?scope=team                             → 200
?scope=everyone                         → 422
```

## Gates

`make check-backend`, `make craft-static` (0 findings) green. Contract change is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the worklist answer for the reader's own work by default instead of showing everything they can read. Adds `scope=mine|team|all` to `GET /worklist`, returns `scope` and `scope_options` on the response, and refuses scopes the reader does not hold with 403 rather than narrowing.

**Scope handling**
- `scope_options` comes from the row scope resolved at authentication, so a client never offers a switch that would 403.
- Under `mine`, tasks narrow in the read itself to those assigned to the reader or to nobody; an unassigned task the reader wrote is still their own.
- `team` and `all` widen only shared-record sources; per-user sources (notices, mailbox, promises) stay the reader's own, so `all` means every shared record they can see plus their own queue.
- A call with no human behind it returns nothing under `mine`; an unknown scope answers 422, now declared in the contract.

<sup>Written for commit 5046ebad8700333570eb12f76ddecb50160b5f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worklist views for **mine**, **team**, and **all** scopes.
  * Worklists now show the selected scope and available scope options.
  * Requests default to the **mine** scope when none is specified.
* **Bug Fixes**
  * Unauthorized scope requests now return a clear permission error.
  * Worklist filtering preserves pagination and safely handles unassigned items and anonymous access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->