### PR TITLE
feat(settings): the provider card stops offering two switches that decide nothing

### DIFF
--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -58,7 +58,6 @@ const UNPINNED_WRITES: readonly string[] = [
   "screens/evidenceverdict.tsx PATCH /organizations/{id}/facts/{factKey}",
   "screens/evidenceverdict.tsx POST /organizations/{id}/facts/{factKey}/confirm",
   "screens/extension-access.tsx PATCH /roles/{key}/objects/{object}",
-  "screens/integrations-provider.tsx PATCH /provider-connections/{provider}",
   "screens/settings.tsx DELETE /stages/{id}",
   "screens/share.tsx DELETE /record-grants/{id}",
   "screens/taskactions.tsx PATCH /activities/{id}",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6769,12 +6769,15 @@ export const de = {
     "Jeder Wert dieses Anbieters verschwindet von jedem Kontakt. Was du ausgegeben hast, bleibt in den Aufzeichnungen; die Daten nicht. Das lässt sich nicht rückgängig machen.",
   "provider.deleteDataConfirm.typed":
     "Zum Bestätigen den Namen des Anbieters eingeben",
-  "provider.autoEnrich": "Neue Kontakte automatisch anreichern",
-  "provider.autoEnrichHint":
-    "Wenn jemand einen Kontakt von Hand anlegt, dessen Daten gleich mitkaufen.",
-  "provider.autoImport": "Kontakte aus Verbindungen anreichern",
-  "provider.autoImportHint":
-    "Jedes Postfach, jeder Kanal und jede weitere Verbindung legt für jede erkannte Person einen Kontakt an — und jeder Kauf kostet Guthaben.",
+  "provider.automaticLookup": "Kontakte automatisch nachschlagen",
+  "provider.automaticLookupHint":
+    "Jeder Kontakt wird einmal nachgeschlagen, für die Angaben, die der Anbieter nicht berechnet: den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber, den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft — die kosten Guthaben und bleiben eine Entscheidung pro Kontakt.\n\nSchalten Sie das aus, wenn Ihre Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
+  "provider.backlog": "Noch nachzuschlagen",
+  "provider.backlogRemaining": "{count} Kontakte",
+  "provider.backlogWorking":
+    "Kontakte, die es beim Verbinden schon gab, werden nach und nach nachgeschlagen.",
+  "provider.backlogPaused":
+    "Zurzeit wird nichts nachgeschlagen: automatische Abfragen sind aus, das Tageslimit ist aufgebraucht, oder der Anbieter ist nicht nutzbar.",
   "provider.credits": "Restguthaben beim Anbieter",
   "provider.credits.none": "Der Anbieter hat uns noch keinen Stand genannt.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6771,9 +6771,12 @@ export const de = {
     "Zum Bestätigen den Namen des Anbieters eingeben",
   "provider.automaticLookup": "Kontakte automatisch nachschlagen",
   "provider.automaticLookupHint":
-    "Jeder Kontakt wird einmal nachgeschlagen, für die Angaben, die der Anbieter nicht berechnet: den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber, den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft — die kosten Guthaben und bleiben eine Entscheidung pro Kontakt.\n\nSchalten Sie das aus, wenn Ihre Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
+    "Jeder Kontakt wird einmal nachgeschlagen — für das, was die Verbindung auswählt und der Anbieter nicht berechnet, in der Regel den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber und den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft: die kosten Guthaben und bleiben eine Entscheidung pro Kontakt.",
+  "provider.automaticLookupJurisdiction":
+    "Schalt das aus, wenn deine Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
   "provider.backlog": "Noch nachzuschlagen",
-  "provider.backlogRemaining": "{count} Kontakte",
+  "provider.backlogRemaining_one": "{count} Kontakt",
+  "provider.backlogRemaining_other": "{count} Kontakte",
   "provider.backlogWorking":
     "Kontakte, die es beim Verbinden schon gab, werden nach und nach nachgeschlagen.",
   "provider.backlogPaused":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6819,12 +6819,15 @@ export const en = {
   "provider.deleteDataConfirm.body":
     "Every value this provider supplied is removed from every contact. What you spent stays in your records; the data does not. This cannot be undone.",
   "provider.deleteDataConfirm.typed": "Type the provider's name to confirm",
-  "provider.autoEnrich": "Enrich new contacts automatically",
-  "provider.autoEnrichHint":
-    "When somebody adds a contact by hand, buy their details straight away.",
-  "provider.autoImport": "Enrich contacts that arrive from a connection",
-  "provider.autoImportHint":
-    "Every mailbox, channel and other connection adds a contact for each person it sees, and buying one spends credits.",
+  "provider.automaticLookup": "Look up contacts automatically",
+  "provider.automaticLookupHint":
+    "Every contact is looked up once for the details the provider charges nothing for: the professional profile link, the current role and employer, the work history. Email addresses and mobile numbers are never bought this way — those cost credits and stay a decision you make per contact.\n\nSwitch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
+  "provider.backlog": "Still to look up",
+  "provider.backlogRemaining": "{count} contacts",
+  "provider.backlogWorking":
+    "Contacts that were already here when the provider was connected are being looked up a few at a time.",
+  "provider.backlogPaused":
+    "Nothing is being looked up right now: automatic lookups are off, the day's limit is spent, or the provider is not usable.",
   "provider.credits": "Credits left with the provider",
   "provider.credits.none": "The provider has not told us a balance yet.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6821,9 +6821,12 @@ export const en = {
   "provider.deleteDataConfirm.typed": "Type the provider's name to confirm",
   "provider.automaticLookup": "Look up contacts automatically",
   "provider.automaticLookupHint":
-    "Every contact is looked up once for the details the provider charges nothing for: the professional profile link, the current role and employer, the work history. Email addresses and mobile numbers are never bought this way — those cost credits and stay a decision you make per contact.\n\nSwitch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
+    "Every contact is looked up once for whatever the connection selects that the provider charges nothing for — typically the professional profile link, the current role and employer, and the work history. Email addresses and mobile numbers are never bought this way: those cost credits and stay a decision you make per contact.",
+  "provider.automaticLookupJurisdiction":
+    "Switch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
   "provider.backlog": "Still to look up",
-  "provider.backlogRemaining": "{count} contacts",
+  "provider.backlogRemaining_one": "{count} contact",
+  "provider.backlogRemaining_other": "{count} contacts",
   "provider.backlogWorking":
     "Contacts that were already here when the provider was connected are being looked up a few at a time.",
   "provider.backlogPaused":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6693,12 +6693,15 @@ export const vi = {
   "provider.deleteDataConfirm.body":
     "Mọi giá trị nhà cung cấp này đã cấp sẽ bị gỡ khỏi mọi liên hệ. Khoản bạn đã chi vẫn được ghi lại; dữ liệu thì không. Không thể hoàn tác.",
   "provider.deleteDataConfirm.typed": "Nhập tên nhà cung cấp để xác nhận",
-  "provider.autoEnrich": "Tự động làm giàu liên hệ mới",
-  "provider.autoEnrichHint":
-    "Khi ai đó thêm một liên hệ thủ công, mua luôn thông tin của họ.",
-  "provider.autoImport": "Làm giàu liên hệ đến từ kết nối",
-  "provider.autoImportHint":
-    "Mỗi hộp thư, kênh và kết nối khác đều thêm một liên hệ cho từng người nó thấy, và mỗi lần mua đều tốn tín dụng.",
+  "provider.automaticLookup": "Tự động tra cứu liên hệ",
+  "provider.automaticLookupHint":
+    "Mỗi liên hệ được tra cứu một lần để lấy những thông tin nhà cung cấp không tính phí: liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này — chúng tốn tín dụng và vẫn là quyết định cho từng liên hệ.\n\nHãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
+  "provider.backlog": "Còn phải tra cứu",
+  "provider.backlogRemaining": "{count} liên hệ",
+  "provider.backlogWorking":
+    "Những liên hệ đã có sẵn khi kết nối nhà cung cấp đang được tra cứu dần.",
+  "provider.backlogPaused":
+    "Hiện không tra cứu gì: tra cứu tự động đang tắt, đã hết hạn mức trong ngày, hoặc nhà cung cấp không dùng được.",
   "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
   "provider.credits.none": "Nhà cung cấp chưa cho biết số dư.",
   "provider.credits.notConnected":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6695,9 +6695,12 @@ export const vi = {
   "provider.deleteDataConfirm.typed": "Nhập tên nhà cung cấp để xác nhận",
   "provider.automaticLookup": "Tự động tra cứu liên hệ",
   "provider.automaticLookupHint":
-    "Mỗi liên hệ được tra cứu một lần để lấy những thông tin nhà cung cấp không tính phí: liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này — chúng tốn tín dụng và vẫn là quyết định cho từng liên hệ.\n\nHãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
+    "Mỗi liên hệ được tra cứu một lần — cho những mục mà kết nối chọn và nhà cung cấp không tính phí, thường là liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, cùng quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này: chúng tốn tín dụng và vẫn là quyết định cho từng liên hệ.",
+  "provider.automaticLookupJurisdiction":
+    "Hãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
   "provider.backlog": "Còn phải tra cứu",
-  "provider.backlogRemaining": "{count} liên hệ",
+  "provider.backlogRemaining_one": "{count} liên hệ",
+  "provider.backlogRemaining_other": "{count} liên hệ",
   "provider.backlogWorking":
     "Những liên hệ đã có sẵn khi kết nối nhà cung cấp đang được tra cứu dần.",
   "provider.backlogPaused":

--- a/frontend/src/screens/integrations-provider.css
+++ b/frontend/src/screens/integrations-provider.css
@@ -156,3 +156,22 @@
   font-size: var(--fs-sm);
   color: var(--textSecondary);
 }
+
+/* The two sentences under the lookup switch. A description is one <p>, and the
+   jurisdiction half has to read as its own paragraph rather than as a clause
+   glued to the end of the pricing one — an operator scanning for the reason to
+   switch this off is reading for a break that a collapsed newline never gives. */
+.provider-hint-para {
+  display: block;
+}
+
+.provider-hint-para + .provider-hint-para {
+  margin-top: var(--space-2);
+}
+
+/* The backlog figure, typed like every other number on this card: a count that
+   changes between reads should not shift the row's width as its digits change. */
+.provider-backlog-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--textContent);
+}

--- a/frontend/src/screens/integrations-provider.stories.tsx
+++ b/frontend/src/screens/integrations-provider.stories.tsx
@@ -90,11 +90,22 @@ const unconnected: ProviderConnection = {
   updated_at: "2026-01-05T09:00:00Z",
 };
 
-function cardStory(allow: GrantSpec, connections: ProviderConnection[]) {
+function cardStory(
+  allow: GrantSpec,
+  connections: ProviderConnection[],
+  automaticLookup = true,
+) {
   return () => {
     installFetchStub({
       "GET /me": () => jsonResponse(meFixture({ allow })),
       "GET /provider-connections": () => jsonResponse({ data: connections }),
+      // Routed explicitly, and defaulting to the INSTALLATION's own default of
+      // on. The stub's fallback answers an empty page, which reads as
+      // `automatic_lookup: undefined` and draws every switch off — so a story
+      // that skipped this route would show the posture off in its screenshot
+      // while its name claimed something else.
+      "GET /integrations/settings": () =>
+        jsonResponse({ automatic_lookup: automaticLookup }),
     });
     return (
       <StoryProviders>
@@ -155,9 +166,19 @@ export const OperatorCatchingUp: Story = {
 // ceiling spent, a provider that stopped answering — reads identically as a
 // number that will not fall, which is why the card says so in words.
 export const OperatorCatchUpPaused: Story = {
-  render: cardStory(OPERATOR, [
-    { ...connected, lookup_backlog: { remaining: 1240, paused: true } },
-  ]),
+  render: cardStory(
+    OPERATOR,
+    [{ ...connected, lookup_backlog: { remaining: 1240, paused: true } }],
+    // Paused BECAUSE the posture is off, which is one of the three causes the
+    // row's sentence names and the only one a screenshot can show.
+    false,
+  ),
+};
+
+// The posture off with nothing pending: what an installation in a jurisdiction
+// that forbids trading personal data looks like after somebody switched it off.
+export const OperatorLookupsOff: Story = {
+  render: cardStory(OPERATOR, [connected], false),
 };
 
 // May bind a key, may not destroy what it bought — so the overflow that holds

--- a/frontend/src/screens/integrations-provider.stories.tsx
+++ b/frontend/src/screens/integrations-provider.stories.tsx
@@ -141,16 +141,22 @@ export const ConnectDialog: Story = {
   },
 };
 
-// Both switches on: the state where a mailbox sync is also buying data, which
-// no other story draws. The two rows carry the same control at the same x, so
-// the only thing separating them is their labels — the picture worth having,
-// since a reader who misreads which one is on has misread the bill.
-export const OperatorEnrichingCapturedContacts: Story = {
+// An installation still working through the contacts it had before the provider
+// was connected. The count and the sentence under it are the picture worth
+// having: a figure alone stops moving for reasons this card would not explain,
+// so the row says whether the sweep is running or paused.
+export const OperatorCatchingUp: Story = {
   render: cardStory(OPERATOR, [
-    {
-      ...connected,
-      configuration: { ...connected.configuration, automatic_import: true },
-    },
+    { ...connected, lookup_backlog: { remaining: 1240, paused: false } },
+  ]),
+};
+
+// The same backlog, going nowhere. Every cause — the posture off, the day's
+// ceiling spent, a provider that stopped answering — reads identically as a
+// number that will not fall, which is why the card says so in words.
+export const OperatorCatchUpPaused: Story = {
+  render: cardStory(OPERATOR, [
+    { ...connected, lookup_backlog: { remaining: 1240, paused: true } },
   ]),
 };
 

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -107,6 +107,12 @@ function routeBody(path: string, principal: Me): unknown {
   if (path === "/v1/provider-connections") {
     return { data: [CONNECTION] };
   }
+  if (path === "/v1/integrations/settings") {
+    // Off, which is the state the flip below moves away from. The installation
+    // default is ON, but a fixture that started there could not tell a working
+    // switch from one wired to a constant.
+    return { automatic_lookup: false };
+  }
   throw new Error(`unstubbed request: ${path}`);
 }
 
@@ -159,7 +165,7 @@ describe("ProviderCard write posture", () => {
   const DISCONNECT = "Disconnect";
   const DELETE_DATA = "Delete bought data";
   const KEY_FIELD = "Replace the API key";
-  const AUTO_IMPORT = "Enrich contacts that arrive from a connection";
+  const AUTOMATIC_LOOKUP = "Look up contacts automatically";
   // Disconnect and delete-data live behind the overflow, because neither is the
   // same weight as Connect: one is recoverable and the other irreversibly
   // destroys purchased contact data. The trigger's presence is what the grant
@@ -242,17 +248,16 @@ describe("ProviderCard write posture", () => {
   );
 
   it(
-    "buys captured contacts only once the import switch is flipped",
+    "buys nothing automatically until the lookup switch is flipped",
     async () => {
       const user = userEvent.setup();
       const fetch = await renderAs(ME_OPERATOR);
 
-      const importSwitch = screen.getByRole("switch", { name: AUTO_IMPORT });
-      // The fixture has it off, which is the state the server defaults to: a
-      // mailbox sync mints a person per counterparty, so nobody is billed for
-      // capture until somebody says so here.
-      expect(importSwitch.getAttribute("aria-checked")).toBe("false");
-      await user.click(importSwitch);
+      const lookupSwitch = await screen.findByRole("switch", {
+        name: AUTOMATIC_LOOKUP,
+      });
+      expect(lookupSwitch.getAttribute("aria-checked")).toBe("false");
+      await user.click(lookupSwitch);
 
       // Waited on rather than read straight after the click: the write leaves
       // on a promise, so the call is recorded a tick later than the event. The
@@ -266,15 +271,12 @@ describe("ProviderCard write posture", () => {
         timeout: SETTLE_MS,
       });
       const request = patched() as Request;
-      expect(await request.clone().json()).toEqual({
-        // Only the switch that moved. Sending the whole configuration would
-        // carry a stale copy of the OTHER switch back to the server, so one
-        // reader's flip would silently revert a colleague's.
-        configuration: { automatic_import: true },
-      });
-      // The row it overwrites is pinned, so a colleague's concurrent edit is a
-      // 409 rather than a silent loss.
-      expect(request.headers.get("If-Match")).toBe(String(CONNECTION.version));
+      // The INSTALLATION's surface, not the connection's. The three
+      // per-connection fields that used to carry this answer are deprecated and
+      // ignored by admission, so a card still patching them would save, answer
+      // 200, and change nothing.
+      expect(new URL(request.url).pathname).toBe("/v1/integrations/settings");
+      expect(await request.clone().json()).toEqual({ automatic_lookup: true });
     },
     // Two waiters, not one: the card has to settle before the switch exists,
     // and the write it sends is awaited after. The ceiling covers the sum, or

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -26,7 +26,7 @@ import { Meter } from "../design-system/readings";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { Switch } from "../design-system/switch";
 import { formatNumber } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import {
   connectionLabel,
@@ -364,13 +364,24 @@ function PolicyRow({
   const t = useT();
   const posture = useLookupPosture();
   const patch = usePatchLookupPosture();
-  const disconnected = connection.status !== "connected";
   return (
     <>
       <FreeTierNote catalog={connection.catalog ?? []} />
       <SettingRow
         label={t("provider.automaticLookup")}
-        description={t("provider.automaticLookupHint")}
+        // Two paragraphs, not one string with a blank line in it: HTML collapses
+        // the break, and the half that would have been glued on is the one an
+        // operator in the wrong jurisdiction has to read.
+        description={
+          <>
+            <span className="provider-hint-para">
+              {t("provider.automaticLookupHint")}
+            </span>
+            <span className="provider-hint-para">
+              {t("provider.automaticLookupJurisdiction")}
+            </span>
+          </>
+        }
         control={(control) => (
           <Switch
             // The row's description reaches the switch: what the lookup DOES
@@ -394,7 +405,7 @@ function PolicyRow({
             // the connection, and an operator deciding it BEFORE connecting a
             // provider is the order this setting is meant to support.
             reason={canEdit ? undefined : t("captureSettings.adminOnly")}
-            disabled={!canEdit || posture.isPending}
+            disabled={!canEdit || posture.isPending || posture.isError}
             pending={patch.isPending}
             // The row already draws this name on the left, so the switch keeps
             // its own copy hidden: it owns its accessible name by design (see
@@ -405,15 +416,19 @@ function PolicyRow({
           />
         )}
       />
-      <LookupBacklogRow connection={connection} disconnected={disconnected} />
+      <LookupBacklogRow connection={connection} />
       {/* Under the row whose flip failed, at the row's full width, rather than
           squeezed into the control column beside the switch: the reason names
           what the reader just tried to change, and a sentence sharing a
           nowrap flex line with a switch is a sentence nobody reads. */}
-      {patch.error && (
+      {/* The READ's failure as well as the write's. A posture we could not ask
+          for renders the switch off, and "off" is a claim about the
+          installation — so a failed GET has to say so rather than let the
+          control answer a question nobody could reach. */}
+      {(patch.error || posture.error) && (
         <div className="provider-row-note">
           <Callout tone="danger" live="alert">
-            {problemMessageOf(patch.error, t)}
+            {problemMessageOf(patch.error ?? posture.error, t)}
           </Callout>
         </div>
       )}
@@ -429,18 +444,21 @@ function PolicyRow({
 // which of the two the reader is looking at — a figure that is not falling is
 // explained rather than read as a stuck sweep.
 //
-// Absent at zero and while disconnected. A backlog of nothing is not a fact
-// worth a row, and a provider nobody has connected has no backlog to have.
+// Absent only at zero. NOT hidden while disconnected: "the provider is not
+// usable" is one of the three causes the paused sentence names, and an
+// installation that disconnects with a thousand contacts pending still has
+// them pending. Hiding the count in the state its own copy explains would be
+// the row disappearing exactly when it had something to say.
 function LookupBacklogRow({
   connection,
-  disconnected,
-}: Readonly<{ connection: ProviderConnection; disconnected: boolean }>) {
+}: Readonly<{ connection: ProviderConnection }>) {
   const t = useT();
+  const plural = usePlural();
   // The reader's own notation: a five-figure backlog is the ordinary case on a
   // real installation, and 12345 reads as a serial number.
   const { locale } = useLocale();
   const backlog = connection.lookup_backlog;
-  if (disconnected || !backlog || backlog.remaining === 0) {
+  if (!backlog || backlog.remaining === 0) {
     return null;
   }
   return (
@@ -453,7 +471,7 @@ function LookupBacklogRow({
       }
       control={() => (
         <span className="provider-backlog-count">
-          {t("provider.backlogRemaining", {
+          {plural("provider.backlogRemaining", backlog.remaining, {
             count: formatNumber(backlog.remaining, locale),
           })}
         </span>

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import "./integrations-provider.css";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plug, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
@@ -29,7 +29,6 @@ import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import {
-  type ConnectionsResult,
   connectionLabel,
   connectionTone,
   useProviderConnections,
@@ -294,55 +293,48 @@ function CreditsReading({
   );
 }
 
-// The half of the saved policy this card decides. A patch carries only the
-// switch that moved, so the two toggles never overwrite each other's value on
-// the way past — the server merges the rest of the policy itself.
-type PolicyPatch = Pick<
-  components["schemas"]["ProviderConfigurationPatch"],
-  "automatic_individual_create" | "automatic_import"
->;
-
-function usePatchConfiguration(
-  provider: ProviderConnection["provider"],
-  version: number,
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (configuration: PolicyPatch) => {
-      const { data, error } = await api.PATCH(
-        "/provider-connections/{provider}",
-        {
-          params: {
-            path: { provider },
-            // The saved policy carries a version, and a blind write would
-            // silently overwrite a colleague's edit. A 409 is version skew,
-            // which the refetch below resolves by showing what is actually
-            // stored.
-            header: { "If-Match": String(version) },
-          },
-          body: { configuration },
-        },
-      );
+// The installation's lookup posture, read and written through its own surface.
+//
+// NOT the connection's configuration. Whether contacts are looked up without
+// anybody asking is one answer for the installation, and the three
+// per-connection fields that used to carry it are deprecated and ignored by
+// admission. A card that still PATCHed them would save successfully, answer
+// 200, and change nothing — worse than a missing control, because the screen
+// would be telling the reader the opposite of what the system does.
+function useLookupPosture() {
+  return useQuery({
+    queryKey: ["integrations-settings"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/integrations/settings");
       if (error) {
         throwProblem(error);
       }
       return data;
     },
-    onSuccess: (updated) => {
-      queryClient.setQueryData(
-        ["provider-connections"],
-        (current: ConnectionsResult | undefined) =>
-          current
-            ? {
-                ...current,
-                connections: current.connections.map((c) =>
-                  c.provider === updated?.provider ? updated : c,
-                ),
-              }
-            : current,
-      );
+  });
+}
+
+function usePatchLookupPosture() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // The posture travels as the mutation's variable rather than closing over
+    // render state: the switch that was pressed is the one that must be saved,
+    // even if the card re-rendered while the write was in flight.
+    mutationFn: async (automaticLookup: boolean) => {
+      const { data, error } = await api.PATCH("/integrations/settings", {
+        body: { automatic_lookup: automaticLookup },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
     },
-    onError: () => {
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["integrations-settings"],
+      });
+      // The backlog rides the connection, and the posture decides whether it
+      // is paused — so the card's other half has to re-read too.
       void queryClient.invalidateQueries({
         queryKey: ["provider-connections"],
       });
@@ -350,80 +342,70 @@ function usePatchConfiguration(
   });
 }
 
-// The two auto-enrich switches are the controls here that a reader who may not
-// change them still needs to READ: this is the only place the installation says
-// whether new contacts are being enriched at somebody's expense. So neither is
-// absent (that would hide a granted read) nor withheld (there is a fact to
-// show) — each is the shape the design system keeps for exactly this: a Switch,
-// because flipping it writes, with `reason` carrying the denial to a screen
-// reader through aria-describedby rather than leaving it beside the control as
+// The lookup switch is the control here that a reader who may not change it
+// still needs to READ: this is the only place the installation says whether
+// contacts are being looked up at somebody's expense. So it is neither absent
+// (that would hide a granted read) nor withheld (there is a fact to show) — it
+// is the shape the design system keeps for exactly this: a Switch, because
+// flipping it writes, with `reason` carrying the denial to a screen reader
+// through aria-describedby rather than leaving it beside the control as
 // decoration.
+//
+// ONE switch, where there were two. Those asked which WRITER a purchase
+// followed — a colleague typing a contact, a connector importing one — and the
+// answer differed because a connector's thousands of contacts each spent
+// credits. A lookup now buys only what the provider gives away, so that
+// distinction stopped paying for itself, and what is left is a question about
+// the installation rather than about the writer.
 function PolicyRow({
   connection,
   canEdit,
 }: Readonly<{ connection: ProviderConnection; canEdit: boolean }>) {
   const t = useT();
-  const patch = usePatchConfiguration(connection.provider, connection.version);
-  const configuration = connection.configuration;
+  const posture = useLookupPosture();
+  const patch = usePatchLookupPosture();
   const disconnected = connection.status !== "connected";
   return (
     <>
       <FreeTierNote catalog={connection.catalog ?? []} />
       <SettingRow
-        label={t("provider.autoEnrich")}
-        description={t("provider.autoEnrichHint")}
+        label={t("provider.automaticLookup")}
+        description={t("provider.automaticLookupHint")}
         control={(control) => (
           <Switch
-            // The row's description reaches the switch: what auto-enrich DOES
+            // The row's description reaches the switch: what the lookup DOES
             // is the sentence on the left, and a node-form control cannot see
             // the id the row minted for it.
             describedBy={control["aria-describedby"]}
-            checked={configuration.automatic_individual_create ?? false}
-            onChange={(next) =>
-              patch.mutate({ automatic_individual_create: next })
-            }
+            checked={posture.data?.automatic_lookup ?? false}
+            onChange={(next) => patch.mutate(next)}
             // Three causes, and only one of them is worth words. A permission
             // is permanent and has to be explained; a write in flight explains
-            // itself by finishing, and a disconnected provider is already
-            // stated by the status beside the provider's name.
+            // itself by finishing, and a posture still loading resolves on its
+            // own.
             //
             // The shared single-control sentence, not the card's own posture
             // line: that one names why the CARD is read-only and would say the
             // same thing twice here, once as prose and once attached to the
             // control.
+            //
+            // NOT disabled while disconnected, unlike the switches this
+            // replaces. The answer belongs to the installation rather than to
+            // the connection, and an operator deciding it BEFORE connecting a
+            // provider is the order this setting is meant to support.
             reason={canEdit ? undefined : t("captureSettings.adminOnly")}
-            disabled={!canEdit || disconnected}
+            disabled={!canEdit || posture.isPending}
             pending={patch.isPending}
             // The row already draws this name on the left, so the switch keeps
             // its own copy hidden: it owns its accessible name by design (see
             // switch.tsx) and pointing it at the row's span as well would name
             // it twice.
-            label={t("provider.autoEnrich")}
+            label={t("provider.automaticLookup")}
             labelHidden
           />
         )}
       />
-      {/* Arrivals from a connection, decided separately from the ones a
-          colleague types. Every connector — a mailbox, a channel, an extension
-          — mints a person per counterparty it sees, so this switch spends per
-          arrival where the one above spends per deliberate act. That is why
-          the customer answers them apart, and why this one starts off. */}
-      <SettingRow
-        label={t("provider.autoImport")}
-        description={t("provider.autoImportHint")}
-        control={(control) => (
-          <Switch
-            describedBy={control["aria-describedby"]}
-            checked={configuration.automatic_import ?? false}
-            reason={canEdit ? undefined : t("captureSettings.adminOnly")}
-            disabled={!canEdit || disconnected}
-            pending={patch.isPending}
-            onChange={(next) => patch.mutate({ automatic_import: next })}
-            label={t("provider.autoImport")}
-            labelHidden
-          />
-        )}
-      />
+      <LookupBacklogRow connection={connection} disconnected={disconnected} />
       {/* Under the row whose flip failed, at the row's full width, rather than
           squeezed into the control column beside the switch: the reason names
           what the reader just tried to change, and a sentence sharing a
@@ -436,6 +418,47 @@ function PolicyRow({
         </div>
       )}
     </>
+  );
+}
+
+// How much of the installation is still waiting to be looked up.
+//
+// The count alone would be a number that sometimes stops moving for reasons
+// nobody on this screen can see: the posture switched off, the day's ceiling
+// spent, the provider not usable. So the server answers both, and the row says
+// which of the two the reader is looking at — a figure that is not falling is
+// explained rather than read as a stuck sweep.
+//
+// Absent at zero and while disconnected. A backlog of nothing is not a fact
+// worth a row, and a provider nobody has connected has no backlog to have.
+function LookupBacklogRow({
+  connection,
+  disconnected,
+}: Readonly<{ connection: ProviderConnection; disconnected: boolean }>) {
+  const t = useT();
+  // The reader's own notation: a five-figure backlog is the ordinary case on a
+  // real installation, and 12345 reads as a serial number.
+  const { locale } = useLocale();
+  const backlog = connection.lookup_backlog;
+  if (disconnected || !backlog || backlog.remaining === 0) {
+    return null;
+  }
+  return (
+    <SettingRow
+      label={t("provider.backlog")}
+      description={
+        backlog.paused
+          ? t("provider.backlogPaused")
+          : t("provider.backlogWorking")
+      }
+      control={() => (
+        <span className="provider-backlog-count">
+          {t("provider.backlogRemaining", {
+            count: formatNumber(backlog.remaining, locale),
+          })}
+        </span>
+      )}
+    />
   );
 }
 


### PR DESCRIPTION
Whether contacts are looked up automatically became one installation setting in
#3278. The card kept showing the two per-connection switches it used to be, and
those had stopped being read: flipping one saved, returned 200, and changed
nothing. An admin who turned enrichment "off" here still had every new contact
looked up.

A screen telling a reader the opposite of what the system does is worse than a
missing control, which is why this is a bug rather than a gap.

## What the card says now

**One switch**, driving `PATCH /integrations/settings`. Its help text says what
a lookup buys, that email and mobile are never bought this way, and why an
installation whose contacts fall under a law forbidding trade in personal data
turns it off — Vietnam's by name, since that is the case the setting exists for.
Real German and Vietnamese, not English three times.

It is deliberately **not** disabled while no provider is connected, unlike the
switches it replaces: the answer belongs to the installation rather than to the
connection, and deciding it before connecting anything is the order this setting
supports.

**The backlog**, from `ProviderConnection.lookup_backlog` (#3299): how many
contacts are still waiting, and whether the sweep is moving. Both, because a
count that stops falling does so for reasons this screen would not otherwise
explain — the posture off, the day's ceiling spent, a provider that stopped
answering — and a number sitting still reads as a bug. Absent at zero and while
disconnected.

## Four things the gates caught, not me

- The four i18n keys for the removed switches were translated three times and
  rendered nowhere.
- The If-Match exemption named a PATCH the card no longer makes.
- The backlog count was drawn with `String()` instead of the reader's own
  notation, where a five-figure backlog reads as a serial number.
- The story setting `automatic_import: true` was drawing a field nothing reads.
  It is now two stories: the backlog working, and the backlog paused.

## Note on how this landed

An earlier attempt at this change cut more of `integrations-provider.tsx` than
intended and was reverted rather than pushed. This one was made with anchored
edits and a typecheck after each.

## Gates

`make check-fe` green (5,488 tests), `make check-backend` green,
`make craft-static` clean across all four trees, `make fe-uat` green with 47
stories captured including the two new ones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the provider card's two dormant per-connection toggles — flipping one saved, returned 200, and changed nothing, so "enrichment off" still looked up every new contact — with a single installation-level lookup switch backed by `PATCH /integrations/settings`, and reports the lookup backlog.

- The new switch stays enabled while no provider is connected, because the answer belongs to the installation rather than the connection.
- The backlog row shows the remaining count and whether the sweep is running or paused, in the reader's locale; it hides only at zero and stays visible while disconnected, since pending lookups still need explaining.
- The jurisdiction half of the switch's help renders as its own paragraph, and a failed read of the posture surfaces the error instead of silently drawing the switch off.
- Adds real German and Vietnamese translations instead of reusing English.
- Removes the unused switch labels, the `If-Match` exemption for the dropped PATCH, and the story field nothing reads.

<sup>Written for commit 119d6986ece032547f064ad8868babdfed9e9335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single installation-wide setting for automatic professional-data lookups.
  * Added lookup backlog status with remaining-item counts and active or paused processing states.
  * Automatic lookup settings remain available when the provider is disconnected.

* **Improvements**
  * Settings now refresh after changes and clearly report loading, read, and update errors.
  * Updated English, German, and Vietnamese translations, including clearer jurisdiction guidance and singular/plural backlog counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->