### PR TITLE
feat(people): the account roster leads with the contact worth writing to

### DIFF
--- a/backend/internal/compose/integration/org360/org360_contactrank_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_contactrank_integration_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package org360
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The people section carries 25 of an account's contacts, and which 25 is a
+// product decision the roster read does not make: it returns them ordered by
+// person id, which is arbitrary as a reading order. Cutting that order keeps
+// the first 25 ids rather than the 25 contacts worth looking at.
+//
+// The fixture puts the ONLY contact who has answered at the end of the id
+// order, which is where the old cut dropped them. A reader opening the account
+// then saw twenty-five untried strangers, no way in, and a has_more flag that
+// truthfully reported more contacts while saying nothing about the one that
+// mattered. Person ids are UUIDv7 and therefore ascend in creation order, so
+// seeding the answered contact last is what places them outside the old cut.
+func TestOrganization360RanksContactsBeforeTruncatingTheSection(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+
+	owner := integration.OwnerConn(t)
+	org := e.SeedOrg(t, "Brandt GmbH", nil)
+
+	const contacts = 30
+	var answered ids.UUID
+	for i := range contacts {
+		person := e.SeedPerson(t, fmt.Sprintf("Contact %02d", i), nil)
+		employ(t, e, person, org, "Fleet")
+		answered = person
+	}
+
+	// One inbound message: the single fact that separates a way in from a
+	// roster. It lands inside the 90-day window ending at the pinned clock.
+	mail := integration.AccountMailDirectedAt(t, owner, e.WS, "Re: your proposal",
+		"inbound", org360Clock.AddDate(0, 0, -3))
+	integration.LinkActivity(t, owner, mail, "person", answered)
+
+	view, err := org360Service(e).Assemble(ctx, ids.OrganizationID{UUID: org})
+	if err != nil {
+		t.Fatalf("assembling the 360: %v", err)
+	}
+	if view.People == nil {
+		t.Fatal("the people section is absent for a caller who may read it")
+	}
+	rows := view.People.Data
+	if len(rows) != 25 {
+		t.Fatalf("the section carried %d contacts, want the 25-row cut", len(rows))
+	}
+	if !view.People.Page.HasMore {
+		t.Fatal("a 30-contact account must report has_more on a 25-row section")
+	}
+
+	// The one who answered leads, because they are the way in.
+	if got := ids.UUID(rows[0].PersonId); got != answered {
+		t.Fatalf("the section opens on %s; the contact who answered is %s and must lead",
+			got, answered)
+	}
+}

