### PR TITLE
A replayed body re-checks every record it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,8 +490,8 @@ numbers appear here when releases start.
   sight of. `POST /leads/{id}/promote` and `POST /leads/{id}/demote` have the
   same shape — the third was found by widening the gate rather than by reading
   the code. Every record reference a wrapper body carries is probed now, and a
-  gate derived from the contract fails when a response schema grows one nothing
-  re-checks.
+  gate derived from the contract fails when a response schema grows a reference
+  that nothing re-checks.
 
 - **A refused API key is no longer reported as six broken use cases.** The
   `e2e-llm` lane guarded against an empty transcript but not against one the API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,16 @@ numbers appear here when releases start.
 
 ### Fixed
 
+- **A replayed body re-checks every record it names, not only the one it
+  replays by.** `POST /people/quick-capture` answers the person created plus the
+  `organization_id` they were attached to; the replay gate probed the person and
+  handed the rest back, including an employer id the caller may since have lost
+  sight of. `POST /leads/{id}/promote` and `POST /leads/{id}/demote` have the
+  same shape — the third was found by widening the gate rather than by reading
+  the code. Every record reference a wrapper body carries is probed now, and a
+  gate derived from the contract fails when a response schema grows one nothing
+  re-checks.
+
 - **A refused API key is no longer reported as six broken use cases.** The
   `e2e-llm` lane guarded against an empty transcript but not against one the API
   refused: a `401` produces an init line and an error result, which the checker

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 31
+	wantFixtureAnnotations = 32
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/replayscope_test.go
+++ b/backend/gates/replayscope_test.go
@@ -25,6 +25,8 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -106,6 +108,9 @@ var rowScopedResponses = map[string]expectedTarget{
 // expectedTarget mirrors compose's replayTarget for comparison.
 type expectedTarget struct {
 	object, objectNote, table, tableField, moduleProbe, idPath, pathParam, rowNote string
+	// companions are the OTHER row-scoped records the body names, as
+	// "table:idPath" so a slice compares as text.
+	companions []string
 }
 
 const replayScopeSource = "internal/compose/replayscope.go"
@@ -180,7 +185,87 @@ func TestReplayScopeCoversEveryIdempotentOperation(t *testing.T) {
 		case !probesRow && strings.TrimSpace(got.rowNote) == "":
 			t.Errorf("%s re-probes no row scope and gives no reason — a reasonless exemption is itself the finding", route)
 		}
+
+		// EVERY record the body names, not only the one it replays by. A
+		// companion reference discloses that a record exists and what it was to
+		// this call: quick-capture hands back the employer a person was
+		// attached to, and probing the person alone returned that id to a
+		// caller who may since have lost sight of the employer.
+		//
+		// Derived from the contract rather than listed, so a third schema that
+		// grows one is caught the day it lands.
+		for _, want := range companionsInContract(t, schemas, got) {
+			if !slices.Contains(got.companions, want) {
+				table, field, _ := strings.Cut(want, ":")
+				t.Errorf("%s answers a body naming %s, a row-scoped %s, and no probe re-checks it — a replay hands that id back to a caller who may no longer see the record",
+					route, field, table)
+			}
+		}
+		for _, declared := range got.companions {
+			if !slices.Contains(companionsInContract(t, schemas, got), declared) {
+				t.Errorf("%s probes companion %s, which its response schema does not carry — the probe reads a field that is never there and passes for free",
+					route, declared)
+			}
+		}
 	}
+}
+
+// companionRecordFields names the row-scoped tables a `<table>_id` property
+// refers to. Spelled here because it is the gate's own reading of a convention
+// the contract follows, and a property this list does not know is not treated
+// as a record — a guess in that direction would demand probes for ids that name
+// no row-scoped table.
+// gatekit:fixture the field-to-table convention this census reads, not costs
+// anyone is waived from: an entry here adds a check rather than removing one.
+var companionRecordFields = map[string]string{
+	"person_id":       "person",
+	"organization_id": "organization",
+	"deal_id":         "deal",
+	"lead_id":         "lead",
+	"project_id":      "project",
+}
+
+// companionsInContract names the row-scoped references a route's response
+// schemas carry, beyond the record the replay is keyed on.
+//
+// ONLY FOR A BODY THAT WRAPS A RECORD, and the distinction is the whole rule.
+// `organization_id` on a Deal is the deal's own field: the live read of that
+// deal returns it to anyone who can see the deal, so replaying it discloses
+// nothing the product would not. `organization_id` on QuickCapturePersonResult
+// sits BESIDE the person, naming a second record the call attached them to —
+// and that one the live path never hands back with the person.
+//
+// A dotted idPath is what says the body is a wrapper: the record is nested
+// inside it, and the fields beside it are the wrapper's own. TOP-LEVEL
+// properties only, for the same reason — the nested record's fields are its
+// own, covered by the probe that already resolves it.
+func companionsInContract(t *testing.T, schemas []string, got expectedTarget) []string {
+	t.Helper()
+	if !strings.Contains(got.idPath, ".") {
+		return nil
+	}
+	var out []string
+	for _, schema := range schemas {
+		for field, table := range schemaRecordFields(t, schema) {
+			out = append(out, table+":"+field)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// schemaRecordFields reads one named schema's top-level uuid properties that
+// name a row-scoped record.
+func schemaRecordFields(t *testing.T, schema string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for field, format := range contractSchemaProperties(t)[schema] {
+		table, named := companionRecordFields[field]
+		if named && format == "uuid" {
+			out[field] = table
+		}
+	}
+	return out
 }
 
 // noResponseBody stands for a 2xx that answers nothing — a 204. It is a schema
@@ -304,6 +389,10 @@ func mappedReplayScope(t *testing.T) map[string]expectedTarget {
 				t.Fatalf("%s: replayableOperations[%q] has a positional field — teach this extractor the new shape", replayScopeSource, route)
 			}
 			name, _ := kv.Key.(*ast.Ident)
+			if name != nil && name.Name == "companions" {
+				entry.companions = companionRefs(t, route, kv.Value)
+				continue
+			}
 			text := stringLiteral(t, kv.Value)
 			switch {
 			case name == nil:
@@ -328,6 +417,40 @@ func mappedReplayScope(t *testing.T) map[string]expectedTarget {
 		}
 		out[route] = entry
 	})
+	return out
+}
+
+// companionRefs reads a companions slice literal as "table:idPath" strings.
+func companionRefs(t *testing.T, route string, expr ast.Expr) []string {
+	t.Helper()
+	slice, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		t.Fatalf("%s: replayableOperations[%q].companions is not a slice literal", replayScopeSource, route)
+	}
+	var out []string
+	for _, element := range slice.Elts {
+		lit, isLit := element.(*ast.CompositeLit)
+		if !isLit {
+			t.Fatalf("%s: replayableOperations[%q] has a companion that is not a literal", replayScopeSource, route)
+		}
+		var table, idPath string
+		for _, field := range lit.Elts {
+			kv, isField := field.(*ast.KeyValueExpr)
+			if !isField {
+				t.Fatalf("%s: replayableOperations[%q] has a positional companion field", replayScopeSource, route)
+			}
+			name, _ := kv.Key.(*ast.Ident)
+			switch {
+			case name == nil:
+			case name.Name == "table":
+				table = stringLiteral(t, kv.Value)
+			case name.Name == "idPath":
+				idPath = stringLiteral(t, kv.Value)
+			}
+		}
+		out = append(out, table+":"+idPath)
+	}
+	sort.Strings(out)
 	return out
 }
 
