### PR TITLE
fix(dev): dev-stop reaps the workers it left behind

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -620,15 +620,26 @@ margince_server_pids() {
 # never enqueued at all. Every other lane keeps running, which is what makes a
 # stale worker read as a broken feature rather than as a process nobody stopped.
 #
-# Matched on the DSN and the Redis address, which are this stack's identity: a
-# parallel worktree holds a different database and a different logical database,
-# so it is never in this list.
-stack_server_pids() { # dsn redis_addr
+# Matched on the DSN, and on the Redis address when the caller knows it. The
+# database name is already one-to-one with the slug — `margince` for the primary
+# worktree, `margince_dev_<slug>` for a linked one — so the DSN alone names a
+# stack. The Redis address narrows it further and is passed whenever a record
+# supplies it.
+#
+# It is OMITTED rather than guessed when there is no record. A stack whose state
+# file is gone has no claim to read, and the registry's fallback for "no claim"
+# is logical database 0 — the PRIMARY stack's. Passing that would ask for a
+# linked worktree's database on the primary's Redis database, match nothing, and
+# clean up nothing, silently: the same shape of miss this function exists to
+# close.
+stack_server_pids() { # dsn [redis_addr]
   local pid cmd
   for pid in $(pgrep -f 'bin/(api|worker)|exe/(api|worker)' 2>/dev/null || true); do
     [[ "$pid" == "$$" ]] && continue
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
-    [[ "$cmd" == *"--dsn $1"* && "$cmd" == *"--redis $2"* ]] && echo "$pid"
+    [[ "$cmd" == *"--dsn $1"* ]] || continue
+    [[ -n "${2:-}" && "$cmd" != *"--redis $2"* ]] && continue
+    echo "$pid"
   done
 }
 
@@ -1178,7 +1189,9 @@ stop)
     # database with nothing left pointing at them. Ports are CLAIMED now rather
     # than derived from the slug, so there is nothing to guess at there — but the
     # DATABASE is the slug's, so the servers can still be named.
-    orphans=$(stack_server_pids "$(with_database "$APP_DSN" "$db")" "$REDIS_ADDR" | sort -u || true)
+    # No Redis address: see stack_server_pids. Without a claim, REDIS_ADDR here
+    # names logical database 0 whatever the slug, which is the primary stack's.
+    orphans=$(stack_server_pids "$(with_database "$APP_DSN" "$db")" | sort -u || true)
     if [[ -n "$orphans" ]]; then
       # shellcheck disable=SC2086
       kill_pids $orphans

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -607,6 +607,31 @@ margince_server_pids() {
   done
 }
 
+# stack_server_pids names THIS stack's api and worker wherever they came from —
+# including a run whose pid the state file no longer holds.
+#
+# The state file records one BACKEND_PID/WORKER_PID and every `make dev`
+# overwrites it, so a worker that outlived its own start is invisible to the
+# only thing that would kill it. The api is caught anyway, by its port; a worker
+# binds none, so nothing looked for it and they accumulated — four against one
+# database, three of them stale builds. They share a River leader election, and
+# the leader is what inserts the periodic jobs: an old leader renewing its lease
+# schedules only the job kinds ITS binary knows, so a job kind added since is
+# never enqueued at all. Every other lane keeps running, which is what makes a
+# stale worker read as a broken feature rather than as a process nobody stopped.
+#
+# Matched on the DSN and the Redis address, which are this stack's identity: a
+# parallel worktree holds a different database and a different logical database,
+# so it is never in this list.
+stack_server_pids() { # dsn redis_addr
+  local pid cmd
+  for pid in $(pgrep -f 'bin/(api|worker)|exe/(api|worker)' 2>/dev/null || true); do
+    [[ "$pid" == "$$" ]] && continue
+    cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
+    [[ "$cmd" == *"--dsn $1"* && "$cmd" == *"--redis $2"* ]] && echo "$pid"
+  done
+}
+
 # Vite resolves out of <repo>/frontend/node_modules, so its command line carries
 # the worktree path — that is what distinguishes our dev server from any other
 # Vite project the developer happens to be running.
@@ -1123,20 +1148,44 @@ stop)
   if [[ -f "$state" ]]; then
     # shellcheck disable=SC1090
     . "$state"
-    kill "${BACKEND_PID:-}" "${FE_PID:-}" "${WORKER_PID:-}" 2>/dev/null || true
+    victims=()
+    for p in "${BACKEND_PID:-}" "${FE_PID:-}" "${WORKER_PID:-}"; do
+      [[ -n "$p" ]] && victims+=("$p")
+    done
     # Backstop: free the recorded ports by listener (reaps vite, pnpm's child).
     for p in "${API_PORT:-}" "${FE_PORT:-}"; do
       [[ -n "$p" ]] || continue