--- a/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package org360
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The direction counts say THAT a contact answered; these two dates say which
+// way the conversation is owed. A contact who replied in March and was chased
+// in August has a non-zero count in both directions, so the counts alone cannot
+// tell "they owe us" from "we owe them" — the pair of dates is what separates
+// them, and a follow-up offered on the wrong side of that is a rep writing
+// again to someone already waiting on them.
+func TestStrengthFoldDatesEachDirectionSeparately(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+
+	org := e.SeedOrg(t, "Brandt GmbH", nil)
+	person := e.SeedPerson(t, "Dietmar Rietsch", nil)
+	employ(t, e, person, org, "Managing Director")
+
+	// TWO inbound messages, not one: with a single reply the newest and the
+	// oldest are the same row, so a fold that took either would pass. The
+	// anchor a follow-up opens must be the LATEST thing they said.
+	firstReply := org360Clock.AddDate(0, 0, -60)
+	replied := org360Clock.AddDate(0, 0, -40)
+	chased := org360Clock.AddDate(0, 0, -5)
+	stale := integration.AccountMailDirectedAt(t, owner, e.WS, "First contact", "inbound", firstReply)
+	integration.LinkActivity(t, owner, stale, "person", person)
+	inbound := integration.AccountMailDirectedAt(t, owner, e.WS, "Re: your proposal", "inbound", replied)
+	integration.LinkActivity(t, owner, inbound, "person", person)
+	outbound := integration.AccountMailDirectedAt(t, owner, e.WS, "Following up", "outbound", chased)
+	integration.LinkActivity(t, owner, outbound, "person", person)
+
+	got := foldOneContact(t, e, org, person)
+
+	assertSameInstant(t, "last inbound", got.LastInbound, replied)
+	assertSameInstant(t, "last outbound", got.LastOutbound, chased)
+	// The anchor a follow-up would answer is their message, not our chase.
+	if got.LastInboundActivity == nil {
+		t.Fatal("no inbound anchor recorded for a contact who wrote in")
+	}
+	if got.LastInboundActivity.UUID != inbound {
+		t.Fatalf("the inbound anchor is %s, want the message they sent (%s)",
+			*got.LastInboundActivity, inbound)
+	}
+	if people.EngagementOf(got) != people.EngagementAnswered {
+		t.Fatalf("a contact who wrote in reads as %q", people.EngagementOf(got))
+	}
+}
+
+// A contact nobody has heard from carries no inbound date and no anchor. The
+// absence is the fact: offering a "follow up" on a thread that does not exist
+// is the composer opening a reply to nothing.
+func TestStrengthFoldLeavesTheInboundAnchorEmptyWhenNobodyWroteIn(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+
+	org := e.SeedOrg(t, "Brandt GmbH", nil)
+	person := e.SeedPerson(t, "Philipp Königs", nil)
+	employ(t, e, person, org, "CFO")
+
+	sent := org360Clock.AddDate(0, 0, -12)
+	outbound := integration.AccountMailDirectedAt(t, owner, e.WS, "Introduction", "outbound", sent)
+	integration.LinkActivity(t, owner, outbound, "person", person)
+
+	got := foldOneContact(t, e, org, person)
+
+	if got.LastInbound != nil {
+		t.Fatalf("a contact who never wrote in carries an inbound date of %s", got.LastInbound)
+	}
+	if got.LastInboundActivity != nil {
+		t.Fatalf("a contact who never wrote in carries an inbound anchor of %s", got.LastInboundActivity)
+	}
+	assertSameInstant(t, "last outbound", got.LastOutbound, sent)
+	if people.EngagementOf(got) != people.EngagementNoReply {
+		t.Fatalf("a contact we wrote to with no reply reads as %q", people.EngagementOf(got))
+	}
+}
+
+// foldOneContact runs the account roster read and returns the one contact's
+// §4 fold — through the real read rather than a hand-built row, so the test
+// measures what the page is served.
+func foldOneContact(t *testing.T, e *integration.Env, org, person ids.UUID) people.RelationshipStrength {
+	t.Helper()
+	var found *people.RelationshipStrength
+	ctx := e.Admin()
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		all, err := people.StrengthForOrgContacts(ctx, tx, ids.OrganizationID{UUID: org}, org360Clock)
+		if err != nil {
+			return err
+		}
+		for _, c := range all {
+			if c.PersonID.UUID == person {
+				strength := c.Strength
+				found = &strength
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("reading the account roster: %v", err)
+	}
+	if found == nil {
+		t.Fatalf("the roster did not carry the seeded contact %s", person)
+	}
+	return *found
+}
+
+func assertSameInstant(t *testing.T, what string, got *time.Time, want time.Time) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s is absent, want %s", what, want)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("%s is %s, want %s", what, got, want)
+	}
+}

--- a/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
@@ -90,6 +90,41 @@ func TestStrengthFoldLeavesTheInboundAnchorEmptyWhenNobodyWroteIn(t *testing.T) 
 	}
 }
 
+// A reply older than the window leaves a DATE but no anchor.
+//
+// The two are answering different questions. "They last wrote eighteen months
+// ago" is history and stays true however old it gets. The anchor is an action —
+// it is what a Follow up button opens a reply against — and it has to agree
+// with the state the counts report. This contact reads untried, because nothing
+// inside the window says otherwise; offering to answer a thread from last year
+// would contradict the same page's own summary.
+func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+
+	org := e.SeedOrg(t, "Brandt GmbH", nil)
+	person := e.SeedPerson(t, "Ute Sommer", nil)
+	employ(t, e, person, org, "Procurement")
+
+	longAgo := org360Clock.AddDate(0, 0, -400)
+	stale := integration.AccountMailDirectedAt(t, owner, e.WS, "Re: 2025 tender", "inbound", longAgo)
+	integration.LinkActivity(t, owner, stale, "person", person)
+
+	got := foldOneContact(t, e, org, person)
+
+	// The history is kept: the date is what the page prints as "last heard from".
+	assertSameInstant(t, "last inbound", got.LastInbound, longAgo)
+	// The action is not offered.
+	if got.LastInboundActivity != nil {
+		t.Fatalf("a reply from %s is outside the 90-day window and must not be offered as a reply anchor, got %s",
+			longAgo.Format("2006-01-02"), got.LastInboundActivity)
+	}
+	if people.EngagementOf(got) != people.EngagementUntried {
+		t.Fatalf("a contact whose only message predates the window reads as %q, want untried",
+			people.EngagementOf(got))
+	}
+}
+
 // foldOneContact runs the account roster read and returns the one contact's
 // §4 fold — through the real read rather than a hand-built row, so the test
 // measures what the page is served.

