### PR TITLE
fix(integrations): a bad minute from the vendor stops being permanent

### DIFF
--- a/backend/internal/modules/integrations/admit.go
+++ b/backend/internal/modules/integrations/admit.go
@@ -41,12 +41,32 @@ type admittedConnection struct {
 // trigger the customer switched off must not spend on their behalf.
 func (s *Store) admit(ctx context.Context, tx pgx.Tx, name string, trigger provider.Trigger) (admittedConnection, error) {
 	var c admittedConnection
+	// A MANUAL run is admitted on a degraded connection; an automatic one is
+	// not. The two are different questions.
+	//
+	// rate_limited, insufficient_credits and provider_error are recoverable
+	// vendor conditions, and execution already says so in as many words: it
+	// authorizes egress on them because "a later success is exactly what proves
+	// recovery and restores connected". Admission refusing to CREATE that run
+	// made the sentence unreachable — one bad minute from the vendor left the
+	// connection refusing everything, with the only path out a human noticing
+	// and re-entering a key that was never the problem.
+	//
+	// Automatic work stays refused: nobody is watching it, and a sweep retrying
+	// a rate limit every minute is how a transient limit becomes a sustained
+	// one. A person pressing the button on a contact is the deliberate probe
+	// this needs — they chose to spend it, and their run is what heals the
+	// connection for everybody else.
+	statuses := []string{"connected"}
+	if !trigger.Automatic() {
+		statuses = append(statuses, "rate_limited", "insufficient_credits", "provider_error")
+	}
 	err := tx.QueryRow(ctx, `
 		SELECT id::text, version, execution_epoch, mode, automatic_individual_create,
 		       automatic_import, categories, refresh_after_days, daily_run_limit
 		  FROM provider_connection
-		 WHERE provider = $1 AND status = 'connected'
-		 FOR SHARE`, name).
+		 WHERE provider = $1 AND status = ANY($2)
+		 FOR SHARE`, name, statuses).
 		Scan(&c.id, &c.version, &c.epoch, &c.mode, &c.autoCreate,
 			&c.autoImport, &c.categories, &c.refreshAge, &c.dailyLimit)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/integrations/backfill_integration_test.go
+++ b/backend/internal/modules/integrations/backfill_integration_test.go
@@ -203,3 +203,45 @@ func (e *runsEnv) plantSubjectWithRun(t *testing.T, state string) ids.PersonID {
 	}
 	return id
 }
+
+// TestAHumanCanProbeADegradedConnection is the escape from a trap that shipped.
+//
+// A vendor error flips the connection to provider_error. Execution treats that
+// as recoverable and says so — it authorizes egress precisely because a later
+// success restores `connected`. Admission used to refuse to CREATE that run, so
+// the sentence was unreachable: one bad minute from the vendor left the
+// connection refusing every lookup, and the only way out was a human noticing
+// and re-entering a key that was never at fault.
+//
+// A person pressing the button is the deliberate probe. A sweep is not: nobody
+// is watching it, and retrying a rate limit every minute is how a transient
+// limit becomes a sustained one.
+func TestAHumanCanProbeADegradedConnection(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	ctx := context.Background()
+
+	for _, status := range []string{"rate_limited", "insufficient_credits", "provider_error"} {
+		if _, err := e.owner.Exec(ctx,
+			`UPDATE provider_connection SET status = $2 WHERE provider = $1`,
+			e.provider, status); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+			PersonID: e.mine.String(), Provider: e.provider, Trigger: provider.TriggerManual,
+		}); err != nil {
+			t.Errorf("a human's run was refused on a %s connection: %v — the only path back to "+
+				"connected is a run that succeeds, so refusing them all makes the state permanent",
+				status, err)
+		}
+
+		_, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+			PersonID: e.theirsInBook.String(), Provider: e.provider,
+			Trigger: provider.TriggerAutomaticBackfill,
+		})
+		if err == nil {
+			t.Errorf("a sweep queued work on a %s connection; automatic retries are how a "+
+				"transient vendor condition becomes a sustained one", status)
+		}
+	}
+}

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -212,11 +212,25 @@ func (s *Store) List(ctx context.Context) ([]Connection, error) {
 				// Read inside this transaction, beside the spend, so the card
 				// shows a balance, a history and a backlog from one moment
 				// rather than three.
+				//
+				// A backlog this read cannot produce is ABSENT, not fatal. It
+				// is one line on a card whose other rows — the key, the
+				// posture, the balance, the spend — are what an operator came
+				// for, and a secondary count taking the whole settings page
+				// down with it is the wrong trade. The contract makes it
+				// optional for exactly this.
+				//
+				// A cancelled request is the exception and still aborts: the
+				// caller has gone, so there is nobody to render a degraded card
+				// for, and swallowing it would turn a disconnect into a
+				// pointless read of every remaining provider.
 				backlog, err := s.backlogInTx(ctx, tx, name)
-				if err != nil {
+				if err != nil && ctx.Err() != nil {
 					return err
 				}
-				c.Backlog = &backlog
+				if err == nil {
+					c.Backlog = &backlog
+				}
 				out = append(out, c)
 				continue
 			}


### PR DESCRIPTION
Two defects a real lookup found on a running stack. The first is why Surfe
stopped working there.

## A vendor error was a one-way door

A failed run flips the connection to `provider_error`, and admission demanded
`status = 'connected'` — so every later lookup was refused before it reached the
vendor. The only way out was a human noticing and re-entering a key that was
never at fault.

Execution has said the opposite all along, in as many words:

> Degraded-but-credentialed statuses (rate_limited, insufficient_credits,
> provider_error) still authorize egress: they are recoverable provider
> conditions, and a later success is exactly what proves recovery and restores
> `connected`.

Admission refusing to *create* that run made the sentence unreachable. #3299
added the healing half and could never fire.

A **manual** run is now admitted on those three statuses. An **automatic** one
still is not: nobody is watching a sweep, and retrying a rate limit every minute
is how a transient limit becomes a sustained one. A person pressing the button on
a contact is the deliberate probe — they chose to spend it, and their run heals
the connection for everybody else.

## The backlog count could fail the settings page

The count I added in #3299 reads inside the connection list, so a read that
failed took the whole card down. Seen once in a dev log:

```
GET /v1/provider-connections → 500
"integrations: reading the sweep's daily allowance: context canceled"
```

A count is one line on a card whose other rows — the key, the posture, the
balance, the spend — are what an operator came for. It is absent now rather than
fatal, which is what the contract's optional field is for. A cancelled request
still aborts: the caller has gone, so there is nobody to render a degraded card
for.

## Test

`TestAHumanCanProbeADegradedConnection` walks all three degraded statuses and
asserts both halves: a human's run is admitted, a sweep's is not.
Mutation-checked — restoring the connected-only filter fails it with the exact
refusal the real lookup hit (`provider: no connected provider`).

## Gates

`make check-backend` green, `make craft-static` clean across all four trees,
integrations integration lane green against real Postgres.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two defects on a running stack. A connection degraded by the vendor (`rate_limited`, `insufficient_credits`, `provider_error`) permanently refused every run because admission only accepted `connected`; manual runs are now admitted on those statuses so a human probe can restore it, while automatic sweeps stay refused. A failed backlog read now leaves the card's backlog field absent instead of failing the whole settings page.

**Bug Fixes**
- Automatic triggers still require `connected` so a transient vendor limit doesn't become a sustained one.
- A cancelled list request still aborts; all other backlog read errors degrade to an absent field.

<sup>Written for commit 2d3bcf54d6cbc748de243662aab63ce59ea702b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual runs can now be queued for connections experiencing rate limits, insufficient credits, or provider errors.
  * Automatic runs remain limited to fully connected providers.

* **Bug Fixes**
  * Connection details can still load when backlog retrieval fails, while cancellation continues to stop the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->