-      pids=$(lsof -ti "tcp:${p}" 2>/dev/null || true)
-      [[ -n "$pids" ]] && kill $pids 2>/dev/null || true
+      for q in $(port_listeners "$p"); do victims+=("$q"); done
     done
+    # And this stack's servers whatever their pid — the state file holds ONE
+    # worker and every `make dev` overwrites it, so an earlier run's worker is
+    # reachable by nothing else. It binds no port, so the port backstop above
+    # misses it too; stack_server_pids says what that cost.
+    for q in $(stack_server_pids "$(with_database "$APP_DSN" "${DB:-$db}")" \
+                                 "localhost:${REDIS_PORT}/${REDIS_DB:-0}"); do
+      victims+=("$q")
+    done
+    # kill_pids, not a bare `kill`: TERM alone leaves a server that ignores it
+    # standing after its record is gone, which is the orphan this is for.
+    stopped=$(printf '%s\n' "${victims[@]+"${victims[@]}"}" | grep -E '^[0-9]+$' | sort -u || true)
+    # shellcheck disable=SC2086
+    [[ -n "$stopped" ]] && kill_pids $stopped
     rm -rf "$rundir"
     echo "stopped $label (freed :${API_PORT:-?} :${FE_PORT:-?})"
   else
-    # Ports are CLAIMED now, not derived from the slug, so there is nothing to
-    # guess at for a stack that was never recorded: naming a port here would
-    # print `:0`. Say what is true instead.
-    echo "no recorded stack for $label — nothing to stop"
+    # No claim, which does not mean no processes: the record is what a crash or
+    # an interrupted boot loses first, and its servers keep running against this
+    # database with nothing left pointing at them. Ports are CLAIMED now rather
+    # than derived from the slug, so there is nothing to guess at there — but the
+    # DATABASE is the slug's, so the servers can still be named.
+    orphans=$(stack_server_pids "$(with_database "$APP_DSN" "$db")" "$REDIS_ADDR" | sort -u || true)
+    if [[ -n "$orphans" ]]; then
+      # shellcheck disable=SC2086
+      kill_pids $orphans
+      echo "stopped $label ($(printf '%s\n' $orphans | wc -l | tr -d ' ') process(es) whose claim was gone)"
+    else
+      echo "no recorded stack for $label — nothing to stop"
+    fi
   fi
   if [[ "$drop" == "1" ]]; then
     if [[ -z "$slug" ]]; then

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -632,13 +632,17 @@ margince_server_pids() {
 # linked worktree's database on the primary's Redis database, match nothing, and
 # clean up nothing, silently: the same shape of miss this function exists to
 # close.
+# The DSN match ends at a WORD BOUNDARY, never mid-value. `margince` is a prefix
+# of every `margince_dev_<slug>`, so a substring test run from the primary
+# worktree matches every linked worktree's servers — and the primary is the one
+# whose cleanup would then kill all of them at once.
 stack_server_pids() { # dsn [redis_addr]
   local pid cmd
   for pid in $(pgrep -f 'bin/(api|worker)|exe/(api|worker)' 2>/dev/null || true); do
     [[ "$pid" == "$$" ]] && continue
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
-    [[ "$cmd" == *"--dsn $1"* ]] || continue
-    [[ -n "${2:-}" && "$cmd" != *"--redis $2"* ]] && continue
+    [[ "$cmd" == *"--dsn $1 "* || "$cmd" == *"--dsn $1" ]] || continue
+    [[ -n "${2:-}" && "$cmd" != *"--redis $2 "* && "$cmd" != *"--redis $2" ]] && continue
     echo "$pid"
   done
 }

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -386,6 +386,12 @@ fake_server() { # dsn redis — sets REPLY to the pid
     bash -c 'exec -a "./bin/worker --dsn '"$1"' --redis '"$2"'" sleep 30' &
     REPLY=$!
 }
+# The two DSNs differ ONLY in the database segment, and the primary's name is a
+# PREFIX of the linked worktree's — which is what production hands out
+# (`margince` and `margince_dev_<slug>` off one APP_DSN). An earlier fixture pair
+# that differed before that segment let a substring match pass every check here
+# while `make dev-stop` on the primary worktree killed every linked worktree's
+# servers at once.
 mine_dsn="postgres://margince_app:pw@localhost:15432/margince"
 theirs_dsn="postgres://margince_app:pw@localhost:15432/margince_dev_band"
 fake_server "$mine_dsn" "localhost:16379/0";    mine=$REPLY
@@ -420,6 +426,18 @@ check "$theirs" "$(stack_server_pids "$theirs_dsn" | sort -u)" \
       "a linked worktree's servers are found with no Redis address — its database name already names the stack"
 check "" "$(stack_server_pids "$theirs_dsn" "localhost:16379/0" | grep -x "$theirs" || true)" \
       "and guessing db 0 for it would have found nothing, which is the miss that made omitting it necessary"
+
+# The dangerous direction, and the one the checks above cannot reach: the PRIMARY
+# worktree, whose database name is a prefix of every linked worktree's. Asked
+# with no Redis address, because that is what the missing-state branch passes —
+# so nothing else narrows the match. A substring test answers both pids here and
+# one `make dev-stop` takes down every parallel session's stack.
+check "$mine" "$(stack_server_pids "$mine_dsn" | sort -u)" \
+      "the primary worktree's cleanup finds ONLY its own — margince must not match margince_dev_band"
+# The same boundary on the Redis half: /6 is a prefix of /64, and the block runs
+# 64..79, so every two-digit logical database has a single-digit prefix.
+check "" "$(stack_server_pids "$theirs_dsn" "localhost:16379/6" | grep -x "$theirs" || true)" \
+      "a logical database matches whole — /6 is not /64"
 kill "$mine" "$theirs" 2>/dev/null || true
 wait "$mine" "$theirs" 2>/dev/null || true
 

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -359,6 +359,60 @@ stray=$(grep -rlE '^[^#]*\.tmp/dev' "$root/scripts" 2>/dev/null \
 check "" "$stray" \
       "no script composes .tmp/dev itself — the state home comes from lib-devstate.sh"
 
+echo "dev.sh: a stack's servers are findable when the state file no longer names them"
+
+# The defect: the state file records ONE worker pid and every `make dev`
+# overwrites it. An earlier run's worker then belonged to no record, and since a
+# worker binds no port, the port backstop that catches the api could not see it
+# either — so `make dev-stop` reported success over a worker it left running.
+# Four accumulated against one database. They share a River leader election, and
+# the leader is what inserts the periodic jobs: the oldest one held the lease and
+# scheduled only the job kinds its own binary knew, so a job kind added later was
+# never enqueued once. Every other lane kept running, which is what made it read
+# as a broken feature rather than as a process nobody had stopped.
+#
+# Lifted, so these checks exercise the matcher production calls.
+lift stack_server_pids
+
+# Real processes with real command lines: the matcher reads `ps`, so a stub would
+# prove only that the stub matches itself. `exec -a` renames a `sleep` into an
+# argv shaped like a worker's, which is the cheapest honest subject.
+# Started in THIS shell, not through a command substitution: `pid=$(fake …)`
+# runs the function in a subshell, and the background child is reparented and
+# lost the moment that subshell exits. The pid then names nothing and every
+# check below reads as "no match" — which is why the liveness check above is the
+# first assertion rather than an afterthought.
+fake_server() { # dsn redis — sets REPLY to the pid
+    bash -c 'exec -a "./bin/worker --dsn '"$1"' --redis '"$2"'" sleep 30' &
+    REPLY=$!
+}
+mine_dsn="postgres://margince_app:pw@localhost:15432/margince"
+theirs_dsn="postgres://margince_app:pw@localhost:15432/margince_dev_band"
+fake_server "$mine_dsn" "localhost:16379/0";    mine=$REPLY
+fake_server "$theirs_dsn" "localhost:16379/64"; theirs=$REPLY
+# The exec'd argv has to be visible to ps before the matcher reads it. Poll for
+# it rather than sleeping a guessed interval.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ] && break
+    sleep 0.1
+done
+check "1" "$([ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ] && echo 1 || echo 0)" \
+      "the fake worker is running — without this the four checks below would pass on an empty machine"
+
+check "$mine" "$(stack_server_pids "$mine_dsn" "localhost:16379/0" | sort -u)" \
+      "this stack's worker is found by its database and its logical Redis database, with no pid on file"
+check "" "$(stack_server_pids "$mine_dsn" "localhost:16379/0" | grep -x "$theirs" || true)" \
+      "a parallel worktree's worker is NOT swept — it holds a different database and a different logical database"
+check "$theirs" "$(stack_server_pids "$theirs_dsn" "localhost:16379/64" | sort -u)" \
+      "and that worktree can still stop its own"
+# Two stacks against the shared `margince` differ ONLY in the logical database,
+# so a matcher reading the DSN alone passes every check above and still sweeps a
+# peer. This is the case that separates them.
+check "" "$(stack_server_pids "$mine_dsn" "localhost:16379/7" | grep -x "$mine" || true)" \
+      "matching the database alone is not enough — the logical Redis database is what separates two stacks on one database"
+kill "$mine" "$theirs" 2>/dev/null || true
+wait "$mine" "$theirs" 2>/dev/null || true
+
 echo "lib-testdb.sh: the integration lane's template is per worktree"
 
 # Lifted from lib-testdb.sh and exercised inside THROWAWAY repositories, because

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -410,6 +410,16 @@ check "$theirs" "$(stack_server_pids "$theirs_dsn" "localhost:16379/64" | sort -
 # peer. This is the case that separates them.
 check "" "$(stack_server_pids "$mine_dsn" "localhost:16379/7" | grep -x "$mine" || true)" \
       "matching the database alone is not enough — the logical Redis database is what separates two stacks on one database"
+
+# The missing-state case, which is the one a linked worktree hits. With no claim
+# to read, the registry answers logical database 0 for EVERY slug — the primary
+# stack's — so a cleanup that insisted on the Redis half would ask for
+# margince_dev_band on db 0, match nothing, and report success over servers it
+# left running. The Redis argument is omitted there instead of guessed.
+check "$theirs" "$(stack_server_pids "$theirs_dsn" | sort -u)" \
+      "a linked worktree's servers are found with no Redis address — its database name already names the stack"
+check "" "$(stack_server_pids "$theirs_dsn" "localhost:16379/0" | grep -x "$theirs" || true)" \
+      "and guessing db 0 for it would have found nothing, which is the miss that made omitting it necessary"
 kill "$mine" "$theirs" 2>/dev/null || true
 wait "$mine" "$theirs" 2>/dev/null || true
 


### PR DESCRIPTION
## What was wrong

`make dev-stop` reported success over workers it left running. They accumulated — four against one database on this machine, three of them stale builds from earlier in the day.

The state file records one `WORKER_PID` and every `make dev` overwrites it, so an earlier run's worker belonged to no record. The api is caught anyway by its port; a worker binds none, so nothing looked for it.

## Why it mattered more than an untidy process list

The workers share a River leader election, and the leader is what inserts the periodic jobs. The oldest process held the lease and renewed it, scheduling only the job kinds its own binary knew. A job kind added since was **never enqueued once** — while every other lane kept running normally.

That is what made it expensive: it reads as a broken feature, not as a process nobody stopped.

## The fix

`stack_server_pids` names a stack's servers by its DSN and its Redis address. That pair is the stack's identity — a parallel worktree holds a different database and a different logical database, so it is never in the list.

Both halves are load-bearing, and the test fails without either:

- DSN alone also sweeps a peer sharing `margince` (verified: it matched two unrelated live processes on this machine)
- Redis database alone also sweeps a peer sharing db 0

Two further holes closed on the way:

- `stop` used a bare `kill`, never escalating to KILL, so a server ignoring TERM survived its own record. It now goes through `kill_pids`, as the sweep does.
- A stack whose state file was lost reported "nothing to stop" while its servers ran. It now names them by database and stops them.

## Test

New section in `test-dev-isolation.sh`, five checks against real processes with real command lines (`exec -a` over `sleep`), lifted from `dev.sh` so it exercises production rather than a copy.

The first check asserts the fixtures are actually running. That is not ceremony — it caught a real bug in my own first draft, where `pid=$(fake_server …)` lost the background child to the command substitution's subshell and two checks passed vacuously.

Mutation-checked one clause at a time: removing the Redis clause fails 3 checks, removing the DSN clause fails 1 and matches unrelated live processes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `make dev-stop` so it stops every server in its stack, including workers whose PID was lost when the state file was overwritten by a later `make dev`. Previously those workers accumulated, and the oldest held the River leader lease, so its binary's job kinds were never enqueued.

- `stack_server_pids` matches servers by DSN and, when a claim exists, Redis address; the DSN alone names a stack because each worktree has a distinct database.
- Both halves match at word boundaries, so `margince` never sweeps `margince_dev_*` and `/6` never matches `/64`.
- The missing-state branch omits the Redis address rather than guessing db 0, which would silently match nothing for a linked worktree.
- `stop` escalates to KILL for servers ignoring TERM.
- New tests cover the matching logic and ensure parallel worktrees' processes are not swept.

<sup>Written for commit 81b10a4e3f7f9c2f5561731860c6455b24c24189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development server shutdown to reliably identify and stop the correct API and worker processes.
  - Added graceful termination with fallback cleanup for orphaned processes or missing state.
  - Improved process matching across development stacks and Redis configurations, preventing similarly named environments from affecting one another.

- **Tests**
  - Added coverage for stack isolation, including database and Redis address prefixes.
  - Verified cleanup targets only the intended development server processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->