### PR TITLE
Who is waiting for a reply is its own source on the Worklist

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31249,7 +31249,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, customer_waiting, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice]
           description: "Which producer raised it, and therefore which endpoint its verbs go to."
         kind: { type: string, description: 'The producer''s own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority.' }
         title:
@@ -31444,7 +31444,7 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice]
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, customer_waiting, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice]
           description: 'Which producer raised it, and therefore which endpoint its verbs go to.'
         category:
           type: string

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -21,6 +21,16 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
+// sourceWaiting names the who-is-waiting producer. A named constant rather
+// than the literal at each site: the classifier, the dedupe and the
+// source-unavailable report all reach for it, and a typo in any of them would
+// produce a lane nothing joins up — silently, because each half would still
+// compile.
+const sourceWaiting = "customer_waiting"
+
+// subjectDeal is the subject type a deal-shaped row names.
+const subjectDeal = "deal"
+
 // classifyDay turns the assembled lanes into ranked candidates.
 //
 // Order of appearance does not matter — rankAll decides the order — so the lanes
@@ -255,8 +265,8 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	}
 	row := crmcontracts.WorklistItem{
 		Id:          waiting.ActivityID.String(),
-		Source:      "customer_waiting",
-		Category:    "customer_waiting",
+		Source:      sourceWaiting,
+		Category:    sourceWaiting,
 		Level:       levelWaiting,
 		Consequence: "buyer_waits",
 		Because: []crmcontracts.WorklistReason{
@@ -265,14 +275,19 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 		},
 		Actions: []crmcontracts.WorklistItemActions{},
 	}