--- a/backend/internal/compose/org360/contacts.go
+++ b/backend/internal/compose/org360/contacts.go
@@ -31,7 +31,21 @@ import (
 func contactsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time,
 	all []people.ContactStrength,
 ) ([]crmcontracts.Organization360Contact, crmcontracts.PageInfo, error) {
-	strengths, page := truncate(all)
+	// Ranked BEFORE the cut, because the cut is what the reader sees. `all`
+	// arrives ordered by person id — the roster read's own deterministic order,
+	// which is arbitrary as a reading order — and truncating that keeps the
+	// first 25 ids rather than the 25 contacts worth looking at. On an account
+	// with a hundred employees the one who answered last week sits wherever
+	// their id falls, so the section that is supposed to open the page could
+	// omit them entirely while reporting nothing worse than has_more.
+	//
+	// Ranking a COPY: `all` is the same slice the account roll-up folds, and
+	// reordering it under that reader would make the summary depend on which
+	// section ran first.
+	ranked := make([]people.ContactStrength, len(all))
+	copy(ranked, all)
+	people.RankContacts(ranked)
+	strengths, page := truncate(ranked)
 	if len(strengths) == 0 {
 		return []crmcontracts.Organization360Contact{}, page, nil
 	}

--- a/backend/internal/modules/people/engagement.go
+++ b/backend/internal/modules/people/engagement.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Where each contact stands with us, and the order a rep triages them in.
+//
+// The roster on its own answers "who works there". Before reaching out the rep
+// is asking something else: who here has ever answered, who has gone quiet on
+// me, and who has nobody tried. Those are three different next moves.
+//
+// This rule used to live in the browser (frontend/src/screens/coverage.ts
+// reachOf), which meant it could only classify the contacts a page had already
+// been sent — and the company page is sent 25 of them, chosen by id. Ranking a
+// 105-contact account by a rule the server does not know is how the person
+// worth writing to ends up on a page nobody renders. The rule moves here so the
+// ranking happens where the whole account is in hand.
+
+import "sort"
+
+// Engagement is one contact's state, in the three values a rep acts on.
+type Engagement string
+
+const (
+	// EngagementAnswered — they have written back inside the window. The way in.
+	EngagementAnswered Engagement = "answered"
+	// EngagementNoReply — we have written and had nothing back. Following up
+	// again is a decision, not a default.
+	EngagementNoReply Engagement = "no_reply"
+	// EngagementUntried — nobody has written to them at all. Free to approach,
+	// and the most commonly missed opportunity on a stalled account.
+	EngagementUntried Engagement = "untried"
+)
+
+// EngagementOf reads the state off the §4 direction counts, which are already
+// folded over the same 90-day window the score uses.
+//
+// Inbound wins over outbound rather than being combined with it: a contact who
+// replied last month and was chased again last week has both, and what decides
+// the next move is that they answered. The window is the fold's, so a reply
+// older than it reads as untried — deliberately, because a year-old reply is
+// not a way in.
+func EngagementOf(rs RelationshipStrength) Engagement {
+	switch {
+	case rs.Inbound90d > 0:
+		return EngagementAnswered
+	case rs.Outbound90d > 0:
+		return EngagementNoReply
+	default:
+		return EngagementUntried
+	}
+}
+
+// engagementOrder puts the people worth acting on first.
+//
+// Whoever answered leads, because they are the way in. Untried comes SECOND: on
+// an account where everyone has gone quiet, the person nobody has written to is
+// the only move left that is not a fourth follow-up. No-reply comes last — not
+// because those contacts are worthless, but because acting on one is the move
+// that needs a reason.
+var engagementOrder = map[Engagement]int{
+	EngagementAnswered: 0,
+	EngagementUntried:  1,
+	EngagementNoReply:  2,
+}
+
+// RankContacts sorts a contact set into triage order in place: engagement
+// first, then the stronger relationship, then by id so two otherwise equal
+// contacts come back in a stable order rather than the scan's.
+//
+// Stable rather than merely sorted, because callers page over the result: an
+// unstable tie-break would let a contact appear on two pages, or on none.
+func RankContacts(contacts []ContactStrength) {
+	sort.SliceStable(contacts, func(i, j int) bool {
+		a, b := contacts[i], contacts[j]
+		ao, bo := engagementOrder[EngagementOf(a.Strength)], engagementOrder[EngagementOf(b.Strength)]
+		if ao != bo {
+			return ao < bo
+		}
+		if a.Strength.Strength != b.Strength.Strength {
+			return a.Strength.Strength > b.Strength.Strength
+		}
+		return a.PersonID.String() < b.PersonID.String()
+	})
+}

--- a/backend/internal/modules/people/engagement_test.go
+++ b/backend/internal/modules/people/engagement_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestEngagementOfReadsTheThreeStatesOffTheDirectionCounts(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		inbound  int
+		outbound int
+		want     Engagement
+	}{
+		{"they wrote back", 2, 0, EngagementAnswered},
+		{"they wrote back after we chased", 1, 4, EngagementAnswered},
+		{"we wrote and heard nothing", 0, 3, EngagementNoReply},
+		{"nobody has written at all", 0, 0, EngagementUntried},
+		{"they wrote first and we never replied", 1, 0, EngagementAnswered},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := EngagementOf(RelationshipStrength{Inbound90d: tc.inbound, Outbound90d: tc.outbound})
+			if got != tc.want {
+				t.Fatalf("inbound=%d outbound=%d: got %q, want %q",
+					tc.inbound, tc.outbound, got, tc.want)
+			}
+		})
+	}
+}
+
+// An answered contact outranks an untried one and an untried one outranks a
+// silent one — the order a rep triages in, and the reason untried sits in the
+// middle rather than last: on an account where everyone has gone quiet, the
+// person nobody has tried is the only move that is not another follow-up.
+func TestRankContactsOrdersAnsweredThenUntriedThenNoReply(t *testing.T) {
+	t.Parallel()
+	silent := contactAt(t, "11111111-1111-4111-8111-111111111111", RelationshipStrength{Outbound90d: 5, Strength: 90})
+	untried := contactAt(t, "22222222-2222-4222-8222-222222222222", RelationshipStrength{Strength: 10})
+	answered := contactAt(t, "33333333-3333-4333-8333-333333333333", RelationshipStrength{Inbound90d: 1, Strength: 5})
+
+	got := []ContactStrength{silent, untried, answered}
+	RankContacts(got)
+
+	want := []ids.PersonID{answered.PersonID, untried.PersonID, silent.PersonID}
+	assertOrder(t, got, want)
+}
+
+// The silent contact here scores highest. If score led, it would sort first and
+// the page would open on the one person whose next move needs a reason.
+func TestRankContactsPutsEngagementAboveScore(t *testing.T) {
+	t.Parallel()
+	strongSilent := contactAt(t, "11111111-1111-4111-8111-111111111111", RelationshipStrength{Outbound90d: 9, Strength: 99})
+	weakAnswered := contactAt(t, "22222222-2222-4222-8222-222222222222", RelationshipStrength{Inbound90d: 1, Strength: 1})
+
+	got := []ContactStrength{strongSilent, weakAnswered}
+	RankContacts(got)
+
+	assertOrder(t, got, []ids.PersonID{weakAnswered.PersonID, strongSilent.PersonID})
+}
+
+func TestRankContactsBreaksAScoreTieByStrengthThenID(t *testing.T) {
+	t.Parallel()
+	weaker := contactAt(t, "11111111-1111-4111-8111-111111111111", RelationshipStrength{Inbound90d: 1, Strength: 40})
+	strongerLateID := contactAt(t, "99999999-9999-4999-8999-999999999999", RelationshipStrength{Inbound90d: 1, Strength: 70})
+	tiedEarlyID := contactAt(t, "22222222-2222-4222-8222-222222222222", RelationshipStrength{Inbound90d: 1, Strength: 70})
+
+	got := []ContactStrength{weaker, strongerLateID, tiedEarlyID}
+	RankContacts(got)
+
+	// Both 70s come before the 40, and the tie between them resolves by id so
+	// the order is the same on every page of a paged read.
+	assertOrder(t, got, []ids.PersonID{tiedEarlyID.PersonID, strongerLateID.PersonID, weaker.PersonID})
+}
+
+// Paging over an unstable order shows a contact twice or never. Ranking the
+// same set from two different starting arrangements must land identically.
+func TestRankContactsIsStableAcrossInputOrder(t *testing.T) {
+	t.Parallel()
+	a := contactAt(t, "11111111-1111-4111-8111-111111111111", RelationshipStrength{Inbound90d: 1, Strength: 50})
+	b := contactAt(t, "22222222-2222-4222-8222-222222222222", RelationshipStrength{Inbound90d: 1, Strength: 50})
+	c := contactAt(t, "33333333-3333-4333-8333-333333333333", RelationshipStrength{Outbound90d: 1, Strength: 50})
+
+	first := []ContactStrength{a, b, c}
+	second := []ContactStrength{c, b, a}
+	RankContacts(first)
+	RankContacts(second)
+
+	for i := range first {
+		if first[i].PersonID != second[i].PersonID {
+			t.Fatalf("position %d differs between input orders: %s vs %s",
+				i, first[i].PersonID.UUID, second[i].PersonID.UUID)
+		}
+	}
+}
+
+func TestRankContactsHandlesAnEmptySet(t *testing.T) {
+	t.Parallel()
+	var none []ContactStrength
+	RankContacts(none)
+	if len(none) != 0 {
+		t.Fatalf("ranking an empty set produced %d contacts", len(none))
+	}
+}
+
+func contactAt(t *testing.T, id string, rs RelationshipStrength) ContactStrength {
+	t.Helper()
+	parsed, err := ids.Parse(id)
+	if err != nil {
+		t.Fatalf("parsing the fixture id %q: %v", id, err)
+	}
+	return ContactStrength{PersonID: ids.PersonID{UUID: parsed}, Strength: rs}
+}
+
+func assertOrder(t *testing.T, got []ContactStrength, want []ids.PersonID) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d contacts, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].PersonID != want[i] {
+			t.Fatalf("position %d: got %s, want %s", i, got[i].PersonID.UUID, want[i].UUID)
+		}
+	}
+}

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -65,8 +65,21 @@ type RelationshipStrength struct {
 	LastInbound  *time.Time
 	LastOutbound *time.Time
 	// LastInboundActivity is the message a follow-up would answer — the anchor
-	// the composer needs to open a reply rather than a fresh thread. Nil where
-	// nobody has written in, which is exactly when there is nothing to answer.
+	// the composer needs to open a reply rather than a fresh thread.
+	//
+	// Bounded by the SAME 90-day window as the direction counts, unlike the two
+	// dates above. Those are history: "they last wrote in March" is true and
+	// worth showing however old it is. An anchor is an ACTION, and it has to
+	// agree with the state the counts report — a contact whose only message is
+	// eighteen months old reads untried, and offering to "follow up" on that
+	// thread would open a reply to a conversation the same page just said had
+	// never happened. Nil is therefore the common case on a cold account, and
+	// it is the honest one.
+	//
+	// Read as a correlated LIMIT 1 rather than an aggregate over the history:
+	// array_agg(...)[1] materialised every inbound id a contact had ever sent
+	// in order to use one of them, which is the payload growing with history
+	// that this fold exists to avoid.
 	LastInboundActivity *ids.ActivityID
 }
 