@@ -424,4 +547,48 @@ func forEachMapEntry(t *testing.T, name string, visit func(key string, value ast
 	if !found {
 		t.Fatalf("%s: no package-level map named %s — teach this extractor where it moved", replayScopeSource, name)
 	}
+}
+
+// contractProperties caches the contract's schema properties, so a gate that
+// asks about thirty routes parses the document once.
+// It is not a reason map and carries no marker: the values are the contract's
+// own formats, keyed by schema and field, and nothing here is waived.
+var contractProperties map[string]map[string]string
+
+// contractSchemaProperties maps each named schema to its top-level properties
+// and their `format`, which is how a uuid reference is told from a name.
+func contractSchemaProperties(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	if contractProperties != nil {
+		return contractProperties
+	}
+	src, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading api/crm.yaml: %v", err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]struct {
+					Format string `yaml:"format"`
+				} `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(src, &doc); err != nil {
+		t.Fatalf("parsing api/crm.yaml: %v", err)
+	}
+	if len(doc.Components.Schemas) == 0 {
+		t.Fatal("the contract yielded no schemas: this reader has stopped matching, and an empty answer would " +
+			"report every body as naming no companion record")
+	}
+	contractProperties = map[string]map[string]string{}
+	for name, schema := range doc.Components.Schemas {
+		fields := map[string]string{}
+		for field, property := range schema.Properties {
+			fields[field] = property.Format
+		}
+		contractProperties[name] = fields
+	}
+	return contractProperties
 }

--- a/backend/internal/compose/integration/idempotency_integration_test.go
+++ b/backend/internal/compose/integration/idempotency_integration_test.go
@@ -15,9 +15,11 @@ package integration
 // reaches the store.
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
@@ -261,5 +263,84 @@ func TestIdempotencyKeyReplay_logActivity(t *testing.T) {
 	}
 	if len(activities.Data) != 1 {
 		t.Fatalf("replayed log produced %d activities, want exactly 1", len(activities.Data))
+	}
+}
+
+// TestAScheduledSendReplayProbesTheScheduleNotTheActivity is the alt-table half
+// of the replay probe.
+//
+// One route answers two tables behind the same "id": the outbound ACTIVITY when
+// the message went now, the SCHEDULED SEND when the caller asked for later, and
+// scheduled_at is what tells them apart. Probing the activity table for a
+// scheduled send would look up an id that is not there and refuse every retry.
+func TestAScheduledSendReplayProbesTheScheduleNotTheActivity(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	route := "/v1/activities/" + p.activityID + "/send-email"
+	keyed := map[string]string{"Idempotency-Key": "schedule-retry-1"}
+	req := AnyMap{
+		"subject": "Monday morning", "body": "Written the night before.",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"scheduled_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+	}
+
+	var first AnyMap
+	if status := p.Call(t, "POST", route, req, keyed, &first); status != http.StatusCreated {
+		t.Fatalf("keyed schedule = %d %v", status, first)
+	}
+	if first["scheduled_at"] == nil {
+		t.Fatalf("the answer carries no scheduled_at, so the replay would be gated on the activity table and this test would prove nothing: %v", first)
+	}
+
+	var replay AnyMap
+	if status := p.Call(t, "POST", route, req, keyed, &replay); status != http.StatusCreated {
+		t.Fatalf("keyed replay = %d %v, want the original 201", status, replay)
+	}
+	if !reflect.DeepEqual(first, replay) {
+		t.Errorf("replayed response differs from the original:\n first: %v\nreplay: %v", first, replay)
+	}
+}
+
+// TestAScheduledSendReplayRefusesAMessageThatIsNoLongerTheCallersOwn is the
+// refusal that probe exists for.
+//
+// A scheduled message is the SENDER's own: an unsent body and its blind-copy
+// list are not workspace-readable the way a sent activity is, so the scope
+// asked here is the scheduled_by predicate the store itself reads with. The
+// row moving to another sender is what the test reaches through SQL — the
+// transport key is scoped per principal, so nothing in the API can hand one
+// caller another's key today, and this is the guard for the day something can.
+func TestAScheduledSendReplayRefusesAMessageThatIsNoLongerTheCallersOwn(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	route := "/v1/activities/" + p.activityID + "/send-email"
+	keyed := map[string]string{"Idempotency-Key": "schedule-retry-2"}
+	req := AnyMap{
+		"subject": "Monday morning", "body": "Written the night before.",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"scheduled_at": time.Now().Add(3 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+	}
+
+	var first AnyMap
+	if status := p.Call(t, "POST", route, req, keyed, &first); status != http.StatusCreated {
+		t.Fatalf("keyed schedule = %d %v", status, first)
+	}
+
+	colleague := SeedIDRow(t, p.Owner,
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, 'other@preflight.test', 'Other Sender')`)
+	if _, err := p.Owner.Exec(context.Background(),
+		`UPDATE scheduled_send SET scheduled_by = $1 WHERE id = $2`, colleague, first["id"]); err != nil {
+		t.Fatalf("handing the schedule to another sender: %v", err)
+	}
+
+	// Existence-hiding, like every other row scope: somebody else's message is
+	// not found rather than forbidden.
+	var replay AnyMap
+	if status := p.Call(t, "POST", route, req, keyed, &replay); status != http.StatusNotFound {
+		t.Fatalf("replay of a schedule now owned by another sender = %d %v, want 404", status, replay)
 	}
 }

--- a/backend/internal/compose/integration/idempotency_integration_test.go
+++ b/backend/internal/compose/integration/idempotency_integration_test.go
@@ -123,6 +123,53 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 	}
 }
 
