### PR TITLE
fix(ci): the migration-version gate now catches a renumbered migration

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -263,3 +263,4 @@ scripts/lib-testdb.sh migration 0015
 scripts/test-migration-versions.sh core 0002
 scripts/test-migration-versions.sh core 0003
 scripts/test-migration-versions.sh core 1799999999
+scripts/test-migration-versions.sh migration 1799999999

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -75,10 +75,16 @@ migrations_in_tree() {
 # matches nothing — its exit 1 is not an error, and under set -eo pipefail an
 # unguarded grep would otherwise abort the whole gate with no FAIL printed the
 # first time a PR adds a namespace, which the header above says is supported.
+# `sed 's#.*/##'`, not `xargs basename`: GNU xargs runs its command once with
+# ZERO arguments on empty input unless told not to, and `basename` with no
+# operand exits 1, which xargs then reports as its own exit 123 — invisible on
+# a Mac, where the default is the other way, and set -e turns that 123 into
+# the same silent whole-gate abort as the two hazards above. sed on empty
+# input just produces no output.
 migrations_at_base() {
   local ns="$1"
   git ls-tree --name-only "$BASE_REF" "$MIGRATIONS_DIR/$ns/" 2>/dev/null |
-    { grep '\.up\.sql$' || true; } | xargs -n1 basename 2>/dev/null | sed 's/\.up\.sql$//' |
+    { grep '\.up\.sql$' || true; } | sed 's#.*/##; s/\.up\.sql$//' |
     sed 's/^\([^_]*\)_\(.*\)$/\1 \2/' | sort
 }
 
@@ -199,7 +205,8 @@ fail() {
 # otherwise turn into a silent abort instead of the FAIL this case exists to
 # print. No namespace in the tree is exactly what should be read here.
 tree_namespaces="$(find "$MIGRATIONS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || true)"
-base_namespaces="$(git ls-tree --name-only -d "$BASE_REF" "$MIGRATIONS_DIR/" 2>/dev/null | xargs -n1 basename 2>/dev/null)"
+# sed, not xargs basename: same empty-input hazard as migrations_at_base above.
+base_namespaces="$(git ls-tree --name-only -d "$BASE_REF" "$MIGRATIONS_DIR/" 2>/dev/null | sed 's#.*/##')"
 all_namespaces="$(printf '%s\n%s\n' "$tree_namespaces" "$base_namespaces" | sort -u)"
 
 for ns in $all_namespaces; do

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -215,6 +215,24 @@ for dir in "$MIGRATIONS_DIR"/*/; do
     ns_reset=1
   fi
 
+  # A version the base already carries that this branch's tree no longer
+  # does. The row loop below only ever asks what THIS branch adds — it
+  # cannot notice one going missing, because a version dropped from the tree
+  # never appears in tree_rows for the loop to walk. A deployed database's
+  # ledger does not forget an applied version because the file that produced
+  # it was renamed or deleted; a fresh install run against the renamed tree
+  # then never applies it under its old name, and the two installations
+  # diverge exactly as silently as the collision above — the difference is
+  # which install is missing the row, not whether one is. Renaming a shipped
+  # migration is this to the ledger whether or not its SQL also changed.
+  vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1) <(echo "$tree_rows" | cut -d' ' -f1))"
+  if [ -n "$vanished" ]; then
+    for v in $vanished; do
+      vname="$(echo "$base_rows" | awk -v v="$v" '$1==v {print $2}' | head -n1)"
+      fail "$ns/$v ('$vname') is on $BASE_REF but this branch no longer has it — a migration a deployed database may already have applied cannot be renamed or removed; add a new one instead of renumbering it. If this branch is a baseline consolidation, set MIGRATION_VERSIONS_BASELINE_RESET=1"
+    done
+  fi
+
   while read -r version name; do
     [ -n "$version" ] || continue
     base_name="$(echo "$base_rows" | awk -v v="$version" '$1==v {print $2}')"

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -57,20 +57,28 @@ MIGRATIONS_DIR="backend/migrations"
 # "<version> <name>" per migration, keyed on `.up.sql` so the down file does not
 # double every row.
 
-# migrations_in_tree NAMESPACE — what the working tree declares.
+# migrations_in_tree NAMESPACE — what the working tree declares. A namespace
+# named only by $BASE_REF (this branch emptied or removed it, taking the
+# now-empty directory with it) has no path here to `find`, and under
+# set -eo pipefail its nonzero exit would abort the whole gate with no FAIL
+# printed — the "|| true" reads that as zero migrations, which is what it is.
 migrations_in_tree() {
   local ns="$1"
-  find "$MIGRATIONS_DIR/$ns" -maxdepth 1 -name '*.up.sql' -exec basename {} .up.sql \; 2>/dev/null |
+  { find "$MIGRATIONS_DIR/$ns" -maxdepth 1 -name '*.up.sql' -exec basename {} .up.sql \; 2>/dev/null || true; } |
     sed 's/^\([^_]*\)_\(.*\)$/\1 \2/' | sort
 }
 
 # migrations_at_base NAMESPACE — the same, read out of the base ref rather than
 # the worktree. `git ls-tree` and not `git diff`: what matters is every version
-# the base ALREADY carries, including the ones this branch never touched.
+# the base ALREADY carries, including the ones this branch never touched. A
+# namespace this branch introduces has none, so `grep` here legitimately
+# matches nothing — its exit 1 is not an error, and under set -eo pipefail an
+# unguarded grep would otherwise abort the whole gate with no FAIL printed the
+# first time a PR adds a namespace, which the header above says is supported.
 migrations_at_base() {
   local ns="$1"
   git ls-tree --name-only "$BASE_REF" "$MIGRATIONS_DIR/$ns/" 2>/dev/null |
-    grep '\.up\.sql$' | xargs -n1 basename 2>/dev/null | sed 's/\.up\.sql$//' |
+    { grep '\.up\.sql$' || true; } | xargs -n1 basename 2>/dev/null | sed 's/\.up\.sql$//' |
     sed 's/^\([^_]*\)_\(.*\)$/\1 \2/' | sort
 }
 
@@ -179,15 +187,31 @@ fail() {
   failed=1
 }
 
-for dir in "$MIGRATIONS_DIR"/*/; do
-  [ -d "$dir" ] || continue
-  ns="$(basename "$dir")"
-  # A namespace is a directory holding migrations, not merely a directory:
-  # `testdata/` sits beside core/ and custom/ and is neither.
-  compgen -G "$dir*.up.sql" >/dev/null || continue
-  checked=$((checked + 1))
+# Namespaces come from the union of the tree and $BASE_REF, not the tree
+# alone. A tree-only walk finds a namespace by its CURRENT `.up.sql` files, so
+# a branch that empties or deletes one entirely drops it from that walk before
+# the vanished-version check below ever runs against it — the same silent
+# divergence this gate exists to report, just for every version in the
+# namespace at once instead of one.
+# || true: a branch that empties every namespace can take $MIGRATIONS_DIR
+# itself with it (git prunes a directory once nothing under it survives), and
+# `find` on a path that is not there exits nonzero — which set -e would
+# otherwise turn into a silent abort instead of the FAIL this case exists to
+# print. No namespace in the tree is exactly what should be read here.
+tree_namespaces="$(find "$MIGRATIONS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || true)"
+base_namespaces="$(git ls-tree --name-only -d "$BASE_REF" "$MIGRATIONS_DIR/" 2>/dev/null | xargs -n1 basename 2>/dev/null)"
+all_namespaces="$(printf '%s\n%s\n' "$tree_namespaces" "$base_namespaces" | sort -u)"
 