@@ -326,8 +339,13 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
-		       (array_agg(a.id ORDER BY a.occurred_at DESC)
-		          FILTER (WHERE a.direction = 'inbound'))[1]
+		       (SELECT i.id FROM activity i
+		          JOIN activity_link il ON il.activity_id = i.id AND il.person_id = l.person_id
+		         WHERE i.direction = 'inbound' AND i.kind IN `+strengthKinds+`
+		           AND i.archived_at IS NULL AND i.occurred_at >= $2
+		           AND ($3::timestamptz IS NULL OR i.occurred_at <= $3)
+		         ORDER BY i.occurred_at DESC, i.id DESC
+		         LIMIT 1)
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id
 		WHERE l.person_id = ANY($1) AND a.kind IN `+strengthKinds+` AND a.archived_at IS NULL
@@ -380,8 +398,12 @@ func strengthInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now t
 		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
-		       (array_agg(a.id ORDER BY a.occurred_at DESC)
-		          FILTER (WHERE a.direction = 'inbound'))[1]
+		       (SELECT i.id FROM activity i
+		          JOIN activity_link il ON il.activity_id = i.id AND il.person_id = $1
+		         WHERE i.direction = 'inbound' AND i.kind IN `+strengthKinds+`
+		           AND i.archived_at IS NULL AND i.occurred_at >= $2
+		         ORDER BY i.occurred_at DESC, i.id DESC
+		         LIMIT 1)
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
 		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`,

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -55,6 +55,19 @@ type RelationshipStrength struct {
 	Inbound90d          int
 	Outbound90d         int
 	ContributingIDs     []ids.ActivityID
+
+	// The two directions dated separately, because "they answered" and "we
+	// wrote and heard nothing" are opposite next moves and the counts above
+	// cannot tell them apart once both are non-zero: a contact who replied in
+	// March and was chased in August has inbound and outbound alike, and only
+	// the dates say which way the conversation is owed. EngagementOf reads the
+	// counts; a caller deciding whether a reply is outstanding reads these.
+	LastInbound  *time.Time
+	LastOutbound *time.Time
+	// LastInboundActivity is the message a follow-up would answer — the anchor
+	// the composer needs to open a reply rather than a fresh thread. Nil where
+	// nobody has written in, which is exactly when there is nothing to answer.
+	LastInboundActivity *ids.ActivityID
 }
 
 // strengthKinds are the activity kinds that count as contact, from the one
@@ -310,7 +323,11 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		       max(a.occurred_at),
 		       count(*) FILTER (WHERE a.occurred_at >= $2),
 		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound')
+		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
+		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
+		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
+		       (array_agg(a.id ORDER BY a.occurred_at DESC)
+		          FILTER (WHERE a.direction = 'inbound'))[1]
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id
 		WHERE l.person_id = ANY($1) AND a.kind IN `+strengthKinds+` AND a.archived_at IS NULL
@@ -327,7 +344,8 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		var personID ids.PersonID
 		var rs RelationshipStrength
 		if err := rows.Scan(&personID, &rs.LastInteraction, &rs.InteractionCount90d,
-			&rs.Inbound90d, &rs.Outbound90d); err != nil {
+			&rs.Inbound90d, &rs.Outbound90d, &rs.LastInbound, &rs.LastOutbound,
+			&rs.LastInboundActivity); err != nil {
 			return nil, err
 		}
 		byPerson[personID] = &rs
@@ -359,11 +377,17 @@ func strengthInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now t
 		SELECT max(a.occurred_at),
 		       count(*) FILTER (WHERE a.occurred_at >= $2),
 		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound')
+		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
+		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
+		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
+		       (array_agg(a.id ORDER BY a.occurred_at DESC)
+		          FILTER (WHERE a.direction = 'inbound'))[1]
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
 		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`,
