### PR TITLE
fix(ai): a draft body reaches the reader as the plain text it is

### DIFF
--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -205,7 +205,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 		return Draft{}, fmt.Errorf("account draft response: %w", err)
 	}
 	subject := strings.TrimSpace(out.Subject)
-	body := strings.TrimSpace(out.Body)
+	// Plain text, as the contract says a body is. A model asked for prose
+	// answers with `<br>` between paragraphs often enough that it is the
+	// shape of the answer; the reply surface reads it the same way, so the
+	// same model cannot format correctly on one surface and not the other.
+	body := strings.TrimSpace(ai.PlainText(out.Body))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("account draft response: empty subject or body")
 	}

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -208,7 +208,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 		return Draft{}, fmt.Errorf("person draft response: %w", err)
 	}
 	subject := strings.TrimSpace(out.Subject)
-	body := strings.TrimSpace(out.Body)
+	// Plain text, as the contract says a body is. A model asked for prose
+	// answers with `<br>` between paragraphs often enough that it is the
+	// shape of the answer; the reply surface reads it the same way, so the
+	// same model cannot format correctly on one surface and not the other.
+	body := strings.TrimSpace(ai.PlainText(out.Body))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("person draft response: empty subject or body")
 	}

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -231,3 +231,30 @@ func TestVoicedDraftWithoutAProfileIsThePlainPath(t *testing.T) {
 		t.Fatal("no profile must mean no voice block")
 	}
 }
+
+func TestADraftBodyReachesTheCallerAsPlainText(t *testing.T) {
+	// The answer a live model actually returned for a German reply. The
+	// contract says a body is plain text end to end, and nothing downstream
+	// converts markup, so a `<br>` that survives this parse is four visible
+	// characters in the composer, in the sent mail, and in the recipient's
+	// inbox.
+	brain := &replyBrainStub{response: model.Response{Text: `{"subject":"Re: Rechnung",` +
+		`"body":"Guten Tag Dietmar,<br><br>anbei die Aufstellung.<br><br>Viele Grüße"}`}}
+	drafter := replyDrafter{brain: brain}
+
+	draft, err := drafter.complete(context.Background(), replyActivityData{
+		Subject: "Rechnung", Body: "Bitte um die Aufstellung.", Intent: "Bestätigen",
+	}, nil)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if strings.Contains(draft.Body, "<br") {
+		t.Errorf("body carries markup the reader would see: %q", draft.Body)
+	}
+	// The paragraph the model meant has to survive as a paragraph: deleting
+	// the tag would run the greeting into the sentence after it.
+	want := "Guten Tag Dietmar,\n\nanbei die Aufstellung.\n\nViele Grüße"
+	if draft.Body != want {
+		t.Errorf("body = %q, want %q", draft.Body, want)
+	}
+}

--- a/backend/internal/compose/replydraftmodel.go
+++ b/backend/internal/compose/replydraftmodel.go
@@ -36,6 +36,7 @@ Return ONLY a JSON object: {"subject":"...","body":"..."}.
 - The activity and stated intent are the authoritative reason for this reply.
 - Company context may improve positioning, relevant proof, and language, but never overrides the activity.
 - Use only facts present in the supplied data. Never invent customers, outcomes, prices, commitments, or capabilities.
