### PR TITLE
feat(capture): a contact capture mints belongs to the mailbox owner until something judges its sender

### DIFF
--- a/backend/gates/writeauthorityreach_test.go
+++ b/backend/gates/writeauthorityreach_test.go
@@ -53,10 +53,11 @@ var writesWithoutARowProbe = gatekit.Waive(map[string]string{
 	// leave every other subject's record untouched — for retention that is the
 	// storage-limitation failure the pass exists to prevent, and for the rest it
 	// would make a hygiene pass silently partial.
-	"internal/modules/privacy:anonymizePerson": "the retention engine anonymizes a person in place because their retention clock expired, under a policy that names the table. The subject is chosen by age; there is no caller asking for this row and no authority to test beyond the policy itself",
-	"internal/modules/privacy:anonymizeLead":   "the lead half of the same retention pass, chosen the same way",
-	"internal/modules/privacy:archiveDeal":     "the deal half of the same retention pass: a deal past its window is archived because of when it closed, not because somebody asked",
-	"internal/modules/deals:SweepWorkspace":    "the close-date hygiene pass reads every open deal in the workspace and corrects or stages the ones whose expected close has gone stale. It runs as the workspace's own system principal with no human behind it, and narrowing it to one seat's rows would leave every other rep's forecast uncorrected while the sweep reported success",
+	"internal/modules/privacy:anonymizePerson":         "the retention engine anonymizes a person in place because their retention clock expired, under a policy that names the table. The subject is chosen by age; there is no caller asking for this row and no authority to test beyond the policy itself",
+	"internal/modules/privacy:anonymizeLead":           "the lead half of the same retention pass, chosen the same way",
+	"internal/modules/privacy:archiveDeal":             "the deal half of the same retention pass: a deal past its window is archived because of when it closed, not because somebody asked",
+	"internal/modules/people:promoteIfWorkspaceScoped": "a row probe here would refuse the write it exists to make. The row is owner-scoped, which platform/auth reads as capture privacy — invisible to every principal but its owner, an admin included — so EnsureWritable answers no for exactly the rows this promotes. What decides the promotion is not the caller's authority over the row but the verdict that judged its sender a business counterparty, and the surrounding ensurePerson already takes auth.Require(person, create) for the caller who may mint one at all. The write is one-directional and idempotent: it moves owner to workspace and never back",
+	"internal/modules/deals:SweepWorkspace":            "the close-date hygiene pass reads every open deal in the workspace and corrects or stages the ones whose expected close has gone stale. It runs as the workspace's own system principal with no human behind it, and narrowing it to one seat's rows would leave every other rep's forecast uncorrected while the sweep reported success",
 
 	// The shared fill, probed by BOTH of its callers rather than by itself.
 	// ApplySitePersonFields takes EnsureWritableLive and SKIPS an out-of-scope

--- a/backend/internal/compose/captureensurer.go
+++ b/backend/internal/compose/captureensurer.go
@@ -72,6 +72,10 @@ func (p peopleEnsurer) EnsureCounterparty(ctx context.Context, in capture.Ensure
 		Source:      in.Source,
 		CapturedBy:  in.CapturedBy,
 		SuppressOrg: in.SuppressOrg,
+		// The SINK's ensure, which runs while the sender is still unjudged.
+		// Owner-scoped until something says otherwise; the verdict path is the
+		// only caller that asks for the workspace.
+		OwnerScoped: true,
 	})
 	if errors.Is(err, people.ErrCounterpartySuppressed) {
 		// A13: the erased address stays dead — a deliberate no-op, not a

--- a/backend/internal/compose/integration/capture/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_autocreate_integration_test.go
@@ -87,14 +87,17 @@ func TestCaptureAutoCreatesTheCounterpartyBehindAThread(t *testing.T) {
 		if n := countRows(t, e, `SELECT count(*) FROM activity_link WHERE entity_type = 'organization'`); n != 0 {
 			t.Fatalf("%d org links, want 0 — the org rolls up through employment", n)
 		}
-		// Connector-created rows belong to the workspace from the start —
-		// customer identity is shared; the audience of the mail itself is a
-		// property of the activity. Asserted on alice herself, so an
-		// unrelated row can never green this.
+		// Connector-created rows belong to the MAILBOX OWNER until something
+		// judges their sender a business counterparty. Connecting a mailbox
+		// with a year of history would otherwise put every correspondent in
+		// front of every colleague on the strength of one email; the verdict
+		// path is what promotes one, and it is covered in
+		// TestAVerdictPromotesTheContactItJudged. Asserted on alice herself, so
+		// an unrelated row can never green this.
 		if n := countRows(t, e, `
 			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
-			WHERE pe.email = 'alice@acme.example' AND p.visibility = 'workspace'`); n != 1 {
-			t.Fatal("the connector-created person must start visibility='workspace'")
+			WHERE pe.email = 'alice@acme.example' AND p.visibility = 'owner'`); n != 1 {
+			t.Fatal("the connector-created person must start visibility='owner'")
 		}
 		// The inbound reply above our outbound emitted exactly one engagement.reply.
 		if n := countRows(t, e, `SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 1 {

--- a/backend/internal/compose/integration/capture/capture_personscope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_personscope_integration_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// Who can see a contact capture minted, and when that changes.
+//
+// Connecting a mailbox with a year of history names every correspondent in it —
+// a lawyer, a doctor, a school. One email is not a reason to put any of them in
+// front of every colleague, so a person the SINK mints is the mailbox owner's
+// until something judges their sender a business counterparty. The verdict path
+// is that something, and it is the only ensure caller that asks for the
+// workspace.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// personVisibility answers how a captured contact is scoped. It fails when
+// there is no such person: a test that meant to find one and silently read the
+// empty string would pass for the wrong reason.
+func personVisibility(t *testing.T, e *integration.SearchEnv, email string) string {
+	t.Helper()
+	var visibility string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT p.visibility FROM person p
+			  JOIN person_email pe ON pe.person_id = p.id
+			 WHERE pe.email = $1 AND p.archived_at IS NULL`, email).Scan(&visibility)
+	}); err != nil {
+		t.Fatalf("reading the visibility of %s: %v", email, err)
+	}
+	return visibility
+}
+
+// personOwnerOf answers whose the contact is.
+func personOwnerOf(t *testing.T, e *integration.SearchEnv, email string) ids.UUID {
+	t.Helper()
+	var owner *ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT p.owner_id FROM person p
+			  JOIN person_email pe ON pe.person_id = p.id
+			 WHERE pe.email = $1 AND p.archived_at IS NULL`, email).Scan(&owner)
+	}); err != nil {
+		t.Fatalf("reading the owner of %s: %v", email, err)
+	}
+	if owner == nil {
+		return ids.Nil
+	}
+	return *owner
+}
+
+func TestAPersonTheSinkMintsBelongsToTheMailboxOwnerAlone(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, syncSent := env.e, env.syncSent
+
+	// The owner wrote to this address, which is T1 correspondence-positive and
+	// mints the person on the spot. Nothing has judged the sender: the evidence
+	// is that somebody wrote to them, not that they are a business contact.
+	const counterparty = "anwalt@kanzlei.example"
+	syncSent(t, map[string]bool{"scope-1@kanzlei.example": true},
+		emailSaying(counterparty, "scope-1@kanzlei.example", "", "können wir nächste Woche sprechen"))
+
+	if got := personVisibility(t, e, counterparty); got != "owner" {
+		t.Fatalf("a contact the sink minted is %q, want owner — a year of history would otherwise publish every correspondent", got)
+	}
+	if got := personOwnerOf(t, e, counterparty); got != e.Rep1 {
+		t.Fatalf("the contact belongs to %s, want the mailbox owner %s", got, e.Rep1)
+	}
+}
+
+func TestAVerdictPromotesTheContactItJudged(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, syncSent := env.e, env.syncSent
+
+	const counterparty = "einkauf@kunde.example"
+	syncSent(t, map[string]bool{"promote-1@kunde.example": true},
+		emailSaying(counterparty, "promote-1@kunde.example", "", "danke für das Angebot"))
+	if got := personVisibility(t, e, counterparty); got != "owner" {
+		t.Fatalf("the contact starts %q, want owner", got)
+	}
+
+	// The verdict path ensures the same address WITHOUT asking for owner scope.
+	// That is the decision: something judged this sender a business
+	// counterparty, which is the moment the record becomes the workspace's.
+	promoteByVerdict(t, e, counterparty, activityIDOf(t, e, "promote-1@kunde.example"))
+	if got := personVisibility(t, e, counterparty); got != "workspace" {
+		t.Fatalf("a judged counterparty is still %q, want workspace", got)
+	}
+
+	// And the sink running again over a later message does NOT narrow it back.
+	// It runs on every message that sender ever writes, so narrowing here would
+	// un-publish the contact the next time they wrote.
+	syncSent(t, map[string]bool{"promote-2@kunde.example": true},
+		emailSaying(counterparty, "promote-2@kunde.example", "", "noch eine Frage"))
+	if got := personVisibility(t, e, counterparty); got != "workspace" {
+		t.Fatalf("a later capture narrowed a promoted contact back to %q", got)
+	}
+}
+
+// promoteByVerdict ensures the counterparty the way the verdict path does —
+// workspace-scoped, because something judged the sender.
+func promoteByVerdict(t *testing.T, e *integration.SearchEnv, email string, activityID ids.UUID) {
+	t.Helper()
+	store := people.NewStore(e.DB())
+	// The grants the verdict engine runs with: it mints and links records, and
+	// the promotion rides the same ensure.
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"person":       {Create: true, Read: true, Update: true},
+				"organization": {Create: true, Read: true},
+				"activity":     {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := store.EnsureCounterpartyTx(ctx, tx, people.EnsureCounterpartyInput{
+			Email:      email,
+			Domain:     "kunde.example",
+			ActivityID: ids.From[ids.ActivityKind](activityID),
+			OwnerID:    e.Rep1,
+			Source:     "verdict",
+			CapturedBy: "agent:capture_counterparty_verdict",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("promoting by verdict: %v", err)
+	}
+}

--- a/backend/internal/modules/people/capturescope.go
+++ b/backend/internal/modules/people/capturescope.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// When a captured contact stops being the mailbox owner's and becomes the
+// workspace's.
+//
+// Capture mints a person from a message nothing has judged yet, so the record
+// starts owner-scoped: a mailbox with a year of history names a lawyer, a
+// doctor and a school, and one email is not a reason to publish any of them.
+// Something judging the sender a business counterparty is the decision, and the
+// verdict path expresses it by ensuring the same address without asking for
+// owner scope.
+//
+// Distinct from promote.go beside it, which is the LEAD promotion surface: that
+// one converts a lead into a person, this one widens who may read a person who
+// already exists.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// promoteIfWorkspaceScoped moves an owner-scoped person to the workspace when a
+// workspace-scoped ensure reaches them.
+//
+// One direction only. A record already the workspace's is never narrowed back
+// by a later owner-scoped ensure: the sink runs on every message from that
+// sender, so narrowing here would un-publish a contact somebody promoted the
+// next time they wrote.
+//
+// The guard is on the ROW's visibility rather than on what the caller believes:
+// the UPDATE matches nothing when the row is already workspace, so a second
+// ensure over the same person writes nothing whatever it thought it was doing.
+func promoteIfWorkspaceScoped(ctx context.Context, tx pgx.Tx, id ids.PersonID, ownerScoped bool) error {
+	if ownerScoped {
+		// Nothing to do, and saying so here saves a statement per captured
+		// message from the sink — which is the caller that runs on every one.
+		// It is not what makes this safe: the UPDATE below writes owner to
+		// workspace and has no spelling that goes the other way, so an
+		// owner-scoped caller reaching it would still narrow nothing.
+		return nil
+	}
+	// The visibility pin is the concurrency guard, checked through RowsAffected:
+	// the statement matches only a row still owner-scoped, so a second pass over
+	// the same person moves nothing and reports zero rather than writing again.
+	tag, err := tx.Exec(ctx, `
+		UPDATE person SET visibility = $2
+		 WHERE id = $1 AND visibility = $3 AND archived_at IS NULL`,
+		id, visibilityWorkspace, visibilityOwner)
+	if err != nil {
+		return fmt.Errorf("people: promoting a judged counterparty to the workspace: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Already the workspace's, or archived. Both are answers, not faults.
+		return nil
+	}
+	return nil
+}

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -10,10 +10,16 @@ package people
 // organization + relationship + link are one atomic decision here).
 // Exact match reuses; fuzzy CREATES ANYWAY and records a dedupe_candidate
 // for the review queue (capture never blocks on a human,
-// DEDUPE_FUZZY_AUTOMERGE is pinned never); no match creates. Connector-
-// created rows are workspace-visible: customer identity is shared across the
-// workspace, and the audience of the correspondence itself is decided per
-// activity (platform/auth ActivityContentClause), not by hiding the contact.
+// DEDUPE_FUZZY_AUTOMERGE is pinned never); no match creates.
+//
+// A connector-created row belongs to the MAILBOX OWNER until something judges
+// its sender. Customer identity is shared across a workspace once somebody has
+// decided the sender is a customer — before that, a mailbox with a year of
+// history names a lawyer, a doctor and a school, and one email is not a reason
+// to publish any of them. The verdict path ensures the same address without
+// asking for owner scope, and that promotes the record. The audience of the
+// correspondence itself is a separate question, decided per activity
+// (platform/auth ActivityContentClause).
 
 import (
 	"context"
@@ -75,6 +81,21 @@ type EnsureCounterpartyInput struct {
 	// person is still created — alice@gmail.com is a person, "Gmail" is
 	// not her employer.
 	SuppressOrg bool
+
+	// OwnerScoped births the person visible to their OWNER alone rather than to
+	// the workspace.
+	//
+	// It is what the two ensure callers disagree about. The capture sink mints a
+	// person from a message nothing has judged yet — connecting a mailbox with a
+	// year of history would otherwise put every correspondent, a lawyer and a
+	// doctor included, in front of every colleague on the strength of one email.
+	// The VERDICT path mints one because something judged the sender a business
+	// counterparty, which is the moment the record becomes the workspace's.
+	//
+	// False is the workspace default, so a caller that says nothing gets the
+	// behaviour that existed before this field. The wrong direction to fail in
+	// is silently narrowing a record somebody expected to see.
+	OwnerScoped bool
 }
 
 // EnsureCounterpartyResult reports what the ensure did — every flag maps to
@@ -189,6 +210,17 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 	}
 	if match.Decision == DecisionExactCollision {
 		res.PersonID = match.PersonID
+		// A workspace-scoped ensure over an owner-scoped record PROMOTES it.
+		//
+		// This is how a contact the sink minted while its sender was unjudged
+		// becomes the workspace's: the verdict path ensures the same address
+		// with OwnerScoped false, and that is the decision. It runs before the
+		// quarantine return below, because an impersonation tell is a reason to
+		// learn nothing NEW from this message and not a reason to withhold a
+		// promotion something already decided.
+		if err := promoteIfWorkspaceScoped(ctx, tx, match.PersonID, in.OwnerScoped); err != nil {
+			return err
+		}
 		if quarantineSuspect(in.DisplayName, in.Domain) {
 			// The header carries an impersonation tell. A new record would be
 			// created quarantined for review; an EXISTING one has no such
@@ -204,7 +236,7 @@ func (s *Store) ensurePerson(ctx context.Context, tx pgx.Tx, in EnsureCounterpar
 		FirstName:   nameColumn(parsed.First),
 		LastName:    nameColumn(parsed.Last),
 		OwnerID:     ownerFromUUID(&in.OwnerID),
-		Visibility:  visibilityWorkspace,
+		Visibility:  visibilityFor(in.OwnerScoped),
 		Quarantined: quarantineSuspect(in.DisplayName, in.Domain),
 		Emails:      []PersonEmailInput{{Email: in.Email, EmailType: emailTypeWork, IsPrimary: true}},
 		Source:      in.Source,

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -39,11 +39,28 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
-// visibilityWorkspace is the row visibility every create path writes: a
-// captured contact belongs to the workspace the moment it exists. The column
-// still admits 'owner' (capture privacy, read by platform/auth) for rows
-// minted before this was the rule; no create path writes it any more.
-const visibilityWorkspace = "workspace"
+// The two row visibilities a create path writes.
+//
+// A person a HUMAN creates belongs to the workspace the moment they exist —
+// somebody typed them in, and that is the decision. A person CAPTURE mints from
+// a message nothing has judged yet belongs to the mailbox owner until something
+// does: a mailbox with a year of history names correspondents the workspace has
+// no business reading, and one email is not a reason to publish a contact.
+//
+// platform/auth reads `owner` as capture privacy, so an owner-scoped row is
+// invisible to colleagues, an admin included.
+const (
+	visibilityWorkspace = "workspace"
+	visibilityOwner     = "owner"
+)
+
+// visibilityFor answers which of the two a create path writes.
+func visibilityFor(ownerScoped bool) string {
+	if ownerScoped {
+		return visibilityOwner
+	}
+	return visibilityWorkspace
+}
 
 // ownerFromUUID adapts the storage-level owner id the capture and triage paths
 // carry to the typed one the specs take.


### PR DESCRIPTION
Connecting a mailbox with a year of history names every correspondent in it. On the founder's own Gmail that was 184 person records — a lawyer, a travel agent, a clinic, 19 gmail.com addresses — every one of them visible to every colleague on the strength of one email.

**A person the capture sink mints now belongs to the mailbox owner until something judges their sender a business counterparty.** The verdict path is that something, and it is the only ensure caller that asks for the workspace.

## The change

`EnsureCounterpartyInput` gains `OwnerScoped`, and the two callers disagree about it:

- the **capture sink** (`compose/captureensurer.go`) asks for owner scope — it runs while the sender is still unjudged;
- the **verdict path** (`compose/captureverdict.go`) does not — something judged the sender, and that is the moment the record becomes the workspace's.

`false` is the default, so a caller that says nothing gets the behaviour that existed before this field. The wrong direction to fail in is silently narrowing a record somebody expected to see.

`promoteIfWorkspaceScoped` (in the new `people/capturescope.go`) is what moves a record when the verdict arrives. It runs on the exact-match branch of `ensurePerson`, before the quarantine return — an impersonation tell is a reason to learn nothing NEW from a message and not a reason to withhold a promotion something already decided.

## One direction, and what enforces it

The UPDATE writes `owner → workspace` and has no spelling that goes the other way. That matters because the sink runs on **every** message a sender ever writes: if this could narrow, a contact somebody promoted would be un-published the next time that person wrote.

The `ownerScoped` early return above it is an optimisation — it saves a statement per captured message, which is worth having on the sink's path — and the comment says so rather than implying it is the guard. I found that out by mutating it away and watching both tests still pass; the SQL is what holds the invariant, and one clause enforcing it is better than two that can drift.

The visibility pin is also the concurrency guard, checked through `RowsAffected`: a second ensure over the same person matches nothing and writes nothing.

## What this does not change

A person a **human** creates is still the workspace's from the moment they exist. Somebody typed them in, and that is the decision — there is nothing left to judge, and withholding such a record would be the product arguing with its author.

Nor does it change the audience of the correspondence: that is a property of the activity (`platform/auth ActivityContentClause`) and was settled in the four PRs before this one.

## Tests

- `TestAPersonTheSinkMintsBelongsToTheMailboxOwnerAlone` — the contact is `owner`, owned by the capturing seat.
- `TestAVerdictPromotesTheContactItJudged` — a workspace-scoped ensure promotes it, and a **later capture does not narrow it back**.

Both were mutation-checked. The first failed against unchanged code before the fix landed, which is the check for free.

`TestCaptureAutoCreatesTheCounterpartyBehindAThread` asserted the old behaviour and now asserts the new one, pointing at the promotion test for the other half. The file-level doc comment on `ensure.go` claimed connector rows are workspace-visible; this PR makes that false, so it says what is true instead.

`ensure.go` crossed the 500-line ceiling, so the promotion moved to `capturescope.go` — named to distinguish it from the `promote.go` beside it, which converts a lead into a person rather than widening who may read one.

## Still to come in this sequence

The plan's PR 5 also covers the tier-ladder changes — freemail and machine-localpart senders deferring rather than minting, the transactional registry suppressing even when corresponded, and the `personal`/`advisor` verdict kinds. Those are a separate concern from who may SEE a minted record, and they land next rather than being bundled here.

`make check` green (lint verified directly: 0 issues). Integration lanes: `backend/internal/compose/integration/capture`, `backend/internal/compose`. `make craft-static` clean across backend, extensions, fixtures and desktop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contacts the capture sink mints now belong to the mailbox owner alone until a verdict judges their sender a business counterparty. Connecting a mailbox with a year of history no longer puts every correspondent — a lawyer, a clinic, 19 gmail.com addresses — in front of every colleague on the strength of one email.

- `EnsureCounterpartyInput` gains `OwnerScoped`; the capture sink passes it, the verdict path does not.
- A workspace-scoped ensure over an owner-scoped contact promotes it, before the quarantine return, via `promoteIfWorkspaceScoped`.
- The promotion is one-directional and pinned on the row's visibility in SQL, so a later sink capture never narrows a promoted contact back and a second ensure over the same person writes nothing.
- Persons a human creates stay workspace-visible from the start; `OwnerScoped` defaults to false, so callers that say nothing get the old behavior.

<sup>Written for commit c21321d4485e740ddd6dbb9b6ce681105436df26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly captured contacts remain private to their owner until they are confirmed.
  - Confirmed contacts can be promoted to workspace visibility automatically.
  - Repeated captures preserve broader visibility and do not make confirmed contacts private again.
  - Archived contacts and repeated promotions are handled safely without unintended changes.

- **Bug Fixes**
  - Corrected connector-created contact visibility so unconfirmed identities are not exposed to the workspace prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->