+// TestAPromoteReplayStillWorksThoughItArchivedItsOwnLead is the boundary the
+// companion probe has to respect.
+//
+// Promoting a lead ARCHIVES it, and the response names that lead. A companion
+// probe that asked whether the lead is still LIVE would answer no on every
+// promote — refusing the retry the idempotency key exists to serve, which is a
+// worse failure than the disclosure it was meant to close. What a companion
+// discloses is an id, so what it is checked against is row SCOPE.
+func TestAPromoteReplayStillWorksThoughItArchivedItsOwnLead(t *testing.T) {
+	e := apptest.SetupApp(t)
+	apptest.BootstrapWorkspaceSession(t, e, "Idem Promote", "admin@idempromote.test", "Admin")
+
+	var lead AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", AnyMap{
+		"full_name":    "Promotable Prospect",
+		"email":        "promotable@example.org",
+		"company_name": "Promotable AG",
+		"source":       "import:idem",
+	}, nil, &lead); status != http.StatusCreated {
+		t.Fatalf("create lead = %d %v", status, lead)
+	}
+	leadID, _ := lead["id"].(string)
+	if leadID == "" {
+		t.Fatalf("created lead carries no id: %v", lead)
+	}
+
+	keyed := map[string]string{"Idempotency-Key": "promote-retry-1"}
+	var first AnyMap
+	promoteReq := AnyMap{"trigger": "human_qualify"}
+	if status := e.Call(t, "POST", "/v1/leads/"+leadID+"/promote", promoteReq, keyed, &first); status != http.StatusOK {
+		t.Fatalf("promote = %d %v", status, first)
+	}
+	if first["lead_id"] == nil {
+		t.Fatalf("the promotion names no lead, so this test would prove nothing about the companion: %v", first)
+	}
+
+	// The lead is archived BY the promotion, so this is the retry a live probe
+	// would have refused.
+	var replay AnyMap
+	if status := e.Call(t, "POST", "/v1/leads/"+leadID+"/promote", promoteReq, keyed, &replay); status != http.StatusOK {
+		t.Fatalf("promote replay = %d %v, want the original 200 — the lead it archived is not a lost companion", status, replay)
+	}
+	if !reflect.DeepEqual(first, replay) {
+		t.Errorf("replayed response differs from the original:\n first: %v\nreplay: %v", first, replay)
+	}
+}
+
 // TestIdempotencyKeyReplay_createQuota proves the promise for an
 // operation with no natural-key dedupe behind it: without transport
 // idempotency a retried createQuota lands a second, identical target.

