### PR TITLE
A pile of alike decisions is one row on the Worklist

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31823,8 +31823,13 @@ components:
         id: { type: string, description: "The owning record's id, as its own endpoint spells it." }
         source:
           type: string
-          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, customer_waiting, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice]
-          description: 'Which producer raised it, and therefore which endpoint its verbs go to.'
+          enum: [approval, dedupe_candidate, task, brief_item, conversation_claim, customer_waiting, deal_at_risk, meeting, relationship_decay, failed_approval, dsr, sync_health, capture_health, ai_work_health, bounce, automation_run, notice, batch]
+          description: |
+            Which producer raised it, and therefore which endpoint its verbs go to.
+
+            `batch` is the one that names no single record: it stands for a GROUP of
+            routine decisions that read alike, so a hundred of them cost the reader one
+            row rather than a hundred. Its own facts ride in `batch`.
         category:
           type: string
           enum: [customer_waiting, deals_at_risk, meetings, tasks, decisions, system]
@@ -31858,6 +31863,7 @@ components:
             date slips, one merely idle drifts.
         subject: { $ref: '#/components/schemas/AttentionSubject' }
         deal: { $ref: '#/components/schemas/WorklistDealFacts' }
+        batch: { $ref: '#/components/schemas/WorklistBatch' }
         due_at: { type: string, format: date-time, description: 'When this is due, or when the meeting starts.' }
         overdue: { type: boolean, description: 'Past due at the read instant, resolved server-side so every surface agrees.' }
         occurred_at: { type: string, format: date-time, description: 'When the thing being reported happened.' }
@@ -31911,6 +31917,36 @@ components:
         currency: { type: string, pattern: '^[A-Z]{3}$' }
         days: { type: integer }
         level: { type: integer, minimum: 0, maximum: 6 }
+
+    WorklistBatch:
+      type: object
+      description: |
+        A group of routine decisions that read alike, standing on the queue as one row.
+
+        The pile is the problem this solves: a hundred and fifty "is this address a
+        contact?" questions are one KIND of work, and asking them one at a time buries
+        every customer beneath them. The reader answers the group, or opens it to answer
+        the exceptions.
+
+        `sample` names a few of the members so the row is checkable — a reader who cannot
+        see what is in a group has to trust it, and a group nobody trusts is worse than
+        the pile it replaced.
+      required: [key, count]
+      properties:
+        key:
+          type: string
+          enum: [likely_automated, company_match, uncertain_contact, duplicates, held_draft]
+          description: |
+            What the members have in common, which is also what makes them safe to answer
+            together. `likely_automated` is mail from senders that are not people;
+            `company_match` are addresses whose domain already names a company we know;
+            `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
+            `held_draft` are messages waiting to be released.
+        count: { type: integer, minimum: 0, description: 'How many decisions this row stands for.' }
+        sample:
+          type: array
+          items: { type: string }
+          description: 'A few members, named, so the group can be checked before it is answered.'
 
     WorklistDealFacts:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31943,6 +31943,12 @@ components:
             `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
             `held_draft` are messages waiting to be released.
         count: { type: integer, minimum: 0, description: 'How many decisions this row stands for.' }
+        at_least:
+          type: boolean
+          description: |
+            The count is a FLOOR, not a total: the read stopped at its own bound before
+            it ran out of members. A client says "200+" rather than "200", because a
+            bound printed as a total is a wrong number rather than a bounded one.
         sample:
           type: array
           items: { type: string }

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Routine decisions, as ONE row each kind.
+//
+// A hundred and fifty "is this address a contact?" questions are one kind of
+// work. Asking them one at a time is what buried the customers on the page this
+// replaces — and it is not a ranking problem, because no ordering saves a
+// reader who must scroll past a hundred and fifty rows to reach the next thing.
+//
+// So the pile becomes a row. The reader answers the group, or opens it to
+// answer the exceptions, and the ordering compares one hygiene row against one
+// customer rather than a hundred against one.
+//
+// A decision that BLOCKS a customer is never folded: it is not routine, whatever
+// it has in common with the rest.
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// batchFloor is how many alike decisions it takes before a group reads better
+// than the rows themselves.
+//
+// Three, not two: a reader meeting two similar questions answers both faster
+// than they would open a group, and a "batch of 2" is a row that costs more
+// than it saves. It is the pile that needs collapsing, not the pair.
+const batchFloor = 3
+
+// foldRoutineDecisions replaces alike routine decisions with one row each.
+//
+// The members are kept in the fold's order, so the sample names the ones the
+// reader would have met first. Everything that is not routine passes through
+// untouched.
+func foldRoutineDecisions(rows []ranked) []ranked {
+	groups := map[crmcontracts.WorklistBatchKey][]ranked{}
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		key, groupable := batchKeyOf(row)
+		if !groupable {
+			kept = append(kept, row)
+			continue
+		}
+		groups[key] = append(groups[key], row)
+	}
+	// A group under the floor is not a pile; its rows go back as themselves.
+	for key, members := range groups {
+		if len(members) < batchFloor {
+			kept = append(kept, members...)
+			continue
+		}
+		kept = append(kept, batchRow(key, members))
+	}
+	return kept
+}
+
+// batchKeyOf says which group a row belongs to, and whether it may be grouped
+// at all.
+//
+// Only LEVEL 6 decisions are foldable. A decision that blocks a customer sits
+// at level 5 and stays its own row however many of it there are: the reader has
+// to see each one, because each holds up somebody different.
+func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
+	if row.item.Category != "decisions" || row.item.Level != levelRoutine {
+		return "", false
+	}
+	if row.item.Source == "dedupe_candidate" {
+		return "duplicates", true
+	}
+	if row.item.Kind == nil {
+		return "", false
+	}
+	switch *row.item.Kind {
+	case "capture_counterparty":
+		return contactBatchKey(row), true
+	case "held_draft", "scheduled_send_held":
+		return "held_draft", true
+	default:
+		return "", false
+	}
+}
+
+// contactBatchKey splits the contact questions into the three the concept names.
+//
+// The split matters because the three are answered differently: a machine
+// sender is rejected without thought, an address whose company we already know
+// is usually accepted, and the remainder is the part that actually needs a
+// person. One group of a hundred and fifty would still be a pile.
+func contactBatchKey(row ranked) crmcontracts.WorklistBatchKey {
+	switch {
+	case row.machineSender:
+		return "likely_automated"
+	case row.knownCompany:
+		return "company_match"
+	default:
+		return "uncertain_contact"
+	}
+}
+
+// batchSample is how many members a batch names.
+//
+// Enough to recognise the kind, few enough to stay one line. A reader who
+// cannot see what is in a group has to trust it, and a group nobody trusts is
+// worse than the pile it replaced.
+const batchSample = 3
+
+// batchRow draws one group as a queue item.
+//
+// It carries no subject: a batch is about no single record, and offering `open`
+// would send the reader to whichever member happened to be first. Its verb is
+// the batch screen, which the client routes from the source alone.
+func batchRow(key crmcontracts.WorklistBatchKey, members []ranked) ranked {
+	sample := make([]string, 0, batchSample)
+	for _, member := range members {
+		if len(sample) == batchSample {
+			break
+		}
+		if member.item.Title != nil && *member.item.Title != "" {
+			sample = append(sample, *member.item.Title)
+		}
+	}
+	count := len(members)
+	row := crmcontracts.WorklistItem{
+		// The key IS the id: one row per kind per read, and a client that
+		// re-reads finds the same row rather than a new one each time.
+		Id:          string(key),
+		Source:      "batch",
+		Category:    "decisions",
+		Level:       levelRoutine,
+		Consequence: "data_drifts",
+		Because:     []crmcontracts.WorklistReason{reason("routine", nil)},
+		Batch: &crmcontracts.WorklistBatch{
+			Key:    key,
+			Count:  count,
+			Sample: &sample,
+		},
+		Actions: []crmcontracts.WorklistItemActions{},
+	}
+	// The oldest member's moment, so a batch sorts where its work would have.
+	occurred := members[0].occurredAt
+	for _, member := range members {
+		if member.occurredAt.Before(occurred) {
+			occurred = member.occurredAt
+		}
+	}
+	return ranked{item: row, occurredAt: occurred}
+}

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -45,6 +45,16 @@ const (
 // reader would have met first. Everything that is not routine passes through
 // untouched.
 func foldRoutineDecisions(rows []ranked) []ranked {
+	return foldRoutineDecisionsBounded(rows, false)
+}
+
+// foldRoutineDecisionsBounded is the same fold, told whether the read that
+// produced these rows stopped at its own bound.
+//
+// A group whose members were cut short says so: "200+" rather than "200",
+// because a bound printed as a total is a wrong number rather than a bounded
+// one, and the reader has no way to tell the two apart.
+func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 	groups := map[crmcontracts.WorklistBatchKey][]ranked{}
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
@@ -61,7 +71,7 @@ func foldRoutineDecisions(rows []ranked) []ranked {
 			kept = append(kept, members...)
 			continue
 		}
-		kept = append(kept, batchRow(key, members))
+		kept = append(kept, batchRow(key, members, bounded))
 	}
 	return kept
 }