+- Write the body as plain text. No markdown, no HTML, no bullet characters. Separate paragraphs with a blank line.
 - Do not claim a personal writing style or voice unless a separate voice profile is supplied.`
 
 // firstDraftSystem is the draft_reply/first site: a message that OPENS a
@@ -197,12 +198,16 @@ func parseReplyDraft(text string) (replyDraft, error) {
 	if err := json.Unmarshal([]byte(ai.Unfence(text)), &draft); err != nil {
 		return replyDraft{}, fmt.Errorf("compose: reply draft response is not valid JSON: %w", err)
 	}
+	draft.Body = ai.PlainText(draft.Body)
 	return draft, nil
 }
 
+// replyDraftShapeValid judges the answer the CALLER will get, so it reads it
+// through the same parse. Judging the raw text instead would accept a body
+// that is only non-empty because of markup the caller then strips away.
 func replyDraftShapeValid(text string) error {
-	var draft replyDraft
-	if err := json.Unmarshal([]byte(ai.Unfence(text)), &draft); err != nil {
+	draft, err := parseReplyDraft(text)
+	if err != nil {
 		return fmt.Errorf(`output must be {"subject":"...","body":"..."}: %w`, err)
 	}
 	return validateReplyDraft(draft)

--- a/backend/internal/modules/ai/plaintext.go
+++ b/backend/internal/modules/ai/plaintext.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Turning a model's answer back into the plain text the contract promises.
+//
+// A draft body is plain text end to end — there is no rich-text storage
+// format and no HTML+text send pair — but a model asked for prose returns
+// what prose looks like on the web, and `<br>` between paragraphs is the
+// common shape of that. Nothing downstream converts it: the tag reaches the
+// textarea, the send, and the recipient's inbox as four visible characters.
+//
+// So the break is honoured rather than deleted. A model that wrote `<br><br>`
+// meant a paragraph, and dropping the tag would run two paragraphs together —
+// which is the same defect wearing a tidier face.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// breakTag matches the line-break tags a model writes, in the spellings it
+// writes them: with or without the XHTML slash, with or without inner spaces.
+var breakTag = regexp.MustCompile(`(?i)<\s*br\s*/?\s*>`)
+
+// blockClose matches the end of a paragraph-shaped element. It ends a
+// PARAGRAPH rather than a line, so it is worth a blank line where a break tag
+// is worth one newline — `<p>a</p><p>b</p>` means the same as `a<br><br>b`.
+var blockClose = regexp.MustCompile(`(?i)<\s*/\s*(p|div|li|h[1-6])\s*>`)
+
+// blockOpen matches the start of one. It carries no break of its own — the
+// preceding close already supplied it — so it simply leaves.
+var blockOpen = regexp.MustCompile(`(?i)<\s*(p|div|ul|ol|li|h[1-6])(\s[^<>]*)?/?\s*>`)
+
+// runsOfBlankLines collapses three or more newlines to a paragraph break.
+var runsOfBlankLines = regexp.MustCompile(`\n{3,}`)
+
+// PlainText converts a model's answer to the plain text a draft body is
+// contractually made of, preserving the structure the model intended.
+//
+// Only the break-shaped tags are translated. Anything else angle-bracketed is
+// left exactly as written: a body may legitimately contain "<" — a comparison,
+// an address in angle brackets, a quoted snippet of somebody's own message —
+// and a general tag stripper would eat the customer's text to fix our own.
+func PlainText(text string) string {
+	if !strings.Contains(text, "<") {
+		return text
+	}
+	out := breakTag.ReplaceAllString(text, "\n")
+	out = blockClose.ReplaceAllString(out, "\n\n")
+	out = blockOpen.ReplaceAllString(out, "")
+	// A tag sat on its own line leaves the surrounding newlines behind, so the
+	// collapse runs after the replacements rather than as part of them.
+	out = runsOfBlankLines.ReplaceAllString(out, "\n\n")
+	return strings.TrimSpace(out)
+}

--- a/backend/internal/modules/ai/plaintext_test.go
+++ b/backend/internal/modules/ai/plaintext_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"testing"
+)
+
+func TestABreakTagBecomesTheLineBreakItMeant(t *testing.T) {
+	// The observed shape: a model asked for a German reply answered with
+	// `<br><br>` between paragraphs, and every one of those eight characters
+	// reached the composer's textarea.
+	got := PlainText("Guten Tag Dietmar,<br><br>anbei die Aufstellung.<br><br>Viele Grüße")
+	want := "Guten Tag Dietmar,\n\nanbei die Aufstellung.\n\nViele Grüße"
+	if got != want {
+		t.Errorf("PlainText = %q, want %q", got, want)
+	}
+}
+
+func TestTheBreakIsHonouredRatherThanDeleted(t *testing.T) {
+	// Dropping the tag would run two paragraphs into one sentence, which is
+	// the same defect with tidier bytes. The paragraph the model wrote has to
+	// survive as a paragraph.
+	got := PlainText("Erste Zeile.<br>Zweite Zeile.")
+	if got != "Erste Zeile.\nZweite Zeile." {
+		t.Errorf("PlainText = %q, want the break kept as a newline", got)
+	}
+}
+
+func TestEverySpellingOfABreakTagIsRecognised(t *testing.T) {
+	// A model writes the tag however its training data did. Recognising only
+	// one spelling fixes the drafts that happen to use it and leaves the rest
+	// broken in a way nobody can tell apart from the fix not shipping.
+	for _, tag := range []string{"<br>", "<BR>", "<br/>", "<br />", "<br  />", "<Br>"} {
+		if got := PlainText("eins" + tag + "zwei"); got != "eins\nzwei" {
+			t.Errorf("PlainText with %q = %q, want eins\\nzwei", tag, got)
+		}
+	}
+}
+
+func TestParagraphMarkupBecomesParagraphs(t *testing.T) {
+	got := PlainText("<p>Erster Absatz.</p><p>Zweiter Absatz.</p>")
+	if got != "Erster Absatz.\n\nZweiter Absatz." {
+		t.Errorf("PlainText = %q, want two paragraphs", got)
+	}
+}
+
+func TestTextTheReaderWroteIsNotEatenByTheConversion(t *testing.T) {
+	// The reason this translates break tags rather than stripping markup: a
+	// body legitimately carries "<". A general tag stripper would silently
+	// delete the customer's own words to fix our formatting.
+	for _, body := range []string{
+		"Der Betrag ist < 500 EUR.",
+		"Bitte an dietmar <dietmar@example.com> weiterleiten.",
+		"Er schrieb: <Das ist nicht vereinbart>.",
+		"a < b und b > c",
+	} {
+		if got := PlainText(body); got != body {
+			t.Errorf("PlainText(%q) = %q, want it unchanged", body, got)
+		}
+	}
+}
+
+func TestPlainTextLeavesPlainTextAlone(t *testing.T) {
+	body := "Guten Tag,\n\nanbei die Aufstellung.\n\nViele Grüße"
+	if got := PlainText(body); got != body {
+		t.Errorf("PlainText = %q, want the body unchanged", got)
+	}
+}
+
+func TestRunsOfBreaksCollapseToOneParagraph(t *testing.T) {
+	// A model that emits four breaks means one paragraph gap, not three blank
+	// lines the reader has to delete before sending.
+	got := PlainText("eins<br><br><br><br>zwei")
+	if got != "eins\n\nzwei" {
+		t.Errorf("PlainText = %q, want a single paragraph break", got)
+	}
+}


### PR DESCRIPTION
## What happens

A drafted German reply arrived in the composer as one wall of run-together
sentences. The model had answered with `<br><br>` between paragraphs and
nothing converted it, so the tag reached the textarea as four visible
characters — and would have reached the sent mail and the recipient's inbox
the same way.

Observed on a live draft. The raw body:

```
Guten Tag Dietmar,<br><br>wie besprochen, erhalten Sie anbei die Aufstellung...
```

The contract is explicit that a body is plain text end to end: *"There is no
rich-text storage format, no paste sanitiser and no HTML+text send pair."*

## Why it reached a user

Two gaps lined up.

`firstDraftSystem` already tells the model *"Write the body as plain text. No
markdown, no HTML"*. `replyDraftSystem` never did — which is why the reply
path was the one producing markup and the first-message path was not.

And nothing on any of the three parse sites converted what came back. The
validator checks emptiness, subject line breaks and length; markup passes it
clean.

## The fix

The reply prompt now carries the plain-text rule its sibling already had, and
the three parse sites — reply, account, person — convert the body through one
shared `ai.PlainText`. A prompt is a request; the parse is the contract. Either
half alone leaves the defect reachable, so both ship.

**The break is honoured, not deleted.** A model that wrote `<br><br>` meant a
paragraph. Stripping the tag would run two paragraphs into one sentence, which
is the same defect with tidier bytes.

**Only break-shaped tags are translated.** A body legitimately carries `<` — a
comparison (`Der Betrag ist < 500 EUR`), an address in angle brackets, a quoted
snippet of somebody else's message. A general tag stripper would silently eat
the customer's own words to fix our formatting, so it is not one.

`replyDraftShapeValid` now judges through the same parse, so the retry check
cannot accept a body that is only non-empty because of markup the caller then
strips away.

## Tests

Seven unit cases plus one that drives the real drafting path with a stubbed
model, fed the exact answer the live server returned.

Covered: every spelling of the tag a model writes (`<br>`, `<BR>`, `<br/>`,
`<br />`, `<Br>`) — recognising one spelling fixes the drafts that happen to
use it and leaves the rest broken in a way nobody can tell apart from the fix
not shipping; paragraph markup becoming paragraphs; runs of breaks collapsing
to one gap rather than three blank lines to delete; plain text passing through
untouched; and the four `<`-carrying bodies above surviving verbatim.

Mutation-verified: deleting the break instead of honouring it, and removing the
conversion from the reply path, each turn a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AI-generated draft bodies so `<br>` markup reaches the reader as the plain-text paragraph breaks they were meant to be, instead of four visible characters in the composer, the sent mail, and the recipient's inbox.

- Adds a shared `ai.PlainText` conversion to the reply, account, and person draft parse sites.
- The reply prompt now asks for plain text, matching the first-message prompt that already did.
- `replyDraftShapeValid` now validates through the same parse so a markup-only body is rejected.
- Only break and paragraph tags are translated; legitimate `<` text (comparisons, addresses) passes through untouched.

<sup>Written for commit b16f8a59468ceb222a898efec76a546b6a062a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI-generated account, contact, and reply drafts by converting HTML-style formatting into clean, readable plain text.
  * Preserved paragraph breaks while removing line-break and block markup.
  * Prevented Markdown, HTML, and bullet formatting from appearing in generated reply bodies.

* **Tests**
  * Added coverage for line breaks, paragraphs, repeated breaks, and literal angle-bracket text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->