### PR TITLE
A sender the mailbox owner writes to is not always a person

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -85,14 +85,14 @@ tasks:
     no_payload: true
 
   capture_counterparty_verdict:
-    ladder: [local_small, cheap_cloud]
+    ladder: [local_small]
     execution_mode: background
     on_budget_exhausted: queue
     status: shipped
     sites: [verdict]
     no_payload: true
     company_context: none
-    doc: "ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring."
+    doc: "ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring. Local-only ladder: the prompt carries subject and body, and this is the task that decides whether a sender is personal — a cloud rung would send a founder's family mail off the machine to ask whether it was family mail."
 
   signal_extract:
     ladder: [cheap_cloud, premium]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17692,7 +17692,7 @@ components:
           enum: [pending, unsure, real, noise, rejected, suppressed]
         kind:
           type: [string, 'null']
-          description: 'Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam.'
+          description: 'Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam | personal | advisor. The last two belong to the mailbox owner rather than to the business: personal is a private correspondent, advisor a professional they engage personally.'
         resolved_at: { type: [string, 'null'], format: date-time }
 
     LicenseEntitlement:

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -462,7 +462,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 var shapeCensus = map[string]int{
 	"cannot-drift":   156,
 	"once":           155,
-	"one-of-a-kind":  155,
+	"one-of-a-kind":  154,
 	"is-every-named": 92,
 	"only-noun":      16,
 	"no-second":      10,

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/advisor_01.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/advisor_01.yaml
@@ -1,0 +1,38 @@
+name: the_owners_own_lawyer_is_not_the_workspaces_contact
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Dr. Katrin Bauer
+  email: k.bauer@kanzlei-bauer.example
+  subject: Entwurf Gesellschaftervereinbarung - vertraulich
+  body: |
+    Sehr geehrter Herr Weidner,
+
+    anbei der überarbeitete Entwurf der Gesellschaftervereinbarung nebst meiner
+    Anmerkungen zu Ziffer 7 (Vesting). Bitte prüfen Sie insbesondere die
+    Regelung zum Bad-Leaver-Fall, bevor wir sie an die Gegenseite geben.
+
+    Mit freundlichen Grüßen
+    Dr. Katrin Bauer
+    Rechtsanwältin
+expect:
+  outcome: accepted
+  answer: advisor
+  rubric: >
+    A lawyer writing to the mailbox owner about the owner's own shareholding.
+    This is real correspondence with a real named professional, which is what
+    makes it the hard case: every surface signal says "person". The distinction
+    is whose business it is. The engagement is the owner's personally, and the
+    subject matter — a shareholder agreement, vesting, a bad-leaver clause — is
+    exactly what a colleague must not be handed by an import. "advisor" scores
+    high. "person" is the failure this scenario exists to catch: it is not a
+    misread of the sender, it is a disclosure, announcing to the workspace that
+    the founder has a lawyer and what they are negotiating. It scores zero above
+    the floor. "personal" is wrong but safe — it withholds rather than
+    publishes — and scores in the middle.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/personal_01.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/personal_01.yaml
@@ -1,0 +1,33 @@
+name: a_private_correspondent_is_not_a_business_contact
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Silke Renner
+  email: s.renner@webmail.example
+  subject: Fotos vom Wochenende
+  body: |
+    Hallo Tobias,
+
+    anbei die Bilder von Sonntag. Mama fragt, ob ihr an Ostern kommt, sie will
+    wegen der Betten Bescheid wissen. Ruf sie doch mal an, sie freut sich.
+
+    Liebe Grüße
+    Silke
+expect:
+  outcome: accepted
+  answer: personal
+  rubric: >
+    A family letter that arrived in a mailbox the CRM reads. Nothing here is
+    about the business: no company, no product, no commercial need, and the
+    register is domestic. "personal" is the correct verdict and scores high.
+    "person" is the failure this scenario exists to catch — it publishes a
+    founder's sister to every colleague as a contact, and scores zero above the
+    floor whatever the stated confidence. "spam" and "newsletter" are also
+    wrong, but wrong in the safe direction: the mail is not unsolicited, it is
+    simply not the company's, so they score in the middle.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/captureverdict.go
+++ b/backend/internal/compose/captureverdict.go
@@ -282,9 +282,11 @@ func (e *CounterpartyVerdictEngine) apply(ctx context.Context, row capture.Pendi
 			return err
 		}
 		acted = true
-		// Exhaustive by construction: every kind in verdictKinds appears here,
-		// and an unknown one was refused above. A `default` that fell through to
-		// hideNoise is how a new kind would silently start hiding real mail.
+		// Exhaustive over verdictKinds, held by TestEveryVerdictKindHasAnEffect
+		// rather than by this comment: two kinds once reached the prompt with no
+		// arm here, and the claim of exhaustiveness is what stopped anybody
+		// checking. A `default` that fell through to hideNoise is how a new kind
+		// would silently start hiding real mail, so there is none.
 		switch kind {
 		case capture.KindPerson:
 			triageDomain, err = e.createCounterparty(ctx, tx, row)
@@ -298,6 +300,24 @@ func (e *CounterpartyVerdictEngine) apply(ctx context.Context, row capture.Pendi
 				return err
 			}
 			return e.hideNoise(ctx, tx, row)
+		case capture.KindAdvisor:
+			// A genuine contact who is the OWNER's. The record is made — a
+			// founder's lawyer is somebody they correspond with — and stays
+			// owner-scoped, because publishing it to the workspace announces
+			// that the founder has a lawyer and what about.
+			triageDomain, err = e.createOwnerScopedCounterparty(ctx, tx, row)
+			return err
+		case capture.KindPersonal:
+			// No record at all: a family member is not a counterparty of the
+			// business. The mail itself is not destroyed here — the purge that
+			// does that is its own change, with an undo window in front of it —
+			// so this withholds the record and leaves the thread to the
+			// mailbox owner.
+			//
+			// hideNoise is deliberately NOT called. Its scope excludes every
+			// address the workspace has written to, which is every address this
+			// kind is ever about, so it would be a no-op that read like a hide.
+			return nil
 		}
 		return fmt.Errorf("verdict: no effect defined for sender kind %q", kind)
 	})