@@ -85,7 +95,7 @@ func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
 	switch *row.item.Kind {
 	case "capture_counterparty":
 		return contactBatchKey(row), true
-	case kindHeldDraft, kindScheduledSend:
+	case kindHeldDraft:
 		return kindHeldDraft, true
 	default:
 		return "", false
@@ -121,7 +131,7 @@ const batchSample = 3
 // It carries no subject: a batch is about no single record, and offering `open`
 // would send the reader to whichever member happened to be first. Its verb is
 // the batch screen, which the client routes from the source alone.
-func batchRow(key crmcontracts.WorklistBatchKey, members []ranked) ranked {
+func batchRow(key crmcontracts.WorklistBatchKey, members []ranked, bounded bool) ranked {
 	sample := make([]string, 0, batchSample)
 	for _, member := range members {
 		if len(sample) == batchSample {
@@ -147,6 +157,10 @@ func batchRow(key crmcontracts.WorklistBatchKey, members []ranked) ranked {
 			Sample: &sample,
 		},
 		Actions: []crmcontracts.WorklistItemActions{},
+	}
+	if bounded {
+		atLeast := true
+		row.Batch.AtLeast = &atLeast
 	}
 	// The oldest member's moment, so a batch sorts where its work would have.
 	occurred := members[0].occurredAt

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -29,6 +29,16 @@ import (
 // than it saves. It is the pile that needs collapsing, not the pair.
 const batchFloor = 3
 
+// The two approval kinds that are a message the product WROTE and is holding.
+//
+// Constants rather than literals at each site: the classifier and the grouper
+// both ask about them, and a typo in either would put the same decision in two
+// places while both halves still compiled.
+const (
+	kindHeldDraft     = "held_draft"
+	kindScheduledSend = "scheduled_send_held"
+)
+
 // foldRoutineDecisions replaces alike routine decisions with one row each.
 //
 // The members are kept in the fold's order, so the sample names the ones the
@@ -75,8 +85,8 @@ func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
 	switch *row.item.Kind {
 	case "capture_counterparty":
 		return contactBatchKey(row), true
-	case "held_draft", "scheduled_send_held":
-		return "held_draft", true
+	case kindHeldDraft, kindScheduledSend:
+		return kindHeldDraft, true
 	default:
 		return "", false
 	}

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -16,7 +16,6 @@ package attention
 // right ones.
 
 import (
-	"strings"
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -363,85 +362,6 @@ func classifyBounce(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelPromise, "system", "customer_never_received")
 	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
 	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
-}
-
-// classifyDecision: a staged proposal or a duplicate pair.
-//
-// The split is what keeps the queue honest. A decision about a SEND blocks
-// customer work and sits at level 5; contact hygiene — capturing a counterparty,
-// merging two records — is level 6 and never outranks a customer, however many
-// of them are waiting. That is the whole answer to a queue of 188 identical
-// contact questions burying an unanswered buyer.
-func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	level, consequence, why := levelRoutine, crmcontracts.WorklistItemConsequence("data_drifts"), "routine"
-	if blocksCustomerWork(item) {
-		level, consequence, why = levelBlocking, "work_blocked", "blocks_customer_work"
-	}
-	row := base(item, level, "decisions", consequence)
-	row.Because = []crmcontracts.WorklistReason{reason(crmcontracts.WorklistReasonKind(why), nil)}
-	// The two facts a routine contact decision is grouped by. They ride on the
-	// wire item's `detail`, which the feed fills from the staged payload — the
-	// verdict engine already decided who the address belongs to, and deriving
-	// it again here would put one decision in two groups across two reads.
-	facts := stagedFactsOf(item)
-	return ranked{
-		item:          row,
-		occurredAt:    occurredOf(item, asOf),
-		machineSender: facts.MachineSender,
-		knownCompany:  facts.KnownCompany,
-	}
-}
-
-// The markers the feed stamps on a contact decision's detail, so the queue can
-// group it without reading the payload a second time. Two words rather than a
-// structure, because `detail` is one line on the wire and this is all it needs
-// to carry.
-const (
-	stagedMachineSender = "machine_sender"
-	stagedKnownCompany  = "known_company"
-)
-
-// stagedFactsOf reads those markers back.
-func stagedFactsOf(item crmcontracts.AttentionItem) StagedFacts {
-	if item.Detail == nil {
-		return StagedFacts{}
-	}
-	return StagedFacts{
-		MachineSender: strings.Contains(*item.Detail, stagedMachineSender),
-		KnownCompany:  strings.Contains(*item.Detail, stagedKnownCompany),
-	}
-}
-
-// blocksCustomerWork reports whether a staged decision is holding up something
-// a customer is waiting on, as opposed to tidying the database.
-//
-// The list is the approval kinds whose SUBJECT is an outbound act. A kind absent
-// here is treated as hygiene, which is the safe direction: mislabelling a merge
-// as urgent costs a reader their attention, while the reverse costs them only a
-// place in a queue they are working through anyway.
-func blocksCustomerWork(item crmcontracts.AttentionItem) bool {
-	if item.Kind == nil {
-		return false
-	}
-	switch *item.Kind {
-	case "send_email", "send_account_email", "send_message",
-		"book_meeting",
-		"deal_follow_up", "transcript_proposal", "site_lead":
-		return true
-	case "held_draft", "scheduled_send_held":
-		// A message the product WROTE and is holding. It blocks a customer in
-		// the sense that nothing reaches them until somebody looks — but five
-		// hundred of them are one kind of work, and treating each as its own
-		// urgent row is what made the old page unreadable. So they group, and
-		// the group sits where routine work sits.
-		//
-		// The distinction from a send: a send is a message the rep MEANT to
-		// send and a person is waiting on it. A held draft is a suggestion
-		// nobody has agreed to yet.
-		return false
-	default:
-		return false
-	}
 }
 
 // classifyDecay: a relationship going quiet. Nobody is waiting on the reader

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -16,6 +16,7 @@ package attention
 // right ones.
 
 import (
+	"strings"
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -378,7 +379,37 @@ func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	}
 	row := base(item, level, "decisions", consequence)
 	row.Because = []crmcontracts.WorklistReason{reason(crmcontracts.WorklistReasonKind(why), nil)}
-	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
+	// The two facts a routine contact decision is grouped by. They ride on the
+	// wire item's `detail`, which the feed fills from the staged payload — the
+	// verdict engine already decided who the address belongs to, and deriving
+	// it again here would put one decision in two groups across two reads.
+	facts := stagedFactsOf(item)
+	return ranked{
+		item:          row,
+		occurredAt:    occurredOf(item, asOf),
+		machineSender: facts.MachineSender,
+		knownCompany:  facts.KnownCompany,
+	}
+}
+
+// The markers the feed stamps on a contact decision's detail, so the queue can
+// group it without reading the payload a second time. Two words rather than a
+// structure, because `detail` is one line on the wire and this is all it needs
+// to carry.
+const (
+	stagedMachineSender = "machine_sender"
+	stagedKnownCompany  = "known_company"
+)
+
+// stagedFactsOf reads those markers back.
+func stagedFactsOf(item crmcontracts.AttentionItem) StagedFacts {
+	if item.Detail == nil {
+		return StagedFacts{}
+	}
+	return StagedFacts{
+		MachineSender: strings.Contains(*item.Detail, stagedMachineSender),
+		KnownCompany:  strings.Contains(*item.Detail, stagedKnownCompany),
+	}
 }
 
 // blocksCustomerWork reports whether a staged decision is holding up something
@@ -394,10 +425,20 @@ func blocksCustomerWork(item crmcontracts.AttentionItem) bool {
 	}
 	switch *item.Kind {
 	case "send_email", "send_account_email", "send_message",
-		"scheduled_send_held", "held_draft",
 		"book_meeting",
 		"deal_follow_up", "transcript_proposal", "site_lead":
 		return true
+	case "held_draft", "scheduled_send_held":
+		// A message the product WROTE and is holding. It blocks a customer in
+		// the sense that nothing reaches them until somebody looks — but five
+		// hundred of them are one kind of work, and treating each as its own
+		// urgent row is what made the old page unreadable. So they group, and
+		// the group sits where routine work sits.
+		//
+		// The distinction from a send: a send is a message the rep MEANT to
+		// send and a person is waiting on it. A held draft is a suggestion
+		// nobody has agreed to yet.
+		return false
 	default:
 		return false
 	}

--- a/backend/internal/compose/attention/classifydecision.go
+++ b/backend/internal/compose/attention/classifydecision.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What a staged decision IS, for the queue that has to rank it against a
+// customer.
+//
+// Split from the other classifiers on the file-length ceiling, and it is the
+// right seam: everything here answers one question the rest do not — whether a
+// decision holds up a person, or is the routine tidying that groups.
+
+import (
+	"strings"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// classifyDecision: a staged proposal or a duplicate pair.
+//
+// The split is what keeps the queue honest. A decision about a SEND blocks
+// customer work and sits at level 5; contact hygiene — capturing a counterparty,
+// merging two records — is level 6 and never outranks a customer, however many
+// of them are waiting. That is the whole answer to a queue of 188 identical
+// contact questions burying an unanswered buyer.
+func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	level, consequence, why := levelRoutine, crmcontracts.WorklistItemConsequence("data_drifts"), "routine"
+	if blocksCustomerWork(item) {
+		level, consequence, why = levelBlocking, "work_blocked", "blocks_customer_work"
+	}
+	row := base(item, level, "decisions", consequence)
+	row.Because = []crmcontracts.WorklistReason{reason(crmcontracts.WorklistReasonKind(why), nil)}
+	// The two facts a routine contact decision is grouped by. They ride on the
+	// wire item's `detail`, which the feed fills from the staged payload — the
+	// verdict engine already decided who the address belongs to, and deriving
+	// it again here would put one decision in two groups across two reads.
+	facts := stagedFactsOf(item)
+	return ranked{
+		item:          row,
+		occurredAt:    occurredOf(item, asOf),
+		machineSender: facts.MachineSender,
+		knownCompany:  facts.KnownCompany,
+	}
+}
+
+// The markers the feed stamps on a contact decision's detail, so the queue can
+// group it without reading the payload a second time. Two words rather than a
+// structure, because `detail` is one line on the wire and this is all it needs
+// to carry.
+const (
+	stagedMachineSender = "machine_sender"
+	stagedKnownCompany  = "known_company"
+)
+
+// stagedFactsOf reads those markers back.
+func stagedFactsOf(item crmcontracts.AttentionItem) StagedFacts {
+	if item.Detail == nil {
+		return StagedFacts{}
+	}
+	return StagedFacts{
+		MachineSender: strings.Contains(*item.Detail, stagedMachineSender),
+		KnownCompany:  strings.Contains(*item.Detail, stagedKnownCompany),
+	}
+}
+
+// blocksCustomerWork reports whether a staged decision is holding up something
+// a customer is waiting on, as opposed to tidying the database.
+//
+// The list is the approval kinds whose SUBJECT is an outbound act. A kind absent
+// here is treated as hygiene, which is the safe direction: mislabelling a merge
+// as urgent costs a reader their attention, while the reverse costs them only a
+// place in a queue they are working through anyway.
+func blocksCustomerWork(item crmcontracts.AttentionItem) bool {
+	if item.Kind == nil {
+		return false
+	}
+	switch *item.Kind {
+	case "send_email", "send_account_email", "send_message",
+		"book_meeting",
+		"deal_follow_up", "transcript_proposal", "site_lead":
+		return true
+	case kindHeldDraft, kindScheduledSend:
+		// A message the product WROTE and is holding. It blocks a customer in
+		// the sense that nothing reaches them until somebody looks — but five
+		// hundred of them are one kind of work, and treating each as its own
+		// urgent row is what made the old page unreadable. So they group, and
+		// the group sits where routine work sits.
+		//
+		// The distinction from a send: a send is a message the rep MEANT to
+		// send and a person is waiting on it. A held draft is a suggestion
+		// nobody has agreed to yet.
+		return false
+	default:
+		return false
+	}
+}

--- a/backend/internal/compose/attention/classifydecision.go
+++ b/backend/internal/compose/attention/classifydecision.go
@@ -80,16 +80,17 @@ func blocksCustomerWork(item crmcontracts.AttentionItem) bool {
 		"book_meeting",
 		"deal_follow_up", "transcript_proposal", "site_lead":
 		return true
-	case kindHeldDraft, kindScheduledSend:
-		// A message the product WROTE and is holding. It blocks a customer in
-		// the sense that nothing reaches them until somebody looks — but five
-		// hundred of them are one kind of work, and treating each as its own
-		// urgent row is what made the old page unreadable. So they group, and
-		// the group sits where routine work sits.
-		//
-		// The distinction from a send: a send is a message the rep MEANT to
-		// send and a person is waiting on it. A held draft is a suggestion
-		// nobody has agreed to yet.
+	case kindScheduledSend:
+		// A message the rep already MEANT to send, stopped at send time. The
+		// accept verb on it reads "yes, still send this", and somebody is
+		// waiting at the other end — so it blocks a customer exactly as a send
+		// does, and never groups.
+		return true
+	case kindHeldDraft:
+		// A message the product WROTE and is holding: a suggestion nobody has
+		// agreed to yet. Five hundred of them are one kind of work, and
+		// treating each as its own urgent row is what made the old page
+		// unreadable, so they group and the group sits where routine work sits.
 		return false
 	default:
 		return false

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -23,6 +23,19 @@ import (
 // numbers on screen contradicted each other.
 const needsYouPage = 10
 
+// batchScanDepth is how many staged decisions the RANKED queue reads.
+//
+// Deeper than needsYouPage on purpose, and for a reason that only applies to
+// the queue: a batch row states how many decisions it stands for, and a count
+// taken from a page of ten would say "10" over a pile of a hundred and fifty.
+// The lane feed's page is a prefetch for a surface that answers one at a time;
+// this is a census for a row that answers a group.
+//
+// Bounded by the approvals engine's own scan cap rather than by a number chosen
+// here — past that the count reads "200+", which is the same message to a reader
+// as the true figure.
+const batchScanDepth = 200
+
 // plannedCap bounds today's agreed work for the same reason. Higher than the
 // decision lane because reading a task costs less than deciding one.
 const plannedCap = 12
@@ -81,7 +94,16 @@ type Service struct {
 	// names is OPTIONAL like the lanes above it: nil means subjects travel
 	// unnamed and the client resolves display names itself (labels.go).
 	names Names
-	now   Clock
+	// machine answers whether an address is a sending system, for the group a
+	// routine contact decision joins. Nil means every address reads as a
+	// person's, which under-groups rather than hiding anything.
+	machine MachineSender
+	// decisionDepth is how many staged decisions a read takes. The lane feed's
+	// page is a prefetch for a surface that answers one at a time; the ranked
+	// queue takes a census, because a batch row that says "10" over a pile of
+	// a hundred and fifty is a wrong number rather than a bounded one.
+	decisionDepth int
+	now           Clock
 	// mineOnly narrows the producers that can be narrowed to the acting
 	// reader's own work. Set per read (Assemble keeps the lane feed's
 	// behaviour; the ranked queue's default scope sets it), because the same
@@ -121,6 +143,21 @@ func (s *Service) WithWaiting(w Waiting) *Service {
 	return s
 }
 
+// WithMachineSender binds the rule that tells a sending system from a person.
+func (s *Service) WithMachineSender(is MachineSender) *Service {
+	s.machine = is
+	return s
+}
+
+// countingDecisions returns a copy of this service that reads decisions to
+// census depth. A copy, because one Service serves every request and a depth
+// set on it would follow one reader's page onto another's.
+func (s *Service) countingDecisions() *Service {
+	deeper := *s
+	deeper.decisionDepth = batchScanDepth
+	return &deeper
+}
+
 // Assemble reads every lane and returns the day.
 //
 // A lane whose read is REFUSED is omitted and named rather than reported empty.
@@ -151,7 +188,7 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 		return crmcontracts.Attention{}, err
 	}
 
-	needsYou, count, err := s.decisions(ctx)
+	needsYou, count, err := s.decisionsToDepth(ctx, s.decisionsDepth())
 	omitted, err = fill(omitted, "needs_you", err, func() {
 		out.NeedsYou = needsYou
 		out.Counts.NeedsYou = count.items
@@ -249,8 +286,19 @@ func (s *Service) thisMorning(ctx context.Context) ([]crmcontracts.AttentionItem
 // Duplicates take the first slot of each round. A merge is the one verb here
 // the product cannot undo, so it leads on stakes — but it leads by one place,
 // not by the whole page.
-func (s *Service) decisions(ctx context.Context) ([]crmcontracts.AttentionItem, laneCount, error) {
-	pairs, err := s.duplicates.OpenCandidates(ctx, needsYouPage)
+// decisionsDepth answers how deep this read goes, defaulting to the lane
+// feed's page.
+func (s *Service) decisionsDepth() int {
+	if s.decisionDepth > 0 {
+		return s.decisionDepth
+	}
+	return needsYouPage
+}
+
+// decisionsToDepth is the same read at a depth the caller chooses: the lane feed
+// takes a page, and the ranked queue takes a census so its batch rows can count.
+func (s *Service) decisionsToDepth(ctx context.Context, depth int) ([]crmcontracts.AttentionItem, laneCount, error) {
+	pairs, err := s.duplicates.OpenCandidates(ctx, depth)
 	if err != nil {
 		return nil, laneCount{}, err
 	}
@@ -258,7 +306,7 @@ func (s *Service) decisions(ctx context.Context) ([]crmcontracts.AttentionItem, 
 	if err != nil {
 		return nil, laneCount{}, err
 	}
-	staged, err := s.approvals.ListWire(ctx, ApprovalQuery{Status: "pending", Limit: needsYouPage})
+	staged, err := s.approvals.ListWire(ctx, ApprovalQuery{Status: "pending", Limit: depth})
 	if err != nil {
 		return nil, laneCount{}, err
 	}
@@ -277,9 +325,9 @@ func (s *Service) decisions(ctx context.Context) ([]crmcontracts.AttentionItem, 
 	}
 	approvals := make([]crmcontracts.AttentionItem, 0, len(staged))
 	for _, approval := range staged {
-		approvals = append(approvals, approvalItem(approval))
+		approvals = append(approvals, approvalItem(approval, s.machine))
 	}
-	return interleave(duplicates, approvals, needsYouPage),
+	return interleave(duplicates, approvals, depth),
 		laneCount{items: openPairs + openStaged, duplicates: openPairs},
 		nil
 }

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -32,6 +32,26 @@ type Approvals interface {
 	CountPending(ctx context.Context) (int, error)
 }
 
+// MachineSender answers whether an address belongs to a sending system rather
+// than a person.
+//
+// Injected rather than imported: this package reaches no module, and the rule
+// belongs to capture, which owns what a machine sender IS. A feed given none
+// treats every address as a person's, which under-groups rather than hiding
+// anything.
+type MachineSender func(address string) bool
+
+// StagedFacts are the few things about a staged proposal this queue needs that
+// its summary sentence does not carry: enough to put a routine decision in the
+// right group without reading the payload twice.
+type StagedFacts struct {
+	// MachineSender is set when the address the decision is about belongs to a
+	// sending system rather than a person.
+	MachineSender bool
+	// KnownCompany is set when its domain already names a company here.
+	KnownCompany bool
+}
+
 // ApprovalQuery is what this feed asks the approvals engine for. Narrower than
 // the engine's own input on purpose: the feed reads one page of one status and
 // takes no part in choosing scope, which stays the engine's to decide.

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -82,6 +82,12 @@ type ranked struct {
 	waitingDays  int
 	strength     int
 	occurredAt   time.Time
+	// What a routine contact decision is ABOUT, for the group it joins. Read
+	// from the staged payload rather than re-derived here: the verdict engine
+	// already decided who the address belongs to, and a second opinion would
+	// put the same decision in two groups on two reads.
+	machineSender bool
+	knownCompany  bool
 }
 
 // rankAll orders the day and explains itself.

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -88,6 +88,11 @@ type ranked struct {
 	// put the same decision in two groups on two reads.
 	machineSender bool
 	knownCompany  bool
+	// crowded marks a row that is one of many of its kind. It sorts below its
+	// unmarked siblings so one kind of work cannot fill the page, and it
+	// changes nothing else: the row is still what it is, and every count that
+	// reads its level still reads the truth.
+	crowded bool
 }
 
 // rankAll orders the day and explains itself.
@@ -118,6 +123,16 @@ func rankAll(rows []ranked) []crmcontracts.WorklistItem {
 // explanation cannot come to disagree — compare() below walks the same steps in
 // the same order and names the first one that decided.
 func less(a, b ranked) bool {
+	// Crowding sorts BEFORE the band, and it is the one thing that does.
+	//
+	// A hundred unanswered customers are all genuinely level 1, so comparing
+	// bands first puts every one of them above the reader's overdue task and
+	// the page becomes a single kind of work again. The few that lead keep
+	// their band's precedence; the rest wait behind the other kinds — still
+	// level 1, still saying a buyer wrote last, just not all at once.
+	if a.crowded != b.crowded {
+		return b.crowded
+	}
 	if a.item.Level != b.item.Level {
 		return a.item.Level < b.item.Level
 	}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -202,11 +202,15 @@ func stagedMarkers(approval crmcontracts.Approval, machine MachineSender) string
 	if address, ok := change["email"].(string); ok && machine != nil && machine(address) {
 		markers = append(markers, stagedMachineSender)
 	}
-	// The engine names the company when it recognised the domain, so its
-	// presence IS the match. An empty name is the honest "we do not know it".
-	if name, ok := change["display_name"].(string); ok && strings.TrimSpace(name) != "" {
-		markers = append(markers, stagedKnownCompany)
-	}
+	// There is no company marker here, and the reason is worth stating: the
+	// only company-ish field the staged payload carries is `display_name`,
+	// which capture labels "untrusted header text — for display, never
+	// matching" (modules/capture/pending.go). A sender types it, so
+	// `Alice <alice@gmail.com>` would have read as a company we know.
+	//
+	// A real match needs a lookup against the organizations this workspace has,
+	// which is a read this assembler does not make. Until it does, a contact
+	// question is either from a machine or is the honest remainder.
 	return strings.Join(markers, " ")
 }
 

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -164,7 +165,7 @@ func evidenceRows(rows []FieldComparison) []crmcontracts.AttentionPairEvidence {
 // sanitized at staging time, so it is what a reader sees. A proposal whose
 // summary is empty falls back to its kind rather than rendering a blank card —
 // an unnamed decision is still a decision somebody has to make.
-func approvalItem(approval crmcontracts.Approval) crmcontracts.AttentionItem {
+func approvalItem(approval crmcontracts.Approval, machine MachineSender) crmcontracts.AttentionItem {
 	kind := approval.Kind
 	item := crmcontracts.AttentionItem{
 		Id:      approval.Id.String(),
@@ -179,7 +180,34 @@ func approvalItem(approval crmcontracts.Approval) crmcontracts.AttentionItem {
 	if approval.TargetEntityType != nil && approval.TargetEntityId != nil {
 		item.Subject = subjectOf(*approval.TargetEntityType, ids.UUID(*approval.TargetEntityId))
 	}
+	if markers := stagedMarkers(approval, machine); markers != "" {
+		item.Detail = &markers
+	}
 	return item
+}
+
+// stagedMarkers says what a routine contact decision is ABOUT, for the group it
+// will join.
+//
+// Read from the payload the verdict engine staged — the address it is asking
+// about, and whether that address's domain already names a company here. Both
+// are facts the engine had; re-deriving them in the queue would be a second
+// opinion, and one decision would land in two groups across two reads.
+func stagedMarkers(approval crmcontracts.Approval, machine MachineSender) string {
+	if approval.Kind != "capture_counterparty" || approval.ProposedChange == nil {
+		return ""
+	}
+	change := *approval.ProposedChange
+	markers := make([]string, 0, 2)
+	if address, ok := change["email"].(string); ok && machine != nil && machine(address) {
+		markers = append(markers, stagedMachineSender)
+	}
+	// The engine names the company when it recognised the domain, so its
+	// presence IS the match. An empty name is the honest "we do not know it".
+	if name, ok := change["display_name"].(string); ok && strings.TrimSpace(name) != "" {
+		markers = append(markers, stagedKnownCompany)
+	}
+	return strings.Join(markers, " ")
 }
 
 // taskItem renders one open task.

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -185,27 +185,38 @@ func (s *Service) worklistFrom(
 	sort.SliceStable(mine, func(i, j int) bool { return mine[i].Since.Before(mine[j].Since) })
 	for i, customer := range mine {
 		row := classifyWaiting(customer, day.AsOf)
-		// Past the lead, a wait keeps its row, its reason and its place in the
-		// ordering — one band lower, so the other kinds of work are reachable
-		// above it. Demoted, never dropped: a queue that hid a waiting customer
-		// to make room would be the failure this whole surface exists to end.
+		// Past the lead, a wait sorts BELOW the other kinds without ceasing to
+		// be one: its level still says a customer is waiting, because that is
+		// what it is and the summary counts on it. What changes is only where
+		// it sits, through the ordering's own last tiebreak.
+		//
+		// Rewriting the level instead would have told the reader the ninth
+		// waiting customer was agreed work, while the row went on saying a
+		// buyer wrote last — the page contradicting itself.
 		if i >= waitingLead {
-			row.item.Level = levelAgreed
+			row.crowded = true
 		}
 		rows = append(rows, row)
 	}
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
-	// And a pile of alike routine decisions is one row, not a hundred. No
-	// ordering saves a reader who must scroll past a hundred to reach the next
-	// thing, so the pile is collapsed before it is ranked.
-	rows = foldRoutineDecisions(rows)
+
 	if mineOnly(scope) {
 		rows = keepReadersOwn(ctx, rows)
 	}
-	if filter != "" && filter != string(crmcontracts.GetWorklistParamsFilterAll) {
+	narrowed := filter != "" && filter != string(crmcontracts.GetWorklistParamsFilterAll)
+	if narrowed {
 		rows = keepCategory(rows, crmcontracts.WorklistItemCategory(filter))
+	}
+	// A pile of alike routine decisions is one row, not a hundred — but ONLY on
+	// the unnarrowed page. A reader who asked for decisions asked to see them,
+	// and answering that with the same group they were trying to open is a door
+	// that leads back to itself. Narrowing IS opening the group.
+	if !narrowed {
+		// The decision read stops at its own scan bound, so a group that filled
+		// it reports a floor rather than a total.
+		rows = foldRoutineDecisionsBounded(rows, len(day.NeedsYou) >= batchScanDepth)
 	}
 	// Cut to the page BEFORE explaining and counting. Ranking the whole set and
 	// then slicing left the last returned row comparing itself against a row the

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -31,6 +31,14 @@ import (
 // worklistPage is how many ranked items one read carries by default.
 const worklistPage = 25
 
+// waitingLead is how many unanswered customers lead the page.
+//
+// Not a cap on the source: the rest are still ranked and still reachable. It is
+// a cap on how much of ONE kind a reader meets before they see the others, and
+// the number is the answer to "how many can somebody act on this morning"
+// rather than to "how many are there".
+const waitingLead = 8
+
 // worklistMaxPage is the ceiling the contract publishes. A larger ask is
 // clamped rather than refused: the number is a request for how much to draw,
 // and answering the most that can be drawn is more useful than an error.
@@ -53,9 +61,11 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	// not filtered afterwards: each store bounds what it returns, so a page
 	// full of colleagues' rows would hide the reader's own work behind a cut
 	// that had already happened.
-	reader := s
+	// Deeper than the lane feed reads: a batch row counts a pile, and a count
+	// taken from a page of ten would report ten over a hundred and fifty.
+	reader := s.countingDecisions()
 	if mineOnly(resolved) {
-		reader = s.forReader()
+		reader = reader.forReader()
 	}
 	day, err := reader.Assemble(ctx)
 	if err != nil {
@@ -163,15 +173,34 @@ func (s *Service) worklistFrom(
 	// colleague's deal is that colleague's to answer. Judged against the deals
 	// this reader owns in THIS day, which is the set `mine` already narrowed.
 	owned := ownedDealsIn(ctx, day, scope)
+	// Longest wait first, so the few that LEAD are the ones most likely to have
+	// been forgotten rather than whichever the database returned first.
+	mine := make([]WaitingCustomer, 0, len(waiting))
 	for _, customer := range waiting {
 		if mineOnly(scope) && !waitingIsMine(customer, owned) {
 			continue
 		}
-		rows = append(rows, classifyWaiting(customer, day.AsOf))
+		mine = append(mine, customer)
+	}
+	sort.SliceStable(mine, func(i, j int) bool { return mine[i].Since.Before(mine[j].Since) })
+	for i, customer := range mine {
+		row := classifyWaiting(customer, day.AsOf)
+		// Past the lead, a wait keeps its row, its reason and its place in the
+		// ordering — one band lower, so the other kinds of work are reachable
+		// above it. Demoted, never dropped: a queue that hid a waiting customer
+		// to make room would be the failure this whole surface exists to end.
+		if i >= waitingLead {
+			row.item.Level = levelAgreed
+		}
+		rows = append(rows, row)
 	}
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
+	// And a pile of alike routine decisions is one row, not a hundred. No
+	// ordering saves a reader who must scroll past a hundred to reach the next
+	// thing, so the pile is collapsed before it is ranked.
+	rows = foldRoutineDecisions(rows)
 	if mineOnly(scope) {
 		rows = keepReadersOwn(ctx, rows)
 	}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -522,3 +522,157 @@ func dealItemOwned(deal, owner ids.UUID) crmcontracts.AttentionItem {
 		Actions: []crmcontracts.AttentionItemActions{},
 	}
 }
+
+func withDetail2(detail string) func(*crmcontracts.AttentionItem) {
+	return func(i *crmcontracts.AttentionItem) { i.Detail = &detail }
+}
+
+// A pile of alike questions is one row. On the real workspace this is 152
+// contact decisions and 545 held drafts — no ordering saves a reader who must
+// scroll past them to reach the next thing.
+func TestAPileOfAlikeDecisionsBecomesOneRow(t *testing.T) {
+	staged := []crmcontracts.AttentionItem{}
+	for i := 0; i < 40; i++ {
+		staged = append(staged, item(
+			"c"+string(rune('a'+i%26))+string(rune('0'+i/26)),
+			"approval", withKind("capture_counterparty")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: staged}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 1 {
+		t.Fatalf("forty alike decisions drew %d rows", len(got))
+	}
+	if got[0].Batch == nil || got[0].Batch.Count != 40 {
+		t.Fatal("the row does not say how many decisions it stands for")
+	}
+}
+
+// The three contact groups are answered differently — a machine is rejected
+// without thought, a known company is usually accepted, and the remainder is
+// the part that needs a person. One group of everything would still be a pile.
+func TestContactDecisionsSplitByWhatTheyAreAbout(t *testing.T) {
+	staged := []crmcontracts.AttentionItem{}
+	for i := 0; i < 3; i++ {
+		staged = append(staged, item("m"+string(rune('a'+i)), "approval",
+			withKind("capture_counterparty"), withDetail2("machine_sender")))
+		staged = append(staged, item("k"+string(rune('a'+i)), "approval",
+			withKind("capture_counterparty"), withDetail2("known_company")))
+		staged = append(staged, item("u"+string(rune('a'+i)), "approval",
+			withKind("capture_counterparty")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: staged}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	keys := map[crmcontracts.WorklistBatchKey]int{}
+	for _, row := range got {
+		if row.Batch != nil {
+			keys[row.Batch.Key] = row.Batch.Count
+		}
+	}
+	for _, want := range []crmcontracts.WorklistBatchKey{
+		"likely_automated", "company_match", "uncertain_contact",
+	} {
+		if keys[want] != 3 {
+			t.Fatalf("group %q holds %d, wanted 3", want, keys[want])
+		}
+	}
+}
+
+// A decision that blocks a customer is never folded, however many of it there
+// are: each holds up somebody different, and the reader has to see each one.
+func TestADecisionThatBlocksACustomerIsNeverFolded(t *testing.T) {
+	staged := []crmcontracts.AttentionItem{}
+	for i := 0; i < 5; i++ {
+		staged = append(staged, item("s"+string(rune('a'+i)), "approval", withKind("send_email")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: staged}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 5 {
+		t.Fatalf("five customer-blocking decisions drew %d rows", len(got))
+	}
+}
+
+// Two alike questions are not a pile. A reader answers both faster than they
+// would open a group, and a "batch of 2" costs more than it saves.
+func TestTwoAlikeDecisionsStayThemselves(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("a", "approval", withKind("capture_counterparty")),
+			item("b", "approval", withKind("capture_counterparty")),
+		},
+	}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 2 {
+		t.Fatalf("two decisions drew %d rows", len(got))
+	}
+}
+
+// The group names a few members, so a reader can check it before answering it.
+func TestABatchNamesSomeOfWhatItHolds(t *testing.T) {
+	staged := []crmcontracts.AttentionItem{}
+	for i := 0; i < 6; i++ {
+		row := item("d"+string(rune('a'+i)), "approval", withKind("capture_counterparty"))
+		title := "Is address " + string(rune('a'+i)) + " a contact?"
+		row.Title = &title
+		staged = append(staged, row)
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: staged}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if got[0].Batch.Sample == nil || len(*got[0].Batch.Sample) != 3 {
+		t.Fatal("the group names none of what it holds, so it cannot be checked")
+	}
+}
+
+// A hundred unanswered threads is a real backlog, and a page that is nothing
+// but them tells a rep their day holds no deals, tasks or decisions. The
+// longest-waiting few lead; the rest are demoted, never dropped.
+func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
+	waiting := []WaitingCustomer{}
+	for i := 0; i < 30; i++ {
+		waiting = append(waiting, WaitingCustomer{
+			ActivityID: ids.NewV7(),
+			Subject:    "Thread " + string(rune('a'+i%26)) + string(rune('0'+i/26)),
+			Since:      rankInstant.Add(-time.Duration(30-i) * 24 * time.Hour),
+		})
+	}
+	day := crmcontracts.Attention{
+		AsOf:    rankInstant,
+		Planned: []crmcontracts.AttentionItem{item("task", "task", withDue(rankInstant.Add(-time.Hour)))},
+	}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waiting)
+
+	// Every wait is still on the page.
+	kept := 0
+	lead := 0
+	for _, row := range out.Queue {
+		if row.Source == "customer_waiting" {
+			kept++
+			if row.Level == levelWaiting {
+				lead++
+			}
+		}
+	}
+	if kept != 30 {
+		t.Fatalf("thirty waits produced %d rows — some were dropped", kept)
+	}
+	if lead != 8 {
+		t.Fatalf("%d waits lead the page, wanted the longest-waiting eight", lead)
+	}
+	// And the task is no longer buried under all thirty.
+	for i, row := range out.Queue {
+		if row.Source == "task" && i > 8 {
+			t.Fatalf("the overdue task sat at position %d, below the whole backlog", i+1)
+		}
+	}
+}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -524,10 +524,6 @@ func dealItemOwned(deal, owner ids.UUID) crmcontracts.AttentionItem {
 	}
 }
 
-func withDetail2(detail string) func(*crmcontracts.AttentionItem) {
-	return func(i *crmcontracts.AttentionItem) { i.Detail = &detail }
-}
-
 // A pile of alike questions is one row. On the real workspace this is 152
 // contact decisions and 545 held drafts — no ordering saves a reader who must
 // scroll past them to reach the next thing.

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -11,6 +11,7 @@ package attention
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -549,20 +550,23 @@ func TestAPileOfAlikeDecisionsBecomesOneRow(t *testing.T) {
 	}
 }
 
-// The three contact groups are answered differently — a machine is rejected
-// without thought, a known company is usually accepted, and the remainder is
-// the part that needs a person. One group of everything would still be a pile.
+// Contact questions split by what they are ABOUT, and the split is derived
+// from the STAGED PAYLOAD rather than fabricated here — a test that writes the
+// marker itself proves nothing about the code that writes it in production.
 func TestContactDecisionsSplitByWhatTheyAreAbout(t *testing.T) {
-	staged := []crmcontracts.AttentionItem{}
+	staged := []crmcontracts.Approval{}
 	for i := 0; i < 3; i++ {
-		staged = append(staged, item("m"+string(rune('a'+i)), "approval",
-			withKind("capture_counterparty"), withDetail2("machine_sender")))
-		staged = append(staged, item("k"+string(rune('a'+i)), "approval",
-			withKind("capture_counterparty"), withDetail2("known_company")))
-		staged = append(staged, item("u"+string(rune('a'+i)), "approval",
-			withKind("capture_counterparty")))
+		staged = append(staged,
+			captureApproval("noreply@vendor.example"),
+			captureApproval("anna.weber@customer.example"))
 	}
-	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: staged}
+	items := make([]crmcontracts.AttentionItem, 0, len(staged))
+	for _, approval := range staged {
+		items = append(items, approvalItem(approval, func(address string) bool {
+			return strings.HasPrefix(address, "noreply@")
+		}))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: items}
 
 	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
 
@@ -572,12 +576,38 @@ func TestContactDecisionsSplitByWhatTheyAreAbout(t *testing.T) {
 			keys[row.Batch.Key] = row.Batch.Count
 		}
 	}
-	for _, want := range []crmcontracts.WorklistBatchKey{
-		"likely_automated", "company_match", "uncertain_contact",
-	} {
-		if keys[want] != 3 {
-			t.Fatalf("group %q holds %d, wanted 3", want, keys[want])
-		}
+	if keys["likely_automated"] != 3 {
+		t.Fatalf("the machine group holds %d, wanted 3", keys["likely_automated"])
+	}
+	if keys["uncertain_contact"] != 3 {
+		t.Fatalf("the remainder holds %d, wanted 3", keys["uncertain_contact"])
+	}
+}
+
+// A company match needs a lookup this assembler does not make. The only
+// company-ish field on the payload is the sender's own display name, which
+// capture labels untrusted and never-for-matching — so `Alice <alice@gmail.com>`
+// must not read as a company we know.
+func TestASendersOwnDisplayNameIsNotACompanyMatch(t *testing.T) {
+	approval := captureApproval("alice@gmail.com")
+	change := map[string]any{"email": "alice@gmail.com", "display_name": "Alice Example"}
+	approval.ProposedChange = &change
+
+	item := approvalItem(approval, func(string) bool { return false })
+
+	if item.Detail != nil && strings.Contains(*item.Detail, stagedKnownCompany) {
+		t.Fatal("a sender's own display name was taken for a company we know")
+	}
+}
+
+func captureApproval(email string) crmcontracts.Approval {
+	change := map[string]any{"email": email}
+	summary := "Is " + email + " a contact worth keeping?"
+	return crmcontracts.Approval{
+		Id:             openapi_types.UUID(ids.NewV7()),
+		Kind:           "capture_counterparty",
+		Summary:        &summary,
+		ProposedChange: &change,
 	}
 }
 
@@ -652,26 +682,25 @@ func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 
 	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waiting)
 
-	// Every wait is still on the page.
+	// Every wait is still on the page, and every one still SAYS it is a wait.
+	// Rewriting the level of the ninth would tell the reader it was agreed work
+	// while its own row went on saying a buyer wrote last.
 	kept := 0
-	lead := 0
 	for _, row := range out.Queue {
 		if row.Source == "customer_waiting" {
 			kept++
-			if row.Level == levelWaiting {
-				lead++
+			if row.Level != levelWaiting {
+				t.Fatalf("a waiting customer was relabelled as level %d", row.Level)
 			}
 		}
 	}
 	if kept != 30 {
 		t.Fatalf("thirty waits produced %d rows — some were dropped", kept)
 	}
-	if lead != 8 {
-		t.Fatalf("%d waits lead the page, wanted the longest-waiting eight", lead)
-	}
-	// And the task is no longer buried under all thirty.
+	// What changes is only the ORDER: the overdue task is reachable rather than
+	// buried under the whole backlog.
 	for i, row := range out.Queue {
-		if row.Source == "task" && i > 8 {
+		if row.Source == "task" && i > waitingLead {
 			t.Fatalf("the overdue task sat at position %d, below the whole backlog", i+1)
 		}
 	}

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -475,5 +475,6 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 			projects:   projects.NewStore(db),
 		},
 		now,
-	).WithWaiting(attentionWaiting{store: activities.NewStore(db), now: now})
+	).WithWaiting(attentionWaiting{store: activities.NewStore(db), now: now}).
+		WithMachineSender(capture.IsMachineAddress)
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11311,6 +11311,33 @@ func (e WorklistScopeOptions) Valid() bool {
 	}
 }
 
+// Defines values for WorklistBatchKey.
+const (
+	CompanyMatch     WorklistBatchKey = "company_match"
+	Duplicates       WorklistBatchKey = "duplicates"
+	HeldDraft        WorklistBatchKey = "held_draft"
+	LikelyAutomated  WorklistBatchKey = "likely_automated"
+	UncertainContact WorklistBatchKey = "uncertain_contact"
+)
+
+// Valid indicates whether the value is a known member of the WorklistBatchKey enum.
+func (e WorklistBatchKey) Valid() bool {
+	switch e {
+	case CompanyMatch:
+		return true
+	case Duplicates:
+		return true
+	case HeldDraft:
+		return true
+	case LikelyAutomated:
+		return true
+	case UncertainContact:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistComparisonComparator.
 const (
 	WorklistComparisonComparatorDeadline        WorklistComparisonComparator = "deadline"
@@ -11469,6 +11496,7 @@ const (
 	WorklistItemSourceAiWorkHealth      WorklistItemSource = "ai_work_health"
 	WorklistItemSourceApproval          WorklistItemSource = "approval"
 	WorklistItemSourceAutomationRun     WorklistItemSource = "automation_run"
+	WorklistItemSourceBatch             WorklistItemSource = "batch"
 	WorklistItemSourceBounce            WorklistItemSource = "bounce"
 	WorklistItemSourceBriefItem         WorklistItemSource = "brief_item"
 	WorklistItemSourceCaptureHealth     WorklistItemSource = "capture_health"
@@ -11493,6 +11521,8 @@ func (e WorklistItemSource) Valid() bool {
 	case WorklistItemSourceApproval:
 		return true
 	case WorklistItemSourceAutomationRun:
+		return true
+	case WorklistItemSourceBatch:
 		return true
 	case WorklistItemSourceBounce:
 		return true
@@ -27299,6 +27329,38 @@ type WorklistScope string
 // WorklistScopeOptions defines model for Worklist.ScopeOptions.
 type WorklistScopeOptions string
 
+// WorklistBatch A group of routine decisions that read alike, standing on the queue as one row.
+//
+// The pile is the problem this solves: a hundred and fifty "is this address a
+// contact?" questions are one KIND of work, and asking them one at a time buries
+// every customer beneath them. The reader answers the group, or opens it to answer
+// the exceptions.
+//
+// `sample` names a few of the members so the row is checkable — a reader who cannot
+// see what is in a group has to trust it, and a group nobody trusts is worse than
+// the pile it replaced.
+type WorklistBatch struct {
+	// Count How many decisions this row stands for.
+	Count int `json:"count"`
+
+	// Key What the members have in common, which is also what makes them safe to answer
+	// together. `likely_automated` is mail from senders that are not people;
+	// `company_match` are addresses whose domain already names a company we know;
+	// `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
+	// `held_draft` are messages waiting to be released.
+	Key WorklistBatchKey `json:"key"`
+
+	// Sample A few members, named, so the group can be checked before it is answered.
+	Sample *[]string `json:"sample,omitempty"`
+}
+
+// WorklistBatchKey What the members have in common, which is also what makes them safe to answer
+// together. `likely_automated` is mail from senders that are not people;
+// `company_match` are addresses whose domain already names a company we know;
+// `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
+// `held_draft` are messages waiting to be released.
+type WorklistBatchKey string
+
 // WorklistComparison The first tie-break at which this item beat the one below it, with both sides'
 // values — so a row can say "above the next because it closes sooner" instead of
 // asking the reader to trust the order.
@@ -27355,6 +27417,18 @@ type WorklistItem struct {
 	// Actions What this item offers, routed to the endpoint that owns the verb.
 	Actions []WorklistItemActions `json:"actions"`
 
+	// Batch A group of routine decisions that read alike, standing on the queue as one row.
+	//
+	// The pile is the problem this solves: a hundred and fifty "is this address a
+	// contact?" questions are one KIND of work, and asking them one at a time buries
+	// every customer beneath them. The reader answers the group, or opens it to answer
+	// the exceptions.
+	//
+	// `sample` names a few of the members so the row is checkable — a reader who cannot
+	// see what is in a group has to trust it, and a group nobody trusts is worse than
+	// the pile it replaced.
+	Batch *WorklistBatch `json:"batch,omitempty"`
+
 	// Because The facts that put this item at this level, in the order they were weighed.
 	Because []WorklistReason `json:"because"`
 
@@ -27400,6 +27474,10 @@ type WorklistItem struct {
 	Score *float32 `json:"score,omitempty"`
 
 	// Source Which producer raised it, and therefore which endpoint its verbs go to.
+	//
+	// `batch` is the one that names no single record: it stands for a GROUP of
+	// routine decisions that read alike, so a hundred of them cost the reader one
+	// row rather than a hundred. Its own facts ride in `batch`.
 	Source WorklistItemSource `json:"source"`
 
 	// Subject The record this item is about, named so a reader knows who it concerns before opening anything.
@@ -27421,6 +27499,10 @@ type WorklistItemCategory string
 type WorklistItemConsequence string
 
 // WorklistItemSource Which producer raised it, and therefore which endpoint its verbs go to.
+//
+// `batch` is the one that names no single record: it stands for a GROUP of
+// routine decisions that read alike, so a hundred of them cost the reader one
+// row rather than a hundred. Its own facts ride in `batch`.
 type WorklistItemSource string
 
 // WorklistReason One fact behind an item's rank, as a typed pair rather than a sentence: the

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -27340,6 +27340,11 @@ type WorklistScopeOptions string
 // see what is in a group has to trust it, and a group nobody trusts is worse than
 // the pile it replaced.
 type WorklistBatch struct {
+	// AtLeast The count is a FLOOR, not a total: the read stopped at its own bound before
+	// it ran out of members. A client says "200+" rather than "200", because a
+	// bound printed as a total is a wrong number rather than a bounded one.
+	AtLeast *bool `json:"at_least,omitempty"`
+
 	// Count How many decisions this row stands for.
 	Count int `json:"count"`
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24139,6 +24139,12 @@ export interface components {
             key: "likely_automated" | "company_match" | "uncertain_contact" | "duplicates" | "held_draft";
             /** @description How many decisions this row stands for. */
             count: number;
+            /**
+             * @description The count is a FLOOR, not a total: the read stopped at its own bound before
+             *     it ran out of members. A client says "200+" rather than "200", because a
+             *     bound printed as a total is a wrong number rather than a bounded one.
+             */
+            at_least?: boolean;
             /** @description A few members, named, so the group can be checked before it is answered. */
             sample?: string[];
         };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24011,9 +24011,13 @@ export interface components {
             id: string;
             /**
              * @description Which producer raised it, and therefore which endpoint its verbs go to.
+             *
+             *     `batch` is the one that names no single record: it stands for a GROUP of
+             *     routine decisions that read alike, so a hundred of them cost the reader one
+             *     row rather than a hundred. Its own facts ride in `batch`.
              * @enum {string}
              */
-            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "customer_waiting" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice";
+            source: "approval" | "dedupe_candidate" | "task" | "brief_item" | "conversation_claim" | "customer_waiting" | "deal_at_risk" | "meeting" | "relationship_decay" | "failed_approval" | "dsr" | "sync_health" | "capture_health" | "ai_work_health" | "bounce" | "automation_run" | "notice" | "batch";
             /**
              * @description The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
              * @enum {string}
@@ -24047,6 +24051,7 @@ export interface components {
             consequence: "buyer_waits" | "promise_breaks" | "deal_drifts" | "deal_slips_past_close" | "meeting_unprepared" | "task_slips" | "work_blocked" | "customer_never_received" | "you_believe_it_happened" | "legal_deadline_missed" | "mailbox_blind" | "data_drifts" | "none";
             subject?: components["schemas"]["AttentionSubject"];
             deal?: components["schemas"]["WorklistDealFacts"];
+            batch?: components["schemas"]["WorklistBatch"];
             /**
              * Format: date-time
              * @description When this is due, or when the meeting starts.
@@ -24109,6 +24114,33 @@ export interface components {
             currency?: string;
             days?: number;
             level?: number;
+        };
+        /**
+         * @description A group of routine decisions that read alike, standing on the queue as one row.
+         *
+         *     The pile is the problem this solves: a hundred and fifty "is this address a
+         *     contact?" questions are one KIND of work, and asking them one at a time buries
+         *     every customer beneath them. The reader answers the group, or opens it to answer
+         *     the exceptions.
+         *
+         *     `sample` names a few of the members so the row is checkable — a reader who cannot
+         *     see what is in a group has to trust it, and a group nobody trusts is worse than
+         *     the pile it replaced.
+         */
+        WorklistBatch: {
+            /**
+             * @description What the members have in common, which is also what makes them safe to answer
+             *     together. `likely_automated` is mail from senders that are not people;
+             *     `company_match` are addresses whose domain already names a company we know;
+             *     `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
+             *     `held_draft` are messages waiting to be released.
+             * @enum {string}
+             */
+            key: "likely_automated" | "company_match" | "uncertain_contact" | "duplicates" | "held_draft";
+            /** @description How many decisions this row stands for. */
+            count: number;
+            /** @description A few members, named, so the group can be checked before it is answered. */
+            sample?: string[];
         };
         /**
          * @description The deal behind an item, with the facts its card states. `expected_minor_base` is

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7116,4 +7116,11 @@ export const de = {
   "worklist.source.failed": "{source} konnte nicht gelesen werden",
   "worklist.source.withheld": "{source} ist für dein Konto nicht sichtbar",
   "worklist.untitled.generic": "Etwas braucht dich",
+  "worklist.batch.likely_automated": "{count} vermutlich automatische Absender",
+  "worklist.batch.company_match": "{count} Adressen bei bekannten Firmen",
+  "worklist.batch.uncertain_contact": "{count} Adressen zu entscheiden",
+  "worklist.batch.duplicates": "{count} mögliche Dubletten",
+  "worklist.batch.held_draft": "{count} Entwürfe warten auf Freigabe",
+  "worklist.untitled.batch": "Eine Gruppe Routineentscheidungen",
+  "worklist.verb.review_batch": "Durchsehen",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7201,6 +7201,13 @@ export const en = {
   "worklist.source.failed": "{source} could not be read",
   "worklist.source.withheld": "{source} is hidden from your account",
   "worklist.untitled.generic": "Something needs you",
+  "worklist.batch.likely_automated": "{count} likely automated senders",
+  "worklist.batch.company_match": "{count} addresses at companies you know",
+  "worklist.batch.uncertain_contact": "{count} addresses to decide on",
+  "worklist.batch.duplicates": "{count} possible duplicate records",
+  "worklist.batch.held_draft": "{count} drafts waiting to be sent",
+  "worklist.untitled.batch": "A group of routine decisions",
+  "worklist.verb.review_batch": "Review",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7050,4 +7050,11 @@ export const vi = {
   "worklist.source.failed": "Không đọc được {source}",
   "worklist.source.withheld": "{source} bị ẩn với tài khoản của bạn",
   "worklist.untitled.generic": "Có việc cần bạn",
+  "worklist.batch.likely_automated": "{count} người gửi có thể tự động",
+  "worklist.batch.company_match": "{count} địa chỉ ở công ty đã biết",
+  "worklist.batch.uncertain_contact": "{count} địa chỉ cần quyết định",
+  "worklist.batch.duplicates": "{count} bản ghi có thể trùng",
+  "worklist.batch.held_draft": "{count} bản nháp đang chờ gửi",
+  "worklist.untitled.batch": "Một nhóm quyết định thường lệ",
+  "worklist.verb.review_batch": "Xem lại",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -213,6 +213,14 @@ export function consequenceText(item: WorklistItem, t: T): string | null {
 // the sentence would have to be invented, and the client writes it from the
 // source instead.
 export function itemTitle(item: WorklistItem, t: T): string {
+  // A group names itself by what it holds and how much: "43 likely automated
+  // senders" is the whole row, and a reader decides whether to open it from
+  // that sentence alone.
+  if (item.batch) {
+    return t(`worklist.batch.${item.batch.key}` as const, {
+      count: String(item.batch.count),
+    });
+  }
   if (item.title) {
     // A title that names no record, on a row that HAS one, gets the record's
     // name beside it. Eight rows reading "Follow up with the new lead" cannot
@@ -265,6 +273,8 @@ const KNOWN_SOURCES = {
   bounce: true,
   automation_run: true,
   notice: true,
+  // A group of routine decisions, which names no single record.
+  batch: true,
 } as const;
 
 function knownSource(

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -212,14 +212,18 @@ export function consequenceText(item: WorklistItem, t: T): string | null {
 // at staging time, a deal's own name, a message's subject. Where it has none
 // the sentence would have to be invented, and the client writes it from the
 // source instead.
-export function itemTitle(item: WorklistItem, t: T): string {
+export function itemTitle(item: WorklistItem, t: T, locale: Locale): string {
   // A group names itself by what it holds and how much: "43 likely automated
   // senders" is the whole row, and a reader decides whether to open it from
   // that sentence alone.
   if (item.batch) {
-    return t(`worklist.batch.${item.batch.key}` as const, {
-      count: String(item.batch.count),
-    });
+    // "200+" where the read stopped at its own bound. A floor printed as a
+    // total is a wrong number rather than a bounded one, and the reader has no
+    // way to tell the two apart.
+    const count = item.batch.at_least
+      ? `${formatNumber(item.batch.count, locale)}+`
+      : formatNumber(item.batch.count, locale);
+    return t(`worklist.batch.${item.batch.key}` as const, { count });
   }
   if (item.title) {
     // A title that names no record, on a row that HAS one, gets the record's

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -47,6 +47,7 @@
   margin: 0;
 }
 
+.worklist-row-sample,
 .worklist-row-because,
 .worklist-row-consequence,
 .worklist-row-above {

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -210,6 +210,31 @@ describe("what the ranked queue tells a reader", () => {
     expect(screen.getByText(/Is noreply@x.com a contact\?/)).toBeTruthy();
   });
 
+  it("says a bounded count is a floor, not a total", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "held_draft",
+            source: "batch",
+            category: "decisions",
+            level: 6,
+            consequence: "data_drifts",
+            batch: { key: "held_draft", count: 200, at_least: true },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The read stopped at its own bound with members left over. "200" would be
+    // a wrong number; "200+" is a bounded one.
+    expect(
+      await screen.findByText("200+ drafts waiting to be sent"),
+    ).toBeTruthy();
+  });
+
   it("opens a group into the work it stands for", async () => {
     const user = userEvent.setup();
     stub(

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -177,6 +177,39 @@ describe("what the ranked queue tells a reader", () => {
     expect(screen.getAllByRole("link", { name: "Open" })).toHaveLength(1);
   });
 
+  it("draws a pile of routine decisions as one row that says how many", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "likely_automated",
+            source: "batch",
+            category: "decisions",
+            level: 6,
+            consequence: "data_drifts",
+            batch: {
+              key: "likely_automated",
+              count: 43,
+              sample: [
+                "Is noreply@x.com a contact?",
+                "Is bot@y.com a contact?",
+              ],
+            },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The row IS the sentence: a reader decides whether to open it from this
+    // alone, so the count is part of the name rather than a badge beside it.
+    expect(await screen.findByText("43 likely automated senders")).toBeTruthy();
+    // And it names some of what it holds, because a group nobody can see into
+    // is a group nobody trusts.
+    expect(screen.getByText(/Is noreply@x.com a contact\?/)).toBeTruthy();
+  });
+
   it("says what happens if the reader does nothing", async () => {
     stub(
       day({

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -210,6 +210,41 @@ describe("what the ranked queue tells a reader", () => {
     expect(screen.getByText(/Is noreply@x.com a contact\?/)).toBeTruthy();
   });
 
+  it("opens a group into the work it stands for", async () => {
+    const user = userEvent.setup();
+    stub(
+      day({
+        queue: [
+          row({
+            id: "likely_automated",
+            source: "batch",
+            category: "decisions",
+            level: 6,
+            consequence: "data_drifts",
+            batch: { key: "likely_automated", count: 43 },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText("43 likely automated senders");
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    // A row whose verb led nowhere would be worse than the pile it replaced,
+    // so this asserts the queue actually narrows rather than that a control
+    // exists.
+    await waitFor(() => {
+      const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const urls = calls.map((call) => {
+        const target = call[0];
+        return target instanceof Request ? target.url : String(target);
+      });
+      expect(urls.some((url) => url.includes("filter=decisions"))).toBe(true);
+    });
+  });
+
   it("says what happens if the reader does nothing", async () => {
     stub(
       day({

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -89,6 +89,13 @@ function WorklistRow({
           <Badge>{t(`worklist.category.${item.category}` as const)}</Badge>
           {item.overdue && <Badge tone="danger">{t("worklist.overdue")}</Badge>}
         </p>
+        {item.batch?.sample && item.batch.sample.length > 0 && (
+          // A group nobody can see into is a group nobody trusts, and an
+          // untrusted group is worse than the pile it replaced.
+          <p className="t-caption worklist-row-sample">
+            {item.batch.sample.join(" · ")}
+          </p>
+        )}
         {because && <p className="t-caption worklist-row-because">{because}</p>}
         {/* What it costs to do nothing. The question a queue exists to answer,
             and the one the lane feed had no field for. */}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -106,7 +106,7 @@ function WorklistRow({
             has nothing below it to beat. */}
         {above && <p className="t-caption worklist-row-above">{above}</p>}
       </div>
-      <RowVerbs item={item} href={href} />
+      {item.batch ? <BatchVerb /> : <RowVerbs item={item} href={href} />}
       {decidable(item) && <RowDecision item={item} />}
     </PanelRow>
   );
@@ -136,6 +136,22 @@ function RowDecision({ item }: Readonly<{ item: WorklistItem }>) {
   return (
     <div className="worklist-row-decision">
       <ApprovalRow approval={usable} extraInvalidateKeys={[worklistKey]} />
+    </div>
+  );
+}
+
+// The way into a group.
+//
+// It narrows the queue to decisions rather than opening a screen of its own:
+// that screen is its own piece of work, and a row whose only verb led nowhere
+// would be worse than the pile it replaced. The filter is the door that exists.
+function BatchVerb() {
+  const t = useT();
+  return (
+    <div className="worklist-row-verbs">
+      <a className="worklist-row-verb" href="#/worklist?filter=decisions">
+        {t("worklist.verb.review_batch")}
+      </a>
     </div>
   );
 }

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Badge, SegmentedControl } from "../design-system/atoms";
+import { Badge, Button, SegmentedControl } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { FilterPills } from "../design-system/filterpills";
 import { Panel, PanelRow } from "../design-system/panel";
@@ -57,7 +57,12 @@ const FILTERS: readonly WorklistFilter[] = [
 function WorklistRow({
   item,
   position,
-}: Readonly<{ item: WorklistItem; position: number }>) {
+  onReview,
+}: Readonly<{
+  item: WorklistItem;
+  position: number;
+  onReview: () => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
@@ -106,7 +111,11 @@ function WorklistRow({
             has nothing below it to beat. */}
         {above && <p className="t-caption worklist-row-above">{above}</p>}
       </div>
-      {item.batch ? <BatchVerb /> : <RowVerbs item={item} href={href} />}
+      {item.batch ? (
+        <BatchVerb onReview={onReview} />
+      ) : (
+        <RowVerbs item={item} href={href} />
+      )}
       {decidable(item) && <RowDecision item={item} />}
     </PanelRow>
   );
@@ -144,14 +153,19 @@ function RowDecision({ item }: Readonly<{ item: WorklistItem }>) {
 //
 // It narrows the queue to decisions rather than opening a screen of its own:
 // that screen is its own piece of work, and a row whose only verb led nowhere
-// would be worse than the pile it replaced. The filter is the door that exists.
-function BatchVerb() {
+// would be worse than the pile it replaced.
+//
+// A button, not a link. The dials live in this screen's state today, so an
+// address carrying `?filter=decisions` would be read by nobody and the control
+// would do nothing — which is the defect it exists to avoid. Moving them into
+// the URL is the right shape and is its own change.
+function BatchVerb({ onReview }: Readonly<{ onReview: () => void }>) {
   const t = useT();
   return (
     <div className="worklist-row-verbs">
-      <a className="worklist-row-verb" href="#/worklist?filter=decisions">
+      <Button small onClick={onReview}>
         {t("worklist.verb.review_batch")}
-      </a>
+      </Button>
     </div>
   );
 }
@@ -352,7 +366,11 @@ function WorklistBody({
           <ol className="worklist-list">
             {day.queue.map((item, index) => (
               <li key={`${item.source}-${item.id}`}>
-                <WorklistRow item={item} position={index + 1} />
+                <WorklistRow
+                  item={item}
+                  position={index + 1}
+                  onReview={() => onFilter("decisions")}
+                />
               </li>
             ))}
           </ol>

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -67,7 +67,7 @@ function WorklistRow({
   const { locale } = useLocale();
   const zone = viewerZone();
   const href = subjectHref(item);
-  const title = itemTitle(item, t);
+  const title = itemTitle(item, t, locale);
   const because = item.because
     .map((reason) => reasonText(reason, t, locale, zone))
     .filter((phrase): phrase is string => phrase !== null)


### PR DESCRIPTION
The real workspace holds **152 contact questions and 545 held drafts**. No ordering saves a reader who must scroll past seven hundred rows to reach the next thing, so the pile is collapsed before it is ranked.

## What a reader sees

```
1-8   Customer waiting        (the eight longest waits)
9+    Follow up with the new lead · Katrin Seibert
      …
      43 likely automated senders          [Review]
      Is t.b@upscaleassociates.net a contact worth keeping? · …
      200+ drafts waiting to be sent       [Review]
```

One row per kind, saying how much it stands for and naming a few of what it holds — a group nobody can see into is a group nobody trusts.

## What never folds

- **A decision that blocks a customer**, however many of it there are: each holds up somebody different.
- **A group under three.** A reader answers two alike questions faster than they would open a group.
- **`scheduled_send_held`** — a message the rep already meant to send, stopped at send time, with somebody waiting. Its accept verb reads "yes, still send this". Only `held_draft`, a suggestion nobody agreed to, is routine.

## One kind cannot take the whole page

A hundred unanswered threads is a real backlog, but a page that is nothing but them tells a rep their day holds no deals, tasks or decisions. The eight longest waits lead; the rest sort below the other kinds — **still level 1, still saying a buyer wrote last**. Nothing is hidden; only the crowding is.

## Five things the review caught

| Defect | Fix |
|---|---|
| The fold ran **before** the filter, so narrowing to decisions returned the same group — a door leading back to itself | Narrowing *is* opening the group |
| `company_match` matched on the sender's **own display name**, which capture labels "untrusted header text — never matching" | Arm removed; a real match needs a lookup this assembler does not make |
| The count reported a scan bound as a total: 545 drafts read as "200" | Says whether the number is a floor; the client draws "200+" |
| Crowding **rewrote** a wait's level, so the ninth was labelled agreed work while its row said a buyer wrote last | Sorts lower without ceasing to be what it is |
| The group's Review control was a link to an address this screen ignores | It presses the filter |

The test for the contact split fabricated its marker instead of exercising the derivation — it now drives the production path, which is how the `display_name` defect would have been caught.

## Gates

`make check-backend`, `make check-fe`, `make craft-static` green. Verified on the real workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns piles of alike routine decisions on the worklist into one row per kind, so hundreds of contact questions and held drafts no longer bury every customer beneath them.

**Grouping**
- Routine decisions group at three or more as `likely_automated`, `company_match`, `uncertain_contact`, `duplicates`, or `held_draft`.
- Decisions that block a customer and `scheduled_send_held` never fold — somebody is waiting on each of them.
- A count taken from a bounded read renders as "200+" rather than "200".
- Each group names a few of its members so a reader can check it before answering it.

**Ordering and opening**
- The eight longest customer waits lead; the rest sort below other kinds without changing their level.
- The fold only runs on the unnarrowed page, so narrowing to decisions is what opens a group.
- A batch row's Review control now presses the decisions filter instead of linking nowhere.

<sup>Written for commit f71591af9108d2c66a8504c4bc64a379504dcb7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Grouped routine decisions now appear as consolidated worklist batches with counts, sample items, and review actions.
  - Batches distinguish automated senders, known companies, uncertain contacts, duplicate candidates, and held drafts.
  - Large result sets display lower-bound counts with a “+” indicator.
  - Blocking customer work remains visible as individual items.
  - Added German and Vietnamese translations for batch-related labels.

- **Improvements**
  - Worklist prioritization preserves visibility across different types of pending work.
  - Machine-generated sender detection improves decision classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->