-	if subject != "" {
+	// The subject line is CONTENT. A reader admitted to know that somebody is
+	// waiting is not thereby admitted to read what they wrote, so a withheld
+	// message travels without its words and the client names it generically.
+	// `readable` is the same arm the timeline applies; this only refuses to
+	// undo it.
+	if subject != "" && waiting.Readable {
 		row.Title = &subject
 	}
 	// The record the reply would be about, most specific first: the deal a
 	// thread belongs to says more than the company it is filed under.
 	switch {
 	case !waiting.DealID.IsZero():
-		row.Subject = subjectOf("deal", waiting.DealID)
+		row.Subject = subjectOf(subjectDeal, waiting.DealID)
 	case !waiting.PersonID.IsZero():
 		row.Subject = subjectOf("person", waiting.PersonID)
 	case !waiting.OrganizationID.IsZero():
@@ -296,8 +311,8 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 func dropDealsAlreadyWaiting(rows []ranked) []ranked {
 	waitingDeals := map[string]bool{}
 	for _, row := range rows {
-		if row.item.Source == "customer_waiting" && row.item.Subject != nil &&
-			row.item.Subject.Type == "deal" {
+		if row.item.Source == sourceWaiting && row.item.Subject != nil &&
+			row.item.Subject.Type == subjectDeal {
 			waitingDeals[row.item.Subject.Id.String()] = true
 		}
 	}

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -237,6 +237,83 @@ func moneyOf(minor int64) *crmcontracts.WorklistValue {
 	return &crmcontracts.WorklistValue{Kind: "money", Minor: &value}
 }
 
+// classifyWaiting: somebody wrote and nobody answered.
+//
+// Level 1, the top band below a pin, and the reason is the concept's own: a
+// customer waiting on a reply is the one thing on this page where the cost of
+// doing nothing falls on somebody else. It outranks a promise, a drifting deal
+// and every decision.
+//
+// The draft verb is offered only when the message can be READ. There is no
+// drafting a reply to words this reader may not see, and a button that opened
+// an empty composer would be worse than no button.
+func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
+	subject := waiting.Subject
+	days := int(asOf.Sub(waiting.Since).Hours() / 24)
+	if days < 0 {
+		days = 0
+	}
+	row := crmcontracts.WorklistItem{
+		Id:          waiting.ActivityID.String(),
+		Source:      "customer_waiting",
+		Category:    "customer_waiting",
+		Level:       levelWaiting,
+		Consequence: "buyer_waits",
+		Because: []crmcontracts.WorklistReason{
+			reason("buyer_wrote_last", nil),
+			reason("waiting_days", daysValue(days)),
+		},
+		Actions: []crmcontracts.WorklistItemActions{},
+	}
+	if subject != "" {
+		row.Title = &subject
+	}
+	// The record the reply would be about, most specific first: the deal a
+	// thread belongs to says more than the company it is filed under.
+	switch {
+	case !waiting.DealID.IsZero():
+		row.Subject = subjectOf("deal", waiting.DealID)
+	case !waiting.PersonID.IsZero():
+		row.Subject = subjectOf("person", waiting.PersonID)
+	case !waiting.OrganizationID.IsZero():
+		row.Subject = subjectOf("organization", waiting.OrganizationID)
+	}
+	if openableSubject(row.Subject) {
+		row.Actions = append(row.Actions, crmcontracts.WorklistItemActions(actionOpen))
+	}
+	occurred := waiting.Since
+	row.OccurredAt = &occurred
+	return ranked{item: row, waitingDays: days, occurredAt: waiting.Since}
+}
+
+// dropDealsAlreadyWaiting removes the at-risk row for a deal somebody is
+// already waiting on.
+//
+// One unanswered message must not become two rows. The waiting row is strictly
+// the more urgent and the more actionable of the two — it names the message to
+// reply to — so it wins, and the drifting row's ground rides along as a reason
+// rather than as a second obligation.
+func dropDealsAlreadyWaiting(rows []ranked) []ranked {
+	waitingDeals := map[string]bool{}
+	for _, row := range rows {
+		if row.item.Source == "customer_waiting" && row.item.Subject != nil &&
+			row.item.Subject.Type == "deal" {
+			waitingDeals[row.item.Subject.Id.String()] = true
+		}
+	}
+	if len(waitingDeals) == 0 {
+		return rows
+	}
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if row.item.Source == "deal_at_risk" && waitingDeals[row.item.Id] {
+			continue
+		}
+		kept = append(kept, row)
+	}
+	return kept
+}
+
 // classifyBriefItem: what the overnight run put at the top of the day. It is a
 // suggestion about where to start rather than something waiting on the reader,
 // so it sits with agreed work — but it belongs ON the queue, because a lane the

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -50,6 +50,10 @@ type Service struct {
 	commitments Commitments
 	// atRisk is OPTIONAL for the reason commitments is: absent lane, not empty.
 	atRisk AtRisk
+	// waiting is OPTIONAL like the lanes above it: an installation that does
+	// not read the mail stream cannot say who is waiting, which is different
+	// from saying nobody is.
+	waiting Waiting
 	// decay is OPTIONAL for the same reason, and says nothing about atRisk:
 	// an installation can warn about deals without deriving relationships.
 	decay    Decay
@@ -104,6 +108,17 @@ func NewService(
 		approvals: a, duplicates: d, tasks: t, receipts: r, briefing: b,
 		commitments: c, atRisk: k, decay: q, meetings: m, failed: f, dsrs: s, syncHealth: h, captureHealth: g, aiWork: w, bounces: o, automations: u, notices: e, names: n, now: now,
 	}
+}
+
+// WithWaiting binds the who-is-waiting reader.
+//
+// An option rather than another positional argument: NewService already takes
+// nineteen, and the next reader to add one would be adding the twentieth to a
+// call nobody can read. The lane is absent when it is not bound, which is the
+// same promise every optional lane makes.
+func (s *Service) WithWaiting(w Waiting) *Service {
+	s.waiting = w
+	return s
 }
 
 // Assemble reads every lane and returns the day.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -296,6 +296,35 @@ type QuietRelationship struct {
 	LastAt time.Time
 }
 
+// Waiting is who has written to this workspace and had no reply.
+//
+// Its own reader rather than a filter over AtRisk, because a fresh inbound
+// makes a deal LESS quiet: deriving "waiting" from "quiet" loses the newest
+// cases, which are the ones a rep most needs. It also reaches a person with no
+// deal at all, whom the deal-shaped lanes never see.
+type Waiting interface {
+	Unanswered(ctx context.Context) ([]WaitingCustomer, error)
+}
+
+// WaitingCustomer is one message nobody has answered.
+type WaitingCustomer struct {
+	// ActivityID is the message itself — what a reply would be drafted to.
+	ActivityID ids.UUID
+	Subject    string
+	// Since is when they wrote. The wait is measured from it, and it is what
+	// the card says out loud.
+	Since time.Time
+	// Readable says whether this reader may see the message's words. A
+	// withheld message still proves somebody is waiting; it just cannot be
+	// answered from here, so the card offers no draft.
+	Readable bool
+	// The record the thread is filed under, most specific first. Any may be
+	// zero: a message from a stranger names nobody.
+	PersonID       ids.UUID
+	OrganizationID ids.UUID
+	DealID         ids.UUID
+}
+
 // Meetings is today's booked meetings that have not happened yet.
 //
 // Optional as the other two are: nil means this feed does not read meetings,

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -137,7 +137,7 @@ func TestAPageOfTheReadersOwnIsNotShortenedByColleaguesRows(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &at}
 
-	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3)
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3, nil)
 
 	if len(out.Queue) != 3 {
 		t.Fatalf("a reader with three of their own rows got a page of %d", len(out.Queue))

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -17,9 +17,11 @@ package attention
 
 import (
 	"context"
+	"errors"
 	"sort"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -56,7 +58,14 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
-	out := s.worklistFrom(ctx, day, resolved, filter, limit)
+	// Read beside the assembled day rather than inside it: /attention has its
+	// own fourteen-lane promise and this source is not one of its lanes. A
+	// refused read is named, never folded into an empty answer.
+	waiting, waitingErr := s.waitingCustomers(ctx)
+	out := s.worklistFrom(ctx, day, resolved, filter, limit, waiting)
+	if waitingErr != nil {
+		out.SourcesUnavailable = append(out.SourcesUnavailable, *waitingErr)
+	}
 	out.Scope = crmcontracts.WorklistScope(resolved)
 	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
 	return out, nil
@@ -103,8 +112,34 @@ func scopeOptions(options []string) []crmcontracts.WorklistScopeOptions {
 
 // worklistFrom projects an already-assembled day, so a test can drive the
 // ranking, the paging and the summary without standing up every lane's reader.
+// waitingCustomers reads who is waiting, or names why it could not.
+//
+// A refusal is reported as a withheld source; any other failure as a failed
+// one. Neither takes the rest of the day down with it — a page that answered
+// nothing because one source stumbled is less useful than a page that says
+// which part it could not read.
+func (s *Service) waitingCustomers(ctx context.Context) ([]WaitingCustomer, *crmcontracts.WorklistSourceUnavailable) {
+	if s.waiting == nil {
+		return nil, nil
+	}
+	rows, err := s.waiting.Unanswered(ctx)
+	switch {
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return nil, &crmcontracts.WorklistSourceUnavailable{
+			Source: "customer_waiting", Reason: crmcontracts.Withheld,
+		}
+	case err != nil:
+		return nil, &crmcontracts.WorklistSourceUnavailable{
+			Source: "customer_waiting", Reason: crmcontracts.Failed,
+		}
+	default:
+		return rows, nil
+	}
+}
+
 func (s *Service) worklistFrom(
 	ctx context.Context, day crmcontracts.Attention, scope, filter string, limit int,
+	waiting []WaitingCustomer,
 ) crmcontracts.Worklist {
 	if limit <= 0 {
 		limit = worklistPage
@@ -113,6 +148,12 @@ func (s *Service) worklistFrom(
 		limit = worklistMaxPage
 	}
 	rows := classifyDay(day, day.AsOf)
+	for _, customer := range waiting {
+		rows = append(rows, classifyWaiting(customer, day.AsOf))
+	}
+	// One unanswered message is one row: the deal it belongs to does not also
+	// appear as drifting.
+	rows = dropDealsAlreadyWaiting(rows)
 	if mineOnly(scope) {
 		rows = keepReadersOwn(ctx, rows)
 	}

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -126,11 +126,11 @@ func (s *Service) waitingCustomers(ctx context.Context) ([]WaitingCustomer, *crm
 	switch {
 	case errors.Is(err, apperrors.ErrPermissionDenied):
 		return nil, &crmcontracts.WorklistSourceUnavailable{
-			Source: "customer_waiting", Reason: crmcontracts.Withheld,
+			Source: sourceWaiting, Reason: crmcontracts.Withheld,
 		}
 	case err != nil:
 		return nil, &crmcontracts.WorklistSourceUnavailable{
-			Source: "customer_waiting", Reason: crmcontracts.Failed,
+			Source: sourceWaiting, Reason: crmcontracts.Failed,
 		}
 	default:
 		return rows, nil

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -457,3 +457,41 @@ func TestTheLongestWaitLeadsAmongWaitingCustomers(t *testing.T) {
 		t.Fatal("the two-day wait outranked the eighty-three-day one")
 	}
 }
+
+// Being told somebody is waiting is not permission to read what they wrote.
+// A withheld message travels without its subject line, and the client names it
+// generically.
+func TestAWithheldWaitingMessageTravelsWithoutItsSubject(t *testing.T) {
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000dddd"),
+		Subject:    "Re: our confidential pricing",
+		Since:      rankInstant.Add(-24 * time.Hour),
+		Readable:   false,
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waiting)
+
+	if out.Queue[0].Title != nil {
+		t.Fatalf("a message this reader may not read published its subject %q", *out.Queue[0].Title)
+	}
+	if len(out.Queue) != 1 {
+		t.Fatal("the withheld message stopped being reported at all — the wait is still a fact")
+	}
+}
+
+// A readable one keeps its subject: withholding everything would make the lane
+// useless to the reader it is for.
+func TestAReadableWaitingMessageKeepsItsSubject(t *testing.T) {
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000eeee"),
+		Subject:    "Re: pricing",
+		Since:      rankInstant.Add(-24 * time.Hour),
+		Readable:   true,
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waiting)
+
+	if out.Queue[0].Title == nil || *out.Queue[0].Title != "Re: pricing" {
+		t.Fatal("a readable message lost its subject line")
+	}
+}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 func item(id string, source crmcontracts.AttentionItemSource, opts ...func(*crmcontracts.AttentionItem)) crmcontracts.AttentionItem {
@@ -321,7 +322,7 @@ func TestThePageIsSummarisedAndExplainedAgainstItself(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3)
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3, nil)
 
 	if out.Summary.Total != len(out.Queue) {
 		t.Fatalf("summary totals %d over a page of %d", out.Summary.Total, len(out.Queue))
@@ -388,5 +389,71 @@ func TestTheBiggerOfTwoDealsIsMaterial(t *testing.T) {
 		if row.item.Level != want {
 			t.Fatalf("%q landed at level %d, wanted %d", row.item.Id, row.item.Level, want)
 		}
+	}
+}
+
+// Somebody waiting on a reply is the top of the day, above every decision and
+// every drifting deal. It is the one thing here whose cost of inaction falls on
+// somebody else.
+func TestAWaitingCustomerLeadsTheDay(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:     rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{item("decision", "approval", withKind("send_email"))},
+		AtRisk:   lane(item("drifting", "deal_at_risk", withDeal(500_000_00))),
+	}
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000aaaa"),
+		Subject:    "Re: pricing",
+		Since:      rankInstant.Add(-83 * 24 * time.Hour),
+		Readable:   true,
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waiting)
+
+	if out.Queue[0].Source != "customer_waiting" {
+		t.Fatalf("the day led with %q, not the customer who is waiting", out.Queue[0].Source)
+	}
+	if out.Queue[0].Consequence != "buyer_waits" {
+		t.Fatalf("a waiting customer says %q happens if ignored", out.Queue[0].Consequence)
+	}
+}
+
+// One unanswered message is ONE row. The deal it belongs to must not also
+// appear as drifting, or the rep is asked twice for the same reply.
+func TestAWaitingDealDoesNotAlsoAppearAsDrifting(t *testing.T) {
+	deal := ids.MustParse("01a05500-0000-7000-8000-00000000bbbb")
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item(deal.String(), "deal_at_risk", withDeal(160_100_00))),
+	}
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000cccc"),
+		Since:      rankInstant.Add(-3 * 24 * time.Hour),
+		Readable:   true,
+		DealID:     deal,
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waiting)
+
+	if len(out.Queue) != 1 {
+		t.Fatalf("one unanswered message produced %d rows", len(out.Queue))
+	}
+	if out.Queue[0].Source != "customer_waiting" {
+		t.Fatalf("the surviving row was %q, wanted the waiting one", out.Queue[0].Source)
+	}
+}
+
+// The longer somebody has waited, the higher they sit — among people who are
+// all waiting, the forgotten one is the one at risk.
+func TestTheLongestWaitLeadsAmongWaitingCustomers(t *testing.T) {
+	waiting := []WaitingCustomer{
+		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000a"), Since: rankInstant.Add(-2 * 24 * time.Hour), Readable: true},
+		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000b"), Since: rankInstant.Add(-83 * 24 * time.Hour), Readable: true},
+	}
+
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waiting)
+
+	if out.Queue[0].Id != "01a05500-0000-7000-8000-00000000000b" {
+		t.Fatal("the two-day wait outranked the eighty-three-day one")
 	}
 }

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -238,6 +238,34 @@ func quietRelationships(
 	return lapsed
 }
 