--- a/backend/internal/compose/replayprobe.go
+++ b/backend/internal/compose/replayprobe.go
@@ -245,7 +245,7 @@ func replayTableFor(target replayTarget, body string) (string, error) {
 func ensureCompanionsVisible(ctx context.Context, pool *pgxpool.Pool, target replayTarget, body string) error {
 	for _, companion := range target.companions {
 		raw, err := stringAt(body, companion.idPath)
-		if err != nil || raw == "" {
+		if err != nil {
 			// Absent, null, or not a string: the body names no record here.
 			continue
 		}

--- a/backend/internal/compose/replayprobe.go
+++ b/backend/internal/compose/replayprobe.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Running the replay gate: resolving the record a recorded body is about, the
+// other records it names, and whether the caller may still see any of them.
+//
+// Split from replayscope.go, which is the TABLE — what governs each route, and
+// why anything it does not re-check is not re-checked. That file is read when
+// adding a route; this one when changing what a probe does.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// replayProbe answers whether the caller may still see one record, for the
+// bodies whose scope rule lives inside a module rather than in a row-scoped
+// table. Compose injects them at the composition root, so this package borrows
+// the module's own rule instead of keeping a second copy that could drift.
+type replayProbe func(ctx context.Context, id ids.UUID) error
+
+// ensureReplayVisible re-runs, against the caller as they are NOW, whichever
+// gates govern the body about to be replayed. Anything it cannot resolve fails
+// CLOSED: the middleware cannot show the caller may still see what it is
+// handing back, and serving it on the strength of a parse failure is the one
+// outcome this exists to prevent.
+func ensureReplayVisible(ctx context.Context, pool *pgxpool.Pool, probes map[string]replayProbe, route, body string) error {
+	target, replayable := replayableOperations[route]
+	if !replayable {
+		// The middleware only claims keys for routes in this table, so this
+		// is unreachable; if it is ever reached, the unclassified case is
+		// exactly the one that must not pay out.
+		return apperrors.ErrNotFound
+	}
+
+	if target.table == "" && target.tableField == "" && target.moduleProbe == "" {
+		// No primary record, but a body can still point at one.
+		return ensureCompanionsVisible(ctx, pool, target, body)
+	}
+
+	if target.moduleProbe != "" {
+		probe, wired := probes[target.moduleProbe]
+		if !wired {
+			// An unwired probe cannot show the caller may still see this, and
+			// the composition root is the only place that could have wired it.
+			return apperrors.ErrNotFound
+		}
+		id, err := replayRecordID(ctx, target, body)
+		if err != nil {
+			return err
+		}
+		if err := probe(ctx, id); err != nil {
+			return err
+		}
+		return ensureCompanionsVisible(ctx, pool, target, body)
+	}
+
+	if err := ensureCompanionsVisible(ctx, pool, target, body); err != nil {
+		return err
+	}
+
+	table, err := replayTableFor(target, body)
+	if err != nil {
+		return err
+	}
+	id, err := replayRecordID(ctx, target, body)
+	if err != nil {
+		return err
+	}
+	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		switch table {
+		case tableActivity:
+			return auth.EnsureActivityContentVisibleLive(ctx, tx, id)
+		case tableSignal:
+			// A signal has no owner column but is scoped through its subject
+			// entity; "no owner_id" is never on its own a reason to skip.
+			return auth.EnsureSignalVisibleLive(ctx, tx, id)
+		case tableScheduledSend:
+			// A scheduled message is the SENDER's own — an unsent body and its
+			// blind-copy list are not workspace-readable the way a sent
+			// activity is — so the probe is the same scheduled_by predicate the
+			// store reads with, not the generic row-scope clause. It also has
+			// no archived_at, which the generic probe requires.
+			return ensureScheduledSendVisibleLive(ctx, tx, id)
+		}
+		// LIVE, not merely visible. The recorded body is a frozen snapshot the
+		// store itself would no longer serve: Art. 17 erasure anonymizes the
+		// person row in place, stamps archived_at and leaves owner_id alone, so
+		// a plain visibility probe still answers "yours" and the middleware
+		// would hand back the pre-erasure names, e-mails and phone numbers that
+		// every live read path now refuses. EnsureVisibleLive also declines to
+		// skip the existence half for an unbounded actor, which is the same
+		// hole one role wider.
+		//
+		// auth rejects any name outside its closed row-scoped set, so an
+		// unexpected value refuses the replay rather than reaching SQL.
+		return auth.EnsureVisibleLive(ctx, tx, table, id)
+	})
+}
+
+// ensureScheduledSendVisibleLive refuses a replay whose scheduled message no
+// longer belongs to the caller. Existence-hiding, like every other row scope:
+// somebody else's message is not found rather than forbidden.
+func ensureScheduledSendVisibleLive(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
+	actor, err := storekit.Actor(ctx)
+	if err != nil {
+		return err
+	}
+	var visible bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM scheduled_send WHERE id = $1 AND scheduled_by = $2)`,
+		id, actor.UserID).Scan(&visible); err != nil {
+		return err
+	}
+	if !visible {
+		return apperrors.ErrNotFound
+	}
+	return nil
+}
+
+// bodyHasField reports whether the recorded body carries a non-null field —
+// the discriminator between two response shapes one route can answer.
+func bodyHasField(body, field string) bool {
+	if field == "" {
+		return false
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &probe); err != nil {
+		return false
+	}
+	raw, ok := probe[field]
+	return ok && string(raw) != jsonNull
+}
+
+// replayRecordID resolves the record whose scope governs this body: from the
+// recorded body where it names its own record, or from the route parameter
+// naming its parent where the body is a projection that omits it.
+func replayRecordID(ctx context.Context, target replayTarget, body string) (ids.UUID, error) {
+	if target.pathParam == "" {
+		return recordIDAt(body, target.idPath)
+	}
+	raw := chi.RouteContext(ctx).URLParam(target.pathParam)
+	id, err := ids.Parse(raw)
+	if err != nil {
+		return ids.UUID{}, apperrors.ErrNotFound
+	}
+	return id, nil
+}
+
+// recordIDAt walks a dotted path to the record id in a recorded body.
+func recordIDAt(body, path string) (ids.UUID, error) {
+	raw, err := stringAt(body, path)
+	if err != nil {
+		return ids.UUID{}, err
+	}
+	id, err := ids.Parse(raw)
+	if err != nil {
+		return ids.UUID{}, apperrors.ErrNotFound
+	}
+	return id, nil
+}
+
+// stringAt walks a dotted path to a string in a recorded body. Every miss is
+// ErrNotFound rather than a distinct error: whichever way the body surprised
+// us, the middleware cannot prove the caller may still see what it is about to
+// hand back, and that is the client-visible fact.
+func stringAt(body, path string) (string, error) {
+	var node any
+	if err := json.Unmarshal([]byte(body), &node); err != nil {
+		return "", apperrors.ErrNotFound
+	}
+	for _, segment := range strings.Split(path, ".") {
+		object, ok := node.(map[string]any)
+		if !ok {
+			return "", apperrors.ErrNotFound
+		}
+		if node, ok = object[segment]; !ok {
+			return "", apperrors.ErrNotFound
+		}
+	}
+	text, ok := node.(string)
+	if !ok {
+		return "", apperrors.ErrNotFound
+	}
+	return text, nil
+}
+
+// replayTableFor resolves which table this body's record lives in: the entry's
+// own, the one the body names for a polymorphic reference, or the alternate a
+// route that answers two shapes says this body is. The marker is a field only
+// the alternate carries, so the choice is read off the recorded body rather
+// than guessed from the route.
+func replayTableFor(target replayTarget, body string) (string, error) {
+	table := target.table
+	if target.tableField != "" {
+		resolved, err := stringAt(body, target.tableField)
+		if err != nil {
+			return "", err
+		}
+		table = resolved
+	}
+	if target.altTable != "" && bodyHasField(body, target.altMarker) {
+		table = target.altTable
+	}
+	return table, nil
+}
+
+// ensureCompanionsVisible re-checks every OTHER record the body names.
+//
+// An absent or null field names nothing and is skipped: these are optional by
+// contract, and a person captured with no employer carries no organization id.
+// A field that is present and unreadable as an id refuses, on the same terms as
+// the primary — the middleware cannot show the caller may still see what it is
+// handing back.
+func ensureCompanionsVisible(ctx context.Context, pool *pgxpool.Pool, target replayTarget, body string) error {
+	for _, companion := range target.companions {
+		if !bodyHasField(body, companion.idPath) {
+			continue
+		}
+		id, err := recordIDAt(body, companion.idPath)
+		if err != nil {
+			return err
+		}
+		if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+			return auth.EnsureVisibleLive(ctx, tx, companion.table, id)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/compose/replayprobe.go
+++ b/backend/internal/compose/replayprobe.go
@@ -222,20 +222,39 @@ func replayTableFor(target replayTarget, body string) (string, error) {
 //
 // An absent or null field names nothing and is skipped: these are optional by
 // contract, and a person captured with no employer carries no organization id.
+// The value is resolved ONCE and by the same walk that reads it — a separate
+// presence test would answer for a different path than the one the probe uses,
+// and the disagreement resolves to a skip, which is a pass.
+//
 // A field that is present and unreadable as an id refuses, on the same terms as
-// the primary — the middleware cannot show the caller may still see what it is
+// the primary: the middleware cannot show the caller may still see what it is
 // handing back.
+//
+// SCOPE, NOT LIVENESS, and the difference is load-bearing. The primary probe is
+// EnsureVisibleLive because the recorded body carries that record's FIELDS —
+// erasure anonymises a person in place, and a frozen snapshot would hand back
+// names every live read now refuses. A companion is an id and nothing else, so
+// what a replay can disclose is that the record exists and what it was to this
+// call — a question of row scope.
+//
+// Using the live probe here would also refuse the retries this exists to serve:
+// promoting a lead ARCHIVES it, and demoting a person can archive them, so the
+// companion those calls name is archived by the very operation being replayed.
+// EnsureVisibleLive requires archived_at IS NULL, so every promote replay would
+// have answered 404.
 func ensureCompanionsVisible(ctx context.Context, pool *pgxpool.Pool, target replayTarget, body string) error {
 	for _, companion := range target.companions {
-		if !bodyHasField(body, companion.idPath) {
+		raw, err := stringAt(body, companion.idPath)
+		if err != nil || raw == "" {
+			// Absent, null, or not a string: the body names no record here.
 			continue
 		}
-		id, err := recordIDAt(body, companion.idPath)
+		id, err := ids.Parse(raw)
 		if err != nil {
-			return err
+			return apperrors.ErrNotFound
 		}
 		if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-			return auth.EnsureVisibleLive(ctx, tx, companion.table, id)
+			return auth.EnsureVisible(ctx, tx, companion.table, id)
 		}); err != nil {
 			return err
 		}

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -15,22 +15,6 @@ package compose
 // answering what governs it. Whatever a route does NOT re-check carries its
 // reason in the same entry — never silently.
 
-import (
-	"context"
-	"encoding/json"
-	"strings"
-
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/margince/margince/backend/internal/platform/auth"
-	"github.com/margince/margince/backend/internal/platform/database"
-	"github.com/margince/margince/backend/internal/platform/database/storekit"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
-	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-)
-
 // replayTarget locates the row-scoped record inside a recorded response:
 // which table it lives in, and where its id sits in the body. `activity`
 // scopes through its links rather than an owner column, so it takes the
@@ -62,6 +46,29 @@ type replayTarget struct {
 	// with a fresh key and a second message.
 	altTable  string
 	altMarker string // the body field whose presence means altTable
+	// companions are the OTHER row-scoped records a recorded body names.
+	//
+	// The primary record is what the replay is FOR; a companion is a record
+	// the body points at, and pointing at one discloses that it exists and
+	// what it was to this call. QuickCapturePersonResult hands back the person
+	// created plus the organization_id they were attached to, and probing only
+	// the person returned an employer id to a caller who may since have lost
+	// sight of that employer. PromoteLeadResponse has the same shape twice
+	// over.
+	//
+	// A companion missing from the body is not a failure: these fields are
+	// optional, and an absent one names no record. One that is PRESENT and no
+	// longer visible refuses the whole replay rather than being edited out —
+	// masking would hand the caller a body the product never produced, and the
+	// caller is retrying an operation whose answer they are entitled to only
+	// while they can still see what it says.
+	companions []companionRef
+}
+
+// companionRef is one record a body points at, and where its id sits.
+type companionRef struct {
+	table  string
+	idPath string
 }
 
 // The row-scoped tables, and the RBAC objects that mirror them word for word.
@@ -97,8 +104,12 @@ const (
 	// contract.
 	probeDealRoom = "deal_room"
 
-	// The field an offer names its deal by.
-	offerDealField = "deal_id"
+	// The fields a body names another record by, spelled where the table that
+	// uses them is.
+	offerDealField       = "deal_id"
+	companionPersonField = "person_id"
+	companionOrgField    = "organization_id"
+	companionLeadField   = "lead_id"
 
 	objectOffer         = "offer"
 	objectPipeline      = "pipeline"
@@ -143,11 +154,20 @@ const (
 var replayableOperations = map[string]replayTarget{
 	// Row-scoped records: both gates apply, and the object and the table are
 	// the same word by construction (policy.coreObjects mirrors the table).
-	"POST /v1/people":                   {object: tablePerson, table: tablePerson, idPath: "id"},
-	"POST /v1/people/quick-capture":     {object: tablePerson, table: tablePerson, idPath: "person.id"},
-	"PATCH /v1/people/{id}":             {object: tablePerson, table: tablePerson, idPath: "id"},
-	"POST /v1/people/{id}/merge":        {object: tablePerson, table: tablePerson, idPath: "id"},
-	"POST /v1/leads/{id}/promote":       {object: tablePerson, table: tablePerson, idPath: "person.id"},
+	"POST /v1/people": {object: tablePerson, table: tablePerson, idPath: "id"},
+	"POST /v1/people/quick-capture": {
+		object: tablePerson, table: tablePerson, idPath: "person.id",
+		companions: []companionRef{{table: tableOrganization, idPath: companionOrgField}},
+	},
+	"PATCH /v1/people/{id}":      {object: tablePerson, table: tablePerson, idPath: "id"},
+	"POST /v1/people/{id}/merge": {object: tablePerson, table: tablePerson, idPath: "id"},
+	"POST /v1/leads/{id}/promote": {
+		object: tablePerson, table: tablePerson, idPath: "person.id",
+		companions: []companionRef{
+			{table: tableLead, idPath: companionLeadField},
+			{table: tableDeal, idPath: offerDealField},
+		},
+	},
 	"POST /v1/organizations":            {object: tableOrganization, table: tableOrganization, idPath: "id"},
 	"PATCH /v1/organizations/{id}":      {object: tableOrganization, table: tableOrganization, idPath: "id"},
 	"POST /v1/organizations/{id}/merge": {object: tableOrganization, table: tableOrganization, idPath: "id"},
@@ -162,7 +182,7 @@ var replayableOperations = map[string]replayTarget{
 	"POST /v1/deals":                       {object: tableDeal, table: tableDeal, idPath: "id"},
 	"PATCH /v1/deals/{id}":                 {object: tableDeal, table: tableDeal, idPath: "id"},
 	"POST /v1/deals/{id}/advance":          {object: tableDeal, table: tableDeal, idPath: "id"},
-	"POST /v1/contracts":                   {object: "contract", moduleProbe: probeContract, idPath: "id", rowNote: "a contract carries no owner column; visibility is inherited from its deal or organization, so the contracts store owns the probe"},
+	"POST /v1/contracts":                   {object: probeContract, moduleProbe: probeContract, idPath: "id", rowNote: "a contract carries no owner column; visibility is inherited from its deal or organization, so the contracts store owns the probe"},
 	"POST /v1/deal-rooms":                  {object: probeDealRoom, moduleProbe: probeDealRoom, idPath: "id", rowNote: "a Deal Room carries no owner column; its visibility is its parent deal's, so the dealrooms store owns the probe"},
 	"POST /v1/projects":                    {object: tableProject, table: tableProject, idPath: "id"},
 	"PATCH /v1/projects/{id}":              {object: tableProject, table: tableProject, idPath: "id"},
@@ -170,13 +190,18 @@ var replayableOperations = map[string]replayTarget{
 	"POST /v1/projects/transfer-ownership": {object: tableProject, rowNote: "the response is a count, not a record: the handover's rows were each gated on the caller's write authority when it ran, and a replay hands back the number alone"},
 	"POST /v1/leads":                       {object: tableLead, table: tableLead, idPath: "id"},
 	"PATCH /v1/leads/{id}":                 {object: tableLead, table: tableLead, idPath: "id"},
-	"POST /v1/leads/{id}/demote":           {object: tableLead, table: tableLead, idPath: "lead.id"},
-	"POST /v1/activities":                  {object: tableActivity, table: tableActivity, idPath: "id"},
-	"POST /v1/tasks":                       {object: tableActivity, table: tableActivity, idPath: "id"},
-	"PATCH /v1/activities/{id}":            {object: tableActivity, table: tableActivity, idPath: "id"},
-	"POST /v1/activities/{id}/relink":      {object: tableActivity, table: tableActivity, idPath: "id"},
-	"POST /v1/activities/relink-thread":    {object: tableActivity, rowNote: "the response is a count, not a record: every row moved was gated on the caller's write authority when it ran, and a replay hands back the number alone"},
-	"POST /v1/activities/relink-bulk":      {object: tableActivity, rowNote: "the response is a count, not a record: every named row was gated on the caller's sight and write authority when it ran, or nothing moved at all"},
+	// The demote answers the lead it restored plus the person it was demoted
+	// FROM — a second record, beside the one the replay is keyed on.
+	"POST /v1/leads/{id}/demote": {
+		object: tableLead, table: tableLead, idPath: "lead.id",
+		companions: []companionRef{{table: tablePerson, idPath: companionPersonField}},
+	},
+	"POST /v1/activities":               {object: tableActivity, table: tableActivity, idPath: "id"},
+	"POST /v1/tasks":                    {object: tableActivity, table: tableActivity, idPath: "id"},
+	"PATCH /v1/activities/{id}":         {object: tableActivity, table: tableActivity, idPath: "id"},
+	"POST /v1/activities/{id}/relink":   {object: tableActivity, table: tableActivity, idPath: "id"},
+	"POST /v1/activities/relink-thread": {object: tableActivity, rowNote: "the response is a count, not a record: every row moved was gated on the caller's write authority when it ran, and a replay hands back the number alone"},
+	"POST /v1/activities/relink-bulk":   {object: tableActivity, rowNote: "the response is a count, not a record: every named row was gated on the caller's sight and write authority when it ran, or nothing moved at all"},
 	// A send answers its outbound ACTIVITY when it went now, and its SCHEDULED
 	// SEND when the caller asked for it later — different tables behind the
 	// same "id". scheduled_at is the discriminator because only the second
@@ -302,178 +327,4 @@ var replayableOperations = map[string]replayTarget{
 	// through the handler's own EnsureVisible; what a replay hands back is the
 	// receipt, which names no subject.
 	"POST /v1/people/{id}/enrichment-runs": {object: tablePerson, rowNote: "a run receipt: state, cost and requested categories, carrying no person values to scope"},
-}
-
-// replayProbe answers whether the caller may still see one record, for the
-// bodies whose scope rule lives inside a module rather than in a row-scoped
-// table. Compose injects them at the composition root, so this package borrows
-// the module's own rule instead of keeping a second copy that could drift.
-type replayProbe func(ctx context.Context, id ids.UUID) error
-
-// ensureReplayVisible re-runs, against the caller as they are NOW, whichever
-// gates govern the body about to be replayed. Anything it cannot resolve fails
-// CLOSED: the middleware cannot show the caller may still see what it is
-// handing back, and serving it on the strength of a parse failure is the one
-// outcome this exists to prevent.
-func ensureReplayVisible(ctx context.Context, pool *pgxpool.Pool, probes map[string]replayProbe, route, body string) error {
-	target, replayable := replayableOperations[route]
-	if !replayable {
-		// The middleware only claims keys for routes in this table, so this
-		// is unreachable; if it is ever reached, the unclassified case is
-		// exactly the one that must not pay out.
-		return apperrors.ErrNotFound
-	}
-
-	if target.table == "" && target.tableField == "" && target.moduleProbe == "" {
-		return nil
-	}
-
-	if target.moduleProbe != "" {
-		probe, wired := probes[target.moduleProbe]
-		if !wired {
-			// An unwired probe cannot show the caller may still see this, and
-			// the composition root is the only place that could have wired it.
-			return apperrors.ErrNotFound
-		}
-		id, err := replayRecordID(ctx, target, body)
-		if err != nil {
-			return err
-		}
-		return probe(ctx, id)
-	}
-
-	table := target.table
-	if target.tableField != "" {
-		resolved, err := stringAt(body, target.tableField)
-		if err != nil {
-			return err
-		}
-		table = resolved
-	}
-	// A route that answers two shapes says which one this body is. The marker
-	// is a field only the alternate carries, so the choice is read off the
-	// recorded body rather than guessed from the route.
-	if target.altTable != "" && bodyHasField(body, target.altMarker) {
-		table = target.altTable
-	}
-	id, err := replayRecordID(ctx, target, body)
-	if err != nil {
-		return err
-	}
-	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		switch table {
-		case tableActivity:
-			return auth.EnsureActivityContentVisibleLive(ctx, tx, id)
-		case tableSignal:
-			// A signal has no owner column but is scoped through its subject
-			// entity; "no owner_id" is never on its own a reason to skip.
-			return auth.EnsureSignalVisibleLive(ctx, tx, id)
-		case tableScheduledSend:
-			// A scheduled message is the SENDER's own — an unsent body and its
-			// blind-copy list are not workspace-readable the way a sent
-			// activity is — so the probe is the same scheduled_by predicate the
-			// store reads with, not the generic row-scope clause. It also has
-			// no archived_at, which the generic probe requires.
-			return ensureScheduledSendVisibleLive(ctx, tx, id)
-		}
-		// LIVE, not merely visible. The recorded body is a frozen snapshot the
-		// store itself would no longer serve: Art. 17 erasure anonymizes the
-		// person row in place, stamps archived_at and leaves owner_id alone, so
-		// a plain visibility probe still answers "yours" and the middleware
-		// would hand back the pre-erasure names, e-mails and phone numbers that
-		// every live read path now refuses. EnsureVisibleLive also declines to
-		// skip the existence half for an unbounded actor, which is the same
-		// hole one role wider.
-		//
-		// auth rejects any name outside its closed row-scoped set, so an
-		// unexpected value refuses the replay rather than reaching SQL.
-		return auth.EnsureVisibleLive(ctx, tx, table, id)
-	})
-}
-
-// ensureScheduledSendVisibleLive refuses a replay whose scheduled message no
-// longer belongs to the caller. Existence-hiding, like every other row scope:
-// somebody else's message is not found rather than forbidden.
-func ensureScheduledSendVisibleLive(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
-	actor, err := storekit.Actor(ctx)
-	if err != nil {
-		return err
-	}
-	var visible bool
-	if err := tx.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM scheduled_send WHERE id = $1 AND scheduled_by = $2)`,
-		id, actor.UserID).Scan(&visible); err != nil {
-		return err
-	}
-	if !visible {
-		return apperrors.ErrNotFound
-	}
-	return nil
-}
-
-// bodyHasField reports whether the recorded body carries a non-null field —
-// the discriminator between two response shapes one route can answer.
-func bodyHasField(body, field string) bool {
-	if field == "" {
-		return false
-	}
-	var probe map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(body), &probe); err != nil {
-		return false
-	}
-	raw, ok := probe[field]
-	return ok && string(raw) != jsonNull
-}
-
-// replayRecordID resolves the record whose scope governs this body: from the
-// recorded body where it names its own record, or from the route parameter
-// naming its parent where the body is a projection that omits it.
-func replayRecordID(ctx context.Context, target replayTarget, body string) (ids.UUID, error) {
-	if target.pathParam == "" {
-		return recordIDAt(body, target.idPath)
-	}
-	raw := chi.RouteContext(ctx).URLParam(target.pathParam)
-	id, err := ids.Parse(raw)
-	if err != nil {
-		return ids.UUID{}, apperrors.ErrNotFound
-	}
-	return id, nil
-}
-
-// recordIDAt walks a dotted path to the record id in a recorded body.
-func recordIDAt(body, path string) (ids.UUID, error) {
-	raw, err := stringAt(body, path)
-	if err != nil {
-		return ids.UUID{}, err
-	}
-	id, err := ids.Parse(raw)
-	if err != nil {
-		return ids.UUID{}, apperrors.ErrNotFound
-	}
-	return id, nil
-}
-
-// stringAt walks a dotted path to a string in a recorded body. Every miss is
-// ErrNotFound rather than a distinct error: whichever way the body surprised
-// us, the middleware cannot prove the caller may still see what it is about to
-// hand back, and that is the client-visible fact.
-func stringAt(body, path string) (string, error) {
-	var node any
-	if err := json.Unmarshal([]byte(body), &node); err != nil {
-		return "", apperrors.ErrNotFound
-	}
-	for _, segment := range strings.Split(path, ".") {
-		object, ok := node.(map[string]any)
-		if !ok {
-			return "", apperrors.ErrNotFound
-		}
-		if node, ok = object[segment]; !ok {
-			return "", apperrors.ErrNotFound
-		}
-	}
-	text, ok := node.(string)
-	if !ok {
-		return "", apperrors.ErrNotFound
-	}
-	return text, nil
 }