-		personID, windowStart).Scan(&out.LastInteraction, &out.InteractionCount90d, &out.Inbound90d, &out.Outbound90d); err != nil {
+		personID, windowStart).Scan(&out.LastInteraction, &out.InteractionCount90d,
+		&out.Inbound90d, &out.Outbound90d, &out.LastInbound, &out.LastOutbound,
+		&out.LastInboundActivity); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## The bug

The company page's People section carries 25 of an account's contacts. It took the first 25 **by person id** — the roster read's own deterministic order, which is arbitrary as a reading order.

On a 105-contact account the one person who answered last week sits wherever their id falls, so the section that is supposed to open the page could omit them entirely while reporting nothing worse than `has_more`. The reader is told there are more contacts; they are not told the one that mattered was among them.

## What changed

**`people.EngagementOf`** — `answered` / `no_reply` / `untried`, read off the 90-day direction counts the §4 fold already produced. The rule previously lived in the browser (`coverage.ts` `reachOf`), where it could only classify the contacts a page had already been sent — which is the 25 chosen by id. It belongs where the whole account is in hand.

**`people.RankContacts`** — engagement, then strength, then id. Answered leads because they are the way in. Untried comes *second*: on an account where everyone has gone quiet, the person nobody has written to is the only move left that is not a fourth follow-up. The id tie-break is what makes a paged read stable.