+// attentionWaiting binds the who-is-waiting lane to the activities module's
+// own gated read. The thread walk, the discover gate and the audience arm all
+// live there; nothing about who may see what is decided here.
+type attentionWaiting struct {
+	store *activities.Store
+	now   attention.Clock
+}
+
+func (w attentionWaiting) Unanswered(ctx context.Context) ([]attention.WaitingCustomer, error) {
+	rows, err := w.store.WaitingReplies(ctx, w.now())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]attention.WaitingCustomer, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, attention.WaitingCustomer{
+			ActivityID:     row.ActivityID,
+			Subject:        row.Subject,
+			Since:          row.OccurredAt,
+			Readable:       row.Readable,
+			PersonID:       row.PersonID,
+			OrganizationID: row.OrganizationID,
+			DealID:         row.DealID,
+		})
+	}
+	return out, nil
+}
+
 // attentionMeetings reads today's remaining meetings through the activities
 // store — the same gated list every other activity surface reads.
 //

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -475,5 +475,5 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 			projects:   projects.NewStore(db),
 		},
 		now,
-	)
+	).WithWaiting(attentionWaiting{store: activities.NewStore(db), now: now})
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1375,6 +1375,7 @@ const (
 	AttentionItemSourceBriefItem         AttentionItemSource = "brief_item"
 	AttentionItemSourceCaptureHealth     AttentionItemSource = "capture_health"
 	AttentionItemSourceConversationClaim AttentionItemSource = "conversation_claim"
+	AttentionItemSourceCustomerWaiting   AttentionItemSource = "customer_waiting"
 	AttentionItemSourceDealAtRisk        AttentionItemSource = "deal_at_risk"
 	AttentionItemSourceDedupeCandidate   AttentionItemSource = "dedupe_candidate"
 	AttentionItemSourceDsr               AttentionItemSource = "dsr"
@@ -1402,6 +1403,8 @@ func (e AttentionItemSource) Valid() bool {
 	case AttentionItemSourceCaptureHealth:
 		return true
 	case AttentionItemSourceConversationClaim:
+		return true
+	case AttentionItemSourceCustomerWaiting:
 		return true
 	case AttentionItemSourceDealAtRisk:
 		return true
@@ -11404,6 +11407,7 @@ const (
 	WorklistItemSourceBriefItem         WorklistItemSource = "brief_item"
 	WorklistItemSourceCaptureHealth     WorklistItemSource = "capture_health"
 	WorklistItemSourceConversationClaim WorklistItemSource = "conversation_claim"
+	WorklistItemSourceCustomerWaiting   WorklistItemSource = "customer_waiting"
 	WorklistItemSourceDealAtRisk        WorklistItemSource = "deal_at_risk"
 	WorklistItemSourceDedupeCandidate   WorklistItemSource = "dedupe_candidate"
 	WorklistItemSourceDsr               WorklistItemSource = "dsr"
@@ -11431,6 +11435,8 @@ func (e WorklistItemSource) Valid() bool {
 	case WorklistItemSourceCaptureHealth:
 		return true
 	case WorklistItemSourceConversationClaim:
+		return true
+	case WorklistItemSourceCustomerWaiting:
 		return true
 	case WorklistItemSourceDealAtRisk:
 		return true
@@ -12693,22 +12699,22 @@ func (e ListProjectsParamsPhase) Valid() bool {
 
 // Defines values for SubmitConfirmDetailsJSONBodyCorrectionsField.
 const (
-	Email    SubmitConfirmDetailsJSONBodyCorrectionsField = "email"
-	FullName SubmitConfirmDetailsJSONBodyCorrectionsField = "full_name"
-	Phone    SubmitConfirmDetailsJSONBodyCorrectionsField = "phone"
-	Title    SubmitConfirmDetailsJSONBodyCorrectionsField = "title"
+	SubmitConfirmDetailsJSONBodyCorrectionsFieldEmail    SubmitConfirmDetailsJSONBodyCorrectionsField = "email"
+	SubmitConfirmDetailsJSONBodyCorrectionsFieldFullName SubmitConfirmDetailsJSONBodyCorrectionsField = "full_name"
+	SubmitConfirmDetailsJSONBodyCorrectionsFieldPhone    SubmitConfirmDetailsJSONBodyCorrectionsField = "phone"
+	SubmitConfirmDetailsJSONBodyCorrectionsFieldTitle    SubmitConfirmDetailsJSONBodyCorrectionsField = "title"
 )
 
 // Valid indicates whether the value is a known member of the SubmitConfirmDetailsJSONBodyCorrectionsField enum.
 func (e SubmitConfirmDetailsJSONBodyCorrectionsField) Valid() bool {
 	switch e {
-	case Email:
+	case SubmitConfirmDetailsJSONBodyCorrectionsFieldEmail:
 		return true
-	case FullName:
+	case SubmitConfirmDetailsJSONBodyCorrectionsFieldFullName:
 		return true
-	case Phone:
+	case SubmitConfirmDetailsJSONBodyCorrectionsFieldPhone:
 		return true
-	case Title:
+	case SubmitConfirmDetailsJSONBodyCorrectionsFieldTitle:
 		return true
 	default:
 		return false

--- a/backend/internal/modules/activities/orgscope_test.go
+++ b/backend/internal/modules/activities/orgscope_test.go
@@ -177,3 +177,19 @@ func TestTheAssigneeClauseStaysExact(t *testing.T) {
 		t.Fatalf("the exact-assignee clause %q now admits unassigned work", clause)
 	}
 }
+
+// An unthreaded message is excluded, not matched loosely.
+//
+// `IS NOT DISTINCT FROM` joins every NULL to every other NULL, so one
+// unthreaded outbound would silence every unthreaded question in the
+// workspace. Plain equality never joins two NULLs, so the rows would all
+// survive and each would be its own thread. Neither is right, so they are
+// excluded — which under-reports by a row rather than by a customer.
+func TestTheWaitingQueryExcludesUnthreadedMessages(t *testing.T) {
+	if !strings.Contains(waitingRepliesSQL, "a.thread_key IS NOT NULL") {
+		t.Fatal("the waiting query admits unthreaded messages, which cross-suppress each other")
+	}
+	if strings.Contains(waitingRepliesSQL, "IS NOT DISTINCT FROM") {
+		t.Fatal("the waiting query matches NULL thread keys to each other")
+	}
+}

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -64,6 +64,13 @@ const waitingScanCap = 200
 // may not READ still answered the customer, and skipping it would report a
 // message as unanswered because the answer was somebody else's to see — the
 // worst failure available here, since it sends a rep to write a second reply.
+//
+// A message with NO thread_key is excluded rather than matched loosely. SQL
+// equality would never join two NULLs, and IS NOT DISTINCT FROM joins them ALL
+// — so an unthreaded message would be silenced by any other unthreaded
+// outbound in the workspace, and one unthreaded reply would hide every
+// unthreaded question at once. Excluding them under-reports, which is the
+// direction that costs a row rather than a customer.
 const waitingRepliesSQL = `
 	SELECT a.id, COALESCE(a.subject, ''), a.occurred_at, %s AS readable,
 	       COALESCE(l.person_id, '00000000-0000-0000-0000-000000000000'::uuid),
@@ -76,15 +83,16 @@ const waitingRepliesSQL = `
 	   AND a.archived_at IS NULL
 	   AND a.occurred_at <= $%d
 	   AND %s
+	   AND a.thread_key IS NOT NULL
 	   AND NOT EXISTS (
 	         SELECT 1 FROM activity later
-	          WHERE later.thread_key IS NOT DISTINCT FROM a.thread_key
+	          WHERE later.thread_key = a.thread_key
 	            AND later.direction = 'outbound'
 	            AND later.archived_at IS NULL
 	            AND later.occurred_at > a.occurred_at)
 	   AND NOT EXISTS (
 	         SELECT 1 FROM activity newer
-	          WHERE newer.thread_key IS NOT DISTINCT FROM a.thread_key
+	          WHERE newer.thread_key = a.thread_key
 	            AND newer.direction = 'inbound'
 	            AND newer.archived_at IS NULL
 	            AND newer.occurred_at > a.occurred_at)

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Who is waiting for a reply.
+//
+// The deal page already answers this for ONE deal, by walking that deal's
+// timeline newest-first and stopping at the first outbound. This is the same
+// question asked of the whole workspace at once, and it cannot be the same walk:
+// a per-deal scan cannot find the person with no deal, and it cannot be run
+// once per record on a page that must render in one read.
+//
+// So it is a query, and the two spellings are held together by a test that
+// feeds both the same timeline and requires the same answer.
+//
+// WHY THIS IS ITS OWN READ rather than a filter over the at-risk deals: a fresh
+// inbound makes a deal LESS quiet, so the deal drops out of the quiet-deal
+// candidate set exactly when somebody starts waiting on it. Deriving "waiting"
+// from "quiet" would therefore lose the newest and most urgent cases, which are
+// the ones a rep most needs.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// WaitingReply is one inbound message nobody has answered.
+type WaitingReply struct {
+	// ActivityID is the message itself — what a draft would reply to.
+	ActivityID ids.UUID
+	Subject    string
+	// OccurredAt is when they wrote, which is what the wait is measured from.
+	OccurredAt time.Time
+	// Readable says whether this reader may see the message's CONTENT. A
+	// withheld message still proves somebody is waiting; it cannot be drafted
+	// a reply, so the card offers none.
+	Readable bool
+	// The record the thread is filed under, when it names one.
+	PersonID       ids.UUID
+	OrganizationID ids.UUID
+	DealID         ids.UUID
+}
+
+// waitingScanCap bounds the work one read does. Beyond this the answer is
+// "there are more", never a silent truncation reported as a total.
+const waitingScanCap = 200
+
+// waitingRepliesSQL finds, per thread, the newest inbound with no later
+// outbound in the same thread.
+//
+// NOT EXISTS rather than a window function or a join: it expresses the question
+// directly — "nobody wrote back after this" — and it stops at the first later
+// outbound rather than materializing every thread's history to sort it.
+//
+// The outbound side deliberately ignores the audience arm. A reply this reader
+// may not READ still answered the customer, and skipping it would report a
+// message as unanswered because the answer was somebody else's to see — the
+// worst failure available here, since it sends a rep to write a second reply.
+const waitingRepliesSQL = `
+	SELECT a.id, COALESCE(a.subject, ''), a.occurred_at, %s AS readable,
+	       COALESCE(l.person_id, '00000000-0000-0000-0000-000000000000'::uuid),
+	       COALESCE(l.organization_id, '00000000-0000-0000-0000-000000000000'::uuid),
+	       COALESCE(l.deal_id, '00000000-0000-0000-0000-000000000000'::uuid)
+	  FROM activity a
+	  LEFT JOIN activity_link l ON l.activity_id = a.id
+	 WHERE a.kind IN ('email', 'message')
+	   AND a.direction = 'inbound'
+	   AND a.archived_at IS NULL
+	   AND a.occurred_at <= $%d
+	   AND %s
+	   AND NOT EXISTS (
+	         SELECT 1 FROM activity later
+	          WHERE later.thread_key IS NOT DISTINCT FROM a.thread_key
+	            AND later.direction = 'outbound'
+	            AND later.archived_at IS NULL
+	            AND later.occurred_at > a.occurred_at)
+	   AND NOT EXISTS (
+	         SELECT 1 FROM activity newer
+	          WHERE newer.thread_key IS NOT DISTINCT FROM a.thread_key
+	            AND newer.direction = 'inbound'
+	            AND newer.archived_at IS NULL
+	            AND newer.occurred_at > a.occurred_at)
+	 ORDER BY a.occurred_at ASC
+	 LIMIT %d`
+
+// WaitingReplies answers who is waiting on this reader for a reply.
+//
+// One row per thread — the newest inbound in it — because a customer who wrote
+// three times is waiting once, and three rows would read as three obligations.
+// Oldest first: the longest wait is the one most likely to have been forgotten.
+func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingReply, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	var waiting []WaitingReply
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		args := []any{}
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		instant := arg(asOf)
+		// The DISCOVER gate decides which rows are listed at all; the audience
+		// arm decides whether their words come too. Both come from the one
+		// place that spells them, so this read and the timeline cannot come to
+		// disagree about what a reader may see.
+		discover, err := auth.ActivityDiscoverClause(ctx, "a", arg)
+		if err != nil {
+			return err
+		}
+		readable, err := auth.ActivityAudienceArm(ctx, "a", arg)
+		if err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx,
+			fmt.Sprintf(waitingRepliesSQL, readable, instant, discover, waitingScanCap), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		waiting = []WaitingReply{}
+		for rows.Next() {
+			var row WaitingReply
+			if err := rows.Scan(&row.ActivityID, &row.Subject, &row.OccurredAt, &row.Readable,
+				&row.PersonID, &row.OrganizationID, &row.DealID); err != nil {
+				return err
+			}
+			waiting = append(waiting, row)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("activities: reading who is waiting for a reply: %w", err)
+	}
+	return waiting, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23543,7 +23543,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "customer_waiting" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice";
             /** @description The producer's own sub-type (an approval kind, a dedupe entity type) — for the icon and the label, never for authority. */
             kind?: string;
             /**
@@ -23755,7 +23755,7 @@ export interface components {
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "customer_waiting" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice";
             /**
              * @description The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
              * @enum {string}

--- a/frontend/src/screens/attentionsource.ts
+++ b/frontend/src/screens/attentionsource.ts
@@ -26,6 +26,9 @@ export const FOCUS_SURFACE = {
   task: "report",
   brief_item: "report",
   conversation_claim: "report",
+  // A waiting customer is reported, not decided: the reply is drafted on the
+  // record the thread belongs to, and the decision lane holds no verb for it.
+  customer_waiting: "report",
   deal_at_risk: "report",
   meeting: "report",
   relationship_decay: "report",


### PR DESCRIPTION
The concept's second ten-second question — **"which customer is waiting on me?"** — had no producer. This adds one.

## Why it could not come from the at-risk lane

The queue could previously reach a waiting buyer only through deals going quiet, and that lane cannot answer the question: **a fresh inbound makes a deal less quiet**, so the deal drops out of the candidate set exactly when somebody starts waiting on it. A person with no deal at all was unreachable.

## The read

`activities.WaitingReplies` asks it directly — per thread, the newest inbound with no later outbound. One row per thread, because a customer who wrote three times is waiting once. Oldest first, because the longest wait is the one that was forgotten.

Two gates, deliberately different:

- The **discover** clause decides which rows are listed.
- The **audience** arm decides whether their words come too, and rides on the row as `readable`. A withheld message still proves somebody is waiting; it just cannot be answered from here, so no draft is offered and the subject line does not travel.

The outbound side **ignores** the audience arm on purpose: a reply this reader may not read still answered the customer. Skipping it would report a message as unanswered because the answer was somebody else's to see — which sends a rep to write a second reply, the worst failure available here.

## Ranking

Level 1, above every promise, deal and decision. It is the one thing on the page whose cost of inaction falls on somebody else.

One unanswered message is **one row**: the deal it belongs to no longer also appears as drifting. The waiting row wins because it is more urgent and more actionable — it names the message to reply to.

## Two faults the security review caught

**The subject line leaked.** It went onto the row whatever the audience arm said. Being admitted to know somebody is waiting is not being admitted to read what they wrote.

**Thread matching joined every NULL to every other NULL.** `IS NOT DISTINCT FROM` meant one unthreaded outbound anywhere in the workspace would silence every unthreaded question at once. Unthreaded messages are now excluded — under-reporting by a row rather than by a customer.

Both pinned by tests.

## Seen working

Against a seeded stack with an inbound email from 83 days ago on a €160,100 deal:

```
#1 L1 customer_waiting  Re: pricing for the retrofit   because=[buyer_wrote_last, waiting_days]
#2 L4 task              Confirm the workshop date
#3 L4 deal_at_risk      Globex Renewal
```

The Acme deal does **not** appear as drifting — the dedupe fired. Before this change the buyer was invisible and the deal sat below nine hygiene decisions.

## Gates

`make check-backend`, `make craft-static` (0 findings) green. `make check-fe` is red on `main` for an unrelated fixture (#3282), not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `customer_waiting` as its own Worklist source so the queue can answer "which customer is waiting on me?". Previously a waiting buyer could only surface through the at-risk deal lane, which drops a deal exactly when a fresh inbound arrives (a new message makes it less quiet) and never reaches a person with no deal at all.

- Ranks Level 1 — above promises, deals, and decisions — one row per thread, oldest wait first.
- A deal with an unanswered message no longer also appears as drifting; the waiting row wins.
- A withheld message still proves somebody is waiting, but travels without its subject line or a draft action.
- Unthreaded messages are now excluded, fixing the `IS NOT DISTINCT FROM` join that let one unthreaded outbound silence every unthreaded question in the workspace.

<sup>Written for commit 8389d0bb1cb8f5a56707a7e7bfb780ada9c0480d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a customer-waiting source to CRM activity data.
  - Added a worklist lane for unanswered inbound messages.
  - Waiting items show wait duration, related records, timestamps, and available actions.
  - Waiting items are prioritized and duplicate deal entries are removed.
  - Message subjects remain hidden when unread or not permitted.

- **Bug Fixes**
  - Excluded unthreaded messages from waiting-reply results.
  - Improved permission and error handling when loading waiting items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->