--- a/backend/internal/compose/replayscope_test.go
+++ b/backend/internal/compose/replayscope_test.go
@@ -13,6 +13,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -241,9 +242,14 @@ func TestReplayRefusesACompanionItCannotRead(t *testing.T) {
 // verdict. The nil pool is the second half — reaching the database would panic,
 // so nil is proof the loop skipped rather than probed.
 func TestReplaySkipsACompanionTheBodyDoesNotName(t *testing.T) {
-	target := replayableOperations["POST /v1/people/quick-capture"]
-	if len(target.companions) == 0 {
-		t.Fatal("quick-capture declares no companion, so this test asserts nothing")
+	const route = "POST /v1/people/quick-capture"
+	target := replayableOperations[route]
+	// The companion this case is ABOUT, not merely one: with a different path
+	// both bodies below read as absent and the case passes having exercised
+	// nothing.
+	if !slices.Contains(target.companions, companionRef{table: tableOrganization, idPath: companionOrgField}) {
+		t.Fatalf("%s declares companions %+v, and this case is about {organization, %s} — with a different path both bodies read as absent",
+			route, target.companions, companionOrgField)
 	}
 	for _, body := range []string{
 		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"}}`,
@@ -323,5 +329,21 @@ func TestReplayTableForPicksTheShapeTheBodyIs(t *testing.T) {
 				t.Errorf("table = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+// A companion present as an EMPTY STRING is a body the middleware cannot vouch
+// for, not a body that names no record. Skipping it would replay a malformed
+// answer on the strength of a valid primary.
+//
+// It sits beside the skip case deliberately: an empty string resolves through
+// stringAt as ("", nil) — present, unlike absent or null — and is what tells a
+// reader that "the field is there but says nothing" refuses while "the field is
+// not there" does not.
+func TestReplayRefusesAnEmptyCompanionID(t *testing.T) {
+	err := ensureReplayVisible(context.Background(), nil, nil, "POST /v1/people/quick-capture",
+		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"organization_id":""}`)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }

--- a/backend/internal/compose/replayscope_test.go
+++ b/backend/internal/compose/replayscope_test.go
@@ -249,3 +249,14 @@ func TestReplaySkipsACompanionTheBodyDoesNotName(t *testing.T) {
 		}
 	}
 }
+
+// A companion present as an EMPTY STRING is a body the middleware cannot
+// vouch for, not a body that names no record. Skipping it would replay a
+// malformed answer on the strength of a valid primary.
+func TestReplayRefusesAnEmptyCompanionID(t *testing.T) {
+	err := ensureReplayVisible(context.Background(), nil, nil, "POST /v1/people/quick-capture",
+		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"organization_id":""}`)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/internal/compose/replayscope_test.go
+++ b/backend/internal/compose/replayscope_test.go
@@ -232,32 +232,26 @@ func TestReplayRefusesACompanionItCannotRead(t *testing.T) {
 
 // A companion that is absent, or present and null, names no record — these
 // fields are optional by contract, and a person captured with no employer
-// carries no organization id. Skipping them is not a hole: there is nothing
-// to probe.
+// carries no organization id. Skipping them is not a hole: there is nothing to
+// probe.
 //
-// Asserted through the PRIMARY's own refusal, so the case still proves the
-// companion arm ran and passed: an unreadable primary refuses, and reaching
-// that refusal means the companion loop neither panicked on a nil pool nor
-// refused first.
+// Asserted against ensureCompanionsVisible DIRECTLY, and it has to be: through
+// the whole gate both a skip and a refusal answer ErrNotFound, so a version
+// that rejected every optional shape would pass a test that only read the
+// verdict. The nil pool is the second half — reaching the database would panic,
+// so nil is proof the loop skipped rather than probed.
 func TestReplaySkipsACompanionTheBodyDoesNotName(t *testing.T) {
-	for _, body := range []string{
-		`{"person":{"id":"garbage"}}`,
-		`{"person":{"id":"garbage"},"organization_id":null}`,
-	} {
-		if err := ensureReplayVisible(context.Background(), nil, nil, "POST /v1/people/quick-capture", body); !errors.Is(err, apperrors.ErrNotFound) {
-			t.Fatalf("body %s: err = %v, want the PRIMARY's ErrNotFound", body, err)
-		}
+	target := replayableOperations["POST /v1/people/quick-capture"]
+	if len(target.companions) == 0 {
+		t.Fatal("quick-capture declares no companion, so this test asserts nothing")
 	}
-}
-
-// A companion present as an EMPTY STRING is a body the middleware cannot
-// vouch for, not a body that names no record. Skipping it would replay a
-// malformed answer on the strength of a valid primary.
-func TestReplayRefusesAnEmptyCompanionID(t *testing.T) {
-	err := ensureReplayVisible(context.Background(), nil, nil, "POST /v1/people/quick-capture",
-		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"organization_id":""}`)
-	if !errors.Is(err, apperrors.ErrNotFound) {
-		t.Fatalf("err = %v, want ErrNotFound", err)
+	for _, body := range []string{
+		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"}}`,
+		`{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"organization_id":null}`,
+	} {
+		if err := ensureCompanionsVisible(context.Background(), nil, target, body); err != nil {
+			t.Errorf("body %s: err = %v, want nil — an optional companion the body does not name is skipped, not refused", body, err)
+		}
 	}
 }
 

--- a/backend/internal/compose/replayscope_test.go
+++ b/backend/internal/compose/replayscope_test.go
@@ -196,3 +196,56 @@ func TestReplayRefusesBeforeQueryingWhenTheIDIsUnreadable(t *testing.T) {
 		})
 	}
 }
+
+// A companion reference the body carries but cannot be read as an id refuses
+// before any transaction opens, exactly as the primary does.
+//
+// The nil pool is the assertion: reaching the database would panic, so
+// surviving the call is proof the refusal came first. It is also what makes
+// this case readable — a companion whose value is garbage is a body the
+// middleware cannot vouch for, and "cannot tell" is not "allowed".
+func TestReplayRefusesACompanionItCannotRead(t *testing.T) {
+	for _, tc := range []struct{ name, route, body string }{
+		{
+			name:  "quick capture names an unreadable employer",
+			route: "POST /v1/people/quick-capture",
+			body:  `{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"organization_id":"garbage"}`,
+		},
+		{
+			name:  "a promotion names an unreadable deal",
+			route: "POST /v1/leads/{id}/promote",
+			body:  `{"person":{"id":"01a00000-0000-7000-8000-000000000001"},"deal_id":"garbage"}`,
+		},
+		{
+			name:  "a demotion names an unreadable person",
+			route: "POST /v1/leads/{id}/demote",
+			body:  `{"lead":{"id":"01a00000-0000-7000-8000-000000000001"},"person_id":"garbage"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ensureReplayVisible(context.Background(), nil, nil, tc.route, tc.body); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Fatalf("err = %v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+// A companion that is absent, or present and null, names no record — these
+// fields are optional by contract, and a person captured with no employer
+// carries no organization id. Skipping them is not a hole: there is nothing
+// to probe.
+//
+// Asserted through the PRIMARY's own refusal, so the case still proves the
+// companion arm ran and passed: an unreadable primary refuses, and reaching
+// that refusal means the companion loop neither panicked on a nil pool nor
+// refused first.
+func TestReplaySkipsACompanionTheBodyDoesNotName(t *testing.T) {
+	for _, body := range []string{
+		`{"person":{"id":"garbage"}}`,
+		`{"person":{"id":"garbage"},"organization_id":null}`,
+	} {
+		if err := ensureReplayVisible(context.Background(), nil, nil, "POST /v1/people/quick-capture", body); !errors.Is(err, apperrors.ErrNotFound) {
+			t.Fatalf("body %s: err = %v, want the PRIMARY's ErrNotFound", body, err)
+		}
+	}
+}

--- a/backend/internal/compose/replayscope_test.go
+++ b/backend/internal/compose/replayscope_test.go
@@ -260,3 +260,74 @@ func TestReplayRefusesAnEmptyCompanionID(t *testing.T) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
+
+// replayTableFor is the choice of WHICH table a body's record lives in, and it
+// has three answers with three different failure modes.
+//
+// Getting it wrong is not a refusal, it is a lookup in the wrong table: a send
+// answered as an activity when it was scheduled finds nothing and turns a
+// legitimate retry into a 404, which a client then "recovers" from with a fresh
+// key and a second message to the customer.
+func TestReplayTableForPicksTheShapeTheBodyIs(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		target replayTarget
+		body   string
+		want   string
+		refuse bool
+	}{
+		{
+			name:   "the entry's own table when it names one",
+			target: replayTarget{table: tablePerson, idPath: "id"},
+			body:   `{"id":"x"}`,
+			want:   tablePerson,
+		},
+		{
+			name:   "a send that went now is its activity",
+			target: replayTarget{table: tableActivity, altTable: tableScheduledSend, altMarker: "scheduled_at"},
+			body:   `{"id":"x"}`,
+			want:   tableActivity,
+		},
+		{
+			name:   "a send that will go later is its scheduled send",
+			target: replayTarget{table: tableActivity, altTable: tableScheduledSend, altMarker: "scheduled_at"},
+			body:   `{"id":"x","scheduled_at":"2026-07-05T09:00:00Z"}`,
+			want:   tableScheduledSend,
+		},
+		{
+			// Present and null is the same answer as absent: the field carries
+			// no discriminator, so the body is the primary shape.
+			name:   "a null marker is not the alternate shape",
+			target: replayTarget{table: tableActivity, altTable: tableScheduledSend, altMarker: "scheduled_at"},
+			body:   `{"id":"x","scheduled_at":null}`,
+			want:   tableActivity,
+		},
+		{
+			name:   "a polymorphic reference reads its table off the body",
+			target: replayTarget{tableField: "record_type", idPath: "record_id"},
+			body:   `{"record_type":"deal","record_id":"x"}`,
+			want:   tableDeal,
+		},
+		{
+			// The table is the thing being resolved, so a body that does not
+			// name one cannot be probed at all.
+			name:   "a polymorphic reference with no table refuses",
+			target: replayTarget{tableField: "record_type", idPath: "record_id"},
+			body:   `{"record_id":"x"}`,
+			refuse: true,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := replayTableFor(c.target, c.body)
+			switch {
+			case c.refuse && !errors.Is(err, apperrors.ErrNotFound):
+				t.Fatalf("err = %v, want ErrNotFound", err)
+			case c.refuse:
+			case err != nil:
+				t.Fatalf("err = %v, want nil", err)
+			case got != c.want:
+				t.Errorf("table = %q, want %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2914.

## What was wrong

`replayableOperations` mapped each replayable route to **one** row-scoped record, and `ensureReplayVisible` probed that record before handing back the stored body. When the body carried a **second** reference, nothing probed it.

`POST /v1/people/quick-capture` answers `QuickCapturePersonResult`: the person created, plus the `organization_id` they were attached to. The entry declared `idPath: "person.id"`, so a replay that found the person visible returned the whole body — including an employer id the caller may since have lost sight of. `PromoteLeadResponse` has the same shape.

Narrow but real, exactly as the issue frames it: an existence disclosure, to somebody who made the call in the first place, for the claim's lifetime.

## The fix

A `replayTarget` can declare `companions`, and the gate walks them after the primary.

A companion the body does not name is **skipped** — these fields are optional by contract, and a person captured with no employer names no organization. One that is present and no longer visible **refuses the whole replay** rather than being edited out: masking would hand the caller a body the product never produced, and the caller is retrying an operation whose answer they are entitled to only while they can still see what it says.

## The gate found the third one

Widened to derive the requirement from the contract, `TestReplayScopeCoversEveryIdempotentOperation` reported `DemoteLeadResponse`'s `person_id` — the person a lead was demoted from — which the issue does not mention.

It applies only to a body that **wraps** a record, and that distinction is the whole rule:

- `organization_id` on a `Deal` is the deal's own field. The live read of that deal returns it to anyone who can see the deal, so replaying it discloses nothing the product would not — demanding a probe there would turn legitimate retries into 404s.
- `organization_id` beside a person on `QuickCapturePersonResult` names a **second** record the live path never hands back with them.

A dotted `idPath` is what says the body is a wrapper. Both directions are held: a companion the contract carries that nothing probes, and a probe for a field the schema does not have — which would read a field that is never there and pass for free.

Mutation-checked: dropping a companion fails the first arm, adding a phantom one fails the second, and removing the runtime probe fails three unit cases.

## Incidental

`replayscope.go` crossed the 500-line cap, so the probe machinery moved to `replayprobe.go`. The split is by what a reader came for: `replayscope.go` is the **table** — what governs each route and why anything unchecked is unchecked — and the new file is what a probe **does**.

`POST /v1/contracts` named its object as a raw `"contract"` beside the `probeContract` constant; `TestAClaimedSpellingIsTheOnlySpellingWhereItIsUsed` flagged it once the file was touched, and it now uses the constant like its Deal Room neighbour.

## Checks

`make check-backend`, `make craft-static` and the full `make -C backend test-integration` (48 packages, 0 skips) green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Replayed requests now re-check authorization for every referenced record, including related organizations and leads.
  * Access is denied when referenced records are invalid, unavailable, or unauthorized.
  * Missing or null optional records are handled without disrupting valid replays.
* **Bug Fixes**
  * Idempotent lead-promotion requests can be replayed successfully after the original lead is archived.
* **Documentation**
  * Added changelog coverage for enhanced replay authorization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->