**The strength fold gains three values** — the last inbound date, the last outbound date, and the latest inbound activity id. The counts say *that* a contact answered; the dates say which way the conversation is owed, and a contact who replied in March and was chased in August has both counts non-zero. The activity id is the anchor a follow-up opens a reply against rather than starting a fresh thread.

`contactsSection` ranks a **copy** before truncating: the same slice is folded by the account strength roll-up, and reordering it under that reader would make the summary depend on which section ran first.

## Cost

No contract change and no new query. The fold gains its columns inside the statement it already ran, in **both** the batch and per-person paths so the two cannot disagree. `org360_querycount_integration_test` still passes — the read is flat in the account's contact count.

The reply anchor is a correlated `LIMIT 1`, deliberately not `array_agg(...)[1]`: the aggregate form materialised every inbound id in a contact's entire history in order to use one of them, which is the payload growing with history that this fold exists to avoid.

## The anchor is windowed; the dates are not

These answer different questions and the asymmetry is on purpose.

A date is history — "they last wrote in March" stays true however old it gets, and the page prints it. The anchor is an **action**, and it has to agree with the state the same read reports. A contact whose only message is eighteen months old reads `untried`; carrying an anchor for them would let the page call someone never approached and simultaneously offer to follow up on a thread from last year.

Both were defects in the first commit here, found in review and fixed in the second.