+for ns in $all_namespaces; do
   tree_rows="$(migrations_in_tree "$ns")"
+  base_rows="$(migrations_at_base "$ns")"
+
+  # A namespace is a directory holding migrations, not merely a directory:
+  # `testdata/` sits beside core/ and custom/ and is neither, on either side.
+  if [ -z "$tree_rows" ] && [ -z "$base_rows" ]; then
+    continue
+  fi
+  checked=$((checked + 1))
 
   # A duplicate inside one tree fails the loader at runtime; naming it here
   # gives the same answer without booting Postgres, and keeps this gate honest
@@ -202,7 +226,6 @@ for dir in "$MIGRATIONS_DIR"/*/; do
     continue
   fi
 
-  base_rows="$(migrations_at_base "$ns")"
   if [ -z "$base_rows" ]; then
     continue # a namespace this branch introduces has nothing to sort after
   fi
@@ -225,7 +248,16 @@ for dir in "$MIGRATIONS_DIR"/*/; do
   # diverge exactly as silently as the collision above — the difference is
   # which install is missing the row, not whether one is. Renaming a shipped
   # migration is this to the ledger whether or not its SQL also changed.
-  vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1) <(echo "$tree_rows" | cut -d' ' -f1))"
+  #
+  # SET membership, not a line-for-line merge. $base_rows can carry one
+  # version TWICE — that is the outage this gate exists to report, and the row
+  # loop below deliberately admits the repair that keeps one claimant and
+  # renumbers the other. `comm` without dedup consumes that repair's survivor
+  # against the base's first occurrence and then has nothing left to match its
+  # second, so it reports the very migration the repair kept as vanished.
+  # Sorting each side down to its distinct versions asks "does this version
+  # still exist", which is the question, instead of "how many times".
+  vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1 | sort -u) <(echo "$tree_rows" | cut -d' ' -f1 | sort -u))"
   if [ -n "$vanished" ]; then
     for v in $vanished; do
       vname="$(echo "$base_rows" | awk -v v="$v" '$1==v {print $2}' | head -n1)"

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -229,7 +229,7 @@ for dir in "$MIGRATIONS_DIR"/*/; do
   if [ -n "$vanished" ]; then
     for v in $vanished; do
       vname="$(echo "$base_rows" | awk -v v="$v" '$1==v {print $2}' | head -n1)"
-      fail "$ns/$v ('$vname') is on $BASE_REF but this branch no longer has it — a migration a deployed database may already have applied cannot be renamed or removed; add a new one instead of renumbering it. If this branch is a baseline consolidation, set MIGRATION_VERSIONS_BASELINE_RESET=1"
+      fail "$ns/$v ('$vname') is on $BASE_REF but this branch no longer has it — a migration a deployed database may already have applied cannot be renamed or removed; add a new one instead of renumbering it. MIGRATION_VERSIONS_BASELINE_RESET=1 will not admit this on its own: the namespace must also end with FEWER migrations than $BASE_REF has, which a rename alone never does — see reset_admitted"
     done
   fi
 

--- a/scripts/test-migration-versions.sh
+++ b/scripts/test-migration-versions.sh
@@ -247,6 +247,45 @@ duplicates_in_tree() {
   printf -- '-- probe\n' > "$1/backend/migrations/core/0002_twin.down.sql"
 }
 
+# The base already has the outage — one version claimed twice — and this
+# branch is the repair: it keeps one claimant at its version and renumbers the
+# other above base_max. The vanished-version check must read this as "0002
+# still exists" (beta survives), not flag beta as vanished because base's two
+# 0002 rows and the tree's one no longer line up one-for-one.
+repairs_a_base_collision() {
+  local dir="$1"
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/0002_twin.up.sql"
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/0002_twin.down.sql"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm 'base gains a collision' || return 1
+  git -C "$dir" branch -qf base
+  git -C "$dir" rm -q backend/migrations/core/0002_twin.up.sql backend/migrations/core/0002_twin.down.sql || return 1
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/1799999999_twin.up.sql"
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/1799999999_twin.down.sql"
+}
+
+# A namespace this branch empties entirely: every migration the base carries
+# in it is gone from the tree, and the outer walk must still find the
+# namespace to compare against — a tree-only walk would skip it before the
+# vanished-version check ever ran.
+empties_a_namespace() {
+  git -C "$1" rm -q backend/migrations/core/0001_alpha.up.sql \
+    backend/migrations/core/0001_alpha.down.sql \
+    backend/migrations/core/0002_beta.up.sql \
+    backend/migrations/core/0002_beta.down.sql \
+    backend/migrations/core/0003_gamma.up.sql \
+    backend/migrations/core/0003_gamma.down.sql || return 1
+}
+
+# A namespace this branch introduces that the base has never heard of:
+# `migrations_at_base` legitimately finds nothing in it, and that "nothing"
+# must read as zero migrations to sort after, not as a shell error.
+adds_a_namespace() {
+  mkdir -p "$1/backend/migrations/extra"
+  printf -- '-- probe\n' > "$1/backend/migrations/extra/1799999999_new.up.sql"
+  printf -- '-- probe\n' > "$1/backend/migrations/extra/1799999999_new.down.sql"
+}
+
 # ---- the cases -----------------------------------------------------------
 
 expect "an untouched tree passes" \
@@ -263,6 +302,12 @@ expect "a consolidation fails when NOT declared" \
   1 plain    consolidates         "is claimed by two different migrations"
 expect "a renumbered migration fails when not declared" \
   1 plain    renumbers_one        "but this branch no longer has it"
+expect "a repair that keeps one collision claimant is not read as vanished" \
+  0 plain    repairs_a_base_collision "repairing, not colliding"
+expect "emptying a namespace still reports its vanished versions" \
+  1 plain    empties_a_namespace  "but this branch no longer has it"
+expect "a namespace new to the base passes" \
+  0 plain    adds_a_namespace     "OK: check-migration-versions"
 
 # The four that decide whether the escape hatch is a gate or a hole.
 expect "a declared consolidation is admitted" \
@@ -292,7 +337,7 @@ expect "a declared reset does not excuse a real collision" \
 # So the total is also pinned. A literal here is not duplication of the case
 # list: it is the one fact the case list cannot state about itself, which is how
 # many of it there should be.
-expected_cases=11
+expected_cases=14
 
 declared_cases="$(grep -c '^expect "' "$SELF")"
 if [ "$ran" -ne "$declared_cases" ]; then

--- a/scripts/test-migration-versions.sh
+++ b/scripts/test-migration-versions.sh
@@ -194,6 +194,16 @@ sorts_below() {
   printf -- '-- probe\n' > "$1/backend/migrations/core/0002x_late.down.sql"
 }
 
+# One shipped migration re-stamped under a new version and left everything
+# else alone: the base's own outage-report case, run backwards. The new
+# version sorts above base_max, so on its own it reads as a normal addition —
+# the defect is what it leaves behind, not what it adds.
+renumbers_one() {
+  git -C "$1" rm -q "backend/migrations/core/0002_beta.up.sql" "backend/migrations/core/0002_beta.down.sql" || return 1
+  printf -- '-- probe\n' > "$1/backend/migrations/core/1799999999_beta.up.sql"
+  printf -- '-- probe\n' > "$1/backend/migrations/core/1799999999_beta.down.sql"
+}
+
 # A genuine consolidation: every version replaced, and FEWER of them.
 consolidates() {
   git -C "$1" rm -q backend/migrations/core/0001_alpha.up.sql \
@@ -251,6 +261,8 @@ expect "one version claimed twice in the tree fails" \
   1 plain    duplicates_in_tree   "declares one version twice"
 expect "a consolidation fails when NOT declared" \
   1 plain    consolidates         "is claimed by two different migrations"
+expect "a renumbered migration fails when not declared" \
+  1 plain    renumbers_one        "but this branch no longer has it"
 
 # The four that decide whether the escape hatch is a gate or a hole.
 expect "a declared consolidation is admitted" \
@@ -280,7 +292,7 @@ expect "a declared reset does not excuse a real collision" \
 # So the total is also pinned. A literal here is not duplication of the case
 # list: it is the one fact the case list cannot state about itself, which is how
 # many of it there should be.
-expected_cases=10
+expected_cases=11
 
 declared_cases="$(grep -c '^expect "' "$SELF")"
 if [ "$ran" -ne "$declared_cases" ]; then


### PR DESCRIPTION
## Summary
Cross-session QC found a near-miss: #3310 renumbered a shipped core migration (`1788149411_who_is_waiting_seeks_within_a_thread` → `1788165933_...`, content identical) rather than adding a new one. Harmless only by luck — the SQL was `CREATE INDEX IF NOT EXISTS` — but a database that already applied the old version (a real one had, in QC's own pin) sees the new number as unapplied and runs the migration again. That's exactly the "additive only" invariant `AGENTS.md` states for `migrations/core` and this gate exists to hold.

`check-migration-versions.sh`'s row loop only ever walks `tree_rows` — what THIS branch's migrations are — checking each for a collision or too-low a sort against the base. It never asked the other direction: does every version the base already has still exist in the tree? A pure renumber removes the old version from `tree_rows` entirely and adds a new one that, sorting above `base_max`, reads as an ordinary addition. The existing `renames_without_collapsing` test covers a *different* shape (same version, new name — already caught by the standard collision check); changing the version itself was the actual gap.

## Fix
Added a check for versions on the base that vanished from the tree, gated through the same admitted-baseline-reset logic the rest of the gate already uses — a genuine consolidation (declared, collapses, shares nothing) is unaffected; anything else that drops a shipped version now fails.

## Test plan
- [x] Added `renumbers_one` mutation + `"a renumbered migration fails when not declared"` case to `test-migration-versions.sh` — 11/11 cases pass
- [x] Mutation-checked the new test against the *old* gate: reverted the fix, confirmed the new case genuinely fails (`exit 0, want 1`), restored it
- [x] Ran the fixed gate against a properly synced checkout of `origin/main` — clean, 0 findings (confirms real history isn't affected; an earlier run against a stale local checkout had looked like a false positive until re-synced)
- [x] `shellcheck` on both files — only pre-existing warnings on lines I didn't touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwGcm813sQunhFBrpmRNyT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the migration-version gate to catch renumbered migrations, which previously slipped through and could cause a deployed database that already applied the old version to mistakenly rerun it. The gate now compares base and tree versions, walks namespaces from both sides so emptied ones still get checked, and dedupes both sides so repairing a pre-existing base collision isn't falsely flagged. Empty namespace reads no longer abort the gate in Linux CI, and the failure message clarifies that `MIGRATION_VERSIONS_BASELINE_RESET=1` alone won't admit a renumber. The new test fixture's migration citation is registered in `danglingcitations.txt` so the citation check passes.

<sup>Written for commit 71f8aee569927ff480a92c4237b8113e2ff227de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration checks now safely handle empty or missing namespaces.
  * Removed migrations and migrations in newly introduced namespaces are detected reliably.
  * Duplicate base-version repairs no longer produce false missing-version reports.
  * Validation continues to identify renumbered migrations and recommend adding a new migration instead.

* **Tests**
  * Added coverage for repaired version collisions, emptied namespaces, and namespaces absent from the baseline.
  * Expanded migration validation scenarios from 11 to 14 cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->