### PR TITLE
The orb reports the ask, not just the run

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -235,15 +235,18 @@ describe("the api client's model-call count", () => {
   // delivered one. Counted down on every ending, or the orb would stay lit for
   // the rest of the session on one 422.
   it("stops counting a model route that was refused", async () => {
+    // Seen rising as well as settling: a route that was never counted also
+    // ends at zero, and that is the invisible failure this file exists for.
+    const seen: number[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify({ code: "validation_error" }), {
-            status: 422,
-            headers: { "Content-Type": "application/problem+json" },
-          }),
-      ),
+      vi.fn(async () => {
+        seen.push(modelCallsInFlight());
+        return new Response(JSON.stringify({ code: "validation_error" }), {
+          status: 422,
+          headers: { "Content-Type": "application/problem+json" },
+        });
+      }),
     );
 
     await api.POST("/people/{id}/draft-email", {
@@ -251,7 +254,31 @@ describe("the api client's model-call count", () => {
       body: {},
     });
 
+    expect(seen).toEqual([1]);
     expect(modelCallsInFlight()).toBe(0);
+  });
+
+  // The dossier and the growth-fit reading are READ at the same paths they are
+  // asked for. A panel loading the last reading is the reader's own click, and
+  // counting it lit the orb for a fetch the agent had nothing to do with.
+  it("does not count a read at a model route's path", async () => {
+    const seen: number[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        seen.push(modelCallsInFlight());
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await api.GET("/organizations/{id}/dossier", {
+      params: { path: { id: "01a0-4cd2" } },
+    });
+
+    expect(seen).toEqual([0]);
   });
 
   // An ordinary read is the reader's own click, not the agent's work. The rail

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { api, REQUEST_TIMEOUT_MS, RequestTimeoutError } from "./client";
+import { modelCallsInFlight } from "./model-inflight";
 
 // The spec for the client's deadline. The failure it exists for is the one
 // nothing above can see: a request that opens and never answers looks exactly
@@ -172,5 +173,105 @@ describe("a gateway that gave up on the app behind it", () => {
     const { error } = await api.GET("/me");
 
     expect(error).not.toMatchObject({ code: "gateway_unavailable" });
+  });
+});
+
+// What the chrome learns from a request while it is still open.
+//
+// The failure this covers is entirely invisible: the count is read by the rail,
+// so a route that stopped being counted looks like an agent that did nothing,
+// which is exactly what the surface would report if the agent HAD done nothing.
+describe("the api client's model-call count", () => {
+  it("counts a route whose handler calls a model and waits", async () => {
+    const seen: number[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        seen.push(modelCallsInFlight());
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await api.POST("/people/{id}/draft-email", {
+      params: { path: { id: "01a0-4cd2" } },
+      body: {},
+    });
+
+    expect(seen).toEqual([1]);
+    expect(modelCallsInFlight()).toBe(0);
+  });
+
+  // The draft is not the only route a person presses and then waits on. This
+  // one is here because the list read three routes while the contract had
+  // nine, and a route missing from it fails the only way that cannot be seen:
+  // the chrome reports an agent at rest, which is exactly what it would report
+  // if the agent were.
+  it("counts a model route that is not the draft", async () => {
+    const seen: number[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        seen.push(modelCallsInFlight());
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await api.POST("/knowledge/corpora/{id}/ask", {
+      params: { path: { id: "01a0-4cd2" } },
+      body: { question: "what did we promise them" },
+    });
+
+    expect(seen).toEqual([1]);
+    expect(modelCallsInFlight()).toBe(0);
+  });
+
+  // A refused draft is the agent no longer working just as surely as a
+  // delivered one. Counted down on every ending, or the orb would stay lit for
+  // the rest of the session on one 422.
+  it("stops counting a model route that was refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ code: "validation_error" }), {
+            status: 422,
+            headers: { "Content-Type": "application/problem+json" },
+          }),
+      ),
+    );
+
+    await api.POST("/people/{id}/draft-email", {
+      params: { path: { id: "01a0-4cd2" } },
+      body: {},
+    });
+
+    expect(modelCallsInFlight()).toBe(0);
+  });
+
+  // An ordinary read is the reader's own click, not the agent's work. The rail
+  // once derived the agent's state from the browser's fetches, and the result
+  // was a Core that reported a list loading in the agent's own vocabulary.
+  it("does not count an ordinary read", async () => {
+    const seen: number[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        seen.push(modelCallsInFlight());
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await api.GET("/me");
+
+    expect(seen).toEqual([0]);
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -140,7 +140,10 @@ const GATEWAY_STATUSES = new Set([502, 503, 504]);
 // pressed the button really is waiting on the agent for that whole time.
 //
 // Suffixes, so one entry covers a route the contract spells for a person, an
-// organization and an activity alike. A route that ENQUEUES model work rather
+// organization and an activity alike. The COUNT reads them for POST only: the
+// dossier and the growth-fit reading are also READ at these paths, and a panel
+// fetching the last reading is the reader's own click, not the agent at work.
+// A route that ENQUEUES model work rather
 // than waiting for it does not belong here in either reader's sense: it answers
 // at once, so there is no long request for a proxy to cut and nothing for this
 // tab to wait on, and its occurrence reaches the chrome the way every
@@ -162,6 +165,7 @@ const MODEL_ROUTE_SUFFIXES = [
   "/enrich",
   "/growth-fit",
   "/regenerate",
+  "/research",
 ];
 
 /**
@@ -207,6 +211,14 @@ function callsAModel(url: string): boolean {
   return MODEL_ROUTE_SUFFIXES.some((suffix) => path.endsWith(suffix));
 }
 
+// Whether THIS request is the agent at work: a POST to a model route. The
+// reads that share those paths are the reader's own, and the gateway reader
+// above keeps its wider view — a cut connection on either is still a request
+// the server did not finish.
+function asksAModel(request: Request): boolean {
+  return request.method === "POST" && callsAModel(request.url);
+}
+
 export const api = createClient<paths>({
   // same-origin absolute base + the /v1 mount: contract paths are
   // unprefixed, the server serves them under /v1 (same as curl :8080/v1/me)
@@ -221,7 +233,7 @@ export const api = createClient<paths>({
     if (language && !request.headers.has("Accept-Language")) {
       request.headers.set("Accept-Language", language);
     }
-    if (!callsAModel(request.url)) {
+    if (!asksAModel(request)) {
       return fetchWithDeadline(request);
     }
     // The chrome learns the agent is working HERE, where it is already known,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import type { paths } from "@composition/schema";
 import createClient from "openapi-fetch";
+import { beginModelCall, endModelCall } from "./model-inflight";
 
 // The ONE API seam (architecture/01: the frontend depends on the generated
 // contract, never Go internals). Types come from src/api/schema.d.ts —
@@ -121,17 +122,47 @@ async function fetchWithDeadline(request: Request): Promise<Response> {
 // rather than the app refusing something.
 const GATEWAY_STATUSES = new Set([502, 503, 504]);
 
-// The routes whose handler calls a model and waits. Only these get the gateway
-// message below, and the narrowness is the point: a bodiless 5xx from any other
-// endpoint is an ordinary server fault, and the app has surfaces that read it
-// as one — the composer branches on a bare 501, the connector screens on a
-// bodiless 503. Rewriting every one of those to say "the work may still be
-// running" would be false about a mailer that is simply not wired.
+// The routes whose handler calls a model and waits.
 //
-// What makes these three different is duration: a model call runs for tens of
-// seconds, so a proxy giving up on one really does leave work in flight, and
-// really does make a retry a second call rather than a repeat.
-const MODEL_ROUTE_SUFFIXES = ["/draft-email", "/dossier", "/growth-fit"];
+// ONE list, TWO readers, and they want the same routes for the same reason.
+// `withGatewayProblem` gives only these a "the work may still be running"
+// sentence when a proxy gives up, and the narrowness is the point: a bodiless
+// 5xx from any other endpoint is an ordinary server fault, and the app has
+// surfaces that read it as one: the composer branches on a bare 501, the
+// connector screens on a bodiless 503. Rewriting every one of those would be
+// false about a mailer that is simply not wired. `model-inflight.ts` counts a
+// request to one of these as the agent working, so the chrome reports the ask
+// at the moment it is made rather than at the next poll of the activity feed.
+//
+// What makes these routes different is duration: a model call runs for tens of
+// seconds, so a proxy giving up on one really does leave work in flight and
+// really does make a retry a second call rather than a repeat, and a person who
+// pressed the button really is waiting on the agent for that whole time.
+//
+// Suffixes, so one entry covers a route the contract spells for a person, an
+// organization and an activity alike. A route that ENQUEUES model work rather
+// than waiting for it does not belong here in either reader's sense: it answers
+// at once, so there is no long request for a proxy to cut and nothing for this
+// tab to wait on, and its occurrence reaches the chrome the way every
+// background run does, through the feed. The deep read, the document
+// extraction, the transcript proposals and the technical enrich are all that
+// shape and all deliberately absent.
+//
+// The list read three routes for a long time while the contract had nine, which
+// was invisible in both directions: the extra six could have their connection
+// cut and say nothing about it, and the whole of a corpus answer or an offer
+// rewrite ran with the chrome at rest. A suffix here is a claim about a
+// handler, so check the handler before adding one.
+const MODEL_ROUTE_SUFFIXES = [
+  "/ask",
+  "/coldstart",
+  "/coldstart/preview",
+  "/draft-email",
+  "/dossier",
+  "/enrich",
+  "/growth-fit",
+  "/regenerate",
+];
 
 /**
  * Give a proxy's failure ON A SLOW AI ROUTE a problem body, so the reader is
@@ -190,7 +221,15 @@ export const api = createClient<paths>({
     if (language && !request.headers.has("Accept-Language")) {
       request.headers.set("Accept-Language", language);
     }
-    return fetchWithDeadline(request);
+    if (!callsAModel(request.url)) {
+      return fetchWithDeadline(request);
+    }
+    // The chrome learns the agent is working HERE, where it is already known,
+    // rather than on the next poll of the activity feed seconds later. Counted
+    // in a `finally` so a refusal and a stall end the call as surely as an
+    // answer does.
+    beginModelCall();
+    return fetchWithDeadline(request).finally(endModelCall);
   },
 });
 

--- a/frontend/src/api/model-inflight.test.tsx
+++ b/frontend/src/api/model-inflight.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import {
+  beginModelCall,
+  endModelCall,
+  modelCallsInFlight,
+  useModelCallsInFlight,
+} from "./model-inflight";
+
+afterEach(() => {
+  cleanup();
+  while (modelCallsInFlight() > 0) {
+    endModelCall();
+  }
+});
+
+// Every change is published, not only the crossings of zero. The rail reads
+// the count as a boolean, but the feed is refetched on each edge of a call, so
+// two calls overlapping would otherwise have their inner edges — the second
+// leaving, the first answering — pass without a read.
+it("reports every step of overlapping calls to its subscribers", () => {
+  const { result } = renderHook(() => useModelCallsInFlight());
+  const seen = [result.current];
+  for (const step of [
+    beginModelCall,
+    beginModelCall,
+    endModelCall,
+    endModelCall,
+  ]) {
+    act(step);
+    seen.push(result.current);
+  }
+  expect(seen).toEqual([0, 1, 2, 1, 0]);
+});
+
+// Nothing began, so nothing can end. A count allowed below zero would read as
+// false in every consumer and hide the NEXT real call instead of the bug.
+it("never goes below zero", () => {
+  endModelCall();
+  expect(modelCallsInFlight()).toBe(0);
+});

--- a/frontend/src/api/model-inflight.ts
+++ b/frontend/src/api/model-inflight.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * How many model calls THIS TAB is waiting on, right now.
+ *
+ * The server's projection is the record of what the agent did, and it is the
+ * only thing that can say what a run was. It cannot say the one thing a reader
+ * pressing a button needs first: that their own ask left the building. The
+ * projection is a read on a poll, so between the click and the next read the
+ * chrome has nothing to report and reports nothing, which is how "Draft with
+ * AI" came to light no orb at all.
+ *
+ * This is the other end of the same fact, observed where it is already known:
+ * the client is holding a request open to a route whose handler calls a model
+ * and waits. It is not a second opinion about what the agent is doing. It
+ * carries no kind, no state and no sentence, because it knows none of those;
+ * everything the rail SAYS still comes from the feed.
+ *
+ * The same shape as `agent-edge-signal.ts`: one module-level value, a publish
+ * that only notifies on a real change, and a snapshot whose identity is stable
+ * between changes so `useSyncExternalStore` does not re-render forever.
+ */
+
+let open = 0;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** A request to a model route has left. */
+export function beginModelCall(): void {
+  open += 1;
+  if (open === 1) {
+    notify();
+  }
+}
+
+/**
+ * A request to a model route has answered, or failed, or timed out.
+ *
+ * Called from a `finally`, so every ending counts: a refused draft is the agent
+ * no longer working just as much as a delivered one, and a count that only came
+ * down on success would leave the orb lit for the rest of the session.
+ */
+export function endModelCall(): void {
+  if (open === 0) {
+    // Nothing began, so nothing can end. Guarded rather than allowed to go
+    // negative: a negative count reads as false in the consumer and would hide
+    // the NEXT real call instead of the bug that caused it.
+    return;
+  }
+  open -= 1;
+  if (open === 0) {
+    notify();
+  }
+}
+
+/** The current count, for a consumer that is not a component. */
+export function modelCallsInFlight(): number {
+  return open;
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+/** The count, as a component sees it. */
+export function useModelCallsInFlight(): number {
+  return useSyncExternalStore(
+    subscribe,
+    modelCallsInFlight,
+    modelCallsInFlight,
+  );
+}

--- a/frontend/src/api/model-inflight.ts
+++ b/frontend/src/api/model-inflight.ts
@@ -20,8 +20,12 @@ import { useSyncExternalStore } from "react";
  * everything the rail SAYS still comes from the feed.
  *
  * The same shape as `agent-edge-signal.ts`: one module-level value, a publish
- * that only notifies on a real change, and a snapshot whose identity is stable
- * between changes so `useSyncExternalStore` does not re-render forever.
+ * on every change, and a snapshot whose identity is stable between changes so
+ * `useSyncExternalStore` does not re-render forever. EVERY change, not only the
+ * crossings of zero: the rail reads the count as a boolean, but the feed is
+ * refetched on each edge of a call, and two calls overlapping would otherwise
+ * have their inner edges — the second leaving, the first answering — pass
+ * without a read.
  */
 
 let open = 0;
@@ -36,9 +40,7 @@ function notify(): void {
 /** A request to a model route has left. */
 export function beginModelCall(): void {
   open += 1;
-  if (open === 1) {
-    notify();
-  }
+  notify();
 }
 
 /**
@@ -56,9 +58,7 @@ export function endModelCall(): void {
     return;
   }
   open -= 1;
-  if (open === 0) {
-    notify();
-  }
+  notify();
 }
 
 /** The current count, for a consumer that is not a component. */

--- a/frontend/src/app/agent-edge.css
+++ b/frontend/src/app/agent-edge.css
@@ -26,12 +26,21 @@
 .agentedge {
   position: fixed;
   inset: 0;
-  /* Just above the chrome, and no higher. The top bar and the rail sit at 20
-     (topbar.css, shell.css) and were painting over the top edge of the glow,
-     which cropped the frame along one side. Everything that wants a reader's
-     attention is at 28 or above (sheets, scrims, menus, tooltips), so it keeps
-     its place over this. */
-  z-index: 21;
+  /* Above everything the page can raise, and below the skip link alone.
+
+     It used to sit at 21, just over the chrome, on the reasoning that anything
+     asking for a reader's attention belongs over it. That reasoning had the
+     subject wrong. The mark is a property of the WINDOW and not of the page: it
+     says the agent is working for this person right now, which stays true while
+     a composer is open over the record, and a scrim that covers the page was
+     covering the one report that is not about the page. Pressing "Draft with
+     AI" in the composer lit an edge nobody could see.
+
+     Safe to sit this high because it can only ever be seen and never touched:
+     `pointer-events: none` and `aria-hidden` throughout, one translucent rim on
+     the window's extreme edge. The skip link (100, shell.css) stays above it,
+     because a keyboard affordance being visible outranks a decoration. */
+  z-index: 90;
   pointer-events: none;
 }
 

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -19,6 +19,7 @@ import userEvent, { type UserEvent } from "@testing-library/user-event";
 import type { ReactNode, RefObject } from "react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { beginModelCall, endModelCall } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { clearAgentEdge, currentAgentEdge } from "./agent-edge-signal";
@@ -1033,6 +1034,47 @@ describe("AgentRail", () => {
     withRuns(RUN());
     const { container } = render(ROUTE);
     await settlesOnLine(container, BRIEF_RUNNING);
+  });
+
+  // The window the feed cannot cover. The projection is written from an event
+  // the router publishes, so between the press of "Draft with AI" and the read
+  // that first carries the occurrence there is a live model call and an orb at
+  // rest, which for a task that runs in seconds was most of the run, and at
+  // the idle cadence was the whole of it.
+  it("moves the Core to working while this tab holds a model call open", async () => {
+    withRuns();
+    const { container } = render(ROUTE);
+    await waitFor(() =>
+      expect(block(container).getAttribute("data-core-state")).toBe("idle"),
+    );
+
+    act(() => {
+      beginModelCall();
+    });
+    await waitFor(() =>
+      expect(block(container).getAttribute("data-core-state")).toBe("working"),
+    );
+
+    act(() => {
+      endModelCall();
+    });
+  });
+
+  // The feed is the only thing that may NAME the work, so the moment it carries
+  // the occurrence it outranks the bare fact that a request is open. Both are
+  // true here at once, and the sentence has to be the run's own.
+  it("lets the feed name the work as soon as it carries the run", async () => {
+    withRuns(RUN());
+    const { container } = render(ROUTE);
+    act(() => {
+      beginModelCall();
+    });
+
+    await settlesOnLine(container, BRIEF_RUNNING);
+
+    act(() => {
+      endModelCall();
+    });
   });
 
   // Two subjects, two slots. They used to share one, so the agent's sentence

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -19,7 +19,11 @@ import userEvent, { type UserEvent } from "@testing-library/user-event";
 import type { ReactNode, RefObject } from "react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { beginModelCall, endModelCall } from "../api/model-inflight";
+import {
+  beginModelCall,
+  endModelCall,
+  modelCallsInFlight,
+} from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { clearAgentEdge, currentAgentEdge } from "./agent-edge-signal";
@@ -325,6 +329,12 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  // The in-flight count is module state, reset here the way clearAgentEdge
+  // resets its sibling signal: a case failing between begin and end would
+  // otherwise start every later case in this file at "working".
+  while (modelCallsInFlight() > 0) {
+    endModelCall();
+  }
   // The frame case spies on Element.prototype.getBoundingClientRect, which every
   // later case in this file shares. Restored here rather than there: a spy left
   // on a prototype is the kind of leak whose failure names a case that is fine.

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -844,13 +844,30 @@ function usePanelFrame(
 /**
  * The state the section shows when nobody has overridden it.
  *
- * ONE SUBJECT: the agent. Nothing the browser does reaches this function. The
- * rail used to derive `ingest` from a query being in flight and `working` from a
- * mutation, which meant the Core spoke the agent's vocabulary while reporting
- * the reader's own clicks: the orb went to `ingest` because a list was loading,
- * and `ingest` was therefore the one state the agent could never cause. What the
- * tool is doing is still reported, in its own quieter line under this one, and
- * it no longer borrows the agent's voice to do it.
+ * ONE SUBJECT: the agent. The rail used to derive `ingest` from a query being in
+ * flight and `working` from any mutation, which meant the Core spoke the agent's
+ * vocabulary while reporting the reader's own clicks: the orb went to `ingest`
+ * because a list was loading, and `ingest` was therefore the one state the agent
+ * could never cause. What the TOOL is doing is still reported, in its own
+ * quieter line under this one, and it no longer borrows the agent's voice.
+ *
+ * The subject stayed the agent when a second observer of it was added. Two
+ * things watch the same work from different ends: the server's projection, which
+ * knows what a run IS and is the only thing that may name it, and this tab's own
+ * count of requests it is holding open to a route whose handler calls a model
+ * and waits (`asking`, from api/model-inflight.ts). The projection arrives on a
+ * poll, so between a person pressing "Draft with AI" and the next read there was
+ * a live model call nothing on screen reported: the orb sat at rest through the
+ * whole of the work it exists to show. `asking` closes that window and claims
+ * nothing else: it ranks BELOW every occurrence the feed carries, so it can
+ * never outrank a run, and the moment the feed can name the work it does.
+ *
+ * The correction that ranking allows is real and is the design working, not a
+ * defect to hide: `asking` answers `working` because a request in flight cannot
+ * say which half of the lifecycle it is in, so a route whose task turns out to
+ * be `ingest` (the enrich and cold-start lanes) shows `working` for the
+ * moment before the feed arrives and settles into its own lane after. A guess
+ * the owner of the fact overrules is the right shape for a bridge.
  *
  * The order is severity, and it starts with the faults that stop the agent
  * running AT ALL, because an agent with no model bound is not a broken run, it
@@ -920,6 +937,18 @@ function derive(
   const live = server.running.find((item) => item.state !== "stalled");
   if (live) {
     return { state: laneFor(live), cause: live };
+  }
+  // This tab's own ask, which the feed has not caught up with yet. `working`
+  // rather than a lane read from the kind, because the kind is exactly what is
+  // not known here: a request in flight says the agent is busy and says nothing
+  // about which half of its lifecycle it is in. `working` is the same answer
+  // laneFor gives an unnamed kind, and for the same reason: the honest half of
+  // what is known. No cause travels with it, so the line under the orb falls
+  // back to the generic word instead of borrowing a sentence about some other
+  // run, and the moment the feed carries the occurrence the branch above wins
+  // and names it.
+  if (server.asking) {
+    return { state: "working", cause: null };
   }
   // A request that failed a moment ago does NOT colour the orb. One dropped
   // request on a flaky connection would otherwise flash the corner of every

--- a/frontend/src/app/ai-activity.test.tsx
+++ b/frontend/src/app/ai-activity.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beginModelCall, endModelCall } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { useAiActivity } from "./ai-activity";
 import { displayedKinds, lineFor } from "./ai-activity-lines";
@@ -294,5 +295,89 @@ describe("the kinds filter", () => {
     for (const kind of new URL(urls[0]).searchParams.getAll("kinds")) {
       expect(lineFor({ kind, state: "done" }, (key) => key)).not.toBeNull();
     }
+  });
+});
+
+// This tab's own ask, which is the half of the fact the feed cannot deliver in
+// time. The projection is written from an event the router publishes, so there
+// is a window between the button and the feed in which the agent is working and
+// the poll has not looked; at the idle cadence that window was thirty seconds,
+// which is longer than most of the tasks a person triggers and then waits on.
+describe("the reader's own ask", () => {
+  it("reports the agent as asked the moment a model call opens", async () => {
+    const { result } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    expect(result.current.asking).toBe(false);
+
+    await act(async () => {
+      beginModelCall();
+    });
+
+    expect(result.current.asking).toBe(true);
+
+    // The count is module state shared by every test in this file, so an ask
+    // left open here would report the NEXT test's agent as busy.
+    await act(async () => {
+      endModelCall();
+    });
+  });
+
+  it("holds the ask long enough to be seen after the call answers", async () => {
+    const { result } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    await act(async () => {
+      beginModelCall();
+    });
+
+    // The offline fake model answers in about this long, so an ask reported
+    // only for the life of its request would never be drawn at all.
+    await advance(100);
+    await act(async () => {
+      endModelCall();
+    });
+    await advance(500);
+    expect(result.current.asking).toBe(true);
+
+    await advance(400);
+    expect(result.current.asking).toBe(false);
+  });
+
+  it("reads the feed at both ends of a call rather than waiting for a poll", async () => {
+    const { reads } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    expect(reads).toHaveLength(1);
+
+    // The occurrence appears when the request leaves.
+    await act(async () => {
+      beginModelCall();
+    });
+    await advance(0);
+    expect(reads).toHaveLength(2);
+
+    // It settles when the request answers, and waiting out the linger first
+    // would put the settled line on screen most of a second late.
+    await act(async () => {
+      endModelCall();
+    });
+    await advance(0);
+    expect(reads).toHaveLength(3);
+  });
+
+  it("polls fast while an ask is open and the feed still reports nothing", async () => {
+    const { reads } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    await act(async () => {
+      beginModelCall();
+    });
+    // The edge read above.
+    await advance(0);
+    const beforeCadence = reads.length;
+
+    await advance(3_000);
+    expect(reads.length).toBeGreaterThan(beforeCadence);
+
+    await act(async () => {
+      endModelCall();
+    });
   });
 });

--- a/frontend/src/app/ai-activity.test.tsx
+++ b/frontend/src/app/ai-activity.test.tsx
@@ -3,7 +3,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { beginModelCall, endModelCall } from "../api/model-inflight";
+import {
+  beginModelCall,
+  endModelCall,
+  modelCallsInFlight,
+} from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { useAiActivity } from "./ai-activity";
 import { displayedKinds, lineFor } from "./ai-activity-lines";
@@ -99,6 +103,12 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  // The in-flight count is module state every case in this file shares. A case
+  // that fails between its begin and its end would otherwise hand the next case
+  // an agent already asking, and the failure would name the wrong test.
+  while (modelCallsInFlight() > 0) {
+    endModelCall();
+  }
   // The listener-registry case spies on document itself, which would otherwise
   // outlive its test.
   vi.restoreAllMocks();
@@ -361,6 +371,44 @@ describe("the reader's own ask", () => {
     });
     await advance(0);
     expect(reads).toHaveLength(3);
+  });
+
+  // The floor is for a call the feed never caught up with. Once the feed
+  // carries the settled run, the idle line names it, and a bare "working" held
+  // over that line would be the presentation contradicting the record.
+  it("yields the linger the moment the feed carries the settled run", async () => {
+    let settled = false;
+    const { result } = mount(() =>
+      jsonResponse(
+        settled
+          ? {
+              as_of: "2026-08-21T05:00:01Z",
+              running: [],
+              recent: [
+                {
+                  ...A_RUN,
+                  kind: "draft_reply",
+                  state: "done",
+                  finished_at: "2026-08-21T05:00:01Z",
+                },
+              ],
+            }
+          : activity([]),
+      ),
+    );
+    await advance(0);
+    await act(async () => {
+      beginModelCall();
+    });
+    await advance(0);
+
+    settled = true;
+    await act(async () => {
+      endModelCall();
+    });
+    // The end-edge read answers, and that is enough: no 900ms wait.
+    await advance(0);
+    expect(result.current.asking).toBe(false);
   });
 
   it("polls fast while an ask is open and the feed still reports nothing", async () => {

--- a/frontend/src/app/ai-activity.ts
+++ b/frontend/src/app/ai-activity.ts
@@ -70,7 +70,6 @@ export function useAiActivity(): AiActivity {
   const client = useQueryClient();
   const [visible, setVisible] = useState(() => !document.hidden);
   const open = useModelCallsInFlight();
-  const asking = useLingeringAsk(open);
 
   useEffect(() => {
     const onVisibilityChange = () => {
@@ -118,8 +117,10 @@ export function useAiActivity(): AiActivity {
     // short window in which this tab knows the agent is working and the feed
     // does not yet, and resting at the idle cadence through that window is how
     // a run that lasted five seconds was read at thirty-second resolution.
+    // The raw count and not the lingering flag: the linger is presentation,
+    // and the cadence follows the fact.
     refetchInterval: (q) =>
-      asking || (q.state.data?.running ?? NOTHING).length > 0
+      open > 0 || (q.state.data?.running ?? NOTHING).length > 0
         ? POLL_LIVE_MS
         : POLL_IDLE_MS,
   });
@@ -165,9 +166,11 @@ export function useAiActivity(): AiActivity {
   // whole section throws instead of reporting nothing.
   const answered = query.data;
   const running = answered?.running ?? NOTHING;
+  const recent = answered?.recent ?? NOTHING;
+  const asking = useLingeringAsk(open, recent[0]?.id);
   return {
     running,
-    recent: answered?.recent ?? NOTHING,
+    recent,
     // STALLED is not working. The server derives that state for an occurrence
     // whose own source says it should have finished by now, and the chrome that
     // reads `working` pulses to say the AI is busy — so counting a stalled item
@@ -185,11 +188,25 @@ export function useAiActivity(): AiActivity {
  * lives here rather than in the store so the count stays honest for anybody
  * else who reads it: a store that lied about what was in flight to make a light
  * look right would hand its next consumer a fact that is not one.
+ *
+ * The floor is for a call the feed never caught up with. `newestSettled` is
+ * the feed's newest settled occurrence; a DIFFERENT one arriving while the ask
+ * lingers is the feed naming the work that just finished, and the linger
+ * yields to it at once — holding a bare "working" over a line that already
+ * says what was done would be the presentation contradicting the record.
  */
-function useLingeringAsk(open: number): boolean {
+function useLingeringAsk(
+  open: number,
+  newestSettled: string | undefined,
+): boolean {
   const [lingering, setLingering] = useState(false);
+  // What the feed's newest settled occurrence was when the ask left. Null
+  // while no ask is being held, so a settlement from some other run does not
+  // count as this one's.
+  const settledAtAsk = useRef<{ id: string | undefined } | null>(null);
   useEffect(() => {
     if (open > 0) {
+      settledAtAsk.current ??= { id: newestSettled };
       setLingering(true);
       return undefined;
     }
@@ -197,6 +214,11 @@ function useLingeringAsk(open: number): boolean {
       // Nothing is being held over, so there is nothing to stop holding. The
       // guard is what keeps a rail that has never seen an ask from arming a
       // timer on every mount, which is a page that never goes quiet.
+      settledAtAsk.current = null;
+      return undefined;
+    }
+    if (settledAtAsk.current && settledAtAsk.current.id !== newestSettled) {
+      setLingering(false);
       return undefined;
     }
     const timer = setTimeout(() => {
@@ -205,6 +227,6 @@ function useLingeringAsk(open: number): boolean {
     return () => {
       clearTimeout(timer);
     };
-  }, [open, lingering]);
+  }, [open, lingering, newestSettled]);
   return open > 0 || lingering;
 }

--- a/frontend/src/app/ai-activity.ts
+++ b/frontend/src/app/ai-activity.ts
@@ -4,6 +4,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
+import { useModelCallsInFlight } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { throwProblem } from "../screens/common";
 import { displayedKinds } from "./ai-activity-lines";
@@ -13,6 +14,21 @@ type AiActivityItem = components["schemas"]["AiActivityItem"];
 /** Fast while the AI is mid-occurrence; slow otherwise. */
 const POLL_LIVE_MS = 3_000;
 const POLL_IDLE_MS = 30_000;
+
+/**
+ * How long this tab's own ask stays reported after its request ended.
+ *
+ * A model call that answers in a tenth of a second is still the agent doing
+ * something a person asked for, and a light that appears and disappears inside
+ * one animation frame is a light nobody sees. This is the same floor the
+ * ticker's lines are given (`LINGER_MS` in agentrail-ticker.ts) and for the
+ * same reason: long enough to register, short enough that the report is never
+ * stale. It stretches the PRESENTATION of a real event and invents none: the
+ * offline fake model answers in about a tenth of a second, so without a floor
+ * every dev stack and every demo would show exactly the nothing this change
+ * exists to fix.
+ */
+const ASK_LINGER_MS = 900;
 
 const ACTIVITY_KEY = ["me", "ai-activity"] as const;
 
@@ -26,6 +42,16 @@ export type AiActivity = Readonly<{
   recent: readonly AiActivityItem[];
   /** Whether any AI work is live RIGHT NOW, as reported by a read that answered. */
   working: boolean;
+  /**
+   * Whether THIS TAB is holding a request open to a route that calls a model.
+   *
+   * Its own fact, beside the feed rather than mixed into it, because the two
+   * know different things. The feed knows what the work IS and is the only
+   * thing that may say so; it arrives on a poll, so it cannot answer the
+   * instant somebody presses a button. This answers exactly that instant and
+   * nothing else: no kind, no state, no sentence.
+   */
+  asking: boolean;
 }>;
 
 /**
@@ -43,6 +69,8 @@ export type AiActivity = Readonly<{
 export function useAiActivity(): AiActivity {
   const client = useQueryClient();
   const [visible, setVisible] = useState(() => !document.hidden);
+  const open = useModelCallsInFlight();
+  const asking = useLingeringAsk(open);
 
   useEffect(() => {
     const onVisibilityChange = () => {
@@ -85,11 +113,33 @@ export function useAiActivity(): AiActivity {
     // Coalesced through NOTHING for the same reason the result below is: the
     // cached body is whatever the server sent, and reaching into it for a
     // length is what turns an off-contract 200 into a throw.
+    // An ask in flight counts as live even before the feed agrees. The
+    // projection is written from an event the router publishes, so there is a
+    // short window in which this tab knows the agent is working and the feed
+    // does not yet, and resting at the idle cadence through that window is how
+    // a run that lasted five seconds was read at thirty-second resolution.
     refetchInterval: (q) =>
-      (q.state.data?.running ?? NOTHING).length > 0
+      asking || (q.state.data?.running ?? NOTHING).length > 0
         ? POLL_LIVE_MS
         : POLL_IDLE_MS,
   });
+
+  // Both EDGES of an ask, read immediately rather than waited for: the request
+  // leaving is when the occurrence appears, and the request answering is when
+  // it settles. Polling alone would show each of those up to a poll late, which
+  // for the short tasks a person triggers and then watches is most of the run.
+  //
+  // On `open` rather than on the lingering flag above, because the linger is a
+  // presentation floor and this is a read: waiting it out would put the settled
+  // line on screen most of a second after the draft it describes.
+  const previousOpen = useRef(open);
+  useEffect(() => {
+    if (open === previousOpen.current) {
+      return;
+    }
+    previousOpen.current = open;
+    void client.refetchQueries({ queryKey: ACTIVITY_KEY });
+  }, [open, client]);
 
   // The app disables focus refetching for every query (FE-PARAM-3), so
   // returning to the tab is otherwise answered out of the cache — and the
@@ -124,5 +174,37 @@ export function useAiActivity(): AiActivity {
     // here would animate "still going" over a line that reads "it may have
     // stopped", softening the one verdict this state exists to deliver.
     working: running.some((item) => item.state !== "stalled"),
+    asking,
   };
+}
+
+/**
+ * An ask, held on screen for long enough to be seen.
+ *
+ * `open` is the truth and this is what a reader can perceive of it. The floor
+ * lives here rather than in the store so the count stays honest for anybody
+ * else who reads it: a store that lied about what was in flight to make a light
+ * look right would hand its next consumer a fact that is not one.
+ */
+function useLingeringAsk(open: number): boolean {
+  const [lingering, setLingering] = useState(false);
+  useEffect(() => {
+    if (open > 0) {
+      setLingering(true);
+      return undefined;
+    }
+    if (!lingering) {
+      // Nothing is being held over, so there is nothing to stop holding. The
+      // guard is what keeps a rail that has never seen an ask from arming a
+      // timer on every mount, which is a page that never goes quiet.
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setLingering(false);
+    }, ASK_LINGER_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [open, lingering]);
+  return open > 0 || lingering;
 }


### PR DESCRIPTION
Pressing **Draft with AI** ran a live model call against an orb at rest. The AI-activity feed is a poll, so the chrome learned about a person's own request seconds after they made it — and at the 30s idle cadence, that was the whole of a run that takes a second. The projection was right the entire time; nothing was asking it.

## What changed

**This tab counts the model calls it is holding open**, and the rail reads that count beside the feed. Two observers of one fact from different ends: the feed knows what a run IS and stays the only thing that may name it, while the count answers the instant a button is pressed and carries no kind, no state and no sentence. It ranks below every occurrence the feed carries, so the moment the feed can name the work it does, and it can never contradict a run.

Both edges of a call also refetch the feed, so an occurrence appears when the request leaves and settles when it answers, rather than up to a poll later. A 900ms floor holds a fast answer on screen long enough to be seen — the offline fake model answers in about a tenth of a second, so without it every dev stack and demo would show exactly the nothing this fixes.

**`MODEL_ROUTE_SUFFIXES` becomes one list with two readers.** It already meant "routes that call a model and wait" for the gateway-problem message, and named three of the contract's nine. That was invisible in both directions: the other six could have their connection cut and say nothing about it, and the whole of a corpus answer or an offer rewrite ran with the chrome at rest. Each addition was checked against its Go handler for the synchronous/enqueued distinction — a route that enqueues does not belong here in either reader's sense.

**The lit margin moves to z-index 90.** It sat at 21 on the reasoning that anything asking for a reader's attention belongs over it, which had the subject wrong: the mark is a property of the *window* rather than of the page. It stays true while a composer is open over the record, and a page-level scrim was covering the one report that is not about the page. Safe that high because it is `pointer-events: none` and `aria-hidden` throughout; the skip link stays above it.

## Verified in the app

Against the real stack, through the real button, on a person's composer:

```
working   Working                      <- this tab's own ask, instantly
working   I'm drafting your reply.     <- the feed catching up and naming it
idle
```

The rim was confirmed painting over the composer at the window's edge, and the count measured against the server: the `draft_reply` row reaches the feed ~140ms after the call.

## Tests

Nine new cases across three files, each covering a failure that is invisible by construction — a route that stops being counted looks exactly like an agent that did nothing.

- the count rises for a model route and falls on every ending, refusals included
- a route that is not the draft is counted too (the gap this PR closes)
- an ordinary read is never counted — the rail once spoke the agent's vocabulary about the browser's own fetches, and must not again
- the ask is reported instantly, held long enough to be seen, and reads the feed at both edges
- the feed outranks the ask as soon as it carries the run

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the agent status rail show when this tab is waiting on a model call, instead of staying quiet until the next poll of the AI-activity feed. Pressing "Draft with AI" now lights the orb instantly rather than up to 30 seconds later.

- Expanded `MODEL_ROUTE_SUFFIXES` from three to nine routes, each verified to wait on the model; enqueuing routes stay excluded, and only POSTs count, so the dossier and growth-fit reads at those paths never light the orb.
- The feed still outranks the ask: once it carries the run, the rail reports the run, and the 900ms linger — which keeps fast answers visible — yields the moment the feed names the settled work.
- Both edges of a call refetch the feed, and every count change is published so overlapping calls don't miss an inner edge.
- Moved the window edge glow to z-index 90 so a page-level scrim no longer hides it; it remains `pointer-events: none` and `aria-hidden` below the skip link.
- Added tests covering refusals that close a call, reads that must never count, overlapping calls, and the feed outranking the ask.

<sup>Written for commit 694a383caa038f8fbeb0b23187a7fa54dc9f729a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer real-time status indicators while AI requests are in progress.
  * The activity rail now shows a working state immediately when a request starts, before server activity appears.
  * Activity updates refresh promptly during requests and briefly remain visible after completion.

* **Bug Fixes**
  * Improved overlay layering so it appears correctly above page content without interfering with accessibility controls.
  * Added safeguards to keep request activity counts accurate across completed and refused requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->