## Tests

Unit (`internal/modules/people`):
- `TestEngagementOfReadsTheThreeStatesOffTheDirectionCounts` — including the case that separates the two rules: inbound *and* outbound both non-zero still reads `answered`.
- `TestRankContactsOrdersAnsweredThenUntriedThenNoReply`, `...PutsEngagementAboveScore` (the highest-scoring contact is the silent one, so score-led ranking would open the page on the person whose next move needs a reason), `...BreaksAScoreTieByStrengthThenID`, `...IsStableAcrossInputOrder`.

Integration (`internal/compose/integration/org360`):
- `TestOrganization360RanksContactsBeforeTruncatingTheSection` — 30 contacts, the only one who answered is last in id order. Fails against the previous behaviour.
- `TestStrengthFoldDatesEachDirectionSeparately` — two inbound messages, not one, so the anchor must pick the newer.
- `TestStrengthFoldLeavesTheInboundAnchorEmptyWhenNobodyWroteIn`
- `TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow` — the correctness defect above.

Every guard test here was mutation-checked: the rule was inverted or removed and the test confirmed to fail. That is what caught the single-inbound-message fixture, which passed against a deliberately reversed sort order and proved nothing until a second, older reply was added.

## Verification

`make lint` 0 issues; `internal/modules/people` and `internal/compose/integration/org360` integration suites green; `go test ./gates/` green apart from two failures that reproduce on clean `origin/main` and are caused by untracked local files (`.pnpm-store/`, an untracked docs page) that do not exist in the repo.

## Scope

This is the data layer plus the ranking fix. Nothing is visible to a user yet — the redesigned People tab reads this in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The people section now ranks an account's contacts by engagement before the 25-row cut, so the page opens with the contact worth writing to instead of the first 25 by person id.

**Ranking**
- Contacts sort by engagement (answered, then untried, then no_reply), then strength, then id; the id tie-break keeps paged reads stable.
- `people.EngagementOf` replaces the browser-side `reachOf` rule, which could only classify the 25 contacts already sent.
- `contactsSection` ranks a copy so the account strength roll-up's folding order isn't affected.

**Reply anchor**
- The strength fold gains last inbound date, last outbound date, and the latest inbound activity id, in both the batch and per-person paths.
- The anchor is bounded by the same 90-day window as the counts, so a stale thread is never offered as a follow-up; the dates stay unwindowed.
- The anchor is read as a correlated `LIMIT 1` rather than an array aggregate, so the payload doesn't grow with a contact's history.
- No contract change and no new query: the fold gains columns in the statement it already ran.

<sup>Written for commit 08a0f4ecd3fd9d88c9c8236e25013be44209e816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization contact lists now prioritize contacts based on recent engagement and relationship strength.
  * Contact engagement is classified as answered, no reply, or untried.
  * Recent inbound and outbound activity are tracked separately, with inbound activity limited to the past 90 days.
* **Bug Fixes**
  * Ensured the most relevant 25 contacts appear first when lists are truncated.
  * Preserved historical engagement dates while excluding outdated inbound activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->