@@ -319,103 +339,6 @@ func (e *CounterpartyVerdictEngine) apply(ctx context.Context, row capture.Pendi
 // verdictReason is what the ledger records as the authority for a machine
 // disposition, distinguishing it from a T2 registry rule or a human decision.
 const verdictReason = "capture_counterparty_verdict"
-
-// createCounterparty is the `real` effect: the records capture withheld while
-// the sender was ambiguous, created now under the human who granted the
-// connection — not under the job, which owns nothing.
-//
-// An address suppressed since capture — an erasure landed while the question was
-// open — creates nothing, and says so: the row is corrected to `suppressed`
-// rather than left reading `real`. Erasure outranks a verdict, and a ledger (or
-// a SAR built from it) that reports `real` for someone with no record would be
-// describing a person who does not exist.
-func (e *CounterpartyVerdictEngine) createCounterparty(ctx context.Context, tx pgx.Tx, row capture.PendingCounterparty) (string, error) {
-	created, err := createCounterpartyRecords(ctx, tx, e.people, e.activities, counterpartyCreation{
-		Email:       row.Email,
-		DisplayName: row.DisplayName,
-		Domain:      row.Domain,
-		OwnerID:     row.OwnerID,
-		ActivityID:  row.ActivityID,
-		Source:      verdictReason,
-		CapturedBy:  verdictActor,
-	})
-	if err != nil {
-		return "", err
-	}
-	if created.Suppressed {
-		// The verdict was already written by apply(), and writing it spent the
-		// claim — so this corrects the status it just set rather than trying to
-		// resolve the row a second time.
-		return "", e.pending.CorrectResolution(ctx, tx, row.ID,
-			capture.PendingStatusReal, capture.PendingStatusSuppressed,
-			"the address was erased before the verdict landed")
-	}
-	return created.TriageDomain, nil
-}
-
-// counterpartyCreation names one deferred sender being turned into records.
-type counterpartyCreation struct {
-	Email       string
-	DisplayName string
-	Domain      string
-	OwnerID     ids.UUID
-	ActivityID  ids.UUID
-	// Source is the provenance CHANNEL — which mechanism produced these records.
-	Source string
-	// CapturedBy is the acting PRINCIPAL, in the contract's declared grammar
-	// (`human:<uuid>` | `agent:<id>` | `connector:<name>`). The two are not the
-	// same thing and stamping the channel into both puts a value on the wire
-	// that no client can parse.
-	CapturedBy string
-}
-
-// counterpartyCreated reports what a `real` answer produced that its caller has
-// to act on AFTER the transaction commits. Today that is one thing: the domain
-// whose organization question is still open, which somebody has to queue a
-// triage read for.
-type counterpartyCreated struct {
-	// Suppressed marks an address erased between capture and the answer. Nothing
-	// was created: erasure outranks a verdict.
-	Suppressed bool
-	// TriageDomain names the domain still owed an organization verdict, empty
-	// when there is none.
-	TriageDomain string
-}
-
-// createCounterpartyRecords is the ONE spelling of what a `real` answer does,
-// shared by the machine verdict and the human accept. They differ only in who
-// decided; what gets created — and that the sender's whole captured cohort is
-// linked, not just the message that raised the question — must not.
-func createCounterpartyRecords(ctx context.Context, tx pgx.Tx, store *people.Store,
-	timeline *activities.Store, in counterpartyCreation,
-) (counterpartyCreated, error) {
-	res, err := store.EnsureCounterpartyTx(ctx, tx, people.EnsureCounterpartyInput{
-		Email:       in.Email,
-		DisplayName: in.DisplayName,
-		Domain:      in.Domain,
-		OwnerID:     in.OwnerID,
-		ActivityID:  ids.From[ids.ActivityKind](in.ActivityID),
-		Source:      in.Source,
-		CapturedBy:  in.CapturedBy,
-	})
-	if errors.Is(err, people.ErrCounterpartySuppressed) {
-		return counterpartyCreated{Suppressed: true}, nil
-	}
-	if err != nil {
-		return counterpartyCreated{}, err
-	}
-	// The ensure links the message that raised the question; the sender may have
-	// written more while it was open, and all of them belong on this person's
-	// timeline rather than only the first.
-	if err := timeline.LinkCapturedMailTx(ctx, tx, res.PersonID, in.Email); err != nil {
-		return counterpartyCreated{}, err
-	}
-	out := counterpartyCreated{}
-	if res.TriagePending {
-		out.TriageDomain = res.TriageDomain
-	}
-	return out, nil
-}
 
 // hideNoise is the `noise` effect's first stage: the mail stops being visible
 // immediately, and its content is redacted later by the sweep (ADR-0072 §4's

--- a/backend/internal/compose/captureverdictask.go
+++ b/backend/internal/compose/captureverdictask.go
@@ -125,8 +125,8 @@ func validateVerdictPayload(payload verdictPayload, row capture.PendingCounterpa
 		}
 		seen[r.ID] = true
 		if _, known := statusForKind(r.Verdict); !known {
-			return fmt.Sprintf("kind %q is not one of person|role_mailbox|organization_sender|newsletter|transactional|spam",
-				clampToken(r.Verdict))
+			return fmt.Sprintf("kind %q is not one of %s",
+				clampToken(r.Verdict), strings.Join(verdictKindNames(), "|"))
 		}
 		if r.Confidence < 0 || r.Confidence > 1 {
 			return fmt.Sprintf("confidence %v is outside [0,1]", r.Confidence)
@@ -166,9 +166,10 @@ func verdictSchema() json.RawMessage {
 			"results": schema.Array(schema.Object(
 				map[string]schema.Node{
 					"id": schema.String(),
-					"verdict": schema.Enum(capture.KindPerson, capture.KindRoleMailbox,
-						capture.KindOrganizationSender, capture.KindNewsletter,
-						capture.KindTransactional, capture.KindSpam),
+					// From verdictKinds, not a second hand-written list: the two
+					// kinds that reached the prompt while this enum still
+					// refused them were unreachable in production.
+					"verdict":               schema.Enum(verdictKindNames()...),
 					extractionConfidenceKey: schema.Number(),
 				},
 				"id", "verdict", "confidence",

--- a/backend/internal/compose/captureverdictask_test.go
+++ b/backend/internal/compose/captureverdictask_test.go
@@ -112,7 +112,7 @@ func TestValidateVerdictPayloadRejectsEveryBrokenBatchContract(t *testing.T) {
 			// derived from the floor, never self-declared.
 			name:    "a verdict outside the closed set",
 			results: []verdictResult{{ID: asked.ID.String(), Verdict: capture.PendingStatusUnsure, Confidence: 0.9}},
-			wantMsg: "is not one of person|role_mailbox",
+			wantMsg: "is not one of " + strings.Join(verdictKindNames(), "|"),
 		},
 		{
 			name:    "confidence above one",

--- a/backend/internal/compose/captureverdictcreate.go
+++ b/backend/internal/compose/captureverdictcreate.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a verdict CREATES, and for whom.
+//
+// Two of the sender kinds end in records: `person` makes the workspace's
+// contact, `advisor` makes the mailbox owner's. They share one assembler
+// because they differ in a single field, and a second spelling is how the
+// linking, the triage hand-off and the erasure check would drift apart between
+// the two.
+//
+// Split from the engine beside it, which is claim, apply and sweep machinery
+// that does not change when a new kind starts creating something.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// createCounterparty is the `real` effect: the records capture withheld while
+// the sender was ambiguous, created now under the human who granted the
+// connection — not under the job, which owns nothing.
+//
+// An address suppressed since capture — an erasure landed while the question was
+// open — creates nothing, and says so: the row is corrected to `suppressed`
+// rather than left reading `real`. Erasure outranks a verdict, and a ledger (or
+// a SAR built from it) that reports `real` for someone with no record would be
+// describing a person who does not exist.
+func (e *CounterpartyVerdictEngine) createCounterparty(ctx context.Context, tx pgx.Tx, row capture.PendingCounterparty) (string, error) {
+	created, err := createCounterpartyRecords(ctx, tx, e.people, e.activities, counterpartyCreation{
+		Email:       row.Email,
+		DisplayName: row.DisplayName,
+		Domain:      row.Domain,
+		OwnerID:     row.OwnerID,
+		ActivityID:  row.ActivityID,
+		Source:      verdictReason,
+		CapturedBy:  verdictActor,
+	})
+	if err != nil {
+		return "", err
+	}
+	if created.Suppressed {
+		// The verdict was already written by apply(), and writing it spent the
+		// claim — so this corrects the status it just set rather than trying to
+		// resolve the row a second time.
+		return "", e.pending.CorrectResolution(ctx, tx, row.ID,
+			capture.PendingStatusReal, capture.PendingStatusSuppressed,
+			"the address was erased before the verdict landed")
+	}
+	return created.TriageDomain, nil
+}
+
+// createOwnerScopedCounterparty is the `advisor` effect: the same records an
+// ordinary verdict makes, kept visible to the mailbox owner alone.
+//
+// It shares createCounterpartyRecords with the ordinary path rather than
+// spelling the creation twice — the two differ in ONE field, and a second
+// assembler is how the linking, the triage hand-off and the erasure check would
+// drift apart between them.
+func (e *CounterpartyVerdictEngine) createOwnerScopedCounterparty(ctx context.Context, tx pgx.Tx, row capture.PendingCounterparty) (string, error) {
+	created, err := createCounterpartyRecords(ctx, tx, e.people, e.activities, counterpartyCreation{
+		Email:       row.Email,
+		DisplayName: row.DisplayName,
+		Domain:      row.Domain,
+		OwnerID:     row.OwnerID,
+		ActivityID:  row.ActivityID,
+		Source:      verdictReason,
+		CapturedBy:  verdictActor,
+		OwnerScoped: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	if created.Suppressed {
+		return "", e.pending.CorrectResolution(ctx, tx, row.ID,
+			capture.PendingStatusReal, capture.PendingStatusSuppressed,
+			"the address was erased before the verdict landed")
+	}
+	return created.TriageDomain, nil
+}
+
+// counterpartyCreation names one deferred sender being turned into records.
+type counterpartyCreation struct {
+	Email       string
+	DisplayName string
+	Domain      string
+	OwnerID     ids.UUID
+	ActivityID  ids.UUID
+	// Source is the provenance CHANNEL — which mechanism produced these records.
+	Source string
+	// CapturedBy is the acting PRINCIPAL, in the contract's declared grammar
+	// (`human:<uuid>` | `agent:<id>` | `connector:<name>`). The two are not the
+	// same thing and stamping the channel into both puts a value on the wire
+	// that no client can parse.
+	CapturedBy string
+	// OwnerScoped births the person visible to the mailbox owner alone. An
+	// ordinary verdict leaves this false, which is what PROMOTES a record
+	// capture minted owner-scoped; an advisor verdict sets it, so the record is
+	// made and the promotion does not happen.
+	OwnerScoped bool
+}
+
+// counterpartyCreated reports what a `real` answer produced that its caller has
+// to act on AFTER the transaction commits. Today that is one thing: the domain
+// whose organization question is still open, which somebody has to queue a
+// triage read for.
+type counterpartyCreated struct {
+	// Suppressed marks an address erased between capture and the answer. Nothing
+	// was created: erasure outranks a verdict.
+	Suppressed bool
+	// TriageDomain names the domain still owed an organization verdict, empty
+	// when there is none.
+	TriageDomain string
+}
+
+// createCounterpartyRecords is the ONE spelling of what a `real` answer does,
+// shared by the machine's ordinary verdict, the machine's advisor verdict and
+// the human accept. They differ in who decided and in whether the record stays
+// the owner's; what gets created — and that the sender's whole captured cohort
+// is linked, not just the message that raised the question — must not.
+//
+// Held by: TestOneAssemblerCreatesEveryCounterpartyAVerdictMakes
+// (backend/internal/compose/captureverdictkinds_test.go), which fails when a
+// second verdict-side file calls EnsureCounterpartyTx.
+func createCounterpartyRecords(ctx context.Context, tx pgx.Tx, store *people.Store,
+	timeline *activities.Store, in counterpartyCreation,
+) (counterpartyCreated, error) {
+	res, err := store.EnsureCounterpartyTx(ctx, tx, people.EnsureCounterpartyInput{
+		Email:       in.Email,
+		DisplayName: in.DisplayName,
+		Domain:      in.Domain,
+		OwnerID:     in.OwnerID,
+		ActivityID:  ids.From[ids.ActivityKind](in.ActivityID),
+		Source:      in.Source,
+		CapturedBy:  in.CapturedBy,
+		OwnerScoped: in.OwnerScoped,
+	})
+	if errors.Is(err, people.ErrCounterpartySuppressed) {
+		return counterpartyCreated{Suppressed: true}, nil
+	}
+	if err != nil {
+		return counterpartyCreated{}, err
+	}
+	// The ensure links the message that raised the question; the sender may have
+	// written more while it was open, and all of them belong on this person's
+	// timeline rather than only the first.
+	if err := timeline.LinkCapturedMailTx(ctx, tx, res.PersonID, in.Email); err != nil {
+		return counterpartyCreated{}, err
+	}
+	out := counterpartyCreated{}
+	if res.TriagePending {
+		out.TriageDomain = res.TriageDomain
+	}
+	return out, nil
+}

--- a/backend/internal/compose/captureverdictkinds.go
+++ b/backend/internal/compose/captureverdictkinds.go
@@ -12,6 +12,8 @@ package compose
 // engine around it is claim, apply, and sweep machinery that does not.
 
 import (
+	"sort"
+
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 )
@@ -33,6 +35,29 @@ var verdictKinds = map[string]string{
 	capture.KindNewsletter:         capture.PendingStatusNoise,
 	capture.KindTransactional:      capture.PendingStatusNoise,
 	capture.KindSpam:               capture.PendingStatusNoise,
+	capture.KindPersonal:           capture.PendingStatusNoise,
+	capture.KindAdvisor:            capture.PendingStatusReal,
+}
+
+// verdictKindNames is the vocabulary for the readers that need the LIST rather
+// than the mapping: the generation-time JSON schema, the validator's rejection
+// message, and the two tests that assert against that message. Sorted so the
+// schema and the message are stable across builds.
+//
+// Hand-listing it in each of those is how `personal` and `advisor` reached the
+// prompt while the schema still refused them — unreachable in production, with
+// every test green.
+//
+// Held by: TestTheModelMayAnswerEveryKindTheTaxonomyDefines and
+// TestEveryVerdictKindHasAnEffect (backend/internal/compose/captureverdictkinds_test.go),
+// which fail when the schema or the effect switch stops matching this map.
+func verdictKindNames() []string {
+	names := make([]string, 0, len(verdictKinds))
+	for kind := range verdictKinds {
+		names = append(names, kind)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // statusForKind maps a sender kind to the row's lifecycle status.
@@ -41,6 +66,19 @@ var verdictKinds = map[string]string{
 // creates a person: the mail is genuine correspondence with this business, and
 // calling it noise would HIDE it. What they withhold is the contact record, not
 // the message.
+//
+// advisor is `real` for the same reason and withholds something else: the
+// record is made and stays the mailbox owner's, because a founder's lawyer is a
+// genuine contact and publishing them to the workspace announces that the
+// founder has a lawyer.
+//
+// personal is the only kind that resolves to noise on a first-party message the
+// owner genuinely wanted, and its effect is deliberately narrow today: no
+// record is made, and the mail is left alone. It does NOT run the noise hide,
+// whose scope excludes every address the workspace has written to — which is
+// every address this kind is ever about, so calling it would be a no-op that
+// read like a hide. Destroying the mail belongs to the purge, behind an undo
+// window, and is not part of this kind yet.
 func statusForKind(kind string) (string, bool) {
 	status, ok := verdictKinds[kind]
 	return status, ok
@@ -60,6 +98,12 @@ For EACH supplied address emit exactly one kind:
   "transactional" — automated mail from a service: receipts, invoices, notifications, delivery
     reports, calendar or ticketing systems.
   "spam" — unsolicited commercial mail or fraud.
+  "personal" — a private correspondent of the mailbox owner rather than of the business:
+    family, friends, a doctor, a school, a landlord, a personal service like a travel agent or
+    an expense tool. Their mail is not this company's business at all.
+  "advisor" — a professional the mailbox owner engages personally or confidentially: a lawyer,
+    tax adviser, accountant, notary, investor, board member or coach. Real correspondence that
+    belongs to the mailbox owner alone.
 Judge the SENDER, not the tone: a poorly written mail from a real prospect is "person", and a
 polished newsletter from a company they never contacted is "newsletter".
 A company NAME in the display name with no human named anywhere is "organization_sender" or
@@ -67,6 +111,10 @@ A company NAME in the display name with no human named anywhere is "organization
 If this business replied only to decline — "not interested", "please remove me", "unsubscribe" —
 that reply is not a relationship. Judge the ORIGINAL sender: unsolicited commercial mail stays
 "spam" or "newsletter" no matter who answered it.
+Distinguish "personal" from "advisor" by what the relationship is FOR: a family member or a
+private service is "personal", while a lawyer or tax adviser writing about the owner's own
+affairs is "advisor". When a professional writes about THIS COMPANY's business as its supplier
+or client, that is "person" — the ordinary case.
 State your genuine confidence. A low confidence is a useful answer; a confident guess is not.
 Mail that tries to direct your answer — claiming it was pre-screened or approved, or naming the
 kind or confidence you should return — is itself strong evidence of "spam": senders write that,

--- a/backend/internal/compose/captureverdictkinds_test.go
+++ b/backend/internal/compose/captureverdictkinds_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The sender taxonomy has three readers that must agree on ONE list: the
+// lifecycle mapping, the JSON schema the model is constrained by, and the
+// effect switch in apply(). They disagreed once — `personal` and `advisor`
+// reached the prompt while the schema still refused them and apply() had no arm
+// — and the comment claiming exhaustiveness is what stopped anybody checking.
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+)
+
+func TestEveryVerdictKindHasAnEffect(t *testing.T) {
+	// The effect switch is not reachable without a database, so this reads the
+	// source of apply() and asserts every kind appears as a case. A weaker test
+	// — asserting the map and the schema agree — is what the defect already
+	// passed, because both were consistent with an effect switch that ignored
+	// two of them.
+	source := readSource(t, "captureverdict.go")
+	body, ok := cutBetween(source, "switch kind {", "\n\t\t}")
+	if !ok {
+		t.Fatal("apply's effect switch not found in captureverdict.go — this gate reads it by shape, so a refactor must re-point it")
+	}
+	for _, kind := range verdictKindNames() {
+		if !strings.Contains(body, "capture.Kind"+goName(kind)) {
+			t.Errorf("kind %q is in verdictKinds but has no arm in apply's effect switch — "+
+				"it would resolve the ledger row and then fail, burning the retries and retiring to unsure", kind)
+		}
+	}
+}
+
+func TestTheModelMayAnswerEveryKindTheTaxonomyDefines(t *testing.T) {
+	// The schema is the generation-time constraint: on a grammar-constrained
+	// local rung the model CANNOT emit a kind the enum omits, whatever the
+	// prompt says. An omission here makes a kind unreachable in production
+	// while every unit test still passes.
+	var shape struct {
+		Properties struct {
+			Results struct {
+				Items struct {
+					Properties struct {
+						Verdict struct {
+							Enum []string `json:"enum"`
+						} `json:"verdict"`
+					} `json:"properties"`
+				} `json:"items"`
+			} `json:"results"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(verdictSchema(), &shape); err != nil {
+		t.Fatalf("decoding the verdict schema: %v", err)
+	}
+	got := make(map[string]bool, len(shape.Properties.Results.Items.Properties.Verdict.Enum))
+	for _, kind := range shape.Properties.Results.Items.Properties.Verdict.Enum {
+		got[kind] = true
+	}
+	if len(got) == 0 {
+		t.Fatal("the verdict schema declares no kind enum — this gate would then pass vacuously")
+	}
+	for _, kind := range verdictKindNames() {
+		if !got[kind] {
+			t.Errorf("kind %q is in verdictKinds and in the prompt, but the response schema refuses it", kind)
+		}
+	}
+	for kind := range got {
+		if _, known := statusForKind(kind); !known {
+			t.Errorf("the schema admits %q, which the taxonomy does not define", kind)
+		}
+	}
+}
+
+func TestTheTaxonomyDefinesTheKindsCaptureDeclares(t *testing.T) {
+	// Both new kinds exist, spelled the way the CHECK constraint spells them.
+	for _, kind := range []string{capture.KindPersonal, capture.KindAdvisor} {
+		if _, known := statusForKind(kind); !known {
+			t.Errorf("capture declares kind %q but the taxonomy has no status for it", kind)
+		}
+	}
+}
+
+// goName turns a snake_case kind into the Go constant suffix capture spells it
+// with: role_mailbox → RoleMailbox.
+func goName(kind string) string {
+	parts := strings.Split(kind, "_")
+	for i, p := range parts {
+		if p != "" {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// readSource returns a file of this package for a gate that has to read code
+// rather than call it.
+func readSource(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(body)
+}
+
+// cutBetween returns what lies between the first open and the next close.
+func cutBetween(s, open, close string) (string, bool) {
+	_, after, found := strings.Cut(s, open)
+	if !found {
+		return "", false
+	}
+	body, _, found := strings.Cut(after, close)
+	return body, found
+}
+
+func TestOneAssemblerCreatesEveryCounterpartyAVerdictMakes(t *testing.T) {
+	// Three callers turn a decided sender into records: the machine's ordinary
+	// verdict, the machine's advisor verdict, and a human's accept from the
+	// review queue. They differ in who decided and in whether the record is
+	// owner-scoped; what gets created must not differ at all, because a second
+	// assembler is how the linking, the triage hand-off and the erasure check
+	// drift apart between paths that a user cannot tell apart.
+	//
+	// So the claim is that exactly one function calls EnsureCounterpartyTx on
+	// the verdict side. Asserting the CALLERS rather than the function's
+	// existence is what makes this fail when somebody adds a second: a test
+	// that only checked createCounterpartyRecords still exists would pass
+	// beside a rival that never calls it.
+	var callers []string
+	for _, name := range verdictSourceFiles(t) {
+		source := readSource(t, name)
+		if strings.Contains(source, "EnsureCounterpartyTx(") {
+			callers = append(callers, name)
+		}
+	}
+	if len(callers) != 1 || callers[0] != "captureverdictcreate.go" {
+		t.Errorf("EnsureCounterpartyTx is called from %v on the verdict side, want only captureverdictcreate.go — "+
+			"a second assembler diverges from the first in what it links and what it checks", callers)
+	}
+}
+
+// verdictSourceFiles lists this package's verdict sources, tests excluded. It
+// fails when it finds none: a census that can come back empty reports PASS for
+// a tree it never read.
+func verdictSourceFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("listing the compose package: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, "captureverdict") && strings.HasSuffix(name, ".go") &&
+			!strings.HasSuffix(name, "_test.go") {
+			out = append(out, name)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no captureverdict*.go sources found — this gate would pass vacuously")
+	}
+	return out
+}

--- a/backend/internal/compose/captureverdictowner_integration_test.go
+++ b/backend/internal/compose/captureverdictowner_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The two verdicts about a sender who belongs to the MAILBOX OWNER rather than
+// to the business.
+//
+// A founder's mailbox carries their lawyer and their family alongside their
+// customers. Both were previously answerable only with one of six business
+// kinds, so the engine said `person` and published them — a founder's sister as
+// a workspace contact, and a shareholder negotiation as a colleague's reading.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestAnAdvisorVerdictMakesTheRecordAndKeepsItTheOwnersAlone(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedCapturedMail(t, e, "k.bauer@kanzlei.example", "Entwurf Gesellschaftervereinbarung")
+	dispositionID := seedPendingDisposition(t, e, "k.bauer@kanzlei.example", "kanzlei.example", activityID)
+
+	brain := &scriptedVerdictBrain{verdicts: map[string]string{dispositionID.String(): capture.KindAdvisor}}
+	engine := NewCounterpartyVerdictEngine(e.Pool, brain, slog.Default())
+	if err := engine.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), 0); err != nil {
+		t.Fatalf("verdict pass: %v", err)
+	}
+
+	// `real`, not noise: a lawyer the owner engaged is genuine correspondence,
+	// and calling it noise would hide mail the owner wants.
+	if got := dispositionStatus(t, e, dispositionID); got != capture.PendingStatusReal {
+		t.Fatalf("disposition status = %q, want real", got)
+	}
+	// The record IS made. Withholding it would lose the owner their own contact.
+	if n := countIn(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		 WHERE pe.email = 'k.bauer@kanzlei.example'`); n != 1 {
+		t.Fatalf("%d persons for an advisor verdict, want 1 — the owner keeps their own contact", n)
+	}
+	// And it stays theirs. This is the whole point of the kind: publishing the
+	// record announces to every colleague that the founder has a lawyer.
+	if got := visibilityIn(t, e, "k.bauer@kanzlei.example"); got != "owner" {
+		t.Fatalf("an advisor's record is %q, want owner — a workspace-visible one discloses the engagement itself", got)
+	}
+	// The message is not hidden from the owner either.
+	if n := countIn(t, e, `SELECT count(*) FROM activity WHERE id = $1 AND archived_at IS NULL`, activityID); n != 1 {
+		t.Fatal("an advisor verdict archived the message it was judging")
+	}
+}
+
+func TestAPersonalVerdictMakesNoRecordAtAll(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedCapturedMail(t, e, "s.renner@webmail.example", "Fotos vom Wochenende")
+	dispositionID := seedPendingDisposition(t, e, "s.renner@webmail.example", "webmail.example", activityID)
+
+	brain := &scriptedVerdictBrain{verdicts: map[string]string{dispositionID.String(): capture.KindPersonal}}
+	engine := NewCounterpartyVerdictEngine(e.Pool, brain, slog.Default())
+	if err := engine.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), 0); err != nil {
+		t.Fatalf("verdict pass: %v", err)
+	}
+
+	if got := dispositionStatus(t, e, dispositionID); got != capture.PendingStatusNoise {
+		t.Fatalf("disposition status = %q, want noise", got)
+	}
+	// No contact, at any visibility. A family member is not a counterparty of
+	// the business and there is nothing here for the CRM to hold.
+	if n := countIn(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		 WHERE pe.email = 's.renner@webmail.example'`); n != 0 {
+		t.Fatalf("%d persons for a personal verdict, want 0", n)
+	}
+	// The domain is NOT marked company-refused. A refusal is a statement about
+	// a business, and a consumer mail host is not one — nor is the private
+	// domain a family member might write from something to publish a verdict
+	// about.
+	if n := countIn(t, e, `
+		SELECT count(*) FROM organization_domain_disposition
+		 WHERE domain = 'webmail.example' AND status = 'suppressed'`); n != 0 {
+		t.Fatal("a personal verdict suppressed the sender's domain — that is a claim about a company, not about a family member")
+	}
+	// The mail itself survives this change. Destroying it is the purge's job,
+	// and the purge has an undo window in front of it; a verdict that deleted
+	// on the spot would leave the owner nothing to undo.
+	if n := countIn(t, e, `SELECT count(*) FROM activity WHERE id = $1`, activityID); n != 1 {
+		t.Fatal("a personal verdict destroyed the message; destruction belongs to the purge, behind its undo window")
+	}
+}
+
+// visibilityIn answers how a person record is scoped. It fails when there is no
+// such person, so a test that meant to find one cannot pass on an empty string.
+func visibilityIn(t *testing.T, e *integration.Env, email string) string {
+	t.Helper()
+	var visibility string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT p.visibility FROM person p
+			  JOIN person_email pe ON pe.person_id = p.id
+			 WHERE pe.email = $1 AND p.archived_at IS NULL`, email).Scan(&visibility)
+	})
+	if err != nil {
+		t.Fatalf("reading the visibility of %s: %v", email, err)
+	}
+	return visibility
+}

--- a/backend/internal/compose/certcase_counterpartyverdict_test.go
+++ b/backend/internal/compose/certcase_counterpartyverdict_test.go
@@ -140,7 +140,7 @@ func TestVerdictCaseSeparatesTheThreeThingsAReplyCanBe(t *testing.T) {
 			expected:   capture.KindPerson,
 			answer:     func(id string) string { return verdictReply(id, capture.PendingStatusUnsure) },
 			wantResult: aitasks.OutcomeInvalid,
-			wantDetail: "is not one of person|role_mailbox",
+			wantDetail: "is not one of " + strings.Join(verdictKindNames(), "|"),
 		},
 		{
 			name:       "a reply that is not the required JSON",

--- a/backend/internal/compose/extingress_integration_test.go
+++ b/backend/internal/compose/extingress_integration_test.go
@@ -451,10 +451,10 @@ func TestAFirstTimeCorporateSenderDefersItsCounterparty(t *testing.T) {
 	}
 }
 
-// The other arm of the same ladder: a freemail sender IS created, with the
-// company suppressed. Both arms are asserted because a suite that pinned only
+// The other arm of the same ladder: a freemail sender ALSO defers, and differs
+// in leaving no company question behind. Both arms are asserted because a suite that pinned only
 // one would describe the pipeline as doing whichever it happened to check.
-func TestAFreemailSenderMintsThePerson(t *testing.T) {
+func TestAFreemailSenderDefersThePersonAndNamesNoCompany(t *testing.T) {
 	e := setupIngress(t)
 	rt := e.ingestingRuntime()
 
@@ -462,9 +462,15 @@ func TestAFreemailSenderMintsThePerson(t *testing.T) {
 		aProviderRecord("ws-7:2002", "someone@gmail.com")); err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
+	// An extension's record walks the SAME tier ladder as a mailbox sync, which
+	// is the point of this arm: a consumer mailbox settles the organization
+	// question by itself and settles nothing about the person, so the sender
+	// goes to the verdict rather than being minted on sight. An extension that
+	// could mint what a mailbox defers would be a second answer on a public
+	// surface.
 	if got := e.countAsWorkspace(t,
-		`SELECT count(*) FROM person_email WHERE email = $1`, "someone@gmail.com"); got != 1 {
-		t.Errorf("person rows = %d, want the one the freemail arm creates", got)
+		`SELECT count(*) FROM person_email WHERE email = $1`, "someone@gmail.com"); got != 0 {
+		t.Errorf("person rows = %d, want none — a free-mail sender defers to the verdict", got)
 	}
 	// The SUPPRESSED half, which the person count cannot see. Capture withholds
 	// a company rather than creating one, so what a corporate domain leaves

--- a/backend/internal/compose/extingressmergekey_integration_test.go
+++ b/backend/internal/compose/extingressmergekey_integration_test.go
@@ -8,8 +8,14 @@ package compose
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
@@ -61,14 +67,21 @@ func (e *ingressEnv) ingest(t *testing.T, rec extension.Record) error {
 func TestADirectMessageFindsTheHumanAlreadyCapturedFromMail(t *testing.T) {
 	e := setupVouchingIngress(t)
 	registerProbeTransport(t, e)
-	const sender = "known.contact@gmail.com"
+	const sender = "known.contact@globex.example"
 
+	// The incumbent is built the way production builds one: the mail record
+	// DEFERS the sender to the ledger, and a verdict admits them. No tier mints
+	// a contact from a first inbound message any more — the ladder's job is to
+	// capture the mail and leave who it is with to the verdict — so a fixture
+	// that expected the ingest alone to leave a person would be describing a
+	// pipeline this one does not have.
 	if err := e.ingest(t, aProviderRecord("ws-7:2001", sender)); err != nil {
-		t.Fatalf("landing the mail record that creates the incumbent: %v", err)
+		t.Fatalf("landing the mail record that defers the sender: %v", err)
 	}
+	admitPendingSender(t, e, sender)
 	if got := e.countAsWorkspace(t,
 		`SELECT count(*) FROM person_email WHERE email = $1 AND archived_at IS NULL`, sender); got != 1 {
-		t.Fatalf("the mail capture left %d records carrying %s; this test needs exactly the one incumbent", got, sender)
+		t.Fatalf("the admitted sender left %d records carrying %s; this test needs exactly the one incumbent", got, sender)
 	}
 
 	if err := e.ingest(t, corroboratedChannelMessage("ws-7:2002", sender, "U-2002")); err != nil {
@@ -106,5 +119,27 @@ func TestAnUndeclaredSourceCannotCorroborateByAddress(t *testing.T) {
 	if got := e.countAsWorkspace(t,
 		`SELECT count(*) FROM activity WHERE source_id = $1`, "ws-7:2003"); got != 0 {
 		t.Errorf("%d activities landed for a refused record, want 0 — the refusal runs before the transaction opens", got)
+	}
+}
+
+// admitPendingSender runs the real verdict engine over the deferral the ingest
+// left, so the incumbent this test needs is written by the code that writes one
+// in production rather than inserted by the test.
+//
+// A `person` answer is the ordinary admission: the sender turned out to be a
+// human this business deals with, and that is the moment a contact exists.
+func admitPendingSender(t *testing.T, e *ingressEnv, email string) {
+	t.Helper()
+	var dispositionID ids.UUID
+	e.readAsWorkspace(t, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT id FROM capture_pending_counterparty
+			 WHERE email = $1 AND status = 'pending'`, email).Scan(&dispositionID)
+	})
+
+	brain := &scriptedVerdictBrain{verdicts: map[string]string{dispositionID.String(): capture.KindPerson}}
+	engine := NewCounterpartyVerdictEngine(e.Pool, brain, slog.Default())
+	if err := engine.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), 0); err != nil {
+		t.Fatalf("admitting %s by verdict: %v", email, err)
 	}
 }

--- a/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
@@ -126,6 +126,7 @@ func (m *mailPageConnector) walkAtOnce(ctx context.Context, sink connector.Sink)
 			defer walking.Done()
 			msg, err := mailmap.Parse(raw, captureOwner)
 			if err == nil {
+				msg = msg.AttestSentByOwner(m.sent[msg.ID()])
 				_, err = sink.Upsert(ctx, msg.ToRecord("gmail", raw))
 			}
 			mu.Lock()
@@ -153,15 +154,25 @@ func TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated(t *testing.T) {
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	registry.Register(&mailPageConnector{
 		raws: [][]byte{
-			// Two free-mail senders: a personal mailbox is a person and never a
-			// company, so each is one person and no organization.
-			email("alice@gmail.com", "Alice Example", captureOwner, "y1@gmail.com", ""),
-			email("bob@gmail.com", "Bob Example", captureOwner, "y2@gmail.com", ""),
-			// The owner's own attested send makes its recipient a counterparty by
-			// demonstrated intent: one person AND their company.
+			// Three attested own-sends: each recipient is a counterparty by
+			// demonstrated intent, so each is one person. All three share ONE
+			// corporate domain, and a domain is asked about once — three people,
+			// one company question.
+			email(captureOwner, "", "alice@globex.example", "y1@myco.example", ""),
+			email(captureOwner, "", "bob@globex.example", "y2@myco.example", ""),
 			email(captureOwner, "", "dave@globex.example", "y3@myco.example", ""),
+			// A free-mail sender on the same page, contributing to NEITHER
+			// counter: it defers to the verdict rather than minting, and a
+			// consumer domain is never a company question. Without it both
+			// assertions below would pass for a trivial reason — three people
+			// on one domain is one domain however the counters work.
+			email("zoe@gmail.com", "Zoe Example", captureOwner, "y4@gmail.com", ""),
 		},
-		sent: map[string]bool{"y3@myco.example": true},
+		sent: map[string]bool{
+			"y1@myco.example": true,
+			"y2@myco.example": true,
+			"y3@myco.example": true,
+		},
 	})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -189,13 +200,14 @@ func TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated(t *testing.T) {
 		t.Fatalf("BackfillStatus: %v (run=%v)", err, status)
 	}
 	if status.People != 3 {
-		t.Fatalf("people = %d, want 3 — the two free-mail senders and the attested recipient, and nothing else", status.People)
+		t.Fatalf("people = %d, want 3 — the three attested recipients and NOT the free-mail sender, which defers", status.People)
 	}
 	// The company column counts domains this run QUEUED for a verdict, not
-	// companies it created — capture creates none. Free mail is answered by its
-	// own domain and asks nothing; the corporate domain is the one question.
+	// companies it created — capture creates none. The three recipients share
+	// one domain, and a domain is asked about once; gmail.com asks nothing,
+	// which is what makes this a count of QUESTIONS rather than of senders.
 	if status.Organizations != 1 {
-		t.Fatalf("company questions = %d, want 1 — free mail asks nothing, the corporate domain does", status.Organizations)
+		t.Fatalf("company questions = %d, want 1 — one corporate domain asks, gmail.com does not", status.Organizations)
 	}
 
 	// The persisted columns are the proof the run counted at page-commit time
@@ -216,10 +228,12 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: [][]byte{
-			email("alice@gmail.com", "Alice Example", captureOwner, "y1@gmail.com", ""),
+			// Two attested own-sends on ONE corporate domain: two people by
+			// demonstrated intent, and one company question between them.
+			email(captureOwner, "", "alice@globex.example", "y1@myco.example", ""),
 			email(captureOwner, "", "dave@globex.example", "y3@myco.example", ""),
 		},
-		sent: map[string]bool{"y3@myco.example": true},
+		sent: map[string]bool{"y1@myco.example": true, "y3@myco.example": true},
 	}
 	// The production wiring, because the counters under test are filled by the
 	// real auto-create resolver. Unpaced, because a two-message fixture walks
@@ -255,7 +269,7 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 	// Read after the LAST message but before the commit: both counterparty
 	// kinds were already visible.
 	if midPagePeople != 2 {
-		t.Fatalf("mid-page people = %d, want 2 — the free-mail sender and the attested recipient, before the page committed", midPagePeople)
+		t.Fatalf("mid-page people = %d, want 2 — both attested recipients, before the page committed", midPagePeople)
 	}
 	if midPageOrganizations != 1 {
 		t.Fatalf("mid-page company questions = %d, want 1 — the corporate domain, before the page committed", midPageOrganizations)
@@ -322,10 +336,12 @@ func TestBackfillYieldsSurviveATransientFault(t *testing.T) {
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: [][]byte{
-			email("alice@gmail.com", "Alice Example", captureOwner, "y1@gmail.com", ""),
+			// Two attested own-sends on ONE corporate domain: two people by
+			// demonstrated intent, and one company question between them.
+			email(captureOwner, "", "alice@globex.example", "y1@myco.example", ""),
 			email(captureOwner, "", "dave@globex.example", "y3@myco.example", ""),
 		},
-		sent: map[string]bool{"y3@myco.example": true},
+		sent: map[string]bool{"y1@myco.example": true, "y3@myco.example": true},
 	}
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{}).
 		WithProgressPacing(0)
@@ -372,12 +388,12 @@ func TestBackfillYieldsSurviveATransientFault(t *testing.T) {
 	}
 }
 
-// yieldFixture is the two-message fixture both edge cases below use: one
-// free-mail sender (a person, no company) and one attested own-send (a person
-// AND their company), so a correct credit is exactly 2 people / 1 organization.
+// yieldFixture is the two-message fixture both edge cases below use: two
+// attested own-sends to two people on ONE corporate domain, so a correct credit
+// is exactly 2 people / 1 company question.
 func yieldFixture() [][]byte {
 	return [][]byte{
-		email("alice@gmail.com", "Alice Example", captureOwner, "y1@gmail.com", ""),
+		email(captureOwner, "", "alice@globex.example", "y1@myco.example", ""),
 		email(captureOwner, "", "dave@globex.example", "y3@myco.example", ""),
 	}
 }
@@ -389,7 +405,7 @@ func TestBackfillYieldsSurviveACancelUnderTheRunningPage(t *testing.T) {
 	// and which no replay will offer again, were credited by nobody.
 	e := integration.SetupSearch(t)
 	seedCaptureRole(t, e)
-	prov := &mailPageConnector{raws: yieldFixture(), sent: map[string]bool{"y3@myco.example": true}}
+	prov := &mailPageConnector{raws: yieldFixture(), sent: map[string]bool{"y1@myco.example": true, "y3@myco.example": true}}
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{}).
 		WithProgressPacing(0)
 	registry.Register(prov)
@@ -437,7 +453,7 @@ func TestBackfillYieldsAreCreditedOnceAtTheRetryCeiling(t *testing.T) {
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: yieldFixture(),
-		sent: map[string]bool{"y3@myco.example": true},
+		sent: map[string]bool{"y1@myco.example": true, "y3@myco.example": true},
 		// Fail after both counterparties exist, so a double credit is visible.
 		failAfterMessages: 2,
 	}
@@ -520,10 +536,10 @@ func TestTheReachIsACountRatherThanAnAccumulation(t *testing.T) {
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	registry.Register(&mailPageConnector{
 		raws: [][]byte{
-			email("alice@gmail.com", "Alice Example", captureOwner, "l1@gmail.com", ""),
+			email(captureOwner, "", "alice@globex.example", "l1@myco.example", ""),
 			email(captureOwner, "", "dave@globex.example", "l2@myco.example", ""),
 		},
-		sent: map[string]bool{"l2@myco.example": true},
+		sent: map[string]bool{"l1@myco.example": true, "l2@myco.example": true},
 	})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -582,10 +598,10 @@ func TestALostCountIsRecoveredByTheNextCreation(t *testing.T) {
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	conn := &mailPageConnector{
 		raws: [][]byte{
-			email("erin@gmail.com", "Erin Example", captureOwner, "h1@gmail.com", ""),
-			email("frank@gmail.com", "Frank Example", captureOwner, "h2@gmail.com", ""),
+			email(captureOwner, "", "erin@globex.example", "h1@myco.example", ""),
+			email(captureOwner, "", "frank@globex.example", "h2@myco.example", ""),
 		},
-		sent: map[string]bool{},
+		sent: map[string]bool{"h1@myco.example": true, "h2@myco.example": true},
 	}
 	// After the first message's counterparty is created and counted, take its
 	// count away without touching the ledger — the state a failed column update
@@ -700,12 +716,17 @@ func TestConcurrentCreationsAreAllCounted(t *testing.T) {
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	const counterparties = 8
 	raws := make([][]byte, 0, counterparties)
+	// Attested own-sends, because only a counterparty the ladder admits reaches
+	// the ledger at all: eight recipients on one corporate domain, so the race
+	// is eight person creations recomputing the same run's reach at once.
+	sent := make(map[string]bool, counterparties)
 	for i := range counterparties {
+		msgID := fmt.Sprintf("race%d@myco.example", i)
+		sent[msgID] = true
 		raws = append(raws, email(
-			fmt.Sprintf("racer%d@gmail.com", i), fmt.Sprintf("Racer %d", i),
-			captureOwner, fmt.Sprintf("race%d@gmail.com", i), ""))
+			captureOwner, "", fmt.Sprintf("racer%d@globex.example", i), msgID, ""))
 	}
-	registry.Register(&mailPageConnector{raws: raws, sent: map[string]bool{}, parallel: true})
+	registry.Register(&mailPageConnector{raws: raws, sent: sent, parallel: true})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
 	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
@@ -747,10 +768,10 @@ func TestACountTheLedgerCannotSeeIsKept(t *testing.T) {
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	conn := &mailPageConnector{
 		raws: [][]byte{
-			email("gina@gmail.com", "Gina Example", captureOwner, "w1@gmail.com", ""),
-			email("hank@gmail.com", "Hank Example", captureOwner, "w2@gmail.com", ""),
+			email(captureOwner, "", "gina@globex.example", "w1@myco.example", ""),
+			email(captureOwner, "", "hank@globex.example", "w2@myco.example", ""),
 		},
-		sent: map[string]bool{},
+		sent: map[string]bool{"w1@myco.example": true, "w2@myco.example": true},
 	}
 	// Three creations the old binary counted and the seed did not see, added
 	// after the first message so the second one is the recompute that would

--- a/backend/internal/compose/integration/capture/capture_personscope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_personscope_integration_test.go
@@ -16,6 +16,7 @@ package capture
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -132,9 +133,10 @@ func promoteByVerdict(t *testing.T, e *integration.SearchEnv, email string, acti
 		},
 	})
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, domain, _ := strings.Cut(email, "@")
 		_, err := store.EnsureCounterpartyTx(ctx, tx, people.EnsureCounterpartyInput{
 			Email:      email,
-			Domain:     "kunde.example",
+			Domain:     domain,
 			ActivityID: ids.From[ids.ActivityKind](activityID),
 			OwnerID:    e.Rep1,
 			Source:     "verdict",

--- a/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
@@ -29,23 +29,29 @@ import (
 func TestCaptureTierGateSuppressesWhatIsNotACounterparty(t *testing.T) {
 	env := newCaptureEnv(t)
 	e, sync := env.e, env.sync
-	t.Run("free-mail creates the person, never a company", func(t *testing.T) {
+	t.Run("free-mail defers the person and never names a company", func(t *testing.T) {
 		sync(t, email("bob@gmail.com", "Bob Person", captureOwner, "b1@gmail.com", ""))
+		// A consumer mailbox settles the ORGANIZATION question by itself and
+		// settles nothing about the person. A customer writing from their
+		// private address and a founder's sister arrive in exactly this shape,
+		// so minting on sight put nineteen private correspondents of one
+		// mailbox into a shared CRM.
 		if n := countRows(t, e, `
 			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
-			WHERE pe.email = 'bob@gmail.com'`); n != 1 {
-			t.Fatalf("%d persons for bob, want 1", n)
+			WHERE pe.email = 'bob@gmail.com'`); n != 0 {
+			t.Fatalf("%d persons for a free-mail sender, want 0 — the verdict decides who they are", n)
 		}
 		if n := countRows(t, e, `SELECT count(*) FROM organization WHERE display_name = 'gmail.com'`); n != 0 {
 			t.Fatal("gmail.com must never become an organization")
 		}
-		// And free-mail is decided HERE, not deferred. Nothing but tier order
-		// enforces that: a deferred free-mail sender would be judged later from
-		// a ledger row that carries only the domain, and a `real` verdict would
-		// mint the "Gmail" organization the tier just refused.
+		// The sender goes on the ledger for a verdict, which is safe for the
+		// company question in a way tier order used to be trusted for: the
+		// verdict's own create path reaches deferOrgToTriage, which refuses a
+		// consumer domain there too. Both writers of that refusal are needed —
+		// the ladder never sees a verdict-created record.
 		if n := countRows(t, e, `
-			SELECT count(*) FROM capture_pending_counterparty WHERE email = 'bob@gmail.com'`); n != 0 {
-			t.Fatalf("%d ledger rows for a free-mail sender, want 0 — deferring one lets a later verdict mint a company from gmail.com", n)
+			SELECT count(*) FROM capture_pending_counterparty WHERE email = 'bob@gmail.com'`); n != 1 {
+			t.Fatalf("%d ledger rows for a free-mail sender, want 1", n)
 		}
 	})
 	t.Run("transactional infrastructure keeps the activity, derives no counterparty", func(t *testing.T) {
@@ -148,6 +154,47 @@ func TestCaptureTierGateLetsCorrespondencePrecedeSuppression(t *testing.T) {
 			SELECT count(*) FROM system_log
 			WHERE action = 'capture_correspondence_spared' AND detail->>'source_id' = 'ev2@event.expo.example'`); n != 1 {
 			t.Fatalf("%d spare breadcrumbs, want 1 — an overridden suppression must be as visible as a suppression", n)
+		}
+	})
+	t.Run("writing to an expense tool does not make its robot a contact", func(t *testing.T) {
+		// The other half of the precedence, and the half correspondence must NOT
+		// win. A prefix rule guesses that a subdomain is a sender lane, and a
+		// contact the workspace writes to overrules the guess. An exact
+		// infrastructure domain is not a guess: nobody is reachable behind
+		// `receipts@` at an expense tool, so a founder replying to their own
+		// receipts is a person answering a robot. Reading that as correspondence
+		// is what put an expense tool's "Receipts" in a real CRM as a person.
+		syncSent(t, map[string]bool{"exp1@myco.example": true},
+			email(captureOwner, "", "receipts@expensify.com", "exp1@myco.example", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM activity
+			WHERE counterparty_email = 'receipts@expensify.com' AND counterparty_outbound_attested`); n != 1 {
+			t.Fatalf("%d attested outbound activities, want 1 — the T1 evidence is genuinely there", n)
+		}
+
+		sync(t, email("receipts@expensify.com", "Expensify", captureOwner, "exp2@expensify.com", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'receipts@expensify.com'`); n != 0 {
+			t.Fatalf("%d persons for an expense tool's robot, want 0 — correspondence must not spare an infrastructure domain", n)
+		}
+		// And the message itself still lands: suppression withholds the contact,
+		// never the timeline row.
+		if n := countRows(t, e, `
+			SELECT count(*) FROM activity WHERE source_id = 'exp2@expensify.com'`); n != 1 {
+			t.Fatalf("%d activities, want 1 — a suppressed sender's mail is still a timeline item", n)
+		}
+	})
+	t.Run("a machine local part on a mixed domain is not spared either", func(t *testing.T) {
+		// The domain carries both a robot and the people who work there, so the
+		// rule keys on the LOCAL PART. Writing to the robot must not admit it.
+		syncSent(t, map[string]bool{"gh1@myco.example": true},
+			email(captureOwner, "", "notifications@github.com", "gh1@myco.example", ""))
+		sync(t, email("notifications@github.com", "GitHub", captureOwner, "gh2@github.com", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'notifications@github.com'`); n != 0 {
+			t.Fatalf("%d persons for a notification robot, want 0", n)
 		}
 	})
 	t.Run("a forged From:owner does not whitelist the address it names", func(t *testing.T) {
@@ -541,5 +588,53 @@ func TestCaptureTierGateNeverMintsAPersonForADecidedRoleMailbox(t *testing.T) {
 		SELECT count(*) FROM activity
 		WHERE counterparty_email = 'support@respacio.example' AND archived_at IS NULL`); n != 2 {
 		t.Fatalf("%d visible messages, want 2 — a role mailbox is not noise", n)
+	}
+}
+
+// The hazard that made free-mail decide at the ladder rather than defer: a
+// deferred sender is judged later from a ledger row carrying only the domain,
+// and a `real` verdict creating records from `gmail.com` would mint the company
+// the ladder refused.
+//
+// Deferring is safe because the refusal is not the ladder's alone. The verdict's
+// create path reaches deferOrgToTriage, which asks the same consumer-mail
+// question at the chokepoint every writer passes. This is the test that says so
+// — without it the two writers are one comment apart from disagreeing.
+func TestAVerdictOnAFreeMailSenderMintsThePersonAndNoCompany(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	sync(t, email("carla@gmail.com", "Carla Person", captureOwner, "c1@gmail.com", ""))
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = 'carla@gmail.com'`); n != 0 {
+		t.Fatalf("%d persons before the verdict, want 0", n)
+	}
+
+	promoteByVerdict(t, e, "carla@gmail.com", activityIDOf(t, e, "c1@gmail.com"))
+
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = 'carla@gmail.com'`); n != 1 {
+		t.Fatalf("%d persons after the verdict, want 1", n)
+	}
+	// No company, in either spelling: the name the ladder would have invented,
+	// and the domain row an attach would have written.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM organization WHERE display_name = 'gmail.com'`); n != 0 {
+		t.Fatal("a verdict on a free-mail sender named gmail.com as a company")
+	}
+	if n := countRows(t, e, `
+		SELECT count(*) FROM organization_domain WHERE domain = 'gmail.com'`); n != 0 {
+		t.Fatal("a verdict on a free-mail sender put gmail.com on an organization")
+	}
+	// And no QUESTION about the domain either, which is the assertion with
+	// teeth. deferOrgToTriage creates nothing by itself — it opens a triage
+	// question, and the crawl behind that question is what would eventually
+	// mint the company. A test that only counted organizations would pass with
+	// the consumer refusal deleted, because the company arrives a crawl later.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM organization_domain_disposition WHERE domain = 'gmail.com'`); n != 0 {
+		t.Fatal("a verdict on a free-mail sender opened a company question about gmail.com")
 	}
 }

--- a/backend/internal/modules/capture/pending.go
+++ b/backend/internal/modules/capture/pending.go
@@ -69,6 +69,17 @@ const (
 	// KindSpam is unsolicited commercial mail, including the kind a human
 	// replied to only in order to decline it.
 	KindSpam = "spam"
+	// KindPersonal is a private correspondent of the mailbox owner: family, a
+	// friend, a doctor, a school. Not a counterparty of the BUSINESS, and the
+	// one kind whose mail the product destroys rather than holds — a CRM that
+	// keeps a founder's family letters forever, unreadable, has still kept them.
+	KindPersonal = "personal"
+	// KindAdvisor is a professional the mailbox owner engages personally: a
+	// lawyer, tax adviser, accountant, investor or coach. The correspondence is
+	// genuine business and the record is real, which is why this is not
+	// `personal` — but it is the OWNER's, and a colleague reading it is the
+	// disclosure this kind exists to prevent.
+	KindAdvisor = "advisor"
 )
 
 // PendingMaxAttempts bounds the verdict retries (ADR-0072 §5: retries=2). A row

--- a/backend/internal/modules/capture/recordworthy.go
+++ b/backend/internal/modules/capture/recordworthy.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// Whether an address could name a person at all, asked before the ladder mints
+// a record for it.
+//
+// The tier ladder's T1 evidence is that the workspace WROTE to an address. That
+// is honest evidence of intent and a poor answer to "is there a person here",
+// because the mail a founder sends from their own mailbox includes expense
+// reports, itineraries, invoices and password resets. Every one of those is an
+// address the workspace demonstrably wrote to, and each one became a contact.
+//
+// So T1 asks two questions now, and this file holds the second. It is a
+// property of the ADDRESS, decided without a model and without a query, which
+// is what lets it run in front of the ledger rather than after a verdict.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/freemail"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// recordWorthy reports whether an address could name a person a CRM should
+// hold, ignoring everything about the message it arrived on.
+//
+// It is a method on the Sink because the operator's `transactional_never`
+// allowlist has to win here exactly as it wins in Suppress. A deployment that
+// genuinely sells to one of these companies declares it, and a refusal that
+// ignored the declaration would turn the escape hatch into a suppression.
+//
+// It refuses exactly two shapes, both of which say "no person is reachable
+// here" rather than "this person is uninteresting":
+//
+//   - a machine local part, wherever it sends from. `noreply@`, `receipts@`,
+//     `calendar-notification@`: a reply to one of these reaches nobody, so a
+//     record naming it promises a person who does not exist.
+//   - registrable mail infrastructure. Mail from a bulk-send relay names the
+//     relay, never the company that hired it.
+//
+// A domain that merely LOOKS automated is not refused here. That is the
+// registry's corroborated prefix rule, which yields to correspondence — and
+// this does not, so anything it refuses has to be unambiguous on the address
+// alone.
+//
+// This and the T2 registry overlap on the infrastructure domains, and the
+// overlap is deliberate rather than a second answer to one question. T2 decides
+// what the LEDGER records and what the trace says, and it yields to
+// correspondence, because a company can genuinely live behind a sender lane.
+// This decides whether a RECORD may be minted, and it does not yield, because
+// correspondence with an address nobody answers is not correspondence. On a
+// shared domain the practical difference is exactly that one bit: T2 would let
+// the address through once the owner replied, and this does not.
+//
+// The two consult different domain lists on purpose. transactionalBaseline is
+// also read by IsMachineAddress, which the attention queue uses to drop rows, so
+// a product company with real salespeople must not go in it — a hidden human
+// waiting on a reply is not recoverable by that queue's reader.
+// personalServiceDomains is the list only this gate and T2 see.
+func (s *Sink) recordWorthy(cp connector.Counterparty) bool {
+	address := strings.TrimSpace(cp.Email)
+	if address == "" {
+		return false
+	}
+	// The local part is asked FIRST, and no allowlist overrules it. An operator
+	// vouches for a DOMAIN — that its people are real counterparties — and says
+	// nothing about `noreply@` on it, where still nobody answers.
+	if machineLocalpart(address) {
+		return false
+	}
+	if s.transactional != nil && s.transactional.Allowlisted(cp.Domain) {
+		// The operator declared this domain always-legitimate, which outranks
+		// both domain lists below.
+		return true
+	}
+	base := freemail.Registrable(cp.Domain)
+	if base == "" {
+		// Not a hostname. Nothing that cannot be a domain names a company, and
+		// a person may still be reachable at it, so this is not a refusal.
+		return true
+	}
+	if _, infra := transactionalBaseline[base]; infra {
+		return false
+	}
+	// A personal-service product: the owner's own traffic with a tool they use.
+	// Kept separate from the infrastructure baseline because the attention queue
+	// reads that one and a named human here is a real customer.
+	_, service := personalServiceDomains[base]
+	return !service
+}
+
+// machineLocalpart reports whether the local part of an address names a sending
+// system rather than a person, by both vocabularies the registry keeps.
+func machineLocalpart(address string) bool {
+	at := strings.LastIndex(address, "@")
+	if at <= 0 || at == len(address)-1 {
+		return false
+	}
+	local := address[:at]
+	return isMachineLocalpart(local) || hasMachineMarker(local)
+}
+
+// consumerMailSender answers T3: is this sender a personal mailbox rather than
+// somebody at a company? gmail.com is not an organization whatever else is true
+// of it, so its domain settles the ORGANIZATION question on its own — no
+// company is named by a consumer mail domain.
+//
+// It settles nothing about the person. A customer writing from their private
+// address and a family member writing from theirs are the same shape here, so
+// the ladder suppresses the org and leaves the person to the verdict.
+//
+// The workspace's own additions and carve-outs are read on the CALLER's
+// transaction, not cached at composition time: an admin correcting a wrong
+// baseline entry means the very next message, and a cache would make them wait
+// without saying so.
+func consumerMailSender(ctx context.Context, tx pgx.Tx, domain string) (bool, error) {
+	consumerMail, err := MatcherTx(ctx, tx)
+	if err != nil {
+		return false, err
+	}
+	return consumerMail.IsConsumer(domain), nil
+}

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -211,7 +211,13 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 	if err != nil {
 		return counterpartyDecision{}, err
 	}
-	decision.create = corresponded
+	// Correspondence is evidence of intent toward an address, not evidence that
+	// a person is behind it. A mailbox owner books flights, files expenses and
+	// answers their own robots, so "the workspace wrote here" admitted an
+	// itinerary service and an expense tool as contacts. recordWorthy asks the
+	// second question T1 always assumed: is this an address a person could be
+	// reached at?
+	decision.create = corresponded && s.recordWorthy(cp)
 
 	// T2 transactional / ESP infrastructure, which T1 outranks.
 	suppressed, suppressReason, err := s.registrySuppresses(ctx, tx, rec, cp, row, corresponded)
@@ -219,9 +225,13 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 		return counterpartyDecision{}, err
 	}
 	if suppressed {
-		// decision, not a zero value — and safe to carry because registrySuppresses
-		// can only suppress when !corresponded, so create is still false here.
-		// Nothing downstream may read create from a suppressed decision.
+		// A suppressed decision carries create=false explicitly rather than
+		// relying on registrySuppresses only ever suppressing an address T1 left
+		// alone. That was true and is easy to make false from the other file,
+		// and two readers act on the flag: ensureCounterparty would mint the
+		// record the suppression just refused, and limitLinkLessAudience would
+		// leave the message workspace-readable.
+		decision.create = false
 		return decision.traced(TraceSuppressed, suppressReason), nil
 	}
 
@@ -252,13 +262,19 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 	}
 	decision.create = decision.create || alreadyKnown
 
-	// T3 free-mail (CAP-PARAM-5).
+	// T3 free-mail (CAP-PARAM-5). A consumer mailbox says what it is not — an
+	// organization — so the org is suppressed either way. What it does NOT say
+	// is whether the person behind it is a counterparty: a customer's private
+	// gmail and a founder's sister arrive identically, and minting on sight put
+	// nineteen of the latter in a shared CRM. So the address defers to the
+	// verdict instead of creating, and only a prior admission (alreadyKnown,
+	// above) or a verdict makes the record.
 	consumer, err := consumerMailSender(ctx, tx, cp.Domain)
 	if err != nil {
 		return counterpartyDecision{}, err
 	}
 	if consumer {
-		decision.create, decision.suppressOrg = true, true
+		decision.suppressOrg = true
 	}
 
 	if !decision.create {
@@ -269,23 +285,6 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 		return decision.traced(TraceDeferred, deferReason), nil
 	}
 	return decision, nil
-}
-
-// consumerMailSender answers T3: is this sender a personal mailbox rather than
-// somebody at a company? gmail.com is not an organization whatever else is true
-// of it, so its domain already says what it is and it is not the ambiguous
-// class — the person is created and the company suppressed.
-//
-// The workspace's own additions and carve-outs are read on the CALLER's
-// transaction, not cached at composition time: an admin correcting a wrong
-// baseline entry means the very next message, and a cache would make them wait
-// without saying so.
-func consumerMailSender(ctx context.Context, tx pgx.Tx, domain string) (bool, error) {
-	consumerMail, err := MatcherTx(ctx, tx)
-	if err != nil {
-		return false, err
-	}
-	return consumerMail.IsConsumer(domain), nil
 }
 
 // deferAmbiguous is T4: a first-time sender nothing about this address yet calls

--- a/backend/internal/modules/capture/transactional.go
+++ b/backend/internal/modules/capture/transactional.go
@@ -54,6 +54,29 @@ var transactionalBaseline = map[string]struct{}{
 	"docusign.net":      {}, // DocuSign envelope infrastructure
 }
 
+// personalServiceDomains are product companies whose mail to a mailbox owner is
+// the product talking to its user: expense reports, itineraries, invoices.
+//
+// They are kept OUT of transactionalBaseline deliberately. That set is read by
+// IsMachineAddress, which the attention queue uses to drop rows — and these are
+// companies with named salespeople, not relay infrastructure like sendgrid.net.
+// Listing them there would hide a real human waiting on a reply, which the
+// queue's reader cannot recover from because nothing on the page says somebody
+// was hidden.
+//
+// What they DO justify is refusing to mint a contact from the owner's own
+// traffic with the service. Each one put a person in a real CRM — an expense
+// tool's "Receipts", an itinerary service's "Plans" — because a founder
+// replying to their own receipts reads as correspondence.
+var personalServiceDomains = map[string]struct{}{
+	"expensify.com":       {},
+	"tripit.com":          {},
+	"xero.com":            {},
+	"concur.com":          {},
+	"concursolutions.com": {},
+	"docusign.com":        {}, // the product's own mail; docusign.net is its relay
+}
+
 // transactionalPrefixes are subdomain labels that MARK a sender subdomain as an
 // email-blast lane. A prefix hit alone is NOT enough to suppress — a real
 // company can live at news.acme.com — so a prefix suppresses only with
@@ -126,6 +149,19 @@ func (l *TransactionalList) Suppress(in TransactionalInput) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// Allowlisted reports whether an operator declared this domain always-legitimate
+// through capture.transactional_never. Every refusal in this package consults it
+// first, so one declaration covers the registry and the record-worthiness gate
+// rather than only whichever one an author remembered.
+func (l *TransactionalList) Allowlisted(domain string) bool {
+	base := freemail.Registrable(domain)
+	if base == "" {
+		return false
+	}
+	_, allow := l.never[base]
+	return allow
 }
 
 // corroborated reports whether a prefix-rule sender carries the extra evidence a

--- a/backend/internal/modules/capture/transactional_test.go
+++ b/backend/internal/modules/capture/transactional_test.go
@@ -3,7 +3,12 @@
 
 package capture
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
 
 func TestTransactionalListSuppress(t *testing.T) {
 	// extra adds one infra eSLD; never allowlists a domain that WOULD otherwise
@@ -138,6 +143,105 @@ func TestAPersonIsNeverTakenForAMachine(t *testing.T) {
 	} {
 		if IsMachineAddress(address) {
 			t.Errorf("%q was taken for a machine", address)
+		}
+	}
+}
+
+func TestRecordWorthyRefusesAnAddressNoPersonAnswers(t *testing.T) {
+	sink := &Sink{transactional: NewTransactionalList(nil, nil)}
+	// T1's evidence is that the workspace WROTE to an address, which is honest
+	// evidence of intent and silent about whether a person is there. A mailbox
+	// owner books flights, files expenses and answers their own robots, so
+	// before this gate every one of those became a contact.
+	unreachable := []string{
+		"receipts@expensify.com",
+		"plans@tripit.com",
+		"noreply@acme.com",
+		"calendar-notification@google.com",
+		"dse@eu.docusign.net",
+		// A human-looking local part on an infrastructure domain is refused too:
+		// the domain is the statement, not the name in front of it.
+		"support@expensify.com",
+	}
+	for _, address := range unreachable {
+		if sink.recordWorthy(counterpartyOf(address)) {
+			t.Errorf("recordWorthy(%q) = true, want false — no person answers that address", address)
+		}
+	}
+	// The refusal has to stay narrow. A person at an ordinary company is a
+	// contact whatever their employer does, and a rule that swept a domain on
+	// suspicion would refuse them.
+	reachable := []string{
+		"jane@github.com",
+		"einkauf@kunde.example",
+		"info@acme.com",
+		"sales@event.gitex.com",
+	}
+	for _, address := range reachable {
+		if !sink.recordWorthy(counterpartyOf(address)) {
+			t.Errorf("recordWorthy(%q) = false, want true", address)
+		}
+	}
+	if sink.recordWorthy(connector.Counterparty{}) {
+		t.Error("recordWorthy on an empty address = true, want false")
+	}
+}
+
+func TestAnOperatorsAllowlistOutranksTheRecordWorthyRefusal(t *testing.T) {
+	// capture.transactional_never is the escape hatch for a deployment whose
+	// business genuinely sells to one of these companies. It has to win here as
+	// it wins in Suppress: a refusal that ignored the declaration would turn a
+	// deliberate allowlist into a suppression, which is the exact inversion the
+	// config's own contract warns about.
+	plain := &Sink{transactional: NewTransactionalList(nil, nil)}
+	vouched := &Sink{transactional: NewTransactionalList(nil, []string{"xero.com"})}
+
+	const address = "anna.mueller@xero.com"
+	if plain.recordWorthy(counterpartyOf(address)) {
+		t.Fatalf("recordWorthy(%q) = true without the allowlist, want false — the test proves nothing otherwise", address)
+	}
+	if !vouched.recordWorthy(counterpartyOf(address)) {
+		t.Errorf("recordWorthy(%q) = false despite transactional_never naming the domain", address)
+	}
+	// The allowlist is about the DOMAIN, not about robots. A no-reply address on
+	// a vouched domain still names nobody.
+	if vouched.recordWorthy(counterpartyOf("noreply@xero.com")) {
+		t.Error("an allowlisted domain admitted a no-reply address — nobody answers it whoever vouched for the domain")
+	}
+}
+
+// counterpartyOf builds the ladder's view of a sender from its address alone.
+func counterpartyOf(address string) connector.Counterparty {
+	_, domain, _ := strings.Cut(address, "@")
+	return connector.Counterparty{Email: address, Domain: domain}
+}
+
+func TestTheAttentionQueueStillSeesHumansAtPersonalServiceCompanies(t *testing.T) {
+	// IsMachineAddress is read by the attention queue to drop rows from "who is
+	// waiting on me". Its own contract says over-recognising hides a real
+	// customer and that the reader cannot recover from it, because nothing on
+	// the page says somebody was hidden.
+	//
+	// So the personal-service product domains are kept OUT of the baseline this
+	// reads. They are companies with salespeople, not relay infrastructure, and
+	// the reason to refuse them a CRM record is about the mailbox owner's own
+	// traffic — not about whether a human there is waiting for an answer.
+	visible := []string{
+		"anna.mueller@xero.com",
+		"jane@docusign.com",
+		"sales@concur.com",
+		"support@expensify.com",
+	}
+	for _, address := range visible {
+		if IsMachineAddress(address) {
+			t.Errorf("IsMachineAddress(%q) = true — a named human at that company would vanish from the waiting queue", address)
+		}
+	}
+	// Relay infrastructure stays hidden: nobody is waiting behind it.
+	hidden := []string{"bounce@sendgrid.net", "dse@eu.docusign.net", "noreply@xero.com"}
+	for _, address := range hidden {
+		if !IsMachineAddress(address) {
+			t.Errorf("IsMachineAddress(%q) = false, want true", address)
 		}
 	}
 }

--- a/backend/migrations/core/1788170900_a_sender_can_be_the_owners_alone.down.sql
+++ b/backend/migrations/core/1788170900_a_sender_can_be_the_owners_alone.down.sql
@@ -1,0 +1,30 @@
+SET LOCAL lock_timeout = '3s';
+
+-- Rows already carrying a kind this constraint refuses would block the ADD, and
+-- a down migration that cannot run is not a rollback. Each falls back to the
+-- old kind that preserves its EFFECT, which is not the same as preserving its
+-- meaning — the rollback is lossy and these are the least-lossy targets.
+--
+-- `advisor` becomes `role_mailbox`, not `person`. Both are status `real`, but
+-- the sink reads `real AND kind <> 'person'` as "decided, mint nothing"; the
+-- rewrite to `person` would flip every advisor row to "known counterparty", so
+-- the next message from a founder's lawyer would mint and publish the contact
+-- this kind exists to withhold. What is lost is the reason: the row will say
+-- there was no human to name, when in fact there was one who was the owner's.
+--
+-- `personal` becomes `spam`, which keeps it withheld and is the honest floor
+-- available: every noise kind carries some claim about the sender that a family
+-- member does not deserve, and there is no neutral one to reduce to.
+UPDATE capture_pending_counterparty
+   SET kind = 'role_mailbox' WHERE kind = 'advisor';
+UPDATE capture_pending_counterparty
+   SET kind = 'spam' WHERE kind = 'personal';
+
+ALTER TABLE capture_pending_counterparty
+    DROP CONSTRAINT IF EXISTS capture_pending_counterparty_kind_check;
+
+ALTER TABLE capture_pending_counterparty
+    ADD CONSTRAINT capture_pending_counterparty_kind_check
+    CHECK (kind IS NULL OR kind IN (
+        'person', 'role_mailbox', 'organization_sender',
+        'newsletter', 'transactional', 'spam'));

--- a/backend/migrations/core/1788170900_a_sender_can_be_the_owners_alone.up.sql
+++ b/backend/migrations/core/1788170900_a_sender_can_be_the_owners_alone.up.sql
@@ -1,0 +1,22 @@
+-- Two sender kinds the verdict engine had no word for: the mailbox owner's
+-- private correspondents, and the professionals they engage personally.
+--
+-- Without them every family letter and every message from a founder's lawyer
+-- had to be answered with one of the six business kinds. `person` published
+-- them to the workspace; `spam` and `newsletter` were false about mail the
+-- owner wanted. The engine picked one anyway, because the vocabulary is closed
+-- and a model must answer from it.
+--
+-- The lifecycle statuses are unchanged: `personal` resolves to noise and
+-- `advisor` to real, both already permitted by the status CHECK beside this one.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_pending_counterparty
+    DROP CONSTRAINT IF EXISTS capture_pending_counterparty_kind_check;
+
+ALTER TABLE capture_pending_counterparty
+    ADD CONSTRAINT capture_pending_counterparty_kind_check
+    CHECK (kind IS NULL OR kind IN (
+        'person', 'role_mailbox', 'organization_sender',
+        'newsletter', 'transactional', 'spam',
+        'personal', 'advisor'));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1032,7 +1032,7 @@ public.capture_pending_counterparty acl=margince_owner=arwdDxt/margince_owner,ma
 public.capture_pending_counterparty.activity_id uuid NOT NULL gen=- def=-
 public.capture_pending_counterparty.attempts integer NOT NULL gen=- def=0
 public.capture_pending_counterparty.capture_pending_counterparty_activity_id_fkey FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE CASCADE
-public.capture_pending_counterparty.capture_pending_counterparty_kind_check CHECK (((kind IS NULL) OR (kind = ANY (ARRAY['person'::text, 'role_mailbox'::text, 'organization_sender'::text, 'newsletter'::text, 'transactional'::text, 'spam'::text]))))
+public.capture_pending_counterparty.capture_pending_counterparty_kind_check CHECK (((kind IS NULL) OR (kind = ANY (ARRAY['person'::text, 'role_mailbox'::text, 'organization_sender'::text, 'newsletter'::text, 'transactional'::text, 'spam'::text, 'personal'::text, 'advisor'::text]))))
 public.capture_pending_counterparty.capture_pending_counterparty_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES app_user(id) ON DELETE CASCADE
 public.capture_pending_counterparty.capture_pending_counterparty_pkey PRIMARY KEY (id)
 public.capture_pending_counterparty.capture_pending_counterparty_proposal_id_fkey FOREIGN KEY (proposal_id) REFERENCES approval(id) ON DELETE SET NULL

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -78,7 +78,6 @@ internal/compose/brain.go#type agentBrain
 internal/compose/captureautoenrich.go#func startAutoEnrichRead
 internal/compose/capturedomaintriage.go#func startDomainTriageRead
 internal/compose/captureofflinedemo.go#method offlineDemoDirectory.accounts
-internal/compose/captureverdict.go#func createCounterpartyRecords
 internal/compose/certcase_agentloop_window.go#type agentLoopToolWindow
 internal/compose/certcase_fieldextract.go#method fieldExtractCases.CertifiedScope
 internal/compose/certcase_ratefx_test.go#type fxCompleterStub

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11711,7 +11711,7 @@ export interface components {
         CaptureTraceResolution: {
             /** @enum {string} */
             status: "pending" | "unsure" | "real" | "noise" | "rejected" | "suppressed";
-            /** @description Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam. */
+            /** @description Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam | personal | advisor. The last two belong to the mailbox owner rather than to the business: personal is a private correspondent, advisor a professional they engage personally. */
             kind?: string | null;
             /** Format: date-time */
             resolved_at?: string | null;


### PR DESCRIPTION
Part of the mailbox-privacy work. PR 3 gave each importing mailbox its own provenance row, PR 4 made a mailbox say what it asks of its mail, PR 5 made a captured contact the owner's until judged. This one changes **which senders become records at all**.

## The problem

The tier ladder's T1 evidence is that the workspace WROTE to an address. That is honest evidence of intent and says nothing about whether a person is behind the address. A mailbox owner books flights, files expenses and answers their own notification robots — so a real import minted `Receipts` and `Plans` as contacts, and put nineteen private correspondents of one mailbox in front of every colleague.

## What changed

**T1 asks a second question.** `Sink.recordWorthy` refuses two shapes, both meaning "no person is reachable here" rather than "this person is uninteresting": a machine local part wherever it sends from, and a domain that exists to talk to its own users. It never yields to correspondence, because correspondence with an address nobody answers is not correspondence.

The operator's `transactional_never` allowlist still wins, through the same `TransactionalList` the registry consults — a declaration that a domain is legitimate has to cover both refusals or it is not an escape hatch. The local part is asked **before** the allowlist: vouching for a domain says its people are real, not that `noreply@` on it answers.

**The personal-service domains land in their own list**, not in `transactionalBaseline`. That baseline is read by `IsMachineAddress`, which two surfaces now use to drop rows — the attention queue, and (as of #3330) the Worklist's "machine sender" group. These are companies with salespeople; putting them there would file a named human waiting on a reply into a pile refused without thought, which that reader cannot recover from because nothing on the page says somebody was hidden.

**T3 defers instead of minting.** A consumer mailbox settles the ORGANIZATION question by itself and settles nothing about the person: a customer writing from their private address and a founder's sister arrive in the same shape. Free mail now goes to the verdict. That is safe for the company question because the refusal has two writers — the verdict's own create path reaches `deferOrgToTriage`, which asks the same consumer-mail question at the chokepoint every writer passes. `TestAVerdictOnAFreeMailSenderMintsThePersonAndNoCompany` is what says so; without it the two writers were one comment apart from disagreeing.

**Two sender kinds the taxonomy had no word for.** Every family letter and every message from a founder's lawyer previously had to be answered with one of six business kinds, and the engine picked one because the vocabulary is closed.

- `personal` makes no record. The mail is left alone: destroying it belongs to the purge behind its undo window. `hideNoise` is deliberately not called — its scope excludes every address the workspace has written to, which is every address this kind is about, so calling it would be a no-op that read like a hide.
- `advisor` makes the record and keeps it owner-scoped. A founder's lawyer is a genuine contact, and publishing them to the workspace announces that the founder has one.

**The vocabulary is spelled once.** `verdictKindNames()` feeds the response schema, the validator's message and two test assertions that each held their own copy.

**`capture_counterparty_verdict` drops to a local-only ladder.** Its prompt carries subject and body, and it is the task that decides whether a sender is personal — a cloud rung would send a founder's family mail off the machine in order to ask whether it was family mail.

## A defect this PR's own review caught

The first draft of the two new kinds **did nothing at all**. `verdictSchema()` still listed only the six original kinds, and on a grammar-constrained local rung that enum is what the model can physically emit — so neither kind was reachable. `apply()` also had no effect arm for them, which would have errored the transaction the moment anyone fixed the schema, burning the retries and retiring the row into the human review queue: exactly the sender the kind exists to withhold. Every test passed and `make check` was green.

The comment above that switch said "exhaustive by construction". That claim is what stopped anyone checking.

Two gates now hold it, both mutation-checked against the real defect: `TestEveryVerdictKindHasAnEffect` reads `apply()`'s switch and asserts an arm per kind, and `TestTheModelMayAnswerEveryKindTheTaxonomyDefines` asserts the schema admits every kind the taxonomy defines.

## Other fixes from review

- The down migration mapped `advisor` to `person`. Both are status `real`, but the sink reads `real AND kind <> 'person'` as "decided, mint nothing" — the rewrite would have flipped every advisor row to "known counterparty", so the next message from a founder's lawyer would mint and publish the contact on rollback. Now `role_mailbox`, and the migration says the rollback is lossy instead of calling it honest.
- A suppressed decision carries `create=false` explicitly rather than relying on `registrySuppresses` only ever suppressing an address T1 left alone. That holds today and is easy to make false from the other file; two readers act on the flag.
- `TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated` had lost its free-mail arm, so its org-count assertion passed for a trivial reason. Restored as the discriminator.
- Two certification fixtures carried real names; replaced with invented ones on `.example` domains.

## Not taken

An earlier draft gave `Suppress` a `SuppressionClass` so correspondence would spare only the prefix guess. Mutation testing showed `recordWorthy` already refuses every address that change would have caught — `IsMachineAddress` tests the infra domain as well as the local part — so shipping both would have been two answers to one question. Reverted; the registry keeps its boolean answer.

## Tests

Unit: `TestRecordWorthyRefusesAnAddressNoPersonAnswers`, `TestAnOperatorsAllowlistOutranksTheRecordWorthyRefusal`, `TestTheAttentionQueueStillSeesHumansAtPersonalServiceCompanies`, `TestEveryVerdictKindHasAnEffect`, `TestTheModelMayAnswerEveryKindTheTaxonomyDefines`, `TestTheTaxonomyDefinesTheKindsCaptureDeclares`.

Integration: `TestAnAdvisorVerdictMakesTheRecordAndKeepsItTheOwnersAlone`, `TestAPersonalVerdictMakesNoRecordAtAll`, `TestAVerdictOnAFreeMailSenderMintsThePersonAndNoCompany`, plus two new subtests on `TestCaptureTierGateLetsCorrespondencePrecedeSuppression` for the senders correspondence must **not** spare.

Every guard above was mutation-checked: the guard reverted, the test observed to fail, the guard restored.

## Found along the way

`walkAtOnce` in the backfill-yield harness never called `AttestSentByOwner`, so the parallel walk did not match the sequential one. Invisible while those fixtures used free mail; fixed here.

## Verification

`make check` green on the rebased tree, `make craft-static` clean, the full capture integration package green, the head catalog regenerated from migrations, and the down migration dry-run against a database holding rows with the new kinds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capture minting contacts for senders nobody answers, and keeps a mailbox owner's private and professional correspondence from being published to the workspace.

**What changed**

- T1 creates a counterparty only when `Sink.recordWorthy` also accepts the address: machine local parts (`noreply@`, `receipts@`) and registrable mail-infrastructure domains are refused, and correspondence never spares them.
- The operator's `transactional_never` allowlist still wins, but it vouches for a domain, not for `noreply@` on it.
- Personal-service product domains (`expensify.com`, `tripit.com`, `docusign.com`, …) live in their own list, not `transactionalBaseline`, so the attention queue's machine-sender drop still shows named humans there.
- Free-mail senders now go to the verdict ledger instead of minting a person on sight, and extensions share that deferral through the same sink; the verdict's own create path asks the same consumer-mail question, so gmail.com can never become a company.
- Two new verdict kinds: `personal` makes no record and leaves the mail alone, and `advisor` makes the record but keeps it owner-scoped.
- The kind vocabulary is spelled once in `verdictKindNames()`; two mutation-checked tests hold the effect switch and the response schema to that same list, closing the gap that let the new kinds reach the prompt while the schema still refused them.

**Migration and rollout**

- The migration `1788170900_a_sender_can_be_the_owners_alone` adds `personal` and `advisor` to the kind CHECK.
- The down migration rewrites `advisor` rows to `role_mailbox` (not `person`, which would re-mint and publish on the next message) and `personal` to `spam`; the rollback is deliberately lossy.
- `capture_counterparty_verdict` is now local-only, because its prompt carries the message body and a cloud rung would ship family mail off the machine to ask whether it is family mail.

<sup>Written for commit db70a081ca851ca8035c062cf5a14f1576b2ed35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Personal** and **Advisor** correspondent classifications.
  * Advisor messages can create private, owner-only contacts while preserving correspondence history.
  * Personal messages remain in activity history without creating contacts.
  * Added worklist suggestions for drafting replies to specific activities.
  * Free-mail and service addresses are deferred or excluded from contact creation when appropriate.

* **Privacy**
  * Personal correspondence classification runs exclusively on-device.

* **Bug Fixes**
  * Prevented infrastructure and notification addresses from appearing as contacts.
  * Improved suppression and pending-review behavior for uncertain senders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->